### PR TITLE
Fix no-extra-lineno test under --baseline

### DIFF
--- a/test/functions/ferguson/lineno/no-extra-lineno.prediff
+++ b/test/functions/ferguson/lineno/no-extra-lineno.prediff
@@ -2,6 +2,6 @@
 
 # Find calls to gcd function (not definition) and then simplify to see
 # number of arguments
-grep gcd genCode/no-extra-lineno.c | grep -v static | sed 's/[a-zA-Z_][0-9a-zA-Z_]*/x/g' | sed 's/ //g' >> $2
+grep gcd genCode/no-extra-lineno.c | grep -v static | grep '(' | sed 's/[a-zA-Z_][0-9a-zA-Z_]*/x/g' | sed 's/ //g' >> $2
 
 rm -rf genCode


### PR DESCRIPTION
This test was added in ##10295 and the prediff is intended to only find
calls to `gcd` or `mygcd`.  It was finding an `_end_mygcd_chpl:` label in
`--baseline` compilations after recent changes. Therefore, this PR
adjusts the prediff to only find calls by grepping for `(`.

Trivial and not reviewed.