### PR TITLE
Add StencilDist to array/domain creation benchmark

### DIFF
--- a/test/performance/array/distCreate-arrays-deinit.cc-perf.graph
+++ b/test/performance/array/distCreate-arrays-deinit.cc-perf.graph
@@ -1,6 +1,5 @@
 perfkeys: arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:
-graphkeys: blockArrDeinit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:,
-cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS: stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:,
+graphkeys: blockArrDeinit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:, cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS:, stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:
 repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Destroying distributed arrays

--- a/test/performance/array/distCreate-arrays-deinit.cc-perf.graph
+++ b/test/performance/array/distCreate-arrays-deinit.cc-perf.graph
@@ -1,5 +1,6 @@
-perfkeys: arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:
-graphkeys: blockArrDeinit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:, cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS:
-repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat
+perfkeys: arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:
+graphkeys: blockArrDeinit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:,
+cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS: stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:,
+repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Destroying distributed arrays

--- a/test/performance/array/distCreate-arrays-init.cc-perf.graph
+++ b/test/performance/array/distCreate-arrays-init.cc-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:, arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:, arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:
-graphkeys: blockArrInit-GETS:, blockArrInit-PUTS:, blockArrInit-ONS:, cyclicArrInit-GETS:, cyclicArrInit-PUTS:, cyclicArrInit-ONS:, blockCycArrInit-GETS:, blockCycArrInit-PUTS:, blockCycArrInit-ONS:
-repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat
+perfkeys: arrInit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:
+graphkeys: blockArrInit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:, cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS: stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:
+repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Creating distributed arrays

--- a/test/performance/array/distCreate-arrays-init.cc-perf.graph
+++ b/test/performance/array/distCreate-arrays-init.cc-perf.graph
@@ -1,5 +1,5 @@
 perfkeys: arrInit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:
-graphkeys: blockArrInit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:, cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS: stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:
+graphkeys: blockArrInit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:, cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS:, stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:
 repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Creating distributed arrays

--- a/test/performance/array/distCreate-domains-deinit.cc-perf.graph
+++ b/test/performance/array/distCreate-domains-deinit.cc-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:
-graphkeys: blockDomDeinit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS:
-repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat
+perfkeys: domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:
+graphkeys: blockDomDeinit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS: stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
+repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Destroying distributed domains

--- a/test/performance/array/distCreate-domains-deinit.cc-perf.graph
+++ b/test/performance/array/distCreate-domains-deinit.cc-perf.graph
@@ -1,5 +1,5 @@
 perfkeys: domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:
-graphkeys: blockDomDeinit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS: stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
+graphkeys: blockDomDeinit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS:, stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
 repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Destroying distributed domains

--- a/test/performance/array/distCreate-domains-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-domains-deinit.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: domDeinit:, domDeinit:, domDeinit:
-graphkeys: blockDomDeinit:, cyclicDomDeinit:, blockCyclicDomDeinit:
-files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
+perfkeys: domDeinit:, domDeinit:, domDeinit:, domDeinit:
+graphkeys: blockDomDeinit:, cyclicDomDeinit:, blockCyclicDomDeinit:, stencilDomDeinit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat, distCreate-tiny-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Destroying distributed domains

--- a/test/performance/array/distCreate-domains-init.cc-perf.graph
+++ b/test/performance/array/distCreate-domains-init.cc-perf.graph
@@ -1,5 +1,5 @@
 perfkeys: domInit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:
-graphkeys: blockDomInit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS: stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
+graphkeys: blockDomInit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS:, stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
 repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Creating distributed domains

--- a/test/performance/array/distCreate-domains-init.cc-perf.graph
+++ b/test/performance/array/distCreate-domains-init.cc-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: domInit-GETS:, domInit-PUTS:, domInit-ONS:, domInit-GETS:, domInit-PUTS:, domInit-ONS:, domInit-GETS:, domInit-PUTS:, domInit-ONS:
-graphkeys: blockDomInit-GETS:, blockDomInit-PUTS:, blockDomInit-ONS:, cyclicDomInit-GETS:, cyclicDomInit-PUTS:, cyclicDomInit-ONS:, blockCycDomInit-GETS:, blockCycDomInit-PUTS:, blockCycDomInit-ONS:
-repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat
+perfkeys: domInit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:
+graphkeys: blockDomInit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS: stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
+repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Creating distributed domains

--- a/test/performance/array/distCreate-domains-init.ml-perf.graph
+++ b/test/performance/array/distCreate-domains-init.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: domInit:, domInit:, domInit:
-graphkeys: blockDomInit:, cyclicDomInit:, blockCyclicDomInit:
-files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
+perfkeys: domInit:, domInit:, domInit:, domInit:
+graphkeys: blockDomInit:, cyclicDomInit:, blockCyclicDomInit:, stencilDomInit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat, distCreate-tiny-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Creating distributed domains

--- a/test/performance/array/distCreate-large-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-large-deinit.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrDeinit:, arrDeinit:, arrDeinit:
-graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
-files: distCreate-large-block.dat, distCreate-large-cyclic.dat, distCreate-large-blockCyc.dat,
+perfkeys: arrDeinit:, arrDeinit:, arrDeinit:, arrDeinit:
+graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:, stencilArrDeinit:
+files: distCreate-large-block.dat, distCreate-large-cyclic.dat, distCreate-large-blockCyc.dat, distCreate-large-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Destroying distributed arrays (1/4 of available memory)

--- a/test/performance/array/distCreate-large-init.ml-perf.graph
+++ b/test/performance/array/distCreate-large-init.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrInit:, arrInit:, arrInit:
-graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
-files: distCreate-large-block.dat, distCreate-large-cyclic.dat, distCreate-large-blockCyc.dat,
+perfkeys: arrInit:, arrInit:, arrInit:, arrInit:
+graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:, stencilArrInit:
+files: distCreate-large-block.dat, distCreate-large-cyclic.dat, distCreate-large-blockCyc.dat, distCreate-large-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Creating distributed arrays (1/4 of available memory)

--- a/test/performance/array/distCreate-small-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-small-deinit.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrDeinit:, arrDeinit:, arrDeinit:
-graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
-files: distCreate-small-block.dat, distCreate-small-cyclic.dat, distCreate-small-blockCyc.dat,
+perfkeys: arrDeinit:, arrDeinit:, arrDeinit:, arrDeinit:
+graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:, stencilArrDeinit:
+files: distCreate-small-block.dat, distCreate-small-cyclic.dat, distCreate-small-blockCyc.dat, distCreate-small-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Destroying distributed arrays (1M elements)

--- a/test/performance/array/distCreate-small-init.ml-perf.graph
+++ b/test/performance/array/distCreate-small-init.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrInit:, arrInit:, arrInit:
-graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
-files: distCreate-small-block.dat, distCreate-small-cyclic.dat, distCreate-small-blockCyc.dat,
+perfkeys: arrInit:, arrInit:, arrInit:, arrInit:
+graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:, stencilArrInit:
+files: distCreate-small-block.dat, distCreate-small-cyclic.dat, distCreate-small-blockCyc.dat, distCreate-small-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Creating distributed arrays (1M elements)

--- a/test/performance/array/distCreate-tiny-deinit.ml-perf.graph
+++ b/test/performance/array/distCreate-tiny-deinit.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrDeinit:, arrDeinit:, arrDeinit:
-graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:
-files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
+perfkeys: arrDeinit:, arrDeinit:, arrDeinit:, arrDeinit:
+graphkeys: blockArrDeinit:, cyclicArrDeinit:, blockCyclicArrDeinit:, stencilArrDeinit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat, distCreate-tiny-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Destroying distributed arrays (1 element per locale)

--- a/test/performance/array/distCreate-tiny-init.ml-perf.graph
+++ b/test/performance/array/distCreate-tiny-init.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrInit:, arrInit:, arrInit:
-graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:
-files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat,
+perfkeys: arrInit:, arrInit:, arrInit:, arrInit:
+graphkeys: blockArrInit:, cyclicArrInit:, blockCyclicArrInit:, stencilArrInit:
+files: distCreate-tiny-block.dat, distCreate-tiny-cyclic.dat, distCreate-tiny-blockCyc.dat, distCreate-tiny-stencil.dat
 ylabel: Time (seconds)
 graphtitle: Creating distributed arrays (1 element per locale)

--- a/test/performance/array/distCreate.cc-execopts
+++ b/test/performance/array/distCreate.cc-execopts
@@ -1,3 +1,4 @@
 --mode=diagMode.commCount --size=arraySize.tiny --dist=distType.block  #distCreate-cc-block
 --mode=diagMode.commCount --size=arraySize.tiny --dist=distType.cyclic   #distCreate-cc-cyclic
 --mode=diagMode.commCount --size=arraySize.tiny --dist=distType.blockCyc   #distCreate-cc-blockCyc
+--mode=diagMode.commCount --size=arraySize.tiny --dist=distType.stencil   #distCreate-cc-stencil

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -5,6 +5,7 @@ use CommDiagnostics;
 use BlockDist;
 use CyclicDist;
 use BlockCycDist;
+use StencilDist;
 
 
 type elemType = int;
@@ -12,7 +13,7 @@ type elemType = int;
 
 enum diagMode { performance, correctness, commCount, verboseComm, verboseMem };
 enum arraySize { tiny, small, large };
-enum distType { block, cyclic, blockCyc };
+enum distType { block, cyclic, blockCyc, stencil };
 
 config const size = arraySize.tiny;
 config const dist = distType.block;
@@ -169,6 +170,27 @@ if mode == diagMode.correctness || dist == distType.blockCyc {
       endDiag("arrDeinit");
     }
 
+    startDiag("domDeinit");
+  }
+  endDiag("domDeinit");
+}
+
+if mode == diagMode.correctness || dist == distType.stencil {
+  { // weird blocks are necessary to measure deinit performance
+    startDiag("domInit");
+    const blockDom = localDom dmapped Stencil(boundingBox=localDom,
+                                              fluff=(1,));
+    endDiag("domInit", blockDom);
+    if createArrays {
+      {
+        startDiag("arrInit");
+        const blockArr: [blockDom] elemType;
+        endDiag("arrInit", blockArr);
+
+        startDiag("arrDeinit");
+      }
+      endDiag("arrDeinit");
+    }
     startDiag("domDeinit");
   }
   endDiag("domDeinit");

--- a/test/performance/array/distCreate.ml-execopts
+++ b/test/performance/array/distCreate.ml-execopts
@@ -1,9 +1,12 @@
 --size=arraySize.tiny --dist=distType.block  #distCreate-tiny-block
 --size=arraySize.tiny --dist=distType.cyclic   #distCreate-tiny-cyclic
 --size=arraySize.tiny --dist=distType.blockCyc   #distCreate-tiny-blockCyc
+--size=arraySize.tiny --dist=distType.stencil   #distCreate-tiny-stencil
 --size=arraySize.small --dist=distType.block  #distCreate-small-block
 --size=arraySize.small --dist=distType.cyclic  #distCreate-small-cyclic
 --size=arraySize.small --dist=distType.blockCyc  #distCreate-small-blockCyc
+--size=arraySize.small --dist=distType.stencil  #distCreate-small-stencil
 --size=arraySize.large --dist=distType.block  #distCreate-large-block
 --size=arraySize.large --dist=distType.cyclic  #distCreate-large-cyclic
 --size=arraySize.large --dist=distType.blockCyc  #distCreate-large-blockCyc
+--size=arraySize.large --dist=distType.stencil  #distCreate-large-stencil

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -505,9 +505,7 @@ class GraphStuff:
             elif key == 'repeat-files' :
                 dFiles = [ s.strip() for s in rest.split(',') ]
                 if len(graphs[currgraph].perfkeys) % len(dFiles) != 0:
-                    sys.stdout.write('[Warning: num .dat files (%d) did not evenly divide into num perfkeys (%d) for %s.  Ignoring.]\n'%(len(dFiles), len(graphs[currgraph].perfkeys), fullFname))
-                    for k in graphs[currgraph].perfkeys:
-                        sys.stdout.write(k)
+                    sys.stdout.write('[Warning: num .dat files did not evenly divide into num perfkeys for %s. Ignoring.]\n'%(fullFname))
                     return
                 keysRange = range(0, (len(graphs[currgraph].perfkeys) // len(dFiles)))
                 for dFile in dFiles:

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -505,7 +505,9 @@ class GraphStuff:
             elif key == 'repeat-files' :
                 dFiles = [ s.strip() for s in rest.split(',') ]
                 if len(graphs[currgraph].perfkeys) % len(dFiles) != 0:
-                    sys.stdout.write('[Warning: num .dat files did not evenly divide into num perfkeys for %s. Ignoring.]\n'%(fullFname))
+                    sys.stdout.write('[Warning: num .dat files (%d) did not evenly divide into num perfkeys (%d) for %s.  Ignoring.]\n'%(len(dFiles), len(graphs[currgraph].perfkeys), fullFname))
+                    for k in graphs[currgraph].perfkeys:
+                        sys.stdout.write(k)
                     return
                 keysRange = range(0, (len(graphs[currgraph].perfkeys) // len(dFiles)))
                 for dFile in dFiles:


### PR DESCRIPTION
As per @ronawho's suggestion, this PR adds StencilDist to the distributed
array/domain creation benchmark in `test/performance/array/distCreate.chpl`.

Current plots from this benchmark is [here](https://chapel-lang.org/perf/16-node-xc/?graphs=creatingdistributeddomains,destroyingdistributeddomains,creatingdistributedarrays1elementperlocale,destroyingdistributedarrays1elementperlocale,creatingdistributedarrays1melements,destroyingdistributedarrays1melements,creatingdistributedarrays14ofavailablememory,destroyingdistributedarrays14ofavailablememory)

Test status:
- [x] local runs produce correct graphs
- [x] correctness
- [x] nightly performance
- [x] nightly correctness