### PR TITLE
Address deinit point and param loops and conditionals

### DIFF
--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -21,6 +21,7 @@
 
 #include "AstVisitor.h"
 #include "build.h"
+#include "passes.h"
 #include "resolution.h"
 #include "resolveFunction.h"
 #include "stringutil.h"
@@ -400,6 +401,8 @@ CallExpr* ParamForLoop::foldForResolve()
   // Insert an "insertion marker" for loop unrolling
   insertAfter(noop);
 
+  bool emptyLoop = true;
+
   if (is_int_type(idxType))
   {
     int64_t low    = lvar->immediate->to_int();
@@ -414,6 +417,7 @@ CallExpr* ParamForLoop::foldForResolve()
 
         map.put(idxSym, new_IntSymbol(i, idxSize));
         copyBodyHelper(noop, i, &map, this, continueSym);
+        emptyLoop = false;
       }
     }
     else
@@ -423,8 +427,8 @@ CallExpr* ParamForLoop::foldForResolve()
         SymbolMap map;
 
         map.put(idxSym, new_IntSymbol(i, idxSize));
-
         copyBodyHelper(noop, i, &map, this, continueSym);
+        emptyLoop = false;
       }
     }
   }
@@ -449,6 +453,7 @@ CallExpr* ParamForLoop::foldForResolve()
         }
 
         copyBodyHelper(noop, i, &map, this, continueSym);
+        emptyLoop = false;
       }
     }
     else
@@ -464,9 +469,13 @@ CallExpr* ParamForLoop::foldForResolve()
         }
 
         copyBodyHelper(noop, i, &map, this, continueSym);
+        emptyLoop = false;
       }
     }
   }
+
+  if (emptyLoop)
+    addMentionToEndOfStatement(this, NULL);
 
   // Remove the "insertion marker"
   noop->remove();

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -127,6 +127,7 @@ bool isVirtualIterator(FnSymbol* iterFn);
 void normalize(FnSymbol* fn);
 void normalize(Expr* expr);
 void checkUseBeforeDefs(FnSymbol* fn);
+void addMentionToEndOfStatement(Expr* node, CallExpr* existingEndOfStatement);
 
 // parallel.cpp
 Type* getOrMakeRefTypeDuringCodegen(Type* type);

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -171,7 +171,7 @@ public:
   virtual Expr*       getFirstExpr();
   virtual Expr*       getNextExpr(Expr* expr);
 
-  CallExpr*           foldConstantCondition();
+  CallExpr*           foldConstantCondition(bool addEndOfStatement);
 
   Expr*               condExpr;
   BlockStmt*          thenStmt;

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -197,7 +197,7 @@ void deadExpressionElimination(FnSymbol* fn) {
 
         // NOAKES 2014/11/14 It's "odd" that folding is being done here
         } else {
-          cond->foldConstantCondition();
+          cond->foldConstantCondition(false);
         }
 
         // NOAKES 2014/11/14 Testing suggests this is always a NOP

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7977,7 +7977,7 @@ static Expr* foldTryCond(Expr* expr) {
 
   if (CondStmt* cond = toCondStmt(expr->parentExpr))
     if (cond->condExpr == expr)
-      if (CallExpr* noop = cond->foldConstantCondition())
+      if (CallExpr* noop = cond->foldConstantCondition(true))
         retval = noop;
 
   return retval;

--- a/test/types/records/expiring/last-mention-param-constructs.chpl
+++ b/test/types/records/expiring/last-mention-param-constructs.chpl
@@ -1,0 +1,123 @@
+class C { }
+record R {
+  var x: int = 0;
+  var ptr: owned C = new owned C();
+  proc init() {
+    this.x = 0;
+    writeln("init");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    writeln("init ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    writeln("init= ", other.x);
+  }
+  proc deinit() {
+    writeln("deinit ", x);
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  writeln("= ", lhs.x, " ", rhs.x);
+  lhs.x = rhs.x;
+}
+
+
+proc test1() {
+  writeln("test1");
+  var r = new R(1);
+
+  writeln(r);
+
+  // point 1
+
+  writeln("before param conditional");
+
+  if false {
+    writeln(r);
+  }
+
+  // point 2
+
+  writeln("after param conditional");
+}
+test1();
+
+proc test2() {
+  writeln("test2");
+  var r = new R(1);
+
+  writeln(r);
+
+  // point 1
+
+  writeln("before param loop");
+
+  for param i in 1..2 {
+    writeln(r);
+  }
+
+  // point 2
+
+  writeln("after param loop");
+}
+test2();
+
+proc test3() {
+  writeln("test3");
+  var r = new R(1);
+
+  writeln(r);
+
+  // point 1
+
+  writeln("before param loop");
+
+  for param i in 1..0 {
+    writeln(r);
+  }
+
+  // point 2
+
+  writeln("after param loop");
+}
+test3();
+
+inline proc f(arg) { }
+
+proc test4() {
+  writeln("test4");
+  var r = new R(1);
+
+  writeln(r);
+
+  // point 1
+
+  writeln("before inlined empty call");
+
+  f(r);
+
+  // point 2
+
+  writeln("after inlined empty call");
+}
+test4();
+
+proc test5() {
+  writeln("test5");
+  var r = new R(1);
+
+  writeln(r);
+
+  // point 1
+
+  writeln("before folded if-expr in call");
+
+  f(if true then 1 else r);
+
+  // point 2
+
+  writeln("after folded if-expr in call");
+}
+test5();

--- a/test/types/records/expiring/last-mention-param-constructs.good
+++ b/test/types/records/expiring/last-mention-param-constructs.good
@@ -1,0 +1,42 @@
+Expiring values for function test1 (last-mention-param-constructs.chpl:27)
+  r (last-mention-param-constructs.chpl:29) expires after last mention
+Expiring values for function test2 (last-mention-param-constructs.chpl:47)
+  r (last-mention-param-constructs.chpl:49) expires after last mention
+Expiring values for function test3 (last-mention-param-constructs.chpl:67)
+  r (last-mention-param-constructs.chpl:69) expires after last mention
+Expiring values for function test4 (last-mention-param-constructs.chpl:89)
+  r (last-mention-param-constructs.chpl:91) expires after last mention
+Expiring values for function test5 (last-mention-param-constructs.chpl:107)
+  r (last-mention-param-constructs.chpl:109) expires after last mention
+test1
+init 1
+(x = 1, ptr = {})
+before param conditional
+deinit 1
+after param conditional
+test2
+init 1
+(x = 1, ptr = {})
+before param loop
+(x = 1, ptr = {})
+(x = 1, ptr = {})
+deinit 1
+after param loop
+test3
+init 1
+(x = 1, ptr = {})
+before param loop
+deinit 1
+after param loop
+test4
+init 1
+(x = 1, ptr = {})
+before inlined empty call
+deinit 1
+after inlined empty call
+test5
+init 1
+(x = 1, ptr = {})
+before folded if-expr in call
+deinit 1
+after folded if-expr in call


### PR DESCRIPTION
Per the discussion in #14817, this PR updates the compiler so that the 
last-mention point for a variable mentioned in a folded-away param
conditional or loop is after that loop.

Reviewed by @benharsh - thanks! 

- [x] full local testing