### PR TITLE
Add perf annotations for 2019-12-05

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -406,6 +406,9 @@ all:
   10/10/19:
     - text: Optimize unorderedCopy for types larger than 8 bytes (#14255)
       config: 16 node XC
+  12/04/19:
+    - text: Warm up the runtime before entering user code (#14567)
+      config: 16 node XC, 16-node-cs
 
 
 AllCompTime:
@@ -612,6 +615,8 @@ create-views:
     - Improve timing and stability of the create-views performance test (#11609)
   05/03/19:
     - Govern slice expressions by slicing domain (#12931)
+  11/27/19:
+    - Close some multilocale distribution and privatization memleaks (#14510)
 
 cs-resize:
   03/05/19:
@@ -1147,6 +1152,12 @@ memleaksfull:
     - Starting running mason as part of memleak testing
   11/01/19:
     - Fix a leak in masonModify (#14375)
+  11/12/19:
+    - Move the essentials of IO.chpl into ChapelIO (#14145)
+  12/04/19:
+    - Access param, type fields without postfix-! (#14549)
+  12/06/19:
+    - Close user-level leaks in some new tests (#14586)
 
 meteor:
   12/18/13:


### PR DESCRIPTION
Add annotations for:
 - [improvements](https://chapel-lang.org/perf/16-node-xc/?startdate=2019/12/01&enddate=2019/12/05&graphs=creatingdistributedarrays1elementperlocale,destroyingdistributedarrays1elementperlocale,creatingdistributedarrays1melements,destroyingdistributedarrays1melements,creatingdistributedarrays14ofavailablememory,destroyingdistributedarrays14ofavailablememory) for distributed array creation (#14567)
 - [regression](https://chapel-lang.org/perf/chapcs/?startdate=2019/11/16&enddate=2019/12/05&graphs=arrayviewcreation) for array view creation (#14510)
 - memory leak [changes](https://chapel-lang.org/perf/chapcs/?startdate=2019/11/04&enddate=2019/12/04&graphs=memoryleaksforalltests,numberoftestswithleaks)