### PR TITLE
Limit non-perf locModel=numa testing to just hellos and localeModels.

### DIFF
--- a/util/cron/test-gasnet.numa.bash
+++ b/util/cron/test-gasnet.numa.bash
@@ -6,6 +6,8 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 source $CWD/common-numa.bash
 
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl localeModels"
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.numa"
 
 # TODO: Do we need/want this? (thomasvandoren, 2014-07-01)

--- a/util/cron/test-numa.bash
+++ b/util/cron/test-numa.bash
@@ -6,6 +6,8 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-numa.bash
 
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl localeModels"
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="numa"
 
 $CWD/nightly -cron


### PR DESCRIPTION
We don't need to be doing nearly so much locModel=numa functional
testing, given that we're also running performance testing on it.  So
here, reduce it to just the hellos and the localeModels suite.

As a beneficial side effect, making numa testing smaller will also make
it a lot simpler to think about moving it around, for load balancing or
other reasons.