### PR TITLE
Distributed sort improvements

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2259,15 +2259,17 @@ module TwoArrayPartitioning {
     const curDomain = {start_n..end_n};
     const intersect = curDomain[localSubdomain];
     if curDomain == intersect {
-      if n > compat.baseCaseSize {
-        compat.bigTasks.clear();
-        compat.smallTasks.clear();
-        partitioningSortWithScratchSpace(start_n, end_n,
-                     A.localSlice(curDomain), Scratch.localSlice(curDomain),
-                     compat, criterion,
-                     startbit);
-      } else {
-        ShellSort.shellSort(A.localSlice(curDomain), criterion, start=start_n, end=end_n);
+      local {
+        if n > compat.baseCaseSize {
+          compat.bigTasks.clear();
+          compat.smallTasks.clear();
+          partitioningSortWithScratchSpace(start_n, end_n,
+                       A.localSlice(curDomain), Scratch.localSlice(curDomain),
+                       compat, criterion,
+                       startbit);
+        } else {
+          ShellSort.shellSort(A.localSlice(curDomain), criterion, start=start_n, end=end_n);
+        }
       }
     } else {
       const size = end_n-start_n+1;
@@ -2545,27 +2547,41 @@ module TwoArrayPartitioning {
         const binSize = binEnd - binStart + 1;
         const binStartBit = state.perLocale[0].compat.bucketizer.getNextStartBit(task.startbit);
         if binSize > 1 {
-          // could this work for block?
-          //var isOnOneLocale = A.domain.dist.idxToLocale(globalStart) ==
-          //                    A.domain.dist.idxToLocale(globalEnd)
           var small = false;
           var theLocaleId = -1;
-          if binSize <= state.distributedBaseCaseSize {
+
+          // Compute the regions on the same locale as the first, last
+          // elements in the bin.
+          const firstLoc = A.domain.dist.idxToLocale(binStart);
+          const lastLoc = A.domain.dist.idxToLocale(binEnd);
+          const onFirstLoc = A.localSubdomain(firstLoc)[binStart..binEnd];
+          const onLastLoc = A.localSubdomain(lastLoc)[binStart..binEnd];
+          var theLocale = firstLoc;
+          if onFirstLoc.size == binSize {
+            // case 1: all elements are on firstLoc
             small = true;
-            // choose a locale owning some of the array
-            var mid = binStart + binSize / 2;
-            theLocaleId = A[mid].locale.id;
-          } else {
-            for (loc,tid) in zip(A.targetLocales(),0..) {
-              const localSubdomain = A.localSubdomain(loc)[task.start..taskEnd];
-              const curDomain = {binStart..binEnd};
-              const intersect = curDomain[localSubdomain];
-              if curDomain == intersect { // curDomain.isSubset(localSubdomain)
-                small = true;
-                theLocaleId = tid;
-              }
-            }
+          } else if binSize == onFirstLoc.size + onLastLoc.size ||
+                    binSize <= state.distributedBaseCaseSize {
+            // case 2: elements are split between at least 2 locales
+            // either:
+            //   only 2 locales store the elements in the region, or
+            //   the size is small enough to do on 1 locale
+            //
+            // Choose the locale with more elements.
+            small = true;
+            if onFirstLoc.size < onLastLoc.size then
+              theLocale = lastLoc;
           }
+
+          theLocaleId = theLocale.id;
+          assert(A.targetLocales()[theLocaleId] == theLocale);
+
+          /*
+          writeln("Recursive bin ", bin,
+                  " start = ", binStart,
+                  " size = ", binSize,
+                  " startbit = ", binStartBit,
+                  " small = ", small);*/
 
           if small {
             state.localTasks[theLocaleId].localTasks.append(
@@ -2583,12 +2599,10 @@ module TwoArrayPartitioning {
       on loc do {
         // Copy the tasks to do from locale 0
         var myTasks = state.localTasks[tid].localTasks;
-        var baseCaseSize = state.baseCaseSize;
         ref compat = state.perLocale[tid].compat;
 
         for task in myTasks {
           const taskEnd = task.start + task.size - 1;
-          const curDomain = {task.start..taskEnd};
 
           distributedPartitioningSortWithScratchSpaceBaseCase(
               task.start, taskEnd,

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1668,22 +1668,23 @@ module ShallowCopy {
       }
     }
   }
-  inline proc parallelShallowCopy(ref DstA, dst, ref SrcA, src, nElts) {
-    const nTasks = if dataParTasksPerLocale > 0
-                   then dataParTasksPerLocale
-                   else here.maxTaskPar;
+  // dst, src are offsets
 
-    halt("buggy");
-    // TODO: something about this code is wrong right now.
-    const blockSize = divceil(nElts, nTasks);
-    const nBlocks = divceil(nElts, blockSize);
-    coforall tid in 0..#nTasks {
-      var start = tid * blockSize;
-      var n = blockSize;
-      if start + n > nElts then
-        n = nElts - start;
-      shallowCopy(DstA, dst+start, SrcA, src+start, n);
+  proc shallowCopyPutGetRefs(ref dst, const ref src, numBytes: size_t) {
+    if dst.locale.id == here.id {
+      __primitive("chpl_comm_get", dst, src.locale.id, src, numBytes);
+    } else if src.locale.id == here.id {
+      __primitive("chpl_comm_put", src, dst.locale.id, dst, numBytes);
+    } else {
+      halt("Remote src and remote dst not yet supported");
     }
+  }
+
+  // For the case in which we know that the source and dest regions
+  // are contiguous within a locale
+  proc shallowCopyPutGet(ref DstA, dst, ref SrcA, src, nElts) {
+    var size = (nElts:size_t)*c_sizeof(DstA.eltType);
+    shallowCopyPutGetRefs(DstA[dst], SrcA[src], size);
   }
 }
 pragma "no doc"
@@ -2430,11 +2431,22 @@ module TwoArrayPartitioning {
             }
             assert(total == localDomain.numIndices);
           }
-          // Now store the counts into the global counts array
-          for bin in vectorizeOnly(0..#nBuckets) {
-            state.perLocale[0].globalCounts[bin*nTasks + tid] = localCounts[bin];
+
+          // Do an all-to-all to send the counts to everybody
+          // To make this communication more efficient, temporarily store
+          // in the order
+          //     count for locale 0, bin 0
+          //     count for locale 0, bin 1
+          //     ...
+          // (i.e. the transpose of the order needed for scan)
+          const toIdx = maxBuckets * tid;
+          forall i in 1..#nTasks with (ref state) {
+            const dstTid = (i + tid) % nTasks;
+            // perLocale[dstTid].globalCounts[toIdx..#maxBuckets] = localCounts;
+            ShallowCopy.shallowCopyPutGet(
+                state.perLocale[dstTid].globalCounts, toIdx,
+                localCounts, 0, maxBuckets);
           }
-          //state.globalCounts[tid.. by nTasks] = localCounts;
         }
       }
       // Now the data is in Scratch
@@ -2443,36 +2455,44 @@ module TwoArrayPartitioning {
         writef("after bucketize local portions, Scratch is %xt\n", Scratch[task.start..taskEnd]);
       }
 
-      // Step 2: scan
-      state.perLocale[0].globalEnds = (+ scan state.perLocale[0].globalCounts) + task.start;
-
-      // Store counts on each other locale
-      forall (loc,tid) in zip(A.targetLocales(),0..) with (ref state) {
-        if tid != 0 {
-          state.perLocale[tid].globalCounts = state.perLocale[0].globalCounts;
-          state.perLocale[tid].globalEnds = state.perLocale[0].globalEnds;
-        }
-      }
-
-      if debug {
-        var total = 0;
-        for i in 0..#state.countsSize {
-          if state.perLocale[0].globalCounts[i] != 0 {
-            total += state.perLocale[0].globalCounts[i];
-            writeln("state.globalCounts[", i, "]=", state.perLocale[0].globalCounts[i]);
-            writeln("state.globalEnds[", i, "]=", state.perLocale[0].globalEnds[i]);
-          }
-        }
-        assert(total == task.size);
-      }
-
-      // Step 3: distribute the keys to the src array according
-      // to the globalEnds.
-      // In particular, bin i from task j should be stored into
-      // globalEnds[i*ntasks+j-1] .. globalEnds[i*ntasks+j] - 1
-      // (because the scan is inclusive)
       coforall (loc,tid) in zip(A.targetLocales(),0..) with (ref state) {
         on loc do {
+
+          // Step 2: scan
+          // Note that the globalCounts arrays are stored in transpose
+          // order up until now to optimize communication, so we first
+          // rearrange them.
+
+          // Temporarily use the globalEnds array to reorder
+          {
+            ref globalCounts = state.perLocale[tid].globalCounts;
+            ref globalEnds = state.perLocale[tid].globalEnds;
+            forall (tid,bkt) in {0..#nTasks, 0..#maxBuckets} {
+              globalEnds[bkt*nTasks+tid] = globalCounts[tid*maxBuckets+bkt];
+            }
+            globalCounts = globalEnds;
+
+            globalEnds = (+ scan globalCounts) + task.start;
+          }
+
+          if debug && tid == 0 {
+            var total = 0;
+            for i in 0..#state.countsSize {
+              if state.perLocale[0].globalCounts[i] != 0 {
+                total += state.perLocale[0].globalCounts[i];
+                writeln("state.globalCounts[", i, "]=", state.perLocale[0].globalCounts[i]);
+                writeln("state.globalEnds[", i, "]=", state.perLocale[0].globalEnds[i]);
+              }
+            }
+            assert(total == task.size);
+          }
+
+          // Step 3: distribute the keys to the src array according
+          // to the globalEnds.
+          // In particular, bin i from task j should be stored into
+          // globalEnds[i*ntasks+j-1] .. globalEnds[i*ntasks+j] - 1
+          // (because the scan is inclusive)
+
           const ref globalCounts = state.perLocale[tid].globalCounts;
           const ref globalEnds = state.perLocale[tid].globalEnds;
           const localSubdomain = A.localSubdomain()[task.start..taskEnd];

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1894,6 +1894,7 @@ module TwoArrayPartitioning {
         TwoArrayDistributedBucketizerStatePerLocale(bucketizerType));
 
     const baseCaseSize:int;
+    const distributedBaseCaseSize:int;
     const endbit:int = max(int);
 
     const countsSize:int = numLocales*maxBuckets;
@@ -2245,10 +2246,10 @@ module TwoArrayPartitioning {
 
   private proc distributedPartitioningSortWithScratchSpaceBaseCase(
           start_n:int, end_n:int, A:[], Scratch:[],
-          ref state: TwoArrayDistributedBucketizerSharedState,
+          ref compat: TwoArrayBucketizerSharedState,
           criterion, startbit:int):void {
 
-    if startbit > state.endbit then
+    if startbit > compat.endbit then
       return;
 
     const n = end_n - start_n + 1;
@@ -2257,11 +2258,13 @@ module TwoArrayPartitioning {
     const curDomain = {start_n..end_n};
     const intersect = curDomain[localSubdomain];
     if curDomain == intersect {
-      if n > state.baseCaseSize {
-        msbRadixSort(start_n, end_n,
-                     A.localSlice(curDomain), criterion,
-                     startbit, state.endbit,
-                     settings=new MSBRadixSortSettings());
+      if n > compat.baseCaseSize {
+        compat.bigTasks.clear();
+        compat.smallTasks.clear();
+        partitioningSortWithScratchSpace(start_n, end_n,
+                     A.localSlice(curDomain), Scratch.localSlice(curDomain),
+                     compat, criterion,
+                     startbit);
       } else {
         ShellSort.shellSort(A.localSlice(curDomain), criterion, start=start_n, end=end_n);
       }
@@ -2269,13 +2272,16 @@ module TwoArrayPartitioning {
       const size = end_n-start_n+1;
       // Copy it to one locale
       var LocalA:[start_n..end_n] A.eltType;
+      var LocalScratch:[start_n..end_n] A.eltType;
       ShallowCopy.shallowCopy(LocalA, start_n, A, start_n, size);
       // Sort it
-      if n > state.baseCaseSize {
-        msbRadixSort(start_n, end_n,
-                     LocalA, criterion,
-                     startbit, state.endbit,
-                     settings=new MSBRadixSortSettings());
+      if n > compat.baseCaseSize {
+        compat.bigTasks.clear();
+        compat.smallTasks.clear();
+        partitioningSortWithScratchSpace(start_n, end_n,
+                     LocalA, LocalScratch,
+                     compat, criterion,
+                     startbit);
       } else {
         ShellSort.shellSort(LocalA, criterion, start=start_n, end=end_n);
       }
@@ -2364,10 +2370,12 @@ module TwoArrayPartitioning {
     if startbit > state.endbit then
       return;
 
+    // If it's really small, just sort it on Locale 0.
     if end_n - start_n < state.baseCaseSize {
+      ref compat = state.perLocale[0].compat;
       distributedPartitioningSortWithScratchSpaceBaseCase(start_n, end_n,
                                                           A, Scratch,
-                                                          state, criterion,
+                                                          compat, criterion,
                                                           startbit);
       return;
     }
@@ -2386,6 +2394,8 @@ module TwoArrayPartitioning {
       const task = state.distTasks.pop();
       const taskStart = task.start;
       const taskEnd = task.start + task.size - 1;
+
+      //writeln("Distributed sorting task ", task);
 
       assert(task.doSort);
       assert(task.inA);
@@ -2518,19 +2528,26 @@ module TwoArrayPartitioning {
           // could this work for block?
           //var isOnOneLocale = A.domain.dist.idxToLocale(globalStart) ==
           //                    A.domain.dist.idxToLocale(globalEnd)
-          var isOnOneLocale = false;
+          var small = false;
           var theLocaleId = -1;
-          for (loc,tid) in zip(A.targetLocales(),0..) {
-            const localSubdomain = A.localSubdomain(loc)[task.start..taskEnd];
-            const curDomain = {binStart..binEnd};
-            const intersect = curDomain[localSubdomain];
-            if curDomain == intersect { // curDomain.isSubset(localSubdomain)
-              isOnOneLocale = true;
-              theLocaleId = tid;
+          if binSize <= state.distributedBaseCaseSize {
+            small = true;
+            // choose a locale owning some of the array
+            var mid = binStart + binSize / 2;
+            theLocaleId = A[mid].locale.id;
+          } else {
+            for (loc,tid) in zip(A.targetLocales(),0..) {
+              const localSubdomain = A.localSubdomain(loc)[task.start..taskEnd];
+              const curDomain = {binStart..binEnd};
+              const intersect = curDomain[localSubdomain];
+              if curDomain == intersect { // curDomain.isSubset(localSubdomain)
+                small = true;
+                theLocaleId = tid;
+              }
             }
           }
 
-          if isOnOneLocale {
+          if small {
             state.localTasks[theLocaleId].localTasks.append(
                 new TwoArraySortTask(binStart, binSize, binStartBit, true, true));
           } else {
@@ -2553,20 +2570,13 @@ module TwoArrayPartitioning {
           const taskEnd = task.start + task.size - 1;
           const curDomain = {task.start..taskEnd};
 
-          // Great! Just sort it locally.
-          if n > baseCaseSize {
-            compat.bigTasks.clear();
-            compat.smallTasks.clear();
-            partitioningSortWithScratchSpace(
-                task.start, taskEnd,
-                A.localSlice(curDomain), Scratch.localSlice(curDomain),
-                compat, criterion, task.startbit);
-          } else {
-            ShellSort.shellSort(A.localSlice(curDomain), criterion,
-                start=task.start, end=taskEnd);
-          }
+          distributedPartitioningSortWithScratchSpaceBaseCase(
+              task.start, taskEnd,
+              A, Scratch,
+              compat, criterion, task.startbit);
+
           if debug {
-            writef("after recursive sorts, dst is %xt\n", A[task.start..taskEnd]);
+            writef("after recursive sort, dst is %xt\n", A[task.start..taskEnd]);
           }
         }
       }
@@ -2583,6 +2593,7 @@ module TwoArrayRadixSort {
 
     var sequentialSizePerTask=4096;
     var baseCaseSize=16;
+    var distributedBaseCaseSize=1024;
 
     var endbit:int;
     endbit = msbRadixSortParamLastStartBit(Data, comparator);
@@ -2608,6 +2619,7 @@ module TwoArrayRadixSort {
         bucketizerType=RadixBucketizer,
         numLocales=Data.targetLocales().numElements,
         baseCaseSize=baseCaseSize,
+        distributedBaseCaseSize=distributedBaseCaseSize,
         endbit=endbit);
 
 
@@ -2630,6 +2642,7 @@ module TwoArraySampleSort {
   proc twoArraySampleSort(Data:[], comparator:?rec=defaultComparator) {
 
     var baseCaseSize=16;
+    var distributedBaseCaseSize=1024;
 
     var endbit:int;
     endbit = msbRadixSortParamLastStartBit(Data, comparator);
@@ -2653,6 +2666,7 @@ module TwoArraySampleSort {
         bucketizerType=SampleBucketizer(Data.eltType),
         numLocales=Data.targetLocales().numElements,
         baseCaseSize=baseCaseSize,
+        distributedBaseCaseSize=distributedBaseCaseSize,
         endbit=endbit);
 
       distributedPartitioningSortWithScratchSpace(

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1229,7 +1229,7 @@ module List {
 
       :arg comparator: A comparator used to sort this list.
     */
-    proc sort(comparator=Sort.defaultComparator) {
+    proc sort(comparator:?t=Sort.defaultComparator) {
       on this {
         _enter();
 


### PR DESCRIPTION
`modules/packages/Sort.chpl` includes two implementations of distributed sorting:
 * `Sort.TwoArrayRadixSort.twoArrayRadixSort`
 * `Sort.TwoArraySampleSort.twoArraySampleSort`

Neither of these `Sort.TwoArray*` submodules are included by default (and so they have limited impact on compilation time). However they can provide more efficient sorting for Block-distributed arrays and they include code specifically for the distributed case. These sorts were added in PR #13347.

 * - [ ] PR message TODO

