### PR TITLE
Additions to .gitignore, .cleanfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ tags
 
 /test/io/bradc/fileIO.out.txt
 /test/io/bradc/subdir/out.dat
+/test/io/diten/myBlockArr.bin
 
 /test/library/packages/HDF5/mydata.h5
 /test/localeModels/gbt/maxTaskPar.good
@@ -296,6 +297,10 @@ tags
 /test/release/examples/primers/FFTWlib
 /test/release/examples/primers/genericClasses
 /test/release/examples/primers/iterators
+/test/release/examples/primers/learnChapelInYMinutes
+/test/release/examples/primers/learnChapelInYMinutes.comp.out.tmp.preserved
+/test/release/examples/primers/learnChapelInYMinutes.exec.out.tmp.preserved
+/test/release/examples/primers/listOps
 /test/release/examples/primers/locales
 /test/release/examples/primers/parIters
 /test/release/examples/primers/procedures

--- a/test/io/diten/testCheckpoint.cleanfiles
+++ b/test/io/diten/testCheckpoint.cleanfiles
@@ -1,0 +1,1 @@
+myBlockArr.bin

--- a/test/release/examples/primers/.gitignore
+++ b/test/release/examples/primers/.gitignore
@@ -1,1 +1,0 @@
-learnChapelInYMinutes.exec.out.tmp.preserved

--- a/test/release/examples/primers/learnChapelInYMinutes.cleanfiles
+++ b/test/release/examples/primers/learnChapelInYMinutes.cleanfiles
@@ -1,1 +1,2 @@
+learnChapelInYMinutes.comp.out.tmp.preserved
 learnChapelInYMinutes.exec.out.tmp.preserved


### PR DESCRIPTION
* Added test/io/diten/myBlockArr.bin

* Added learnChapelInYMinutes.comp.out.tmp.preserved
  next to learnChapelInYMinutes.exec.out.tmp.preserved
  in case the test causes compiler errors.

* Moved the contents of test/release/examples/primers/.gitignore
  to join its buddies in CHPL_HOME/.gitignore

Trivial, not reviewed.