### PR TITLE
Check the type argument of numFields() et al.

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -1004,11 +1004,11 @@ module DefaultAssociative {
   inline proc chpl__defaultHash(r : range): uint {
     use Reflection;
     var ret : uint;
-    for param i in 1..numFields(r.type) {
-      if isParam(getField(r, i)) == false &&
-         isType(getField(r, i)) == false &&
-         isNothingType(getField(r, i).type) == false {
-        const ref field = getField(r, i);
+    for param i in 1..numImplementationFields(r.type) {
+      if isParam(getImplementationField(r, i)) == false &&
+         isType(getImplementationField(r, i)) == false &&
+         isNothingType(getImplementationField(r, i).type) == false {
+        const ref field = getImplementationField(r, i);
         const fieldHash = chpl__defaultHash(field);
         if i == 1 then
           ret = fieldHash;

--- a/test/library/standard/Reflection/field-queries-error-int.chpl
+++ b/test/library/standard/Reflection/field-queries-error-int.chpl
@@ -1,0 +1,6 @@
+// Check that numFields() responds gracefully to an invalid argument type.
+// See also: test/param/ferguson/field*
+
+use Reflection;
+
+param nf = numFields(int);

--- a/test/library/standard/Reflection/field-queries-error-int.good
+++ b/test/library/standard/Reflection/field-queries-error-int.good
@@ -1,0 +1,1 @@
+field-queries-error-int.chpl:6: error: int(64) is not a class, record, or union type

--- a/test/library/standard/Reflection/field-queries-error-string.chpl
+++ b/test/library/standard/Reflection/field-queries-error-string.chpl
@@ -1,0 +1,6 @@
+// Check that numFields() responds gracefully to an invalid argument type.
+// See also: test/param/ferguson/field*
+
+use Reflection;
+
+param nf = numFields(string);

--- a/test/library/standard/Reflection/field-queries-error-string.good
+++ b/test/library/standard/Reflection/field-queries-error-string.good
@@ -1,0 +1,1 @@
+field-queries-error-string.chpl:6: error: string is not a class, record, or union type

--- a/test/library/standard/Reflection/field-queries-ok.chpl
+++ b/test/library/standard/Reflection/field-queries-ok.chpl
@@ -1,0 +1,74 @@
+// Check that numFields et al. handles a variety of aggregate types.
+// See also: test/param/ferguson/field*
+use Reflection;
+
+proc test(type tp) {
+  compilerWarning("===== ", tp:string);
+  compilerWarning("  numFields       ", numFields(tp)            :string);
+  compilerWarning("  getFieldName    ", getFieldName(tp, 6)             );
+  compilerWarning("  hasField        ", hasField(tp, "f6")       :string);
+  compilerWarning("  getFieldIndex   ", getFieldIndex(tp, "f6")  :string);
+  compilerWarning("  isFieldBound 6  ", isFieldBound(tp, 6)      :string);
+  compilerWarning("  isFieldBound f6 ", isFieldBound(tp, "f6")   :string);
+}
+
+
+class CCon {
+  var f1, f2, f3, f4, f5, f6: int;
+}
+
+test(CCon);
+test(CCon: owned class);
+test(CCon: owned class?);
+test(CCon: shared class);
+test(CCon: shared class?);
+test(CCon: borrowed class);
+test(CCon: borrowed class?);
+test(CCon: unmanaged class);
+test(CCon: unmanaged class?);
+
+
+class CGen {
+  var f1, f2, f3, f4, f5, f6;
+}
+
+test(CGen);
+test(CGen: owned class);
+test(CGen: owned class?);
+test(CGen: shared class);
+test(CGen: shared class?);
+test(CGen: borrowed class);
+test(CGen: borrowed class?);
+test(CGen: unmanaged class);
+test(CGen: unmanaged class?);
+
+
+record RCon {
+  var f1, f2, f3, f4, f5, f6: int;
+}
+
+test(RCon);
+
+
+record RGen {
+  var f1, f2, f3, f4, f5, f6;
+}
+
+test(RGen);
+
+
+union UCon {
+  var f1, f2, f3, f4, f5, f6: int;
+}
+
+test(UCon);
+
+
+union UGen {
+  var f1, f2, f3, f4, f5, f6;
+}
+
+test(UGen);
+
+
+compilerError("=== done ===");

--- a/test/library/standard/Reflection/field-queries-ok.good
+++ b/test/library/standard/Reflection/field-queries-ok.good
@@ -1,0 +1,155 @@
+field-queries-ok.chpl:20: warning: ===== CCon
+field-queries-ok.chpl:20: warning:   numFields       6
+field-queries-ok.chpl:20: warning:   getFieldName    f6
+field-queries-ok.chpl:20: warning:   hasField        true
+field-queries-ok.chpl:20: warning:   getFieldIndex   6
+field-queries-ok.chpl:20: warning:   isFieldBound 6  true
+field-queries-ok.chpl:20: warning:   isFieldBound f6 true
+field-queries-ok.chpl:21: warning: ===== owned CCon
+field-queries-ok.chpl:21: warning:   numFields       6
+field-queries-ok.chpl:21: warning:   getFieldName    f6
+field-queries-ok.chpl:21: warning:   hasField        true
+field-queries-ok.chpl:21: warning:   getFieldIndex   6
+field-queries-ok.chpl:21: warning:   isFieldBound 6  true
+field-queries-ok.chpl:21: warning:   isFieldBound f6 true
+field-queries-ok.chpl:22: warning: ===== owned CCon?
+field-queries-ok.chpl:22: warning:   numFields       6
+field-queries-ok.chpl:22: warning:   getFieldName    f6
+field-queries-ok.chpl:22: warning:   hasField        true
+field-queries-ok.chpl:22: warning:   getFieldIndex   6
+field-queries-ok.chpl:22: warning:   isFieldBound 6  true
+field-queries-ok.chpl:22: warning:   isFieldBound f6 true
+field-queries-ok.chpl:23: warning: ===== shared CCon
+field-queries-ok.chpl:23: warning:   numFields       6
+field-queries-ok.chpl:23: warning:   getFieldName    f6
+field-queries-ok.chpl:23: warning:   hasField        true
+field-queries-ok.chpl:23: warning:   getFieldIndex   6
+field-queries-ok.chpl:23: warning:   isFieldBound 6  true
+field-queries-ok.chpl:23: warning:   isFieldBound f6 true
+field-queries-ok.chpl:24: warning: ===== shared CCon?
+field-queries-ok.chpl:24: warning:   numFields       6
+field-queries-ok.chpl:24: warning:   getFieldName    f6
+field-queries-ok.chpl:24: warning:   hasField        true
+field-queries-ok.chpl:24: warning:   getFieldIndex   6
+field-queries-ok.chpl:24: warning:   isFieldBound 6  true
+field-queries-ok.chpl:24: warning:   isFieldBound f6 true
+field-queries-ok.chpl:25: warning: ===== borrowed CCon
+field-queries-ok.chpl:25: warning:   numFields       6
+field-queries-ok.chpl:25: warning:   getFieldName    f6
+field-queries-ok.chpl:25: warning:   hasField        true
+field-queries-ok.chpl:25: warning:   getFieldIndex   6
+field-queries-ok.chpl:25: warning:   isFieldBound 6  true
+field-queries-ok.chpl:25: warning:   isFieldBound f6 true
+field-queries-ok.chpl:26: warning: ===== borrowed CCon?
+field-queries-ok.chpl:26: warning:   numFields       6
+field-queries-ok.chpl:26: warning:   getFieldName    f6
+field-queries-ok.chpl:26: warning:   hasField        true
+field-queries-ok.chpl:26: warning:   getFieldIndex   6
+field-queries-ok.chpl:26: warning:   isFieldBound 6  true
+field-queries-ok.chpl:26: warning:   isFieldBound f6 true
+field-queries-ok.chpl:27: warning: ===== unmanaged CCon
+field-queries-ok.chpl:27: warning:   numFields       6
+field-queries-ok.chpl:27: warning:   getFieldName    f6
+field-queries-ok.chpl:27: warning:   hasField        true
+field-queries-ok.chpl:27: warning:   getFieldIndex   6
+field-queries-ok.chpl:27: warning:   isFieldBound 6  true
+field-queries-ok.chpl:27: warning:   isFieldBound f6 true
+field-queries-ok.chpl:28: warning: ===== unmanaged CCon?
+field-queries-ok.chpl:28: warning:   numFields       6
+field-queries-ok.chpl:28: warning:   getFieldName    f6
+field-queries-ok.chpl:28: warning:   hasField        true
+field-queries-ok.chpl:28: warning:   getFieldIndex   6
+field-queries-ok.chpl:28: warning:   isFieldBound 6  true
+field-queries-ok.chpl:28: warning:   isFieldBound f6 true
+field-queries-ok.chpl:35: warning: ===== CGen
+field-queries-ok.chpl:35: warning:   numFields       6
+field-queries-ok.chpl:35: warning:   getFieldName    f6
+field-queries-ok.chpl:35: warning:   hasField        true
+field-queries-ok.chpl:35: warning:   getFieldIndex   6
+field-queries-ok.chpl:35: warning:   isFieldBound 6  false
+field-queries-ok.chpl:35: warning:   isFieldBound f6 false
+field-queries-ok.chpl:36: warning: ===== owned CGen
+field-queries-ok.chpl:36: warning:   numFields       6
+field-queries-ok.chpl:36: warning:   getFieldName    f6
+field-queries-ok.chpl:36: warning:   hasField        true
+field-queries-ok.chpl:36: warning:   getFieldIndex   6
+field-queries-ok.chpl:36: warning:   isFieldBound 6  false
+field-queries-ok.chpl:36: warning:   isFieldBound f6 false
+field-queries-ok.chpl:37: warning: ===== owned CGen?
+field-queries-ok.chpl:37: warning:   numFields       6
+field-queries-ok.chpl:37: warning:   getFieldName    f6
+field-queries-ok.chpl:37: warning:   hasField        true
+field-queries-ok.chpl:37: warning:   getFieldIndex   6
+field-queries-ok.chpl:37: warning:   isFieldBound 6  false
+field-queries-ok.chpl:37: warning:   isFieldBound f6 false
+field-queries-ok.chpl:38: warning: ===== shared CGen
+field-queries-ok.chpl:38: warning:   numFields       6
+field-queries-ok.chpl:38: warning:   getFieldName    f6
+field-queries-ok.chpl:38: warning:   hasField        true
+field-queries-ok.chpl:38: warning:   getFieldIndex   6
+field-queries-ok.chpl:38: warning:   isFieldBound 6  false
+field-queries-ok.chpl:38: warning:   isFieldBound f6 false
+field-queries-ok.chpl:39: warning: ===== shared CGen?
+field-queries-ok.chpl:39: warning:   numFields       6
+field-queries-ok.chpl:39: warning:   getFieldName    f6
+field-queries-ok.chpl:39: warning:   hasField        true
+field-queries-ok.chpl:39: warning:   getFieldIndex   6
+field-queries-ok.chpl:39: warning:   isFieldBound 6  false
+field-queries-ok.chpl:39: warning:   isFieldBound f6 false
+field-queries-ok.chpl:40: warning: ===== borrowed CGen
+field-queries-ok.chpl:40: warning:   numFields       6
+field-queries-ok.chpl:40: warning:   getFieldName    f6
+field-queries-ok.chpl:40: warning:   hasField        true
+field-queries-ok.chpl:40: warning:   getFieldIndex   6
+field-queries-ok.chpl:40: warning:   isFieldBound 6  false
+field-queries-ok.chpl:40: warning:   isFieldBound f6 false
+field-queries-ok.chpl:41: warning: ===== borrowed CGen?
+field-queries-ok.chpl:41: warning:   numFields       6
+field-queries-ok.chpl:41: warning:   getFieldName    f6
+field-queries-ok.chpl:41: warning:   hasField        true
+field-queries-ok.chpl:41: warning:   getFieldIndex   6
+field-queries-ok.chpl:41: warning:   isFieldBound 6  false
+field-queries-ok.chpl:41: warning:   isFieldBound f6 false
+field-queries-ok.chpl:42: warning: ===== unmanaged CGen
+field-queries-ok.chpl:42: warning:   numFields       6
+field-queries-ok.chpl:42: warning:   getFieldName    f6
+field-queries-ok.chpl:42: warning:   hasField        true
+field-queries-ok.chpl:42: warning:   getFieldIndex   6
+field-queries-ok.chpl:42: warning:   isFieldBound 6  false
+field-queries-ok.chpl:42: warning:   isFieldBound f6 false
+field-queries-ok.chpl:43: warning: ===== unmanaged CGen?
+field-queries-ok.chpl:43: warning:   numFields       6
+field-queries-ok.chpl:43: warning:   getFieldName    f6
+field-queries-ok.chpl:43: warning:   hasField        true
+field-queries-ok.chpl:43: warning:   getFieldIndex   6
+field-queries-ok.chpl:43: warning:   isFieldBound 6  false
+field-queries-ok.chpl:43: warning:   isFieldBound f6 false
+field-queries-ok.chpl:50: warning: ===== RCon
+field-queries-ok.chpl:50: warning:   numFields       6
+field-queries-ok.chpl:50: warning:   getFieldName    f6
+field-queries-ok.chpl:50: warning:   hasField        true
+field-queries-ok.chpl:50: warning:   getFieldIndex   6
+field-queries-ok.chpl:50: warning:   isFieldBound 6  true
+field-queries-ok.chpl:50: warning:   isFieldBound f6 true
+field-queries-ok.chpl:57: warning: ===== RGen
+field-queries-ok.chpl:57: warning:   numFields       6
+field-queries-ok.chpl:57: warning:   getFieldName    f6
+field-queries-ok.chpl:57: warning:   hasField        true
+field-queries-ok.chpl:57: warning:   getFieldIndex   6
+field-queries-ok.chpl:57: warning:   isFieldBound 6  false
+field-queries-ok.chpl:57: warning:   isFieldBound f6 false
+field-queries-ok.chpl:64: warning: ===== UCon
+field-queries-ok.chpl:64: warning:   numFields       6
+field-queries-ok.chpl:64: warning:   getFieldName    f6
+field-queries-ok.chpl:64: warning:   hasField        true
+field-queries-ok.chpl:64: warning:   getFieldIndex   6
+field-queries-ok.chpl:64: warning:   isFieldBound 6  true
+field-queries-ok.chpl:64: warning:   isFieldBound f6 true
+field-queries-ok.chpl:71: warning: ===== UGen
+field-queries-ok.chpl:71: warning:   numFields       6
+field-queries-ok.chpl:71: warning:   getFieldName    f6
+field-queries-ok.chpl:71: warning:   hasField        true
+field-queries-ok.chpl:71: warning:   getFieldIndex   6
+field-queries-ok.chpl:71: warning:   isFieldBound 6  false
+field-queries-ok.chpl:71: warning:   isFieldBound f6 false
+field-queries-ok.chpl:74: error: === done ===

--- a/test/param/ferguson/field-name-not-in-range.good
+++ b/test/param/ferguson/field-name-not-in-range.good
@@ -1,3 +1,3 @@
-$CHPL_HOME/modules/standard/Reflection.chpl:47: In function 'getFieldName':
-$CHPL_HOME/modules/standard/Reflection.chpl:48: error: '2' is not a valid field number for R
-field-name-not-in-range.chpl:7: Function 'getFieldName' instantiated as: getFieldName(type t = R, param i = 2)
+$CHPL_HOME/modules/standard/Reflection.chpl:: In function 'getFieldName':
+$CHPL_HOME/modules/standard/Reflection.chpl:: error: '2' is not a valid field number for R
+field-name-not-in-range.chpl:: Function 'getFieldName' instantiated as: getFieldName(type t = R, param i = 2)

--- a/test/param/ferguson/field-name-not-in-range.prediff
+++ b/test/param/ferguson/field-name-not-in-range.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+output=$2
+
+sed -e 's/:[0-9]*:/::/' $output > $output.tmp
+mv $output.tmp $output


### PR DESCRIPTION
Make it a user error, not a compiler crash, when a non-record/class/union
type is passed to Reflection.numFields() and the other field-query functions
in the Reflection module. The types that are implemented internally
using records however are not Chapel records result in such an error as well.

Also, for a class type, unwrap the _owned/_shared wrapper if applicable.
This augments existing unwrapping in preFold.cpp for PRIM_NUM_FIELDS et al.

Given that DefaultAssociative.chpl uses numFields() and getField() on ranges,
I created internal counterparts of these that accept ranges.
numImplementationFields() and getImplementationField() still need to be
protected from an arbitrary type argument because otherwise they would
result in a compiler crash. The set of permitted argument types for these
can be extended by editing isImplementedWithRecords().

An alternative solution would be to enumerate range fields explicitly
in DefaultAssociative.chpl. Pro: eliminates the need in these newly-added
"implementation" functions. Cons: requires maintenance when range's
fields change.

Follow-up design issues: #14546 and #14547.

Testing: standard paratest.
