### PR TITLE
Squash warnings about incompatible pointers types

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -126,6 +126,12 @@ SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 SQUASH_WARN_GEN_CFLAGS += -Wno-pointer-sign
 
 #
+# Don't warn/error for incompatible pointer types (see
+# https://github.com/chapel-lang/chapel/issues/7983)
+#
+SQUASH_WARN_GEN_CFLAGS += -Wno-incompatible-pointer-types
+
+#
 # Don't warn for unsigned pointer comparisons
 #
 # uint32_t i = foo();

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -162,6 +162,14 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-pointer-sign
 endif
 
 #
+# Don't warn/error for incompatible pointer types (see
+# https://github.com/chapel-lang/chapel/issues/7983)
+#
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -lt 5; echo "$$?"),1)
+SQUASH_WARN_GEN_CFLAGS += -Wno-incompatible-pointer-types
+endif
+
+#
 # Don't warn/error for tautological compares (ex. x == x)
 #
 ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -lt 6; echo "$$?"),1)

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -124,13 +124,14 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 # Warnings squashed for generated code
 #
 #  111 : warns about unreachable statements
+#  167 : warns about incompatible parameter type (https://github.com/chapel-lang/chapel/issues/7983)
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
 
 WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
-SQUASH_WARN_GEN_CFLAGS = -wr111,174,177
+SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177
 
 #
 # Don't warn for signed pointer issues (ex. c_ptr(c_char) )


### PR DESCRIPTION
For interop we get a lot of incompatible pointer type warnings because
we don't preserve typedefs through codegen (#7983.) Until that is
resolved, squash the warnings.