### PR TITLE
Eliminate spurious "this source location is a guess" in warnings

### DIFF
--- a/test/arrays/vass/initialization-mapped-1.good
+++ b/test/arrays/vass/initialization-mapped-1.good
@@ -1,5 +1,3 @@
 initialization-mapped-1.chpl:8: warning: BlockDom(1,int(64),false,unmanaged DefaultDist)
 initialization-mapped-1.chpl:9: warning: BlockDom(1,int(64),false,unmanaged DefaultDist)
-Note: This source location is a guess.
-initialization-mapped-1.chpl:9: warning: BlockDom(1,int(64),false,unmanaged DefaultDist)
 initialization-mapped-1.chpl:11: error: done

--- a/test/classes/nilability/nilable-equalities.good
+++ b/test/classes/nilability/nilable-equalities.good
@@ -3,19 +3,11 @@ nilable-equalities.chpl:23: warning: borrowed MyClass
 nilable-equalities.chpl:24: warning: owned MyClass?
 nilable-equalities.chpl:25: warning: shared MyClass
 nilable-equalities.chpl:26: warning: borrowed MyClass
-Note: This source location is a guess.
-nilable-equalities.chpl:26: warning: borrowed MyClass
 nilable-equalities.chpl:27: warning: shared MyClass?
 nilable-equalities.chpl:28: warning: borrowed MyClass
-Note: This source location is a guess.
-nilable-equalities.chpl:28: warning: borrowed MyClass
-nilable-equalities.chpl:29: warning: borrowed MyClass
-Note: This source location is a guess.
 nilable-equalities.chpl:29: warning: borrowed MyClass
 nilable-equalities.chpl:30: warning: borrowed MyClass?
 nilable-equalities.chpl:31: warning: unmanaged MyClass
-nilable-equalities.chpl:32: warning: borrowed MyClass
-Note: This source location is a guess.
 nilable-equalities.chpl:32: warning: borrowed MyClass
 nilable-equalities.chpl:33: warning: unmanaged MyClass?
 nilable-equalities.chpl:195: error: done

--- a/test/parsing/precedence/memmanage-vs-cast.good
+++ b/test/parsing/precedence/memmanage-vs-cast.good
@@ -1,6 +1,4 @@
 memmanage-vs-cast.chpl:8: warning: borrowed C
 memmanage-vs-cast.chpl:9: warning: borrowed C
-Note: This source location is a guess.
-memmanage-vs-cast.chpl:9: warning: borrowed C
 memmanage-vs-cast.chpl:10: warning: owned C
 memmanage-vs-cast.chpl:12: error: done

--- a/test/types/enum/addEnumUint8.good
+++ b/test/types/enum/addEnumUint8.good
@@ -1,6 +1,4 @@
 addEnumUint8.chpl:5: warning: uint(8)
 addEnumUint8.chpl:6: warning: uint(8)
-Note: This source location is a guess.
-addEnumUint8.chpl:6: warning: uint(8)
 addEnumUint8.chpl:7: error: unresolved call '+(E, 1)'
 (prediff deleted module lines)

--- a/test/users/vass/isX/isX.sync-by-const.good
+++ b/test/users/vass/isX/isX.sync-by-const.good
@@ -1,15 +1,7 @@
 isX.sync-by-const.chpl:7: warning: true
 isX.sync-by-const.chpl:8: warning: true
-Note: This source location is a guess.
-isX.sync-by-const.chpl:8: warning: true
-isX.sync-by-const.chpl:9: warning: true
-Note: This source location is a guess.
 isX.sync-by-const.chpl:9: warning: true
 isX.sync-by-const.chpl:12: warning: false
 isX.sync-by-const.chpl:13: warning: false
-Note: This source location is a guess.
-isX.sync-by-const.chpl:13: warning: false
-isX.sync-by-const.chpl:14: warning: false
-Note: This source location is a guess.
 isX.sync-by-const.chpl:14: warning: false
 isX.sync-by-const.chpl:16: error: done

--- a/test/users/vass/type-tests.isSubtype.good
+++ b/test/users/vass/type-tests.isSubtype.good
@@ -61,8 +61,6 @@ type-tests.isSubtype.chpl:95: warning: U1,       C1       false
 type-tests.isSubtype.chpl:96: warning: U1,       R1       false
 type-tests.isSubtype.chpl:98: warning: isProperSubtype - scalars
 type-tests.isSubtype.chpl:99: warning: int, real   false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:99: warning: int, real   false
 type-tests.isSubtype.chpl:100: warning: real, real  false
 type-tests.isSubtype.chpl:102: warning: isProperSubtype - domains and arrays
 type-tests.isSubtype.chpl:103: warning: D1, D2            false
@@ -73,137 +71,55 @@ type-tests.isSubtype.chpl:107: warning: {AA1,AA2}._value  false
 type-tests.isSubtype.chpl:109: warning: isProperSubtype - classes
 type-tests.isSubtype.chpl:110: warning: C1, C1  false
 type-tests.isSubtype.chpl:111: warning: C1, C2  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:111: warning: C1, C2  false
-type-tests.isSubtype.chpl:112: warning: C1, C3  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:112: warning: C1, C3  false
 type-tests.isSubtype.chpl:113: warning: C1, C4  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:113: warning: C1, C4  false
-type-tests.isSubtype.chpl:114: warning: C2, C1  true
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:114: warning: C2, C1  true
 type-tests.isSubtype.chpl:115: warning: C2, C2  false
 type-tests.isSubtype.chpl:116: warning: C2, C3  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:116: warning: C2, C3  false
-type-tests.isSubtype.chpl:117: warning: C2, C4  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:117: warning: C2, C4  false
 type-tests.isSubtype.chpl:118: warning: C3, C1  true
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:118: warning: C3, C1  true
-type-tests.isSubtype.chpl:119: warning: C3, C2  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:119: warning: C3, C2  false
 type-tests.isSubtype.chpl:120: warning: C3, C3  false
 type-tests.isSubtype.chpl:121: warning: C3, C4  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:121: warning: C3, C4  false
-type-tests.isSubtype.chpl:122: warning: C4, C1  true
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:122: warning: C4, C1  true
 type-tests.isSubtype.chpl:123: warning: C4, C2  true
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:123: warning: C4, C2  true
-type-tests.isSubtype.chpl:124: warning: C4, C3  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:124: warning: C4, C3  false
 type-tests.isSubtype.chpl:125: warning: C4, C4  false
 type-tests.isSubtype.chpl:127: warning: isProperSubtype - records
 type-tests.isSubtype.chpl:128: warning: R1, R1  false
 type-tests.isSubtype.chpl:147: warning: isProperSubtype - mixing up
 type-tests.isSubtype.chpl:148: warning: real,     D1.type  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:148: warning: real,     D1.type  false
-type-tests.isSubtype.chpl:149: warning: real,     AA1.type false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:149: warning: real,     AA1.type false
 type-tests.isSubtype.chpl:150: warning: real,     C1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:150: warning: real,     C1       false
-type-tests.isSubtype.chpl:151: warning: real,     R1       false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:151: warning: real,     R1       false
 type-tests.isSubtype.chpl:152: warning: real,     U1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:152: warning: real,     U1       false
-type-tests.isSubtype.chpl:153: warning: D1.type,  real     false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:153: warning: D1.type,  real     false
 type-tests.isSubtype.chpl:154: warning: D1.type,  D1.type  false
 type-tests.isSubtype.chpl:155: warning: D1.type,  AA1.type false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:155: warning: D1.type,  AA1.type false
-type-tests.isSubtype.chpl:156: warning: D1.type,  C1       false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:156: warning: D1.type,  C1       false
 type-tests.isSubtype.chpl:157: warning: D1.type,  R1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:157: warning: D1.type,  R1       false
-type-tests.isSubtype.chpl:158: warning: D1.type,  U1       false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:158: warning: D1.type,  U1       false
 type-tests.isSubtype.chpl:159: warning: AA1.type, real     false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:159: warning: AA1.type, real     false
-type-tests.isSubtype.chpl:160: warning: AA1.type, D1.type  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:160: warning: AA1.type, D1.type  false
 type-tests.isSubtype.chpl:161: warning: AA1.type, AA1.type false
 type-tests.isSubtype.chpl:162: warning: AA1.type, C        false
 type-tests.isSubtype.chpl:163: warning: AA1.type, R        false
 type-tests.isSubtype.chpl:164: warning: AA1.type, U1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:164: warning: AA1.type, U1       false
-type-tests.isSubtype.chpl:165: warning: C1,       real     false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:165: warning: C1,       real     false
 type-tests.isSubtype.chpl:166: warning: C1,       D1.type  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:166: warning: C1,       D1.type  false
-type-tests.isSubtype.chpl:167: warning: C1,       AA1.type false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:167: warning: C1,       AA1.type false
 type-tests.isSubtype.chpl:168: warning: C1,       R1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:168: warning: C1,       R1       false
-type-tests.isSubtype.chpl:169: warning: C1,       U1       false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:169: warning: C1,       U1       false
 type-tests.isSubtype.chpl:170: warning: R1,       real     false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:170: warning: R1,       real     false
-type-tests.isSubtype.chpl:171: warning: R1,       D1.type  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:171: warning: R1,       D1.type  false
 type-tests.isSubtype.chpl:172: warning: R1,       AA1.type false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:172: warning: R1,       AA1.type false
-type-tests.isSubtype.chpl:173: warning: R1,       C1       false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:173: warning: R1,       C1       false
 type-tests.isSubtype.chpl:174: warning: R1,       U1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:174: warning: R1,       U1       false
-type-tests.isSubtype.chpl:175: warning: U1,       real     false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:175: warning: U1,       real     false
 type-tests.isSubtype.chpl:176: warning: U1,       D1.type  false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:176: warning: U1,       D1.type  false
-type-tests.isSubtype.chpl:177: warning: U1,       AA1.type false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:177: warning: U1,       AA1.type false
 type-tests.isSubtype.chpl:178: warning: U1,       C1       false
-Note: This source location is a guess.
-type-tests.isSubtype.chpl:178: warning: U1,       C1       false
-type-tests.isSubtype.chpl:179: warning: U1,       R1       false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:179: warning: U1,       R1       false
 type-tests.isSubtype.chpl:182: warning: U1, U2  false
-type-tests.isSubtype.chpl:183: warning: U1, U2  false
-Note: This source location is a guess.
 type-tests.isSubtype.chpl:183: warning: U1, U2  false
 type-tests.isSubtype.chpl:185: error: done


### PR DESCRIPTION
In some cases the compiler produces this output for a compilerWarning() call:

    LOCATION: warning: TEXT
    Note: This source location is a guess.
    LOCATION: warning: TEXT

where LOCATION and TEXT are determined by the call.
This PR changes it to just:

    LOCATION: warning: TEXT

It updates .good files correspondingly.

### Background

The compiler uses caching when issuing warnings for compilerWarning() calls
in Chapel code. There is a good reason for it. The compiler prints a
warning - by invoking USR_WARN - when it encounters __primitive("warning")
while resolving a compilerWarning function. This happens only the first time
that compilerWarning() is invoked with a given set of actual arguments.
If there is a compilerWarning() call with the same set of actuals in a
different point in the code, compilerWarning() is not resolved again.
Instead, the compiler checks the cache and invokes USR_WARN when there is
a cache entry.

What if there are several different paths to the compilerWarning() call that
share a suffix? ex. `a() -> x() -> y() -> compilerWarning("example")` and
`b() -> x() -> y() -> compilerWarning("example")` ? To issue the warning,
the cache needs entries for the appropriate instantiations of compilerWarning(),
y(), and x().

The current implementation of caching, based on `innerMap` and `outerMap`,
is not perfect because it works incorrectly in some corner cases and because
it can generate the same warning twice, doubting itself the first time by
printing "Note: This source location is a guess."

The current PR does not address the imperfection. It simply improves user
experience by recognizing the latter scenario happens and fixing it up.
"This source location is a guess" note is still printed when appropriate.

Testing: standard and gasnet, with futures.