### PR TITLE
Drop support for gasnet-gemini from the XE module

### DIFF
--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -128,7 +128,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         compilers=gnu,cray,intel
         comms=gasnet,none,ugni
         launchers=pbs-aprun,aprun,none,slurm-srun
-        substrates=gemini,mpi,none
+        substrates=mpi,none
         auxfs=none,lustre
 
         log_info "Start build_configs $dry_run $verbose # no make target"


### PR DESCRIPTION
GASNet-EX 2019.9.0 removes support for Gemini, so we have to disable
that configuration before we can upgrade gasnet versions.