### PR TITLE
Add mason build before linux64 test.

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -62,6 +62,7 @@ $startdate = "-1";
 $numtrials = "";
 $cronrecipient = "";
 $junit_xml = 0;
+$mason_build = 0;
 
 while (@ARGV) {
     $flag = shift @ARGV;
@@ -146,6 +147,8 @@ while (@ARGV) {
         $junit_xml = 1;
     } elsif ($flag eq "-asserts") {
         $asserts = 1;
+    } elsif ($flag eq "-mason") {
+        $mason_build = 1;
     } else {
         $printusage = 1;
         last;
@@ -197,6 +200,7 @@ if ($printusage == 1) {
     print "\t-hellos                        : run the release/examples/hello*.chpl tests only\n";
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
     print "\t-llvm                          : run tests using --llvm\n";
+    print "\t-mason                         : build mason before running tests\n";
     print "\t-memleaks <log>                : run memleaks tests\n";
     print "\t-multilocale                   : run multilocale tests only\n";
     print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
@@ -555,6 +559,11 @@ if ($makestat != 0) {
 print "Making modules\n";
 $makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", 1, 1);
 
+# Build mason
+if ($mason_build == 1) {
+  print "Making mason\n";
+  mysystem("cd $chplhomedir && $make -j$num_procs mason", "making mason", 1, 1);
+}
 
 #
 # run tests

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -12,4 +12,4 @@ source $CWD/common.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
 nightly_args="${nightly_args} -compperformance (default)"
-$CWD/nightly -cron -futures ${nightly_args}
+$CWD/nightly -cron -mason -futures ${nightly_args}


### PR DESCRIPTION
Making mason so it can be called from the command line during testing.

After a bunch of fluffing around in chapel-ci-config, I believe the make call actually belongs here. Ran it on chapvm04 and it seemed to build. Did not run linux64 to completion since it takes 21 hours.