### PR TITLE
Remove deprecated enableParScan config

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -23,9 +23,6 @@ module ChapelReduce {
   private use ChapelStandard;
   private use ChapelLocks;
 
-  config param enableParScan = false;
-  if enableParScan then compilerWarning("'enableParScan' has been deprecated (it is now always enabled)");
-
   proc chpl__scanStateResTypesMatch(op) param {
     type resType = op.generate().type;
     type stateType = op.identity.type;

--- a/test/deprecated/enableParScan.chpl
+++ b/test/deprecated/enableParScan.chpl
@@ -1,3 +1,0 @@
-var A: [1..3] int = 1;
-var B = + scan A;
-writeln(B);

--- a/test/deprecated/enableParScan.compopts
+++ b/test/deprecated/enableParScan.compopts
@@ -1,1 +1,0 @@
--senableParScan

--- a/test/deprecated/enableParScan.good
+++ b/test/deprecated/enableParScan.good
@@ -1,2 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelReduce.chpl:27: warning: 'enableParScan' has been deprecated (it is now always enabled)
-1 2 3


### PR DESCRIPTION
This removes the enableParScan config that was deprecated in the previous release.