### PR TITLE
Improve expiring value analysis for begin in sync

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2160,7 +2160,7 @@ buildSyncStmt(Expr* stmt) {
 
   // Note that a sync statement can contain arbitrary code,
   // including code that throws. As a result, we need to take
-  // care call _waitDynamicEndCount even if such errors are thrown.
+  // care call chpl_waitDynamicEndCount even if such errors are thrown.
 
   // This code takes the approach of wrapping the sync body with
   //
@@ -2194,7 +2194,7 @@ buildSyncStmt(Expr* stmt) {
 
   block->insertAtTail(t);
 
-  // waitDynamicEndCount might throw, but we need to clean up the
+  // chpl_waitDynamicEndCount might throw, but we need to clean up the
   // end counts either way.
 
   BlockStmt* cleanup = new BlockStmt();
@@ -2203,7 +2203,7 @@ buildSyncStmt(Expr* stmt) {
   cleanup->insertAtTail(new CallExpr(PRIM_SET_DYNAMIC_END_COUNT, endCountSave));
 
   block->insertAtTail(new DeferStmt(cleanup));
-  block->insertAtTail(new CallExpr("_waitDynamicEndCount"));
+  block->insertAtTail(new CallExpr(astr_chpl_waitDynamicEndCount));
   return block;
 }
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1989,6 +1989,7 @@ const char* astr_chpl_cname = NULL;
 const char* astr_chpl_forward_tgt = NULL;
 const char* astr_chpl_manager = NULL;
 const char* astr_chpl_statementLevelSymbol = NULL;
+const char* astr_chpl_waitDynamicEndCount = NULL;
 const char* astr_forallexpr = NULL;
 const char* astr_forexpr = NULL;
 const char* astr_loopexpr_iter = NULL;
@@ -2017,6 +2018,7 @@ void initAstrConsts() {
   astr_chpl_forward_tgt = astr("_chpl_forward_tgt");
   astr_chpl_manager = astr("_chpl_manager");
   astr_chpl_statementLevelSymbol = astr("chpl_statementLevelSymbol");
+  astr_chpl_waitDynamicEndCount = astr("chpl_waitDynamicEndCount");
 
   astr_forallexpr    = astr("chpl__forallexpr");
   astr_forexpr       = astr("chpl__forexpr");

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -699,6 +699,7 @@ extern const char* astr_chpl_cname;
 extern const char* astr_chpl_forward_tgt;
 extern const char* astr_chpl_manager;
 extern const char* astr_chpl_statementLevelSymbol;
+extern const char* astr_chpl_waitDynamicEndCount;
 extern const char* astr_forallexpr;
 extern const char* astr_forexpr;
 extern const char* astr_loopexpr_iter;

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -3305,6 +3305,24 @@ static bool isCapturingVariable(Symbol* var) {
          var->type->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE);
 }
 
+static bool inSyncBlock(Expr* e) {
+
+  for (Expr* cur = e; cur != NULL; cur = cur->parentExpr) {
+    if (BlockStmt* block = toBlockStmt(cur)) {
+      // Recognize sync blocks by the call to chpl_waitDynamicEndCount
+      // (and then a if-check-error CondStmt) at the end of them.
+      if (CondStmt* cond = toCondStmt(block->body.last()))
+        if (CallExpr* condCall = toCallExpr(cond->condExpr))
+          if (condCall->isPrimitive(PRIM_CHECK_ERROR))
+            if (CallExpr* prevCall = toCallExpr(cond->prev))
+              if (prevCall->isNamedAstr(astr_chpl_waitDynamicEndCount))
+                return true;
+    }
+  }
+
+  return false;
+}
+
 bool MarkCapturesVisitor::enterCallExpr(CallExpr* call) {
   // handle
   // * storing something with lifetime of a into another formal argument
@@ -3317,13 +3335,15 @@ bool MarkCapturesVisitor::enterCallExpr(CallExpr* call) {
   // 0: Handle task functions
   if (FnSymbol* calledFn = call->resolvedOrVirtualFunction()) {
     if (isTaskFun(calledFn)) {
-      // Consider a 'begin' to be a capture
-      // TODO?: unless it is in a sync block?
+      // Consider a 'begin' to be a capture unless it is
+      // lexically enclosed in a sync block.
       if (calledFn->hasFlag(FLAG_BEGIN)) {
-        for_formals_actuals(formal, actual, call) {
-          SymExpr* actualSe = toSymExpr(actual);
-          Symbol* actualSym = actualSe->symbol();
-          markAliasesAndSymPotentiallyCaptured(actualSym, call);
+        if (!inSyncBlock(call)) {
+          for_formals_actuals(formal, actual, call) {
+            SymExpr* actualSe = toSymExpr(actual);
+            Symbol* actualSym = actualSe->symbol();
+            markAliasesAndSymPotentiallyCaptured(actualSym, call);
+          }
         }
       }
       // Descend into task functions

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1300,7 +1300,7 @@ module ChapelBase {
   // This version is called for normal sync blocks.
   pragma "task join impl fn"
   pragma "unchecked throws"
-  proc _waitDynamicEndCount(param countRunningTasks=true) throws {
+  proc chpl_waitDynamicEndCount(param countRunningTasks=true) throws {
     var e = __primitive("get dynamic end count");
     _waitEndCount(e, countRunningTasks);
 

--- a/test/types/records/expiring/deinit-points.chpl
+++ b/test/types/records/expiring/deinit-points.chpl
@@ -445,3 +445,35 @@ proc t27() {
   writeln("end");
 }
 t27();
+
+proc t28() {
+  writeln("t28");
+  var r: R;
+  sync {
+    {
+      begin {
+        writeln("begin inner");
+        r;
+        writeln("end inner");
+      }
+    }
+  }
+  writeln("end outer");
+}
+t28();
+
+proc t29() {
+  writeln("t29");
+  var r: R;
+  sync {
+    if option {
+      begin {
+        writeln("begin inner");
+        r;
+        writeln("end inner");
+      }
+    }
+  }
+  writeln("end outer");
+}
+t29();

--- a/test/types/records/expiring/deinit-points.good
+++ b/test/types/records/expiring/deinit-points.good
@@ -39,7 +39,7 @@ Expiring values for function t15 (deinit-points.chpl:230)
 Expiring values for function t16 (deinit-points.chpl:245)
   r (deinit-points.chpl:248) expires after last mention
 Expiring values for function t17 (deinit-points.chpl:261)
-  r (deinit-points.chpl:263) expires at end of block
+  r (deinit-points.chpl:263) expires after last mention
   chpl_sync_error (deinit-points.chpl:265) expires after last mention
 Expiring values for function t18 (deinit-points.chpl:275)
   r (deinit-points.chpl:277) expires at end of block
@@ -176,8 +176,8 @@ end inner
 end outer
 t17
 end inner
-end outer
 deinit
+end outer
 t18
 task one (x = 0)
 end outer

--- a/test/types/records/expiring/deinit-points.good
+++ b/test/types/records/expiring/deinit-points.good
@@ -82,6 +82,12 @@ Expiring values for function t26 (deinit-points.chpl:434)
   r (deinit-points.chpl:436) expires after last mention
 Expiring values for function t27 (deinit-points.chpl:441)
   r (deinit-points.chpl:443) expires after last mention
+Expiring values for function t28 (deinit-points.chpl:449)
+  r (deinit-points.chpl:451) expires after last mention
+  chpl_sync_error (deinit-points.chpl:452) expires after last mention
+Expiring values for function t29 (deinit-points.chpl:465)
+  r (deinit-points.chpl:467) expires after last mention
+  chpl_sync_error (deinit-points.chpl:468) expires after last mention
 t1
 deinit
 t2
@@ -249,3 +255,13 @@ t27
 R
 deinit
 end
+t28
+begin inner
+end inner
+deinit
+end outer
+t29
+begin inner
+end inner
+deinit
+end outer

--- a/test/types/records/expiring/sync-begin-points.chpl
+++ b/test/types/records/expiring/sync-begin-points.chpl
@@ -1,0 +1,92 @@
+// This test is intentionally racy. It should not generally be run.
+
+record R {
+  var x:int = 0;
+  proc deinit() {
+    assert(x == 0);
+    x = 99;
+    writeln("deinit");
+  }
+}
+
+config const option = true;
+
+proc t28EOB() {
+  writeln("t28");
+  sync {
+    var r: R;
+    begin {
+      writeln("begin inner");
+      r;
+      writeln("end inner");
+    }
+  }
+  writeln("end outer");
+}
+t28EOB();
+
+proc t29EOB() {
+  writeln("t29");
+  sync {
+    {
+      var r: R;
+      begin {
+        writeln("begin inner");
+        r;
+        writeln("end inner");
+      }
+    }
+  }
+  writeln("end outer");
+}
+t29EOB();
+
+proc t30EOB() {
+  writeln("t30");
+  sync {
+    var r: R;
+    {
+      begin {
+        writeln("begin inner");
+        r;
+        writeln("end inner");
+      }
+    }
+  }
+  writeln("end outer");
+}
+t30EOB();
+
+proc t31EOB() {
+  writeln("t31");
+  sync {
+    if option {
+      var r: R;
+      if option {
+        begin {
+          writeln("begin inner");
+          r;
+          writeln("end inner");
+        }
+      }
+    }
+  }
+  writeln("end outer");
+}
+t31EOB();
+
+proc t32EOB() {
+  writeln("t32");
+  var r: R;
+  {
+    if option {
+      begin {
+        writeln("begin inner");
+        r;
+        writeln("end inner");
+      }
+    }
+  }
+  writeln("end outer");
+}
+t32EOB();

--- a/test/types/records/expiring/sync-begin-points.good
+++ b/test/types/records/expiring/sync-begin-points.good
@@ -1,0 +1,14 @@
+Expiring values for function t28EOB (sync-begin-points.chpl:14)
+  r (sync-begin-points.chpl:17) expires at end of block
+  chpl_sync_error (sync-begin-points.chpl:16) expires after last mention
+Expiring values for function t29EOB (sync-begin-points.chpl:28)
+  r (sync-begin-points.chpl:32) expires at end of block
+  chpl_sync_error (sync-begin-points.chpl:30) expires after last mention
+Expiring values for function t30EOB (sync-begin-points.chpl:44)
+  r (sync-begin-points.chpl:47) expires at end of block
+  chpl_sync_error (sync-begin-points.chpl:46) expires after last mention
+Expiring values for function t31EOB (sync-begin-points.chpl:60)
+  r (sync-begin-points.chpl:64) expires at end of block
+  chpl_sync_error (sync-begin-points.chpl:62) expires after last mention
+Expiring values for function t32EOB (sync-begin-points.chpl:78)
+  r (sync-begin-points.chpl:80) expires at end of block


### PR DESCRIPTION
Given a program like this:

``` chapel
proc testSync() {
  var x: SomeRecord = new SomeRecord();
  sync {
    begin {
      f(x);
      // point 1
    }
  }
  // point 2
  g();
  // point 3
}
```

This PR makes `x` deinitialize after last mention, because the mention of
it in a begin is contained within a sync block. The last mention is
considered to be point 2 above. This change is following the discussion
in #14750.

Along the way it renames `_waitDynamicEndCount` to
`chpl_waitDynamicEndCount` and adds a astr in the compiler for this name.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing