### PR TITLE
Move the RPM and module, for Shasta.

### DIFF
--- a/util/build_configs/cray-internal/generate-rpmspec.bash
+++ b/util/build_configs/cray-internal/generate-rpmspec.bash
@@ -21,6 +21,12 @@ source $cwd/common.bash
 
 # Generate the first part of the spec file with shell expansion
 
+if [ "$chpl_platform" = cray-shasta ]; then
+    default_prefix=/opt/cray
+else
+    default_prefix=/opt
+fi
+
 cat <<PART_1
 %define name chapel-$pkg_version
 %define real_name chapel
@@ -29,6 +35,7 @@ cat <<PART_1
 %define chpl_home_basename $( basename "$CHPL_HOME" )
 %define pkg_release $rpm_release
 %define build_type $chpl_platform
+%define default_prefix $default_prefix
 %define _binary_payload w9.gzdio
 PART_1
 
@@ -45,12 +52,11 @@ PART_1
 # Generate the rest of the spec file, without shell expansion
 
 cat <<\PART_2
-
 Summary: Chapel language compiler and libraries
 Name:    %{name}
 Version: %{version}
 Release: %{pkg_release}
-Prefix:  /opt
+Prefix:  %{default_prefix}
 License: Copyright 2019, Cray Inc. All Rights Reserved.
 Packager: Cray, Inc
 Group:   Development/Languages/Other
@@ -83,8 +89,8 @@ chmod -Rf a+rX,u+w,g-w,o-w .
 %install
 
 cd          %{_topdir}
-mkdir -p                                                $RPM_BUILD_ROOT/%{prefix}/cray/admin-pe/set_default_files
-cp -p       set_default_%{real_name}_%{pkg_version}     $RPM_BUILD_ROOT/%{prefix}/cray/admin-pe/set_default_files
+mkdir -p                                                $RPM_BUILD_ROOT/opt/cray/admin-pe/set_default_files
+cp -p       set_default_%{real_name}_%{pkg_version}     $RPM_BUILD_ROOT/opt/cray/admin-pe/set_default_files
 mkdir -p                                                $RPM_BUILD_ROOT/%{prefix}/modulefiles/%{real_name}
 rm -f                                                   $RPM_BUILD_ROOT/%{prefix}/modulefiles/%{real_name}/%{pkg_version}
 cp -p       modulefile-%{pkg_version}                   $RPM_BUILD_ROOT/%{prefix}/modulefiles/%{real_name}/%{pkg_version}
@@ -119,7 +125,7 @@ if [ -f $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/.version ]
 then
 chmod 644 $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/.version
 fi
-chmod 755 $RPM_INSTALL_PREFIX/cray/admin-pe/set_default_files/set_default_%{real_name}_%{pkg_version}
+chmod 755 /opt/cray/admin-pe/set_default_files/set_default_%{real_name}_%{pkg_version}
 
 sed --in-place "s:\[BASE_INSTALL_DIR\]:$RPM_INSTALL_PREFIX:g" $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/%{pkg_version}
 
@@ -144,5 +150,5 @@ fi
 %defattr(-,root,root)
 %{prefix}/%{real_name}/%{pkg_version}
 %{prefix}/modulefiles/%{real_name}/%{pkg_version}
-%{prefix}/cray/admin-pe/set_default_files/set_default_%{real_name}_%{pkg_version}
+/opt/cray/admin-pe/set_default_files/set_default_%{real_name}_%{pkg_version}
 PART_2

--- a/util/build_configs/cray-internal/generate-set_default.bash
+++ b/util/build_configs/cray-internal/generate-set_default.bash
@@ -21,13 +21,19 @@ source $cwd/common.bash
 
 # Generate the first part of the file with shell expansion
 
+if [ "$chpl_platform" = cray-shasta ]; then
+    default_prefix=/opt/cray
+else
+    default_prefix=/opt
+fi
+
 cat <<PART_1
 #!/bin/bash
 
 export CRAY_product=chapel
 export CRAY_version=$pkg_version
 export CRAY_inst_dir=/opt
-export CRAY_mod_dir=/opt/modulefiles
+export CRAY_mod_dir=$default_prefix/modulefiles
 export CRAY_mod_names=chapel
 
 PART_1


### PR DESCRIPTION
We've been using `/opt` as the base prefix for the Cray Chapel module, but
that's turning out to be problematic on Shasta systems.  Here, switch to
`/opt/cray` instead, though only on Shasta.  So the modules themselves will
be in `/opt/cray/chapel` and the modulefiles in `/opt/cray/modulefiles/chapel`.

A wrinkle is that we're also referring to /opt/cray/admin-pe/... for
some stuff that appears to be specific to XC and earlier systems.  I'm
checking on that, but it's working for now and doesn't have to be fixed
right away.