### PR TITLE
String literal initialization uses a SymExpr

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -33,6 +33,7 @@
 #include "resolveIntents.h"
 #include "resolution.h"
 #include "stringutil.h"
+#include "wellknown.h"
 
 #include <algorithm>
 
@@ -1490,7 +1491,13 @@ VarSymbol *new_StringSymbol(const char *str) {
   // DefExpr(s) always goes into the module scope to make it a global
   stringLiteralModule->block->insertAtTail(stringLitDef);
 
-  CallExpr *initCall = new CallExpr(astr("createStringWithBorrowedBuffer"),
+  Expr* initFn = NULL;
+  if (gChplCreateStringWithLiteral != NULL)
+    initFn = new SymExpr(gChplCreateStringWithLiteral);
+  else
+    initFn = new UnresolvedSymExpr("chpl_createStringWithLiteral");
+
+  CallExpr *initCall = new CallExpr(initFn,
                                     cstrTemp,
                                     new_IntSymbol(strLength));
 

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -60,6 +60,7 @@ FnSymbol *gChplSaveTaskError;
 FnSymbol *gChplForallError;
 FnSymbol *gAtomicFenceFn;
 FnSymbol *gChplAfterForallFence;
+FnSymbol *gChplCreateStringWithLiteral;
 
 /************************************* | **************************************
 *                                                                             *
@@ -318,6 +319,13 @@ static WellKnownFn sWellKnownFns[] = {
     &gChplAfterForallFence,
     FLAG_UNKNOWN
   },
+
+  {
+    "chpl_createStringWithLiteral",
+    &gChplCreateStringWithLiteral,
+    FLAG_UNKNOWN
+  },
+
 };
 
 void gatherWellKnownFns() {

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -68,5 +68,6 @@ extern FnSymbol *gChplSaveTaskError;
 extern FnSymbol *gChplForallError;
 extern FnSymbol *gAtomicFenceFn;
 extern FnSymbol *gChplAfterForallFence;
+extern FnSymbol *gChplCreateStringWithLiteral;
 
 #endif

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -118,7 +118,7 @@ static void cleanup(ModuleSymbol* module) {
     }
   }
 
-  if (module == stringLiteralModule) {
+  if (module == stringLiteralModule && !fMinimalModules) {
     // Fix calls to chpl_createStringWithLiteral to use resolved expression.
     // For compiler performance reasons, we'd like to have new_StringSymbol
     // emit calls to a resolved function; however new_StringSymbol might

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -34,6 +34,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "wellknown.h"
 
 static void cleanup(ModuleSymbol* module);
 
@@ -114,6 +115,27 @@ static void cleanup(ModuleSymbol* module) {
       }
     } else if (CatchStmt* catchStmt = toCatchStmt(ast)) {
       catchStmt->cleanup();
+    }
+  }
+
+  if (module == stringLiteralModule) {
+    // Fix calls to chpl_createStringWithLiteral to use resolved expression.
+    // For compiler performance reasons, we'd like to have new_StringSymbol
+    // emit calls to a resolved function; however new_StringSymbol might
+    // run before that function is parsed. So fix up any literals created
+    // during parsing here.
+    INT_ASSERT(gChplCreateStringWithLiteral != NULL);
+    const char* name = gChplCreateStringWithLiteral->name;
+
+    for_vector(BaseAST, ast, asts) {
+      if (CallExpr* call = toCallExpr(ast)) {
+        if (UnresolvedSymExpr* urse = toUnresolvedSymExpr(call->baseExpr)) {
+          if (urse->unresolved == name) {
+            SET_LINENO(urse);
+            urse->replace(new SymExpr(gChplCreateStringWithLiteral));
+          }
+        }
+      }
     }
   }
 }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -482,11 +482,15 @@ module String {
 
     :returns: A new `string`
   */
-  proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+  inline proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+    return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
+                                                            size=length+1);
+  }
+
+  pragma "no doc"
+  proc chpl_createStringWithLiteral(s: c_string, length:int) {
     //NOTE: This function is heavily used by the compiler to create string
-    //literals. So, inlining this causes some bloat in the AST that increases
-    //the compilation time slightly. Therefore, currently we are keeping this
-    //one non-inlined.
+    //literals.
     return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }


### PR DESCRIPTION
Adjusts the compiler to initialize string literals with a call to a
well-known function so that time need not be spent resolving it. This
approach was complicated by the fact that string literal initialization
is created at the time string literals are parsed - and so the well-known
function might not exist yet. It adds some code to cleanup.cpp to adjust
the string literals module to fix.

* about 32x faster at finding visible functions for string literal
  initialization (in debug compiler)
* saves about 0.03s in resolution time for hello - which is about 2% of
  resolution time - with a compiler built with optimizations

- [x] full local testing

Reviewed by @e-kayrakli and @lydia-duncan - thanks!