### PR TITLE
Fix a few tests after sphinx upgrade

### DIFF
--- a/test/chpldoc/compflags/folder/oneWord.doc.catfiles
+++ b/test/chpldoc/compflags/folder/oneWord.doc.catfiles
@@ -1,1 +1,1 @@
-myDocs/_sources/modules/oneWord.doc.txt
+myDocs/_sources/modules/oneWord.doc.rst.txt

--- a/test/chpldoc/compflags/folder/withHyphen.doc.catfiles
+++ b/test/chpldoc/compflags/folder/withHyphen.doc.catfiles
@@ -1,1 +1,1 @@
-my-docs/_sources/modules/withHyphen.doc.txt
+my-docs/_sources/modules/withHyphen.doc.rst.txt

--- a/test/chpldoc/compflags/folder/withUnderscore.doc.catfiles
+++ b/test/chpldoc/compflags/folder/withUnderscore.doc.catfiles
@@ -1,1 +1,1 @@
-my_docs/_sources/modules/withUnderscore.doc.txt
+my_docs/_sources/modules/withUnderscore.doc.rst.txt

--- a/test/mason/mason-doc/docPkg.good
+++ b/test/mason/mason-doc/docPkg.good
@@ -1,6 +1,5 @@
 chpldoc src/Pkg.chpl -o doc/ --process-used-modules
-Running Sphinx v1.3.3
-loading pickled environment... not yet created
+Running Sphinx v1.8.5
 building [mo]: targets for 0 po files that are out of date
 building [html]: targets for 3 source files that are out of date
 updating environment: 3 added, 0 changed, 0 removed
@@ -23,4 +22,6 @@ copying extra files... done
 dumping search index in English (code: en) ... done
 dumping object inventory... done
 build succeeded.
+
+The HTML pages are in doc.
 HTML files are at: doc/


### PR DESCRIPTION
Follow-on to PR #14276.

For some reason the Sphinx upgrade caused some `_sources` output to be in
e.g. oneWord.doc.rst.txt rather than the earlier oneWord.doc.txt. This PR
just updates the catfiles for such tests. 

Additionally, it updates the Sphinx version number that is in one test's
.good file.

Trivial and not reviewed.

- [x] chpldoc tests pass