### PR TITLE
Rename Shasta rpms as desired by delivery mechanisms.

### DIFF
--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -50,6 +50,7 @@ Usage: $( basename "${BASH_SOURCE[0]}" )" '[options]
                             package version string to be generated in this script.
                           Alphanumeric/underscore chars only.
                           Default value: current hostname. See NOTES below.
+    -R rel_name         : Shasta RPM release name, synthesized if not given
     -r rc_number        : Release candidate number (0,1,2,...9)
                           Default: 0
     -o outputs  : Where to deliver the Chapel RPM file created by this script.
@@ -79,6 +80,7 @@ setenv=
 
 chpl_platform=cray-xc
 release_type=
+rel_name=
 rc_number=0
 version_tag=$( hostname | sed -e 's,[^0-9a-zA-Z_],,g' )
 src_version=
@@ -89,7 +91,7 @@ keepdir=
 verbose=
 dry_run=
 
-while getopts :vnkC:t:s:T:o:b:p:r:h opt; do
+while getopts :vnkC:t:s:T:o:b:p:R:r:h opt; do
     case $opt in
     ( C ) workdir=$OPTARG ;;
     ( t ) tarball=$OPTARG ;;
@@ -101,6 +103,7 @@ while getopts :vnkC:t:s:T:o:b:p:r:h opt; do
     ( o ) outputs=$OPTARG ;;
     ( b ) release_type=$OPTARG ;;
     ( p ) chpl_platform=$OPTARG ;;
+    ( R ) rel_name=$OPTARG ;;
     ( r ) rc_number=$OPTARG ;;
 
     ( v ) verbose=-v ;;
@@ -153,6 +156,11 @@ bash "$setenv" $verbose $dry_run
 
 # Create the Chapel package
 
-"$cwd/chapel_package-cray.bash" $verbose $dry_run $keepdir -C "$workdir" -T "$version_tag" -o "$outputs" -b "$release_type" -p "$chpl_platform" -r "$rc_number"
+if [ "$chpl_platform" = cray-shasta ]; then
+    rpm_id_option="-R $rel_name"
+else
+    rpm_id_option="-r $rc_number"
+fi
+"$cwd/chapel_package-cray.bash" $verbose $dry_run $keepdir -C "$workdir" -T "$version_tag" -o "$outputs" -b "$release_type" -p "$chpl_platform" $rpm_id_option
 
 log_info "End $( basename "${BASH_SOURCE[0]}" )"

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -30,6 +30,7 @@ Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
                             package version string to be generated in this script.
                           Alphanumeric/underscore chars only.
                           Default value: current hostname. See NOTES below.
+    -R rel_name         : Shasta RPM release name, synthesized if not given
     -r rc_number        : Release candidate number (0,1,2,...9)
                           Default: 0
     -o outputs  : Where to deliver the Chapel RPM file created by this script.
@@ -62,6 +63,7 @@ Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
 
 chpl_platform=cray-xc
 release_type=
+rel_name=
 rc_number=0
 version_tag=$( hostname | sed -e 's,[^0-9a-zA-Z_],,g' )
 src_version=
@@ -75,7 +77,7 @@ dry_run=
 date_ymd=$( date '+%Y%m%d' )
 date_hms=$( date '+%H%M%S' )
 
-while getopts :vnkC:T:o:b:p:r:h opt; do
+while getopts :vnkC:T:o:b:p:R:r:h opt; do
     case $opt in
     ( k ) keepdir=-k ;;
     ( C ) workdir=$OPTARG ;;
@@ -83,6 +85,7 @@ while getopts :vnkC:T:o:b:p:r:h opt; do
     ( o ) outputs=$OPTARG ;;
     ( b ) release_type=$OPTARG ;;
     ( p ) chpl_platform=$OPTARG ;;
+    ( R ) rel_name=$OPTARG ;;
     ( r ) rc_number=$OPTARG ;;
     ( v ) verbose=-v ;;
     ( n ) dry_run=-n ;;

--- a/util/build_configs/cray-internal/common.bash
+++ b/util/build_configs/cray-internal/common.bash
@@ -12,7 +12,7 @@ log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 
 # rpm_name,
 #   rpm_version : The fake name and version tags described below.
-# rpm_release   : The RPM "release" tag, from $rc_prefix$rc_number
+# rpm_release   : The RPM "release" tag, default $rc_prefix$rc_number
 #                   (e.g. "crayxc1" in chapel-1.17.1-crayxc1.aarch64.rpm)
 # rc_prefix     : As above
 #                   (rc_number comes from the global package-common)
@@ -37,11 +37,26 @@ log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 # RPM Version   : 020949
 # RPM Release   : crayxc0
 
-
 case "${rc_prefix:-}" in
 ( "" )
-    # default: strip out the "dash" from $chpl_platform (e.g. cray-xc -> crayxc)
-    rc_prefix=$( sed -e 's,-,,' <<<"$chpl_platform" )
+    # default: strip out dashes from $chpl_platform (e.g. cray-xc -> crayxc)
+    rc_prefix=${chpl_platform//-}
+    if [ "$chpl_platform" = cray-shasta ]; then
+        #
+        # For Shasta, need timestamp and SHA before (dashless) platform,
+        # and no release candidate number.
+        #
+        if [ -n "$rel_name" ]; then
+            rc_prefix="${rel_name}.${rc_prefix}"
+        else
+            if [ -n "$CHPL_HOME" -a -d $CHPL_HOME/.git ]; then
+                sha=$(cd $CHPL_HOME && git show --pretty=format:%H HEAD | \
+                      head -1 | cut -c1-7)
+            fi
+            rc_prefix="$(date '+%Y%m%d%H%M%S')_${sha}.${rc_prefix}"
+        fi
+        rc_number=''
+    fi
     ;;
 ( *[!0-9a-zA-Z_]* )
     log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid rc_prefix='$rc_prefix'"; exit 2
@@ -54,13 +69,15 @@ esac
 
 # Derived values
 
-case "$rc_prefix" in
-( *[0-9] )
-    case "${rc_number:=0}" in
-        ( [0-9]* ) log_warn "$( basename "${BASH_SOURCE[0]}" ): rc_prefix='$rc_prefix', rc_number='$rc_number' (too many digits?)";;
+if [ -n "$rc_number" ]; then
+    case "$rc_prefix" in
+    ( *[0-9] )
+        case "${rc_number:=0}" in
+            ( [0-9]* ) log_warn "$( basename "${BASH_SOURCE[0]}" ): rc_prefix='$rc_prefix', rc_number='$rc_number' (too many digits?)";;
+        esac
+        ;;
     esac
-    ;;
-esac
+fi
 rpm_release=$rc_prefix$rc_number
 
 case "${release_type:-}" in
@@ -79,14 +96,12 @@ rpm_name="chapel-$pkg_version"
 rpm_filename="chapel-$pkg_version-$rpm_release.$CPU.rpm"
 rpmbuild_filename="chapel-$pkg_version-$rpm_version-$rpm_release.$CPU.rpm"
 
-log_debug "Using rc_prefix='$rc_prefix'"
 log_debug "Using rpm_release='$rpm_release'"
 log_debug "Using rpm_name='$rpm_name'"
 log_debug "Using rpm_version='$rpm_version'"
 log_debug "Using rpm_filename='$rpm_filename'"
 log_debug "Using rpmbuild_filename='$rpmbuild_filename'"
 
-export rc_prefix
 export rpm_release
 export rpm_name
 export rpm_version

--- a/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
+++ b/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
@@ -128,11 +128,11 @@ Dependencies:
 Installation instructions:
 --------------------------
 
-    Copy the appropriate Chapel RPM file to the current directory and execute
-    one of the following commands:
+    Copy the Chapel RPM file to the current directory and execute
+    the appropriate one of the following commands:
 
       #On Cray Shasta systems (x86_64):
-      rpm -ivh chapel-$pkg_version-crayshasta$rc_number.x86_64.rpm
+      rpm -ivh chapel-$pkg_version-$rpm_release.x86_64.rpm
 
       #On Cray XC systems (x86_64):
       rpm -ivh chapel-$pkg_version-crayxc$rc_number.x86_64.rpm

--- a/util/build_configs/package-common.bash
+++ b/util/build_configs/package-common.bash
@@ -29,6 +29,7 @@ fi
 #                   e.g. "1.17.1.20181016" for a nightly build
 # release_type  : nightly or release or developer
 # chpl_platform : linux64, cray-xc, etc             # as in, $CHPL_HOME/bin/$chpl_platform
+# rel_name      : Shasta RPM release name, synthesized if not given
 # rc_number     : Release candidate number (0,1,2..); something to distinguish different instances of
 #                 otherwise-identical packages. May be applied in different ways dep. on package-format.
 # date_ymd,
@@ -108,17 +109,13 @@ log_debug "Using src_version='$src_version'"
 log_debug "Using version_tag='$version_tag'"
 log_debug "Using pkg_version='$pkg_version'"
 log_debug "Using release_type='$release_type'"
+log_debug "Using rel_name='$rel_name'"
 log_debug "Using rc_number='$rc_number'"
-log_debug "Using date_ymd='$date_ymd'"
-log_debug "Using date_hms='$date_hms'"
 
 export chpl_platform
 export src_version major minor update
-export version_tag
 export pkg_version
-export release_type
+export rel_name
 export rc_number
-export date_ymd
-export date_hms
 
 log_debug "End $( basename "${BASH_SOURCE[0]}" )"


### PR DESCRIPTION
This duplicates #14366 into the release/1.20 branch.

For Shasta, the module delivery mechanism requires RPMs with filenames
of the form name-version-release[.dist].arch.rpm, where 'version' is
major.minor.update and 'release' is a YYYYmmddHHMMSS timestamp (in
date(1) formatting terms), an underbar, and a 7-digit SHA for the branch
from which the RPM was built. Here, add a -R option so the module
build driver can tell us that part of the name, and also arrange to try
to create it ourselves for Shasta RPMs if that option is not given.

While here, also do some cleaning up, mostly renaming variables to more
clearly indicate their usage and demoting environment variables not
actually needed by subprocesses to shell variables.