### PR TITLE
Issue initializer errors for forall-stmt iterands

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -686,6 +686,7 @@ static InitNormalize preNormalize(AggregateType* at,
       stmt = stmt->next;
 
     } else if (ForallStmt* forall = toForallStmt(stmt)) {
+      preNormalize(at, block, state, forall->iteratedExpressions().head);
       preNormalize(at,
                    forall->loopBody(),
                    InitNormalize(forall, state));

--- a/test/classes/initializers/phase1/loopUpdate.bad
+++ b/test/classes/initializers/phase1/loopUpdate.bad
@@ -1,2 +1,5 @@
 loopUpdate.chpl:5: In initializer:
 loopUpdate.chpl:7: error: field "N" used before it is initialized
+loopUpdate.chpl:8: error: field "N" used before it is initialized
+loopUpdate.chpl:9: error: field "N" used before it is initialized
+loopUpdate.chpl:9: error: field "N" used before it is initialized

--- a/test/classes/initializers/phase1/loopUpdate.chpl
+++ b/test/classes/initializers/phase1/loopUpdate.chpl
@@ -5,6 +5,8 @@ class Params {
   proc init() {
     numProbSizes = 3;
     for n in N do n = 10;
+    forall n in N do n = 10;
+    forall (n1, n2) in zip(N, N) do n1 = 10;
   }
 }
 


### PR DESCRIPTION
This PR updates the compiler to check for initializer semantic errors in a forall-stmt's iterands.

Resolves #12771 

Testing:
- [x] local + futures
- [x] gasnet + futures

