### PR TITLE
Add a cache for determining if an actual type is coercible in function resolution

### DIFF
--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -23,12 +23,16 @@
 #include "baseAST.h"
 #include "vec.h"
 
+#include <map>
 #include <vector>
 
 class ArgSymbol;
 class CallInfo;
 class FnSymbol;
 class Symbol;
+
+extern std::map<Type*,std::map<Type*,bool>*> actualFormalCoercible;
+void clearCoercibleCache(void);
 
 typedef enum {
   // These are in order of severity, for failedCandidateIsBetterMatch.

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -36,6 +36,9 @@ static ResolutionCandidateFailureReason
 classifyTypeMismatch(Type* actualType, Type* formalType);
 static Type* getInstantiationType(Symbol* actual, ArgSymbol* formal, Expr* ctx);
 static bool shouldAllowCoercions(Symbol* actual, ArgSymbol* formal);
+static bool shouldAllowCoercionsType(Type* actualType, Type* formalType);
+
+std::map<Type*,std::map<Type*,bool>*> actualFormalCoercible;
 
 /************************************* | **************************************
 *                                                                             *
@@ -414,28 +417,54 @@ static bool shouldAllowCoercions(Symbol* actual, ArgSymbol* formal) {
     // ... however, make an exception for class subtyping.
     Type* actualType = actual->getValType();
     Type* formalType = formal->getValType();
-    if (isClassLikeOrManaged(actualType) && isClassLikeOrManaged(formalType)) {
-      Type* canonicalActual = canonicalClassType(actualType);
-      ClassTypeDecorator actualD = classTypeDecorator(actualType);
-
-      Type* canonicalFormal = canonicalClassType(formalType);
-      ClassTypeDecorator formalD = classTypeDecorator(formalType);
-
-      AggregateType* at = toAggregateType(canonicalActual);
-
-      if (canInstantiateOrCoerceDecorators(actualD, formalD, false, false)) {
-        if (canonicalActual == canonicalFormal ||
-            isDispatchParent(canonicalActual, canonicalFormal) ||
-            (at && at->instantiatedFrom &&
-             canonicalFormal->symbol->hasFlag(FLAG_GENERIC) &&
-             getConcreteParentForGenericFormal(at, canonicalFormal) != NULL)) {
-          allowCoercions = true;
-        }
+    std::map<Type*,bool> *formalCoercible = actualFormalCoercible[actualType];
+    if (formalCoercible != NULL) {
+      if (formalCoercible->count(formalType) > 0) {
+        allowCoercions = (*formalCoercible)[formalType];
+      } else {
+        allowCoercions = shouldAllowCoercionsType(actualType, formalType);
+        (*formalCoercible)[formalType] = allowCoercions;
       }
+    } else {
+      std::map<Type*,bool> *formalCoercible = new std::map<Type*,bool>();
+      allowCoercions = shouldAllowCoercionsType(actualType, formalType);
+      (*formalCoercible)[formalType] = allowCoercions;
+      actualFormalCoercible[actualType] = formalCoercible;
     }
   }
 
   return allowCoercions;
+}
+
+static bool shouldAllowCoercionsType(Type* actualType, Type* formalType) {
+  if (isClassLikeOrManaged(actualType) && isClassLikeOrManaged(formalType)) {
+    Type* canonicalActual = canonicalClassType(actualType);
+    ClassTypeDecorator actualD = classTypeDecorator(actualType);
+
+    Type* canonicalFormal = canonicalClassType(formalType);
+    ClassTypeDecorator formalD = classTypeDecorator(formalType);
+
+    AggregateType* at = toAggregateType(canonicalActual);
+
+    if (canInstantiateOrCoerceDecorators(actualD, formalD, false, false)) {
+      if (canonicalActual == canonicalFormal ||
+          isDispatchParent(canonicalActual, canonicalFormal) ||
+          (at && at->instantiatedFrom &&
+           canonicalFormal->symbol->hasFlag(FLAG_GENERIC) &&
+           getConcreteParentForGenericFormal(at, canonicalFormal) != NULL)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void clearCoercibleCache() {
+  std::map<Type*,std::map<Type*,bool>*>::iterator it;
+  for (it = actualFormalCoercible.begin(); it != actualFormalCoercible.end();
+       ++it) {
+    delete it->second;
+  }
 }
 
 // Uses formalSym and actualSym to compute allowCoercion and implicitBang

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8131,6 +8131,8 @@ void resolve() {
 
   clearPartialCopyDataFnMap();
 
+  clearCoercibleCache();
+
   forv_Vec(BlockStmt, stmt, gBlockStmts) {
     stmt->useListClear();
   }


### PR DESCRIPTION
While individual actuals being able to coerce to individual formals would be an
independent operation, it seemed likely that there could be some time saved
by remembering if a particular type combination for formals and actuals was
coercible.

The FFT compiler performance test showed a 6.9% speedup with this change
in resolution and 3% speedup in compilation, and arkouda seemed to compile
1.4% faster, though there was some slight overlap with the baseline timings for
FFT.  These were all compared on my machine

Passed a full paratest with futures and gasnet testing in release/examples