### PR TITLE
Improve error message for typeless type methods

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -359,7 +359,11 @@ checkFunction(FnSymbol* fn) {
     USR_FATAL_CONT(fn, "method 'these' must have parentheses");
 
   if (fn->thisTag != INTENT_BLANK && fn->isMethod() == false) {
-    USR_FATAL_CONT(fn, "'this' intents can only be applied to methods");
+    if (fn->thisTag == INTENT_TYPE) {
+      USR_FATAL_CONT(fn, "Missing type for type method");
+    } else {
+      USR_FATAL_CONT(fn, "'this' intents can only be applied to methods");
+    }
   }
 
 #if 0 // Do not issue the warning yet.

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -360,7 +360,7 @@ checkFunction(FnSymbol* fn) {
 
   if (fn->thisTag != INTENT_BLANK && fn->isMethod() == false) {
     if (fn->thisTag == INTENT_TYPE) {
-      USR_FATAL_CONT(fn, "Missing type for type method");
+      USR_FATAL_CONT(fn, "Missing type for secondary type method");
     } else {
       USR_FATAL_CONT(fn, "'this' intents can only be applied to methods");
     }

--- a/test/functions/bradc/thisIntentStandalone.good
+++ b/test/functions/bradc/thisIntentStandalone.good
@@ -1,2 +1,2 @@
 thisIntentStandalone.chpl:7: error: 'this' intents can only be applied to methods
-thisIntentStandalone.chpl:11: error: 'this' intents can only be applied to methods
+thisIntentStandalone.chpl:11: error: Missing type for type method

--- a/test/functions/bradc/thisIntentStandalone.good
+++ b/test/functions/bradc/thisIntentStandalone.good
@@ -1,2 +1,2 @@
 thisIntentStandalone.chpl:7: error: 'this' intents can only be applied to methods
-thisIntentStandalone.chpl:11: error: Missing type for type method
+thisIntentStandalone.chpl:11: error: Missing type for secondary type method


### PR DESCRIPTION
This PR tries to improve the error message for the following case:

```chapel
class C {}
proc type thisIsSupposedToBeTypeMethodOnC() {}
```

The error message used to say `'this' intents can only be applied to methods`
After this PR it says `Missing type for secondary type method`

I got this message on a much larger file, where I assumed that I was adding
the method inside a class definition, and got surprised by the error message.

Test:
- [x] standard