### PR TITLE
Update LAPACK tests to work now that 'use' is public in user modules

### DIFF
--- a/test/library/packages/LAPACK/TestHelpers.chpl
+++ b/test/library/packages/LAPACK/TestHelpers.chpl
@@ -1,5 +1,5 @@
 module TestHelpers {
-  use LAPACK;
+  public use LAPACK;
   param default_epsilon: real = 10.0e-14;  
 
   class LAPACK_Matrix {


### PR DESCRIPTION
Add `public use` to helper module used by test(s).  I missed this due to the narrow scope of where it is tested.