### PR TITLE
Fix some more string + value calls

### DIFF
--- a/modules/packages/DistributedIters.chpl
+++ b/modules/packages/DistributedIters.chpl
@@ -694,7 +694,7 @@ private proc writeTimeStatistics(wallTime:real,
   {
     const localeTime = localeTimes[i];
     localeTotalTime += localeTime;
-    localeTimesFormatted += (i + ": " + localeTime);
+    localeTimesFormatted += (i:string + ": " + localeTime:string);
     localeTimesFormatted += if i == localeRange.high
                             then ""
                             else ", ";


### PR DESCRIPTION
Turning on the option to print additional timing information for the
DistributedIters module revealed some additional string + value
calls that I'd failed to detect when working on PR #13658.
Reported by @carcarah — thanks!