### PR TITLE
Adjust IO future to have deterministic output

### DIFF
--- a/test/io/errors/writeThisUserError.bad
+++ b/test/io/errors/writeThisUserError.bad
@@ -1,3 +1,1 @@
-uncaught IOError: Input/output error (in channel.write(a:foo, b:ioNewline) with path "unknown" offset -1)
-  writeThisUserError.chpl:20: thrown here
-  writeThisUserError.chpl:20: uncaught here
+SystemError

--- a/test/io/errors/writeThisUserError.chpl
+++ b/test/io/errors/writeThisUserError.chpl
@@ -17,6 +17,18 @@ record foo {
 
 proc main() {
   var x = new foo();
-  writeln(x);
+  try {
+    stdout.write(x);
+  } catch err: SystemError {
+    writeln("SystemError");
+  } catch err: IllegalArgumentError {
+    writeln("IllegalArgumentError"); 
+  } catch err {}
+
+  //
+  // You have to use `clearError` here to prevent a crash when destroying
+  // the internal channel.
+  //
+  stdout.clearError();  
 }
 

--- a/test/io/errors/writeThisUserError.good
+++ b/test/io/errors/writeThisUserError.good
@@ -1,3 +1,1 @@
-uncaught IllegalArgumentError: User error thrown from writeThis!
-  Test.chpl:12: thrown here
-  Test.chpl:20: uncaught here
+IllegalArgumentError


### PR DESCRIPTION
A future I added in #14430 was non-deterministic because it ended up printing platform sensitive details about `stdout`. This PR adjusts the test to catch the thrown `Error` and print its subclass type instead.

Trivial, change to test.