### PR TITLE
Align binaryInsertionSort perfdat filename with sorts-quadratic.graph

### DIFF
--- a/test/library/packages/Sort/performance/performance.perfexecopts
+++ b/test/library/packages/Sort/performance/performance.perfexecopts
@@ -4,4 +4,4 @@
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort
---sorts='r' --M=12 --correctness=false            # binary insertion sort
+--sorts='r' --M=12 --correctness=false            # binaryInsertionSort

--- a/test/library/packages/Sort/performance/sorts-quadratic.graph
+++ b/test/library/packages/Sort/performance/sorts-quadratic.graph
@@ -1,4 +1,4 @@
-perfkeys: (seconds):, (seconds):, (seconds):
+perfkeys: (seconds):, (seconds):, (seconds):, (seconds):
 files: insertionSort.dat, selectionSort.dat, bubbleSort.dat, binaryInsertionSort.dat
 graphkeys: insertionSort, selectionSort, bubbleSort, binaryInsertionSort
 graphtitle: Quadratic sorts on 2^12 bytes of shuffled data


### PR DESCRIPTION
sorts-quadratic.graph expects the binary insertion sort's perfdat file
to be named binaryInsertionSort, so adjust the perfexecopts file to
name it that.

Also, add binaryInsertionSort perfkey to sorts-quadratic.graph (Thanks @ronawho )

resolves #13255
