### PR TITLE
Non-nilable variables to be non-nil in nilChecking

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1187,6 +1187,13 @@ static void checkTypesForInstantiation(AggregateType* at, CallExpr* call, const 
   }
 }
 
+static void markManagedPointerIfNonNilable(AggregateType* mp, Symbol* mps) {
+  if (! mps->hasFlag(FLAG_GENERIC))
+    if (Symbol* chpl_t = mp->getField("chpl_t", false))
+      if (isNonNilableClassType(chpl_t->type))
+        mps->addFlag(FLAG_MANAGED_POINTER_NONNILABLE);
+}
+
 AggregateType* AggregateType::generateType(SymbolMap& subs, CallExpr* call, const char* callString, bool evalDefaults, Expr* insnPoint) {
   AggregateType* retval = this;
 
@@ -1246,6 +1253,9 @@ AggregateType* AggregateType::generateType(SymbolMap& subs, CallExpr* call, cons
       }
     }
   }
+
+  if (retval->symbol->hasFlag(FLAG_MANAGED_POINTER))
+    markManagedPointerIfNonNilable(retval, retval->symbol);
 
   return retval;
 }

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -230,6 +230,7 @@ symbolFlag( FLAG_LOCAL_FN , npr, "local fn" , "function is completely local (no 
 symbolFlag( FLAG_LOCAL_ON, npr, "local on", ncm)
 symbolFlag( FLAG_LOOP_BODY_ARGUMENT_CLASS , npr, "loop body argument class" , ncm )
 symbolFlag( FLAG_MANAGED_POINTER , ypr, "managed pointer" , "e.g. Owned and Shared" )
+symbolFlag( FLAG_MANAGED_POINTER_NONNILABLE , npr, "managed pointer nonnilable" , "e.g. non-nilable Owned and Shared" )
 symbolFlag( FLAG_MARKED_GENERIC , npr, "marked generic" , "formal is marked generic using the type query syntax" )
 symbolFlag( FLAG_MAYBE_ARRAY_TYPE , npr, "maybe array type" , "function may be computing array type")
 symbolFlag( FLAG_MAYBE_PARAM , npr, "maybe param" , "symbol can resolve to a param" )


### PR DESCRIPTION
This PR is a follow-up to #14660. It modifies nilChecking so it treats variables
of non-nilable types as "known to contain non-nil" -- in some cases.
Specifically:
* the formals of non-nilable types
* results of calls to postfix-! (singled out because it is easy to check)
* results of calls to functions whose return types are non-nilable

Due to loopholes currently in typechecking of non-nilable types,
this is not sound. So nilChecking is also modified so it no longer removes
ALL postfix-! calls in a conditional statement's branch that is known to the
analysis as unreachable. nilChecking continues removing those postfix-! calls
where the argument is known as non-nil. If the argument is actually nil at
runtime, due to a current typechecking loophole, the old-style runtime nil check
- still inserted by the compiler regardless of the outcomes of nilChecking -
will fire and halt the program, instead of postfix-! halting the program.
Note that regardless of this change, postfix-! does not include the runtime
check when the argument type is non-nilable.

#### Implementation Details

Detection of non-/nilability of a type during the nilChecking pass cannot be
done the way it is done during resolution, i.e. using isNonNilableClassType().
This is because for `owned` and `shared` types the latter involved checking
the type of the owned/shared record's field `chpl_t`. Since this is a type
field, it is removed at the end of resolution. To communicate non-nilability
of owned/shared types to nilChecking, this PR introduces
FLAG_MANAGED_POINTER_NONNILABLE.

Suggested by/discussed with @mppf .