### PR TITLE
Fix few tests that run on LLVM only

### DIFF
--- a/test/extern/ferguson/externblock/readme_examples2.chpl
+++ b/test/extern/ferguson/externblock/readme_examples2.chpl
@@ -49,7 +49,15 @@ module OuterModule {
 
   var str:c_string;
   setString(c_ptrTo(str));
-  writeln(createStringWithNewBuffer(str));
+  try {
+    writeln(createStringWithNewBuffer(str));
+  }
+  catch e:DecodeError {
+    writeln("Decode error creating string");
+  }
+  catch {
+    writeln("Unknown error creating string");
+  }
 
   module MyCModule {
     extern {

--- a/test/extern/jjueckstock/basic.chpl
+++ b/test/extern/jjueckstock/basic.chpl
@@ -15,7 +15,15 @@ module OuterModule {
     const char* greet_str = "Hello";
   } }
 
-  writeln(createStringWithNewBuffer(C.greeting()));
+  try {
+    writeln(createStringWithNewBuffer(C.greeting()));
+  }
+  catch e: DecodeError {
+    writeln("Decode error creating string");
+  }
+  catch {
+    writeln("Unknown error creating string");
+  }
   writeln(C.my_doub);
   writeln(C.my_int);
   writeln(C.add_one(1000));

--- a/test/extern/jjueckstock/types.chpl
+++ b/test/extern/jjueckstock/types.chpl
@@ -32,7 +32,15 @@ module OuterModule {
   //NOTE: either C.my_struct or my_struct will work with the use C; statement.
   var strct: C.my_struct = new my_struct(42, "bar".c_str());
   writeln(strct.foo);
-  writeln(createStringWithNewBuffer(strct.bar));
+  try {
+    writeln(createStringWithNewBuffer(strct.bar));
+  }
+  catch e: DecodeError {
+    writeln("Decode error creating string");
+  }
+  catch {
+    writeln("Unknown error creating string");
+  }
 
   //NOTE: due to an issue with the way Chapel implements type aliases,
   //


### PR DESCRIPTION
These tests are run with LLVM only and needed some error handling for 
string factory functions. This PR adds that.

I intended to just add `try!` but bumped into 
https://github.com/chapel-lang/chapel/issues/14465 again.