### PR TITLE
Manually inline copy fn in ig-variants test

### DIFF
--- a/test/studies/bale/indexgather/ig-variants.chpl
+++ b/test/studies/bale/indexgather/ig-variants.chpl
@@ -45,10 +45,6 @@ for param explicit in false..true {
   }
 }
 
-inline proc copy(ref dst, ref src, param explicit) {
-  if explicit then unorderedCopy(dst, src);
-              else dst = src;
-}
 proc testit(mode: Mode, param explicit, printStats) {
 
   tmp = -1;
@@ -80,8 +76,10 @@ proc testit(mode: Mode, param explicit, printStats) {
       }
     }
     when Mode.promotion {
-      if explicit then unorderedCopy(tmp, A[rindex]);
-                  else tmp = A[rindex];
+      if explicit then
+        unorderedCopy(tmp, A[rindex]);
+      else
+        tmp = A[rindex];
     }
   }
   t.stop();

--- a/test/studies/bale/indexgather/ig-variants.chpl
+++ b/test/studies/bale/indexgather/ig-variants.chpl
@@ -56,16 +56,28 @@ proc testit(mode: Mode, param explicit, printStats) {
   var t: Timer; t.start();
   select mode {
     when Mode.directIndexLocal {
-      forall i in D2 do
-        copy(tmp.localAccess[i], A[rindex.localAccess[i]], explicit);
+      forall i in D2 {
+        if explicit then
+          unorderedCopy(tmp.localAccess[i], A[rindex.localAccess[i]]);
+        else
+          tmp.localAccess[i] = A[rindex.localAccess[i]];
+      }
     }
     when Mode.directIndex {
-      forall i in D2 do
-        copy(tmp[i], A[rindex[i]], explicit);
+      forall i in D2 {
+        if explicit then
+          unorderedCopy(tmp[i], A[rindex[i]]);
+        else
+          tmp[i] = A[rindex[i]];
+      }
     }
     when Mode.zipArray {
-      forall (t, r) in zip(tmp, rindex) do
-        copy(t, A[r], explicit);
+      forall (t, r) in zip(tmp, rindex) {
+        if explicit then
+          unorderedCopy(t, A[r]);
+        else
+          t = A[r];
+      }
     }
     when Mode.promotion {
       if explicit then unorderedCopy(tmp, A[rindex]);


### PR DESCRIPTION
The inlined function prevents the unordered-forall optimization since
part of the analysis runs before inlining. See #12413.

Reviewed by @ronawho - thanks!