### PR TITLE
Restore one of the two QIO hints

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -18,7 +18,8 @@ param eol = "\n".toByte();      // end-of-line, as an integer
 const table = createTable();    // create the table of code complements
 
 // a channel and coordination variable for writing data to stdout
-var stdoutBin = openfd(1).writer(iokind.native, locking=false),
+var stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                 hints=QIO_CH_ALWAYS_UNBUFFERED),
     seqToWrite: atomic int = 1;
 
 


### PR DESCRIPTION
Pulling both did hurt performance badly; restoring one to see whether
both are necessary.