### PR TITLE
Better use of init= for sync/single

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5888,6 +5888,8 @@ static void resolveInitVar(CallExpr* call) {
   Type* targetType = NULL;
   bool addedCoerce = false;
 
+  bool inferType = call->numActuals() == 2;
+
   if (call->numActuals() > 3) {
     INT_FATAL(call, "unexpected number of actuals in variable init call");
   }
@@ -5943,8 +5945,6 @@ static void resolveInitVar(CallExpr* call) {
     // Insert a coercion if the types are different. Some internal types use a
     // coercion because their initCopy returns a different type.
     if (targetType->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE) ||
-        isSyncType(src->getValType()) ||
-        isSingleType(src->getValType()) ||
         (targetType->symbol->hasFlag(FLAG_TUPLE) && mismatch) ||
         (isRecord(targetType->getValType()) == false && mismatch)) {
 
@@ -5979,6 +5979,7 @@ static void resolveInitVar(CallExpr* call) {
   // which is handled in the 'init=' branch.
   bool isDomainWithoutNew = targetType->getValType()->symbol->hasFlag(FLAG_DOMAIN) &&
                             src->hasFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW) == false;
+  bool initCopySyncSingle = inferType && (isSyncType(srcType->getValType()) || isSingleType(srcType->getValType()));
 
   if (dst->hasFlag(FLAG_NO_COPY) ||
       isPrimitiveScalar(targetType) ||
@@ -5996,10 +5997,9 @@ static void resolveInitVar(CallExpr* call) {
 
   } else if (isRecord(targetType->getValType()) == false ||
              isParamString ||
-             isSyncType(srcType->getValType()) ||
-             isSingleType(srcType->getValType()) ||
              targetType->getValType()->symbol->hasFlag(FLAG_ARRAY) ||
              isDomainWithoutNew ||
+             initCopySyncSingle ||
              srcType->getValType()->symbol->hasFlag(FLAG_TUPLE) ||
              srcType->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
     // These cases require an initCopy to implement special initialization

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -142,6 +142,19 @@ module ChapelSyncvar {
       this.isOwned = false;
     }
 
+    proc init=(const other : _syncvar) {
+      // Allow initialization from compatible sync variables, e.g.:
+      //   var x : sync int = 5;
+      //   var y : sync real = x;
+      if isCoercible(other.valType, this.type.valType) == false {
+        param theseTypes = "'" + this.type:string + "' from '" + other.type:string + "'";
+        param because = "because '" + other.valType:string + "' is not coercible to '" + this.type.valType:string + "'";
+        compilerError("cannot initialize ", theseTypes, " ",  because);
+      }
+      this.init(this.type.valType);
+      this.writeEF(other.readFE());
+    }
+
     pragma "dont disable remote value forwarding"
     proc init=(const other : this.valType) {
       this.init(other.type);

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -681,6 +681,19 @@ module ChapelSyncvar {
       isOwned = false;
     }
 
+    proc init=(const other : _singlevar) {
+      // Allow initialization from compatible single variables, e.g.:
+      //   var x : single int = 5;
+      //   var y : single real = x;
+      if isCoercible(other.valType, this.type.valType) == false {
+        param theseTypes = "'" + this.type:string + "' from '" + other.type:string + "'";
+        param because = "because '" + other.valType:string + "' is not coercible to '" + this.type.valType:string + "'";
+        compilerError("cannot initialize ", theseTypes, " ",  because);
+      }
+      this.init(this.type.valType);
+      this.writeEF(other.readFF());
+    }
+
     pragma "dont disable remote value forwarding"
     proc init=(const other : this.type.valType) {
       this.init(other.type);

--- a/test/types/single/sungeun/single-cannot-coerce.chpl
+++ b/test/types/single/sungeun/single-cannot-coerce.chpl
@@ -1,0 +1,3 @@
+
+var i : single int = 100;
+var s : single string = i;

--- a/test/types/single/sungeun/single-cannot-coerce.good
+++ b/test/types/single/sungeun/single-cannot-coerce.good
@@ -1,0 +1,1 @@
+single-cannot-coerce.chpl:3: error: cannot initialize 'single string' from 'single int(64)' because 'int(64)' is not coercible to 'string'

--- a/test/types/single/sungeun/single-copy-init.chpl
+++ b/test/types/single/sungeun/single-copy-init.chpl
@@ -1,0 +1,11 @@
+var outersingle: single int = 1;
+var foo1: single int = outersingle;
+writeln(foo1.type:string);
+writeln(foo1.isFull);
+writeln(outersingle.isFull);
+
+var r : single real = foo1;
+writeln(r.type:string);
+writeln(r.readXX());
+writeln(r.isFull);
+writeln(foo1.isFull);

--- a/test/types/single/sungeun/single-copy-init.good
+++ b/test/types/single/sungeun/single-copy-init.good
@@ -1,0 +1,7 @@
+single int(64)
+true
+true
+single real(64)
+1.0
+true
+true

--- a/test/types/sync/ferguson/sync-copy-init-cannot-coerce.chpl
+++ b/test/types/sync/ferguson/sync-copy-init-cannot-coerce.chpl
@@ -1,0 +1,3 @@
+
+var i : sync int = 100;
+var s : sync string = i;

--- a/test/types/sync/ferguson/sync-copy-init-cannot-coerce.good
+++ b/test/types/sync/ferguson/sync-copy-init-cannot-coerce.good
@@ -1,0 +1,1 @@
+sync-copy-init-cannot-coerce.chpl:3: error: cannot initialize 'sync string' from 'sync int(64)' because 'int(64)' is not coercible to 'string'

--- a/test/types/sync/ferguson/sync-copy-init-other-sync.chpl
+++ b/test/types/sync/ferguson/sync-copy-init-other-sync.chpl
@@ -3,3 +3,9 @@ var foo1: sync int = outersync;
 writeln(foo1.type:string);
 writeln(foo1.isFull);
 writeln(outersync.isFull);
+
+var r : sync real = foo1;
+writeln(r.type:string);
+writeln(r.readXX());
+writeln(r.isFull);
+writeln(foo1.isFull);

--- a/test/types/sync/ferguson/sync-copy-init-other-sync.good
+++ b/test/types/sync/ferguson/sync-copy-init-other-sync.good
@@ -1,3 +1,7 @@
 sync int(64)
 true
 false
+sync real(64)
+1.0
+true
+false


### PR DESCRIPTION
This PR updates the compiler to invoke ``init=`` for initialization of a sync variable from another sync variable. Prior to this PR the compiler default-initialized and used assignment.

This PR also improves an error message for initializing a sync variable from an incompatible type.

Testing:
- [x] local + futures
- [x] gasnet + futures