### PR TITLE
Remove unnecessary prediffs

### DIFF
--- a/test/modules/vass/use-a-Math-function.prediff
+++ b/test/modules/vass/use-a-Math-function.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-output=$2
-sed -e 's/:[0-9][0-9][0-9]*:/::/' $output > $output.tmp
-mv $output.tmp $output

--- a/test/modules/vass/use-a-Reflection-function.prediff
+++ b/test/modules/vass/use-a-Reflection-function.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-output=$2
-sed -e 's/:[0-9][0-9][0-9]*:/::/' $output > $output.tmp
-mv $output.tmp $output


### PR DESCRIPTION
These prediffs were added in #14536 to ensure clean match against .bad
regardless of future changes to Reflection.chpl. This is unnecessary,
however, because start_test already takes care of that via
`diff-ignoring-module-line-numbers`. So, removing these prediffs.

Thanks @lydia-duncan for pointing this out.