### PR TITLE
Adjust split init to allow some try, if with returns

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2550,6 +2550,7 @@ static void errorIfSplitInitializationRequired(DefExpr* def, Expr* cur);
 
 typedef enum {
   FOUND_NOTHING = 0,
+  FOUND_RET, // throw or return
   FOUND_USE,
   FOUND_INIT
 } found_init_t;
@@ -2625,7 +2626,16 @@ static found_init_t doFindInitPoints(DefExpr* def,
           errorIfSplitInitializationRequired(def, cur);
           return FOUND_USE;
         }
+
+        if (call->isPrimitive(PRIM_RETURN) || call->isPrimitive(PRIM_THROW)) {
+          return FOUND_RET;
+        }
       }
+
+    // return
+    } else if (GotoStmt* gt = toGotoStmt(cur)) {
+      if (gt->gotoTag == GOTO_RETURN)
+        return FOUND_RET;
 
     // { x = ... }
     } else if (BlockStmt* block = toBlockStmt(cur)) {
@@ -2644,6 +2654,8 @@ static found_init_t doFindInitPoints(DefExpr* def,
         } else if (found == FOUND_USE) {
           errorIfSplitInitializationRequired(def, cur);
           return FOUND_USE;
+        } else if (found == FOUND_RET) {
+          return FOUND_RET;
         }
       }
 
@@ -2651,23 +2663,37 @@ static found_init_t doFindInitPoints(DefExpr* def,
       Expr* start = tr->body()->body.first();
       found_init_t foundBody = doFindInitPoints(def, start, initAssigns);
 
+      bool allCatchesRet = true;
+
       // if there are any catches, check them for uses;
       // also a catch block prevents initialization in the try body
       for_alist(elt, tr->_catches) {
         if (CatchStmt* ctch = toCatchStmt(elt)) {
           Expr* start = ctch->body()->body.first();
           found_init_t foundCatch = doFindInitPoints(def, start, initAssigns);
-          if (foundCatch != FOUND_NOTHING || foundBody != FOUND_NOTHING) {
+          if (foundCatch == FOUND_USE) {
             // Consider even an assignment in a catch block as a use
             errorIfSplitInitializationRequired(def, cur);
             return FOUND_USE;
+          } else if (foundCatch != FOUND_RET) {
+            allCatchesRet = false;
           }
         }
       }
 
-      if (foundBody != FOUND_NOTHING) {
+      // if we got here, no catch returned FOUND_USE.
+
+      if (foundBody == FOUND_USE) {
         errorIfSplitInitializationRequired(def, cur);
         return FOUND_USE;
+      } else if (foundBody == FOUND_INIT) {
+        if (allCatchesRet) {
+          // all catches are either FOUND_RET or FOUND_INIT
+          return FOUND_INIT;
+        } else {
+          errorIfSplitInitializationRequired(def, cur);
+          return FOUND_USE;
+        }
       }
 
     // if _ { x = ... } else { x = ... }
@@ -2686,7 +2712,9 @@ static found_init_t doFindInitPoints(DefExpr* def,
       if (elseStart != NULL)
         foundElse = doFindInitPoints(def, elseStart, elseAssigns);
 
-      if (foundIf == FOUND_INIT && foundElse == FOUND_INIT) {
+      if ((foundIf == FOUND_INIT && foundElse == FOUND_INIT) ||
+          (foundIf == FOUND_INIT && foundElse == FOUND_RET) ||
+          (foundIf == FOUND_RET && foundElse == FOUND_INIT)) {
         for_vector(CallExpr, call, ifAssigns) {
           initAssigns.push_back(call);
         }
@@ -2702,6 +2730,8 @@ static found_init_t doFindInitPoints(DefExpr* def,
         // at least one of them must be FOUND_USE, so return that
         errorIfSplitInitializationRequired(def, cur);
         return FOUND_USE;
+      } else if (foundIf == FOUND_RET && foundElse == FOUND_RET) {
+        return FOUND_RET;
       }
 
     } else {

--- a/compiler/resolution/AutoDestroyScope.h
+++ b/compiler/resolution/AutoDestroyScope.h
@@ -68,7 +68,7 @@ private:
                                             AutoDestroyScope* startingScope) const;
 
   void                     destroyOuterVariables(Expr* before,
-                                                 const std::set<VarSymbol*>& ignored) const;
+                                                 std::set<VarSymbol*>& ignored) const;
 
 
   // Returns true if the variable has already been initialized in

--- a/compiler/resolution/AutoDestroyScope.h
+++ b/compiler/resolution/AutoDestroyScope.h
@@ -67,6 +67,10 @@ private:
                                             const std::set<VarSymbol*>& ignored,
                                             AutoDestroyScope* startingScope) const;
 
+  void                     destroyOuterVariables(Expr* before,
+                                                 const std::set<VarSymbol*>& ignored) const;
+
+
   // Returns true if the variable has already been initialized in
   // this or a parent scope.
   bool                     isVariableInitialized(VarSymbol* var) const;

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -82,7 +82,7 @@ The ``type-part`` of a variable declaration specifies the type of the
 variable. It is optional.
 
 The ``initialization-part`` of a variable declaration specifies an
-initialization expression for the variable. It is option. When present,
+initialization expression for the variable. It is optional. When present,
 the initialization expression will be stored into the variable as its
 initial value.
 
@@ -129,9 +129,9 @@ If the ``initialization-part`` of a local variable declaration is
 omitted, the compiler will search forward in the function for the
 earliest assignment statement(s) setting that variable that occur before
 the variable is otherwise mentioned. It will search only within block
-declarations ``{ }`` and conditionals. These assignment statements are
-called applicable assignment statements. They perform initialization, not
-assignment, of that variable.
+declarations ``{ }``, ``try`` blocks, ``try!`` blocks, and conditionals.
+These assignment statements are called applicable assignment statements.
+They perform initialization, not assignment, of that variable.
 
    *Example (simple-split-init.chpl)*
 
@@ -210,8 +210,13 @@ Split initialization does not apply:
  * when an applicable assignment statement is in a loop, ``on``
    statement, or ``begin`` statement
  * when an applicable assignment statement is in one branch of a
-   conditional but not in the other, including when the conditional has
-   no ``else`` branch.
+   conditional but not in the other, and when the other branch
+   does not always return or throw. This rule prevents
+   split-initialization when the applicable assignment statement is
+   in a conditional that has no ``else`` branch.
+ * when an applicable assignment statement is in a ``try`` or ``try!``
+   block which has ``catch`` clauses that mention the variable
+   or which has ``catch`` clauses that do not always throw or return.
 
 In the case that the variable is declared without a ``type-part`` and
 where multiple applicable assignment statements are identified, all of

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4188,42 +4188,53 @@ module ChapelArray {
 
     if size > 0 then allocateData(true, size);
 
-    for elt in ir {
+    try {
+      for elt in ir {
 
-      // Future: we should generally remove this copy.
-      // Note though that in some cases it invokes this function
-      // recursively - in that case it shouldn't be removed!
-      pragma "no auto destroy"
-      pragma "no copy"
-      var eltCopy = chpl__initCopy(elt);
+        // Future: we should generally remove this copy.
+        // Note though that in some cases it invokes this function
+        // recursively - in that case it shouldn't be removed!
+        pragma "no auto destroy"
+        pragma "no copy"
+        var eltCopy = try chpl__initCopy(elt);
 
-      if i >= size {
-        // Allocate a new buffer and then copy.
-        var oldSize = size;
-        var oldData = data;
+        if i >= size {
+          // Allocate a new buffer and then copy.
+          var oldSize = size;
+          var oldData = data;
 
-        if size == 0 then
-          size = 4;
-        else
-          size = 2 * size;
+          if size == 0 then
+            size = 4;
+          else
+            size = 2 * size;
 
-        allocateData(true, size);
+          allocateData(true, size);
 
-        // Now copy the data over
-        for i in 0..#oldSize {
-          // this is a move, transferring ownership
-          __primitive("=", data[i], oldData[i]);
+          // Now copy the data over
+          for i in 0..#oldSize {
+            // this is a move, transferring ownership
+            __primitive("=", data[i], oldData[i]);
+          }
+
+          // Then, free the old data
+          _ddata_free(oldData, oldSize);
         }
 
-        // Then, free the old data
-        _ddata_free(oldData, oldSize);
+        // Now move the element to the array
+        // The intent here is to transfer ownership to the array.
+        __primitive("=", data[i], eltCopy);
+
+        i += 1;
       }
-
-      // Now move the element to the array
-      // The intent here is to transfer ownership to the array.
-      __primitive("=", data[i], eltCopy);
-
-      i += 1;
+    } catch e {
+      // Deinitialize any elements that have been iniitalized.
+      for j in 0..i-1 {
+        chpl__autoDestroy(data[j]);
+      }
+      // Free the allocated memory.
+      _ddata_free(data, size);
+      // Propagate the thrown error.
+      throw e;
     }
 
     // Create the domain of the array that we will return.

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4138,6 +4138,11 @@ module ChapelArray {
     return result;
   }
 
+  pragma "unchecked throws"
+  proc chpl__throwErrorUnchecked(in e: owned Error) throws {
+    throw e;
+  }
+
   pragma "init copy fn"
   proc chpl__initCopy(ir: _iteratorRecord) {
 
@@ -4233,8 +4238,9 @@ module ChapelArray {
       }
       // Free the allocated memory.
       _ddata_free(data, size);
-      // Propagate the thrown error.
-      throw e;
+      // Propagate the thrown error, but don't consider this
+      // function throwing just because of this call.
+      chpl__throwErrorUnchecked(e);
     }
 
     // Create the domain of the array that we will return.

--- a/test/types/records/split-init/split-init-2-conds.chpl
+++ b/test/types/records/split-init/split-init-2-conds.chpl
@@ -2,7 +2,8 @@ class C { var x: int; }
 
 config const option = true;
 
-proc main() {
+proc test1() {
+  writeln("test1");
   var a;
   var b;
   if option then
@@ -17,3 +18,104 @@ proc main() {
   writeln(a.type:string, " ", a);
   writeln(b.type:string, " ", b);
 }
+test1();
+
+record R {
+  var x: int = 0;
+  var ptr: owned C = new owned C();
+  proc init() {
+    this.x = 0;
+    writeln("init");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    this.ptr = new owned C(arg);
+    writeln("init ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    writeln("init= ", other.x);
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  writeln("= ", lhs.x, " ", rhs.x);
+  lhs.x = rhs.x;
+}
+
+proc test2() {
+  writeln("test2");
+  var a;
+  if option then
+    return;
+  else
+    a = new R(1);
+}
+test2();
+
+proc test3() {
+  writeln("test3");
+  var a;
+  if !option then
+    return;
+  else
+    a = new R(1);
+}
+test3();
+
+proc test4() throws {
+  writeln("test4");
+  var a;
+  if option then
+    a = new R(1);
+  else
+    throw new Error();
+}
+try { test4(); } catch e { writeln(e); }
+
+proc test5() throws {
+  writeln("test5");
+  var a;
+  if !option then
+    a = new R(1);
+  else
+    throw new Error();
+}
+try { test5(); } catch e { writeln(e); }
+
+proc test6() throws {
+  writeln("test6");
+  var a;
+  {
+    if option {
+      {
+        if option {
+          return;
+        } else {
+          throw new Error();
+        }
+      }
+    } else {
+      a = new R(1);
+    }
+  }
+}
+try { test6(); } catch e { writeln(e); }
+
+proc test7() throws {
+  writeln("test7");
+  var a;
+  {
+    if !option {
+      {
+        if option {
+          return;
+        } else {
+          throw new Error();
+        }
+      }
+    } else {
+      a = new R(1);
+    }
+  }
+}
+try { test7(); } catch e { writeln(e); }

--- a/test/types/records/split-init/split-init-2-conds.good
+++ b/test/types/records/split-init/split-init-2-conds.good
@@ -1,2 +1,13 @@
+test1
 owned C {x = 1}
 owned C {x = 4}
+test2
+test3
+init 1
+test4
+init 1
+test5
+Error: 
+test6
+test7
+init 1

--- a/test/types/records/split-init/split-init-examples-inspired-by-ak.chpl
+++ b/test/types/records/split-init/split-init-examples-inspired-by-ak.chpl
@@ -1,0 +1,226 @@
+module M {
+  // inspired by Arkouda and its transition to non-nilable classes
+
+  use Map;
+
+  class Entry {
+    var x: int;
+  }
+
+  class Table {
+    var tab: map(string, shared Entry);
+
+    proc store(name: string, x: int) {
+      if tab.contains(name) {
+        tab[name].x = x;
+      } else {
+        tab.add(name, new shared Entry(x));
+      }
+    }
+  }
+
+  proc Table.lookup(name:string): borrowed Entry throws {
+
+    if !tab.contains(name) {
+      throw new Error("no entry for " + name);
+    }
+
+    ref r = tab[name]; // workaround for an issue solved by 14793
+    return r.borrow();
+  }
+
+  proc Table.tryLookup(name:string): borrowed Entry? {
+
+    if !tab.contains(name) {
+      return nil;
+    }
+
+    ref r = tab[name]; // workaround for an issue solved by 14793
+    return r.borrow();
+  }
+
+
+  proc test0(t: Table, numerators:[] string, denominator:string): string {
+
+    var denominatorEntryQ: borrowed Entry? = t.tryLookup(denominator);
+    
+    if denominatorEntryQ == nil {
+      return "no entry for " + denominator;
+    }
+    var denominatorEntry = denominatorEntryQ!;
+
+    if denominatorEntry.x == 0 then
+      return "cannot divide by 0";
+
+    var denom = denominatorEntry.x;
+
+    for numerator in numerators {
+      var numeratorEntryQ: borrowed Entry? = t.tryLookup(numerator);
+      if numeratorEntryQ == nil {
+        return "no entry for " + numerator;
+      } else if numeratorEntryQ!.x == 0 {
+        return "0 numerator not supported";
+      }
+    }
+
+    var sum = 0;
+    for numerator in numerators {
+      var numeratorEntryQ: borrowed Entry? = t.tryLookup(numerator);
+      sum += numeratorEntryQ!.x;
+    }
+
+    return "result: " + (sum / denom):string;
+  }
+
+  proc test1(t: Table, numerators:[] string, denominator:string): string {
+    var denominatorEntryQ: borrowed Entry?;
+    
+    try {
+      denominatorEntryQ = t.lookup(denominator);
+    } catch e {
+      return e.message();
+    }
+
+    var denominatorEntry = denominatorEntryQ!;
+
+    if denominatorEntry.x == 0 then
+      return "cannot divide by 0";
+
+    var denom = denominatorEntry.x;
+
+    for numerator in numerators {
+      try {
+        var numeratorEntry: borrowed Entry = t.lookup(numerator);
+        if numeratorEntry.x == 0 then
+          return "0 numerator not supported";
+      } catch e {
+        return e.message();
+      }
+    }
+
+    var sum = 0;
+    for numerator in numerators {
+      try {
+        var numeratorEntry: borrowed Entry = t.lookup(numerator);
+        sum += numeratorEntry.x;
+      } catch e {
+        return e.message();
+      }
+    }
+
+    return "result: " + (sum / denom):string;
+  }
+
+  proc test2(t: Table, numerators:[] string, denominator:string): string {
+    var denominatorEntry: borrowed Entry;
+    
+    try {
+      denominatorEntry = t.lookup(denominator);
+    } catch e {
+      return e.message();
+    }
+
+    if denominatorEntry.x == 0 then
+      return "cannot divide by 0";
+
+    var denom = denominatorEntry.x;
+
+    for numerator in numerators {
+      try {
+        var numeratorEntry: borrowed Entry = t.lookup(numerator);
+        if numeratorEntry.x == 0 then
+          return "0 numerator not supported";
+      } catch e {
+        return e.message();
+      }
+    }
+
+    var sum = 0;
+    for numerator in numerators {
+      try {
+        var numeratorEntry: borrowed Entry = t.lookup(numerator);
+        sum += numeratorEntry.x;
+      } catch e {
+        return e.message();
+      }
+    }
+
+    return "result: " + (sum / denom):string;
+  }
+
+  proc doTest3(t: Table, numerators:[] string, denominator:string): string
+                                                                    throws {
+    var denominatorEntry: borrowed Entry;
+    
+    try {
+      denominatorEntry = t.lookup(denominator);
+    }
+
+    if denominatorEntry.x == 0 then
+      throw new Error("cannot divide by 0");
+
+    var denom = denominatorEntry.x;
+
+    for numerator in numerators {
+      try {
+        var numeratorEntry: borrowed Entry = t.lookup(numerator);
+        if numeratorEntry.x == 0 then
+          throw new Error("0 numerator not supported");
+      }
+    }
+
+    var sum = 0;
+    for numerator in numerators {
+      try {
+        var numeratorEntry: borrowed Entry = t.lookup(numerator);
+        sum += numeratorEntry.x;
+      }
+    }
+
+    return "result: " + (sum / denom):string;
+  }
+
+  proc test3(t: Table, numerators:[] string, denominator:string):string {
+    try {
+      return doTest3(t, numerators, denominator);
+    } catch e {
+      return e.message();
+    }
+  }
+
+  proc main() {
+    var t = new Table();
+    t.store("z", 0);
+    t.store("a", 1);
+    t.store("b", 3);
+    t.store("c", 2);
+
+    writeln("test0");
+    writeln(test0(t, ["a", "b"], "c"));
+    writeln(test0(t, ["a", "b"], "z"));
+    writeln(test0(t, ["z", "b"], "c"));
+    writeln(test0(t, ["a", "b"], "x"));
+    writeln(test0(t, ["a", "y"], "c"));
+ 
+    writeln("test1");
+    writeln(test1(t, ["a", "b"], "c"));
+    writeln(test1(t, ["a", "b"], "z"));
+    writeln(test1(t, ["z", "b"], "c"));
+    writeln(test1(t, ["a", "b"], "x"));
+    writeln(test1(t, ["a", "y"], "c"));
+    
+    writeln("test2");
+    writeln(test2(t, ["a", "b"], "c"));
+    writeln(test2(t, ["a", "b"], "z"));
+    writeln(test2(t, ["z", "b"], "c"));
+    writeln(test2(t, ["a", "b"], "x"));
+    writeln(test2(t, ["a", "y"], "c"));
+
+    writeln("test3");
+    writeln(test3(t, ["a", "b"], "c"));
+    writeln(test3(t, ["a", "b"], "z"));
+    writeln(test3(t, ["z", "b"], "c"));
+    writeln(test3(t, ["a", "b"], "x"));
+    writeln(test3(t, ["a", "y"], "c"));
+  }
+}

--- a/test/types/records/split-init/split-init-examples-inspired-by-ak.good
+++ b/test/types/records/split-init/split-init-examples-inspired-by-ak.good
@@ -1,0 +1,24 @@
+test0
+result: 2
+cannot divide by 0
+0 numerator not supported
+no entry for x
+no entry for y
+test1
+result: 2
+cannot divide by 0
+0 numerator not supported
+no entry for x
+no entry for y
+test2
+result: 2
+cannot divide by 0
+0 numerator not supported
+no entry for x
+no entry for y
+test3
+result: 2
+cannot divide by 0
+0 numerator not supported
+no entry for x
+no entry for y

--- a/test/types/records/split-init/split-init-try-more.chpl
+++ b/test/types/records/split-init/split-init-try-more.chpl
@@ -1,3 +1,5 @@
+config const option = true;
+
 class C { }
 record R {
   var x: int = 0;
@@ -26,14 +28,14 @@ proc =(ref lhs:R, rhs:R) {
 proc makeR(arg: int, error: bool) throws {
   if error then
     throw new Error();
-  
+
   return new R(arg);
 }
 
 proc test1() {
   writeln("test1");
   var r:R;
-  
+
   try {
     r = makeR(1, false);
   } catch {
@@ -46,7 +48,7 @@ test1();
 proc test2() {
   writeln("test2");
   var r:R;
-  
+
   try {
     r = makeR(1, true);
   } catch {
@@ -58,9 +60,10 @@ test2();
 
 proc testAB00() {
   writeln("testAB00");
+  var outer = makeR(0, false);
   var a:R;
   var b:R;
-  
+
   try {
     a = makeR(1, false);
     b = makeR(2, false);
@@ -68,14 +71,18 @@ proc testAB00() {
     writeln("error encountered");
     return;
   }
+
+  writeln(outer, " ", a, " ", b);
+  writeln("end");
 }
 testAB00();
 
 proc testAB01() {
   writeln("testAB01");
+  var outer = makeR(0, false);
   var a:R;
   var b:R;
-  
+
   try {
     a = makeR(1, false);
     b = makeR(2, true);
@@ -83,14 +90,18 @@ proc testAB01() {
     writeln("error encountered");
     return;
   }
+
+  writeln(outer, " ", a, " ", b);
+  writeln("end");
 }
 testAB01();
 
 proc testAB10() {
   writeln("testAB10");
+  var outer = makeR(0, false);
   var a:R;
   var b:R;
-  
+
   try {
     a = makeR(1, true);
     b = makeR(2, false);
@@ -98,14 +109,18 @@ proc testAB10() {
     writeln("error encountered");
     return;
   }
+
+  writeln(outer, " ", a, " ", b);
+  writeln("end");
 }
 testAB10();
 
 proc testAB11() {
   writeln("testAB11");
+  var outer = makeR(0, false);
   var a:R;
   var b:R;
-  
+
   try {
     a = makeR(1, true);
     b = makeR(2, true);
@@ -113,5 +128,285 @@ proc testAB11() {
     writeln("error encountered");
     return;
   }
+
+  writeln(outer, " ", a, " ", b);
+  writeln("end");
 }
 testAB11();
+
+proc test1eob() {
+  writeln("test1eob");
+  var r:R;
+
+  try {
+    r = makeR(1, false);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+
+  ref rr = r;
+}
+test1eob();
+
+proc test2eob() {
+  writeln("test2eob");
+  var r:R;
+
+  try {
+    r = makeR(1, true);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+
+  r;
+}
+test2eob();
+
+proc testAB00eob() {
+  writeln("testAB00eob");
+  var a:R;
+  var b:R;
+
+  try {
+    a = makeR(1, false);
+    b = makeR(2, false);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+
+  ref ra = a;
+  ref rb = b;
+}
+testAB00eob();
+
+proc testAB01eob() {
+  writeln("testAB01");
+  var a:R;
+  var b:R;
+
+  try {
+    a = makeR(1, false);
+    b = makeR(2, true);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+
+  ref ra = a;
+  ref rb = b;
+}
+testAB01eob();
+
+proc testAB10eob() {
+  writeln("testAB10eob");
+  var a:R;
+  var b:R;
+
+  try {
+    a = makeR(1, true);
+    b = makeR(2, false);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+
+  a; b;
+}
+testAB10eob();
+
+proc testAB11eob() {
+  writeln("testAB11eob");
+  var a:R;
+  var b:R;
+
+  try {
+    a = makeR(1, true);
+    b = makeR(2, true);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+
+  ref ra = a;
+  ref rb = b;
+}
+testAB11eob();
+
+
+proc makeRNoThrow(arg: int) {
+  return new R(arg);
+}
+
+proc doThrow() throws {
+  throw new Error();
+}
+proc doThrow(arg) throws {
+  throw new Error();
+}
+
+proc f(a, b) { }
+
+proc test11() {
+  writeln("test11");
+  var r:R;
+
+  try {
+    r = new R(1);
+    doThrow(r);
+    doThrow();
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test11();
+
+proc test12() {
+  writeln("test12");
+
+  try {
+    var r:R;
+    r = new R(1);
+    doThrow(r);
+    doThrow();
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test12();
+
+proc test13() {
+  writeln("test13");
+
+  try {
+    var r:R;
+    r = new R(1);
+    ref rr = r;
+    doThrow(r);
+    doThrow();
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test13();
+
+proc test14() {
+  writeln("test14");
+
+  try {
+    var r:R;
+    r = makeR(1, true);
+    doThrow(r);
+    doThrow();
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test14();
+
+proc test15() {
+  writeln("test15");
+
+  try {
+    var r:R;
+    r = makeR(1, true);
+    ref rr = r;
+    doThrow(r);
+    doThrow();
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test15();
+
+proc test16() {
+  writeln("test16");
+
+  try {
+    makeR(1, true);
+    doThrow();
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test16();
+
+proc test611() {
+  writeln("test611");
+
+  try {
+    f(makeR(1, true), makeR(2, true));
+    writeln("after f");
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test611();
+
+proc test610() {
+  writeln("test610");
+
+  try {
+    f(makeR(1, true), makeR(2, false));
+    writeln("after f");
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test610();
+
+proc test601() {
+  writeln("test601");
+
+  try {
+    f(makeR(1, false), makeR(2, true));
+    writeln("after f");
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test601();
+
+proc test600() {
+  writeln("test600");
+
+  try {
+    f(makeR(1, false), makeR(2, false));
+    writeln("after f");
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test600();
+
+
+proc test17() {
+  writeln("test17");
+
+  try {
+    makeRNoThrow(1);
+    if option {
+      doThrow();
+    } else {
+    }
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test17();
+
+// TODO: try/catch combined with if statement and split init
+// TODO: check initialization order for multiple outer variables

--- a/test/types/records/split-init/split-init-try-more.chpl
+++ b/test/types/records/split-init/split-init-try-more.chpl
@@ -1,0 +1,117 @@
+class C { }
+record R {
+  var x: int = 0;
+  var ptr: owned C = new owned C();
+  proc init() {
+    this.x = 0;
+    writeln("init");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    writeln("init ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    writeln("init= ", other.x);
+  }
+  proc deinit() {
+    writeln("deinit ", x);
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  writeln("= ", lhs.x, " ", rhs.x);
+  lhs.x = rhs.x;
+}
+
+proc makeR(arg: int, error: bool) throws {
+  if error then
+    throw new Error();
+  
+  return new R(arg);
+}
+
+proc test1() {
+  writeln("test1");
+  var r:R;
+  
+  try {
+    r = makeR(1, false);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test1();
+
+proc test2() {
+  writeln("test2");
+  var r:R;
+  
+  try {
+    r = makeR(1, true);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+test2();
+
+proc testAB00() {
+  writeln("testAB00");
+  var a:R;
+  var b:R;
+  
+  try {
+    a = makeR(1, false);
+    b = makeR(2, false);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+testAB00();
+
+proc testAB01() {
+  writeln("testAB01");
+  var a:R;
+  var b:R;
+  
+  try {
+    a = makeR(1, false);
+    b = makeR(2, true);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+testAB01();
+
+proc testAB10() {
+  writeln("testAB10");
+  var a:R;
+  var b:R;
+  
+  try {
+    a = makeR(1, true);
+    b = makeR(2, false);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+testAB10();
+
+proc testAB11() {
+  writeln("testAB11");
+  var a:R;
+  var b:R;
+  
+  try {
+    a = makeR(1, true);
+    b = makeR(2, true);
+  } catch {
+    writeln("error encountered");
+    return;
+  }
+}
+testAB11();

--- a/test/types/records/split-init/split-init-try-more.chpl
+++ b/test/types/records/split-init/split-init-try-more.chpl
@@ -408,5 +408,281 @@ proc test17() {
 }
 test17();
 
-// TODO: try/catch combined with if statement and split init
-// TODO: check initialization order for multiple outer variables
+proc test2000() {
+  writeln("test2000");
+
+  var outer = makeR(0, false);
+  var r;
+
+  try {
+    writeln("begin try");
+    if option {
+      r = makeR(1, false);
+    } else {
+      r = makeR(2, false);
+    }
+    writeln("end try");
+  } catch e {
+    writeln("error encountered");
+    return;
+  }
+}
+proc test2001() {
+  writeln("test2010");
+
+  var outer = makeR(0, false);
+  var r;
+
+  try {
+    writeln("begin try");
+    if option {
+      r = makeR(1, true);
+    } else {
+      r = makeR(2, false);
+    }
+    writeln("end try");
+  } catch e {
+    writeln("error encountered");
+    return;
+  }
+
+  outer;
+}
+test2001();
+
+proc test2100() {
+  writeln("test2100");
+
+  var outer = makeR(0, false);
+  var r;
+
+  try {
+    writeln("begin try");
+    if !option {
+      r = makeR(1, false);
+    } else {
+      r = makeR(2, false);
+    }
+    writeln("end try");
+  } catch e {
+    writeln("error encountered");
+    return;
+  }
+
+  outer;
+}
+test2100();
+
+proc test2101() {
+  writeln("test2101");
+
+  var outer = makeR(0, false);
+  var r;
+
+  try {
+    writeln("begin try");
+    if !option {
+      r = makeR(1, false);
+    } else {
+      r = makeR(2, true);
+    }
+    writeln("end try");
+  } catch e {
+    writeln("error encountered");
+    return;
+  }
+
+  outer;
+}
+test2101();
+
+proc test3000() {
+  writeln("test3000");
+
+  var outer = makeR(0, false);
+  var r;
+
+  if option {
+    try {
+      writeln("begin try1");
+      r = makeR(1, false);
+      writeln("end try1");
+    } catch e {
+      writeln("error encountered1");
+      return;
+    }
+  } else {
+    try {
+      writeln("begin try2");
+      r = makeR(2, false);
+      writeln("end try2");
+    } catch e {
+      writeln("error encountered2");
+      return;
+    }
+  }
+
+  outer;
+}
+test3000();
+
+proc test3010() {
+  writeln("test3010");
+
+  var outer = makeR(0, false);
+  var r;
+
+  if option {
+    try {
+      writeln("begin try1");
+      r = makeR(1, true);
+      writeln("end try1");
+    } catch e {
+      writeln("error encountered1");
+      return;
+    }
+  } else {
+    try {
+      writeln("begin try2");
+      r = makeR(2, false);
+      writeln("end try2");
+    } catch e {
+      writeln("error encountered2");
+      return;
+    }
+  }
+
+  outer;
+}
+test3010();
+
+proc test3111() {
+  writeln("test3111");
+
+  var outer = makeR(0, false);
+  var r;
+
+  if !option {
+    try {
+      writeln("begin try1");
+      r = makeR(1, true);
+      writeln("end try1");
+    } catch e {
+      writeln("error encountered1");
+      return;
+    }
+  } else {
+    try {
+      writeln("begin try2");
+      r = makeR(2, true);
+      writeln("end try2");
+    } catch e {
+      writeln("error encountered2");
+      return;
+    }
+  }
+
+  outer;
+}
+test3111();
+
+proc test19() throws {
+  writeln("test19");
+
+  var r: R;
+
+  {
+    writeln("begin inner");
+    try {
+
+      {
+        r = makeR(1, false);
+        doThrow();
+      }
+    } catch e {
+      writeln("error encountered");
+      throw e;
+    }
+    writeln("end inner");
+  }
+}
+try { test19(); } catch e { writeln(e); }
+
+
+proc test20() throws {
+  writeln("test20");
+
+  var a: R;
+  var b: R;
+  var c: R;
+
+  {
+    writeln("begin inner");
+    try {
+
+      {
+        a = makeR(1, false);
+        b = makeR(2, false);
+        c = makeR(3, false);
+      }
+    } catch e {
+      writeln("error encountered");
+      throw e;
+    }
+    writeln("end inner");
+  }
+}
+try { test20(); } catch e { writeln(e); }
+
+proc test21() throws {
+  writeln("test21");
+
+  var a: R;
+  var b: R;
+  var c: R;
+
+  {
+    writeln("begin inner");
+    try {
+
+      {
+        a = makeR(1, false);
+        b = makeR(2, false);
+        c = makeR(3, false);
+        doThrow();
+      }
+    } catch e {
+      writeln("error encountered");
+      throw e;
+    }
+    writeln("end inner");
+  }
+}
+try { test21(); } catch e { writeln(e); }
+
+proc test22() throws {
+  writeln("test22");
+
+  var a: R;
+  var b: R;
+  var c: R;
+
+  {
+    writeln("begin inner");
+    try {
+
+      {
+        a = makeR(1, false);
+        b = makeR(2, false);
+        c = makeR(3, false);
+        doThrow();
+      }
+    } catch e {
+      writeln("error encountered");
+    }
+    writeln("end inner");
+  }
+
+  writeln(a, " ", b, " ", c);
+}
+try { test22(); } catch e { writeln(e); }

--- a/test/types/records/split-init/split-init-try-more.good
+++ b/test/types/records/split-init/split-init-try-more.good
@@ -1,0 +1,82 @@
+test1
+init 1
+deinit 1
+test2
+error encountered
+testAB00
+init 0
+init 1
+init 2
+(x = 0, ptr = {}) (x = 1, ptr = {}) (x = 2, ptr = {})
+deinit 2
+deinit 1
+deinit 0
+end
+testAB01
+init 0
+init 1
+deinit 1
+error encountered
+deinit 0
+testAB10
+init 0
+error encountered
+deinit 0
+testAB11
+init 0
+error encountered
+deinit 0
+test1eob
+init 1
+deinit 1
+test2eob
+error encountered
+testAB00eob
+init 1
+init 2
+deinit 2
+deinit 1
+testAB01
+init 1
+deinit 1
+error encountered
+testAB10eob
+error encountered
+testAB11eob
+error encountered
+test11
+init 1
+deinit 1
+error encountered
+test12
+init 1
+deinit 1
+error encountered
+test13
+init 1
+deinit 1
+error encountered
+test14
+error encountered
+test15
+error encountered
+test16
+error encountered
+test611
+error encountered
+test610
+error encountered
+test601
+init 1
+deinit 1
+error encountered
+test600
+init 1
+init 2
+deinit 2
+deinit 1
+after f
+test17
+init 1
+deinit 1
+error encountered

--- a/test/types/records/split-init/split-init-try-more.good
+++ b/test/types/records/split-init/split-init-try-more.good
@@ -80,3 +80,82 @@ test17
 init 1
 deinit 1
 error encountered
+test2010
+init 0
+begin try
+error encountered
+deinit 0
+test2100
+init 0
+begin try
+init 2
+end try
+deinit 2
+deinit 0
+test2101
+init 0
+begin try
+error encountered
+deinit 0
+test3000
+init 0
+begin try1
+init 1
+end try1
+deinit 1
+deinit 0
+test3010
+init 0
+begin try1
+error encountered1
+deinit 0
+test3111
+init 0
+begin try2
+error encountered2
+deinit 0
+test19
+begin inner
+init 1
+deinit 1
+error encountered
+Error: 
+test20
+begin inner
+init 1
+init 2
+init 3
+end inner
+deinit 3
+deinit 2
+deinit 1
+test21
+begin inner
+init 1
+init 2
+init 3
+deinit 3
+deinit 2
+deinit 1
+error encountered
+Error: 
+test22
+init
+init
+init
+begin inner
+init 1
+= 0 1
+deinit 1
+init 2
+= 0 2
+deinit 2
+init 3
+= 0 3
+deinit 3
+error encountered
+end inner
+(x = 1, ptr = {}) (x = 2, ptr = {}) (x = 3, ptr = {})
+deinit 3
+deinit 2
+deinit 1

--- a/test/types/records/split-init/split-init-try.chpl
+++ b/test/types/records/split-init/split-init-try.chpl
@@ -16,6 +16,9 @@ record R {
     this.x = other.x;
     writeln("init= ", other.x);
   }
+  proc deinit() {
+    writeln("deinit ", x);
+  }
 }
 proc =(ref lhs:R, rhs:R) {
   writeln("= ", lhs.x, " ", rhs.x);
@@ -32,23 +35,89 @@ proc makeR(arg:int) throws {
 proc test() throws {
   writeln("test");
 
-  writeln("x");
-  var x:R = makeR(0);
-
-  writeln("no00");
-  var no00:R;
-  try {
-    no00 = makeR(1);
+  {
+    writeln("x");
+    var x:R = makeR(0);
   }
-  writeln(no00);
 
-  writeln("no01");
-  var no01:R;
-  try! {
-    no01 = makeR(2);
+  {
+    writeln("yes0");
+    var yes0:R;
+    try {
+      yes0 = makeR(0);
+    }
+    writeln(yes0);
   }
-  writeln(no01);
+ 
+  {
+    writeln("yes1");
+    var yes1:R;
+    try {
+      yes1 = makeR(1);
+    } catch {
+      return;
+    }
+    writeln(yes1);
+  }
 
+  {
+    writeln("yes2");
+    var yes2:R;
+    try {
+      yes2 = makeR(2);
+    } catch {
+      throw new Error();
+    }
+    writeln(yes2);
+  }
+
+  {
+    writeln("yes3");
+    var yes3:R;
+    try {
+      yes3 = makeR(3);
+    } catch {
+      throw new Error();
+    }
+    writeln(yes3);
+  }
+
+  {
+    writeln("yes1b");
+    var yes1b:R;
+    try! {
+      yes1b = makeR(1);
+    } catch {
+      return;
+    }
+    writeln(yes1b);
+  }
+
+  {
+    writeln("yes2b");
+    var yes2b:R;
+    try! {
+      yes2b = makeR(2);
+    } catch {
+      throw new Error();
+    }
+    writeln(yes2b);
+  }
+
+  {
+    writeln("yes3b");
+    var yes3b:R;
+    try {
+      yes3b = makeR(3);
+    } catch {
+      throw new Error();
+    }
+    writeln(yes3b);
+  }
+}
+try! test();
+
+proc test1() throws {
   writeln("no1");
   var no1:R;
   try {
@@ -57,16 +126,23 @@ proc test() throws {
     writeln(e);
   }
   writeln(no1);
+}
+try! test1();
 
+proc test2() throws {
   writeln("no2");
   var no2:R;
   try {
+    return;
     no2 = makeR(1);
   } catch e {
     writeln(e);
   }
   writeln(no2);
-  
+}
+try! test2();
+ 
+proc test3() throws {
   writeln("no3");
   var no3:R;
   try {
@@ -76,4 +152,43 @@ proc test() throws {
   }
   writeln(no3);
 }
-try! test();
+try! test3();
+
+proc test4() throws {
+  writeln("no4");
+  var no4:R;
+  try {
+    return;
+  } catch e {
+    no4 = makeR(1);
+    writeln(e);
+  }
+  writeln(no4);
+}
+try! test4();
+
+proc test5() throws {
+  writeln("no5");
+  var no5:R;
+  try {
+    no5 = makeR(1);
+    throw new Error();
+  } catch e {
+    no5 = makeR(2);
+  }
+  writeln(no5);
+}
+try! test5();
+
+proc test6() throws {
+  writeln("no6");
+  var no6:R;
+  try {
+    no6 = makeR(1);
+    throw new Error();
+  } catch e {
+    no6 = makeR(2);
+  }
+  writeln(no6);
+}
+try! test6();

--- a/test/types/records/split-init/split-init-try.good
+++ b/test/types/records/split-init/split-init-try.good
@@ -1,26 +1,69 @@
 test
 x
 init 0
-no00
-init
+deinit 0
+yes0
+init 0
+(x = 0, ptr = {})
+deinit 0
+yes1
 init 1
-= 0 1
 (x = 1, ptr = {})
-no01
-init
+deinit 1
+yes2
 init 2
-= 0 2
 (x = 2, ptr = {})
+deinit 2
+yes3
+init 3
+(x = 3, ptr = {})
+deinit 3
+yes1b
+init 1
+(x = 1, ptr = {})
+deinit 1
+yes2b
+init 2
+(x = 2, ptr = {})
+deinit 2
+yes3b
+init 3
+(x = 3, ptr = {})
+deinit 3
 no1
 init
 init 1
 = 0 1
+deinit 1
 (x = 1, ptr = {})
+deinit 1
 no2
 init
-init 1
-= 0 1
-(x = 1, ptr = {})
+deinit 0
 no3
 init
 (x = 0, ptr = {})
+deinit 0
+no4
+init
+deinit 0
+no5
+init
+init 1
+= 0 1
+deinit 1
+init 2
+= 1 2
+deinit 2
+(x = 2, ptr = {})
+deinit 2
+no6
+init
+init 1
+= 0 1
+deinit 1
+init 2
+= 1 2
+deinit 2
+(x = 2, ptr = {})
+deinit 2


### PR DESCRIPTION
* Split init is now allowed within a conditional if the other conditional
  branch always returns or throws
* Split init is now allowed within a try block if there are not catch
  statements or if all catch statements return or throw
* Adjusts callDestructors code to handle split-init try/catch patterns. 
  Along the way, applied a different strategy to resolve a memory leak
  for `var a = for ...` (replacing the workaround PR #14192).
* Adds a split-init example inspired by Arkouda
* Updates spec

Reviewed by @benharsh - thanks!

- [x] full local testing
- [x] primers valgrind and memleak testing