### PR TITLE
Add a needed header for C++ cygwin compilation

### DIFF
--- a/runtime/include/encoding/encoding-support.h
+++ b/runtime/include/encoding/encoding-support.h
@@ -22,6 +22,7 @@
 
 // Note: This header is used by both the compiler and the runtime.
 
+#include <sys/types.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <wchar.h>


### PR DESCRIPTION
This runtime header is used by the compiler as well. To use `ssize_t` with g++
including `sys/types.h` was necessary. This PR adds that include.