### PR TITLE
Make factory functions more consistent

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -26,6 +26,7 @@
 #include "AstToText.h"
 #include "AstVisitor.h"
 #include "astutil.h"
+#include "build.h"
 #include "docsDriver.h"
 #include "driver.h"
 #include "ForallStmt.h"
@@ -1479,7 +1480,8 @@ VarSymbol *new_StringSymbol(const char *str) {
   // DefExpr(s) always goes into the module scope to make it a global
   stringLiteralModule->block->insertAtTail(stringLitDef);
 
-  CallExpr *initCall = new CallExpr(astr("createStringWithBorrowedBuffer"),
+  CallExpr *initCall = new CallExpr(buildDotExpr(dtString->symbol,
+                                                 "createWithBorrowedBuffer"),
                                     cstrTemp,
                                     new_IntSymbol(strLength));
 
@@ -1495,6 +1497,8 @@ VarSymbol *new_StringSymbol(const char *str) {
   insertPt->insertBefore(new DefExpr(cstrTemp));
   insertPt->insertBefore(cstrMove);
   insertPt->insertBefore(moveCall);
+
+  normalize(moveCall);
 
   s->immediate = new Immediate;
   *s->immediate = imm;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1539,7 +1539,8 @@ VarSymbol *new_BytesSymbol(const char *str) {
   // DefExpr(s) always goes into the module scope to make it a global
   stringLiteralModule->block->insertAtTail(bytesLitDef);
 
-  CallExpr *initCall = new CallExpr(astr("createBytesWithBorrowedBuffer"),
+  CallExpr *initCall = new CallExpr(buildDotExpr(dtBytes->symbol,
+                                                 "createWithBorrowedBuffer"),
                                     bytesTemp,
                                     new_IntSymbol(bytesLength));
 
@@ -1556,6 +1557,8 @@ VarSymbol *new_BytesSymbol(const char *str) {
   insertPt->insertBefore(new DefExpr(bytesTemp));
   insertPt->insertBefore(bytesMove);
   insertPt->insertBefore(moveCall);
+
+  normalize(moveCall);
 
   s->immediate = new Immediate;
   *s->immediate = imm;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -254,10 +254,10 @@ domain or array.
 
     use BlockDist;
 
-    var BlockDom1 = newBlockDom({1..5, 1..5});
-    var BlockArr1 = newBlockArr({1..5, 1..5}, real);
-    var BlockDom2 = newBlockDom(1..5, 1..5);
-    var BlockArr2 = newBlockArr(1..5, 1..5, real);
+    var BlockDom1 = BlockDom.create({1..5, 1..5});
+    var BlockArr1 = BlockArr.create({1..5, 1..5}, real);
+    var BlockDom2 = BlockDom.create(1..5, 1..5);
+    var BlockArr2 = BlockArr.create(1..5, 1..5, real);
 
 **Data-Parallel Iteration**
 
@@ -1627,20 +1627,45 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
   return res;
 }
 
-proc newBlockDom(dom: domain) {
+
+proc type BlockDom.create(dom: domain) {
   return dom dmapped Block(dom);
 }
 
-proc newBlockArr(dom: domain, type eltType) {
-  var D = newBlockDom(dom);
+proc newBlockDom(dom: domain) {
+  compilerWarning("newBlockDom is deprecated - " +
+                  "please use BlockDom.create instead");
+  return BlockDom.create(dom);
+}
+
+proc type BlockArr.create(dom: domain, type eltType) {
+  var D = BlockDom.create(dom);
   var A: [D] eltType;
   return A;
 }
 
+proc newBlockArr(dom: domain, type eltType) {
+  compilerWarning("newBlockArr is deprecated - " +
+                  "please use BlockArr.create instead");
+  return BlockArr.create(dom, eltType);
+}
+
+proc type BlockDom.create(rng: range...) {
+  return BlockDom.create({(...rng)});
+}
+
 proc newBlockDom(rng: range...) {
-  return newBlockDom({(...rng)});
+  compilerWarning("newBlockDom is deprecated - " +
+                  "please use BlockDom.create instead");
+  return BlockDom.create({(...rng)});
+}
+
+proc type BlockArr.create(rng: range..., type eltType) {
+  return BlockArr.create({(...rng)}, eltType);
 }
 
 proc newBlockArr(rng: range..., type eltType) {
-  return newBlockArr({(...rng)}, eltType);
+  compilerWarning("newBlockArr is deprecated - " +
+                  "please use BlockArr.create instead");
+  return BlockArr.create({(...rng)}, eltType);
 }

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1197,20 +1197,44 @@ proc CyclicDom.dsiLocalSubdomain(loc: locale) {
   }
 }
 
-proc newCyclicDom(dom: domain) {
+proc type CyclicDom.create(dom: domain) {
   return dom dmapped Cyclic(startIdx=dom.low);
 }
 
-proc newCyclicArr(dom: domain, type eltType) {
-  var D = newCyclicDom(dom);
+proc newCyclicDom(dom: domain) {
+  compilerWarning("newCyclicDom is deprecated - " +
+                  "please use CyclicDom.create instead");
+  return CyclicDom.create(dom);
+}
+
+proc type CyclicArr.create(dom: domain, type eltType) {
+  var D = CyclicDom.create(dom);
   var A: [D] eltType;
   return A;
 }
 
+proc newCyclicArr(dom: domain, type eltType) {
+  compilerWarning("newCyclicArr is deprecated - " +
+                  "please use CyclicArr.create instead");
+  return CyclicArr.create(dom, eltType);
+}
+
+proc type CyclicDom.create(rng: range...) {
+  return CyclicDom.create({(...rng)});
+}
+
 proc newCyclicDom(rng: range...) {
-  return newCyclicDom({(...rng)});
+  compilerWarning("newCyclicDom is deprecated - " +
+                  "please use CyclicDom.create instead");
+  return CyclicDom.create(rng);
+}
+
+proc type CyclicArr.create(rng: range..., type eltType) {
+  return CyclicArr.create({(...rng)}, eltType);
 }
 
 proc newCyclicArr(rng: range..., type eltType) {
-  return newCyclicArr({(...rng)}, eltType);
+  compilerWarning("newCyclicArr is deprecated - " +
+                  "please use CyclicArr.create instead");
+  return CyclicArr.create(rng, eltType);
 }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -34,7 +34,7 @@ Creating :record:`bytes`
 
 - If you need to create :record:`bytes` using a specific buffer (i.e. data in
   another :record:`bytes`, a `c_string` or a C pointer) you can use the
-  factory functions shown below, such as :proc:`createBytesWithNewBuffer`.
+  factory functions shown below, such as :proc:`bytes.createWithNewBuffer`.
 
 :record:`bytes` and :record:`~String.string`
 --------------------------------------------
@@ -122,8 +122,15 @@ module Bytes {
   pragma "no doc"
   type idxType = int; 
 
+  private proc factoryDeprWarning() {
+    if showStringBytesInitDeprWarnings {
+      compilerWarning("createBytesWith* functions are deprecated - "+
+                      "please use bytes.createWith* instead");
+    }
+  }
+
   //
-  // createBytes* functions
+  // bytes.create* functions
   //
 
   /*
@@ -135,10 +142,15 @@ module Bytes {
 
     :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithBorrowedBuffer(s: bytes) {
+  inline proc type bytes.createWithBorrowedBuffer(s: bytes) {
     var ret: bytes;
     initWithBorrowedBuffer(ret, s);
     return ret;
+  }
+
+  inline proc createBytesWithBorrowedBuffer(s: bytes) {
+    factoryDeprWarning();
+    return bytes.createWithBorrowedBuffer(s);
   }
 
   /*
@@ -154,13 +166,18 @@ module Bytes {
 
     :returns: A new :record:`bytes`
   */
-  proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
+  proc type bytes.createWithBorrowedBuffer(s: c_string, length=s.length) {
     //NOTE: This function is heavily used by the compiler to create bytes
     //literals. So, inlining this causes some bloat in the AST that increases
     //the compilation time slightly. Therefore, currently we are keeping this
     //one non-inlined.
-    return createBytesWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
+    return bytes.createWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
+  }
+
+  proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
+    factoryDeprWarning();
+    return bytes.createWithBorrowedBuffer(s, length);
   }
 
   /*
@@ -177,14 +194,26 @@ module Bytes {
 
      :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithBorrowedBuffer(s: bufferType, length: int, size: int) {
+  inline proc type bytes.createWithBorrowedBuffer(s: bufferType, length: int,
+                                                                 size: int) {
     var ret: bytes;
     initWithBorrowedBuffer(ret, s, length,size);
     return ret;
   }
 
+  inline proc createBytesWithBorrowedBuffer(s: bufferType, length: int, size: int) {
+    factoryDeprWarning();
+    return bytes.createWithBorrowedBuffer(s, length, size);
+  }
+
   pragma "no doc"
+  inline proc type bytes.createWithOwnedBuffer(s: bytes) {
+    // should we allow stealing ownership?
+    compilerError("A bytes cannot be passed to bytes.createWithOwnedBuffer");
+  }
+
   inline proc createBytesWithOwnedBuffer(s: bytes) {
+    factoryDeprWarning();
     // should we allow stealing ownership?
     compilerError("A bytes cannot be passed to createBytesWithOwnedBuffer");
   }
@@ -200,9 +229,14 @@ module Bytes {
 
     :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithOwnedBuffer(s: c_string, length=s.length) {
-    return createBytesWithOwnedBuffer(s: bufferType, length=length,
+  inline proc type bytes.createWithOwnedBuffer(s: c_string, length=s.length) {
+    return bytes.createWithOwnedBuffer(s: bufferType, length=length,
                                                       size=length+1);
+  }
+
+  inline proc createBytesWithOwnedBuffer(s: c_string, length=s.length) {
+    factoryDeprWarning();
+    return bytes.createWithOwnedBuffer(s, length);
   }
 
   /*
@@ -219,10 +253,16 @@ module Bytes {
 
      :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithOwnedBuffer(s: bufferType, length: int, size: int) {
+  inline proc type bytes.createWithOwnedBuffer(s: bufferType, length: int,
+                                                              size: int) {
     var ret: bytes;
     initWithOwnedBuffer(ret, s, length, size);
     return ret;
+  }
+
+  inline proc createBytesWithOwnedBuffer(s: bufferType, length: int, size: int) {
+    factoryDeprWarning();
+    return bytes.createWithOwnedBuffer(s, length, size);
   }
 
   /*
@@ -233,10 +273,15 @@ module Bytes {
 
     :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithNewBuffer(s: bytes) {
+  inline proc type bytes.createWithNewBuffer(s: bytes) {
     var ret: bytes;
     initWithNewBuffer(ret, s);
     return ret;
+  }
+
+  inline proc createBytesWithNewBuffer(s: bytes) {
+    factoryDeprWarning();
+    return bytes.createWithNewBuffer(s);
   }
 
   /*
@@ -250,9 +295,13 @@ module Bytes {
 
     :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithNewBuffer(s: c_string, length=s.length) {
-    return createBytesWithNewBuffer(s: bufferType, length=length,
+  inline proc type bytes.createWithNewBuffer(s: c_string, length=s.length) {
+    return bytes.createWithNewBuffer(s: bufferType, length=length,
                                                     size=length+1);
+  }
+  inline proc createBytesWithNewBuffer(s: c_string, length=s.length) {
+    factoryDeprWarning();
+    return bytes.createWithNewBuffer(s, length);
   }
 
   /*
@@ -267,10 +316,16 @@ module Bytes {
 
      :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithNewBuffer(s: bufferType, length: int, size: int) {
+  inline proc type bytes.createWithNewBuffer(s: bufferType, length: int,
+                                                            size: int) {
     var ret: bytes;
     initWithNewBuffer(ret, s, length, size);
     return ret;
+  }
+
+  inline proc createBytesWithNewBuffer(s: bufferType, length: int, size: int) {
+    factoryDeprWarning();
+    return bytes.createWithNewBuffer(s, length, size);
   }
 
   record _bytes {
@@ -410,7 +465,7 @@ module Bytes {
     */
     inline proc localize() : bytes {
       if _local || this.locale_id == chpl_nodeID {
-        return createBytesWithBorrowedBuffer(this);
+        return bytes.createWithBorrowedBuffer(this);
       } else {
         const x:bytes = this; // assignment makes it local
         return x;
@@ -445,7 +500,7 @@ module Bytes {
         then halt("index out of bounds of bytes: ", i);
       var (buf, size) = bufferCopy(buf=this.buff, off=i-1, len=1,
                                    loc=this.locale_id);
-      return createBytesWithOwnedBuffer(buf, length=1, size=size);
+      return bytes.createWithOwnedBuffer(buf, length=1, size=size);
     }
 
     /*
@@ -1307,7 +1362,7 @@ module Bytes {
 
   pragma "no doc"
   inline proc _cast(type t: bytes, x: string) {
-    return createBytesWithNewBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);
+    return bytes.createWithNewBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);
   }
 
   /*

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -278,11 +278,11 @@ module CPtr {
   }
   pragma "no doc"
   inline proc _cast(type t:string, x:c_void_ptr) {
-    return createStringWithOwnedBuffer(__primitive("ref to string", x));
+    return string.createWithOwnedBuffer(__primitive("ref to string", x));
   }
   pragma "no doc"
   inline proc _cast(type t:string, x:c_ptr) {
-    return createStringWithOwnedBuffer(__primitive("ref to string", x));
+    return string.createWithOwnedBuffer(__primitive("ref to string", x));
   }
   pragma "last resort"
   pragma "no doc"

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -131,27 +131,27 @@ module CString {
   // casts from c_string to bool types
   //
   inline proc _cast(type t:chpl_anybool, x:c_string) throws
-    return try ((createStringWithNewBuffer(x)).strip()): t;
+    return try ((string.createWithNewBuffer(x)).strip()): t;
 
   //
   // casts from c_string to integer types
   //
   inline proc _cast(type t:integral, x:c_string) throws
-    return try ((createStringWithNewBuffer(x)).strip()): t;
+    return try ((string.createWithNewBuffer(x)).strip()): t;
 
   //
   // casts from c_string to real/imag types
   //
   inline proc _cast(type t:chpl_anyreal, x:c_string) throws
-    return try ((createStringWithNewBuffer(x)).strip()): t;
+    return try ((string.createWithNewBuffer(x)).strip()): t;
   inline proc _cast(type t:chpl_anyimag, x:c_string) throws
-    return try ((createStringWithNewBuffer(x)).strip()): t;
+    return try ((string.createWithNewBuffer(x)).strip()): t;
 
   //
   // casts from c_string to complex types
   //
   inline proc _cast(type t:chpl_anycomplex, x:c_string) throws
-    return try ((createStringWithNewBuffer(x)).strip()): t;
+    return try ((string.createWithNewBuffer(x)).strip()): t;
 
   //
   // primitive c_string functions and methods

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1466,7 +1466,7 @@ module ChapelArray {
        .. code-block:: chapel
 
           var spsDom: sparse subdomain(parentDom);
-          var idxBuf = spsDom.makeIndexBuffer(size=N);
+          var idxBuf = spsDom.createIndexBuffer(size=N);
           for i in someIndexIterator() do
             idxBuf.add(i);
           idxBuf.commit();
@@ -1483,8 +1483,14 @@ module ChapelArray {
      :arg size: Size of the buffer in number of indices.
      :type size: int
     */
+    inline proc createIndexBuffer(size: int) {
+      return _value.dsiCreateIndexBuffer(size);
+    }
+
     inline proc makeIndexBuffer(size: int) {
-      return _value.dsiMakeIndexBuffer(size);
+      compilerWarning("domain.makeIndexBuffer is deprecated - " +
+                      "please use domain.createIndexBuffer instead");
+      return dsiCreateIndexBuffer(size);
     }
 
     /*

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1350,7 +1350,7 @@ module ChapelBase {
     if isAtomicType(t) then
       compilerError("config variables of atomic type are not supported");
 
-    var str = createStringWithNewBuffer(x);
+    var str = string.createWithNewBuffer(x);
     if t == string {
       return str;
     } else {
@@ -2325,7 +2325,7 @@ module ChapelBase {
     const deinitFun:  c_fn_ptr;          // module deinit function
     const prevModule: unmanaged chpl_ModuleDeinit?; // singly-linked list / LIFO queue
     proc writeThis(ch) throws { 
-      ch.writef("chpl_ModuleDeinit(%s)",createStringWithNewBuffer(moduleName));
+      ch.writef("chpl_ModuleDeinit(%s)",string.createWithNewBuffer(moduleName));
     }
   }
   var chpl_moduleDeinitFuns = nil: unmanaged chpl_ModuleDeinit?;

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -85,7 +85,7 @@ module ChapelDebugPrint {
       // yet defined).
       const file_cs : c_string = __primitive("chpl_lookupFilename",
                                         __primitive("_get_user_file"));
-      const file = createStringWithNewBuffer(file_cs);
+      const file = string.createWithNewBuffer(file_cs);
       const line = __primitive("_get_user_line");
       var str = chpl_debug_stringify((...args));
       extern proc printf(fmt:c_string, f:c_string, ln:c_int, s:c_string);
@@ -97,7 +97,7 @@ module ChapelDebugPrint {
     if chpl__testParFlag && chpl__testParOn {
       const file_cs : c_string = __primitive("chpl_lookupFilename",
                                         __primitive("_get_user_file"));
-      const file = createStringWithBorrowedBuffer(file_cs);
+      const file = string.createWithBorrowedBuffer(file_cs);
       const line = __primitive("_get_user_line");
       writeln("CHPL TEST PAR (", file, ":", line, "): ", (...args));
     }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -626,7 +626,7 @@ module ChapelDistribution {
     proc dsiAlignedLow { return parentDom.alignedLow; }
     proc dsiAlignedHigh { return parentDom.alignedHigh; }
 
-    proc dsiMakeIndexBuffer(size) {
+    proc dsiCreateIndexBuffer(size) {
       return new SparseIndexBuffer(rank=this.rank, obj=this, size=size);
     }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -341,7 +341,7 @@ module ChapelError {
   proc chpl_error_type_name(err: borrowed Error) : string {
     var cid =  __primitive("getcid", err);
     var nameC: c_string = __primitive("class name by id", cid);
-    var nameS = createStringWithNewBuffer(nameC);
+    var nameS = string.createWithNewBuffer(nameC);
     return nameS;
   }
   pragma "no doc"
@@ -427,12 +427,12 @@ module ChapelError {
 
     const myFileC:c_string = __primitive("chpl_lookupFilename",
                                          __primitive("_get_user_file"));
-    const myFileS = createStringWithBorrowedBuffer(myFileC);
+    const myFileS = string.createWithBorrowedBuffer(myFileC);
     const myLine = __primitive("_get_user_line");
 
     const thrownFileC:c_string = __primitive("chpl_lookupFilename",
                                              err.thrownFileId);
-    const thrownFileS = createStringWithBorrowedBuffer(thrownFileC);
+    const thrownFileS = string.createWithBorrowedBuffer(thrownFileC);
     const thrownLine = err.thrownLine;
 
     var s = "uncaught " + chpl_describe_error(err) +

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -195,7 +195,7 @@ module ChapelLocale {
       extern proc chpl_nodeName(): c_string;
       var hname: string;
       on this {
-        hname = createStringWithNewBuffer(chpl_nodeName());
+        hname = string.createWithNewBuffer(chpl_nodeName());
       }
       return hname;
     }

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -120,7 +120,7 @@ module ChapelUtil {
 
     for i in 0..#arg.argc {
       // FIX ME: leak c_string
-      array[i] = createStringWithNewBuffer(chpl_get_argument_i(local_arg,
+      array[i] = string.createWithNewBuffer(chpl_get_argument_i(local_arg,
                                                                i:int(32)));
     }
 
@@ -136,7 +136,7 @@ module ChapelUtil {
     if (flag != "--chpl-mli-socket-loc") {
       halt("chpl_get_mli_connection called with unexpected arguments, missing "
            + "'--chpl-mli-socket-loc <connection>', instead got " +
-           createStringWithNewBuffer(flag));
+           string.createWithNewBuffer(flag));
     }
     var result: c_string = chpl_get_argument_i(local_arg,
                                                (local_arg.argc-1): int(32));

--- a/modules/internal/ExportWrappers.chpl
+++ b/modules/internal/ExportWrappers.chpl
@@ -52,7 +52,7 @@ module ExportWrappers {
   }
 
   proc chpl__exportConv(val: c_string, type rt: string): rt {
-    return createStringWithBorrowedBuffer(val);
+    return string.createWithBorrowedBuffer(val);
   }
 
   //
@@ -80,7 +80,7 @@ module ExportWrappers {
   // the Chapel heap.
   //
   proc chpl__exportConv(val: chpl_bytes_wrapper, type rt: bytes): rt {
-    return createBytesWithNewBuffer(val.data:c_string, val.size.safeCast(int));
+    return string.createWithNewBuffer(val.data:c_string, val.size.safeCast(int));
   }
 
 } // End module "ExportWrappers".

--- a/modules/internal/ExportWrappers.chpl
+++ b/modules/internal/ExportWrappers.chpl
@@ -80,7 +80,7 @@ module ExportWrappers {
   // the Chapel heap.
   //
   proc chpl__exportConv(val: chpl_bytes_wrapper, type rt: bytes): rt {
-    return string.createWithNewBuffer(val.data:c_string, val.size.safeCast(int));
+    return bytes.createWithNewBuffer(val.data:c_string, val.size.safeCast(int));
   }
 
 } // End module "ExportWrappers".

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -124,7 +124,7 @@ module LocaleModelHelpSetup {
     // at least this setup method) must be run on the node it is
     // intended to describe.
     extern proc chpl_nodeName(): c_string;
-    const _node_name = createStringWithNewBuffer(chpl_nodeName());
+    const _node_name = string.createWithNewBuffer(chpl_nodeName());
     const _node_id = (chpl_nodeID: int): string;
 
     return if localSpawn() then _node_name + "-" + _node_id else _node_name;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -448,6 +448,13 @@ module String {
     return x != 0;
   // End index arithmetic support
 
+  private proc factoryDeprWarning() {
+    if showStringBytesInitDeprWarnings {
+      compilerWarning("createStringWith* functions are deprecated - "+
+                      "please use string.createWith* instead");
+    }
+  }
+
   //
   // createString* functions
   //
@@ -462,10 +469,16 @@ module String {
 
     :returns: A new `string`
   */
-  inline proc createStringWithBorrowedBuffer(s: string) {
+  inline proc type string.createWithBorrowedBuffer(s: string) {
     var ret: string;
     initWithBorrowedBuffer(ret, s);
     return ret;
+  }
+
+  pragma "no doc"
+  inline proc createStringWithBorrowedBuffer(s: string) {
+    factoryDeprWarning();
+    return string.createWithBorrowedBuffer(s);
   }
 
   /*
@@ -482,12 +495,23 @@ module String {
 
     :returns: A new `string`
   */
-  proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+  proc type string.createWithBorrowedBuffer(s: c_string, length=s.length) {
     //NOTE: This function is heavily used by the compiler to create string
     //literals. So, inlining this causes some bloat in the AST that increases
     //the compilation time slightly. Therefore, currently we are keeping this
     //one non-inlined.
-    return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
+    return string.createWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
+                                                            size=length+1);
+  }
+
+  pragma "no doc"
+  proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+    factoryDeprWarning();
+    //NOTE: This function is heavily used by the compiler to create string
+    //literals. So, inlining this causes some bloat in the AST that increases
+    //the compilation time slightly. Therefore, currently we are keeping this
+    //one non-inlined.
+    return string.createWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }
 
@@ -508,10 +532,17 @@ module String {
 
      :returns: A new `string`
   */
-  inline proc createStringWithBorrowedBuffer(s: bufferType, length: int, size: int) {
+  inline proc type string.createWithBorrowedBuffer(s: bufferType, length: int,
+                                                   size: int) {
     var ret: string;
-    initWithBorrowedBuffer(ret, s, length,size);
+    initWithBorrowedBuffer(ret, s, length, size);
     return ret;
+  }
+
+  pragma "no doc"
+  inline proc createStringWithBorrowedBuffer(s: bufferType, length: int, size: int) {
+    factoryDeprWarning();
+    return string.createWithBorrowedBuffer(s, length, size);
   }
 
   pragma "no doc"
@@ -533,8 +564,15 @@ module String {
 
     :returns: A new `string`
   */
+  inline proc type string.createWithOwnedBuffer(s: c_string, length=s.length) {
+    return string.createWithOwnedBuffer(s: bufferType, length=length,
+                                                      size=length+1);
+  }
+
+  pragma "no doc"
   inline proc createStringWithOwnedBuffer(s: c_string, length=s.length) {
-    return createStringWithOwnedBuffer(s: bufferType, length=length,
+    factoryDeprWarning();
+    return string.createWithOwnedBuffer(s: bufferType, length=length,
                                                       size=length+1);
   }
 
@@ -554,10 +592,17 @@ module String {
 
      :returns: A new `string`
   */
-  inline proc createStringWithOwnedBuffer(s: bufferType, length: int, size: int) {
+  inline proc type string.createWithOwnedBuffer(s: bufferType, length: int,
+                                                size: int) {
     var ret: string;
     initWithOwnedBuffer(ret, s, length, size);
     return ret;
+  }
+
+  pragma "no doc"
+  inline proc createStringWithOwnedBuffer(s: bufferType, length: int, size: int) {
+    factoryDeprWarning();
+    return string.createWithOwnedBuffer(s, length, size);
   }
 
   /*
@@ -568,10 +613,16 @@ module String {
 
     :returns: A new `string`
   */
-  inline proc createStringWithNewBuffer(s: string) {
+  inline proc type string.createWithNewBuffer(s: string) {
     var ret: string;
     initWithNewBuffer(ret, s);
     return ret;
+  }
+
+  pragma "no doc"
+  inline proc createStringWithNewBuffer(s: string) {
+    factoryDeprWarning();
+    return string.createWithNewBuffer(s);
   }
 
   /*
@@ -586,8 +637,15 @@ module String {
 
     :returns: A new `string`
   */
+  inline proc type string.createWithNewBuffer(s: c_string, length=s.length) {
+    return string.createWithNewBuffer(s: bufferType, length=length,
+                                                    size=length+1);
+  }
+
+  pragma "no doc"
   inline proc createStringWithNewBuffer(s: c_string, length=s.length) {
-    return createStringWithNewBuffer(s: bufferType, length=length,
+    factoryDeprWarning();
+    return string.createWithNewBuffer(s: bufferType, length=length,
                                                     size=length+1);
   }
 
@@ -606,10 +664,17 @@ module String {
 
      :returns: A new `string`
   */
-  inline proc createStringWithNewBuffer(s: bufferType, length: int, size: int) {
+  inline proc type string.createWithNewBuffer(s: bufferType, length: int,
+                                              size: int) {
     var ret: string;
     initWithNewBuffer(ret, s, length, size);
     return ret;
+  }
+
+  pragma "no doc"
+  inline proc createStringWithNewBuffer(s: bufferType, length: int, size: int) {
+    factoryDeprWarning();
+    return string.createWithNewBuffer(s, length, size);
   }
 
   //
@@ -675,15 +740,15 @@ module String {
     proc type chpl__deserialize(data) {
       if data.locale_id != chpl_nodeID {
         if data.len <= CHPL_SHORT_STRING_SIZE {
-          return createStringWithNewBuffer(
+          return string.createWithNewBuffer(
                   chpl__getInPlaceBufferData(data.shortData), data.len,
                   data.size);
         } else {
           var localBuff = bufferCopyRemote(data.locale_id, data.buff, data.len);
-          return createStringWithOwnedBuffer(localBuff, data.len, data.size);
+          return string.createWithOwnedBuffer(localBuff, data.len, data.size);
         }
       } else {
-        return createStringWithBorrowedBuffer(data.buff, data.len, data.size);
+        return string.createWithBorrowedBuffer(data.buff, data.len, data.size);
       }
     }
 
@@ -777,7 +842,7 @@ module String {
     */
     inline proc localize() : string {
       if _local || this.locale_id == chpl_nodeID {
-        return createStringWithBorrowedBuffer(this);
+        return string.createWithBorrowedBuffer(this);
       } else {
         const x:string = this; // assignment makes it local
         return x;
@@ -2248,7 +2313,7 @@ module String {
     var buffer = bufferAllocExact(2);
     buffer[0] = i;
     buffer[1] = 0;
-    var s = createStringWithOwnedBuffer(buffer, 1, 2);
+    var s = string.createWithOwnedBuffer(buffer, 1, 2);
     return s;
   }
 
@@ -2261,7 +2326,7 @@ module String {
     var (buffer, mbsize) = bufferAlloc(mblength+1);
     qio_encode_char_buf(buffer, i);
     buffer[mblength] = 0;
-    var s = createStringWithOwnedBuffer(buffer, mblength, mbsize);
+    var s = string.createWithOwnedBuffer(buffer, mblength, mbsize);
     return s;
   }
 

--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -165,7 +165,7 @@ module ChapelTaskTable {
     for taskID in chpldev_taskTable!.dom {
       try! stderr.writeln(
              "- ",
-             createStringWithNewBuffer(chpl_lookupFilename(
+             string.createWithNewBuffer(chpl_lookupFilename(
                                         chpldev_taskTable!.map[taskID].filename)),
              ":",  chpldev_taskTable!.map[taskID].lineno,
              " is ", chpldev_taskTable!.map[taskID].state);

--- a/modules/packages/Buffers.chpl
+++ b/modules/packages/Buffers.chpl
@@ -697,7 +697,7 @@ module Buffers {
         err = qbuffer_copyout(this._buf_internal,
                               start._bufit_internal, end._bufit_internal,
                               buf, len);
-        value = createStringWithOwnedBuffer(buf, length=len, size=len+1);
+        value = string.createWithOwnedBuffer(buf, length=len, size=len+1);
         ret = end;
       }
     }

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -2182,7 +2182,7 @@ module Sparse {
     const parentDT = transpose(D.parentDom);
     var Dom: sparse subdomain(parentDT) dmapped CS(sortedIndices=false);
 
-    var idxBuffer = Dom.makeIndexBuffer(size=D.numIndices);
+    var idxBuffer = Dom.createIndexBuffer(size=D.numIndices);
     for (i,j) in D do idxBuffer.add((j,i));
     idxBuffer.commit();
     return Dom;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1890,7 +1890,7 @@ module TwoArrayPartitioning {
     type bucketizerType;
 
     var numLocales:int;
-    var perLocale = newBlockArr(0..#numLocales,
+    var perLocale = BlockArr.create(0..#numLocales,
         TwoArrayDistributedBucketizerStatePerLocale(bucketizerType));
 
     const baseCaseSize:int;

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -493,7 +493,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.ctx == nil {
-        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+        var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
         halt("Error in ContextClass.init(): %s\n", errmsg);
       }
     }
@@ -502,7 +502,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_ctx_term(this.ctx):int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in ContextClass.deinit(): %s\n", errmsg);
         }
       }
@@ -579,7 +579,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.socket == nil {
-        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+        var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
         halt("Error in SocketClass.init(): %s\n", errmsg);
       }
     }
@@ -588,7 +588,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_close(socket):int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in SocketClass.deinit(): %s\n", errmsg);
         }
         socket = c_nil;
@@ -689,7 +689,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_bind(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in Socket.bind(): ", errmsg);
         }
       }
@@ -703,7 +703,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_connect(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           writef("Error in Socket.connect(): %s\n", errmsg);
         }
       }
@@ -734,7 +734,7 @@ module ZMQ {
                                  c_ptrTo(copy):c_void_ptr,
                                  numBytes(T)): int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in Socket.setsockopt(): ", errmsg);
         }
       }
@@ -772,13 +772,13 @@ module ZMQ {
         var err = zmq_getsockopt_string_helper(classRef.socket,
                                                ZMQ_LAST_ENDPOINT, str);
         if err == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLastEndpoint(): " +
                                    errmsg);
         }
-        ret = createStringWithOwnedBuffer(str);
+        ret = string.createWithOwnedBuffer(str);
       }
       return ret;
     }
@@ -799,7 +799,7 @@ module ZMQ {
         var ret = zmq_getsockopt_int_helper(classRef.socket, ZMQ_LINGER,
                                             copy);
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLinger(): " + errmsg);
@@ -825,7 +825,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setLinger(): " + errmsg);
@@ -849,7 +849,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = string.createWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setSubscribe(): " + errmsg);
@@ -948,7 +948,7 @@ module ZMQ {
         //
         // TODO: If *not crossing locales*, check for ownership and
         // conditionally have ZeroMQ free the memory.
-        var copy = createStringWithNewBuffer(s=data);
+        var copy = string.createWithNewBuffer(s=data);
         copy.isowned = false;
 
         // Create the ZeroMQ message from the string buffer
@@ -1049,7 +1049,7 @@ module ZMQ {
         // Construct the string on the current locale, copying the data buffer
         // from the message object; then, release the message object
         var len = zmq_msg_size(msg):int;
-        var str = createStringWithNewBuffer(zmq_msg_data(msg):c_ptr(uint(8)),
+        var str = string.createWithNewBuffer(zmq_msg_data(msg):c_ptr(uint(8)),
                                             length=len, size=len+1);
         if (0 != zmq_msg_close(msg)) {
           try throw_socket_error(errno, "recv");
@@ -1104,7 +1104,7 @@ module ZMQ {
     pragma "no doc"
     proc throw_socket_error(socket_errno: c_int, err_fn: string) throws {
       var errmsg_zmq =
-        createStringWithBorrowedBuffer(zmq_strerror(socket_errno));
+        string.createWithBorrowedBuffer(zmq_strerror(socket_errno));
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -390,12 +390,12 @@ module BigInteger {
       if _local {
         var tmpvar = chpl_gmp_mpz_get_str(base_, this.mpz);
 
-        ret = createStringWithOwnedBuffer(tmpvar);
+        ret = string.createWithOwnedBuffer(tmpvar);
 
       } else if this.localeId == chpl_nodeID {
         var tmpvar = chpl_gmp_mpz_get_str(base_, this.mpz);
 
-        ret = createStringWithOwnedBuffer(tmpvar);
+        ret = string.createWithOwnedBuffer(tmpvar);
 
       } else {
         const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
@@ -403,7 +403,7 @@ module BigInteger {
         on __primitive("chpl_on_locale_num", thisLoc) {
           var tmpvar = chpl_gmp_mpz_get_str(base_, this.mpz);
 
-          ret = createStringWithOwnedBuffer(tmpvar);
+          ret = string.createWithOwnedBuffer(tmpvar);
         }
       }
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -433,7 +433,7 @@ module DateTime {
     timeStruct.tm_yday = (this - new date(year, 1, 1)).days: int(32);
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = createStringWithNewBuffer( __primitive("cast",
+    var str = string.createWithNewBuffer( __primitive("cast",
                                                      c_string, c_ptrTo(buf)));
 
     return str;
@@ -682,7 +682,7 @@ module DateTime {
     }
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = createStringWithNewBuffer(__primitive("cast",
+    var str = string.createWithNewBuffer(__primitive("cast",
                                                     c_string, c_ptrTo(buf)));
 
     return str;
@@ -1192,7 +1192,7 @@ module DateTime {
     timeStruct.tm_yday = (this.replace(tzinfo=nil) - new datetime(year, 1, 1)).days: int(32);
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = createStringWithNewBuffer(__primitive("cast",
+    var str = string.createWithNewBuffer(__primitive("cast",
                                                     c_string, c_ptrTo(buf)));
 
     return str;

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -593,7 +593,7 @@ proc locale.cwd(): string throws {
     var tmp:c_string;
     // c_strings can't cross on statements.
     err = chpl_fs_cwd(tmp);
-    ret = createStringWithOwnedBuffer(tmp);
+    ret = string.createWithOwnedBuffer(tmp);
   }
   if err != ENOERR then try ioerror(err, "in cwd");
   return ret;
@@ -876,7 +876,7 @@ private module GlobWrappers {
   // glob_index wrapper that takes care of casting
   inline proc glob_index_w(glb: glob_t, idx: int): string {
     extern proc chpl_glob_index(glb: glob_t, idx: size_t): c_string;
-    return createStringWithNewBuffer(chpl_glob_index(glb,
+    return string.createWithNewBuffer(chpl_glob_index(glb,
                                                        idx.safeCast(size_t)));
   }
 
@@ -1182,7 +1182,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = createStringWithBorrowedBuffer(ent.d_name());
+      const filename = string.createWithBorrowedBuffer(ent.d_name());
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {
           const fullpath = path + "/" + filename;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1565,7 +1565,7 @@ proc file.path : string throws {
     }
     chpl_free_c_string(tmp);
     if !err {
-      ret = createStringWithOwnedBuffer(tmp2);
+      ret = string.createWithOwnedBuffer(tmp2);
     }
   }
   if err then try ioerror(err, "in file.path");
@@ -1713,7 +1713,7 @@ proc openplugin(pluginFile: QioPluginFile, mode:iomode,
       if path_err {
         path = "unknown";
       } else {
-        path = createStringWithOwnedBuffer(str, len);
+        path = string.createWithOwnedBuffer(str, len);
       }
     }
 
@@ -1786,7 +1786,7 @@ proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE, style:iostyle = defaultIOStyle(
     var path_cs:c_string;
     var path_err = qio_file_path_for_fd(fd, path_cs);
     var path = if path_err then "unknown"
-                           else createStringWithOwnedBuffer(path_cs);
+                           else string.createWithOwnedBuffer(path_cs);
     try ioerror(err, "in openfd", path);
   }
   return ret;
@@ -1828,7 +1828,7 @@ proc openfp(fp: _file, hints:iohints=IOHINT_NONE, style:iostyle = defaultIOStyle
     var path_cs:c_string;
     var path_err = qio_file_path_for_fp(fp, path_cs);
     var path = if path_err then "unknown"
-                           else createStringWithOwnedBuffer(path_cs);
+                           else string.createWithOwnedBuffer(path_cs);
     try ioerror(err, "in openfp", path);
   }
   return ret;
@@ -2053,7 +2053,7 @@ pragma "no doc"
 inline proc _cast(type t:string, x: ioChar) {
   var csc: c_string =  qio_encode_to_string(x.ch);
   // The caller has responsibility for freeing the returned string.
-  return createStringWithOwnedBuffer(csc);
+  return string.createWithOwnedBuffer(csc);
 }
 
 
@@ -2153,7 +2153,7 @@ proc channel._ch_ioerror(error:syserr, msg:string) throws {
     var err:syserr = ENOERR;
     err = qio_channel_path_offset(locking, _channel_internal, tmp_path, tmp_offset);
     if !err {
-      path = createStringWithOwnedBuffer(tmp_path);
+      path = string.createWithOwnedBuffer(tmp_path);
       offset = tmp_offset;
     }
   }
@@ -2171,7 +2171,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
     var err:syserr = ENOERR;
     err = qio_channel_path_offset(locking, _channel_internal, tmp_path, tmp_offset);
     if !err {
-      path = createStringWithOwnedBuffer(tmp_path);
+      path = string.createWithOwnedBuffer(tmp_path);
       offset = tmp_offset;
     }
   }
@@ -2771,7 +2771,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
     var len:int(64);
     var tx: c_string;
     var ret = qio_channel_scan_string(false, _channel_internal, tx, len, -1);
-    x = createStringWithOwnedBuffer(tx, length=len);
+    x = string.createWithOwnedBuffer(tx, length=len);
     return ret;
   } else if t == bytes {
     // handle _bytes
@@ -2914,7 +2914,7 @@ private inline proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, p
     var ret = qio_channel_read_string(false, byteorder:c_int,
                                       qio_channel_str_style(_channel_internal),
                                       _channel_internal, tx, len, -1);
-    x = createStringWithOwnedBuffer(tx, length=len);
+    x = string.createWithOwnedBuffer(tx, length=len);
     return ret;
   } else if t == bytes {
     // handle _bytes (nothing special for bytes vs string in this case)
@@ -3509,7 +3509,7 @@ proc stringify(const args ...?k):string {
       // Add the terminating NULL byte to make C string conversion easy.
       buf[offset] = 0;
 
-      return createStringWithOwnedBuffer(buf, offset, offset+1);
+      return string.createWithOwnedBuffer(buf, offset, offset+1);
     }
   }
 }
@@ -3783,7 +3783,7 @@ private proc readBytesOrString(ch: channel, ref out_var: ?t,  len: int(64))
     }
 
     if t == string {
-      out_var = createStringWithOwnedBuffer(tx, length=lenread);
+      out_var = string.createWithOwnedBuffer(tx, length=lenread);
     }
     else {
       out_var = createBytesWithOwnedBuffer(tx, length=lenread);
@@ -6750,7 +6750,7 @@ private inline proc chpl_do_format(fmt:string, args ...?k): string throws {
   // Add the terminating NULL byte to make C string conversion easy.
   buf[offset] = 0;
 
-  return createStringWithOwnedBuffer(buf, offset, offset+1);
+  return string.createWithOwnedBuffer(buf, offset, offset+1);
 }
 
 
@@ -6803,7 +6803,7 @@ proc channel._extractMatch(m:reMatch, ref arg:string, ref error:syserr) {
     error =
         qio_channel_read_string(false, iokind.native:c_int, stringStyleExactLen(len),
                                 _channel_internal, ts, gotlen, len: ssize_t);
-    s = createStringWithOwnedBuffer(ts, length=gotlen);
+    s = string.createWithOwnedBuffer(ts, length=gotlen);
   }
 
   if ! error {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2778,7 +2778,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
     var len:int(64);
     var tx: c_string;
     var ret = qio_channel_scan_bytes(false, _channel_internal, tx, len, -1);
-    x = createBytesWithOwnedBuffer(tx, length=len);
+    x = bytes.createWithOwnedBuffer(tx, length=len);
     return ret;
   } else if isEnumType(t) {
     var err:syserr = ENOERR;
@@ -2923,7 +2923,7 @@ private inline proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, p
     var ret = qio_channel_read_string(false, byteorder:c_int,
                                       qio_channel_str_style(_channel_internal),
                                       _channel_internal, tx, len, -1);
-    x = createBytesWithOwnedBuffer(tx, length=len);
+    x = bytes.createWithOwnedBuffer(tx, length=len);
     return ret;
   } else if isEnumType(t) {
     var i:chpl_enum_mintype(t);
@@ -3786,7 +3786,7 @@ private proc readBytesOrString(ch: channel, ref out_var: ?t,  len: int(64))
       out_var = string.createWithOwnedBuffer(tx, length=lenread);
     }
     else {
-      out_var = createBytesWithOwnedBuffer(tx, length=lenread);
+      out_var = bytes.createWithOwnedBuffer(tx, length=lenread);
     }
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3437,7 +3437,7 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
   for param i in 1..tup.size {
     if i != 1 then str += ", ";
     if tup[i].type == c_string {
-      str += createStringWithBorrowedBuffer(tup[i]);
+      str += string.createWithBorrowedBuffer(tup[i]);
     }
     else {
       str += tup[i]:string;
@@ -3471,7 +3471,7 @@ proc stringify(const args ...?k):string {
       if args[i].type == string {
         str += args[i];
       } else if args[i].type == c_string {
-        str += createStringWithBorrowedBuffer(args[i]);
+        str += string.createWithBorrowedBuffer(args[i]);
       } else if args[i].type == bytes {
         //decodePolicy.replace never throws
         try! {

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -358,7 +358,7 @@ proc dirname(name: string): string {
            if (h != 1) {
              value = "${" + env_var + "}";
            } else {
-             value = createStringWithBorrowedBuffer(value_c);
+             value = string.createWithBorrowedBuffer(value_c);
            }
            res += value;
          }
@@ -375,7 +375,7 @@ proc dirname(name: string): string {
          if (h != 1) {
            value = "$" + env_var;
          } else {
-           value = createStringWithBorrowedBuffer(value_c);
+           value = string.createWithBorrowedBuffer(value_c);
          }
          res += value;
          if (ind <= path_p.numBytes) {
@@ -407,7 +407,7 @@ proc file.getParentName(): string throws {
   try check();
 
   try {
-    return dirname(createStringWithNewBuffer(this.realPath()));
+    return dirname(string.createWithNewBuffer(this.realPath()));
   } catch {
     return "unknown";
   }
@@ -575,7 +575,7 @@ proc realPath(name: string): string throws {
   var res: c_string;
   var err = chpl_fs_realpath(name.localize().c_str(), res);
   if err then try ioerror(err, "realPath", name);
-  return createStringWithOwnedBuffer(res);
+  return string.createWithOwnedBuffer(res);
 }
 
 pragma "no doc"
@@ -613,7 +613,7 @@ proc file.realPath(): string throws {
   var res: c_string;
   var err = chpl_fs_realpath_file(_file_internal, res);
   if err then try ioerror(err, "in file.realPath");
-  return createStringWithOwnedBuffer(res);
+  return string.createWithOwnedBuffer(res);
 }
 
 pragma "no doc"

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -468,7 +468,7 @@ proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=f
   qio_regexp_create_compile(pattern.localize().c_str(), pattern.numBytes, opts, ret._regexp);
   if !qio_regexp_ok(ret._regexp) {
     var err_str = qio_regexp_error(ret._regexp);
-    var err_msg = createStringWithNewBuffer(err_str) + 
+    var err_msg = string.createWithNewBuffer(err_str) + 
                   " when compiling regexp '" + pattern + "'";
     throw new owned BadRegexpError(err_msg);
   }
@@ -951,7 +951,7 @@ record regexp {
     } else {
       nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.numBytes, text.localize().c_str(), text.numBytes, pos:int, endpos:int, global, replaced, replaced_len);
     }
-    const ret = createStringWithOwnedBuffer(replaced);
+    const ret = string.createWithOwnedBuffer(replaced);
     return (ret, nreplaced);
   }
 
@@ -978,7 +978,7 @@ record regexp {
     on this.home {
       var patternTemp:c_string;
       qio_regexp_get_pattern(this._regexp, patternTemp);
-      pattern = createStringWithNewBuffer(patternTemp);
+      pattern = string.createWithNewBuffer(patternTemp);
     }
     // Note -- this is wrong because we didn't quote
     // and there's no way to get the flags
@@ -1043,7 +1043,7 @@ inline proc _cast(type t, x: regexp) where t == string {
   on x.home {
     var cs: c_string;
     qio_regexp_get_pattern(x._regexp, cs);
-    pattern = createStringWithOwnedBuffer(cs);
+    pattern = string.createWithOwnedBuffer(cs);
   }
   return pattern;
 }

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -58,7 +58,7 @@ class SystemError : Error {
   override proc message() {
     var strerror_err: err_t = ENOERR;
     var errstr              = sys_strerror_syserr_str(err, strerror_err);
-    var err_msg             = createStringWithOwnedBuffer(errstr);
+    var err_msg             = string.createWithOwnedBuffer(errstr);
 
     if !details.isEmpty() then
       err_msg += " (" + details + ")";
@@ -384,9 +384,9 @@ private proc quote_string(s:string, len:ssize_t) {
   // This doesn't handle the case where ret==NULL as did the previous
   // version in QIO, but I'm not sure how that was used.
 
-  if err then return createStringWithOwnedBuffer(qio_strdup("<error>"));
+  if err then return string.createWithOwnedBuffer(qio_strdup("<error>"));
 
-  return createStringWithOwnedBuffer(ret);
+  return string.createWithOwnedBuffer(ret);
 }
 
 /* Create and throw a :class:`SystemError` if an error occurred, formatting a
@@ -462,7 +462,7 @@ proc errorToString(error:syserr):string
 {
   var strerror_err:err_t = ENOERR;
   const errstr = sys_strerror_syserr_str(error, strerror_err);
-  return createStringWithOwnedBuffer(errstr);
+  return string.createWithOwnedBuffer(errstr);
 }
 
 }

--- a/test/arrays/slices/sliceUsesDom-locality.chpl
+++ b/test/arrays/slices/sliceUsesDom-locality.chpl
@@ -3,7 +3,7 @@ use BlockDist;
 var D = {1..9, 1..9};
 var SubD = {4..6, 4..6};
 
-var DB = newBlockDom(D);
+var DB = BlockDom.create(D);
 var SubDB = DB[SubD];
 
 testit(D, SubD);

--- a/test/arrays/slices/sliceUsesDom.chpl
+++ b/test/arrays/slices/sliceUsesDom.chpl
@@ -3,7 +3,7 @@ use BlockDist;
 var D = {1..9, 1..9};
 var SubD = {2..4, 2..4};
 
-var DB = newBlockDom(D);
+var DB = BlockDom.create(D);
 var SubDB = DB[SubD];
 
 testit(D);

--- a/test/compflags/link/deitz/test_link1.chpl
+++ b/test/compflags/link/deitz/test_link1.chpl
@@ -3,4 +3,4 @@ extern proc bar(i: int): c_string;
 
 foo("hello world");
 var s = bar(12);
-writeln(createStringWithNewBuffer(s));
+writeln(string.createWithNewBuffer(s));

--- a/test/compflags/link/deitz/test_link2.chpl
+++ b/test/compflags/link/deitz/test_link2.chpl
@@ -3,4 +3,4 @@ extern proc bar(i: int): c_string;
 
 foo("hello world");
 var s = bar(12);
-writeln(createStringWithNewBuffer(s));
+writeln(string.createWithNewBuffer(s));

--- a/test/distributions/diten/testBlockUtilityFns.chpl
+++ b/test/distributions/diten/testBlockUtilityFns.chpl
@@ -2,10 +2,10 @@ use BlockDist;
 var rng = (1..10, 1..10);
 var D = {(...rng)};
 
-var BD1 = newBlockDom(D);
-var BA1 = newBlockArr(D, int);
-var BD2 = newBlockDom((...rng));
-var BA2 = newBlockArr((...rng), int);
+var BD1 = BlockDom.create(D);
+var BA1 = BlockArr.create(D, int);
+var BD2 = BlockDom.create((...rng));
+var BA2 = BlockArr.create((...rng), int);
 
 printLocales(BD1);
 writeln();

--- a/test/distributions/diten/testCyclicUtilityFns.chpl
+++ b/test/distributions/diten/testCyclicUtilityFns.chpl
@@ -2,10 +2,10 @@ use CyclicDist;
 var rng = (1..10, 1..10);
 var D = {(...rng)};
 
-var CD1 = newCyclicDom(D);
-var CA1 = newCyclicArr(D, int);
-var CD2 = newCyclicDom((...rng));
-var CA2 = newCyclicArr((...rng), int);
+var CD1 = CyclicDom.create(D);
+var CA1 = CyclicArr.create(D, int);
+var CD2 = CyclicDom.create((...rng));
+var CA2 = CyclicArr.create((...rng), int);
 
 printLocales(CD1);
 writeln();

--- a/test/execflags/gbt/dash-E.chpl
+++ b/test/execflags/gbt/dash-E.chpl
@@ -1,2 +1,2 @@
 extern proc getenv(const name: c_string): c_string;
-writeln(createStringWithNewBuffer(getenv('DASH_E_ENV_VAR')));
+writeln(string.createWithNewBuffer(getenv('DASH_E_ENV_VAR')));

--- a/test/execflags/gbt/shell-meta-env.chpl
+++ b/test/execflags/gbt/shell-meta-env.chpl
@@ -1,3 +1,3 @@
 var ev: c_string;
 if sys_getenv('SHELL_META_ENV', ev) != 0 then
-  writeln(createStringWithNewBuffer(ev));
+  writeln(string.createWithNewBuffer(ev));

--- a/test/expressions/ferguson/dynamic-class-name.chpl
+++ b/test/expressions/ferguson/dynamic-class-name.chpl
@@ -2,7 +2,7 @@ proc getNameFromClass(obj:borrowed object) : string
 {
   var cid =  __primitive("getcid", obj);
   var cs: c_string = __primitive("class name by id", cid);
-  var str = createStringWithNewBuffer(cs);
+  var str = string.createWithNewBuffer(cs);
   return str;
 }
 

--- a/test/extern/bradc/extern_string_test-remote.chpl
+++ b/test/extern/bradc/extern_string_test-remote.chpl
@@ -3,7 +3,7 @@ use IO;
 extern proc return_string_test():c_string;
 extern proc return_string_arg_test(ref c_string);
 
-writeln("returned string ",createStringWithNewBuffer(return_string_test()));
+writeln("returned string ",string.createWithNewBuffer(return_string_test()));
 stdout.flush();
 
 var s:string;

--- a/test/extern/ferguson/c_strings.chpl
+++ b/test/extern/ferguson/c_strings.chpl
@@ -14,9 +14,9 @@ proc go() {
   var gotc = returns_c_string();
   print_c_string(gotc);
 
-  writeln(createStringWithNewBuffer(gotc));
+  writeln(string.createWithNewBuffer(gotc));
 
-  var gots = createStringWithNewBuffer(gotc);
+  var gots = string.createWithNewBuffer(gotc);
   writeln(gots);
 
   writeln("Should be returned_c_string_in_argument x3");
@@ -25,9 +25,9 @@ proc go() {
 
   print_c_string(argc);
 
-  writeln(createStringWithNewBuffer(argc));
+  writeln(string.createWithNewBuffer(argc));
 
-  var args = createStringWithNewBuffer(argc);
+  var args = string.createWithNewBuffer(argc);
   writeln(args);
 
   writeln("Should be returned_c_string_in_argument_with_length x3");
@@ -37,9 +37,9 @@ proc go() {
 
   print_c_string_len(arg2c, len);
 
-  writeln((createStringWithNewBuffer(arg2c))[1..len]);
+  writeln((string.createWithNewBuffer(arg2c))[1..len]);
 
-  var arg2s = (createStringWithNewBuffer(arg2c))[1..len];
+  var arg2s = (string.createWithNewBuffer(arg2c))[1..len];
   writeln(arg2s);
 }
 

--- a/test/extern/ferguson/c_strings_global.chpl
+++ b/test/extern/ferguson/c_strings_global.chpl
@@ -14,9 +14,9 @@ proc go() {
   var gotc = returns_c_string();
   print_c_string(gotc);
 
-  writeln(createStringWithNewBuffer(gotc));
+  writeln(string.createWithNewBuffer(gotc));
 
-  var gots = createStringWithNewBuffer(gotc);
+  var gots = string.createWithNewBuffer(gotc);
   writeln(gots);
 
   writeln("Should be returned_c_string_in_argument x3");
@@ -25,9 +25,9 @@ proc go() {
 
   print_c_string(argc);
 
-  writeln(createStringWithNewBuffer(argc));
+  writeln(string.createWithNewBuffer(argc));
 
-  var args = createStringWithNewBuffer(argc);
+  var args = string.createWithNewBuffer(argc);
   writeln(args);
 
   writeln("Should be returned_c_string_in_argument_with_length x3");
@@ -37,9 +37,9 @@ proc go() {
 
   print_c_string_len(arg2c, len);
 
-  writeln((createStringWithNewBuffer(arg2c))[1..len]);
+  writeln((string.createWithNewBuffer(arg2c))[1..len]);
 
-  var arg2s = (createStringWithNewBuffer(arg2c))[1..len];
+  var arg2s = (string.createWithNewBuffer(arg2c))[1..len];
   writeln(arg2s);
 }
 

--- a/test/extern/ferguson/externblock/readme_examples2.chpl
+++ b/test/extern/ferguson/externblock/readme_examples2.chpl
@@ -48,7 +48,7 @@ setSpace(c_ptrTo(space));
 
 var str:c_string;
 setString(c_ptrTo(str));
-writeln(createStringWithNewBuffer(str));
+writeln(string.createWithNewBuffer(str));
 
 module MyCModule {
   extern {

--- a/test/extern/gbt/string_from_c_string.chpl
+++ b/test/extern/gbt/string_from_c_string.chpl
@@ -1,4 +1,4 @@
 extern proc returns_c_string(): c_string;
 
 writeln("Should be returned_c_string");
-writeln(createStringWithNewBuffer(returns_c_string()));
+writeln(string.createWithNewBuffer(returns_c_string()));

--- a/test/extern/jjueckstock/basic.chpl
+++ b/test/extern/jjueckstock/basic.chpl
@@ -14,7 +14,7 @@ module C { extern {
   const char* greet_str = "Hello";
 } }
 
-writeln(createStringWithNewBuffer(C.greeting()));
+writeln(string.createWithNewBuffer(C.greeting()));
 writeln(C.my_doub);
 writeln(C.my_int);
 writeln(C.add_one(1000));

--- a/test/extern/jjueckstock/types.chpl
+++ b/test/extern/jjueckstock/types.chpl
@@ -31,7 +31,7 @@ use C;
 //NOTE: either C.my_struct or my_struct will work with the use C; statement.
 var strct: C.my_struct = new my_struct(42, "bar".c_str());
 writeln(strct.foo);
-writeln(createStringWithNewBuffer(strct.bar));
+writeln(string.createWithNewBuffer(strct.bar));
 
 //NOTE: due to an issue with the way Chapel implements type aliases,
 //

--- a/test/interop/fortran/genFortranInterface/unhandledType.chpl
+++ b/test/interop/fortran/genFortranInterface/unhandledType.chpl
@@ -1,5 +1,5 @@
 export proc takesCstring(s: c_string) {
-  writeln(createStringWithNewBuffer(s));
+  writeln(string.createWithNewBuffer(s));
 }
 
 

--- a/test/interop/python/defaultValues.chpl
+++ b/test/interop/python/defaultValues.chpl
@@ -1,5 +1,5 @@
 export proc cstringDefault(in x: c_string = "blah") {
-  writeln(createStringWithNewBuffer(x));
+  writeln(string.createWithNewBuffer(x));
 }
 
 export proc intDefault(x: int = 3) {

--- a/test/interop/python/stringAllocated.chpl
+++ b/test/interop/python/stringAllocated.chpl
@@ -9,5 +9,5 @@ export proc g(size: int, ptr: c_ptr(uint(8))): int {
 }
 
 export proc writeStr(in x: c_string) {
-  writeln(createStringWithNewBuffer(x));
+  writeln(string.createWithNewBuffer(x));
 }

--- a/test/interop/python/stringFunctions.chpl
+++ b/test/interop/python/stringFunctions.chpl
@@ -1,6 +1,6 @@
 /* Tests accepting a c_string */
 export proc takesString(in x: c_string) {
-  writeln(createStringWithNewBuffer(x));
+  writeln(string.createWithNewBuffer(x));
 }
 
 /* Tests returning a c_string */

--- a/test/io/diten/testCheckpoint.chpl
+++ b/test/io/diten/testCheckpoint.chpl
@@ -5,7 +5,7 @@ config const filename = "myBlockArr.bin";
 
 config const m = 5, n = 4;
 
-var Dom = newBlockDom({1..m, 1..n});
+var Dom = BlockDom.create({1..m, 1..n});
 
 var A: [Dom] int;
 

--- a/test/io/ferguson/json-distributed-arrays.chpl
+++ b/test/io/ferguson/json-distributed-arrays.chpl
@@ -29,7 +29,7 @@ var expectfile = openmem();
 
 {
   writeln("Testing block array");
-  var A = newBlockArr({1..5}, int);
+  var A = BlockArr.create({1..5}, int);
   A = 1..5;
 
   writef("%jt\n", A);
@@ -45,7 +45,7 @@ var expectfile = openmem();
 
 {
   writeln("Testing cyclic array");
-  var A = newCyclicArr({1..5}, int);
+  var A = CyclicArr.create({1..5}, int);
   A = 1..5;
 
   writef("%jt\n", A);

--- a/test/io/ferguson/open-remote-string.chpl
+++ b/test/io/ferguson/open-remote-string.chpl
@@ -20,7 +20,7 @@ for f in DistFiles {
     var base = basename(f);
     var uname:c_string;
     sys_getenv(c"USER", uname);
-    var to = "/tmp/" + createStringWithNewBuffer(uname)+ base;
+    var to = "/tmp/" + string.createWithNewBuffer(uname)+ base;
     if verbose then writeln("on ", here.id, " copying from ", from, " to ", to);
     copy(from, to);
     f = to;

--- a/test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl
+++ b/test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl
@@ -145,7 +145,7 @@ proc main() {
   // Declare the distributed array that holds the same number of elements
   // as all of the files involved combined.
   const bbox = {0..#numElements};
-  const blockDom = newBlockDom(bbox);
+  const blockDom = BlockDom.create(bbox);
   var blockArr: [blockDom] eltType;
 
   // Read the files into the distributed array

--- a/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
+++ b/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
@@ -14,7 +14,7 @@ proc simpletestcore(input:[]) {
   var localCopy = input;
   shuffle(localCopy, seed);
 
-  const blockDom = newBlockDom(input.domain);
+  const blockDom = BlockDom.create(input.domain);
   var A: [blockDom] uint = localCopy;
 
   if debug {
@@ -65,7 +65,7 @@ simpletest([0x01:uint,
 
 
 proc randomtest(n:int) {
-  const blockDom = newBlockDom({0..#n});
+  const blockDom = BlockDom.create({0..#n});
   var A: [blockDom] uint;
   var seed = SeedGenerator.oddCurrentTime;
   fillRandom(A, seed);

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -1836,7 +1836,7 @@ proc simpletestcore(input:[], seed:int) {
   var localCopy = input;
   shuffle(localCopy, seed);
 
-  const blockDom = input.domain; //newBlockDom(input.domain);
+  const blockDom = input.domain; //BlockDom.create(input.domain);
   var A: [blockDom] uint = localCopy;
 
   assert(isSorted(input));
@@ -1897,7 +1897,7 @@ simpletest([0xda524a179483bc7:uint,
             0xde0546a7b5c06e9:uint]);
 
 proc randomtest(n:int) {
-  const blockDom = {0..#n}; //newBlockDom({0..#n});
+  const blockDom = {0..#n}; //BlockDom.create({0..#n});
   var A: [blockDom] uint;
 
   if skew {

--- a/test/library/packages/Sort/performance/dist-performance.chpl
+++ b/test/library/packages/Sort/performance/dist-performance.chpl
@@ -68,7 +68,7 @@ inline proc endDiag(name, x) {
 }
 
 proc main() {
-  var A = newBlockArr({1..nElems}, elemType);
+  var A = BlockArr.create({1..nElems}, elemType);
   fillRandom(A, seed=314159265);
 
   startDiag();

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -222,7 +222,7 @@ module DataFrames {
       var idxWidth = 0;
       for idx in this {
         // TODO: clean up to simple cast after bugfix
-        var idxStr = createStringWithNewBuffer(idx: string);
+        var idxStr = string.createWithNewBuffer(idx: string);
         if idxStr.length > idxWidth then
           idxWidth = idxStr.length;
       }
@@ -234,7 +234,7 @@ module DataFrames {
       var idxWidth = writeIdxWidth() + 4;
       for (idx, (v, d)) in zip(this, s!._these()) {
         // TODO: clean up to simple cast after bugfix
-        var idxStr = createStringWithNewBuffer(idx: string);
+        var idxStr = string.createWithNewBuffer(idx: string);
         f <~> idx;
         for space in 1..idxWidth-idxStr.length do
           f <~> " ";
@@ -259,7 +259,7 @@ module DataFrames {
       for idx in this {
         f <~> "\n";
         // TODO: clean up to simple cast after bugfix
-        var idxStr = createStringWithNewBuffer(idx: string);
+        var idxStr = string.createWithNewBuffer(idx: string);
         f <~> idxStr;
         for space in 1..idxWidth-idxStr.length do
           f <~> " ";
@@ -280,7 +280,7 @@ module DataFrames {
       for idx in this {
         f <~> "\n";
         // TODO: clean up to simple cast after bugfix
-        var idxStr = createStringWithNewBuffer(idx: string);
+        var idxStr = string.createWithNewBuffer(idx: string);
         f <~> idxStr;
         for space in 1..idxWidth-idxStr.length do
           f <~> " ";
@@ -734,7 +734,7 @@ module DataFrames {
     proc writeElem(f, i, len: int) {
       // TODO: clean up to simple cast after bugfix
       var output = if this.valid(i)
-                   then createStringWithNewBuffer(this[i]: string)
+                   then string.createWithNewBuffer(this[i]: string)
                    else "None";
 
       for space in 1..len-output.length do
@@ -747,7 +747,7 @@ module DataFrames {
     proc writeElemNoIndex(f, i: int, len: int) {
       // TODO: clean up to simple cast after bugfix
       var output = if this.valid_at(i)
-                   then createStringWithNewBuffer(this.at(i): string)
+                   then string.createWithNewBuffer(this.at(i): string)
                    else "None";
 
       for space in 1..len-output.length do
@@ -830,7 +830,7 @@ module DataFrames {
         idx!.writeThis(f, _to_unmanaged(this));
       } else {
         var n = nrows();
-        var nStr = createStringWithNewBuffer(n: string);
+        var nStr = string.createWithNewBuffer(n: string);
         var idxWidth = nStr.length + 1;
 
         for space in 1..idxWidth do
@@ -841,7 +841,7 @@ module DataFrames {
 
         for i in 1..n {
           f <~> "\n";
-          var iStr = createStringWithNewBuffer(i: string);
+          var iStr = string.createWithNewBuffer(i: string);
           f <~> iStr;
           for space in 1..idxWidth-iStr.length do
             f <~> " ";

--- a/test/library/standard/FileSystem/bharshbarg/filer.chpl
+++ b/test/library/standard/FileSystem/bharshbarg/filer.chpl
@@ -48,7 +48,7 @@ iter listdir(path: string, hidden=false, dirs=true, files=true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = createStringWithNewBuffer(ent.d_name());
+      const filename = string.createWithNewBuffer(ent.d_name());
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {
           //

--- a/test/localeModels/dmk/locale_name.chpl
+++ b/test/localeModels/dmk/locale_name.chpl
@@ -3,9 +3,9 @@ extern var chpl_nodeID: chpl_nodeID_t;
 
 var locale_name = here.chpl_name();
 
-if locale_name == createStringWithNewBuffer(chpl_nodeName()) then
+if locale_name == string.createWithNewBuffer(chpl_nodeName()) then
   writeln("matches nodeName");
-else if locale_name == createStringWithNewBuffer(chpl_nodeName()) + "-" + chpl_nodeID:string then
+else if locale_name == string.createWithNewBuffer(chpl_nodeName()) + "-" + chpl_nodeID:string then
   writeln("matches nodeName-nodeID");
 else
   writeln("unknown format: ", locale_name);

--- a/test/runtime/gbt/tasks/idToString.chpl
+++ b/test/runtime/gbt/tasks/idToString.chpl
@@ -14,7 +14,7 @@ proc main() {
     var idStr = chpl_task_idToString(c_ptrTo(buf), buf.size:size_t, id);
     writeln('task ID of ', what, ' is: ',
             if idStr==c_nil:c_string then '<OVF>'
-                                     else createStringWithNewBuffer(idStr));
+                                     else string.createWithNewBuffer(idStr));
   }
 
   showMe('main()');

--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -45,10 +45,10 @@ iter my_wordexp(pattern:string, recursive:bool = false, flags:int = 0, directory
   for i in 0..wordexpNum -1 {
     tx = wordexp_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
-      const pth = createStringWithNewBuffer(tx)+ "/";
+      const pth = string.createWithNewBuffer(tx)+ "/";
       for fl in my_wordexp(pattern, recursive, flags, pth) do
         yield fl;
-    } else yield createStringWithNewBuffer(tx);
+    } else yield string.createWithNewBuffer(tx);
   }
 
   wordfree(glb);
@@ -107,10 +107,10 @@ iter my_glob(pattern:string, recursive:bool = false, flags:int = 0, directory:st
   for i in 0..globNum - 1 {
     tx = glob_index(glb, i);
     if recursive && chpl_isdir(tx) == 1 {
-      const pth = createStringWithNewBuffer(tx)+ "/";
+      const pth = string.createWithNewBuffer(tx)+ "/";
       for fl in my_glob(pattern, recursive, flags, pth) do
         yield fl;
-    } else yield createStringWithNewBuffer(tx);
+    } else yield string.createWithNewBuffer(tx);
   }
 
   globfree(glb);

--- a/test/types/bytes/basic.chpl
+++ b/test/types/bytes/basic.chpl
@@ -4,7 +4,7 @@ var cs: c_string = "this is a c_string";
 
 writeln(b);
 writeln(s);
-writeln(createStringWithNewBuffer(cs));
+writeln(string.createWithNewBuffer(cs));
 writeln();
 
 // TEST INITIALIZERS

--- a/test/types/bytes/basic.chpl
+++ b/test/types/bytes/basic.chpl
@@ -9,8 +9,8 @@ writeln();
 
 // TEST INITIALIZERS
 writeln("Initializer tests");
-var b_from_s = createBytesWithNewBuffer(s:bytes);
-var b_from_cs = createBytesWithNewBuffer(cs);
+var b_from_s = bytes.createWithNewBuffer(s:bytes);
+var b_from_cs = bytes.createWithNewBuffer(cs);
 
 var c_char_arr = c_malloc(uint(8), 4);
 c_char_arr[0] = 65; //A
@@ -19,7 +19,7 @@ c_char_arr[2] = 67; //C
 c_char_arr[3] = 0;
 
 //length and size are in bytes
-var b_from_c_ptr = createBytesWithNewBuffer(c_char_arr, length=3, size=4);
+var b_from_c_ptr = bytes.createWithNewBuffer(c_char_arr, length=3, size=4);
 
 writeln("bytes object from string: ", b_from_s);
 writeln("bytes object from c_string: ", b_from_cs);

--- a/test/types/bytes/factory/basic.chpl
+++ b/test/types/bytes/factory/basic.chpl
@@ -4,9 +4,9 @@ var myBytes = b"A Chapel bytes";
 on targetLocale {
   // there should be 2 allocations, 2 frees
   writeln("Initialize from bytes");
-  var sNew = createBytesWithNewBuffer(myBytes);
-  var sBorrowed = createBytesWithBorrowedBuffer(sNew);
-  var sNewFromNew = createBytesWithNewBuffer(sNew);
+  var sNew = bytes.createWithNewBuffer(myBytes);
+  var sBorrowed = bytes.createWithBorrowedBuffer(sNew);
+  var sNewFromNew = bytes.createWithNewBuffer(sNew);
 
   writeln(sNew);
   writeln(sBorrowed);
@@ -24,9 +24,9 @@ var cStr = cPtrTmp:c_string;
 {
   // there should be 1 allocation 1 free
   writeln("Initialize from c_string");
-  var sNew = createBytesWithNewBuffer(cStr);
-  var sBorrowed = createBytesWithBorrowedBuffer(cStr);
-  var sOwned = createBytesWithOwnedBuffer(cStr);
+  var sNew = bytes.createWithNewBuffer(cStr);
+  var sBorrowed = bytes.createWithBorrowedBuffer(cStr);
+  var sOwned = bytes.createWithOwnedBuffer(cStr);
   /*var sOwned = new string(cStr, isowned=true, needToCopy=false);*/
 
   writeln(sNew);
@@ -45,9 +45,9 @@ cPtr[3] = 0:uint(8);
   // there should be 1 allocate, 2 frees
   writeln("Initialize from c_ptr");
 
-  var sNew = createBytesWithNewBuffer(cPtr, length=3, size=4);
-  var sBorrowed = createBytesWithBorrowedBuffer(cPtr, length=3, size=4);
-  var sOwned = createBytesWithOwnedBuffer(cPtr, length=3, size=4);
+  var sNew = bytes.createWithNewBuffer(cPtr, length=3, size=4);
+  var sBorrowed = bytes.createWithBorrowedBuffer(cPtr, length=3, size=4);
+  var sOwned = bytes.createWithOwnedBuffer(cPtr, length=3, size=4);
 
   writeln(sNew);
   writeln(sBorrowed);

--- a/test/types/bytes/io/writeread-pattern.chpl
+++ b/test/types/bytes/io/writeread-pattern.chpl
@@ -21,7 +21,7 @@ proc test(byteRange) {
   }
   buf[nBytes] = 0;
 
-  const randomBytes = createBytesWithOwnedBuffer(buf, length=nBytes,
+  const randomBytes = bytes.createWithOwnedBuffer(buf, length=nBytes,
                                                       size=nBytes+1);
 
   if randomBytes.length != nBytes {

--- a/test/types/bytes/io/writeread-random.chpl
+++ b/test/types/bytes/io/writeread-random.chpl
@@ -10,7 +10,7 @@ for i in 0..#nBytes {
 }
 buf[nBytes] = 0;
 
-const randomBytes = createBytesWithOwnedBuffer(buf, length=nBytes,
+const randomBytes = bytes.createWithOwnedBuffer(buf, length=nBytes,
                                                     size=nBytes+1);
 
 if randomBytes.length != nBytes {

--- a/test/types/bytes/param/param.chpl
+++ b/test/types/bytes/param/param.chpl
@@ -4,7 +4,7 @@ param b2 = b"bytes2";
 
 writeln(b1, " as ", b1.type:string);
 param b1CStr = b1.c_str();
-writeln(createStringWithNewBuffer(b1CStr), " as ", b1CStr.type:string);
+writeln(string.createWithNewBuffer(b1CStr), " as ", b1CStr.type:string);
 
 param numBytes = b1.numBytes;
 param size = bAnother1.size;

--- a/test/types/records/sungeun/recordWithRefCopyFns.chpl
+++ b/test/types/records/sungeun/recordWithRefCopyFns.chpl
@@ -21,5 +21,5 @@ inline proc chpl__autoCopy(ref r: myR) {
 var s0: myR;
 s0.base = c"s0";
 sync {
-  begin writeln(createStringWithNewBuffer(s0.base));
+  begin writeln(string.createWithNewBuffer(s0.base));
 }

--- a/test/types/string/StringImpl/memLeaks/concat.chpl
+++ b/test/types/string/StringImpl/memLeaks/concat.chpl
@@ -204,9 +204,9 @@ module unitTest {
       const s: t = "s";
       const cs: c_string = "0";
       if useExpr {
-        writeMe(s+createStringWithNewBuffer(cs));
+        writeMe(s+string.createWithNewBuffer(cs));
       } else {
-        const scs = s+createStringWithNewBuffer(cs);
+        const scs = s+string.createWithNewBuffer(cs);
         writeMe(scs);
       }
     }
@@ -220,9 +220,9 @@ module unitTest {
       const cs: c_string = "s";
       const s: t = "0";
       if useExpr {
-        writeMe(createStringWithNewBuffer(cs)+s);
+        writeMe(string.createWithNewBuffer(cs)+s);
       } else {
-        const css = createStringWithNewBuffer(cs)+s;
+        const css = string.createWithNewBuffer(cs)+s;
         writeMe(css);
       }
     }
@@ -237,9 +237,9 @@ module unitTest {
       on Locales[numLocales-1] {
         const cs: c_string = "r";
         if useExpr {
-          writeMe(s+createStringWithNewBuffer(cs));
+          writeMe(s+string.createWithNewBuffer(cs));
         } else {
-          const scs = s+createStringWithNewBuffer(cs);
+          const scs = s+string.createWithNewBuffer(cs);
           writeMe(scs);
         }
       }
@@ -255,9 +255,9 @@ module unitTest {
       on Locales[numLocales-1] {
         const cs: c_string = "s";
         if useExpr {
-          writeMe(createStringWithNewBuffer(cs)+s);
+          writeMe(string.createWithNewBuffer(cs)+s);
         } else {
-          const css = createStringWithNewBuffer(cs)+s;
+          const css = string.createWithNewBuffer(cs)+s;
           writeMe(css);
         }
       }

--- a/test/types/string/dmk/join.chpl
+++ b/test/types/string/dmk/join.chpl
@@ -28,9 +28,9 @@ proc main() {
     if s1c != s2c {
       writeln("Mismatched!");
       writeln("  s1  = ", s1);
-      writeln("  s1c = ", createStringWithNewBuffer(s1c));
+      writeln("  s1c = ", string.createWithNewBuffer(s1c));
       writeln("  s2  = ", s2);
-      writeln("  s2c = ", createStringWithNewBuffer(s2c));
+      writeln("  s2c = ", string.createWithNewBuffer(s2c));
     }
   }
 }

--- a/test/types/string/dmk/utf8_env.chpl
+++ b/test/types/string/dmk/utf8_env.chpl
@@ -5,6 +5,6 @@
 // when run outside the test harness.
 //
 extern proc getenv(const name: c_string): c_string;
-writeln("LANG=", createStringWithNewBuffer(getenv('LANG')));
-writeln("LC_ALL=", createStringWithNewBuffer(getenv('LC_ALL')));
-writeln("LC_COLLATE=", createStringWithNewBuffer(getenv('LC_COLLATE')));
+writeln("LANG=", string.createWithNewBuffer(getenv('LANG')));
+writeln("LC_ALL=", string.createWithNewBuffer(getenv('LC_ALL')));
+writeln("LC_COLLATE=", string.createWithNewBuffer(getenv('LC_COLLATE')));

--- a/test/types/string/factory/basic.chpl
+++ b/test/types/string/factory/basic.chpl
@@ -4,9 +4,9 @@ var chplStr = "A Chapel string";
 on targetLocale {
   // there should be 2 allocations, 2 frees
   writeln("Initialize from string");
-  var sNew = createStringWithNewBuffer(chplStr);
-  var sBorrowed = createStringWithBorrowedBuffer(sNew);
-  var sNewFromNew = createStringWithNewBuffer(sNew);
+  var sNew = string.createWithNewBuffer(chplStr);
+  var sBorrowed = string.createWithBorrowedBuffer(sNew);
+  var sNewFromNew = string.createWithNewBuffer(sNew);
 
   writeln(sNew);
   writeln(sBorrowed);
@@ -24,9 +24,9 @@ var cStr = cPtrTmp:c_string;
 {
   // there should be 1 allocation 1 free
   writeln("Initialize from c_string");
-  var sNew = createStringWithNewBuffer(cStr);
-  var sBorrowed = createStringWithBorrowedBuffer(cStr);
-  var sOwned = createStringWithOwnedBuffer(cStr);
+  var sNew = string.createWithNewBuffer(cStr);
+  var sBorrowed = string.createWithBorrowedBuffer(cStr);
+  var sOwned = string.createWithOwnedBuffer(cStr);
   /*var sOwned = new string(cStr, isowned=true, needToCopy=false);*/
 
   writeln(sNew);
@@ -45,9 +45,9 @@ cPtr[3] = 0:uint(8);
   // there should be 1 allocate, 2 frees
   writeln("Initialize from c_ptr");
 
-  var sNew = createStringWithNewBuffer(cPtr, length=3, size=4);
-  var sBorrowed = createStringWithBorrowedBuffer(cPtr, length=3, size=4);
-  var sOwned = createStringWithOwnedBuffer(cPtr, length=3, size=4);
+  var sNew = string.createWithNewBuffer(cPtr, length=3, size=4);
+  var sBorrowed = string.createWithBorrowedBuffer(cPtr, length=3, size=4);
+  var sOwned = string.createWithOwnedBuffer(cPtr, length=3, size=4);
 
   writeln(sNew);
   writeln(sBorrowed);

--- a/test/types/string/ferguson/return-coerce-to-c-string.chpl
+++ b/test/types/string/ferguson/return-coerce-to-c-string.chpl
@@ -3,4 +3,4 @@ proc f():c_string {
 }
 
 var x = f();
-writeln(createStringWithNewBuffer(x), " ", x.type:string);
+writeln(string.createWithNewBuffer(x), " ", x.type:string);

--- a/test/types/string/ferguson/string-useless-cast.chpl
+++ b/test/types/string/ferguson/string-useless-cast.chpl
@@ -1,6 +1,6 @@
 proc bad(type t, x:c_string) {
   try! {
-    return createStringWithNewBuffer(x):t;
+    return string.createWithNewBuffer(x):t;
   }
 }
 

--- a/test/types/string/psahabu/perf/allocate.chpl
+++ b/test/types/string/psahabu/perf/allocate.chpl
@@ -25,7 +25,7 @@ if timing then tCopy.start();
 var keepAlive: int;
 var copied = "copycat";
 for i in 1..n {
-  var copy = createStringWithNewBuffer(copied);
+  var copy = string.createWithNewBuffer(copied);
   keepAlive += copy.len;
 }
 if timing then tCopy.stop();

--- a/test/types/string/sungeun/c_string/casts.chpl
+++ b/test/types/string/sungeun/c_string/casts.chpl
@@ -30,8 +30,8 @@ writeln(vcstri:imag(32));
 writeln(vcstri:imag(64));
 writeln(vcstrc:complex(64));
 writeln(vcstrc:complex(128));
-writeln(createStringWithNewBuffer(vcstrE):E);
-writeln(createStringWithNewBuffer(vcstrB):bool);
+writeln(string.createWithNewBuffer(vcstrE):E);
+writeln(string.createWithNewBuffer(vcstrB):bool);
 
 for param i in 1..4 do writeln(str:uint(4<<i));
 for param i in 1..4 do writeln(str:int(4<<i));

--- a/test/types/string/sungeun/c_string/concat.chpl
+++ b/test/types/string/sungeun/c_string/concat.chpl
@@ -7,42 +7,42 @@ use checkType;
 checkType(string, (c"8"+n:string).type);
 checkType(string, ("8"+n:string).type);
 checkType(string, (cstr+n:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+n:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+n:string).type);
 checkType(string, ("8"+nn:string).type);
-checkType(string, (createStringWithNewBuffer(cstr)+nn:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+nn:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+nn:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+nn:string).type);
 
 checkType(string, ("8"+r:string).type);   // no param c_string cast from real
-checkType(string, (createStringWithNewBuffer(cstr)+r:string).type);  // no param c_string cast from real
-checkType(string, (createStringWithNewBuffer(vcstr)+r:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+r:string).type);  // no param c_string cast from real
+checkType(string, (string.createWithNewBuffer(vcstr)+r:string).type);
 checkType(string, ("8"+rr:string).type);
-checkType(string, (createStringWithNewBuffer(cstr)+rr:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+rr:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+rr:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+rr:string).type);
 
 checkType(string, ("8"+i:string).type);   // no param c_string cast from imag
-checkType(string, (createStringWithNewBuffer(cstr)+i:string).type);  // no param c_string cast from imag
-checkType(string, (createStringWithNewBuffer(vcstr)+i:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+i:string).type);  // no param c_string cast from imag
+checkType(string, (string.createWithNewBuffer(vcstr)+i:string).type);
 checkType(string, ("8"+ii:string).type);
-checkType(string, (createStringWithNewBuffer(cstr)+ii:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+ii:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+ii:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+ii:string).type);
 
 checkType(string, ("8"+c:string).type);   // no param complex
-checkType(string, (createStringWithNewBuffer(cstr)+c:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+c:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+c:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+c:string).type);
 
 checkType(string, (c"8"+e:string).type);
 checkType(string, ("8"+e:string).type);
 checkType(string, (cstr+e:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+e:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+e:string).type);
 checkType(string, ("8"+ee:string).type);
-checkType(string, (createStringWithNewBuffer(cstr)+ee:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+ee:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+ee:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+ee:string).type);
 
 checkType(string, (c"8"+b:string).type);
 checkType(string, ("8"+b:string).type);
 checkType(string, (cstr+b:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+b:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+b:string).type);
 checkType(string, ("8"+bb:string).type);
-checkType(string, (createStringWithNewBuffer(cstr)+bb:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+bb:string).type);
+checkType(string, (string.createWithNewBuffer(cstr)+bb:string).type);
+checkType(string, (string.createWithNewBuffer(vcstr)+bb:string).type);
 

--- a/test/types/string/sungeun/c_string/intents.chpl
+++ b/test/types/string/sungeun/c_string/intents.chpl
@@ -31,16 +31,16 @@ if errorCase == 1 {
 }
 
 var hi_c = c"hi";
-var ss = createStringWithNewBuffer(hi_c)+ createStringWithNewBuffer(hi_c);
+var ss = string.createWithNewBuffer(hi_c)+ string.createWithNewBuffer(hi_c);
 var s = ss.c_str();
 
-f(createStringWithNewBuffer(s));
-fi(createStringWithNewBuffer(s));
+f(string.createWithNewBuffer(s));
+fi(string.createWithNewBuffer(s));
 if errorCase == 2 then
-  fo(createStringWithNewBuffer(s));
+  fo(string.createWithNewBuffer(s));
 
 if errorCase == 3 then
-  fio(createStringWithNewBuffer(s));
+  fio(string.createWithNewBuffer(s));
 
 if errorCase == 4 then
-  fr(createStringWithNewBuffer(s));
+  fr(string.createWithNewBuffer(s));

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
@@ -1,4 +1,4 @@
 var s = "0123456789";
 on Locales[numLocales-1] {
-  writeln(createStringWithNewBuffer(s.c_str()));
+  writeln(string.createWithNewBuffer(s.c_str()));
 }

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
@@ -5,7 +5,7 @@
 
   on Locales[numLocales-1] {
     var cs = s.c_str();
-    var s2 = createStringWithNewBuffer(cs);
+    var s2 = string.createWithNewBuffer(cs);
     writeln(s2);
   }
 }

--- a/test/types/string/sungeun/c_string/returnString.chpl
+++ b/test/types/string/sungeun/c_string/returnString.chpl
@@ -2,7 +2,7 @@ use checkType;
 
 proc rcs() {
   var s = c"hi";
-  var ss = createStringWithNewBuffer(s) + createStringWithNewBuffer(s);
+  var ss = string.createWithNewBuffer(s) + string.createWithNewBuffer(s);
   var cs = ss.c_str();
   return cs;
 }
@@ -11,9 +11,9 @@ checkType(c_string, rcs().type);
 
 proc rcss():string {
   var s = c"hi";
-  var ss = createStringWithNewBuffer(s) + createStringWithNewBuffer(s);
+  var ss = string.createWithNewBuffer(s) + string.createWithNewBuffer(s);
   var cs = ss.c_str();
-  return createStringWithNewBuffer(cs);
+  return string.createWithNewBuffer(cs);
 }
 
 checkType(rcss().type);

--- a/test/users/engin/sparse_index_buffer/deinitTest.chpl
+++ b/test/users/engin/sparse_index_buffer/deinitTest.chpl
@@ -15,7 +15,7 @@ iter indexGen(d) {
 }
 
 {
-  var spsIndexBuffer = sparseDom1D.makeIndexBuffer(size=10);
+  var spsIndexBuffer = sparseDom1D.createIndexBuffer(size=10);
   for i in indexGen(sparseDom1D) do
     spsIndexBuffer.add(i);
 }

--- a/test/users/engin/sparse_index_buffer/sparseIndexBuffer.chpl
+++ b/test/users/engin/sparse_index_buffer/sparseIndexBuffer.chpl
@@ -26,7 +26,7 @@ iter indexGen(d) {
 }
 
 proc test(d) {
-  var spsIndexBuffer = d.makeIndexBuffer(size=4);
+  var spsIndexBuffer = d.createIndexBuffer(size=4);
   for i in indexGen(d) do
     spsIndexBuffer.add(i);
   spsIndexBuffer.commit();

--- a/test/users/ferguson/extern_string_test.chpl
+++ b/test/users/ferguson/extern_string_test.chpl
@@ -1,9 +1,9 @@
 extern proc return_string_test():c_string;
 extern proc return_string_arg_test(ref c_string);
 
-writeln("returned string ", createStringWithNewBuffer(return_string_test()));
+writeln("returned string ", string.createWithNewBuffer(return_string_test()));
 var cs: c_string;
 return_string_arg_test(cs);
-var s = createStringWithNewBuffer(cs);
+var s = string.createWithNewBuffer(cs);
 writeln("returned string arg ",s);
 

--- a/test/users/ferguson/extern_string_test2.chpl
+++ b/test/users/ferguson/extern_string_test2.chpl
@@ -10,8 +10,8 @@ get_string(ca);
 var cb: c_string;
 modify_string(cb, ca);
 
-a = createStringWithNewBuffer(ca);
-b = createStringWithNewBuffer(cb);
+a = string.createWithNewBuffer(ca);
+b = string.createWithNewBuffer(cb);
 writeln("a is: ", a);
 writeln("b is: ", b);
 

--- a/test/users/ferguson/sys/getenv/getenv.chpl
+++ b/test/users/ferguson/sys/getenv/getenv.chpl
@@ -8,13 +8,13 @@ proc main()
 
   if sys_getenv(ENV_VAR, foo)
   {
-    writeln("found $", createStringWithNewBuffer(ENV_VAR), " = ",
-                       createStringWithNewBuffer(foo));
+    writeln("found $", string.createWithNewBuffer(ENV_VAR), " = ",
+                       string.createWithNewBuffer(foo));
     exit(0);
   }
   else
   {
-    writeln("failed to find $", createStringWithNewBuffer(ENV_VAR));
+    writeln("failed to find $", string.createWithNewBuffer(ENV_VAR));
     exit(1);
   }
 

--- a/test/users/npadmana/gsl_demonstration/gsl_demo.chpl
+++ b/test/users/npadmana/gsl_demonstration/gsl_demo.chpl
@@ -26,14 +26,14 @@ writeln(gsl_sf_erf(0.1));
 // Note how the res structure is available to the user
 var ret = gsl_sf_erf_e(0.1, c_ptrTo(res));
 writeln(res);
-writeln(createStringWithNewBuffer(gsl_strerror(ret)));
+writeln(string.createWithNewBuffer(gsl_strerror(ret)));
 
 // Use GSL precision modes. These are #defines and the extern block code
 // gets the types wrong, so we need to explicitly case.
 ret = gsl_sf_airy_Ai_e(10.0, GSL_PREC_DOUBLE : c_uint, c_ptrTo(res));
-writeln(createStringWithNewBuffer(gsl_strerror(ret)), res);
+writeln(string.createWithNewBuffer(gsl_strerror(ret)), res);
 ret = gsl_sf_airy_Ai_e(10.0, GSL_PREC_APPROX : c_uint,c_ptrTo(res));
-writeln(createStringWithNewBuffer(gsl_strerror(ret)), res);
+writeln(string.createWithNewBuffer(gsl_strerror(ret)), res);
 
 // Random number generators
 // Note that this follows the C-API --- so you need to explicitly free things.

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -35,7 +35,7 @@ extern proc getenv(name : c_string) : c_string;
 proc getEnv(name: string): string {
   var cname: c_string = name.c_str();
   var value = getenv(cname);
-  return createStringWithNewBuffer(value);
+  return string.createWithNewBuffer(value);
 }
 
 


### PR DESCRIPTION
This PR deprecates existing factory functions in the standard libraries to use
the convention `type.create()` as applicable.

Resolves #14291

(Resolving that issue also requires changes in the Random module. But it
required a bit more refactor in the Random module to make similar changes.
See #14435)

Summary of changes:

- `createStringWith*` functions are deprecated in favor of `string.createWith*`
- `createBytesWith*` functions are deprecated in favor of `bytes.createWith*`
- Compiler is adjusted to use these new functions while creating literals.
- `newBlock*` and `newCyclic*` are deprecated in favor of `Block*.create` and
  `Cyclic*.create`
- `sparseDom.makeIndexBuffer` is deprecated in favor of
  `sparseDom.createIndexBuffer` (this is not a type method)
- A ton of pertinent changes in modules/tests.

Test:

- [x] standard
- [x] gasnet