### PR TITLE
Update verbose printing to include comm ids

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -101,7 +101,7 @@ static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3);
 //static void codegenCallNotValues(const char* fnName, GenRet a1, GenRet a2, GenRet a3);
 static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, GenRet a4);
 static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, GenRet a4, GenRet a5);
-//static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, GenRet a4, GenRet a5, GenRet a6);
+static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, GenRet a4, GenRet a5, GenRet a6);
 
 static GenRet codegenZero();
 static GenRet codegenZero32();
@@ -2802,7 +2802,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a5);
   codegenCall(fnName, args);
 }
-/*
+
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6)
@@ -2816,7 +2816,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a6);
   codegenCall(fnName, args);
 }
-*/
+
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7)
@@ -4774,6 +4774,7 @@ DEFINE_PRIM(PRIM_CHPL_COMM_REMOTE_PREFETCH) {
                 locale,
                 remoteAddr,
                 len,
+                genCommID(gGenInfo),
                 call->get(4),
                 call->get(5));
 }

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -70,7 +70,7 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                          size_t size, int32_t commID, int ln, int32_t fn);
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t size, int ln, int32_t fn);
+                              size_t size, int32_t commID, int ln, int32_t fn);
 void  chpl_cache_comm_get_strd(
                    void *addr, void *dststr, c_nodeid_t node, void *raddr,
                    void *srcstr, void *count, int32_t strlevels,

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -59,7 +59,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
 
 static inline
 void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
-                            size_t size, int ln, int32_t fn)
+                            size_t size, int32_t commID, int ln, int32_t fn)
 {
   const size_t MAX_BYTES_LOCAL_PREFETCH = 1024;
   size_t offset;
@@ -74,7 +74,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
     }
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_prefetch(node, raddr, size, ln, fn);
+    chpl_cache_comm_prefetch(node, raddr, size, commID, ln, fn);
 #endif
   } else {
     // Can't do anything if we don't have a remote data cache

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -138,17 +138,19 @@ void chpl_comm_diags_verbose_printf(chpl_bool is_unstable,
   }
 }
 
-#define chpl_comm_diags_verbose_rdma(op, node, size, ln, fn)            \
-  chpl_comm_diags_verbose_printf(false,                                 \
-                                 "%s:%d: remote %s, node %d, %zu bytes",\
-                                 chpl_lookupFilename(fn), ln, op,       \
-                                 (int) node, size)
+#define chpl_comm_diags_verbose_rdma(op, node, size, ln, fn, commid)     \
+  chpl_comm_diags_verbose_printf(false,                                  \
+                                 "%s:%d: remote %s, node %d, %zu bytes, " \
+                                 "commid %d",                            \
+                                 chpl_lookupFilename(fn), ln, op,        \
+                                 (int) node, size, (int) commid)
 
-#define chpl_comm_diags_verbose_rdmaStrd(op, node, ln, fn)              \
+#define chpl_comm_diags_verbose_rdmaStrd(op, node, ln, fn, commid)      \
   chpl_comm_diags_verbose_printf(false,                                 \
-                                 "%s:%d: remote strided %s, node %d",   \
+                                 "%s:%d: remote strided %s, node %d, "  \
+                                 "commid %d",                           \
                                  chpl_lookupFilename(fn), ln, op,       \
-                                 (int) node)
+                                 (int) node, (int) commid)
 
 #define chpl_comm_diags_verbose_amo(op, node, ln, fn)                   \
   chpl_comm_diags_verbose_printf(true,                                  \

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2797,7 +2797,7 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
                "from %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn, commID);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2820,7 +2820,7 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                "%d:%p to %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn, commID);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2839,7 +2839,7 @@ void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   TRACE_PRINT(("%d: in chpl_cache_comm_prefetch\n", chpl_nodeID));
-  chpl_comm_diags_verbose_rdma("prefetch", node, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("prefetch", node, size, ln, fn, 0);
   // Always use the cache for prefetches.
   //saturating_increment(&info->prefetch_since_acquire);
   cache_get(cache, NULL, node, (raddr_t)raddr, size, task_local->last_acquire,

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2834,12 +2834,12 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t size, int ln, int32_t fn)
+                              size_t size, int32_t commID, int ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   TRACE_PRINT(("%d: in chpl_cache_comm_prefetch\n", chpl_nodeID));
-  chpl_comm_diags_verbose_rdma("prefetch", node, size, ln, fn, 0);
+  chpl_comm_diags_verbose_rdma("prefetch", node, size, ln, fn, commID);
   // Always use the cache for prefetches.
   //saturating_increment(&info->prefetch_since_acquire);
   cache_get(cache, NULL, node, (raddr_t)raddr, size, task_local->last_acquire,

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1068,7 +1068,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_rdma("put", node, size, ln, fn);
+    chpl_comm_diags_verbose_rdma("put", node, size, ln, fn, commID);
     chpl_comm_diags_incr(put);
 
     // Handle remote address not in remote segment.
@@ -1143,7 +1143,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_rdma("get", node, size, ln, fn);
+    chpl_comm_diags_verbose_rdma("get", node, size, ln, fn, commID);
     chpl_comm_diags_incr(get);
 
     // Handle remote address not in remote segment.
@@ -1285,7 +1285,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
   }
   
   // the case (chpl_nodeID == srcnode) is internally managed inside gasnet
-  chpl_comm_diags_verbose_rdmaStrd("get", srcnode, ln, fn);
+  chpl_comm_diags_verbose_rdmaStrd("get", srcnode, ln, fn, commID);
   if (chpl_nodeID != srcnode) {
     chpl_comm_diags_incr(get);
   }
@@ -1330,7 +1330,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
   }
 
   // the case (chpl_nodeID == dstnode) is internally managed inside gasnet
-  chpl_comm_diags_verbose_rdmaStrd("put", dstnode, ln, fn);
+  chpl_comm_diags_verbose_rdmaStrd("put", dstnode, ln, fn, commID);
   if (chpl_nodeID != dstnode) {
     chpl_comm_diags_incr(put);
   }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2483,7 +2483,7 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn, commID);
   chpl_comm_diags_incr(put);
 
   (void) ofi_put(addr, node, raddr, size);
@@ -2515,7 +2515,7 @@ void chpl_comm_get(void* addr, int32_t node, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn, commID);
   chpl_comm_diags_incr(get);
 
   (void) ofi_get(addr, node, raddr, size);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5285,7 +5285,7 @@ void chpl_comm_put(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("put", locale, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("put", locale, size, ln, fn, commID);
   chpl_comm_diags_incr(put);
 
   do_remote_put(addr, locale, raddr, size, NULL, may_proxy_true);
@@ -5805,7 +5805,7 @@ void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("unordered get", locale, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("unordered get", locale, size, ln, fn, commID);
   chpl_comm_diags_incr(get);
 
   do_remote_get_buff(addr, locale, raddr, size, may_proxy_true);
@@ -5836,7 +5836,7 @@ void chpl_comm_put_unordered(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("unordered put", locale, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("unordered put", locale, size, ln, fn, commID);
   chpl_comm_diags_incr(put);
 
   do_remote_put_buff(addr, locale, raddr, size, may_proxy_true);
@@ -5871,7 +5871,7 @@ void chpl_comm_get(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("get", locale, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("get", locale, size, ln, fn, commID);
   chpl_comm_diags_incr(get);
 
   do_remote_get(addr, locale, raddr, size, may_proxy_true);
@@ -6323,7 +6323,8 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
     chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_rdma("non-blocking get", locale, size, ln, fn);
+  chpl_comm_diags_verbose_rdma("non-blocking get", locale, size,
+                               ln, fn, commID);
   chpl_comm_diags_incr(get_nb);
 
   //

--- a/test/multilocale/engin/verboseComm.good
+++ b/test/multilocale/engin/verboseComm.good
@@ -1,3 +1,3 @@
 0: verboseComm.chpl:5: remote executeOn, node 1
 1
-1: verboseComm.chpl:6: remote put, node 0, 8 bytes
+1: verboseComm.chpl:6: remote put, node 0, 8 bytes, commid #

--- a/test/multilocale/engin/verboseComm.prediff
+++ b/test/multilocale/engin/verboseComm.prediff
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 
 # Sort output; multilocale stdout/stderr isn't deterministic.
-sort < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2
+cat $2 | sed 's/commid [0-9]*/commid #/' | sort > $2.prediff.tmp && mv $2.prediff.tmp $2


### PR DESCRIPTION
Verbose comms printing (i.e. with startVerboseComm from CommDiagnostics) 
now prints out the comm ID numbers for the comms that have IDs so that
these can be correlated with the C code (and then to the AST logs).

- [x] passed full gasnet+futures testing

Reviewed by @gbtitus and @ronawho - thanks!