### PR TITLE
Add mason-no-chpldoc target and use it in XE builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,9 @@ chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
 	cd tools/chplvis && $(MAKE) install
 
-mason: compiler chpldoc modules FORCE
+mason: comprt chpldoc mason-no-chpldoc FORCE
+
+mason-no-chpldoc: comprt FORCE
 	cd tools/mason && $(MAKE) && $(MAKE) install
 
 c2chapel: FORCE

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -175,7 +175,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         log_info "Start build_configs $dry_run $verbose -- mason"
 
         $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.mason.log" \
-            --target-compiler=gnu -- mason
+            --target-compiler=gnu -- mason-no-chpldoc
         ;;
     ( * )
         log_info "NO building Chapel component: mason"

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -174,6 +174,8 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
         log_info "Start build_configs $dry_run $verbose -- mason"
 
+        # build mason but don't build chpldoc since it
+        # doesn't build on XE due to Python version dependencies
         $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.mason.log" \
             --target-compiler=gnu -- mason-no-chpldoc
         ;;


### PR DESCRIPTION
Continuing #14641.

Adds a top-level Makefile target mason-no-chpldoc
and uses it in the XE module build (because chpldoc will not work on XE).

Reviewed by @lydia-duncan - thanks!