### PR TITLE
Update ReplicatedVar to keep Arkouda working for private standard uses

### DIFF
--- a/modules/packages/ReplicatedVar.chpl
+++ b/modules/packages/ReplicatedVar.chpl
@@ -98,7 +98,7 @@ Declarations
 */
 module ReplicatedVar {
 
-use ReplicatedDist;
+public use ReplicatedDist;
 
 private const rcDomainIx   = 1; // todo convert to param
 /* Use this domain when replicating over a subset of locales,


### PR DESCRIPTION
Now that `use` means `private use` in standard modules, Arkouda
won't build unless ReplicatedVar's `use` of `ReplicatedDist` is
made `public`.