### PR TITLE
Suppress Fortran unhandledType test until LLVM munges internal symbols

### DIFF
--- a/test/interop/fortran/genFortranInterface/unhandledType.suppressif
+++ b/test/interop/fortran/genFortranInterface/unhandledType.suppressif
@@ -1,0 +1,3 @@
+# munging of internal symbols is currently disabled for llvm, so
+# suppress this test which is sensitive to such symbols for now
+COMPOPTS <= --llvm


### PR DESCRIPTION
This test is sensitive to the names of symbols in the generated code
and required updating when I started munging internal symbols in PR
#14487.  However, when I disabled this munging for `--llvm` compiles
last night in PR #14513, I failed to think that it would cause problems
for this test in LLVM test configurations.

Here, I'm suppressing the failure when `--llvm` is thrown to address this
and to help remember to re-enable it when LLVM isn't special-cased in
this way.