### PR TITLE
Add skipif for test that fails with --baseline

### DIFF
--- a/test/errhandling/misc/forExprReturnsRecOrThrows.skipif
+++ b/test/errhandling/misc/forExprReturnsRecOrThrows.skipif
@@ -1,0 +1,3 @@
+# this test fails with baseline error: throwing non-inlined iterators are not
+# yet supported
+COMPOPTS <= --baseline


### PR DESCRIPTION
`test/errhandling/misc/forExprReturnsRecOrThrows` was added recently as a stopgap
for possible memory leaks in the future. Apparently throwing for expressions are not
supported with --baseline. So this PR adds a skipif to skip this test with baseline for now.

I confirmed that the test is skipped with `start_test -compopts --baseline`