### PR TITLE
Fix bug when initializing from iterator expression

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5985,6 +5985,7 @@ static void resolveInitVar(CallExpr* call) {
   bool isDomainWithoutNew = targetType->getValType()->symbol->hasFlag(FLAG_DOMAIN) &&
                             src->hasFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW) == false;
   bool initCopySyncSingle = inferType && (isSyncType(srcType->getValType()) || isSingleType(srcType->getValType()));
+  bool initCopyIter = inferType && srcType->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD);
 
   if (dst->hasFlag(FLAG_NO_COPY) ||
       isPrimitiveScalar(targetType) ||
@@ -6006,7 +6007,7 @@ static void resolveInitVar(CallExpr* call) {
              isDomainWithoutNew ||
              initCopySyncSingle ||
              srcType->getValType()->symbol->hasFlag(FLAG_TUPLE) ||
-             srcType->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
+             initCopyIter) {
     // These cases require an initCopy to implement special initialization
     // semantics (e.g. reading a sync for variable initialization).
     //

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1036,14 +1036,8 @@ module UnitTest {
         }
       }
       if !canRun {
-        var localesStr: string = this.dictDomain: string;
-        var tempLocales: list(string);
-        for loc in localesStr.split(" ") {
-          tempLocales.append(loc: string);
-        }
         var localesErrorStr= "Required Locales = ";
-        if tempLocales.size > 1 then localesErrorStr += ",".join(tempLocales.toArray()); 
-        else localesErrorStr += localesStr:string;
+        localesErrorStr += ",".join(this.dictDomain:string);
         throw new owned TestIncorrectNumLocales(localesErrorStr);
       }
     }


### PR DESCRIPTION
This PR fixes a compiler bug where a variable had the wrong type when being initialized from an iterator expression. This PR also fixes a user error hiding behind this bug.

Resolves #14363 

Testing:
- [x] local + futures
- [x] gasnet + futures