### PR TITLE
Guard privatization checks with param flag

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3164,12 +3164,12 @@ module ChapelArray {
         if domToRemove != nil {
           // remove that domain
           (domToFree, distToRemove) = domToRemove!.remove();
-          domIsPrivatized = domToRemove!.pid != nullPid;
+          domIsPrivatized = _privatization && (domToRemove!.pid != nullPid);
         }
         var distIsPrivatized = false;
         if distToRemove != nil {
           distToFree = distToRemove!.remove();
-          distIsPrivatized = distToRemove!.pid != nullPid;
+          distIsPrivatized = _privatization && (distToRemove!.pid != nullPid);
         }
         if arrToFree != nil then
           _delete_arr(_instance, _isPrivatized(_instance));

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -954,7 +954,7 @@ module ChapelDistribution {
   proc _delete_dist(dist:unmanaged BaseDist, privatized:bool) {
     dist.dsiDestroyDist();
 
-    if privatized {
+    if _privatization && privatized {
       _freePrivatizedClass(dist.pid, dist);
     }
 
@@ -965,7 +965,7 @@ module ChapelDistribution {
 
     dom.dsiDestroyDom();
 
-    if privatized {
+    if _privatization && privatized {
       _freePrivatizedClass(dom.pid, dom);
     }
 
@@ -983,7 +983,7 @@ module ChapelDistribution {
     // refer to this inner domain.
     arr.decEltCountsIfNeeded();
 
-    if privatized {
+    if _privatization && privatized {
       _freePrivatizedClass(arr.pid, arr);
     }
 


### PR DESCRIPTION
This PR uses the param flag `_privatization` at privatization-related checks that
caused some [performance regressions](https://chapel-lang.org/perf/chapcs/?startdate=2019/11/12&enddate=2019/12/05&graphs=arrayviewcreation) after #14510. This seems to bring the performance of the array view creation benchmark (the issue is more about its destruction rather than creation).

FWIW, this might improve the performance a bit when dmaps are used with 
privatization disabled (e.g. local runs). But I haven't run any test to back that claim up.

Test:
- [x] standard correctness
- [x] gasnet correctness