### PR TITLE
Have chpl_launchcmd ignore irrelevant sbatch output.

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -1084,7 +1084,8 @@ class SlurmJob(AbstractJob):
                 else:
                     job_id = id_parts[3].strip()
                     return job_id
-        raise ValueError('Could not parse output from sbatch submission: {0}'.format(stdout))
+
+        raise ValueError('Did not see expected output from sbatch submission: {0}'.format(stdout))
 
 
 @contextlib.contextmanager

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -1074,13 +1074,17 @@ class SlurmJob(AbstractJob):
             logging.error(msg)
             raise ValueError(msg)
 
-        # Output is: Submitted batch job 106001
-        id_parts = stdout.split(' ')
-        if len(id_parts) < 4:
-            raise ValueError('Could not parse output from sbatch submission: {0}'.format(stdout))
-        else:
-            job_id = id_parts[3].strip()
-            return job_id
+        # The output line we want is: Submitted batch job 106001
+        lines = stdout.split('\n')
+        for line in lines:
+            if line.startswith('Submitted batch job'):
+                id_parts = line.split(' ')
+                if len(id_parts) < 4:
+                    raise ValueError('Could not parse output from sbatch submission: {0}'.format(stdout))
+                else:
+                    job_id = id_parts[3].strip()
+                    return job_id
+        raise ValueError('Could not parse output from sbatch submission: {0}'.format(stdout))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
In some cases we're seeing `sbatch` produce irrelevant (to us) output,
such as the first 3 lines of this:

```
  sbatch: Not running node verification test prior to job execution.
  sbatch: If desired, run with --verify to request node verification.

  Submitted batch job 125953
```

Here, adjust `chpl_launchcmd.py` to attend to only the important line, that
is, the one that contains the job ID.