### PR TITLE
Fix tuple equality comparisons for mismatched sizes

### DIFF
--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -663,20 +663,24 @@ module ChapelTuple {
   }
 
   inline proc ==(a: _tuple, b: _tuple) {
-    if a.size != b.size then
+    if a.size != b.size {
       return false;
-    for param i in 1..a.size do
-      if a(i) != b(i) then
-        return false;
+    } else {
+      for param i in 1..a.size do
+        if a(i) != b(i) then
+          return false;
+    }
     return true;
   }
 
   inline proc !=(a: _tuple, b: _tuple) {
-    if a.size != b.size then
+    if a.size != b.size {
       return true;
-    for param i in 1..a.size do
-      if a(i) != b(i) then
-        return true;
+    } else {
+      for param i in 1..a.size do
+        if a(i) != b(i) then
+          return true;
+    }
     return false;
   }
 

--- a/test/types/tuple/tupleEquality.chpl
+++ b/test/types/tuple/tupleEquality.chpl
@@ -1,0 +1,18 @@
+// Equality tests for tuples
+
+var A = (1,2,3);
+var B = (1,2,3);
+var C = (1,2,4);
+var D = (1,2,3,4);
+
+writeln(A == B);
+writeln(A != B);
+
+writeln(A == C);
+writeln(A != C);
+
+writeln(A == D);
+writeln(A != D);
+
+writeln(D == A);
+writeln(D != A);

--- a/test/types/tuple/tupleEquality.good
+++ b/test/types/tuple/tupleEquality.good
@@ -1,0 +1,8 @@
+true
+false
+false
+true
+false
+true
+false
+true


### PR DESCRIPTION
Allow comparing tuples of non-equal size, e.g.

```chpl
var a = (1,2,3);
var b = (1,2);

writeln(a != b);
```

This was the originally intended behavior in the implementation, but a bug in compiler param-folding resulted in a compiler-error.

- [x] linux64

Closes #14680