### PR TITLE
Rework distribution equality tests

### DIFF
--- a/test/distributions/sungeun/equality.chpl
+++ b/test/distributions/sungeun/equality.chpl
@@ -1,0 +1,18 @@
+use BlockDist;
+
+const d1 = defaultDist;
+writeln(d1 == defaultDist);
+
+const d2 = defaultDist;
+writeln(d2 != defaultDist);
+
+const d3 = new dmap(new Block({1..10}));
+const d4 = new dmap(new Block({1..10}));
+
+writeln(d3==d4);
+writeln(d3!=d4);
+
+var dom = {1..1} dmapped Block({1..10});
+writeln(d3==dom.dist);
+writeln(d3!=dom.dist);
+

--- a/test/distributions/sungeun/equality.good
+++ b/test/distributions/sungeun/equality.good
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false

--- a/test/distributions/sungeun/equality1.chpl
+++ b/test/distributions/sungeun/equality1.chpl
@@ -1,6 +1,0 @@
-const d1 = defaultDist;
-writeln(d1 == defaultDist);
-
-const d2 = new dmap(new DefaultDist());
-writeln(d2 == defaultDist);
-

--- a/test/distributions/sungeun/equality1.good
+++ b/test/distributions/sungeun/equality1.good
@@ -1,2 +1,0 @@
-true
-true

--- a/test/distributions/sungeun/equality2.chpl
+++ b/test/distributions/sungeun/equality2.chpl
@@ -1,6 +1,0 @@
-const d1 = defaultDist;
-writeln(d1 != defaultDist);
-
-const d2 = new dmap(new DefaultDist());
-writeln(d2 != defaultDist);
-

--- a/test/distributions/sungeun/equality2.good
+++ b/test/distributions/sungeun/equality2.good
@@ -1,2 +1,0 @@
-false
-false


### PR DESCRIPTION
This PR replaces :

- `test/distributions/sungeun/equality1.chpl`
- `test/distributions/sungeun/equality2.chpl`

with:

- `test/distributions/sungeun/equality.chpl`

which has the union of tests from those two separate tests and some more similar
equality checks. The key motivation here is to remove `new DefaultDist()` from
application code as much as possible because it leaks. See #14280 

I don't think the tests are supposed to check anything particular about
DefaultDist. They were added in 2011 and weren't modified ever since. The commit
message says:

> Adding a couple of futures for implementing == and != for
  distributions.
>
> Currently distributions are treated as regular ol' objects and a C
  pointer comparison is used to test for equality.

Tested the new test with:
- [x] standard memleaks
- [x] standard
- [x] gasnet