### PR TITLE
Fix nightly testing failures due to IO no longer being included by default

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2661,6 +2661,9 @@ AggregateType* AggregateType::discoverParentAndCheck(Expr* storesName) {
 
   if (UnresolvedSymExpr* se = toUnresolvedSymExpr(storesName)) {
     Symbol* sym = lookup(se->unresolved, storesName);
+    if (sym == NULL) {
+      USR_FATAL(se, "Unable to find super class named '%s'", se->unresolved);
+    }
     // Use AggregateType in class hierarchy rather than generic-management
     if (isDecoratedClassType(sym->type)) {
       sym = canonicalClassType(sym->type)->symbol;

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2662,7 +2662,7 @@ AggregateType* AggregateType::discoverParentAndCheck(Expr* storesName) {
   if (UnresolvedSymExpr* se = toUnresolvedSymExpr(storesName)) {
     Symbol* sym = lookup(se->unresolved, storesName);
     if (sym == NULL) {
-      USR_FATAL(se, "Unable to find super class named '%s'", se->unresolved);
+      USR_FATAL(se, "unable to find parent class named '%s'", se->unresolved);
     }
     // Use AggregateType in class hierarchy rather than generic-management
     if (isDecoratedClassType(sym->type)) {

--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -165,7 +165,8 @@ module ChapelTaskTable {
     for taskID in chpldev_taskTable!.dom {
       try! stderr.writeln(
              "- ",
-             chpl_lookupFilename(chpldev_taskTable!.map[taskID].filename):string,
+             createStringWithNewBuffer(chpl_lookupFilename(
+                                        chpldev_taskTable!.map[taskID].filename)),
              ":",  chpldev_taskTable!.map[taskID].lineno,
              " is ", chpldev_taskTable!.map[taskID].state);
     }

--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -157,6 +157,7 @@ module ChapelTaskTable {
   
   export proc chpldev_taskTable_print() 
   {
+    use IO;
     extern proc chpl_lookupFilename(idx: int(32)): c_string;
 
     if (chpldev_taskTable == nil) then return;

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -111,6 +111,7 @@ Curl Support Types and Functions
 
  */
 module Curl {
+  public use IO;
 
   require "curl/curl.h";
   require "-lcurl";
@@ -393,6 +394,7 @@ module Curl {
 
     use Sys only ;
     use Time only ;
+    private use IO;
 
     class CurlFile : QioPluginFile {
 

--- a/modules/packages/URL.chpl
+++ b/modules/packages/URL.chpl
@@ -41,6 +41,7 @@ For example, the following program downloads a web-page from http://example.com 
  */
 
 module URL {
+  public use IO;
 
   /*
 

--- a/test/classes/lydia/inherit-from-not-visible.chpl
+++ b/test/classes/lydia/inherit-from-not-visible.chpl
@@ -1,0 +1,16 @@
+module A {
+  class Foo {
+    var x: int;
+  }
+}
+module B {
+  // should use A; but doesn't to lock in error message
+  class Bar: Foo {
+    var y: bool;
+  }
+
+  proc main() {
+    var bar = new Bar();
+    writeln(bar);
+  }
+}

--- a/test/classes/lydia/inherit-from-not-visible.good
+++ b/test/classes/lydia/inherit-from-not-visible.good
@@ -1,1 +1,1 @@
-inherit-from-not-visible.chpl:8: error: Unable to find super class named 'Foo'
+inherit-from-not-visible.chpl:8: error: unable to find parent class named 'Foo'

--- a/test/classes/lydia/inherit-from-not-visible.good
+++ b/test/classes/lydia/inherit-from-not-visible.good
@@ -1,0 +1,1 @@
+inherit-from-not-visible.chpl:8: error: Unable to find super class named 'Foo'

--- a/test/library/packages/BLAS/test_blas1.chpl
+++ b/test/library/packages/BLAS/test_blas1.chpl
@@ -1,5 +1,6 @@
 use BLAS;
 use blas_helpers;
+use IO;
 
 proc main() {
   test_rotg();

--- a/test/library/packages/BLAS/test_blas2.chpl
+++ b/test/library/packages/BLAS/test_blas2.chpl
@@ -1,6 +1,7 @@
 use Random;
 use BLAS;
 use blas_helpers;
+use IO;
 
 /* BLAS 2 Testing TODO:
     - [ ] Banded matrices (commented out)

--- a/test/library/packages/BLAS/test_blas3.chpl
+++ b/test/library/packages/BLAS/test_blas3.chpl
@@ -1,6 +1,7 @@
 use Random;
 use BLAS;
 use blas_helpers;
+use IO;
 
 proc main() {
   test_gemm();

--- a/test/library/packages/Curl/check-http.chpl
+++ b/test/library/packages/Curl/check-http.chpl
@@ -1,6 +1,7 @@
 use RunServer;
 use URL;
 use FileSystem;
+use IO;
 
 config const verbose = false;
 config const bufsz = 0;

--- a/test/library/packages/Curl/download-http-upload-ftp.chpl
+++ b/test/library/packages/Curl/download-http-upload-ftp.chpl
@@ -1,5 +1,6 @@
 use RunServer;
 use URL;
+private use IO;
 
 config const verbose = false;
 config const outUrl = "ftp://127.0.0.1/upload/";

--- a/test/library/packages/Curl/upload-ftp.chpl
+++ b/test/library/packages/Curl/upload-ftp.chpl
@@ -1,5 +1,6 @@
 use RunServer;
 use URL;
+private use IO;
 
 config const verbose = false;
 config const outUrl = "ftp://127.0.0.1/upload/";

--- a/test/library/packages/HDFS/hdfsNumbers.chpl
+++ b/test/library/packages/HDFS/hdfsNumbers.chpl
@@ -4,6 +4,7 @@
    expected.
 */
 use HDFS only;
+use IO;
 
 config const path = "/tmp/lots-of-numbers.txt";
 

--- a/test/library/packages/HDFS/hello-hadoop.chpl
+++ b/test/library/packages/HDFS/hello-hadoop.chpl
@@ -1,4 +1,5 @@
 use HDFS only;
+use IO;
 
 config const path = "/tmp/testfile.txt";
 

--- a/test/library/packages/LinearAlgebra/correctness/test_identities1.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/test_identities1.chpl
@@ -1,5 +1,6 @@
 use LinearAlgebra;
 use Random;
+use IO;
 
 config const seed=3141592;
 config const verbose=false;

--- a/test/release/examples/primers/FFTWlib.chpl
+++ b/test/release/examples/primers/FFTWlib.chpl
@@ -119,6 +119,7 @@ proc runtest(param ndim : int, fn : string) {
 */
   var A,B,goodA,goodB : [D] complex(128);
   {
+    use IO;
     var f = open(fn,iomode.r).reader(kind=iokind.little);
 
     // Read in dimensions


### PR DESCRIPTION
Certain code was only run in certain configurations, so had been missed
in the initial PR.  Update this code (both included modules and test code)
for IO no longer being included by default.

One of the failure modes encountered was a compiler segfault when a
class inherited from another class.  While I was here, I decided to change
that segfault to a user facing error (since it was actually the user's fault).

Checked the individual failures in one of the configurations they failed in.
Running a full paratest with futures for the new error message.