### PR TITLE
Continue my day of being blindsided by skipif tests

### DIFF
--- a/test/interop/fortran/fortArrayToDRAutomatic/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDRAutomatic/chapelProcs.chpl
@@ -1,4 +1,6 @@
 export proc chpl_library_init_ftn() {
+  use SysCTypes;
+
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
@@ -1,4 +1,6 @@
 export proc chpl_library_init_ftn() {
+  use SysCTypes;
+
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;

--- a/test/interop/fortran/multidimArray/chapelProcs.chpl
+++ b/test/interop/fortran/multidimArray/chapelProcs.chpl
@@ -1,4 +1,6 @@
 export proc chpl_library_init_ftn() {
+  use SysCTypes;
+
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;


### PR DESCRIPTION
These three Fortran-only, finish after 6pm tests also needed
SysCtypes to be used in order to keep working.  Obviously.