### PR TITLE
Make the Shasta module really relocatable, with respect to the files.

### DIFF
--- a/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
+++ b/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
@@ -131,6 +131,9 @@ Installation instructions:
     Copy the appropriate Chapel RPM file to the current directory and execute
     one of the following commands:
 
+      #On Cray Shasta systems (x86_64):
+      rpm -ivh chapel-$pkg_version-crayshasta$rc_number.x86_64.rpm
+
       #On Cray XC systems (x86_64):
       rpm -ivh chapel-$pkg_version-crayxc$rc_number.x86_64.rpm
 

--- a/util/build_configs/cray-internal/generate-rpmspec.bash
+++ b/util/build_configs/cray-internal/generate-rpmspec.bash
@@ -22,9 +22,13 @@ source $cwd/common.bash
 # Generate the first part of the spec file with shell expansion
 
 if [ "$chpl_platform" = cray-shasta ]; then
-    default_prefix=/opt/cray
+    # Shasta rpm may be relocatable, since all %files start with %prefix.
+    platform_prefix=/opt/cray
+    set_def_subdir=admin-pe/set_default_files
 else
-    default_prefix=/opt
+    # Before Shasta, rpm is not relocatable.
+    platform_prefix=/opt
+    set_def_subdir=cray/admin-pe/set_default_files
 fi
 
 cat <<PART_1
@@ -35,7 +39,8 @@ cat <<PART_1
 %define chpl_home_basename $( basename "$CHPL_HOME" )
 %define pkg_release $rpm_release
 %define build_type $chpl_platform
-%define default_prefix $default_prefix
+%define platform_prefix $platform_prefix
+%define set_def_subdir $set_def_subdir
 %define _binary_payload w9.gzdio
 PART_1
 
@@ -56,7 +61,7 @@ Summary: Chapel language compiler and libraries
 Name:    %{name}
 Version: %{version}
 Release: %{pkg_release}
-Prefix:  %{default_prefix}
+Prefix:  %{platform_prefix}
 License: Copyright 2019, Cray Inc. All Rights Reserved.
 Packager: Cray, Inc
 Group:   Development/Languages/Other
@@ -89,8 +94,8 @@ chmod -Rf a+rX,u+w,g-w,o-w .
 %install
 
 cd          %{_topdir}
-mkdir -p                                                $RPM_BUILD_ROOT/opt/cray/admin-pe/set_default_files
-cp -p       set_default_%{real_name}_%{pkg_version}     $RPM_BUILD_ROOT/opt/cray/admin-pe/set_default_files
+mkdir -p                                                $RPM_BUILD_ROOT/%{prefix}/%{set_def_subdir}
+cp -p       set_default_%{real_name}_%{pkg_version}     $RPM_BUILD_ROOT/%{prefix}/%{set_def_subdir}/
 mkdir -p                                                $RPM_BUILD_ROOT/%{prefix}/modulefiles/%{real_name}
 rm -f                                                   $RPM_BUILD_ROOT/%{prefix}/modulefiles/%{real_name}/%{pkg_version}
 cp -p       modulefile-%{pkg_version}                   $RPM_BUILD_ROOT/%{prefix}/modulefiles/%{real_name}/%{pkg_version}
@@ -125,7 +130,7 @@ if [ -f $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/.version ]
 then
 chmod 644 $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/.version
 fi
-chmod 755 /opt/cray/admin-pe/set_default_files/set_default_%{real_name}_%{pkg_version}
+chmod 755 $RPM_INSTALL_PREFIX/%{set_def_subdir}/set_default_%{real_name}_%{pkg_version}
 
 sed --in-place "s:\[BASE_INSTALL_DIR\]:$RPM_INSTALL_PREFIX:g" $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/%{pkg_version}
 
@@ -150,5 +155,5 @@ fi
 %defattr(-,root,root)
 %{prefix}/%{real_name}/%{pkg_version}
 %{prefix}/modulefiles/%{real_name}/%{pkg_version}
-/opt/cray/admin-pe/set_default_files/set_default_%{real_name}_%{pkg_version}
+%{prefix}/%{set_def_subdir}/set_default_%{real_name}_%{pkg_version}
 PART_2

--- a/util/build_configs/cray-internal/generate-set_default.bash
+++ b/util/build_configs/cray-internal/generate-set_default.bash
@@ -22,9 +22,9 @@ source $cwd/common.bash
 # Generate the first part of the file with shell expansion
 
 if [ "$chpl_platform" = cray-shasta ]; then
-    default_prefix=/opt/cray
+    platform_prefix=/opt/cray
 else
-    default_prefix=/opt
+    platform_prefix=/opt
 fi
 
 cat <<PART_1
@@ -32,8 +32,8 @@ cat <<PART_1
 
 export CRAY_product=chapel
 export CRAY_version=$pkg_version
-export CRAY_inst_dir=/opt
-export CRAY_mod_dir=$default_prefix/modulefiles
+export CRAY_inst_dir=$platform_prefix
+export CRAY_mod_dir=$platform_prefix/modulefiles
 export CRAY_mod_names=chapel
 
 PART_1


### PR DESCRIPTION
There are several requirements for an RPM to be relocatable, but the
most fundamental is that all the filepaths begin with the installation
"prefix".  Here, ensure that this is true for Shasta systems.  It
remains untrue for systems before Shasta, but we are not concerned with
those.

While here, update a comment to reflect how to install a Shasta Chapel RPM.