### PR TITLE
Add comparison operators for records

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -732,7 +732,7 @@ static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
   if (functionExists(op, ct, ct))
     return;
 
-  bool isNotEqual = strncmp(op, "!=", 2) == 0;
+  bool isNotEqual = (astr(op) == astrSne);
 
   FnSymbol* fn = new FnSymbol(op);
   fn->addFlag(FLAG_COMPILER_GENERATED);

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -37,24 +37,24 @@
 FnSymbol* chplUserMain = NULL;
 static bool mainReturnsSomething;
 
-static void build_chpl_entry_points();
-static void build_accessors(AggregateType* ct, Symbol* field);
+static void buildChplEntryPoints();
+static void buildAccessors(AggregateType* ct, Symbol* field);
 
 static void buildDefaultOfFunction(AggregateType* ct);
 
-static void build_union_assignment_function(AggregateType* ct);
+static void buildUnionAssignmentFunction(AggregateType* ct);
 
-static void build_enum_cast_function(EnumType* et);
-static void build_enum_first_function(EnumType* et);
-static void build_enum_enumerate_function(EnumType* et);
-static void build_enum_size_function(EnumType* et);
-static void build_enum_order_functions(EnumType* et);
+static void buildEnumCastFunction(EnumType* et);
+static void buildEnumFirstFunction(EnumType* et);
+static void buildEnumEnumerateFunction(EnumType* et);
+static void buildEnumSizeFunction(EnumType* et);
+static void buildEnumOrderFunctions(EnumType* et);
 
-static void build_extern_assignment_function(Type* type);
+static void buildExternAssignmentFunction(Type* type);
 
-static void build_record_assignment_function(AggregateType* ct);
-static void check_not_pod(AggregateType* ct);
-static void build_record_hash_function(AggregateType* ct);
+static void buildRecordAssignmentFunction(AggregateType* ct);
+static void checkNotPod(AggregateType* ct);
+static void buildRecordHashFunction(AggregateType* ct);
 static void buildRecordComparisonFunc(AggregateType* ct, const char* op);
 
 static void buildDefaultReadWriteFunctions(AggregateType* type);
@@ -65,7 +65,7 @@ static void buildFieldAccessorFunctions(AggregateType* at);
 
 
 void buildDefaultFunctions() {
-  build_chpl_entry_points();
+  buildChplEntryPoints();
 
   SET_LINENO(rootModule); // todo - remove reset_ast_loc() calls below?
 
@@ -116,14 +116,14 @@ void buildDefaultFunctions() {
             buildRecordComparisonFunc(ct, ">=");
           }
 
-          build_record_assignment_function(ct);
-          build_record_hash_function(ct);
+          buildRecordAssignmentFunction(ct);
+          buildRecordHashFunction(ct);
 
-          check_not_pod(ct);
+          checkNotPod(ct);
         }
 
         if (isUnion(ct)) {
-          build_union_assignment_function(ct);
+          buildUnionAssignmentFunction(ct);
         }
 
       } else if (EnumType* et = toEnumType(type->type)) {
@@ -138,7 +138,7 @@ void buildDefaultFunctions() {
         // definitions for those assignments here.
         if (type->hasFlag(FLAG_EXTERN)) {
           //build_extern_init_function(type->type);
-          build_extern_assignment_function(type->type);
+          buildExternAssignmentFunction(type->type);
         }
       }
     }
@@ -150,23 +150,23 @@ static void buildFieldAccessorFunctions(AggregateType* at) {
   for_fields(field, at) {
     if (!field->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD)) {
       if (isVarSymbol(field)) {
-        build_accessors(at, field);
+        buildAccessors(at, field);
       } else if (isEnumType(field->type)) {
-        build_accessors(at, field);
+        buildAccessors(at, field);
       }
     }
   }
 }
 
 
-// function_exists returns true iff
+// functionExists returns true iff
 //  function's name matches name
 //  function's number of formals matches numFormals
 //  function's first formal's type matches formalType1 if not NULL
 //  function's second formal's type matches formalType2 if not NULL
 //  function's third formal's type matches formalType3 if not NULL
 
-static bool type_match(Type* type, Symbol* sym) {
+static bool typeMatch(Type* type, Symbol* sym) {
   if (type == dtAny)
     return true;
   if (sym->type == type)
@@ -181,20 +181,20 @@ typedef enum {
   FIND_EITHER = 0,
   FIND_REF,
   FIND_NOT_REF
-} function_exists_kind_t;
+} functionExists_kind_t;
 
-static FnSymbol* function_exists(const char* name,
+static FnSymbol* functionExists(const char* name,
                                  int numFormals,
                                  Type* formalType1,
                                  Type* formalType2,
                                  Type* formalType3,
                                  Type* formalType4,
-                                 function_exists_kind_t kind)
+                                 functionExists_kind_t kind)
 {
   switch(numFormals)
   {
    default:
-    INT_FATAL("function_exists checks at most 4 argument types.  Add more if needed.");
+    INT_FATAL("functionExists checks at most 4 argument types.  Add more if needed.");
     break;
    case 4:  if (!formalType4)   INT_FATAL("Missing argument formalType4");  break;
    case 3:  if (!formalType3)   INT_FATAL("Missing argument formalType3");  break;
@@ -213,19 +213,19 @@ static FnSymbol* function_exists(const char* name,
         continue;
 
     if (formalType1)
-      if (!type_match(formalType1, fn->getFormal(1)))
+      if (!typeMatch(formalType1, fn->getFormal(1)))
         continue;
 
     if (formalType2)
-      if (!type_match(formalType2, fn->getFormal(2)))
+      if (!typeMatch(formalType2, fn->getFormal(2)))
         continue;
 
     if (formalType3)
-      if (!type_match(formalType3, fn->getFormal(3)))
+      if (!typeMatch(formalType3, fn->getFormal(3)))
         continue;
 
     if (formalType4)
-      if (!type_match(formalType4, fn->getFormal(4)))
+      if (!typeMatch(formalType4, fn->getFormal(4)))
         continue;
 
     if (kind == FIND_REF && fn->retTag != RET_REF)
@@ -241,34 +241,34 @@ static FnSymbol* function_exists(const char* name,
   return NULL;
 }
 
-static FnSymbol* function_exists(const char* name,
+static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
-                                 function_exists_kind_t kind=FIND_EITHER)
+                                 functionExists_kind_t kind=FIND_EITHER)
 {
-  return function_exists(name, 1, formalType1, NULL, NULL, NULL, kind);
+  return functionExists(name, 1, formalType1, NULL, NULL, NULL, kind);
 }
 
 
 
-static FnSymbol* function_exists(const char* name,
+static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
                                  Type* formalType2,
-                                 function_exists_kind_t kind=FIND_EITHER)
+                                 functionExists_kind_t kind=FIND_EITHER)
 {
-  return function_exists(name, 2, formalType1, formalType2, NULL, NULL, kind);
+  return functionExists(name, 2, formalType1, formalType2, NULL, NULL, kind);
 }
 
-static FnSymbol* function_exists(const char* name,
+static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
                                  Type* formalType2,
                                  Type* formalType3,
-                                 function_exists_kind_t kind=FIND_EITHER)
+                                 functionExists_kind_t kind=FIND_EITHER)
 {
-  return function_exists(name, 3,
+  return functionExists(name, 3,
                          formalType1, formalType2, formalType3, NULL, kind);
 }
 
-static void fixup_accessor(AggregateType* ct, Symbol *field,
+static void fixupAccessor(AggregateType* ct, Symbol *field,
                            bool fieldIsConst, bool recordLike,
                            FnSymbol* fn)
 {
@@ -459,20 +459,20 @@ FnSymbol* build_accessor(AggregateType* ct, Symbol* field,
 // These functions have the same binding strength as if they were user-defined.
 // This function calls build_accessor multiple times to create appropriate
 // accessors.
-static void build_accessors(AggregateType* ct, Symbol *field) {
+static void buildAccessors(AggregateType* ct, Symbol *field) {
   const bool fieldIsConst = field->hasFlag(FLAG_CONST);
   const bool recordLike = ct->isRecord() || ct->isUnion();
   const bool fieldTypeOrParam = field->isParameter() ||
                                 field->hasFlag(FLAG_TYPE_VARIABLE);
 
-  FnSymbol *setter = function_exists(field->name,
+  FnSymbol *setter = functionExists(field->name,
                                      dtMethodToken, ct, FIND_REF);
-  FnSymbol *getter = function_exists(field->name,
+  FnSymbol *getter = functionExists(field->name,
                                      dtMethodToken, ct, FIND_NOT_REF);
   if (setter)
-    fixup_accessor(ct, field, fieldIsConst, recordLike, setter);
+    fixupAccessor(ct, field, fieldIsConst, recordLike, setter);
   if (getter)
-    fixup_accessor(ct, field, fieldIsConst, recordLike, getter);
+    fixupAccessor(ct, field, fieldIsConst, recordLike, getter);
   if (getter || setter)
     return;
 
@@ -495,7 +495,7 @@ static void build_accessors(AggregateType* ct, Symbol *field) {
   }
 }
 
-static FnSymbol* chpl_gen_main_exists() {
+static FnSymbol* chplGenMainExists() {
   bool          errorP   = false;
   ModuleSymbol* module   = ModuleSymbol::mainModule();
   FnSymbol*     matchFn  = NULL;
@@ -562,12 +562,12 @@ static FnSymbol* chpl_gen_main_exists() {
 }
 
 
-static void build_chpl_entry_points() {
+static void buildChplEntryPoints() {
   //
   // chpl_user_main is the (user) programmatic portion of the app
   //
   ModuleSymbol* mainModule   = ModuleSymbol::mainModule();
-  chplUserMain = chpl_gen_main_exists();
+  chplUserMain = chplGenMainExists();
 
   if (fLibraryCompile == true && chplUserMain != NULL) {
     USR_WARN(chplUserMain,
@@ -729,7 +729,7 @@ static void build_chpl_entry_points() {
 }
 
 static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
-  if (function_exists(op, ct, ct))
+  if (functionExists(op, ct, ct))
     return;
 
   bool isNotEqual = strncmp(op, "!=", 2) == 0;
@@ -783,16 +783,16 @@ static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
 void buildEnumFunctions(EnumType* et) {
   buildStringCastFunction(et);
 
-  build_enum_cast_function(et);
-  build_enum_enumerate_function(et);
-  build_enum_first_function(et);
-  build_enum_size_function(et);
-  build_enum_order_functions(et);
+  buildEnumCastFunction(et);
+  buildEnumEnumerateFunction(et);
+  buildEnumFirstFunction(et);
+  buildEnumSizeFunction(et);
+  buildEnumOrderFunctions(et);
 }
 
 
-static void build_enum_size_function(EnumType* et) {
-  if (function_exists("size", et))
+static void buildEnumSizeFunction(EnumType* et) {
+  if (functionExists("size", et))
     return;
   // Build a function that returns the length of the enum specified
   FnSymbol* fn = new FnSymbol("size");
@@ -828,8 +828,8 @@ static void build_enum_size_function(EnumType* et) {
 
 
 
-static void build_enum_first_function(EnumType* et) {
-  if (function_exists("chpl_enum_first", et))
+static void buildEnumFirstFunction(EnumType* et) {
+  if (functionExists("chpl_enum_first", et))
     return;
   // Build a function that returns the first option for the enum
   // specified, also known as the default.
@@ -864,7 +864,7 @@ static void build_enum_first_function(EnumType* et) {
   fn->tagIfGeneric();
 }
 
-static void build_enum_enumerate_function(EnumType* et) {
+static void buildEnumEnumerateFunction(EnumType* et) {
   // Build a function that returns a tuple of the enum's values
   // Each enum type has its own chpl_enum_enumerate function.
   FnSymbol* fn = new FnSymbol("chpl_enum_enumerate");
@@ -888,7 +888,7 @@ static void build_enum_enumerate_function(EnumType* et) {
   fn->tagIfGeneric();
 }
 
-static void build_enum_cast_function(EnumType* et) {
+static void buildEnumCastFunction(EnumType* et) {
   bool initsExist = !et->isAbstract();
 
   FnSymbol* fn;
@@ -1073,7 +1073,7 @@ static void build_enum_cast_function(EnumType* et) {
 //
 //   'proc chpl_enumToOrder([param] e: enumerated) [param] : int'
 //
-static void build_enum_to_order_function(EnumType* et, bool paramVersion) {
+static void buildEnumToOrderFunction(EnumType* et, bool paramVersion) {
   FnSymbol* fn = new FnSymbol(astr("chpl__enumToOrder"));
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
@@ -1115,7 +1115,7 @@ static void build_enum_to_order_function(EnumType* et, bool paramVersion) {
 //
 //   'proc chpl_enumToOrder(i: integral, type et: et): et'
 //
-static void build_order_to_enum_function(EnumType* et) {
+static void buildOrderToEnumFunction(EnumType* et) {
   FnSymbol* fn = new FnSymbol(astr("chpl__orderToEnum"));
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
@@ -1154,19 +1154,19 @@ static void build_order_to_enum_function(EnumType* et) {
 // Build functions for converting enums to 0-based ordinal values and
 // back again
 //
-static void build_enum_order_functions(EnumType* et) {
+static void buildEnumOrderFunctions(EnumType* et) {
   //
   // TODO: optimize case when enums are adjacent by using math rather
   // than select statements
   //
-  build_enum_to_order_function(et, true);
-  build_enum_to_order_function(et, false);
-  build_order_to_enum_function(et);
+  buildEnumToOrderFunction(et, true);
+  buildEnumToOrderFunction(et, false);
+  buildOrderToEnumFunction(et);
 }
 
 
-static void build_record_assignment_function(AggregateType* ct) {
-  if (function_exists("=", ct, ct))
+static void buildRecordAssignmentFunction(AggregateType* ct) {
+  if (functionExists("=", ct, ct))
     return;
 
   bool externRecord = ct->symbol->hasFlag(FLAG_EXTERN);
@@ -1212,9 +1212,9 @@ static void build_record_assignment_function(AggregateType* ct) {
   normalize(fn);
 }
 
-static void build_extern_assignment_function(Type* type)
+static void buildExternAssignmentFunction(Type* type)
 {
-  if (function_exists("=", type, type))
+  if (functionExists("=", type, type))
     return;
 
   FnSymbol* fn = new FnSymbol("=");
@@ -1241,8 +1241,8 @@ static void build_extern_assignment_function(Type* type)
 
 
 // TODO: we should know what field is active after assigning unions
-static void build_union_assignment_function(AggregateType* ct) {
-  if (function_exists("=", ct, ct))
+static void buildUnionAssignmentFunction(AggregateType* ct) {
+  if (functionExists("=", ct, ct))
     return;
 
   FnSymbol* fn = new FnSymbol("=");
@@ -1282,14 +1282,14 @@ static void build_union_assignment_function(AggregateType* ct) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void check_not_pod(AggregateType* at) {
-  if (function_exists("chpl__initCopy", at) == NULL) {
+static void checkNotPod(AggregateType* at) {
+  if (functionExists("chpl__initCopy", at) == NULL) {
 
     if (at->hasUserDefinedInitEquals()) {
       at->symbol->addFlag(FLAG_NOT_POD);
     } else {
       // Compiler-generated copy-initializers should not disable POD
-      FnSymbol* fn = function_exists("init", dtMethodToken, at, at);
+      FnSymbol* fn = functionExists("init", dtMethodToken, at, at);
       if (fn != NULL && fn->hasFlag(FLAG_COMPILER_GENERATED) == false) {
         at->symbol->addFlag(FLAG_NOT_POD);
       }
@@ -1303,8 +1303,8 @@ static void check_not_pod(AggregateType* at) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void build_record_hash_function(AggregateType *ct) {
-  if (function_exists("chpl__defaultHash", ct))
+static void buildRecordHashFunction(AggregateType *ct) {
+  if (functionExists("chpl__defaultHash", ct))
     return;
 
   FnSymbol *fn = new FnSymbol("chpl__defaultHash");
@@ -1353,7 +1353,7 @@ static void build_record_hash_function(AggregateType *ct) {
 static void buildDefaultOfFunction(AggregateType* ct) {
   if (ct->symbol->hasEitherFlag(FLAG_TUPLE, FLAG_ITERATOR_RECORD) &&
       ct->defaultValue != gNil &&
-      function_exists("_defaultOf", ct) == NULL) {
+      functionExists("_defaultOf", ct) == NULL) {
 
     FnSymbol*  fn  = new FnSymbol("_defaultOf");
     ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", ct);
@@ -1476,15 +1476,15 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
     return;
 
   // If we have a readWriteThis, we'll call it from readThis/writeThis.
-  if (function_exists("readWriteThis", dtMethodToken, ct, dtAny)) {
+  if (functionExists("readWriteThis", dtMethodToken, ct, dtAny)) {
     hasReadWriteThis = true;
   }
 
-  if (function_exists("writeThis", dtMethodToken, ct, dtAny)) {
+  if (functionExists("writeThis", dtMethodToken, ct, dtAny)) {
     hasWriteThis = true;
   }
 
-  if (function_exists("readThis", dtMethodToken, ct, dtAny)) {
+  if (functionExists("readThis", dtMethodToken, ct, dtAny)) {
     hasReadThis = true;
   }
 
@@ -1576,7 +1576,7 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
 
 
 static void buildStringCastFunction(EnumType* et) {
-  if (function_exists(astr_cast, dtString, et))
+  if (functionExists(astr_cast, dtString, et))
     return;
 
   FnSymbol* fn = new FnSymbol(astr_cast);
@@ -1610,7 +1610,7 @@ static void buildStringCastFunction(EnumType* et) {
 
 
 void buildDefaultDestructor(AggregateType* ct) {
-  if (function_exists("deinit", dtMethodToken, ct) == NULL) {
+  if (functionExists("deinit", dtMethodToken, ct) == NULL) {
     SET_LINENO(ct->symbol);
 
     FnSymbol* fn = new FnSymbol("deinit");

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -159,14 +159,6 @@ static void buildFieldAccessorFunctions(AggregateType* at) {
   }
 }
 
-
-// functionExists returns true iff
-//  function's name matches name
-//  function's number of formals matches numFormals
-//  function's first formal's type matches formalType1 if not NULL
-//  function's second formal's type matches formalType2 if not NULL
-//  function's third formal's type matches formalType3 if not NULL
-
 static bool typeMatch(Type* type, Symbol* sym) {
   if (type == dtAny)
     return true;
@@ -182,15 +174,22 @@ typedef enum {
   FIND_EITHER = 0,
   FIND_REF,
   FIND_NOT_REF
-} functionExists_kind_t;
+} functionExistsKind;
 
+
+// functionExists returns true iff
+//  function's name matches name
+//  function's number of formals matches numFormals
+//  function's first formal's type matches formalType1 if not NULL
+//  function's second formal's type matches formalType2 if not NULL
+//  function's third formal's type matches formalType3 if not NULL
 static FnSymbol* functionExists(const char* name,
                                  int numFormals,
                                  Type* formalType1,
                                  Type* formalType2,
                                  Type* formalType3,
                                  Type* formalType4,
-                                 functionExists_kind_t kind)
+                                 functionExistsKind kind)
 {
   switch(numFormals)
   {
@@ -244,7 +243,7 @@ static FnSymbol* functionExists(const char* name,
 
 static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
-                                 functionExists_kind_t kind=FIND_EITHER)
+                                 functionExistsKind kind=FIND_EITHER)
 {
   return functionExists(name, 1, formalType1, NULL, NULL, NULL, kind);
 }
@@ -254,7 +253,7 @@ static FnSymbol* functionExists(const char* name,
 static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
                                  Type* formalType2,
-                                 functionExists_kind_t kind=FIND_EITHER)
+                                 functionExistsKind kind=FIND_EITHER)
 {
   return functionExists(name, 2, formalType1, formalType2, NULL, NULL, kind);
 }
@@ -263,7 +262,7 @@ static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
                                  Type* formalType2,
                                  Type* formalType3,
-                                 functionExists_kind_t kind=FIND_EITHER)
+                                 functionExistsKind kind=FIND_EITHER)
 {
   return functionExists(name, 3,
                          formalType1, formalType2, formalType3, NULL, kind);
@@ -791,7 +790,7 @@ static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
 
   // we need to special case `!=`:
   // it can return true early, and returns false after checking all fields
-  // all other operators does the exact opposite
+  // all other operators do the exact opposite
   bool isNotEqual = (astrOp == astrSne);
 
   FnSymbol* fn = new FnSymbol(op);

--- a/test/library/packages/Sort/errors/errors-key.chpl
+++ b/test/library/packages/Sort/errors/errors-key.chpl
@@ -20,7 +20,7 @@ proc main() {
 
 /* Broken keys */
 
-// Return record 'foobar'
+// Return class 'foobar'
 record rec { }
 class foobar { };
 

--- a/test/library/packages/Sort/errors/errors-key.chpl
+++ b/test/library/packages/Sort/errors/errors-key.chpl
@@ -22,7 +22,7 @@ proc main() {
 
 // Return record 'foobar'
 record rec { }
-record foobar { };
+class foobar { };
 
 proc rec.key(a) {
   return new foobar();

--- a/test/types/records/engin/comparison.chpl
+++ b/test/types/records/engin/comparison.chpl
@@ -1,0 +1,86 @@
+write("Basic record... ");
+{
+  record R {
+    var x: int;
+  }
+
+  var small = new R(1);
+  var small2 = new R(1);
+  var big = new R(2);
+
+  test(small, small2, big);
+}
+writeln("success");
+
+write("Multiple fields... ");
+{
+  record R {
+    var x, y: int;
+  }
+
+  var small = new R(1, 1);
+  var small2 = new R(1, 1);
+  var big = new R(2, 2);
+
+  test(small, small2, big);
+}
+writeln("success");
+
+write("Generic record... ");
+{
+  record R {
+    type t = int;
+    var x: t;
+  }
+
+  var small = new R(int, 1);
+  var small2 = new R(int, 1);
+  var big = new R(int, 2);
+
+  test(small, small2, big);
+}
+writeln("success");
+
+write("Class field with operators overloaded... ");
+{
+  class C { var x = 0; }
+  proc ==(c1: borrowed C, c2: borrowed C) return c1.x == c2.x;
+  proc !=(c1: borrowed C, c2: borrowed C) return c1.x != c2.x;
+  proc <(c1: borrowed C, c2: borrowed C) return c1.x < c2.x;
+  proc <=(c1: borrowed C, c2: borrowed C) return c1.x <= c2.x;
+  proc >(c1: borrowed C, c2: borrowed C) return c1.x > c2.x;
+  proc >=(c1: borrowed C, c2: borrowed C) return c1.x >= c2.x;
+
+  record R {
+    var c: owned C;
+    proc init(x: int) { this.c = new C(x); }
+  }
+
+  var small = new R(1);
+  var small2 = new R(1);
+  var big = new R(2);
+
+  test(small, small2, big);
+}
+writeln("success");
+
+proc test(small, small2, big) {
+  assert((small == small2) == true);
+  assert((small != small2) == false);
+  assert((small == big) == false);
+  assert((small != big) == true);
+
+  assert((small < small2) == false);
+  assert((small < big) == true);
+  assert((big < small) == false);
+  assert((small <= small2) == true);
+  assert((small <= big) == true);
+  assert((big <= small) == false);
+
+  assert((small > small2) == false);
+  assert((small > big) == false);
+  assert((big > small) == true);
+  assert((small >= small2) == true);
+  assert((small >= big) == false);
+  assert((big >= small) == true);
+}

--- a/test/types/records/engin/comparison.good
+++ b/test/types/records/engin/comparison.good
@@ -1,0 +1,4 @@
+Basic record... success
+Multiple fields... success
+Generic record... success
+Class field with operators overloaded... success

--- a/test/types/records/engin/comparisonEmptyRecord.chpl
+++ b/test/types/records/engin/comparisonEmptyRecord.chpl
@@ -1,0 +1,17 @@
+record R {}
+
+var r1 = new R();
+var r2 = new R();
+
+assert((r1 == r2) == true);
+assert((r1 != r2) == false);
+
+assert((r1 < r2) == false);
+assert((r2 < r1) == false);
+assert((r1 <= r2) == true);
+assert((r2 <= r1) == true);
+
+assert((r1 > r2) == false);
+assert((r2 > r1) == false);
+assert((r1 >= r2) == true);
+assert((r2 >= r1) == true);

--- a/test/types/records/engin/comparisonEmptyRecord.chpl
+++ b/test/types/records/engin/comparisonEmptyRecord.chpl
@@ -1,17 +1,36 @@
-record R {}
+write("Empty record... ");
+{
+  record R {}
 
-var r1 = new R();
-var r2 = new R();
+  var r1 = new R();
+  var r2 = new R();
 
-assert((r1 == r2) == true);
-assert((r1 != r2) == false);
+  test(r1, r2);
+}
+writeln("success");
 
-assert((r1 < r2) == false);
-assert((r2 < r1) == false);
-assert((r1 <= r2) == true);
-assert((r2 <= r1) == true);
+write("Record with only type field... ");
+{
+  record R { type t; }
 
-assert((r1 > r2) == false);
-assert((r2 > r1) == false);
-assert((r1 >= r2) == true);
-assert((r2 >= r1) == true);
+  var r1 = new R(int);
+  var r2 = new R(int);
+
+  test(r1, r2);
+}
+writeln("success");
+
+proc test(r1, r2) {
+  assert((r1 == r2) == true);
+  assert((r1 != r2) == false);
+
+  assert((r1 < r2) == false);
+  assert((r2 < r1) == false);
+  assert((r1 <= r2) == true);
+  assert((r2 <= r1) == true);
+
+  assert((r1 > r2) == false);
+  assert((r2 > r1) == false);
+  assert((r1 >= r2) == true);
+  assert((r2 >= r1) == true);
+}

--- a/test/types/records/engin/comparisonEmptyRecord.good
+++ b/test/types/records/engin/comparisonEmptyRecord.good
@@ -1,0 +1,2 @@
+Empty record... success
+Record with only type field... success


### PR DESCRIPTION
This PR adds default comparison operators for records.

Resolves #11347

In more detail, this refactors

- `build_record_equality_function(AggregateType* ct)` and
- `build_record_inequality_function(AggregateType* ct)`

into

- `buildRecordComparisonFunc(AggregateType* ct, const char* op)`

that supports `==`, `!=`, `<`, `<=`, `>` and `>=` as the second argument.

Also, the where clause added to the operator overloads now checks whether
the same operator can be resolved for all the fields of the record.

The only slight complication with that was the logic difference between `!=`
(can return early) and other comparisons (must check all fields). I don't think
that adds too much to the complexity, though.

While there, this PR also renames the static functions in
buildDefaultFunctions.cpp to have camelCase names.

Test:
- [x] standard
- [x] gasnet