### PR TITLE
Fix a simple bug that had crept into ChapelIteratorSupport

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -166,7 +166,7 @@ module ChapelIteratorSupport {
     type shapeType = chpl_iteratorShapeStaticTypeOrVoid(irType);
 
     proc standinType() type {
-      if shapeType == nothing {
+      if shapeType == void {
         // shapeless case
         return domain(1);
 
@@ -280,7 +280,7 @@ module ChapelIteratorSupport {
     if hasField(ir, "_shape_") then
       return __primitive("static field type", ir, "_shape_");
     else
-      return none;
+      return void;
   }
 
   proc chpl_iteratorFromForExpr(ir: _iteratorRecord) param {

--- a/test/arrays/skyline/spawnPromoteBug.chpl
+++ b/test/arrays/skyline/spawnPromoteBug.chpl
@@ -1,0 +1,10 @@
+use Spawn;
+
+proc f(s: string) {
+  var p = spawnshell(s, stdout=PIPE, stderr=PIPE);
+  p.communicate();
+  return p;
+}
+
+var p = f(['ls', '-l']);
+var lines = p.stdout.lines(); // <-- offending expression

--- a/test/arrays/skyline/spawnPromoteBug.good
+++ b/test/arrays/skyline/spawnPromoteBug.good
@@ -1,0 +1,1 @@
+spawnPromoteBug.chpl:10: error: creating an array of arrays using a for- or forall-expression is not supported, except when using a for-expression over a range


### PR DESCRIPTION
This fixes a bug that crept into ChapelIteratorSupport in which we
were returning the 'none' value in a function that is supposed to
return types.  Here, rather than changing the type into 'nothing', I
changed it back to the original 'void' since (a) it matches the
original function name's statement of what it's doing and (b) the type
is used as a sentinel value, so it doesn't particularly matter that
it's a type that has no values.

Resolves #14408 