### PR TITLE
Better determination of genericity of FnSymbols

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -67,6 +67,8 @@ FnSymbol::FnSymbol(const char* initName) : Symbol(E_FnSymbol, initName) {
   llvmDISubprogram   = NULL;
   mIsNormalized      = false;
   _throwsError       = false;
+  mIsGeneric         = false;
+  mIsGenericIsValid  = false;
 
   substitutions.clear();
 
@@ -193,8 +195,10 @@ FnSymbol* FnSymbol::copyInnerCore(SymbolMap* map) {
   newFn->thisTag            = this->thisTag;
   newFn->cname              = this->cname;
   newFn->retTag             = this->retTag;
-  newFn->instantiatedFrom   = this->instantiatedFrom;
-  newFn->_instantiationPoint = this->_instantiationPoint;
+  newFn->mIsGeneric         = this->mIsGeneric;
+  newFn->mIsGenericIsValid  = this->mIsGenericIsValid;
+  newFn->instantiatedFrom          = this->instantiatedFrom;
+  newFn->_instantiationPoint       = this->_instantiationPoint;
   newFn->_backupInstantiationPoint = this->_backupInstantiationPoint;
 
   return newFn;
@@ -719,26 +723,32 @@ CallExpr* FnSymbol::singleInvocation() const {
 
 
 //
-// If the function is not currently marked as generic
-//    then if it is generic
-//      1) Update some flags
-//      2) Return true to indicate the status has been modified
+// Labels this function as generic or non-generic.
+// Returns:
+// * TGR_NEWLY_TAGGED - if this function has not been labeled before,
+// * TGR_ALREADY_TAGGED - otherwise,
+// * TGR_TAGGING_ABORTED - if this invocation is recursive and so is aborted.
 //
-bool FnSymbol::tagIfGeneric(SymbolMap* map) {
-  bool retval = false;
+TagGenericResult FnSymbol::tagIfGeneric(SymbolMap* map, bool abortOK) {
+  if (isGenericIsValid()) {
+    // generic-ness has already been established
+    return TGR_ALREADY_TAGGED;
 
-  if (hasFlag(FLAG_GENERIC) == false) {
-    int result = hasGenericFormals(map);
-
-    // If this function has at least 1 generic formal
-    if (result > 0) {
-      addFlag(FLAG_GENERIC);
-
-      retval = true;
+  } else {
+    // avoid recursing for the function.
+    static std::set<Symbol*> seen;
+    if (seen.count(this)) {
+      INT_ASSERT(abortOK);
+      return TGR_TAGGING_ABORTED;
     }
-  }
+    seen.insert(this);
 
-  return retval;
+    // compute and set this function's genericity
+    bool generic = hasGenericFormals(map);
+    setGeneric(generic);
+    seen.erase(this);
+    return TGR_NEWLY_TAGGED;
+  }
 }
 
 
@@ -753,13 +763,14 @@ bool FnSymbol::tagIfGeneric(SymbolMap* map) {
 //
 // 'map' is expected to be non-NULL if this function has been instantiated.
 //
-int FnSymbol::hasGenericFormals(SymbolMap* map) const {
-  bool hasGenericFormal   = false;
-  bool hasGenericDefaults =  true;
-  int  retval             =     0;
-
+bool FnSymbol::hasGenericFormals(SymbolMap* map) const {
   for_formals(formal, this) {
     bool isGeneric = false;
+
+    if (formal->type == dtUnknown && formal->typeExpr != NULL) {
+      resolveBlockStmt(formal->typeExpr);
+      formal->type = formal->typeExpr->body.tail->getValType();
+    }
 
     if (formal->intent == INTENT_PARAM) {
       isGeneric = true;
@@ -799,35 +810,16 @@ int FnSymbol::hasGenericFormals(SymbolMap* map) const {
 
     if (isGeneric == true) {
       if (hasFlag(FLAG_EXPORT)) {
-        if (!hasGenericFormal) {
-          USR_FATAL_CONT(this,
+        USR_FATAL_CONT(this,
                          "exported function `%s` can't be generic", name);
-        }
         USR_PRINT(this,
                   "   formal argument '%s' causes it to be", formal->name);
       }
-      hasGenericFormal = true;
-
-      if (formal->defaultExpr == NULL) {
-        hasGenericDefaults = false;
-      }
+      return true; // no need to examine the remaining formals
     }
   }
 
-  if (hasGenericFormal == false) {
-    retval = 0;
-
-  } else if (hasGenericDefaults == false) {
-    retval = 1;
-
-  } else if (hasGenericDefaults ==  true) {
-    retval = 2;
-
-  } else {
-    INT_ASSERT(false);
-  }
-
-  return retval;
+  return false;
 }
 
 bool FnSymbol::isNormalized() const {
@@ -1077,6 +1069,24 @@ void FnSymbol::throwsErrorInit() {
 
 bool FnSymbol::throwsError() const {
   return _throwsError;
+}
+
+bool FnSymbol::isGeneric() {
+  INT_ASSERT(mIsGenericIsValid);
+  return mIsGeneric;
+}
+
+bool FnSymbol::isGenericIsValid() {
+  return mIsGenericIsValid;
+}
+
+void FnSymbol::setGeneric(bool generic) {
+  mIsGeneric = generic;
+  mIsGenericIsValid = true;
+}
+
+void FnSymbol::clearGeneric() {
+  mIsGeneric = mIsGenericIsValid = false;
 }
 
 bool FnSymbol::retExprDefinesNonVoid() const {

--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -293,6 +293,7 @@ handleArrayTypeCase(LoopExpr* loopExpr, FnSymbol* fn, Expr* indices,
   //
   FnSymbol* isArrayTypeFn = new FnSymbol("_isArrayTypeFn");
   isArrayTypeFn->addFlag(FLAG_INLINE);
+  isArrayTypeFn->setGeneric(false);
   fn->insertAtTail(new DefExpr(isArrayTypeFn));
 
   // Result of '_isArrayTypeFn'
@@ -390,7 +391,7 @@ static FnSymbol* buildSerialIteratorFn(const char* iteratorName,
 {
   FnSymbol* sifn = new FnSymbol(iteratorName);
   sifn->addFlag(FLAG_ITERATOR_FN);
-  sifn->addFlag(FLAG_GENERIC);
+  sifn->setGeneric(true);
 
   ArgSymbol* sifnIterator = new ArgSymbol(INTENT_BLANK, "iterator", dtAny);
   sifn->insertFormalAtTail(sifnIterator);
@@ -426,7 +427,7 @@ static FnSymbol* buildLeaderIteratorFn(const char* iteratorName,
 {
   FnSymbol* lifn = new FnSymbol(iteratorName);
   lifn->addFlag(FLAG_FN_RETURNS_ITERATOR);
-  lifn->addFlag(FLAG_GENERIC);
+  lifn->setGeneric(true);
 
   Expr* tag = new SymExpr(gLeaderTag);
   ArgSymbol* lifnTag = new ArgSymbol(INTENT_PARAM, "tag", dtUnknown,
@@ -460,7 +461,7 @@ static FnSymbol* buildFollowerIteratorFn(const char* iteratorName,
 {
   FnSymbol* fifn = new FnSymbol(iteratorName);
   fifn->addFlag(FLAG_ITERATOR_FN);
-  fifn->addFlag(FLAG_GENERIC);
+  fifn->setGeneric(true);
 
   Expr* tag = new SymExpr(gFollowerTag);
   ArgSymbol* fifnTag = new ArgSymbol(INTENT_PARAM, "tag", dtUnknown,
@@ -710,7 +711,7 @@ static CallExpr* buildLoopExprFunctions(LoopExpr* loopExpr) {
   fn->addFlag(FLAG_COMPILER_NESTED_FUNCTION);
   fn->addFlag(FLAG_FN_RETURNS_ITERATOR);
   fn->addFlag(FLAG_COMPILER_GENERATED);
-  fn->addFlag(FLAG_GENERIC);
+  fn->setGeneric(true);
   if (forall) fn->addFlag(FLAG_MAYBE_ARRAY_TYPE);
 
   if (insideArgSymbol) {

--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -121,6 +121,8 @@ static void viewSymbolFlags(Symbol* sym) {
         printf("a TypeSymbol\n");
 
       } else if (FnSymbol* fs = toFnSymbol(sym)) {
+        printf("isGeneric %s\n", fs->isGenericIsValid() ?
+               (fs->isGeneric() ? "yes" : "no") : "unset");
         printf("fn %s(%d args) %s\n",
                fs->_this ? intentDescrString(fs->thisTag) : "",
                fs->numFormals(),

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -507,6 +507,7 @@ CallExpr* setIteratorRecordShape(Expr* ref, Symbol* ir, Symbol* shapeSpec,
     iRecord->fields.insertAtTail(new DefExpr(field));
     // An accessor lets us get _shape_ in Chapel code.
     FnSymbol* accessor = build_accessor(iRecord, field, false, false);
+    accessor->setGeneric(false);
     // This sidesteps the visibility issue in the presence of nested
     // LoopExprs. Ex. test/expressions/loop-expr/scoping.chpl
     theProgram->block->insertAtTail(accessor->defPoint->remove());

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -260,6 +260,13 @@ bool Symbol::hasEitherFlag(Flag aflag, Flag bflag) const {
   return hasFlag(aflag) || hasFlag(bflag);
 }
 
+bool Symbol::isKnownToBeGeneric() {
+  if (FnSymbol* fn = toFnSymbol(this))
+    return fn->isGenericIsValid() && fn->isGeneric();
+  else
+    return hasFlag(FLAG_GENERIC);
+}
+
 // Don't generate documentation for this symbol, either because it is private,
 // or because the symbol should not be documented independent of privacy
 bool Symbol::noDocGen() const {

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -407,7 +407,7 @@ void clearGenericWellKnownFunctions()
 
   for (int i = 0; i < nEntries; ++i) {
     WellKnownFn& wkfn = sWellKnownFns[i];
-    if (*wkfn.fn != NULL && (*wkfn.fn)->hasFlag(FLAG_GENERIC))
+    if (*wkfn.fn != NULL && (*wkfn.fn)->isGeneric())
       *wkfn.fn = NULL;
   }
 }

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -33,6 +33,12 @@ enum RetTag {
   RET_TYPE
 };
 
+enum TagGenericResult {
+  TGR_ALREADY_TAGGED,
+  TGR_NEWLY_TAGGED,
+  TGR_TAGGING_ABORTED
+};
+
 class FnSymbol : public Symbol {
 public:
   // each formal is an ArgSymbol, but the elements are DefExprs
@@ -154,7 +160,7 @@ public:
 
   CallExpr*                  singleInvocation()                          const;
 
-  bool                       tagIfGeneric(SymbolMap* map = NULL);
+  TagGenericResult           tagIfGeneric(SymbolMap* map = NULL, bool abortOK = false);
 
   bool                       isNormalized()                              const;
   void                       setNormalized(bool value);
@@ -175,6 +181,11 @@ public:
   bool                       isPostInitializer()                         const;
   bool                       isDefaultInit()                             const;
   bool                       isCopyInit()                                const;
+
+  bool                       isGeneric();
+  bool                       isGenericIsValid();
+  void                       setGeneric(bool generic);
+  void                       clearGeneric();
 
   AggregateType*             getReceiver()                               const;
 
@@ -197,10 +208,12 @@ public:
 private:
   virtual std::string        docsDirective();
 
-  int                        hasGenericFormals(SymbolMap* map)           const;
+  bool                       hasGenericFormals(SymbolMap* map)           const;
 
   bool                       mIsNormalized;
   bool                       _throwsError;
+  bool                       mIsGeneric;
+  bool                       mIsGenericIsValid;
 };
 
 const char*                     toString(FnSymbol* fn);

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -135,6 +135,7 @@ CallExpr* findDownEndCount(FnSymbol* fn);
 
 // resolution
 Expr*     resolveExpr(Expr* expr);
+void      resolveBlockStmt(BlockStmt* blockStmt);
 
 // type.cpp
 void initForTaskIntents();

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -206,7 +206,6 @@ disambiguateForInit(CallInfo&                    info,
                     Vec<ResolutionCandidate*>&   candidates);
 
 // Regular resolve functions
-void      resolveBlockStmt(BlockStmt* blockStmt);
 void      resolveCall(CallExpr* call);
 void      resolveCallAndCallee(CallExpr* call, bool allowUnresolved = false);
 

--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -26,10 +26,7 @@ class FnSymbol;
 class Type;
 
 void  resolveSignatureAndFunction(FnSymbol* fn);
-
-// Note: resolveSignature resolves declared return types
 void  resolveSignature(FnSymbol* fn);
-
 void  resolveFunction(FnSymbol* fn, CallExpr* forCall = 0);
 
 bool  isParallelIterator(FnSymbol* fn);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -177,6 +177,7 @@ public:
   void               removeFlag(Flag flag);
   void               copyFlags(const Symbol* other);
 
+  bool               isKnownToBeGeneric();
   virtual bool       isVisible(BaseAST* scope)                 const;
   bool               noDocGen()                                const;
 

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -80,8 +80,10 @@ void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>* v);
 void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>& v);
 void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>* v);
 void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>& v);
-void        vec_view(std::vector<Symbol*>* vec);
-void        vec_view(std::vector<Symbol*>& vec);
+void        vec_view(std::vector<Symbol*>* syms);
+void        vec_view(std::vector<Symbol*>& syms);
+void        vec_view(std::vector<FnSymbol*>* syms);
+void        vec_view(std::vector<FnSymbol*>& syms);
 
 
 void        fnsWithName(const char* name);

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -58,7 +58,11 @@ ResolutionCandidate::ResolutionCandidate(FnSymbol* function) {
 bool ResolutionCandidate::isApplicable(CallInfo& info) {
   bool retval = false;
 
-  if (fn->hasFlag(FLAG_GENERIC) == false) {
+  TagGenericResult tagResult = fn->tagIfGeneric(NULL, true);
+  if (tagResult == TGR_TAGGING_ABORTED)
+    return false;
+
+  if (! fn->isGeneric()) {
     retval = isApplicableConcrete(info);
   } else {
     retval = isApplicableGeneric (info);
@@ -183,7 +187,7 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
 
       while (formal != NULL) {
         if (formal->variableExpr) {
-          return (fn->hasFlag(FLAG_GENERIC)) ? true : false;
+          return fn->isGeneric();
         }
 
         if (formalIdxToActual[j] == NULL) {
@@ -202,7 +206,7 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
 
       // Fail if there are too many unnamed actuals.
       if (match == false) {
-        if (fn->hasFlag(FLAG_GENERIC) == false) {
+        if (! fn->isGeneric()) {
           failingArgument = info.actuals.v[i];
           reason = RESOLUTION_CANDIDATE_TOO_MANY_ARGUMENTS;
           return false;

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -59,7 +59,7 @@ static void removeUnusedFunctions() {
   std::vector<FnSymbol*> fns = getWellKnownFunctions();
 
   for_vector(FnSymbol, fn, fns) {
-    INT_ASSERT(fn->hasFlag(FLAG_GENERIC) == false);
+    INT_ASSERT(! fn->isGeneric());
 
     concreteWellKnownFunctionsSet.insert(fn);
   }

--- a/compiler/resolution/expandVarArgs.cpp
+++ b/compiler/resolution/expandVarArgs.cpp
@@ -24,6 +24,7 @@
 #include "callInfo.h"
 #include "expr.h"
 #include "PartialCopyData.h"
+#include "passes.h"
 #include "resolution.h"
 #include "stlUtil.h"
 #include "stmt.h"
@@ -200,7 +201,7 @@ static void expandVarArgsFixed(FnSymbol* fn, CallInfo& info) {
           expandVarArgsFormal(fn, formal, varArgsCount(formal, nVar));
         }
 
-      } else if (fn->hasFlag(FLAG_GENERIC) == false) {
+      } else if (! fn->isGeneric()) {
         INT_FATAL("bad variableExpr");
       }
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -25,6 +25,7 @@
 #include "driver.h"
 #include "expr.h"
 #include "PartialCopyData.h"
+#include "passes.h"
 #include "resolveFunction.h"
 #include "resolveIntents.h"
 #include "stmt.h"
@@ -590,7 +591,7 @@ FnSymbol* instantiateFunction(FnSymbol*  fn,
                               SymbolMap& allSubsBeforeDefaultExprs) {
   FnSymbol* newFn = fn->partialCopy(&map);
 
-  newFn->removeFlag(FLAG_GENERIC);
+  newFn->clearGeneric();
   newFn->addFlag(FLAG_INVISIBLE_FN);
   newFn->instantiatedFrom = fn;
   newFn->substitutions.map_union(allSubs);
@@ -758,7 +759,7 @@ void explainAndCheckInstantiation(FnSymbol* newFn, FnSymbol* fn) {
                      &explainInstantiationModule);
   }
 
-  if (!newFn->hasFlag(FLAG_GENERIC) && explainInstantiationLine) {
+  if (!newFn->isGeneric() && explainInstantiationLine) {
     explainInstantiation(newFn);
   }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -784,7 +784,7 @@ static void makeActualsVector(const CallInfo&          info,
       }
 
       // Fail if there are too many unnamed actuals.
-      if (!match && !(fn->hasFlag(FLAG_GENERIC) && fn->hasFlag(FLAG_INIT_TUPLE))) {
+      if (!match && !(fn->isGeneric() && fn->hasFlag(FLAG_INIT_TUPLE))) {
         INT_FATAL(call,
                   "Compilation should have verified this action was valid");
       }

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -77,7 +77,6 @@ void resolveSignatureAndFunction(FnSymbol* fn) {
 ************************************** | *************************************/
 
 void resolveSignature(FnSymbol* fn) {
-  if (fn->hasFlag(FLAG_GENERIC) == false) {
     // Don't resolve formals for concrete functions
     // more often than necessary.
     static std::set<FnSymbol*> done;
@@ -87,7 +86,6 @@ void resolveSignature(FnSymbol* fn) {
 
       resolveFormals(fn);
     }
-  }
 }
 
 /************************************* | **************************************
@@ -478,6 +476,8 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
     }
 
     fn->addFlag(FLAG_RESOLVED);
+
+    fn->tagIfGeneric();
 
     if (strcmp(fn->name, "init") == 0 && fn->isMethod()) {
       AggregateType* at = toAggregateType(fn->_this->getValType());

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -497,13 +497,9 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
   ret.defaultExprFn = wrapper;
 
   //wrapper->addFlag(FLAG_WRAPPER);
-
   wrapper->addFlag(FLAG_INVISIBLE_FN);
-
   wrapper->addFlag(FLAG_INLINE);
-
   wrapper->addFlag(FLAG_LINE_NUMBER_OK);
-
   wrapper->retTag = RET_VALUE;
 
   if (fn->hasFlag(FLAG_METHOD)) {
@@ -528,6 +524,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
   wrapper->addFlag(FLAG_COMPILER_GENERATED);
   wrapper->addFlag(FLAG_MAYBE_PARAM);
   wrapper->addFlag(FLAG_MAYBE_TYPE);
+  wrapper->setGeneric(false); // We are here only when resolving a call.
 
   if (fn->throwsError())
     wrapper->throwsErrorInit();
@@ -2064,7 +2061,7 @@ static void buildLeaderIterator(FnSymbol* wrapFn,
   BlockStmt* loop = buildChapelStmt(fs);
 
   liFn->addFlag(FLAG_INLINE_ITERATOR);
-  liFn->addFlag(FLAG_GENERIC);
+  liFn->setGeneric(true);
   liFn->removeFlag(FLAG_INVISIBLE_FN);
 
   liFn->insertFormalAtTail(liFnTag);
@@ -2119,7 +2116,7 @@ static void buildFollowerIterator(PromotionInfo& promotion,
   fiFnFollower = new ArgSymbol(INTENT_BLANK, iterFollowthisArgname, dtAny);
   fastFollower = new ArgSymbol(INTENT_PARAM, "fast", dtBool, NULL, symFalse);
 
-  fiFn->addFlag(FLAG_GENERIC);
+  fiFn->setGeneric(true);
   fiFn->removeFlag(FLAG_INVISIBLE_FN);
 
   fiFn->insertFormalAtTail(fiFnTag);
@@ -2611,8 +2608,6 @@ static void buildFastFollowerCheck(bool                  isStatic,
 
     forward = new CallExpr(astr(fnName, "Zip"), pTup, lead);
 
-    checkFn->addFlag(FLAG_GENERIC);
-
   } else {
     forward = new CallExpr(astr(fnName, "Zip"), pTup);
 
@@ -2645,6 +2640,8 @@ static void buildFastFollowerCheck(bool                  isStatic,
   theProgram->block->insertAtTail(new DefExpr(checkFn));
 
   normalize(checkFn);
+  checkFn->setGeneric(addLead);
+  INT_ASSERT(! wrapper->isGeneric()); //fyi
 }
 
 void buildFastFollowerChecksIfNeeded(CallExpr* checkCall) {

--- a/test/exercises/duplicates/duplicates-alt-assoc-reduce.chpl
+++ b/test/exercises/duplicates/duplicates-alt-assoc-reduce.chpl
@@ -1,6 +1,5 @@
 // This version uses an associative array instead of sorting
 // and works in parallel by + reducing the associative array.
-// Unfortunately it leaks memory.
 
 use FileHashing;
 use FileSystem;

--- a/test/functions/bradc/resolution/badEnumDispatch.good
+++ b/test/functions/bradc/resolution/badEnumDispatch.good
@@ -41,12 +41,12 @@ badEnumDispatch.chpl:15: note: candidates are: int8or32(x: int(32))
 badEnumDispatch.chpl:90: error: unresolved call 'param64OrNot(sizes)'
 badEnumDispatch.chpl:19: note: this candidate did not match: param64OrNot(param x: int(64))
 badEnumDispatch.chpl:90: note: because call actual argument #1 with type sizes
-badEnumDispatch.chpl:19: note: is passed to formal 'x: int(64)'
+badEnumDispatch.chpl:19: note: is passed to formal 'param x: int(64)'
 badEnumDispatch.chpl:23: note: candidates are: param64OrNot(x: int(64))
 badEnumDispatch.chpl:91: error: unresolved call 'param64OrNot(sizes)'
 badEnumDispatch.chpl:19: note: this candidate did not match: param64OrNot(param x: int(64))
 badEnumDispatch.chpl:91: note: because call actual argument #1 with type sizes
-badEnumDispatch.chpl:19: note: is passed to formal 'x: int(64)'
+badEnumDispatch.chpl:19: note: is passed to formal 'param x: int(64)'
 badEnumDispatch.chpl:23: note: candidates are: param64OrNot(x: int(64))
 badEnumDispatch.chpl:92: error: unresolved call 'param64OrNot(sizes)'
 badEnumDispatch.chpl:23: note: this candidate did not match: param64OrNot(x: int(64))
@@ -61,12 +61,12 @@ badEnumDispatch.chpl:19: note: candidates are: param64OrNot(param x: int(64))
 badEnumDispatch.chpl:97: error: unresolved call 'param8OrNot(sizes)'
 badEnumDispatch.chpl:27: note: this candidate did not match: param8OrNot(param x: int(8))
 badEnumDispatch.chpl:97: note: because call actual argument #1 with type sizes
-badEnumDispatch.chpl:27: note: is passed to formal 'x: int(8)'
+badEnumDispatch.chpl:27: note: is passed to formal 'param x: int(8)'
 badEnumDispatch.chpl:31: note: candidates are: param8OrNot(x: int(8))
 badEnumDispatch.chpl:98: error: unresolved call 'param8OrNot(sizes)'
 badEnumDispatch.chpl:27: note: this candidate did not match: param8OrNot(param x: int(8))
 badEnumDispatch.chpl:98: note: because call actual argument #1 with type sizes
-badEnumDispatch.chpl:27: note: is passed to formal 'x: int(8)'
+badEnumDispatch.chpl:27: note: is passed to formal 'param x: int(8)'
 badEnumDispatch.chpl:31: note: candidates are: param8OrNot(x: int(8))
 badEnumDispatch.chpl:99: error: unresolved call 'param8OrNot(sizes)'
 badEnumDispatch.chpl:31: note: this candidate did not match: param8OrNot(x: int(8))
@@ -81,14 +81,14 @@ badEnumDispatch.chpl:27: note: candidates are: param8OrNot(param x: int(8))
 badEnumDispatch.chpl:104: error: unresolved call 'param8Or32OrNot(sizes)'
 badEnumDispatch.chpl:35: note: this candidate did not match: param8Or32OrNot(param x: int(8))
 badEnumDispatch.chpl:104: note: because call actual argument #1 with type sizes
-badEnumDispatch.chpl:35: note: is passed to formal 'x: int(8)'
+badEnumDispatch.chpl:35: note: is passed to formal 'param x: int(8)'
 badEnumDispatch.chpl:39: note: candidates are: param8Or32OrNot(x: int(8))
 badEnumDispatch.chpl:43: note:                 param8Or32OrNot(param x: int(32))
 note: and 1 other candidates, use --print-all-candidates to see them
 badEnumDispatch.chpl:105: error: unresolved call 'param8Or32OrNot(sizes)'
 badEnumDispatch.chpl:35: note: this candidate did not match: param8Or32OrNot(param x: int(8))
 badEnumDispatch.chpl:105: note: because call actual argument #1 with type sizes
-badEnumDispatch.chpl:35: note: is passed to formal 'x: int(8)'
+badEnumDispatch.chpl:35: note: is passed to formal 'param x: int(8)'
 badEnumDispatch.chpl:39: note: candidates are: param8Or32OrNot(x: int(8))
 badEnumDispatch.chpl:43: note:                 param8Or32OrNot(param x: int(32))
 note: and 1 other candidates, use --print-all-candidates to see them

--- a/test/functions/export/exportGenericArgs.good
+++ b/test/functions/export/exportGenericArgs.good
@@ -8,4 +8,3 @@ exportGenericArgs.chpl:10: error: exported function `queryType` can't be generic
 exportGenericArgs.chpl:10: note:    formal argument 'y' causes it to be
 exportGenericArgs.chpl:13: error: exported function `twoGenerics` can't be generic
 exportGenericArgs.chpl:13: note:    formal argument 't' causes it to be
-exportGenericArgs.chpl:13: note:    formal argument 'p' causes it to be

--- a/test/functions/generic/arg-type-is-a-call.chpl
+++ b/test/functions/generic/arg-type-is-a-call.chpl
@@ -1,0 +1,38 @@
+// From test/release/examples/benchmarks/lcals/LCALSMain.chpl
+//
+//  proc initData(ra: LCALS_Overlapping_Array_3D(real), id: int) {...}
+//  var RealArray_3D_2xNx4: [...] owned LCALS_Overlapping_Array_3D(real) ...;
+//  initData(s_loop_data.RealArray_3D_2xNx4[i], i+1);
+
+class OAR {
+  type t;
+}
+
+proc ASDF(ra: OAR(bool)) {  // 'ra' is generic over management strategy
+  compilerWarning("ra: ", ra.type:string);
+}
+
+var ELM = new owned OAR(bool);
+ASDF(ELM);
+
+// Recreating the above with user records
+
+record GRec {
+  param p;
+}
+
+proc getGeneric(dummyArg) type  return GRec;
+
+proc test1(ref formal1: GRec) {
+  compilerWarning("formal1: ", formal1.type:string);
+}
+
+proc test2(ref formal2: getGeneric(0)) {
+  compilerWarning("formal2: ", formal2.type:string);
+}
+
+var act = new GRec(5);
+test1(act);
+test2(act);
+
+compilerError("done");

--- a/test/functions/generic/arg-type-is-a-call.good
+++ b/test/functions/generic/arg-type-is-a-call.good
@@ -1,0 +1,4 @@
+arg-type-is-a-call.chpl:16: warning: ra: owned OAR(bool)
+arg-type-is-a-call.chpl:35: warning: formal1: GRec(5)
+arg-type-is-a-call.chpl:36: warning: formal2: GRec(5)
+arg-type-is-a-call.chpl:38: error: done

--- a/test/functions/lydia/infinite-recursion-arg.bad
+++ b/test/functions/lydia/infinite-recursion-arg.bad
@@ -1,8 +1,3 @@
-infinite-recursion-arg.chpl:1: internal error: PAS-RES-NTS-0127 chpl version 1.19.0 pre-release (cfeb6592b3)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+infinite-recursion-arg.chpl:5: In function 'infinite2':
+infinite-recursion-arg.chpl:6: error: unresolved call 'infinite1(int(64))'
+infinite-recursion-arg.chpl:1: note: this candidate did not match: infinite1(x: int, y = infinite2(x))

--- a/test/functions/resolution/paramUintNoTypeInError.bad
+++ b/test/functions/resolution/paramUintNoTypeInError.bad
@@ -1,4 +1,4 @@
 paramUintNoTypeInError.chpl:7: error: unresolved call 'takesInt(512)'
 paramUintNoTypeInError.chpl:1: note: this candidate did not match: takesInt(param x: int(8))
 paramUintNoTypeInError.chpl:7: note: because call actual argument #1 with type uint(64)
-paramUintNoTypeInError.chpl:1: note: is passed to formal 'x: int(8)'
+paramUintNoTypeInError.chpl:1: note: is passed to formal 'param x: int(8)'

--- a/test/functions/whereClauses/whereClauseCantFold.good
+++ b/test/functions/whereClauses/whereClauseCantFold.good
@@ -1,4 +1,4 @@
 whereClauseCantFold.chpl:5: error: unresolved call 'foo(1.2)'
 whereClauseCantFold.chpl:1: note: this candidate did not match: foo(param x: uint(8))
 whereClauseCantFold.chpl:5: note: because call actual argument #1 with type real(64)
-whereClauseCantFold.chpl:1: note: is passed to formal 'x: uint(8)'
+whereClauseCantFold.chpl:1: note: is passed to formal 'param x: uint(8)'

--- a/test/functions/whereClauses/whereClauseParamArgMismatch2.good
+++ b/test/functions/whereClauses/whereClauseParamArgMismatch2.good
@@ -1,4 +1,4 @@
 whereClauseParamArgMismatch2.chpl:10: error: unresolved call 'foo(1.2)'
 whereClauseParamArgMismatch2.chpl:1: note: this candidate did not match: foo(param x: uint(8))
 whereClauseParamArgMismatch2.chpl:10: note: because call actual argument #1 with type real(64)
-whereClauseParamArgMismatch2.chpl:1: note: is passed to formal 'x: uint(8)'
+whereClauseParamArgMismatch2.chpl:1: note: is passed to formal 'param x: uint(8)'

--- a/test/functions/whereClauses/whereClauseParamArgMismatch3.good
+++ b/test/functions/whereClauses/whereClauseParamArgMismatch3.good
@@ -1,4 +1,4 @@
 whereClauseParamArgMismatch3.chpl:10: error: unresolved call 'foo(1.2)'
 whereClauseParamArgMismatch3.chpl:1: note: this candidate did not match: foo(param x: uint(64))
 whereClauseParamArgMismatch3.chpl:10: note: because call actual argument #1 with type real(64)
-whereClauseParamArgMismatch3.chpl:1: note: is passed to formal 'x: uint(64)'
+whereClauseParamArgMismatch3.chpl:1: note: is passed to formal 'param x: uint(64)'

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -25,8 +25,7 @@ module LCALSLoops {
     ia = 0;
   }
 
-  proc initData(ra: LCALS_Overlapping_Array_3D, id: int) {
-    compilerAssert(ra.t == real);
+  proc initData(ra: LCALS_Overlapping_Array_3D(real), id: int) {
     const factor: Real_type = if id % 2 != 0 then 0.1 else 0.2;
     for (r,j) in zip(ra, 0..) {
       r = factor*(j + 1.1)/(j + 1.12345);


### PR DESCRIPTION
Resolves #13721.

This PR makes two key changes.

#### Ensures computing the genericity of a FnSymbol before querying it

Switch from FnSymbol->hasFlag(FLAG_GENERIC) to FnSymbol->isGeneric().
This is so that we can assert that this has been computed.
If we are comfortable to drop the assertion, we can switch back.
Although I changed some conditionals from testing "is it generic" to
testing "have we calculated genericity". As a result, this is not
a 1:1 change.

For this switch, add two private fields in FnSymbol, one two indicate if it
is generic, the other to indicate whether the first has been calculated
intentionally. `isGeneric()` asserts that the second field is true.

Also add more calls to `FnSymbol::tagIfGeneric()`, which is the function
that computes genericity.

Remove `markGenericFunctions()`, that was invoked at start of resolution.
This is because it ran before formals' types were resolved and so could
miss a generic function. Instead, postpone computing genericity until
the function is examined for applicability to a call. That is, upon
resolveCall() --> filterCandidate() --> isApplicable(). See next.

#### Adds resolution of formal arguments' types before computing genericity

Before this change, a formal was sometimes mis-qualified as non-generic
because its type was not resolved yet. Causing a generic function to be
considered non-generic and leading to the resolution failure that was
worked around in #14166. See https://github.com/chapel-lang/chapel/issues/13721#issuecomment-535164115 for details

Now tagIfGeneric() / hasGenericFormals() resolves the formal's type as needed.
I borrowed this from resolveSignature() / resolveFormals(). This is a step
towards running hasGenericFormals() and resolveFormals() simultaneously
for each formal, instead of running each for all of a function's formals
at once.

Ideally, we will also be detecting at the same time whether the function
is applicable to the CallExpr at hand and computing the bindings and the types
of already-instantiated formals. That way, if the function is found to be
not applicalbe due to one formal, we exit this process right away. Instead of
continuing to ponder whether the function is generic, which in this case
is irrelevant.

Notes:

* resolveFormals() does more than just resolve the `typeExpr`. However,
for this PR resolving the `typeExpr` is sufficient.

* hasGenericFormals() now completes as soon as it finds a generic formal,
instead of examining all formals always.

  - Otherwise, resolving a formal's type fails, for example, for the declaration:
    `proc +(x: _tuple, y: x(1).type) ....`
    There, we do not know `x(1).type` because we are not binding
    this FnSymbol to the call yet, so we do not know the type of `x`.
    Detecting applicability at the same time, discussed above, would remove
    this obstacle.

  - hasGenericFormals() used to detect whether there are generic formals
    without a default value. This required examining **all** formals.
    Given that this information has been unused, hasGenericFormals() does not
    compute it any longer.

  - When an `extern` function had multiple generic formals, the compiler would
    list them all in a single compilation. Now, only the first generic formal
    is reported.

* `tagIfGeneric()` is now called recursively on the same function sometimes,
so includes a guard that detects recursion and and aborts.

<details><summary>Here is what happens.</summary>

Consider the call `64*2` and these functions:
```chpl
proc *(a: real(?w), b: complex(w*2)) ...
proc *(a: imag(?w), b: complex(w*2)) ...
proc *(a: complex(?w), b: real(w/2)) ...
proc *(a: complex(?w), b: imag(w/2)) ...
```
which are cloned into:
```
proc *(a: real(32), b: complex(32*2)) ...
proc *(a: real(64), b: complex(64*2)) ...
proc *(a: imag(32), b: complex(32*2)) ...
......
```
Call them p1, p2, .... The compiler's steps are:
  - For each of the visible functions p1, p2, ..., is it applicable to this call?
  - Is p1 applicable?
  - Is p1 generic?
  - resolve the type `complex(32*2)`
  - resolve `32*2`
    - The visible functions are p1, p2, ... Check their applicability.
    - Is p1 applicable?
    - Is p1 generic?
    - We are already working on p1, abort the is-generic computation.
    - Condier p1 not applicable to this call since we aborted.
    - Is p2 applicable?
    - Is p2 generic?
    - resolve the type `complex(64*2)`
    - resolve the `64*2`
      - The visible functions are p1, p2, ... Check their applicability.
      - Now we skip p1, p2 and proceed with p3.
      - etc.

Thankfully this pattern has limited occurrences. Also, once a formal's type
has been resolved, the result is saved in the ArgSymbol, avoiding re-resolving
when this formal is encountered next time.  The compiler's `callStack` grows
to 25 calls with the above going on, however it is less than what we already get
for SSCA2 on master. I spot-checked SSCA2 compilation times and did not
discern a difference from master.

</details>

* For those of us sensitive to the resolution order, note that the formal's type
may be resolved when checking the function's applicability to a call - during
tagIfGeneric(). Rather than when resolving the already-chosen best candidate.
I do not think that this is a change in behavior because we need to know
the formal's type in order to determine whether it applies. Indeed, the
compiler already calls resolveSignature() in isApplicableConcrete(). (Not sure
why it doesn't in isApplicableGeneric().)

#### What about hack_resolve_types() ?

Turns out that `function_exists()` in buildDefaultFunctions.cpp
relies on it to notice that there is a `=` on two tuples.
I think if we rewrite `proc =` in ChapelTuple.chpl using
function calls for argument types, the compiler will not recognize
that this is a tuple assignment and will generate the default one.
Then we will get the "ambiguous" error upon a tuple assignment call.
So, it is less of a hack than expected. I am tempted to leave it alone
for now.

#### Other

Compiler trivia: an FnSymbol with a type formal is considered non-generic
when it is used as the resolvedFunction() of a CallExpr. Even when the call
passes a generic type to that formal. This makes sense, first, because we
want CallExpr targets to be concrete, resolve them, etc. Second, at this point
all formals are instantiated as appropriate for this call and the FnSymbol
will not be instantiated any further.

While there:
* Switch from casts to CLASS_TYPE_UNMANAGED to casts to
  CLASS_TYPE_UNMANAGED_NONNIL to avoid unnecessary genericity.
* Remove a comment "it leaks memory" on a test that no longer does
  and an obsolete comment on resolveSignature().
* Improve the output format for vectors of Symbols in view.cpp.

Remaining tasks:

* [ ] decide what to do with the the added `param` in compiler messages,
  see the changes in .good files - is this something to fix?
* [ ] add tests specifically for this change

Testing passed: linux64 -futures, gasnet multilocale tests.

