### PR TITLE
Fix KNL locale model afterdecorated new PR

### DIFF
--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -434,7 +434,7 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      helpSetupLocaleNUMA(this, local_name, numSublocales);
+      helpSetupLocaleNUMA(this, local_name, numSublocales, NumaDomain);
 
       ddr = new unmanaged MemoryLocale(c_sublocid_any, this);
 


### PR DESCRIPTION
PR #14298 added an argument to helpSetupLocaleNUMA but missed adding this 
argument to the KNL locale model. This PR resolves the issue.

- [x] hellos pass on a KNL system

Trivial and not reviewed.