### PR TITLE
Disable --cache-remote prefetch when guard pages are in use

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -312,6 +312,11 @@ uint32_t chpl_task_getMaxPar(void);
 size_t chpl_task_getCallStackSize(void);
 
 //
+// This returns whether guard pages (stack checks) are in use
+//
+chpl_bool chpl_task_guardPagesInUse(void);
+
+//
 // returns the number of tasks that are ready to run on the current locale,
 // not including any that have already started running.
 //

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2134,13 +2134,14 @@ void cache_get_trigger_readahead(struct rdcache_s* cache,
     ok = 0;
     // Assuming we have a request for raddr..raddr+len-1,
     // can we prefetch prefetch_addr..prefetch_addr+prefetch_len-1 ?
-    // Checks to see if the prefetch would move out of registered memory
+    // Checks to see if guard pages are enabled (which makes guarded paged
+    // un-gettable) if the prefetch would move out of registered memory
     //  (if chpl_comm_get_segment returns segment information)
     //  or to a new page (if segment information is not available)
 
     // Can we prefetch len bytes starting at prefetch_raddr?
     // If not, compute the smaller amount that we can prefetch.
-    if( chpl_comm_addr_gettable(node, (void*)prefetch_start, len) ) {
+    if( !chpl_task_guardPagesInUse() && chpl_comm_addr_gettable(node, (void*)prefetch_start, len) ) {
       ok = 1;
     }
 

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -842,6 +842,10 @@ size_t chpl_task_getCallStackSize(void) {
   return chpl_thread_getCallStackSize();
 }
 
+chpl_bool chpl_task_guardPagesInUse(void) {
+  return chpl_use_guard_page;
+}
+
 uint32_t chpl_task_getNumQueuedTasks(void) {
   return queued_task_cnt;
 }

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -176,6 +176,8 @@ chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
 
 static aligned_t exit_ret = 0;
 
+static chpl_bool guardPagesInUse = true;
+
 void chpl_task_yield(void)
 {
     PROFILE_INCR(profile_task_yield,1);
@@ -577,9 +579,11 @@ static void setupCallStacks(void) {
     size_t qt_rtds_size;
 
     size_t maxPoolAllocSize;
+
     char newenv_alloc[QT_ENV_S];
 
-    guardPagesEnabled = (int)setupGuardPages();
+    guardPagesInUse = setupGuardPages();
+    guardPagesEnabled = (int)guardPagesInUse;
 
     // Setup the base call stack size (Precedence high-to-low):
     // 1) Chapel environment (CHPL_RT_CALL_STACK_SIZE)
@@ -1041,6 +1045,11 @@ size_t chpl_task_getCallStackSize(void)
     PROFILE_INCR(profile_task_getCallStackSize,1);
 
     return qthread_readstate(STACK_SIZE);
+}
+
+chpl_bool chpl_task_guardPagesInUse(void)
+{
+  return guardPagesInUse;
 }
 
 // XXX: Should probably reflect all shepherds


### PR DESCRIPTION
The prefetcher assumes that if a region of memory is in the registered
heap it is directly GET-able. However, this is not true when guard pages
are enabled since mprotect'd pages cannot be read. Disable prefetching
when guard pages are in use to fix this.

Resolves https://github.com/chapel-lang/chapel/issues/14340