### PR TITLE
Add multilocale memleak graphs

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -243,6 +243,7 @@ performance/compiler/bradc/AllCompTime.graph
 # suite: Memory tracking
 memleaks.graph
 memleaksfull.graph
+ml-memleaksfull.graph
 # suite: Memory allocation
 memory/lifetime/allocation.graph
 # suite: Code size tracking

--- a/test/memleaks.graph
+++ b/test/memleaks.graph
@@ -1,17 +1,14 @@
 perfkeys: Total Allocated Memory:, Total Freed Memory:
 files: memleaks.dat, memleaks.dat
 ylabel: bytes
-graphname: memusage
 graphtitle: Memory Usage for examples Tests
 
 perfkeys: Total Leaked Memory:
 files: memleaks.dat
 ylabel: bytes
-graphname: memleaks
 graphtitle: Memory Leaks for examples Tests
 
 perfkeys: Number of Tests with Leaks:
 files: memleaks.dat
 ylabel: # tests
-graphname: leakingtests
 graphtitle: Number of Tests with Leaks (examples only)

--- a/test/memleaksfull.graph
+++ b/test/memleaksfull.graph
@@ -1,17 +1,14 @@
 perfkeys: Total Allocated Memory:, Total Freed Memory:
 files: memleaksfull.dat, memleaksfull.dat
 ylabel: bytes
-graphname: memusagefull
 graphtitle: Memory Usage for all Tests
 
 perfkeys: Total Leaked Memory:
 files: memleaksfull.dat
 ylabel: bytes
-graphname: memleaksfull
 graphtitle: Memory Leaks for all Tests
 
 perfkeys: Number of Tests with Leaks:
 files: memleaksfull.dat
 ylabel: # tests
-graphname: leakingtestsfull
 graphtitle: Number of Tests with Leaks

--- a/test/ml-memleaksfull.graph
+++ b/test/ml-memleaksfull.graph
@@ -1,0 +1,17 @@
+perfkeys: Total Allocated Memory:, Total Freed Memory:
+files: ml-memleaksfull.dat, ml-memleaksfull.dat
+ylabel: bytes
+graphname: ml-memusagefull
+graphtitle: Memory Usage for Multilocale Tests
+
+perfkeys: Total Leaked Memory:
+files: ml-memleaksfull.dat
+ylabel: bytes
+graphname: ml-memleaksfull
+graphtitle: Memory Leaks for Multilocale Tests
+
+perfkeys: Number of Tests with Leaks:
+files: ml-memleaksfull.dat
+ylabel: # tests
+graphname: ml-leakingtestsfull
+graphtitle: Number of Multilocale Tests with Leaks

--- a/test/ml-memleaksfull.graph
+++ b/test/ml-memleaksfull.graph
@@ -1,17 +1,14 @@
 perfkeys: Total Allocated Memory:, Total Freed Memory:
 files: ml-memleaksfull.dat, ml-memleaksfull.dat
 ylabel: bytes
-graphname: ml-memusagefull
 graphtitle: Memory Usage for Multilocale Tests
 
 perfkeys: Total Leaked Memory:
 files: ml-memleaksfull.dat
 ylabel: bytes
-graphname: ml-memleaksfull
 graphtitle: Memory Leaks for Multilocale Tests
 
 perfkeys: Number of Tests with Leaks:
 files: ml-memleaksfull.dat
 ylabel: # tests
-graphname: ml-leakingtestsfull
 graphtitle: Number of Multilocale Tests with Leaks


### PR DESCRIPTION
We have been running nightly multilocale memleak testing for a while now.
This PR adds necessary files to produce a plot for the data.

While there, also removes `graphname`s from all memleak graph files.