### PR TITLE
Improve how we initialize the runtime for --cache-remote

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2725,20 +2725,6 @@ void chpl_cache_do_init(void)
 
 void chpl_cache_init(void) {
 
-  // Take default CHPL_CACHE_REMOTE value from the environment if it is set.
-  /*char* p;
-  if ((p = getenv("CHPL_CACHE_REMOTE")) != NULL) {
-    if( p[0] == 'y' || p[0] == 'Y' || p[0] == '1' ) CHPL_CACHE_REMOTE = 1;
-    else if( p[0] == 'n' || p[0] == 'N' || p[0] == '0' ) CHPL_CACHE_REMOTE = 0;
-    else chpl_warning("unknown setting for CHPL_CACHE_REMOTE, try 0 or 1", 0, NULL);
-  }
-
-  // Don't enable the cache for 1-locale runs.
-  if( chpl_numNodes <= 1 ) {
-    CHPL_CACHE_REMOTE = 0;
-  }*/
-
-  // Don't initialize TLS if the cache is not enabled.
   if( ! chpl_cache_enabled() ) {
     return;
   }

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -23,6 +23,7 @@
 #include "chpl_rt_utils_static.h"
 #include "chplcast.h"
 #include "chplcgfns.h"
+#include "chpl-cache.h"
 #include "chpl-comm.h"
 #include "chplexit.h"
 #include "chplio.h"
@@ -197,6 +198,9 @@ void chpl_rt_init(int argc, char* argv[]) {
   // tasking layer is initialized.
   //
   chpl_comm_post_task_init();
+#ifdef HAS_CHPL_CACHE_FNS
+  chpl_cache_init();
+#endif
   chpl_comm_rollcall();
 
   //

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -40,7 +40,6 @@
 #include "error.h"
 #include "chpl-mem-desc.h"
 #include "chpl-mem-sys.h" // mem layer not initialized in init, need sys alloc
-#include "chpl-cache.h" // to call chpl_cache_init()
 
 // Don't get warning macros for chpl_comm_get etc
 #include "chpl-comm-no-warning-macros.h"
@@ -898,9 +897,6 @@ int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {
 
 void chpl_comm_post_task_init(void) {
   start_polling();
-
-  // Initialize the caching layer, if it is active.
-  chpl_cache_init();
 }
 
 void chpl_comm_rollcall(void) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -24,7 +24,6 @@
 #include "chplrt.h"
 #include "chpl-env-gen.h"
 
-// #include "chpl-cache.h"
 #include "chpl-comm.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
@@ -461,8 +460,6 @@ void chpl_comm_post_task_init(void) {
     return;
   init_ofi();
   init_bar();
-
-  // chpl_cache_init();
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -51,7 +51,6 @@
 #include "chplcgfns.h"
 #include "chpl-gen-includes.h"
 #include "chplrt.h"
-#include "chpl-cache.h"
 #include "chpl-comm.h"
 #include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
@@ -2167,11 +2166,6 @@ void chpl_comm_post_task_init(void)
   //
   while (polling_task_running == false)
     sched_yield();
-
-  //
-  // Initialize the caching layer, if it is active.
-  //
-  chpl_cache_init();
 }
 
 


### PR DESCRIPTION
Previously `--cache-remote` was broken for `-nl 1` under ugni. ugni
wasn't calling `chpl_cache_init()`, but `chpl_cache_fence()` was getting
called, which called `pthread_setspecific()` on a key that was never
created. Instead of adjusting ugni, change to always calling
`chpl_cache_init()`.