### PR TITLE
User error, not crash, for compilerWarning(string,bool)

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7887,14 +7887,10 @@ static void resolveExprMaybeIssueError(CallExpr* call) {
 
        if         (var                        != NULL &&
                    var->immediate             != NULL &&
-                   var->immediate->const_kind != CONST_KIND_STRING) {
-        if (var->immediate->const_kind == NUM_KIND_BOOL) {
-          USR_FATAL_CONT(from, "bool arguments to compilerWarning()"
-            " and compilerError() must be cast to string");
-          str = astr(str, var->immediate->v_bool ? "true" : "false");
-        } else
-          INT_FATAL(call, "unexpected case");
-       } else
+                   var->immediate->const_kind != CONST_KIND_STRING)
+        USR_FATAL(from, "arguments to compilerWarning() and compilerError(),"
+          " except for the optional depth argument, must be cast to string");
+       else
         str = astr(str, var->immediate->v_string);
       }
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7885,10 +7885,16 @@ static void resolveExprMaybeIssueError(CallExpr* call) {
       if (foundDepthVal == false || arg->defPoint != fn->formals.tail) {
         var = toVarSymbol(paramMap.get(arg));
 
-        INT_ASSERT(var                        != NULL &&
+       if         (var                        != NULL &&
                    var->immediate             != NULL &&
-                   var->immediate->const_kind == CONST_KIND_STRING);
-
+                   var->immediate->const_kind != CONST_KIND_STRING) {
+        if (var->immediate->const_kind == NUM_KIND_BOOL) {
+          USR_FATAL_CONT(from, "bool arguments to compilerWarning()"
+            " and compilerError() must be cast to string");
+          str = astr(str, var->immediate->v_bool ? "true" : "false");
+        } else
+          INT_FATAL(call, "unexpected case");
+       } else
         str = astr(str, var->immediate->v_string);
       }
     }

--- a/test/trivial/vass/warning-with-bool.chpl
+++ b/test/trivial/vass/warning-with-bool.chpl
@@ -1,0 +1,5 @@
+
+compilerWarning("hasField 1 ", false);
+compilerWarning("hasField 2 ", "actually ", true);
+compilerWarning("either way ", "is fine");
+writeln("hi");

--- a/test/trivial/vass/warning-with-bool.good
+++ b/test/trivial/vass/warning-with-bool.good
@@ -1,0 +1,5 @@
+warning-with-bool.chpl:2: error: bool arguments to compilerWarning() and compilerError() must be cast to string
+warning-with-bool.chpl:2: warning: hasField 1 false
+warning-with-bool.chpl:3: error: bool arguments to compilerWarning() and compilerError() must be cast to string
+warning-with-bool.chpl:3: warning: hasField 2 actually true
+warning-with-bool.chpl:4: warning: either way is fine

--- a/test/trivial/vass/warning-with-bool.good
+++ b/test/trivial/vass/warning-with-bool.good
@@ -1,5 +1,1 @@
-warning-with-bool.chpl:2: error: bool arguments to compilerWarning() and compilerError() must be cast to string
-warning-with-bool.chpl:2: warning: hasField 1 false
-warning-with-bool.chpl:3: error: bool arguments to compilerWarning() and compilerError() must be cast to string
-warning-with-bool.chpl:3: warning: hasField 2 actually true
-warning-with-bool.chpl:4: warning: either way is fine
+warning-with-bool.chpl:2: error: arguments to compilerWarning() and compilerError(), except for the optional depth argument, must be cast to string


### PR DESCRIPTION
Given a user call like `compilerWarning("hi", true)`, the compiler now issues a user error "bool arguments to compilerWarning() and compilerError() must be cast to string". Before this change it would crash with an assertion.

#### Background

When a function has a param int formal, a param boolean can be passed to it,
as expected, because of to implicit conversion bool->int.
While resolving that function, however, while the formal's type is `int`,
`paramMap` has the boolean value for that formal. This used to crash
`resolveExprMaybeIssueError()` in the compiler. This mismatch might get us
in trouble in other corner cases too, although I am unaware of that.

Testing: standard paratest.