### PR TITLE
Remove a redundant and poorly placed copyright in the online spec's front page

### DIFF
--- a/doc/rst/language/spec/index.rst
+++ b/doc/rst/language/spec/index.rst
@@ -3,8 +3,6 @@
 Chapel Language Specification
 |||||||||||||||||||||||||||||
 
-©2020 Cray Inc.
-
 .. toctree::
    :caption: Chapters
    :maxdepth: 1


### PR DESCRIPTION
While doing other spec edits last week, I noticed that this copyright
was a bit of a visual stumbling block and redundant with the ones at the
bottom of the page, so am removing it.  There's arguably more we
should do to make the front page of the online spec more descriptive
and easier to approach, but this was low-hanging fruit at the moment.
