### PR TITLE
Preserve the line number when re-throwing an exception

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -41,7 +41,7 @@ module ChapelError {
     var thrownFileId:int(32);
 
     pragma "no doc"
-    var hasThrowInfo: bool = false;
+    var _hasThrowInfo: bool = false;
 
     /* Construct an Error */
     proc init() {
@@ -372,8 +372,8 @@ module ChapelError {
     // TODO: Adjust/remove calls to this routine that are present in
     // catch blocks rather than adding runtime information?
     //
-    if !fixErr!.hasThrowInfo {
-      fixErr!.hasThrowInfo = true;
+    if !fixErr!._hasThrowInfo {
+      fixErr!._hasThrowInfo = true;
       fixErr!.thrownLine = line;
       fixErr!.thrownFileId = fileId;
     }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -40,6 +40,9 @@ module ChapelError {
     pragma "no doc"
     var thrownFileId:int(32);
 
+    pragma "no doc"
+    var hasThrowInfo: bool = false;
+
     /* Construct an Error */
     proc init() {
       _next = nil;
@@ -364,8 +367,16 @@ module ChapelError {
 
     const line = __primitive("_get_user_line");
     const fileId = __primitive("_get_user_file");
-    fixErr!.thrownLine = line;
-    fixErr!.thrownFileId = fileId;
+
+    //
+    // TODO: Adjust/remove calls to this routine that are present in
+    // catch blocks rather than adding runtime information?
+    //
+    if !fixErr!.hasThrowInfo {
+      fixErr!.hasThrowInfo = true;
+      fixErr!.thrownLine = line;
+      fixErr!.thrownFileId = fileId;
+    }
 
     return _to_nonnil(fixErr);
   }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -369,8 +369,8 @@ module ChapelError {
     const fileId = __primitive("_get_user_file");
 
     //
-    // TODO: Adjust/remove calls to this routine that are present in
-    // catch blocks rather than adding runtime information?
+    // TODO: Adjust/remove calls to this routine that are present in catch
+    // blocks rather than doing extra work at runtime?
     //
     if !fixErr!._hasThrowInfo {
       fixErr!._hasThrowInfo = true;

--- a/test/errhandling/errorMessages/preserveLineNoUponRethrow.bad
+++ b/test/errhandling/errorMessages/preserveLineNoUponRethrow.bad
@@ -1,6 +1,0 @@
-in rethrow
-in willthrow
-catch in rethrow
-uncaught Error: 
-  preserveLineNoUponRethrow.chpl:14: thrown here
-  preserveLineNoUponRethrow.chpl:18: uncaught here

--- a/test/errhandling/errorMessages/preserveLineNoUponRethrow.future
+++ b/test/errhandling/errorMessages/preserveLineNoUponRethrow.future
@@ -1,2 +1,0 @@
-unimplemented feature: preserve file/line number upon rethrow
-#11300

--- a/test/errhandling/lydia/rethrownGenerally.good
+++ b/test/errhandling/lydia/rethrownGenerally.good
@@ -1,4 +1,4 @@
 Caught NilThrownError
 uncaught NilThrownError: thrown error was nil
-  rethrownGenerally.chpl:9: thrown here
+  rethrownGenerally.chpl:5: thrown here
   rethrownGenerally.chpl:3: uncaught here


### PR DESCRIPTION
This PR adjusts error handling so that thrown Errors only have their file/line info set the first time they are thrown, (rather than every time they are thrown).

It adds a `bool` flag to the Error class and uses that internally so that calls to `chpl_do_fix_thrown_error` inserted by the compiler only insert the file/line number into the Error once.

Resolves #11300.

---

I chose this approach because it is simple (took me only five minutes to implement). A side effect of this approach is that the compiler is still inserting redundant calls to `chpl_fix_thrown_error` that essentially do nothing, and that Errors take up a bit more space.

In an ideal world we would do one of:

a) Tie getting file/line info to when a new Error is _initialized_, @vasslitvinov brings this up in #11300, mentioning that this is what Java opts to do.
b) Have the compiler ensure that line/file info is set only the first time a particular Error is thrown.

However (A) seems like more of a commitment while (B) is seemingly too difficult for me at this time.

---

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet`

