### PR TITLE
Add unordered_{get,put} API to non-ugni configurations

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -4248,13 +4248,6 @@ DEFINE_PRIM(PRIM_ASSIGN) {
   codegenAssign(lg, rg);
 }
 
-static bool commUnorderedOpsAvailable(Type* elementType) {
-  if (0 == strcmp(CHPL_COMM, "ugni")) {
-    return true;
-  }
-  return false;
-}
-
 DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
 
   Expr* lhsExpr = call->get(1);
@@ -4262,9 +4255,8 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
   bool lhsWide = lhsExpr->isWideRef();
   bool rhsWide = rhsExpr->isWideRef();
 
-  // Unordered ops not supported or both sides are narrow, do a normal assign
-  Type* elementType = lhsExpr->getValType();
-  if (!commUnorderedOpsAvailable(elementType) || (!lhsWide && !rhsWide)) {
+  // Both sides are narrow, do a normal assign
+  if (!lhsWide && !rhsWide) {
     FORWARD_PRIM(PRIM_ASSIGN);
     return;
   }
@@ -4280,7 +4272,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
 
   if (!lhsWide && rhsWide) {
     // do an unordered GET
-    // chpl_comm_get_unordered(void *dst,
+    // chpl_gen_comm_get_unordered(void *dst,
     //   c_nodeid_t src_locale, void* src_raddr,
     //   size_t size, int32_t commID,
     //   int ln, int32_t fn);
@@ -4289,7 +4281,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
     if (dstRef)
       dst = codegenDeref(dst);
 
-    codegenCall("chpl_comm_get_unordered",
+    codegenCall("chpl_gen_comm_get_unordered",
                 codegenCastToVoidStar(codegenAddrOf(dst)),
                 codegenRnode(src),
                 codegenRaddr(src),
@@ -4298,7 +4290,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
                 ln, fn);
   } else if (lhsWide && !rhsWide) {
     // do an unordered PUT
-    // chpl_comm_put_unordered(void *src,
+    // chpl_gen_comm_put_unordered(void *src,
     //   c_nodeid_t dst_locale, void* dst_raddr,
     //   size_t size, int32_t commID,
     //   int ln, int32_t fn);
@@ -4307,7 +4299,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
     if (srcRef)
       src = codegenDeref(src);
 
-    codegenCall("chpl_comm_put_unordered",
+    codegenCall("chpl_gen_comm_put_unordered",
                 codegenCastToVoidStar(codegenAddrOf(src)),
                 codegenRnode(dst),
                 codegenRaddr(dst),
@@ -4321,7 +4313,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
     //   c_nodeid_t src_locale, void* src_raddr,
     //   size_t size, int32_t commID,
     //   int ln, int32_t fn);
-    codegenCall("chpl_comm_getput_unordered",
+    codegenCall("chpl_gen_comm_getput_unordered",
                 codegenRnode(dst),
                 codegenRaddr(dst),
                 codegenRnode(src),

--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -76,8 +76,8 @@
      communication layers fall back to regular operations. Under ugni, GETs are
      internally buffered. When the buffers are flushed, the operations are
      performed all at once. Cray Linux Environment (CLE) 5.2.UP04 or newer is
-     required for best performance. In our experience, buffered gets can
-     achieve up to a 5X performance improvement over non-buffered gets for CLE
+     required for best performance. In our experience, unordered copies can
+     achieve up to a 5X performance improvement over ordered copies for CLE
      5.2UP04 or newer.
  */
 module UnorderedCopy {
@@ -109,20 +109,14 @@ module UnorderedCopy {
     if !sameType || !validType then
       compilerError("unorderedCopy is only supported between identical trivially copyable types");
 
-    if CHPL_COMM == 'ugni' {
-      __primitive("unordered=", dst, src);
-    } else {
-      __primitive("=", dst, src);
-    }
+    __primitive("unordered=", dst, src);
   }
 
   /*
      Fence any pending unordered copies issued by the current task.
    */
   inline proc unorderedCopyTaskFence(): void {
-    if CHPL_COMM == 'ugni' {
-      extern proc chpl_comm_getput_unordered_task_fence();
-      chpl_comm_getput_unordered_task_fence();
-    }
+    extern proc chpl_gen_comm_getput_unordered_task_fence();
+    chpl_gen_comm_getput_unordered_task_fence();
   }
 }

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -128,6 +128,36 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
   }
 }
 
+
+static inline
+void chpl_gen_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
+                                 size_t size, int32_t commID, int ln, int32_t fn)
+{
+  chpl_comm_get_unordered(addr, node, raddr, size, commID, ln, fn);
+}
+
+static inline
+void chpl_gen_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
+                                 size_t size, int32_t commID, int ln, int32_t fn)
+{
+  chpl_comm_put_unordered(addr, node, raddr, size, commID, ln, fn);
+}
+
+static inline
+void chpl_gen_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
+                                    c_nodeid_t srcnode, void* srcaddr,
+                                    size_t size, int32_t commID,
+                                    int ln, int32_t fn)
+{
+  chpl_comm_getput_unordered(dstnode, dstaddr, srcnode, srcaddr, size, commID, ln, fn);
+}
+
+static inline
+void chpl_gen_comm_getput_unordered_task_fence(void)
+{
+  chpl_comm_getput_unordered_task_fence();
+}
+
 // Returns true if the given node ID matches the ID of the currently node,
 // false otherwise.
 static inline

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -423,6 +423,23 @@ void chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
                         int32_t stridelevels, size_t elemSize, int32_t commID,
                         int ln, int32_t fn);
 
+
+//
+// Unordered ops
+//
+void chpl_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
+                             size_t size, int32_t commID, int ln, int32_t fn);
+
+void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
+                             size_t size, int32_t commID, int ln, int32_t fn);
+
+void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
+                                c_nodeid_t srcnode, void* srcaddr,
+                                size_t size, int32_t commID,
+                                int ln, int32_t fn);
+
+void chpl_comm_getput_unordered_task_fence(void);
+
 //
 // Runs a function f on a remote locale, passing it
 // arg where size of arg is stored in arg_size.

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -59,22 +59,6 @@ chpl_bool chpl_comm_impl_regMemFree(void* p, size_t size);
 #include "chpl-comm-native-atomics.h"
 
 //
-// Unordered ops
-//
-void chpl_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn);
-
-void chpl_comm_put_unordered(void* addr, c_nodeid_t locale, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn);
-
-void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
-                                c_nodeid_t src_locale, void* src_addr,
-                                size_t size, int32_t commID, 
-                                int ln, int32_t fn);
-
-void chpl_comm_getput_unordered_task_fence(void);
-
-//
 // Internal statistics gathering and reporting.
 //
 void chpl_comm_statsStartHere(void);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1335,6 +1335,54 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
   gasnet_puts_bulk(dstnode, dstaddr, dststr, srcaddr, srcstr, cnt, strlvls); 
 }
 
+#define MAX_UNORDERED_TRANS_SZ 1024
+void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
+                                c_nodeid_t srcnode, void* srcaddr,
+                                size_t size, int32_t commID,
+                                int ln, int32_t fn) {
+  assert(dstaddr != NULL);
+  assert(srcaddr != NULL);
+
+  if (size == 0)
+    return;
+
+  if (dstnode == chpl_nodeID && srcnode == chpl_nodeID) {
+    memmove(dstaddr, srcaddr, size);
+    return;
+  }
+
+  if (dstnode == chpl_nodeID) {
+    chpl_comm_get(dstaddr, srcnode, srcaddr, size, commID, ln, fn);
+  } else if (srcnode == chpl_nodeID) {
+    chpl_comm_put(srcaddr, dstnode, dstaddr, size, commID, ln, fn);
+  } else {
+    if (size <= MAX_UNORDERED_TRANS_SZ) {
+      char buf[MAX_UNORDERED_TRANS_SZ];
+      chpl_comm_get(buf, srcnode, srcaddr, size, commID, ln, fn);
+      chpl_comm_put(buf, dstnode, dstaddr, size, commID, ln, fn);
+    } else {
+      // Note, we do not expect this case to trigger, but if it does we may
+      // want to do on-stmt to src node and then transfer
+      char* buf = chpl_mem_alloc(size, CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);
+      chpl_comm_get(buf, srcnode, srcaddr, size, commID, ln, fn);
+      chpl_comm_put(buf, dstnode, dstaddr, size, commID, ln, fn);
+      chpl_mem_free(buf, 0, 0);
+    }
+  }
+}
+
+void chpl_comm_get_unordered(void* addr, c_nodeid_t node, void* raddr,
+                             size_t size, int32_t commID, int ln, int32_t fn) {
+  chpl_comm_get(addr, node, raddr, size, commID, ln, fn);
+}
+
+void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
+                             size_t size, int32_t commID, int ln, int32_t fn) {
+  chpl_comm_put(addr, node, raddr, size, commID, ln, fn);
+}
+
+void chpl_comm_getput_unordered_task_fence(void) { }
+
 static inline
 void  execute_on_common(c_nodeid_t node, c_sublocid_t subloc,
                         chpl_fn_int_t fid,

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -183,6 +183,32 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcno
                   commID, ln, fn);
 }
 
+void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
+                                c_nodeid_t srcnode, void* srcaddr,
+                                size_t size, int32_t commID,
+                                int ln, int32_t fn)
+{
+  assert(srcnode==0);
+  assert(dstnode==0);
+  memmove(dstaddr, srcaddr, size);
+}
+
+void chpl_comm_get_unordered(void* addr, c_nodeid_t node, void* raddr,
+                             size_t size, int32_t commID, int ln, int32_t fn)
+{
+  assert(node == 0);
+  memmove(addr, raddr, size);
+}
+
+void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
+                             size_t size, int32_t commID, int ln, int32_t fn)
+{
+  assert(node == 0);
+  memmove(raddr, addr, size);
+}
+
+void chpl_comm_getput_unordered_task_fence(void) { }
+
 typedef struct {
   chpl_fn_int_t fid;
   size_t        arg_size;


### PR DESCRIPTION
Previously unordered copy was only implemented for ugni. Here extend the
API to comm={none,gasnet,ofi}. Note that this is just adding the API,
nothing is optimized yet and we're just doing blocking comm for non-ugni
configurations.