### PR TITLE
Have compiler performance testing write temp files to a tmp dir

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -935,7 +935,7 @@ def set_up_performance_testing_B():
 
         compperf_test_name += args.comp_performance_description
 
-        temp_dat_dir = os.path.join(comp_perf_dir, "tempCompPerfDatFiles", "")
+        temp_dat_dir = os.path.join(chpl_test_tmp_dir, "tempCompPerfDatFiles", "")
         os.environ["CHPL_TEST_COMP_PERF_TEMP_DAT_DIR"] = temp_dat_dir
         #remove it if it wasn't cleaned up last time
         if os.path.isdir(temp_dat_dir):


### PR DESCRIPTION
Previously, the compiler performance testing would write all the timings
into the eventual compiler performance dir. Our compiler performance dir
is usually NFS mounted, so this meant we were writing logs for 10,000+
tests to NFS. Adjust to just write to chpl_test_tmp_dir, which should be
on a local disk.