### PR TITLE
Perf annotations from the last couple of weeks

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1368,6 +1368,8 @@ regexdna: &regexdna-base
     - Free strings leaked by Regex.subn() / qio_regexp_replace() (#6509)
   08/09/19:
     - Change string.length to measure in codepoints (#13675)
+  12/17/19:
+    - Add UTF8 validation for strings (#14384)
 regexdna-redux:
   <<: *regexdna-base
 regexdna-submitted:
@@ -1452,6 +1454,8 @@ search:
     - Avoid 'use'ing ByteBufferHelpers ExportWrappers (#14377)
   11/05/19:
     - Remove standardModuleSet and all code involving it from the compiler (#14270)
+  12/10/19:
+    - Allow messages in new Errors (#14545)
 
 spectralnorm:
   01/21/15:


### PR DESCRIPTION
Adds the following annotations:

- [regex-dna regressions post UTF8 validation](https://chapel-lang.org/perf/chapcs/?startdate=2019/10/29&enddate=2020/01/09&graphs=regexdnashootoutbenchmark,regexdnareduxshootoutbenchmark,submittedregexdnashootoutbenchmark,submittedregexdnareduxshootoutbenchmark)
   I hoped #14726 would resolve this but it didn't. This is on me, still.
- [Peculiar regression on Searches over n strings](https://chapel-lang.org/perf/chapcs/?startdate=2019/12/07&enddate=2019/12/16&graphs=searchesovernstrings)
  This one's from several weeks ago that I got curious about. I brought the culprit down to #14545. But I don't know why exactly that could cause the regression. I cannot reproduce it locally. We are not too worried about this.