### PR TITLE
Remove pragma "unsafe" on chpl__buildDistType()

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -867,10 +867,9 @@ module ChapelArray {
   pragma "syntactic distribution"
   record dmap { }
 
-  pragma "unsafe"
   proc chpl__buildDistType(type t) type where isSubtype(_to_borrowed(t), BaseDist) {
-    var x: _to_unmanaged(t);
-    var y = new _distribution(x);
+    var x: _to_unmanaged(t)?;
+    var y = new _distribution(x!);
     return y.type;
   }
 


### PR DESCRIPTION
Resolves #13634.

This "unsafe" pragma was added in #13397 to because the function was illegal by
the new nilability typechecking rules. The body of this `type`
function is important because it computes a runtime type.
This PR makes a minor modification that seems to retain the type computation
while making it legal.

Testing: linux64 -futures; gasnet multilocale files.