### PR TITLE
Fix a leak in masonModify

### DIFF
--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -92,6 +92,7 @@ proc masonModify(args) throws {
 
     const result = modifyToml(add, dep, external, system, projectHome);
     generateToml(result[1], result[2]);
+    delete result[1];
   }
   catch e: MasonError {
     writeln(e.message());


### PR DESCRIPTION
Delete an unmanaged Toml that was getting leaked