### PR TITLE
Don't try to build chpldoc on XE module builds

### DIFF
--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -149,7 +149,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         ;;
     esac
 
-    venv_targets="test-venv chpldoc"
+    venv_targets="test-venv"
     case ",$components," in
     ( *,venv,* )
         log_info "Building Chapel component: venv ($venv_targets)"


### PR DESCRIPTION
Follow-on to PR #14276.

The chpldoc Sphinx dependency now requires Python 2.7 but XE systems don't have Python 2.7.