### PR TITLE
Accept increase comm counts for cyclic sliceOps

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/sliceOps.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/sliceOps.cyclic.good
@@ -1,7 +1,7 @@
 create slice (module-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 use slice via assignment (module-scope):
-(execute_on_nb = 3) (get = 6) (get = 6) (get = 6)
+(execute_on_nb = 3) (get = 8) (get = 8) (get = 8)
 0 serializing a slice
 0 serializing a slice
 0 serializing a slice
@@ -25,7 +25,7 @@ use slice as follower (module-scope):
 create slice (local-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 use slice via assignment (local-scope):
-(execute_on_nb = 3) (get = 6) (get = 6) (get = 6)
+(execute_on_nb = 3) (get = 8) (get = 8) (get = 8)
 0 serializing a slice
 0 serializing a slice
 0 serializing a slice

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/sliceOps.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/sliceOps.cyclic.na-none.good
@@ -1,7 +1,7 @@
 create slice (module-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 use slice via assignment (module-scope):
-(execute_on_nb = 3) (get = 6, execute_on_fast = 1) (get = 6, execute_on_fast = 1) (get = 6, execute_on_fast = 1)
+(execute_on_nb = 3) (get = 8, execute_on_fast = 1) (get = 8, execute_on_fast = 1) (get = 8, execute_on_fast = 1)
 0 serializing a slice
 0 serializing a slice
 0 serializing a slice
@@ -25,7 +25,7 @@ use slice as follower (module-scope):
 create slice (local-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 use slice via assignment (local-scope):
-(execute_on_nb = 3) (get = 6, execute_on_fast = 1) (get = 6, execute_on_fast = 1) (get = 6, execute_on_fast = 1)
+(execute_on_nb = 3) (get = 8, execute_on_fast = 1) (get = 8, execute_on_fast = 1) (get = 8, execute_on_fast = 1)
 0 serializing a slice
 0 serializing a slice
 0 serializing a slice


### PR DESCRIPTION
Improving the running task counter accuracy in #14236 has led to cyclic
slices going parallel, which for some reason is increasing comm counts.
For now just accept the increases since the better running task count
and going parallel are good things, but I'll dig into the comm
regressions more in https://github.com/Cray/chapel-private/issues/514