### PR TITLE
Rename interop type chpl_bytes to chpl_bytes_wrapper to avoid name conflicts

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -511,7 +511,7 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     fprintf(pyx.fptr, "chpl_make_external_array, chpl_make_external_array_ptr");
     fprintf(pyx.fptr, ", chpl_free_external_array, chpl_opaque_array, ");
     fprintf(pyx.fptr, "cleanupOpaqueArray, ");
-    fprintf(pyx.fptr, "chpl_bytes, chpl_bytes_free, ");
+    fprintf(pyx.fptr, "chpl_bytes_wrapper, chpl_bytes_wrapper_free, ");
     fprintf(pyx.fptr, "PyBytes_FromStringAndSize\n");
 
     std::vector<FnSymbol*> moduleInits;

--- a/compiler/include/fixupExports.h
+++ b/compiler/include/fixupExports.h
@@ -30,7 +30,7 @@ class Type;
 // during resolution.
 //
 extern Type* exportTypeCharPtr;
-extern Type* exportTypeChplBytes;
+extern Type* exportTypeChplBytesWrapper;
 
 FnSymbol* getUnwrappedFunction(FnSymbol* wrapper);
 void fixupExportedFunctions(const std::vector<FnSymbol*>& fns);

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -39,7 +39,7 @@ static std::map<FnSymbol*, FnSymbol*> wrapperMap;
 static std::map<const char*, FnSymbol*> conversionCallMap;
 
 Type* exportTypeCharPtr = NULL;
-Type* exportTypeChplBytes = NULL;
+Type* exportTypeChplBytesWrapper = NULL;
 
 std::set<FnSymbol*> exportedStrRets;
 
@@ -78,7 +78,8 @@ static void resolveExportWrapperTypeAliases(void) {
   const char* mod = "ExportWrappers";
 
   exportTypeCharPtr = resolveTypeAlias(mod, "chpl__exportTypeCharPtr");
-  exportTypeChplBytes = resolveTypeAlias(mod, "chpl__exportTypeChplBytes");
+  exportTypeChplBytesWrapper =
+    resolveTypeAlias(mod, "chpl__exportTypeChplBytesWrapper");
 
   return;
 }
@@ -308,7 +309,7 @@ static Type* getTypeForFixup(Type* t, bool ret) {
     Type* result = ret ? exportTypeCharPtr : dtStringC;
     return result;
   } else if (t == dtBytes) {
-    return exportTypeChplBytes;
+    return exportTypeChplBytesWrapper;
   } else {
     INT_FATAL("Type %s is unsupported in %s", t->name(), __FUNCTION__);
   }

--- a/modules/internal/ExportWrappers.chpl
+++ b/modules/internal/ExportWrappers.chpl
@@ -22,21 +22,21 @@ module ExportWrappers {
   use CPtr;
 
   // Actual definition is in "runtime/include/chpl-export-wrappers.h".
-  extern record chpl_bytes {
+  extern record chpl_bytes_wrapper {
     var isOwned: c_int;
     var data: c_ptr(c_char);
     var size: size_t;
   }
 
   // May need to call this in one of the conversion routines.
-  extern proc chpl_bytes_free(cb: chpl_bytes);
+  extern proc chpl_bytes_wrapper_free(cb: chpl_bytes_wrapper);
 
   //
   // TODO: Using type aliases to resolve a type shouldn't be necessary. The
   // compiler should be able to figure this out on its own.
   //
   type chpl__exportTypeCharPtr = c_ptr(c_char);
-  type chpl__exportTypeChplBytes = chpl_bytes;
+  type chpl__exportTypeChplBytesWrapper = chpl_bytes_wrapper;
 
   private proc chpl__exportCopyStringBuffer(s: string): c_ptr(c_char) {
     const nBytes = s.numBytes;
@@ -56,13 +56,13 @@ module ExportWrappers {
   }
 
   //
-  // TODO: For multilocale, we have to make sure to free the `chpl_bytes`
-  // buffer ourselves after we are done beaming it out over the wire.
+  // TODO: For multilocale, we have to make sure to free the wrapper buffer
+  // ourselves after we are done beaming it out over the wire.
   //
   // TODO: Seperate set of conversion calls used in multilocale libraries.
   //
-  proc chpl__exportConv(ref val: bytes, type rt: chpl_bytes): rt {
-    var result: chpl_bytes;
+  proc chpl__exportConv(ref val: bytes, type rt: chpl_bytes_wrapper): rt {
+    var result: chpl_bytes_wrapper;
     result.isOwned = val.isowned:c_int;
     result.data = val.buff:c_ptr(c_char);
     // Assume ownership of the bytes buffer.
@@ -79,7 +79,7 @@ module ExportWrappers {
   // buffer instead? We would have to allocated a piece of tracked memory on
   // the Chapel heap.
   //
-  proc chpl__exportConv(val: chpl_bytes, type rt: bytes): rt {
+  proc chpl__exportConv(val: chpl_bytes_wrapper, type rt: bytes): rt {
     use ByteBufferHelpers;
     var data = val.data:ByteBufferHelpers.bufferType;
     // TODO: Are these casts safe casts?

--- a/runtime/include/chpl-export-wrappers.h
+++ b/runtime/include/chpl-export-wrappers.h
@@ -23,12 +23,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef struct chpl_bytes {
+typedef struct chpl_bytes_wrapper {
   int isOwned;
   char* data;
   size_t size;
-} chpl_bytes;
+} chpl_bytes_wrapper;
 
-void chpl_bytes_free(chpl_bytes cb);
+void chpl_bytes_wrapper_free(chpl_bytes_wrapper cb);
 
 #endif

--- a/runtime/include/python/chplrt.pxd
+++ b/runtime/include/python/chplrt.pxd
@@ -27,10 +27,10 @@ cdef extern from "chpl-external-array.h":
 	void cleanupOpaqueArray(chpl_opaque_array* arr)
 
 cdef extern from "chpl-export-wrappers.h":
-	ctypedef struct chpl_bytes:
+	ctypedef struct chpl_bytes_wrapper:
 		int isOwned
 		char* data
 		size_t size
 
-	void chpl_bytes_free(chpl_bytes cb)
+	void chpl_bytes_wrapper_free(chpl_bytes_wrapper cb)
 

--- a/runtime/src/chpl-export-wrappers.c
+++ b/runtime/src/chpl-export-wrappers.c
@@ -21,7 +21,7 @@
 #include "chpl-export-wrappers.h"
 #include "chpl-mem.h"
 
-void chpl_bytes_free(chpl_bytes cb) {
+void chpl_bytes_wrapper_free(chpl_bytes_wrapper cb) {
   if (!cb.isOwned) { return; }
 
   if (cb.data != NULL) {

--- a/test/interop/C/exportBytes/noArgsRetBytes.test.c
+++ b/test/interop/C/exportBytes/noArgsRetBytes.test.c
@@ -8,13 +8,13 @@
 int main(int argc, char** argv) {
   chpl_library_init(argc, argv);
   
-  chpl_bytes msg = noArgsRetBytes();
+  chpl_bytes_wrapper msg = noArgsRetBytes();
 
   printf("cb.isOwned: %s\n", (msg.isOwned ? "true" : "false"));
   printf("cb.data: %s\n", msg.data);
   printf("cb.size: %zu\n", msg.size);
 
-  chpl_bytes_free(msg);
+  chpl_bytes_wrapper_free(msg);
 
   chpl_library_finalize();
 


### PR DESCRIPTION
This PR renames the interop type `chpl_bytes` to `chpl_bytes_wrapper` to avoid redefinition errors in generated programs compiled with `--baseline`. The symbol `chpl_bytes` is reserved for use by the compiler for the bytes type. 

I am not sure why this issue didn't come up earlier during testing, but I probably should have just named the interop type `chpl_bytes_wrapper` from the beginning.

Testing:

- [x] Build compiler with `GCC v8.3` and `-std=c++98`
- [x] `ALL` on `linux64` with `CHPL_COMM=none`, `CHPL_LLVM=system`
- [x] `types/bytes` with `CHPL_COMM=none` and `--baseline`
- [x] `release/examples/primers` with `CHPL_COMM=none` and `--baseline`
