### PR TITLE
Update package modules w.r.t. public uses of HDFS

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -210,7 +210,7 @@ module BLAS {
 
   use C_BLAS;
 
-  use SysCTypes;
+  public use SysCTypes;
 
   /* Return `true` if type is supported by BLAS */
   proc isBLASType(type t) param: bool {

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -111,7 +111,7 @@ Curl Support Types and Functions
 
  */
 module Curl {
-  public use IO;
+  public use IO, SysCTypes;
 
   require "curl/curl.h";
   require "-lcurl";

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -122,7 +122,7 @@ module FFTW {
   */
   config param isFFTW_MKL=false;
 
-  use SysCTypes;
+  public use SysCTypes;
   require "fftw3.h"; // This is common
   if (isFFTW_MKL) {
     require "fftw3_mkl.h";

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -54,6 +54,7 @@ The native HDF5 functions can be called directly by calling into the
 :mod:`C_HDF5` submodule.
 */
 module HDF5 {
+  use SysCTypes;
 
   // This interface was generated with HDF5 1.10.1. Due to a change of the
   // `hid_t` type from 32-bit to 64-bit in this version, versions prior
@@ -73,6 +74,7 @@ module HDF5 {
      https://portal.hdfgroup.org/display/HDF5/HDF5
   */
   module C_HDF5 {
+    public use SysCTypes;
 
     // Header given to c2chapel:
     require "hdf5_hl.h";

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -125,6 +125,7 @@ HDFS Support Types and Functions
 module HDFS {
 
   use IO, SysBasic, SysError;
+  public use SysCTypes;
 
   require "hdfs.h";
 

--- a/modules/packages/LAPACK.chpl
+++ b/modules/packages/LAPACK.chpl
@@ -165,7 +165,7 @@ module LAPACK {
                    else 'lapacke.h'
                  else lapackHeader;
 
-  use SysCTypes;
+  public use SysCTypes;
 
   /* Return `true` if type is supported by LAPACK */
   proc isLAPACKType(type t) param: bool {


### PR DESCRIPTION
This PR updates the set of package modules whose interfaces require
C types as defined in SysCTypes to include a `public use SysCTypes`
so that clients of the modules will not have to use SysCTypes in
order to make calls into them.

Ideally, it would be nice if any Chapel-facing code in these modules
did not require C types and that any conversion to C took place under
the hood if need be, but that was a bigger change than I was able to take 
on here.  And arguably, since they're just package modules, it's not so big 
of a deal.  But we might consider making this an expectation for a given
module before it transition to the standard modules directory.  The
HDF5 module was a nice example of this in that the top-level HDF5
module only needed a `private use SysCTypes;` while the C_HDF5
sub-module needed a `public use SysCTypes;` for its clients.

These updates were missed in PR #14524 since these modules are not
tested for vanilla linux64 runs.  As a separate effort, I may look into
making some .noexec tests that run on linux64 to make sure we get to
the codegen stage for each of these libraries to catch such issues
ealier.