### PR TITLE
Rename Shasta rpms as desired by delivery mechanisms.

### DIFF
--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -50,6 +50,7 @@ Usage: $( basename "${BASH_SOURCE[0]}" )" '[options]
                             package version string to be generated in this script.
                           Alphanumeric/underscore chars only.
                           Default value: current hostname. See NOTES below.
+    -R rel_name         : Shasta RPM release name, synthesized if not given
     -r rc_number        : Release candidate number (0,1,2,...9)
                           Default: 0
     -o outputs  : Where to deliver the Chapel RPM file created by this script.
@@ -79,6 +80,7 @@ setenv=
 
 chpl_platform=cray-xc
 release_type=
+rel_name=
 rc_number=0
 version_tag=$( hostname | sed -e 's,[^0-9a-zA-Z_],,g' )
 src_version=
@@ -89,7 +91,7 @@ keepdir=
 verbose=
 dry_run=
 
-while getopts :vnkC:t:s:T:o:b:p:r:h opt; do
+while getopts :vnkC:t:s:T:o:b:p:R:r:h opt; do
     case $opt in
     ( C ) workdir=$OPTARG ;;
     ( t ) tarball=$OPTARG ;;
@@ -101,6 +103,7 @@ while getopts :vnkC:t:s:T:o:b:p:r:h opt; do
     ( o ) outputs=$OPTARG ;;
     ( b ) release_type=$OPTARG ;;
     ( p ) chpl_platform=$OPTARG ;;
+    ( R ) rel_name=$OPTARG ;;
     ( r ) rc_number=$OPTARG ;;
 
     ( v ) verbose=-v ;;
@@ -153,6 +156,11 @@ bash "$setenv" $verbose $dry_run
 
 # Create the Chapel package
 
-"$cwd/chapel_package-cray.bash" $verbose $dry_run $keepdir -C "$workdir" -T "$version_tag" -o "$outputs" -b "$release_type" -p "$chpl_platform" -r "$rc_number"
+if [ "$chpl_platform" = cray-shasta ]; then
+    rpm_id_option="-R $rel_name"
+else
+    rpm_id_option="-r $rc_number"
+fi
+"$cwd/chapel_package-cray.bash" $verbose $dry_run $keepdir -C "$workdir" -T "$version_tag" -o "$outputs" -b "$release_type" -p "$chpl_platform" $rpm_id_option
 
 log_info "End $( basename "${BASH_SOURCE[0]}" )"

--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -64,14 +64,6 @@ Usage: $( basename "${BASH_SOURCE[0]}" )" '[options]
     By convention, this directory name is "chapel-" plus the Chapel release
     version number defined in version_num.h.
 
-    CHPL_RPM is a working subtree created by this script for use by rpmbuild.
-    CHPL_RPM will be removed without warning if it exists when this script is run.
-    The directory name will be "$CHPL_HOME-" plus the generated version.
-
-    If -C workdir was given, workdir must point to an existing directory, and
-    CHPL_RPM will be created as a subdir.
-    If no -C workdir, CHPL_RPM will be created in the users CWD.
-
     An empty version_tag may be given on the command line (-T "").
     If not, the default version_tag is the local hostname. This is to avoid
     accidentally replacing an official Cray Chapel release with a locally-

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -35,12 +35,12 @@ Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
     -o outputs  : Where to deliver the Chapel RPM file created by this script.
                   If given, -o outputs must point to an existing directory.
                   If none, the RPM file will be written to the users CWD.
-    -C newdir   : cd to this directory before creating CHPL_RPM (optional).
+    -C newdir   : cd to this directory before creating rpmbuild_dir (optional).
                   If given, -C newdir must point to an existing directory
-                    and CHPL_RPM will be created as a subdir.
-                  If none, CHPL_RPM will be created in the users CWD.
-    -k  : Keep CHPL_RPM.
-          By default, CHPL_RPM will be removed if script ends successfully.
+                    and rpmbuild_dir will be created as a subdir.
+                  If none, rpmbuild_dir will be created in the users CWD.
+    -k  : Keep rpmbuild_dir.
+          By default, rpmbuild_dir will be removed if script ends successfully.
 
   NOTES:
     CHPL_HOME must be defined in the environment when this script is run, and
@@ -48,8 +48,8 @@ Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
     will not modify CHPL_HOME or its contents, except possibly the Linux file
     and directory permissions which will be forced to 644, 755, etc.
 
-    CHPL_RPM is a working subtree created by this script for use by rpmbuild.
-    CHPL_RPM will be removed without warning if it exists when this script is run.
+    rpmbuild_dir is a working subtree created by this script for use by rpmbuild.
+    rpmbuild_dir will be removed without warning if it exists when this script is run.
     The directory name will be "$CHPL_HOME-" plus the generated version.
 
     An empty version_tag may be given on the command line (-T "").
@@ -154,13 +154,13 @@ if [ -n "$keepdir" ]; then
     log_info "Using -k (keepdir)"
 fi
 
-# Create CHPL_RPM, the packaging counterpart to CHPL_HOME, in workdir
+# Create rpmbuild_dir, the packaging counterpart to CHPL_HOME, in workdir
 
-export CHPL_RPM="$workdir/$pkg_filename"
-log_info "Creating CHPL_RPM='$CHPL_RPM'"
+rpmbuild_dir="$workdir/$pkg_filename"
+log_info "Creating rpmbuild_dir='$rpmbuild_dir'"
 
-rm -rf "$CHPL_RPM"
-mkdir "$CHPL_RPM"
+rm -rf "$rpmbuild_dir"
+mkdir "$rpmbuild_dir"
 
 
 if [ "$release_type" = release ]; then
@@ -171,38 +171,38 @@ if [ "$release_type" = release ]; then
         log_error "Expected release_info file not found in CHPL_HOME='$CHPL_HOME'"
         exit 2
     fi
-    cat "$CHPL_HOME/release_info" > "$CHPL_RPM/release_info"
+    cat "$CHPL_HOME/release_info" > "$rpmbuild_dir/release_info"
     rm -f "$CHPL_HOME/release_info"
-    chmod 644 "$CHPL_RPM/release_info"
+    chmod 644 "$rpmbuild_dir/release_info"
 else
 
     log_debug "Generate draft/placeholder release_info ..."
 
-    $cwd/generate-dev-releaseinfo.bash > "$CHPL_RPM/release_info"
-    chmod 644 "$CHPL_RPM/release_info"
+    $cwd/generate-dev-releaseinfo.bash > "$rpmbuild_dir/release_info"
+    chmod 644 "$rpmbuild_dir/release_info"
 fi
 
 # Generate modulefile, w versions
 
 log_debug "Generate modulefile-$pkg_version ..."
-$cwd/generate-modulefile.bash > "$CHPL_RPM/modulefile-$pkg_version"
-chmod 644 "$CHPL_RPM/modulefile-$pkg_version"
+$cwd/generate-modulefile.bash > "$rpmbuild_dir/modulefile-$pkg_version"
+chmod 644 "$rpmbuild_dir/modulefile-$pkg_version"
 
 # Generate set_default script, w versions
 
 log_debug "Generate set_default_chapel_$pkg_version ..."
-$cwd/generate-set_default.bash > "$CHPL_RPM/set_default_chapel_$pkg_version"
-chmod 755 "$CHPL_RPM/set_default_chapel_$pkg_version"
+$cwd/generate-set_default.bash > "$rpmbuild_dir/set_default_chapel_$pkg_version"
+chmod 755 "$rpmbuild_dir/set_default_chapel_$pkg_version"
 
 # Generate chapel.spec, w versions
 
 log_debug "Generate chapel.spec ..."
-$cwd/generate-rpmspec.bash > "$CHPL_RPM/chapel.spec"
+$cwd/generate-rpmspec.bash > "$rpmbuild_dir/chapel.spec"
 
-# Prepare the CHPL_RPM subdirectory structure, with hardlinked files from CHPL_HOME/...
+# Prepare the rpmbuild_dir subdirectory structure, with hardlinked files from CHPL_HOME/...
 
-log_info "Prepare CHPL_RPM subdirs."
-mkdir -p "$CHPL_RPM/SOURCES" "$CHPL_RPM/BUILD" "$CHPL_RPM/RPMS/$CPU" "$CHPL_RPM/tmp"
+log_info "Prepare rpmbuild_dir subdirs."
+mkdir -p "$rpmbuild_dir/SOURCES" "$rpmbuild_dir/BUILD" "$rpmbuild_dir/RPMS/$CPU" "$rpmbuild_dir/tmp"
 (
     set -e
     chpl_home_base=$( basename "$CHPL_HOME" )
@@ -211,13 +211,13 @@ mkdir -p "$CHPL_RPM/SOURCES" "$CHPL_RPM/BUILD" "$CHPL_RPM/RPMS/$CPU" "$CHPL_RPM/
     fi
     : Begin subshell
 
-    : Hard-link CHPL_HOME subtree into CHPL_RPM/BUILD/$chpl_home_base
+    : Hard-link CHPL_HOME subtree into rpmbuild_dir/BUILD/$chpl_home_base
     cd "$CHPL_HOME/.."
     ls >/dev/null -d $chpl_home_base
-    find $chpl_home_base -depth -print | cpio -pmdlu "$CHPL_RPM/BUILD"
+    find $chpl_home_base -depth -print | cpio -pmdlu "$rpmbuild_dir/BUILD"
 
-    : Temporarily reset CHPL_HOME=CHPL_RPM/BUILD/$chpl_home_base
-    cd "$CHPL_RPM/BUILD/$chpl_home_base"
+    : Temporarily reset CHPL_HOME=rpmbuild_dir/BUILD/$chpl_home_base
+    cd "$rpmbuild_dir/BUILD/$chpl_home_base"
     export CHPL_HOME=$PWD
     . util/setchplenv.bash
 
@@ -236,8 +236,8 @@ mkdir -p "$CHPL_RPM/SOURCES" "$CHPL_RPM/BUILD" "$CHPL_RPM/RPMS/$CPU" "$CHPL_RPM/
     : End subshell
 )
 
-log_debug "cd '$CHPL_RPM'"
-cd "$CHPL_RPM"
+log_debug "cd '$rpmbuild_dir'"
+cd "$rpmbuild_dir"
 
 # Dry-run or rpmbuild with post processing
 
@@ -245,32 +245,32 @@ if [ -n "$dry_run" ]; then
     # Dry-run
     log_info "Dry-run:
       # rpmbuild:
-        rpmbuild -bb --buildroot '$CHPL_RPM/BUILDROOT' --define '_tmppath $CHPL_RPM/tmp' --define '_topdir $CHPL_RPM' '$CHPL_RPM/chapel.spec'
+        rpmbuild -bb --buildroot '$rpmbuild_dir/BUILDROOT' --define '_tmppath $rpmbuild_dir/tmp' --define '_topdir $rpmbuild_dir' '$rpmbuild_dir/chapel.spec'
       # save and rename the RPM file
-        mv -f '$CHPL_RPM/RPMS/$CPU/$rpmbuild_filename' '$outputs/$rpm_filename'"
+        mv -f '$rpmbuild_dir/RPMS/$CPU/$rpmbuild_filename' '$outputs/$rpm_filename'"
 else
     # Real rpmbuild
     quiet=--quiet
     if [ -n "$verbose" ]; then
         quiet=
         log_debug "Start rpmbuild:
-        rpmbuild -bb $quiet --buildroot '$CHPL_RPM/BUILDROOT' --define '_tmppath $CHPL_RPM/tmp' --define '_topdir $CHPL_RPM' '$CHPL_RPM/chapel.spec'"
+        rpmbuild -bb $quiet --buildroot '$rpmbuild_dir/BUILDROOT' --define '_tmppath $rpmbuild_dir/tmp' --define '_topdir $rpmbuild_dir' '$rpmbuild_dir/chapel.spec'"
     else
         log_info "Start rpmbuild. This may take a while."
     fi
 
-    rpmbuild -bb $quiet --buildroot "$CHPL_RPM/BUILDROOT" --define "_tmppath $CHPL_RPM/tmp" --define "_topdir $CHPL_RPM" "$CHPL_RPM/chapel.spec"
+    rpmbuild -bb $quiet --buildroot "$rpmbuild_dir/BUILDROOT" --define "_tmppath $rpmbuild_dir/tmp" --define "_topdir $rpmbuild_dir" "$rpmbuild_dir/chapel.spec"
 
     log_info "Finished rpmbuild."
 
     # Save and rename the RPM file
     log_info "Save $rpmbuild_filename as '$outputs/$rpm_filename'"
-    mv -f "$CHPL_RPM/RPMS/$CPU/$rpmbuild_filename" "$outputs/$rpm_filename"
+    mv -f "$rpmbuild_dir/RPMS/$CPU/$rpmbuild_filename" "$outputs/$rpm_filename"
 
-    # Remove CHPL_RPM dir, in background
+    # Remove rpmbuild_dir dir, in background
     if [ -z "$keepdir" ]; then
-        log_info "Removing CHPL_RPM in background."
-        nohup rm -rf "$CHPL_RPM" >/dev/null 2>/dev/null </dev/null &
+        log_info "Removing rpmbuild_dir in background."
+        nohup rm -rf "$rpmbuild_dir" >/dev/null 2>/dev/null </dev/null &
     fi
 fi
 

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -30,6 +30,7 @@ Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
                             package version string to be generated in this script.
                           Alphanumeric/underscore chars only.
                           Default value: current hostname. See NOTES below.
+    -R rel_name         : Shasta RPM release name, synthesized if not given
     -r rc_number        : Release candidate number (0,1,2,...9)
                           Default: 0
     -o outputs  : Where to deliver the Chapel RPM file created by this script.
@@ -62,6 +63,7 @@ Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
 
 chpl_platform=cray-xc
 release_type=
+rel_name=
 rc_number=0
 version_tag=$( hostname | sed -e 's,[^0-9a-zA-Z_],,g' )
 src_version=
@@ -75,7 +77,7 @@ dry_run=
 date_ymd=$( date '+%Y%m%d' )
 date_hms=$( date '+%H%M%S' )
 
-while getopts :vnkC:T:o:b:p:r:h opt; do
+while getopts :vnkC:T:o:b:p:R:r:h opt; do
     case $opt in
     ( k ) keepdir=-k ;;
     ( C ) workdir=$OPTARG ;;
@@ -83,6 +85,7 @@ while getopts :vnkC:T:o:b:p:r:h opt; do
     ( o ) outputs=$OPTARG ;;
     ( b ) release_type=$OPTARG ;;
     ( p ) chpl_platform=$OPTARG ;;
+    ( R ) rel_name=$OPTARG ;;
     ( r ) rc_number=$OPTARG ;;
     ( v ) verbose=-v ;;
     ( n ) dry_run=-n ;;

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -156,7 +156,7 @@ fi
 
 # Create rpmbuild_dir, the packaging counterpart to CHPL_HOME, in workdir
 
-rpmbuild_dir="$workdir/$pkg_filename"
+rpmbuild_dir="$workdir/$rpm_filename%.$CPU.rpm"
 log_info "Creating rpmbuild_dir='$rpmbuild_dir'"
 
 rm -rf "$rpmbuild_dir"

--- a/util/build_configs/cray-internal/common.bash
+++ b/util/build_configs/cray-internal/common.bash
@@ -12,7 +12,7 @@ log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 
 # rpm_name,
 #   rpm_version : The fake name and version tags described below.
-# rpm_release   : The RPM "release" tag, from $rc_prefix$rc_number
+# rpm_release   : The RPM "release" tag, default $rc_prefix$rc_number
 #                   (e.g. "crayxc1" in chapel-1.17.1-crayxc1.aarch64.rpm)
 # rc_prefix     : As above
 #                   (rc_number comes from the global package-common)
@@ -37,11 +37,26 @@ log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 # RPM Version   : 020949
 # RPM Release   : crayxc0
 
-
 case "${rc_prefix:-}" in
 ( "" )
-    # default: strip out the "dash" from $chpl_platform (e.g. cray-xc -> crayxc)
-    rc_prefix=$( sed -e 's,-,,' <<<"$chpl_platform" )
+    # default: strip out dashes from $chpl_platform (e.g. cray-xc -> crayxc)
+    rc_prefix=${chpl_platform//-}
+    if [ "$chpl_platform" = cray-shasta ]; then
+        #
+        # For Shasta, need timestamp and SHA before (dashless) platform,
+        # and no release candidate number.
+        #
+        if [ -n "$rel_name" ]; then
+            rc_prefix="${rel_name}.${rc_prefix}"
+        else
+            if [ -n "$CHPL_HOME" -a -d $CHPL_HOME/.git ]; then
+                sha=$(cd $CHPL_HOME && git show --pretty=format:%H HEAD | \
+                      head -1 | cut -c1-7)
+            fi
+            rc_prefix="$(date '+%Y%m%d%H%M%S')_${sha}.${rc_prefix}"
+        fi
+        rc_number=''
+    fi
     ;;
 ( *[!0-9a-zA-Z_]* )
     log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid rc_prefix='$rc_prefix'"; exit 2
@@ -54,13 +69,15 @@ esac
 
 # Derived values
 
-case "$rc_prefix" in
-( *[0-9] )
-    case "${rc_number:=0}" in
-        ( [0-9]* ) log_warn "$( basename "${BASH_SOURCE[0]}" ): rc_prefix='$rc_prefix', rc_number='$rc_number' (too many digits?)";;
+if [ -n "$rc_number" ]; then
+    case "$rc_prefix" in
+    ( *[0-9] )
+        case "${rc_number:=0}" in
+            ( [0-9]* ) log_warn "$( basename "${BASH_SOURCE[0]}" ): rc_prefix='$rc_prefix', rc_number='$rc_number' (too many digits?)";;
+        esac
+        ;;
     esac
-    ;;
-esac
+fi
 rpm_release=$rc_prefix$rc_number
 
 case "${release_type:-}" in
@@ -79,14 +96,12 @@ rpm_name="chapel-$pkg_version"
 rpm_filename="chapel-$pkg_version-$rpm_release.$CPU.rpm"
 rpmbuild_filename="chapel-$pkg_version-$rpm_version-$rpm_release.$CPU.rpm"
 
-log_debug "Using rc_prefix='$rc_prefix'"
 log_debug "Using rpm_release='$rpm_release'"
 log_debug "Using rpm_name='$rpm_name'"
 log_debug "Using rpm_version='$rpm_version'"
 log_debug "Using rpm_filename='$rpm_filename'"
 log_debug "Using rpmbuild_filename='$rpmbuild_filename'"
 
-export rc_prefix
 export rpm_release
 export rpm_name
 export rpm_version

--- a/util/build_configs/cray-internal/common.bash
+++ b/util/build_configs/cray-internal/common.bash
@@ -16,8 +16,6 @@ log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 #                   (e.g. "crayxc1" in chapel-1.17.1-crayxc1.aarch64.rpm)
 # rc_prefix     : As above
 #                   (rc_number comes from the global package-common)
-# pkg_filename  : The external pkg filename, with the pkg name and version we use by convention,
-#                   but not including the CPU arch and the ".rpm"
 # rpm_filename  : The complete external pkg filename as we use it.
 
 
@@ -78,7 +76,6 @@ case "${release_type:-}" in
 esac
 rpm_name="chapel-$pkg_version"
 
-pkg_filename="chapel-$pkg_version-$rpm_release"
 rpm_filename="chapel-$pkg_version-$rpm_release.$CPU.rpm"
 rpmbuild_filename="chapel-$pkg_version-$rpm_version-$rpm_release.$CPU.rpm"
 
@@ -86,7 +83,6 @@ log_debug "Using rc_prefix='$rc_prefix'"
 log_debug "Using rpm_release='$rpm_release'"
 log_debug "Using rpm_name='$rpm_name'"
 log_debug "Using rpm_version='$rpm_version'"
-log_debug "Using pkg_filename='$pkg_filename'"
 log_debug "Using rpm_filename='$rpm_filename'"
 log_debug "Using rpmbuild_filename='$rpmbuild_filename'"
 
@@ -94,7 +90,6 @@ export rc_prefix
 export rpm_release
 export rpm_name
 export rpm_version
-export pkg_filename
 export rpm_filename
 export rpmbuild_filename
 

--- a/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
+++ b/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
@@ -128,11 +128,11 @@ Dependencies:
 Installation instructions:
 --------------------------
 
-    Copy the appropriate Chapel RPM file to the current directory and execute
-    one of the following commands:
+    Copy the Chapel RPM file to the current directory and execute
+    the appropriate one of the following commands:
 
       #On Cray Shasta systems (x86_64):
-      rpm -ivh chapel-$pkg_version-crayshasta$rc_number.x86_64.rpm
+      rpm -ivh chapel-$pkg_version-$rpm_release.x86_64.rpm
 
       #On Cray XC systems (x86_64):
       rpm -ivh chapel-$pkg_version-crayxc$rc_number.x86_64.rpm

--- a/util/build_configs/package-common.bash
+++ b/util/build_configs/package-common.bash
@@ -29,6 +29,7 @@ fi
 #                   e.g. "1.17.1.20181016" for a nightly build
 # release_type  : nightly or release or developer
 # chpl_platform : linux64, cray-xc, etc             # as in, $CHPL_HOME/bin/$chpl_platform
+# rel_name      : Shasta RPM release name, synthesized if not given
 # rc_number     : Release candidate number (0,1,2..); something to distinguish different instances of
 #                 otherwise-identical packages. May be applied in different ways dep. on package-format.
 # date_ymd,
@@ -108,17 +109,13 @@ log_debug "Using src_version='$src_version'"
 log_debug "Using version_tag='$version_tag'"
 log_debug "Using pkg_version='$pkg_version'"
 log_debug "Using release_type='$release_type'"
+log_debug "Using rel_name='$rel_name'"
 log_debug "Using rc_number='$rc_number'"
-log_debug "Using date_ymd='$date_ymd'"
-log_debug "Using date_hms='$date_hms'"
 
 export chpl_platform
 export src_version major minor update
-export version_tag
 export pkg_version
-export release_type
+export rel_name
 export rc_number
-export date_ymd
-export date_hms
 
 log_debug "End $( basename "${BASH_SOURCE[0]}" )"


### PR DESCRIPTION
For Shasta, the module delivery mechanism requires RPMs with filenames
of the form `name-version-release[.dist].arch.rpm`, where 'version' is
major.minor.update and 'release' is a YYYYmmddHHMMSS timestamp (in
date(1) formatting terms), an underbar, and a 7-digit SHA for the branch
from which the RPM was built.  Here, add a `-R` option so the module
build driver can tell us that part of the name, and also arrange to try
to create it ourselves for Shasta RPMs if that option is not given.

While here, do some cleanups.  Remove mention of environment variable
`CHPL_RPM` from one script in which it's neither set nor referenced.
Rename it to `rpmbuild_dir` in the other one that uses it, because it's
really a directory not an RPM.  Get rid of `pkg_filename`, which was
really a dirname rather than a filename, because we can create that path
based on `rpm_filename`.  Also, stop exporting a number of variables to
the environment, because they're just used locally and don't need to be
inherited by other scripts.  And finally, update some internal build
documentation about naming and installing RPMs.