### PR TITLE
Avoid 'use'ing ByteBufferHelpers ExportWrappers

### DIFF
--- a/modules/internal/ExportWrappers.chpl
+++ b/modules/internal/ExportWrappers.chpl
@@ -80,13 +80,7 @@ module ExportWrappers {
   // the Chapel heap.
   //
   proc chpl__exportConv(val: chpl_bytes_wrapper, type rt: bytes): rt {
-    use ByteBufferHelpers;
-    var data = val.data:ByteBufferHelpers.bufferType;
-    // TODO: Are these casts safe casts?
-    var length = val.size:int(64);
-    var buflen = (val.size + 1):int(64);
-    var result = createBytesWithNewBuffer(data, length=length, size=buflen);
-    return result;
+    return createBytesWithNewBuffer(val.data:c_string, val.size.safeCast(int));
   }
 
 } // End module "ExportWrappers".


### PR DESCRIPTION
For some reason the `use ByteBufferHelpers;` in `ExportWrappers` hurt
performance for the string search test. We don't understand the root
cause, and it's likely some weird cache-effect, but we can avoid the use
and cleanup the code.

https://github.com/chapel-lang/chapel/issues/14376 has more info

Resolves https://github.com/chapel-lang/chapel/issues/14376