### PR TITLE
Add a `locale.hostname` method

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -186,7 +186,21 @@ module ChapelLocale {
     proc localeid : chpl_localeID_t return __primitive("_wide_get_locale", this);
 
     /*
-      Get the name of this locale.
+      Get the hostname of this locale.
+
+      :returns: the hostname of the compute node associated with the locale
+      :rtype: string
+    */
+    proc hostname: string {
+      extern proc chpl_nodeName(): c_string;
+      var name = chpl_nodeName():string;
+      return name;
+    }
+
+    /*
+      Get the name of this locale.  In practice, this is often the
+      same as the hostname, though in some cases (like when using
+      local launchers), it may be modified.
 
       :returns: locale name
       :rtype: string

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -193,8 +193,11 @@ module ChapelLocale {
     */
     proc hostname: string {
       extern proc chpl_nodeName(): c_string;
-      var name = chpl_nodeName():string;
-      return name;
+      var hname: string;
+      on this {
+        hname = chpl_nodeName():string;
+      }
+      return hname;
     }
 
     /*

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -107,6 +107,7 @@ writeln();
  number of other queries about their properties.  For example:
 
  * ``locale.name``       : returns a string indicating the locale's name
+ * ``locale.hostname``   : returns a string indicating the locale's hostname
  * ``locale.numPUs()``   : returns the number of processor cores on the locale
  * ``locale.physicalMemory()`` : returns the amount of memory on the locale
  * ``locale.maxTaskPar`` : returns the likely maximum parallelism available
@@ -121,6 +122,7 @@ if printLocaleInfo then
     on loc {
       writeln("locale #", here.id, "...");
       writeln("  ...is named: ", here.name);
+      writeln("  ...has hostname: ", here.hostname);
       writeln("  ...has ", here.numPUs(), " processor cores");
       writeln("  ...has ", here.physicalMemory(unit=MemUnits.GB, retType=real),
               " GB of memory");

--- a/test/types/locale/.gitignore
+++ b/test/types/locale/.gitignore
@@ -1,0 +1,1 @@
+hostname.good

--- a/test/types/locale/CLEANFILES
+++ b/test/types/locale/CLEANFILES
@@ -1,0 +1,1 @@
+hostname.good

--- a/test/types/locale/hostname.chpl
+++ b/test/types/locale/hostname.chpl
@@ -1,0 +1,3 @@
+for loc in Locales do
+  on loc do
+    writeln(here.hostname);

--- a/test/types/locale/hostname.prediff
+++ b/test/types/locale/hostname.prediff
@@ -1,0 +1,2 @@
+#!/bin/bash
+hostname > hostname.good


### PR DESCRIPTION
This adds a method named `hostname` to the `locale` type as a means of
letting users query the hostname that the locale represents / on which
it is running.  The existing `name` query typically returns the same
value, though in some cases we munge the hostname with additional
information or use different names (e.g., when using the local spawner
with certain GASNet configurations; for certain sub-locales).

The PR updates the locales primer to mention the method and adds a
test (for CHPL_COMM=none configurations only) which generates its
.good file dynamically using `hostname` from bash.