### PR TITLE
Update a call to regexp.compile in mason

### DIFF
--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -99,7 +99,7 @@ proc pkgSearch(args) throws {
   if pkgName == "" {
     throw new owned MasonError("Must include a package name");
   }
-  const pattern = compile(pkgName, ignorecase=true);
+  const pattern = compile(pkgName, ignoreCase=true);
   const command = "pkg-config --list-all";
   const cmd = command.split();
   var sub = spawn(cmd, stdout=PIPE);


### PR DESCRIPTION
Fixes an argument name that was causing deprecation warnings due to #14686

Test:
`make -C tools/mason` does not produce the warning with this PR. 