### PR TITLE
Drop support for gasnet-gemini from the XE module

### DIFF
--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -126,9 +126,9 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         log_info "Building Chapel component: runtime"
 
         compilers=gnu,cray,intel
-        comms=gasnet,none,ugni
+        comms=none,ugni
         launchers=pbs-aprun,aprun,none,slurm-srun
-        substrates=mpi,none
+        substrates=none
         auxfs=none,lustre
 
         log_info "Start build_configs $dry_run $verbose # no make target"


### PR DESCRIPTION
GASNet-EX 2019.9.0 removed support for gemini, and we used some of the
gemini cross-configure scripts for mpi too. We could probably get gn-mpi
working on XE/XK, but it's not tested and ugni is the preferred config.

Follow on to https://github.com/chapel-lang/chapel/pull/14348