### PR TITLE
Update future write_no_flush.chpl to continue failing

### DIFF
--- a/test/types/file/diten/write_no_flush.chpl
+++ b/test/types/file/diten/write_no_flush.chpl
@@ -18,4 +18,5 @@ proc main {
   }
   //w.flush();
   f.close();
+  w; // mention w to prevent it from being deinited (and flushed) earlier
 }


### PR DESCRIPTION
PR #14804 made this future pass:
`test/types/file/diten/write_no_flush.chpl`. But it passes because the
writing channel (`w`) is now automatically deinited (and so flushed)
before the `f.close()` call.  Since the is requesting a feature on
`file.close()`, this PR updates the test to avoid the early deinit (so it
will remain a future).

Trivial and not reviewed (but discussed with @daviditen ).
