### PR TITLE
Improve string.these

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -895,10 +895,21 @@ module String {
         d
      */
     iter these() : string {
-      for cp in this.codepoints() do
-        // This is pretty painful from a performance perspective right now,
-        // allocates w/ every yield
-        yield codepointToString(cp);
+      var localThis: string = this.localize();
+
+      var i = 0;
+      while i < localThis.len {
+        const curPos = localThis.buff+i;
+        var cp: int(32);
+        var nBytes: c_int;
+        var maxBytes = (localThis.len - i): ssize_t;
+        qio_decode_char_buf(cp, nBytes, curPos:c_string, maxBytes);
+
+        var (newBuf, newSize) = bufferCopyLocal(curPos, nBytes);
+        yield chpl_createStringWithOwnedBufferNV(newBuf, nBytes, newSize);
+
+        i += nBytes;
+      }
     }
 
     /*


### PR DESCRIPTION
This PR improves the performance of `string.these`. This is mainly motivated by
performance regression after UTF8 validation. After that, every single-character
string yielded by this method was validated. Now, this method uses the
non-validating factory function.

While there, this PR also changes the logic which was to extract a codepoint
from string (encode), then, create a string from the codepoint (decode). This
codepoint-based logic was unnecessary. After this PR, we decode the string
at the current position in order to determine the length of the next codepoint,
then copy a buffer out with that length and create the string on top of that.

Test:
- [x] standard
- [x] gasnet