### PR TITLE
Add bytes version of regexredux

### DIFF
--- a/test/studies/shootout/regexdna-redux/engin/PERFTIMEEXEC
+++ b/test/studies/shootout/regexdna-redux/engin/PERFTIMEEXEC
@@ -1,0 +1,1 @@
+../../submitted/PERFTIMEEXEC

--- a/test/studies/shootout/regexdna-redux/engin/PREEXEC
+++ b/test/studies/shootout/regexdna-redux/engin/PREEXEC
@@ -1,0 +1,1 @@
+../../submitted/PREEXEC

--- a/test/studies/shootout/regexdna-redux/engin/fasta-regexredux.small
+++ b/test/studies/shootout/regexdna-redux/engin/fasta-regexredux.small
@@ -1,0 +1,1 @@
+../../submitted/fasta-regexredux.small

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.chpl
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.chpl
@@ -1,0 +1,63 @@
+/* The Computer Language Benchmarks Game
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
+   regex-dna program contributed by Ben Harshbarger
+   derived from the GNU C++ RE2 version by Alexey Zolotov
+
+   converted from regex-dna program
+*/
+
+use IO;
+use Regexp;
+
+proc main(args: [] string) {
+  var variants = [
+    b"agggtaaa|tttaccct",
+    b"[cgt]gggtaaa|tttaccc[acg]",
+    b"a[act]ggtaaa|tttacc[agt]t",
+    b"ag[act]gtaaa|tttac[agt]ct",
+    b"agg[act]taaa|ttta[agt]cct",
+    b"aggg[acg]aaa|ttt[cgt]ccct",
+    b"agggt[cgt]aa|tt[acg]accct",
+    b"agggta[cgt]a|t[acg]taccct",
+    b"agggtaa[cgt]|[acg]ttaccct"
+  ];
+
+  var subst = [
+    (b"tHa[Nt]", b"<4>"), (b"aND|caN|Ha[DS]|WaS", b"<3>"), (b"a[NSt]|BY", b"<2>"), 
+    (b"<[^>]*>", b"|"), (b"\\|[^|][^|]*\\|", b"-")
+  ];
+
+  var data: bytes;
+  stdin.readbytes(data); // read in the entire file
+  const initLen = data.length;
+
+  // remove newlines
+  data = compile(b">.*\n|\n").sub(b"", data);
+
+  var copy = data; // make a copy so we can perform replacements in parallel
+
+  var results: [variants.domain] int;
+
+  sync {
+    // fire off a task to perform replacements
+    begin with (ref copy) {
+      for (f, r) in subst do
+        copy = compile(f).sub(r, copy);
+    }
+
+    // count patterns
+    forall (pattern, result) in zip(variants, results) do
+      for m in compile(pattern).matches(data) do
+        result += 1;
+  }
+
+  // print results
+  for (p,r) in zip(variants, results) do
+    writeln(p, " ", r);
+  writeln();
+
+  writeln(initLen);
+  writeln(data.length);
+  writeln(copy.length);
+}

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.execopts
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.execopts
@@ -1,0 +1,1 @@
+--n=0 < fasta-regexredux.small

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.good
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.good
@@ -1,0 +1,13 @@
+agggtaaa|tttaccct 1
+[cgt]gggtaaa|tttaccc[acg] 0
+a[act]ggtaaa|tttacc[agt]t 0
+ag[act]gtaaa|tttac[agt]ct 0
+agg[act]taaa|ttta[agt]cct 1
+aggg[acg]aaa|ttt[cgt]ccct 0
+agggt[cgt]aa|tt[acg]accct 0
+agggta[cgt]a|t[acg]taccct 0
+agggtaa[cgt]|[acg]ttaccct 2
+
+10245
+10000
+5262

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.perfexecopts
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.perfexecopts
@@ -1,0 +1,1 @@
+--n=0 < $CHPL_TEST_TMP_DIR/fasta.regex

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.perfkeys
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.perfkeys
@@ -1,0 +1,4 @@
+# file: regexdnaredux-submitted.dat
+real
+verify:agggtaa\[cgt\]|\[acg\]ttaccct 2178
+verify:50833411

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.perfkeys
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.perfkeys
@@ -1,4 +1,4 @@
-# file: regexdnaredux-submitted.dat
+# file: regexdnaredux-bytes.dat
 real
 verify:agggtaa\[cgt\]|\[acg\]ttaccct 2178
 verify:50833411

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.skipif
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.skipif
@@ -1,0 +1,1 @@
+CHPL_REGEXP!=re2

--- a/test/studies/shootout/regexdna-redux/regexdna-redux.graph
+++ b/test/studies/shootout/regexdna-redux/regexdna-redux.graph
@@ -1,6 +1,5 @@
-perfkeys: real
-files: regexdnaredux-release.dat
-graphkeys: regexdnaredux-release
+perfkeys: real real
+files: regexdnaredux-release.dat regexdnaredux-bytes.dat
+graphkeys: regexdnaredux-release regexdnaredux-bytes
 graphtitle: Regex-dna redux Shootout Benchmark
 ylabel: Time (seconds)
-graphname: regexdnaredux

--- a/test/studies/shootout/submitted/regexredux.future
+++ b/test/studies/shootout/submitted/regexredux.future
@@ -1,1 +1,1 @@
-Needs a use of the IO module
+Needs use of the IO and Regexp modules


### PR DESCRIPTION
To see the performance difference between string and bytes, this PR adds a variation of regexredux as a study. The main motivation being recovering from the regression caused by UTF8 validation:

https://chapel-lang.org/perf/chapcs/?startdate=2019/10/29&enddate=2020/01/09&graphs=regexdnashootoutbenchmark,regexdnareduxshootoutbenchmark,submittedregexdnashootoutbenchmark,submittedregexdnareduxshootoutbenchmark

Also updates the relevant future for missing `use Regexp`

Added test passes correctness and performance testing with standard local config.