### PR TITLE
Add futures for #13154 type method inheritance

### DIFF
--- a/test/classes/inherit/instance-method-dispatch.chpl
+++ b/test/classes/inherit/instance-method-dispatch.chpl
@@ -1,0 +1,33 @@
+class Grandparent {
+    proc foo() {
+        writeln(this.type :string, ".foo");
+    }
+}
+
+class Parent: Grandparent {
+    override proc foo() {
+        writeln(this.type :string, ".foo");
+        write("  ");
+        this.bar(); // foo calls bar.
+    }
+
+    proc bar() {
+        writeln(this.type :string, ".bar");
+    }
+}
+
+class Child: Parent {
+    override proc bar() {
+        writeln(this.type :string, ".bar");
+    }
+}
+
+proc main() {
+    var gp = new Grandparent();
+    var p = new Parent();
+    var c = new Child();
+
+    gp.foo();
+    p.foo();
+    c.foo();
+}

--- a/test/classes/inherit/instance-method-dispatch.good
+++ b/test/classes/inherit/instance-method-dispatch.good
@@ -1,0 +1,5 @@
+borrowed Grandparent.foo
+borrowed Parent.foo
+  borrowed Parent.bar
+borrowed Parent.foo
+  borrowed Child.bar

--- a/test/classes/inherit/instance-method-super.chpl
+++ b/test/classes/inherit/instance-method-super.chpl
@@ -1,0 +1,26 @@
+class Grandparent {
+    proc foo() {
+        writeln(this.type :string);
+    }
+}
+
+class Parent: Grandparent {
+    override proc foo() {
+        writeln(this.type :string);
+        write("  ");
+        super.foo();
+    }
+}
+
+// foo calls its ancestor's foo, but Child does not override foo.
+class Child: Parent {}
+
+proc main() {
+    var gp = new Grandparent();
+    var p = new Parent();
+    var c = new Child();
+
+    gp.foo();
+    p.foo();
+    c.foo();
+}

--- a/test/classes/inherit/instance-method-super.good
+++ b/test/classes/inherit/instance-method-super.good
@@ -1,0 +1,5 @@
+borrowed Grandparent
+borrowed Parent
+  borrowed Grandparent
+borrowed Parent
+  borrowed Grandparent

--- a/test/classes/inherit/type-method-dispatch.bad
+++ b/test/classes/inherit/type-method-dispatch.bad
@@ -1,0 +1,5 @@
+Grandparent.foo
+Parent.foo
+  Parent.bar
+Parent.foo
+  Parent.bar

--- a/test/classes/inherit/type-method-dispatch.chpl
+++ b/test/classes/inherit/type-method-dispatch.chpl
@@ -1,0 +1,29 @@
+class Grandparent {
+    proc type foo() {
+        writeln(this :string, ".foo");
+    }
+}
+
+class Parent: Grandparent {
+    /* override */ proc type foo() {
+        writeln(this :string, ".foo");
+        write("  ");
+        this.bar(); // foo calls bar.
+    }
+
+    proc type bar() {
+        writeln(this :string, ".bar");
+    }
+}
+
+class Child: Parent {
+    /* override */ proc type bar() {
+        writeln(this :string, ".bar");
+    }
+}
+
+proc main() {
+    Grandparent.foo();
+    Parent.foo();
+    Child.foo();
+}

--- a/test/classes/inherit/type-method-dispatch.future
+++ b/test/classes/inherit/type-method-dispatch.future
@@ -1,0 +1,5 @@
+bug: child type method is not called when child calls type method that only exists on parent
+
+See #13154. When type method `foo` calls another type method `bar`, if the
+Child only overloads/overrides `bar` but calls Child.foo, the Parent's `bar` is
+incorrectly called.

--- a/test/classes/inherit/type-method-dispatch.good
+++ b/test/classes/inherit/type-method-dispatch.good
@@ -1,0 +1,5 @@
+Grandparent.foo
+Parent.foo
+  Parent.bar
+Child.foo
+  Child.bar

--- a/test/classes/inherit/type-method-super.chpl
+++ b/test/classes/inherit/type-method-super.chpl
@@ -1,0 +1,22 @@
+class Grandparent {
+    proc type foo() {
+        writeln(this :string);
+    }
+}
+
+class Parent: Grandparent {
+    /* override */ proc type foo() {
+        writeln(this :string);
+        write("  ");
+        super.foo(); // equivalent to Grandparent.foo();
+    }
+}
+
+// foo calls its ancestor's foo, but Child does not override foo.
+class Child: Parent {}
+
+proc main() {
+    Grandparent.foo();
+    Parent.foo();
+    Child.foo();
+}

--- a/test/classes/inherit/type-method-super.future
+++ b/test/classes/inherit/type-method-super.future
@@ -1,0 +1,45 @@
+open question: enable use of `super` in inheritance + type methods?
+
+Issue #14356
+
+In regular inheritance, if a child calls a parent's method that then calls
+`super.method`, the `super` will resolve to the grandparent because the method
+is defined and called from the parent.
+
+With type methods, the same should be true *even though we have chosen to
+instantiate the type methods onto the child*. `super.<type method>` should
+still resolve to the grandparent even though the type method is in the child!
+
+This sounds confusing, but because it is a type method that is, for all intents
+and purposes, exactly the same as the parent's type method that it was
+instantiated from, there isn't a reason to call the parent's version of the
+type method from the child's `super.<type method>`.
+Doing so would be duplicative work (e.g., reinitialize the same variables with
+the same values). The exception, of course, is if the parent's type method is
+overridden in the child.
+
+```
+DIFF OUTPUT / ACTUAL
+==== ===============
+     Grandparent
+     Parent
+       Grandparent
+  *  Parent
+       Grandparent
+
+     EXPECTED
+     ========
+     Grandparent
+     Parent
+       Grandparent
+  ~  Child         <- This result is a consequence of type-method-dispatch
+       Grandparent <- Parent.foo is not called because it's the same as Child.foo!
+
+ Legend:
+  x  This result is different between OUTPUT and EXPECTED
+  ~  This result is different between type-method-super and instance-method-super
+```
+
+Or Chapel could simply not allow `super` inside a type method. This is fine
+too. Users working with type-method inheritance would need to know more about
+the hierarchy to explicitly call an ancestor's type method without super.

--- a/test/classes/inherit/type-method-super.good
+++ b/test/classes/inherit/type-method-super.good
@@ -1,0 +1,5 @@
+Grandparent
+Parent
+  Grandparent
+Child
+  Grandparent


### PR DESCRIPTION
This PR adds four codes related to the discussion in #13154.

I put these futures in test/users/blam/classes/inherit/, but I can move them if desired.