### PR TITLE
Improve sparse-iter-performance test to avoid negative time issue

### DIFF
--- a/test/sparse/parallel/PREDIFF
+++ b/test/sparse/parallel/PREDIFF
@@ -10,7 +10,7 @@ case $outfile in
      ;;
   (sparse-iter-performance.*)
      # smooth out the timings
-     cat $outfile | sed 's@ [0-9][0-9.]* ms@ XXX ms@' > $outfile.tmp
+     cat $outfile | sed 's@ -*[0-9][0-9.]* ms@ XXX ms@' > $outfile.tmp
      mv $outfile.tmp $outfile
      ;;
   (sparse-csr-simple-dom-manips.* | sparse-default-simple-dom-manips.*)

--- a/test/sparse/parallel/sparse-iter-performance.chpl
+++ b/test/sparse/parallel/sparse-iter-performance.chpl
@@ -24,12 +24,14 @@ proc test(param dim:int, d: domain(dim)) {
   populateDomain(dim, sd);
 //  writeln("sd(", dim, ") = ", sd);
 
-  tm.start();
-  var startTm = tm.elapsed(TimeUnits.milliseconds); 
-  proc st      { startTm = tm.elapsed(TimeUnits.milliseconds); }
+  proc st      {
+    tm.clear();
+    tm.start();
+  }
   proc fi(msg) {
-    var endTm = tm.elapsed(TimeUnits.milliseconds);
-    writeln(msg, " : ", endTm - startTm, " ms");
+    tm.stop();
+    var ms = tm.elapsed(TimeUnits.milliseconds);
+    writeln(msg, " : ", ms, " ms");
   }
 
   var A, B, C: [sd] int;
@@ -64,8 +66,6 @@ proc test(param dim:int, d: domain(dim)) {
 
   st; for    (a,b,c) in zip(A,B,C) { a = b + alpha * c; }
   fi("ivar1 = ivar2, ivar3 | seq");
-
-  tm.stop();
 }
 
 proc populateDomain(param dim, ref sd) where dim == 1 {


### PR DESCRIPTION
We saw a failure for a line like this

    ix1 = ix2, ix3 | par : -25.364 ms

because the elapsed time was negative but the prediff didn't allow for
that.

This commit:
 * adjusts the test to use timers in a more normal way
 * adjusts the prediff to allow and ignore `-` in times

I believe that this test predates the performance testing infrastructure 
and it would make sense to make it more similar to other performance
tests by:
 * using a config const to enable/disable time printing 
 * making the performance numbers be graphed (i.e. make it a real
   performance test).


Test change only, not reviewed.