### PR TITLE
Add .skipif and .compopts for currently passing .futures

### DIFF
--- a/test/extern/diten/externLong.compopts
+++ b/test/extern/diten/externLong.compopts
@@ -1,1 +1,1 @@
---no-inline
+--no-inline --ccflags -Wincompatible-pointer-types

--- a/test/extern/diten/externLong.skipif
+++ b/test/extern/diten/externLong.skipif
@@ -1,0 +1,2 @@
+# This test uses a gnu specific compiler option, so skip for other compilers
+CHPL_TARGET_COMPILER!=gnu

--- a/test/extern/diten/passlongptr.compopts
+++ b/test/extern/diten/passlongptr.compopts
@@ -1,0 +1,1 @@
+--ccflags -Wincompatible-pointer-types

--- a/test/extern/diten/passlongptr.skipif
+++ b/test/extern/diten/passlongptr.skipif
@@ -1,0 +1,2 @@
+# This test uses a gnu specific compiler option, so skip for other compilers
+CHPL_TARGET_COMPILER!=gnu


### PR DESCRIPTION
Add '--ccflags -Wincompatible-pointer-types' for two .future tests, then
since it is a gnu specific option, add .skipif files to skip for non-gnu.