### PR TITLE
'==' operator overload for LinkedList

### DIFF
--- a/modules/standard/LinkedLists.chpl
+++ b/modules/standard/LinkedLists.chpl
@@ -42,6 +42,27 @@ class listNode {
       l1.append(i);
   }
 
+  pragma "no doc"
+  proc ==(const ref l1: LinkedList(?t), const ref l2: LinkedList(?t2)) : LinkedList(bool) where t == t2 {
+    private use HaltWrappers only;
+    if l1.length != l2.length {
+      HaltWrappers.boundsCheckHalt("Element-wise equality comparison on linked lists of different lengths (" +
+          l1.length:string + ") and (" + l2.length:string + ")" );
+    }
+    var bool_linkedlist = new LinkedList(bool);
+    if l1.length == 0 {
+      return bool_linkedlist;
+    }
+    var el_l1 : borrowed listNode(t)? = l1.first.borrow();
+    var el_l2 : borrowed listNode(t2)? = l2.first.borrow();
+    do {
+      bool_linkedlist.append(el_l1.data == el_l2.data);
+      el_l1 = el_l1.next;
+      el_l2 = el_l2.next;
+    } while (el_l1 != nil);
+    return bool_linkedlist;
+  }
+
   private use IO;
 
 /*


### PR DESCRIPTION
Follow up for #13137
Performs element-wise comparison and returns a linked list of booleans.
Can only be used on lists of equal length

Creating pull req for now, will add tests soon