### PR TITLE
Remove need to suppress slurm/aprun revcomp failures

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.suppressif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.suppressif
@@ -1,2 +1,0 @@
-CHPL_LAUNCHER <= slurm
-CHPL_LAUNCHER <= aprun


### PR DESCRIPTION
Our revcomp versions have historically relied on querying the size
of stdin, which hasn't been supported for slurm/aprun, so those
configurations were suppressed.  In my latest version, I removed
the need to query the length of the file, so the suppress should
have been removed as well.