### PR TITLE
Improve performance for large transfers under --cache-remote

### DIFF
--- a/test/runtime/configMatters/comm/cache-remote/bulk-comm.chpl
+++ b/test/runtime/configMatters/comm/cache-remote/bulk-comm.chpl
@@ -1,0 +1,17 @@
+// Test that writes to array elemnets are fenced before a large transfer
+// containing those elements is issued.
+proc testArr(A) {
+  on Locales[numLocales-1] {
+    var B: [A.domain] int = 1;
+    for i in A.domain.first..#10 {
+      A[i] = i;
+    }
+    A = B;
+  }
+  forall a in A do assert(a == 1);
+}
+
+var small: [1..10] int;
+var large: [1..2**23] int; //64 MB
+testArr(small);
+testArr(large);


### PR DESCRIPTION
Bypass the cache when doing transfers that are bigger than 1/4 of the
cache. For large transfers, we used to break the transfer into cached
sized sections. We'd add a section to the cache and immediately flush it
for the next section until all sections were done. This had performance
overheads and it limited the max RDMA size. e.g. instead of doing a
single 8GB transfer, we might have done a thousand 8M transfers, which
limited peak bandwidth.

Now we bypass the cache and directly initiate bulk comm, flushing any
pending operations that overlap with the bulk comm region first.

This resolves performance regressions for the arrayTransfer test, ISx,
and the blockToBlock exchange test.

Resolves https://github.com/Cray/chapel-private/issues/543