### PR TITLE
Add two prediffs back in a correct way

### DIFF
--- a/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.good
+++ b/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.good
@@ -1,1 +1,1 @@
-sparseBulkBoundsCheck.chpl:19: error: halt reached - Sparse domain/array index out of bounds: (8, 8) (expected to be within {0..7, 0..7})
+sparseBulkBoundsCheck.chpl:19: error: halt reached - Sparse domain/array index out of bounds

--- a/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.prediff
+++ b/test/users/engin/sparse_bulk/sparseBulkBoundsCheck.prediff
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+out=$2
+cut -d":" -f1-4 $2  > $out.tmp
+mv $out.tmp $out

--- a/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.good
+++ b/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.good
@@ -1,1 +1,1 @@
-sparseBulkBoundsCheck.chpl:20: error: halt reached - Sparse domain/array index out of bounds: (8, 8) (expected to be within {0..7, 0..7})
+sparseBulkBoundsCheck.chpl:20: error: halt reached - Sparse domain/array index out of bounds

--- a/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.prediff
+++ b/test/users/engin/sparse_bulk_dist/sparseBulkBoundsCheck.prediff
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+out=$2
+cut -d":" -f1-4 $2  > $out.tmp
+mv $out.tmp $out


### PR DESCRIPTION
I was over-confident in adjusting prediffs and good files for these tests
earlier. On a separate paratest, I realized that we still need to do some
prediff'ing for correct behavior of tests in gasnet setup.

This PR adds the prediff's back with a fix. With this, the important part of the
halt message is still kept.

Tests passed locally on standard and gasnet configs with and without `--fast`
