### PR TITLE
Fix a number of flaws in comm=ofi functional testing.

### DIFF
--- a/util/cron/common-cs.bash
+++ b/util/cron/common-cs.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Check for, and configure environment for, a Cray CS system.
+#  input: $1: 'y' to print a message if this doesn't seem to be a
+#             Cray CS system, otherwise silent 
+#  output: iff this seems to be a CS, CHPL_HOST_PLATFORM=cray-cs
+
+function loadCSModule()
+{
+  local m=$@
+  if module avail $m 2>&1 | grep -F -q $m ; then
+    module load $m
+  else
+    log_info "This seems to be a Cray CS system, but lacks module $m."
+  fi
+}
+
+if module avail craype- 2>&1 | grep -q craype- ; then
+  export CHPL_HOST_PLATFORM=cray-cs
+  loadCSModule gcc
+  loadCSModule python/2.7.6
+else
+  [ "$1" == y ] && log_info "Expected Cray CS, but does not seem to be one."
+fi

--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -5,7 +5,11 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 source $CWD/common.bash
-source $CWD/common-oversubscribed.bash
+source $CWD/common-cs.bash
+
+if [ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-* ] ; then
+  source $CWD/common-oversubscribed.bash
+fi
 
 export CHPL_COMM=ofi
 
@@ -17,21 +21,20 @@ export CHPL_COMM=ofi
 # on Cray CS systems, for example.  Otherwise, our only option is the
 # stopgap mpirun4ofi launcher, in which case we also need MPI and the
 # MPI-based out-of-band support.
-lch=$($CHPL_HOME/util/chplenv/chpl_launcher.py)
 lchOK=
-
 if [ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) == cray-x* ] ; then
   lchOK=y
-elif [ "$lch" == slurm-srun ] && \
-       srun --mpi=list 2>&1 | grep -q pmix && \
-       module avail pmix 2>&1 | grep -q pmix ; then
+elif [ "$($CHPL_HOME/util/chplenv/chpl_launcher.py)" == slurm-srun ] && \
+     srun --mpi=list 2>&1 | grep -q pmix && \
+     module avail pmix 2>&1 | grep -q pmix ; then
   module load pmix
+  export CHPL_LAUNCHER=slurm-srun
   export CHPL_COMM_OFI_OOB=slurm-pmi2
   export SLURM_MPI_TYPE=pmix
   lchOK=y
 fi
 
-if [ -z "$lch" ] ; then
+if [ -z "$lchOK" ] ; then
   export CHPL_LAUNCHER=mpirun4ofi
 
   # Load OpenMPI environment module and confirm it has loaded

--- a/util/cron/test-ofi.bash
+++ b/util/cron/test-ofi.bash
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 #
-# Test comm=ofi on linux64.
+# Test comm=ofi, functionally.
 
 CWD=$(cd $(dirname $0) ; pwd)
 
 source $CWD/common-ofi.bash || \
   ( echo "Could not set up comm=ofi testing." && exit 1 )
 
+if [ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) == cray-cs ] ; then
+  # Need fixed heap on CS systems.
+  # As we test on more targets we might need to adjust this to be a
+  # check against the expected libfabric provider.
+  export CHPL_RT_MAX_HEAP_SIZE=16g
+fi
+
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_DIRS="release/examples"
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ofi"
 


### PR DESCRIPTION
Yesterday's trial runs of comm=ofi function testing revealed a number of
flaws in the scripts.  Fix those here: move cray-cs oriented setup into
its own script, do a better job of recognizing whether or not we're on a
cray-cs platform, and add some cray-cs specific setup that was missing
(notably, loading gcc and python modules).

In a future change, I'll also use the new common Cray CS setup script
for our cray-cs,comm=gasnet testing.