### PR TITLE
Undo recent changes to 16-node-cs annotations/title

### DIFF
--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
 
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -7,9 +7,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
-export CHPL_NIGHTLY_LOGDIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
-export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
-export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
+export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.fast"
 

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
 
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
@@ -7,9 +7,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
-export CHPL_NIGHTLY_LOGDIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
-export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
-export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
+export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.large"
 

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
 
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -7,9 +7,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
-export CHPL_NIGHTLY_LOGDIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
-export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
-export CHPL_TEST_PERF_DIR="$CHPL_NIGHTLY_LOGDIR"
+export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-mpi"
 


### PR DESCRIPTION
Revert #14208 and #14223, which unsuccessfully attempted to change the 16 node CS annotation title. It's messing up the graph sync, so just revert for now.