### PR TITLE
Improve testing error message when compilation fails

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1663,7 +1663,7 @@ for testname in testsrc:
                 continue
 
             if not os.path.isfile(goodfile) or not os.access(goodfile, os.R_OK):
-                if perftest:
+                if perftest or executebin:
                     sys.stdout.write('[Error compilation failed for %s]\n'%(test_name))
                 else:
                     sys.stdout.write('[Error cannot locate compiler output comparison file %s/%s]\n'%(localdir, goodfile))


### PR DESCRIPTION
When compilation fails and there's no <basename>.good or compopt
specific .good file to match against, issue a "compilation failed" error
message instead of saying "there was no .good file". This should make
it more obvious that there was a hard failure rather than just a lack of
a testing file. This is an extension of #4376.

See https://github.com/chapel-lang/chapel/pull/14593 for motivation