### PR TITLE
Implement bytes->enum cast

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1603,6 +1603,20 @@ VarSymbol *new_BytesSymbol(const char *str) {
   return s;
 }
 
+// Just a convenience function
+VarSymbol *new_StringOrBytesSymbol(const char *str, AggregateType *t) {
+  if (t == dtString) {
+    return new_StringSymbol(str);
+  }
+  else if (t == dtBytes) {
+    return new_BytesSymbol(str);
+  }
+  else {
+    INT_FATAL("new_StringOrBytesSymbol accepts dtString and dtBytes only");
+    return NULL;
+  }
+}
+
 VarSymbol *new_CStringSymbol(const char *str) {
   Immediate imm;
   imm.const_kind = CONST_KIND_STRING;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -614,6 +614,9 @@ VarSymbol *new_StringSymbol(const char *s);
 //
 // Creates a new bytes literal with the given value.
 VarSymbol *new_BytesSymbol(const char *s);
+//
+// Creates a new string or bytes literal with the given value.
+VarSymbol *new_StringOrBytesSymbol(const char *s, AggregateType *at);
 
 // Creates a new C string literal with the given value.
 VarSymbol *new_CStringSymbol(const char *s);

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1092,55 +1092,6 @@ static void buildEnumCastFunction(EnumType* et) {
   }
 
   {
-    // string to enumerated type cast function
-    fn = new FnSymbol(astr_cast);
-    fn->addFlag(FLAG_COMPILER_GENERATED);
-    fn->addFlag(FLAG_LAST_RESORT);
-    arg1 = new ArgSymbol(INTENT_BLANK, "t", et);
-    arg1->addFlag(FLAG_TYPE_VARIABLE);
-    arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", dtString);
-    fn->insertFormalAtTail(arg1);
-    fn->insertFormalAtTail(arg2);
-
-    CondStmt* cond = NULL;
-    for_enums(constant, et) {
-      cond = new CondStmt(
-               new CallExpr("==", arg2, new_StringSymbol(constant->sym->name)),
-               new CallExpr(PRIM_RETURN, constant->sym),
-               cond);
-      cond = new CondStmt(
-               new CallExpr("==", arg2,
-                            new_StringSymbol(
-                              astr(et->symbol->name, ".", constant->sym->name))),
-               new CallExpr(PRIM_RETURN, constant->sym),
-               cond);
-    }
-
-    fn->insertAtTail(cond);
-
-    fn->throwsErrorInit();
-    fn->insertAtTail(new TryStmt(
-                       false,
-                       new BlockStmt(
-                         new CallExpr("chpl_enum_cast_error",
-                                      arg2,
-                                      new_StringSymbol(et->symbol->name))),
-                       NULL));
-    fn->addFlag(FLAG_INSERT_LINE_FILE_INFO);
-    fn->addFlag(FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO);
-
-    fn->insertAtTail(new CallExpr(PRIM_RETURN,
-                                  toDefExpr(et->constants.first())->sym));
-
-    def = new DefExpr(fn);
-    //
-    // these cast functions need to go in the base module because they
-    // are automatically inserted to handle implicit coercions
-    //
-    baseModule->block->insertAtTail(def);
-    reset_ast_loc(def, et->symbol);
-    normalize(fn);
-    fn->tagIfGeneric();
   }
 
   {
@@ -1728,6 +1679,56 @@ static void buildStringCastFunction(EnumType* et) {
   fn->insertAtTail(new CallExpr(PRIM_RETURN, new_StringSymbol("")));
 
   DefExpr* def = new DefExpr(fn);
+  //
+  // these cast functions need to go in the base module because they
+  // are automatically inserted to handle implicit coercions
+  //
+  baseModule->block->insertAtTail(def);
+  reset_ast_loc(def, et->symbol);
+  normalize(fn);
+  fn->tagIfGeneric();
+
+  // string to enumerated type cast function
+  fn = new FnSymbol(astr_cast);
+  fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
+  arg1 = new ArgSymbol(INTENT_BLANK, "t", et);
+  arg1->addFlag(FLAG_TYPE_VARIABLE);
+  arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", dtString);
+  fn->insertFormalAtTail(arg1);
+  fn->insertFormalAtTail(arg2);
+
+  CondStmt* cond = NULL;
+  for_enums(constant, et) {
+    cond = new CondStmt(
+             new CallExpr("==", arg2, new_StringSymbol(constant->sym->name)),
+             new CallExpr(PRIM_RETURN, constant->sym),
+             cond);
+    cond = new CondStmt(
+             new CallExpr("==", arg2,
+                          new_StringSymbol(
+                            astr(et->symbol->name, ".", constant->sym->name))),
+             new CallExpr(PRIM_RETURN, constant->sym),
+             cond);
+  }
+
+  fn->insertAtTail(cond);
+
+  fn->throwsErrorInit();
+  fn->insertAtTail(new TryStmt(
+                     false,
+                     new BlockStmt(
+                       new CallExpr("chpl_enum_cast_error",
+                                    arg2,
+                                    new_StringSymbol(et->symbol->name))),
+                     NULL));
+  fn->addFlag(FLAG_INSERT_LINE_FILE_INFO);
+  fn->addFlag(FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO);
+
+  fn->insertAtTail(new CallExpr(PRIM_RETURN,
+                                toDefExpr(et->constants.first())->sym));
+
+  def = new DefExpr(fn);
   //
   // these cast functions need to go in the base module because they
   // are automatically inserted to handle implicit coercions

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -44,11 +44,13 @@ static void buildDefaultOfFunction(AggregateType* ct);
 
 static void buildUnionAssignmentFunction(AggregateType* ct);
 
-static void buildEnumCastFunction(EnumType* et);
+static void buildEnumIntegerCastFunctions(EnumType* et);
 static void buildEnumFirstFunction(EnumType* et);
 static void buildEnumEnumerateFunction(EnumType* et);
 static void buildEnumSizeFunction(EnumType* et);
 static void buildEnumOrderFunctions(EnumType* et);
+static void buildEnumStringOrBytesCastFunctions(EnumType* type,
+                                                AggregateType* otherType);
 
 static void buildExternAssignmentFunction(Type* type);
 
@@ -59,8 +61,6 @@ static FnSymbol* buildRecordIsComparableFunc(AggregateType* ct, const char* op);
 static void buildRecordComparisonFunc(AggregateType* ct, const char* op);
 
 static void buildDefaultReadWriteFunctions(AggregateType* type);
-
-static void buildStringCastFunction(EnumType* type, AggregateType* otherType);
 
 static void buildFieldAccessorFunctions(AggregateType* at);
 
@@ -856,10 +856,10 @@ static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
 // It is necessary to have this separated out, because such functions are not
 // automatically created when the EnumType is copied.
 void buildEnumFunctions(EnumType* et) {
-  buildStringCastFunction(et, dtBytes);
-  buildStringCastFunction(et, dtString);
+  buildEnumStringOrBytesCastFunctions(et, dtBytes);
+  buildEnumStringOrBytesCastFunctions(et, dtString);
 
-  buildEnumCastFunction(et);
+  buildEnumIntegerCastFunctions(et);
   buildEnumEnumerateFunction(et);
   buildEnumFirstFunction(et);
   buildEnumSizeFunction(et);
@@ -964,7 +964,7 @@ static void buildEnumEnumerateFunction(EnumType* et) {
   fn->tagIfGeneric();
 }
 
-static void buildEnumCastFunction(EnumType* et) {
+static void buildEnumIntegerCastFunctions(EnumType* et) {
   bool initsExist = !et->isAbstract();
 
   FnSymbol* fn;
@@ -1090,62 +1090,6 @@ static void buildEnumCastFunction(EnumType* et) {
     reset_ast_loc(def, et->symbol);
     normalize(fn);
     fn->tagIfGeneric();
-  }
-
-  {
-  }
-
-  {
-    ////
-    //// bytes to enumerated type cast function
-    //fn = new FnSymbol(astr_cast);
-    //fn->addFlag(FLAG_COMPILER_GENERATED);
-    //fn->addFlag(FLAG_LAST_RESORT);
-    //arg1 = new ArgSymbol(INTENT_BLANK, "t", et);
-    //arg1->addFlag(FLAG_TYPE_VARIABLE);
-    //arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", dtBytes);
-    //fn->insertFormalAtTail(arg1);
-    //fn->insertFormalAtTail(arg2);
-
-    //CondStmt* cond = NULL;
-    //for_enums(constant, et) {
-      //cond = new CondStmt(
-               //new CallExpr("==", arg2, new_BytesSymbol(constant->sym->name)),
-               //new CallExpr(PRIM_RETURN, constant->sym),
-               //cond);
-      //cond = new CondStmt(
-               //new CallExpr("==", arg2,
-                            //new_BytesSymbol(
-                              //astr(et->symbol->name, ".", constant->sym->name))),
-               //new CallExpr(PRIM_RETURN, constant->sym),
-               //cond);
-    //}
-
-    //fn->insertAtTail(cond);
-
-    //fn->throwsErrorInit();
-    //fn->insertAtTail(new TryStmt(
-                       //false,
-                       //new BlockStmt(
-                         //new CallExpr("chpl_enum_cast_error",
-                                      //arg2,
-                                      //new_StringSymbol(et->symbol->name))),
-                       //NULL));
-    //fn->addFlag(FLAG_INSERT_LINE_FILE_INFO);
-    //fn->addFlag(FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO);
-
-    //fn->insertAtTail(new CallExpr(PRIM_RETURN,
-                                  //toDefExpr(et->constants.first())->sym));
-
-    //def = new DefExpr(fn);
-    ////
-    //// these cast functions need to go in the base module because they
-    //// are automatically inserted to handle implicit coercions
-    ////
-    //baseModule->block->insertAtTail(def);
-    //reset_ast_loc(def, et->symbol);
-    //normalize(fn);
-    //fn->tagIfGeneric();
   }
 }
 
@@ -1657,10 +1601,10 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
 }
 
 
-static void buildStringCastFunction(EnumType* et, AggregateType *otherType) {
+static void buildEnumStringOrBytesCastFunctions(EnumType* et,
+                                                AggregateType *otherType) {
   if (otherType != dtString && otherType != dtBytes) {
-    // TODO
-    INT_FATAL("");
+    INT_FATAL("wrong type was passed to buildEnumStringOrBytesCastFunctions");
   }
   if (functionExists(astr_cast, otherType, et))
     return;

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -335,8 +335,8 @@ module BytesCasts {
   // enum 
   // not sure if this is quite necessary, but adding it just to make bytes as
   // similar to string as possible
-  proc _cast(type t:bytes, x: enumerated) {
-    return x:string:bytes;
-  }
+  /*proc _cast(type t:bytes, x: enumerated) {*/
+    /*return x:string:bytes;*/
+  /*}*/
 
 } // end of module BytesCasts

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -329,14 +329,4 @@ module BytesCasts {
 
     return retVal;
   }
-
-
-  //
-  // enum 
-  // not sure if this is quite necessary, but adding it just to make bytes as
-  // similar to string as possible
-  /*proc _cast(type t:bytes, x: enumerated) {*/
-    /*return x:string:bytes;*/
-  /*}*/
-
 } // end of module BytesCasts

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -503,4 +503,18 @@ module ChapelError {
     else
       throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to " + enumName);
   }
+
+  // The compiler generates functions to cast from bytes to enums. This
+  // function helps the compiler throw errors from those generated casts.
+  pragma "no doc"
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_enum_cast_error(casted: bytes, enumName: string) throws {
+    if casted.isEmpty() then
+      throw new owned IllegalArgumentError("bad cast from empty bytes to " + enumName);
+    else
+      throw new owned IllegalArgumentError("bad cast from bytes '" +
+                                           casted.decode(decodePolicy.replace) +
+                                           "' to " + enumName);
+  }
 }

--- a/test/types/bytes/casts.chpl
+++ b/test/types/bytes/casts.chpl
@@ -73,6 +73,11 @@
   print(E.Foo:bytes);
   print(E.Bar:bytes);
 
+  print((b"Foo"):E);
+  print((b"Bar"):E);
+  print((b"E.Foo"):E);
+  print((b"E.Bar"):E);
+
 }
 
 proc print(val) {

--- a/test/types/bytes/casts.good
+++ b/test/types/bytes/casts.good
@@ -19,3 +19,7 @@ Value = 3.0 + 2.0i Type = complex(128)
 Value = some string Type = bytes
 Value = Foo Type = bytes
 Value = Bar Type = bytes
+Value = Foo Type = E
+Value = Bar Type = E
+Value = Foo Type = E
+Value = Bar Type = E


### PR DESCRIPTION
This PR implements bytes->enum cast.

Previously, enum->bytes casts were implemented in a "hacky" way. This PR also
implements that cast via the compiler.

There is also a slight refactor in the enum-related functions in
`buildDefaultFunctions`

Summary of changes:
- `enum<->string/bytes` casts are now handled in
  `buildEnumStringOrBytesCastFunctions`

- `buildEnumCastFunction` was a mixed one that handled `int<->enum` casts *and*
  `string->enum` (one-way) casts. Now it is refactored into
  `buildEnumIntegerCastFunctions` and limited to only integer casts.

- In order to keep "generic" operations with string/bytes in compiler clean,
  this also adds `new_StringOrBytesSymbol` that has an argument to control which
  of these symbols to generate.

- A `bytes` cast test is updated.

Test:
- [x] standard local
- [x] gasnet
