### PR TITLE
Reduce array size for arrayTransfer test (valgrind only)

### DIFF
--- a/test/performance/comm/low-level/arrayTransfer.execopts
+++ b/test/performance/comm/low-level/arrayTransfer.execopts
@@ -1,1 +1,7 @@
---xferMB=2048
+#!/usr/bin/env python
+import os
+# Valgrind causes a program to "use a lot more memory", so limit mem fraction
+if os.getenv('CHPL_TEST_VGRND_EXE') == 'on':
+    print('--xferMB=2')
+else:
+    print('--xferMB=2048')


### PR DESCRIPTION
This test was timing out for valgrind at 18 minutes (normally runs 14
minutes, which is way too long for correctness)