### PR TITLE
Fix flag suggestion for e.g. `chpl -`

### DIFF
--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -745,6 +745,10 @@ static void print_suggestions(const char* flag, const ArgumentDescription* desc)
     if (!developer && i >= firstDeveloperOnly)
       break;
 
+    // Ignore empty entries
+    if (desc[i].name[0] == '\0')
+      continue;
+
     if (usearg[0] == desc[i].key && usearg[1] == '\0') {
       // e.g. --s was used instead of -s
       fprintf(stderr, "       Did you mean -%c ?\n", desc[i].key);
@@ -769,8 +773,11 @@ static void print_suggestions(const char* flag, const ArgumentDescription* desc)
       if (!developer && i >= firstDeveloperOnly)
         break;
 
-      if (desc[i].name[0] != '\0' &&
-          startsWith(usearg, desc[i].name)) {
+      // Ignore empty entries
+      if (desc[i].name[0] == '\0')
+        continue;
+
+      if (startsWith(usearg, desc[i].name)) {
         fprintf(stderr, "       Did you mean --%s ?\n", desc[i].name);
         helped = true;
       }
@@ -784,8 +791,11 @@ static void print_suggestions(const char* flag, const ArgumentDescription* desc)
       if (!developer && i >= firstDeveloperOnly)
         break;
 
-      if (desc[i].name[0] != '\0' &&
-          startsWith(desc[i].name, usearg)) {
+      // Ignore empty entries
+      if (desc[i].name[0] == '\0')
+        continue;
+
+      if (startsWith(desc[i].name, usearg)) {
         fprintf(stderr, "       Did you mean --%s ?\n", desc[i].name);
       }
     }

--- a/test/compflags/ferguson/suggestions.6.good
+++ b/test/compflags/ferguson/suggestions.6.good
@@ -1,0 +1,3 @@
+Unrecognized flag: '-' (use '-h' for help)
+       Did you mean --help-env ?
+       Did you mean --help-settings ?

--- a/test/compflags/ferguson/suggestions.7.good
+++ b/test/compflags/ferguson/suggestions.7.good
@@ -1,0 +1,3 @@
+Unrecognized flag: '--' (use '-h' for help)
+       Did you mean --help-env ?
+       Did you mean --help-settings ?

--- a/test/compflags/ferguson/suggestions.compopts
+++ b/test/compflags/ferguson/suggestions.compopts
@@ -3,3 +3,5 @@
 --inline-functions  # suggestions.3.good
 -ieee               # suggestions.4.good
 --CHPL_REGEXP=re2   # suggestions.5.good
+-                   # suggestions.6.good
+--                  # suggestions.7.good


### PR DESCRIPTION
I have noticed over time that certain erroneous flags such as `chpl -` 
printed useless suggestion lines like the below:

```
Unrecognized flag: '-' (use '-h' for help)
       Did you mean -- ?
       Did you mean -- ?
       Did you mean -- ?
       Did you mean -- ?
```

This PR fixes the problem by ignoring compiler flag entries with no name 
(which are used for dividers in the usage output).

Reviewed by @ben-albrecht - thanks!

- [x] full local testing 