### PR TITLE
Support multiple system prediff scripts in one test run.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -669,7 +669,7 @@ def set_up_environment():
         os.environ["CHPL_SYSTEM_PREEXEC"] = args.preexec
 
     if args.prediff:
-        os.environ["CHPL_SYSTEM_PREDIFF"] = args.prediff
+        os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(args.prediff)
 
     # compopts (note that we have to strip out our preprocessing)
     if args.compopts:
@@ -1092,14 +1092,15 @@ def set_up_executables():
 
     # pre-diff
     if args.prediff:
-        if os.path.isfile(args.prediff) and os.access(args.prediff, os.X_OK):
-            args.prediff = os.path.abspath(args.prediff)
-            logger.write("[system-wide prediff: {0}]".format(args.prediff))
-        else:
-            logger.write("[Error: Cannot find or execute system-wide prediff: "
-                    "{0}".format(args.prediff))
-            finish()
-        os.environ["CHPL_SYSTEM_PREDIFF"] = args.prediff
+        for pdf in args.prediff:
+            if os.path.isfile(pdf) and os.access(pdf, os.X_OK):
+                pdf = os.path.abspath(pdf)
+                logger.write("[system-wide prediff: {0}]".format(pdf))
+            else:
+                logger.write("[Error: Cannot find or execute system-wide prediff: "
+                        "{0}".format(pdf))
+                finish()
+            os.environ["CHPL_SYSTEM_PREDIFF"] += ','+pdf
 
 
 def auto_generate_tests():
@@ -1306,8 +1307,10 @@ def parser_setup():
     parser.add_argument("-syspreexec", "--syspreexec", action="store",
             dest="preexec", 
             help="set a PREEXEC script to run before execution")
-    parser.add_argument("-sysprediff", "--sysprediff", action="store",
-            dest="prediff", help="set a PREDIFF script to run on test output")
+    parser.add_argument("-sysprediff", "--sysprediff", action="append",
+                        dest="prediff",
+                        help="set a PREDIFF script to run on test output"
+                             ", may be given more than once")
     # future mode args
     futures_mode = 0
     parser.add_argument("-futures", "--futures", action="store_const", const=1,

--- a/util/start_test
+++ b/util/start_test
@@ -1092,15 +1092,15 @@ def set_up_executables():
 
     # pre-diff
     if args.prediff:
-        for pdf in args.prediff:
-            if os.path.isfile(pdf) and os.access(pdf, os.X_OK):
-                pdf = os.path.abspath(pdf)
-                logger.write("[system-wide prediff: {0}]".format(pdf))
+        for prediff in args.prediff:
+            if os.path.isfile(prediff) and os.access(prediff, os.X_OK):
+                prediff = os.path.abspath(prediff)
+                logger.write("[system-wide prediff: {0}]".format(prediff))
             else:
                 logger.write("[Error: Cannot find or execute system-wide prediff: "
-                        "{0}".format(pdf))
+                        "{0}".format(prediff))
                 finish()
-            os.environ["CHPL_SYSTEM_PREDIFF"] += ','+pdf
+            os.environ["CHPL_SYSTEM_PREDIFF"] += ','+prediff
 
 
 def auto_generate_tests():

--- a/util/start_test
+++ b/util/start_test
@@ -664,13 +664,6 @@ def set_up_tmpdir():
 
 
 def set_up_environment():
-    # pre-
-    if args.preexec:
-        os.environ["CHPL_SYSTEM_PREEXEC"] = args.preexec
-
-    if args.prediff:
-        os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(args.prediff)
-
     # compopts (note that we have to strip out our preprocessing)
     if args.compopts:
         args.compopts = [strip_preprocessing(x) for x in args.compopts]
@@ -1081,17 +1074,22 @@ def set_up_executables():
 
     # pre-exec
     if args.preexec:
-        if os.path.isfile(args.preexec) and os.access(args.preexec, os.X_OK):
-            args.preexec = os.path.abspath(args.preexec)
-            logger.write("[system-wide preexec: {0}]".format(args.preexec))
-        else:
-            logger.write("[Error: Cannot find or execute system-wide preexec:"
-                    "{0}".format(args.preexec))
-            finish()
-        os.environ["CHPL_SYSTEM_PREEXEC"] = args.preexec
+        chpl_system_preexec = []
+        for preexec in args.preexec:
+            if os.path.isfile(preexec) and os.access(preexec, os.X_OK):
+                preexec = os.path.abspath(preexec)
+                logger.write("[system-wide preexec: {0}]".format(preexec))
+            else:
+                logger.write("[Error: Cannot find or execute system-wide preexec: "
+                        "{0}".format(preexec))
+                finish()
+            chpl_system_preexec.append(preexec)
+        os.environ["CHPL_SYSTEM_PREEXEC"] = ','.join(chpl_system_preexec)
+
 
     # pre-diff
     if args.prediff:
+        chpl_system_prediff = []
         for prediff in args.prediff:
             if os.path.isfile(prediff) and os.access(prediff, os.X_OK):
                 prediff = os.path.abspath(prediff)
@@ -1100,7 +1098,8 @@ def set_up_executables():
                 logger.write("[Error: Cannot find or execute system-wide prediff: "
                         "{0}".format(prediff))
                 finish()
-            os.environ["CHPL_SYSTEM_PREDIFF"] += ','+prediff
+            chpl_system_prediff.append(prediff)
+        os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(chpl_system_prediff)
 
 
 def auto_generate_tests():
@@ -1304,9 +1303,10 @@ def parser_setup():
     parser.add_argument("-valgrindexe", "--valgrindexe", action="store_true",
             dest="valgrind_exe", help="execute tests using valgrind")
     # pre exec, pre- etc....
-    parser.add_argument("-syspreexec", "--syspreexec", action="store",
-            dest="preexec", 
-            help="set a PREEXEC script to run before execution")
+    parser.add_argument("-syspreexec", "--syspreexec", action="append",
+                        dest="preexec",
+                        help="set a PREEXEC script to run before execution"
+                             ", may be given more than once")
     parser.add_argument("-sysprediff", "--sysprediff", action="append",
                         dest="prediff",
                         help="set a PREDIFF script to run on test output"

--- a/util/test/prediff-for-slurm-srun
+++ b/util/test/prediff-for-slurm-srun
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# This script is a system-wide prediff for use with the slurm-srun
+# launcher.
+#
+import sys, re
+
+# These match the message blocks we want to remove.
+msgs = (
+"""srun: error: .+: task [0-9]+: Exited with exit code [0-9]+
+""",
+"""srun: error: .+: task [0-9]+: Terminated
+""",
+"""srun: Terminating job step [0-9.]+
+""",
+"""slurmstepd: error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ \*\*\*
+""",
+"""slurmstepd: error: .+ \[[0-9]+] .*
+""",
+)
+
+outfname = sys.argv[2]
+with open(outfname, "r") as f:
+    outText = f.read()
+for m in msgs:
+    outText = re.sub(m, "", outText, flags = re.MULTILINE)
+with open(outfname, "w") as f:
+    f.write(outText)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -45,7 +45,7 @@
 # CHPL_ONETEST: Name of the one test in this directory to run
 # CHPL_TEST_SINGLES: If false, test the entire directory
 # CHPL_SYSTEM_PREEXEC: If set, run script on test output prior to execution
-# CHPL_SYSTEM_PREDIFF: If set, run that script on each test output
+# CHPL_SYSTEM_PREDIFF: If set, run comma-separated scripts on each test output
 # CHPL_COMM: Chapel communication layer
 # CHPL_COMPONLY: Only build the test (same as -noexec flag)
 # CHPL_TEST_NUM_LOCALES_AVAILABLE: same as CHPL_TEST_MAX_LOCALES (for backwards compatibility)
@@ -717,11 +717,12 @@ if systemPreexec is not None:
     if not os.access(systemPreexec, os.R_OK|os.X_OK):
         Fatal("Cannot execute system-wide preexec '{0}'".format(systemPreexec))
 
-# Get the system-wide prediff
-systemPrediff = os.getenv('CHPL_SYSTEM_PREDIFF')
-if systemPrediff:
-  if not os.access(systemPrediff,os.R_OK|os.X_OK):
-    Fatal('Cannot execute system-wide prediff \''+systemPrediff+'\'')
+# Get the system-wide prediff(s)
+systemPrediffs = os.getenv('CHPL_SYSTEM_PREDIFF').strip().split(',')
+if systemPrediffs:
+    for spdf in systemPrediffs:
+        if not os.access(spdf,os.R_OK|os.X_OK):
+            Fatal('Cannot execute system-wide prediff \''+spdf+'\'')
 
 # Use the launcher walltime option for timeout
 useLauncherTimeout = os.getenv('CHPL_LAUNCHER_TIMEOUT')
@@ -1071,8 +1072,8 @@ sys.stdout.write('[Starting subtest - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %
 #sys.stdout.write('[compiler: \'%s\']\n'%(compiler))
 if systemPreexec:
     sys.stdout.write("[system-wide preexec: '{0}']\n".format(systemPreexec))
-if systemPrediff:
-    sys.stdout.write('[system-wide prediff: \'%s\']\n'%(systemPrediff))
+if systemPrediffs:
+    sys.stdout.write('[system-wide prediff(s): \'%s\']\n'%(', '.join(systemPrediffs)))
 
 # consistently look only at the files in the current directory
 dirlist=os.listdir(".")
@@ -1612,14 +1613,15 @@ for testname in testsrc:
             with open(complog, 'w') as complogfile:
                 complogfile.write('%s'%(output))
 
-            if systemPrediff:
-                sys.stdout.write('[Executing system-wide prediff]\n')
-                sys.stdout.flush()
-                p = py3_compat.Popen([systemPrediff, execname, complog, compiler,
-                                     ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
-                sys.stdout.flush()
+            if systemPrediffs:
+                for spdf in systemPrediffs:
+                    sys.stdout.write('[Executing system-wide prediff %s]\n'%(spdf))
+                    sys.stdout.flush()
+                    p = py3_compat.Popen([spdf, execname, complog, compiler,
+                                          ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    sys.stdout.write(p.communicate()[0])
+                    sys.stdout.flush()
 
             if globalPrediff:
                 sys.stdout.write('[Executing ./PREDIFF]\n')
@@ -2115,13 +2117,14 @@ for testname in testsrc:
                     execlogfile.write(output_content)
 
                 if not exectimeout and not launcher_error:
-                    if systemPrediff:
-                        sys.stdout.write('[Executing system-wide prediff]\n')
-                        sys.stdout.flush()
-                        p = py3_compat.Popen([systemPrediff, execname, execlog, compiler,
-                                             ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                        sys.stdout.write(p.communicate()[0])
+                    if systemPrediffs:
+                        for spdf in systemPrediffs:
+                            sys.stdout.write('[Executing system-wide prediff %s]\n'%(spdf))
+                            sys.stdout.flush()
+                            p = py3_compat.Popen([spdf, execname, execlog, compiler,
+                                                  ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                            sys.stdout.write(p.communicate()[0])
 
                     if globalPrediff:
                         sys.stdout.write('[Executing ./PREDIFF]\n')

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -720,9 +720,9 @@ if systemPreexec is not None:
 # Get the system-wide prediff(s)
 systemPrediffs = os.getenv('CHPL_SYSTEM_PREDIFF').strip().split(',')
 if systemPrediffs:
-    for spdf in systemPrediffs:
-        if not os.access(spdf,os.R_OK|os.X_OK):
-            Fatal('Cannot execute system-wide prediff \''+spdf+'\'')
+    for sprediff in systemPrediffs:
+        if not os.access(sprediff,os.R_OK|os.X_OK):
+            Fatal('Cannot execute system-wide prediff \''+sprediff+'\'')
 
 # Use the launcher walltime option for timeout
 useLauncherTimeout = os.getenv('CHPL_LAUNCHER_TIMEOUT')
@@ -1614,10 +1614,10 @@ for testname in testsrc:
                 complogfile.write('%s'%(output))
 
             if systemPrediffs:
-                for spdf in systemPrediffs:
-                    sys.stdout.write('[Executing system-wide prediff %s]\n'%(spdf))
+                for sprediff in systemPrediffs:
+                    sys.stdout.write('[Executing system-wide prediff %s]\n'%(sprediff))
                     sys.stdout.flush()
-                    p = py3_compat.Popen([spdf, execname, complog, compiler,
+                    p = py3_compat.Popen([sprediff, execname, complog, compiler,
                                           ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
                                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     sys.stdout.write(p.communicate()[0])
@@ -2118,10 +2118,10 @@ for testname in testsrc:
 
                 if not exectimeout and not launcher_error:
                     if systemPrediffs:
-                        for spdf in systemPrediffs:
-                            sys.stdout.write('[Executing system-wide prediff %s]\n'%(spdf))
+                        for sprediff in systemPrediffs:
+                            sys.stdout.write('[Executing system-wide prediff %s]\n'%(sprediff))
                             sys.stdout.flush()
-                            p = py3_compat.Popen([spdf, execname, execlog, compiler,
+                            p = py3_compat.Popen([sprediff, execname, execlog, compiler,
                                                   ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
                                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                             sys.stdout.write(p.communicate()[0])

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -44,7 +44,7 @@
 # CHPL_TEST_PERF_TRIALS: Default number of trials for perf tests
 # CHPL_ONETEST: Name of the one test in this directory to run
 # CHPL_TEST_SINGLES: If false, test the entire directory
-# CHPL_SYSTEM_PREEXEC: If set, run script on test output prior to execution
+# CHPL_SYSTEM_PREEXEC: If set, run comma-separated scripts on test output prior to execution
 # CHPL_SYSTEM_PREDIFF: If set, run comma-separated scripts on each test output
 # CHPL_COMM: Chapel communication layer
 # CHPL_COMPONLY: Only build the test (same as -noexec flag)
@@ -711,15 +711,18 @@ platform = platform.strip()
 machine=os.uname()[1].split('.', 1)[0]
 # sys.stdout.write('machine='+machine+'\n')
 
-# Get the system-wide preexec
-systemPreexec = os.getenv('CHPL_SYSTEM_PREEXEC')
-if systemPreexec is not None:
-    if not os.access(systemPreexec, os.R_OK|os.X_OK):
-        Fatal("Cannot execute system-wide preexec '{0}'".format(systemPreexec))
+# Get the system-wide preexec(s)
+systemPreexecs = os.getenv('CHPL_SYSTEM_PREEXEC')
+if systemPreexecs:
+    systemPreexecs = systemPreexecs.strip().split(',')
+    for spreexec in systemPreexecs:
+        if not os.access(spreexec, os.R_OK|os.X_OK):
+            Fatal('Cannot execute system-wide preexec \''+spreexec+'\'')
 
 # Get the system-wide prediff(s)
-systemPrediffs = os.getenv('CHPL_SYSTEM_PREDIFF').strip().split(',')
+systemPrediffs = os.getenv('CHPL_SYSTEM_PREDIFF')
 if systemPrediffs:
+    systemPrediffs = systemPrediffs.strip().split(',')
     for sprediff in systemPrediffs:
         if not os.access(sprediff,os.R_OK|os.X_OK):
             Fatal('Cannot execute system-wide prediff \''+sprediff+'\'')
@@ -1070,8 +1073,8 @@ else:
 #
 sys.stdout.write('[Starting subtest - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', time.localtime())))
 #sys.stdout.write('[compiler: \'%s\']\n'%(compiler))
-if systemPreexec:
-    sys.stdout.write("[system-wide preexec: '{0}']\n".format(systemPreexec))
+if systemPreexecs:
+    sys.stdout.write('[system-wide preexec(s): \'%s\']\n'%(', '.join(systemPreexecs)))
 if systemPrediffs:
     sys.stdout.write('[system-wide prediff(s): \'%s\']\n'%(', '.join(systemPrediffs)))
 
@@ -1731,7 +1734,7 @@ for testname in testsrc:
                 for i in range(1, len(execoptslist) + 1):
                     exec_log_names.append(get_exec_log_name(execname, compoptsnum, i))
 
-            # Write the log(s), so it/they can be modified by preexec.
+            # Write the log(s), so it/they can be modified by preexec(s).
             for exec_log_name in exec_log_names:
                 with open(exec_log_name, 'w') as execlogfile:
                     execlogfile.write(compoutput)
@@ -1838,13 +1841,14 @@ for testname in testsrc:
                 explicitexecgoodfile = explicitcompgoodfile
             del tlist
 
-            if systemPreexec:
-                sys.stdout.write('[Executing system-wide preexec]\n')
-                sys.stdout.flush()
-                p = py3_compat.Popen([systemPreexec, execname, execlog, compiler],
-                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
-                sys.stdout.flush()
+            if systemPreexecs:
+                for spreexec in systemPreexecs:
+                    sys.stdout.write('[Executing system-wide preexec %s]\n'%(spreexec))
+                    sys.stdout.flush()
+                    p = py3_compat.Popen([spreexec, execname, execlog, compiler],
+                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    sys.stdout.write(p.communicate()[0])
+                    sys.stdout.flush()
 
             if globalPreexec:
                 sys.stdout.write('[Executing ./PREEXEC]\n')


### PR DESCRIPTION
This allows for running more than one system prediff script.  The
`start_test -sysprediff` option can be given more than once and is
additive, and `CHPL_SYSTEM_PREDIFF` is now a comma-separated list.

While here I'm also adding a slurm-srun specific system prediff.  This
filters out the meta-messages slurm produces when jobs or job instances
exit erroneously.