### PR TITLE
Include prototype in the keywords section of the spec

### DIFF
--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -186,6 +186,7 @@ The following identifiers are reserved as keywords:
    owned
    param
    private
+   prototype
    proc
    public
    real


### PR DESCRIPTION
Thanks to @rahulghangas for pointing out that it was missing.

Trivial and not reviewed.