### PR TITLE
Extend LinearAlgebra.eig() to support complex types

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1463,7 +1463,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
   } else if left && !right {
     var vl: [1..n, 1..n] t;
     var vr: [1..1, 1..n] t;
-    var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
+    var vlcplx: if t == complex then [1..n, 1..n] t else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
       LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, vl, vr);
       eigVals = wr;
@@ -1477,7 +1477,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
   } else if right && !left {
     var vl: [1..1, 1..n] t;
     var vr: [1..n, 1..n] t;
-    var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
+    var vrcplx: if t == complex then [1..n, 1..n] t else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
       LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, vl, vr);
       eigVals = wr;
@@ -1492,8 +1492,8 @@ proc eig(A: [] ?t, param left = false, param right = false)
     // left && right
     var vl: [1..n, 1..n] t;
     var vr: [1..n, 1..n] t;
-    var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
-    var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
+    var vlcplx: if t == complex then [1..n, 1..n] t else [1..n, 1..n] complex(numBits(t)*2);
+    var vrcplx: if t == complex then [1..n, 1..n] t else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
       LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, vl, vr);
       eigVals = wr;

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1452,7 +1452,6 @@ proc eig(A: [] ?t, param left = false, param right = false)
 
   if !left && !right {
     var vl, vr: [1..1, 1..n] t;
-    var eigVals;
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, vl, vr);
     eigVals = w;

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1453,40 +1453,40 @@ proc eig(A: [] ?t, param left = false, param right = false)
   if !left && !right {
     var vl, vr: [1..1, 1..n] t;
     if t == complex {
-    LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, vl, vr);
-    eigVals = wr;
-    }else{
-    LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, wi, vl, vr);
-    eigVals = convertToCplx(wr, wi);
-      }
+      LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, vl, vr);
+      eigVals = wr;
+    } else {
+      LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, wi, vl, vr);
+      eigVals = convertToCplx(wr, wi);
+    }
     return eigVals;
   } else if left && !right {
     var vl: [1..n, 1..n] t;
     var vr: [1..1, 1..n] t;
     var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
-    LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, vl, vr);
-    eigVals = wr;
-    vlcplx = vl;
-    }else{
-    LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, wi, vl, vr);
-    eigVals = convertToCplx(wr, wi);
-    vlcplx = flattenCplxEigenVecs(wi, vl);
-      }
+      LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, vl, vr);
+      eigVals = wr;
+      vlcplx = vl;
+    } else {
+      LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, wi, vl, vr);
+      eigVals = convertToCplx(wr, wi);
+      vlcplx = flattenCplxEigenVecs(wi, vl);
+    }
     return (eigVals, vlcplx);
   } else if right && !left {
     var vl: [1..1, 1..n] t;
     var vr: [1..n, 1..n] t;
     var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
-    LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, vl, vr);
-    eigVals = wr;
-    vrcplx = vr;
-    }else{
-    LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, wi, vl, vr);
-    eigVals = convertToCplx(wr, wi);
-    vrcplx = flattenCplxEigenVecs(wi, vr);
-      }
+      LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, vl, vr);
+      eigVals = wr;
+      vrcplx = vr;
+    } else {
+      LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, wi, vl, vr);
+      eigVals = convertToCplx(wr, wi);
+      vrcplx = flattenCplxEigenVecs(wi, vr);
+    }
     return (eigVals, vrcplx);
   } else {
     // left && right
@@ -1495,16 +1495,16 @@ proc eig(A: [] ?t, param left = false, param right = false)
     var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
     var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
-    LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, vl, vr);
-    eigVals = wr;
-    vlcplx = vl;
-    vrcplx = vr;
-    }else{
-    LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, wi, vl, vr);
-    eigVals = convertToCplx(wr, wi);
-    vlcplx = flattenCplxEigenVecs(wi, vl);
-    vrcplx = flattenCplxEigenVecs(wi, vr);
-      }
+      LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, vl, vr);
+      eigVals = wr;
+      vlcplx = vl;
+      vrcplx = vr;
+    } else {
+      LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, wi, vl, vr);
+      eigVals = convertToCplx(wr, wi);
+      vlcplx = flattenCplxEigenVecs(wi, vl);
+      vrcplx = flattenCplxEigenVecs(wi, vr);
+    }
     return (eigVals, vlcplx, vrcplx);
   }
 }

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1374,7 +1374,7 @@ proc cholesky(A: [] ?t, lower = true)
       compiler error if ``lapackImpl`` is ``none``.
 
 */
-proc eigvals(A: [] ?t) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+proc eigvals(A: [] ?t) where A.domain.rank == 2 && usingLAPACK {
   return eig(A, left=false, right=false);
 }
 
@@ -1403,7 +1403,7 @@ proc eigvals(A: [] ?t) where isRealType(t) && A.domain.rank == 2 && usingLAPACK 
 
  */
 proc eig(A: [] ?t, param left = false, param right = false)
-  where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+  where A.domain.rank == 2 && usingLAPACK {
 
   proc convertToCplx(wr: [] t, wi: [] t) {
     const n = wi.numElements;
@@ -1641,7 +1641,7 @@ proc jacobi(A: [?Adom] ?eltType, ref X: [?Xdom] eltType,
 
 pragma "no doc"
 proc eig(A: [] ?t, param left = false, param right = false)
-  where isRealType(t) && A.domain.rank == 2 && !usingLAPACK {
+  where A.domain.rank == 2 && !usingLAPACK {
   compilerError("eigvals() requires LAPACK");
 }
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1454,7 +1454,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
     var vl, vr: [1..1, 1..n] t;
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, vl, vr);
-    eigVals = w;
+    eigVals = wr;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, wi, vl, vr);
     eigVals = convertToCplx(wr, wi);
@@ -1466,7 +1466,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
     var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, vl, vr);
-    eigVals = w;
+    eigVals = wr;
     vlcplx = vl;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, wi, vl, vr);
@@ -1480,7 +1480,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
     var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, vl, vr);
-    eigVals = w;
+    eigVals = wr;
     vrcplx = vr;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, wi, vl, vr);
@@ -1496,7 +1496,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
     var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, vl, vr);
-    eigVals = w;
+    eigVals = wr;
     vlcplx = vl;
     vrcplx = vr;
     }else{

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1446,50 +1446,52 @@ proc eig(A: [] ?t, param left = false, param right = false)
   if !isSquare(A) then
     halt("Matrix passed to eigvals must be square");
   var copy = A;
-  var wr, wi: [1..n] t;
+  var wr: [1..n] t;
+  var wi: if t == complex then nothing else [1..n] t;
 
   if !left && !right {
     var vl, vr: [1..1, 1..n] t;
-    if t == complex{
-    LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, w, vl, vr);
+    var eigVals;
+    if t == complex {
+    LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, vl, vr);
     var eigVals = w;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, wi, vl, vr);
     var eigVals = convertToCplx(wr, wi);
-         }
+      }
     return eigVals;
   } else if left && !right {
     var vl: [1..n, 1..n] t;
     var vr: [1..1, 1..n] t;
-    if t == complex{
-    LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, w, vl, vr);
+    if t == complex {
+    LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, vl, vr);
     var eigVals = w;
     var vlcplx = vl;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, wi, vl, vr);
     var eigVals = convertToCplx(wr, wi);
     var vlcplx = flattenCplxEigenVecs(wi, vl);
-         }
+      }
     return (eigVals, vlcplx);
   } else if right && !left {
     var vl: [1..1, 1..n] t;
     var vr: [1..n, 1..n] t;
-    if t == complex{
-    LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, w, vl, vr);
+    if t == complex {
+    LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, vl, vr);
     var eigVals = w;
     var vrcplx = vr;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, wi, vl, vr);
     var eigVals = convertToCplx(wr, wi);
     var vrcplx = flattenCplxEigenVecs(wi, vr);
-        }
+      }
     return (eigVals, vrcplx);
   } else {
     // left && right
     var vl: [1..n, 1..n] t;
     var vr: [1..n, 1..n] t;
-    if t == complex{
-    LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, w, vl, vr);
+    if t == complex {
+    LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, vl, vr);
     var eigVals = w;
     var vlcplx = vl;
     var vrcplx = vr;
@@ -1498,7 +1500,7 @@ proc eig(A: [] ?t, param left = false, param right = false)
     var eigVals = convertToCplx(wr, wi);
     var vlcplx = flattenCplxEigenVecs(wi, vl);
     var vrcplx = flattenCplxEigenVecs(wi, vr);
-        }
+      }
     return (eigVals, vlcplx, vrcplx);
   }
 }

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1448,58 +1448,63 @@ proc eig(A: [] ?t, param left = false, param right = false)
   var copy = A;
   var wr: [1..n] t;
   var wi: if t == complex then nothing else [1..n] t;
+  var eigVals: if t == complex then [1..n] t else [1..n] complex(numBits(t)*2);
 
   if !left && !right {
     var vl, vr: [1..1, 1..n] t;
     var eigVals;
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, vl, vr);
-    var eigVals = w;
+    eigVals = w;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, wi, vl, vr);
-    var eigVals = convertToCplx(wr, wi);
+    eigVals = convertToCplx(wr, wi);
       }
     return eigVals;
   } else if left && !right {
     var vl: [1..n, 1..n] t;
     var vr: [1..1, 1..n] t;
+    var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, vl, vr);
-    var eigVals = w;
-    var vlcplx = vl;
+    eigVals = w;
+    vlcplx = vl;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, wi, vl, vr);
-    var eigVals = convertToCplx(wr, wi);
-    var vlcplx = flattenCplxEigenVecs(wi, vl);
+    eigVals = convertToCplx(wr, wi);
+    vlcplx = flattenCplxEigenVecs(wi, vl);
       }
     return (eigVals, vlcplx);
   } else if right && !left {
     var vl: [1..1, 1..n] t;
     var vr: [1..n, 1..n] t;
+    var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, vl, vr);
-    var eigVals = w;
-    var vrcplx = vr;
+    eigVals = w;
+    vrcplx = vr;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, wi, vl, vr);
-    var eigVals = convertToCplx(wr, wi);
-    var vrcplx = flattenCplxEigenVecs(wi, vr);
+    eigVals = convertToCplx(wr, wi);
+    vrcplx = flattenCplxEigenVecs(wi, vr);
       }
     return (eigVals, vrcplx);
   } else {
     // left && right
     var vl: [1..n, 1..n] t;
     var vr: [1..n, 1..n] t;
+    var vlcplx: if t == complex then vl else [1..n, 1..n] complex(numBits(t)*2);
+    var vrcplx: if t == complex then vr else [1..n, 1..n] complex(numBits(t)*2);
     if t == complex {
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, vl, vr);
-    var eigVals = w;
-    var vlcplx = vl;
-    var vrcplx = vr;
+    eigVals = w;
+    vlcplx = vl;
+    vrcplx = vr;
     }else{
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, wi, vl, vr);
-    var eigVals = convertToCplx(wr, wi);
-    var vlcplx = flattenCplxEigenVecs(wi, vl);
-    var vrcplx = flattenCplxEigenVecs(wi, vr);
+    eigVals = convertToCplx(wr, wi);
+    vlcplx = flattenCplxEigenVecs(wi, vl);
+    vrcplx = flattenCplxEigenVecs(wi, vr);
       }
     return (eigVals, vlcplx, vrcplx);
   }

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1450,37 +1450,55 @@ proc eig(A: [] ?t, param left = false, param right = false)
 
   if !left && !right {
     var vl, vr: [1..1, 1..n] t;
+    if t == complex{
+    LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, w, vl, vr);
+    var eigVals = w;
+    }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'N', copy, wr, wi, vl, vr);
     var eigVals = convertToCplx(wr, wi);
+         }
     return eigVals;
   } else if left && !right {
     var vl: [1..n, 1..n] t;
     var vr: [1..1, 1..n] t;
+    if t == complex{
+    LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, w, vl, vr);
+    var eigVals = w;
+    var vlcplx = vl;
+    }else{
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'N', copy, wr, wi, vl, vr);
-
     var eigVals = convertToCplx(wr, wi);
     var vlcplx = flattenCplxEigenVecs(wi, vl);
-
+         }
     return (eigVals, vlcplx);
   } else if right && !left {
     var vl: [1..1, 1..n] t;
     var vr: [1..n, 1..n] t;
+    if t == complex{
+    LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, w, vl, vr);
+    var eigVals = w;
+    var vrcplx = vr;
+    }else{
     LAPACK.geev(lapack_memory_order.row_major, 'N', 'V', copy, wr, wi, vl, vr);
-
     var eigVals = convertToCplx(wr, wi);
     var vrcplx = flattenCplxEigenVecs(wi, vr);
-
+        }
     return (eigVals, vrcplx);
   } else {
     // left && right
     var vl: [1..n, 1..n] t;
     var vr: [1..n, 1..n] t;
+    if t == complex{
+    LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, w, vl, vr);
+    var eigVals = w;
+    var vlcplx = vl;
+    var vrcplx = vr;
+    }else{
     LAPACK.geev(lapack_memory_order.row_major, 'V', 'V', copy, wr, wi, vl, vr);
-
     var eigVals = convertToCplx(wr, wi);
     var vlcplx = flattenCplxEigenVecs(wi, vl);
     var vrcplx = flattenCplxEigenVecs(wi, vr);
-
+        }
     return (eigVals, vlcplx, vrcplx);
   }
 }

--- a/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
@@ -132,3 +132,129 @@ var cplxA: [1..10, 1..10] complex = A;
   }
 }
 
+
+var B: [1..10, 1..10] complex;
+fillRandom(B);
+
+{
+  var eigenvalues = eigvals(B);
+
+  // Check that:
+  // trace(B) = sum(eigenvalues)
+  {
+    var tr = trace(B);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(B) != sum(eigenvalues) ", tr, " != ", ev);
+    }
+  }
+}
+
+{
+  var eigenvalues = eig(B);
+
+  // Check that:
+  // trace(B) = sum(eigenvalues)
+  {
+    var tr = trace(B);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(B) != sum(eigenvalues) ", tr, " != ", ev);
+    }
+  }
+}
+
+{
+  var (eigenvalues, right) = eig(B, right=true);
+
+  // trace(B) = sum(eigenvalues)
+  {
+    var tr = trace(B);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(B) != sum(eigenvalues) ", tr, " != ", ev);
+    }
+  }
+
+  // Check that:
+  // Bv = e * v
+  // Where e and v are corresponding eigenvalues and right eigenvectors
+  for (e, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = right[.., i];
+    var Bv = dot(B, eigVec);
+    var ev = dot(e, eigVec);
+
+    for (b, e) in zip(Bv, ev) {
+      if !isClose(b, e) then
+        writeln(b, " != ", e);
+    }
+  }
+}
+
+{
+  var (eigenvalues, left) = eig(B, left=true);
+
+  // trace(B) = sum(eigenvalues)
+  {
+    var tr = trace(B);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(B) != sum(eigenvalues) ", tr, " != ", ev);
+    }
+  }
+
+  // Check that
+  // u^H * B = k * u^H
+  // Where k and u are corresponding eigenvalues and left eigenvectors
+  // and ^H means conjugate transpose.
+  for (k, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = conjg(left[.., i]);
+    var Bv = dot(eigVec, B);
+    var ku = dot(k, eigVec);
+
+    for (b, k) in zip(Bv, ku) {
+      if !isClose(b, k) then
+        writeln(b, " != ", k);
+    }
+  }
+}
+
+{
+  var (eigenvalues, left, right) = eig(B, left=true, right=true);
+  // Check that the above properties hold when computing both eigenvectors
+  // at the same time.
+
+  // trace(B) = sum(eigenvalues)
+  {
+    var tr = trace(B);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(B) != sum(eigenvalues) ", tr, " != ", ev);
+    }
+  }
+
+  // Bv = e * v
+  for (e, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = right[.., i];
+    var Bv = dot(B, eigVec);
+    var ev = dot(e, eigVec);
+
+    for (b, e) in zip(Bv, ev) {
+      if !isClose(b, e) then
+        writeln(b, " != ", e);
+    }
+  }
+
+  // u^H * B = k * u^H
+  for (k, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = conjg(left[.., i]);
+    var Bv = dot(eigVec, B);
+    var ku = dot(k, eigVec);
+
+    for (b, k) in zip(Bv, ku) {
+      if !isClose(b, k) then
+        writeln(b, " != ", k);
+    }
+  }
+}
+


### PR DESCRIPTION
The `LinearAlgebra.eig()` function only supported operations for real matrices. Now the function has been extended to support real as well as complex type matrices.

Fixes #14725 