### PR TITLE
Update spec w.r.t default record comparisons

### DIFF
--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -508,8 +508,8 @@ The following example demonstrates record assignment.
 Default Comparison Operators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Default functions to overload ``==`` and ``!=`` are defined for
-records if none are explicitly defined. These functions have the
+Default functions to overload comparison operators are defined for
+records if none are explicitly defined. ``==`` and ``!=`` functions have the
 following signatures for a record ``R``:
 
 
@@ -519,8 +519,13 @@ following signatures for a record ``R``:
    proc ==(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
    proc !=(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
 
-Each of these compare the fields, one at a time, returning ``false`` if
-the property is not satisfied by the given pair of fields.
+Other comparison operator overloads, namely ``<``, ``<=``, ``>``, and ``>=`` have
+similar signatures but their where clauses also check whether the relevant
+operator is supported by each field.
+
+All except ``!=`` compare the fields, one at a time, returning ``false`` if
+the property is not satisfied by the given pair of fields. Whereas ``!=`` returns
+``true`` if the property is satisfied by any field.
 
 .. _Class_and_Record_Differences:
 

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -519,13 +519,14 @@ following signatures for a record ``R``:
    proc ==(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
    proc !=(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
 
-Other comparison operator overloads, namely ``<``, ``<=``, ``>``, and ``>=`` have
-similar signatures but their where clauses also check whether the relevant
+Other comparison operator overloads (namely ``<``, ``<=``, ``>``, and ``>=``)
+have similar signatures but their where clauses also check whether the relevant
 operator is supported by each field.
 
-All except ``!=`` compare the fields, one at a time, returning ``false`` if
-the property is not satisfied by the given pair of fields. Whereas ``!=`` returns
-``true`` if the property is satisfied by any field.
+All of these comparison operators except ``!=`` compare the fields, one at a
+time, returning ``false`` if the property is not satisfied by the given pair of
+fields. Whereas ``!=`` returns ``true`` if the property is satisfied by any
+field.
 
 .. _Class_and_Record_Differences:
 


### PR DESCRIPTION
Adds new default comparison operators to the spec.

Fixes the sentence:

> Each of these compare the fields, one at a time, returning false if the property is not satisfied by the given pair of fields.

Which was not true for `!=`. It returns true if the property is satisfied for any field.

Test:
- [x] `make docs` builds specs successfully
