### PR TITLE
Add unordered GET/PUT support in comm=ofi.

### DIFF
--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -35,6 +35,9 @@
 typedef struct {
   chpl_cache_taskPrvData_t cache_data;
   int numTxnsOut;    // number of transactions outstanding
+  void* amo_nf_buff;
+  void* get_buff;
+  void* put_buff;
 } chpl_comm_taskPrvData_t;
 
 //

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -35,7 +35,6 @@
 typedef struct {
   chpl_cache_taskPrvData_t cache_data;
   int numTxnsOut;    // number of transactions outstanding
-  void* amo_nf_buff;
   void* get_buff;
   void* put_buff;
 } chpl_comm_taskPrvData_t;

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -61,6 +61,7 @@ FILE* chpl_comm_ofi_dbg_file;
 #define DBG_RMA                0x100000UL
 #define DBG_RMAWRITE           0x200000UL
 #define DBG_RMAREAD            0x400000UL
+#define DBG_RMAUNORD           0x800000UL
 #define DBG_AMO               0x1000000UL
 #define DBG_ACK               0x2000000UL
 #define DBG_MR               0x10000000UL

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3179,7 +3179,7 @@ void ofi_put_V(int v_len, void** addr_v, void** local_mr_v,
  *** START OF BUFFERED PUT OPERATIONS ***
  *
  * Support for buffered PUT operations. We internally buffer PUT operations and
- * then initiate them with chained transactions for increased transaction rate.
+ * then initiate them all at once for increased transaction rate.
  */
 
 // Flush buffered PUTs for the specified task info and reset the counter.
@@ -3382,7 +3382,7 @@ void ofi_get_V(int v_len, void** addr_v, void** local_mr_v,
  *** START OF BUFFERED GET OPERATIONS ***
  *
  * Support for buffered GET operations. We internally buffer GET operations and
- * then initiate them with chained transactions for increased transaction rate.
+ * then initiate them all at once for increased transaction rate.
  */
 
 // Flush buffered GETs for the specified task info and reset the counter.


### PR DESCRIPTION
The ofi comm layer has just been doing regular ordered operations for
the unordered GET/PUT/AMO interface calls.  This is functionally correct
but obviously doesn't produce the expected performance benefit.  Here,
really do unordered operations for GET and PUT.  The code was more or
less just copied from the ugni comm layer, changed where necessary for
things like memory registration details.  This should facilitate a
future change in which we move the bulk of the support into common code
and just leave the low-level details of actually initiating and tracking
transactions in the comm layers.

Related to this, the transaction tracking count in the transmit context
descriptors is now overloaded to count just transactions in flight if
the tx context uses a completion queue for tracking, or all transactions
ever initiated if it uses a counter for completion tracking.  This grows
out of how the two tracking mechanisms work: a completion queue reports
each individual transaction as it completes, while a counter reports the
total number of completed transactions so far.  So to tell if everything
initiated has completed, it seems more natural to count the transactions
differently for the two cases.

Unordered AMOs will be dealt with in a separate PR.

This resolves https://github.com/Cray/chapel-private/issues/680.