### PR TITLE
Split a perftest into multiple runs to avoid OOM 

### DIFF
--- a/test/performance/array/distCreate-domains-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-domains-deinit.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockDomDeinit:, cyclicDomDeinit:, blockCyclicDomDeinit:
-repeat-files: distCreate-tiny.dat
+perfkeys: domDeinit:, domDeinit:, domDeinit:
+graphkeys: blockDomDeinit:, cyclicDomDeinit:, blockCyclicDomDeinit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Destroying distributed domains

--- a/test/performance/array/distCreate-domains-init.ml-perf.graph
+++ b/test/performance/array/distCreate-domains-init.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockDomInit:, cyclicDomInit:, blockCyclicDomInit:
-repeat-files: distCreate-tiny.dat
+perfkeys: domInit:, domInit:, domInit:
+graphkeys: blockDomInit:, cyclicDomInit:, blockCyclicDomInit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Creating distributed domains

--- a/test/performance/array/distCreate-large-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-large-deinit.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
-repeat-files: distCreate-large.dat
+perfkeys: arrDeinit:, arrDeinit:, arrDeinit:
+graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
+files: distCreate-large-block.dat, distCreate-large-cyclic.dat, distCreate-large-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Destroying distributed arrays (1/4 of available memory)

--- a/test/performance/array/distCreate-large-init.ml-perf.graph
+++ b/test/performance/array/distCreate-large-init.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
-repeat-files: distCreate-large.dat
+perfkeys: arrInit:, arrInit:, arrInit:
+graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
+files: distCreate-large-block.dat, distCreate-large-cyclic.dat, distCreate-large-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Creating distributed arrays (1/4 of available memory)

--- a/test/performance/array/distCreate-small-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-small-deinit.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
-repeat-files: distCreate-small.dat
+perfkeys: arrDeinit:, arrDeinit:, arrDeinit:
+graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
+files: distCreate-small-block.dat, distCreate-small-cyclic.dat, distCreate-small-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Destroying distributed arrays (1M elements)

--- a/test/performance/array/distCreate-small-init.ml-perf.graph
+++ b/test/performance/array/distCreate-small-init.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
-repeat-files: distCreate-small.dat
+perfkeys: arrInit:, arrInit:, arrInit:
+graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
+files: distCreate-small-block.dat, distCreate-small-cyclic.dat, distCreate-small-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Creating distributed arrays (1M elements)

--- a/test/performance/array/distCreate-tiny-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-tiny-deinit.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
-repeat-files: distCreate-tiny.dat
+perfkeys: arrDeinit:, arrDeinit:, arrDeinit:
+graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Destroying distributed arrays (1 element per locale)

--- a/test/performance/array/distCreate-tiny-init.ml-perf.graph
+++ b/test/performance/array/distCreate-tiny-init.ml-perf.graph
@@ -1,4 +1,5 @@
-perfkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
-repeat-files: distCreate-tiny.dat
+perfkeys: arrInit:, arrInit:, arrInit:
+graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
 ylabel: Time (seconds)
 graphtitle: Creating distributed arrays (1 element per locale)

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -57,7 +57,7 @@ inline proc endDiag(name, x) {
 
 const localDom = {1..nElems};
 
-if !correctness && dist == distType.block {
+if correctness || dist == distType.block {
   { // weird blocks are necessary to measure deinit performance
     startDiag();
     const blockDom = localDom dmapped Block(boundingBox=localDom);
@@ -76,7 +76,7 @@ if !correctness && dist == distType.block {
   endDiag("domDeinit");
 }
 
-if !correctness && dist == distType.cyclic {
+if correctness || dist == distType.cyclic {
   { // weird blocks are necessary to measure deinit performance
     startDiag();
     const cyclicDom = localDom dmapped Cyclic(startIdx=localDom.first);
@@ -96,7 +96,7 @@ if !correctness && dist == distType.cyclic {
   endDiag("domDeinit");
 }
 
-if !correctness && dist == distType.blockCyc {
+if correctness || dist == distType.blockCyc {
   { // weird blocks are necessary to measure deinit performance
     startDiag();
     const blockCyclicDom = localDom dmapped BlockCyclic(startIdx=localDom.first,

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -18,8 +18,10 @@ config const nElemsSmall = if correctness then 100 else 1000000;
 config const nElemsLarge = numLocales*((totMem/numBytes(elemType))/memFraction);
 
 enum arraySize { tiny, small, large};
+enum distType { block, cyclic, blockCyc};
 
 config const size = arraySize.tiny;
+config const dist = distType.block;
 
 const nElems = if size == arraySize.tiny then nElemsTiny else
                if size == arraySize.small then nElemsSmall else
@@ -55,56 +57,62 @@ inline proc endDiag(name, x) {
 
 const localDom = {1..nElems};
 
-{
-  startDiag();
-  const blockDom = localDom dmapped Block(boundingBox=localDom);
-  endDiag("blockDomInit", blockDom);
-  {
+if !correctness && dist == distType.block {
+  { // weird blocks are necessary to measure deinit performance
     startDiag();
-    const blockArr: [blockDom] elemType;
-    endDiag("blockArrInit", blockArr);
+    const blockDom = localDom dmapped Block(boundingBox=localDom);
+    endDiag("domInit", blockDom);
+    {
+      startDiag();
+      const blockArr: [blockDom] elemType;
+      endDiag("arrInit", blockArr);
 
-    startDiag();
-  }
-  endDiag("blockArrDeinit");
-
-  startDiag();
-}
-endDiag("blockDomDeinit");
-
-{
-  startDiag();
-  const cyclicDom = localDom dmapped Cyclic(startIdx=localDom.first);
-  endDiag("cyclicDomInit", cyclicDom);
-  {
-
-    startDiag();
-    const cyclicArr: [cyclicDom] elemType;
-    endDiag("cyclicArrInit", cyclicArr);
+      startDiag();
+    }
+    endDiag("arrDeinit");
 
     startDiag();
   }
-  endDiag("cyclicArrDeinit");
-
-  startDiag();
+  endDiag("domDeinit");
 }
-endDiag("cyclicDomDeinit");
 
-{
-  startDiag();
-  const blockCyclicDom = localDom dmapped BlockCyclic(startIdx=localDom.first,
-                                                      blocksize=5);
-  endDiag("blockCyclicDomInit", blockCyclicDom);
-  {
-
+if !correctness && dist == distType.cyclic {
+  { // weird blocks are necessary to measure deinit performance
     startDiag();
-    const blockCyclicArr: [blockCyclicDom] elemType;
-    endDiag("blockCyclicArrInit", blockCyclicArr);
-    
+    const cyclicDom = localDom dmapped Cyclic(startIdx=localDom.first);
+    endDiag("domInit", cyclicDom);
+    {
+
+      startDiag();
+      const cyclicArr: [cyclicDom] elemType;
+      endDiag("arrInit", cyclicArr);
+
+      startDiag();
+    }
+    endDiag("arrDeinit");
+
     startDiag();
   }
-  endDiag("blockCyclicArrDeinit");
-
-  startDiag();
+  endDiag("domDeinit");
 }
-endDiag("blockCyclicDomDeinit");
+
+if !correctness && dist == distType.blockCyc {
+  { // weird blocks are necessary to measure deinit performance
+    startDiag();
+    const blockCyclicDom = localDom dmapped BlockCyclic(startIdx=localDom.first,
+                                                        blocksize=5);
+    endDiag("domInit", blockCyclicDom);
+    {
+
+      startDiag();
+      const blockCyclicArr: [blockCyclicDom] elemType;
+      endDiag("arrInit", blockCyclicArr);
+      
+      startDiag();
+    }
+    endDiag("arrDeinit");
+
+    startDiag();
+  }
+  endDiag("domDeinit");
+}

--- a/test/performance/array/distCreate.ml-execopts
+++ b/test/performance/array/distCreate.ml-execopts
@@ -1,3 +1,9 @@
---size=arraySize.tiny   #distCreate-tiny
---size=arraySize.small  #distCreate-small
---size=arraySize.large  #distCreate-large
+--size=arraySize.tiny --dist=distType.block  #distCreate-tiny-block
+--size=arraySize.tiny --dist=distType.cyclic   #distCreate-tiny-cyclic
+--size=arraySize.tiny --dist=distType.blockCyc   #distCreate-tiny-blockCyc
+--size=arraySize.small --dist=distType.block  #distCreate-small-block
+--size=arraySize.small --dist=distType.cyclic  #distCreate-small-cyclic
+--size=arraySize.small --dist=distType.blockCyc  #distCreate-small-blockCyc
+--size=arraySize.large --dist=distType.block  #distCreate-large-block
+--size=arraySize.large --dist=distType.cyclic  #distCreate-large-cyclic
+--size=arraySize.large --dist=distType.blockCyc  #distCreate-large-blockCyc

--- a/test/performance/array/distCreate.ml-keys
+++ b/test/performance/array/distCreate.ml-keys
@@ -1,12 +1,4 @@
-blockDomInit:
-blockDomDeinit:
-blockArrInit:
-blockArrDeinit:
-cyclicDomInit:
-cyclicDomDeinit:
-cyclicArrInit:
-cyclicArrDeinit:
-blockCyclicDomInit:
-blockCyclicDomDeinit:
-blockCyclicArrInit:
-blockCyclicArrDeinit:
+domInit:
+domDeinit:
+arrInit:
+arrDeinit:


### PR DESCRIPTION
This PR splits the newly added distributed array/domain creation benchmark
into multiple runs to avoid out-of-memory errors we have seen on CS systems.

The reason for the OOM error was not immediately obvious, so it'll require some
time to track it down.

Test:
- [x] passes on 16 node cs
- [x] passes on 16 node xc
- [x] standard correctness
- [x] gasnet correctness
- [x] plots rendered correctly