### PR TITLE
Fix nilChecking for REFVAR

### DIFF
--- a/compiler/resolution/nilChecking.cpp
+++ b/compiler/resolution/nilChecking.cpp
@@ -320,6 +320,9 @@ static void checkForNilDereferencesInCall(
     AliasMap::const_iterator it = aliasMap.find(argSym);
     if (it != aliasMap.end()) {
       AliasLocation loc = it->second;
+      if (loc.type == MUST_ALIAS_REFVAR)
+        if (Symbol* referent = getReferent(argSym, aliasMap))
+          loc = aliasLocationFromValue(referent, aliasMap, call);
       if (loc.type == MUST_ALIAS_NIL) {
         issueNilError("applying postfix-! to nil", call, argSym, loc);
       } else if (loc.type == MUST_ALIAS_ALLOCATED) {

--- a/test/classes/delete-free/nil-checking/nil-check-control.chpl
+++ b/test/classes/delete-free/nil-checking/nil-check-control.chpl
@@ -11,100 +11,100 @@ config const maybe = true;
 config const n = 0;
 
 proc badNilBothBranches() {
-  var x:owned MyClass = new owned MyClass(1);
+  var x:owned MyClass? = new owned MyClass(1);
   if maybe then
     x = nil;
   else
     x = nil;
-  x.method();
+  x!.method();
 }
 badNilBothBranches();
 
 proc badNilAccessInBranch() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   if maybe then
-    x.method();
+    x!.method();
 }
 badNilAccessInBranch();
 
 proc badNilInWhileLoop() {
-  var x:owned MyClass = new owned MyClass(1);
+  var x:owned MyClass? = new owned MyClass(1);
   while true {
     x = nil;
-    x.method();
+    x!.method();
   }
 }
 badNilInWhileLoop();
 
 proc badNilInForLoop() {
-  var x:owned MyClass = new owned MyClass(1);
+  var x:owned MyClass? = new owned MyClass(1);
   for i in 1..n {
     x = nil;
-    x.method();
+    x!.method();
   }
 }
 badNilInForLoop();
 
 proc badNilInCoforallLoop() {
   coforall i in 1..n {
-    var x:owned MyClass;
-    x.method();
+    var x:owned MyClass?;
+    x!.method();
   }
 }
 badNilInCoforallLoop();
 
 proc okNilWhileLoop() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   while true {
     // because this block has an in-edge from
     // itself (with x being the result of new) and also from
     // above (with x being nil), the analysis decides it can't
     // say if x is nil or not.
-    x.method();
+    x!.method();
     x = new owned MyClass(1);
   }
 }
 okNilWhileLoop();
 
 proc okNilWhileLoop2() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   var go = maybe;
   while go {
     x = new owned MyClass(1);
     go = false;
   }
   // loop might run >0 times -> no error
-  x.method();
+  x!.method();
 }
 okNilWhileLoop2();
 
 
 proc okNilForLoop() {
-  var x:owned MyClass = new owned MyClass(1);
+  var x:owned MyClass? = new owned MyClass(1);
   for i in 1..n {
     x = nil;
   }
   // Loop might run 0 times -> no error
-  x.method();
+  x!.method();
 }
 okNilForLoop();
 
 proc okNilForLoop2() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   for i in 1..n {
     x = new owned MyClass(1);
   }
   // Loop might run 0 times or many times -> no error
-  x.method();
+  x!.method();
 }
 okNilForLoop2();
 
 
 proc okNilDependsOnRuntime() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   if maybe {
     x = new owned MyClass(1);
   }
-  x.method();
+  x!.method();
 }
 okNilDependsOnRuntime();

--- a/test/classes/delete-free/nil-checking/nil-check-control.compopts
+++ b/test/classes/delete-free/nil-checking/nil-check-control.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/delete-free/nil-checking/nil-check-control.good
+++ b/test/classes/delete-free/nil-checking/nil-check-control.good
@@ -1,15 +1,20 @@
 nil-check-control.chpl:13: In function 'badNilBothBranches':
-nil-check-control.chpl:19: error: attempt to dereference nil
+nil-check-control.chpl:19: error: applying postfix-! to nil
+nil-check-control.chpl:19: note: variable x is nil at this point
 nil-check-control.chpl:18: note: this statement may be relevant
 nil-check-control.chpl:23: In function 'badNilAccessInBranch':
-nil-check-control.chpl:26: error: attempt to dereference nil
+nil-check-control.chpl:26: error: applying postfix-! to nil
+nil-check-control.chpl:26: note: variable x is nil at this point
 nil-check-control.chpl:24: note: this statement may be relevant
 nil-check-control.chpl:30: In function 'badNilInWhileLoop':
-nil-check-control.chpl:34: error: attempt to dereference nil
+nil-check-control.chpl:34: error: applying postfix-! to nil
+nil-check-control.chpl:34: note: variable x is nil at this point
 nil-check-control.chpl:33: note: this statement may be relevant
 nil-check-control.chpl:39: In function 'badNilInForLoop':
-nil-check-control.chpl:43: error: attempt to dereference nil
+nil-check-control.chpl:43: error: applying postfix-! to nil
+nil-check-control.chpl:43: note: variable x is nil at this point
 nil-check-control.chpl:42: note: this statement may be relevant
 nil-check-control.chpl:48: In function 'badNilInCoforallLoop':
-nil-check-control.chpl:51: error: attempt to dereference nil
+nil-check-control.chpl:51: error: applying postfix-! to nil
+nil-check-control.chpl:51: note: variable x is nil at this point
 nil-check-control.chpl:50: note: this statement may be relevant

--- a/test/classes/delete-free/nil-checking/nilcheck-empty-refs.chpl
+++ b/test/classes/delete-free/nil-checking/nilcheck-empty-refs.chpl
@@ -6,31 +6,31 @@ class MyClass {
 }
 
 proc badRefToNilOwned() {
-  var x: owned MyClass;
+  var x: owned MyClass?;
   ref r = x;
-  r.method();
+  r!.method();
 }
 badRefToNilOwned();
 
 proc badSetNilByRef() {
-  var x: owned MyClass = new owned MyClass(1);
+  var x: owned MyClass? = new owned MyClass(1);
   ref r = x;
   r = nil;
-  x.method();
+  x!.method();
 }
 badSetNilByRef();
 
 proc badSetNilByRefX() {
-  var x: owned MyClass = new owned MyClass(1);
+  var x: owned MyClass? = new owned MyClass(1);
   ref r = x;
   x = nil;
-  r.method();
+  r!.method();
 }
 badSetNilByRefX();
 
 proc badSetNilByRefAssign() {
   var x: owned MyClass = new owned MyClass(1);
-  var y: owned MyClass;
+  var y: owned MyClass?;
   ref r = x;
   y = r; // clears x/r
   x.method();
@@ -39,9 +39,57 @@ badSetNilByRefAssign();
 
 proc badSetNilByRefXAssign() {
   var x: owned MyClass = new owned MyClass(1);
-  var y: owned MyClass;
+  var y: owned MyClass?;
   ref r = x;
   y = x; // clears x/r
   r.method();
 }
 badSetNilByRefXAssign();
+
+// the same with two levels of refs
+
+proc badRefToNilOwned2() {
+  var x: owned MyClass?;
+  ref q = x;
+  ref r = q;
+  r!.method();
+}
+badRefToNilOwned2();
+
+proc badSetNilByRef2() {
+  var x: owned MyClass? = new owned MyClass(1);
+  ref q = x;
+  ref r = q;
+  r = nil;
+  x!.method();
+}
+badSetNilByRef2();
+
+proc badSetNilByRefX2() {
+  var x: owned MyClass? = new owned MyClass(1);
+  ref q = x;
+  ref r = q;
+  x = nil;
+  r!.method();
+}
+badSetNilByRefX2();
+
+proc badSetNilByRefAssign2() {
+  var x: owned MyClass = new owned MyClass(1);
+  var y: owned MyClass?;
+  ref q = x;
+  ref r = q;
+  y = r; // clears x/r
+  x.method();
+}
+badSetNilByRefAssign2();
+
+proc badSetNilByRefXAssign2() {
+  var x: owned MyClass = new owned MyClass(1);
+  var y: owned MyClass?;
+  ref q = x;
+  ref r = q;
+  y = x; // clears x/r
+  r.method();
+}
+badSetNilByRefXAssign2();

--- a/test/classes/delete-free/nil-checking/nilcheck-empty-refs.compopts
+++ b/test/classes/delete-free/nil-checking/nilcheck-empty-refs.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/delete-free/nil-checking/nilcheck-empty-refs.good
+++ b/test/classes/delete-free/nil-checking/nilcheck-empty-refs.good
@@ -1,11 +1,14 @@
 nilcheck-empty-refs.chpl:8: In function 'badRefToNilOwned':
-nilcheck-empty-refs.chpl:11: error: attempt to dereference nil
+nilcheck-empty-refs.chpl:11: error: applying postfix-! to nil
+nilcheck-empty-refs.chpl:11: note: variable r is nil at this point
 nilcheck-empty-refs.chpl:9: note: this statement may be relevant
 nilcheck-empty-refs.chpl:15: In function 'badSetNilByRef':
-nilcheck-empty-refs.chpl:19: error: attempt to dereference nil
+nilcheck-empty-refs.chpl:19: error: applying postfix-! to nil
+nilcheck-empty-refs.chpl:19: note: variable x is nil at this point
 nilcheck-empty-refs.chpl:18: note: this statement may be relevant
 nilcheck-empty-refs.chpl:23: In function 'badSetNilByRefX':
-nilcheck-empty-refs.chpl:27: error: attempt to dereference nil
+nilcheck-empty-refs.chpl:27: error: applying postfix-! to nil
+nilcheck-empty-refs.chpl:27: note: variable r is nil at this point
 nilcheck-empty-refs.chpl:26: note: this statement may be relevant
 nilcheck-empty-refs.chpl:31: In function 'badSetNilByRefAssign':
 nilcheck-empty-refs.chpl:36: error: attempt to dereference nil
@@ -13,3 +16,21 @@ nilcheck-empty-refs.chpl:35: note: this statement may be relevant
 nilcheck-empty-refs.chpl:40: In function 'badSetNilByRefXAssign':
 nilcheck-empty-refs.chpl:45: error: attempt to dereference nil
 nilcheck-empty-refs.chpl:44: note: this statement may be relevant
+nilcheck-empty-refs.chpl:51: In function 'badRefToNilOwned2':
+nilcheck-empty-refs.chpl:55: error: applying postfix-! to nil
+nilcheck-empty-refs.chpl:55: note: variable r is nil at this point
+nilcheck-empty-refs.chpl:52: note: this statement may be relevant
+nilcheck-empty-refs.chpl:59: In function 'badSetNilByRef2':
+nilcheck-empty-refs.chpl:64: error: applying postfix-! to nil
+nilcheck-empty-refs.chpl:64: note: variable x is nil at this point
+nilcheck-empty-refs.chpl:63: note: this statement may be relevant
+nilcheck-empty-refs.chpl:68: In function 'badSetNilByRefX2':
+nilcheck-empty-refs.chpl:73: error: applying postfix-! to nil
+nilcheck-empty-refs.chpl:73: note: variable r is nil at this point
+nilcheck-empty-refs.chpl:72: note: this statement may be relevant
+nilcheck-empty-refs.chpl:77: In function 'badSetNilByRefAssign2':
+nilcheck-empty-refs.chpl:83: error: attempt to dereference nil
+nilcheck-empty-refs.chpl:82: note: this statement may be relevant
+nilcheck-empty-refs.chpl:87: In function 'badSetNilByRefXAssign2':
+nilcheck-empty-refs.chpl:93: error: attempt to dereference nil
+nilcheck-empty-refs.chpl:92: note: this statement may be relevant

--- a/test/classes/delete-free/nil-checking/nilcheck.chpl
+++ b/test/classes/delete-free/nil-checking/nilcheck.chpl
@@ -6,64 +6,64 @@ class MyClass {
 }
 
 proc bad1() {
-  var x:borrowed MyClass;
-  x.method();
+  var x:borrowed MyClass?;
+  x!.method();
 }
 bad1();
 
 proc bad2() {
-  var x:borrowed MyClass;
+  var x:borrowed MyClass?;
   x = nil;
-  x.method();
+  x!.method();
 }
 bad2();
 
 proc bad3() {
-  var x:unmanaged MyClass;
-  x.method();
+  var x:unmanaged MyClass?;
+  x!.method();
 }
 bad3();
 
 proc bad4() {
-  var x:unmanaged MyClass;
+  var x:unmanaged MyClass?;
   x = nil;
-  x.method();
+  x!.method();
 }
 bad4();
 
 proc bad5() {
-  var x:owned MyClass;
-  x.method();
+  var x:owned MyClass?;
+  x!.method();
 }
 bad5();
 
 proc bad6() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   x = nil;
-  x.method();
+  x!.method();
 }
 bad6();
 
 proc bad7() {
-  var x:owned MyClass;
-  x.method();
+  var x:shared MyClass?;
+  x!.method();
 }
 bad7();
 
 proc bad8() {
-  var x:owned MyClass;
+  var x:shared MyClass?;
   x = nil;
-  x.method();
+  x!.method();
 }
 bad8();
 
 config param falseParam = false;
 
 proc bad9() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   if falseParam then
     x = new owned MyClass(1);
-  x.method();
+  x!.method();
 }
 bad9();
 
@@ -76,9 +76,9 @@ proc ok1() {
 ok1();
 
 proc ok2() {
-  var x:borrowed MyClass;
+  var x:borrowed MyClass?;
   x = new borrowed MyClass(1);
-  x.method();
+  x!.method();
 }
 ok2();
 
@@ -89,9 +89,9 @@ proc ok3() {
 ok3();
 
 proc ok4() {
-  var x:owned MyClass;
+  var x:owned MyClass?;
   x = new owned MyClass(1);
-  x.method();
+  x!.method();
 }
 ok4();
 
@@ -102,9 +102,9 @@ proc ok5() {
 ok5();
 
 proc ok6() {
-  var x:shared MyClass;
+  var x:shared MyClass?;
   x = new shared MyClass(1);
-  x.method();
+  x!.method();
 }
 ok6();
 
@@ -115,8 +115,8 @@ proc ok7() {
 ok7();
 
 proc ok8() {
-  var x:unmanaged MyClass;
+  var x:unmanaged MyClass?;
   x = new unmanaged MyClass(1);
-  x.method();
+  x!.method();
 }
 ok8();

--- a/test/classes/delete-free/nil-checking/nilcheck.compopts
+++ b/test/classes/delete-free/nil-checking/nilcheck.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/delete-free/nil-checking/nilcheck.good
+++ b/test/classes/delete-free/nil-checking/nilcheck.good
@@ -1,29 +1,36 @@
 nilcheck.chpl:8: In function 'bad1':
-nilcheck.chpl:10: error: attempt to dereference nil
+nilcheck.chpl:10: error: applying postfix-! to nil
 nilcheck.chpl:10: note: variable x is nil at this point
 nilcheck.chpl:9: note: this statement may be relevant
 nilcheck.chpl:14: In function 'bad2':
-nilcheck.chpl:17: error: attempt to dereference nil
+nilcheck.chpl:17: error: applying postfix-! to nil
 nilcheck.chpl:17: note: variable x is nil at this point
 nilcheck.chpl:16: note: this statement may be relevant
 nilcheck.chpl:21: In function 'bad3':
-nilcheck.chpl:23: error: attempt to dereference nil
+nilcheck.chpl:23: error: applying postfix-! to nil
+nilcheck.chpl:23: note: variable x is nil at this point
 nilcheck.chpl:22: note: this statement may be relevant
 nilcheck.chpl:27: In function 'bad4':
-nilcheck.chpl:30: error: attempt to dereference nil
+nilcheck.chpl:30: error: applying postfix-! to nil
+nilcheck.chpl:30: note: variable x is nil at this point
 nilcheck.chpl:29: note: this statement may be relevant
 nilcheck.chpl:34: In function 'bad5':
-nilcheck.chpl:36: error: attempt to dereference nil
+nilcheck.chpl:36: error: applying postfix-! to nil
+nilcheck.chpl:36: note: variable x is nil at this point
 nilcheck.chpl:35: note: this statement may be relevant
 nilcheck.chpl:40: In function 'bad6':
-nilcheck.chpl:43: error: attempt to dereference nil
+nilcheck.chpl:43: error: applying postfix-! to nil
+nilcheck.chpl:43: note: variable x is nil at this point
 nilcheck.chpl:42: note: this statement may be relevant
 nilcheck.chpl:47: In function 'bad7':
-nilcheck.chpl:49: error: attempt to dereference nil
+nilcheck.chpl:49: error: applying postfix-! to nil
+nilcheck.chpl:49: note: variable x is nil at this point
 nilcheck.chpl:48: note: this statement may be relevant
 nilcheck.chpl:53: In function 'bad8':
-nilcheck.chpl:56: error: attempt to dereference nil
+nilcheck.chpl:56: error: applying postfix-! to nil
+nilcheck.chpl:56: note: variable x is nil at this point
 nilcheck.chpl:55: note: this statement may be relevant
 nilcheck.chpl:62: In function 'bad9':
-nilcheck.chpl:66: error: attempt to dereference nil
+nilcheck.chpl:66: error: applying postfix-! to nil
+nilcheck.chpl:66: note: variable x is nil at this point
 nilcheck.chpl:63: note: this statement may be relevant

--- a/test/classes/nilability/if-object-1.chpl
+++ b/test/classes/nilability/if-object-1.chpl
@@ -5,14 +5,26 @@ class C {
   var x: int;
 }
 
-proc main() {
-  var obj: borrowed C?;
+proc test(type CT) {
+  var obj: CT?;
+
+  if obj == nil then
+    writeln(obj.type:string);
 
   writeln(obj!.x);    // error
 
   if obj then
-    writeln(obj!.x);  // ok
+    writeln(obj!.x);  // never executed
 
   if obj != nil then
-    writeln(obj!.x);  // ok
+    writeln(obj!.x);  // never executed
+}
+
+proc main {
+  test(owned C);
+  test(shared C);
+  test(borrowed C);
+  test(unmanaged C);
+
+  writeln("done");
 }

--- a/test/classes/nilability/if-object-1.good
+++ b/test/classes/nilability/if-object-1.good
@@ -1,4 +1,16 @@
-if-object-1.chpl:8: In function 'main':
-if-object-1.chpl:11: error: applying postfix-! to nil
-if-object-1.chpl:11: note: variable obj is nil at this point
+if-object-1.chpl:8: In function 'test':
+if-object-1.chpl:14: error: applying postfix-! to nil
+if-object-1.chpl:14: note: variable obj is nil at this point
+if-object-1.chpl:9: note: this statement may be relevant
+if-object-1.chpl:8: In function 'test':
+if-object-1.chpl:14: error: applying postfix-! to nil
+if-object-1.chpl:14: note: variable obj is nil at this point
+if-object-1.chpl:9: note: this statement may be relevant
+if-object-1.chpl:8: In function 'test':
+if-object-1.chpl:14: error: applying postfix-! to nil
+if-object-1.chpl:14: note: variable obj is nil at this point
+if-object-1.chpl:9: note: this statement may be relevant
+if-object-1.chpl:8: In function 'test':
+if-object-1.chpl:14: error: applying postfix-! to nil
+if-object-1.chpl:14: note: variable obj is nil at this point
 if-object-1.chpl:9: note: this statement may be relevant

--- a/test/classes/nilability/if-object-2.chpl
+++ b/test/classes/nilability/if-object-2.chpl
@@ -8,14 +8,16 @@ class C {
 proc test(type CT) {
   var obj: CT?;
 
-  if obj then
-    writeln(obj!.x); // never executed
-
-  if obj != nil then
-    writeln(obj!.x); // never executed
-
   if obj == nil then
     writeln(obj.type:string);
+
+//writeln(obj!.x);    // error
+
+  if obj then
+    writeln(obj!.x);  // never executed
+
+  if obj != nil then
+    writeln(obj!.x);  // never executed
 }
 
 proc main {


### PR DESCRIPTION
Fix one case in nilChecking where the referent of a `ref` variable
was not analyzed.

Adjust the nil* tests to compile without --legacy-classes.

Beef up nilcheck-empty-refs.chpl and if-object-*.chpl.

Together with #14660, this changes resolves #13630.

Trivial, not reviewed.