### PR TITLE
Fix typos

### DIFF
--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -794,7 +794,7 @@ static void transformAtomicStmt(Expr* stmt) {
   }
 
   // TODO: This could just be a release fence (and then we could do an
-  // aquire fence at the end of the forall loop in addition to just
+  // acquire fence at the end of the forall loop in addition to just
   // completing the unordered ops). That could help in 2 cases:
   //  1. If --cache-remote is used, we can still use cached GETs
   //     during the unordered loop

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2489,7 +2489,7 @@ static found_init_t doFindInitPoints(DefExpr* def,
         }
         return FOUND_INIT;
       } else if (foundIf == FOUND_INIT || foundElse == FOUND_INIT) {
-        // intialized on one side but not the other
+        // initialized on one side but not the other
         errorIfSplitInitializationRequired(def, cur);
         return FOUND_USE;
       } else if (foundIf == FOUND_USE || foundElse == FOUND_USE) {
@@ -3848,7 +3848,7 @@ static void expandQueryForGenericTypeSpecifier(FnSymbol*  fn,
 
   // Fix type constructor calls to owned e.g.
   // (call dtOwned SomeGenericClass( arg ))
-  // This is relant to test/functions/ferguson/query/owned-generic
+  // This is relevant to test/functions/ferguson/query/owned-generic
   if (call->baseExpr != NULL) {
     if (SymExpr* se = toSymExpr(call->baseExpr)) {
       if (TypeSymbol* ts = toTypeSymbol(se->symbol())) {

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -283,7 +283,7 @@ if ``T`` is a class type, then ``T: class?`` indicates its nilable counterpart,
 or ``T`` itself if it is already nilable. ``T: borrowed class?`` produces
 the nilable ``borrowed`` variant of ``T``.
 
-To create a non-nilalble class type from a nilable class type, apply a
+To create a non-nilable class type from a nilable class type, apply a
 cast to ``class`` or to a more specific type. For example, if ``T`` is
 a class type, then ``T: class`` indicates its non-nilable counterpart,
 or ``T`` itself if it is already non-nilable. ``T: borrowed class``

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -983,7 +983,7 @@ module Bytes {
 
             // if nbytes is 1, then we must have read a single byte and found
             // that it was invalid, if nbytes is >1 then we must have read
-            // multible bytes where the last one broke the sequence. But it can
+            // multiple bytes where the last one broke the sequence. But it can
             // be a valid byte itself. So we rewind by 1 in that case
             // we use nInvalidBytes to store how many bytes we are ignoring or
             // replacing

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -552,7 +552,7 @@ module String {
 
   /*
     Creates a new string which takes ownership of the internal buffer of a
-    `c_string`. The buffer will be freed when the bytes is deinitialized.
+    `c_string`. The buffer will be freed when the string is deinitialized.
 
     :arg s: Object to take ownership of the buffer from
     :type s: `c_string`
@@ -570,7 +570,7 @@ module String {
 
   /*
      Creates a new string which takes ownership of the memory allocated for a
-     `c_ptr(uint(8))`. The buffer will be freed when the bytes is deinitialized.
+     `c_ptr(uint(8))`. The buffer will be freed when the string is deinitialized.
 
      :arg s: Object to take ownership of the buffer from
      :type s: `bufferType` (i.e. `c_ptr(uint(8))`)

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -917,7 +917,7 @@ module QuickSort {
     // c+1..d-1 store elements > pivot
     // d+1..hi  stores equal elements
 
-    // initally, entire array is in b..c
+    // initially, entire array is in b..c
     var a = lo;
     var b = lo;
     var c = hi;

--- a/runtime/include/encoding/encoding-support.h
+++ b/runtime/include/encoding/encoding-support.h
@@ -113,7 +113,7 @@ int chpl_enc_decode_char_buf_ascii(int32_t* CHPL_ENC_RESTRICT chr,
  * :arg buflen: Upper limit for number of bytes to read
  *
  * :returns: 0 if successful, -1 if illegal byte sequence, -2 if the
- * sytem does not have wctype.h
+ * system does not have wctype.h
  */
 static inline
 int chpl_enc_decode_char_buf_wctype(int32_t* CHPL_ENC_RESTRICT chr,

--- a/runtime/src/chpl-export-wrappers.c
+++ b/runtime/src/chpl-export-wrappers.c
@@ -34,7 +34,7 @@ void chpl_byte_buffer_free(chpl_byte_buffer cb) {
 }
 
 chpl_byte_buffer chpl_byte_buffer_make(const char* data) {
-  // We can get away with this cast because we mark "isOWned" as false.
+  // We can get away with this cast because we mark "isOwned" as false.
   chpl_byte_buffer result = { 0, (char*) data, strlen(data) };
   return result;
 }


### PR DESCRIPTION
Fix typos in
optimizeForallUnorderedOps.cpp, normalize.cpp,
classes.rst
Bytes.chpl, String.chpl, Sort.chpl
encoding-support.h, chpl-export-wrappers.c