### PR TITLE
Add #include to use NULL as the default value in a function declaration

### DIFF
--- a/compiler/include/scopeResolve.h
+++ b/compiler/include/scopeResolve.h
@@ -27,6 +27,7 @@ class DefExpr;
 class FnSymbol;
 class Symbol;
 
+#include <cstddef>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
This was causing a compilation failure with gcc 4.9

Verified that the compiler built and ran hello.chpl successfully with gcc 4.9,
and a full paratest with futures.