### PR TITLE
Remove array-as-vec test from GRAPHFILES

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1598,34 +1598,6 @@ time-write:
   03/05/15:
     - no strings with externs update
 
-timeVectorArray:
-  03/05/16:
-    - implemented doubling/halving for array-as-vec (#3380) (no timing from 4th)
-  03/09/16:
-    - increased array-as-vec problem size (#3422)
-  05/28/16:
-    - upgrade jemalloc to 4.2.0 (#3919)
-  01/31/17:
-    - upgrade jemalloc to 4.4.0 (#5278)
-  07/26/17:
-    - Allow domains to implement specialized assignment (#6722)
-  09/13/17:
-    - Support arrays as args to array.{push_front,push_back,insert} (#7180)
-  09/16/17:
-    - Resolve timeVectorArray regressions (#7333)
-  09/20/17:
-    - Resolve push_back / pop_front regressions w/ inline (#7397)
-  12/05/17:
-    - Enforce qualified refs after inlining (#7906)
-  06/22/18:
-    - Make 'for' loop in dsiReallocate parallel (#9895)
-  08/17/18:
-    - Add a new dsiReallocate that is aware of allocated size (#10793)
-  09/07/18:
-    - Fix performance regression in pop_front/pop_back from PR 10793 (#11017)
-  04/23/19:
-    - Denormalize the test in CondStmts (#12867)
-
 views-forall-iter:
   10/12/17:
     - Switch from these(tag) to foralls for some standalone iters (#7578)

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -67,7 +67,6 @@ users/npadmana/npb-mg/mg-b.graph
 arrays/diten/time_iterate.graph
 arrays/diten/time_array_vs_tuple.graph
 arrays/diten/time_array_vs_ddata.graph
-deprecated/arrayAsVec/timeVectorArray.graph
 arrays/ferguson/return-array-40000000.graph
 arrays/lydia/time_access.graph
 domains/ferguson/build-associative.graph

--- a/util/test/prediff-for-incremental-warning
+++ b/util/test/prediff-for-incremental-warning
@@ -12,7 +12,7 @@ import sys, subprocess
 import re
 
 # These are the tests that currently do not require the warning to be present in the output
-incrementalTests = ["time_iterate", "timeVectorArray", "time_access", "optimizeOnClauses_basic", "optimizeOnClauses_basic_record",
+incrementalTests = ["time_iterate", "time_access", "optimizeOnClauses_basic", "optimizeOnClauses_basic_record",
                     "optimizeOnClauses_basic_tuple", "parSafeMember", "formalDomainChecks", "formalDomainChecks2", "access1d",
                     "access2d", "access3d", "ri-4-arrdom", "ri-4-arrdom.replicated", "ri-3-stress", "ri-3-stress-coforall", "assign",
                     "assign_across_locales", "copy_to_local", "dgemm", "init", "reductions-stress-fast", "sparse-iter-performance",


### PR DESCRIPTION
This PR removes an "array-as-vec" test that was listed in GRAPHFILES (the test itself was removed in #14557).