### PR TITLE
Skip do_smu_soa under valgrind because it runs too long.

### DIFF
--- a/test/users/npadmana/twopt/do_smu_soa.skipif
+++ b/test/users/npadmana/twopt/do_smu_soa.skipif
@@ -1,0 +1,2 @@
+# This test runs too long under valgrind.
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
The do_smu_soa test has timed out 3 nights in a row in valgrind
testing.  For now skip it, pending hearing back from the test owner
whether it would be practical to reduce the problem size.