### PR TITLE
Adjust failing future added in #14360

### DIFF
--- a/test/classes/errors/throws/writeThis/NoThrowDefaultGenParent.chpl
+++ b/test/classes/errors/throws/writeThis/NoThrowDefaultGenParent.chpl
@@ -5,7 +5,7 @@ class A {
 class A1: A {
   var y: int = 0;
 
-  override proc writeThis(ch) throws {
+  proc writeThis(ch) throws {
     ch <~> "Hello from class A1!";
   }
 }

--- a/test/classes/errors/throws/writeThis/NoThrowDefaultGenParent.good
+++ b/test/classes/errors/throws/writeThis/NoThrowDefaultGenParent.good
@@ -1,1 +1,1 @@
-Not sure what compiler output for this will look like yet!
+NoThrowDefaultGenParent.chpl:8: error: A1.writeThis override keyword required for method matching signature of superclass method


### PR DESCRIPTION
This PR adjusts a future added in #14360 to better align it with its original intent. A second future testing what happens _when_ the override keyword is used with a subclass overload of `writeThis` (where the parent `writeThis` is default generated) will be added soon.

The future has also been marked as `.noexec`, since it expects a compiler error.

---

Change to a future, trivial and not reviewed.