### PR TITLE
Add infrastructure to build/test Arkouda

### DIFF
--- a/test/studies/arkouda.skipif
+++ b/test/studies/arkouda.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_ARKOUDA != true

--- a/test/studies/arkouda/.gitignore
+++ b/test/studies/arkouda/.gitignore
@@ -1,0 +1,1 @@
+arkouda

--- a/test/studies/arkouda/functions.bash
+++ b/test/studies/arkouda/functions.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Helper functions for logging and marking test start/stop. Formats output in
+# the way the testing infrastructure expects.
+
+function log_error() {
+  local msg=$@
+  echo "[Error ${msg}]"
+  exit 0
+}
+
+function log_success() {
+  local msg=$@
+  echo "[Success matching ${msg}]"
+}
+
+function subtest_start() {
+  subtest_start_time=$(date +%s)
+  echo "[Starting subtest - $(date)]"
+}
+
+function subtest_end() {
+  local subtest_end_time=$(date +%s)
+  local elapsed=$(( $subtest_end_time - $subtest_start_time ))
+  echo "[Finished subtest \"studies/arkouda\" - $elapsed seconds"
+}
+
+function test_start() {
+  local tname=$1
+  echo "[test: \"$tname\"]"
+  SECONDS=0
+}
+
+function test_end() {
+  local tname="$1"
+  elapsed=$SECONDS
+  echo "[Elapsed time to compile and execute all versions of \"$tname\" - $elapsed.000 seconds]"
+}

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Custom sub_test to run Arkouda testing. Clones, installs dependencies, builds
+# Arkouda and runs testing.
+
+ARKOUDA_URL=git@github.com:mhmerrill/arkouda.git
+ARKOUDA_BRANCH=master
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/functions.bash
+
+subtest_start
+
+# Arkouda needs chpl in PATH
+bin_subdir=$($CHPL_HOME/util/chplenv/chpl_bin_subdir.py)
+export "PATH=$CHPL_HOME/bin/$bin_subdir:$PATH"
+chpl --version
+
+export ARKOUDA_HOME=$CWD/arkouda
+rm -rf ${ARKOUDA_HOME}
+
+# Clone Arkouda 
+if ! git clone --depth=1 ${ARKOUDA_URL} --branch=${ARKOUDA_BRANCH} ; then
+  log_error "cloning Arkouda"
+fi
+cd ${ARKOUDA_HOME}
+
+# Install dependencies
+if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
+  log_error "installing dependencies"
+fi
+
+# Compile Arkouda
+if ! make ; then
+  log_error "compiling arkouda"
+fi
+
+# Install Arkouda and python dependencies
+if ! pip3 install -e .[test] --user ; then
+  log_error "installing arkouda"
+fi
+
+# Check installation
+test_start "make check"
+if make check ; then
+  log_success "make check output"
+else
+  log_error "running make check"
+fi
+test_end "make check"
+
+# Run benchmarks
+test_start "benchmarks"
+benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+if ./benchmarks/run_benchmarks.py ${benchmark_opts} ; then
+  log_success "benchmark output"
+else
+  log_error "running benchmarks"
+fi
+test_end "benchmarks"
+
+subtest_end

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Run arkouda testing with the latest chapel release
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/arkouda/chapcs/release
+export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.arkouda.release"
+
+source /cray/css/users/chapelu/setup_python36.bash
+export CHPL_TEST_ARKOUDA=true
+
+# check out 1.20.0, but then grab the current tests
+currentSha=`git rev-parse HEAD`
+git checkout 1.20.0
+git checkout $currentSha -- $CHPL_HOME/test/
+git checkout $currentSha -- $CHPL_HOME/util/cron/
+
+$CWD/nightly -cron
+
+$CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME


### PR DESCRIPTION
Add a custom sub_test that will clone Arkouda, install dependencies, build/compile, and run testing.

This is a bit weird because our testing system isn't really designed to test things like Arkouda, which is a separate project with its own build and testing infrastructure. Here we abuse our testing system a bit with a custom sub_test that will then run Arkouda's testing system.

I considered avoiding start_test and just directly testing Arkouda.  This ended up being pretty infeasible since so much of our testing infrastructure (node reservation, Jenkins integration, triage mails, performance graphing, etc) is based around start_test. I also looked just using a prediff to clone/build and then launch the arkouda server/client through a test driver written in Chapel (since start_test/sub_test are designed to run chapel programs.) That didn't really work for multi-locale testing since we need the driver to run on the login node, but we only build Chapel to run on compute nodes. In the end I decided to just write a custom sub_test and implement enough functionality/formatting to integrate into our testing system.

For now this just adds comm=none performance testing against 1.20, but more correctness and performance testing will be added over time and I expect these scripts to improve with those efforts.

Part of https://github.com/Cray/chapel-private/issues/497 and https://github.com/Cray/chapel-private/issues/713