### PR TITLE
Remove more c_string:string casts from tests

### DIFF
--- a/test/interop/python/multilocale/defaultValues.chpl
+++ b/test/interop/python/multilocale/defaultValues.chpl
@@ -1,5 +1,5 @@
 export proc cstringDefault(in x: c_string = "blah") {
-  writeln(x: string);
+  writeln(createStringWithNewBuffer(x));
 }
 
 export proc intDefault(x: int = 3) {

--- a/test/interop/python/multilocale/stringFunctions.chpl
+++ b/test/interop/python/multilocale/stringFunctions.chpl
@@ -1,6 +1,6 @@
 /* Tests accepting a c_string */
 export proc takesString(in x: c_string) {
-  writeln(x: string);
+  writeln(createStringWithNewBuffer(x));
 }
 
 /* Tests returning a c_string */


### PR DESCRIPTION
This PR fixes two more tests that we missed in yesterday's nightlies.