### PR TITLE
Enable the unordered-forall optimization for more index gather variants

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -537,6 +537,23 @@ void setIteratorRecordShape(CallExpr* call) {
   call->replace(shapeCall);
 }
 
+// Find the parent block that is either
+//  * a loop
+//  * or, not a BlockStmt
+// Used to ignore non-loop BlockStmts
+// (these come up in particular with local and unlocal blocks).
+static Expr* loopOrNonBlockParent(Expr* expr) {
+  Expr* parent = expr->parentExpr;
+  while (parent != NULL) {
+    if (!isBlockStmt(parent))
+      break;
+    if (isLoopStmt(parent))
+      break;
+
+    parent = parent->parentExpr;
+  }
+  return parent;
+}
 
 //
 // Determines that an iterator has a single loop with a single yield
@@ -568,9 +585,16 @@ isSingleLoopIterator(FnSymbol* fn, Vec<BaseAST*>& asts) {
         // Select yield statements whose parent expression is a loop statement
         // (except for dowhile statements, for some reason....
 
+        // Find the parent block that is either
+        //  * a loop
+        //  * or, a conditional
+        // Ignore non-loop BlockStmts
+        // (conditionals could probably be allowed if both sides yielded)
+        Expr* parent = loopOrNonBlockParent(call);
+
         // This test is not logically related to the preceding quick-exit, so
         // putting "else" here would be misleading.
-        if (isLoopStmt(call->parentExpr)) {
+        if (isLoopStmt(parent)) {
           // NOAKES 2014/11/25  It is interesting the DoWhile loops aren't supported
           if (isDoWhileStmt(call->parentExpr))
             return NULL;
@@ -603,8 +627,9 @@ isSingleLoopIterator(FnSymbol* fn, Vec<BaseAST*>& asts) {
 
       Expr*      expr  = toExpr(ast);
       BlockStmt* block = toBlockStmt(ast);
+      Expr*     parent = loopOrNonBlockParent(expr);
 
-      if (expr->parentExpr == fn->body) {
+      if (parent == NULL && expr->parentSymbol == fn) {
         // This captures the first loop statement, but does not fail if there
         // is more than one.  Compare the test for a single yield above.
         // Is this intentional?

--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -213,11 +213,45 @@ bool MarkOptimizableForallLastStmts::enterForallStmt(ForallStmt* forall) {
 
   if (fNoOptimizeForallUnordered == false) {
     // If the optimization is enabled, do this
+
+    bool addNoTaskPrivate = forallNoTaskPrivate(forall);
+    std::vector< std::vector<Expr*> > lastStatementsPerBody;
+
+    // Gather the last statements in each loop body
     std::vector<BlockStmt*> bodies = forall->loopBodies();
     for_vector(BlockStmt, block, bodies) {
       std::vector<Expr*> lastStmts;
       getLastStmts(block, lastStmts);
-      for_vector(Expr, stmt, lastStmts) {
+      lastStatementsPerBody.push_back(lastStmts);
+    }
+
+    // Compute the number of last statements
+    // (expecting it matches across fast-follower/follower bodies)
+    int numLastStmts = -1;
+    for (size_t loopNum = 0;
+         loopNum < lastStatementsPerBody.size();
+         loopNum++) {
+      int numThisLoop = (int) lastStatementsPerBody[loopNum].size();
+      if (numLastStmts == -1)
+        numLastStmts = numThisLoop;
+      else
+        INT_ASSERT(numLastStmts == numThisLoop);
+    }
+
+    // Consider the last statements
+    for (int stmtNum = 0; stmtNum < numLastStmts; stmtNum++) {
+
+      int loopNum;
+
+      // For this last statement, compute the lifetime
+      // properties, but do so ignoring the difference between
+      // fast-follower/follower loops.
+      bool addLhsOutlivesForall = false;
+      bool addRhsOutlivesForall = false;
+
+      loopNum = 0;
+      for_vector(BlockStmt, block, bodies) {
+        Expr* stmt = lastStatementsPerBody[loopNum][stmtNum];
         if (exprIsOptimizable(block, stmt, lifetimeInfo)) {
           SymExpr* lhs = NULL;
           SymExpr* rhs = NULL;
@@ -228,12 +262,37 @@ bool MarkOptimizableForallLastStmts::enterForallStmt(ForallStmt* forall) {
               rhs = toSymExpr(call->get(2));
           }
           if (lhs && symbolOutlivesLoop(block, lhs->symbol(), lifetimeInfo))
-            addOptimizationFlag(stmt, OPT_INFO_LHS_OUTLIVES_FORALL);
+            addLhsOutlivesForall = true;
           if (rhs && symbolOutlivesLoop(block, rhs->symbol(), lifetimeInfo))
+            addRhsOutlivesForall = true;
+        }
+
+        loopNum++;
+      }
+
+      // Now that we have the lifetime properties, mark all follower
+      // loop bodies with the appropriate optimization info.
+      loopNum = 0;
+      for_vector(BlockStmt, block, bodies) {
+        Expr* stmt = lastStatementsPerBody[loopNum][stmtNum];
+        if (exprIsOptimizable(block, stmt, lifetimeInfo)) {
+          SymExpr* lhs = NULL;
+          SymExpr* rhs = NULL;
+          if (CallExpr* call = toCallExpr(stmt)) {
+            if (call->numActuals() >= 1)
+              lhs = toSymExpr(call->get(1));
+            if (call->numActuals() >= 2)
+              rhs = toSymExpr(call->get(2));
+          }
+          if (lhs && addLhsOutlivesForall)
+            addOptimizationFlag(stmt, OPT_INFO_LHS_OUTLIVES_FORALL);
+          if (rhs && addRhsOutlivesForall)
             addOptimizationFlag(stmt, OPT_INFO_RHS_OUTLIVES_FORALL);
-          if (forallNoTaskPrivate(forall))
+          if (addNoTaskPrivate)
             addOptimizationFlag(stmt, OPT_INFO_FLAG_NO_TASK_PRIVATE);
         }
+
+        loopNum++;
       }
     }
   }

--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -248,7 +248,7 @@ void MarkOptimizableForallLastStmts::markLoopsInForall(ForallStmt* forall) {
     if (numLastStmts == -1)
       numLastStmts = numThisLoop;
     else if (numLastStmts != numThisLoop)
-      INT_ASSERT(numLastStmts == numThisLoop); // return; // Give up now
+      return; // Give up on optimizing it
   }
 
   // Consider the last statements


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/210

Continuing #14194. 

The unordered forall optimization wasn't optimizing the
performance-relevant loops in zippered and promoted variants of
index-gather. The reason turned out to be two issues:
 * lifetime analysis was ignoring fast follower loops, and as a result
   not marking these for optimization
 * these same loops were not being marked as order independent in
   lowerIterators due to the compiler not handling enclosing/nested
   local/unlocal blocks in isSingleLoopIterator. (yes the compiler has
   unlocal blocks, see ee913f3ce061871f1e81062b46a289f0d9045acc).

This PR fixes both issues and as a result allows all of the index gather
variants in ig-variants.chpl to optimize.

- [x] full local testing
- [x] passed full gasnet+futures testing

Reviewed by @ronawho - thanks!