### PR TITLE
Suggest adding postfix-! upon unresolved errors

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -1001,6 +1001,10 @@ void explainCandidateRejection(CallInfo& info, FnSymbol* fn) {
                     toString(failingActual->getValType()));
       USR_PRINT(failingFormal, "is passed to formal '%s'",
                                toString(failingFormal));
+      if (isNilableClassType(failingActual->getValType()) &&
+          isNonNilableClassType(failingFormal->getValType()))
+        USR_PRINT(call, "try to apply the postfix ! operator to %s",
+                  failingActualDesc);
       break;
     case RESOLUTION_CANDIDATE_WHERE_FAILED:
       USR_PRINT(fn, "because where clause evaluated to false");

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1226,6 +1226,7 @@ static void errorIfValueCoercionToRef(CallExpr* call, ArgSymbol* formal) {
     // compiler is currently producing this pattern for chpl__unref.
     // This is a workaround and a better solution would be preferred.
   } else if (argumentCanModifyActual(intent)) {
+   if (! inGenerousResolutionForErrors()) {
     // Error for coerce->value passed to ref / out / etc
     USR_FATAL_CONT(call,
                    "value from coercion passed to ref formal '%s'",
@@ -1233,6 +1234,7 @@ static void errorIfValueCoercionToRef(CallExpr* call, ArgSymbol* formal) {
     USR_FATAL_CONT(formal->getFunction(),
                    "to function '%s' defined here",
                    formal->getFunction()->name);
+   }
   } else {
     // Error for coerce->value passed to 'const ref' (ref case handled above).
     // Note that coercing SubClass to ParentClass is theoretically
@@ -1244,7 +1246,7 @@ static void errorIfValueCoercionToRef(CallExpr* call, ArgSymbol* formal) {
     // visible).
     bool formalIsRef = formal->isRef() || (intent & INTENT_REF);
 
-    if (formalIsRef) {
+    if (formalIsRef && ! inGenerousResolutionForErrors()) {
       USR_FATAL_CONT(call,
                      "value from coercion passed to const ref formal '%s'",
                      formal->name);

--- a/test/classes/nilability/demo3.good
+++ b/test/classes/nilability/demo3.good
@@ -2,3 +2,4 @@ demo3.chpl:13: error: unresolved call 'getTheValue(borrowed C?)'
 demo3.chpl:4: note: this candidate did not match: getTheValue(x: borrowed C)
 demo3.chpl:13: note: because call actual argument #1 with type borrowed C?
 demo3.chpl:4: note: is passed to formal 'x: borrowed C'
+demo3.chpl:13: note: try to apply the postfix ! operator to call actual argument #1

--- a/test/classes/nilability/demo4.good
+++ b/test/classes/nilability/demo4.good
@@ -2,3 +2,4 @@ demo4.chpl:17: error: unresolved call 'getTheValue(borrowed C?)'
 demo4.chpl:4: note: this candidate did not match: getTheValue(x: borrowed C)
 demo4.chpl:17: note: because call actual argument #1 with type borrowed C?
 demo4.chpl:4: note: is passed to formal 'x: borrowed C'
+demo4.chpl:17: note: try to apply the postfix ! operator to call actual argument #1

--- a/test/classes/nilability/error-method-on-nilable-borrow.good
+++ b/test/classes/nilability/error-method-on-nilable-borrow.good
@@ -4,3 +4,4 @@ error-method-on-nilable-borrow.chpl:10: error: unresolved call 'borrowed MyClass
 error-method-on-nilable-borrow.chpl:3: note: this candidate did not match: MyClass.mymethod()
 error-method-on-nilable-borrow.chpl:10: note: because method call receiver with type borrowed MyClass?
 error-method-on-nilable-borrow.chpl:3: note: is passed to formal 'this: borrowed MyClass'
+error-method-on-nilable-borrow.chpl:10: note: try to apply the postfix ! operator to method call receiver

--- a/test/classes/nilability/error-method-on-nilable-owned.good
+++ b/test/classes/nilability/error-method-on-nilable-owned.good
@@ -4,3 +4,4 @@ error-method-on-nilable-owned.chpl:11: error: unresolved call 'owned MyClass?.my
 error-method-on-nilable-owned.chpl:3: note: this candidate did not match: MyClass.mymethod()
 error-method-on-nilable-owned.chpl:11: note: because method call receiver with type owned MyClass?
 error-method-on-nilable-owned.chpl:3: note: is passed to formal 'this: borrowed MyClass'
+error-method-on-nilable-owned.chpl:11: note: try to apply the postfix ! operator to method call receiver

--- a/test/classes/nilability/error-method-on-nilable-shared.good
+++ b/test/classes/nilability/error-method-on-nilable-shared.good
@@ -4,3 +4,4 @@ error-method-on-nilable-shared.chpl:11: error: unresolved call 'shared MyClass?.
 error-method-on-nilable-shared.chpl:3: note: this candidate did not match: MyClass.mymethod()
 error-method-on-nilable-shared.chpl:11: note: because method call receiver with type shared MyClass?
 error-method-on-nilable-shared.chpl:3: note: is passed to formal 'this: borrowed MyClass'
+error-method-on-nilable-shared.chpl:11: note: try to apply the postfix ! operator to method call receiver

--- a/test/classes/nilability/error-with-bang-suggestion.chpl
+++ b/test/classes/nilability/error-with-bang-suggestion.chpl
@@ -1,0 +1,41 @@
+use M;
+
+var test = new Test();
+
+class Test {
+  var ffout : shared H5File?;
+
+  proc init() {
+    this.complete();
+    ffout = createH5File();
+    writeScalarAttribute(ffout);
+  }
+}
+
+module M {
+
+  // Basic file operations
+  class H5File {
+    var fid : int;
+    proc mymethod(arg: int) {
+      writeln("in mymethod");
+    }
+  }
+
+  proc createH5File() {
+    var ret = new shared H5File();
+    return ret;
+  }
+
+  proc myfun(arg:H5File) {
+    writeln("in myfun");
+  }    
+
+  proc writeScalarAttribute(loc) {
+    var gg = loc.fid;
+    loc.mymethod(5);
+    const locc = loc;
+    myfun(locc);
+  }
+
+}

--- a/test/classes/nilability/error-with-bang-suggestion.good
+++ b/test/classes/nilability/error-with-bang-suggestion.good
@@ -1,0 +1,17 @@
+error-with-bang-suggestion.chpl:34: In function 'writeScalarAttribute':
+error-with-bang-suggestion.chpl:35: error: unresolved call 'shared H5File?.fid'
+error-with-bang-suggestion.chpl:19: note: this candidate did not match: H5File.fid
+error-with-bang-suggestion.chpl:35: note: because method call receiver with type shared H5File?
+error-with-bang-suggestion.chpl:19: note: is passed to formal 'this: borrowed H5File'
+error-with-bang-suggestion.chpl:35: note: try to apply the postfix ! operator to method call receiver
+error-with-bang-suggestion.chpl:36: error: unresolved call 'shared H5File?.mymethod(5)'
+error-with-bang-suggestion.chpl:20: note: this candidate did not match: H5File.mymethod(arg: int)
+error-with-bang-suggestion.chpl:36: note: because method call receiver with type shared H5File?
+error-with-bang-suggestion.chpl:18: note: is passed to formal 'this: borrowed H5File'
+error-with-bang-suggestion.chpl:36: note: try to apply the postfix ! operator to method call receiver
+error-with-bang-suggestion.chpl:38: error: unresolved call 'myfun(shared H5File?)'
+error-with-bang-suggestion.chpl:30: note: this candidate did not match: myfun(arg: H5File)
+error-with-bang-suggestion.chpl:38: note: because call actual argument #1 with type shared H5File?
+error-with-bang-suggestion.chpl:30: note: is passed to formal 'arg: H5File'
+error-with-bang-suggestion.chpl:38: note: try to apply the postfix ! operator to call actual argument #1
+error-with-bang-suggestion.chpl:11: Function 'writeScalarAttribute' instantiated as: writeScalarAttribute(loc: shared H5File?)

--- a/test/classes/nilability/multiple-errors.1.good
+++ b/test/classes/nilability/multiple-errors.1.good
@@ -3,30 +3,37 @@ multiple-errors.chpl:41: error: unresolved call 'borrowed C?.foo()'
 multiple-errors.chpl:14: note: this candidate did not match: C.foo()
 multiple-errors.chpl:41: note: because method call receiver with type borrowed C?
 multiple-errors.chpl:14: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:41: note: try to apply the postfix ! operator to method call receiver
 multiple-errors.chpl:42: error: unresolved call 'borrowed C?.bar()'
 multiple-errors.chpl:17: note: this candidate did not match: C.bar()
 multiple-errors.chpl:42: note: because method call receiver with type borrowed C?
 multiple-errors.chpl:17: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:42: note: try to apply the postfix ! operator to method call receiver
 multiple-errors.chpl:24: note: candidates are: bar()
 multiple-errors.chpl:43: error: unresolved call 'baz(borrowed C?)'
 multiple-errors.chpl:20: note: this candidate did not match: baz(arg: C)
 multiple-errors.chpl:43: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:20: note: is passed to formal 'arg: C'
+multiple-errors.chpl:43: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:29: In function 'testInit':
 multiple-errors.chpl:32: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:32: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:32: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:33: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:33: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:33: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:34: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:34: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:34: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:24: In function 'bar':
 multiple-errors.chpl:26: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:26: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:26: note: try to apply the postfix ! operator to call actual argument #1

--- a/test/classes/nilability/multiple-errors.2.good
+++ b/test/classes/nilability/multiple-errors.2.good
@@ -3,33 +3,40 @@ multiple-errors.chpl:41: error: unresolved call 'borrowed C?.foo()'
 multiple-errors.chpl:14: note: this candidate did not match: C.foo()
 multiple-errors.chpl:41: note: because method call receiver with type borrowed C?
 multiple-errors.chpl:14: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:41: note: try to apply the postfix ! operator to method call receiver
 multiple-errors.chpl:42: error: unresolved call 'borrowed C?.bar()'
 multiple-errors.chpl:17: note: this candidate did not match: C.bar()
 multiple-errors.chpl:42: note: because method call receiver with type borrowed C?
 multiple-errors.chpl:17: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:42: note: try to apply the postfix ! operator to method call receiver
 multiple-errors.chpl:24: note: candidates are: bar()
 multiple-errors.chpl:43: error: unresolved call 'baz(borrowed C?)'
 multiple-errors.chpl:20: note: this candidate did not match: baz(arg: C)
 multiple-errors.chpl:43: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:20: note: is passed to formal 'arg: C'
+multiple-errors.chpl:43: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:29: In function 'testInit':
 multiple-errors.chpl:32: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:32: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:32: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:33: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:33: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:33: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:34: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:34: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:34: note: try to apply the postfix ! operator to call actual argument #1
 multiple-errors.chpl:24: In function 'bar':
 multiple-errors.chpl:26: error: unresolved call 'R.init(borrowed C?)'
 multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
 multiple-errors.chpl:26: note: because call actual argument #1 with type borrowed C?
 multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:26: note: try to apply the postfix ! operator to call actual argument #1
 foo({x = 0})
 bar({x = 0})
 baz({x = 0})


### PR DESCRIPTION
Resolves #14532.

The compiler now suggests "try to apply the postfix ! operator"
when an "unresolved call" error occurs because the actual is nilable
and the formal is not.

The change to wrappers.cpp eliminates the spurious errors saying
"value from coercion passed to const ref formal 'arg'". These
would arise because the compiler inserts postfix `!` when trying
to continue resolving the code despite the nilability mismatch.

Testing: linux64, gasnet with futures.