### PR TITLE
Add public use SysCTypes to MPI module

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -189,7 +189,7 @@ MPI Module Documentation
 
 */
 module MPI {
-  use SysCTypes;
+  public use SysCTypes;
   require "mpi.h";
 
   use ReplicatedVar;


### PR DESCRIPTION
This should've been part of #14599, but it escaped me there.
Here, I'm making the `use` of SysCTypes public since the MPI
package's interface includes C types.  Better would be to
rewrite the package to avoid the need for C types from the
Chapel user and convert under the covers before calling the
external C routines, but that was more than I was able to
take on today.