### PR TITLE
Rename expected filenames in docPkg test

### DIFF
--- a/test/mason/mason-doc/docPkg.chpl
+++ b/test/mason/mason-doc/docPkg.chpl
@@ -17,9 +17,9 @@ setenv("PWD", newPWD.c_str(), 1);
 MasonDoc.masonDoc(['mason', 'doc']);
 
 const sourcesDir = 'doc/_sources/modules/src/',
-      Pkg = sourcesDir + 'Pkg.txt',
-      SubPkg = sourcesDir + 'SubPkg.txt',
-      FS = sourcesDir + 'FileSystem.txt';
+      Pkg = sourcesDir + 'Pkg.rst.txt',
+      SubPkg = sourcesDir + 'SubPkg.rst.txt',
+      FS = sourcesDir + 'FileSystem.rst.txt';
 
 // Confirm Pkg was documented
 if !exists(Pkg) then


### PR DESCRIPTION
Follow-on to PR #14276 which upgraded sphinx.

The _sources file names changed,
from Something.txt to Something.rst.txt.
This PR adjusts docPkg to respond to that.

Trivial and not reviewed.