### PR TITLE
Tune the transfer size for bypassing --cache-remote

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2777,7 +2777,7 @@ void chpl_cache_fence(int acquire, int release, int ln, int32_t fn)
 static inline
 int size_merits_direct_comm(struct rdcache_s* cache, size_t size)
 {
-  return size > (cache->max_pages* CACHEPAGE_SIZE / 4);
+  return size >= CACHEPAGE_SIZE;
 }
 
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,


### PR DESCRIPTION
It was previously set to 1/4 of the cache, but this decreases it to 1
cache page. This improves performance for Arkouda and some
microbenchmarks that do a lot of 16-32K transfers.

This hasn't been extensively tuned. It worked well for the arkouda
benchmarks and the size is around when we switch from FMA to BTE in
ugni, and a point at which gn-ibv throughput starts to be decent.

I think we'll need to tune this over time, especially if we add
heuristics to disable/enable the cache on the fly. In this case I went
with a smaller size with the thought that 1024 byte transfer performance
is decent and for the most part the things we care about caching tend to
be small like array metadata or class instance pointers.

Follow on to #14352