### PR TITLE
Update my version of revcomp to use recursive doubling 

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -3,6 +3,7 @@
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the Rust #2 version by Matt Brubeck
+   updated to avoid allocating the buffer to be the right size from the start
 */
 use IO;
 


### PR DESCRIPTION
The shootout website has started requiring revcomp solutions to avoid
allocating the entire buffer to be the right size from the start.
This takes the approach used by the leading C version of recursively
doubling the buffer size when we need more space.

This solution is likely to be a good chunk slower than our previous ones,
but may also provide overdue motivation for optimizing the case of
resizing a 1D array whose low bound and stride doesn't change...