### PR TITLE
Add .notest files

### DIFF
--- a/test/classes/errors/nilability-generate.chpl.notest
+++ b/test/classes/errors/nilability-generate.chpl.notest
@@ -16,6 +16,9 @@ for the combinations of memory management that are not "ok" in this table:
     | shared    |  ok   |  ok    |          |           |
     | borrowed  |  ok   |  ok    |  ok      |  ok       |
     | unmanaged |       |        |          |  ok       |
+
+This is not a .chpl file to avoid accidental execution, as it would
+modify existing files in place, creating incorrect .good files.
 */
 
 use FileSystem;

--- a/test/classes/errors/nilability-generate.notest
+++ b/test/classes/errors/nilability-generate.notest
@@ -1,1 +1,0 @@
-This is a script to generate tests.

--- a/test/mason/publish-tests/publishCheck.notest
+++ b/test/mason/publish-tests/publishCheck.notest
@@ -1,0 +1,5 @@
+The directory ./publishCheck is created during testing and may end up
+staying around after testing completes. There may be .chpl files in
+../publishCheck/src that paratest will discover and test.
+Paratest-ing will fail because these files are not intended/suited for it.
+Adding this .notest to avoid that.


### PR DESCRIPTION
* Renames `test/classes/errors/nilability-generate.chpl` to append `.notest`
suffix. I ran it under start_test as a .chpl file without realizing that
it was doing that and that it modifies exiting .good files, causing testing
failures. Prevent such accidents in the future. The original .notest file
is no longer needed.

* Adds `test/mason/publish-tests/publishCheck.notest`.
The directory test/mason/publish-tests/publishCheck/ is created during
testing and may end up staying around after testing completes. There
may be .chpl files in publishCheck/src that paratest will discover
and test. Paratest-ing will fail because these files are not intended/suited
for it. Avoid this in the future.

Discussed with BenA (publishCheck.notest); Vass's preference (nilability-generate.chpl).