### PR TITLE
Simplify visible function determination of use visibility

### DIFF
--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -64,8 +64,6 @@ public:
 
   bool            providesNewSymbols(const UseStmt* other)               const;
 
-  bool            isVisible(BaseAST* scope)                              const;
-
   BaseAST*        getSearchScope()                                       const;
 
   ModuleSymbol*   checkIfModuleNameMatches(const char* name);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2137,46 +2137,6 @@ bool Symbol::isVisible(BaseAST* scope) const {
 
 /************************************* | **************************************
 *                                                                             *
-* Returns true if this use statement is in the provided scope or capable of   *
-* being found in from the provided scope, false if the use statement is       *
-* private and the scope is not in its direct parent.                          *
-*                                                                             *
-************************************** | *************************************/
-bool UseStmt::isVisible(BaseAST* scope) const {
-  if (isPrivate) {
-    BaseAST* parentScope = getScope(this->parentExpr);
-    BaseAST* searchScope = scope;
-
-    INT_ASSERT(parentScope != NULL);
-
-    // We need to walk up scopes until we either find our parent scope (in
-    // which case, we're visible if it "use"s us) or we run out of scope to
-    // check against (in which case we are most certainly *not* visible)
-    while (searchScope != NULL) {
-      if (searchScope == parentScope) {
-        return true;
-      } else if (FnSymbol* fn = toFnSymbol(searchScope)) {
-        // Check instantiation points as well
-        if (BaseAST* inPt = fn->instantiationPoint()) {
-          if (isVisible(inPt)) {
-            return true;
-          }
-        }
-      }
-
-      searchScope = getScope(searchScope);
-    }
-
-    // We got to the top of the scope without finding the parent.
-    return false;
-  }
-
-  // If we got here, it's because the use statement was public
-  return true;
-}
-
-/************************************* | **************************************
-*                                                                             *
 * getScope returns the BaseAST that corresponds to the scope where 'ast'      *
 * exists; 'ast' must be an Expr or a Symbol.  Note that if you pass this a    *
 * BaseAST that defines a scope, the BaseAST that defines the scope where it   *

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -68,6 +68,11 @@ bool ResolutionCandidate::isApplicable(CallInfo& info) {
     retval = isApplicableGeneric (info);
   }
 
+  // Note: for generic instantiations, this code will be executed twice.
+  // This is because by the time the generic branch returns, its function will
+  // have been replaced by the instantiation, which will have already had this
+  // function called on it.  However, reducing the scope for this operation does
+  // not seem to have a noticeable impact.
   if (retval && fn->retExprType != NULL && fn->retType == dtUnknown) {
     resolveSpecifiedReturnType(fn);
   }

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -314,21 +314,16 @@ static void getVisibleFunctions(const char*           name,
     // We've seen this block already, but we just found it again from going up
     // in scope from the call site.  That means that we may have skipped private
     // uses, so we should go through only the private uses.
-    bool moduleBlock = false;
-    bool fnBlock = false;
     ModuleSymbol* inMod = block->getModule();
     FnSymbol* inFn = block->getFunction();
     BlockStmt* instantiationPt = NULL;
-    if (block->parentExpr != NULL) {
-      // not a module or function level block
-    } else if (inMod && block == inMod->block) {
-      moduleBlock = true;
+    if (block->parentExpr != NULL || (inMod && block == inMod->block)) {
+      // only care about instantiations right now, all the rest is unnecessary
     } else if (inFn != NULL) {
       // TODO - probably remove this assert
       INT_ASSERT(block->parentSymbol == inFn ||
                  isArgSymbol(block->parentSymbol) ||
                  isShadowVarSymbol(block->parentSymbol));
-      fnBlock = true;
       BlockStmt* inFnInstantiationPoint = inFn->instantiationPoint();
       if (inFnInstantiationPoint && !inFnInstantiationPoint->parentSymbol) {
         INT_FATAL(inFn, "instantiation point not in tree\n"


### PR DESCRIPTION
In profiling function resolution to determine reasons why it is so slow,
I discovered that the UseStmt::isVisible function was accounting for a
significant portion of resolution, basically dominating the execution of
getVisibleFunctions, which was dominating the execution of
resolveNormalCall.

The intention behind the computation was to ensure we do not go
into private use statements unless we are in the scope in which they
were defined.  It determined this by walking the scope of the call to
the top level possible to see if we could find the scope with the use
statement.

This change simplifies the computation UseStmt::isVisible was
accomplishing, by recognizing that most private use statements are not
going to be in a scope relevant to the call.  The only situation where a
private use should be traversed is if we are in that scope, so the only
time we should even try it is if we aren't looking through a use chain for
symbols.  Then, since it is theoretically possible for a used module to
use a parent scope, instead of ignoring already seen parent scopes, we
only check their private uses.

Another way of phrasing this: instead of traversing the call scope every
time we find a private use, only check the private uses in the call scope
and ignore all other private uses.

Initial results show that this will improve resolution time by around 1.8x,
and improve compilation around 1.4x (by looking at local runs of the FFT
compiler performance test).

Passed a full paratest with futures and a full gasnet paratest with futures.