### PR TITLE
Fix the cc-execopts file for the distCreate benchmark

### DIFF
--- a/test/performance/array/distCreate.cc-execopts
+++ b/test/performance/array/distCreate.cc-execopts
@@ -1,3 +1,3 @@
---commCount --size=arraySize.tiny --dist=distType.block  #distCreate-cc-block
---commCount --size=arraySize.tiny --dist=distType.cyclic   #distCreate-cc-cyclic
---commCount --size=arraySize.tiny --dist=distType.blockCyc   #distCreate-cc-blockCyc
+--mode=diagMode.commCount --size=arraySize.tiny --dist=distType.block  #distCreate-cc-block
+--mode=diagMode.commCount --size=arraySize.tiny --dist=distType.cyclic   #distCreate-cc-cyclic
+--mode=diagMode.commCount --size=arraySize.tiny --dist=distType.blockCyc   #distCreate-cc-blockCyc


### PR DESCRIPTION
I missed the cc-execopts file while adjusting the distCreate benchmark. This PR fixes it.