### PR TITLE
Enable split init for ref and const ref

### DIFF
--- a/compiler/AST/IfExpr.cpp
+++ b/compiler/AST/IfExpr.cpp
@@ -124,3 +124,13 @@ GenRet IfExpr::codegen() {
   return ret;
 }
 
+bool isLoweredIfExprBlock(BlockStmt* block) {
+  if (CallExpr* call = toCallExpr(block->body.last()))
+    if (call->isPrimitive(PRIM_MOVE) || call->isPrimitive(PRIM_ASSIGN))
+      if (SymExpr* lhs = toSymExpr(call->get(1)))
+        if (lhs->symbol()->hasFlag(FLAG_IF_EXPR_RESULT))
+          return true;
+
+  return false;
+}
+

--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -28,6 +28,7 @@
 #include "build.h"
 #include "expr.h"
 #include "ForLoop.h"
+#include "IfExpr.h"
 #include "LoopExpr.h"
 #include "passes.h"
 #include "scopeResolve.h"
@@ -717,7 +718,28 @@ static CallExpr* buildLoopExprFunctions(LoopExpr* loopExpr) {
   if (insideArgSymbol) {
     loopExpr->getModule()->block->insertAtHead(new DefExpr(fn));
   } else {
-    loopExpr->getStmtExpr()->insertBefore(new DefExpr(fn));
+    if (loopExpr->id == 197967 || fn->id == 533949)
+      gdbShouldBreakHere();
+    BlockStmt* block = NULL;
+    CondStmt* ifExprCond = NULL;
+    for (Expr* cur = loopExpr->getStmtExpr();
+         cur != NULL;
+         cur = cur->parentExpr) {
+      if (BlockStmt* b = toBlockStmt(cur)) {
+        block = b;
+        break;
+      }
+    }
+
+    if (block != NULL && isLoweredIfExprBlock(block)) {
+      ifExprCond = toCondStmt(block->parentExpr);
+    }
+
+    if (ifExprCond != NULL)
+      // for if-exprs, insert just before the CondStmt
+      ifExprCond->insertBefore(new DefExpr(fn));
+    else
+      loopExpr->getStmtExpr()->insertBefore(new DefExpr(fn));
   }
 
   SymbolMap outerMap;

--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -718,8 +718,6 @@ static CallExpr* buildLoopExprFunctions(LoopExpr* loopExpr) {
   if (insideArgSymbol) {
     loopExpr->getModule()->block->insertAtHead(new DefExpr(fn));
   } else {
-    if (loopExpr->id == 197967 || fn->id == 533949)
-      gdbShouldBreakHere();
     BlockStmt* block = NULL;
     CondStmt* ifExprCond = NULL;
     for (Expr* cur = loopExpr->getStmtExpr();

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -576,6 +576,13 @@ CondStmt::CondStmt(Expr* iCondExpr, BaseAST* iThenStmt, BaseAST* iElseStmt) :
   gCondStmts.add(this);
 }
 
+static void fixIfExprFoldedBlock(Expr* stmt) {
+  if (BlockStmt* block = toBlockStmt(stmt)) {
+    // This addresses lifetime issues with variables created within if-exprs.
+    block->flattenAndRemove();
+  }
+}
+
 CallExpr* CondStmt::foldConstantCondition() {
   CallExpr* result = NULL;
 
@@ -589,6 +596,7 @@ CallExpr* CondStmt::foldConstantCondition() {
 
         insertBefore(result);
 
+        bool isIfExpr = false;
         // A squashed IfExpr's result does not need FLAG_IF_EXPR_RESULT, which
         // is only used when there are multiple paths that could return a
         // different type.
@@ -597,6 +605,7 @@ CallExpr* CondStmt::foldConstantCondition() {
             Symbol* LHS = toSymExpr(call->get(1))->symbol();
             if (LHS->hasFlag(FLAG_IF_EXPR_RESULT)) {
               LHS->removeFlag(FLAG_IF_EXPR_RESULT);
+              isIfExpr = true;
             }
           }
         }
@@ -605,16 +614,16 @@ CallExpr* CondStmt::foldConstantCondition() {
           Expr* then_stmt = thenStmt;
 
           then_stmt->remove();
-
           replace(then_stmt);
+          if (isIfExpr) fixIfExprFoldedBlock(then_stmt);
 
         } else {
           Expr* else_stmt = elseStmt;
 
           if (else_stmt != NULL) {
             else_stmt->remove();
-
             replace(else_stmt);
+            if (isIfExpr) fixIfExprFoldedBlock(else_stmt);
           } else {
             remove();
           }

--- a/compiler/include/IfExpr.h
+++ b/compiler/include/IfExpr.h
@@ -53,4 +53,7 @@ private:
   BlockStmt* elseStmt;
 };
 
+// This function works only before conditional statement folding
+bool isLoweredIfExprBlock(BlockStmt* block);
+
 #endif

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2649,11 +2649,14 @@ static void emitRefVarInit(Expr* after, Symbol* var, Expr* init) {
 
 static void normRefVar(DefExpr* defExpr) {
   VarSymbol* var         = toVarSymbol(defExpr->sym);
-  Expr*      init        = defExpr->init->remove();
+  Expr*      init        = defExpr->init;
 
   if (init == NULL || isSplitInitExpr(init)) {
     USR_FATAL_CONT(var, "References must be initialized");
   }
+
+  if (init != NULL)
+    init->remove();
 
   emitRefVarInit(defExpr, var, init);
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -105,6 +105,7 @@ static void        normalizeTypeAlias(DefExpr* defExpr);
 static void        normalizeConfigVariableDefinition(DefExpr* defExpr);
 static void        normalizeVariableDefinition(DefExpr* defExpr);
 
+static void        emitRefVarInit(Expr* after, Symbol* var, Expr* init);
 static void        normRefVar(DefExpr* defExpr);
 
 static void        updateVariableAutoDestroy(DefExpr* defExpr);
@@ -2286,7 +2287,6 @@ static void normalizeVariableDefinition(DefExpr* defExpr) {
     foundSplitInit = findInitPoints(defExpr, initAssign);
 
   if ((init != NULL && !requestedSplitInit) ||
-      var->hasFlag(FLAG_REF_VAR) || // TODO REMOVE
       foundSplitInit == false) {
     // handle non-split initialization
 
@@ -2311,13 +2311,19 @@ static void normalizeVariableDefinition(DefExpr* defExpr) {
   } else {
     // handle split initialization
 
-    // Emit PRIM_INIT_VAR_SPLIT.
-    // It sets the type, if we have a type expression.
-    if (type == NULL)
-      defExpr->insertAfter( new CallExpr(PRIM_INIT_VAR_SPLIT_DECL, var));
-    else
-      defExpr->insertAfter(
-          new CallExpr(PRIM_INIT_VAR_SPLIT_DECL, var, defExpr->exprType->remove()));
+    // remove the init expression if present
+    if (init != NULL)
+      init->remove();
+
+    if (refVar == false) {
+      // Emit PRIM_INIT_VAR_SPLIT for non-ref variables
+      // It sets the type, if we have a type expression.
+      if (type == NULL)
+        defExpr->insertAfter( new CallExpr(PRIM_INIT_VAR_SPLIT_DECL, var));
+      else
+        defExpr->insertAfter(
+            new CallExpr(PRIM_INIT_VAR_SPLIT_DECL, var, defExpr->exprType->remove()));
+    }
 
     for_vector(CallExpr, call, initAssign) {
       SET_LINENO(call);
@@ -2325,10 +2331,11 @@ static void normalizeVariableDefinition(DefExpr* defExpr) {
       // Consider the RHS of the '=' call to be the init expr.
       Expr* rhs = call->get(2)->remove();
 
-      if (var->hasFlag(FLAG_REF_VAR)) {
+      if (refVar) {
         //       ref x = <value>;
         // const ref y : <type> = <value>;
-        INT_FATAL("not implemented yet");
+        emitRefVarInit(call, var, rhs);
+        call->remove();
 
       } else {
         // var x;
@@ -2579,15 +2586,8 @@ static void errorIfSplitInitializationRequired(DefExpr* def, Expr* cur) {
 
 
 
-
-static void normRefVar(DefExpr* defExpr) {
-  VarSymbol* var         = toVarSymbol(defExpr->sym);
-  Expr*      init        = defExpr->init;
-  Expr*      varLocation = NULL;
-
-  if (init == NULL || isSplitInitExpr(init)) {
-    USR_FATAL_CONT(var, "References must be initialized");
-  }
+static void emitRefVarInit(Expr* after, Symbol* var, Expr* init) {
+  Expr* varLocation = NULL;
 
   // If this is a const reference to an immediate, we need to insert a temp
   // variable so we can take the address of it, non-const references to an
@@ -2597,10 +2597,11 @@ static void normRefVar(DefExpr* defExpr) {
       if (initSym->symbol()->isImmediate()) {
         VarSymbol* constRefTemp  = newTemp("const_ref_immediate_tmp");
 
-        defExpr->insertBefore(new DefExpr(constRefTemp));
-        defExpr->insertBefore(new CallExpr(PRIM_MOVE,
-                                           constRefTemp,
-                                           init->remove()));
+        // Store the temp variable to the immediate next to the
+        // variable definition because `after` might be at an inner scope
+        Expr* before = var->defPoint;
+        before->insertBefore(new DefExpr(constRefTemp));
+        before->insertBefore(new CallExpr(PRIM_MOVE, constRefTemp, init));
 
         varLocation = new SymExpr(constRefTemp);
       }
@@ -2608,7 +2609,7 @@ static void normRefVar(DefExpr* defExpr) {
   }
 
   if (varLocation == NULL && init != NULL) {
-    varLocation = init->remove();
+    varLocation = init;
   }
 
   if (SymExpr* sym = toSymExpr(varLocation)) {
@@ -2641,10 +2642,22 @@ static void normRefVar(DefExpr* defExpr) {
     }
   }
 
-  defExpr->insertAfter(new CallExpr(PRIM_MOVE,
-                                    var,
-                                    new CallExpr(PRIM_ADDR_OF, varLocation)));
+  after->insertAfter(new CallExpr(PRIM_MOVE,
+                                  var,
+                                  new CallExpr(PRIM_ADDR_OF, varLocation)));
 }
+
+static void normRefVar(DefExpr* defExpr) {
+  VarSymbol* var         = toVarSymbol(defExpr->sym);
+  Expr*      init        = defExpr->init->remove();
+
+  if (init == NULL || isSplitInitExpr(init)) {
+    USR_FATAL_CONT(var, "References must be initialized");
+  }
+
+  emitRefVarInit(defExpr, var, init);
+}
+
 
 //
 // const <name> = <value>;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6255,7 +6255,7 @@ static void  moveHaltForUnacceptableTypes(CallExpr* call);
 
 static void  resolveMoveForRhsSymExpr(CallExpr* call, SymExpr* rhs);
 
-static void  resolveMoveForRhsCallExpr(CallExpr* call);
+static void  resolveMoveForRhsCallExpr(CallExpr* call, Type* rhsType);
 
 static void  moveSetConstFlagsAndCheck(CallExpr* call, CallExpr* rhs);
 
@@ -6314,7 +6314,7 @@ static void resolveMove(CallExpr* call) {
       resolveMoveForRhsSymExpr(call, rhsSymExpr);
 
     } else if (isCallExpr(rhs) == true) {
-      resolveMoveForRhsCallExpr(call);
+      resolveMoveForRhsCallExpr(call, rhsType);
 
     } else {
       INT_ASSERT(false);
@@ -6608,7 +6608,7 @@ static void resolveMoveForRhsSymExpr(CallExpr* call, SymExpr* rhs) {
   moveFinalize(call);
 }
 
-static void resolveMoveForRhsCallExpr(CallExpr* call) {
+static void resolveMoveForRhsCallExpr(CallExpr* call, Type* rhsType) {
   CallExpr* rhs = toCallExpr(call->get(2));
 
   moveSetConstFlagsAndCheck(call, rhs);
@@ -6682,6 +6682,19 @@ static void resolveMoveForRhsCallExpr(CallExpr* call) {
         if (SymExpr* se = toSymExpr(call->get(1))) {
           se->symbol()->addFlag(FLAG_DELAY_GENERIC_EXPANSION);
         }
+      }
+    } else if (rhs->isPrimitive(PRIM_ADDR_OF)) {
+      // Check that the types match
+      SymExpr* lhsSe = toSymExpr(call->get(1));
+      Symbol* lhs = lhsSe->symbol();
+      INT_ASSERT(lhs->isRef());
+
+      if (lhs->getValType() != rhsType->getValType()) {
+        USR_FATAL_CONT(call, "Initializing a reference with another type");
+        USR_PRINT(lhs, "Reference has type %s", toString(lhs->getValType()));
+        USR_PRINT(call, "Initializing with type %s",
+                        toString(rhsType->getValType()));
+        USR_STOP();
       }
     }
 

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -2285,12 +2285,14 @@ void EmitLifetimeErrorsVisitor::emitErrors() {
     if (erroredSymbols.count(key))
       continue;
 
+    bool user = !key->hasFlag(FLAG_TEMP);
+
     if (key->isRef()) {
       if (// check if intrinsic lifetime < symbol lifetime
-          (!intrinsic.referent.unknown &&
+          (!intrinsic.referent.unknown && user &&
            isLifetimeShorter(intrinsic.referent, scope)) ||
           // check if inferred lifetime < symbol lifetime
-          (!inferred.referent.unknown &&
+          (!inferred.referent.unknown && user &&
            isLifetimeShorter(inferred.referent, scope)) ||
           // check if inferred lifetime < intrinsic lifetime
           (!inferred.referent.unknown &&
@@ -2309,10 +2311,10 @@ void EmitLifetimeErrorsVisitor::emitErrors() {
 
     if (isOrContainsBorrowedClass(key->type)) {
       if (// check if intrinsic lifetime < symbol lifetime
-          (!intrinsic.borrowed.unknown &&
+          (!intrinsic.borrowed.unknown && user &&
            isLifetimeShorter(intrinsic.borrowed, scope)) ||
           // check if inferred lifetime < symbol lifetime
-          (!inferred.borrowed.unknown &&
+          (!inferred.borrowed.unknown && user &&
            isLifetimeShorter(inferred.borrowed, scope)) ||
           // check if inferred lifetime < intrinsic lifetime
           (!inferred.borrowed.unknown &&

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -2286,7 +2286,8 @@ void EmitLifetimeErrorsVisitor::emitErrors() {
     if (key->isRef() &&
         !inferred.referent.unknown &&
         !intrinsic.referent.unknown &&
-        isLifetimeShorter(inferred.referent, intrinsic.referent)) {
+        (isLifetimeShorter(inferred.referent, intrinsic.referent) ||
+         isLifetimeShorter(intrinsic.referent, scopeLifetimeForSymbol(key)))) {
       Expr* at = key->defPoint;
       if (inferred.referent.relevantExpr)
         at = inferred.referent.relevantExpr;

--- a/test/classes/errors/nilability-init-field-arg/COMPOPTS
+++ b/test/classes/errors/nilability-init-field-arg/COMPOPTS
@@ -1,1 +1,3 @@
---no-codegen
+--no-codegen --no-lifetime-checking
+# lifetime checking is disabled for these tests because they
+# are checking specifically nilability errors

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.chpl
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.chpl
@@ -1,13 +1,70 @@
 class C {
   var intField: int;
 }
-
-proc test() {
-  var b;
-  {
-    var inner = new owned C(1);
-    b = inner.borrow();
-  }
-  writeln(b);
+record R {
+  var classField: borrowed C;
 }
-test();
+record RQ {
+  var classField: borrowed C?;
+}
+
+proc testRassign() {
+  var outer = new owned C(0);
+  var x: R = new R(outer.borrow());
+  {
+    var myC = new owned C(1);
+    x = new R(myC.borrow());
+  }
+  writeln(x);
+}
+testRassign();
+
+proc testRQassign() {
+  var x: RQ = new RQ(nil);
+  {
+    var myC = new owned C(1);
+    x = new RQ(myC.borrow());
+  }
+  writeln(x);
+}
+testRQassign();
+
+proc testRsplitType() {
+  var x: R;
+  {
+    var myC = new owned C(1);
+    x = new R(myC.borrow());
+  }
+  writeln(x);
+}
+testRsplitType();
+
+proc testRQsplitType() {
+  var x: RQ;
+  {
+    var myC = new owned C(1);
+    x = new RQ(myC.borrow());
+  }
+  writeln(x);
+}
+testRQsplitType();
+
+proc testRsplitNoType() {
+  var x;
+  {
+    var myC = new owned C(1);
+    x = new R(myC.borrow());
+  }
+  writeln(x);
+}
+testRsplitNoType();
+
+proc testRQsplitNoType() {
+  var x;
+  {
+    var myC = new owned C(1);
+    x = new RQ(myC.borrow());
+  }
+  writeln(x);
+}
+testRQsplitNoType();

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.chpl
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.chpl
@@ -8,6 +8,46 @@ record RQ {
   var classField: borrowed C?;
 }
 
+proc testCborrowedCQassign() {
+  var c:borrowed C? = nil;
+  {
+    var inner = new owned C(1);
+    c = inner.borrow();
+  }
+  writeln(c);
+}
+testCborrowedCQassign();
+
+proc testCborrowedC() {
+  var c:borrowed C;
+  {
+    var inner = new owned C(1);
+    c = inner.borrow();
+  }
+  writeln(c);
+}
+testCborrowedC();
+
+proc testCborrowedCQ() {
+  var c:borrowed C?;
+  {
+    var inner = new owned C(1);
+    c = inner.borrow();
+  }
+  writeln(c);
+}
+testCborrowedCQ();
+
+proc testCNoType() {
+  var c;
+  {
+    var inner = new owned C(1);
+    c = inner.borrow();
+  }
+  writeln(c);
+}
+testCNoType();
+
 proc testRassign() {
   var outer = new owned C(0);
   var x: R = new R(outer.borrow());

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.chpl
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.chpl
@@ -1,0 +1,13 @@
+class C {
+  var intField: int;
+}
+
+proc test() {
+  var b;
+  {
+    var inner = new owned C(1);
+    b = inner.borrow();
+  }
+  writeln(b);
+}
+test();

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.good
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.good
@@ -1,3 +1,18 @@
-split-init-borrow-lifetime-error.chpl:5: In function 'test':
-split-init-borrow-lifetime-error.chpl:9: error: Scoped variable b would outlive the value it is set to
-split-init-borrow-lifetime-error.chpl:8: note: consider scope of inner
+split-init-borrow-lifetime-error.chpl:11: In function 'testRassign':
+split-init-borrow-lifetime-error.chpl:16: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:15: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:22: In function 'testRQassign':
+split-init-borrow-lifetime-error.chpl:26: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:25: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:32: In function 'testRsplitType':
+split-init-borrow-lifetime-error.chpl:36: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:35: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:42: In function 'testRQsplitType':
+split-init-borrow-lifetime-error.chpl:46: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:45: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:52: In function 'testRsplitNoType':
+split-init-borrow-lifetime-error.chpl:56: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:55: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:62: In function 'testRQsplitNoType':
+split-init-borrow-lifetime-error.chpl:66: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:65: note: consider scope of myC

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.good
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.good
@@ -1,0 +1,3 @@
+split-init-borrow-lifetime-error.chpl:5: In function 'test':
+split-init-borrow-lifetime-error.chpl:9: error: Scoped variable b would outlive the value it is set to
+split-init-borrow-lifetime-error.chpl:8: note: consider scope of inner

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.good
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.good
@@ -1,18 +1,32 @@
-split-init-borrow-lifetime-error.chpl:11: In function 'testRassign':
-split-init-borrow-lifetime-error.chpl:16: error: Scoped variable x reachable after lifetime ends
-split-init-borrow-lifetime-error.chpl:15: note: consider scope of myC
-split-init-borrow-lifetime-error.chpl:22: In function 'testRQassign':
-split-init-borrow-lifetime-error.chpl:26: error: Scoped variable x reachable after lifetime ends
-split-init-borrow-lifetime-error.chpl:25: note: consider scope of myC
-split-init-borrow-lifetime-error.chpl:32: In function 'testRsplitType':
-split-init-borrow-lifetime-error.chpl:36: error: Scoped variable x reachable after lifetime ends
-split-init-borrow-lifetime-error.chpl:35: note: consider scope of myC
-split-init-borrow-lifetime-error.chpl:42: In function 'testRQsplitType':
-split-init-borrow-lifetime-error.chpl:46: error: Scoped variable x reachable after lifetime ends
-split-init-borrow-lifetime-error.chpl:45: note: consider scope of myC
-split-init-borrow-lifetime-error.chpl:52: In function 'testRsplitNoType':
+split-init-borrow-lifetime-error.chpl:11: In function 'testCborrowedCQassign':
+split-init-borrow-lifetime-error.chpl:15: error: Scoped variable c would outlive the value it is set to
+split-init-borrow-lifetime-error.chpl:14: note: consider scope of inner
+split-init-borrow-lifetime-error.chpl:21: In function 'testCborrowedC':
+split-init-borrow-lifetime-error.chpl:25: error: Scoped variable c would outlive the value it is set to
+split-init-borrow-lifetime-error.chpl:24: note: consider scope of inner
+split-init-borrow-lifetime-error.chpl:31: In function 'testCborrowedCQ':
+split-init-borrow-lifetime-error.chpl:35: error: Scoped variable would outlive the value it is set to
+split-init-borrow-lifetime-error.chpl:34: note: consider scope of inner
+split-init-borrow-lifetime-error.chpl:35: error: Scoped variable c reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:34: note: consider scope of inner
+split-init-borrow-lifetime-error.chpl:41: In function 'testCNoType':
+split-init-borrow-lifetime-error.chpl:45: error: Scoped variable c would outlive the value it is set to
+split-init-borrow-lifetime-error.chpl:44: note: consider scope of inner
+split-init-borrow-lifetime-error.chpl:51: In function 'testRassign':
 split-init-borrow-lifetime-error.chpl:56: error: Scoped variable x reachable after lifetime ends
 split-init-borrow-lifetime-error.chpl:55: note: consider scope of myC
-split-init-borrow-lifetime-error.chpl:62: In function 'testRQsplitNoType':
+split-init-borrow-lifetime-error.chpl:62: In function 'testRQassign':
 split-init-borrow-lifetime-error.chpl:66: error: Scoped variable x reachable after lifetime ends
 split-init-borrow-lifetime-error.chpl:65: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:72: In function 'testRsplitType':
+split-init-borrow-lifetime-error.chpl:76: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:75: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:82: In function 'testRQsplitType':
+split-init-borrow-lifetime-error.chpl:86: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:85: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:92: In function 'testRsplitNoType':
+split-init-borrow-lifetime-error.chpl:96: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:95: note: consider scope of myC
+split-init-borrow-lifetime-error.chpl:102: In function 'testRQsplitNoType':
+split-init-borrow-lifetime-error.chpl:106: error: Scoped variable x reachable after lifetime ends
+split-init-borrow-lifetime-error.chpl:105: note: consider scope of myC

--- a/test/types/records/split-init/split-init-const-ref-multiple.chpl
+++ b/test/types/records/split-init/split-init-const-ref-multiple.chpl
@@ -1,0 +1,12 @@
+config const setting = false;
+
+proc main() {
+  const ref a;
+
+  if setting {
+    a = 9.0;
+  } else {
+    a = 100;
+  }
+  writeln(a);
+}

--- a/test/types/records/split-init/split-init-const-ref-multiple.good
+++ b/test/types/records/split-init/split-init-const-ref-multiple.good
@@ -1,0 +1,4 @@
+split-init-const-ref-multiple.chpl:3: In function 'main':
+split-init-const-ref-multiple.chpl:9: error: Initializing a reference with another type
+split-init-const-ref-multiple.chpl:4: note: Reference has type real(64)
+split-init-const-ref-multiple.chpl:9: note: Initializing with type int(64)

--- a/test/types/records/split-init/split-init-ref-const.chpl
+++ b/test/types/records/split-init/split-init-ref-const.chpl
@@ -1,0 +1,6 @@
+proc main() {
+  const x:int = 0;
+  ref r;
+  r = x;
+  writeln(r);
+}

--- a/test/types/records/split-init/split-init-ref-const.good
+++ b/test/types/records/split-init/split-init-ref-const.good
@@ -1,0 +1,1 @@
+split-init-ref-const.chpl:4: error: Cannot set a non-const reference to a const variable.

--- a/test/types/records/split-init/split-init-ref-lifetime-error.chpl
+++ b/test/types/records/split-init/split-init-ref-lifetime-error.chpl
@@ -1,0 +1,11 @@
+proc test() {
+
+  ref x;
+  {
+    var innerInt = 4;
+    x = innerInt;
+  }
+
+  writeln(x);
+}
+test();

--- a/test/types/records/split-init/split-init-ref-lifetime-error.good
+++ b/test/types/records/split-init/split-init-ref-lifetime-error.good
@@ -1,0 +1,3 @@
+split-init-ref-lifetime-error.chpl:1: In function 'test':
+split-init-ref-lifetime-error.chpl:6: error: Reference to scoped variable x reachable after lifetime ends
+split-init-ref-lifetime-error.chpl:5: note: consider scope of innerInt

--- a/test/types/records/split-init/split-init-ref-multiple.chpl
+++ b/test/types/records/split-init/split-init-ref-multiple.chpl
@@ -1,0 +1,13 @@
+config const setting = false;
+
+proc main() {
+  var oneInt = 1;
+  var twoReal = 2.0;
+  ref b;
+  if setting {
+    b = oneInt;
+  } else {
+    b = twoReal;
+  }
+  writeln(b);
+}

--- a/test/types/records/split-init/split-init-ref-multiple.good
+++ b/test/types/records/split-init/split-init-ref-multiple.good
@@ -1,0 +1,4 @@
+split-init-ref-multiple.chpl:3: In function 'main':
+split-init-ref-multiple.chpl:10: error: Initializing a reference with another type
+split-init-ref-multiple.chpl:6: note: Reference has type int(64)
+split-init-ref-multiple.chpl:10: note: Initializing with type real(64)

--- a/test/types/records/split-init/split-init-ref.chpl
+++ b/test/types/records/split-init/split-init-ref.chpl
@@ -1,0 +1,53 @@
+config const cond = false;
+
+proc printRef(name, ref arg) {
+  writeln(name, ": ", arg.type:string, " = ", arg);
+}
+proc printConstRef(name, const ref arg) {
+  writeln(name, ": ", arg.type:string, " = ", arg);
+}
+
+proc test() {
+  var x:int = 0;
+
+  ref yes1;
+  yes1 = x;
+  x = 1;
+  printRef("yes1", yes1);
+
+  const ref yes2;
+  {
+    x = 24;
+    yes2 = 2;
+  }
+  printConstRef("yes2", yes2);
+
+  const ref yes3;
+  {
+    if cond {
+      yes3 = 123;
+    } else {
+      yes3 = x;
+      x = 3;
+    }
+    printConstRef("yes3", yes3);
+  }
+
+  const ref yes4;
+  {
+    if !cond {
+      yes4 = 4;
+    } else {
+      yes4 = x;
+      x = 124;
+    }
+    printConstRef("yes4", yes4);
+  }
+
+
+  ref yes5:int;
+  yes5 = x;
+  x = 5;
+  printRef("yes5", yes5);
+}
+test();

--- a/test/types/records/split-init/split-init-ref.good
+++ b/test/types/records/split-init/split-init-ref.good
@@ -1,0 +1,5 @@
+yes1: int(64) = 1
+yes2: int(64) = 2
+yes3: int(64) = 3
+yes4: int(64) = 4
+yes5: int(64) = 5

--- a/test/types/records/split-init/split-init.chpl
+++ b/test/types/records/split-init/split-init.chpl
@@ -225,6 +225,3 @@ proc testRecs() {
   }
 }
 testRecs();
-
-// TODO: param set in a conditional
-// TODO: references and types

--- a/test/variables/sungeun/refvar-compare-nil.good
+++ b/test/variables/sungeun/refvar-compare-nil.good
@@ -1,1 +1,1 @@
-refvar-compare-nil.chpl:1: error: References must be initialized when they are defined.
+refvar-compare-nil.chpl:1: error: References must be initialized

--- a/test/variables/sungeun/refvar-no-init-with-def.good
+++ b/test/variables/sungeun/refvar-no-init-with-def.good
@@ -1,1 +1,1 @@
-refvar-no-init-with-def.chpl:1: error: References must be initialized when they are defined.
+refvar-no-init-with-def.chpl:1: error: References must be initialized

--- a/test/variables/sungeun/refvar-no-init-with-use.good
+++ b/test/variables/sungeun/refvar-no-init-with-use.good
@@ -1,1 +1,1 @@
-refvar-no-init-with-use.chpl:1: error: References must be initialized when they are defined.
+refvar-no-init-with-use.chpl:1: error: References must be initialized


### PR DESCRIPTION
PR #14564 added split initialization for var / const variable
declarations. This PR continues the effort by enabling the feature for
`ref` and `const ref` declarations.

 * Adjusts normalizeVariableDefinition to handle split-init for reference 
   variables
 * Adjusts resolveMoveForRhsCallExpr to give a user error for references 
   initialized with different types (which can happen with split-init and
   conditionals)
 * Adjusts resolvePrimInit to fix a problem with split initialization of
   class types
 * Improves checking in the lifetime checker for cases that came up in
   testing split-init and refs (see split-init-ref-lifetime-error.chpl  )
 * Adjusts CondStmt::foldConstantCondition to flatten blocks resulting
   from folded if-exprs (which resolves errors created by the additional
   lifetime checking and is related to issue #10879).

Reviewed by @vasslitvinov - thanks!

- [x] full local testing
