### PR TITLE
Close user-level leaks in a test

### DIFF
--- a/test/distributions/ferguson/islayout.chpl
+++ b/test/distributions/ferguson/islayout.chpl
@@ -7,6 +7,9 @@ proc main() {
   // to keep up to date. But, check one to be sure.
   var blk = new unmanaged Block(boundingBox={1..10});
   assert(!blk.dsiIsLayout());
+  
+  //properly cleanup the distribution
+  blk.dsiDestroyDist();
   delete blk;
 
   var cs = new unmanaged CS();
@@ -31,4 +34,8 @@ proc main() {
   var ptr:c_ptr(int) = c_calloc(int, 1);
   var B = makeArrayFromPtr(ptr, 1);
   assert(B.domain.dist.dsiIsLayout());
+
+  //make array from ptr creates an array that borrows the buffer. So, the
+  //allocation needs to be cleaned up using the pointer.
+  c_free(ptr);
 }


### PR DESCRIPTION
The test in `test/distributions/ferguson/islayout.chpl` has two user-level leaks:

- It creates a distribution instance that is not record wrapped. However, distributions/domains/arrays are not cleaned up via deinits. Their cleanup is managed by the _distribution etc wrappers by calling `dsiDestroyDist` and similar methods.

  Since this test creates the object in such fashion (to test a `dsi*` method), I think it should be calling `dsiDestroyDist` as well. I attempted to rely on deinits more to cleanup distribution memory [here](https://github.com/chapel-lang/chapel/compare/master...e-kayrakli:close-distobj-leaks) but this doesn't seem to work today.

- The test creates an external array which is created by borrowing the buffer. Therefore, the buffer is not freed when the array goes out of scope.

This PR fixes those two leaks by calling appropriate methods.

Tested with:
- [x] standard correctness
- [x] standard memleaks
- [x] quickstart valgrind
- [x] gasnet correctness