### PR TITLE
Remove two .futures fixed by #14218

### DIFF
--- a/test/functions/firstClassFns/storeTheType.future
+++ b/test/functions/firstClassFns/storeTheType.future
@@ -1,2 +1,0 @@
-bug: compiler segfault with storing type of fcf directly into type variable
-#13209

--- a/test/functions/firstClassFns/storeTheType.good
+++ b/test/functions/firstClassFns/storeTheType.good
@@ -1,1 +1,1 @@
-borrowed chpl__fcf_type_void_void
+shared chpl__fcf_type_void_void

--- a/test/functions/sungeun/type_illegal.future
+++ b/test/functions/sungeun/type_illegal.future
@@ -1,5 +1,0 @@
-bug: Querying the type of a function (without calling the function) returns unexpected results.
-
-There should be some way to do it (see retType.future), so this test should
-either return the function's return type or be illegal.
-

--- a/test/functions/sungeun/type_illegal.good
+++ b/test/functions/sungeun/type_illegal.good
@@ -1,1 +1,1 @@
-type_illegal.chpl:5: syntax error: near '.type'
+shared chpl__fcf_type_void_int64_t


### PR DESCRIPTION
Clean up and remove two .futures about taking the type of a first class
function that were fixed by #14218. They now print the first class function
type name instead of crashing the compiler.

#14218 also resolves issue #13209