### PR TITLE
Remove a prediff, update a good file

### DIFF
--- a/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.good
+++ b/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.good
@@ -1,1 +1,1 @@
-sparseBulkBoundsCheck.chpl:19: error: halt reached 
+sparseBulkBoundsCheck.chpl:19: error: halt reached - Sparse domain/array index out of bounds: (8, 8) (expected to be within {0..7, 0..7})

--- a/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.prediff
+++ b/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.prediff
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-out=$2
-cut -d"-" -f1 $2  > $out.tmp
-mv $out.tmp $out

--- a/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.good
+++ b/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.good
@@ -1,1 +1,1 @@
-sparseBulkBoundsCheck.chpl:20: error: halt reached 
+sparseBulkBoundsCheck.chpl:20: error: halt reached - Sparse domain/array index out of bounds: (8, 8) (expected to be within {0..7, 0..7})

--- a/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.prediff
+++ b/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.prediff
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-out=$2
-cut -d"-" -f1 $2  > $out.tmp
-mv $out.tmp $out


### PR DESCRIPTION
This PR removes the `prediff` of `test/users/engin/sparse_bulk[_dist]/sparseBulkBoundsCheck` and adjusts their `good` file.

These tests are suppressed with `--fast` and started to give false positives because the prediff was cutting the important parts of the error message.