### PR TITLE
Add comm=ofi testing support scripts.

### DIFF
--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -39,7 +39,6 @@ if [ -z "$lch" ] ; then
   module load gnu-openmpi
 
   set -x
-  : confirm mpi module is loaded
   module list -l 2>&1 | grep -E -q '\bgnu-openmpi\b' || return $?
 
   export MPI_DIR=$(which mpicc | sed 's,/bin/mpicc$,,')

--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Configure environment for CHPL_COMM=ofi testing.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
+source $CWD/common.bash
+source $CWD/common-oversubscribed.bash
+
+export CHPL_COMM=ofi
+
+# Select a launcher and out-of-band support.  If we're on a Cray XC
+# system this will just fall out automatically.  On a slurm-based system
+# where slurm was configured with the PMIx server-side plugin and we can
+# find a PMIx client-side library, then we can use slurm-srun directly,
+# along with the comm=ofi slurm-pmi2 out-of-band support.  This is seen
+# on Cray CS systems, for example.  Otherwise, our only option is the
+# stopgap mpirun4ofi launcher, in which case we also need MPI and the
+# MPI-based out-of-band support.
+lch=$($CHPL_HOME/util/chplenv/chpl_launcher.py)
+lchOK=
+
+if [ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) == cray-x* ] ; then
+  lchOK=y
+else if [ "$lch" == slurm-srun ] && \
+        srun --mpi=list 2>&1 | grep -q pmix && \
+        module avail pmix 2>&1 | grep -q pmix ; then
+  module load pmix
+  export CHPL_COMM_OFI_OOB=slurm-pmi2
+  export SLURM_MPI_TYPE=pmix
+  lchOK=y
+fi
+
+if [ -z "$lch" ] ; then
+  export CHPL_LAUNCHER=mpirun4ofi
+
+  # Load OpenMPI environment module and confirm it has loaded
+  echo >&2 module load gnu-openmpi
+  module load gnu-openmpi
+
+  set -x
+  : confirm mpi module is loaded
+  module list -l 2>&1 | grep -E -q '\bgnu-openmpi\b' || return $?
+
+  export MPI_DIR=$(which mpicc | sed 's,/bin/mpicc$,,')
+fi
+
+# Make sure we have a libfabric to use, with the required API version.
+source /cray/css/users/chapelu/setup_libfabric.bash || return 1
+
+if [ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-* ] ; then
+  # Bump the timeout slightly if we might be oversubscribed.
+  export CHPL_TEST_TIMEOUT=500
+fi
+

--- a/util/cron/test-ofi.bash
+++ b/util/cron/test-ofi.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Test comm=ofi on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+source $CWD/common-ofi.bash || \
+  ( echo "Could not set up comm=ofi testing." && exit 1 )
+
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_DIRS="release/examples"
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="ofi"
+
+$CWD/nightly -cron -futures $(get_nightly_paratest_args 3)

--- a/util/cron/test-perf.cray-cs.ofi.bash
+++ b/util/cron/test-perf.cray-cs.ofi.bash
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Run performance tests with comm=ofi on a cray-cs system.
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
+
+source $CWD/common-perf.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.ofi"
+
+module load gcc
+module load python/2.7.6
+module load pmix
+
+export CHPL_HOST_PLATFORM=cray-cs
+export CHPL_COMM=ofi
+export CHPL_COMM_OFI_OOB=slurm-pmi2
+export SLURM_MPI_TYPE=pmix
+export CHPL_RT_MAX_HEAP_SIZE=83G
+export CHPL_LAUNCHER=slurm-srun
+export CHPL_LAUNCHER_PARTITION=bdw18
+export CHPL_TARGET_CPU=broadwell
+
+source /cray/css/users/chapelu/setup_libfabric.bash || return 1
+
+nightly_args="${nightly_args} -no-buildcheck"
+
+perf_args="-performance-description ofi -performance-configs gn-ibv-large,gn-ibv-fast:v,gn-mpi"
+perf_args="${perf_args} -performance -perflabel ml- -numtrials 1 -startdate 12/01/19"
+
+$CWD/nightly -cron ${perf_args} ${nightly_args}

--- a/util/cron/test-perf.cray-cs.ofi.bash
+++ b/util/cron/test-perf.cray-cs.ofi.bash
@@ -27,7 +27,7 @@ source /cray/css/users/chapelu/setup_libfabric.bash || return 1
 
 nightly_args="${nightly_args} -no-buildcheck"
 
-perf_args="-performance-description ofi -performance-configs gn-ibv-large,gn-ibv-fast:v,gn-mpi"
-perf_args="${perf_args} -performance -perflabel ml- -numtrials 1 -startdate 12/01/19"
+perf_args="-performance-description ofi -performance-configs gn-ibv-large,gn-ibv-fast:v,gn-mpi,ofi:v"
+perf_args="${perf_args} -performance -perflabel ml- -numtrials 1 -startdate 11/20/19"
 
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
This is the initial attempt at setup scripts for comm=ofi functional and
performance testing.  Initially this is just aimed at supporting testing
on Cray CS systems.  The perf testing part may still need some work,
but we're going to delay turning that on for now.  The functional part
should be ready to go.