### PR TITLE
Add a gasnet-smp docker image

### DIFF
--- a/util/dockerfiles/gasnet-smp/Dockerfile
+++ b/util/dockerfiles/gasnet-smp/Dockerfile
@@ -1,12 +1,9 @@
 FROM chapel/chapel:latest
 
 ENV CHPL_COMM gasnet
-ENV CHPL_GASNET_SUBSTRATE fast
+ENV CHPL_COMM_SUBSTRATE smp
+ENV CHPL_RT_OVERSUBSCRIBED yes
 
 RUN make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall
-
-ENV QT_AFFINITY no
-ENV QT_SPINCOUNT 300
-ENV GASNET_SPAWNFN L


### PR DESCRIPTION
Replace the gasnet-experimental image with gasnet-smp. They are similar,
but the smp one uses newer features for oversubscription as well as the
smp substrate (which defaults to segment fast) instead of udp with a
manually set segment fast and local spawning.

The motivation for this is the same as #12903. We want docker images to
do CI testing for Chapel projects, but gasnet udp defaults to segment
everything. udp-everything has more overhead for local testing because
comm will go through the sockets API instead of being short-circuited
with shared memory. This isn't a problem for true multi-locale testing,
but it does impact local oversubscribed testing.