### PR TITLE
Fix munging with LLVM

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1235,16 +1235,6 @@ static void protectNameFromC(Symbol* sym) {
     return;
   }
 
-  //
-  // For reasons not clear to me, renaming internal module symbols
-  // when LLVM is being used causes problems, so let's not do it for
-  // now.
-  //
-  ModuleSymbol* symMod = sym->getModule();
-  if (llvmCodegen && symMod->modTag == MOD_INTERNAL) {
-    return;
-  }
-
   // Don't rename fields
   if (isVarSymbol(sym)) {
     if (isAggregateType(sym->defPoint->parentSymbol->type)) {
@@ -1257,6 +1247,7 @@ static void protectNameFromC(Symbol* sym) {
   // is declared within an extern declaration, we should preserve its
   // name for similar reasons.
   //
+  ModuleSymbol* symMod = sym->getModule();
   if (sym != symMod) {
     Symbol* parentSym = sym->defPoint->parentSymbol;
     while (parentSym != symMod) {

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -650,7 +650,7 @@ GenRet VarSymbol::codegenVarSymbol(bool lhsInSetReference) {
     if(isImmediate()) {
       ret.isLVPtr = GEN_VAL;
       if(immediate->const_kind == CONST_KIND_STRING) {
-        if(llvm::Value *value = info->module->getNamedGlobal(name)) {
+        if(llvm::Value *value = info->module->getNamedGlobal(cname)) {
           ret.val = value;
           ret.isLVPtr = GEN_PTR;
           return ret;

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -49,6 +49,9 @@ int64_t getTypeSizeInBytes(const llvm::DataLayout& layout, llvm::Type* ty);
 bool isTypeSizeSmallerThan(const llvm::DataLayout& layout, llvm::Type* ty, uint64_t max_size_bytes);
 uint64_t getTypeFieldNext(const llvm::DataLayout& layout, llvm::Type* ty, uint64_t offset);
 
+void print_llvm(llvm::Type* t);
+void print_llvm(llvm::Value* v);
+
 #if HAVE_LLVM_VER >= 60
 #define TOOL_OUTPUT_FILE ToolOutputFile
 #else

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -19,6 +19,8 @@
 
 #include "llvmUtil.h"
 
+#include "llvm/Support/Debug.h"
+
 #include <cstdio>
 #include <cassert>
 
@@ -397,6 +399,27 @@ uint64_t getTypeFieldNext(const llvm::DataLayout& layout, llvm::Type* ty, uint64
 
   return doGetTypeFieldNext(layout, ty, offset, 0, sz);
 }
+
+void print_llvm(llvm::Type* t)
+{
+  if (t == NULL)
+    fprintf(stderr, "NULL");
+  else
+    t->print(llvm::dbgs(), true);
+
+  fprintf(stderr, "\n");
+}
+
+void print_llvm(llvm::Value* v)
+{
+  if (v == NULL)
+    fprintf(stderr, "NULL");
+  else
+    v->print(llvm::dbgs(), true);
+
+  fprintf(stderr, "\n");
+}
+
 
 #endif
 

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -19,12 +19,12 @@
 
 #include "llvmUtil.h"
 
-#include "llvm/Support/Debug.h"
-
 #include <cstdio>
 #include <cassert>
 
 #ifdef HAVE_LLVM
+
+#include "llvm/Support/Debug.h"
 
 bool isArrayVecOrStruct(llvm::Type* t)
 {

--- a/test/interop/fortran/genFortranInterface/unhandledType.suppressif
+++ b/test/interop/fortran/genFortranInterface/unhandledType.suppressif
@@ -1,3 +1,0 @@
-# munging of internal symbols is currently disabled for llvm, so
-# suppress this test which is sensitive to such symbols for now
-COMPOPTS <= --llvm

--- a/test/llvm/lifetime-intrinsics/lifetime-temporaries.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-temporaries.chpl
@@ -5,10 +5,11 @@
 proc mytest_temporaries() {
   var x = 1;
   var y = 2;
-  // CHECK: %[[REG1:[0-9]+]] = bitcast i64* %call_tmp_chpl5 to i8*
+  // CHECK: %[[TMP:[a-zA-Z0-9_]+]] = alloca i64
+  // CHECK: %[[REG1:[0-9]+]] = bitcast i64* %[[TMP]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
-  // CHECK: %{{[0-9]+}} = bitcast i64* %call_tmp_chpl5 to i8*
-  // CHECK: %[[REG2:[0-9]+]] = bitcast i64* %call_tmp_chpl5 to i8*
+  // CHECK: %{{[0-9]+}} = bitcast i64* %[[TMP]] to i8*
+  // CHECK: %[[REG2:[0-9]+]] = bitcast i64* %[[TMP]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG2]])
   return x + y;
 }

--- a/test/llvm/tbaa/tbaa_class.chpl
+++ b/test/llvm/tbaa/tbaa_class.chpl
@@ -37,7 +37,7 @@ writeln(myClass);
 // CHECK-DAG: ![[REAL:[0-9]+]] = !{!"_real64", ![[UNIONS]], i64 0}
 //
 // Class object TBAA type descriptors:  reference to superclass and each field
-// CHECK-DAG: ![[OBJOBJ:[0-9]+]] = !{!"chpl_object{{[0-9]*}}_object", ![[INT32]], i64 0}
+// CHECK-DAG: ![[OBJOBJ:[0-9]+]] = !{!"chpl_object{{[0-9]*}}_chpl_object", ![[INT32]], i64 0}
 // CHECK-DAG: ![[CLSOBJ:[0-9]+]] = !{!"chpl_MyClass_chpl{{[0-9]*}}_object", ![[OBJOBJ]], i64 0, ![[INT]], i64 {{[0-9]+}}, ![[REAL]], i64 {{[0-9]+}}}
 //
 // Now validate those access tags.

--- a/test/llvm/tbaa/tbaa_scalar.chpl
+++ b/test/llvm/tbaa/tbaa_scalar.chpl
@@ -46,7 +46,7 @@ delete got;
 // CHECK-DAG: ![[CVOIDPTR:[0-9]+]] = !{!"C void ptr", ![[UNIONS]], i64 0}
 //
 // Note that class pointers are scalars.
-// CHECK-DAG: ![[OBJECT:[0-9]+]] = !{!"object{{[0-9]*}}", ![[CVOIDPTR]], i64 0}
+// CHECK-DAG: ![[OBJECT:[0-9]+]] = !{!"object_chpl{{[0-9]*}}", ![[CVOIDPTR]], i64 0}
 // CHECK-DAG: ![[CLSPTR:[0-9]+]] = !{!"MyClass_chpl{{[0-9]*}}", ![[OBJECT]], i64 0}
 //
 // Now validate those access tags.

--- a/test/users/npadmana/empty.skipif
+++ b/test/users/npadmana/empty.skipif
@@ -1,1 +1,0 @@
-COMPOPTS <= --llvm


### PR DESCRIPTION
Continues #14513.
Resolves #14473.

The main fix here replaces a use of `name` with `cname` for string 
literals. The issue was that the string literal cname was being munged,
but the LLVM-specific string literal code generation was looking under
the un-munged name.

Additionally, added some helper functions for use when debugging the 
compiler with LLVM.

- [x] full local --llvm testing

Reviewed by @bradcray - thanks!