### PR TITLE
Have extern blocks inject `use SysCTypes;` at same scope

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -649,8 +649,11 @@ buildIfStmt(Expr* condExpr, Expr* thenExpr, Expr* elseExpr) {
 
 BlockStmt*
 buildExternBlockStmt(const char* c_code) {
-  BlockStmt* ret = NULL;
-  ret = buildChapelStmt(new ExternBlockStmt(c_code));
+  CallExpr* sysCTypes = new CallExpr(PRIM_ACTUALS_LIST,
+                                     new UnresolvedSymExpr("SysCTypes"));
+  BlockStmt* useSysCTypes = buildUseStmt(sysCTypes, /* private = */ false);
+  useSysCTypes->insertAtTail(new ExternBlockStmt(c_code));
+  BlockStmt* ret = buildChapelStmt(useSysCTypes);
 
   // Check that the compiler supports extern blocks
   // but skip these checks for chpldoc.

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -653,7 +653,10 @@ the enclosing Chapel module.  This is similar to what one might do
 manually using the extern declarations (as described above), but can
 save a lot of labor for a large API.  Moreover, using an inline extern
 block permits you to write C declarations directly within Chapel
-without having to create distinct C files.
+without having to create distinct C files.  Using an extern block in
+this way also injects an implicit ``public use SysCTypes;`` statement
+into the scope of the extern block to make standard C types that the
+extern block is likely to require available.
 
 If you don't want to have a lot of C symbols cluttering up a module's
 namespace, it's easy to put the C code into its own Chapel module:


### PR DESCRIPTION
This fixes a regression introduced in PR #14524 in which, now that
SysCTypes is no longer auto-used, extern blocks break since they
relied on the C types being automatically available.

The approach taken here is to have the parser's build routine that
generates a new extern block also insert a `[public] use SysCTypes;`
statement just before it using the same pattern that the parser uses
to build that statement if it were in user code.

Why a public use?
Because (at present anyway), we don't have a way to distinguish
between whether the symbols introduced by the extern block are
public or private, so they end up being public; and it seemed to make
sense to have anything that could see the extern block's symbols
see the C symbols that were required to utilize them as well.

I also updated the documentation of extern blocks to mention the
behavior.