### PR TITLE
Update tests that require `use SysCTypes` to work

### DIFF
--- a/test/library/packages/Curl/check-http.chpl
+++ b/test/library/packages/Curl/check-http.chpl
@@ -2,6 +2,7 @@ use RunServer;
 use URL;
 use FileSystem;
 use IO;
+use SysCTypes;
 
 config const verbose = false;
 config const bufsz = 0;

--- a/test/library/packages/HDFS/hdfsNumbers.chpl
+++ b/test/library/packages/HDFS/hdfsNumbers.chpl
@@ -5,6 +5,7 @@
 */
 use HDFS only;
 use IO;
+use SysCTypes;
 
 config const path = "/tmp/lots-of-numbers.txt";
 

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -42,6 +42,7 @@ prototype module DistributedFFT {
   use FFTW.C_FFTW;
   use FFT_Locks;
   use FFT_Timers;
+  use SysCTypes, CPtr;
 
   /*
     Compile time parameters for higher performance.

--- a/test/runtime/configMatters/interop/unordered-atomics.chpl
+++ b/test/runtime/configMatters/interop/unordered-atomics.chpl
@@ -6,7 +6,7 @@ extern proc pthread_create(thread:c_ptr(pthread_t),
                            start_routine:c_fn_ptr, arg:c_void_ptr): c_int;
 extern proc pthread_join(thread:pthread_t, retval:c_ptr(c_void_ptr)): c_int;
 
-use UnorderedAtomics;
+use UnorderedAtomics, SysCTypes;
 
 config const numThreadsPerLocale = here.maxTaskPar;
 config const numTrials = 10;


### PR DESCRIPTION
These are tests that aren't run in the standard linux configuration,
so I missed them when locking down SysCTypes to not be implicitly
available.