### PR TITLE
Make a variety of portability improvements in comm=ofi.

### DIFF
--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -50,3 +50,11 @@ ifneq (, $(findstring mpi, $(CHPL_MAKE_LAUNCHER) $(CHPL_COMM_OFI_OOB)))
   endif
   LIBS += -l$(MPI_LIB_NAME)
 endif
+
+#
+# If we're using the slurm PMI2 out-of-band support we have to
+# reference that library explicitly.
+#
+ifneq (, $(findstring slurm-pmi2, $(CHPL_COMM_OFI_OOB)))
+  LIBS += -lpmi2
+endif

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -28,7 +28,7 @@ COMM_SRCS = \
 # on other Cray systems or with an MPI-based launcher, else "sockets".
 # Use hugepages only on Cray X* systems.
 #
-ifneq (, $(findstring $(CHPL_COMM_OFI_OOB), mpi pmi sockets))
+ifneq (, $(findstring $(CHPL_COMM_OFI_OOB), mpi pmi sockets slurm-pmi2))
   COMM_SRCS += comm-ofi-oob-$(CHPL_COMM_OFI_OOB).c
 else ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
   COMM_SRCS += comm-ofi-oob-pmi.c

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -157,6 +157,16 @@ int chpl_comm_ofi_abort_on_error;
 
 // wish we had typeof() in all target compilers ...
 
+#define CHK_SYS_MALLOC_SZ(p, n, s)                                      \
+    do {                                                                \
+      if ((p = sys_malloc((n) * (s))) == NULL) {                        \
+        INTERNAL_ERROR_V("sys_malloc(%#zx): out of memory",             \
+                         (size_t) (n) * (size_t) (s));                  \
+      }                                                                 \
+    } while (0)
+
+#define CHK_SYS_MALLOC(p, n) CHK_SYS_MALLOC_SZ(p, n, sizeof(*(p)))
+
 #define CHK_SYS_CALLOC_SZ(p, n, s)                                      \
     do {                                                                \
       if ((p = sys_calloc((n), (s))) == NULL) {                         \

--- a/runtime/src/comm/ofi/comm-ofi-oob-slurm-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-slurm-pmi2.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// PMI2-based out-of-band support for the OFI-based Chapel comm layer.
+//
+
+#include "chplrt.h"
+#include "chpl-env-gen.h"
+
+#include "chpl-comm.h"
+#include "chpl-mem.h"
+#include "chpl-mem-sys.h"
+#include "chpl-gen-includes.h"
+#include "chplsys.h"
+#include "error.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "comm-ofi-internal.h"
+
+
+#define PMI2_SUCCESS 0
+#define PMI2_ID_NULL -1
+
+extern int PMI2_Initialized(void);
+extern int PMI2_Init(int* spawned, int* size, int* rank, int* appnum);
+extern int PMI2_Finalize(void);
+extern int PMI2_KVS_Put(const char key[], const char value[]);
+extern int PMI2_KVS_Fence(void);
+extern int PMI2_KVS_Get(const char* jobid, int src_pmi_id,
+                        const char key[], char value[],
+                        int maxvalue, int* vallen);
+
+
+#define PMI2_CHK(expr) CHK_EQ_TYPED(expr, PMI2_SUCCESS, int, "d")
+
+
+void chpl_comm_ofi_oob_init(void) {
+  int spawned, size, rank, appnum;
+
+  if (!PMI2_Initialized()) {
+    PMI2_CHK(PMI2_Init(&spawned, &size, &rank, &appnum));
+    assert(spawned == 0);
+    chpl_nodeID = (c_nodeid_t) rank;
+    chpl_numNodes = (int32_t) size;
+  }
+
+  DBG_PRINTF(DBG_OOB, "OOB init: node %" PRI_c_nodeid_t " of %" PRId32,
+             chpl_nodeID, chpl_numNodes);
+}
+
+
+void chpl_comm_ofi_oob_fini(void) {
+  if (PMI2_Initialized()) {
+    DBG_PRINTF(DBG_OOB, "OOB finalize");
+    PMI2_CHK(PMI2_Finalize());
+  }
+}
+
+
+void chpl_comm_ofi_oob_barrier(void) {
+  DBG_PRINTF(DBG_OOB, "OOB barrier");
+  PMI2_CHK(PMI2_KVS_Fence());
+}
+
+
+static inline void encode_kvs(char* enc, const char* raw, size_t size);
+static inline void decode_kvs(char* raw, const char* enc, size_t size);
+
+void chpl_comm_ofi_oob_allgather(const void* mine_v, void* all_v,
+                                 size_t size) {
+  DBG_PRINTF(DBG_OOB, "OOB allgather: %zd", size);
+
+  const char* mine = (const char*) mine_v;
+  char* all = (char*) all_v;
+
+  //
+  // Key values need to be NUL-terminated printable strings.
+  //
+  size_t size_enc = 2 * size + 1;
+  char* enc;
+  CHK_SYS_MALLOC_SZ(enc, 1, size_enc);
+  encode_kvs(enc, mine, size);
+
+  char key[64];
+  const char* key_fmt = "ChplAllgthr%d_N%d";
+  static int key_cntr;
+
+  key_cntr++;
+  CHK_TRUE(snprintf(key, sizeof(key), key_fmt, key_cntr, chpl_nodeID)
+           < sizeof(key));
+
+  DBG_PRINTF(DBG_OOB, "PMI2_KVS_Put(\"%s\", \"%s\")", key, enc);
+  PMI2_CHK(PMI2_KVS_Put(key, enc));
+
+  PMI2_CHK(PMI2_KVS_Fence());
+
+  for (int node = 0; node < chpl_numNodes; node++) {
+    CHK_TRUE(snprintf(key, sizeof(key), key_fmt, key_cntr, node)
+             < sizeof(key));
+    int size_ret;
+    PMI2_CHK(PMI2_KVS_Get(NULL, PMI2_ID_NULL, key, enc, size_enc, &size_ret));
+    CHK_TRUE(((size_t) size_ret) == size_enc - 1);
+    decode_kvs(all + node * size, enc, size);
+  }
+
+  sys_free(enc);
+}
+
+
+void chpl_comm_ofi_oob_bcast(void* buf_v, size_t size) {
+  DBG_PRINTF(DBG_OOB, "OOB bcast: %zd", size);
+
+  char* buf = (char*) buf_v;
+
+  //
+  // Key values need to be NUL-terminated printable strings.
+  //
+  size_t size_enc = 2 * size + 1;
+  char* enc;
+  CHK_SYS_MALLOC_SZ(enc, 1, size_enc);
+
+  char key[64];
+  const char* key_fmt = "ChplBcast%d";
+  static int key_cntr;
+  key_cntr++;
+  CHK_TRUE(snprintf(key, sizeof(key), key_fmt, key_cntr, chpl_nodeID)
+           < sizeof(key));
+
+  if (chpl_nodeID == 0) {
+    encode_kvs(enc, buf, size);
+    DBG_PRINTF(DBG_OOB, "PMI2_KVS_Put(\"%s\", \"%s\")", key, enc);
+    PMI2_CHK(PMI2_KVS_Put(key, enc));
+  }
+
+  PMI2_CHK(PMI2_KVS_Fence());
+
+  if (chpl_nodeID != 0) {
+    int size_ret;
+    PMI2_CHK(PMI2_KVS_Get(NULL, PMI2_ID_NULL, key, enc, size_enc, &size_ret));
+    CHK_TRUE(((size_t) size_ret) == size_enc - 1);
+    decode_kvs(buf, enc, size);
+  }
+
+  sys_free(enc);
+}
+
+
+static inline
+void encode_kvs(char* enc, const char* raw, size_t size) {
+  for (size_t i = 0; i < size; i++) {
+    enc[2 * i + 0] = ((raw[i] >> (0 * 4)) & 0xf) + 'a';
+    enc[2 * i + 1] = ((raw[i] >> (1 * 4)) & 0xf) + 'a';
+  }
+  enc[2 * size] = '\0';
+}
+
+
+static inline
+void decode_kvs(char* raw, const char* enc, size_t size) {
+  for (size_t i = 0; i < size; i++) {
+    raw[i] =   ((enc[2 * i + 0] - 'a') << (0 * 4))
+             | ((enc[2 * i + 1] - 'a') << (1 * 4));
+  }
+}

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -511,6 +511,7 @@ void init_ofiFabricDomain(void) {
   hints->domain_attr->mr_mode = ((getNetworkType() == networkAries)
                                  ? FI_MR_BASIC
                                  : FI_MR_UNSPEC);
+  hints->domain_attr->mr_mode |= FI_MR_ENDPOINT;
   hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 
   //
@@ -1044,6 +1045,10 @@ void init_ofiForMem(void) {
                "[%d] fi_mr_reg(%p, %#zx): key %#" PRIx64,
                i, memTab[i].addr, memTab[i].size,
                memTab[i].key);
+    if ((ofi_info->domain_attr->mr_mode & FI_MR_ENDPOINT) != 0) {
+      OFI_CHK(fi_mr_bind(ofiMrTab[i], &ofi_rxEpRma->fid, 0));
+      OFI_CHK(fi_mr_enable(ofiMrTab[i]));
+    }
   }
 
   //

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -651,7 +651,9 @@ void init_ofiEp(void) {
   // Compute numbers of transmit and receive contexts, and then create
   // the transmit context table.
   //
-  useScalableTxEp = (ofi_info->domain_attr->max_ep_tx_ctx > 1);
+  useScalableTxEp = (ofi_info->domain_attr->max_ep_tx_ctx > 1
+                     && chpl_env_rt_get_bool("COMM_OFI_USE_SCALABLE_EP",
+                                             true));
   init_ofiEpNumCtxs();
 
   tciTabLen = numTxCtxs;


### PR DESCRIPTION
This duplicates #14193 into the release/1.20 branch.

This is a collection of improvements in several parts of the ofi-based
comm layer, to make it more portable across providers, platforms, and
build environments.  The highlights are as follows.

Add slurm PMI2-based out-of-band support.  This is based on "pure" (I
hope) PMI2, which can be used (via `srun --mpi=pmi2 ...`) in slurm
installs that have the PMI2 support.  This will let us run in situations
where we have a slurm WLM with PMI2 but not Cray's PMI, notably certain
Cray CS systems.

Simplify memory registration.  Specifically, support just two models,
one in which the provider does scalable registration of the entire
address space, and another in which the user specifies a fixed heap and
we register that and only that.  Along with this work, add support for
`FI_MR_VIRT_ADDR` and `FI_MR_ENDPOINT`, and fix a couple of bugs and
generally clean up in the `FI_MR_LOCAL` support.  (We may want to extend
the second model to allow for registering other memory regions besides
just the heap, but that can be work for the future.)

Instead of requiring the user to tell us not to use a waitset to drive
manual progress in the AM handler, just use one if the provider supports
them and don't use one otherwise.  Except don't use a waitset with the
gni provider, because there we get an error we don't yet understand when
closing the waitset.

Undo a workaround added a while ago (59f1de31) in response to complaints
from provider progress engines about not having completion queues or
counters for tracking receives on the transmit endpoints.  (Such traffic
can be present, for example, on networks which require software to
ensure transaction progress.)  That workaround modified the domain
attributes returned by the provider at startup time, which in retrospect
isn't at all a safe thing to do -- those attributes are intended as
communication from the provider to the client, not the other way around.
Instead, just make sure completion queues and/or counters with the
appropriate flags are bound to the transmit endpoints and contexts, even
if from the comm layer's point of view such receive transactions cannot
occur.

Bind just one remote address vector to all the endpoints, rather than
separate AVs to each one.  Without going into too much detail, long ago
(f9ec748d) I misinterpreted an error when binding an AV to a transmit
context as indicating that each endpoint needed its own AV, which isn't
the case.