### PR TITLE
Compute nightly memleaks date once instead of on the fly

### DIFF
--- a/util/cron/common-memleaks.bash
+++ b/util/cron/common-memleaks.bash
@@ -5,11 +5,12 @@
 
 export CHPL_NIGHTLY_MEMLEAKS_DIR=${CHPL_NIGHTLY_MEMLEAKS_DIR:-$PERF_LOGDIR_PREFIX/NightlyMemLeaks}
 export CHPL_COMM=none
+export MEM_LEAKS_DATE_VAL=$(date '+%Y-%m-%d')
 
 function memleaks_log()
 {
     local tests=$1
-    local date_val=$(date '+%Y-%m-%d')
+    local date_val=$MEM_LEAKS_DATE_VAL
 
     case $tests in
         examples)


### PR DESCRIPTION
The memleaks log file looks like `memleaks.YYYY-MM-DD.nightlyfull.log`.
Previously, we computed the date dynamically each time `memleaks_log()`
was called, but this could cause problems when testing ran past a new
day since at the end we'd try to copy a file for the current day instead
of the day testing started.

To fix this just compute the date once when testing starts.