### PR TITLE
Remove IO enum deprecation funcs

### DIFF
--- a/modules/internal/LastResortIO.chpl
+++ b/modules/internal/LastResortIO.chpl
@@ -23,26 +23,6 @@ private use IO;
 private use ChapelBase;
 
 pragma "last resort"
-proc iomode type {
-  compilerError("iomode is no longer available by default, please insert\na use of the IO module to access it.");
-}
-
-pragma "last resort"
-proc iokind type {
-  compilerError("iokind is no longer available by default, please insert\na use of the IO module to access it.");
-}
-
-pragma "last resort"
-proc iostringstyle type {
-  compilerError("iostringstyle is no longer available by default, please insert\na use of the IO module to access it.");
-}
-
-pragma "last resort"
-proc iostringformat type {
-  compilerError("iostringformat is no longer available by default, please insert\na use of the IO module to access it.");
-}
-
-pragma "last resort"
 proc iodynamic param {
   compilerWarning("iodynamic will no longer be available by default, please\ninsert a use of the IO module to access it.");
   return IO.iodynamic;

--- a/test/deprecated/io/iokindCheck.chpl
+++ b/test/deprecated/io/iokindCheck.chpl
@@ -1,2 +1,0 @@
-var x = iokind.dynamic;
-writeln(x);

--- a/test/deprecated/io/iokindCheck.good
+++ b/test/deprecated/io/iokindCheck.good
@@ -1,2 +1,0 @@
-iokindCheck.chpl:1: error: iokind is no longer available by default, please insert
-a use of the IO module to access it.

--- a/test/deprecated/io/iomodeCheck.chpl
+++ b/test/deprecated/io/iomodeCheck.chpl
@@ -1,2 +1,0 @@
-var x = iomode.r;
-writeln(x);

--- a/test/deprecated/io/iomodeCheck.good
+++ b/test/deprecated/io/iomodeCheck.good
@@ -1,2 +1,0 @@
-iomodeCheck.chpl:1: error: iomode is no longer available by default, please insert
-a use of the IO module to access it.

--- a/test/deprecated/io/iostringformatCheck.chpl
+++ b/test/deprecated/io/iostringformatCheck.chpl
@@ -1,2 +1,0 @@
-var x = iostringformat.word;
-writeln(x);

--- a/test/deprecated/io/iostringformatCheck.good
+++ b/test/deprecated/io/iostringformatCheck.good
@@ -1,2 +1,0 @@
-iostringformatCheck.chpl:1: error: iostringformat is no longer available by default, please insert
-a use of the IO module to access it.

--- a/test/deprecated/io/iostringstyleCheck.chpl
+++ b/test/deprecated/io/iostringstyleCheck.chpl
@@ -1,2 +1,0 @@
-var x = iostringstyle.len1b_data;
-writeln(x);

--- a/test/deprecated/io/iostringstyleCheck.good
+++ b/test/deprecated/io/iostringstyleCheck.good
@@ -1,2 +1,0 @@
-iostringstyleCheck.chpl:1: error: iostringstyle is no longer available by default, please insert
-a use of the IO module to access it.

--- a/test/studies/shootout/submitted/fasta3.bad
+++ b/test/studies/shootout/submitted/fasta3.bad
@@ -1,4 +1,1 @@
-fasta3.chpl:87: warning: openfd will no longer be available by default,
-please insert a use of the IO module to continue calling it.
-fasta3.chpl:87: error: iokind is no longer available by default, please insert
-a use of the IO module to access it.
+fasta3.chpl:87: error: 'iokind' undeclared (first use this function)

--- a/test/studies/shootout/submitted/fasta4.bad
+++ b/test/studies/shootout/submitted/fasta4.bad
@@ -1,4 +1,1 @@
-fasta4.chpl:83: warning: openfd will no longer be available by default,
-please insert a use of the IO module to continue calling it.
-fasta4.chpl:83: error: iokind is no longer available by default, please insert
-a use of the IO module to access it.
+fasta4.chpl:83: error: 'iokind' undeclared (first use this function)

--- a/test/studies/shootout/submitted/revcomp.bad
+++ b/test/studies/shootout/submitted/revcomp.bad
@@ -1,2 +1,3 @@
 revcomp.chpl:12: In function 'main':
+revcomp.chpl:42: error: 'iokind' undeclared (first use this function)
 revcomp.chpl:43: error: 'QIO_CH_ALWAYS_UNBUFFERED' undeclared (first use this function)

--- a/test/studies/shootout/submitted/revcomp2.bad
+++ b/test/studies/shootout/submitted/revcomp2.bad
@@ -1,3 +1,5 @@
 revcomp2.chpl:9: In function 'main':
+revcomp2.chpl:11: error: 'iokind' undeclared (first use this function)
+revcomp2.chpl:9: In function 'main':
 revcomp2.chpl:35: error: 'EOFError' undeclared (first use this function)
 revcomp2.chpl:57: error: 'QIO_CH_ALWAYS_UNBUFFERED' undeclared (first use this function)


### PR DESCRIPTION
In certain circumstances, I think when LastResortIO and IO are equally deep in
a use chain, instead of getting the proper deprecation warning we instead see:

error: symbol iomode is multiply defined
note: also defined as a function here (and possibly elsewhere)

This means that having the deprecation warning is not as useful as we would like
so remove it for the enums

Also removed the deprecation tests that locked in the error message

Testing:
- full std paratest with futures (in progress)