### PR TITLE
Remove active_tasks counter from EpochManager

### DIFF
--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -809,10 +809,6 @@ prototype module EpochManager {
     pragma "no doc"
     var locale_epoch : atomic uint;
 
-    //  Number of active (pinned) tasks on current locale
-    pragma "no doc"
-    var active_tasks : atomic uint;
-
     //  Local flag to indicate a task is trying to advance global epoch
     pragma "no doc"
     var is_setting_epoch : atomic bool;
@@ -921,7 +917,6 @@ prototype module EpochManager {
       // An inactive task has local_epoch set to 0. A value other than 0
       // implies active task
       if (tok.local_epoch.read() == INACTIVE) {
-        active_tasks.add(1);
         tok.local_epoch.write(locale_epoch.read());
       }
     }
@@ -965,13 +960,11 @@ prototype module EpochManager {
       var safeToReclaim = true;
       coforall loc in Locales with (&& reduce safeToReclaim) do on loc {
         var _this = getPrivatizedInstance();
-        if _this.active_tasks.read() != 0 {
-          for tok in _this.allocated_list {
-            var local_epoch = tok.local_epoch.read();
-            if (local_epoch != 0 && local_epoch != current_global_epoch) {
-              safeToReclaim = false;
-              break;
-            } 
+        for tok in _this.allocated_list {
+          var local_epoch = tok.local_epoch.read();
+          if (local_epoch != 0 && local_epoch != current_global_epoch) {
+            safeToReclaim = false;
+            break;
           }
         }
       }
@@ -1010,10 +1003,7 @@ prototype module EpochManager {
 
     pragma "no doc"
     proc unpin(tok: unmanaged _token) {
-      if (tok.local_epoch.read() != INACTIVE) {
-        active_tasks.sub(1);
-        tok.local_epoch.write(INACTIVE);
-      }
+      tok.local_epoch.write(INACTIVE);
     }
 
     /*


### PR DESCRIPTION
The counter can be a big bottleneck, as is visible from the following benchmarks performed on a Hash Table data structure I and @LouisJenkinsCS are working on:


**With `active_tasks` counter**
```
Intset Benchmark:
1 tasks, 347.816 ns/op
2 tasks, 306.365 ns/op
4 tasks, 251.258 ns/op
8 tasks, 262.818 ns/op
16 tasks, 204.799 ns/op
32 tasks, 210.513 ns/op
44 tasks, 131.005 ns/op
```


**Without `active_tasks` counter**
```
Intset Benchmark:
1 tasks, 333.38 ns/op
2 tasks, 212.159 ns/op
4 tasks, 114.36 ns/op
8 tasks, 59.4826 ns/op
16 tasks, 31.6458 ns/op
32 tasks, 19.9671 ns/op
44 tasks, 14.7049 ns/op
```

My initial intention to keep this counter was to speed up reclamation on nodes which did not have any pinned tasks, saving the locale the effort to scan through the list of tokens to detect if any task is active. However, as it is clear from the benchmarks, this can create serious bottlenecks, and the GC is much more efficient without the counter.