### PR TITLE
Add optimized COO->CSR/CSC sparse domain assignment

### DIFF
--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -166,7 +166,10 @@ class CSDom: BaseSparseDomImpl {
       this.idx = rhs.idx;
     } else if _to_borrowed(rhs._instance.type) < DefaultSparseDom {
       // Optimized COO -> CSR/CSC
-      this.dsiBulkAdd(rhs._instance.indices[rhs.nnzDom.low..#rhs._nnz], dataSorted=true, isUnique=true);
+
+      // Note: only COO->CSR can take advantage of COO having sorted indices
+      this.dsiBulkAdd(rhs._instance.indices[rhs.nnzDom.low..#rhs._nnz],
+                      dataSorted=this.compressRows, isUnique=true);
     } else {
       // Unoptimized generic case
       chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);


### PR DESCRIPTION
Add an optimized COO -> CSR/CSC domain assignment implementation. 

Local trials show ~100 and ~1000x speedup for 0.99 and 0.01 matrix density, respectively.

The CSC layout does not benefit from the row-major order sorted indices of the original COO domain, but the performance improvements is still significant.

<details>


```bash
#
# similar domain assignment
#

# master
$ ./domainAssignment-similar --correctness=false --numIndices=5000000 --density=0.99
COO to COO: 0.051614
COO to CSR: 2.10224 # <---
CSR to COO: 0.461293
CSR to CSR: 0.011463
CSC to CSC: 0.012636
# PR 14272
$ ./domainAssignment-similar --correctness=false --numIndices=5000000 --density=0.99
COO to COO: 0.049277
COO to CSR: 0.014922 # <---
CSR to COO: 0.439472
CSR to CSR: 0.011769
CSC to CSC: 0.011514

# master
$ ./domainAssignment-similar --correctness=false --numIndices=5000000 --density=0.01
COO to COO: 0.05985
COO to CSR: 21.4467 # <---
CSR to COO: 0.463566
CSR to CSR: 0.011735
CSC to CSC: 0.011537
# PR 14272
$ ./domainAssignment-similar --correctness=false --numIndices=5000000 --density=0.01
COO to COO: 0.04887
COO to CSR: 0.012929 # <---
CSR to COO: 0.433861
CSR to CSR: 0.011563
CSC to CSC: 0.011324

#
# dissimilar domain assignment
#

# master
$ ./domainAssignment-dissimilar --correctness=false --numIndices=50000 --density=0.99
CSR to CSC: 0.262992
CSC to COO: 0.537015
CSC to CSR: 0.263508
COO to CSC: 0.258398 # <---
# PR 14272
$ ./domainAssignment-dissimilar --correctness=false --numIndices=50000 --density=0.99
CSR to CSC: 0.260226
CSC to COO: 0.534276
CSC to CSR: 0.262133
COO to CSC: 0.002127 # <---

# master
$ ./domainAssignment-dissimilar --correctness=false --numIndices=50000 --density=0.01
CSR to CSC: 0.300687
CSC to COO: 0.654119
CSC to CSR: 0.286684
COO to CSC: 0.27466 # <---
# PR 14272
$ ./domainAssignment-dissimilar --correctness=false --numIndices=50000 --density=0.01
CSR to CSC: 0.276841
CSC to COO: 0.535641
CSC to CSR: 0.274538
COO to CSC: 0.001611 # <---

```
</details>

- [x] Full linux testing

closes #14261