### PR TITLE
Added udevRandomSeed type for use in RNGs.

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -647,12 +647,19 @@ module Random {
       to lock this object to ensure two tasks do not both pull the same
       bit of entropy.
       */
-      proc type udevRandomSeed: int(64) {
+      proc type devURandomSeed: int(64) {
         use IO;
-        var entropy = open('/dev/urandom', iomode.r);
-        var entropyStream = entropy.reader();
-        const seed: int(64);
-        entropyStream.readbits(seed, 64);
+        var seed: int(64);
+        try {
+          var entropy = open('/dev/urandom', iomode.r);
+          var entropyStream = entropy.reader();
+          entropyStream.readbits(seed, 64);
+        } catch {
+          // it would be nice to default to the timer, except
+          // we shouldn't invisibly use the timer when /dev/urandom isn't
+          // available.  So for now, this is 0.
+          // seed = oddCurrentTime;
+        }
         return seed;
       }
     }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -638,6 +638,23 @@ module Random {
         const oddseed = if seed % 2 == 0 then seed + 1 else seed;
         return oddseed;
       }
+      /*
+      Generate a seed based on the entropy pool in the OS; this requires
+      the presence of /dev/urandom.  This should be standard on both macOS
+      and Linux systems.
+
+      For highly parallel applications on one locale, it may be necessary
+      to lock this object to ensure two tasks do not both pull the same
+      bit of entropy.
+      */
+      proc type udevRandomSeed: int(64) {
+        use IO;
+        var entropy = open('/dev/urandom', iomode.r);
+        var entropyStream = entropy.reader();
+        const seed: int(64);
+        entropyStream.readbits(seed, 64);
+        return seed;
+      }
     }
 
 

--- a/test/library/standard/Random/devRandomTest.chpl
+++ b/test/library/standard/Random/devRandomTest.chpl
@@ -1,0 +1,20 @@
+use Random;
+use RandomSupport;
+config param n_retries: int = 10;
+
+{
+  var seed = RandomSupport.SeedGenerator.devURandomSeed;
+  if (seed == 0) {
+    for i in 1..n_retries {
+      seed = RandomSupport.SeedGenerator.devURandomSeed;
+      if (seed != 0) {
+        break;
+      }
+    }
+    if (seed == 0) {
+      writeln("Looks like /dev/urandom is not available.");
+    }
+  }
+  // ensure that it works to create a random stream.
+  var udr = createRandomStream(real, seed=seed);
+}


### PR DESCRIPTION
This PR addresses #12540, and enables the use of the entropy pool on posix type systems, which would make Chapel more suitable for cryptographic applications (amongst other things).  There are a few points I'm unsure of:

1. Where should a test for this live?
2. I'm not sure whether /dev/urandom is a POSIX standard.
3. /dev/urandom should really be locked, as nothing about this is inherently thread safe; is there a way to do that with the IO module?  I've run into circumstances where two tasks on the same node create two RNGs that happen to pull the same bit of entropy from /dev/urandom.  It's possible that was due to how my application was constructed, but in the case of generating UUIDs it resulted in collisions.
4. /dev/urandom is a non-blocking source of entropy; that is, regardless of whether the system has generated sufficient entropy, it returns random data.  There are some crypto applications where you may wish for this call to block, apparently, but for many purposes it's perfectly suitable.  Perhaps a /dev/random variant should be included, as well?