### PR TITLE
Make some postprocessing errors on memleaks nightlies fatal

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -845,7 +845,7 @@ if ($runtests == 0) {
 # analyze memory leaks tests
 #
     if (!($memleaks eq "")) {
-        mysystem("$chplhomedir/util/devel/analyzeMemLeaksLog $basetmpdir/$memleaks > $memleaksdir/$memleaks");
+        mysystem("$chplhomedir/util/devel/analyzeMemLeaksLog $basetmpdir/$memleaks > $memleaksdir/$memleaks", "analyzeMemLeaksLog", 1, 0, 0);
 
         # Update the memory leaks status for performance testing runs to
         #  generate graphs for the memory leaks data
@@ -862,7 +862,7 @@ if ($runtests == 0) {
             }
         }
 
-        mysystem("cd $testdir && cp $memleaksdir/$memleaks ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir");
+        mysystem("cd $testdir && cp $memleaksdir/$memleaks ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir", "computePerfStats", 1, 0, 0);
     }
 }
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -862,7 +862,7 @@ if ($runtests == 0) {
             }
         }
 
-        mysystem("cd $testdir && cp $memleaksdir/$memleaks ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir", "computePerfStats", 1, 0, 0);
+        mysystem("cd $testdir && cp $memleaksdir/$memleaks ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir", "memLeak computePerfStats", 1, 0, 0);
     }
 }
 


### PR DESCRIPTION
Nightly memleak testing calls two scripts to postprocess the generated logs.
Return codes of these scripts aren't checked, so even if they fail, the whole test
is marked as successful.

This PR adds checks for those scripts' return codes.