### PR TITLE
Update version to 1.20.1, preparing for releases based on this branch.

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -22,7 +22,7 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION "20"
-#define UPDATE_VERSION "0"
+#define UPDATE_VERSION "1"
 
 static const char* BUILD_VERSION =
 #include "BUILD_VERSION"

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -65,7 +65,7 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.20.0'
+release = '1.20.1'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.20.0
+:Version: 1.20.1
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.20.0
+:Version: 1.20.1
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.20.0
+ version 1.20.1


### PR DESCRIPTION
Shasta development and maintenance will be based on the 1.20 release
sources rather than the more volatile master branch.  Here, prepare the
release/1.20 branch for that, by updating the version number.