### PR TITLE
Fix new align test for 32-bit platforms

### DIFF
--- a/test/runtime/configMatters/mem/align.chpl
+++ b/test/runtime/configMatters/mem/align.chpl
@@ -1,10 +1,11 @@
 use CPtr;
+use SysCTypes;
 
 // try with size = 2*alignment
 for i in 3..20 {
   const alignment = (1 << i) : uint;
   var ptr = c_aligned_alloc(uint(8), alignment, 2*alignment);
-  writeln(alignment, " => ", ptr : uint % alignment);
+  writeln(alignment, " => ", ptr : c_uintptr : uint % alignment);
   c_free(ptr);
 }
 
@@ -12,6 +13,6 @@ for i in 3..20 {
 for i in 3..20 {
   const alignment = (1 << i) : uint;
   var ptr = c_aligned_alloc(uint(8), alignment, 1);
-  writeln(alignment, " => ", ptr : uint % alignment);
+  writeln(alignment, " => ", ptr : c_uintptr : uint % alignment);
   c_free(ptr);
 }


### PR DESCRIPTION
We were seeing a warning on 32-bit Cygwin.

Follow-on to PR #14267.

Trivial and not reviewed.