### PR TITLE
Change bytes interop test to use portable C99 format specifier

### DIFF
--- a/test/interop/C/exportBytes/noArgsRetBytes.test.c
+++ b/test/interop/C/exportBytes/noArgsRetBytes.test.c
@@ -1,4 +1,5 @@
 #include "lib/TestLibrary.h"
+#include <stdint.h>
 
 //
 // This test verifies some of the behavior of the `chpl_bytes` wrapper that
@@ -12,7 +13,7 @@ int main(int argc, char** argv) {
 
   printf("cb.isOwned: %s\n", (msg.isOwned ? "true" : "false"));
   printf("cb.data: %s\n", msg.data);
-  printf("cb.size: %zu\n", msg.size);
+  printf("cb.size: %" PRIu64 "\n", msg.size);
 
   chpl_bytes_wrapper_free(msg);
 


### PR DESCRIPTION
This PR adjusts a test to use a portable C99 format specifier. In #14471 I changed the bytes wrapper type to use fixed width scalars for portability, and forgot to adjust this test.

---

Testing:

- [x] `interop/C/exportBytes/noArgsRetBytes.test.c` on `darwin` with `CHPL_COMM=none`
- [x] `interop/C/exportBytes/noArgsRetBytes.test.c` on `linux64` with `CHPL_COMM=none`