### PR TITLE
Add bytes support to ZMQ

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -167,7 +167,7 @@ Serialization
 +++++++++++++
 
 In Chapel, sending or receiving messages is supported for a variety of types.
-Primitive numeric types, along with ``string`` and ``bytes`` are supported as the
+Primitive numeric types, strings and bytes are supported as the
 foundation.  In addition, user-defined ``record`` types may be serialized
 automatically as `multipart messages
 <http://zguide.zeromq.org/page:all#Multipart-Messages>`_ by internal use of the

--- a/test/library/packages/ZMQ/pair.chpl
+++ b/test/library/packages/ZMQ/pair.chpl
@@ -80,6 +80,13 @@ proc Master() {
     socket.send(val);
   }
 
+  // Bytes
+  {
+    var val = socket.recv(bytes);
+    val += b"jumps over the lazy dog again.";
+    socket.send(val);
+  }
+
   // "Basic" Records
   {
     var val = socket.recv(Foo);
@@ -118,6 +125,14 @@ proc Worker() {
     var val = "The quick brown fox...";
     socket.send(val);
     val = socket.recv(string);
+    writeln("val = ", val);
+  }
+
+  // Bytes
+  {
+    var val = b"The quick brown fox...";
+    socket.send(val);
+    val = socket.recv(bytes);
     writeln("val = ", val);
   }
 

--- a/test/library/packages/ZMQ/pair.chpl
+++ b/test/library/packages/ZMQ/pair.chpl
@@ -83,7 +83,7 @@ proc Master() {
   // Bytes
   {
     var val = socket.recv(bytes);
-    val += b"jumps over the lazy dog again.";
+    val += b"jumps over the \xff\xff\xff non-UTF8 bytes.";
     socket.send(val);
   }
 
@@ -130,7 +130,7 @@ proc Worker() {
 
   // Bytes
   {
-    var val = b"The quick brown fox...";
+    var val = b"The quick \xff\xff\xff brown fox...";
     socket.send(val);
     val = socket.recv(bytes);
     writeln("val = ", val);

--- a/test/library/packages/ZMQ/pair.good
+++ b/test/library/packages/ZMQ/pair.good
@@ -1,5 +1,5 @@
 val = 546.0
 val = D
 val = The quick brown fox...jumps over the lazy dog.
-val = The quick brown fox...jumps over the lazy dog again.
+val = The quick ÿÿÿ brown fox...jumps over the ÿÿÿ non-UTF8 bytes.
 val = (a = 84, b = 42.0, c = HELLO, d = (a = 8.0 - 4.0i, b = Good Bye))

--- a/test/library/packages/ZMQ/pair.good
+++ b/test/library/packages/ZMQ/pair.good
@@ -1,4 +1,5 @@
 val = 546.0
 val = D
 val = The quick brown fox...jumps over the lazy dog.
+val = The quick brown fox...jumps over the lazy dog again.
 val = (a = 84, b = 42.0, c = HELLO, d = (a = 8.0 - 4.0i, b = Good Bye))


### PR DESCRIPTION
This PR adds support for the `bytes` type in the ZMQ module.

Summary:
- Mimic the support for send/recv `string`s.
- Update docs
- Update a ZMQ test to send/recv `bytes`

This is should ideally be merged before the UTF8 validation PR (#14384), so that
arbitrary data can be send/recv'd using `bytes` object with ZMQ.

Test status:
- [x] standard `test/library/packages/ZMQ` (run locally)
- [x] full standard
- [x] full gasnet