### PR TITLE
Give compiler performance jobs symbolic graph names

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -105,9 +105,10 @@ export CHPL_NIGHTLY_CRON_LOGDIR=$CHPL_NIGHTLY_LOGDIR
 
 # It is tempting to use hostname --short, but macs only support the short form
 # of the argument.
+export CHPL_TEST_PERF_CONFIG_NAME=${CHPL_TEST_PERF_CONFIG_NAME:-$(hostname -s)}
 if [ -z "$CHPL_TEST_PERF_DIR" ]; then
-    export CHPL_TEST_PERF_DIR=$PERF_LOGDIR_PREFIX/NightlyPerformance/$(hostname -s)
+    export CHPL_TEST_PERF_DIR=$PERF_LOGDIR_PREFIX/NightlyPerformance/$CHPL_TEST_PERF_CONFIG_NAME
 fi
 if [ -z "$CHPL_TEST_COMP_PERF_DIR" ]; then
-    export CHPL_TEST_COMP_PERF_DIR=$PERF_LOGDIR_PREFIX/NightlyPerformance/$(hostname -s)
+    export CHPL_TEST_COMP_PERF_DIR=$PERF_LOGDIR_PREFIX/NightlyPerformance/$CHPL_TEST_PERF_CONFIG_NAME
 fi

--- a/util/cron/test-fast.bash
+++ b/util/cron/test-fast.bash
@@ -4,6 +4,9 @@
 # linux64.
 
 CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='comp-fast'
+
 source $CWD/common.bash
 source $CWD/common-fast.bash
 

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -4,6 +4,9 @@
 # linux64.
 
 CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='comp-default'
+
 source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"

--- a/util/cron/test-no-local.bash
+++ b/util/cron/test-no-local.bash
@@ -4,6 +4,9 @@
 # on linux64.
 
 CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='comp-no-local'
+
 source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-local"


### PR DESCRIPTION
Previously, we just used the machine name as the config name, but we're
moving machines soon, so give them symbolic names.

 - chap01 -> comp-default
 - chap08 -> comp-no-local
 - chap12 -> comp-fast