### PR TITLE
Close multilocale leaks in two tests that are huge

### DIFF
--- a/test/performance/ferguson/remote-class-read.chpl
+++ b/test/performance/ferguson/remote-class-read.chpl
@@ -7,9 +7,9 @@ class C {
   var z:int;
 }
 
-var A:[1..n] unmanaged C;
+var A:[1..n] owned C;
 for i in 1..n {
-  A[i] = new unmanaged C(i, i+1, i+2);
+  A[i] = new owned C(i, i+1, i+2);
 }
 
 var toOutput = 0;

--- a/test/performance/ferguson/remote-class-write.chpl
+++ b/test/performance/ferguson/remote-class-write.chpl
@@ -7,9 +7,9 @@ class C {
   var z:int;
 }
 
-var A:[1..n] unmanaged C;
+var A:[1..n] owned C;
 for i in 1..n {
-  A[i] = new unmanaged C(i, i+1, i+2);
+  A[i] = new owned C(i, i+1, i+2);
 }
 
 start();


### PR DESCRIPTION
This PR closes trivial/application leaks in two multilocale tests.

I am almost certain there are still tests that leak from the application code. However,
these two tests used to create a huge amount of unmanaged class instances without
cleaning up after them. So, the leak from these two constituted 97% of multilocale
leaks in the latest tally. I want to get rid of these so that when we start running nightly
tests and generating plots things will be more clean.

Tests do not leak after this PR and pass on gasnet (they are skipped with comm=none)  
`perflabel cc` tests also pass and generate correct numbers