### PR TITLE
Update testFFTW_MT.chpl to work in "private use by default" world

### DIFF
--- a/test/users/npadmana/fftw/testFFTW_MT.chpl
+++ b/test/users/npadmana/fftw/testFFTW_MT.chpl
@@ -20,6 +20,7 @@
    This test case just calls the routines in testFFTW; see documentation there.
 */
 use FFTWlib;
+use FFTW;
 
 config var nthread = 2; // Number of threads
 


### PR DESCRIPTION
This is another test case I missed due to it not being tested in
standard configurations.  Here, I've added an explicit `use FFTW`
where previously it had been relying on transitive uses.