### PR TITLE
Throw -Wincompatible-pointer-types to 2 baseline futures

### DIFF
--- a/test/types/cptr/func_ptr_as_c_fn_ptr.compopts
+++ b/test/types/cptr/func_ptr_as_c_fn_ptr.compopts
@@ -1,1 +1,1 @@
-struct_with_fn_ptr.h struct_with_fn_ptr.c
+struct_with_fn_ptr.h struct_with_fn_ptr.c --ccflags -Wincompatible-pointer-types

--- a/test/types/cptr/func_ptr_as_void_ptr.compopts
+++ b/test/types/cptr/func_ptr_as_void_ptr.compopts
@@ -1,1 +1,1 @@
-struct_with_fn_ptr.h struct_with_fn_ptr.c
+struct_with_fn_ptr.h struct_with_fn_ptr.c --ccflags -Wincompatible-pointer-types


### PR DESCRIPTION
Add  `--ccflags -Wincompatible-pointer-types` to 2 baseline failures that track
that we incorrectly represent all c_fn_ptr's as one type. Similar to #14461,
follow on to #14446.