### PR TITLE
Print loop information in AST logs

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -36,6 +36,7 @@
 #include "CForLoop.h"
 #include "ForallStmt.h"
 #include "ForLoop.h"
+#include "LoopStmt.h"
 #include "ParamForLoop.h"
 #include "TryStmt.h"
 #include "CatchStmt.h"
@@ -497,6 +498,7 @@ bool AstDump::enterWhileDoStmt(WhileDoStmt* node) {
       write(false, "where ", false);
 
   write("WhileDo");
+  printLoopStmtDetails(node);
   newline();
   write("{");
   printBlockID(node);
@@ -524,6 +526,7 @@ bool AstDump::enterDoWhileStmt(DoWhileStmt* node) {
       write(false, "where ", false);
 
   write("DoWhile");
+  printLoopStmtDetails(node);
   newline();
   write("{");
   printBlockID(node);
@@ -551,6 +554,7 @@ bool AstDump::enterForLoop(ForLoop* node) {
       write(false, "where ", false);
 
   write("ForLoop");
+  printLoopStmtDetails(node);
   newline();
   write("{");
   printBlockID(node);
@@ -578,6 +582,7 @@ bool AstDump::enterCForLoop(CForLoop* node) {
       write(false, "where ", false);
 
   write("CForLoop");
+  printLoopStmtDetails(node);
   newline();
   write("{");
   printBlockID(node);
@@ -605,6 +610,7 @@ bool AstDump::enterParamForLoop(ParamForLoop* node) {
       write(false, "where ", false);
 
   write("ParamForLoop");
+  printLoopStmtDetails(node);
   newline();
   write("{");
   printBlockID(node);
@@ -893,6 +899,15 @@ void AstDump::write(bool spaceBefore, const char* text, bool spaceAfter) {
 void AstDump::printBlockID(Expr* expr) {
   if (fdump_html_print_block_IDs)
     fprintf(mFP, " %d", expr->id);
+}
+
+void AstDump::printLoopStmtDetails(LoopStmt* loop) {
+  if (fLogIds)
+    fprintf(mFP, "[%d]", loop->id);
+  if (loop->hasVectorizationHazard())
+    write("hazard");
+  if (loop->isOrderIndependent())
+    write("order-independent");
 }
 
 void AstDump::newline() {

--- a/compiler/include/AstDump.h
+++ b/compiler/include/AstDump.h
@@ -28,6 +28,7 @@ class AggregateType;
 class BaseAST;
 class Expr;
 class FnSymbol;
+class LoopStmt;
 class ModuleSymbol;
 class Symbol;
 
@@ -133,6 +134,7 @@ private:
   void             write(bool spaceBefore, const char* text, bool spaceAfter);
 
   void             printBlockID(Expr* expr);
+  void             printLoopStmtDetails(LoopStmt* loop);
   void             newline();
 
   const char*      mName;           // The name of the file for the log


### PR DESCRIPTION
AST logs now include IDs for LoopStmts. Also, for LoopStmts, now prints if
there was a hazard and if the loop is order-independent.

- [x] passed full gasnet+futures testing

Reviewed by @vasslitvinov - thanks!