### PR TITLE
Resolve memory leaks with quicksort with array-of-arrays

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9337,6 +9337,11 @@ static void replaceRuntimeTypeDefaultInit(CallExpr* call) {
   Type*    rt = typeSe->symbol()->type;
 
   if (rt->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE)) {
+    if (var->hasFlag(FLAG_NO_INIT)) {
+      call->convertToNoop();
+      return;
+    }
+
     // ('init' x foo), where typeof(foo) has flag "runtime type value"
     //
     // ==>

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1716,7 +1716,7 @@ module ShallowCopy {
     }
 
     if A._instance.isDefaultRectangular() {
-      type st = __primitive("static field type", A, "eltType");
+      type st = __primitive("static field type", A._value, "eltType");
       var size = (nElts:size_t)*c_sizeof(st);
       c_memcpy(ptrTo(A[dst]), ptrTo(A[src]), size);
     } else {
@@ -1743,7 +1743,7 @@ module ShallowCopy {
 
     if DstA._instance.isDefaultRectangular() &&
        SrcA._instance.isDefaultRectangular() {
-      type st = __primitive("static field type", DstA, "eltType");
+      type st = __primitive("static field type", DstA._value, "eltType");
       var size = (nElts:size_t)*c_sizeof(st);
       c_memcpy(ptrTo(DstA[dst]), ptrTo(SrcA[src]), size);
     } else {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1664,9 +1664,11 @@ module ShallowCopy {
     } else {
       var size = c_sizeof(st);
       c_memcpy(ptrTo(dst), ptrTo(src), size);
-      // The version moved from should never be used again,
-      // but we clear it out just in case.
-      c_memset(ptrTo(src), 0, size);
+      if boundsChecking {
+        // The version moved from should never be used again,
+        // but we clear it out just in case.
+        c_memset(ptrTo(src), 0, size);
+      }
     }
   }
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1646,7 +1646,12 @@ module ShallowCopy {
 
   private use SysCTypes;
 
-  // work around c_ptrTo on array returning pointer to 1st element
+  // The shallowCopy / shallowSwap code needs to be able to copy/swap
+  // _array records. But c_ptrTo on an _array will return a pointer to
+  // the first element, which messes up the shallowCopy/shallowSwap code
+  //
+  // As a workaround, this function just returns a pointer to the argument,
+  // whether or not it is an array.
   private inline proc ptrTo(ref x) {
     return c_pointer_return(x);
   }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1644,48 +1644,69 @@ module RadixSortHelp {
 pragma "no doc"
 module ShallowCopy {
 
+  private use SysCTypes;
+
+  // compute size of local variable without considering runtime types
+  pragma "fn synchronization free"
+  private extern proc sizeof(x): size_t;
+
+  // work around c_ptrTo on array returning pointer to 1st element
+  private inline proc ptrTo(ref x) {
+    return c_pointer_return(x);
+  }
+
   // These shallow copy functions "move" a record around
   // (i.e. they neither swap nor call a copy initializer).
   //
   // TODO: move these out of the Sort module and/or consider
   // language support for it. See issue #14576.
 
-  inline proc shallowCopy(ref dst:?t, ref src:t) {
-    if isPODType(t) {
+  inline proc shallowCopy(ref dst, ref src) {
+    type st = __primitive("static typeof", dst);
+    if isPODType(st) {
       dst = src;
     } else {
-      var size = c_sizeof(t);
-      c_memcpy(c_ptrTo(dst), c_ptrTo(src), size);
+      pragma "no init"
+      pragma "no auto destroy"
+      var tmp: st;
+      var size = sizeof(tmp);
+      c_memcpy(ptrTo(dst), ptrTo(src), size);
       // The version moved from should never be used again,
       // but we clear it out just in case.
-      c_memset(c_ptrTo(src), 0, size);
+      c_memset(ptrTo(src), 0, size);
     }
   }
 
   // returns the result of shallow copying src
   pragma "unsafe"
-  inline proc shallowCopyInit(ref src:?t) {
-    var dst: t;
+  pragma "no copy return"
+  inline proc shallowCopyInit(ref src) {
+    type st = __primitive("static typeof", src);
+    pragma "no init"
+    pragma "no auto destroy"
+    var dst: st;
     shallowCopy(dst, src);
     return dst;
   }
 
   pragma "unsafe"
   inline proc shallowSwap(ref lhs:?t, ref rhs:t) {
+    type st = __primitive("static typeof", lhs);
+    pragma "no init"
     pragma "no auto destroy"
-    var tmp: t;
-    if isPODType(t) {
+    var tmp: st;
+    if isPODType(st) {
       tmp = lhs;
       lhs = rhs;
       rhs = tmp;
     } else {
-      var size = c_sizeof(t);
+      var size = sizeof(tmp);
       // tmp = lhs
-      c_memcpy(c_ptrTo(tmp), c_ptrTo(lhs), size);
+      c_memcpy(ptrTo(tmp), ptrTo(lhs), size);
       // lhs = rhs
-      c_memcpy(c_ptrTo(lhs), c_ptrTo(rhs), size);
+      c_memcpy(ptrTo(lhs), ptrTo(rhs), size);
       // rhs = tmp
-      c_memcpy(c_ptrTo(rhs), c_ptrTo(tmp), size);
+      c_memcpy(ptrTo(rhs), ptrTo(tmp), size);
     }
   }
 
@@ -1702,8 +1723,9 @@ module ShallowCopy {
     }
 
     if A._instance.isDefaultRectangular() {
-      var size = (nElts:size_t)*c_sizeof(A.eltType);
-      c_memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size);
+      type st = __primitive("static field type", A, "eltType");
+      var size = (nElts:size_t)*c_sizeof(st);
+      c_memcpy(ptrTo(A[dst]), ptrTo(A[src]), size);
     } else {
       var ok = chpl__bulkTransferArray(/*dst*/ A, {dst..#nElts},
                                        /*src*/ A, {src..#nElts});
@@ -1728,8 +1750,9 @@ module ShallowCopy {
 
     if DstA._instance.isDefaultRectangular() &&
        SrcA._instance.isDefaultRectangular() {
-      var size = (nElts:size_t)*c_sizeof(DstA.eltType);
-      c_memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size);
+      type st = __primitive("static field type", DstA, "eltType");
+      var size = (nElts:size_t)*c_sizeof(st);
+      c_memcpy(ptrTo(DstA[dst]), ptrTo(SrcA[src]), size);
     } else {
       var ok = chpl__bulkTransferArray(/*dst*/ DstA, {dst..#nElts},
                                        /*src*/ SrcA, {src..#nElts});
@@ -1739,23 +1762,6 @@ module ShallowCopy {
           __primitive("=", DstA[dst+i], SrcA[src+i]);
         }
       }
-    }
-  }
-  inline proc parallelShallowCopy(ref DstA, dst, ref SrcA, src, nElts) {
-    const nTasks = if dataParTasksPerLocale > 0
-                   then dataParTasksPerLocale
-                   else here.maxTaskPar;
-
-    halt("buggy");
-    // TODO: something about this code is wrong right now.
-    const blockSize = divceil(nElts, nTasks);
-    const nBlocks = divceil(nElts, blockSize);
-    coforall tid in 0..#nTasks {
-      var start = tid * blockSize;
-      var n = blockSize;
-      if start + n > nElts then
-        n = nElts - start;
-      shallowCopy(DstA, dst+start, SrcA, src+start, n);
     }
   }
 }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1646,10 +1646,6 @@ module ShallowCopy {
 
   private use SysCTypes;
 
-  // compute size of local variable without considering runtime types
-  pragma "fn synchronization free"
-  private extern proc sizeof(x): size_t;
-
   // work around c_ptrTo on array returning pointer to 1st element
   private inline proc ptrTo(ref x) {
     return c_pointer_return(x);
@@ -1666,10 +1662,7 @@ module ShallowCopy {
     if isPODType(st) {
       dst = src;
     } else {
-      pragma "no init"
-      pragma "no auto destroy"
-      var tmp: st;
-      var size = sizeof(tmp);
+      var size = c_sizeof(st);
       c_memcpy(ptrTo(dst), ptrTo(src), size);
       // The version moved from should never be used again,
       // but we clear it out just in case.
@@ -1700,7 +1693,7 @@ module ShallowCopy {
       lhs = rhs;
       rhs = tmp;
     } else {
-      var size = sizeof(tmp);
+      var size = c_sizeof(st);
       // tmp = lhs
       c_memcpy(ptrTo(tmp), ptrTo(lhs), size);
       // lhs = rhs

--- a/test/library/packages/Sort/correctness/sort-array-of-owned.chpl
+++ b/test/library/packages/Sort/correctness/sort-array-of-owned.chpl
@@ -41,17 +41,6 @@ record ValueComparator {
     if A[i] == nil then halt("nil was introduced");
   }
   assert(isSorted(A, comparator));
-
-  /*
-  for i in 1..n {
-    A[i] = new owned Value(n-i);
-  }
-  QuickSort.quickSort(A, comparator=comparator);
-  if n <= 20 then writeln(A);
-  for i in 1..n {
-    if A[i] == nil then halt("nil was introduced");
-  }
-  assert(isSorted(A, comparator));*/
 }
 
 // TEST 2: SORTING RECORD CONTAINING OWNED ELEMENTS
@@ -95,17 +84,6 @@ record WrapperComparator {
     if A[i].elt == nil then halt("nil was introduced");
   }
   assert(isSorted(A, comparator));
-
-  /*
-  for i in 1..n {
-    A[i] = new Wrapper(new owned Value(n-i));
-  }
-  QuickSort.quickSort(A, comparator=comparator);
-  if n <= 20 then writeln(A);
-  for i in 1..n {
-    if A[i].elt == nil then halt("nil was introduced");
-  }
-  assert(isSorted(A, comparator));*/
 }
 
 // TEST 3: SORTING RECORD CONTAINING ARRAY OF OWNED ELEMENTS
@@ -151,15 +129,39 @@ record ArrayWrapperComparator {
     if A[i].elts[1] == nil then halt("nil was introduced");
   }
   assert(isSorted(A, comparator));
+}
 
-  /*
-  for i in 1..n {
-    A[i] = new ArrayWrapper(new owned Value(n-i));
+// TEST 4: SORTING ARRAY CONTAINING ARRAY OF OWNED ELEMENTS
+
+record ArrayComparator {
+  proc key(v: [] owned Value?) where useKeyComparator {
+    if v[1] == nil then
+      return 0;
+    else
+      return v[1]!.x;
   }
-  QuickSort.quickSort(A, comparator=comparator);
+  proc compare(a: [] owned Value?, b: [] owned Value?) where !useKeyComparator {
+    var aNum = 0;
+    if a[1] != nil then
+      aNum = a[1]!.x;
+    var bNum = 0;
+    if b[1] != nil then
+      bNum = b[1]!.x;
+    return aNum - bNum;
+  }
+}
+
+{
+  writeln("Testing sorting array containing array of owned");
+  var A: [1..n] [1..1] owned Value?;
+  var comparator = new ArrayComparator();
+  for i in 1..n {
+    A[i][1] = new owned Value(n-i);
+  }
+  sort(A, comparator=comparator);
   if n <= 20 then writeln(A);
   for i in 1..n {
-    if A[i].elts[1] == nil then halt("nil was introduced");
+    if A[i][1] == nil then halt("nil was introduced");
   }
-  assert(isSorted(A, comparator));*/
+  assert(isSorted(A, comparator));
 }

--- a/test/library/packages/Sort/correctness/sort-array-of-owned.good
+++ b/test/library/packages/Sort/correctness/sort-array-of-owned.good
@@ -1,3 +1,4 @@
 Testing sorting owned
 Testing sorting record containing owned
 Testing sorting record containing array of owned
+Testing sorting array containing array of owned


### PR DESCRIPTION
This PR addresses a memory leak with
`test/library/packages/Sort/correctness/sort-array-of-owned.chpl` with
`-suseKeyComparator=false`. The problem was that `shallowSwap` was
creating a temporary variable which was default-initialized but not
destroyed. This variable should be neither initialized nor destroyed.

* use `pragma "no init"` to avoid allocating memory for swap temporary in
  shallowSwap
* Respect `pragma "no init"` for values with runtime types (e.g. arrays)
* Adjust sort shallowCopy code to handle arrays (which required working
  around some special behavior of `c_ptrTo` with arrays, namely returning
  the first element; and also working around the fact that array types
  have a runtime component. The runtime component is not of interest
  here).

The first change fixed the memory leak but then I thought to extend the
test to sorting array-of-array-of-owned and that revealed further issues
that the subsequent changes addressed.

Reviewed by @ronawho - thanks!

- [x] full local testing