### PR TITLE
Fix a 32-bit sensitivity with the I/O plug-in

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -744,7 +744,7 @@ module Curl {
       // lock the channel if it's not already locked
       assert(cc!.have_channel_lock);
 
-      var amt = realsize.safeCast(int(64));
+      var amt = realsize.safeCast(ssize_t);
 
       //writeln("curl_write_received offset=", qio_channel_offset_unlocked(cc.qio_ch), " len=", amt);
 

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -455,7 +455,7 @@ module HDFS {
       var remaining = amt;
       while remaining > 0 {
         var ptr:c_void_ptr = c_nil;
-        var len = 0;
+        var len = 0:ssize_t;
         var offset = 0;
         err = qio_channel_get_allocated_ptr_unlocked(qio_ch, amt, ptr, len, offset);
         if err then
@@ -494,7 +494,7 @@ module HDFS {
       var remaining = amt;
       while remaining > 0 {
         var ptr:c_void_ptr = c_nil;
-        var len = 0;
+        var len = 0:ssize_t;
         var offset = 0;
         err = qio_channel_get_write_behind_ptr_unlocked(qio_ch, ptr, len, offset);
         if err then
@@ -502,7 +502,7 @@ module HDFS {
         if ptr == nil || len == 0 then
           return EINVAL;
 
-        len = min(len, amt);
+        len = min(len, amt.safeCast(ssize_t));
         if len >= max(int(32)) then
           len = max(int(32));
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1701,7 +1701,7 @@ proc openplugin(pluginFile: QioPluginFile, mode:iomode,
     var path:string = "unknown";
     if pluginFile {
       var str:c_string = nil;
-      var len:ssize_t;
+      var len:int;
       var path_err = pluginFile.getpath(str, len);
       if path_err {
         path = "unknown";


### PR DESCRIPTION
The addition of my compile-but-don't-link package tests revealed some
pre-existing portability issues in the HDFS and Curl modules on 32-bit
platforms in which we were relying on ssize_t and int(64) being the same
size.  Here, I'm:

* changing a variable of type ssize_t to int(64) in the IO module because
  all calls to which its passed seem to expect int(64)
* changing some variables of type int(64) to ssize_t in the Curl and HDFS
  modules to match the qio interface's expectation
