### PR TITLE
Add unorderedCopy support for plain old data (POD) types

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -4250,17 +4250,7 @@ DEFINE_PRIM(PRIM_ASSIGN) {
 
 static bool commUnorderedOpsAvailable(Type* elementType) {
   if (0 == strcmp(CHPL_COMM, "ugni")) {
-    // the ugni layer only supports unordered gets for up to 8 bytes
-    // and we use numeric type as a stand-in for that
-    if (is_bool_type(elementType) ||
-        is_int_type(elementType) ||
-        is_uint_type(elementType) ||
-        is_real_type(elementType) ||
-        is_imag_type(elementType) ||
-        elementType == dtComplex[COMPLEX_SIZE_64] ||
-        // note: default sized complex is too big at present
-        is_enum_type(elementType))
-      return true;
+    return true;
   }
   return false;
 }

--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -710,17 +710,6 @@ static void transformAtomicStmt(Expr* stmt) {
 
 }
 
-static bool hasAcceptableType(Symbol* sym) {
-  Type* t = sym->getValType();
-  return is_bool_type(t) ||
-         is_int_type(t) ||
-         is_uint_type(t) ||
-         is_real_type(t) ||
-         is_imag_type(t) ||
-         is_complex_type(t) ||
-         is_enum_type(t);
-}
-
 static bool isOptimizableAssignStmt(Expr* stmt, BlockStmt* loop) {
   Symbol* lhs = NULL;
   if (CallExpr* call = toCallExpr(stmt))
@@ -734,11 +723,7 @@ static bool isOptimizableAssignStmt(Expr* stmt, BlockStmt* loop) {
         if (CallExpr* marker = findMarkerNear(stmt))
           if (hasOptimizationFlag(marker, OPT_INFO_LHS_OUTLIVES_FORALL) &&
               hasOptimizationFlag(marker, OPT_INFO_FLAG_NO_TASK_PRIVATE))
-            // This last check can be relaxed in the future if the
-            // runtime unordered code supports more cases.
-            // The earlier part already checked that it's a POD type.
-            if (hasAcceptableType(lhs))
-              return true;
+            return true;
 
   return false;
 }

--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -23,16 +23,16 @@
      change over time.
 
    This module provides an unordered version of copy/assign for trivially
-   copyable types types. Trivially copyable types are types that can be
-   duplicated by copying bits. They include ``numeric`` and ``bool`` types as
-   well as ``numeric``/``bool`` tuples and ``numeric``/``bool`` records
-   provided the record has no user-defined initializers, deinitializers, or
-   assignment overloads.
+   copyable types. Trivially copyable types require no special behavior to be
+   copied and merely copying their representation is sufficient. They include
+   ``numeric`` and ``bool`` types as well as tuples or records consisting only
+   of ``numeric``/``bool``. Records cannot have user-defined copy-initializers,
+   deinitializers, or assignment overloads.
 
-   The results from :proc:`unorderedCopy()`, are not visible until task or
-   forall termination or an explicit :proc:`unorderedCopyTaskFence()`, but it
-   can provide a significant speedup for bulk assignment operations that do not
-   require ordering of operations:
+   :proc:`unorderedCopy()` can provide a significant speedup for batch
+   assignment operations that do not require ordering of operations. The
+   results from :proc:`unorderedCopy()` are not visible until task or forall
+   termination or an explicit :proc:`unorderedCopyTaskFence()`:
 
    .. code-block:: chapel
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5972,7 +5972,7 @@ void do_remote_get_buff(void* tgt_addr, c_nodeid_t locale, void* src_addr,
   if (local_mr == NULL || remote_mr == NULL || info == NULL ||
       !IS_ALIGNED_32((size_t) (intptr_t) src_addr) ||
       !IS_ALIGNED_32((size_t) (intptr_t) tgt_addr) ||
-      !IS_ALIGNED_32(size)) {
+      !IS_ALIGNED_32(size) || size > 8) {
     do_remote_get(tgt_addr, locale, src_addr, size, may_proxy);
     return;
   }

--- a/test/runtime/configMatters/comm/unordered/many-to-many-getputs.ml-perf.graph
+++ b/test/runtime/configMatters/comm/unordered/many-to-many-getputs.ml-perf.graph
@@ -1,5 +1,17 @@
 perfkeys: GETPUT rate(mOps/sec):, GETPUT rate(mOps/sec):, GETPUT rate(mOps/sec):
 files: ordered-many-to-many.dat, ordered-oversub-many-to-many.dat, unordered-many-to-many.dat
 graphkeys: GETPUT (ordered), GETPUT (4x oversub), GETPUT (unordered)
-graphtitle: Remote many-to-many GETPUT Performance
+graphtitle: Remote many-to-many int GETPUT Performance
+ylabel: Performance (10**6 ops/sec)
+
+perfkeys: GETPUT rate(mOps/sec):, GETPUT rate(mOps/sec):
+files: ordered-many-to-many-2-tup.dat, unordered-many-to-many-2-tup.dat
+graphkeys: GETPUT (ordered), GETPUT (unordered)
+graphtitle: Remote many-to-many 2*int GETPUT Performance
+ylabel: Performance (10**6 ops/sec)
+
+perfkeys: GETPUT rate(mOps/sec):, GETPUT rate(mOps/sec):
+files: ordered-many-to-many-16-tup.dat, unordered-many-to-many-16-tup.dat
+graphkeys: GETPUT (ordered), GETPUT (unordered)
+graphtitle: Remote many-to-many 16*int GETPUT Performance
 ylabel: Performance (10**6 ops/sec)

--- a/test/runtime/configMatters/comm/unordered/many-to-many-gets.ml-perf.graph
+++ b/test/runtime/configMatters/comm/unordered/many-to-many-gets.ml-perf.graph
@@ -1,5 +1,17 @@
 perfkeys: GET    rate(mOps/sec):, GET    rate(mOps/sec):, GET    rate(mOps/sec):
 files: ordered-many-to-many.dat, ordered-oversub-many-to-many.dat, unordered-many-to-many.dat
 graphkeys: GET (ordered), GET (4x oversub), GET (unordered)
-graphtitle: Remote many-to-many GET Performance
+graphtitle: Remote many-to-many int GET Performance
+ylabel: Performance (10**6 ops/sec)
+
+perfkeys: GET    rate(mOps/sec):, GET    rate(mOps/sec):
+files: ordered-many-to-many-2-tup.dat, unordered-many-to-many-2-tup.dat
+graphkeys: GET (ordered), GET (unordered)
+graphtitle: Remote many-to-many 2*int GET Performance
+ylabel: Performance (10**6 ops/sec)
+
+perfkeys: GET    rate(mOps/sec):, GET    rate(mOps/sec):
+files: ordered-many-to-many-16-tup.dat, unordered-many-to-many-16-tup.dat
+graphkeys: GET (ordered), GET (unordered)
+graphtitle: Remote many-to-many 16*int GET Performance
 ylabel: Performance (10**6 ops/sec)

--- a/test/runtime/configMatters/comm/unordered/many-to-many-puts.ml-perf.graph
+++ b/test/runtime/configMatters/comm/unordered/many-to-many-puts.ml-perf.graph
@@ -1,5 +1,17 @@
 perfkeys: PUT    rate(mOps/sec):, PUT    rate(mOps/sec):, PUT    rate(mOps/sec):
 files: ordered-many-to-many.dat, ordered-oversub-many-to-many.dat, unordered-many-to-many.dat
 graphkeys: PUT (ordered), PUT (4x oversub), PUT (unordered)
-graphtitle: Remote many-to-many PUT Performance
+graphtitle: Remote many-to-many int PUT intPerformance
+ylabel: Performance (10**6 ops/sec)
+
+perfkeys: PUT    rate(mOps/sec):, PUT    rate(mOps/sec):
+files: ordered-many-to-many-2-tup.dat, unordered-many-to-many-2-tup.dat
+graphkeys: PUT (ordered), PUT (unordered)
+graphtitle: Remote many-to-many 2*int PUT Performance
+ylabel: Performance (10**6 ops/sec)
+
+perfkeys: PUT    rate(mOps/sec):, PUT    rate(mOps/sec):
+files: ordered-many-to-many-16-tup.dat, unordered-many-to-many-16-tup.dat
+graphkeys: PUT (ordered), PUT (unordered)
+graphtitle: Remote many-to-many 16*int PUT Performance
 ylabel: Performance (10**6 ops/sec)

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyBasic.compopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyBasic.compopts
@@ -2,5 +2,7 @@
 -scopyType=int --no-remote-value-forwarding
 -scopyType=real
 -scopyType=complex
+-scopyType=imag
 -scopyType=bool
--scopyType='bool(16)'
+-scopyType=TupInt
+-scopyType=RecInt

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyLoop.printResults.good
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyLoop.printResults.good
@@ -8,6 +8,10 @@ real(64) unordered PUT local
 1.0 0.0 1.0 0.0
 complex(128) unordered PUT local
 1.0 + 0.0i 0.0 + 0.0i 1.0 + 0.0i 0.0 + 0.0i
+2*int(64) unordered PUT local
+(1, 1) (0, 0) (1, 1) (0, 0)
+R unordered PUT local
+(a = 1, b = 1) (a = 0, b = 0) (a = 1, b = 1) (a = 0, b = 0)
 
 bool unordered PUT array
 true false true false
@@ -19,6 +23,10 @@ real(64) unordered PUT array
 1.0 0.0 1.0 0.0
 complex(128) unordered PUT array
 1.0 + 0.0i 0.0 + 0.0i 1.0 + 0.0i 0.0 + 0.0i
+2*int(64) unordered PUT array
+(1, 1) (0, 0) (1, 1) (0, 0)
+R unordered PUT array
+(a = 1, b = 1) (a = 0, b = 0) (a = 1, b = 1) (a = 0, b = 0)
 
 bool unordered GET
 true false true false
@@ -30,6 +38,10 @@ real(64) unordered GET
 1.0 0.0 1.0 0.0
 complex(128) unordered GET
 1.0 + 0.0i 0.0 + 0.0i 1.0 + 0.0i 0.0 + 0.0i
+2*int(64) unordered GET
+(1, 1) (0, 0) (1, 1) (0, 0)
+R unordered GET
+(a = 1, b = 1) (a = 0, b = 0) (a = 1, b = 1) (a = 0, b = 0)
 
 Unordered PUT combo
 true false true false
@@ -37,6 +49,8 @@ true false true false
 1 2 3 4
 1.0 2.0 3.0 4.0
 1.0 + 0.0i 2.0 + 0.0i 3.0 + 0.0i 4.0 + 0.0i
+(1, 1) (2, 2) (3, 3) (4, 4)
+(a = 1, b = 1) (a = 2, b = 2) (a = 3, b = 3) (a = 4, b = 4)
 
 Unordered GET combo
 true false true false
@@ -44,3 +58,5 @@ true false true false
 1 2 3 4
 1.0 2.0 3.0 4.0
 1.0 + 0.0i 2.0 + 0.0i 3.0 + 0.0i 4.0 + 0.0i
+(1, 1) (2, 2) (3, 3) (4, 4)
+(a = 1, b = 1) (a = 2, b = 2) (a = 3, b = 3) (a = 4, b = 4)

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.chpl
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.chpl
@@ -9,6 +9,7 @@ config const printStats = true,
 config const oversubscription = 1,
              tasksPerLocale = here.maxTaskPar * oversubscription;
 
+config type copyType = int;
 config param useUnorderedCopy = true;
 config const concurrentFencing = false;
 config param commDiags = false;
@@ -18,7 +19,12 @@ config const sizePerLocale = 10000,
 
 const space = {0..size};
 const D = space dmapped Block(space, dataParTasksPerLocale=tasksPerLocale);
-var A, reversedA: [D] int = D;
+var A, reversedA: [D] copyType;
+
+forall (a, r, d) in zip(A, reversedA, D) {
+  a += d;
+  r += d;
+}
 
 inline proc assign(ref dst, ref src) {
   if useUnorderedCopy then unorderedCopy(dst, src);
@@ -31,7 +37,7 @@ inline proc assign(ref dst, ref src) {
 var t: Timer;
 
 proc start() {
-  reversedA = 0;
+  reversedA -= reversedA;
   if commDiags { resetCommDiagnostics(); startCommDiagnostics(); }
   t.clear(); t.start();
 }
@@ -49,8 +55,11 @@ proc stop(opType: string) {
   writeln(ordering, opType, timing, " : ", ordering, opType, rate, diags);
 
   if verify then
-    forall (rA, i) in zip(reversedA, D) do
-      assert(rA == size-i);
+    forall (rA, i) in zip(reversedA, D) {
+      var expected: copyType;
+      expected += size-i;
+      assert(rA == expected);
+    }
 }
 
 

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.compopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.compopts
@@ -1,1 +1,3 @@
---no-checks --no-optimize-forall-unordered-ops
+--no-checks --no-optimize-forall-unordered-ops -scopyType=int
+--no-checks --no-optimize-forall-unordered-ops -scopyType=2*int
+--no-checks --no-optimize-forall-unordered-ops -scopyType=512*int

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.ml-compopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.ml-compopts
@@ -1,3 +1,9 @@
--suseUnorderedCopy=false --no-optimize-forall-unordered-ops                      # ordered-many-to-many
--suseUnorderedCopy=false --no-optimize-forall-unordered-ops -soversubscription=4 # ordered-oversub-many-to-many
--suseUnorderedCopy=true  --no-optimize-forall-unordered-ops                      # unordered-many-to-many
+-suseUnorderedCopy=false --no-optimize-forall-unordered-ops -scopyType=int                      # ordered-many-to-many
+-suseUnorderedCopy=false --no-optimize-forall-unordered-ops -scopyType=int -soversubscription=4 # ordered-oversub-many-to-many
+-suseUnorderedCopy=true  --no-optimize-forall-unordered-ops -scopyType=int                      # unordered-many-to-many
+
+-suseUnorderedCopy=false --no-optimize-forall-unordered-ops -scopyType=2*int                    # ordered-many-to-many-2-tup
+-suseUnorderedCopy=true  --no-optimize-forall-unordered-ops -scopyType=2*int                    # unordered-many-to-many-2-tup
+
+-suseUnorderedCopy=false --no-optimize-forall-unordered-ops -scopyType=16*int                   # ordered-many-to-many-16-tup
+-suseUnorderedCopy=true  --no-optimize-forall-unordered-ops -scopyType=16*int                   # unordered-many-to-many-16-tup


### PR DESCRIPTION
This enables unorderedCopy initial support for POD tuples and records.
POD probably isn't the right terminology long term so the user-facing
documentation refers to these as "trivially copyable" and gives some
examples. I expect us to update and improve that documentation once
#14228 is resolved.

Note that the runtime only optimizes unorderedCopy for types that are
smaller than 8 bytes. The next step will be to optimize for larger
types.

Part of https://github.com/chapel-lang/chapel/issues/13113