### PR TITLE
New chunk-by-chunk revcomp version with dynamic resizing and OOP

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -37,33 +37,33 @@ class Seq {
     last = cursor + readSize - 1;
     if (last >= dataLen) {
       dataLen *= 2;
-      if debug then writeln("resizing seq ", id, " to ", dataLen);
+      if debug then stderr.writeln("resizing seq ", id, " to ", dataLen);
       dom = {0..#dataLen};
     }
-    if debug then writeln("reading into ", cursor..last);
+    if debug then stderr.writeln("reading into ", cursor..last);
     return !input.read(data[cursor..last]);
   }
 
   proc processChunk() {
     for i in cursor..last {
       if data[i] == ">".toByte() {
-        if debug then writeln("Found a '>' at offset ", i);
+        if debug then stderr.writeln("Found a '>' at offset ", i);
         if start == -1 {
-          if debug then writeln("Setting start to ", i);  // TODO: we always set start to 0
+          if debug then stderr.writeln("Setting start to ", i);  // TODO: we always set start to 0
           start = i;
 	} else {
-          if debug then writeln("Setting end to ", i-1);
+          if debug then stderr.writeln("Setting end to ", i-1);
 	  end = i-1;
 	  return 1;
 	}
       } else if data[i] == 0 {
-        if debug then writeln("Found end of data at ", i);
+        if debug then stderr.writeln("Found end of data at ", i);
         end = i-1;
 	return 2;
       }
     }
 
-    if debug then writeln("Advancing cursor");
+    if debug then stderr.writeln("Advancing cursor");
     // we did not find the end of a sequence; set up for the next read
     cursor = last+1;
     return 0;
@@ -71,7 +71,7 @@ class Seq {
 
   proc copyTail() {
     const tailLen = last - end;
-    if debug then writeln("Copying tail of ", tailLen, " from ", end+1..#tailLen);
+    if debug then stderr.writeln("Copying tail of ", tailLen, " from ", end+1..#tailLen);
     var newSeq = new Seq(id = id+1,
                          cursor = 0,
                          last = tailLen-1);
@@ -81,7 +81,7 @@ class Seq {
   }
 
   proc revcomp() {
-    if debug then writeln("Processing sequence from ", start, " to ", end);
+    if debug then stderr.writeln("Processing sequence from ", start, " to ", end);
     const last = end;
     do {
       start += 1;

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -2,97 +2,128 @@
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
-   derived from the Rust #2 version by Matt Brubeck
-   updated to avoid allocating the buffer to be the right size from the start
+   informed by the C gcc #6 version by Jeremy Zerfas, particularly in
+   terms of recursively doubling the buffer size and the read chunk size
 */
 
-// TODO: All variables read?
+// TODO: if I add a flush and remove the unbuffered, does perf improve?
 
 use IO;
 
-config const debug = false;
+config const readSize = 16384;  // the chunk size to read at a time
 
-config const readSize = 16384;
+param eol = "\n".toByte();      // end-of-line, as an integer
 
-param eol = "\n".toByte();    // end-of-line, as an integer
+const table = createTable();    // create the table of code complements
 
-const table = createTable();  // create the table of code complements
+// a channel and coordination variable for writing data to stdout
+var stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                 hints=QIO_CH_ALWAYS_UNBUFFERED),
+    seqToWrite: atomic int = 1;
 
-// write the data that we read to stdout once all tasks have completed	
-const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED);
-var seqToWrite: atomic int = 1;
 
+proc main(args: [] string) {
+  const stdin = openfd(0),
+        input = stdin.reader(iokind.native, locking=false,
+                             hints=QIO_HINT_PARALLEL);
+
+  var curSeq = new Seq(id=1);
+
+  do {
+    const eof = curSeq.readChunk(input);
+
+    // look for one or more sequences in the chunk we just read
+    do {
+      const foundSeq = curSeq.processChunk();
+
+      if (foundSeq) {
+        // if the chunk completed a sequence, save it away and copy the
+        // remainder into the next one
+        var lastSeq = curSeq;
+        curSeq = lastSeq.copyTail();
+
+        // then fire off an asynchronous task to process the last sequence
+        begin with (in lastSeq) {
+          lastSeq.revcomp();
+        }
+      }
+    } while foundSeq == 1;
+  } while !eof;
+}
+
+// a class representing a sequence
 class Seq {
-  const id = 0;
-  var cursor = 0,
-      last = 0,
-      start = -1,
-      end = -1;
-  var dataLen = readSize;
-  var dom = {0..#dataLen};
-  var data: [dom] uint(8);
+  const id = 0;              // the sequence ID
+  var cursor = 0,            // a cursor for reading the next chunk
+      last = 0,              // the index of the last byte in the chunk
+      start = -1,            // the start of the sequence
+      end = -1,              // the end of the sequence
+      dataLen = readSize,    // the size of the data buffer
+      inds = {0..#dataLen},  // the domain describing the data buffer
+      data: [inds] uint(8);  // the data buffer
 
+  // read a chunk of bytes into the data buffer from the input channel;
+  // returns whether we've seen EOF (true) or not (false)
   proc readChunk(input) {
     last = cursor + readSize - 1;
     if (last >= dataLen) {
       dataLen *= 2;
-      if debug then stderr.writeln("resizing seq ", id, " to ", dataLen);
-      dom = {0..#dataLen};
+      inds = {0..#dataLen};
     }
-    if debug then stderr.writeln("reading into ", cursor..last);
     return !input.read(data[cursor..last]);
   }
 
+  // process the chunk from cursor through last looking for '>'s or '\0's;
+  // returns 0 if we did not find the end of the sequence, 1 if we did and
+  // another sequence follows, 2 if we did and it's the end of the file (EOF)
   proc processChunk() {
     for i in cursor..last {
-      if data[i] == ">".toByte() {
-        if debug then stderr.writeln("Found a '>' at offset ", i);
-        if start == -1 {
-          if debug then stderr.writeln("Setting start to ", i);  // TODO: we always set start to 0
-          start = i;
-	} else {
-          if debug then stderr.writeln("Setting end to ", i-1);
-	  end = i-1;
-	  return 1;
-	}
-      } else if data[i] == 0 {
-        if debug then stderr.writeln("Found end of data at ", i);
+      if data[i] == ">".toByte() {  // if we find '>'
+        if start == -1 {            // and haven't started a sequence yet
+          start = i;                // this is the start
+        } else {
+          end = i-1;                // otherwise, it starts the next one
+          return 1;
+        }
+      } else if data[i] == 0 {      // if we find '\0', this is the file's end;
         end = i-1;
-	return 2;
+        if start != -1 then
+          return 2;                 // indicate that we found a sequence
       }
     }
 
-    if debug then stderr.writeln("Advancing cursor");
-    // we did not find the end of a sequence; set up for the next read
+    // we did not find the end of a sequence, so advance the cursor to
+    // prepare for the next read
     cursor = last+1;
     return 0;
   }
 
+  // copy the unused tail of our data buffer into a new sequence
   proc copyTail() {
     const tailLen = last - end;
-    if debug then stderr.writeln("Copying tail of ", tailLen, " from ", end+1..#tailLen);
-    var newSeq = new Seq(id = id+1,
-                         cursor = 0,
-                         last = tailLen-1);
+    var newSeq = new Seq(id = id+1, cursor = 0, last = tailLen-1);
     newSeq.data[0..#tailLen] = data[end+1..#tailLen];
 
     return newSeq;
   }
 
+  // reverse and complement the sequence, then write out the result
   proc revcomp() {
-    if debug then stderr.writeln("Processing sequence from ", start, " to ", end);
-    const last = end;
+    last = end;                  // snapshot the end of the sequence
+
+    // advance 'start' to the first end-of-line
     do {
       start += 1;
     } while data[start] != eol;
 
-    while start <= end {
+    while start < end {
+      // swap the end values, replacing them with their complements
       ref d1 = data[start],
           d2 = data[end];
 
       (d1, d2) = (table[d2], table[d1]);
 
+      // advance the cursors, skipping over end-of-line characters
       advance(start, 1);
       advance(end, -1);
 
@@ -103,37 +134,13 @@ class Seq {
       }
     }
 
-    seqToWrite.waitFor(id);
-    stdoutBin.write(data[..last]);
-    stdoutBin.flush();
-    seqToWrite.write(id+1);
+    // write the sequence to stdout
+    seqToWrite.waitFor(id);         // wait for our ID's turn to write
+    stdoutBin.write(data[..last]);  // write the transformed data
+    seqToWrite.write(id+1);         // make it the next sequence's turn
   }
 }
 
-
-proc main(args: [] string) {
-  const stdin = openfd(0),
-        input = stdin.reader(iokind.native, locking=false,
-                             hints=QIO_HINT_PARALLEL);
-
-  // if the file isn't empty, wait for all tasks to complete before continuing
-  if stdin.length() != 0 then sync {
-    var curSeq = new Seq(id=1);
-
-    do {
-      const eof = curSeq.readChunk(input);
-      // TODO: Can we use a while...do here or is that a problem w.r.t. curSeq?
-      do {
-        const foundSeq = curSeq.processChunk();
-        if (foundSeq) {
-	  var lastSeq = curSeq;
-          curSeq = lastSeq.copyTail();
-          begin with (in lastSeq) { lastSeq.revcomp(); }
-        }
-      } while foundSeq == 1;
-    } while !eof;
-  }
-}
 
 proc createTable() {
   // `pairs` compactly represents the table we're creating, where the

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -1,9 +1,10 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
-   contributed by Ben Harshbarger and Brad Chamberlain
-   informed by the C gcc #6 version by Jeremy Zerfas, particularly in
-   terms of recursively doubling the buffer size and the read chunk size
+   contributed by Brad Chamberlain
+   based on the Chapel #1-#3 versions by Ben Harshbarger and myself,
+   and informed by the C gcc #6 version by Jeremy Zerfas, particularly in
+   terms of the read chunk size and the recursive doubling of the buffer
 */
 
 // TODO: if I add a flush and remove the unbuffered, does perf improve?


### PR DESCRIPTION
This is a new version of revcomp that does dynamic resizing of the buffer (correctly,
this time) and which reads the data in chunk-by-chunk.  It takes more of an OOP
organization than our previous versions, simply because it was easier for me to
reason about it that way, and I think the result ends up cleaner.
