### PR TITLE
Refactor Random module

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1385,7 +1385,7 @@ module SampleSortHelp {
                                    seed=1) {
     private use Random;
     var Tmp:[1..1] A.eltType;
-    var randNums = makeRandomStream(seed=seed, eltType=int, parSafe=false);
+    var randNums = createRandomStream(seed=seed, eltType=int, parSafe=false);
     while numSamples > 0 {
       numSamples -= 1;
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -211,9 +211,9 @@ module Random {
     :returns: an owned RandomStream
   */
   proc createRandomStream(type eltType,
-                                  seed: int(64) = SeedGenerator.oddCurrentTime,
-                                  param parSafe: bool = true,
-                                  param algorithm = defaultRNG) {
+                          seed: int(64) = SeedGenerator.oddCurrentTime,
+                          param parSafe: bool = true,
+                          param algorithm = defaultRNG) {
     if algorithm == RNG.PCG then
       return new owned PCGRandomStream(seed=seed,
                                        parSafe=parSafe,
@@ -751,14 +751,6 @@ module Random {
          TestU01 by requesting values in [0..,2**31+2**30+1) until we
          had two values < 2**31, removing the top 0 bit, and then combining
          the top 16 bits into the value provided to TestU01).
-
-
-      .. note::
-
-         This class is currently called RandomStream, but at some point
-         we expect to rename it PCGRandomStream. At that point, RandomStream
-         will represent the default RNG and will initially refer to
-         PCGRandomStream.
 
     */
     class PCGRandomStream {

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -54,18 +54,6 @@
 
    .. note::
 
-      Right now, :class:`~NPBRandom.NPBRandomStream` and
-      :class:`~PCGRandom.RandomStream` are available (where
-      :class:`~PCGRandom.RandomStream` implements the PCG algorithm). In the
-      future, we expect that `PCGRandomStream` will be available as another name
-      for the PCG RNG stream.  At that point, `RandomStream` will change to a
-      type alias for the default RNG. The function :proc:`makeRandomStream` is
-      available to avoid compatibility problems from this naming change.
-      Programs that need to specifically request PCG should do so with
-      :proc:`makeRandomStream` until the name `PCGRandomStream` is available..
-
-   .. note::
-
        The RandomStream API (:class:`RandomStreamInterface`) is expected to
        change.
 
@@ -426,7 +414,7 @@ module Random {
 
     .. note::
 
-      This RandomStreamInterface is expected to change.
+      This RandomStreamInterface is expected to change`.
 
     .. note::
 
@@ -711,7 +699,7 @@ module Random {
       match the C PCG reference implementation and have specifically verified
       equal output given the same seed. However, this implementation differs
       from the C PCG reference implementation in how it produces random integers
-      within particular bounds (with :proc:`RandomStream.getNext` using `min`
+      within particular bounds (with :proc:`PCGRandomStream.getNext` using `min`
       and `max` arguments). In addition, this implementation directly supports
       the generation of random `real` values, unlike the C PCG implementation.
 
@@ -950,7 +938,7 @@ module Random {
         Fill the argument array with pseudorandom values.  This method is
         identical to the standalone :proc:`~Random.fillRandom` procedure,
         except that it consumes random values from the
-        :class:`RandomStream` object on which it's invoked rather
+        :class:`PCGRandomStream` object on which it's invoked rather
         than creating a new stream for the purpose of the call.
 
         :arg arr: The array to be filled

--- a/test/distributions/bradc/assoc/userAssoc-domain-stress.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-domain-stress.chpl
@@ -11,7 +11,7 @@ if requestCapacity then
 
 coforall loc in Locales with (ref D) {
   on loc {
-    var rng = makeRandomStream(eltType=int, seed=100+loc.id);
+    var rng = createRandomStream(eltType=int, seed=100+loc.id);
     forall r in rng.iterate({1..updatesPerLocale}) with (ref D) {
       D += r;
     }
@@ -21,7 +21,7 @@ coforall loc in Locales with (ref D) {
 // Now check that each update is present!
 coforall loc in Locales {
   on loc {
-    var rng = makeRandomStream(eltType=int, seed=100+loc.id);
+    var rng = createRandomStream(eltType=int, seed=100+loc.id);
     forall r in rng.iterate({1..updatesPerLocale}) {
       assert(D.contains(r));
     }

--- a/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
@@ -6,7 +6,7 @@ use Norm;
 
 config const is2D2Norm = false;
 
-var rng = makeRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
+var rng = createRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
 
 rng.fillRandom(R1D);
 rng.fillRandom(R2D);

--- a/test/distributions/robust/arithmetic/modules/test_module_Random.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Random.chpl
@@ -5,8 +5,8 @@ use Random;
 
 config const printRefArrays = true;
 
-var rng  = makeRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
-var trng = makeRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
+var rng  = createRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
+var trng = createRandomStream(314159265, eltType=real(64), algorithm=RNG.NPB);
 
 proc fillRefArrays() {
   rng.fillRandom(R1D);

--- a/test/domains/diten/assocDomIntersect.chpl
+++ b/test/domains/diten/assocDomIntersect.chpl
@@ -7,7 +7,7 @@ proc setupDoms(ref D1, ref D2) {
   use Random;
   D1.clear();
   D2.clear();
-  var rs = makeRandomStream(real);
+  var rs = createRandomStream(real);
   for i in 1..1000 {
     var rnd1 = (rs.getNext()*10000):int;
     var rnd2 = (rs.getNext()*10000):int;

--- a/test/domains/ferguson/build-associative.chpl
+++ b/test/domains/ferguson/build-associative.chpl
@@ -6,7 +6,7 @@ config const table = false;
 use Time;
 use Random;
 
-var rng = makeRandomStream(eltType=int, seed=0, parSafe=false, algorithm=RNG.PCG);
+var rng = createRandomStream(eltType=int, seed=0, parSafe=false, algorithm=RNG.PCG);
 
 //var t2 = new Timer();
 //var t3 = new Timer();

--- a/test/exercises/life.chpl
+++ b/test/exercises/life.chpl
@@ -25,7 +25,7 @@ var Grid:     [BigD] bool, // grid of life
     NextGrid: [D]    bool; // grid for next iteration
 
 // initialize grid
-var rs = makeRandomStream(seed, eltType=real(64), algorithm=RNG.NPB);
+var rs = createRandomStream(seed, eltType=real(64), algorithm=RNG.NPB);
 
 for i in D do
   Grid(i) = if rs.getNext() <= p:real / 100 then true else false;

--- a/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
@@ -29,7 +29,7 @@ use Random;
 {
   var B: [1..n] real;
 
-  var rs = makeRandomStream(real, seed=315, algorithm=RNG.NPB);
+  var rs = createRandomStream(real, seed=315, algorithm=RNG.NPB);
 
   forall (i, r) in zip({1..n}, rs.iterate({1..n})) do
     B(i) = r;
@@ -40,7 +40,7 @@ use Random;
 {
   var B: [1..n] real;
 
-  var rs = makeRandomStream(real, seed=315, algorithm=RNG.NPB);
+  var rs = createRandomStream(real, seed=315, algorithm=RNG.NPB);
 
   forall (f, r) in zip(foo(n), rs.iterate({1..n})) do
     B(f) = r;

--- a/test/library/packages/BLAS/blas_helpers.chpl
+++ b/test/library/packages/BLAS/blas_helpers.chpl
@@ -236,7 +236,7 @@ proc adjoint(A: [?D] ?t) where A.rank == 2 {
 
 /* Pseudo-random nonsingular matrix ((1/n**2)*A**2 + I) */
 proc makeRandomInvertible (A: [?Adom] ?t) {
-  var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+  var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
   rng.fillRandom(A);
 
   var I: [Adom] t;

--- a/test/library/packages/BLAS/test_blas2.chpl
+++ b/test/library/packages/BLAS/test_blas2.chpl
@@ -216,11 +216,11 @@ proc test_gbmv_helper(type t){
         Y : [{0.. #m}]t,
         R : [{0.. #m}]t; // Result
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var alpha = 1: t, //rng.getNext();
         beta = 2: t;//rng.getNext();
-    //var rngint = makeRandomStream(eltType=int,algorithm=RNG.PCG);
+    //var rngint = createRandomStream(eltType=int,algorithm=RNG.PCG);
     //var kl = rng.getNext(0, min(m, n)) ,
     //    ku = rng.getNext(0, min(m, n)) ;
     var kl = 3,
@@ -267,7 +267,7 @@ proc test_gemv_helper(type t){
         R : [{0.. #m}]t; // Result
 
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -296,7 +296,7 @@ proc test_gemv_helper(type t){
         R : [{0.. #m}]t; // Result
 
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -324,7 +324,7 @@ proc test_gemv_helper(type t){
         R : [{0.. #m}]t; // Result
 
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -356,7 +356,7 @@ proc test_gemv_helper(type t){
         R : [{0.. #m}]t; // Result
 
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -399,7 +399,7 @@ proc test_ger_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -429,7 +429,7 @@ proc test_ger_helper(type t){
         R : [{0.. #m, 0..#n}] t; // Result
 
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -469,7 +469,7 @@ proc test_gerc_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -500,7 +500,7 @@ proc test_gerc_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -539,7 +539,7 @@ proc test_geru_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -569,7 +569,7 @@ proc test_geru_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(X);
     rng.fillRandom(Y);
@@ -621,7 +621,7 @@ proc test_hemv_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t, algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t, algorithm=RNG.PCG);
 
     rng.fillRandom(A);
     rng.fillRandom(X);
@@ -654,7 +654,7 @@ proc test_hemv_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t, algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t, algorithm=RNG.PCG);
 
     rng.fillRandom(A);
     rng.fillRandom(X);
@@ -687,7 +687,7 @@ proc test_hemv_helper(type t){
 
 
     // Populate values
-    var rng = makeRandomStream(eltType=t, algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t, algorithm=RNG.PCG);
 
     rng.fillRandom(A);
     rng.fillRandom(X);
@@ -722,7 +722,7 @@ proc test_her_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}]t,
@@ -753,7 +753,7 @@ proc test_her_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}]t,
@@ -785,7 +785,7 @@ proc test_her_helper(type t){
     const m = 10 : c_int;
     const ld = 20;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #ld}] t,
         X : [{0.. #m}]t,
@@ -825,7 +825,7 @@ proc test_her2_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -857,7 +857,7 @@ proc test_her2_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -890,7 +890,7 @@ proc test_her2_helper(type t){
     const m = 10 : c_int;
     const ld = 20;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0..#m, 0..#ld}] t,
         X : [{0..#m}] t,
@@ -1029,7 +1029,7 @@ proc test_symv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1064,7 +1064,7 @@ proc test_symv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1098,7 +1098,7 @@ proc test_symv_helper(type t){
     const m = 10 : c_int;
     const ld = 20: c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #ld}] t,
         X : [{0.. #m}] t,
@@ -1140,7 +1140,7 @@ proc test_syr_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1170,7 +1170,7 @@ proc test_syr_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1201,7 +1201,7 @@ proc test_syr_helper(type t){
     const m = 10 : c_int;
     const ld = 20;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0..#m, 0..#ld}] t,
         X : [{0.. #m}] t,
@@ -1240,7 +1240,7 @@ proc test_syr2_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1273,7 +1273,7 @@ proc test_syr2_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1307,7 +1307,7 @@ proc test_syr2_helper(type t){
     const m = 10 : c_int;
     const ld = 20;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #ld}] t,
         X : [{0.. #m}] t,
@@ -1350,7 +1350,7 @@ proc test_tbmv_helper(type t){
   {
     const m = 5 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1406,7 +1406,7 @@ proc test_trmv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1431,7 +1431,7 @@ proc test_trmv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1456,7 +1456,7 @@ proc test_trmv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1481,7 +1481,7 @@ proc test_trmv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1511,7 +1511,7 @@ proc test_trmv_helper(type t){
     const m = 10 : c_int;
     const ld = 20;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #ld}] t,
         X : [{0.. #m}] t,
@@ -1546,7 +1546,7 @@ proc test_trsv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1575,7 +1575,7 @@ proc test_trsv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1604,7 +1604,7 @@ proc test_trsv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1633,7 +1633,7 @@ proc test_trsv_helper(type t){
   {
     const m = 10 : c_int;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #m}] t,
         X : [{0.. #m}] t,
@@ -1667,7 +1667,7 @@ proc test_trsv_helper(type t){
     const m = 10 : c_int;
     const ld = 20;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
 
     var A : [{0.. #m, 0.. #ld}] t,
         X : [{0.. #m}] t,

--- a/test/library/packages/BLAS/test_blas3.chpl
+++ b/test/library/packages/BLAS/test_blas3.chpl
@@ -90,7 +90,7 @@ proc test_gemm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(B);
     rng.fillRandom(C);
@@ -115,7 +115,7 @@ proc test_gemm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(B);
     rng.fillRandom(C);
@@ -140,7 +140,7 @@ proc test_gemm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(B);
     rng.fillRandom(C);
@@ -166,7 +166,7 @@ proc test_gemm_helper(type t) {
         C : [{0.. #m, 0.. #ld}]t,
         D : [{0.. #m, 0.. #ld}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(B);
     rng.fillRandom(C);
@@ -202,7 +202,7 @@ proc test_symm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     makeSymm(A);
     rng.fillRandom(B);
@@ -236,7 +236,7 @@ proc test_symm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     makeSymm(A);
     rng.fillRandom(B);
@@ -280,7 +280,7 @@ proc test_hemm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     makeHerm(A);
     rng.fillRandom(B);
@@ -314,7 +314,7 @@ proc test_hemm_helper(type t) {
         C : [{0.. #m, 0.. #n}]t,
         D : [{0.. #m, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     makeHerm(A);
     rng.fillRandom(B);
@@ -355,7 +355,7 @@ proc test_syrk_helper(type t) {
         C : [{0.. #n, 0.. #n}]t,
         D : [{0.. #n, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     var B = A;
     rng.fillRandom(C);
@@ -421,7 +421,7 @@ proc test_herk_helper(type t) {
         C : [{0.. #n, 0.. #n}]t,
         D : [{0.. #n, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     var B = A;
     rng.fillRandom(C);
@@ -491,7 +491,7 @@ proc test_syr2k_helper(type t) {
         C : [{0.. #n, 0.. #n}]t,
         D : [{0.. #n, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(B);
     rng.fillRandom(C);
@@ -563,7 +563,7 @@ proc test_her2k_helper(type t) {
         C : [{0.. #n, 0.. #n}]t,
         D : [{0.. #n, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(A);
     rng.fillRandom(B);
     rng.fillRandom(C);
@@ -639,7 +639,7 @@ proc test_trmm_helper(type t) {
         B : [{0.. #n, 0.. #n}]t,
         C : [{0.. #n, 0.. #n}]t;
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(B);
     var saveB = B;
     const alpha = rng.getNext();
@@ -706,7 +706,7 @@ proc test_trsm_helper(type t) {
 
     makeUnit(Id, 5.0);
 
-    var rng = makeRandomStream(eltType=t,algorithm=RNG.PCG);
+    var rng = createRandomStream(eltType=t,algorithm=RNG.PCG);
     rng.fillRandom(B);
     var saveB = B;
     const alpha = rng.getNext();

--- a/test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl
+++ b/test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl
@@ -106,7 +106,7 @@ proc createDemoFiles() {
         nFiles = numLocales,
         maxVariableSize = 100;
   var elements = 0;
-  var randstream = makeRandomStream(int);
+  var randstream = createRandomStream(int);
 
   for i in 0..#nFiles {
     const name = filenameBase + i + filenameExt,

--- a/test/library/packages/LinearAlgebra/performance/MatrixUtils.chpl
+++ b/test/library/packages/LinearAlgebra/performance/MatrixUtils.chpl
@@ -17,7 +17,7 @@ proc populate(ref A, ref ADom, nnz: int, seed: int) where isCSArr(A) {
   use Random;
   //const nnz = (ADom._value.parentDom.size * sparsity): int;
   var indices: [1..nnz] 2*int;
-  var randomIndices = makeRandomStream(eltType=int, seed=seed);
+  var randomIndices = createRandomStream(eltType=int, seed=seed);
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
@@ -30,7 +30,7 @@ proc populate(ref A, ref ADom, nnz: int, seed: int) where isCSArr(A) {
 
   ADom += indices;
 
-  var randomReals = makeRandomStream(eltType=real, seed=seed);
+  var randomReals = createRandomStream(eltType=real, seed=seed);
   for idx in ADom {
     A[idx] = 2.0; //randomReals.getNext();
   }

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -480,7 +480,7 @@ proc copyifchecks(A:[], start_n:int, end_n:int) {
 
 proc putSampleAtArrayStart(in start_n:int, end_n:int, A:[], in numSamples:int) {
   use Random;
-  var randNums = makeRandomStream(0, eltType=int, parSafe=false);
+  var randNums = createRandomStream(0, eltType=int, parSafe=false);
   while numSamples > 0 {
     numSamples -= 1;
 
@@ -1901,7 +1901,7 @@ proc randomtest(n:int) {
   var A: [blockDom] uint;
 
   if skew {
-    var rng = makeRandomStream(seed, eltType=uint);
+    var rng = createRandomStream(seed, eltType=uint);
     A = rng.choice([1:uint, 17:uint,
                     100:uint, 0xffff:uint, 0xffffffffffffffff:uint], n);
   } else {

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -132,7 +132,7 @@ proc test_extract() {
 
 proc test_tz_aware_arithmetic() {
   use Random;
-  var rng = makeRandomStream(eltType=int);
+  var rng = createRandomStream(eltType=int);
 
   var now = datetime.now();
   var tz55 = new shared FixedOffset(-330, "west 5:30");

--- a/test/library/standard/Random/RandomStreamInterface/choiceTest.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTest.chpl
@@ -3,9 +3,9 @@ use Random, Map;
 config const debug = false;
 
 proc main() {
-  var pcg = makeRandomStream(real, algorithm=RNG.PCG, seed=42);
+  var pcg = createRandomStream(real, algorithm=RNG.PCG, seed=42);
   runTests(pcg);
-  var pcgInt = makeRandomStream(int, algorithm=RNG.PCG, seed=420);
+  var pcgInt = createRandomStream(int, algorithm=RNG.PCG, seed=420);
   runTests(pcgInt);
 }
 

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestErrors.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestErrors.chpl
@@ -7,7 +7,7 @@ proc main() throws {
 
   var success = true;
 
-  var stream = makeRandomStream(real);
+  var stream = createRandomStream(real);
 
   // size=0
   try {

--- a/test/library/standard/Random/RandomStreamInterface/getNextTestHalts.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/getNextTestHalts.chpl
@@ -2,7 +2,7 @@ use Random;
 
 proc main() throws {
 
-  var pcgStream = makeRandomStream(int, algorithm=RNG.PCG);
+  var pcgStream = createRandomStream(int, algorithm=RNG.PCG);
   // Note: getNext(min, max) is not available for NPB
 
   var x = pcgStream.getNext(2, 1);

--- a/test/library/standard/Random/bradc/randomAcrossTypes.chpl
+++ b/test/library/standard/Random/bradc/randomAcrossTypes.chpl
@@ -17,9 +17,9 @@ writeln(A);
 writeln(B);
 writeln(C);
 
-var rs1 = makeRandomStream(seed=314159265, eltType=real, algorithm=rtype);
-var rs2 = makeRandomStream(seed=314159265, eltType=imag, algorithm=rtype);
-var rs3 = makeRandomStream(seed=314159265, eltType=complex, algorithm=rtype);
+var rs1 = createRandomStream(seed=314159265, eltType=real, algorithm=rtype);
+var rs2 = createRandomStream(seed=314159265, eltType=imag, algorithm=rtype);
+var rs3 = createRandomStream(seed=314159265, eltType=complex, algorithm=rtype);
 
 //
 // Check fillRandom method
@@ -31,9 +31,9 @@ writeln(A);
 writeln(B);
 writeln(C);
 
-var rs4 = makeRandomStream(seed=314159265, eltType=real, algorithm=rtype);
-var rs5 = makeRandomStream(seed=314159265, eltType=imag, algorithm=rtype);
-var rs6 = makeRandomStream(seed=314159265, eltType=complex, algorithm=rtype);
+var rs4 = createRandomStream(seed=314159265, eltType=real, algorithm=rtype);
+var rs5 = createRandomStream(seed=314159265, eltType=imag, algorithm=rtype);
+var rs6 = createRandomStream(seed=314159265, eltType=complex, algorithm=rtype);
 
 //
 // Check consecutive implementations of fillRandom method()
@@ -79,9 +79,9 @@ writeln(A);
 writeln(B);
 writeln(C);
 
-var rs7 = makeRandomStream(seed=314159265, eltType=real, algorithm=rtype);
-var rs8 = makeRandomStream(seed=314159265, eltType=imag, algorithm=rtype);
-var rs9 = makeRandomStream(seed=314159265, eltType=complex, algorithm=rtype);
+var rs7 = createRandomStream(seed=314159265, eltType=real, algorithm=rtype);
+var rs8 = createRandomStream(seed=314159265, eltType=imag, algorithm=rtype);
+var rs9 = createRandomStream(seed=314159265, eltType=complex, algorithm=rtype);
 //
 // Check getNext() method
 //

--- a/test/library/standard/Random/bradc/test-Random-evenseed.chpl
+++ b/test/library/standard/Random/bradc/test-Random-evenseed.chpl
@@ -14,7 +14,7 @@ proc main() {
   var Vec2 : [Vector1] real;
   var Vec3 : [Vector1] real;
 
-  var rng = makeRandomStream(real, 314159264, algorithm=rtype);
+  var rng = createRandomStream(real, 314159264, algorithm=rtype);
 
   rng.fillRandom(Vec1);
 

--- a/test/library/standard/Random/bradc/testGetNth.chpl
+++ b/test/library/standard/Random/bradc/testGetNth.chpl
@@ -5,9 +5,9 @@ config var n = 100;
 config param useNPB = true;
 config param rtype = if useNPB then RNG.NPB else RNG.PCG;
 
-var randStr1 = makeRandomStream(real, 314159265, algorithm=rtype);
-var randStr2 = makeRandomStream(real, 314159265, algorithm=rtype);
-var randStr3 = makeRandomStream(real, 314159265, algorithm=rtype);
+var randStr1 = createRandomStream(real, 314159265, algorithm=rtype);
+var randStr2 = createRandomStream(real, 314159265, algorithm=rtype);
+var randStr3 = createRandomStream(real, 314159265, algorithm=rtype);
 
 for i in 1..n {
   const r1 = randStr1.getNext();

--- a/test/library/standard/Random/bradc/testGetNth2.chpl
+++ b/test/library/standard/Random/bradc/testGetNth2.chpl
@@ -5,9 +5,9 @@ config var n = 100;
 config param useNPB = true;
 config param rtype = if useNPB then RNG.NPB else RNG.PCG;
 
-var randStr1 = makeRandomStream(real, 314159265, algorithm=rtype);
-var randStr2 = makeRandomStream(real, 314159265, algorithm=rtype);
-var randStr3 = makeRandomStream(real, 314159265, algorithm=rtype);
+var randStr1 = createRandomStream(real, 314159265, algorithm=rtype);
+var randStr2 = createRandomStream(real, 314159265, algorithm=rtype);
+var randStr3 = createRandomStream(real, 314159265, algorithm=rtype);
 
 var A, B: [1..n] real;
 

--- a/test/library/standard/Random/bradc/writeRandomStream.chpl
+++ b/test/library/standard/Random/bradc/writeRandomStream.chpl
@@ -5,7 +5,7 @@ module A2 {
   config param rtype  = if useNPB then RNG.NPB else RNG.PCG;
 
   proc main() {
-    var rnd  = makeRandomStream(real, seed=314159265, algorithm=rtype);
+    var rnd  = createRandomStream(real, seed=314159265, algorithm=rtype);
 
     writeln(rnd);
   }

--- a/test/library/standard/Random/deitz/test1D2D.chpl
+++ b/test/library/standard/Random/deitz/test1D2D.chpl
@@ -7,21 +7,21 @@ config const n: int = 8;
 config param algo = RNG.NPB;
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   writeln(for i in 1..n do "%{#.#####}".format(rs.getNext()));
   writeln(rs.getNext());
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   writeln(for i in 1..n do "%{#.#####}".format(rs.getNth(i)));
   writeln(rs.getNext());
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [1..n] real;
   rs.fillRandom(A);
@@ -30,7 +30,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [1..n/2, 1..2] real;
   rs.fillRandom(A);
@@ -39,7 +39,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n})] real;
   rs.fillRandom(A);
@@ -49,7 +49,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n/2})] real;
   rs.fillRandom(A);
@@ -59,7 +59,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n})] real;
   forall (a,r) in zip(A,rs.iterate(A.domain)) do
@@ -70,7 +70,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n/2})] real;
   forall (a,r) in zip(A,rs.iterate(A.domain)) do
@@ -81,7 +81,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n})] real;
   forall (r,a) in zip(rs.iterate(A.domain), A) do
@@ -92,7 +92,7 @@ config param algo = RNG.NPB;
 }
 
 {
-  var rs = makeRandomStream(real, seed, algorithm=algo);
+  var rs = createRandomStream(real, seed, algorithm=algo);
 
   var A: [{1..n} dmapped Block(rank=1,boundingBox={1..n/2})] real;
   forall (r,a) in zip(rs.iterate(A.domain), A) do

--- a/test/library/standard/Random/elliot/testBadNth.chpl
+++ b/test/library/standard/Random/elliot/testBadNth.chpl
@@ -3,8 +3,8 @@ use Random;
 config const useNPB = true;
 config const getNth = true;
 
-var npbRand = makeRandomStream(real, 314159265, algorithm=RNG.NPB);
-var pcgRand = makeRandomStream(real, 314159265, algorithm=RNG.PCG);
+var npbRand = createRandomStream(real, 314159265, algorithm=RNG.NPB);
+var pcgRand = createRandomStream(real, 314159265, algorithm=RNG.PCG);
 
 if useNPB {
   if getNth {

--- a/test/library/standard/Random/elliot/testCaughtNth.chpl
+++ b/test/library/standard/Random/elliot/testCaughtNth.chpl
@@ -3,8 +3,8 @@ use Random;
 config const useNPB = true;
 config const getNth = true;
 
-var npbRand = makeRandomStream(real, 314159265, algorithm=RNG.NPB);
-var pcgRand = makeRandomStream(real, 314159265, algorithm=RNG.PCG);
+var npbRand = createRandomStream(real, 314159265, algorithm=RNG.NPB);
+var pcgRand = createRandomStream(real, 314159265, algorithm=RNG.PCG);
 
 try! {
   if useNPB {

--- a/test/library/standard/Random/ferguson/chapel-testu01/chplu01.chpl
+++ b/test/library/standard/Random/ferguson/chapel-testu01/chplu01.chpl
@@ -26,23 +26,23 @@ proc getRNG() {
   if useNPB {
     // NPB
     if testRealBits == 64 then
-      return makeRandomStream(seed, eltType=real(64), parSafe=false, algorithm=RNG.NPB);
+      return createRandomStream(seed, eltType=real(64), parSafe=false, algorithm=RNG.NPB);
     else if testRealBits == 32 then
-      return makeRandomStream(seed, eltType=real(64), parSafe=false, algorithm=RNG.NPB);
+      return createRandomStream(seed, eltType=real(64), parSafe=false, algorithm=RNG.NPB);
   } else {
     // PCG
     if testReal && realTruncateBits == 0 {
       // Make native RNG with eltType=real(size)
       if testRealBits == 64 then
-        return makeRandomStream(seed, eltType=real(64), parSafe=false, algorithm=RNG.PCG);
+        return createRandomStream(seed, eltType=real(64), parSafe=false, algorithm=RNG.PCG);
       else if testRealBits == 32 then
-        return makeRandomStream(seed, eltType=real(32), parSafe=false, algorithm=RNG.PCG);
+        return createRandomStream(seed, eltType=real(32), parSafe=false, algorithm=RNG.PCG);
     } else {
       // Make an integer RNG
       if testUintBits == 64 then
-        return makeRandomStream(seed, eltType=uint(64), parSafe=false, algorithm=RNG.PCG);
+        return createRandomStream(seed, eltType=uint(64), parSafe=false, algorithm=RNG.PCG);
       else if testUintBits == 32 then
-        return makeRandomStream(seed, eltType=uint(32), parSafe=false, algorithm=RNG.PCG);
+        return createRandomStream(seed, eltType=uint(32), parSafe=false, algorithm=RNG.PCG);
     }
   }
 }

--- a/test/library/standard/Random/ferguson/check-bounded-rng-fixed-offset.chpl
+++ b/test/library/standard/Random/ferguson/check-bounded-rng-fixed-offset.chpl
@@ -5,7 +5,7 @@ config const seed = 1;
 
 proc createRandomArraySerial(minimum:int, maximum:int) {
   var A:[0..#n] int;
-  var rng = makeRandomStream(eltType=int, seed=seed);
+  var rng = createRandomStream(eltType=int, seed=seed);
   for i in 0..#n {
     A[i] = rng.getNext(minimum, maximum);
   }
@@ -23,7 +23,7 @@ proc createRandomArrayParallel(nTasks:int, minimum:int, maximum:int) {
       end = n-1;
 
     // Each task computes nPerTask random numbers
-    var rng = makeRandomStream(eltType=int, seed=seed);
+    var rng = createRandomStream(eltType=int, seed=seed);
     // Each task generates the same random values as in a serial program
     // (skipping ahead / advancing the RNG past values it would have made)
     rng.skipToNth(1+start);

--- a/test/library/standard/Random/ferguson/check-time-seed.chpl
+++ b/test/library/standard/Random/ferguson/check-time-seed.chpl
@@ -18,7 +18,7 @@ proc getRealRandoms(method:int) {
   }
 
   if method == 1 {
-    var R = makeRandomStream(eltType=real);
+    var R = createRandomStream(eltType=real);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -29,7 +29,7 @@ proc getRealRandoms(method:int) {
 
 
   if method == 2 {
-    var R = makeRandomStream(eltType=real, algorithm=RNG.PCG);
+    var R = createRandomStream(eltType=real, algorithm=RNG.PCG);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -49,7 +49,7 @@ proc getRealRandoms(method:int) {
   }
 
   if method == 4 {
-    var R = makeRandomStream(eltType=real, algorithm=RNG.NPB);
+    var R = createRandomStream(eltType=real, algorithm=RNG.NPB);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -75,7 +75,7 @@ proc getUintRandoms(method:int) {
   }
 
   if method == 1 {
-    var R = makeRandomStream(eltType=uint);
+    var R = createRandomStream(eltType=uint);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -85,7 +85,7 @@ proc getUintRandoms(method:int) {
   }
 
   if method == 2 {
-    var R = makeRandomStream(eltType=uint, algorithm=RNG.PCG);
+    var R = createRandomStream(eltType=uint, algorithm=RNG.PCG);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);

--- a/test/library/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-check.chpl
@@ -13,7 +13,7 @@ var expect32_2 = [0xff85ecc9, 0x4de4d2f6, 0x72eb3394,
 
 writeln("Checking 32-bit RNG seq 1");
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(32), algorithm=RNG.PCG);
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -41,7 +41,7 @@ writeln("Checking 32-bit RNG seq 1");
 }
 
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = int(32), algorithm=RNG.PCG);
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -69,7 +69,7 @@ writeln("Checking 32-bit RNG seq 1");
 
 // check 8 bit version
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(8), algorithm=RNG.PCG);
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -99,7 +99,7 @@ writeln("Checking 32-bit RNG seq 1");
 
 // check 16 bit version
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(16), algorithm=RNG.PCG);
 
   for i in 1..6 {
@@ -132,7 +132,7 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
 
 // check 64 bit version
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(64), algorithm=RNG.PCG);
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -168,7 +168,7 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
 
   fillRandom(expect, seed=seed, algorithm=RNG.PCG);
 
-  var rs = makeRandomStream(seed = seed, eltType = real(32), algorithm=RNG.PCG);
+  var rs = createRandomStream(seed = seed, eltType = real(32), algorithm=RNG.PCG);
 
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
@@ -57,7 +57,7 @@ var histo:[0..255] int;
 
 // Check we produce every random byte
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(8), algorithm=RNG.PCG);
 
   for i in 1..1000000 {
@@ -78,7 +78,7 @@ histo = 0;
 
 // Check we produce every random byte with sub-range
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(8), algorithm=RNG.PCG);
 
   for i in 1..1000000 {
@@ -98,7 +98,7 @@ histo = 0;
 
 // Check we produce every random byte with sub-range
 {
-  var rs = makeRandomStream(seed = seed, parSafe=false,
+  var rs = createRandomStream(seed = seed, parSafe=false,
                             eltType = uint(64), algorithm=RNG.PCG);
 
   for i in 1..1000000 {

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
@@ -33,7 +33,7 @@ for i in 0..#n {
   writeln();
 }
 
-var rs = makeRandomStream(seed=seed, parSafe=false, eltType=uint(32), algorithm=RNG.PCG);
+var rs = createRandomStream(seed=seed, parSafe=false, eltType=uint(32), algorithm=RNG.PCG);
 
 var got:[0..#n] uint(32);
 
@@ -54,7 +54,7 @@ for i in 0..#n {
   assert(got[i] == num);
 }
 
-var rs2 = makeRandomStream(seed=seed, parSafe=false, eltType=uint(64), algorithm=RNG.PCG);
+var rs2 = createRandomStream(seed=seed, parSafe=false, eltType=uint(64), algorithm=RNG.PCG);
 
 var max2:uint = (2**32 + max):uint;
 

--- a/test/library/standard/Random/ferguson/pcg-real32-bug.chpl
+++ b/test/library/standard/Random/ferguson/pcg-real32-bug.chpl
@@ -2,7 +2,7 @@ use Random;
 
 config const verbose = false;
 
-var rng = makeRandomStream(eltType=real(32), algorithm=RNG.PCG);
+var rng = createRandomStream(eltType=real(32), algorithm=RNG.PCG);
 
 
 var displace = (rng.getNext(), rng.getNext(), rng.getNext());

--- a/test/library/standard/Random/ferguson/rand-range-different-types.chpl
+++ b/test/library/standard/Random/ferguson/rand-range-different-types.chpl
@@ -1,6 +1,6 @@
 use Random;
 
-var rng = makeRandomStream(real);
+var rng = createRandomStream(real);
 
 var expectInt = rng.getNext(int, 1, 10);
 assert(expectInt.type == int);

--- a/test/library/standard/Random/ferguson/rmixed-error.chpl
+++ b/test/library/standard/Random/ferguson/rmixed-error.chpl
@@ -1,6 +1,6 @@
 use Random;
 
-var rng = makeRandomStream(seed=17, parSafe=false,
+var rng = createRandomStream(seed=17, parSafe=false,
                            eltType=real(64), algorithm=RNG.PCG);
 
 var v1 = rng.getNext();

--- a/test/library/standard/Random/ferguson/rmixed.chpl
+++ b/test/library/standard/Random/ferguson/rmixed.chpl
@@ -1,7 +1,7 @@
 use Random;
 
 {
-  var rng = makeRandomStream(seed=17, parSafe=false,
+  var rng = createRandomStream(seed=17, parSafe=false,
                              eltType=real(64), algorithm=RNG.PCG);
 
   var v1 = rng.getNext();
@@ -19,7 +19,7 @@ use Random;
   var v2: uint(64);
 
   {
-    var rng = makeRandomStream(seed=17, parSafe=false,
+    var rng = createRandomStream(seed=17, parSafe=false,
                                eltType=uint(64), algorithm=RNG.PCG);
 
     var v1  = rng.getNext();
@@ -28,7 +28,7 @@ use Random;
   }
 
   {
-    var rng = makeRandomStream(seed=17, parSafe=false,
+    var rng = createRandomStream(seed=17, parSafe=false,
                                eltType=uint(64), algorithm=RNG.PCG);
 
     var v1     = rng.getNext(uint(8));
@@ -43,7 +43,7 @@ use Random;
   var v2: real;
 
   {
-    var rng = makeRandomStream(seed=17, parSafe=false,
+    var rng = createRandomStream(seed=17, parSafe=false,
                                eltType=real(64), algorithm=RNG.PCG);
 
     var v1 = rng.getNext();
@@ -52,7 +52,7 @@ use Random;
   }
 
   {
-    var rng = makeRandomStream(seed=17, parSafe=false,
+    var rng = createRandomStream(seed=17, parSafe=false,
                                eltType=real(64), algorithm=RNG.PCG);
 
     var v1 = rng.getNext(uint(8));
@@ -68,7 +68,7 @@ use Random;
   var v2: complex;
 
   {
-    var rng = makeRandomStream(seed=17, parSafe=false,
+    var rng = createRandomStream(seed=17, parSafe=false,
                                eltType=complex(64), algorithm=RNG.PCG);
 
     var v1 = rng.getNext();
@@ -77,7 +77,7 @@ use Random;
   }
 
   {
-    var rng = makeRandomStream(seed=17, parSafe=false,
+    var rng = createRandomStream(seed=17, parSafe=false,
                                eltType=complex(64), algorithm=RNG.PCG);
 
     var v1     = rng.getNext(uint(8));

--- a/test/library/standard/Random/marybeth/test-Random.chpl
+++ b/test/library/standard/Random/marybeth/test-Random.chpl
@@ -4,7 +4,7 @@ proc main() {
   var Vector1 = {1..20};
   var Vec1 : [Vector1] real;
 
-  var rng = makeRandomStream(real, 314159265, algorithm=RNG.NPB);
+  var rng = createRandomStream(real, 314159265, algorithm=RNG.NPB);
 
   rng.fillRandom(Vec1);
   writeln(Vec1);

--- a/test/performance/thomasvandoren/TestHelpers.chpl
+++ b/test/performance/thomasvandoren/TestHelpers.chpl
@@ -15,7 +15,7 @@ config const printC = true,
 // matrices.
 config const scalingFactor = 1;
 
-var randStream = makeRandomStream(eltType=real, seed=randSeed, algorithm=RNG.NPB),
+var randStream = createRandomStream(eltType=real, seed=randSeed, algorithm=RNG.NPB),
   timer: Timer;
 
 const inner = 1..5 * scalingFactor,

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -10,7 +10,7 @@ use Random;
 // This primer shows two ways to generate a sequence of random numbers:
 // The first is by creating an array of random numbers using the
 // :proc:`Random.fillRandom` function. The second way is to use
-// a :class:`~PCGRandom.RandomStream` instance.
+// a :class:`~PCGRandom.PCGRandomStream` instance.
 //
 
 // Using fillRandom
@@ -45,7 +45,7 @@ writeln();
 
 //
 // The second way to generate a sequence of random numbers is by creating a
-// :class:`~PCGRandom.RandomStream` class instance.  The first argument is the
+// :class:`~PCGRandom.PCGRandomStream` class instance.  The first argument is the
 // type of the elements that the instance should generate. If a particular seed
 // is desired, it should be specified upon creation of this instance.
 //
@@ -54,7 +54,7 @@ var randStreamSeeded = new owned RandomStream(real, seed);
 
 //
 // Then the instance can be used to obtain the numbers.  This can be done in a
-// large chunk by calling :proc:`~PCGRandom.RandomStream.fillRandom`:
+// large chunk by calling :proc:`~PCGRandom.PCGRandomStream.fillRandom`:
 //
 var randsFromStream: [1..10] real;
 randStream.fillRandom(randsFromStream);
@@ -104,7 +104,7 @@ for i in randStreamSeeded.iterate({5..10}, real) {
 
 
 //
-// By default, access using the :class:`~PCGRandom.RandomStream` instance will
+// By default, access using the :class:`~PCGRandom.PCGRandomStream` instance will
 // be safe in the presence of parallelism. This can be changed for the entire
 // stream during class creation.  As a result, two parallel accesses or updates
 // to the position from which reading is intended may conflict.
@@ -112,7 +112,7 @@ for i in randStreamSeeded.iterate({5..10}, real) {
 var parallelUnsafe       = new owned RandomStream(real, parSafe=false);
 var parallelSeededUnsafe = new owned RandomStream(real, seed, false);
 
-// Now :class:`~PCGRandom.RandomStream` functions, such as
+// Now :class:`~PCGRandom.PCGRandomStream` functions, such as
 // ``parallelUnsafe.getNext()`` and ``parallelSeededUnsafe.getNext()`` can be
 // called.
 

--- a/test/sparse/CS/multiplication/performance.chpl
+++ b/test/sparse/CS/multiplication/performance.chpl
@@ -56,7 +56,7 @@ proc main() {
 proc populate(ref A, ref ADom, sparsity: real, seed: int) where isSparseArr(A) {
   const nnz = (ADom._value.parentDom.size * sparsity): int;
   var indices: [1..nnz] 2*int;
-  var randomIndices = makeRandomStream(eltType=int, seed=seed);
+  var randomIndices = createRandomStream(eltType=int, seed=seed);
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
@@ -68,7 +68,7 @@ proc populate(ref A, ref ADom, sparsity: real, seed: int) where isSparseArr(A) {
 
   ADom += indices;
 
-  var randomReals = makeRandomStream(eltType=real, seed=seed);
+  var randomReals = createRandomStream(eltType=real, seed=seed);
   for idx in ADom {
     A[idx] = randomReals.getNext();
   }
@@ -78,7 +78,7 @@ proc populate(ref A, ref ADom, sparsity: real, seed: int) where isSparseArr(A) {
 proc populate(ref A: [?ADom], sparsity: real, seed: int) where !isSparseArr(A) {
   const nnz= (ADom.size * sparsity): int;
   var indices: [1..nnz] 2*int;
-  var randomIndices = makeRandomStream(eltType=int, seed=seed);
+  var randomIndices = createRandomStream(eltType=int, seed=seed);
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
@@ -88,7 +88,7 @@ proc populate(ref A: [?ADom], sparsity: real, seed: int) where !isSparseArr(A) {
     idx = newIdx;
   }
 
-  var randomReals = makeRandomStream(eltType=real, seed=seed);
+  var randomReals = createRandomStream(eltType=real, seed=seed);
   for idx in indices {
     A[idx] = randomReals.getNext();
   }

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -495,7 +495,7 @@ proc create_and_analyze_graph(Pairs)
       var maxcount = 0;
       // TODO -- performance -- this allocates memory.
       // There might not be a tie.
-      var tiebreaker = makeRandomStream(seed+vid, eltType=bool,
+      var tiebreaker = createRandomStream(seed+vid, eltType=bool,
                                         parSafe=false, algorithm=RNG.PCG);
       for (count,lab) in zip(counts, counts.domain) {
         if count > maxcount || (count == maxcount && tiebreaker.getNext()) {

--- a/test/types/bytes/io/writeread-random.chpl
+++ b/test/types/bytes/io/writeread-random.chpl
@@ -3,7 +3,7 @@ use Random, IO;
 config const nBytes = 1024;
 
 // create bytes with random bytes
-var randomStream = makeRandomStream(eltType=uint(8));
+var randomStream = createRandomStream(eltType=uint(8));
 var buf = c_malloc(uint(8), nBytes+1);
 for i in 0..#nBytes {
   buf[i] = randomStream.getNext();

--- a/test/types/string/dmk/join.chpl
+++ b/test/types/string/dmk/join.chpl
@@ -1,6 +1,6 @@
 // Credit goes to Bryant for this test of a former bug in string.join().
 
-use Random.PCGRandom only RandomStream;
+use Random.PCGRandom only PCGRandomStream;
 
 config const count = 100;
 
@@ -13,7 +13,7 @@ proc get_str_with_join(x: int, y: int): string {
 }
 
 proc main() {
-  var r = new owned RandomStream(int);
+  var r = new owned PCGRandomStream(int);
 
   for i in 1..count {
     var x = r.getNext(1, 20000);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -162,7 +162,7 @@ proc checkRegistryPath(registryPath : string, trueIfLocal : bool) throws {
 proc publishPackage(username: string, registryPath : string, isLocal : bool) throws {
   try! {
     const packageLocation = absPath(here.cwd());
-    var stream = makeRandomStream(int);
+    var stream = createRandomStream(int);
     var uniqueDir = stream.getNext(): string;
     const name = getPackageName();
     var safeDir = '';


### PR DESCRIPTION
This PR refactors the Random module as documented in several notes.
Specifically:

- `RandomStream` class is renamed to `PCGRandomStream`.
- `RandomStream` is now a type alias for the default random stream.
- `defaultRNG` is now a `config param` instead of just `param`.
- `makeRandomStream` is now deprecated in favor of 
   `createRandomStream`

As a result, several modules and tests are modified to use the new factory
function.

Test:

- [x] standard
- [x] gasnet