### PR TITLE
Make more uses private in distributions

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -43,9 +43,9 @@ private use ChapelUtil;
 private use CommDiagnostics;
 private use ChapelLocks;
 private use ChapelDebugPrint;
+private use LayoutCS;
 
 public use SparseBlockDist;
-public use LayoutCS;
 //
 // These flags are used to output debug information and run extra
 // checks when using Block.  Should these be promoted so that they can

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -36,6 +36,7 @@ private use ChapelUtil;
 private use BlockDist;
 private use RangeChunk;
 private use HaltWrappers;
+private use LayoutCS;
 
 //
 // These flags are used to output debug information and run extra

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -42,8 +42,8 @@ Parsing module files:
   $CHPL_HOME/modules/standard/Random.chpl
   $CHPL_HOME/modules/dists/BlockDist.chpl
   $CHPL_HOME/modules/standard/Time.chpl
-  $CHPL_HOME/modules/dists/SparseBlockDist.chpl
   $CHPL_HOME/modules/layouts/LayoutCS.chpl
+  $CHPL_HOME/modules/dists/SparseBlockDist.chpl
   $CHPL_HOME/modules/dists/ReplicatedDist.chpl
 In bar
 In baz

--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -3,6 +3,7 @@ use BlockDist;
 use CyclicDist;
 use BlockCycDist;
 use Search;
+use LayoutCS;
 
 //
 // DefaultRectangular support


### PR DESCRIPTION
Follow up to #14475, this PR changes couple of `use`s around BlockDist, SparseBlockDist and Layout CS.

Test:
- [x] gasnet
- [x] standard