### PR TITLE
Set a stopgap timeout in the hope comm=ofi perf testing will succeed.

### DIFF
--- a/util/cron/test-perf.cray-cs.ofi.bash
+++ b/util/cron/test-perf.cray-cs.ofi.bash
@@ -15,6 +15,10 @@ source $CWD/common-cray-cs.bash y
 source $CWD/common-perf-cray-cs.bash
 source $CWD/common-ofi.bash
 
+# Stopgap: bump the timeout so all tests pass.  (empty-chpl-remote-taskspawn
+# and miniMD time out with the default limit of 300.)
+export CHPL_TEST_TIMEOUT=1800
+
 if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-cs ]] || \
    [[ "$CHPL_COMM_OFI_OOB" != slurm-pmi2 ]] || \
    [[ "$SLURM_MPI_TYPE" != pmix ]] ; then


### PR DESCRIPTION
Comm=ofi perf testing is completing, but the graph generation (?) and
syncing is failing.  Two tests are timing out.  Increase the timeout to
allow them to pass, in the hope that this will let everything work.