### PR TITLE
Better error for untyped variable never inited

### DIFF
--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -170,6 +170,7 @@ assignment, of that variable.
       no-split-init.chpl:1: In function 'main':
       no-split-init.chpl:2: error: 'x' cannot be default initialized
       no-split-init.chpl:3: note: 'x' is used here before being initialized
+      no-split-init.chpl:2: error: Variable 'x' is not initialized and has no type
 
 
    *Example (split-cond-blocks-init.chpl)*

--- a/test/parsing/vass/line-numbers-after-newline-in-string.good
+++ b/test/parsing/vass/line-numbers-after-newline-in-string.good
@@ -1,2 +1,1 @@
 line-numbers-after-newline-in-string.chpl:3: error: Variable 'x' is not initialized and has no type
-line-numbers-after-newline-in-string.chpl:3: note: split initialization is not supported for globals

--- a/test/trivial/deitz/vars-scopes/infer1.good
+++ b/test/trivial/deitz/vars-scopes/infer1.good
@@ -1,3 +1,4 @@
 infer1.chpl:1: In function 'main':
 infer1.chpl:2: error: 'x' cannot be default initialized
 infer1.chpl:3: note: 'x' is used here before being initialized
+infer1.chpl:2: error: Variable 'x' is not initialized and has no type

--- a/test/types/records/split-init/error-never-initialized.chpl
+++ b/test/types/records/split-init/error-never-initialized.chpl
@@ -1,0 +1,13 @@
+proc error() {
+  var a;
+  type t;
+}
+error();
+
+var b;
+type tt;
+
+var c;
+c = 1;
+type ttt;
+ttt = int;

--- a/test/types/records/split-init/error-never-initialized.good
+++ b/test/types/records/split-init/error-never-initialized.good
@@ -1,0 +1,7 @@
+error-never-initialized.chpl:1: In function 'error':
+error-never-initialized.chpl:2: error: Variable 'a' is not initialized and has no type
+error-never-initialized.chpl:3: error: type alias 't' is not initialized
+error-never-initialized.chpl:7: error: Variable 'b' is not initialized and has no type
+error-never-initialized.chpl:8: error: type alias 'tt' is not initialized
+error-never-initialized.chpl:10: error: split initialization is not supported for globals
+error-never-initialized.chpl:12: error: split initialization is not supported for globals

--- a/test/types/records/split-init/split-init-oops.good
+++ b/test/types/records/split-init/split-init-oops.good
@@ -1,5 +1,7 @@
 split-init-oops.chpl:5: In function 'test':
 split-init-oops.chpl:7: error: 'a' cannot be default initialized
 split-init-oops.chpl:8: note: 'a' is used here before being initialized
+split-init-oops.chpl:7: error: Variable 'a' is not initialized and has no type
 split-init-oops.chpl:15: error: 'b' cannot be default initialized
 split-init-oops.chpl:16: note: 'b' is used here before being initialized
+split-init-oops.chpl:15: error: Variable 'b' is not initialized and has no type


### PR DESCRIPTION
This PR improves the error message for a program such as

``` chapel
proc error() {
  var a;
}
error();
```

The error here is that `a` is never initialized but previous to this PR 
there was an error about an initCopy call.

Reviewed by @benharsh - thanks!

- [x] full local testing