### PR TITLE
Explain unresolved call due to missing parens

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -1013,6 +1013,12 @@ void explainCandidateRejection(CallInfo& info, FnSymbol* fn) {
       break;
     case RESOLUTION_CANDIDATE_OTHER:
     case RESOLUTION_CANDIDATE_MATCH:
+      if (c.reason == RESOLUTION_CANDIDATE_MATCH &&
+          call->methodTag == true                &&
+          ! fn->hasFlag(FLAG_NO_PARENS)          ) {
+        USR_PRINT(call, "because call is written without parentheses");
+        USR_PRINT(fn, "but candidate function has parentheses");
+      }
       // Print nothing else
       break;
     // No default -> compiler warning

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3822,7 +3822,7 @@ static void generateUnresolvedMsg(CallInfo& info, Vec<FnSymbol*>& visibleFns) {
       if (i > nPrintDetails)
         break;
 
-      explainCandidateRejection(info, visibleFns.v[0]);
+      explainCandidateRejection(info, fn);
     }
 
     i = 0;

--- a/test/functions/resolution/parenless-call-error.chpl
+++ b/test/functions/resolution/parenless-call-error.chpl
@@ -1,0 +1,16 @@
+// This tests the explanation for the unresolved call error
+// where the call is paren-less and the function is paren-ful.
+//
+// This has to be a method. If it is a call to a non-method function
+// written without parens (and without args), ex. "myFun;", it is
+// currently treated as capturing 'myFun' as a first-class function (FCF),
+// and does not result in an error.
+
+class C {
+  proc mm() {
+    writeln("in mm()");
+  }
+}
+
+var cc = new C();
+cc.mm;

--- a/test/functions/resolution/parenless-call-error.good
+++ b/test/functions/resolution/parenless-call-error.good
@@ -1,0 +1,4 @@
+parenless-call-error.chpl:16: error: unresolved call 'owned C.mm'
+parenless-call-error.chpl:10: note: this candidate did not match: C.mm()
+parenless-call-error.chpl:16: note: because call is written without parentheses
+parenless-call-error.chpl:10: note: but candidate function has parentheses


### PR DESCRIPTION
Extend explainCandidateRejection() to explain the case of a call
to a function with parentheses that's written without parentheses
(and without arguments).

Currently it does not fire for a non-method function because
in that case there is no resolution error - it is treated as capture
as a first-class function (FCF).

While there, fix a glitch in generateUnresolvedMsg().

Testing: linux64; multilocale tests under gasnet.