### PR TITLE
Switch mpicc testing back to mpich

### DIFF
--- a/test/library/packages/MPI/spmd/hello-chapel/hello.compopts
+++ b/test/library/packages/MPI/spmd/hello-chapel/hello.compopts
@@ -1,1 +1,0 @@
--srequireThreadedMPI=false

--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -9,14 +9,5 @@ source $CWD/common.bash
 export CHPL_TASKS=fifo
 export CHPL_TARGET_COMPILER=mpi-gnu
 
-# Load OpenMPI environment module and confirm it has loaded
-echo >&2 module load gnu-openmpi
-module load gnu-openmpi
-
-set -x
-: confirm mpi module is loaded
-module list -l 2>&1 | grep -E -q '\bgnu-openmpi\b' || exit $?
-
-if [[ ${CHPL_RT_OVERSUBSCRIBED:-n} == [1tTyY]* && -z $MPIRUN_CMD ]] ; then
-  export MPIRUN_CMD='mpirun -np %N -map-by node:oversubscribe %C'
-fi
+# setup mpich 3.3.1
+source /data/cf/chapel/setup_mpich331.bash


### PR DESCRIPTION
We tried using OpenMPI, but the version we have doesn't support
MPI_THREAD_MULTIPLE, which is required for this configuration. I ended
up building a version of mpich from source for us to use.

For more info see https://github.com/Cray/chapel-private/issues/577