### PR TITLE
Fix broken formatting in tuple spec

### DIFF
--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -845,7 +845,11 @@ Returns true if ``t`` is a homogeneous tuple; otherwise false.
 
 Returns true if ``t`` is a tuple; otherwise false.
 
-BLOCK-protohead proc isTupleType(type t) param
+
+
+.. code-block:: chapel
+
+  proc isTupleType(type t) param
 
 Returns true if ``t`` is a tuple of types; otherwise false.
 


### PR DESCRIPTION
This PR fixes the formatting of the prototype for a tuple routine so that it renders properly. Previously, it looked something like this:

```
BLOCK-protohead proc isTupleType(type t) param

Returns true if t is a tuple of types; otherwise false.
```

Small bugs like this may exist due to the automated conversion of the spec from TEX to RST.

---

Testing:

- [x] Render docs on `web.us.cray.com/~dlongnecke/`