### PR TITLE
Improve AM response time in comm=ofi.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -480,6 +480,27 @@ void init_ofi(void) {
   init_ofiForMem();
   init_ofiForRma();
   init_ofiForAms();
+
+  DBG_PRINTF(DBG_CFG,
+             "AM config: recv buf size %zd MiB, %s, responses use %s",
+             ofi_iov_reqs.iov_len / (1L << 20),
+             (ofi_amhWaitSet == NULL) ? "polling" : "wait set",
+             (tciTab[tciTabLen - 1].txCQ != NULL) ? "CQ" : "counter");
+  if (useScalableTxEp) {
+    DBG_PRINTF(DBG_CFG,
+               "per node config: 1 scalable tx ep + %d tx ctx%s (%d fixed), "
+               "%d rx ctx%s",
+               numTxCtxs, (numTxCtxs == 1) ? "" : "s",
+               tciTabFixedAssignments ? chpl_task_getFixedNumThreads() : 0,
+               numRxCtxs, (numRxCtxs == 1) ? "" : "s");
+  } else {
+    DBG_PRINTF(DBG_CFG,
+               "per node config: %d regular tx ep+ctx%s (%d fixed), "
+               "%d rx ctx%s",
+               numTxCtxs, (numTxCtxs == 1) ? "" : "s",
+               tciTabFixedAssignments ? chpl_task_getFixedNumThreads() : 0,
+               numRxCtxs, (numRxCtxs == 1) ? "" : "s");
+  }
 }
 
 
@@ -887,22 +908,6 @@ void init_ofiEpNumCtxs(void) {
   //
   CHK_TRUE(dom_attr->max_ep_rx_ctx >= numAmHandlers);
   numRxCtxs = numAmHandlers;
-
-  if (useScalableTxEp) {
-    DBG_PRINTF(DBG_CFG,
-               "per node: 1 scalable tx ep + %d tx ctx%s (%d fixed), "
-               "%d rx ctx%s",
-               numTxCtxs, (numTxCtxs == 1) ? "" : "s",
-               tciTabFixedAssignments ? fixedNumThreads : 0,
-               numRxCtxs, (numRxCtxs == 1) ? "" : "s");
-  } else {
-    DBG_PRINTF(DBG_CFG,
-               "per node: %d regular tx ep+ctx%s (%d fixed), "
-               "%d rx ctx%s",
-               numTxCtxs, (numTxCtxs == 1) ? "" : "s",
-               tciTabFixedAssignments ? fixedNumThreads : 0,
-               numRxCtxs, (numRxCtxs == 1) ? "" : "s");
-  }
 }
 
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -167,12 +167,12 @@ static inline struct perTxCtxInfo_t* tciAlloc(void);
 static inline struct perTxCtxInfo_t* tciAllocForAmHandler(void);
 static inline chpl_bool tciTryRealloc(struct perTxCtxInfo_t*);
 static inline void tciFree(struct perTxCtxInfo_t*);
-static /*inline*/ chpl_comm_nb_handle_t ofi_put(const void*, c_nodeid_t,
-                                                void*, size_t);
-static /*inline*/ void ofi_put_ll(const void*, c_nodeid_t,
-                                  void*, size_t, void*);
-static /*inline*/ chpl_comm_nb_handle_t ofi_get(void*, c_nodeid_t,
-                                                void*, size_t);
+static inline chpl_comm_nb_handle_t ofi_put(const void*, c_nodeid_t,
+                                            void*, size_t);
+static inline void ofi_put_ll(const void*, c_nodeid_t,
+                              void*, size_t, void*);
+static inline chpl_comm_nb_handle_t ofi_get(void*, c_nodeid_t,
+                                            void*, size_t);
 static inline void waitForCQThisTxn(struct perTxCtxInfo_t*, atomic_bool*);
 static inline void waitForCQAllTxns(struct perTxCtxInfo_t*,
                                     chpl_comm_taskPrvData_t*);
@@ -2746,7 +2746,7 @@ void tciFree(struct perTxCtxInfo_t* tcip) {
 }
 
 
-static /*inline*/
+static inline
 chpl_comm_nb_handle_t ofi_put(const void* addr, c_nodeid_t node,
                               void* raddr, size_t size) {
   DBG_PRINTF(DBG_RMA | DBG_RMAWRITE,
@@ -2824,7 +2824,7 @@ chpl_comm_nb_handle_t ofi_put(const void* addr, c_nodeid_t node,
 }
 
 
-static /*inline*/
+static inline
 void ofi_put_ll(const void* addr, c_nodeid_t node,
                  void* raddr, size_t size, void* ctx) {
   DBG_PRINTF(DBG_RMA | DBG_RMAWRITE,
@@ -2853,7 +2853,7 @@ void ofi_put_ll(const void* addr, c_nodeid_t node,
 }
 
 
-static /*inline*/
+static inline
 chpl_comm_nb_handle_t ofi_get(void* addr, c_nodeid_t node,
                               void* raddr, size_t size) {
   DBG_PRINTF(DBG_RMA | DBG_RMAREAD,

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2266,13 +2266,12 @@ void amWrapExecOnLrgBody(void* p) {
     static __thread chpl_comm_amDone_t* myGotArg = NULL;
     if (myGotArg == NULL) {
       myGotArg = allocBounceBuf(1);
-      CHK_TRUE(mrGetDesc(NULL, myGotArg, 1) == 0);
       *myGotArg = 1;
     }
 
     chpl_comm_amDone_t* origGotArg = &reqOnOrig->comm.xol.gotArg;
-    CHK_TRUE(mrGetKey(NULL, NULL, node, origGotArg, sizeof(*origGotArg)) == 0);
-    (void) ofi_put(myGotArg, node, origGotArg, sizeof(*origGotArg));
+    ofi_put_ll(myGotArg, node, origGotArg, sizeof(*origGotArg),
+               txnTrkEncode(txnTrkNone, NULL));
   }
 
   //


### PR DESCRIPTION
In the AM handler, we have to send a 'done' indicator to the initiator
for each executeOn as we finish performing them, except for nonblocking
ones.  We've been waiting for the network completions for these.  Here,
stop doing so.  Just collect the network responses as they trickle in,
later.

Do the same for the notifications sent from the AM handler when it has
finished GETting the part of a large non-blocking AM argument block that
wouldn't fit in the initial request.  The initiator cannot proceed after
sending a large AM request until it knows the receiver has retrieved it
all.  For a blocking AM this is implicit in the 'AM done' indication,
but for a non-blocking one we send a special 'got the arg' indicator.

With this change, the many-to-one test with op=fastOn gets 1.40 mOps/sec
when run on a CS system with 8 initiating nodes and 1 thread/node,
compared to 0.22 mOps/sec before.  Interestingly, though, it drops back
down to 0.13 mOps/sec with 14 initiating nodes and 18 threads/node
(effectively the 16-node performance testing setting on BW-18 nodes).
So there is still more work to do.

In addition, with this change an ml-16 performance testing run on a Cray
CS system finishes in around 3h 00m, with no timeouts although a couple
of tests need higher time limits: 400 seconds for MiniMD and 1200 for
parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.  This is close
enough to the 2h 10m gasnet-ibv-fast ml-16 takes that I think we can
start regular comm=ofi perf testing.

Also, I'm now convinced that comm=ofi as such doesn't actually have a
CPU monopolization problem.  Launcher=mpirun4ofi may have one, with
respect to MPI progress threads, but mpirun4ofi is a stopgap and I don't
think we need to worry as much about it.

I believe this resolves https://github.com/Cray/chapel-private/issues/424.
