### PR TITLE
Add perf annotations for 2019-12-12

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -617,6 +617,8 @@ create-views:
     - Govern slice expressions by slicing domain (#12931)
   11/27/19:
     - Close some multilocale distribution and privatization memleaks (#14510)
+  12/10/19:
+    - Guard privatization checks with param flag (#14604)
 
 cs-resize:
   03/05/19:
@@ -1158,6 +1160,9 @@ memleaksfull:
     - Access param, type fields without postfix-! (#14549)
   12/06/19:
     - Close user-level leaks in some new tests (#14586)
+    - Fix quicksort to work with owned array elements (#14204)
+  12/10/19:
+    - Allow messages in new Errors (#14545)
 
 meteor:
   12/18/13:


### PR DESCRIPTION
Annotates:

- increases in [memleaks](https://chapel-lang.org/perf/chapcs/?startdate=2019/11/19&enddate=2019/12/11&graphs=memoryleaksforalltests)
- recovering [array view creation performance](https://chapel-lang.org/perf/chapcs/?startdate=2019/11/23&enddate=2019/12/11&graphs=arrayviewcreation,arrayofstringelementaccess,memoryleaksforexamplestests,numberoftestswithleaksexamplesonly,memoryleaksforalltests,numberoftestswithleaks,castfromstringtimebydesttype,stringtemporarycopies,splittingastringonwhitespace,allocatingstringoperations,passingandreturningstrings,searchesovernstrings,searchwithinastring)