### PR TITLE
mpicc.gasnet testing must first do gasnet settings, then mpicc ones.

### DIFF
--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -3,8 +3,8 @@
 # Test MPI Module for CHPL_COMM=gasnet on linux64
 
 CWD=$(cd $(dirname $0) ; pwd)
-source $CWD/common-mpicc.bash
 source $CWD/common-gasnet.bash
+source $CWD/common-mpicc.bash
 
 export CHPL_COMM_SUBSTRATE=mpi
 


### PR DESCRIPTION
In mpicc.gasnet testing, the mpicc-related settings now depend partly on
the gasnet-related ones, so it's important to do them in the right
order!  Yesterday's #14316 changes, which created this dependence,
didn't arrange for this.  Do so here.