### PR TITLE
Update PALS-based launcher copyright year.

### DIFF
--- a/runtime/src/launch/pals/Makefile
+++ b/runtime/src/launch/pals/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Cray Inc.
+# Copyright 2004-2020 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/pals/Makefile.include
+++ b/runtime/src/launch/pals/Makefile.include
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Cray Inc.
+# Copyright 2004-2020 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/pals/Makefile.share
+++ b/runtime/src/launch/pals/Makefile.share
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Cray Inc.
+# Copyright 2004-2020 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/pals/launch-pals.c
+++ b/runtime/src/launch/pals/launch-pals.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 Cray Inc.
+ * Copyright 2004-2020 Cray Inc.
  * Other additional copyright holders may be indicated within.
  * 
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/pals/pals-utils.c
+++ b/runtime/src/launch/pals/pals-utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 Cray Inc.
+ * Copyright 2004-2020 Cray Inc.
  * Other additional copyright holders may be indicated within.
  * 
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/pals/pals-utils.h
+++ b/runtime/src/launch/pals/pals-utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 Cray Inc.
+ * Copyright 2004-2020 Cray Inc.
  * Other additional copyright holders may be indicated within.
  * 
  * The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
I created the PR for the PALS-based launcher in 2019 but it didn't get
merged until just now in 2020, so the ending year in the copyright range
was incorrect.  Fix that.