### PR TITLE
Allow LIBFABRIC_DIR to override pkg-config, when the latter isn't there.

### DIFF
--- a/util/chplenv/chpl_3p_libfabric_configs.py
+++ b/util/chplenv/chpl_3p_libfabric_configs.py
@@ -10,13 +10,13 @@ def get_uniq_cfg_path():
 def get_compile_args(libfabric):
     flags = []
     if libfabric == 'system':
-      # Try using pkg-config to get the compile-time flags.
-      pcflags = third_party_utils.pkgconfig_get_compile_args(
-                       'libfabric', system=True)
-      for pcl in pcflags:
-        flags.append(pcl)
+        # Try using pkg-config to get the compile-time flags.
+        pcflags = third_party_utils.pkgconfig_get_compile_args('libfabric',
+                                                               system=True)
+        for pcl in pcflags:
+            flags.append(pcl)
     elif libfabric == 'libfabric':
-      error("CHPL_LIBFABRIC=libfabric is not yet supported", ValueError)
+        error("CHPL_LIBFABRIC=libfabric is not yet supported", ValueError)
 
     launcher_val = chpl_launcher.get()
     ofi_oob_val = overrides.get_environ('CHPL_RT_COMM_OFI_OOB')
@@ -31,15 +31,15 @@ def get_compile_args(libfabric):
 def get_link_args(libfabric):
     libs = []
     if libfabric == 'system':
-      # Try using pkg-config to get the libraries to link
-      # libfabric with.
-      pclibs = third_party_utils.pkgconfig_get_link_args(
-                       'libfabric', system=True)
-      for pcl in pclibs:
-        libs.append(pcl)
-        if pcl.startswith('-L'):
-          libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
+        # Try using pkg-config to get the libraries to link
+        # libfabric with.
+        pclibs = third_party_utils.pkgconfig_get_link_args('libfabric',
+                                                           system=True)
+        for pcl in pclibs:
+            libs.append(pcl)
+            if pcl.startswith('-L'):
+                libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
     elif libfabric == 'libfabric':
-      error("CHPL_LIBFABRIC=libfabric is not yet supported", ValueError)
+        error("CHPL_LIBFABRIC=libfabric is not yet supported", ValueError)
 
     return libs

--- a/util/chplenv/chpl_3p_libfabric_configs.py
+++ b/util/chplenv/chpl_3p_libfabric_configs.py
@@ -10,11 +10,17 @@ def get_uniq_cfg_path():
 def get_compile_args(libfabric):
     flags = []
     if libfabric == 'system':
-        # Try using pkg-config to get the compile-time flags.
-        pcflags = third_party_utils.pkgconfig_get_compile_args('libfabric',
-                                                               system=True)
-        for pcl in pcflags:
-            flags.append(pcl)
+        # Allow overriding pkg-config via LIBFABRIC_DIR, for platforms
+        # without pkg-config.
+        libfab_dir_val = overrides.get('LIBFABRIC_DIR')
+        if libfab_dir_val:
+            flags.append('-I' + libfab_dir_val + '/include')
+        else:
+            # Try using pkg-config to get the compile-time flags.
+            pcflags = third_party_utils.pkgconfig_get_compile_args('libfabric',
+                                                                   system=True)
+            for pcl in pcflags:
+                flags.append(pcl)
     elif libfabric == 'libfabric':
         error("CHPL_LIBFABRIC=libfabric is not yet supported", ValueError)
 
@@ -31,14 +37,22 @@ def get_compile_args(libfabric):
 def get_link_args(libfabric):
     libs = []
     if libfabric == 'system':
-        # Try using pkg-config to get the libraries to link
-        # libfabric with.
-        pclibs = third_party_utils.pkgconfig_get_link_args('libfabric',
-                                                           system=True)
-        for pcl in pclibs:
-            libs.append(pcl)
-            if pcl.startswith('-L'):
-                libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
+        # Allow overriding pkg-config via LIBFABRIC_DIR, for platforms
+        # without pkg-config.
+        libfab_dir_val = overrides.get('LIBFABRIC_DIR')
+        if libfab_dir_val:
+            libs.extend(['-L' + libfab_dir_val + '/lib',
+                         '-Wl,-rpath,' + libfab_dir_val + '/lib',
+                         '-lfabric'])
+        else:
+            # Try using pkg-config to get the libraries to link
+            # libfabric with.
+            pclibs = third_party_utils.pkgconfig_get_link_args('libfabric',
+                                                               system=True)
+            for pcl in pclibs:
+                libs.append(pcl)
+                if pcl.startswith('-L'):
+                    libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
     elif libfabric == 'libfabric':
         error("CHPL_LIBFABRIC=libfabric is not yet supported", ValueError)
 


### PR DESCRIPTION
Some platforms don't have `pkg-config`.  For such cases, allow overriding
the need for that by means of a `LIBFABRIC_DIR` environment variable.

(A better solution would be to check `pkg-config` availability first, and
only look at `LIBFABRIC_DIR` as a fallback if that isn't there.  But doing
that looked like more of a divergence than I wanted to subject myself to
right now.)

While here, I also fixed some indentation.