### PR TITLE
Fix TOML tests to work with 'private use' in standard modules by default

### DIFF
--- a/test/library/packages/TOML/BurntSushi/Passing.chpl
+++ b/test/library/packages/TOML/BurntSushi/Passing.chpl
@@ -1,4 +1,4 @@
-use TOML;
+use TOML, IO;
 
 /*
   Tests from BurntSushi/toml-test 'valid' suite:

--- a/test/library/packages/TOML/BurntSushi/TomlTest.chpl
+++ b/test/library/packages/TOML/BurntSushi/TomlTest.chpl
@@ -1,4 +1,4 @@
-use TOML;
+use TOML, IO;
 
 /*
   Tests from BurntSushi/toml-test 'valid' suite:

--- a/test/library/packages/TOML/test/fileTest.chpl
+++ b/test/library/packages/TOML/test/fileTest.chpl
@@ -1,4 +1,4 @@
-use TOML;
+use TOML, IO;
 
 config const f: string;
 


### PR DESCRIPTION
I'm not sure how these slipped by in my testing, but these three tests
required a `use IO` to work in a world where they weren't getting that
transitively from the `TOML` module, as they were before.