### PR TITLE
Add support for bytes regular expressions

### DIFF
--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -115,7 +115,7 @@ class RecordReader {
   /* The channel to read from */
   var myReader;
   /* The regular expression to read (using match on the channel) */
-  var matchRegexp: regexp;
+  var matchRegexp: regexp(string);
   pragma "no doc"
   param num_fields = numFields(t); // Number of fields in record
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5629,7 +5629,7 @@ class _channel_regexp_info {
   proc allocate_captures() {
     ncaptures = qio_regexp_get_ncaptures(theRegexp);
     matches = _ddata_allocate(qio_regexp_string_piece_t, ncaptures+1);
-    capArr = _ddata_allocate(string, ncaptures);
+    capArr = _ddata_allocate(this.exprType, ncaptures);
     capturei = 0;
   }
   proc deinit() {
@@ -5765,7 +5765,7 @@ proc channel._format_reader(
           error = qio_format_error_write_regexp();
         } else {
           // allocate regexp info if needed
-          if r == nil then r = new unmanaged _channel_regexp_info();
+          if r == nil then r = new unmanaged _channel_regexp_info(r.exprType);
           const rnn = r!;  // indicate that it is non-nil
           // clear out old data, if there is any.
           rnn.clear();
@@ -6524,7 +6524,11 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
               }
               else {
                 // match it here.
-                if r == nil then r = new unmanaged _channel_regexp_info(t.exprType);
+                /*extern proc printf(fmt, str);*/
+                /*printf("t.type: %s\n", t.type:string);*/
+                /*printf("t.exprType: %s\n", t.exprType:string);*/
+                /*printf("r.exprType: %s\n", r.exprType:string);*/
+                if r == nil then r = new unmanaged _channel_regexp_info(r.exprType);
                 const rnn = r!;  // indicate that it is non-nil
                 rnn.clear();
                 rnn.theRegexp = t._regexp;
@@ -6561,6 +6565,9 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                     // but only if it's a primitive type
                     // (so that we can avoid problems with string-to-record).
                     try {
+                      /*extern proc printf(fmt, str): void;*/
+                      /*printf("cap type %s\n", rnn.capArr[rnn.capturei].type:string);*/
+                      /*printf("arg type %s\n", args(i).type:string);*/
                       args(i) = rnn.capArr[rnn.capturei]:args(i).type;
                     } catch {
                       err = qio_format_error_bad_regexp();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5600,7 +5600,7 @@ proc _toRegexp(x:?t)
 
 pragma "no doc"
 class _channel_regexp_info {
-  type exprType = string;
+  type exprType;
   var hasRegexp = false;
   var matchedRegexp = false;
   var releaseRegexp = false;
@@ -5609,10 +5609,6 @@ class _channel_regexp_info {
   var capArr: _ddata(exprType) = nil; // size = ncaptures
   var capturei: int;
   var ncaptures: int;
-
-  proc init(type exprType=string) {
-    this.exprType = exprType;
-  }
 
   proc clear() {
     if releaseRegexp {
@@ -5691,7 +5687,7 @@ proc channel._match_regexp_if_needed(cur:size_t, len:size_t, ref error:syserr,
     } else {
       // otherwise, clear out caps...
       for j in 0..#ncaps {
-        r.capArr[j] = "";
+        r.capArr[j] = "":r.exprType;
       }
       // ... and put the channel before the match.
       var cur = qio_channel_offset_unlocked(_channel_internal);
@@ -6158,7 +6154,7 @@ proc channel.writef(fmtStr: ?t, const args ...?k): bool throws
     var end:size_t;
     var argType:(k+5)*c_int;
 
-    var r:unmanaged _channel_regexp_info?;
+    var r:unmanaged _channel_regexp_info(t)?;
     defer {
       if r then delete r;
     }
@@ -6312,7 +6308,7 @@ proc channel.writef(fmtStr:?t): bool throws
     var end:size_t;
     var dummy:c_int;
 
-    var r:unmanaged _channel_regexp_info?;
+    var r:unmanaged _channel_regexp_info(t)?;
     defer {
       if r then delete r;
     }
@@ -6524,10 +6520,6 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
               }
               else {
                 // match it here.
-                /*extern proc printf(fmt, str);*/
-                /*printf("t.type: %s\n", t.type:string);*/
-                /*printf("t.exprType: %s\n", t.exprType:string);*/
-                /*printf("r.exprType: %s\n", r.exprType:string);*/
                 if r == nil then r = new unmanaged _channel_regexp_info(r.exprType);
                 const rnn = r!;  // indicate that it is non-nil
                 rnn.clear();
@@ -6565,9 +6557,6 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                     // but only if it's a primitive type
                     // (so that we can avoid problems with string-to-record).
                     try {
-                      /*extern proc printf(fmt, str): void;*/
-                      /*printf("cap type %s\n", rnn.capArr[rnn.capturei].type:string);*/
-                      /*printf("arg type %s\n", args(i).type:string);*/
                       args(i) = rnn.capArr[rnn.capturei]:args(i).type;
                     } catch {
                       err = qio_format_error_bad_regexp();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5587,14 +5587,14 @@ proc _setIfChar(ref lhs:?t, rhs:int(32)) where !(t==string||isIntegralType(t))
 
 
 private inline
-proc _toRegexp(x:?t) where isSubtype(t, regexp)
+proc _toRegexp(x:?t) where isSubtype(t, regexp(?))
 {
   return (x, true);
 }
 private inline
 proc _toRegexp(x:?t)
 {
-  var r:regexp;
+  var r:regexp(string);
   return (r, false);
 }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5600,13 +5600,12 @@ proc _toRegexp(x:?t)
 
 pragma "no doc"
 class _channel_regexp_info {
-  type exprType;
   var hasRegexp = false;
   var matchedRegexp = false;
   var releaseRegexp = false;
   var theRegexp = qio_regexp_null();
   var matches: _ddata(qio_regexp_string_piece_t) = nil; // size = ncaptures+1
-  var capArr: _ddata(exprType) = nil; // size = ncaptures
+  var capArr: _ddata(bytes) = nil; // size = ncaptures
   var capturei: int;
   var ncaptures: int;
 
@@ -5619,13 +5618,13 @@ class _channel_regexp_info {
     matchedRegexp = false;
     releaseRegexp = false;
     if matches then _ddata_free(matches, ncaptures+1);
-    for i in 0..#ncaptures do capArr[i] = "";
+    for i in 0..#ncaptures do capArr[i] = b"";
     if capArr then _ddata_free(capArr, ncaptures);
   }
   proc allocate_captures() {
     ncaptures = qio_regexp_get_ncaptures(theRegexp);
     matches = _ddata_allocate(qio_regexp_string_piece_t, ncaptures+1);
-    capArr = _ddata_allocate(this.exprType, ncaptures);
+    capArr = _ddata_allocate(bytes, ncaptures);
     capturei = 0;
   }
   proc deinit() {
@@ -5687,7 +5686,7 @@ proc channel._match_regexp_if_needed(cur:size_t, len:size_t, ref error:syserr,
     } else {
       // otherwise, clear out caps...
       for j in 0..#ncaps {
-        r.capArr[j] = "":r.exprType;
+        r.capArr[j] = b"";
       }
       // ... and put the channel before the match.
       var cur = qio_channel_offset_unlocked(_channel_internal);
@@ -5761,7 +5760,7 @@ proc channel._format_reader(
           error = qio_format_error_write_regexp();
         } else {
           // allocate regexp info if needed
-          if r == nil then r = new unmanaged _channel_regexp_info(r.exprType);
+          if r == nil then r = new unmanaged _channel_regexp_info();
           const rnn = r!;  // indicate that it is non-nil
           // clear out old data, if there is any.
           rnn.clear();
@@ -6154,7 +6153,7 @@ proc channel.writef(fmtStr: ?t, const args ...?k): bool throws
     var end:size_t;
     var argType:(k+5)*c_int;
 
-    var r:unmanaged _channel_regexp_info(t)?;
+    var r:unmanaged _channel_regexp_info?;
     defer {
       if r then delete r;
     }
@@ -6308,7 +6307,7 @@ proc channel.writef(fmtStr:?t): bool throws
     var end:size_t;
     var dummy:c_int;
 
-    var r:unmanaged _channel_regexp_info(t)?;
+    var r:unmanaged _channel_regexp_info?;
     defer {
       if r then delete r;
     }
@@ -6374,7 +6373,7 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
     var end:size_t;
     var argType:(k+5)*c_int;
 
-    var r:unmanaged _channel_regexp_info(t)?;
+    var r:unmanaged _channel_regexp_info?;
     defer {
       if r then delete r;
     }
@@ -6520,7 +6519,7 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
               }
               else {
                 // match it here.
-                if r == nil then r = new unmanaged _channel_regexp_info(r.exprType);
+                if r == nil then r = new unmanaged _channel_regexp_info();
                 const rnn = r!;  // indicate that it is non-nil
                 rnn.clear();
                 rnn.theRegexp = t._regexp;
@@ -6557,7 +6556,10 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                     // but only if it's a primitive type
                     // (so that we can avoid problems with string-to-record).
                     try {
-                      args(i) = rnn.capArr[rnn.capturei]:args(i).type;
+                      if args(i).type == string then
+                        args(i) = rnn.capArr[rnn.capturei].decode();
+                      else
+                        args(i) = rnn.capArr[rnn.capturei]:args(i).type;
                     } catch {
                       err = qio_format_error_bad_regexp();
                     }
@@ -6629,7 +6631,7 @@ proc channel.readf(fmtStr:?t) throws
     var end:size_t;
     var dummy:c_int;
 
-    var r:unmanaged _channel_regexp_info(t)?;
+    var r:unmanaged _channel_regexp_info?;
     defer {
       if r then delete r;
     }
@@ -6826,14 +6828,14 @@ proc channel._extractMatch(m:reMatch, ref arg:reMatch, ref error:syserr) {
 }
 
 pragma "no doc"
-proc channel._extractMatch(m:reMatch, ref arg:string, ref error:syserr) {
+proc channel._extractMatch(m:reMatch, ref arg:bytes, ref error:syserr) {
   var cur:int(64);
   var target = m.offset:int;
   var len = m.length;
 
   // If there was no match, return the default value of the type
   if !m.matched {
-    arg = "";
+    arg = b"";
   }
 
   // Read into a string the appropriate region of the file.
@@ -6849,37 +6851,52 @@ proc channel._extractMatch(m:reMatch, ref arg:string, ref error:syserr) {
     error = qio_channel_advance(false, _channel_internal, target - cur);
   }
 
-  var s:string;
+  var s:bytes;
   if ! error {
     var gotlen:int(64);
     var ts: c_string;
     error =
         qio_channel_read_string(false, iokind.native:c_int, stringStyleExactLen(len),
                                 _channel_internal, ts, gotlen, len: ssize_t);
-    s = try! createStringWithOwnedBuffer(ts, length=gotlen);
+    s = createBytesWithOwnedBuffer(ts, length=gotlen);
   }
 
   if ! error {
     arg = s;
   } else {
-    arg = "";
+    arg = b"";
   }
 }
 
 pragma "no doc"
-proc channel._extractMatch(m:reMatch, ref arg:?t, ref error:syserr) where t != reMatch && t != string {
+proc channel._extractMatch(m:reMatch, ref arg:?t, ref error:syserr)
+      where t != reMatch && t != bytes {
   // If there was no match, return the default value of the type
   if !m.matched {
     var empty:arg.type;
     arg = empty;
   }
 
-  // Read into a string the appropriate region of the file.
-  var s:string;
+  // Read into a bytes the appropriate region of the file.
+  var s:bytes;
   _extractMatch(m, s, error);
 
+
   if ! error {
-    arg = s:arg.type;
+    if arg.type == string {
+      try {
+        // throws if trying to extract a non UTF8 match into a string
+        // at this point this is unlikely to happen. So, just catch the error
+        // and set error to EFORMAT
+        arg = s.decode();
+      }
+      catch {
+        error = EFORMAT;
+      }
+    }
+    else {
+      arg = s:arg.type;
+    }
   } else {
     var empty:arg.type;
     arg = empty;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6566,7 +6566,15 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                         args(i) = rnn.capArr[rnn.capturei].decode():args(i).type;
                       else
                         args(i) = rnn.capArr[rnn.capturei]:args(i).type;
+                    } catch e: DecodeError {
+                      // someone's trying to capture a non UTF8 sequence in a
+                      // string -- argument type mismatch
+                      err = qio_format_error_arg_mismatch(i);
+                      
+                      // Engin: maybe in the future we can just propagate
+                      // DecodeError here?
                     } catch {
+                      // maybe a cast error for the enum cast
                       err = qio_format_error_bad_regexp();
                     }
                   }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6558,6 +6558,10 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                     try {
                       if args(i).type == string then
                         args(i) = rnn.capArr[rnn.capturei].decode();
+                      // the following is a workaround for bytes->enum casts
+                      // being unimplemented See #14553
+                      else if isEnumType(args(i).type) then
+                        args(i) = rnn.capArr[rnn.capturei].decode():args(i).type;
                       else
                         args(i) = rnn.capArr[rnn.capturei]:args(i).type;
                     } catch {

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -583,7 +583,7 @@ record regexp {
   /*proc init() {*/
   /*}*/
 
-  proc init=(x: regexp) {
+  proc init=(x: regexp(?)) {
     this.exprType = x.exprType;
     this.home = x.home;
     this._regexp = x._regexp;
@@ -1006,7 +1006,7 @@ record regexp {
 }
 
 pragma "no doc"
-proc =(ref ret:regexp, x:regexp)
+proc =(ref ret:regexp(?t), x:regexp(t))
 {
   // retain -- release
   if x.home == ret.home {
@@ -1050,7 +1050,7 @@ inline proc _cast(type t, x: regexp(?exprType)) where t == exprType  {
 // Cast string to regexp
 pragma "no doc"
 inline proc _cast(type t, x: ?valType) throws
-  where t == regexp  && (valType == string || valType == bytes) {
+  where t == regexp(valType)  && (valType == string || valType == bytes) {
   return compile(x);
 }
 

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -493,27 +493,6 @@ proc compile(pattern: string, out error:syserr, utf8, posix, literal, nocapture,
   return ret;
 }
 
-/***
- *** sungeun: AFAIK, there are no tests programs or examples that use
- *** this.  Depending on how it is generally used, it might be
- *** easier/cheaper to use a c_string here and provide a custom
- *** constructor.
- ***/
-/* mferguson - I agree - I think we should remove this one at some point,
-  at least it makes no sense if the string contained here will
-  copy the entire larger string, which is what I think we are building.
-  */
-/*  Regular expression search routines also can work with
-    a stringPart, which refers to a substring within another
-    string.
- */
-pragma "no doc"
-record stringPart {
-  var offset:byteIndex;
-  var numBytes:int;
-  var from:string;
-}
-
 /*  The reMatch record records a regular expression search match
     or a capture group.
 
@@ -662,26 +641,23 @@ record regexp {
 
     */
   proc search(text: ?t, ref captures ...?k):reMatch
-    where t == string || t == stringPart
+    where t == string
   {
     var ret:reMatch;
     on this.home {
       var pos:byteIndex;
       var endpos:byteIndex;
 
-      if t == stringPart then pos = text.offset;
-      else pos = 0;
+      pos = 0;
       endpos = pos + text.numBytes;
 
       var matches:_ddata(qio_regexp_string_piece_t);
       var nmatches = 1 + captures.size;
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
-      if t == stringPart {
-        got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
-      } else {
-        got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
-      }
+      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
+                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED,
+                             matches, nmatches);
       // Now try to coerce the read strings into the captures.
       _handle_captures(text, matches, nmatches, captures);
       // Now return where we matched.
@@ -694,26 +670,23 @@ record regexp {
   // documented in the captures version
   pragma "no doc"
   proc search(text: ?t):reMatch
-    where t == string || t == stringPart
+    where t == string
   {
     var ret:reMatch;
     on this.home {
       var pos:byteIndex;
       var endpos:byteIndex;
 
-      if t == stringPart then pos = text.offset;
-      else pos = 0;
+      pos = 0;
       endpos = pos + text.numBytes;
 
       var matches:_ddata(qio_regexp_string_piece_t);
       var nmatches = 1;
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
-      if t == stringPart {
-        got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
-      } else {
-        got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
-      }
+      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
+                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED,
+                             matches, nmatches);
       // Now return where we matched.
       ret = new reMatch(got, matches[0].offset:byteIndex, matches[0].len);
       _ddata_free(matches, nmatches);
@@ -742,26 +715,23 @@ record regexp {
                where a match occurred
    */
   proc match(text: ?t, ref captures ...?k):reMatch
-    where t == string || t == stringPart
+    where t == string
   {
     var ret:reMatch;
     on this.home {
       var pos:byteIndex;
       var endpos:byteIndex;
 
-      if t == stringPart then pos = text.offset;
-      else pos = 0;
+      pos = 0;
       endpos = pos + text.numBytes;
 
       var matches:_ddata(qio_regexp_string_piece_t);
       var nmatches = 1 + captures.size;
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
-      if t == stringPart {
-        got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_START, matches, nmatches);
-      } else {
-        got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_START, matches, nmatches);
-      }
+      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
+                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_START,
+                             matches, nmatches);
       // Now try to coerce the read strings into the captures.
       _handle_captures(text, matches, nmatches, captures);
       // Now return where we matched.
@@ -774,26 +744,23 @@ record regexp {
   // documented in the version taking captures.
   pragma "no doc"
   proc match(text: ?t):reMatch
-    where t == string || t == stringPart
+    where t == string
   {
     var ret:reMatch;
     on this.home {
       var pos:byteIndex;
       var endpos:byteIndex;
 
-      if t == stringPart then pos = text.offset;
-      else pos = 0;
+      pos = 0;
       endpos = pos + text.numBytes;
 
       var matches:_ddata(qio_regexp_string_piece_t);
       var nmatches = 1;
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
-      if t == stringPart {
-        got = qio_regexp_match(_regexp, text.from.localize().c_str(), text.from.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_START, matches, nmatches);
-      } else {
-        got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_START, matches, nmatches);
-      }
+      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
+                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_START,
+                             matches, nmatches);
       // Now return where we matched.
       ret = new reMatch(got, matches[0].offset:byteIndex, matches[0].len);
       _ddata_free(matches, nmatches);
@@ -814,7 +781,7 @@ record regexp {
      :yields: each split portion, one at a time
    */
   iter split(text: ?t, maxsplit: int = 0)
-    where t == string || t == stringPart
+    where t == string
   {
     var matches:_ddata(qio_regexp_string_piece_t);
     var ncaptures = qio_regexp_get_ncaptures(_regexp);
@@ -826,8 +793,7 @@ record regexp {
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
     }
 
-    if t == stringPart then pos = text.offset;
-    else pos = 0;
+    pos = 0;
     endpos = pos + text.numBytes;
 
     var splits = 0;
@@ -839,7 +805,6 @@ record regexp {
       var splitend:byteIndex = 0;
       var got:bool;
       on this.home {
-        // This doesn't have a case for stringPart.  Mistake?
         got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes, pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       }
 
@@ -888,7 +853,7 @@ record regexp {
               the match for the whole pattern and the rest are the capture groups.
    */
   iter matches(text: ?t, param captures=0, maxmatches: int = max(int))
-    where t == string || t == stringPart
+    where t == string
   {
     var matches:_ddata(qio_regexp_string_piece_t);
     var nmatches = 1 + captures;
@@ -899,8 +864,7 @@ record regexp {
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
     }
 
-    if t == stringPart then pos = text.offset;
-    else pos = 0;
+    pos = 0;
     textLength = text.numBytes;
     endpos = pos + textLength;
 
@@ -909,7 +873,6 @@ record regexp {
     while nfound < maxmatches && cur < endpos {
       var got:bool;
       on this.home {
-        // This doesn't have a case for stringPart.  Mistake?
         got = qio_regexp_match(_regexp, text.localize().c_str(), textLength, cur:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED, matches, nmatches);
       }
       if !got then break;
@@ -937,28 +900,25 @@ record regexp {
    */
   // TODO -- move subn after sub for documentation clarity
   proc subn(repl:string, text: ?t, global = true ):(string, int)
-    where t == string || t == stringPart
+    where t == string
   {
     var pos:byteIndex;
     var endpos:byteIndex;
 
-    if t == stringPart then pos = text.offset;
-    else pos = 0;
+    pos = 0;
     endpos = pos + text.numBytes;
 
     var replaced:c_string;
     var nreplaced:int;
     var replaced_len:int(64);
-    if t == stringPart {
-      nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.numBytes, text.from.localize().c_str(), text.from.numBytes, pos:int, endpos:int, global, replaced, replaced_len);
-    } else {
-      nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.numBytes, text.localize().c_str(), text.numBytes, pos:int, endpos:int, global, replaced, replaced_len);
-    }
-    var ret: string;
+    nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(),
+                                   repl.numBytes, text.localize().c_str(),
+                                   text.numBytes, pos:int, endpos:int, global,
+                                   replaced, replaced_len);
     try! {
-      ret = createStringWithOwnedBuffer(replaced);
+      const ret = createStringWithOwnedBuffer(replaced);
+      return (ret, nreplaced);
     }
-    return (ret, nreplaced);
   }
 
   /*
@@ -972,7 +932,7 @@ record regexp {
      :returns: the new string
    */
   proc sub(repl:string, text: ?t, global = true )
-    where t == string || t == stringPart
+    where t == string
   {
     var (str, count) = subn(repl, text, global);
     return str;

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -449,7 +449,7 @@ class BadRegexpError : Error {
  */
 proc compile(pattern: ?t, posix=false, literal=false, nocapture=false,
              /*i*/ ignorecase=false, /*m*/ multiline=false, /*s*/ dotnl=false,
-             /*U*/ nongreedy=false): regexp throws where t==string || t==bytes {
+             /*U*/ nongreedy=false): regexp(t) throws where t==string || t==bytes {
 
   if CHPL_REGEXP == "none" {
     compilerError("Cannot use Regexp with CHPL_REGEXP=none");
@@ -488,7 +488,7 @@ proc compile(pattern: ?t, posix=false, literal=false, nocapture=false,
 pragma "no doc"
 proc compile(pattern: ?t, out error:syserr, posix, literal, nocapture,
              /*i*/ ignorecase, /*m*/ multiline, /*s*/ dotnl,
-             /*U*/ nongreedy): regexp where t==string || t==bytes {
+             /*U*/ nongreedy): regexp(t) where t==string || t==bytes {
 
   compilerWarning("'out error: syserr' pattern has been deprecated, use 'throws' function instead");
   var ret: regexp(t);
@@ -574,7 +574,7 @@ pragma "ignore noinit"
 record regexp {
 
   pragma "no doc"
-  type exprType;
+  type exprType = string;
   pragma "no doc"
   var home: locale = here;
   pragma "no doc"
@@ -1092,14 +1092,14 @@ proc bytes.search(needle: bytes, ignorecase=false):reMatch
 
 // documented in the captures version
 pragma "no doc"
-proc string.search(needle: regexp):reMatch
+proc string.search(needle: regexp(string)):reMatch
 {
   return needle.search(this);
 }
 
 // documented in the captures version
 pragma "no doc"
-proc bytes.search(needle: regexp):reMatch
+proc bytes.search(needle: regexp(bytes)):reMatch
 {
   return needle.search(this);
 }
@@ -1113,7 +1113,7 @@ proc bytes.search(needle: regexp):reMatch
    :returns: an :record:`reMatch` object representing the offset in the
              receiving string where a match occurred
  */
-proc string.search(needle: regexp, ref captures ...?k):reMatch
+proc string.search(needle: regexp(string), ref captures ...?k):reMatch
 {
   return needle.search(this, (...captures));
 }
@@ -1127,21 +1127,21 @@ proc string.search(needle: regexp, ref captures ...?k):reMatch
    :returns: an :record:`reMatch` object representing the offset in the
              receiving string where a match occurred
  */
-proc bytes.search(needle: regexp, ref captures ...?k):reMatch
+proc bytes.search(needle: regexp(bytes), ref captures ...?k):reMatch
 {
   return needle.search(this, (...captures));
 }
 
 // documented in the captures version
 pragma "no doc"
-proc string.match(pattern: regexp):reMatch
+proc string.match(pattern: regexp(string)):reMatch
 {
   return pattern.match(this);
 }
 
 // documented in the captures version
 pragma "no doc"
-proc bytes.match(pattern: regexp):reMatch
+proc bytes.match(pattern: regexp(bytes)):reMatch
 {
   return pattern.match(this);
 }
@@ -1158,7 +1158,7 @@ proc bytes.match(pattern: regexp):reMatch
              receiving string where a match occurred
  */
 
-proc string.match(pattern: regexp, ref captures ...?k):reMatch
+proc string.match(pattern: regexp(string), ref captures ...?k):reMatch
 {
   return pattern.match(this, (...captures));
 }
@@ -1175,7 +1175,7 @@ proc string.match(pattern: regexp, ref captures ...?k):reMatch
              receiving string where a match occurred
  */
 
-proc bytes.match(pattern: regexp, ref captures ...?k):reMatch
+proc bytes.match(pattern: regexp(bytes), ref captures ...?k):reMatch
 {
   return pattern.match(this, (...captures));
 }
@@ -1188,7 +1188,7 @@ proc bytes.match(pattern: regexp, ref captures ...?k):reMatch
    :arg maxsplit: if nonzero, the maximum number of splits to do
    :yields: each split portion, one at a time
  */
-iter string.split(pattern: regexp, maxsplit: int = 0)
+iter string.split(pattern: regexp(string), maxsplit: int = 0)
 {
   for v in pattern.split(this, maxsplit) {
     yield v;
@@ -1203,7 +1203,7 @@ iter string.split(pattern: regexp, maxsplit: int = 0)
    :arg maxsplit: if nonzero, the maximum number of splits to do
    :yields: each split portion, one at a time
  */
-iter bytes.split(pattern: regexp, maxsplit: int = 0)
+iter bytes.split(pattern: regexp(bytes), maxsplit: int = 0)
 {
   for v in pattern.split(this, maxsplit) {
     yield v;
@@ -1221,7 +1221,8 @@ iter bytes.split(pattern: regexp, maxsplit: int = 0)
             the match for the whole pattern and the rest are the capture groups.
 
 */
-iter string.matches(pattern:regexp, param captures=0, maxmatches:int=max(int))
+iter string.matches(pattern:regexp(string), param captures=0,
+                    maxmatches:int=max(int))
 {
   for v in pattern.matches(this, captures, maxmatches) {
     yield v;
@@ -1239,7 +1240,8 @@ iter string.matches(pattern:regexp, param captures=0, maxmatches:int=max(int))
             the match for the whole pattern and the rest are the capture groups.
 
 */
-iter bytes.matches(pattern:regexp, param captures=0, maxmatches:int=max(int))
+iter bytes.matches(pattern:regexp(bytes), param captures=0,
+                   maxmatches:int=max(int))
 {
   for v in pattern.matches(this, captures, maxmatches) {
     yield v;

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -489,7 +489,8 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
 }
 
 pragma "no doc"
-proc compile(pattern: string, utf8, posix=false, literal=false,
+pragma "last resort"  // otherwise compile("some regex") resolves calling this
+proc compile(pattern: string, utf8=true, posix=false, literal=false,
              nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false,
              /*s*/ dotnl=false, /*U*/ nongreedy=false): regexp(string) throws {
   compilerWarning("Regexp.compile with 'utf8' argument is deprecated. Use generic Regexp.compile, instead");

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -425,12 +425,12 @@ class BadRegexpError : Error {
    :arg literal: (optional) set to true to treat the regular expression as a
                  literal (ie, create a regexp matching ``pattern`` as a string
                  rather than as a regular expression).
-   :arg nocapture: (optional) set to true in order to disable all capture groups
+   :arg noCapture: (optional) set to true in order to disable all capture groups
                    in the regular expression
-   :arg ignorecase: (optional) set to true in order to ignore case when
+   :arg ignoreCase: (optional) set to true in order to ignore case when
                     matching. Note that this can be set inside the regular
                     expression with ``(?i)``.
-   :arg multiline: (optional) set to true in order to activate multiline mode
+   :arg multiLine: (optional) set to true in order to activate multiline mode
                    (meaning that ``^`` and ``$`` match the beginning and end
                    of a line instead of just the beginning and end of the text.
                    Note that this can be set inside a regular expression
@@ -438,7 +438,7 @@ class BadRegexpError : Error {
    :arg dotnl: (optional, default false) set to true in order to allow ``.``
                to match a newline. Note that this can be set inside the
                regular expression with ``(?s)``.
-   :arg nongreedy: (optional) set to true in order to prefer shorter matches for
+   :arg nonGreedy: (optional) set to true in order to prefer shorter matches for
                    repetitions; for example, normally x* will match as many x
                    characters as possible and x*? will match as few as possible.
                    This flag swaps the two, so that x* will match as few as
@@ -447,9 +447,9 @@ class BadRegexpError : Error {
                    ``(?U)``.
 
  */
-proc compile(pattern: ?t, posix=false, literal=false, nocapture=false,
-             /*i*/ ignorecase=false, /*m*/ multiline=false, /*s*/ dotnl=false,
-             /*U*/ nongreedy=false): regexp(t) throws where t==string || t==bytes {
+proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
+             /*i*/ ignoreCase=false, /*m*/ multiLine=false, /*s*/ dotnl=false,
+             /*U*/ nonGreedy=false): regexp(t) throws where t==string || t==bytes {
 
   if CHPL_REGEXP == "none" {
     compilerError("Cannot use Regexp with CHPL_REGEXP=none");
@@ -463,11 +463,11 @@ proc compile(pattern: ?t, posix=false, literal=false, nocapture=false,
   opts.utf8 = t==string;
   opts.posix = posix;
   opts.literal = literal;
-  opts.nocapture = nocapture;
-  opts.ignorecase = ignorecase;
-  opts.multiline = multiline;
+  opts.nocapture = noCapture;
+  opts.ignorecase = ignoreCase;
+  opts.multiline = multiLine;
   opts.dotnl = dotnl;
-  opts.nongreedy = nongreedy;
+  opts.nongreedy = nonGreedy;
 
   var ret: regexp(t);
   qio_regexp_create_compile(pattern.localize().c_str(), pattern.numBytes, opts, ret._regexp);
@@ -486,22 +486,19 @@ proc compile(pattern: ?t, posix=false, literal=false, nocapture=false,
 }
 
 pragma "no doc"
-proc compile(pattern: ?t, out error:syserr, posix, literal, nocapture,
-             /*i*/ ignorecase, /*m*/ multiline, /*s*/ dotnl,
-             /*U*/ nongreedy): regexp(t) where t==string || t==bytes {
+proc compile(pattern: string, utf8=true, posix=false, literal=false,
+             nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false,
+             /*s*/ dotnl=false, /*U*/ nongreedy=false): regexp(string) throws {
+  compilerWarning("Regexp.compile with 'utf8' argument is deprecated. Use generic Regexp.compile, instead");
 
-  compilerWarning("'out error: syserr' pattern has been deprecated, use 'throws' function instead");
-  var ret: regexp(t);
-  try {
-    ret = compile(pattern, posix, literal, nocapture, ignorecase,
-                  multiline, dotnl, nongreedy);
-  } catch e: SystemError {
-    error = e.err;
-  } catch {
-    error = EINVAL;
-  }
-  return ret;
+  if utf8 == false then
+    throw new owned IllegalArgumentError("utf8 argument cannot be false");
+  else
+    return compile(pattern, posix, literal, noCapture=nocapture,
+                   ignoreCase=ignorecase, multiLine=multiline, dotnl,
+                   nonGreedy=nongreedy);
 }
+
 
 /*  The reMatch record records a regular expression search match
     or a capture group.

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -486,7 +486,7 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
 }
 
 pragma "no doc"
-proc compile(pattern: string, utf8=true, posix=false, literal=false,
+proc compile(pattern: string, utf8, posix=false, literal=false,
              nocapture=false, /*i*/ ignorecase=false, /*m*/ multiline=false,
              /*s*/ dotnl=false, /*U*/ nongreedy=false): regexp(string) throws {
   compilerWarning("Regexp.compile with 'utf8' argument is deprecated. Use generic Regexp.compile, instead");
@@ -577,8 +577,9 @@ record regexp {
   pragma "no doc"
   var _regexp:qio_regexp_t = qio_regexp_null();
 
-  /*proc init() {*/
-  /*}*/
+  proc init(type exprType) {
+    this.exprType = exprType;
+  }
 
   proc init=(x: regexp(?)) {
     this.exprType = x.exprType;

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -574,7 +574,7 @@ pragma "ignore noinit"
 record regexp {
 
   pragma "no doc"
-  type exprType = string;
+  type exprType;
   pragma "no doc"
   var home: locale = here;
   pragma "no doc"

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -419,7 +419,10 @@ class BadRegexpError : Error {
                  Note that you may have to escape backslashes. For example, to
                  get the regular expression ``\s``, you'd have to write
                  ``"\\s"`` because the ``\`` is the escape character within
-                 Chapel string/bytes literals
+                 Chapel string/bytes literals. Note that, Chapel supports
+                 triple-quoted raw string/bytes literals, which do not require
+                 escaping backslashes. For example ``"""\s"""`` or ``b"""\s"""``
+                 can be used.
    :arg posix: (optional) set to true to disable non-POSIX regular expression
                syntax
    :arg literal: (optional) set to true to treat the regular expression as a

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -1031,28 +1031,43 @@ proc =(ref ret:regexp(?t), x:regexp(t))
 
 // Cast regexp to string.
 pragma "no doc"
-inline proc _cast(type t, x: regexp(?exprType)) where t == exprType  {
+inline proc _cast(type t: string, x: regexp(string)) {
   var pattern: t;
   on x.home {
     var cs: c_string;
     qio_regexp_get_pattern(x._regexp, cs);
-    if t == string then
+    if t == string {
       try! {
         pattern = createStringWithOwnedBuffer(cs);
       }
-    else
-      pattern = createBytesWithOwnedBuffer(cs);
+    }
   }
   return pattern;
 }
-// Cast string to regexp
+
 pragma "no doc"
-inline proc _cast(type t, x: ?valType) throws
-  where t == regexp(valType)  && (valType == string || valType == bytes) {
-  return compile(x);
+inline proc _cast(type t:bytes, x: regexp(bytes)) {
+  var pattern: t;
+  on x.home {
+    var cs: c_string;
+    qio_regexp_get_pattern(x._regexp, cs);
+    pattern = createBytesWithOwnedBuffer(cs);
+  }
+  return pattern;
 }
 
 
+// Cast string to regexp
+pragma "no doc"
+inline proc _cast(type t: regexp(string), x: string) throws {
+  return compile(x);
+}
+
+// Cast bytes to regexp
+pragma "no doc"
+inline proc _cast(type t: regexp(bytes), x: bytes) throws {
+  return compile(x);
+}
 
 /*
 

--- a/test/deprecated/regexCompile.chpl
+++ b/test/deprecated/regexCompile.chpl
@@ -1,0 +1,12 @@
+use Regexp;
+
+var r = compile(".*oob.*", utf8=true);  // compiler warning
+writeln("foobar".match(r));
+
+try! {
+  var r = compile(".*oob.*", utf8=false);  // Illegal argument error
+  writeln("foobar".match(r));
+}
+catch e: IllegalArgumentError {
+  writeln("Caught expected error");
+}

--- a/test/deprecated/regexCompile.good
+++ b/test/deprecated/regexCompile.good
@@ -1,0 +1,4 @@
+regexCompile.chpl:3: warning: Regexp.compile with 'utf8' argument is deprecated. Use generic Regexp.compile, instead
+regexCompile.chpl:7: warning: Regexp.compile with 'utf8' argument is deprecated. Use generic Regexp.compile, instead
+(matched = true, offset = 0, length = 6)
+Caught expected error

--- a/test/regexp/bytes/cast.chpl
+++ b/test/regexp/bytes/cast.chpl
@@ -1,0 +1,16 @@
+// check bytes (and while here string) casts to/from regular expressions
+
+use Regexp;
+
+var s = "contains";
+var b = b"contains";
+
+var rs = s:regexp(string);
+var rb = b:regexp(bytes);
+
+writeln("contains regular expression".search(rs));
+writeln(b"contains regular expression".search(rb));
+
+writeln("doesn't contain regular expression".search(rs));
+writeln(b"doesn't contain regular expression".search(rb));
+

--- a/test/regexp/bytes/cast.good
+++ b/test/regexp/bytes/cast.good
@@ -1,0 +1,4 @@
+(matched = true, offset = 0, length = 8)
+(matched = true, offset = 0, length = 8)
+(matched = false, offset = -1, length = 0)
+(matched = false, offset = -1, length = 0)

--- a/test/regexp/bytes/nonUTFIO.chpl
+++ b/test/regexp/bytes/nonUTFIO.chpl
@@ -1,0 +1,127 @@
+/* stdin of this test contains:
+   4 (almost) identical lines like "Pattern:Capture" but they have different
+   UTF8 characteristics
+
+   Pattern:Capture
+   Patt\xffern:Capture
+   Patt\xffern:Cap\xffture
+   Pattern:Cap\xffture
+*/
+
+use IO;
+
+{
+  var f = openmem();
+
+  var w = f.writer();
+  w.write("Pattern:Capture\n");
+  w.write(b"Patt\xffern:Capture\n");
+  w.write(b"Patt\xffern:Cap\xffture\n");
+  w.write(b"Pattern:Cap\xffture\n");
+  w.close();
+
+  // read from it -- following four reads are how these should be read
+  var r = f.reader();
+  var captureString: string;
+  var captureBytes: bytes;
+
+  writeln("Case 1");
+  r.readf("%/Pattern:(.*)\n/", captureString);
+  writeln("Captured string length should be 7 : ", captureString.length);
+
+  writeln("Case 2");
+  r.readf(b"%/Patt\xffern:(.*)\n/", captureString);
+  writeln("Captured string length should be 7 : ", captureString.length);
+
+  writeln("Case 3");
+  r.readf(b"%/Patt\xffern:(.*)\n/", captureBytes);
+  writeln("Captured bytes length should be 8 : ", captureBytes.length);
+
+  writeln("Case 4");
+  r.readf(b"%/Pattern:(.*)\n/", captureBytes);
+  writeln("Captured bytes length should be 8 : ", captureBytes.length);
+
+  r.close();
+  f.close();
+}
+
+
+{
+  var f = openmem();
+
+  var w = f.writer();
+  w.write("Pattern:Capture\n");
+  w.write(b"Patt\xffern:Capture\n");
+  w.write(b"Patt\xffern:Cap\xffture\n");
+  w.write(b"Pattern:Cap\xffture\n");
+  w.close();
+
+  // read from it -- following reads are somewhat more interesting and some
+  // should fail
+  var r = f.reader();
+  var captureString: string;
+  var captureBytes: bytes;
+
+  writeln("Case 5");
+  // you can read the first line however you want, here test reading it with a
+  // bytes pattern and storing it in a string  -- should work fine
+  r.readf(b"%/Pattern:(.*)\n/", captureString);
+  writeln("Captured string length should be 7 : ", captureString.length);
+
+  writeln("Case 6");
+  // you cannot create a string literal for this pattern anyway, so here try to
+  // capture the match in a bytes -- should work fine
+  r.readf(b"%/Patt\xffern:(.*)\n/", captureBytes);
+  writeln("Captured string length should be 7 : ", captureBytes.length);
+
+  writeln("Case 7 -- Take 1");
+  // here the capture is non UTF8 -- so cannot be captured in a string
+  try! {  // halt if we get a different error
+    r.readf(b"%/Patt\xffern:(.*)\n/", captureString);
+    writeln("(FAILURE) Captured string length : ", captureString.length);
+  }
+  catch e: SystemError {
+    writeln("Caught expected error: ");
+    writeln(e);
+  }
+
+  writeln("Case 7 -- Take 2");
+  // here the channel must have been rewound back. Read it the right way to move
+  // it forward
+  r.readf(b"%/Patt\xffern:(.*)\n/", captureBytes);
+  writeln("Captured bytes length should be 8 : ", captureBytes.length);
+
+  writeln("Case 8 -- Take 1");
+  // Case 4 above can go wrong in two ways:
+  // (1) use a string regular expression to capture non UTF8 data -- should be
+  // BadFormatError
+  try! {
+    r.readf("%/Pattern:(.*)\n/", captureBytes);
+    writeln("(FAILURE) Captured bytes length : ", captureBytes.length);
+  }
+  catch e: BadFormatError {
+    writeln("Caught expected error");
+    writeln(e);
+  }
+
+  writeln("Case 8 -- Take 2");
+  // (2) correctly use a bytes regular expression but try to capture the match
+  // into a string -- should be argument mismatch
+  try! {
+    r.readf(b"%/Pattern:(.*)\n/", captureString);
+    writeln("(FAILURE) Captured string length : ", captureString.length);
+  }
+  catch e: SystemError {
+    writeln("Caught expected error");
+    writeln(e);
+  }
+
+  writeln("Case 8 -- Take 3");
+  // read it correctly just for the sake of it
+  r.readf(b"%/Pattern:(.*)\n/", captureBytes);
+  writeln("Captured bytes length should be 8 : ", captureBytes.length);
+
+  r.close();
+  f.close();
+}
+

--- a/test/regexp/bytes/nonUTFIO.execopts
+++ b/test/regexp/bytes/nonUTFIO.execopts
@@ -1,0 +1,2 @@
+--preCompiled=false
+--preCompiled=true

--- a/test/regexp/bytes/nonUTFIO.good
+++ b/test/regexp/bytes/nonUTFIO.good
@@ -12,7 +12,7 @@ Case 6
 Captured string length should be 7 : 7
 Case 7 -- Take 1
 Caught expected error: 
-SystemError: Invalid argument: Argument type mismatch in argument 1 (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
+SystemError: Invalid argument: Argument type mismatch in argument x (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
 Case 7 -- Take 2
 Captured bytes length should be 8 : 8
 Case 8 -- Take 1
@@ -20,6 +20,6 @@ Caught expected error
 BadFormatError: bad format: no match (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
 Case 8 -- Take 2
 Caught expected error
-SystemError: Invalid argument: Argument type mismatch in argument 1 (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
+SystemError: Invalid argument: Argument type mismatch in argument x (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
 Case 8 -- Take 3
 Captured bytes length should be 8 : 8

--- a/test/regexp/bytes/nonUTFIO.good
+++ b/test/regexp/bytes/nonUTFIO.good
@@ -1,0 +1,25 @@
+Case 1
+Captured string length should be 7 : 7
+Case 2
+Captured string length should be 7 : 7
+Case 3
+Captured bytes length should be 8 : 8
+Case 4
+Captured bytes length should be 8 : 8
+Case 5
+Captured string length should be 7 : 7
+Case 6
+Captured string length should be 7 : 7
+Case 7 -- Take 1
+Caught expected error: 
+SystemError: Invalid argument: Argument type mismatch in argument 1 (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
+Case 7 -- Take 2
+Captured bytes length should be 8 : 8
+Case 8 -- Take 1
+Caught expected error
+BadFormatError: bad format: no match (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
+Case 8 -- Take 2
+Caught expected error
+SystemError: Invalid argument: Argument type mismatch in argument 1 (in channel.readf(fmt:string, ...) with path "unknown" offset -1)
+Case 8 -- Take 3
+Captured bytes length should be 8 : 8

--- a/test/regexp/bytes/nonUTFIO.prediff
+++ b/test/regexp/bytes/nonUTFIO.prediff
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed "s/Argument type mismatch in argument [1|2]/Argument type mismatch in argument x/" $2 >$2.tmp
+mv $2.tmp $2

--- a/test/regexp/ferguson/readfre.chpl
+++ b/test/regexp/ferguson/readfre.chpl
@@ -34,15 +34,20 @@ writeln(r.offset(), " ", ok);
 writeln("#5 captures 9, should match");
 ok = r.readf("%/([0-9])/":t, str);
 writeln(r.offset(), " ", ok, ":", str);
+
+
+// in the following two, the format strings to readf are hardcoded and string
+// and bytes, respectively. One can match a bytes regex using a string format
+// and vice versa
 writeln("#6 passes x, should match");
 {
   var re = compile("x":t);
-  ok = r.readf("%/*/":t, re);
+  ok = r.readf("%/*/", re);
   writeln(r.offset(), " ", ok);
 }
 writeln("#7 captures zz, should match");
 {
   var re = compile("(z+)":t);
-  ok = r.readf("%/*/":t, re, str);
+  ok = r.readf(b"%/*/", re, str);
   writeln(r.offset(), " ", ok, ":", str);
 }

--- a/test/regexp/ferguson/readfre.chpl
+++ b/test/regexp/ferguson/readfre.chpl
@@ -1,6 +1,7 @@
 use Regexp;
 use IO;
 
+config type t = string;
 writeln("RE TESTS");
 var f = openmem();
 var w = f.writer();
@@ -8,22 +9,22 @@ w.write("Baz9xzz");
 w.close();
 
 var r = f.reader();
-var str:string;
+var str:t;
 var ok:bool;
 
 writeln("#1 not match");
-ok = r.readf("%/[a-z]/");
+ok = r.readf("%/[a-z]/":t);
 writeln(r.offset(), " ", ok);
 writeln("#2 passes B, should match");
-ok = r.readf("%/[A-Z]/");
+ok = r.readf("%/[A-Z]/":t);
 writeln(r.offset(), " ", ok);
 writeln("#3 captures az, should match");
-ok = r.readf("%/([a-z]+)/", str);
+ok = r.readf("%/([a-z]+)/":t, str);
 writeln(r.offset(), " ", ok, ":", str);
 writeln("#4 should not match");
 
 try {
-  r.readf("%/(0-9)/", str);
+  r.readf("%/(0-9)/":t, str);
   ok = true;
 } catch {
   ok = false;
@@ -31,17 +32,17 @@ try {
 writeln(r.offset(), " ", ok);
 
 writeln("#5 captures 9, should match");
-ok = r.readf("%/([0-9])/", str);
+ok = r.readf("%/([0-9])/":t, str);
 writeln(r.offset(), " ", ok, ":", str);
 writeln("#6 passes x, should match");
 {
-  var re = compile("x");
-  ok = r.readf("%/*/", re);
+  var re = compile("x":t);
+  ok = r.readf("%/*/":t, re);
   writeln(r.offset(), " ", ok);
 }
 writeln("#7 captures zz, should match");
 {
-  var re = compile("(z+)");
-  ok = r.readf("%/*/", re, str);
+  var re = compile("(z+)":t);
+  ok = r.readf("%/*/":t, re, str);
   writeln(r.offset(), " ", ok, ":", str);
 }

--- a/test/regexp/ferguson/readfre.compopts
+++ b/test/regexp/ferguson/readfre.compopts
@@ -1,0 +1,2 @@
+-st=string
+-st=bytes

--- a/test/regexp/ferguson/regex-no-leak.good
+++ b/test/regexp/ferguson/regex-no-leak.good
@@ -2,7 +2,12 @@ Compile/Delete
 Search 1
 (matched = true, offset = 1, length = 4)
 test
+(matched = true, offset = 1, length = 4)
+test
 Search 2
+(matched = true, offset = 1, length = 4)
+t
+test
 (matched = true, offset = 1, length = 4)
 t
 test
@@ -10,7 +15,13 @@ Search 3
 (matched = true, offset = 1, length = 4)
 (matched = true, offset = 1, length = 1)
 test
+(matched = true, offset = 1, length = 4)
+(matched = true, offset = 1, length = 1)
+test
 Search 4
+(matched = true, offset = 1, length = 4)
+(matched = true, offset = 1, length = 4)
+test
 (matched = true, offset = 1, length = 4)
 (matched = true, offset = 1, length = 4)
 test
@@ -18,10 +29,18 @@ Search 5
 (matched = true, offset = 1, length = 2)
 57
 57
+(matched = true, offset = 1, length = 2)
+57
+57
 Match 1
 (matched = true, offset = 0, length = 4)
 test
+(matched = true, offset = 0, length = 4)
+test
 Match 2
+(matched = true, offset = 0, length = 4)
+t
+test
 (matched = true, offset = 0, length = 4)
 t
 test
@@ -29,7 +48,14 @@ Match 3
 (matched = false, offset = -1, length = 0)
 
 
+(matched = false, offset = -1, length = 0)
+
+
 Split 1
+Words
+words
+words
+
 Words
 words
 words
@@ -42,7 +68,18 @@ words
 words
 .
 
+Words
+, 
+words
+, 
+words
+.
+
 Split 3
+
+words
+words
+
 
 words
 words
@@ -55,10 +92,22 @@ words
 words
 ...
 
+
+...
+words
+, 
+words
+...
+
 Split 5
 Words
 words, words.
+Words
+words, words.
 Split 6
+Words
+words
+words.
 Words
 words
 words.
@@ -66,7 +115,16 @@ Matches 1
 Words
 words
 word
+Words
+words
+word
 Matches 2
+words
+w
+ords
+word
+w
+ord
 words
 w
 ords

--- a/test/regexp/ferguson/regex.chpl
+++ b/test/regexp/ferguson/regex.chpl
@@ -12,11 +12,20 @@ writeln("Search 1");
   var r = compile("[a-z]+":t);
 
   var str = " test ":t;
-  var match = r.search(str);
+  {
+    var match = r.search(str);
 
-  writeln(match);
+    writeln(match);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.search(r);
+
+    writeln(match);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Search 2");
@@ -25,12 +34,22 @@ writeln("Search 2");
 
   var str = " test ":t;
   var cap:t;
-  var match = r.search(str, cap);
+  {
+    var match = r.search(str, cap);
 
-  writeln(match);
-  writeln(cap);
+    writeln(match);
+    writeln(cap);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.search(r, cap);
+
+    writeln(match);
+    writeln(cap);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Search 3");
@@ -39,12 +58,22 @@ writeln("Search 3");
 
   var str = " test ":t;
   var cap:reMatch;
-  var match = r.search(str, cap);
+  {
+    var match = r.search(str, cap);
 
-  writeln(match);
-  writeln(cap);
+    writeln(match);
+    writeln(cap);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.search(r, cap);
+
+    writeln(match);
+    writeln(cap);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Search 4");
@@ -53,12 +82,21 @@ writeln("Search 4");
 
   var str = " test ":t;
   var cap:reMatch;
-  var match = r.search(str, cap);
+  {
+    var match = r.search(str, cap);
 
-  writeln(match);
-  writeln(cap);
+    writeln(match);
+    writeln(cap);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }{
+    var match = str.search(r, cap);
+
+    writeln(match);
+    writeln(cap);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Search 5");
@@ -67,12 +105,22 @@ writeln("Search 5");
 
   var str = " 57 ":t;
   var cap:int;
-  var match = r.search(str, cap);
+  {
+    var match = r.search(str, cap);
 
-  writeln(match);
-  writeln(cap);
+    writeln(match);
+    writeln(cap);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.search(r, cap);
+
+    writeln(match);
+    writeln(cap);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Match 1");
@@ -80,11 +128,20 @@ writeln("Match 1");
   var r = compile("[a-z]+":t);
 
   var str = "test ":t;
-  var match = r.match(str);
+  {
+    var match = r.match(str);
 
-  writeln(match);
+    writeln(match);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.match(r);
+
+    writeln(match);
+
+    writeln(str[match]);
+  } 
 }
 
 writeln("Match 2");
@@ -93,12 +150,22 @@ writeln("Match 2");
 
   var str = "test ":t;
   var cap:t;
-  var match = r.match(str, cap);
+  {
+    var match = r.match(str, cap);
 
-  writeln(match);
-  writeln(cap);
+    writeln(match);
+    writeln(cap);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.match(r, cap);
+
+    writeln(match);
+    writeln(cap);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Match 3");
@@ -107,18 +174,32 @@ writeln("Match 3");
 
   var str = " test ":t;
   var cap:t;
-  var match = r.match(str, cap);
+  {
+    var match = r.match(str, cap);
 
-  writeln(match);
-  writeln(cap);
+    writeln(match);
+    writeln(cap);
 
-  writeln(str[match]);
+    writeln(str[match]);
+  }
+  {
+    var match = str.match(r, cap);
+
+    writeln(match);
+    writeln(cap);
+
+    writeln(str[match]);
+  }
 }
 
 writeln("Split 1");
 {
   var split = compile("\\W+":t);
-  for s in split.split("Words, words, words.":t) {
+  var str = "Words, words, words.":t;
+  for s in split.split(str) {
+    writeln(s);
+  }
+  for s in str.split(split) {
     writeln(s);
   }
 }
@@ -126,7 +207,11 @@ writeln("Split 1");
 writeln("Split 2");
 {
   var split = compile("(\\W+)":t);
-  for s in split.split("Words, words, words.":t) {
+  var str = "Words, words, words.":t ;
+  for s in split.split(str) {
+    writeln(s);
+  }
+  for s in str.split(split) {
     writeln(s);
   }
 }
@@ -134,7 +219,11 @@ writeln("Split 2");
 writeln("Split 3");
 {
   var split = compile("\\W+":t);
-  for s in split.split("...words, words...":t) {
+  var str = "...words, words...":t;
+  for s in split.split(str) {
+    writeln(s);
+  }
+  for s in str.split(split) {
     writeln(s);
   }
 }
@@ -142,7 +231,11 @@ writeln("Split 3");
 writeln("Split 4");
 {
   var split = compile("(\\W+)":t);
-  for s in split.split("...words, words...":t) {
+  var str = "...words, words...":t;
+  for s in split.split(str) {
+    writeln(s);
+  }
+  for s in str.split(split) {
     writeln(s);
   }
 }
@@ -150,7 +243,11 @@ writeln("Split 4");
 writeln("Split 5");
 {
   var split = compile("\\W+":t);
-  for s in split.split("Words, words, words.":t, 1) {
+  var str = "Words, words, words.":t;
+  for s in split.split(str, 1) {
+    writeln(s);
+  }
+  for s in str.split(split, 1) {
     writeln(s);
   }
 }
@@ -158,7 +255,11 @@ writeln("Split 5");
 writeln("Split 6");
 {
   var split = compile("\\W+":t);
-  for s in split.split("Words, words, words.":t, 2) {
+  var str = "Words, words, words.":t;
+  for s in split.split(str, 2) {
+    writeln(s);
+  }
+  for s in str.split(split, 2) {
     writeln(s);
   }
 }
@@ -171,12 +272,20 @@ writeln("Matches 1");
   for s in re.matches(str, 0) {
     writeln(str[s[1]]);
   }
+  for s in str.matches(re, 0) {
+    writeln(str[s[1]]);
+  }
 }
 writeln("Matches 2");
 {
   var re = compile("(w)(\\w+)":t);
   var str = "Words, words, word.":t;
   for s in re.matches(str, 2) {
+    writeln(str[s[1]]);
+    writeln(str[s[2]]);
+    writeln(str[s[3]]);
+  }
+  for s in str.matches(re, 2) {
     writeln(str[s[1]]);
     writeln(str[s[2]]);
     writeln(str[s[3]]);

--- a/test/regexp/ferguson/regex.chpl
+++ b/test/regexp/ferguson/regex.chpl
@@ -1,15 +1,17 @@
 use Regexp;
 
+config type t = string;
+
 writeln("Compile/Delete");
 {
-  var r = compile("[a-z]+");
+  var r = compile("[a-z]+":t);
 }
 
 writeln("Search 1");
 {
-  var r = compile("[a-z]+");
+  var r = compile("[a-z]+":t);
 
-  var str = " test ";
+  var str = " test ":t;
   var match = r.search(str);
 
   writeln(match);
@@ -19,10 +21,10 @@ writeln("Search 1");
 
 writeln("Search 2");
 {
-  var r = compile("(t)[a-z]+");
+  var r = compile("(t)[a-z]+":t);
 
-  var str = " test ";
-  var cap:string;
+  var str = " test ":t;
+  var cap:t;
   var match = r.search(str, cap);
 
   writeln(match);
@@ -33,9 +35,9 @@ writeln("Search 2");
 
 writeln("Search 3");
 {
-  var r = compile("(t)[a-z]+");
+  var r = compile("(t)[a-z]+":t);
 
-  var str = " test ";
+  var str = " test ":t;
   var cap:reMatch;
   var match = r.search(str, cap);
 
@@ -47,9 +49,9 @@ writeln("Search 3");
 
 writeln("Search 4");
 {
-  var r = compile("([a-z]+)");
+  var r = compile("([a-z]+)":t);
 
-  var str = " test ";
+  var str = " test ":t;
   var cap:reMatch;
   var match = r.search(str, cap);
 
@@ -61,9 +63,9 @@ writeln("Search 4");
 
 writeln("Search 5");
 {
-  var r = compile("([0-9]+)");
+  var r = compile("([0-9]+)":t);
 
-  var str = " 57 ";
+  var str = " 57 ":t;
   var cap:int;
   var match = r.search(str, cap);
 
@@ -75,9 +77,9 @@ writeln("Search 5");
 
 writeln("Match 1");
 {
-  var r = compile("[a-z]+");
+  var r = compile("[a-z]+":t);
 
-  var str = "test ";
+  var str = "test ":t;
   var match = r.match(str);
 
   writeln(match);
@@ -87,10 +89,10 @@ writeln("Match 1");
 
 writeln("Match 2");
 {
-  var r = compile("(t)[a-z]+");
+  var r = compile("(t)[a-z]+":t);
 
-  var str = "test ";
-  var cap:string;
+  var str = "test ":t;
+  var cap:t;
   var match = r.match(str, cap);
 
   writeln(match);
@@ -101,10 +103,10 @@ writeln("Match 2");
 
 writeln("Match 3");
 {
-  var r = compile("(t)[a-z]+");
+  var r = compile("(t)[a-z]+":t);
 
-  var str = " test ";
-  var cap:string;
+  var str = " test ":t;
+  var cap:t;
   var match = r.match(str, cap);
 
   writeln(match);
@@ -115,48 +117,48 @@ writeln("Match 3");
 
 writeln("Split 1");
 {
-  var split = compile("\\W+");
-  for s in split.split("Words, words, words.") {
+  var split = compile("\\W+":t);
+  for s in split.split("Words, words, words.":t) {
     writeln(s);
   }
 }
 
 writeln("Split 2");
 {
-  var split = compile("(\\W+)");
-  for s in split.split("Words, words, words.") {
+  var split = compile("(\\W+)":t);
+  for s in split.split("Words, words, words.":t) {
     writeln(s);
   }
 }
 
 writeln("Split 3");
 {
-  var split = compile("\\W+");
-  for s in split.split("...words, words...") {
+  var split = compile("\\W+":t);
+  for s in split.split("...words, words...":t) {
     writeln(s);
   }
 }
 
 writeln("Split 4");
 {
-  var split = compile("(\\W+)");
-  for s in split.split("...words, words...") {
+  var split = compile("(\\W+)":t);
+  for s in split.split("...words, words...":t) {
     writeln(s);
   }
 }
 
 writeln("Split 5");
 {
-  var split = compile("\\W+");
-  for s in split.split("Words, words, words.", 1) {
+  var split = compile("\\W+":t);
+  for s in split.split("Words, words, words.":t, 1) {
     writeln(s);
   }
 }
 
 writeln("Split 6");
 {
-  var split = compile("\\W+");
-  for s in split.split("Words, words, words.", 2) {
+  var split = compile("\\W+":t);
+  for s in split.split("Words, words, words.":t, 2) {
     writeln(s);
   }
 }
@@ -164,16 +166,16 @@ writeln("Split 6");
 
 writeln("Matches 1");
 {
-  var re = compile("\\w+");
-  var str = "Words, words, word.";
+  var re = compile("\\w+":t);
+  var str = "Words, words, word.":t;
   for s in re.matches(str, 0) {
     writeln(str[s[1]]);
   }
 }
 writeln("Matches 2");
 {
-  var re = compile("(w)(\\w+)");
-  var str = "Words, words, word.";
+  var re = compile("(w)(\\w+)":t);
+  var str = "Words, words, word.":t;
   for s in re.matches(str, 2) {
     writeln(str[s[1]]);
     writeln(str[s[2]]);
@@ -183,21 +185,21 @@ writeln("Matches 2");
 
 writeln("sub 1");
 {
-  var re = compile("(w)(\\w+)");
-  var str = "Words, words, word.";
-  writeln(re.sub("\\1-\\2", str, true));
+  var re = compile("(w)(\\w+)":t);
+  var str = "Words, words, word.":t;
+  writeln(re.sub("\\1-\\2":t, str, true));
 }
 
 writeln("sub 2");
 {
-  var re = compile("(w)(\\w+)");
-  var str = "Words, words, word.";
-  writeln(re.subn("\\1-\\2", str, true));
+  var re = compile("(w)(\\w+)":t);
+  var str = "Words, words, word.":t;
+  writeln(re.subn("\\1-\\2":t, str, true));
 }
 
 writeln("sub 3");
 {
-  var re = compile("(w)(\\w+)");
-  var str = "Words, words, word.";
-  writeln(re.sub("\\1-\\2", str, false));
+  var re = compile("(w)(\\w+)":t);
+  var str = "Words, words, word.":t;
+  writeln(re.sub("\\1-\\2":t, str, false));
 }

--- a/test/regexp/ferguson/regex.compopts
+++ b/test/regexp/ferguson/regex.compopts
@@ -1,0 +1,2 @@
+-st=string
+-st=bytes

--- a/test/regexp/ferguson/regex.good
+++ b/test/regexp/ferguson/regex.good
@@ -2,7 +2,12 @@ Compile/Delete
 Search 1
 (matched = true, offset = 1, length = 4)
 test
+(matched = true, offset = 1, length = 4)
+test
 Search 2
+(matched = true, offset = 1, length = 4)
+t
+test
 (matched = true, offset = 1, length = 4)
 t
 test
@@ -10,7 +15,13 @@ Search 3
 (matched = true, offset = 1, length = 4)
 (matched = true, offset = 1, length = 1)
 test
+(matched = true, offset = 1, length = 4)
+(matched = true, offset = 1, length = 1)
+test
 Search 4
+(matched = true, offset = 1, length = 4)
+(matched = true, offset = 1, length = 4)
+test
 (matched = true, offset = 1, length = 4)
 (matched = true, offset = 1, length = 4)
 test
@@ -18,10 +29,18 @@ Search 5
 (matched = true, offset = 1, length = 2)
 57
 57
+(matched = true, offset = 1, length = 2)
+57
+57
 Match 1
 (matched = true, offset = 0, length = 4)
 test
+(matched = true, offset = 0, length = 4)
+test
 Match 2
+(matched = true, offset = 0, length = 4)
+t
+test
 (matched = true, offset = 0, length = 4)
 t
 test
@@ -29,7 +48,14 @@ Match 3
 (matched = false, offset = -1, length = 0)
 
 
+(matched = false, offset = -1, length = 0)
+
+
 Split 1
+Words
+words
+words
+
 Words
 words
 words
@@ -42,7 +68,18 @@ words
 words
 .
 
+Words
+, 
+words
+, 
+words
+.
+
 Split 3
+
+words
+words
+
 
 words
 words
@@ -55,10 +92,22 @@ words
 words
 ...
 
+
+...
+words
+, 
+words
+...
+
 Split 5
 Words
 words, words.
+Words
+words, words.
 Split 6
+Words
+words
+words.
 Words
 words
 words.
@@ -66,7 +115,16 @@ Matches 1
 Words
 words
 word
+Words
+words
+word
 Matches 2
+words
+w
+ords
+word
+w
+ord
 words
 w
 ords

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -60,7 +60,7 @@ proc masonSearch(ref args: list(string)) {
   // If no query is provided, list all packages in registry
   const query = if args.size > 0 then args[args.size].toLower()
                 else ".*";
-  const pattern = compile(query, ignorecase=true);
+  const pattern = compile(query, ignoreCase=true);
 
   var results: list(string);
   var packages: list(string);


### PR DESCRIPTION
This PR adds support for using `bytes` values as regular expressions to be used
with other `bytes` values.

Summary:
- Makes `regexp` generic on `type exprType` which can be `string` or `bytes`
   
  Currently, this PR doesn't assign a default to `exprType`. But we might want to
  make `string` the default type. See #14693 

- Removes `stringPart` from Regexp module. This was based on some comments in
  the code that says it is not tested, and in some places, support for it is not
  fully implemented.

  This is not absolutely necessary for this PR to move on and I can revert back.
  But it makes the interface and sometimes implementation much easier to remove
  that.

- Remove the deprecated `compile` with `out err`, deprecates the `compile`
  with `utf8`  argument and all lowercase arguments.

  The new `compile` uses `utf8` encoding with strings and `Latin1` with bytes
  internally.

- Adds `bytes` methods with regexp arguments. `bytes.this(reMatch)`,
  `bytes.search(regexp(bytes))` etc
  
- Adds support for doing formatted reads for `regexp(bytes)`.

  The internal class `channel_regexp_info` now stores only `bytes`. They are
  `decode`d into strings as necessary when they are extracted.

  Making this also generic cannot be easily done, I think. Because `readf`
  needs to create a `channel_regexp_info` instance before starting to read the
  arguments. And before starting to read the arguments we don't know whether
  they are `regexp(bytes)` or `regexp(string)`.

  Note that the type of the format string does not determine the type of the
  regular expression. Therefore, one can capture a bytes-based regular
  expression using `"%/*/"` and a string-based regular expression using
  `b"%/*/"`

- Modifies some tests to test bytes-based regular expressions in the same way
  string-based ones are tested.

- Adjusts the `RecordParser` module to use `regexp(string)`

- Adjusts mason to use new `compile`

- Adds tests for non-UTF8 regexp matching and casts.

- Minor adjustment in the docs to emphasize that we have raw string/bytes
  literals.

Test:
- [x] standard
- [x] gasnet