### PR TITLE
Reduce unorderedCopyStress problem size

### DIFF
--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.execopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.execopts
@@ -7,14 +7,14 @@ comm_sub = os.getenv('CHPL_COMM_SUBSTRATE')
 ugni = comm == 'ugni'
 gn_aries = comm == 'gasnet' and comm_sub == 'aries'
 
-size = 10000
+size = 1000
 fenceSize = 1000
 if gn_aries:
-    size = 1000000
-    fenceSize = 10000
+    size = 100000
+    fenceSize = 1000
 elif ugni:
-    size = 10000000
-    fenceSize = 10000
+    size = 1000000
+    fenceSize = 1000
 
 print('--printStats=false --concurrentFencing=false --sizePerLocale={0} --oversubscription=1'.format(size))
 print('--printStats=false --concurrentFencing=false --sizePerLocale={0} --oversubscription=2'.format(size//2))


### PR DESCRIPTION
The new `512*int` tuple variant used ~75GB of memory for ugni. Drop the
problem size for ugni to avoid that and drop the problem size for other
configs since the new tuple variants take too long to run.