### PR TITLE
Throw -srequireThreadedMPI=false for all mpicc testing with OpenMPI.

### DIFF
--- a/test/library/packages/MPI/spmd/hello-chapel/hello.compopts
+++ b/test/library/packages/MPI/spmd/hello-chapel/hello.compopts
@@ -1,1 +1,0 @@
--srequireThreadedMPI=false

--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -12,11 +12,17 @@ export CHPL_TARGET_COMPILER=mpi-gnu
 # Load OpenMPI environment module and confirm it has loaded
 echo >&2 module load gnu-openmpi
 module load gnu-openmpi
+set mpiType=openmpi
 
 set -x
 : confirm mpi module is loaded
 module list -l 2>&1 | grep -E -q '\bgnu-openmpi\b' || exit $?
 
-if [[ ${CHPL_RT_OVERSUBSCRIBED:-n} == [1tTyY]* && -z $MPIRUN_CMD ]] ; then
-  export MPIRUN_CMD='mpirun -np %N -map-by node:oversubscribe %C'
+if [[ $mpiType == openmpi ]] ; then
+  mpicc_nightly_opts='-compopts -srequireThreadedMPI=false'
+
+  if [[ ${CHPL_RT_OVERSUBSCRIBED:-n} == [1tTyY]* && -z $MPIRUN_CMD ]] ; then
+    export MPIRUN_CMD='mpirun -np %N -map-by node:oversubscribe %C'
+  fi
 fi
+

--- a/util/cron/test-mpicc.bash
+++ b/util/cron/test-mpicc.bash
@@ -11,4 +11,4 @@ export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl library/packages/MPI
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc"
 
-$CWD/nightly -cron -no-buildcheck
+$CWD/nightly -cron -no-buildcheck $mpicc_nightly_opts

--- a/util/cron/test-mpicc.gasnet.bash
+++ b/util/cron/test-mpicc.gasnet.bash
@@ -14,4 +14,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="mpicc.gasnet"
 
 export GASNET_QUIET=Y
 
-$CWD/nightly -cron -no-buildcheck
+$CWD/nightly -cron -no-buildcheck $mpicc_nightly_opts


### PR DESCRIPTION
If we're using MPI from OpenMPI, it appears we need to arrange to not
make concurrent MPI calls from multiple tasks/threads.  Do that here.

(We didn't/wouldn't need to do this with MPICH, but we switched away
from MPICH MPI in #14316 because we had trouble getting it to work with
our SLES12 testing systems.)
