### PR TITLE
Add future for throwing bracketed forall bug

### DIFF
--- a/test/errhandling/misc/bracketForallThrowsBug.bad
+++ b/test/errhandling/misc/bracketForallThrowsBug.bad
@@ -1,0 +1,2 @@
+bracketForallThrowsBug.chpl:22: error: call to throwing function foo without throws, try, or try! (relaxed mode)
+bracketForallThrowsBug.chpl:7: note: throwing function foo defined here

--- a/test/errhandling/misc/bracketForallThrowsBug.chpl
+++ b/test/errhandling/misc/bracketForallThrowsBug.chpl
@@ -1,0 +1,38 @@
+module SomeModule {
+  /*
+   Putting everything outside a module compiles fine
+   */
+
+  config const shouldThrow = false;
+  proc foo(i, shouldThrow=false) throws {
+    if shouldThrow && i == 0 then throw new Error();
+    else return i*2;
+  }
+
+  proc main() {
+    try {
+      /*
+       Below version compiles fine:
+
+        var junk1 = forall i in -5..5 do foo(i, shouldThrow=shouldThrow);
+        writeln(junk1);
+      */
+
+      var junk2: [-5..5] int;
+      junk2 = [i in -5..5] foo(i, shouldThrow=shouldThrow);
+
+      /*
+       Turning this into:
+      
+        var junk2 = [i in -5..5] foo(i, shouldThrow=shouldThrow);
+
+       doesn't change the behavior.
+      */
+
+      writeln(junk2);
+    }
+    catch e {
+      writeln("Error caught");
+    }
+  }
+}

--- a/test/errhandling/misc/bracketForallThrowsBug.future
+++ b/test/errhandling/misc/bracketForallThrowsBug.future
@@ -1,0 +1,1 @@
+bug: try block check does not work for bracketed forall expression

--- a/test/errhandling/misc/bracketForallThrowsBug.future
+++ b/test/errhandling/misc/bracketForallThrowsBug.future
@@ -1,1 +1,2 @@
 bug: try block check does not work for bracketed forall expression
+#14233

--- a/test/errhandling/misc/bracketForallThrowsBug.good
+++ b/test/errhandling/misc/bracketForallThrowsBug.good
@@ -1,0 +1,1 @@
+Error caught


### PR DESCRIPTION
This adds a future for the bug reported in issue #14233.

Tested locally with standard config