### PR TITLE
Normalize Shasta builds

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -13,7 +13,7 @@ HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host ma
 # Cray X* builds are cross-compilations
 #
 GMP_CROSS_COMPILED=no
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 GMP_CROSS_COMPILED=yes
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
@@ -30,7 +30,7 @@ endif
 # On cross-compiled systems, building the shared libraries causes issues.
 # On Macs, not building the shared libraries causes warnings.
 #
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -8,7 +8,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 #
 # Cray X* builds are cross-compilations.
 #
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_HWLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -8,7 +8,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 #
 # Cray X* builds are cross-compilations.
 #
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -18,7 +18,7 @@ QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 #
 # Cray X* builds are cross-compilations
 #
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_QTHREAD_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -50,7 +50,7 @@ chomp($user);
 $tmpdir = tempdir("chapel-release.$user.deleteme.XXXXX", DIR => $basetmpdir, CLEANUP => 1);
 $archive_dir = "$tmpdir/$reldir";
 SystemOrDie("rm -rf $tmpdir");
-SystemOrDie("mkdir -pv $tmpdir");
+SystemOrDie("mkdir -pv $archive_dir");
 $rootdir = "$tmpdir/chpl_home";
 
 # If CHPL_GEN_RELEASE_NO_CLONE is set in environment, do not clone the repo
@@ -59,12 +59,11 @@ $rootdir = "$tmpdir/chpl_home";
 if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
 
     # copy the current CHPL_HOME into the directory where chapel will be built
-    print "[gen_release] CHPL_GEN_RELEASE_NO_CLONE: Creating build workspace with cp --archive ...\n";
-    SystemOrDie("cp --archive $chplhome $archive_dir");
+    print "[gen_release] CHPL_GEN_RELEASE_NO_CLONE: Creating build workspace with tar...\n";
+    SystemOrDie("cd $chplhome && tar -cf - . | (cd $archive_dir && tar -xf -)");
 
     $resultdir = "$chplhome/tar";
 } else {
-    SystemOrDie("mkdir -pv $archive_dir");
 
     # check out a clean copy of the sources into the directory where chapel will be built
     $git_url = $ENV{'CHPL_HOME_REPOSITORY'};

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -40,7 +40,7 @@ def get(flag='host'):
                     platform_val = 'cray-xc'
 
     if not platform_val:
-        network = os.environ.get('CRAYPE_NETWORK_TARGET')
+        network = os.environ.get('CRAYPE_NETWORK_TARGET', '')
         if network.startswith("slingshot") or network == "ofi":
             platform_val = 'cray-shasta'
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -26,8 +26,6 @@ def get(flag='host'):
         cle_info_file = os.path.abspath('/etc/opt/cray/release/CLEinfo')
         if not os.path.exists(cle_info_file):
             cle_info_file = os.path.abspath('/etc/opt/cray/release/cle-release')
-            if not os.path.exists(cle_info_file):
-                cle_info_file = os.path.abspath('/etc/opt/cray/release/cray-release')
 
         if os.path.exists(cle_info_file):
             with open(cle_info_file, 'r') as fp:
@@ -40,11 +38,11 @@ def get(flag='host'):
                     platform_val = 'cray-xe'
                 elif net.lower() == 'ari':
                     platform_val = 'cray-xc'
-            if not platform_val:
-                product_pattern = re.compile(r'^PRODUCT=.*\b[Ss]hasta\b', re.MULTILINE)
-                product_match = product_pattern.search(cle_info)
-                if product_match is not None:
-                    platform_val = 'cray-shasta'
+
+    if not platform_val:
+        network = os.environ.get('CRAYPE_NETWORK_TARGET')
+        if network.startswith("slingshot") or network == "ofi":
+            platform_val = 'cray-shasta'
 
     if not platform_val:
         # uname() -> (system, node, release, version, machine, processor)


### PR DESCRIPTION
This duplicates #14205 into the release/1.20 branch (and the first reference
to 'master' immediately below should be read as 'release/1.20').

This brings Shasta builds back into master. It merges in a couple of
recent PRs (#14086 and #14116) that went originally to the shasta-builds
side branch instead of to master during the period when we were keeping
the latter stable for the 1.20 release. It also reverts a previous
commit that changed from using tar to using cp --archive to copy a
file hierarchy during the module build, since we now realize this breaks
on Mac OS X.