### PR TITLE
Munge most internal symbol names as we do for other modules

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -622,6 +622,7 @@ void initPrimitiveTypes() {
 
   dtNil = createInternalType ("_nilType", "_nilType");
   CREATE_DEFAULT_SYMBOL (dtNil, gNil, "nil");
+  gNil->addFlag(FLAG_EXTERN);
 
   // dtStringC defaults to nil
   dtStringC->defaultValue = gNil;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1227,12 +1227,8 @@ static void protectNameFromC(Symbol* sym) {
   }
 
   //
-  // For now, we only rename our user and standard symbols.  Internal
-  // modules symbols should arguably similarly be protected, to ensure
-  // that we haven't inadvertently used a name that some user library
-  // will; most file-level symbols should be protected by 'chpl_' or
-  // somesuch, but of course local symbols may not be, and can cause
-  // conflicts (at present, a local variable named 'socket' would).
+  // For now, we don't rename internal module type symbols.  They
+  // should arguably similarly be protected.
   // The challenges to handling MOD_INTERNAL symbols in the same way
   // today is that things like chpl_string and uint64_t should not be
   // renamed, and should arguably have FLAG_EXTERN on them; however,
@@ -1241,7 +1237,7 @@ static void protectNameFromC(Symbol* sym) {
   // a TODO (currently in Brad's court).
   //
   ModuleSymbol* symMod = sym->getModule();
-  if (symMod->modTag == MOD_INTERNAL) {
+  if (symMod->modTag == MOD_INTERNAL && isTypeSymbol(sym)) {
     return;
   }
 

--- a/test/users/npadmana/empty.chpl
+++ b/test/users/npadmana/empty.chpl
@@ -1,0 +1,2 @@
+export proc empty() { writeln("I am *not* empty!"); }
+empty();

--- a/test/users/npadmana/empty.good
+++ b/test/users/npadmana/empty.good
@@ -1,0 +1,1 @@
+I am *not* empty!


### PR DESCRIPTION
This extends the symbol munging via a `_chpl` suffix that was introduced in PR #1197 to internal modules—except for type symbols, which have historically caused problems due to the way we handle type aliases.
