### PR TITLE
Prepare the bytes type and relevant I/O for UTF-8 validation for strings

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -78,6 +78,13 @@ module ByteBufferHelpers {
     return (newBuff, allocSize);
   }
 
+  proc bufferEnsureSize(buf, currentSize, requestedSize) {
+    if currentSize < requestedSize then
+      return bufferRealloc(buf, requestedSize);
+    else
+      return (buf, currentSize);
+  }
+
   proc bufferCopyRemote(src_loc_id: int(64), src_addr: bufferType,
                         len: int): bufferType {
       const dest = chpl_here_alloc(len+1, offset_STR_COPY_REMOTE): bufferType;

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -964,10 +964,10 @@ module Bytes {
             // that it was invalid, if nbytes is >1 then we must have read
             // multible bytes where the last one broke the sequence. But it can
             // be a valid byte itself. So we rewind by 1 in that case
-            if nbytes == 1 then
-              thisIdx += nbytes;
-            else
-              thisIdx += nbytes-1;
+            // we use nInvalidBytes to store how many bytes we are ignoring or
+            // replacing
+            const nInvalidBytes = if nbytes==1 then nbytes else nbytes-1;
+            thisIdx += nInvalidBytes;
 
             if errors == decodePolicy.replace {
               param replChar: int(32) = 0xfffd;
@@ -977,8 +977,10 @@ module Bytes {
               // 0xfffd. It is encoded in `encodedReplChar` and its encoded
               // length is `nbytesRepl`, which is 3 bytes in UTF8. If it is used
               // in place of a single byte, we may overflow
+              const sizeChange = 3-nInvalidBytes;
               (ret.buff, ret._size) = bufferEnsureSize(ret.buff, ret._size,
-                                                       decodedIdx+3);
+                                                       ret._size+sizeChange);
+
               qio_encode_char_buf(ret.buff+decodedIdx, replChar);
 
               decodedIdx += 3;  // replacement character is 3 bytes in UTF8

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -97,9 +97,6 @@ module Bytes {
   private use ByteBufferHelpers;
   private use BytesStringCommon;
 
-  extern proc printf(std: c_string);
-  extern proc printf(std: c_string, val: c_int);
-
   /*
      ``decodePolicy`` specifies what happens when there is malformed characters
      when decoding a :record:`bytes` into a UTF-8 :record:`String.string`.

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -958,9 +958,10 @@ module Bytes {
         var nbytes: c_int;
         var bufToDecode = (localThis.buff + thisIdx): c_string;
         var maxbytes = (localThis.len - thisIdx): ssize_t;
-        qio_decode_char_buf(cp, nbytes, bufToDecode, maxbytes);
+        const decodeRet = qio_decode_char_buf(cp, nbytes,
+                                              bufToDecode, maxbytes);
 
-        if cp == 0xfffd {  //decoder returns the replacement character
+        if decodeRet != 0 {  //decoder returns error
           if errors == decodePolicy.strict {
             throw new owned DecodeError();
           }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -934,6 +934,8 @@ module Bytes {
       var localThis: bytes = this.localize();
 
       // create the encoded replacement character just in case
+      // TODO: maybe this can be moved to runtime to avoid running this
+      // everytime we call decode?
       param replChar: int(32) = 0xfffd;
       const nbytesRepl = qio_nbytes_char(replChar);
       const encodedReplChar = c_malloc(c_char, nbytesRepl);

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -958,6 +958,20 @@ module Bytes {
             thisIdx += nbytes; //skip over the malformed bytes
             continue;
           }
+          else if errors == decodePolicy.replace {
+            // Replacement can cause the string to be larger than initially
+            // expected. The UTF8 replacement character is 0xfffd. If it is used
+            // in place of a single byte, we may overflow
+            (ret.buff, ret._size) = bufferEnsureSize(ret.buff, ret._size,
+                                                     decodedIdx+2);
+
+            ret.buff[decodedIdx] = 0xff:byteType;
+            ret.buff[decodedIdx+1] = 0xfd:byteType;
+
+            thisIdx += nbytes;
+            decodedIdx += 2;
+            continue;
+          }
         }
 
         // do a naive copy

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -97,6 +97,9 @@ module Bytes {
   private use ByteBufferHelpers;
   private use BytesStringCommon;
 
+  extern proc printf(std: c_string);
+  extern proc printf(std: c_string, val: c_int);
+
   /*
      ``decodePolicy`` specifies what happens when there is malformed characters
      when decoding a :record:`bytes` into a UTF-8 :record:`String.string`.
@@ -970,15 +973,15 @@ module Bytes {
 
             thisIdx += nbytes;
             decodedIdx += 2;
-            continue;
           }
         }
-
-        // do a naive copy
-        bufferMemcpyLocal(dst=ret.buff, src=bufToDecode, len=nbytes,
-                          dst_off=decodedIdx);
-        thisIdx += nbytes;
-        decodedIdx += nbytes;
+        else {  // we got valid characters
+          // do a naive copy
+          bufferMemcpyLocal(dst=ret.buff, src=bufToDecode, len=nbytes,
+                            dst_off=decodedIdx);
+          thisIdx += nbytes;
+          decodedIdx += nbytes;
+        }
       }
 
       ret.len = decodedIdx;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5434,22 +5434,6 @@ proc _toString(x:?t) where !_isIoPrimitiveType(t)
 {
   return ("", false);
 }
-private inline
-proc _toStringFromBytesOrString(x:bytes)
-{
-  return (createStringWithBorrowedBuffer(x.buff, length=x.length, size=x._size),
-          true);
-}
-private inline
-proc _toStringFromBytesOrString(x:string)
-{
-  return (x, true);
-}
-private inline
-proc _toStringFromBytesOrString(x)
-{
-  return ("", false);
-}
 
 private inline
 proc _toChar(x:?t) where isIntegralType(t)
@@ -6194,7 +6178,7 @@ proc channel.writef(fmtStr: string, const args ...?k): bool throws {
               err = qio_format_error_arg_mismatch(i);
             } else err = _write_one_internal(_channel_internal, iokind.dynamic, new ioChar(t), origLocale);
           } when QIO_CONV_ARG_TYPE_BINARY_STRING {
-            var (t,ok) = _toStringFromBytesOrString(args(i));
+            var (t,ok) = _toBytes(args(i));
             if ! ok {
               err = qio_format_error_arg_mismatch(i);
             } else err = _write_one_internal(_channel_internal, iokind.dynamic, t, origLocale);
@@ -6444,7 +6428,7 @@ proc channel.readf(fmtStr:string, ref args ...?k): bool throws {
               } else err = _read_one_internal(_channel_internal, iokind.dynamic, chr, origLocale);
               if ! err then _setIfChar(args(i),chr.ch);
             } when QIO_CONV_ARG_TYPE_BINARY_STRING {
-              var (t,ok) = _toStringFromBytesOrString(args(i));
+              var (t,ok) = _toBytes(args(i));
               if ! ok {
                 err = qio_format_error_arg_mismatch(i);
               }

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -803,7 +803,7 @@ unlock:
   return err;
 }
 
-// allocates and returns a string.
+// allocates and returns a string without checking for valid encoding
 qioerr qio_channel_scan_bytes(const int threadsafe, qio_channel_t* restrict ch, const char* restrict * restrict out, int64_t* restrict len_out, ssize_t maxlen_bytes)
 {
   qioerr err;

--- a/test/types/bytes/decode.chpl
+++ b/test/types/bytes/decode.chpl
@@ -44,6 +44,10 @@ var almostHwairToStringRepl = almostHwairFlippedBit.decode(decodePolicy.replace)
 // valid bytes
 writeln("Should be 9: ", almostHwairToStringRepl.numBytes);
 
+//make sure the decoded buffer is actually valid (i.e. can be re-decoded with
+//decodePolicy.strict)
+writeln((almostHwairToStringRepl:bytes).decode());
+
 
 //now create another almost equal one where the fourth byte is replaced with a
 //valid ASCII character. All continuation bytes must be in form 0b10xxxxxx in
@@ -57,9 +61,17 @@ almostHwairToStringRepl = almostHwairValidAscii.decode(decodePolicy.replace);
 // valid bytes
 writeln("Should be 7: ", almostHwairToStringRepl.numBytes);
 
+//make sure the decoded buffer is actually valid (i.e. can be re-decoded with
+//decodePolicy.strict)
+writeln((almostHwairToStringRepl:bytes).decode());
+
 var almostHwairToStringIgnr = almostHwairValidAscii.decode(decodePolicy.ignore);
 // number of bytes should be 4 -- only the last four must be in the string
 writeln("Should be 4: ", almostHwairToStringIgnr.numBytes);
+
+//make sure the decoded buffer is actually valid (i.e. can be re-decoded with
+//decodePolicy.strict)
+writeln((almostHwairToStringIgnr:bytes).decode());
 writeln("End Hwair tests");
 
 //finally make sure that the strict error policy is actually strict

--- a/test/types/bytes/decode.chpl
+++ b/test/types/bytes/decode.chpl
@@ -14,6 +14,37 @@ writeln("String with the ignore policy: ", ignoredString,
 const replacedString = invalid_utf8.decode(errors=decodePolicy.replace);
 writeln("String with the replace policy: ", replacedString,
         " (length=", replacedString.numBytes, ")");
+
+// what happens if replacement increases the size of the string?
+var allInvalidBytes = b"\xff\xff\xff\xff\xff";  // 5 invalid bytes
+writeln(allInvalidBytes.decode(errors=decodePolicy.replace).numBytes); // 10
+
+// what happens if there is a broken byte in an otherwise valid multibyte
+// sequence?
+var hwair = b"\xF0\x90\x8D\x88"; // UTF-8 encoding for gothic letter "hwair"
+
+//first make sure that this is decoded correctly:
+writeln(hwair.decode());
+
+writeln("Hwair tests");
+//now create an almost equal one with single flipped bit. All continuation bytes
+//must be in form 0b10xxxxxx in UTF-8. However, we flip one bit in the last byte
+//to make it 0b11xxxxxx, which is invalid
+var almostHwair = b"\xF0\x90\x8D\xC8"; // the last byte is broken
+
+// the decoded string should contain two replacement characters in this
+// scenario: (1) for the first three characters, because the first byte said
+// that this is a 4-byte sequence, but the last byte is not valid continuation
+// which should have been in the form 0b10xxxxxxx
+var almostHwairToString = almostHwair.decode(decodePolicy.replace);
+writeln(almostHwairToString.numBytes); // number of bytes should be 4
+writeln(almostHwairToString.length); // number of bytes should be 4
+writeln(almostHwairToString.numCodepoints);
+for cp in almostHwairToString.codepoints() do
+  writeln(cp);
+writeln("End Hwair tests");
+
+//finally make sure that the strict error policy is actually strict
 try! {
   const strictString = invalid_utf8.decode(errors=decodePolicy.strict);
 }

--- a/test/types/bytes/decode.chpl
+++ b/test/types/bytes/decode.chpl
@@ -17,7 +17,8 @@ writeln("String with the replace policy: ", replacedString,
 
 // what happens if replacement increases the size of the string?
 var allInvalidBytes = b"\xff\xff\xff\xff\xff";  // 5 invalid bytes
-writeln(allInvalidBytes.decode(errors=decodePolicy.replace).numBytes); // 10
+writeln("Should be 15: ",
+        allInvalidBytes.decode(errors=decodePolicy.replace).numBytes);
 
 // what happens if there is a broken byte in an otherwise valid multibyte
 // sequence?
@@ -29,19 +30,36 @@ writeln(hwair.decode());
 writeln("Hwair tests");
 //now create an almost equal one with single flipped bit. All continuation bytes
 //must be in form 0b10xxxxxx in UTF-8. However, we flip one bit in the last byte
-//to make it 0b11xxxxxx, which is invalid
-var almostHwair = b"\xF0\x90\x8D\xC8"; // the last byte is broken
+//to make it 0b11xxxxxx, which is invalid. This one also have some ASCII
+//(therefore, UTF-8) bytes following the invalid byte
+var almostHwairFlippedBit = b"\xF0\x90\x8D\xC8\x41\x42\x43"; // the 4th byte is broken
 
 // the decoded string should contain two replacement characters in this
 // scenario: (1) for the first three characters, because the first byte said
 // that this is a 4-byte sequence, but the last byte is not valid continuation
-// which should have been in the form 0b10xxxxxxx
-var almostHwairToString = almostHwair.decode(decodePolicy.replace);
-writeln(almostHwairToString.numBytes); // number of bytes should be 4
-writeln(almostHwairToString.length); // number of bytes should be 4
-writeln(almostHwairToString.numCodepoints);
-for cp in almostHwairToString.codepoints() do
-  writeln(cp);
+// which should have been in the form 0b10xxxxxxx (2) for the last invalid byte
+// itself
+var almostHwairToStringRepl = almostHwairFlippedBit.decode(decodePolicy.replace);
+// number of bytes should be 9 = 2*3 from replacement bytes, 3 from the trailing
+// valid bytes
+writeln("Should be 9: ", almostHwairToStringRepl.numBytes);
+
+
+//now create another almost equal one where the fourth byte is replaced with a
+//valid ASCII character. All continuation bytes must be in form 0b10xxxxxx in
+//UTF-8. So, that ASCII character will break the previous sequence but itself is
+//valid and should remain in the decoded string. This one also have some ASCII
+//(therefore, UTF-8) bytes following the invalid byte
+var almostHwairValidAscii = b"\xF0\x90\x8D\x41\x41\x42\x43"; // the 4th byte is broken
+
+almostHwairToStringRepl = almostHwairValidAscii.decode(decodePolicy.replace);
+// number of bytes should be 7 = 1*3 from replacement byte, 4 from the trailing
+// valid bytes
+writeln("Should be 7: ", almostHwairToStringRepl.numBytes);
+
+var almostHwairToStringIgnr = almostHwairValidAscii.decode(decodePolicy.ignore);
+// number of bytes should be 4 -- only the last four must be in the string
+writeln("Should be 4: ", almostHwairToStringIgnr.numBytes);
 writeln("End Hwair tests");
 
 //finally make sure that the strict error policy is actually strict

--- a/test/types/bytes/decode.good
+++ b/test/types/bytes/decode.good
@@ -2,5 +2,12 @@ Base unicode string : Türkçe (length=8)
 Print as bytes: Türkçe
 Decoded string: Türkçe
 String with the ignore policy: Türkçe (length=8)
-String with the replace policy: Tü��rkçe (length=10)
+String with the replace policy: Tü�rkçe (length=11)
+Should be 15: 15
+𐍈
+Hwair tests
+Should be 9: 9
+Should be 7: 7
+Should be 4: 4
+End Hwair tests
 DecodeError: Invalid UTF-8 character encountered.

--- a/test/types/bytes/decode.good
+++ b/test/types/bytes/decode.good
@@ -2,5 +2,5 @@ Base unicode string : Türkçe (length=8)
 Print as bytes: Türkçe
 Decoded string: Türkçe
 String with the ignore policy: Türkçe (length=8)
-String with the replace policy: Tü�rkçe (length=9)
+String with the replace policy: Tü��rkçe (length=10)
 DecodeError: Invalid UTF-8 character encountered.

--- a/test/types/bytes/decode.good
+++ b/test/types/bytes/decode.good
@@ -7,7 +7,10 @@ Should be 15: 15
 𐍈
 Hwair tests
 Should be 9: 9
+��ABC
 Should be 7: 7
+�AABC
 Should be 4: 4
+AABC
 End Hwair tests
 DecodeError: Invalid UTF-8 character encountered.


### PR DESCRIPTION
While investigating the potential side effects of UTF-8 validation on the
`bytes` type I found two issues that are fixed in this PR:

- `decode()` checked whether the returned codepoint from 
   `qio_decode_char_buf` was replacement character (0xfffd) to determine
    whether the byte sequence was UTF-8 or not. This was wrong, because the
    replacement character is valid UTF-8.

- `decode()` with `decodePolicy.replace` did not actually replace the non-UTF-8
  byte sequence with the UTF-8 replacement character. Now it replaces each
  sequence with a single replacement character. This is aligned to what
  `qio_decode_char_buf` is doing. We may consider replacing each byte in the
   sequence with the replacement character.

- Binary reads and writes with `bytes` type used `string` temporaries. This was
  an intentional corner-cutting while implementing the initial I/O support for
  the `bytes` type. But currently we don't need that.

Resolves https://github.com/Cray/chapel-private/issues/400

Todo:
- [x] add more complicated tests for `decode`
- [x] correctness tests
  - [x] standard (with -futures, just in case)
  - [x] gasnet
  - [x] quickstart valgrind in `test/types/bytes`
