### PR TITLE
Give an error when an init= does not have exactly one argument

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -517,6 +517,13 @@ void AggregateType::addDeclaration(DefExpr* defExpr) {
     } else {
       ArgSymbol* arg = new ArgSymbol(fn->thisTag, "this", this);
 
+      if (fn->name == astrInitEquals) {
+        if (fn->numFormals() != 1) {
+          USR_FATAL_CONT(fn, "%s.init= must have exactly one argument",
+                         this->name());
+        }
+      }
+
       fn->_this = arg;
 
       if (fn->thisTag == INTENT_TYPE) {

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -93,10 +93,10 @@ module Map {
       :arg parSafe: If `true`, this map will use parallel safe operations.
       :type parSafe: bool
     */
-    proc init=(const ref other: map(?kt, ?vt, ?ps), param parSafe=ps) {
+    proc init=(const ref other: map(?kt, ?vt, ?ps)) {
       this.keyType = kt;
       this.valType = vt;
-      this.parSafe = parSafe;
+      this.parSafe = ps;
 
       this.complete();
 

--- a/test/classes/initializers/initequals/wrongArgCount.chpl
+++ b/test/classes/initializers/initequals/wrongArgCount.chpl
@@ -1,0 +1,5 @@
+class C {
+  proc init=() { }  // should give an error
+  proc init=(a1: C) { }
+  proc init=(a1: C, a1: C) { }  // should give an error
+}

--- a/test/classes/initializers/initequals/wrongArgCount.good
+++ b/test/classes/initializers/initequals/wrongArgCount.good
@@ -1,0 +1,2 @@
+wrongArgCount.chpl:2: error: C.init= must have exactly one argument
+wrongArgCount.chpl:6: error: C.init= must have exactly one argument

--- a/test/classes/initializers/initequals/wrongArgCount.good
+++ b/test/classes/initializers/initequals/wrongArgCount.good
@@ -1,2 +1,2 @@
 wrongArgCount.chpl:2: error: C.init= must have exactly one argument
-wrongArgCount.chpl:6: error: C.init= must have exactly one argument
+wrongArgCount.chpl:4: error: C.init= must have exactly one argument


### PR DESCRIPTION
This PR adds a check while adding methods to an AggregateType to detect `init=`
that does not have exactly one argument.

Also:
- removes the extraneous `parSafe` argument from `map.init=`
- adds a test for the new error message

Test:
- [x] standard
- [x] standard futures
- [x] gasnet