### PR TITLE
Include local-from-distributed warning in .goods after split init

### DIFF
--- a/test/distributions/dm/s7.chpl
+++ b/test/distributions/dm/s7.chpl
@@ -105,7 +105,7 @@ proc test(X, Y, Z) {
 // copy to a default-rectangular array, for writeln()
 proc copyToDF(A:[]) {
   var D: domain(A.rank, A.domain.idxType, A.domain.stridable);
-  D; D = A.domain; // see issue #14746
+  D = A.domain;
   var Res: [D] A.eltType = A;
   return Res;
 }

--- a/test/distributions/dm/s7.comm-none.good
+++ b/test/distributions/dm/s7.comm-none.good
@@ -1,3 +1,9 @@
+s7.chpl:106: In function 'copyToDF':
+s7.chpl:108: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s7.chpl:73: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockCyclicDim,ReplicatedDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),Replicated1dom(int(64),false))] int(64))
+s7.chpl:106: In function 'copyToDF':
+s7.chpl:108: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s7.chpl:74: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,ReplicatedDim,BlockCyclicDim,int(64),2),Replicated1dom(int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64))
 n 8  blkSize 2  locales 1*1
 
 11000101 12000102 11000103 12000104 11000105 12000106 11000107 12000108 0

--- a/test/distributions/dm/s7.good
+++ b/test/distributions/dm/s7.good
@@ -1,3 +1,9 @@
+s7.chpl:106: In function 'copyToDF':
+s7.chpl:108: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s7.chpl:73: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockCyclicDim,ReplicatedDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),Replicated1dom(int(64),false))] int(64))
+s7.chpl:106: In function 'copyToDF':
+s7.chpl:108: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s7.chpl:74: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,ReplicatedDim,BlockCyclicDim,int(64),2),Replicated1dom(int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64))
 n 8  blkSize 2  locales 3*3
 
 11000101 12000102 1011000103 1012000104 2011000105 2012000106 11000107 12000108 0

--- a/test/distributions/dm/s8.chpl
+++ b/test/distributions/dm/s8.chpl
@@ -58,7 +58,7 @@ proc test(A, ix1, ix2) {
   tl();
 
   var D: domain(A.rank, A.domain.idxType, A.domain.stridable);
-  D; D = A.domain; // see issue #14746
+  D = A.domain;
 
   hd("zippered iterator (A,D)");
   forall (a,i) in zip(A,D) do msg(i, "  ", a);

--- a/test/distributions/dm/s8.comm-none.good
+++ b/test/distributions/dm/s8.comm-none.good
@@ -127,3 +127,9 @@
 51 52 53 54 55 56 57 58
 61 62 63 64 65 66 67 68
 71 72 73 74 75 76 77 78
+s8.chpl:38: In function 'test':
+s8.chpl:38: In function 'test':
+s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s8.chpl:72: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64), ix1: 2*int(64), ix2: 2*int(64))
+s8.chpl:73: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),true),BlockCyclic1dom(int(64),int(64),true))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/dm/s8.good
+++ b/test/distributions/dm/s8.good
@@ -126,3 +126,9 @@
 51 52 53 54 55 56 57 58
 61 62 63 64 65 66 67 68
 71 72 73 74 75 76 77 78
+s8.chpl:38: In function 'test':
+s8.chpl:38: In function 'test':
+s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s8.chpl:72: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64), ix1: 2*int(64), ix2: 2*int(64))
+s8.chpl:73: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),true),BlockCyclic1dom(int(64),int(64),true))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/dm/s9.chpl
+++ b/test/distributions/dm/s9.chpl
@@ -62,7 +62,7 @@ proc test(A, ix1, ix2) {
   tl();
 
   var D: domain(A.rank, A.domain.idxType, A.domain.stridable);
-  D; D = A.domain; // see issue #14746
+  D = A.domain;
 
   hd("zippered iterator (A,D)");
   forall (a,i) in zip(A,D) do msg(i, "  ", a);

--- a/test/distributions/dm/s9.comm-none.good
+++ b/test/distributions/dm/s9.comm-none.good
@@ -127,3 +127,9 @@
 51 52 53 54 55 56 57 58
 61 62 63 64 65 66 67 68
 71 72 73 74 75 76 77 78
+s9.chpl:42: In function 'test':
+s9.chpl:42: In function 'test':
+s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s9.chpl:76: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),false,BlockDim(int(64))),Block1dom(int(64),false,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))
+s9.chpl:77: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),true,BlockDim(int(64))),Block1dom(int(64),true,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/dm/s9.good
+++ b/test/distributions/dm/s9.good
@@ -126,3 +126,9 @@
 51 52 53 54 55 56 57 58
 61 62 63 64 65 66 67 68
 71 72 73 74 75 76 77 78
+s9.chpl:42: In function 'test':
+s9.chpl:42: In function 'test':
+s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+s9.chpl:76: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),false,BlockDim(int(64))),Block1dom(int(64),false,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))
+s9.chpl:77: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] borrowed locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),true,BlockDim(int(64))),Block1dom(int(64),true,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/ferguson/init-local-from-distributed-warning.chpl
+++ b/test/distributions/ferguson/init-local-from-distributed-warning.chpl
@@ -17,11 +17,19 @@ proc warning2() {
 
 }
 
+proc warning3() {
+
+  var myDomain: domain(2);
+  myDomain = {1..n, 1..n} dmapped Block({1..n, 1..n});
+  writeln(myDomain);
+
+}
 
 proc ok1() {
 
   var myDomain: domain(2);
-  myDomain; // see issue #14746
+  myDomain;  // disabling split-init for myDomain
+  // this one is a warning too as discussed in issue #14746
   myDomain = {1..n, 1..n} dmapped Block({1..n, 1..n});
   writeln(myDomain);
 
@@ -30,4 +38,5 @@ proc ok1() {
 
 warning1();
 warning2();
+warning3();
 ok1();

--- a/test/distributions/ferguson/init-local-from-distributed-warning.good
+++ b/test/distributions/ferguson/init-local-from-distributed-warning.good
@@ -2,6 +2,9 @@ init-local-from-distributed-warning.chpl:6: In function 'warning1':
 init-local-from-distributed-warning.chpl:8: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
 init-local-from-distributed-warning.chpl:13: In function 'warning2':
 init-local-from-distributed-warning.chpl:15: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+init-local-from-distributed-warning.chpl:20: In function 'warning3':
+init-local-from-distributed-warning.chpl:23: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+{1..2, 1..2}
 {1..2, 1..2}
 {1..2, 1..2}
 {1..2, 1..2}

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
@@ -41,7 +41,7 @@ proc compare(D, R, a, s=2) {
 proc test(ref D) {
   D = rangeTuple(D.rank, 1..10);
   var R : domain(D.rank, D.idxType, D.stridable);
-  R; R = D; // see issue #14746
+  R = D;
 
   compare(D, R, 0);
   compare(D, R, 1);

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.comm-none.good
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.comm-none.good
@@ -1,0 +1,12 @@
+Testing {1..10}[.. by 2 align 0]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS
+Testing {1..10}[.. by 2 align 1]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS
+Testing {1..10, 1..10}[.. by 2 align 0]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS
+Testing {1..10, 1..10}[.. by 2 align 1]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.good
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.good
@@ -1,3 +1,9 @@
+test_domain_align.chpl:41: In function 'test':
+test_domain_align.chpl:44: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+test_domain_align.chpl:6: Function 'test' instantiated as: test(D: BlockDom(1,int(64),false,unmanaged DefaultDist))
+test_domain_align.chpl:41: In function 'test':
+test_domain_align.chpl:44: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+test_domain_align.chpl:7: Function 'test' instantiated as: test(D: BlockDom(2,int(64),false,unmanaged DefaultDist))
 Testing {1..10}[.. by 2 align 0]
 	serial iter: SUCCESS
 	leader/follower: SUCCESS

--- a/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
@@ -185,8 +185,8 @@ proc schurComplement(Ab: [?AbD] elemType, AD: domain, BD: domain, Rest: domain) 
   //
   var replAD: domain(2, indexType),
       replBD: domain(2, indexType);
-  replAD; replAD = AD; // see issue #14746
-  replBD; replBD = BD; // see issue #14746
+  replAD = AD;
+  replBD = BD;
     
   const replA : [replAD] elemType = Ab[replAD],
         replB : [replBD] elemType = Ab[replBD];

--- a/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.good
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.good
@@ -1,3 +1,7 @@
+hpl-blc-noreindex.chpl:176: In function 'schurComplement':
+hpl-blc-noreindex.chpl:188: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+hpl-blc-noreindex.chpl:189: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+hpl-blc-noreindex.chpl:143: Function 'schurComplement' instantiated as: schurComplement(Ab: [BlockCyclicDom(2,int(64),false)] real(64), AD: BlockCyclicDom(2,int(64),false), BD: BlockCyclicDom(2,int(64),false), Rest: BlockCyclicDom(2,int(64),false))
 Problem size = 30 x 30
 Bytes per array = 7200
 Total memory required (GB) = 6.70552e-06


### PR DESCRIPTION
Per discussion in #14746, update .good files to include warning about 
initializing a non-distributed domain from a distributed one, in tests
that now run into this due to split-init.

The warning was added in PR #10791, the workarounds added in #14691.

Test changes only; not reviewed.