### PR TITLE
Fix the good file of a deprecation test

### DIFF
--- a/test/deprecated/string-bytes-comp.good
+++ b/test/deprecated/string-bytes-comp.good
@@ -1,7 +1,7 @@
-string-bytes-comp.chpl:4: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
-string-bytes-comp.chpl:5: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
-string-bytes-comp.chpl:6: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
-string-bytes-comp.chpl:7: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:4: warning: Comparison between bytes and string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:5: warning: Comparison between bytes and string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:6: warning: Comparison between bytes and string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:7: warning: Comparison between bytes and string is deprecated. Cast the string to bytes first
 true
 false
 true


### PR DESCRIPTION
I changed the deprecation message after review, but forgot to change the good file to reflect that.

The test passes after this change