### PR TITLE
Remove some .compopts with --legacy-classes

### DIFF
--- a/test/classes/delete-free/default-arg-typeless-error.compopts
+++ b/test/classes/delete-free/default-arg-typeless-error.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/delete-free/default-arg-typeless-legacy.chpl
+++ b/test/classes/delete-free/default-arg-typeless-legacy.chpl
@@ -1,1 +1,0 @@
-default-arg-typeless.chpl

--- a/test/classes/delete-free/default-arg-typeless-legacy.compopts
+++ b/test/classes/delete-free/default-arg-typeless-legacy.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/delete-free/default-arg-typeless-legacy.good
+++ b/test/classes/delete-free/default-arg-typeless-legacy.good
@@ -1,9 +1,0 @@
-Calling foo
-borrowed C
-{x = 0}
-Calling bar
-owned C
-{x = 0}
-Calling baz
-borrowed C
-{x = 0}

--- a/test/classes/errors/newValueNotType2.compopts
+++ b/test/classes/errors/newValueNotType2.compopts
@@ -1,2 +1,0 @@
---ignore-errors-for-pass --no-legacy-classes
---ignore-errors-for-pass --legacy-classes

--- a/test/classes/errors/newValueNotType2.legacy.good
+++ b/test/classes/errors/newValueNotType2.legacy.good
@@ -1,4 +1,0 @@
-newValueNotType2.chpl:7: error: cannot use decorator borrowed on a value
-newValueNotType2.chpl:7: error: invalid use of 'new'
-newValueNotType2.chpl:10: error: cannot use decorator unmanaged on a value
-newValueNotType2.chpl:10: error: invalid use of 'new'

--- a/test/classes/ferguson/class-double-modifier.compopts
+++ b/test/classes/ferguson/class-double-modifier.compopts
@@ -1,3 +1,0 @@
---legacy-classes
-# When this test is updated, change the .good to reflect the errors.
-# It is similar to duplicate-management.chpl but tests a generic class.

--- a/test/classes/ferguson/class-double-modifier.good
+++ b/test/classes/ferguson/class-double-modifier.good
@@ -1,64 +1,36 @@
-Section 1
-{x = 1}
-1
-unmanaged A(int(64))
-{x = 1}
-1
-unmanaged A(int(64))
-{x = 1}
-1
-unmanaged A(int(64))
-{x = 1}
-1
-unmanaged A(int(64))
-{x = 1}
-1
-unmanaged A(int(64))
-Section 2
-{x = 2}
-2
-owned A(int(64))
-{x = 2}
-2
-owned A(int(64))
-{x = 2}
-2
-owned A(int(64))
-{x = 2}
-2
-owned A(int(64))
-{x = 2}
-2
-owned A(int(64))
-Section 3
-{x = 3}
-3
-shared A(int(64))
-{x = 3}
-3
-shared A(int(64))
-{x = 3}
-3
-shared A(int(64))
-{x = 3}
-3
-shared A(int(64))
-{x = 3}
-3
-shared A(int(64))
-Section 4
-{x = 4}
-4
-unmanaged A(int(64))
-{x = 4}
-4
-owned A(int(64))
-{x = 4}
-4
-shared A(int(64))
-{x = 4}
-4
-owned A(int(64))
-{x = 4}
-4
-owned A(int(64))
+class-double-modifier.chpl:6: In function 'doit':
+class-double-modifier.chpl:8: error: duplicate decorators - unmanaged unmanaged A(int(64))
+class-double-modifier.chpl:41: Function 'doit' instantiated as: doit(type C = unmanaged A(int(64)))
+class-double-modifier.chpl:6: In function 'doit':
+class-double-modifier.chpl:8: error: duplicate decorators - unmanaged owned A(int(64))
+class-double-modifier.chpl:42: Function 'doit' instantiated as: doit(type C = owned A(int(64)))
+class-double-modifier.chpl:6: In function 'doit':
+class-double-modifier.chpl:8: error: duplicate decorators - unmanaged shared A(int(64))
+class-double-modifier.chpl:43: Function 'doit' instantiated as: doit(type C = shared A(int(64)))
+class-double-modifier.chpl:6: In function 'doit':
+class-double-modifier.chpl:8: error: duplicate decorators - unmanaged borrowed A(int(64))
+class-double-modifier.chpl:44: Function 'doit' instantiated as: doit(type C = borrowed A(int(64)))
+class-double-modifier.chpl:15: In function 'doit2':
+class-double-modifier.chpl:17: error: duplicate decorators - owned unmanaged A(int(64))
+class-double-modifier.chpl:48: Function 'doit2' instantiated as: doit2(type C = unmanaged A(int(64)))
+class-double-modifier.chpl:15: In function 'doit2':
+class-double-modifier.chpl:17: error: duplicate decorators - owned owned A(int(64))
+class-double-modifier.chpl:49: Function 'doit2' instantiated as: doit2(type C = owned A(int(64)))
+class-double-modifier.chpl:15: In function 'doit2':
+class-double-modifier.chpl:17: error: duplicate decorators - owned shared A(int(64))
+class-double-modifier.chpl:50: Function 'doit2' instantiated as: doit2(type C = shared A(int(64)))
+class-double-modifier.chpl:15: In function 'doit2':
+class-double-modifier.chpl:17: error: duplicate decorators - owned borrowed A(int(64))
+class-double-modifier.chpl:51: Function 'doit2' instantiated as: doit2(type C = borrowed A(int(64)))
+class-double-modifier.chpl:23: In function 'doit3':
+class-double-modifier.chpl:24: error: duplicate decorators - shared unmanaged A(int(64))
+class-double-modifier.chpl:55: Function 'doit3' instantiated as: doit3(type C = unmanaged A(int(64)))
+class-double-modifier.chpl:23: In function 'doit3':
+class-double-modifier.chpl:24: error: duplicate decorators - shared owned A(int(64))
+class-double-modifier.chpl:56: Function 'doit3' instantiated as: doit3(type C = owned A(int(64)))
+class-double-modifier.chpl:23: In function 'doit3':
+class-double-modifier.chpl:24: error: duplicate decorators - shared shared A(int(64))
+class-double-modifier.chpl:57: Function 'doit3' instantiated as: doit3(type C = shared A(int(64)))
+class-double-modifier.chpl:23: In function 'doit3':
+class-double-modifier.chpl:24: error: duplicate decorators - shared borrowed A(int(64))
+class-double-modifier.chpl:58: Function 'doit3' instantiated as: doit3(type C = borrowed A(int(64)))


### PR DESCRIPTION
`test/classes/delete-free/default-arg-typeless-error.compopts`
-- this code is unaffected by --legacy-classes.

`test/classes/delete-free/default-arg-typeless-legacy.chpl`
`test/classes/delete-free/default-arg-typeless-legacy.compopts`
`test/classes/delete-free/default-arg-typeless-legacy.good`
-- this test is the same as `default-arg-typeless.chpl`, except
tested with --legacy-classes. The only difference in behavior is that
with --legacy-classes the type `C` means `borrowed C`. This is still
not a reason to keep this test, because `default-arg-typeless.chpl`
already includes this case explicitly.

`test/classes/errors/newValueNotType2.compopts`
-- this test now has nothing to do with --legacy-classes
and does not need ---ignore-errors-for-pass.

`test/classes/errors/newValueNotType2.legacy.good`
-- unused since #14298.

`test/classes/ferguson/class-double-modifier.compopts`
`test/classes/ferguson/class-double-modifier.good`
-- .compopts was added in #13899 to postpone updating the test
to the new "stacking management types a compiler error" rule. Updating it
now. Without --legacy-classes the compiler issues errors correctly.
