### PR TITLE
Remove more c_string to string casts

### DIFF
--- a/test/extern/ferguson/externblock/readme_examples2.chpl
+++ b/test/extern/ferguson/externblock/readme_examples2.chpl
@@ -48,7 +48,7 @@ setSpace(c_ptrTo(space));
 
 var str:c_string;
 setString(c_ptrTo(str));
-writeln(str:string);
+writeln(createStringWithNewBuffer(str));
 
 module MyCModule {
   extern {

--- a/test/extern/jjueckstock/basic.chpl
+++ b/test/extern/jjueckstock/basic.chpl
@@ -14,7 +14,7 @@ module C { extern {
   const char* greet_str = "Hello";
 } }
 
-writeln(C.greeting():string);
+writeln(createStringWithNewBuffer(C.greeting()));
 writeln(C.my_doub);
 writeln(C.my_int);
 writeln(C.add_one(1000));

--- a/test/extern/jjueckstock/types.chpl
+++ b/test/extern/jjueckstock/types.chpl
@@ -31,7 +31,7 @@ use C;
 //NOTE: either C.my_struct or my_struct will work with the use C; statement.
 var strct: C.my_struct = new my_struct(42, "bar".c_str());
 writeln(strct.foo);
-writeln(strct.bar:string);
+writeln(createStringWithNewBuffer(strct.bar));
 
 //NOTE: due to an issue with the way Chapel implements type aliases,
 //

--- a/test/interop/python/defaultValues.chpl
+++ b/test/interop/python/defaultValues.chpl
@@ -1,5 +1,5 @@
 export proc cstringDefault(in x: c_string = "blah") {
-  writeln(x: string);
+  writeln(createStringWithNewBuffer(x));
 }
 
 export proc intDefault(x: int = 3) {

--- a/test/interop/python/stringAllocated.chpl
+++ b/test/interop/python/stringAllocated.chpl
@@ -9,5 +9,5 @@ export proc g(size: int, ptr: c_ptr(uint(8))): int {
 }
 
 export proc writeStr(in x: c_string) {
-  writeln(x: string);
+  writeln(createStringWithNewBuffer(x));
 }

--- a/test/interop/python/stringFunctions.chpl
+++ b/test/interop/python/stringFunctions.chpl
@@ -1,6 +1,6 @@
 /* Tests accepting a c_string */
 export proc takesString(in x: c_string) {
-  writeln(x: string);
+  writeln(createStringWithNewBuffer(x));
 }
 
 /* Tests returning a c_string */


### PR DESCRIPTION
We have seen failures in extern block and python interop tests due to 
now-deprecated c_string to string casts. This PR fixes those tests.