### PR TITLE
Adjust isDefAndOrUse to return 0 for PRIM_END_OF_STATEMENT

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -505,6 +505,8 @@ int isDefAndOrUse(SymExpr* se) {
       } else {
         return USE; // ? = se;
       }
+    } else if (call->isPrimitive(PRIM_END_OF_STATEMENT)) {
+      return 0; // neither def nor use
     } else if (isOpEqualPrim(call) && isFirstActual) {
       // Both a def and a use:
       // se   =   se <op> ?


### PR DESCRIPTION
This is a follow-on to PR #14691 which introduced `PRIM_END_OF_STATEMENT`.

`PRIM_END_OF_STATEMENT` has weak links to Symbols and isn't intended to
prevent their removal. Therefore isDefAndOrUse should not consider
SymExprs in `PRIM_END_OF_STATEMENT` calls as defs or uses.

This adjustment allows symbols only used in `PRIM_END_OF_STATEMENT` to be
removed in removeUnusedModuleVariables if they are otherwise unused and
as a result resolves warnings like

```
warning: Could not find extern def of type CBLAS_ORDER
```

for the LinearAlgebralib.chpl primer (and other tests) compiled with --llvm.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing
- [x] full local --llvm testing