### PR TITLE
Add option to prevent making concurrent MPI calls in multiple tasks.

### DIFF
--- a/test/library/packages/MPI/spmd/hello-chapel/hello.compopts
+++ b/test/library/packages/MPI/spmd/hello-chapel/hello.compopts
@@ -1,0 +1,1 @@
+-srequireThreadedMPI=false


### PR DESCRIPTION
In #14316 we switched from MPICH to OpenMPI because our MPICH doesn't
work with SLES12.  But now we're running into the OpenMPI limitation
documented in #6516.  Here, throw `-srequireThreadedMPI=false` at compile
time to work around this.