### PR TITLE
Add use of SysCTypes to some more tests

### DIFF
--- a/test/errhandling/ferguson/err-return.chpl
+++ b/test/errhandling/ferguson/err-return.chpl
@@ -1,6 +1,6 @@
 require "err-return.h";
 
-use ExampleErrors;
+use ExampleErrors, SysCTypes;
 
 extern record my_struct {
   var x:c_int;

--- a/test/mason/mason-modify/masonModifyTest.chpl
+++ b/test/mason/mason-modify/masonModifyTest.chpl
@@ -5,6 +5,7 @@ use MasonSearch;
 use TOML;
 use FileSystem;
 
+use SysCTypes;
 extern proc setenv(name : c_string, envval : c_string, overwrite : c_int) : c_int;
 
 /* Copy the toml file into a package (empty directory) as 'Mason.toml',


### PR DESCRIPTION
Add `use SysCTypes` to errhandling/ferguson/err-return.chpl and
mason/mason-modify/masonModifyTest.chpl. Fixes fallout from #14524