### PR TITLE
Compute CLANG_SETTINGS and configured-clang-sysroot-arguments every make

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -143,11 +143,13 @@ $(BUILD_VERSION_FILE): FORCE
 $(CHPL_MAKE_HOME)/configured-prefix:
 	echo > $(CHPL_MAKE_HOME)/configured-prefix
 
-$(CONFIGURED_PREFIX_FILE): $(COMPILER_BUILD) $(CHPL_MAKE_HOME)/configured-prefix
-	echo '"'`cat $(CHPL_MAKE_HOME)/configured-prefix`'"' \ > $(CONFIGURED_PREFIX_FILE)
+$(CONFIGURED_PREFIX_FILE): FORCE $(COMPILER_BUILD) $(CHPL_MAKE_HOME)/configured-prefix
+	@echo '"'`cat $(CHPL_MAKE_HOME)/configured-prefix`'"' \ > $(CONFIGURED_PREFIX_FILE).incoming
+	@$(CHPL_MAKE_HOME)/util/config/update-if-different $(CONFIGURED_PREFIX_FILE) $(CONFIGURED_PREFIX_FILE).incoming
 
-$(CLANG_SETTINGS_FILE): $(COMPILER_BUILD)
-	echo '{"'$(CLANG_CC)'","'$(CLANG_CXX)'","'`$(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments $(CLANG_CC)`'"}' | $(FIXPATH_CMD) > $(CLANG_SETTINGS_FILE)
+$(CLANG_SETTINGS_FILE): FORCE $(COMPILER_BUILD)
+	@echo '{"'$(CLANG_CC)'","'$(CLANG_CXX)'","'`$(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments $(CLANG_CC)`'"}' | $(FIXPATH_CMD) > $(CLANG_SETTINGS_FILE).incoming
+	@$(CHPL_MAKE_HOME)/util/config/update-if-different $(CLANG_SETTINGS_FILE) $(CLANG_SETTINGS_FILE).incoming
 
 $(CHPL_CONFIG_CHECK): | $(CHPL_BIN_DIR)
 	rm -rf $(CHPL_CONFIG_CHECK_PREFIX)

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -177,13 +177,14 @@ $(LLVM_CLANG_FILE):
 # This file is necessary on darwin where important headers are
 # not in /usr/include. This causes a problem when building another clang
 # because the new clang can't find the appropriate headers.
-$(LLVM_CLANG_CONFIG_FILE):
-	mkdir -p $(LLVM_INSTALL_DIR)
-	if [ "clang" = "$(CHPL_MAKE_HOST_COMPILER)" ]; then \
-	  ../../util/config/gather-clang-sysroot-arguments clang > $(LLVM_CLANG_CONFIG_FILE) ; \
+$(LLVM_CLANG_CONFIG_FILE): FORCE
+	@mkdir -p $(LLVM_INSTALL_DIR)
+	@if [ "clang" = "$(CHPL_MAKE_HOST_COMPILER)" ]; then \
+	  $(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments clang > $(LLVM_CLANG_CONFIG_FILE).incoming ; \
         else \
-          touch $(LLVM_CLANG_CONFIG_FILE) ; \
+          touch $(LLVM_CLANG_CONFIG_FILE).incoming ; \
         fi
+	@$(CHPL_MAKE_HOME)/util/config/update-if-different $(LLVM_CLANG_CONFIG_FILE) $(LLVM_CLANG_CONFIG_FILE).incoming
 
 configure-llvm: $(LLVM_CONFIGURED_HEADER_FILE)
 

--- a/util/config/update-if-different
+++ b/util/config/update-if-different
@@ -58,7 +58,7 @@ def main():
                 dst_content = dst_file.read()
                 if dst_content != src_content:
                     replace = True
-        except FileNotFoundError:
+        except:
             replace = True
 
         if replace:

--- a/util/config/update-if-different
+++ b/util/config/update-if-different
@@ -1,72 +1,25 @@
 #!/usr/bin/env python
 
+import filecmp
 import optparse
 import os
+import shutil
 import sys
-#
-#script_dir = os.path.dirname(os.path.realpath(__file__))
-#chpl_home_dir = os.path.dirname(os.path.dirname(script_dir))
-#chplenv_dir = os.path.join(chpl_home_dir, "util", "chplenv")
-#sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-dst = ""
-src = ""
+parser = optparse.OptionParser(
+    usage = 'usage: %prog dst src',
+    description = 'Updates dst with src. If they differ, copies dst to src. '
+                  'Deletes src either way.')
 
-def parseArguments():
-    global dst
-    global src
+(options, args) = parser.parse_args()
 
-    parser = optparse.OptionParser(
-        usage='usage: %prog [dst] [src]',
-        description =
-          'Updates [dst] with [src]'
-          'If they differ, copies [dst] to [src]'
-          'Deletes [src] either way.')
+if len(args) != 2:
+    parser.error("Requires exactly 2 arguments")
 
-    (options, args) = parser.parse_args()
+(dst, src) = args
 
-    # Handle VAR=VAL environment variable setting
-    for arg in args:
-        if dst == "":
-            dst = arg
-        elif src == "":
-            src = arg
-        else:
-            parser.error("Accepts only 2 arguments")
+if not os.path.exists(dst) or not filecmp.cmp(src, dst):
+    sys.stdout.write("Copying {0} to {1}\n".format(src, dst))
+    shutil.copyfile(src, dst)
 
-    if dst == "":
-        parser.error("[dst] not set")
-
-    if src == "":
-        parser.error("[src] not set")
-
-def main():
-    global dst
-    global src
-
-    parseArguments()
-
-    replace = False
-    dst_content = None
-    src_content = None
-
-    with open(src, 'r') as src_file:
-        src_content = src_file.read()
-
-        try:
-            with open(dst, 'r') as dst_file:
-                dst_content = dst_file.read()
-                if dst_content != src_content:
-                    replace = True
-        except:
-            replace = True
-
-        if replace:
-            sys.stdout.write("Updating {0}\n".format(dst))
-            with open(dst, 'w') as dst_file:
-                dst_file.write(src_content)
-
-    os.remove(src)
-
-if __name__ == '__main__':
-    main()
+os.remove(src)

--- a/util/config/update-if-different
+++ b/util/config/update-if-different
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import optparse
+import os
+import sys
+#
+#script_dir = os.path.dirname(os.path.realpath(__file__))
+#chpl_home_dir = os.path.dirname(os.path.dirname(script_dir))
+#chplenv_dir = os.path.join(chpl_home_dir, "util", "chplenv")
+#sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+dst = ""
+src = ""
+
+def parseArguments():
+    global dst
+    global src
+
+    parser = optparse.OptionParser(
+        usage='usage: %prog [dst] [src]',
+        description =
+          'Updates [dst] with [src]'
+          'If they differ, copies [dst] to [src]'
+          'Deletes [src] either way.')
+
+    (options, args) = parser.parse_args()
+
+    # Handle VAR=VAL environment variable setting
+    for arg in args:
+        if dst == "":
+            dst = arg
+        elif src == "":
+            src = arg
+        else:
+            parser.error("Accepts only 2 arguments")
+
+    if dst == "":
+        parser.error("[dst] not set")
+
+    if src == "":
+        parser.error("[src] not set")
+
+def main():
+    global dst
+    global src
+
+    parseArguments()
+
+    replace = False
+    dst_content = None
+    src_content = None
+
+    with open(src, 'r') as src_file:
+        src_content = src_file.read()
+
+        try:
+            with open(dst, 'r') as dst_file:
+                dst_content = dst_file.read()
+                if dst_content != src_content:
+                    replace = True
+        except FileNotFoundError:
+            replace = True
+
+        if replace:
+            sys.stdout.write("Updating {0}\n".format(dst))
+            with open(dst, 'w') as dst_file:
+                dst_file.write(src_content)
+
+    os.remove(src)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
But don't actually update those files unless they changed, so the
compiler need not rebuild.

This PR is intended to resolve problems with Chapel source directories 
when the clang version is updated.

Note that this doesn't actually recompute configured-clang-sysroot-arguments
on every make, because third-party/llvm/Makefile does not run on every make.
Fixing that is left as future work.

Reviewed by @ronawho - thanks!

- [x] full local testing