### PR TITLE
Depend on Jinja2 2.10.1 instead of 2.10.3

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,5 +1,5 @@
 # Many of these packages have newer versions that work on Python 3 only.
-Jinja2==2.10.3
+Jinja2==2.10.1
 MarkupSafe==1.1.1
 Pygments==2.4.2
 Sphinx==1.8.5


### PR DESCRIPTION
to give pip mirrors time to catch up.

Trivial and not reviewed.