### PR TITLE
Don't unload cray-libsci in the Chapel module for Shasta any more.

### DIFF
--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -153,9 +153,6 @@ if { [string match cray-shasta $CHPL_HOST_PLATFORM] } {
         module swap PrgEnv-pgi PrgEnv-gnu
     }
 
-    # The cray-libsci module is loading hugepages, which we don't want (yet).
-    module unload cray-libsci
-
     # Some libraries are not yet available in static form.
     setenv CRAYPE_LINK_TYPE dynamic
 


### PR DESCRIPTION
We've been unloading the cray-libsci module in the Chapel module for
Shasta systems, because cray-libsci caused the addition of -lhugetlbfs
in linker command lines and there wasn't a libhugetlbfs on at least some
of the Shasta systems we used.  This led to link errors.

Here, stop doing this.  The unload is now failing because of certain
changes in how the PE modules are integrated with each other.  And in
addition, based on some experimentation it appears that now even with
the cray-libsci module loaded we only get a -lhugetlbfs in the linker
command if we also have a craype-hugepages module loaded.
