### PR TITLE
Skip two extern .futures for --llvm

### DIFF
--- a/test/extern/diten/externLong.skipif
+++ b/test/extern/diten/externLong.skipif
@@ -1,2 +1,3 @@
 # This test uses a gnu specific compiler option, so skip for other compilers
 CHPL_TARGET_COMPILER!=gnu
+COMPOPTS <= --llvm

--- a/test/extern/diten/passlongptr.skipif
+++ b/test/extern/diten/passlongptr.skipif
@@ -1,2 +1,3 @@
 # This test uses a gnu specific compiler option, so skip for other compilers
 CHPL_TARGET_COMPILER!=gnu
+COMPOPTS <= --llvm


### PR DESCRIPTION

These two .future tests use the -Wincompatible-pointer-types flag to get
warnings/errors for incompatible pointer types. The llvm backend doesn't
recognize/issue the warnings for this flag, so skip the tests if --llvm
is used.

[trivial test update]