### PR TITLE
Fix record comparisons to have lexicographical order

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -884,7 +884,7 @@ static void buildRecordNotEqualsBody(AggregateType *ct, FnSymbol *fn,
   // either it is an empty record, and we didn't add any meaningful comparisons,
   // or we added those comparisons but they never returned
 
-  // for !=, in either case we return fales
+  // for !=, in either case we return false
   fn->insertAtTail(new CallExpr(PRIM_RETURN, gFalse));
 }
 
@@ -895,26 +895,24 @@ static void buildRecordLessThanBody(AggregateType *ct, FnSymbol *fn,
   for_fields(tmp, ct) {
     if (!tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD) &&
         !tmp->hasFlag(FLAG_TYPE_VARIABLE)) {  // types fields must be equal
-      {
-        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
-        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
-        CallExpr *elemCompTrue = new CallExpr("<", left, right);
+
+        CallExpr *elemCompTrue = new CallExpr("<",
+                                   new CallExpr(tmp->name, gMethodToken, arg1),
+                                   new CallExpr(tmp->name, gMethodToken, arg2));
         fn->insertAtTail(new CondStmt(elemCompTrue,
                                       new CallExpr(PRIM_RETURN, gTrue)));
-      }
-      {
-        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
-        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
-        CallExpr *elemCompFalse = new CallExpr(">", left, right);
+
+        CallExpr *elemCompFalse = new CallExpr(">",
+                                   new CallExpr(tmp->name, gMethodToken, arg1),
+                                   new CallExpr(tmp->name, gMethodToken, arg2));
+
         fn->insertAtTail(new CondStmt(elemCompFalse,
                                       new CallExpr(PRIM_RETURN, gFalse)));
-      }
     }
   }
+
   // either it is an empty record, and we didn't add any meaningful comparisons,
   // or we added those comparisons but they never returned
-
-  // for <, in either case we return false
   if (allowEquals) {
     fn->insertAtTail(new CallExpr(PRIM_RETURN, gTrue));
   }
@@ -930,26 +928,24 @@ static void buildRecordGreaterThanBody(AggregateType *ct, FnSymbol *fn,
   for_fields(tmp, ct) {
     if (!tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD) &&
         !tmp->hasFlag(FLAG_TYPE_VARIABLE)) {  // types fields must be equal
-      {
-        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
-        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
-        CallExpr *elemCompTrue = new CallExpr(">", left, right);
+
+        CallExpr *elemCompTrue = new CallExpr(">",
+                                   new CallExpr(tmp->name, gMethodToken, arg1),
+                                   new CallExpr(tmp->name, gMethodToken, arg2));
         fn->insertAtTail(new CondStmt(elemCompTrue,
                                       new CallExpr(PRIM_RETURN, gTrue)));
-      }
-      {
-        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
-        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
-        CallExpr *elemCompFalse = new CallExpr("<", left, right);
+
+        CallExpr *elemCompFalse = new CallExpr("<",
+                                   new CallExpr(tmp->name, gMethodToken, arg1),
+                                   new CallExpr(tmp->name, gMethodToken, arg2));
+
         fn->insertAtTail(new CondStmt(elemCompFalse,
                                       new CallExpr(PRIM_RETURN, gFalse)));
-      }
     }
   }
+
   // either it is an empty record, and we didn't add any meaningful comparisons,
   // or we added those comparisons but they never returned
-
-  // for <, in either case we return false
   if (allowEquals) {
     fn->insertAtTail(new CallExpr(PRIM_RETURN, gTrue));
   }

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -57,8 +57,19 @@ static void buildExternAssignmentFunction(Type* type);
 static void buildRecordAssignmentFunction(AggregateType* ct);
 static void checkNotPod(AggregateType* ct);
 static void buildRecordHashFunction(AggregateType* ct);
+
 static FnSymbol* buildRecordIsComparableFunc(AggregateType* ct, const char* op);
 static void buildRecordComparisonFunc(AggregateType* ct, const char* op);
+static void buildRecordEqualsBody(AggregateType* ct, FnSymbol *fn,
+                                  ArgSymbol *arg1, ArgSymbol *arg2);
+static void buildRecordNotEqualsBody(AggregateType* ct, FnSymbol *fn,
+                                     ArgSymbol *arg1, ArgSymbol *arg2);
+static void buildRecordLessThanBody(AggregateType* ct, FnSymbol *fn,
+                                    ArgSymbol *arg1, ArgSymbol *arg2,
+                                    bool allowEquals);
+static void buildRecordGreaterThanBody(AggregateType* ct, FnSymbol *fn,
+                                       ArgSymbol *arg1, ArgSymbol *arg2,
+                                       bool allowEquals);
 
 static void buildDefaultReadWriteFunctions(AggregateType* type);
 
@@ -791,8 +802,6 @@ static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
   // we need to special case `!=`:
   // it can return true early, and returns false after checking all fields
   // all other operators do the exact opposite
-  bool isNotEqual = (astrOp == astrSne);
-
   FnSymbol* fn = new FnSymbol(op);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
@@ -811,44 +820,142 @@ static void buildRecordComparisonFunc(AggregateType* ct, const char* op) {
                                        arg1, arg2);
   fn->where = new BlockStmt(new CallExpr(PRIM_AND, typeComp, fieldsCheckExpr));
 
+  if (astrOp == astrSeq) {
+    buildRecordEqualsBody(ct, fn, arg1, arg2);
+  }
+  else if (astrOp == astrSne) {
+    buildRecordNotEqualsBody(ct, fn, arg1, arg2);
+  }
+  else if (astrOp == astrSgt) {
+    buildRecordGreaterThanBody(ct, fn, arg1, arg2, false);
+  }
+  else if (astrOp == astrSgte) {
+    buildRecordGreaterThanBody(ct, fn, arg1, arg2, true);
+  }
+  else if (astrOp == astrSlt) {
+    buildRecordLessThanBody(ct, fn, arg1, arg2, false);
+  }
+  else if (astrOp == astrSlte) {
+    buildRecordLessThanBody(ct, fn, arg1, arg2, true);
+  }
+  else {
+    INT_FATAL("Unrecognized operator was passed to buildRecordComparisonFunc");
+  }
+
+  DefExpr* def = new DefExpr(fn);
+  ct->symbol->defPoint->insertBefore(def);
+  reset_ast_loc(def, ct->symbol);
+  normalize(fn);
+}
+
+static void buildRecordEqualsBody(AggregateType *ct, FnSymbol *fn,
+                                  ArgSymbol *arg1, ArgSymbol *arg2) {
   // add comparisons for fields
   for_fields(tmp, ct) {
     if (!tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD) &&
         !tmp->hasFlag(FLAG_TYPE_VARIABLE)) {  // types fields must be equal
       Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
       Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
-      CallExpr *elemComp = new CallExpr(op, left, right);
-      if (isNotEqual) {
-        fn->insertAtTail(new CondStmt(elemComp,
+      CallExpr *elemComp = new CallExpr("!=", left, right);
+      fn->insertAtTail(new CondStmt(elemComp,
+                                    new CallExpr(PRIM_RETURN, gFalse)));
+    }
+  }
+  // either it is an empty record, and we didn't add any meaningful comparisons,
+  // or we added those comparisons but they never returned
+
+  // for ==, in either case we return true
+  fn->insertAtTail(new CallExpr(PRIM_RETURN, gTrue));
+}
+
+static void buildRecordNotEqualsBody(AggregateType *ct, FnSymbol *fn,
+                                  ArgSymbol *arg1, ArgSymbol *arg2) {
+  // add comparisons for fields
+  for_fields(tmp, ct) {
+    if (!tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD) &&
+        !tmp->hasFlag(FLAG_TYPE_VARIABLE)) {  // types fields must be equal
+      Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
+      Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
+      CallExpr *elemComp = new CallExpr("!=", left, right);
+      fn->insertAtTail(new CondStmt(elemComp,
+                                    new CallExpr(PRIM_RETURN, gTrue)));
+    }
+  }
+  // either it is an empty record, and we didn't add any meaningful comparisons,
+  // or we added those comparisons but they never returned
+
+  // for !=, in either case we return fales
+  fn->insertAtTail(new CallExpr(PRIM_RETURN, gFalse));
+}
+
+static void buildRecordLessThanBody(AggregateType *ct, FnSymbol *fn,
+                                    ArgSymbol *arg1, ArgSymbol *arg2,
+                                    bool allowEquals) {
+  // add comparisons for fields
+  for_fields(tmp, ct) {
+    if (!tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD) &&
+        !tmp->hasFlag(FLAG_TYPE_VARIABLE)) {  // types fields must be equal
+      {
+        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
+        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
+        CallExpr *elemCompTrue = new CallExpr("<", left, right);
+        fn->insertAtTail(new CondStmt(elemCompTrue,
                                       new CallExpr(PRIM_RETURN, gTrue)));
       }
-      else {
-        fn->insertAtTail(new CondStmt(new CallExpr("!", elemComp), 
+      {
+        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
+        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
+        CallExpr *elemCompFalse = new CallExpr(">", left, right);
+        fn->insertAtTail(new CondStmt(elemCompFalse,
                                       new CallExpr(PRIM_RETURN, gFalse)));
       }
     }
   }
+  // either it is an empty record, and we didn't add any meaningful comparisons,
+  // or we added those comparisons but they never returned
 
-  // find the return value and add the return statement
-  VarSymbol* ret;
-  if (fn->body->length() > 0) { // we added comparison statements: not empty
-    if (isNotEqual)
-      ret = gFalse;
-    else
-      ret = gTrue;
+  // for <, in either case we return false
+  if (allowEquals) {
+    fn->insertAtTail(new CallExpr(PRIM_RETURN, gTrue));
   }
-  else { // this is an empty record, so instances are always equal to each other
-    if (astrOp == astrSeq || astrOp == astrSlte || astrOp == astrSgte)
-      ret = gTrue;
-    else
-      ret = gFalse;
+  else {
+    fn->insertAtTail(new CallExpr(PRIM_RETURN, gFalse));
   }
-  fn->insertAtTail(new CallExpr(PRIM_RETURN, ret));
+}
 
-  DefExpr* def = new DefExpr(fn);
-  ct->symbol->defPoint->insertBefore(def);
-  reset_ast_loc(def, ct->symbol);
-  normalize(fn);
+static void buildRecordGreaterThanBody(AggregateType *ct, FnSymbol *fn,
+                                       ArgSymbol *arg1, ArgSymbol *arg2,
+                                       bool allowEquals) {
+  // add comparisons for fields
+  for_fields(tmp, ct) {
+    if (!tmp->hasFlag(FLAG_IMPLICIT_ALIAS_FIELD) &&
+        !tmp->hasFlag(FLAG_TYPE_VARIABLE)) {  // types fields must be equal
+      {
+        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
+        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
+        CallExpr *elemCompTrue = new CallExpr(">", left, right);
+        fn->insertAtTail(new CondStmt(elemCompTrue,
+                                      new CallExpr(PRIM_RETURN, gTrue)));
+      }
+      {
+        Expr* left = new CallExpr(tmp->name, gMethodToken, arg1);
+        Expr* right = new CallExpr(tmp->name, gMethodToken, arg2);
+        CallExpr *elemCompFalse = new CallExpr("<", left, right);
+        fn->insertAtTail(new CondStmt(elemCompFalse,
+                                      new CallExpr(PRIM_RETURN, gFalse)));
+      }
+    }
+  }
+  // either it is an empty record, and we didn't add any meaningful comparisons,
+  // or we added those comparisons but they never returned
+
+  // for <, in either case we return false
+  if (allowEquals) {
+    fn->insertAtTail(new CallExpr(PRIM_RETURN, gTrue));
+  }
+  else {
+    fn->insertAtTail(new CallExpr(PRIM_RETURN, gFalse));
+  }
 }
 
 // Builds default enum functions that are defined outside of the scope in which

--- a/test/types/records/bharshbarger/recordArrCmp.bad
+++ b/test/types/records/bharshbarger/recordArrCmp.bad
@@ -1,6 +1,7 @@
-recordArrCmp.chpl:9: error: unresolved call '!(promoted expression)'
-$CHPL_HOME/modules/internal/String.chpl:438: note: this candidate did not match: !(x: ?t)
-$CHPL_HOME/modules/internal/String.chpl:438: note: because where clause evaluated to false
-$CHPL_HOME/modules/internal/ChapelBase.chpl:551: note: candidates are: !(a: bool)
-$CHPL_HOME/modules/internal/ChapelBase.chpl:552: note:                 !(a: int(8))
-note: and 19 other candidates, use --print-all-candidates to see them
+recordArrCmp.chpl:2: internal error: AST-EXP-0538 chpl version 1.19.0 pre-release (ddd8270625)
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/types/records/bharshbarger/recordArrCmp.future
+++ b/test/types/records/bharshbarger/recordArrCmp.future
@@ -1,18 +1,3 @@
-bug: confusing compiler error when comparing records with array fields
-
-After changing the logic default record comparisons via #14752, compiler creates
-something that is probably closer to what we want for this to work. However, as
-array comparisons are promoted, in the end it generates a promoted expression
-that throws off the compilation.
-
-Issues:
-https://github.com/chapel-lang/chapel/issues/7615 (initial issue that got this
-                                                   future in)
-https://github.com/chapel-lang/chapel/issues/11490
-https://github.com/chapel-lang/chapel/issues/11487
-
-Previous future report:
------------------------
 bug: Generated C code fails to compile when the != or == operators are used between records containing an array.
 
 Compiler output:
@@ -23,13 +8,4 @@ In file included from /tmp/chpl-bharshbarg-7938.deleteme/_main.c:33:
 /tmp/chpl-bharshbarg-7938.deleteme/recordArrCmp.c:176: error: used struct type value where scalar is required
 gmake: *** [/tmp/chpl-bharshbarg-7938.deleteme/a.out.tmp] Error 1
 error: compiling generated source
-
-Previous .bad file:
--------------------
-recordArrCmp.chpl:2: internal error: AST-EXP-0538 chpl version 1.19.0 pre-release (ddd8270625)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
 

--- a/test/types/records/engin/comparisonOrder.chpl
+++ b/test/types/records/engin/comparisonOrder.chpl
@@ -1,0 +1,27 @@
+// the snippet is from Paul Cassella's bug report #14783
+record R {
+  var x, y: int;
+}
+
+var small = new R(1, 1);
+var mid1 = new R(1, 2);
+var mid2 = new R(2, 1);
+var big = new R(2, 2);
+
+
+var Rs = [ small, mid1, mid2, big ];
+
+for r1 in Rs {
+  for r2 in Rs {
+    writeln(r1, " == ", r2, ": ", r1 == r2);
+    writeln(r1, " < ", r2, ": ", r1 < r2);
+    writeln(r1, " <= ", r2, ": ", r1 <= r2);
+    writeln(r1, " > ", r2, ": ", r1 >
+        r2);
+    writeln(r1, " >= ", r2, ": ",
+        r1 >= r2);
+    writeln(r1, " != ", r2,
+        ": ", r1 != r2);
+    writeln();
+  }
+}

--- a/test/types/records/engin/comparisonOrder.good
+++ b/test/types/records/engin/comparisonOrder.good
@@ -1,0 +1,112 @@
+(x = 1, y = 1) == (x = 1, y = 1): true
+(x = 1, y = 1) < (x = 1, y = 1): false
+(x = 1, y = 1) <= (x = 1, y = 1): true
+(x = 1, y = 1) > (x = 1, y = 1): false
+(x = 1, y = 1) >= (x = 1, y = 1): true
+(x = 1, y = 1) != (x = 1, y = 1): false
+
+(x = 1, y = 1) == (x = 1, y = 2): false
+(x = 1, y = 1) < (x = 1, y = 2): true
+(x = 1, y = 1) <= (x = 1, y = 2): true
+(x = 1, y = 1) > (x = 1, y = 2): false
+(x = 1, y = 1) >= (x = 1, y = 2): false
+(x = 1, y = 1) != (x = 1, y = 2): true
+
+(x = 1, y = 1) == (x = 2, y = 1): false
+(x = 1, y = 1) < (x = 2, y = 1): true
+(x = 1, y = 1) <= (x = 2, y = 1): true
+(x = 1, y = 1) > (x = 2, y = 1): false
+(x = 1, y = 1) >= (x = 2, y = 1): false
+(x = 1, y = 1) != (x = 2, y = 1): true
+
+(x = 1, y = 1) == (x = 2, y = 2): false
+(x = 1, y = 1) < (x = 2, y = 2): true
+(x = 1, y = 1) <= (x = 2, y = 2): true
+(x = 1, y = 1) > (x = 2, y = 2): false
+(x = 1, y = 1) >= (x = 2, y = 2): false
+(x = 1, y = 1) != (x = 2, y = 2): true
+
+(x = 1, y = 2) == (x = 1, y = 1): false
+(x = 1, y = 2) < (x = 1, y = 1): false
+(x = 1, y = 2) <= (x = 1, y = 1): false
+(x = 1, y = 2) > (x = 1, y = 1): true
+(x = 1, y = 2) >= (x = 1, y = 1): true
+(x = 1, y = 2) != (x = 1, y = 1): true
+
+(x = 1, y = 2) == (x = 1, y = 2): true
+(x = 1, y = 2) < (x = 1, y = 2): false
+(x = 1, y = 2) <= (x = 1, y = 2): true
+(x = 1, y = 2) > (x = 1, y = 2): false
+(x = 1, y = 2) >= (x = 1, y = 2): true
+(x = 1, y = 2) != (x = 1, y = 2): false
+
+(x = 1, y = 2) == (x = 2, y = 1): false
+(x = 1, y = 2) < (x = 2, y = 1): true
+(x = 1, y = 2) <= (x = 2, y = 1): true
+(x = 1, y = 2) > (x = 2, y = 1): false
+(x = 1, y = 2) >= (x = 2, y = 1): false
+(x = 1, y = 2) != (x = 2, y = 1): true
+
+(x = 1, y = 2) == (x = 2, y = 2): false
+(x = 1, y = 2) < (x = 2, y = 2): true
+(x = 1, y = 2) <= (x = 2, y = 2): true
+(x = 1, y = 2) > (x = 2, y = 2): false
+(x = 1, y = 2) >= (x = 2, y = 2): false
+(x = 1, y = 2) != (x = 2, y = 2): true
+
+(x = 2, y = 1) == (x = 1, y = 1): false
+(x = 2, y = 1) < (x = 1, y = 1): false
+(x = 2, y = 1) <= (x = 1, y = 1): false
+(x = 2, y = 1) > (x = 1, y = 1): true
+(x = 2, y = 1) >= (x = 1, y = 1): true
+(x = 2, y = 1) != (x = 1, y = 1): true
+
+(x = 2, y = 1) == (x = 1, y = 2): false
+(x = 2, y = 1) < (x = 1, y = 2): false
+(x = 2, y = 1) <= (x = 1, y = 2): false
+(x = 2, y = 1) > (x = 1, y = 2): true
+(x = 2, y = 1) >= (x = 1, y = 2): true
+(x = 2, y = 1) != (x = 1, y = 2): true
+
+(x = 2, y = 1) == (x = 2, y = 1): true
+(x = 2, y = 1) < (x = 2, y = 1): false
+(x = 2, y = 1) <= (x = 2, y = 1): true
+(x = 2, y = 1) > (x = 2, y = 1): false
+(x = 2, y = 1) >= (x = 2, y = 1): true
+(x = 2, y = 1) != (x = 2, y = 1): false
+
+(x = 2, y = 1) == (x = 2, y = 2): false
+(x = 2, y = 1) < (x = 2, y = 2): true
+(x = 2, y = 1) <= (x = 2, y = 2): true
+(x = 2, y = 1) > (x = 2, y = 2): false
+(x = 2, y = 1) >= (x = 2, y = 2): false
+(x = 2, y = 1) != (x = 2, y = 2): true
+
+(x = 2, y = 2) == (x = 1, y = 1): false
+(x = 2, y = 2) < (x = 1, y = 1): false
+(x = 2, y = 2) <= (x = 1, y = 1): false
+(x = 2, y = 2) > (x = 1, y = 1): true
+(x = 2, y = 2) >= (x = 1, y = 1): true
+(x = 2, y = 2) != (x = 1, y = 1): true
+
+(x = 2, y = 2) == (x = 1, y = 2): false
+(x = 2, y = 2) < (x = 1, y = 2): false
+(x = 2, y = 2) <= (x = 1, y = 2): false
+(x = 2, y = 2) > (x = 1, y = 2): true
+(x = 2, y = 2) >= (x = 1, y = 2): true
+(x = 2, y = 2) != (x = 1, y = 2): true
+
+(x = 2, y = 2) == (x = 2, y = 1): false
+(x = 2, y = 2) < (x = 2, y = 1): false
+(x = 2, y = 2) <= (x = 2, y = 1): false
+(x = 2, y = 2) > (x = 2, y = 1): true
+(x = 2, y = 2) >= (x = 2, y = 1): true
+(x = 2, y = 2) != (x = 2, y = 1): true
+
+(x = 2, y = 2) == (x = 2, y = 2): true
+(x = 2, y = 2) < (x = 2, y = 2): false
+(x = 2, y = 2) <= (x = 2, y = 2): true
+(x = 2, y = 2) > (x = 2, y = 2): false
+(x = 2, y = 2) >= (x = 2, y = 2): true
+(x = 2, y = 2) != (x = 2, y = 2): false
+


### PR DESCRIPTION
This PR fixes the record comparison so that it has lexicographical ordering. The
inital PR that first added these functions were #14752.

Resolves #14783.

This change mainly involves separating the functions that build the bodies of
the comparison overloads. I think all this can still be done within a single
function, but I am choosing code redundancy over complicated logic.

Test:
- [x] standard
- [x] gasnet