### PR TITLE
Adjust .bad file for interop future

### DIFF
--- a/test/interop/C/multilocale/arrays/exportFuncWithArrayArg.bad
+++ b/test/interop/C/multilocale/arrays/exportFuncWithArrayArg.bad
@@ -1,1 +1,1 @@
-exportFuncWithArrayArg.chpl:1: error: Multi-locale libraries do not support formal type: _ref(chpl_external_array)
+exportFuncWithArrayArg.chpl:1: error: Multi-locale libraries do not support formal type: chpl_external_array


### PR DESCRIPTION
This PR adjusts the expected output for a `.bad` file of a future. After #14471 aggregate types are passed by value in exported Chapel routines. Adjust this "arrays in multilocale interop" future to account for that.