### PR TITLE
Force 2 NUMA domains per compute node, for numa functional testing.

### DIFF
--- a/util/cron/test-gasnet.numa.bash
+++ b/util/cron/test-gasnet.numa.bash
@@ -6,6 +6,13 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 source $CWD/common-numa.bash
 
+#
+# Force runtime topology to say we have 2 NUMA domains per compute node.
+# If we actually do this has no real effect.  If not, in all likelihood
+# we have 0 (zero), and we need this to get the expected testing output.
+#
+export CHPL_RT_NUM_NUMA_DOMAINS=2
+
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl localeModels"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.numa"

--- a/util/cron/test-numa.bash
+++ b/util/cron/test-numa.bash
@@ -6,6 +6,13 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-numa.bash
 
+#
+# Force runtime topology to say we have 2 NUMA domains per compute node.
+# If we actually do this has no real effect.  If not, in all likelihood
+# we have 0 (zero), and we need this to get the expected testing output.
+#
+export CHPL_RT_NUM_NUMA_DOMAINS=2
+
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl localeModels"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="numa"


### PR DESCRIPTION
For locModel=numa testing, force 2 NUMA domains per node.  If we really
do have 2 domains per node, doing this has no real effect.  If not, in
all likelihood we have 0 (zero) NUMA domains per node, and we need this
setting to get the expected testing output.  In any case, this now lets
us run that testing anywhere.
