### PR TITLE
Skip new test for memleaks testing

### DIFF
--- a/test/execflags/configs/privateconfigs.skipif
+++ b/test/execflags/configs/privateconfigs.skipif
@@ -1,0 +1,1 @@
+CHPL_MEM_LEAK_TESTING == true


### PR DESCRIPTION
The output of this test is sensitive to whether or not memleaks testing is running and the test
itself is not interesting w.r.t. memory leaks, so for simplicity, let's just skip it in that configuration.
