### PR TITLE
Fix leftover \begin and \end in rst spec

### DIFF
--- a/doc/rst/language/spec.rst
+++ b/doc/rst/language/spec.rst
@@ -889,10 +889,11 @@ Interpreted string literals are designated by the following syntax:
 
    hexadecimal-escape-character:
      `\x' hexadecimal-digits
-   \end{syntax}
 
-   Uninterpreted string literals are designated by the following syntax:
-   \begin{syntax}
+Uninterpreted string literals are designated by the following syntax:
+
+.. code-block:: syntax
+
    uninterpreted-string-literal:
      """ uninterpreted-double-quote-delimited-characters """
      ''' uninterpreted-single-quote-delimited-characters '''


### PR DESCRIPTION
Follow-on to PR #14165.

Addresses a formatting problem pointed out by @cassella - thanks @cassella !

Trivial and not reviewed.