### PR TITLE
Address testing failures after deinit points change

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1135,6 +1135,7 @@ bool isClassLikeOrPtr(Type* t) {
   return isClassLike(t) || (t->symbol->hasFlag(FLAG_C_PTR_CLASS) ||
                             t->symbol->hasFlag(FLAG_DATA_CLASS) ||
                             t == dtCVoidPtr ||
+                            t == dtStringC ||
                             t == dtCFnPtr);
 }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1304,6 +1304,7 @@ bool canCoerceAsSubtype(Type*     actualType,
                         bool*     paramNarrows) {
 
   if (actualType == dtNil && isClassLikeOrPtr(formalType) &&
+      formalType != dtStringC &&
       (!isNonNilableClassType(formalType) || useLegacyNilability(actualSym)))
     return true;
 

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -2999,6 +2999,9 @@ static bool typeCanAlias(Type* t) {
   if (isClassLikeOrPtr(t) || isManagedPtrType(t))
     return true; // classes, ptrs of any flavor can alias other things
 
+  else if (t->symbol->hasFlag(FLAG_ITERATOR_RECORD))
+    return true; // iterator records generally contain aliases of arguments
+
   else if (AggregateType* at = toAggregateType(t)) {
     // Does it contain any pointer fields, recursively?
     if (isRecord(at)) {
@@ -3299,6 +3302,7 @@ bool MarkCapturesVisitor::enterDefExpr(DefExpr* def) {
 }
 
 // user variables "capture" aliases, so do runtime type variables
+// (TODO: Should this include iterator records as well?)
 static bool isCapturingVariable(Symbol* var) {
   return !var->hasFlag(FLAG_TEMP) ||
          var->type->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE);

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -3462,8 +3462,12 @@ static void printExpiringForVar(Symbol* sym, FnSymbol* fn, bool& printedAny,
                   fn->name, fn->fname(), fn->linenum());
         }
 
-        fprintf(stdout, "  %s (%s:%i) expires %s\n",
-                name, def->fname(), def->linenum(), state);
+        if (developer)
+          fprintf(stdout, "  %s (%s:%i) [%i] expires %s\n",
+                  name, def->fname(), def->linenum(), sym->id, state);
+        else
+          fprintf(stdout, "  %s (%s:%i) expires %s\n",
+                  name, def->fname(), def->linenum(), state);
       }
     }
   }
@@ -3485,8 +3489,12 @@ bool ReportExpiringVisitor::enterDefExpr(DefExpr* def) {
         if (shouldPrintExpiringForVar(sym) &&
             printed.count(sym) == 0 &&
             (developer || !sym->hasFlag(FLAG_TEMP))) {
-          fprintf(stdout, "    alias %s (%s:%i)\n",
-                  sym->name, def->fname(), def->linenum());
+          if (developer)
+            fprintf(stdout, "    alias %s (%s:%i) [%i]\n",
+                    sym->name, def->fname(), def->linenum(), sym->id);
+          else
+            fprintf(stdout, "    alias %s (%s:%i)\n",
+                    sym->name, def->fname(), def->linenum());
           printed.insert(sym);
         }
       }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -637,7 +637,15 @@ proc file.realPath(out error: syserr): string {
 /* Compute the common prefix length between two lists of path components. */
 private
 proc commonPrefixLength(const a1: [] string, const a2: [] string): int {
-  const ref (a, b) = if a1.size < a2.size then (a1, a2) else (a2, a1);
+  const ref a;
+  const ref b;
+  if a1.size < a2.size {
+    a = a1;
+    b = a2;
+  } else {
+    a = a2;
+    b = a1;
+  }
   var result = 0;
 
   for i in 1..a.size do

--- a/test/types/records/expiring/bug-based-on-sudoku2.chpl
+++ b/test/types/records/expiring/bug-based-on-sudoku2.chpl
@@ -1,0 +1,45 @@
+config var print = true;
+
+class C { }
+record R {
+  var x: int = 0;
+  var ptr: shared C = new shared C();
+  proc init() {
+    this.x = 0;
+    if print then writeln("init (default)");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    if print then writeln("init ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    if print then writeln("init= ", other.x);
+  }
+  proc deinit() {
+    if print then writeln("deinit ", x);
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  if print then writeln("= ", lhs.x, " ", rhs.x);
+  lhs.x = rhs.x;
+}
+
+proc val(arg: R) {
+  return arg.x;
+}
+
+iter iterateAllOf(tuple...?k) {
+  for param i in 1..k {
+    for j in tuple(i) {
+      yield j;
+    }
+  }
+}
+
+proc main() {
+  var A:[1..2, 1..2] R = for (i,j) in {1..2, 1..2} do new R(10*i + j);
+  if 121 == + reduce val(iterateAllOf(A, A[1..2, 1..1], A[1, ..])) {
+    writeln("OK");
+  }
+}

--- a/test/types/records/expiring/bug-based-on-sudoku2.compopts
+++ b/test/types/records/expiring/bug-based-on-sudoku2.compopts
@@ -1,0 +1,1 @@
+--no-report-expiring

--- a/test/types/records/expiring/bug-based-on-sudoku2.good
+++ b/test/types/records/expiring/bug-based-on-sudoku2.good
@@ -1,0 +1,37 @@
+init (default)
+init (default)
+init (default)
+init (default)
+init 11
+= 0 11
+deinit 11
+init 12
+= 0 12
+deinit 12
+init 21
+= 0 21
+deinit 21
+init 22
+= 0 22
+deinit 22
+init= 11
+deinit 11
+init= 12
+deinit 12
+init= 21
+deinit 21
+init= 22
+deinit 22
+init= 11
+deinit 11
+init= 21
+deinit 21
+init= 11
+deinit 11
+init= 12
+deinit 12
+OK
+deinit 11
+deinit 12
+deinit 21
+deinit 22

--- a/test/types/tuple/ferguson/const-ref-tuple-decl.chpl
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.chpl
@@ -1,0 +1,61 @@
+config const cond = false;
+config const otherCond = true;
+var print = true;
+
+class C { }
+record R {
+  var x: int = 0;
+  var ptr: shared C = new shared C();
+  proc init() {
+    this.x = 0;
+    if print then writeln("init (default)");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    if print then writeln("init ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    if print then writeln("init= ", other.x);
+  }
+  proc deinit() {
+    if print then writeln("deinit ", x);
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  if print then writeln("= ", lhs.x, " ", rhs.x);
+  lhs.x = rhs.x;
+}
+
+proc val(arg: R) {
+  return arg.x;
+}
+
+proc commonPrefixLength(const a1: [] R, const a2: [] R) {
+  writeln("in commonPrefixLength");
+  const ref (a, b) = if a1.size < a2.size then (a1, a2) else (a2, a1);
+  /* this alternative functions correctly:
+  const ref a;
+  const ref b;
+  if a1.size < a2.size {
+    a = a1;
+    b = a2;
+  } else {
+    a = a2;
+    b = a1;
+  }*/
+
+  for x in a {
+    writeln(x);
+  }
+
+  writeln("end commonPrefixLength");
+}
+
+
+proc main() {
+  var A:[1..2] R = for i in 1..2 do new R(i);
+  var B:[1..3] R = for i in 1..3 do new R(10*i);
+
+  commonPrefixLength(A, B);
+}

--- a/test/types/tuple/ferguson/const-ref-tuple-decl.future
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.future
@@ -1,0 +1,2 @@
+bug: problem with const ref tuple declaration
+#14778

--- a/test/types/tuple/ferguson/const-ref-tuple-decl.good
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.good
@@ -1,0 +1,29 @@
+init (default)
+init (default)
+init 1
+= 0 1
+deinit 1
+init 2
+= 0 2
+deinit 2
+init (default)
+init (default)
+init (default)
+init 10
+= 0 10
+deinit 10
+init 20
+= 0 20
+deinit 20
+init 30
+= 0 30
+deinit 30
+in commonPrefixLength
+(x = 1, ptr = {})
+(x = 2, ptr = {})
+end commonPrefixLength
+deinit 10
+deinit 20
+deinit 30
+deinit 1
+deinit 2


### PR DESCRIPTION
This PR makes several changes as follow-up to testing failures after PR #14691 .

* Consider `c_string` as a kind of pointer in `isClassLikeOrPtr` which
  matters for `typeCanAlias` in the expiring value analysis
* Add a workaround for issues with iterator records demonstrated in the
  test test/types/records/expiring/bug-based-on-sudoku2.chpl . The
  workaround makes the expiring value analysis consider an iterator
  record to potentially contain aliases. This addresses the issue of the
  array A in that program being de-initialized too early because the
  current ForallStmt happens to use a dummy record to store the result of
  the iterated expression call. The preferred approach would be to adjust
  the compiler to consider the entire if-statement in the example,
  including the reduction, to consist of one statement for the purposes
  of deinit points. That might be achieved by adding a nested BlockStmt
  around the reduction, for example.
* Improve --report-expiring to include AST ids for developers
* Apply a workaround to Path.commonPrefixLength to avoid issue #14778
  (and create a future for it)

Reviewed by @vasslitvinov - thanks!

- [x] full local testing