### PR TITLE
Adjust mpicc/gasnet testing settings.

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -6,6 +6,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 source $CWD/common.bash
+source $CWD/common-oversubscribed.bash
 
 export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
@@ -17,9 +18,6 @@ export CHPL_TEST_TIMEOUT=500
 
 tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 if [ "${tasks}" == "qthreads" ] ; then
-
-    source $CWD/common-oversubscribed.bash
-
     # Even with oversubscription we still have some timeouts with
     # qtheads+gasnet on "low" core count machines. The main issue is
     # that qthreads assumes it owns the whole machine. When running

--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -9,10 +9,14 @@ source $CWD/common.bash
 export CHPL_TASKS=fifo
 export CHPL_TARGET_COMPILER=mpi-gnu
 
-# Load MPI environment module and confirm it has loaded
-echo >&2 module load mpi
-module load mpi
+# Load OpenMPI environment module and confirm it has loaded
+echo >&2 module load gnu-openmpi
+module load gnu-openmpi
 
 set -x
 : confirm mpi module is loaded
-module list -l 2>&1 | grep -E '\bmpi/mpich\b' || exit $?
+module list -l 2>&1 | grep -E -q '\bgnu-openmpi\b' || exit $?
+
+if [[ ${CHPL_RT_OVERSUBSCRIBED:-n} == [1tTyY]* && -z $MPIRUN_CMD ]] ; then
+  export MPIRUN_CMD='mpirun -np %N -map-by node:oversubscribe %C'
+fi


### PR DESCRIPTION
Use an OpenMPI module instead of an MPICH module for mpicc testing.

Always set CHPL_RT_OVERSUBSCRIBED for gasnet testing, not just with
qthreads tasking.  The tasking layer does matter in some ways, and we
make further adjustments based on that, but we'll be running multiple
processes per node no matter what.

When using mpicc and oversubscribed, throw the 'mpirun --map-by
node:oversubscribed' option, via MPIRUN_CMD.  This tells mpirun the
oversubscription is intentional and what to do about it.