### PR TITLE
Improve error messages related to renaming a module upon its use

### DIFF
--- a/compiler/include/scopeResolve.h
+++ b/compiler/include/scopeResolve.h
@@ -20,12 +20,14 @@
 #ifndef _SCOPE_RESOLVE_H_
 #define _SCOPE_RESOLVE_H_
 
+class astlocT;
 class BaseAST;
 class CallExpr;
 class DefExpr;
 class FnSymbol;
 class Symbol;
 
+#include <map>
 #include <vector>
 
 void     addToSymbolTable(FnSymbol* fn);
@@ -36,11 +38,15 @@ Symbol*  lookup(const char*           name,
 
 void     lookup(const char*           name,
                 BaseAST*              context,
-                std::vector<Symbol*>& symbols);
+                std::vector<Symbol*>& symbols,
+                std::map<Symbol*, astlocT*>& renameLocs,
+                bool storeRenames = false);
 
 Symbol*  lookupAndCount(const char*           name,
                         BaseAST*              context,
-                        int&                  nSymbolsFound);
+                        int&                  nSymbolsFound,
+                        bool storeRenames = false,
+                        astlocT** renameLoc = NULL);
 
 
 BaseAST* getScope(BaseAST* ast);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -20,6 +20,7 @@
 #include "scopeResolve.h"
 
 #include "astutil.h"
+#include "baseAST.h"
 #include "build.h"
 #include "CatchStmt.h"
 #include "DecoratedClassType.h"
@@ -75,7 +76,8 @@ static void          scopeResolveExpr(Expr* expr, ResolveScope* scope);
 static bool          isStableClassType(Type* t);
 static Expr*         handleUnstableClassType(SymExpr* se);
 
-static void          resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr);
+static astlocT*      resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
+                                              bool returnRename = false);
 
 static void          resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
                                               Symbol* sym);
@@ -83,7 +85,9 @@ static void          resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
 static bool lookupThisScopeAndUses(const char*           name,
                                    BaseAST*              context,
                                    BaseAST*              scope,
-                                   std::vector<Symbol*>& symbols);
+                                   std::vector<Symbol*>& symbols,
+                                   std::map<Symbol*, astlocT*>& renameLocs,
+                                   bool storeRenames);
 
 static ModuleSymbol* definesModuleSymbol(Expr* expr);
 
@@ -650,32 +654,14 @@ static void resolveUnresolvedSymExprs() {
   // that is used to determine visible functions.
   //
 
-  int maxResolved = 0;
-  int i           = 0;
-
-  forv_Vec(UnresolvedSymExpr, unresolvedSymExpr, gUnresolvedSymExprs) {
-    resolveUnresolvedSymExpr(unresolvedSymExpr);
-
-    maxResolved++;
-  }
-
   forv_Vec(CallExpr, call, gCallExprs) {
     resolveModuleCall(call);
   }
 
-  // Note that the extern C resolution might add new UnresolvedSymExprs, and it
-  // might do that within resolveModuleCall, so we try resolving unresolved
-  // symbols a second time as the extern C block support might have added some.
-  //
-  // TODO: have the externCResolve call resolveUnresolved directly
   forv_Vec(UnresolvedSymExpr, unresolvedSymExpr, gUnresolvedSymExprs) {
-    // Only try resolving symbols that are new after last attempt.
-    if (i >= maxResolved) {
-      resolveUnresolvedSymExpr(unresolvedSymExpr);
-    }
-
-    i++;
+    resolveUnresolvedSymExpr(unresolvedSymExpr);
   }
+
 }
 
 void resolveUnresolvedSymExprs(BaseAST* inAst) {
@@ -915,16 +901,22 @@ static Expr* handleUnstableClassType(SymExpr* se) {
   return se;
 }
 
-static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
+static astlocT* resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
+                                         bool returnRename) {
+  if (usymExpr->parentExpr == NULL)
+    return NULL;
+
   SET_LINENO(usymExpr);
 
   const char* name = usymExpr->unresolved;
   int nSymbols = 0;
 
   if (name == astrSdot || !usymExpr->inTree())
-    return;
+    return NULL;
 
-  Symbol* sym = lookupAndCount(name, usymExpr, nSymbols);
+  astlocT* renameLoc = NULL;
+  Symbol* sym = lookupAndCount(name, usymExpr, nSymbols, returnRename,
+                               &renameLoc);
   if (sym != NULL) {
     resolveUnresolvedSymExpr(usymExpr, sym);
   } else {
@@ -938,6 +930,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
     }
 #endif
   }
+  return renameLoc;
 }
 
 // usymExpr is the UnresolveSymExpr and sym is what we
@@ -1376,72 +1369,102 @@ static CallExpr* resolveModuleGetNewExpr(CallExpr* call, Symbol* sym);
 
 static void resolveModuleCall(CallExpr* call) {
   if (call->isNamedAstr(astrSdot) == true) {
-    if (SymExpr* se = toSymExpr(call->get(1))) {
-      if (ModuleSymbol* mod = toModuleSymbol(se->symbol())) {
-        SET_LINENO(call);
+    if (UnresolvedSymExpr* uSE = toUnresolvedSymExpr(call->get(1))) {
+      astlocT* renameLoc = resolveUnresolvedSymExpr(uSE, true);
 
-        ModuleSymbol* currModule = call->getModule();
-        ResolveScope* scope      = ResolveScope::getScopeFor(mod->block);
-        const char*   mbrName    = get_string(call->get(2));
+      // Now that we've resolved the unresolved sym expr, check if it's been
+      // replaced with a sym expr, and operate within it if so.
+      if (SymExpr* se = toSymExpr(call->get(1))) {
+        if (ModuleSymbol* mod = toModuleSymbol(se->symbol())) {
+          SET_LINENO(call);
 
-        currModule->moduleUseAdd(mod);
+          ModuleSymbol* currModule = call->getModule();
+          ResolveScope* scope      = ResolveScope::getScopeFor(mod->block);
+          const char*   mbrName    = get_string(call->get(2));
 
-        // First, try regular scope resolution
-        Symbol* sym = scope->lookupNameLocally(mbrName);
+          currModule->moduleUseAdd(mod);
 
-        // Adjust class types to undecorated
-        if (sym && isClass(sym->type) && !fLegacyClasses) {
-          // Switch to the CLASS_TYPE_GENERIC_NONNIL decorated class type.
-          ClassTypeDecorator d = CLASS_TYPE_GENERIC_NONNIL;
-          Type* t = getDecoratedClass(sym->type, d);
-          sym = t->symbol;
-        }
+          // First, try regular scope resolution
+          Symbol* sym = scope->lookupNameLocally(mbrName);
 
-        // Failing that, try looking in an extern block.
+          // Adjust class types to undecorated
+          if (sym && isClass(sym->type) && !fLegacyClasses) {
+            // Switch to the CLASS_TYPE_GENERIC_NONNIL decorated class type.
+            ClassTypeDecorator d = CLASS_TYPE_GENERIC_NONNIL;
+            Type* t = getDecoratedClass(sym->type, d);
+            sym = t->symbol;
+          }
+
+          // Failing that, try looking in an extern block.
 #ifdef HAVE_LLVM
-        if (sym == NULL && gExternBlockStmts.size() > 0) {
-          sym = tryCResolveLocally(mod, mbrName);
-        }
+          if (sym == NULL && gExternBlockStmts.size() > 0) {
+            sym = tryCResolveLocally(mod, mbrName);
+          }
 #endif
 
-        if (sym != NULL) {
-          if (sym->isVisible(call) == true) {
-            if (FnSymbol* fn = toFnSymbol(sym)) {
-              if (fn->_this == NULL && fn->hasFlag(FLAG_NO_PARENS) == true) {
-                call->replace(new CallExpr(fn));
+          if (sym != NULL) {
+            if (sym->isVisible(call) == true) {
+              if (FnSymbol* fn = toFnSymbol(sym)) {
+                if (fn->_this == NULL && fn->hasFlag(FLAG_NO_PARENS) == true) {
+                  call->replace(new CallExpr(fn));
+
+                } else {
+                  CallExpr* parent = toCallExpr(call->parentExpr);
+
+                  call->replace(new UnresolvedSymExpr(mbrName));
+
+                  parent->insertAtHead(mod);
+                  parent->insertAtHead(gModuleToken);
+                }
+
+              } else if (CallExpr* c = resolveModuleGetNewExpr(call, sym)) {
+                call->replace(new SymExpr(sym));
+
+                c->insertAtHead(mod);
+                c->insertAtHead(gModuleToken);
 
               } else {
-                CallExpr* parent = toCallExpr(call->parentExpr);
-
-                call->replace(new UnresolvedSymExpr(mbrName));
-
-                parent->insertAtHead(mod);
-                parent->insertAtHead(gModuleToken);
+                call->replace(new SymExpr(sym));
               }
 
-            } else if (CallExpr* c = resolveModuleGetNewExpr(call, sym)) {
-              call->replace(new SymExpr(sym));
-
-              c->insertAtHead(mod);
-              c->insertAtHead(gModuleToken);
-
             } else {
-              call->replace(new SymExpr(sym));
+              if (uSE->unresolved == mod->name) {
+                USR_FATAL(call,
+                          "Cannot access '%s', '%s' is private to '%s'",
+                          mbrName,
+                          mbrName,
+                          mod->name);
+
+              } else {
+                USR_FATAL_CONT(call,
+                               "Cannot access '%s', '%s' is private to '%s'",
+                               mbrName,
+                               mbrName,
+                               uSE->unresolved);
+                USR_PRINT("module '%s' was renamed from '%s' at %s:%d",
+                          uSE->unresolved, mod->name, renameLoc->filename,
+                          renameLoc->lineno);
+
+              }
             }
 
           } else {
-            USR_FATAL(call,
-                      "Cannot access '%s', '%s' is private to '%s'",
-                      mbrName,
-                      mbrName,
-                      mod->name);
-          }
+            if (uSE->unresolved == mod->name) {
+              USR_FATAL_CONT(call,
+                             "Symbol '%s' undeclared in module '%s'",
+                             mbrName,
+                             mod->name);
 
-        } else {
-          USR_FATAL_CONT(call,
-                         "Symbol '%s' undeclared in module '%s'",
-                         mbrName,
-                         mod->name);
+            } else {
+              USR_FATAL_CONT(call,
+                             "Symbol '%s' undeclared in module '%s'",
+                             mbrName,
+                             uSE->unresolved);
+              USR_PRINT("module '%s' was renamed from '%s' at %s:%d",
+                        uSE->unresolved, mod->name, renameLoc->filename,
+                        renameLoc->lineno);
+            }
+          }
         }
       }
     }
@@ -1577,18 +1600,32 @@ static void lookup(const char*           name,
                    BaseAST*              scope,
                    Vec<BaseAST*>&        visited,
 
-                   std::vector<Symbol*>& symbols);
+                   std::vector<Symbol*>& symbols,
+                   std::map<Symbol*, astlocT*>& renameLocs,
+                   bool storeRenames);
 
 // Show what symbols from 'symbols' conflict with the given 'sym'.
-static void printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym)
+static void printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym,
+                                    const char* nameUsed,
+                                    bool storeRenames,
+                                    std::map<Symbol*, astlocT*> renameLocs)
 {
   Symbol* sampleFunction = NULL;
   for_vector(Symbol, another, symbols) if (another != sym)
   {
     if (isFnSymbol(another))
       sampleFunction = another;
-    else
-      USR_PRINT(another, "also defined here", another->name);
+    else {
+      astlocT* renameLoc = renameLocs[another];
+      if (storeRenames && renameLoc != NULL) {
+        USR_PRINT(another,
+                  "symbol '%s', defined here, was renamed to '%s' at %s:%d",
+                  another->name, nameUsed, renameLoc->filename,
+                  renameLoc->lineno);
+      } else {
+        USR_PRINT(another, "also defined here", another->name);
+      }
+    }
   }
 
   if (sampleFunction)
@@ -1600,12 +1637,15 @@ static void printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym)
 // by that name in the context of that call
 Symbol* lookupAndCount(const char*           name,
                        BaseAST*              context,
-                       int&                  nSymbolsFound) {
+                       int&                  nSymbolsFound,
+                       bool storeRenames,
+                       astlocT** renameLoc) {
 
   std::vector<Symbol*> symbols;
+  std::map<Symbol*, astlocT*> renameLocs;
   Symbol*              retval = NULL;
 
-  lookup(name, context, symbols);
+  lookup(name, context, symbols, renameLocs, storeRenames);
 
   nSymbolsFound = symbols.size();
 
@@ -1614,6 +1654,11 @@ Symbol* lookupAndCount(const char*           name,
 
   } else if (symbols.size() == 1) {
     retval = symbols[0];
+    if (storeRenames) {
+      if (astlocT* retvalRenameLoc = renameLocs[retval]) {
+        *renameLoc = retvalRenameLoc;
+      }
+    }
 
   } else {
     // Multiple symbols found for this name.
@@ -1623,8 +1668,13 @@ Symbol* lookupAndCount(const char*           name,
 
     for_vector(Symbol, sym, symbols) {
       if (! isFnSymbol(sym)) {
+        astlocT* symRenameLoc = renameLocs[sym];
         USR_FATAL_CONT(sym, "symbol %s is multiply defined", name);
-        printConflictingSymbols(symbols, sym);
+        if (storeRenames && symRenameLoc != NULL) {
+          USR_PRINT("'%s' was renamed to '%s' at %s:%d", sym->name,
+                    name, symRenameLoc->filename, symRenameLoc->lineno);
+        }
+        printConflictingSymbols(symbols, sym, name, storeRenames, renameLocs);
         break;
       }
     }
@@ -1642,10 +1692,12 @@ Symbol* lookup(const char* name, BaseAST* context) {
 
 void lookup(const char*           name,
             BaseAST*              context,
-            std::vector<Symbol*>& symbols) {
+            std::vector<Symbol*>& symbols,
+            std::map<Symbol*, astlocT*>& renameLocs,
+            bool storeRenames) {
   Vec<BaseAST*> visited;
 
-  lookup(name, context, context, visited, symbols);
+  lookup(name, context, context, visited, symbols, renameLocs, storeRenames);
 }
 
 static void lookup(const char*           name,
@@ -1654,12 +1706,15 @@ static void lookup(const char*           name,
                    BaseAST*              scope,
                    Vec<BaseAST*>&        visited,
 
-                   std::vector<Symbol*>& symbols) {
+                   std::vector<Symbol*>& symbols,
+                   std::map<Symbol*, astlocT*>& renameLocs,
+                   bool storeRenames) {
 
   if (!visited.set_in(scope)) {
     visited.set_add(scope);
 
-    if (lookupThisScopeAndUses(name, context, scope, symbols) == true) {
+    if (lookupThisScopeAndUses(name, context, scope, symbols, renameLocs,
+                               storeRenames) == true) {
       // We've found an instance here.
       // Lydia note: in the access call case, we'd want to look in our
       // surrounding scopes for the symbols on the left and right part
@@ -1676,7 +1731,8 @@ static void lookup(const char*           name,
     if (scope->getModule()->block == scope) {
       BaseAST* outerScope = getScope(scope);
       if (outerScope != NULL) {
-        lookup(name, context, outerScope, visited, symbols);
+        lookup(name, context, outerScope, visited, symbols, renameLocs,
+               storeRenames);
         // As a last ditch effort, see if this module's name happens to match.
         // This handles the case when we refer to the name of the module in
         // which we are declared (e.g., `module M { ...M.xyz... }`
@@ -1697,7 +1753,8 @@ static void lookup(const char*           name,
         // within the aggregate type
         if (AggregateType* ct =
             toAggregateType(canonicalClassType(fn->_this->type))) {
-          lookup(name, context, ct->symbol, visited, symbols);
+          lookup(name, context, ct->symbol, visited, symbols, renameLocs,
+                 storeRenames);
         }
       }
 
@@ -1705,7 +1762,8 @@ static void lookup(const char*           name,
       if (symbols.size() == 0) {
         // If we didn't find something in the aggregate type that matched,
         // or we weren't in an aggregate type method, so look at next scope up.
-        lookup(name, context, getScope(scope), visited, symbols);
+        lookup(name, context, getScope(scope), visited, symbols, renameLocs,
+               storeRenames);
       }
     }
   }
@@ -1740,7 +1798,9 @@ static bool      skipUse(std::map<Symbol*, std::vector<UseStmt*> >* seen,
 static bool lookupThisScopeAndUses(const char*           name,
                                    BaseAST*              context,
                                    BaseAST*              scope,
-                                   std::vector<Symbol*>& symbols) {
+                                   std::vector<Symbol*>& symbols,
+                                   std::map<Symbol*, astlocT*>& renameLocs,
+                                   bool storeRenames) {
   if (Symbol* sym = inSymbolTable(name, scope)) {
     if (sym->hasFlag(FLAG_PRIVATE) == true) {
       if (sym->isVisible(context) == true) {
@@ -1801,10 +1861,16 @@ static bool lookupThisScopeAndUses(const char*           name,
                   if (sym->isVisible(context) == true &&
                       isRepeat(sym, symbols)  == false) {
                     symbols.push_back(sym);
+                    if (storeRenames && use->isARename(name)) {
+                      renameLocs[sym] = &use->astloc;
+                    }
                   }
 
                 } else if (isRepeat(sym, symbols) == false) {
                   symbols.push_back(sym);
+                  if (storeRenames && use->isARename(name)) {
+                    renameLocs[sym] = &use->astloc;
+                  }
                 }
               }
             }
@@ -1846,6 +1912,9 @@ static bool lookupThisScopeAndUses(const char*           name,
               if (Symbol* modSym = use->checkIfModuleNameMatches(name)) {
                 if (isRepeat(modSym, symbols) == false) {
                   symbols.push_back(modSym);
+                  if (storeRenames && use->isARename()) {
+                    renameLocs[modSym] = &use->astloc;
+                  }
                 }
               }
             }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -907,6 +907,9 @@ static Expr* handleUnstableClassType(SymExpr* se) {
 
 static astlocT* resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
                                          bool returnRename) {
+  // Avoid duplicate work by not trying to resolve UnresolvedSymExprs that
+  // we've already either removed from the tree or encountered an error when
+  // trying to resolve.
   if (usymExpr->parentExpr == NULL)
     return NULL;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -907,19 +907,6 @@ static Expr* handleUnstableClassType(SymExpr* se) {
 
 static astlocT* resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
                                          bool returnRename) {
-  // Avoid duplicate work by not trying to resolve UnresolvedSymExprs that
-  // we've already either removed from the tree or encountered an error when
-  // trying to resolve.
-  if (usymExpr->parentExpr == NULL)
-    return NULL;
-
-  for_vector(BaseAST, node, failedUSymExprs) {
-    // Should only be expensive in case where we are already erroring out,
-    // and we're already exiting compilation early in that case.
-    if (node == usymExpr)
-      return NULL;
-  }
-
   SET_LINENO(usymExpr);
 
   const char* name = usymExpr->unresolved;
@@ -927,6 +914,15 @@ static astlocT* resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
 
   if (name == astrSdot || !usymExpr->inTree())
     return NULL;
+
+  // Avoid duplicate work by not trying to resolve UnresolvedSymExprs that we've
+  // already encountered an error when trying to resolve.
+  for_vector(BaseAST, node, failedUSymExprs) {
+    // Should only be expensive in case where we are already erroring out,
+    // and we're already exiting compilation early in that case.
+    if (node == usymExpr)
+      return NULL;
+  }
 
   astlocT* renameLoc = NULL;
   Symbol* sym = lookupAndCount(name, usymExpr, nSymbols, returnRename,

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1004,6 +1004,11 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
     if (call == NULL || call->baseExpr != usymExpr) {
       CallExpr* primFn = NULL;
 
+      // Avoid duplicate wrapping with PRIM_CAPTURE_FN_*
+      if (call != NULL && (call->isPrimitive(PRIM_CAPTURE_FN_FOR_C) ||
+                           call->isPrimitive(PRIM_CAPTURE_FN_FOR_CHPL)))
+        return;
+
       // Wrap the FN in the appropriate way
       if (call != NULL && call->isNamed("c_ptrTo") == true) {
         primFn = new CallExpr(PRIM_CAPTURE_FN_FOR_C);

--- a/test/visibility/rename/renameUsedMod/renameModRenameSymBadAccess2.bad
+++ b/test/visibility/rename/renameUsedMod/renameModRenameSymBadAccess2.bad
@@ -1,2 +1,0 @@
-renameModRenameSymBadAccess2.chpl:8: In function 'main':
-renameModRenameSymBadAccess2.chpl:12: error: Symbol 'y' undeclared in module 'Foo'

--- a/test/visibility/rename/renameUsedMod/renameModRenameSymBadAccess2.future
+++ b/test/visibility/rename/renameUsedMod/renameModRenameSymBadAccess2.future
@@ -1,2 +1,0 @@
-error message: no mention of renamed symbol name in error message
-chapel-private #663

--- a/test/visibility/rename/renameUsedMod/renameSameNameConflict.bad
+++ b/test/visibility/rename/renameUsedMod/renameSameNameConflict.bad
@@ -1,2 +1,0 @@
-renameSameNameConflict.chpl:4: error: symbol L is multiply defined
-renameSameNameConflict.chpl:1: note: also defined here

--- a/test/visibility/rename/renameUsedMod/renameSameNameConflict.future
+++ b/test/visibility/rename/renameUsedMod/renameSameNameConflict.future
@@ -1,2 +1,0 @@
-error message: no mention of renamed symbol name in error message
-chapel-private #663

--- a/test/visibility/rename/renameUsedMod/renameSameNameConflict2.bad
+++ b/test/visibility/rename/renameUsedMod/renameSameNameConflict2.bad
@@ -1,2 +1,0 @@
-renameSameNameConflict2.chpl:1: error: symbol L is multiply defined
-renameSameNameConflict2.chpl:4: note: also defined here

--- a/test/visibility/rename/renameUsedMod/renameSameNameConflict2.future
+++ b/test/visibility/rename/renameUsedMod/renameSameNameConflict2.future
@@ -1,2 +1,0 @@
-error message: no mention of renamed symbol name in error message
-chapel-private #663

--- a/test/visibility/rename/renameUsedMod/renameSameNameConflict3.bad
+++ b/test/visibility/rename/renameUsedMod/renameSameNameConflict3.bad
@@ -1,2 +1,0 @@
-renameSameNameConflict3.chpl:1: error: symbol L is multiply defined
-renameSameNameConflict3.chpl:4: note: also defined here

--- a/test/visibility/rename/renameUsedMod/renameSameNameConflict3.future
+++ b/test/visibility/rename/renameUsedMod/renameSameNameConflict3.future
@@ -1,2 +1,0 @@
-error message: no mention of renamed symbol name in error message
-chapel-private #663


### PR DESCRIPTION
Prior to this change, there were two error messages that were less than
ideal:
- when renaming a module to the same name as another module being
used, we would point to the definition of the renamed module as problematic
rather than to the `use` statement that renamed it
- when trying to access a symbol that didn't exist in a renamed module using
explicit naming (e.g. `Bar.x` when Foo was renamed to Bar and Foo didn't
contain an `x`), we would use the original name of the module instead of
what the user wrote.

Both of these error messages now point out the renaming point and the
module definition, while telling the user that the module was renamed.

Details:
--------
What made these error messages tricky was that they were separated
from the original context.  We only had the resulting ModuleSymbol, we
weren't near the rename that had caused us to select that particular
symbol.  In the case of the latter, we had already resolved the
UnresolvedSymExpr that gave us the module and were in the process of
resolving another name.

This change rearranges scope resolution so that the resolution of the
`Bar` and `x` portions of `Bar.x` were in the same context.  It also causes
resolveUnresolvedSymExpr to conditionally calculate where a rename
occurred when resolving and return that rename location.  We only trigger
this calculation for resolveModuleCall (which it what handles `Bar.x`)

Testing:
- [x] full paratest with futures