### PR TITLE
Fix regressions from runtime warmup work (#14567)

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -465,11 +465,11 @@ module ChapelLocale {
         on __primitive("chpl_on_locale_num",
                        chpl_buildLocaleID(locIdx:chpl_nodeID_t,
                                           c_sublocid_any)) {
-          warmupRuntime();
           chpl_defaultDistInitPrivate();
           yield locIdx;
           b.wait(locIdx, flags);
           chpl_rootLocaleInitPrivate(locIdx);
+          warmupRuntime();
         }
       }
     }

--- a/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.wrap
+++ b/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.wrap
@@ -9,6 +9,7 @@
 hpm=$(module list --terse 2>&1 | grep craype-hugepages)
 if [[ -n "$hpm" ]] ; then module unload $hpm ; fi
 
+export CHPL_RT_CALL_STACK_SIZE=128K
 case $($CHPL_HOME/util/chplenv/chpl_platform.py --target) in
 cray-xe) module load craype-hugepages128K
          export CHPL_RT_MAX_HEAP_SIZE=2049M;;

--- a/test/runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence.good
+++ b/test/runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence.good
@@ -1,7 +1,7 @@
 ../needsFence.chpl:14: note: Optimized atomic call to be unordered
 ../needsFence.chpl:14: note: Optimized atomic call to be unordered
-atomic_fence;
+atomic_fence_chpl;
 chpl_comm_atomic_add_unordered_int64;
 --
-atomic_fence;
+atomic_fence_chpl;
 chpl_comm_atomic_add_unordered_int64;


### PR DESCRIPTION
Move warmup until after the root locale is initialized to avoid comm
that was caused by task creation touching the dummy locale, which lives
on locale 0. This fixes modules/sungeun/init/printInitCommCounts

Limit stack size for runtime/configMatters/comm/ugni/overflow-nic-tlb.
It sets an artifically low heap size and on systems with a lot of cores
we're now creating a fair number of task stacks at startup.

runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence
is also updated to work post #14487. This doesn't run in any nightly
configurations, but was failing in my local testing.