### PR TITLE
Make the use of MemConsistency in ChapelLocks private

### DIFF
--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -22,7 +22,7 @@
  */
 module ChapelLocks {
   private use Atomics, ChapelBase;
-  use MemConsistency;
+  private use MemConsistency;
   /*
    * Local processor atomic spinlock. Intended for situations with minimal
    * contention or very short critical sections.


### PR DESCRIPTION
This module utilizes MemConsistency's memoryOrders, but it does so as part of
their implementation.  As a result, the use of MemConsistency does not need to
be public.

Note: the use of Atomics in this module maybe should be public rather than
private.  chpl_LocalSpinlock's field does use a symbol from it for its type,
but it's possible that field could become private once private fields are
implemented.

Passed a full paratest with futures