### PR TITLE
Update tests of parsing postfix-!, postfix-?

### DIFF
--- a/test/parsing/precedence/bang-vs-new-etc.chpl
+++ b/test/parsing/precedence/bang-vs-new-etc.chpl
@@ -48,16 +48,16 @@ proc main {
   check("z01a = new C()?!", z01a, "borrowed C");
 
   var z01b = new owned C()?!;
-  check("z01b = new owned C()?!", z01b, "borrowed C"); // get owned C, #13957
+  check("z01b = new owned C()?!", z01b, "borrowed C");
 
-  var z01c = new unmanaged C()?!;  // error: duplicate decorators, #13950
+  var z01c = new unmanaged C()?!;
   check("z01c = new unmanaged C()?!", z01c, "unmanaged C");
 
   var z02 = new C?()!;
   check("z02 = new C?()!", z02, "borrowed C");
 
   // var z = new C()!?;  -- error "? on a value"
-  // var z = new C()??; -- syntax error, #13957
+  // var z = new C()??; -- syntax error
 
   var z03 = new C?()?;
   check("z03 = new C?()?", z03, "owned C?");
@@ -75,7 +75,7 @@ proc main {
   check("z11 = new owned (tm())()?", z11, "owned C?");
 
   var z07 = new owned (tm())()?!;
-  check("z07 = new owned (tm())()?!", z07, "borrowed C"); // get owned C, #13957
+  check("z07 = new owned (tm())()?!", z07, "borrowed C");
 
   var z08 = new (owned tm())?();
   check("z08 = new (owned tm())?()", z08, "owned C?");
@@ -83,7 +83,7 @@ proc main {
   var z12 = new (tm())?();
   check("z12 = new (tm())?()", z08, "owned C?");
 
-  var z09 = new owned (tm()?)()!;   // get owned C, #13957
+  var z09 = new owned (tm()?)()!;
   check("z09 = new owned (tm()?)()!", z09, "borrowed C");
 
   var z10 = new owned (tm()?)()?;
@@ -108,8 +108,8 @@ proc main {
   var z15b = xx: unmanaged C?;
   check("z15b = xx: unmanaged C?", z15b, "unmanaged C?");
 
-  var z15c = xx: unmanaged C!;  // error: duplicate decorators, #13950
-  check("z15c = xx: unmanaged C!", z15c, "unmanaged C");
+  // var z15c = xx: unmanaged C!; // parsed 'unmanaged (C!)' -- illegal
+  // check("z15c = xx: unmanaged C!", z15c, "unmanaged C");
 
   var z16a = xx!: unmanaged C;
   check("z16a = xx!: unmanaged C", z16a, "unmanaged C");
@@ -117,8 +117,8 @@ proc main {
   var z16b = xx!: unmanaged C?;
   check("z16b = xx!: unmanaged C?", z16b, "unmanaged C?");
 
-  var z16c = xx!: unmanaged C!;  // error: duplicate decorators, #13950
-  check("z16c = xx!: unmanaged C!", z16c, "unmanaged C");
+  // var z16c = xx!: unmanaged C!; // like z15c
+  // check("z16c = xx!: unmanaged C!", z16c, "unmanaged C");
 
   var z17a = xx : class? : unmanaged class; // cast binds most loosely, left associative
   check("z17a = xx : class?: unmanaged class", z17a, "unmanaged C");
@@ -152,10 +152,10 @@ proc main {
   var z19e = new borrowed C() : unmanaged class?;
   check("z19e = new borrowed C() :unmanaged class?", z19e, "unmanaged C?");
 
-  // '.' binds more tightly than 
+  // '.' binds more tightly than 'new'
   // param z = new C().meth;  -- error: C.meth is not a type method
 
-  // treated as new (C().tmeth) -- should parens after 'tmeth' be required? #13957
+  // treated as new (C().tmeth)()
   var z20a = new C().tmeth();
   check("z20a = new C().m", z20a, "owned D(int(64))");
 

--- a/test/parsing/precedence/bang-vs-new-etc.good
+++ b/test/parsing/precedence/bang-vs-new-etc.good
@@ -9,11 +9,7 @@ bang-vs-new-etc.chpl:95: warning: applying the postfix-! operator to a type is d
 bang-vs-new-etc.chpl:98: warning: applying the postfix-! operator to a type is deprecated; instead use a cast to 'class' or 'borrowed class', e.g. 'MyType :borrowed class'
 bang-vs-new-etc.chpl:102: warning: applying the postfix-! operator to a type is deprecated; instead use a cast to 'class' or 'borrowed class', e.g. 'MyType :borrowed class'
 bang-vs-new-etc.chpl:109: warning: z15b = xx: unmanaged C?  expected: unmanaged C?  actual: unmanaged C?
-bang-vs-new-etc.chpl:111: warning: applying the postfix-! operator to a type is deprecated; instead use a cast to 'class' or 'borrowed class', e.g. 'MyType :borrowed class'
-bang-vs-new-etc.chpl:111: error: duplicate decorators - unmanaged borrowed C
 bang-vs-new-etc.chpl:118: warning: z16b = xx!: unmanaged C?  expected: unmanaged C?  actual: unmanaged C?
-bang-vs-new-etc.chpl:120: warning: applying the postfix-! operator to a type is deprecated; instead use a cast to 'class' or 'borrowed class', e.g. 'MyType :borrowed class'
-bang-vs-new-etc.chpl:120: error: duplicate decorators - unmanaged borrowed C
 bang-vs-new-etc.chpl:131: warning: z18a = xx : class : unmanaged class?  expected: unmanaged C?  actual: unmanaged C?
 bang-vs-new-etc.chpl:134: warning: z18b = xx : class? : unmanaged C?  expected: unmanaged C?  actual: unmanaged C?
 bang-vs-new-etc.chpl:142: warning: z19b = new C()? : unmanaged  expected: unmanaged C?  actual: unmanaged C?

--- a/test/parsing/precedence/new-c-q-q.bad
+++ b/test/parsing/precedence/new-c-q-q.bad
@@ -1,1 +1,0 @@
-new-c-q-q.chpl:2: syntax error: near '?'

--- a/test/parsing/precedence/new-c-q-q.future
+++ b/test/parsing/precedence/new-c-q-q.future
@@ -1,2 +1,0 @@
-bug: syntax error upon new C()??
-#13957

--- a/test/parsing/precedence/new-c-q-q.good
+++ b/test/parsing/precedence/new-c-q-q.good
@@ -1,1 +1,1 @@
-new-c-q-q.chpl:3: error: owned object?
+new-c-q-q.chpl:2: syntax error: near '?'


### PR DESCRIPTION
bang-vs-new-etc.chpl and new-c-q-q.chpl have been behaving correctly
due to recent compiler changes. This PR adjusts these tests:

* remove "this is incorrect"-implying comments from `bang-vs-new-etc.chpl`
* defuturize `new-c-q-q.chpl`

Suggested by @mppf.