### PR TITLE
Fix cray-cs perf logdir

### DIFF
--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -7,7 +7,9 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
-export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
+export CHPL_NIGHTLY_LOGDIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
+export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
+export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.fast"
 

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
@@ -7,7 +7,9 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
-export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
+export CHPL_NIGHTLY_LOGDIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
+export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
+export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.large"
 

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -7,7 +7,9 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
-export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
+export CHPL_NIGHTLY_LOGDIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
+export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
+export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-mpi"
 


### PR DESCRIPTION
In #14208 I tried to change the graph/annotation name to "16 node CS",
but this also set the logdir. Manually set the logdir to the old
"16-node-cs" to avoid paths with spaces.