### PR TITLE
Skip chpldoc test for Python 2.6.9 or 3.4.6.

### DIFF
--- a/test/release/examples/primers/chpldoc.doc.skipif
+++ b/test/release/examples/primers/chpldoc.doc.skipif
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# chpldoc requires Python 2 >= 2.7 or Python 3 >= 3.5
+# This file skips versions that are known not to work.
+PYTHON_VERSION=`python --version 2>&1`
+
+case "$PYTHON_VERSION" in
+"Python 3.4.6")
+  # Need 3.5 or greater for Pygments
+  echo True
+  ;;
+"Python 2.6.9")
+  # Need 2.7 or greater for many dependencies
+  echo True
+  ;;
+ *)
+  echo False
+  ;;
+esac


### PR DESCRIPTION
Skip this test in configurations where chpldoc does
not build due to Python dependencies not being met.

Reviewed by @lydia-duncan - thanks!