### PR TITLE
Fix typo: bash var expansion with suffix removal needs curly braces.

### DIFF
--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -159,7 +159,7 @@ fi
 
 # Create rpmbuild_dir, the packaging counterpart to CHPL_HOME, in workdir
 
-rpmbuild_dir="$workdir/$rpm_filename%.$CPU.rpm"
+rpmbuild_dir="$workdir/${rpm_filename%.$CPU.rpm}"
 log_info "Creating rpmbuild_dir='$rpmbuild_dir'"
 
 rm -rf "$rpmbuild_dir"


### PR DESCRIPTION
Without the curly braces the '%' had no special effect and became part
of the path.  When that path then appeared in a Makefile rule the '%'
confused make's parser and resulted in the message "mixed implicit and
normal rules: deprecated syntax".