### PR TITLE
Munge internal module symbols similar to user/standard; don't munge fields

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -209,7 +209,19 @@ bool Symbol::isParameter() const {
 }
 
 bool Symbol::isRenameable() const {
-  return !(hasFlag(FLAG_EXPORT) || hasFlag(FLAG_EXTERN));
+  // we can't rename symbols that we're exporting or that are extern
+  // because the other language will require the name to be as specified.
+  // and we can't rename symbols that say not to.
+  if (hasFlag(FLAG_EXPORT) || hasFlag(FLAG_EXTERN) || hasFlag(FLAG_NO_RENAME)) {
+    return false;
+  }
+  // There are some fields named "locale" and "addr" which, if renamed,
+  // broke some compiler-generated accesses to the fields; I couldn't
+  // sort out how to keep them working quickly, so am special-casing.
+  if (strcmp(name, "locale") == 0 || strcmp(name, "addr") == 0) {
+    return false;
+  }
+  return true;
 }
 
 bool Symbol::isRef() {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -622,6 +622,7 @@ void initPrimitiveTypes() {
 
   dtNil = createInternalType ("_nilType", "_nilType");
   CREATE_DEFAULT_SYMBOL (dtNil, gNil, "nil");
+  gNil->addFlag(FLAG_EXTERN);
 
   // dtStringC defaults to nil
   dtStringC->defaultValue = gNil;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -569,6 +569,7 @@ static VarSymbol*     createSymbol(PrimitiveType* primType, const char* name);
 //  well as internal types and other types used in the generated code
 void initPrimitiveTypes() {
   dtVoid                               = createInternalType("void", "void");
+  dtVoid->symbol->addFlag(FLAG_EXTERN);
   dtNothing                            = createInternalType ("nothing",  "nothing");
 
   dtBools[BOOL_SIZE_SYS]               = createPrimitiveType("bool",     "chpl_bool");
@@ -621,6 +622,7 @@ void initPrimitiveTypes() {
   uniqueConstantsHash.put(gTrue->immediate,  gTrue);
 
   dtNil = createInternalType ("_nilType", "_nilType");
+  dtNil->symbol->addFlag(FLAG_EXTERN);
   CREATE_DEFAULT_SYMBOL (dtNil, gNil, "nil");
   gNil->addFlag(FLAG_EXTERN);
 
@@ -805,7 +807,9 @@ void initPrimitiveTypes() {
 }
 
 static PrimitiveType* createPrimitiveType(const char* name, const char* cname) {
-  return createType(name, cname, false);
+  PrimitiveType* newType = createType(name, cname, false);
+  newType->symbol->addFlag(FLAG_EXTERN);
+  return newType;
 }
 
 static PrimitiveType* createInternalType(const char* name, const char* cname) {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -569,7 +569,7 @@ static VarSymbol*     createSymbol(PrimitiveType* primType, const char* name);
 //  well as internal types and other types used in the generated code
 void initPrimitiveTypes() {
   dtVoid                               = createInternalType("void", "void");
-  dtVoid->symbol->addFlag(FLAG_EXTERN);
+  dtVoid->symbol->addFlag(FLAG_NO_RENAME);
   dtNothing                            = createInternalType ("nothing",  "nothing");
 
   dtBools[BOOL_SIZE_SYS]               = createPrimitiveType("bool",     "chpl_bool");
@@ -622,9 +622,9 @@ void initPrimitiveTypes() {
   uniqueConstantsHash.put(gTrue->immediate,  gTrue);
 
   dtNil = createInternalType ("_nilType", "_nilType");
-  dtNil->symbol->addFlag(FLAG_EXTERN);
+  dtNil->symbol->addFlag(FLAG_NO_RENAME);
   CREATE_DEFAULT_SYMBOL (dtNil, gNil, "nil");
-  gNil->addFlag(FLAG_EXTERN);
+  gNil->addFlag(FLAG_NO_RENAME);
 
   // dtStringC defaults to nil
   dtStringC->defaultValue = gNil;
@@ -808,7 +808,7 @@ void initPrimitiveTypes() {
 
 static PrimitiveType* createPrimitiveType(const char* name, const char* cname) {
   PrimitiveType* newType = createType(name, cname, false);
-  newType->symbol->addFlag(FLAG_EXTERN);
+  newType->symbol->addFlag(FLAG_NO_RENAME);
   return newType;
 }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1237,9 +1237,11 @@ static void protectNameFromC(Symbol* sym) {
   // a TODO (currently in Brad's court).
   //
   ModuleSymbol* symMod = sym->getModule();
+  /*
   if (symMod->modTag == MOD_INTERNAL && isTypeSymbol(sym)) {
     return;
   }
+  */
 
   //
   // If this symbol is exported of an extern symbol then someone

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1227,9 +1227,9 @@ static void protectNameFromC(Symbol* sym) {
   }
 
   //
-  // If this symbol is exported of an extern symbol then someone
-  // outside of Chapel is relying on it to have a certain name and we
-  // need to respect that.
+  // Don't rename the symbol if it's not able to be (typically because
+  // it's exported, extern, or has otherwise been flagged as not being
+  // renameable).
   //
   if (!sym->isRenameable()) {
     return;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1227,23 +1227,6 @@ static void protectNameFromC(Symbol* sym) {
   }
 
   //
-  // For now, we don't rename internal module type symbols.  They
-  // should arguably similarly be protected.
-  // The challenges to handling MOD_INTERNAL symbols in the same way
-  // today is that things like chpl_string and uint64_t should not be
-  // renamed, and should arguably have FLAG_EXTERN on them; however,
-  // putting it on them causes it to bleed over onto type aliases in a
-  // way that breaks things and wasn't easy to fix.  So this remains
-  // a TODO (currently in Brad's court).
-  //
-  ModuleSymbol* symMod = sym->getModule();
-  /*
-  if (symMod->modTag == MOD_INTERNAL && isTypeSymbol(sym)) {
-    return;
-  }
-  */
-
-  //
   // If this symbol is exported of an extern symbol then someone
   // outside of Chapel is relying on it to have a certain name and we
   // need to respect that.
@@ -1264,6 +1247,7 @@ static void protectNameFromC(Symbol* sym) {
   // is declared within an extern declaration, we should preserve its
   // name for similar reasons.
   //
+  ModuleSymbol* symMod = sym->getModule();
   if (sym != symMod) {
     Symbol* parentSym = sym->defPoint->parentSymbol;
     while (parentSym != symMod) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1227,12 +1227,8 @@ static void protectNameFromC(Symbol* sym) {
   }
 
   //
-  // For now, we only rename our user and standard symbols.  Internal
-  // modules symbols should arguably similarly be protected, to ensure
-  // that we haven't inadvertently used a name that some user library
-  // will; most file-level symbols should be protected by 'chpl_' or
-  // somesuch, but of course local symbols may not be, and can cause
-  // conflicts (at present, a local variable named 'socket' would).
+  // For now, we don't rename internal module type symbols.  They
+  // should arguably similarly be protected.
   // The challenges to handling MOD_INTERNAL symbols in the same way
   // today is that things like chpl_string and uint64_t should not be
   // renamed, and should arguably have FLAG_EXTERN on them; however,
@@ -1241,7 +1237,7 @@ static void protectNameFromC(Symbol* sym) {
   // a TODO (currently in Brad's court).
   //
   ModuleSymbol* symMod = sym->getModule();
-  if (symMod->modTag == MOD_INTERNAL) {
+  if (symMod->modTag == MOD_INTERNAL && isTypeSymbol(sym)) {
     return;
   }
 

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -261,6 +261,7 @@ symbolFlag( FLAG_NO_INIT , ypr, "no init", "Do not initialize this variable" )
 symbolFlag( FLAG_NO_OBJECT , ypr, "no object" , ncm )
 symbolFlag( FLAG_NO_PARENS , npr, "no parens" , "function without parentheses" )
 symbolFlag( FLAG_NO_REMOTE_MEMORY_FENCE , ypr, "no remote memory fence" , ncm)
+symbolFlag( FLAG_NO_RENAME, npr, "no rename", ncm)
 symbolFlag( FLAG_NO_RVF, npr, "do not RVF", ncm)
 symbolFlag( FLAG_NO_WIDE_CLASS , ypr, "no wide class" , ncm )
 

--- a/test/compflags/bradc/mungeUserIdents/testmunge-extern.prediff
+++ b/test/compflags/bradc/mungeUserIdents/testmunge-extern.prediff
@@ -21,15 +21,19 @@ for line in open(actualGenCodeFile):
     for key in counts:
         if key in line:
             refkey = "_ref_" + key
+            heapkey = "heap_" + key
             if not refkey in line:
-                counts[key] += 1
+                if not heapkey in line:
+                    counts[key] += 1
 
 for line in open(genHeader):
     for key in counts:
         if key in line:
             refkey = "_ref_" + key
+            heapkey = "heap_" + key
             if not refkey in line:
-                counts[key] += 1
+                if not heapkey in line:
+                    counts[key] += 1
 
 with open(testOutputFile, 'a') as f:
     success = True

--- a/test/compflags/bradc/mungeUserIdents/testmunge-extern.prediff
+++ b/test/compflags/bradc/mungeUserIdents/testmunge-extern.prediff
@@ -20,12 +20,16 @@ counts = {n:0 for n in names}
 for line in open(actualGenCodeFile):
     for key in counts:
         if key in line:
-            counts[key] += 1
+            refkey = "_ref_" + key
+            if not refkey in line:
+                counts[key] += 1
 
 for line in open(genHeader):
     for key in counts:
         if key in line:
-            counts[key] += 1
+            refkey = "_ref_" + key
+            if not refkey in line:
+                counts[key] += 1
 
 with open(testOutputFile, 'a') as f:
     success = True
@@ -38,6 +42,6 @@ with open(testOutputFile, 'a') as f:
             f.write("ERROR: Didn't find {}'s in output\n".format(key))
             success = False
     if success:
-        f.write("Success!\n");
+        f.write("Success!\n")
 
 shutil.rmtree(genCodeDir)

--- a/test/interop/fortran/genFortranInterface/unhandledType.good
+++ b/test/interop/fortran/genFortranInterface/unhandledType.good
@@ -2,5 +2,5 @@ unhandledType.chpl:1: In function 'takesCstring':
 unhandledType.chpl:1: warning: Unknown Fortran KIND generating interface for C type: c_string
 unhandledType.chpl:1: warning: Unknown Fortran type generating interface for C type: c_string
 unhandledType.chpl:6: In function 'returnsTuple':
-unhandledType.chpl:6: warning: Unknown Fortran KIND generating interface for C type: _ref__tuple_2_star_int64_t
-unhandledType.chpl:6: warning: Unknown Fortran type generating interface for C type: _ref__tuple_2_star_int64_t
+unhandledType.chpl:6: warning: Unknown Fortran KIND generating interface for C type: _ref__tuple_2_star_int64_t_chpl
+unhandledType.chpl:6: warning: Unknown Fortran type generating interface for C type: _ref__tuple_2_star_int64_t_chpl

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -34,7 +34,7 @@ for (i_chpl# = tmp_x#_chpl; ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#
 
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
 _ic__F#_i_chpl = INT#(#);
-for (_ic__F#_i_chpl = INT#(#),_ic__F#_i_chpl# = INT#(#); (tmp_chpl = (_ic__F#_i_chpl <= INT#(#)),tmp_chpl); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT#(#),_ic__F#_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(-#),_ic__F#_i_chpl# = tmp_chpl#) {
+for (_ic__F#_i_chpl = INT#(#),_ic__F#_i_chpl# = INT#(#); (tmp_chpl# = (_ic__F#_i_chpl <= INT#(#)),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT#(#),_ic__F#_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(-#),_ic__F#_i_chpl# = tmp_chpl#) {
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
 for (_ic__F#_i_chpl# = INT#(#),_ic__F#_i_chpl = tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += ret_chpl,_ic__F#_i_chpl = tmp_chpl#) {

--- a/test/users/npadmana/empty.chpl
+++ b/test/users/npadmana/empty.chpl
@@ -1,0 +1,2 @@
+export proc empty() { writeln("I am *not* empty!"); }
+empty();

--- a/test/users/npadmana/empty.good
+++ b/test/users/npadmana/empty.good
@@ -1,0 +1,1 @@
+I am *not* empty!


### PR DESCRIPTION
This PR munges most MOD_INTERNAL symbols with a `_chpl` suffix in order to prevent the likelihood of conflicts with user variables as noted in issue #14473.  It is a logical follow-on to #1209 and #1197.  The approach taken here is to not treat internal symbols differently from standard and user symbols, and to flag some built-in symbols as not being able to be renamed in cases where doing so would break code.

Some tests that were sensitive to the generated code needed to be updated as a result of these changes.

As part of this effort, I ran into challenges with the built-in `locale` and `addr` fields being munged in some places, but not others.  However, fields don't need to be protected from user symbols, since they're scoped names, so this PR also stops munging fields (in any module type).

Resolves #14473.