### PR TITLE
Avoid complexes in multi-locale interop

### DIFF
--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -514,7 +514,7 @@ std::string MLIContext::genMarshalRoutine(Type* t, bool out) {
   // Handle translation of different type classes here. Note that right now
   // what we can translate is limited.
   //
-  if (isPrimitiveScalar(t)) {
+  if (isPrimitiveScalar(t) && !is_complex_type(t)) {
     gen += this->genMarshalBodyPrimitiveScalar(t, out);
   } else if (t == dtStringC) {
     gen += this->genMarshalBodyString(t, out);
@@ -722,7 +722,7 @@ MLIContext::genServerDispatchSwitch(const std::vector<FnSymbol*>& fns) {
 //
 bool MLIContext::isSupportedType(Type* t) {
   return (
-      isPrimitiveScalar(t) ||
+      (isPrimitiveScalar(t) && !is_complex_type(t)) ||
       t == dtStringC ||
       t == exportTypeChplBytesWrapper
   );


### PR DESCRIPTION
PR #14657 changed isPrimitiveScalar to include complexes,
but multilocale interop code isn't ready to handle complexes,
so adjust the calls to isPrimitiveScalar to rule out complexes.

Reviewed by @dlongnecke-cray - thanks!

- [x] test/interop/{C,python}/multilocale passes