### PR TITLE
Change MPI_Abort calls into halts.

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -265,8 +265,7 @@ module MPI {
       if (provided != MPI_THREAD_MULTIPLE) &&
          requireThreadedMPI
       {
-        writeln("Unable to get a high enough MPI thread support");
-        C_MPI.MPI_Abort(MPI_COMM_WORLD, 10);
+        halt("Unable to get a high enough MPI thread support.\nTry setting 'MPICH_MAX_THREAD_SAFETY=multiple' or its equivalent");
       }
       setChplComm();
     }
@@ -292,8 +291,7 @@ module MPI {
             try {
               cookieJar[lastcookie] = ((cookieJar[lastcookie]):int + 1):string;
             } catch e {
-              writeln("Unable to parse PMI_GNI_COOKIE");
-              C_MPI.MPI_Abort(MPI_COMM_WORLD, 10);
+              halt("Unable to parse PMI_GNI_COOKIE");
             }
             const newVal = ":".join(cookieJar);
             C_Env.setenv("PMI_GNI_COOKIE",newVal.c_str(),1);
@@ -309,8 +307,7 @@ module MPI {
       if (provided != MPI_THREAD_MULTIPLE) &&
          requireThreadedMPI
       {
-        writeln("Unable to get a high enough MPI thread support");
-        C_MPI.MPI_Abort(MPI_COMM_WORLD, 10);
+        halt("Unable to get a high enough MPI thread support.\nTry setting 'MPICH_MAX_THREAD_SAFETY=multiple' or its equivalent");
       }
       C_MPI.MPI_Barrier(MPI_COMM_WORLD);
     }


### PR DESCRIPTION
Calling MPI_Abort can cause things printed before the call to be lost. So
a pattern like 'writeln("bad setting for foo"); MPI_Abort();' would lose the error
message and just print a partial callstack and a message saying MPI aborted
without giving a good indication of where the problem is.

Replace those calls with halts so that the intended error gets printed and
the line and filename information is printed as well.

Also, update some error messages to suggest setting an environment variable
to fix the problem.