### PR TITLE
Update a test's prediff

### DIFF
--- a/test/memory/gbt/test-memLog.prediff
+++ b/test/memory/gbt/test-memLog.prediff
@@ -3,8 +3,9 @@
 for loc in 0 1 ; do
   echo "========== Locale $loc memLog ==========" >> $2
   if [ -f $1.memLog.$loc ] ; then
-    sed -e 's/ allocate [0-9]*B / allocate <BYTES> /' \
-	-e 's/ at 0x[0-9a-f]*$/ at <ADDR>/' \
+    sed -e 's/ allocate [0-9]*B of C at 0x[0-9a-f]*$/ allocate <BYTES> of C at <ADDR>/' \
+        -e 's/ free \([0-9]*B of C \)\{0,1\}at 0x[0-9a-f]*$/ free at <ADDR>/' \
+        -e '/.*<internal>.*/d' \
 	< $1.memLog.$loc \
 	>> $2
   fi


### PR DESCRIPTION
This test failed with new multilocale memleaks testing. Apparently the memlog
output for free changes whether memleak flag is thrown or not.

This PR adjusts the prediff so that:
- an optional amount of bytes is removed from the free line
- memlog outputs that start with `<internal>` is removed.
  On the testing machine that this was run last night, there was a memlog coming
  from internal allocations. Those doesn't seem to be relevant to what this test
  is doing.