### PR TITLE
Don't test comd-elegant with comm=ofi.

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
@@ -3,6 +3,8 @@
 # Skip this test for gasnet+mpi and gasnet+ibv-large performance testing.
 # Also skip this test when using MPI-based launchers in other configs,
 # because mpirun barks at the fork(2) resulting from the spawn().
+# Also skip this test for comm=ofi; we have trouble with the spawn() in
+# that case also, at least with the verbs;ofi_rxm provider.
 import os
 
 comm = os.getenv('CHPL_COMM')
@@ -15,5 +17,6 @@ ml_perf = (os.getenv('CHPL_TEST_PERF') == 'on' and
 gn_mpi_perf = ml_perf and comm == 'gasnet' and substrate == 'mpi'
 gn_ibv_lg_perf = ml_perf and comm == 'gasnet' and substrate == 'ibv' and segment == 'large'
 mpi_config = launcher.startswith('mpi')
+comm_ofi = comm == 'ofi'
 
-print(gn_mpi_perf or gn_ibv_lg_perf or mpi_config)
+print(gn_mpi_perf or gn_ibv_lg_perf or mpi_config or comm_ofi)


### PR DESCRIPTION
Similar to other configurations, with comm=ofi comd-elegant's `spawn()`
call causes trouble, at least with the 'verbs;ofi-rxm' provider in ml-16
perf testing.  Skip this test for comm=ofi for now, until we can better
characterize just what the problem is and either figure out a way to
deal with it or refine the skipping.