### PR TITLE
Add a basic PALS-based launcher.

### DIFF
--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -25,6 +25,8 @@
 //
 // Defined in main_launcher.c
 //
+void chpl_append_to_largv(int* largc, const char*** largv, int* largv_len,
+                          const char* arg);
 int chpl_run_utility1K(const char *command, char *const argv[],
                        char *outbuf, int outbuflen);
 int chpl_run_cmdstr(const char *commandStr, char *outbuf, int outbuflen);

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -70,6 +70,21 @@ static void chpl_launch_sanity_checks(const char* argv0) {
 }
 
 //
+// Use this utility routine to build up an argv[] list.  Start with
+// *largc==0, *largv==NULL, *largv_len==0, and it will keep those
+// updated as you append args one after another.
+//
+void chpl_append_to_largv(int* largc, const char*** largv, int* largv_len,
+                          const char* arg) {
+  if (*largc >= *largv_len) {
+    *largv_len += 10;
+    *largv = chpl_mem_realloc(*largv, *largv_len * sizeof(**largv),
+                              CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+  }
+  (*largv)[(*largc)++] = (arg);
+}
+
+//
 // Use this function to run short utility programs that will return less
 //  than 1024 characters of output.  The program must not expect any input.
 //  On success, returns the number of bytes read and the output of the

--- a/runtime/src/launch/mpirun4ofi/Makefile
+++ b/runtime/src/launch/mpirun4ofi/Makefile
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 RUNTIME_ROOT = ../../..
-RUNTIME_SUBDIR = src/launch/mpirun4ofi
+RUNTIME_SUBDIR = src/launch/$(CHPL_MAKE_LAUNCHER)
 
 ifndef CHPL_MAKE_HOME
 export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..

--- a/runtime/src/launch/mpirun4ofi/Makefile.include
+++ b/runtime/src/launch/mpirun4ofi/Makefile.include
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LAUNCH_SUBDIR = src/launch/mpirun4ofi
+LAUNCH_SUBDIR = src/launch/$(CHPL_MAKE_LAUNCHER)
 
 LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
 

--- a/runtime/src/launch/mpirun4ofi/Makefile.share
+++ b/runtime/src/launch/mpirun4ofi/Makefile.share
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 LAUNCHER_SRCS = \
-        launch-mpirun4ofi.c \
+        launch-$(CHPL_MAKE_LAUNCHER).c \
 
 SVN_SRCS = $(LAUNCHER_SRCS)
 SRCS = $(SVN_SRCS)

--- a/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
+++ b/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
@@ -37,17 +37,10 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
   snprintf(_nlbuf, sizeof(_nlbuf), "%d", getArgNumLocales());
 
   char** largv = NULL;
-  int largv_size = 0;
+  int largv_len = 0;
   int largc = 0;
-#define ADD_LARGV(s)                                                    \
-  do {                                                                  \
-    if (largc >= largv_size) {                                          \
-      largv_size += 10;                                                 \
-      largv = chpl_mem_realloc(largv, largv_size * sizeof(*largv),      \
-                               CHPL_RT_MD_COMMAND_BUFFER, -1, 0);       \
-    }                                                                   \
-    largv[largc++] = (char*) (s);                                       \
-  } while (0)
+#define ADD_LARGV(arg) chpl_append_to_largv(&largc, (const char***) &largv, \
+                                            &largv_len, arg)
 
   ADD_LARGV(launch_cmd);
   ADD_LARGV("-np");

--- a/runtime/src/launch/pals/Makefile
+++ b/runtime/src/launch/pals/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/$(CHPL_MAKE_LAUNCHER)
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
+endif
+
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/pals/Makefile.include
+++ b/runtime/src/launch/pals/Makefile.include
@@ -1,0 +1,24 @@
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCH_SUBDIR = src/launch/$(CHPL_MAKE_LAUNCHER)
+
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/pals/Makefile.share
+++ b/runtime/src/launch/pals/Makefile.share
@@ -1,0 +1,25 @@
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCHER_SRCS = \
+        launch-$(CHPL_MAKE_LAUNCHER).c \
+        $(CHPL_MAKE_LAUNCHER)-utils.c \
+
+SRCS = $(LAUNCHER_SRCS)
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/pals/launch-pals.c
+++ b/runtime/src/launch/pals/launch-pals.c
@@ -27,17 +27,54 @@
 #include "pals-utils.h"
 
 
+#define CPU_BIND_OPT_STR "-cc"
+static const char *ccArg = NULL;
+
+
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
   return chpl_launch_using_exec("cray",
-                                chpl_create_pals_cmd(argc, argv, numLocales),
+                                chpl_create_pals_cmd(argc, argv, numLocales,
+                                                     ccArg),
                                 argv[0]);
 }
 
 
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
                            int32_t lineno, int32_t filename) {
-  return 0;
+  int numArgs = 0;
+  if (!strcmp(argv[argNum], CPU_BIND_OPT_STR)) {
+    ccArg = argv[argNum+1];
+    numArgs = 2;
+  } else if (!strncmp(argv[argNum], CPU_BIND_OPT_STR"=",
+                      strlen(CPU_BIND_OPT_STR) + 1)) {
+    ccArg = &(argv[argNum][strlen(CPU_BIND_OPT_STR) + 1]);
+    numArgs = 1;
+  }
+  if (numArgs > 0) {
+      //
+      // We don't support "list" or "mask" yet, though we may someday.
+      //
+    if (strcmp(ccArg, "none") &&
+        strcmp(ccArg, "numa") &&
+        strcmp(ccArg, "socket") &&
+        strcmp(ccArg, "core") &&
+        strcmp(ccArg, "thread") &&
+        strcmp(ccArg, "depth")) {
+      char msg[100];
+      snprintf(msg, sizeof(msg), "'%s' is not a valid cpu assignment", ccArg);
+      chpl_error(msg, 0, 0);
+    }
+  }
+  return numArgs;
 }
 
 
-void chpl_launch_print_help(void) { }
+void chpl_launch_print_help(void) {
+  int width;
+  printf("LAUNCHER FLAGS:\n");
+  printf("===============\n");
+  printf("  %s keyword : %nspecify cpu assignment within a node: "
+         "none (default),\n",
+         CPU_BIND_OPT_STR, &width);
+  printf("%*snuma, socket, core, thread, depth\n", width, "");
+}

--- a/runtime/src/launch/pals/launch-pals.c
+++ b/runtime/src/launch/pals/launch-pals.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include "chpllaunch.h"
+#include "pals-utils.h"
+
+
+int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  return chpl_launch_using_exec("cray",
+                                chpl_create_pals_cmd(argc, argv, numLocales),
+                                argv[0]);
+}
+
+
+int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
+                           int32_t lineno, int32_t filename) {
+  return 0;
+}
+
+
+void chpl_launch_print_help(void) { }

--- a/runtime/src/launch/pals/pals-utils.c
+++ b/runtime/src/launch/pals/pals-utils.c
@@ -112,5 +112,8 @@ char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocales,
     APPEND_LARGV(nodeList);
   }
 
+  // craycli arg parser needs a marker at end of system launcher opts
+  APPEND_LARGV("--");
+
   return chpl_bundle_exec_args(argc, argv, largc, (char* const *) largv);
 }

--- a/runtime/src/launch/pals/pals-utils.c
+++ b/runtime/src/launch/pals/pals-utils.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// These are utility functions for the PALS-based launchers.
+//
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include "chpllaunch.h"
+#include "chpl-mem.h"
+#include "chpltypes.h"
+#include "error.h"
+
+#include "pals-utils.h"
+
+
+static
+char *getNodeList(void) {
+  const char *nodeList = getenv("CHPL_LAUNCHER_NODELIST");
+  char *buf = NULL;
+  if (nodeList) {
+    buf = chpl_mem_alloc(strlen(nodeList) + 1,
+                         CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+    strcpy(buf, nodeList);
+  }
+  return buf;
+}
+
+
+static
+char* int_str(int val) {
+    size_t buf_len = 20 + 1;
+    char* buf = chpl_mem_alloc(buf_len, CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+    if (snprintf(buf, buf_len, "%d", val) >= buf_len) {
+        chpl_error("int_str buffer overflow", 0, 0);
+    }
+    return buf;
+}
+
+
+char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocales) {
+  int largc = 0;
+  const char **largv = NULL;
+  int largv_len = 0;
+#define APPEND_LARGV(arg) chpl_append_to_largv(&largc, &largv, &largv_len, arg)
+
+  APPEND_LARGV("cray");
+  APPEND_LARGV("mpiexec");
+
+  APPEND_LARGV("-n");                   // num processes
+  APPEND_LARGV(int_str(numLocales));
+
+  APPEND_LARGV("--ppn");                // num processes per node
+  APPEND_LARGV(int_str(1));
+
+  char *nodeList;
+  if ((nodeList = getNodeList()) != NULL) {
+    APPEND_LARGV("--hosts");            // list of compute nodes
+    APPEND_LARGV(nodeList);
+  }
+
+  return chpl_bundle_exec_args(argc, argv, largc, (char* const *) largv);
+}

--- a/runtime/src/launch/pals/pals-utils.h
+++ b/runtime/src/launch/pals/pals-utils.h
@@ -20,6 +20,7 @@
 #ifndef _APRUN_UTILS_H_
 #define _APRUN_UTILS_H_
 
-char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocalesa);
+char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocales,
+                            const char* ccArg);
 
 #endif

--- a/runtime/src/launch/pals/pals-utils.h
+++ b/runtime/src/launch/pals/pals-utils.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _APRUN_UTILS_H_
+#define _APRUN_UTILS_H_
+
+char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocalesa);
+
+#endif


### PR DESCRIPTION
This adds a basic Chapel launcher for the Cray PALS system launcher on
Shasta systems.

In support of this, I also added an argv-builder function to the common
launcher code, adapted from existing code in the mpirun4ofi launcher.
This helps avoid the problems with the statically sized buffers and arg
lists which are used in the other launchers.

This resolves https://github.com/Cray/chapel-private/issues/621.
