### PR TITLE
Improve owned/shared module docs

### DIFF
--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -20,9 +20,11 @@
 /*
 
 :record:`shared` (along with :record:`~OwnedObject.owned`) manage the
-deallocation of a class instance. :record:`shared` is meant to be used when
-many different references will exist to the object and these references need
-to keep the object alive.
+deallocation of a class instance. :record:`shared` is meant to be used when many
+different references will exist to the object at the same time and these
+references need to keep the object alive.
+
+Please see also the language spec section :ref:`Class_Lifetime_and_Borrows`.
 
 Using `shared`
 --------------
@@ -75,27 +77,10 @@ subclass of ``U``.
 
 See :ref:`about-owned-coercions` for more details and examples.
 
-`shared` Intents and Instantiation
-----------------------------------
+`shared` Default Intent
+-----------------------
 
-Intents and instantiation for :record:`shared` are similar
-to :record:`~OwnedObject.owned`. Namely:
-
- * for formal arguments declared with a type, the
-   default intent is `const in`, which updates the
-   reference count and shares the instance.
- * for generic formal arguments with no type component that are
-   passed actuals of :record:`shared` type,
-   the formal argument will be instantiated with the borrow type,
-   and no reference count changes will occur.
-
-   .. note::
-
-      It is expected that this rule will change in the future with
-      more experience with this language design.
-
-
-See also :ref:`about-owned-intents-and-instantiation` which includes examples.
+The default intent for :record:`shared` types is ``const ref``.
 
  */
 module SharedObject {
@@ -202,6 +187,7 @@ module SharedObject {
       // since it would refer to `this` as a whole here.
     }
 
+    pragma "no doc"
     proc init(p: ?T)
     where isClass(T) == false &&
           isSubtype(T, _shared) == false &&
@@ -303,16 +289,19 @@ module SharedObject {
         this.chpl_pn!.retain();
     }
 
+    pragma "no doc"
     proc init=(src: borrowed) {
       compilerError("cannot create a shared variable from a borrowed class instance");
       this.chpl_t = int; //dummy
     }
 
+    pragma "no doc"
     proc init=(src: unmanaged) {
       compilerError("cannot create a shared variable from an unmanaged class instance");
       this.chpl_t = int; //dummy
     }
 
+    pragma "no doc"
     pragma "leaves this nil"
     proc init=(src : _nilType) {
       this.init(this.type.chpl_t);
@@ -497,6 +486,7 @@ module SharedObject {
   }
 
   // this version handles downcast to non-nil shared
+  pragma "no doc"
   inline proc _cast(type t:shared class, const ref x:shared class?) throws
     where isProperSubtype(t.chpl_t,_to_nonnil(x.chpl_t))
   {
@@ -508,6 +498,7 @@ module SharedObject {
 
     return new _shared(true, _to_borrowed(p.type), p, x.chpl_pn);
   }
+  pragma "no doc"
   inline proc _cast(type t:shared class, const ref x:shared class) throws
     where isProperSubtype(t.chpl_t,x.chpl_t)
   {
@@ -519,6 +510,7 @@ module SharedObject {
 
 
   // this version handles downcast to nilable shared
+  pragma "no doc"
   inline proc _cast(type t:shared class?, const ref x:shared class?)
     where isProperSubtype(t.chpl_t,x.chpl_t)
   {
@@ -526,6 +518,7 @@ module SharedObject {
     var p = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
     return new _shared(true, _to_borrowed(p.type), p, x.chpl_pn);
   }
+  pragma "no doc"
   inline proc _cast(type t:shared class?, const ref x:shared class)
     where isProperSubtype(t.chpl_t,_to_nilable(x.chpl_t))
   {


### PR DESCRIPTION
Improves the owned/shared module docs to correct some details that are 
out of date, clean up functions that don't need to be listed, and link to
the relevant spec section.

Reviewed by @daviditen - thanks!