### PR TITLE
Deprecate --legacy-classes

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -66,7 +66,6 @@ VarSymbol *gFalse = NULL;
 VarSymbol *gBoundsChecking = NULL;
 VarSymbol *gCastChecking = NULL;
 VarSymbol *gNilChecking = NULL;
-VarSymbol *gLegacyClasses = NULL;
 VarSymbol *gOverloadSetsChecks = NULL;
 VarSymbol *gDivZeroChecking = NULL;
 VarSymbol* gPrivatization = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -890,10 +890,6 @@ void initCompilerGlobals() {
   gNilChecking->addFlag(FLAG_PARAM);
   setupBoolGlobal(gNilChecking, !fNoNilChecks);
 
-  gLegacyClasses = new VarSymbol("chpl_legacyClasses", dtBool);
-  gLegacyClasses->addFlag(FLAG_PARAM);
-  setupBoolGlobal(gLegacyClasses, fLegacyClasses);
-
   gOverloadSetsChecks = new VarSymbol("chpl_overloadSetsChecks", dtBool);
   gOverloadSetsChecks->addFlag(FLAG_PARAM);
   setupBoolGlobal(gOverloadSetsChecks, fOverloadSetsChecks);

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -46,7 +46,6 @@ extern bool fNoLiveAnalysis;
 extern bool fNoFormalDomainChecks;
 extern bool fNoLocalChecks;
 extern bool fNoNilChecks;
-extern bool fLegacyClasses;
 extern bool fIgnoreNilabilityErrors;
 extern bool fOverloadSetsChecks;
 extern bool fNoStackChecks;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -746,7 +746,6 @@ extern VarSymbol *gFalse;
 extern VarSymbol *gBoundsChecking;
 extern VarSymbol *gCastChecking;
 extern VarSymbol *gNilChecking;
-extern VarSymbol *gLegacyClasses;
 extern VarSymbol *gOverloadSetsChecks;
 extern VarSymbol *gDivZeroChecking;
 extern VarSymbol *gPrivatization;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -550,14 +550,22 @@ static void setPrintIr(const ArgumentDescription* desc, const char* arg) {
   }
 }
 
-static void verifyStageAndSetStageNum(const ArgumentDescription* desc, const
-    char* arg)
+static void verifyStageAndSetStageNum(const ArgumentDescription* desc,
+                                      const char* arg)
 {
   llvmStageNum_t stageNum = llvmStageNumFromLlvmStageName(arg);
   if(stageNum == llvmStageNum::NOPRINT)
     USR_FATAL("Unknown llvm-print-ir-stage argument");
 
   llvmPrintIrStageNum = stageNum;
+}
+
+static void warnUponLegacyClasses(const ArgumentDescription* desc,
+                                  const char* arg)
+{
+  USR_WARN("'--legacy-classes' option has been deprecated"
+           " and will be removed in the next Chapel release;"
+           " it no longer affects compilation");
 }
 
 // In order to handle accumulating ccflags arguments, the argument
@@ -1062,7 +1070,7 @@ static ArgumentDescription arg_desc[] = {
  DRIVER_ARG_DEBUGGERS,
  {"interprocedural-alias-analysis", ' ', NULL, "Enable [disable] interprocedural alias analysis", "n", &fNoInterproceduralAliasAnalysis, NULL, NULL},
  {"lifetime-checking", ' ', NULL, "Enable [disable] lifetime checking pass", "N", &fLifetimeChecking, NULL, NULL},
- {"legacy-classes", ' ', NULL, "Class variables match 1.19 - borrowed by default, can store nil", "N", &fLegacyClasses, NULL, NULL},
+ {"legacy-classes", ' ', NULL, "Deprecated flag - does not affect compilation", "N", &fLegacyClasses, NULL, &warnUponLegacyClasses},
  {"ignore-nilability-errors", ' ', NULL, "Allow compilation to continue by coercing away nilability", "N", &fIgnoreNilabilityErrors, NULL, NULL},
  {"overload-sets-checks", ' ', NULL, "Report potentially hijacked calls", "N", &fOverloadSetsChecks, NULL, NULL},
  {"compile-time-nil-checking", ' ', NULL, "Enable [disable] compile-time nil checking", "N", &fCompileTimeNilChecking, "CHPL_NO_COMPILE_TIME_NIL_CHECKS", NULL},

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -264,7 +264,6 @@ void ResolveScope::addBuiltIns() {
   extend(gBoundsChecking);
   extend(gCastChecking);
   extend(gNilChecking);
-  extend(gLegacyClasses);
   extend(gOverloadSetsChecks);
   extend(gDivZeroChecking);
   extend(gPrivatization);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2559,8 +2559,7 @@ static void errorIfSplitInitializationRequired(DefExpr* def, Expr* cur) {
       }
 
       // can't default init a non-nilable class type
-      // unless --legacy-classes is on
-      if (isNonNilableClassType(ts->type) && !fLegacyClasses) {
+      if (isNonNilableClassType(ts->type)) {
         canDefaultInit = false;
         nonNilableType = ts->type;
       }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -961,11 +961,11 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
         INT_ASSERT(t);
         sym = t->symbol;
       } else if (isClass(sym->type)) {
-            // Make 'MyClass' mean generic-management.
-            // Switch to the CLASS_TYPE_GENERIC_NONNIL decorated class type.
-            ClassTypeDecorator d = CLASS_TYPE_GENERIC_NONNIL;
-            Type* t = getDecoratedClass(sym->type, d);
-            sym = t->symbol;
+        // Make 'MyClass' mean generic-management.
+        // Switch to the CLASS_TYPE_GENERIC_NONNIL decorated class type.
+        ClassTypeDecorator d = CLASS_TYPE_GENERIC_NONNIL;
+        Type* t = getDecoratedClass(sym->type, d);
+        sym = t->symbol;
       }
     }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -961,16 +961,11 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
         INT_ASSERT(t);
         sym = t->symbol;
       } else if (isClass(sym->type)) {
-        // e.g. 'MyClass' becomes 'MyClass with any management'
-          // make MyClass mean generic-management unless
-          // --legacy-classes is passed.
-          bool defaultIsGenericHere = !fLegacyClasses;
-          if (defaultIsGenericHere) {
+            // Make 'MyClass' mean generic-management.
             // Switch to the CLASS_TYPE_GENERIC_NONNIL decorated class type.
             ClassTypeDecorator d = CLASS_TYPE_GENERIC_NONNIL;
             Type* t = getDecoratedClass(sym->type, d);
             sym = t->symbol;
-          }
       }
     }
 
@@ -1390,7 +1385,7 @@ static void resolveModuleCall(CallExpr* call) {
         Symbol* sym = scope->lookupNameLocally(mbrName);
 
         // Adjust class types to undecorated
-        if (sym && isClass(sym->type) && !fLegacyClasses) {
+        if (sym && isClass(sym->type)) {
           // Switch to the CLASS_TYPE_GENERIC_NONNIL decorated class type.
           ClassTypeDecorator d = CLASS_TYPE_GENERIC_NONNIL;
           Type* t = getDecoratedClass(sym->type, d);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9918,13 +9918,13 @@ void printUndecoratedClassTypeNote(Expr* ctx, Type* type) {
 }
 
 void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx) {
-    if (isClassLikeOrManaged(decorator) && isClassLikeOrManaged(decorated)) {
-      ClassTypeDecorator d = classTypeDecorator(decorated);
+  if (isClassLikeOrManaged(decorator) && isClassLikeOrManaged(decorated)) {
+    ClassTypeDecorator d = classTypeDecorator(decorated);
 
-      if (!isDecoratorUnknownManagement(d))
-        USR_FATAL_CONT(ctx, "duplicate decorators - %s %s",
-                             toString(decorator), toString(decorated));
-    }
+    if (!isDecoratorUnknownManagement(d))
+      USR_FATAL_CONT(ctx, "duplicate decorators - %s %s",
+                           toString(decorator), toString(decorated));
+  }
 }
 
 void startGenerousResolutionForErrors() {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -204,8 +204,6 @@ static void  moveHaltMoveIsUnacceptable(CallExpr* call);
 
 
 static bool useLegacyNilability(Expr* at) {
-  if (fLegacyClasses) return true;
-
   if (at != NULL) {
     FnSymbol* fn = at->getFunction();
     ModuleSymbol* mod = at->getModule();
@@ -5877,8 +5875,7 @@ static const char* describeLHS(CallExpr* call, const char* nonnilable) {
 }
 
 void checkMoveIntoClass(CallExpr* call, Type* lhs, Type* rhs) {
-  if (! fLegacyClasses &&
-      isNonNilableClassType(lhs) && isNilableClassType(rhs))
+  if (isNonNilableClassType(lhs) && isNilableClassType(rhs))
     USR_FATAL(userCall(call), "cannot %s '%s' from a nilable '%s'",
               describeLHS(call, " non-nilable"), toString(lhs), toString(rhs));
 
@@ -6978,7 +6975,7 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
           } else {
             manager = dtOwned;
           }
-        } else if (isClass(type) && !fLegacyClasses) {
+        } else if (isClass(type)) {
           manager = dtBorrowed;
         } else if (isClass(type) && isUndecoratedClassNew(newExpr, type)) {
           manager = dtOwned;
@@ -9921,7 +9918,6 @@ void printUndecoratedClassTypeNote(Expr* ctx, Type* type) {
 }
 
 void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx) {
-  if (fLegacyClasses == false) {
     if (isClassLikeOrManaged(decorator) && isClassLikeOrManaged(decorated)) {
       ClassTypeDecorator d = classTypeDecorator(decorated);
 
@@ -9929,7 +9925,6 @@ void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx) {
         USR_FATAL_CONT(ctx, "duplicate decorators - %s %s",
                              toString(decorator), toString(decorated));
     }
-  }
 }
 
 void startGenerousResolutionForErrors() {

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -292,10 +292,8 @@ module CPtr {
   pragma "no doc"
   inline proc _cast(type t:_anyManagementAnyNilable, x:c_void_ptr) {
     if isUnmanagedClass(t) || isBorrowedClass(t) {
-      {
-        compilerWarning("cast from c_void_ptr to "+ t:string +" is deprecated");
-        compilerWarning("cast to "+ _to_nilable(t):string +" instead");
-      }
+      compilerWarning("cast from c_void_ptr to "+ t:string +" is deprecated");
+      compilerWarning("cast to "+ _to_nilable(t):string +" instead");
       return __primitive("cast", t, x);
     } else {
       compilerWarning("invalid cast from c_void_ptr to managed type " +

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -292,7 +292,7 @@ module CPtr {
   pragma "no doc"
   inline proc _cast(type t:_anyManagementAnyNilable, x:c_void_ptr) {
     if isUnmanagedClass(t) || isBorrowedClass(t) {
-      if !chpl_legacyClasses {
+      {
         compilerWarning("cast from c_void_ptr to "+ t:string +" is deprecated");
         compilerWarning("cast to "+ _to_nilable(t):string +" instead");
       }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -108,7 +108,7 @@ module ChapelBase {
     // assignments defined for sync and single class types.
   inline proc =(ref a, b:_nilType) where isBorrowedOrUnmanagedClassType(a.type)
   {
-    if isNonNilableClassType(a.type) && !chpl_legacyClasses {
+    if isNonNilableClassType(a.type) {
       compilerError("cannot assign to " + a.type:string + " from nil");
     }
     __primitive("=", a, nil);
@@ -1378,17 +1378,12 @@ module ChapelBase {
 
   inline proc _cast(type t:unmanaged class, x:_nilType)
   {
-    if !chpl_legacyClasses {
       compilerError("cannot cast nil to " + t:string);
-    }
   }
   inline proc _cast(type t:borrowed class, x:_nilType)
   {
-    if !chpl_legacyClasses {
       compilerError("cannot cast nil to " + t:string);
-    }
   }
-
 
   // casting to unmanaged?, no class downcast
   inline proc _cast(type t:unmanaged class?, x:borrowed class?)
@@ -1579,8 +1574,7 @@ module ChapelBase {
   pragma "suppress lvalue error"
   pragma "unsafe"
   inline proc _createFieldDefault(type t, init) {
-    if !chpl_legacyClasses && isNonNilableClassType(t)
-                           && isNilableClassType(init.type) then
+    if isNonNilableClassType(t) && isNilableClassType(init.type) then
       compilerError("default-initializing a field with a non-nilable type ",
           t:string, " from an instance of nilable ", init.type:string);
 
@@ -1602,7 +1596,7 @@ module ChapelBase {
   pragma "no copy return"
   pragma "unsafe"
   inline proc _createFieldDefault(type t, init: _nilType) {
-    if !chpl_legacyClasses && isNonNilableClassType(t) then
+    if isNonNilableClassType(t) then
       compilerError("default-initializing a field with a non-nilable type ",
                     t:string, " from nil");
 
@@ -2239,6 +2233,12 @@ module ChapelBase {
   proc isBorrowedOrUnmanagedClassType(type t:unmanaged) param return true;
   proc isBorrowedOrUnmanagedClassType(type t:borrowed) param return true;
   proc isBorrowedOrUnmanagedClassType(type t) param return false;
+
+  // Former support for --legacy-classes, to be removed after 1.21.
+  proc chpl_legacyClasses param {
+    compilerWarning("'chpl_legacyClasses' is deprecated and will be removed in the next release; it is now always false");
+    return false;
+  }
 
   proc isRecordType(type t) param {
     if __primitive("is record type", t) == false then

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1382,7 +1382,7 @@ module ChapelBase {
   }
   inline proc _cast(type t:borrowed class, x:_nilType)
   {
-      compilerError("cannot cast nil to " + t:string);
+    compilerError("cannot cast nil to " + t:string);
   }
 
   // casting to unmanaged?, no class downcast

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -80,7 +80,7 @@ module ChapelSyncvar {
     if isSupported(t) == false then
       compilerError("sync/single types cannot contain type '", t : string, "'");
 
-    if !chpl_legacyClasses && isNonNilableClass(t) then
+    if isNonNilableClass(t) then
       compilerError("sync/single types cannot contain non-nilable classes");
 
     if isGenericType(t) then

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -245,9 +245,7 @@ module OwnedObject {
        refer to `nil` after this call.
      */
     proc init=(pragma "leaves arg nil" pragma "nil from arg" ref src:_owned) {
-      if isNonNilableClass(this.type) && isNilableClass(src) &&
-         !chpl_legacyClasses
-      then
+      if isNonNilableClass(this.type) && isNilableClass(src) then
         compilerError("cannot create a non-nilable owned variable from a nilable class instance");
 
       if isCoercible(src.chpl_t, this.type.chpl_t) == false then
@@ -279,9 +277,8 @@ module OwnedObject {
     proc init=(src : _nilType) {
       this.init(this.type.chpl_t);
 
-      if isNonNilableClass(chpl_t) && !chpl_legacyClasses {
+      if isNonNilableClass(chpl_t) then
         compilerError("Assigning non-nilable owned to nil");
-      }
     }
 
     // Copy-init implementation to allow for 'new _owned(foo)' in module code
@@ -347,8 +344,6 @@ module OwnedObject {
 
       if _to_nilable(chpl_t) == chpl_t {
         return _to_unmanaged(oldPtr);
-      } else if chpl_legacyClasses {
-        return _to_unmanaged(_to_nonnil(oldPtr));
       } else {
         return _to_unmanaged(oldPtr!);
       }
@@ -366,8 +361,6 @@ module OwnedObject {
     proc /*const*/ borrow() {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_p;
-      } else if chpl_legacyClasses {
-        return _to_nonnil(chpl_p);
       } else {
         return chpl_p!;
       }
@@ -390,8 +383,7 @@ module OwnedObject {
   proc =(ref lhs:_owned,
          pragma "leaves arg nil"
          ref rhs: _owned)
-    where chpl_legacyClasses ||
-          ! (isNonNilableClass(lhs) && isNilableClass(rhs))
+    where ! (isNonNilableClass(lhs) && isNilableClass(rhs))
   {
     use HaltWrappers only;
     // Work around issues in associative arrays of owned
@@ -415,7 +407,7 @@ module OwnedObject {
 
   pragma "no doc"
   proc =(ref lhs:_owned, rhs:_nilType)
-    where chpl_legacyClasses || ! isNonNilableClass(lhs)
+    where ! isNonNilableClass(lhs)
   {
     lhs.clear();
   }
@@ -558,7 +550,7 @@ module OwnedObject {
   // cast from nil to owned
   pragma "no doc"
   inline proc _cast(type t:_owned, pragma "nil from arg" x:_nilType) {
-    if _to_nilable(t.chpl_t) != t.chpl_t && !chpl_legacyClasses then
+    if isNonNilableClass(t.chpl_t) then
       compilerError("Illegal cast from nil to non-nilable owned type");
 
     var tmp:t;

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -275,9 +275,7 @@ module SharedObject {
     //   var s : shared = ownedThing;
     pragma "no doc"
     proc init=(pragma "nil from arg" in take: owned) {
-      if isNonNilableClass(this.type) && isNilableClass(take) &&
-         !chpl_legacyClasses
-      then
+      if isNonNilableClass(this.type) && isNilableClass(take) then
         compilerError("cannot create a non-nilable shared variable from a nilable class instance");
 
       this.init(take);
@@ -289,9 +287,7 @@ module SharedObject {
        These will share responsibility for managing the instance.
      */
     proc init=(pragma "nil from arg" const ref src:_shared) {
-      if isNonNilableClass(this.type) && isNilableClass(src) &&
-         !chpl_legacyClasses
-      then
+      if isNonNilableClass(this.type) && isNilableClass(src) then
         compilerError("cannot create a non-nilable shared variable from a nilable class instance");
 
       if isCoercible(src.chpl_t, this.type.chpl_t) == false then
@@ -321,10 +317,8 @@ module SharedObject {
     proc init=(src : _nilType) {
       this.init(this.type.chpl_t);
 
-      if _to_nilable(chpl_t) != chpl_t && !chpl_legacyClasses {
+      if isNonNilableClass(chpl_t) then
         compilerError("Assigning non-nilable shared to nil");
-      }
-
     }
 
     /*
@@ -390,8 +384,6 @@ module SharedObject {
     proc /*const*/ borrow() {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_p;
-      } else if chpl_legacyClasses {
-        return _to_nonnil(chpl_p);
       } else {
         return chpl_p!;
       }
@@ -409,8 +401,7 @@ module SharedObject {
      ``lhs`` will refer to the same object as ``rhs``.
    */
   proc =(ref lhs:_shared, rhs: _shared)
-    where chpl_legacyClasses ||
-          ! (isNonNilableClass(lhs) && isNilableClass(rhs))
+    where ! (isNonNilableClass(lhs) && isNilableClass(rhs))
   {
     // retain-release
     if rhs.chpl_pn != nil then
@@ -435,7 +426,7 @@ module SharedObject {
 
   pragma "no doc"
   proc =(ref lhs:shared, rhs:_nilType)
-    where chpl_legacyClasses || ! isNonNilableClass(lhs)
+    where ! isNonNilableClass(lhs)
   {
     lhs.clear();
   }
@@ -546,7 +537,7 @@ module SharedObject {
   // cast from nil to shared
   pragma "no doc"
   inline proc _cast(type t:_shared, pragma "nil from arg" x:_nilType) {
-    if _to_nilable(t.chpl_t) != t.chpl_t && !chpl_legacyClasses then
+    if isNonNilableClass(t.chpl_t) then
       compilerError("Illegal cast from nil to non-nilable shared type");
 
     var tmp:t;

--- a/test/deprecated/legacy-classes-opt.chpl
+++ b/test/deprecated/legacy-classes-opt.chpl
@@ -1,0 +1,2 @@
+// This test checks the compiler output for --legacy-classes.
+compilerError("done");

--- a/test/deprecated/legacy-classes-opt.compopts
+++ b/test/deprecated/legacy-classes-opt.compopts
@@ -1,0 +1,2 @@
+--legacy-classes
+--no-legacy-classes

--- a/test/deprecated/legacy-classes-opt.good
+++ b/test/deprecated/legacy-classes-opt.good
@@ -1,0 +1,2 @@
+warning: '--legacy-classes' option has been deprecated and will be removed in the next Chapel release; it no longer affects compilation
+legacy-classes-opt.chpl:2: error: done

--- a/test/deprecated/legacy-classes-param.chpl
+++ b/test/deprecated/legacy-classes-param.chpl
@@ -1,0 +1,6 @@
+
+if chpl_legacyClasses then
+  compilerError("yes");
+
+if !chpl_legacyClasses then
+  compilerError("no");

--- a/test/deprecated/legacy-classes-param.good
+++ b/test/deprecated/legacy-classes-param.good
@@ -1,0 +1,3 @@
+legacy-classes-param.chpl:2: warning: 'chpl_legacyClasses' is deprecated and will be removed in the next release; it is now always false
+legacy-classes-param.chpl:5: warning: 'chpl_legacyClasses' is deprecated and will be removed in the next release; it is now always false
+legacy-classes-param.chpl:6: error: no


### PR DESCRIPTION
Switch the compiler flag `--legacy-classes` to no-op
and the corresponding predefined param `chpl_legacyClasses` to always-false.

Using either of these now causes a deprecation warning.
The intention is to remove them both after v1.21.

Remove all references to `fLegacyClasses` and `gLegacyClasses`
in the compiler and `chpl_legacyClasses` in the modules,
except as needed for the deprecation warnings.

Add tests of the deprecation warnings.