### PR TITLE
Replace USR_FATAL_CONT with USR_PRINT in two cases

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1231,7 +1231,7 @@ static void errorIfValueCoercionToRef(CallExpr* call, ArgSymbol* formal) {
     USR_FATAL_CONT(call,
                    "value from coercion passed to ref formal '%s'",
                    formal->name);
-    USR_FATAL_CONT(formal->getFunction(),
+    USR_PRINT(formal->getFunction(),
                    "to function '%s' defined here",
                    formal->getFunction()->name);
    }
@@ -1250,7 +1250,7 @@ static void errorIfValueCoercionToRef(CallExpr* call, ArgSymbol* formal) {
       USR_FATAL_CONT(call,
                      "value from coercion passed to const ref formal '%s'",
                      formal->name);
-      USR_FATAL_CONT(formal->getFunction(),
+      USR_PRINT(formal->getFunction(),
                      "to function '%s' defined here",
                      formal->getFunction()->name);
 

--- a/test/classes/delete-free/shared/shared-default-arg-nil-ref.good
+++ b/test/classes/delete-free/shared/shared-default-arg-nil-ref.good
@@ -1,2 +1,2 @@
 shared-default-arg-nil-ref.chpl:13: error: value from coercion passed to ref formal 'opt'
-shared-default-arg-nil-ref.chpl:7: error: to function 'foo' defined here
+shared-default-arg-nil-ref.chpl:7: note: to function 'foo' defined here

--- a/test/compflags/ferguson/unstable-owned-shared-intent2.1.good
+++ b/test/compflags/ferguson/unstable-owned-shared-intent2.1.good
@@ -1,5 +1,5 @@
 unstable-owned-shared-intent2.chpl:5: warning: default intent for owned Parent has changed from `in` to `const ref`
 unstable-owned-shared-intent2.chpl:7: In function 'test1':
 unstable-owned-shared-intent2.chpl:11: error: value from coercion passed to const ref formal 'arg'
-unstable-owned-shared-intent2.chpl:5: error: to function 'foo' defined here
+unstable-owned-shared-intent2.chpl:5: note: to function 'foo' defined here
 unstable-owned-shared-intent2.chpl:5: note: default intent for owned Parent has changed from `in` to `const ref`

--- a/test/compflags/ferguson/unstable-owned-shared-intent2.2.good
+++ b/test/compflags/ferguson/unstable-owned-shared-intent2.2.good
@@ -1,4 +1,4 @@
 unstable-owned-shared-intent2.chpl:7: In function 'test1':
 unstable-owned-shared-intent2.chpl:11: error: value from coercion passed to const ref formal 'arg'
-unstable-owned-shared-intent2.chpl:5: error: to function 'foo' defined here
+unstable-owned-shared-intent2.chpl:5: note: to function 'foo' defined here
 unstable-owned-shared-intent2.chpl:5: note: default intent for owned Parent has changed from `in` to `const ref`

--- a/test/parallel/sync/bradc/testBadSyncSingle-arr.good
+++ b/test/parallel/sync/bradc/testBadSyncSingle-arr.good
@@ -1,4 +1,4 @@
 testBadSyncSingle.chpl:4: In function 'main':
 testBadSyncSingle.chpl:5: error: value from coercion passed to ref formal 'this'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: error: to function 'chpl__promotionType' defined here
+$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: note: to function 'chpl__promotionType' defined here
 testBadSyncSingle.chpl:5: error: sync/single types cannot contain type '[domain(1,int(64),false)] int(64)'

--- a/test/parallel/sync/bradc/testBadSyncSingle-arr2.good
+++ b/test/parallel/sync/bradc/testBadSyncSingle-arr2.good
@@ -1,4 +1,4 @@
 testBadSyncSingle.chpl:4: In function 'main':
 testBadSyncSingle.chpl:5: error: value from coercion passed to ref formal 'this'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: error: to function 'chpl__promotionType' defined here
+$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: note: to function 'chpl__promotionType' defined here
 testBadSyncSingle.chpl:5: error: sync/single types cannot contain type '[domain(1,int(64),false)] sync int(64)'

--- a/test/types/sync/ferguson/sync-coerce-to-ref.good
+++ b/test/types/sync/ferguson/sync-coerce-to-ref.good
@@ -1,3 +1,3 @@
 sync-coerce-to-ref.chpl:5: In function 'test':
 sync-coerce-to-ref.chpl:10: error: value from coercion passed to ref formal 'arg'
-sync-coerce-to-ref.chpl:1: error: to function 'acceptRef' defined here
+sync-coerce-to-ref.chpl:1: note: to function 'acceptRef' defined here

--- a/test/types/sync/vass/ref-sync-2.good
+++ b/test/types/sync/vass/ref-sync-2.good
@@ -1,2 +1,2 @@
 ref-sync-2.chpl:5: error: value from coercion passed to ref formal 'FORMAL'
-ref-sync-2.chpl:7: error: to function 'MYPROC' defined here
+ref-sync-2.chpl:7: note: to function 'MYPROC' defined here


### PR DESCRIPTION
This converts two error cases in the compiler to our common practice
of using USR_PRINT, not USR_FATAL_CONT, when supplying additional
information for an error message.

Trivial, not reviewed.
