### PR TITLE
Append library as last link arg in C compiles in addition to LLVM

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -252,15 +252,12 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
     fprintf(makefile.fptr, "%s", requires.c_str());
   }
 
-  if (!llvmCodegen) {
-    fprintf(makefile.fptr, " %s\n", libraries.c_str());
-  } else {
-    // LLVM requires a bit more work to make the GNU linker happy.
-    removeTrailingNewlines(libraries);
-
-    // Append the Chapel library as the last linker argument.
-    fprintf(makefile.fptr, " %s %s\n\n", libraries.c_str(), libname.c_str());
-  }
+  //
+  // Append the Chapel library as the last linker argument. We do this as a
+  // stopgap to make the GNU linker happy.
+  //
+  removeTrailingNewlines(libraries);
+  fprintf(makefile.fptr, " %s %s\n\n", libraries.c_str(), libname.c_str());
 }
 
 const char* getLibraryExtension() {


### PR DESCRIPTION
This PR is more for consistency's sake than anything else.

Certain linkers (*cough, cough* GNU) need some extra hand holding when resolving symbols. To help out, we can append the generated user library as the last link argument, ensuring that everything links just fine. This has no effect when using a modern linker (which will have resolved the symbols regardless).

We already do this for `--llvm` compiles. This PR just removes a branch and appends the user library as the last link argument regardless of the chosen backend. 

Resolves #13457. 

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none` and `--llvm`
- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet`