### PR TITLE
Fix unordered forall opt under --cache-remote

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -336,6 +336,7 @@ symbolFlag( FLAG_REF_TEMP , npr, "ref temp" , "compiler-inserted reference tempo
 symbolFlag( FLAG_REMOVABLE_ARRAY_ACCESS, ypr, "removable array access", "array access calls that can be replaced with a reference")
 symbolFlag( FLAG_REMOVABLE_AUTO_COPY , ypr, "removable auto copy" , ncm )
 symbolFlag( FLAG_REMOVABLE_AUTO_DESTROY , ypr, "removable auto destroy" , ncm )
+symbolFlag( FLAG_COMPILER_ADDED_REMOTE_FENCE , ypr, "compiler added remote fence" , ncm )
 symbolFlag( FLAG_RESOLVED , npr, "resolved" , "this function has been resolved" )
 symbolFlag( FLAG_RETARG, npr, "symbol is a _retArg", ncm )
 symbolFlag( FLAG_RETURNS_ALIASING_ARRAY, ypr, "fn returns aliasing array", "array alias/slice/reindex/rank change function" )

--- a/modules/internal/MemConsistency.chpl
+++ b/modules/internal/MemConsistency.chpl
@@ -88,22 +88,36 @@ module MemConsistency {
 
   // These functions are memory consistency fences (ie acquire or
   // release fences) for the remote data cache.
+  // Calls to them are added by the compiler when --cache-remote is used.
 
   pragma "insert line file info"
+  pragma "no doc"
+  pragma "compiler added remote fence"
   extern proc chpl_rmem_consist_release();
   pragma "insert line file info"
+  pragma "no doc"
+  pragma "compiler added remote fence"
   extern proc chpl_rmem_consist_acquire();
   pragma "insert line file info"
+  pragma "no doc"
+  pragma "compiler added remote fence"
   extern proc chpl_rmem_consist_maybe_release(order:memory_order);
+  pragma "compiler added remote fence"
   proc chpl_rmem_consist_maybe_release(param order:memoryOrder) {
     chpl_rmem_consist_maybe_release(c_memory_order(order));
   }
   pragma "insert line file info"
+  pragma "no doc"
+  pragma "compiler added remote fence"
   extern proc chpl_rmem_consist_maybe_acquire(order:memory_order);
+  pragma "compiler added remote fence"
   proc chpl_rmem_consist_maybe_acquire(param order:memoryOrder) {
     chpl_rmem_consist_maybe_acquire(c_memory_order(order));
   }
+
+  // This one can be used in module code.
   pragma "insert line file info"
+  pragma "no doc"
   extern proc chpl_rmem_consist_fence(order:memory_order);
   proc chpl_rmem_consist_fence(param order:memoryOrder) {
     chpl_rmem_consist_fence(c_memory_order(order));


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/541

Compiling with --cache-remote was inhibiting the forall unordered
optimization for atomics. This PR fixes that problem by making the
optimization aware of the extra fences that the --cache-remote support
was adding around atomic calls.

In the future we could do more to minimize the fencing around the
unordered operations, so that the --cache-remote could cache values from
GETs during the loop doing the unordered operations.

Reviewed by @ronawho - thanks!

- [x] test/optimizations/forall-unordered-opt/ passes with CHPL_COMM=ugni
- [x] test/runtime/configMatters/forall-unordered-opt/ passes on a
  CHPL_COMM=ugni with and without --cache-remote
- [x] sanity check performance on real ugni system
- [x] full local testing
