### PR TITLE
Remove --legacy-classes from two .compopts

### DIFF
--- a/test/classes/diten/callNilClassesMethod.chpl
+++ b/test/classes/diten/callNilClassesMethod.chpl
@@ -7,8 +7,8 @@ class Unallocated {
     return str;
   }
 }
-
+var ARR: [LocaleSpace] unmanaged Unallocated;
 proc main {
-  var aaa: unmanaged Unallocated;
+  var aaa = ARR[0]; // nil of non-nilablel type, due to a typechecking loophole
   writeln(aaa.method());
 }

--- a/test/classes/diten/callNilClassesMethod.compopts
+++ b/test/classes/diten/callNilClassesMethod.compopts
@@ -1,1 +1,1 @@
---legacy-classes --no-compile-time-nil-checking
+--no-compile-time-nil-checking

--- a/test/classes/diten/nilDynamicDispatch.chpl
+++ b/test/classes/diten/nilDynamicDispatch.chpl
@@ -10,7 +10,7 @@ class D:C {
   }
 }
 
-var c: borrowed C;
-var d: borrowed D;
+var ARR: [LocaleSpace] borrowed C;
+var c = ARR[0]; // nil of non-nilablel type, due to a typechecking loophole
 
 c.foo();

--- a/test/classes/diten/nilDynamicDispatch.compopts
+++ b/test/classes/diten/nilDynamicDispatch.compopts
@@ -1,1 +1,1 @@
---legacy-classes --no-compile-time-nil-checking
+--no-compile-time-nil-checking


### PR DESCRIPTION
This furthers the goal of eliminating `--legacy-classes` compiler flag.
See also #13625.

This PR modifies these two tests:

    test/classes/diten/callNilClassesMethod.chpl
    test/classes/diten/nilDynamicDispatch.chpl

They used to require --legacy-classes to have a variable of a non-nilable
class type that holds `nil`. Now they use a hole in typechecking of
nilable types to achieve that. Specifically, right now array elements
can be `nil` despite having a non-nilable type.

When this hole is fixed, we can switch to using another hole.
When no holes remain, we can remove altogether the nil-checking being tested
here, and therefore these tests as well.

#### Background

These tests' purpose is to test "old-style" runtime nil checking, which applies
to the receiver upon each method call. To observe it fire, we need
a class variable holding `nil`.

Alas, if this variable has a nilable type, the old-style check will not fire
because:
* the typechecker will insist on calling postfix-`!` on the variable
  before it is passed to a method, and
* postfix-`!` will fire its own error, so the old-style check is never
  executed.

Therefore we need the variable to have a non-nilable type, so that
the typechecker does not insist on calling postfix-`!`.
This change relies on a loophole in the typechecker to make it happen.
Which loophole is used does not matter.