### PR TITLE
Allow for testing locModel=numa on non-NUMA systems

### DIFF
--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -151,8 +151,8 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, out numSublocales, type NumaDomain) {
     helpSetupLocaleFlat(dst, local_name);
 
-    extern proc chpl_task_getNumSublocales(): int(32);
-    numSublocales = chpl_task_getNumSublocales();
+    extern proc chpl_topo_getNumNumaDomains(): c_int;
+    numSublocales = chpl_topo_getNumNumaDomains();
 
     extern proc chpl_task_getMaxPar(): uint(32);
 

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -147,9 +147,9 @@ module LocaleModel {
   export
   proc chpl_localeModel_sublocToExecutionSubloc(full_subloc:chpl_sublocID_t)
   {
-    extern proc chpl_task_getNumSublocales(): int(32);
+    extern proc chpl_topo_getNumNumaDomains(): c_int;
     const (whichNuma, memoryKind) =
-      unpackSublocID(chpl_task_getNumSublocales(),
+      unpackSublocID(chpl_topo_getNumNumaDomains(),
                      full_subloc:chpl_sublocID_t);
     return whichNuma:chpl_sublocID_t;
   }
@@ -158,8 +158,8 @@ module LocaleModel {
   proc chpl_localeModel_sublocMerge(full_subloc:chpl_sublocID_t,
                            execution_subloc:chpl_sublocID_t): chpl_sublocID_t
   {
-    extern proc chpl_task_getNumSublocales(): int(32);
-    var nNumaDomains:int = chpl_task_getNumSublocales();
+    extern proc chpl_topo_getNumNumaDomains(): c_int;
+    var nNumaDomains:int = chpl_topo_getNumNumaDomains();
     var memoryKind:int;
     //
     // Strip the memory kind out of the full_subloc and attach it
@@ -207,13 +207,13 @@ module LocaleModel {
     }
 
     proc init(_sid, _parent) {
-      extern proc chpl_task_getNumSublocales(): int(32);
+      extern proc chpl_topo_getNumNumaDomains(): c_int;
 
       super.init(_parent);
 
       sid = _sid: chpl_sublocID_t;
       const (whichNuma, kind) =
-        unpackSublocID(chpl_task_getNumSublocales(), sid);
+        unpackSublocID(chpl_topo_getNumNumaDomains(), sid);
       var kindstr:string;
       if kind == memoryKindDDR() then
         kindstr = "DDR";
@@ -274,8 +274,8 @@ module LocaleModel {
     }
 
     proc init(_sid, _parent) {
-      extern proc chpl_task_getNumSublocales(): int(32);
-      var numSublocales = chpl_task_getNumSublocales();
+      extern proc chpl_topo_getNumNumaDomains(): c_int;
+      var numSublocales = chpl_topo_getNumNumaDomains();
 
       super.init(_parent);
 
@@ -553,15 +553,15 @@ module LocaleModel {
   //
   private inline
   proc allocatingInHbmSublocale(): bool {
-    extern proc chpl_task_getNumSublocales(): int(32);
-    return chpl_task_getRequestedSubloc() >= chpl_task_getNumSublocales();
+    extern proc chpl_topo_getNumNumaDomains(): c_int;
+    return chpl_task_getRequestedSubloc() >= chpl_topo_getNumNumaDomains();
   }
 
   private inline
   proc addrIsInHbm(addr:c_void_ptr): bool {
     extern proc chpl_topo_getMemLocality(p:c_void_ptr): chpl_sublocID_t;
-    extern proc chpl_task_getNumSublocales(): int(32);
-    return chpl_topo_getMemLocality(addr) >= chpl_task_getNumSublocales();
+    extern proc chpl_topo_getNumNumaDomains(): c_int;
+    return chpl_topo_getMemLocality(addr) >= chpl_topo_getNumNumaDomains();
   }
 
   export

--- a/runtime/include/chpl-env.h
+++ b/runtime/include/chpl-env.h
@@ -32,11 +32,12 @@ const char* chpl_env_rt_get(const char*, const char*);
 
 //
 // These convert string values, presumably from environment variables,
-// to typed values (boolean, int, or size), with a default.
+// to typed values (boolean, int, uint, or size), with a default.
 //
 chpl_bool chpl_env_str_to_bool(const char*, const char*, chpl_bool);
 int64_t chpl_env_str_to_int(const char*, const char*, int64_t);
 int chpl_env_str_to_int_pct(const char*, const char*, int, chpl_bool);
+uint64_t chpl_env_str_to_uint(const char*, const char*, uint64_t);
 size_t chpl_env_str_to_size(const char*, const char*, size_t);
 
 //
@@ -56,6 +57,11 @@ int64_t chpl_env_rt_get_int(const char* ev, int64_t dflt) {
 static inline
 int chpl_env_rt_get_int_pct(const char* ev, int dflt, chpl_bool doWarn) {
   return chpl_env_str_to_int_pct(ev, chpl_env_rt_get(ev, NULL), dflt, doWarn);
+}
+
+static inline
+uint64_t chpl_env_rt_get_uint(const char* ev, uint64_t dflt) {
+  return chpl_env_str_to_uint(ev, chpl_env_rt_get(ev, NULL), dflt);
 }
 
 static inline

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -305,12 +305,6 @@ chpl_task_ChapelData_t* chpl_task_getChapelData(void)
 uint32_t chpl_task_getMaxPar(void);
 
 //
-// Returns the number of sublocales the tasking layer knows about,
-// within the span of hardware it is managing tasks on.
-//
-c_sublocid_t chpl_task_getNumSublocales(void);
-
-//
 // returns the value of the call stack size limit being used in
 // practice; the value returned may potentially differ from one locale
 // to the next

--- a/runtime/src/chpl-env.c
+++ b/runtime/src/chpl-env.c
@@ -34,6 +34,22 @@
 #include <string.h>
 
 
+#define GRIPE(name, kind, val, kindFmt, dflt)                           \
+  do {                                                                  \
+    if (name == NULL) {                                                 \
+      chpl_msg(1,                                                       \
+               "warning: env var improper %s value \"%s\", "            \
+               "assuming %" kindFmt "\n",                               \
+               val, kind, dflt);                                        \
+    } else {                                                            \
+      chpl_msg(1,                                                       \
+               "warning: CHPL_RT_%s improper %s value \"%s\", "         \
+               "assuming %" kindFmt "\n",                               \
+               name, kind, val, dflt);                                  \
+    }                                                                   \
+  } while (0)
+
+
 const char* chpl_env_rt_get(const char* evs, const char* dflt) {
   char evName[100];
   const char* evVal;
@@ -57,15 +73,7 @@ chpl_bool chpl_env_str_to_bool(const char* evName, const char* evVal,
   if (strchr("1tTyY", evVal[0]) != NULL)
     return true;
 
-  if (evName == NULL) {
-    chpl_msg(1,
-             "warning: env var improper bool value \"%s\", assuming %c\n",
-             evVal, (dflt ? 'T' : 'F'));
-  } else {
-    chpl_msg(1,
-             "warning: CHPL_RT_%s improper bool value \"%s\", assuming %c\n",
-             evName, evVal, (dflt ? 'T' : 'F'));
-  }
+  GRIPE(evName, "bool", evVal, "c", (dflt ? 'T' : 'F'));
 
   return dflt;
 }
@@ -81,17 +89,7 @@ int64_t chpl_env_str_to_int(const char* evName, const char* evVal,
   if (sscanf(evVal, "%" SCNi64, &val) == 1)
     return val;
 
-  if (evName == NULL) {
-    chpl_msg(1,
-             "warning: env var improper int value \"%s\", assuming "
-             "%" PRId64 "\n",
-             evVal, dflt);
-  } else {
-    chpl_msg(1,
-             "warning: CHPL_RT_%s improper int value \"%s\", assuming "
-             "%" PRId64 "\n",
-             evName, evVal, dflt);
-  }
+  GRIPE(evName, "int", evVal, PRId64, dflt);
 
   return dflt;
 }
@@ -112,18 +110,25 @@ int chpl_env_str_to_int_pct(const char* evName, const char* evVal,
   }
 
   if (doWarn) {
-    if (evName == NULL) {
-      chpl_msg(1,
-               "warning: env var improper int percentage \"%s\", assuming "
-               "%d\n",
-               evVal, dflt);
-    } else {
-      chpl_msg(1,
-               "warning: CHPL_RT_%s improper int percentage \"%s\", assuming "
-               "%d\n",
-               evName, evVal, dflt);
-    }
+    GRIPE(evName, "int percentage", evVal, "d", dflt);
   }
+
+  return dflt;
+}
+
+
+uint64_t chpl_env_str_to_uint(const char* evName, const char* evVal,
+                              uint64_t dflt) {
+  int64_t val;
+
+  if (evVal == NULL)
+    return dflt;
+
+  if (isdigit(evVal[0])
+      && sscanf(evVal, "%" SCNu64, &val) == 1)
+    return val;
+
+  GRIPE(evName, "unsigned int", evVal, PRIu64, dflt);
 
   return dflt;
 }
@@ -157,17 +162,7 @@ size_t chpl_env_str_to_size(const char* evName, const char* evVal,
   }
 
   if (!okay) {
-    if (evName == NULL) {
-      chpl_msg(1,
-               "warning: env var improper size value \"%s\", assuming %zd\n",
-               evVal, dflt);
-    } else {
-      chpl_msg(1,
-               "warning: CHPL_RT_%s improper size value \"%s\", assuming "
-               "%zd\n",
-               evName, evVal, dflt);
-    }
-
+    GRIPE(evName, "size", evVal, "zd", dflt);
     return dflt;
   }
 

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -829,10 +829,6 @@ uint32_t chpl_task_getMaxPar(void) {
   return max;
 }
 
-c_sublocid_t chpl_task_getNumSublocales(void) {
-  return 0;
-}
-
 chpl_task_prvData_t* chpl_task_getPrvData(void) {
   return & get_current_ptask()->chpl_data.prvdata;
 }

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1018,14 +1018,6 @@ uint32_t chpl_task_getMaxPar(void) {
     return (uint32_t) qthread_num_workers();
 }
 
-c_sublocid_t chpl_task_getNumSublocales(void)
-{
-    // FIXME: What we really want here is the number of NUMA
-    // sublocales we are supporting.  For now we use the number of
-    // shepherds as a proxy for that.
-    return (c_sublocid_t) qthread_num_shepherds();
-}
-
 size_t chpl_task_getCallStackSize(void)
 {
     PROFILE_INCR(profile_task_getCallStackSize,1);

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -497,6 +497,18 @@ static void setupAvailableParallelism(int32_t maxThreads) {
             hwpar = maxThreads;
         }
 
+        //
+        // If we have NUMA sublocales we have to have at least that many
+        // shepherds, or we'll get internal errors when the module code
+        // tries to fire tasks on those sublocales.
+        //
+        {
+            int numNumaDomains = chpl_topo_getNumNumaDomains();
+            if (numNumaDomains > hwpar) {
+                hwpar = numNumaDomains;
+            }
+        }
+
         // If there is more parallelism requested than the number of cores, set the
         // worker unit to pu, otherwise core.
         if (hwpar > chpl_topo_getNumCPUsPhysical(true)) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -504,8 +504,13 @@ static void setupAvailableParallelism(int32_t maxThreads) {
         //
         {
             int numNumaDomains = chpl_topo_getNumNumaDomains();
-            if (numNumaDomains > hwpar) {
-                hwpar = numNumaDomains;
+            if (hwpar < numNumaDomains) {
+                char msg[100];
+                snprintf(msg, sizeof(msg),
+                         "%d NUMA domains but only %d Qthreads shepherds; "
+                         "may get internal errors",
+                         numNumaDomains, (int) hwpar);
+                chpl_warning(msg, 0, 0);
             }
         }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -504,7 +504,8 @@ static void setupAvailableParallelism(int32_t maxThreads) {
         //
         {
             int numNumaDomains = chpl_topo_getNumNumaDomains();
-            if (hwpar < numNumaDomains) {
+            if (hwpar < numNumaDomains
+                && strcmp(CHPL_LOCALE_MODEL, "flat") != 0) {
                 char msg[100];
                 snprintf(msg, sizeof(msg),
                          "%d NUMA domains but only %d Qthreads shepherds; "

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -23,6 +23,7 @@
 #include "chplrt.h"
 
 #include "chpl-align.h"
+#include "chpl-env.h"
 #include "chpl-env-gen.h"
 #include "chplcgfns.h"
 #include "chplsys.h"
@@ -172,9 +173,29 @@ void chpl_topo_init(void) {
   //
   // Find the NUMA nodes, that is, the objects at numaLevel that also
   // have CPUs.  This is as opposed to things like Xeon Phi HBM, which
-  // is memory-only, no CPUs.
+  // is memory-only, no CPUs.  Allow for overriding this through the
+  // environment.
   //
-  {
+  if (strcmp(CHPL_LOCALE_MODEL, "flat") != 0) {
+    //
+    // The number of NUMA domains only matters for locale models other
+    // than 'flat'.
+    //
+    numNumaDomains = (int) chpl_env_rt_get_uint("NUM_NUMA_DOMAINS", 0);
+    if (numNumaDomains != 0) {
+      //
+      // If you're using Qthreads tasking, forcing the number of NUMA
+      // domains also forces the number of Qthreads shepherds.  (If we
+      // don't do this we can find ourselves trying to queue tasks on
+      // nonexistent shepherds.)
+      //
+      if (strcmp(CHPL_TASKS, "qthreads") == 0) {
+        chpl_env_set_uint("CHPL_RT_NUM_THREADS_PER_LOCALE", numNumaDomains, 1);
+      }
+    }
+  }
+
+  if (numNumaDomains == 0) {
     const hwloc_cpuset_t cpusetAll = hwloc_get_root_obj(topology)->cpuset;
     numNumaDomains =
       hwloc_get_nbobjs_inside_cpuset_by_depth(topology, cpusetAll, numaLevel);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -182,17 +182,6 @@ void chpl_topo_init(void) {
     // than 'flat'.
     //
     numNumaDomains = (int) chpl_env_rt_get_uint("NUM_NUMA_DOMAINS", 0);
-    if (numNumaDomains != 0) {
-      //
-      // If you're using Qthreads tasking, forcing the number of NUMA
-      // domains also forces the number of Qthreads shepherds.  (If we
-      // don't do this we can find ourselves trying to queue tasks on
-      // nonexistent shepherds.)
-      //
-      if (strcmp(CHPL_TASKS, "qthreads") == 0) {
-        chpl_env_set_uint("CHPL_RT_NUM_THREADS_PER_LOCALE", numNumaDomains, 1);
-      }
-    }
   }
 
   if (numNumaDomains == 0) {

--- a/test/localeModels/gbt/maxTaskPar.skipif
+++ b/test/localeModels/gbt/maxTaskPar.skipif
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Skip the test if we're running with a synthetic NUMA domain count.
+# When we use that feature we don't end up with an entirely rational
+# topology and thus the program's output is somewhat bizarre.  Making
+# the .prediff match that would be hard.
+
+if [ -n "$CHPL_RT_NUM_NUMA_DOMAINS" ] ; then
+    echo "True"
+else
+    echo "False"
+fi


### PR DESCRIPTION
We've been getting the number of NUMA domains (sublocales) by calling a
function in the tasking layer.  But the topology layer can also supply
that information and is a better source.  So here, switch to the latter.

In addition, allow for explicitly forcing the apparent number of NUMA
domains, by setting the environment variable `CHPL_RT_NUM_NUMA_DOMAINS`.
This allows testing locModel=numa on systems that don't actually have
multiple NUMA domains.  This internal-only env var is intentionally not
documented, because while it makes it appear there are the given number
of NUMA domains it doesn't completely adjust the topology to match, and
this can lead to bizarre results if things are carried too far.  All the
same, with this the release/examples/hello and localeModels tests we
currently run all pass, expect for localeModels/gbt/maxTaskPar.  With a
synthetic NUMA domain count that one produces output which would be hard
to predict in its .prediff file without going to more effort than seems
worthwhile.  So we just skip it, if `CHPL_RT_NUMA_NUMA_DOMAINS` is set.

This resolves https://github.com/Cray/chapel-private/issues/540.