### PR TITLE
Deprecate casts from c_string to string

### DIFF
--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -131,27 +131,27 @@ module CString {
   // casts from c_string to bool types
   //
   inline proc _cast(type t:chpl_anybool, x:c_string) throws
-    return try ((x:string).strip()): t;
+    return try ((createStringWithNewBuffer(x)).strip()): t;
 
   //
   // casts from c_string to integer types
   //
   inline proc _cast(type t:integral, x:c_string) throws
-    return try ((x:string).strip()): t;
+    return try ((createStringWithNewBuffer(x)).strip()): t;
 
   //
   // casts from c_string to real/imag types
   //
   inline proc _cast(type t:chpl_anyreal, x:c_string) throws
-    return try ((x:string).strip()): t;
+    return try ((createStringWithNewBuffer(x)).strip()): t;
   inline proc _cast(type t:chpl_anyimag, x:c_string) throws
-    return try ((x:string).strip()): t;
+    return try ((createStringWithNewBuffer(x)).strip()): t;
 
   //
   // casts from c_string to complex types
   //
   inline proc _cast(type t:chpl_anycomplex, x:c_string) throws
-    return try ((x:string).strip()): t;
+    return try ((createStringWithNewBuffer(x)).strip()): t;
 
   //
   // primitive c_string functions and methods

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1350,7 +1350,7 @@ module ChapelBase {
     if isAtomicType(t) then
       compilerError("config variables of atomic type are not supported");
 
-    var str = x:string;
+    var str = createStringWithNewBuffer(x);
     if t == string {
       return str;
     } else {
@@ -2324,7 +2324,9 @@ module ChapelBase {
     const moduleName: c_string;          // for debugging; non-null, not owned
     const deinitFun:  c_fn_ptr;          // module deinit function
     const prevModule: unmanaged chpl_ModuleDeinit?; // singly-linked list / LIFO queue
-    proc writeThis(ch) throws {ch.writef("chpl_ModuleDeinit(%s)",moduleName:string);}
+    proc writeThis(ch) throws { 
+      ch.writef("chpl_ModuleDeinit(%s)",createStringWithNewBuffer(moduleName));
+    }
   }
   var chpl_moduleDeinitFuns = nil: unmanaged chpl_ModuleDeinit?;
 

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -85,7 +85,7 @@ module ChapelDebugPrint {
       // yet defined).
       const file_cs : c_string = __primitive("chpl_lookupFilename",
                                         __primitive("_get_user_file"));
-      const file = file_cs:string;
+      const file = createStringWithNewBuffer(file_cs);
       const line = __primitive("_get_user_line");
       var str = chpl_debug_stringify((...args));
       extern proc printf(fmt:c_string, f:c_string, ln:c_int, s:c_string);

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -97,7 +97,7 @@ module ChapelDebugPrint {
     if chpl__testParFlag && chpl__testParOn {
       const file_cs : c_string = __primitive("chpl_lookupFilename",
                                         __primitive("_get_user_file"));
-      const file = file_cs:string;
+      const file = createStringWithBorrowedBuffer(file_cs);
       const line = __primitive("_get_user_line");
       writeln("CHPL TEST PAR (", file, ":", line, "): ", (...args));
     }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -341,7 +341,7 @@ module ChapelError {
   proc chpl_error_type_name(err: borrowed Error) : string {
     var cid =  __primitive("getcid", err);
     var nameC: c_string = __primitive("class name by id", cid);
-    var nameS = nameC:string;
+    var nameS = createStringWithNewBuffer(nameC);
     return nameS;
   }
   pragma "no doc"
@@ -427,12 +427,12 @@ module ChapelError {
 
     const myFileC:c_string = __primitive("chpl_lookupFilename",
                                          __primitive("_get_user_file"));
-    const myFileS = myFileC:string;
+    const myFileS = createStringWithBorrowedBuffer(myFileC);
     const myLine = __primitive("_get_user_line");
 
     const thrownFileC:c_string = __primitive("chpl_lookupFilename",
                                              err.thrownFileId);
-    const thrownFileS = thrownFileC:string;
+    const thrownFileS = createStringWithBorrowedBuffer(thrownFileC);
     const thrownLine = err.thrownLine;
 
     var s = "uncaught " + chpl_describe_error(err) +

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -195,7 +195,7 @@ module ChapelLocale {
       extern proc chpl_nodeName(): c_string;
       var hname: string;
       on this {
-        hname = chpl_nodeName():string;
+        hname = createStringWithNewBuffer(chpl_nodeName());
       }
       return hname;
     }

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -136,7 +136,7 @@ module ChapelUtil {
     if (flag != "--chpl-mli-socket-loc") {
       halt("chpl_get_mli_connection called with unexpected arguments, missing "
            + "'--chpl-mli-socket-loc <connection>', instead got " +
-           flag: string);
+           createStringWithNewBuffer(flag));
     }
     var result: c_string = chpl_get_argument_i(local_arg,
                                                (local_arg.argc-1): int(32));

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -120,7 +120,8 @@ module ChapelUtil {
 
     for i in 0..#arg.argc {
       // FIX ME: leak c_string
-      array[i] = chpl_get_argument_i(local_arg, i:int(32)):string;
+      array[i] = createStringWithNewBuffer(chpl_get_argument_i(local_arg,
+                                                               i:int(32)));
     }
 
     return array;

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -124,7 +124,7 @@ module LocaleModelHelpSetup {
     // at least this setup method) must be run on the node it is
     // intended to describe.
     extern proc chpl_nodeName(): c_string;
-    const _node_name = chpl_nodeName(): string;
+    const _node_name = createStringWithNewBuffer(chpl_nodeName());
     const _node_id = (chpl_nodeID: int): string;
 
     return if localSpawn() then _node_name + "-" + _node_id else _node_name;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2377,6 +2377,8 @@ module String {
   // Cast from c_string to string
   pragma "no doc"
   proc _cast(type t, cs: c_string) where t == string {
+    compilerWarning("Cast from c_string to string is deprecated - "+
+                    "please use createString* functions instead");
     var ret: string;
     ret.len = cs.length;
     ret._size = ret.len+1;

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -493,7 +493,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.ctx == nil {
-        var errmsg = zmq_strerror(errno):string;
+        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
         halt("Error in ContextClass.init(): %s\n", errmsg);
       }
     }
@@ -502,7 +502,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_ctx_term(this.ctx):int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in ContextClass.deinit(): %s\n", errmsg);
         }
       }
@@ -579,7 +579,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.socket == nil {
-        var errmsg = zmq_strerror(errno):string;
+        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
         halt("Error in SocketClass.init(): %s\n", errmsg);
       }
     }
@@ -588,7 +588,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_close(socket):int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in SocketClass.deinit(): %s\n", errmsg);
         }
         socket = c_nil;
@@ -689,7 +689,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_bind(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in Socket.bind(): ", errmsg);
         }
       }
@@ -703,7 +703,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_connect(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           writef("Error in Socket.connect(): %s\n", errmsg);
         }
       }
@@ -734,7 +734,7 @@ module ZMQ {
                                  c_ptrTo(copy):c_void_ptr,
                                  numBytes(T)): int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in Socket.setsockopt(): ", errmsg);
         }
       }
@@ -772,7 +772,7 @@ module ZMQ {
         var err = zmq_getsockopt_string_helper(classRef.socket,
                                                ZMQ_LAST_ENDPOINT, str);
         if err == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLastEndpoint(): " +
@@ -799,7 +799,7 @@ module ZMQ {
         var ret = zmq_getsockopt_int_helper(classRef.socket, ZMQ_LINGER,
                                             copy);
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLinger(): " + errmsg);
@@ -825,7 +825,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setLinger(): " + errmsg);
@@ -849,7 +849,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setSubscribe(): " + errmsg);
@@ -1103,7 +1103,8 @@ module ZMQ {
 
     pragma "no doc"
     proc throw_socket_error(socket_errno: c_int, err_fn: string) throws {
-      var errmsg_zmq = zmq_strerror(socket_errno):string;
+      var errmsg_zmq =
+        createStringWithBorrowedBuffer(zmq_strerror(socket_errno));
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -433,7 +433,8 @@ module DateTime {
     timeStruct.tm_yday = (this - new date(year, 1, 1)).days: int(32);
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = __primitive("cast", c_string, c_ptrTo(buf)): string;
+    var str = createStringWithNewBuffer( __primitive("cast",
+                                                     c_string, c_ptrTo(buf)));
 
     return str;
   }
@@ -681,7 +682,8 @@ module DateTime {
     }
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = __primitive("cast", c_string, c_ptrTo(buf)): string;
+    var str = createStringWithNewBuffer(__primitive("cast",
+                                                    c_string, c_ptrTo(buf)));
 
     return str;
   }
@@ -1190,7 +1192,8 @@ module DateTime {
     timeStruct.tm_yday = (this.replace(tzinfo=nil) - new datetime(year, 1, 1)).days: int(32);
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = __primitive("cast", c_string, c_ptrTo(buf)): string;
+    var str = createStringWithNewBuffer(__primitive("cast",
+                                                    c_string, c_ptrTo(buf)));
 
     return str;
   }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -876,7 +876,8 @@ private module GlobWrappers {
   // glob_index wrapper that takes care of casting
   inline proc glob_index_w(glb: glob_t, idx: int): string {
     extern proc chpl_glob_index(glb: glob_t, idx: size_t): c_string;
-    return chpl_glob_index(glb, idx.safeCast(size_t)): string;
+    return createStringWithNewBuffer(chpl_glob_index(glb,
+                                                       idx.safeCast(size_t)));
   }
 
   // globfree wrapper that exists only for symmetry in the routine names
@@ -1181,7 +1182,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = ent.d_name():string;
+      const filename = createStringWithBorrowedBuffer(ent.d_name());
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {
           const fullpath = path + "/" + filename;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3436,7 +3436,12 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
 
   for param i in 1..tup.size {
     if i != 1 then str += ", ";
-    str += tup[i]:string;
+    if tup[i].type == c_string {
+      str += createStringWithBorrowedBuffer(tup[i]);
+    }
+    else {
+      str += tup[i]:string;
+    }
   }
 
  str += ")";
@@ -3463,9 +3468,10 @@ proc stringify(const args ...?k):string {
     var str = "";
 
     for param i in 1..k {
-      if args[i].type == string ||
-         args[i].type == c_string {
-        str += args[i]:string;
+      if args[i].type == string {
+        str += args[i];
+      } else if args[i].type == c_string {
+        str += createStringWithBorrowedBuffer(args[i]);
       } else if args[i].type == bytes {
         //decodePolicy.replace never throws
         try! {

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -358,7 +358,7 @@ proc dirname(name: string): string {
            if (h != 1) {
              value = "${" + env_var + "}";
            } else {
-             value = value_c: string;
+             value = createStringWithBorrowedBuffer(value_c);
            }
            res += value;
          }
@@ -375,7 +375,7 @@ proc dirname(name: string): string {
          if (h != 1) {
            value = "$" + env_var;
          } else {
-           value = value_c: string;
+           value = createStringWithBorrowedBuffer(value_c);
          }
          res += value;
          if (ind <= path_p.numBytes) {

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -468,7 +468,8 @@ proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=f
   qio_regexp_create_compile(pattern.localize().c_str(), pattern.numBytes, opts, ret._regexp);
   if !qio_regexp_ok(ret._regexp) {
     var err_str = qio_regexp_error(ret._regexp);
-    var err_msg = err_str:string + " when compiling regexp '" + pattern + "'";
+    var err_msg = createStringWithNewBuffer(err_str) + 
+                  " when compiling regexp '" + pattern + "'";
     throw new owned BadRegexpError(err_msg);
   }
   return ret;

--- a/test/associative/thomasvandoren/c_string-to-string.chpl
+++ b/test/associative/thomasvandoren/c_string-to-string.chpl
@@ -2,9 +2,9 @@ use Map;
 
 // strMap - map string keys to string values
 var strMap = new map(string, string);
-const a: c_string = "a";
+const a: string = "a";
 
-strMap[a:string] = "123";
+strMap[a] = "123";
 
 for key in strMap do
   writeln(key, " = ", strMap[key]);

--- a/test/compflags/link/deitz/test_link1.chpl
+++ b/test/compflags/link/deitz/test_link1.chpl
@@ -3,4 +3,4 @@ extern proc bar(i: int): c_string;
 
 foo("hello world");
 var s = bar(12);
-writeln(s:string);
+writeln(createStringWithNewBuffer(s));

--- a/test/compflags/link/deitz/test_link2.chpl
+++ b/test/compflags/link/deitz/test_link2.chpl
@@ -3,4 +3,4 @@ extern proc bar(i: int): c_string;
 
 foo("hello world");
 var s = bar(12);
-writeln(s:string);
+writeln(createStringWithNewBuffer(s));

--- a/test/execflags/gbt/dash-E.chpl
+++ b/test/execflags/gbt/dash-E.chpl
@@ -1,2 +1,2 @@
 extern proc getenv(const name: c_string): c_string;
-writeln(getenv('DASH_E_ENV_VAR'):string);
+writeln(createStringWithNewBuffer(getenv('DASH_E_ENV_VAR')));

--- a/test/execflags/gbt/shell-meta-env.chpl
+++ b/test/execflags/gbt/shell-meta-env.chpl
@@ -1,3 +1,3 @@
 var ev: c_string;
 if sys_getenv('SHELL_META_ENV', ev) != 0 then
-  writeln(ev:string);
+  writeln(createStringWithNewBuffer(ev));

--- a/test/expressions/ferguson/dynamic-class-name.chpl
+++ b/test/expressions/ferguson/dynamic-class-name.chpl
@@ -2,7 +2,7 @@ proc getNameFromClass(obj:borrowed object) : string
 {
   var cid =  __primitive("getcid", obj);
   var cs: c_string = __primitive("class name by id", cid);
-  var str = cs:string;
+  var str = createStringWithNewBuffer(cs);
   return str;
 }
 

--- a/test/extern/bradc/extern_string_test-remote.chpl
+++ b/test/extern/bradc/extern_string_test-remote.chpl
@@ -3,7 +3,9 @@ use IO;
 extern proc return_string_test():c_string;
 extern proc return_string_arg_test(ref c_string);
 
-writeln("returned string ",return_string_test():string); stdout.flush();
+writeln("returned string ",createStringWithNewBuffer(return_string_test()));
+stdout.flush();
+
 var s:string;
 on Locales(1) {
   var temp_cs: c_string;

--- a/test/extern/ferguson/c_strings.chpl
+++ b/test/extern/ferguson/c_strings.chpl
@@ -14,9 +14,9 @@ proc go() {
   var gotc = returns_c_string();
   print_c_string(gotc);
 
-  writeln(gotc:string);
+  writeln(createStringWithNewBuffer(gotc));
 
-  var gots = gotc:string;
+  var gots = createStringWithNewBuffer(gotc);
   writeln(gots);
 
   writeln("Should be returned_c_string_in_argument x3");
@@ -25,9 +25,9 @@ proc go() {
 
   print_c_string(argc);
 
-  writeln(argc:string);
+  writeln(createStringWithNewBuffer(argc));
 
-  var args = argc:string;
+  var args = createStringWithNewBuffer(argc);
   writeln(args);
 
   writeln("Should be returned_c_string_in_argument_with_length x3");
@@ -37,9 +37,9 @@ proc go() {
 
   print_c_string_len(arg2c, len);
 
-  writeln((arg2c:string)[1..len]);
+  writeln((createStringWithNewBuffer(arg2c))[1..len]);
 
-  var arg2s = (arg2c:string)[1..len];
+  var arg2s = (createStringWithNewBuffer(arg2c))[1..len];
   writeln(arg2s);
 }
 

--- a/test/extern/ferguson/c_strings_global.chpl
+++ b/test/extern/ferguson/c_strings_global.chpl
@@ -14,9 +14,9 @@ proc go() {
   var gotc = returns_c_string();
   print_c_string(gotc);
 
-  writeln(gotc:string);
+  writeln(createStringWithNewBuffer(gotc));
 
-  var gots = gotc:string;
+  var gots = createStringWithNewBuffer(gotc);
   writeln(gots);
 
   writeln("Should be returned_c_string_in_argument x3");
@@ -25,9 +25,9 @@ proc go() {
 
   print_c_string(argc);
 
-  writeln(argc:string);
+  writeln(createStringWithNewBuffer(argc));
 
-  var args = argc:string;
+  var args = createStringWithNewBuffer(argc);
   writeln(args);
 
   writeln("Should be returned_c_string_in_argument_with_length x3");
@@ -37,9 +37,9 @@ proc go() {
 
   print_c_string_len(arg2c, len);
 
-  writeln((arg2c:string)[1..len]);
+  writeln((createStringWithNewBuffer(arg2c))[1..len]);
 
-  var arg2s = (arg2c:string)[1..len];
+  var arg2s = (createStringWithNewBuffer(arg2c))[1..len];
   writeln(arg2s);
 }
 

--- a/test/extern/gbt/string_from_c_string.chpl
+++ b/test/extern/gbt/string_from_c_string.chpl
@@ -1,4 +1,4 @@
 extern proc returns_c_string(): c_string;
 
 writeln("Should be returned_c_string");
-writeln(returns_c_string():string);
+writeln(createStringWithNewBuffer(returns_c_string()));

--- a/test/interop/fortran/genFortranInterface/unhandledType.chpl
+++ b/test/interop/fortran/genFortranInterface/unhandledType.chpl
@@ -1,5 +1,5 @@
 export proc takesCstring(s: c_string) {
-  writeln(s: string);
+  writeln(createStringWithNewBuffer(s));
 }
 
 

--- a/test/io/ferguson/open-remote-string.chpl
+++ b/test/io/ferguson/open-remote-string.chpl
@@ -20,7 +20,7 @@ for f in DistFiles {
     var base = basename(f);
     var uname:c_string;
     sys_getenv(c"USER", uname);
-    var to = "/tmp/" + uname:string + base;
+    var to = "/tmp/" + createStringWithNewBuffer(uname)+ base;
     if verbose then writeln("on ", here.id, " copying from ", from, " to ", to);
     copy(from, to);
     f = to;

--- a/test/library/standard/FileSystem/bharshbarg/filer.chpl
+++ b/test/library/standard/FileSystem/bharshbarg/filer.chpl
@@ -48,7 +48,7 @@ iter listdir(path: string, hidden=false, dirs=true, files=true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = ent.d_name():string;
+      const filename = createStringWithNewBuffer(ent.d_name());
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {
           //

--- a/test/localeModels/dmk/locale_name.chpl
+++ b/test/localeModels/dmk/locale_name.chpl
@@ -3,9 +3,9 @@ extern var chpl_nodeID: chpl_nodeID_t;
 
 var locale_name = here.chpl_name();
 
-if locale_name == chpl_nodeName():string then
+if locale_name == createStringWithNewBuffer(chpl_nodeName()) then
   writeln("matches nodeName");
-else if locale_name == chpl_nodeName():string + "-" + chpl_nodeID:string then
+else if locale_name == createStringWithNewBuffer(chpl_nodeName()) + "-" + chpl_nodeID:string then
   writeln("matches nodeName-nodeID");
 else
   writeln("unknown format: ", locale_name);

--- a/test/runtime/gbt/tasks/idToString.chpl
+++ b/test/runtime/gbt/tasks/idToString.chpl
@@ -13,7 +13,8 @@ proc main() {
     var buf: [1..bufLen] buf_t;
     var idStr = chpl_task_idToString(c_ptrTo(buf), buf.size:size_t, id);
     writeln('task ID of ', what, ' is: ',
-            if idStr==c_nil:c_string then '<OVF>' else idStr:string);
+            if idStr==c_nil:c_string then '<OVF>'
+                                     else createStringWithNewBuffer(idStr));
   }
 
   showMe('main()');

--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -45,10 +45,10 @@ iter my_wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory
   for i in 0..wordexpNum -1 {
     tx = wordexp_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
-      const pth = tx:string + "/";
+      const pth = createStringWithNewBuffer(tx)+ "/";
       for fl in my_wordexp(pattern, recursive, flags, pth) do
         yield fl;
-    } else yield tx:string;
+    } else yield createStringWithNewBuffer(tx);
   }
 
   wordfree(glb);
@@ -107,10 +107,10 @@ iter my_glob(pattern:string, recursive:bool = false, flags:int = 0, directory:st
   for i in 0..globNum - 1 {
     tx = glob_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
-      const pth = tx:string + "/";
+      const pth = createStringWithNewBuffer(tx)+ "/";
       for fl in my_glob(pattern, recursive, flags, pth) do
         yield fl;
-    } else yield tx:string;
+    } else yield createStringWithNewBuffer(tx);
   }
 
   globfree(glb);

--- a/test/types/bytes/basic.chpl
+++ b/test/types/bytes/basic.chpl
@@ -4,7 +4,7 @@ var cs: c_string = "this is a c_string";
 
 writeln(b);
 writeln(s);
-writeln(cs:string);
+writeln(createStringWithNewBuffer(cs));
 writeln();
 
 // TEST INITIALIZERS

--- a/test/types/records/sungeun/recordWithRefCopyFns.chpl
+++ b/test/types/records/sungeun/recordWithRefCopyFns.chpl
@@ -19,7 +19,7 @@ inline proc chpl__autoCopy(ref r: myR) {
 
 
 var s0: myR;
-s0.base = "s0";
+s0.base = c"s0";
 sync {
-  begin writeln(s0.base:string);
+  begin writeln(createStringWithNewBuffer(s0.base));
 }

--- a/test/types/string/StringImpl/memLeaks/cast.chpl
+++ b/test/types/string/StringImpl/memLeaks/cast.chpl
@@ -92,40 +92,8 @@ module unitTest {
     fbool();
   }
 
-  proc cast_from_c_string(type t, useExpr=false) {
-    writeln("=== cast from c_string");
-    const m0 = allMemoryUsed();
-    {
-      const x: c_string = "cs";
-      if useExpr {
-        writeMe(x:t);
-      } else {
-        const s = x:t;
-        writeMe(s);
-      }
-    }
-    checkMemLeaks(m0);
-  }
-
-  proc cast_to_c_string(type t, useExpr=false) {
-    writeln("=== cast to c_string");
-    const m0 = allMemoryUsed();
-    {
-      const x: t = c"cs";
-      if useExpr {
-        writeMe(x.c_str():t);
-      } else {
-        const s = x.c_str();
-        writeMe(s:t);
-      }
-    }
-    checkMemLeaks(m0);
-  }
-
   proc doIt(type t) {
     castAll(t); castAll(t, true);
-    cast_from_c_string(t); cast_from_c_string(t, true);
-    cast_to_c_string(t); cast_to_c_string(t, true);
   }
 
 }

--- a/test/types/string/StringImpl/memLeaks/cast.good
+++ b/test/types/string/StringImpl/memLeaks/cast.good
@@ -62,11 +62,3 @@ true
 three
 === cast from bool
 true
-=== cast from c_string
-cs
-=== cast from c_string
-cs
-=== cast to c_string
-cs
-=== cast to c_string
-cs

--- a/test/types/string/StringImpl/memLeaks/concat.chpl
+++ b/test/types/string/StringImpl/memLeaks/concat.chpl
@@ -204,9 +204,9 @@ module unitTest {
       const s: t = "s";
       const cs: c_string = "0";
       if useExpr {
-        writeMe(s+cs:string);
+        writeMe(s+createStringWithNewBuffer(cs));
       } else {
-        const scs = s+cs:string;
+        const scs = s+createStringWithNewBuffer(cs);
         writeMe(scs);
       }
     }
@@ -220,9 +220,9 @@ module unitTest {
       const cs: c_string = "s";
       const s: t = "0";
       if useExpr {
-        writeMe(cs:string+s);
+        writeMe(createStringWithNewBuffer(cs)+s);
       } else {
-        const css = cs:string+s;
+        const css = createStringWithNewBuffer(cs)+s;
         writeMe(css);
       }
     }
@@ -237,9 +237,9 @@ module unitTest {
       on Locales[numLocales-1] {
         const cs: c_string = "r";
         if useExpr {
-          writeMe(s+cs:string);
+          writeMe(s+createStringWithNewBuffer(cs));
         } else {
-          const scs = s+cs:string;
+          const scs = s+createStringWithNewBuffer(cs);
           writeMe(scs);
         }
       }
@@ -255,9 +255,9 @@ module unitTest {
       on Locales[numLocales-1] {
         const cs: c_string = "s";
         if useExpr {
-          writeMe(cs:string+s);
+          writeMe(createStringWithNewBuffer(cs)+s);
         } else {
-          const css = cs:string+s;
+          const css = createStringWithNewBuffer(cs)+s;
           writeMe(css);
         }
       }

--- a/test/types/string/dmk/join.chpl
+++ b/test/types/string/dmk/join.chpl
@@ -28,9 +28,9 @@ proc main() {
     if s1c != s2c {
       writeln("Mismatched!");
       writeln("  s1  = ", s1);
-      writeln("  s1c = ", s1c :string);
+      writeln("  s1c = ", createStringWithNewBuffer(s1c));
       writeln("  s2  = ", s2);
-      writeln("  s2c = ", s2c :string);
+      writeln("  s2c = ", createStringWithNewBuffer(s2c));
     }
   }
 }

--- a/test/types/string/dmk/utf8_env.chpl
+++ b/test/types/string/dmk/utf8_env.chpl
@@ -5,6 +5,6 @@
 // when run outside the test harness.
 //
 extern proc getenv(const name: c_string): c_string;
-writeln("LANG=", getenv('LANG'):string);
-writeln("LC_ALL=", getenv('LC_ALL'):string);
-writeln("LC_COLLATE=", getenv('LC_COLLATE'):string);
+writeln("LANG=", createStringWithNewBuffer(getenv('LANG')));
+writeln("LC_ALL=", createStringWithNewBuffer(getenv('LC_ALL')));
+writeln("LC_COLLATE=", createStringWithNewBuffer(getenv('LC_COLLATE')));

--- a/test/types/string/ferguson/return-coerce-to-c-string.chpl
+++ b/test/types/string/ferguson/return-coerce-to-c-string.chpl
@@ -3,4 +3,4 @@ proc f():c_string {
 }
 
 var x = f();
-writeln(x:string, " ", x.type:string);
+writeln(createStringWithNewBuffer(x), " ", x.type:string);

--- a/test/types/string/ferguson/string-useless-cast.chpl
+++ b/test/types/string/ferguson/string-useless-cast.chpl
@@ -1,6 +1,6 @@
 proc bad(type t, x:c_string) {
   try! {
-    return x:string:t;
+    return createStringWithNewBuffer(x):t;
   }
 }
 

--- a/test/types/string/kushal/cast_to_bool_ignore_whitespace.chpl
+++ b/test/types/string/kushal/cast_to_bool_ignore_whitespace.chpl
@@ -10,7 +10,7 @@ writeln(a4);
 var a5 = a:bool(64);
 writeln(a5);
 
-var x = " true ":c_string;
+var x = c" true ";
 var x1 = x:bool;
 writeln(x1);
 var x2 = x:bool(8);

--- a/test/types/string/sungeun/c_string/casts.chpl
+++ b/test/types/string/sungeun/c_string/casts.chpl
@@ -30,8 +30,8 @@ writeln(vcstri:imag(32));
 writeln(vcstri:imag(64));
 writeln(vcstrc:complex(64));
 writeln(vcstrc:complex(128));
-writeln(vcstrE:string:E);
-writeln(vcstrB:string:bool);
+writeln(createStringWithNewBuffer(vcstrE):E);
+writeln(createStringWithNewBuffer(vcstrB):bool);
 
 for param i in 1..4 do writeln(str:uint(4<<i));
 for param i in 1..4 do writeln(str:int(4<<i));

--- a/test/types/string/sungeun/c_string/concat.chpl
+++ b/test/types/string/sungeun/c_string/concat.chpl
@@ -7,42 +7,42 @@ use checkType;
 checkType(string, (c"8"+n:string).type);
 checkType(string, ("8"+n:string).type);
 checkType(string, (cstr+n:string).type);
-checkType(string, (vcstr:string+n:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+n:string).type);
 checkType(string, ("8"+nn:string).type);
-checkType(string, (cstr:string+nn:string).type);
-checkType(string, (vcstr:string+nn:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+nn:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+nn:string).type);
 
 checkType(string, ("8"+r:string).type);   // no param c_string cast from real
-checkType(string, (cstr:string+r:string).type);  // no param c_string cast from real
-checkType(string, (vcstr:string+r:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+r:string).type);  // no param c_string cast from real
+checkType(string, (createStringWithNewBuffer(vcstr)+r:string).type);
 checkType(string, ("8"+rr:string).type);
-checkType(string, (cstr:string+rr:string).type);
-checkType(string, (vcstr:string+rr:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+rr:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+rr:string).type);
 
 checkType(string, ("8"+i:string).type);   // no param c_string cast from imag
-checkType(string, (cstr:string+i:string).type);  // no param c_string cast from imag
-checkType(string, (vcstr:string+i:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+i:string).type);  // no param c_string cast from imag
+checkType(string, (createStringWithNewBuffer(vcstr)+i:string).type);
 checkType(string, ("8"+ii:string).type);
-checkType(string, (cstr:string+ii:string).type);
-checkType(string, (vcstr:string+ii:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+ii:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+ii:string).type);
 
 checkType(string, ("8"+c:string).type);   // no param complex
-checkType(string, (cstr:string+c:string).type);
-checkType(string, (vcstr:string+c:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+c:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+c:string).type);
 
 checkType(string, (c"8"+e:string).type);
 checkType(string, ("8"+e:string).type);
 checkType(string, (cstr+e:string).type);
-checkType(string, (vcstr:string+e:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+e:string).type);
 checkType(string, ("8"+ee:string).type);
-checkType(string, (cstr:string+ee:string).type);
-checkType(string, (vcstr:string+ee:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+ee:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+ee:string).type);
 
 checkType(string, (c"8"+b:string).type);
 checkType(string, ("8"+b:string).type);
 checkType(string, (cstr+b:string).type);
-checkType(string, (vcstr:string+b:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+b:string).type);
 checkType(string, ("8"+bb:string).type);
-checkType(string, (cstr:string+bb:string).type);
-checkType(string, (vcstr:string+bb:string).type);
+checkType(string, (createStringWithNewBuffer(cstr)+bb:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+bb:string).type);
 

--- a/test/types/string/sungeun/c_string/intents.chpl
+++ b/test/types/string/sungeun/c_string/intents.chpl
@@ -30,17 +30,17 @@ if errorCase == 1 {
   gr("hi");
 }
 
-var hi_c: c_string = "hi";
-var ss = hi_c:string + hi_c:string;
+var hi_c = c"hi";
+var ss = createStringWithNewBuffer(hi_c)+ createStringWithNewBuffer(hi_c);
 var s = ss.c_str();
 
-f(s:string);
-fi(s:string);
+f(createStringWithNewBuffer(s));
+fi(createStringWithNewBuffer(s));
 if errorCase == 2 then
-  fo(s:string);
+  fo(createStringWithNewBuffer(s));
 
 if errorCase == 3 then
-  fio(s:string);
+  fio(createStringWithNewBuffer(s));
 
 if errorCase == 4 then
-  fr(s:string);
+  fr(createStringWithNewBuffer(s));

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
@@ -1,4 +1,4 @@
 var s = "0123456789";
 on Locales[numLocales-1] {
-  writeln(s.c_str():string);
+  writeln(createStringWithNewBuffer(s.c_str()));
 }

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
@@ -5,7 +5,7 @@
 
   on Locales[numLocales-1] {
     var cs = s.c_str();
-    var s2 = cs: string;
+    var s2 = createStringWithNewBuffer(cs);
     writeln(s2);
   }
 }

--- a/test/types/string/sungeun/c_string/returnString.chpl
+++ b/test/types/string/sungeun/c_string/returnString.chpl
@@ -1,8 +1,8 @@
 use checkType;
 
 proc rcs() {
-  var s:c_string = "hi";
-  var ss = s:string + s:string;
+  var s = c"hi";
+  var ss = createStringWithNewBuffer(s) + createStringWithNewBuffer(s);
   var cs = ss.c_str();
   return cs;
 }
@@ -10,10 +10,10 @@ proc rcs() {
 checkType(c_string, rcs().type);
 
 proc rcss():string {
-  var s:c_string = "hi";
-  var ss = s:string + s:string;
+  var s = c"hi";
+  var ss = createStringWithNewBuffer(s) + createStringWithNewBuffer(s);
   var cs = ss.c_str();
-  return cs;
+  return createStringWithNewBuffer(cs);
 }
 
 checkType(rcss().type);

--- a/test/users/ferguson/extern_string_test.chpl
+++ b/test/users/ferguson/extern_string_test.chpl
@@ -1,9 +1,9 @@
 extern proc return_string_test():c_string;
 extern proc return_string_arg_test(ref c_string);
 
-writeln("returned string ", return_string_test():string);
+writeln("returned string ", createStringWithNewBuffer(return_string_test()));
 var cs: c_string;
 return_string_arg_test(cs);
-var s = cs:string;
+var s = createStringWithNewBuffer(cs);
 writeln("returned string arg ",s);
 

--- a/test/users/ferguson/extern_string_test2.chpl
+++ b/test/users/ferguson/extern_string_test2.chpl
@@ -10,8 +10,8 @@ get_string(ca);
 var cb: c_string;
 modify_string(cb, ca);
 
-a = ca:string;
-b = cb:string;
+a = createStringWithNewBuffer(ca);
+b = createStringWithNewBuffer(cb);
 writeln("a is: ", a);
 writeln("b is: ", b);
 

--- a/test/users/ferguson/sys/getenv/getenv.chpl
+++ b/test/users/ferguson/sys/getenv/getenv.chpl
@@ -8,12 +8,13 @@ proc main()
 
   if sys_getenv(ENV_VAR, foo)
   {
-    writeln("found $", ENV_VAR:string, " = ", foo:string);
+    writeln("found $", createStringWithNewBuffer(ENV_VAR), " = ",
+                       createStringWithNewBuffer(foo));
     exit(0);
   }
   else
   {
-    writeln("failed to find $", ENV_VAR:string);
+    writeln("failed to find $", createStringWithNewBuffer(ENV_VAR));
     exit(1);
   }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -35,7 +35,7 @@ extern proc getenv(name : c_string) : c_string;
 proc getEnv(name: string): string {
   var cname: c_string = name.c_str();
   var value = getenv(cname);
-  return value:string;
+  return createStringWithNewBuffer(value);
 }
 
 


### PR DESCRIPTION
This PR deprecates casts from `c_string` to `string` and removes its 
occurrences from the modules and the tests.

This PR does not remove the `c_string` to `string` coercion. It is used in param
string support and I thought it should come in as a separate effort (maybe as
part of removing `c_string` altogether). I don't have a strong argument for
postponing, though. And don't mind adding that into this PR, or creating a
separate PR for that before this one is merged.

Among test changes there are some that are not as trivial as the rest:

-  [test/associative/thomasvandoren/c_string-to-string.chpl](https://github.com/chapel-lang/chapel/compare/master...e-kayrakli:deprecate-cstring-cast#diff-8fbc640305dc091a7586b18a3d6540fc)

   I don't quite get the purpose of this test. If anything it was testing
   creating a `c_string` using a `string`. I modified it to remove `c_string`
   from the test altogether.

 - [test/types/string/StringImpl/memLeaks/cast.chpl](https://github.com/chapel-lang/chapel/compare/master...e-kayrakli:deprecate-cstring-cast#diff-f3cdeeeec0e56b194dd2340140b983c1)

   Seemed like it was specifically testing the casts. And this PR removes those
   parts. Even if we were to keep it we'd have to remove this part with
   deprecation of `c_string` type.

-  [test/types/string/sungeun/c_string/casts.chpl](https://github.com/chapel-lang/chapel/compare/master...e-kayrakli:deprecate-cstring-cast#diff-a439d52ecc6824ea14265ecb79c346cc)

    This also tests casts specifically. But in a way more simpler fashion, so I
    converted it to use the factory functions. It feels a bit awkward, though.
    In all likelihood, we'll remove those lines when `c_string` is deprecated.

Test:

- [x] standard correctness
- [x] quickstart valgrind in `test/release/example/primers`
- [x] memleaks on changed tests
- [x] standard gasnet