### PR TITLE
Add multilocale memleak testing scripts

### DIFF
--- a/util/cron/common-memleaks.bash
+++ b/util/cron/common-memleaks.bash
@@ -4,7 +4,6 @@
 # other scripts that wish to make use of the variables set here.
 
 export CHPL_NIGHTLY_MEMLEAKS_DIR=${CHPL_NIGHTLY_MEMLEAKS_DIR:-$PERF_LOGDIR_PREFIX/NightlyMemLeaks}
-export CHPL_COMM=none
 export MEM_LEAKS_DATE_VAL=$(date '+%Y-%m-%d')
 
 function memleaks_log()
@@ -18,6 +17,9 @@ function memleaks_log()
             ;;
         full)
             local suffix=nightlyfull
+            ;;
+        ml)
+            local suffix=ml-nightlyfull
             ;;
         *)
             log_error "Unknown test suite: ${tests}"

--- a/util/cron/test-memleaks.bash
+++ b/util/cron/test-memleaks.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-memleaks.bash
 
+export CHPL_COMM=none
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks"
 
 $CWD/nightly -cron -memleaks $(memleaks_log full) -no-futures

--- a/util/cron/test-memleaks.bash
+++ b/util/cron/test-memleaks.bash
@@ -6,7 +6,6 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-memleaks.bash
 
-export CHPL_COMM=none
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks"
 
 $CWD/nightly -cron -memleaks $(memleaks_log full) -no-futures

--- a/util/cron/test-ml-memleaks.bash
+++ b/util/cron/test-ml-memleaks.bash
@@ -14,4 +14,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -futures -multilocale -memleaks $(memleaks_log ml) $(get_nightly_paratest_args 3)
+$CWD/nightly -cron -futures -multilocale -memleaks $(memleaks_log ml)

--- a/util/cron/test-ml-memleaks.bash
+++ b/util/cron/test-ml-memleaks.bash
@@ -14,4 +14,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -futures -memleaks $(memleaks_log ml) $(get_nightly_paratest_args 3)
+$CWD/nightly -cron -futures -multilocale -memleaks $(memleaks_log ml) $(get_nightly_paratest_args 3)

--- a/util/cron/test-ml-memleaks.bash
+++ b/util/cron/test-ml-memleaks.bash
@@ -4,7 +4,6 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
-source $CWD/common-localnode-paratest.bash
 source $CWD/common-memleaks.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ml-memleaks"

--- a/util/cron/test-ml-memleaks.bash
+++ b/util/cron/test-ml-memleaks.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment everything) against full suite on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-gasnet.bash
+source $CWD/common-localnode-paratest.bash
+source $CWD/common-memleaks.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="ml-memleaks"
+
+export GASNET_QUIET=Y
+
+# Test a GASNet compile using the default segment (everything for linux64)
+export CHPL_GASNET_SEGMENT=everything
+
+$CWD/nightly -cron -futures -memleaks $(memleaks_log ml) $(get_nightly_paratest_args 3)


### PR DESCRIPTION
This PR adjusts nightly testing scripts to run multilocale memleak testing.

Summary of changes:
- Adds `util/cron/test-ml-memleaks.bash` which is a combination of gasnet and
  memleaks testing scripts. This script sets the config name as `ml-memleaks`
  and calls the `nightly` script with `-multilocale -memleaks -futures` (Not so
  sure if we need `-futures`)

- Adjusts `common-memleaks.bash` to support multilocale
  memleak testing.