### PR TITLE
Update non-standard locale model helper files to use SysCTypes

### DIFF
--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -22,6 +22,7 @@ module LocaleModelHelpAPU {
 
   use LocaleModelHelpSetup;
   use LocaleModelHelpRuntime;
+  private use SysCTypes;
 
   pragma "no doc"
   config param debugAPULocale = false;

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -18,6 +18,7 @@
  */
 
 module LocaleModelHelpNUMA {
+  private use SysCTypes;
 
   param localeModelHasSublocales = true;
 


### PR DESCRIPTION
In PR #14524, when updating some of the LocaleModelHelp*.chpl files, I
should've noticed that there were others that aren't involved in
normal testing which needed similar uses of SysCTypes added to them
now that those symbols aren't available by default.  This addresses
those cases.