### PR TITLE
Add perf annotations for 2019-11-02

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -396,12 +396,15 @@ all:
     - Stop pinning the progress thread to the last CPU (#13423)
   07/16/19:
     - text: Use a blocking progress thread for gasnet-infiniband (#13473)
-      config: 16 node CS
+      config: 16-node-cs
   08/08/19:
     - text: Machine upgraded to CLE7
       config: 16 node XC
   10/02/19:
     - text: system update
+      config: 16 node XC
+  10/10/19:
+    - text: Optimize unorderedCopy for types larger than 8 bytes (#14255)
       config: 16 node XC
 
 
@@ -605,6 +608,12 @@ create-views:
 cs-resize:
   03/05/19:
     - Add radix sort to Sort package module (#12452)
+
+domainAssignment-similar: &domainAssign-base
+  10/26/19:
+    - Add optimized COO->CSR/CSC sparse domain assignment (#14272)
+domainAssignment-dissimilar:
+  <<: *domainAssign-base
 
 dgemm.128:
   09/06/13:
@@ -1124,6 +1133,12 @@ memleaksfull:
     - fix another deletion size mismatch error (introduced leaks) (#13671)
   09/26/19:
     - Fix memory leak caused by use of first class functions (#14163)
+  10/17/19:
+    - Rework several sparse tests (#14283)
+  10/22/19:
+    - Starting running mason as part of memleak testing
+  11/01/19:
+    - Fix a leak in masonModify (#14375)
 
 meteor:
   12/18/13:
@@ -1407,6 +1422,10 @@ search:
     - Tuple iteration yields (const) refs (#11866)
   09/04/19:
     - Inline small wrappers in string and bytes implementations (#13971)
+  10/25/19:
+    - Support the Chapel bytes type in single locale Python interop (#14310)
+  11/01/19:
+    - Avoid 'use'ing ByteBufferHelpers ExportWrappers (#14377)
 
 spectralnorm:
   01/21/15:
@@ -1643,6 +1662,9 @@ compilerAndTestingStats: &compiler-perf-base
     - Require 'use' of top level modules rather than lexical scoping (#13930)
   09/06/19:
     - Turn "array-as-vec" deprecation warnings on (#13999)
+  10/30/19:
+    - Switched test machine
+
 allTotalTime:
   <<: *compiler-perf-base
 allPasses:

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -91,7 +91,7 @@ def check_graph_names(ann_data, graph_list):
 def check_configs(ann_data):
     """Check that all the configs used in the annotation file are 'known'"""
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
-                     '16 node XC', 'Single node XC', '16 node CS'}
+                     '16 node XC', 'Single node XC', '16-node-cs'}
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():
             for ann in annotations:


### PR DESCRIPTION
Add annotations for:
 - [improvement](https://chapel-lang.org/perf/16-node-xc/?startdate=2019/09/08&enddate=2019/10/29&configs=gnuugniqthreads&graphs=remotemanytomany2intgetperformance,remotemanytomany16intgetperformance,remotemanytomany2intputperformance,remotemanytomany16intputperformance) for larger unorderedCopy (#14255)
 - [improvement](https://chapel-lang.org/perf/chapcs/?startdate=2019/10/18&enddate=2019/11/02&graphs=sparsedomainassignmentsimilarlayouts5mindices,sparsedomainassignmentdissimilarlayouts50kindices) for CCO->CSR/CSC domains (#14272)
 - memory leak [changes](https://chapel-lang.org/perf/chapcs/?startdate=2019/10/12&enddate=2019/11/02&graphs=memoryleaksforalltests,numberoftestswithleaks)
 - weird [regression and fix](https://chapel-lang.org/perf/chapcs/?startdate=2019/10/23&enddate=2019/11/02&graphs=searchesovernstrings) for string search (#14310, #14377)
 - compiler performance [differences](https://chapel-lang.org/perf/comp-default/?startdate=2019/10/26&enddate=2019/10/31&suite=top10compilationpasstimings) from machine change