### PR TITLE
Remove the module from few references to the string type

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -39,7 +39,7 @@ Creating :record:`bytes`
 :record:`bytes` and :record:`~String.string`
 --------------------------------------------
 
-As :record:`bytes` can store arbitrary data, any :record:`String.string` can be
+As :record:`bytes` can store arbitrary data, any :record:`~String.string` can be
 cast to :record:`bytes`. In that event, the bytes will store UTF-8 encoded
 character data. However, a :record:`bytes` can contain non-UTF-8 bytes and needs
 to be decoded to be converted to string.
@@ -99,7 +99,7 @@ module Bytes {
 
   /*
      ``decodePolicy`` specifies what happens when there is malformed characters
-     when decoding a :record:`bytes` into a UTF-8 :record:`String.string`.
+     when decoding a :record:`bytes` into a UTF-8 :record:`~String.string`.
        
        - **strict**: default policy; raise error
        - **replace**: replace with UTF-8 replacement character


### PR DESCRIPTION
I noticed that few references to `string` in Bytes doc doesn't omit the module
name which showed as `String.string` in the `bytes` docs. This PR fixes that.