### PR TITLE
Undeprecate cstring to string cast

### DIFF
--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -97,7 +97,7 @@ module ChapelDebugPrint {
     if chpl__testParFlag && chpl__testParOn {
       const file_cs : c_string = __primitive("chpl_lookupFilename",
                                         __primitive("_get_user_file"));
-      const file = createStringWithBorrowedBuffer(file_cs);
+      const file = createStringWithNewBuffer(file_cs);
       const line = __primitive("_get_user_line");
       writeln("CHPL TEST PAR (", file, ":", line, "): ", (...args));
     }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -427,12 +427,12 @@ module ChapelError {
 
     const myFileC:c_string = __primitive("chpl_lookupFilename",
                                          __primitive("_get_user_file"));
-    const myFileS = createStringWithBorrowedBuffer(myFileC);
+    const myFileS = createStringWithNewBuffer(myFileC);
     const myLine = __primitive("_get_user_line");
 
     const thrownFileC:c_string = __primitive("chpl_lookupFilename",
                                              err.thrownFileId);
-    const thrownFileS = createStringWithBorrowedBuffer(thrownFileC);
+    const thrownFileS = createStringWithNewBuffer(thrownFileC);
     const thrownLine = err.thrownLine;
 
     var s = "uncaught " + chpl_describe_error(err) +

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2277,8 +2277,6 @@ module String {
   // Cast from c_string to string
   pragma "no doc"
   proc _cast(type t, cs: c_string) where t == string {
-    compilerWarning("Cast from c_string to string is deprecated - "+
-                    "please use createString* functions instead");
     var ret: string;
     ret.len = cs.length;
     ret._size = ret.len+1;

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -493,7 +493,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.ctx == nil {
-        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+        var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
         halt("Error in ContextClass.init(): %s\n", errmsg);
       }
     }
@@ -502,7 +502,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_ctx_term(this.ctx):int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           halt("Error in ContextClass.deinit(): %s\n", errmsg);
         }
       }
@@ -579,7 +579,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.socket == nil {
-        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+        var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
         halt("Error in SocketClass.init(): %s\n", errmsg);
       }
     }
@@ -588,7 +588,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_close(socket):int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           halt("Error in SocketClass.deinit(): %s\n", errmsg);
         }
         socket = c_nil;
@@ -689,7 +689,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_bind(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           halt("Error in Socket.bind(): ", errmsg);
         }
       }
@@ -703,7 +703,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_connect(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           writef("Error in Socket.connect(): %s\n", errmsg);
         }
       }
@@ -734,7 +734,7 @@ module ZMQ {
                                  c_ptrTo(copy):c_void_ptr,
                                  numBytes(T)): int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           halt("Error in Socket.setsockopt(): ", errmsg);
         }
       }
@@ -772,7 +772,7 @@ module ZMQ {
         var err = zmq_getsockopt_string_helper(classRef.socket,
                                                ZMQ_LAST_ENDPOINT, str);
         if err == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLastEndpoint(): " +
@@ -799,7 +799,7 @@ module ZMQ {
         var ret = zmq_getsockopt_int_helper(classRef.socket, ZMQ_LINGER,
                                             copy);
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLinger(): " + errmsg);
@@ -825,7 +825,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setLinger(): " + errmsg);
@@ -849,7 +849,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
+          var errmsg = createStringWithNewBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setSubscribe(): " + errmsg);
@@ -1104,7 +1104,7 @@ module ZMQ {
     pragma "no doc"
     proc throw_socket_error(socket_errno: c_int, err_fn: string) throws {
       var errmsg_zmq =
-        createStringWithBorrowedBuffer(zmq_strerror(socket_errno));
+        createStringWithNewBuffer(zmq_strerror(socket_errno));
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1182,7 +1182,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = createStringWithBorrowedBuffer(ent.d_name());
+      const filename = createStringWithNewBuffer(ent.d_name());
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {
           const fullpath = path + "/" + filename;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3437,7 +3437,7 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
   for param i in 1..tup.size {
     if i != 1 then str += ", ";
     if tup[i].type == c_string {
-      str += createStringWithBorrowedBuffer(tup[i]);
+      str += createStringWithNewBuffer(tup[i]);
     }
     else {
       str += tup[i]:string;
@@ -3471,7 +3471,7 @@ proc stringify(const args ...?k):string {
       if args[i].type == string {
         str += args[i];
       } else if args[i].type == c_string {
-        str += createStringWithBorrowedBuffer(args[i]);
+        str += createStringWithNewBuffer(args[i]);
       } else if args[i].type == bytes {
         //decodePolicy.replace never throws
         try! {

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -358,7 +358,7 @@ proc dirname(name: string): string {
            if (h != 1) {
              value = "${" + env_var + "}";
            } else {
-             value = createStringWithBorrowedBuffer(value_c);
+             value = createStringWithNewBuffer(value_c);
            }
            res += value;
          }
@@ -375,7 +375,7 @@ proc dirname(name: string): string {
          if (h != 1) {
            value = "$" + env_var;
          } else {
-           value = createStringWithBorrowedBuffer(value_c);
+           value = createStringWithNewBuffer(value_c);
          }
          res += value;
          if (ind <= path_p.numBytes) {

--- a/test/extern/ferguson/c_strings.chpl
+++ b/test/extern/ferguson/c_strings.chpl
@@ -14,9 +14,9 @@ proc go() {
   var gotc = returns_c_string();
   print_c_string(gotc);
 
-  writeln(createStringWithNewBuffer(gotc));
+  writeln(gotc:string);
 
-  var gots = createStringWithNewBuffer(gotc);
+  var gots = gotc:string;
   writeln(gots);
 
   writeln("Should be returned_c_string_in_argument x3");
@@ -25,9 +25,9 @@ proc go() {
 
   print_c_string(argc);
 
-  writeln(createStringWithNewBuffer(argc));
+  writeln(argc:string);
 
-  var args = createStringWithNewBuffer(argc);
+  var args = argc:string;
   writeln(args);
 
   writeln("Should be returned_c_string_in_argument_with_length x3");
@@ -37,9 +37,9 @@ proc go() {
 
   print_c_string_len(arg2c, len);
 
-  writeln((createStringWithNewBuffer(arg2c))[1..len]);
+  writeln((arg2c:string)[1..len]);
 
-  var arg2s = (createStringWithNewBuffer(arg2c))[1..len];
+  var arg2s = (arg2c:string)[1..len];
   writeln(arg2s);
 }
 

--- a/test/extern/ferguson/c_strings_global.chpl
+++ b/test/extern/ferguson/c_strings_global.chpl
@@ -14,9 +14,9 @@ proc go() {
   var gotc = returns_c_string();
   print_c_string(gotc);
 
-  writeln(createStringWithNewBuffer(gotc));
+  writeln(gotc:string);
 
-  var gots = createStringWithNewBuffer(gotc);
+  var gots = gotc:string;
   writeln(gots);
 
   writeln("Should be returned_c_string_in_argument x3");
@@ -25,9 +25,9 @@ proc go() {
 
   print_c_string(argc);
 
-  writeln(createStringWithNewBuffer(argc));
+  writeln(argc:string);
 
-  var args = createStringWithNewBuffer(argc);
+  var args = argc:string;
   writeln(args);
 
   writeln("Should be returned_c_string_in_argument_with_length x3");
@@ -37,9 +37,9 @@ proc go() {
 
   print_c_string_len(arg2c, len);
 
-  writeln((createStringWithNewBuffer(arg2c))[1..len]);
+  writeln((arg2c:string)[1..len]);
 
-  var arg2s = (createStringWithNewBuffer(arg2c))[1..len];
+  var arg2s = (arg2c:string)[1..len];
   writeln(arg2s);
 }
 

--- a/test/types/string/sungeun/c_string/casts.chpl
+++ b/test/types/string/sungeun/c_string/casts.chpl
@@ -30,8 +30,8 @@ writeln(vcstri:imag(32));
 writeln(vcstri:imag(64));
 writeln(vcstrc:complex(64));
 writeln(vcstrc:complex(128));
-writeln(createStringWithNewBuffer(vcstrE):E);
-writeln(createStringWithNewBuffer(vcstrB):bool);
+writeln(vcstrE:string:E);
+writeln(vcstrB:string:bool);
 
 for param i in 1..4 do writeln(str:uint(4<<i));
 for param i in 1..4 do writeln(str:int(4<<i));


### PR DESCRIPTION
This PR removes the deprecation warning from c_string to string cast.

The motivation is that we are not sure whether we'll get to deprecate c_string 
altogether before the release and while it is worthy to remove wonky usages
of c_string (such as its cast to Chapel string) from the module code,
requiring the user to use clunkier factory functions with no clear advantage
is not where we want to be in the interim.

This PR also:
- Reverts some tests back to do c_string to string casting so that we have
some coverage for it
- Updates some of the factory functions to strictly use
`createStringWithNewBuffer`. In my original PR there were some that
made sense with `createStringWithBorrowedBuffer`, but I want to have
them unified.

Test:
- [x] standard
- [x] gasnet