### PR TITLE
Make some uses in ChapelDistribution intentionally public

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -20,8 +20,8 @@
 module ChapelDistribution {
 
   private use ChapelArray, ChapelRange;
-  use ChapelLocks;
-  use LinkedLists;
+  public use ChapelLocks; // maybe make private when fields can be private?
+  public use LinkedLists; // maybe make private when fields can be private?
 
   //
   // Abstract distribution class


### PR DESCRIPTION
ChapelLocks is used so that the _domsLock field's type can be used in calls to
its initializer.

LinkedLists are used so that the _doms field's type can be used in calls to its
initializer.

These field names start with an underscore, so are potential private field
candidates when that support exists.  If the fields become private, these use
statements could also potentially become private.

As expected, passed a full paratest with futures without incident.