### PR TITLE
Add enum to manually control the diagnostic mode of a nightly perf test

### DIFF
--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -17,6 +17,9 @@ config const correctness = false;
 config const commCount = false;
 config const verboseComm = false;
 config const verboseMem = false;
+
+config const createArrays = true;
+
 config const nElemsTiny = numLocales;
 config const nElemsSmall = if correctness then 100 else 1000000;
 config const nElemsLarge = numLocales*((totMem/numBytes(elemType))/memFraction);
@@ -92,15 +95,16 @@ if correctness || dist == distType.block {
     startDiag();
     const blockDom = localDom dmapped Block(boundingBox=localDom);
     endDiag("domInit", blockDom);
-    {
-      startDiag();
-      const blockArr: [blockDom] elemType;
-      endDiag("arrInit", blockArr);
+    if createArrays {
+      {
+        startDiag();
+        const blockArr: [blockDom] elemType;
+        endDiag("arrInit", blockArr);
 
-      startDiag();
+        startDiag();
+      }
+      endDiag("arrDeinit");
     }
-    endDiag("arrDeinit");
-
     startDiag();
   }
   endDiag("domDeinit");
@@ -111,16 +115,16 @@ if correctness || dist == distType.cyclic {
     startDiag();
     const cyclicDom = localDom dmapped Cyclic(startIdx=localDom.first);
     endDiag("domInit", cyclicDom);
-    {
+    if createArrays {
+      {
+        startDiag();
+        const cyclicArr: [cyclicDom] elemType;
+        endDiag("arrInit", cyclicArr);
 
-      startDiag();
-      const cyclicArr: [cyclicDom] elemType;
-      endDiag("arrInit", cyclicArr);
-
-      startDiag();
+        startDiag();
+      }
+      endDiag("arrDeinit");
     }
-    endDiag("arrDeinit");
-
     startDiag();
   }
   endDiag("domDeinit");
@@ -132,15 +136,16 @@ if correctness || dist == distType.blockCyc {
     const blockCyclicDom = localDom dmapped BlockCyclic(startIdx=localDom.first,
                                                         blocksize=5);
     endDiag("domInit", blockCyclicDom);
-    {
-
-      startDiag();
-      const blockCyclicArr: [blockCyclicDom] elemType;
-      endDiag("arrInit", blockCyclicArr);
-      
-      startDiag();
+    if createArrays {
+      {
+        startDiag();
+        const blockCyclicArr: [blockCyclicDom] elemType;
+        endDiag("arrInit", blockCyclicArr);
+        
+        startDiag();
+      }
+      endDiag("arrDeinit");
     }
-    endDiag("arrDeinit");
 
     startDiag();
   }

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -15,6 +15,7 @@ config const memFraction = 4;
 
 config const correctness = false;
 config const commCount = false;
+config const verboseComm = false;
 config const nElemsTiny = numLocales;
 config const nElemsSmall = if correctness then 100 else 1000000;
 config const nElemsLarge = numLocales*((totMem/numBytes(elemType))/memFraction);
@@ -37,6 +38,9 @@ inline proc startDiag() {
     if commCount {
       startCommDiagnostics();
     }
+    else if verboseComm {
+      startVerboseComm();
+    }
     else {
       t.start();
     }
@@ -53,6 +57,9 @@ inline proc endDiag(name) {
       writeln(name, "-ONS: ", + reduce (d.execute_on + d.execute_on_fast +
                                         d.execute_on_nb));
       resetCommDiagnostics();
+    }
+    else if verboseComm {
+      stopVerboseComm();
     }
     else {
       t.stop();

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -10,7 +10,7 @@ use BlockCycDist;
 type elemType = int;
 
 
-enum diagMode { correctness, performance, commCount, verboseComm, verboseMem };
+enum diagMode { performance, correctness, commCount, verboseComm, verboseMem };
 enum arraySize { tiny, small, large };
 enum distType { block, cyclic, blockCyc };
 
@@ -51,6 +51,9 @@ inline proc startDiag(name) {
   if !shouldRunDiag(name) then return;
 
   select(mode) {
+    when diagMode.performance {
+      t.start();
+    }
     when diagMode.correctness { }
     when diagMode.commCount {
       startCommDiagnostics();
@@ -60,9 +63,6 @@ inline proc startDiag(name) {
     }
     when diagMode.verboseMem {
       startVerboseMem();
-    }
-    when diagMode.performance {
-      t.start();
     }
     otherwise {
       halt("Unrecognized diagMode");

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -16,6 +16,7 @@ config const memFraction = 4;
 config const correctness = false;
 config const commCount = false;
 config const verboseComm = false;
+config const verboseMem = false;
 config const nElemsTiny = numLocales;
 config const nElemsSmall = if correctness then 100 else 1000000;
 config const nElemsLarge = numLocales*((totMem/numBytes(elemType))/memFraction);
@@ -41,6 +42,9 @@ inline proc startDiag() {
     else if verboseComm {
       startVerboseComm();
     }
+    else if verboseMem {
+      startVerboseMem();
+    }
     else {
       t.start();
     }
@@ -60,6 +64,9 @@ inline proc endDiag(name) {
     }
     else if verboseComm {
       stopVerboseComm();
+    }
+    else if verboseMem {
+      stopVerboseMem();
     }
     else {
       t.stop();

--- a/test/performance/array/distCreate.compopts
+++ b/test/performance/array/distCreate.compopts
@@ -1,1 +1,0 @@
--scorrectness=true

--- a/test/performance/array/distCreate.execopts
+++ b/test/performance/array/distCreate.execopts
@@ -1,0 +1,1 @@
+--mode=diagMode.correctness


### PR DESCRIPTION
This PR adds an enum to control the multilocale perf test in
`test/performance/arrays/distCreate.chpl`.

This test measures distributed array/domain init/deinit times, and the following enum
and `config const` is added:

```chapel
enum diagMode { performance, correctness, commCount, verboseComm, verboseMem };
//...
config const mode = diagMode.performance;
```

Also, adds the following flags to control behavior in more detail:
- `createArrays=true`: Whether arrays need to be created
- `reportInit=true`: Report the init diagnostics (time or verbose comm or verbose mem)
- `reportDeinit=true`: Report the init diagnostics (time or verbose comm or verbose mem)

With these defaults nightlies shouldn't be affected. However these flags can be used to eliminate reporting or performance noise to some extent. For example:

```
distCreate -nl2 --mode=diagMode.commCount --createArrays=false --reportDeinit=false ...
```

can be used to track comm calls that happen in domain initialization only.

Test status:
- [x] flags work locally as intended
- [x] standard and gasnet correctness
- [x] nightly performance run isn't affected
        The impact I observe here is not distinguishable from noise. There may be some small bump due to a string operation. I'll observe nightly performance for a while and we may decide to revert it back.