### PR TITLE
Adjust two IO futures

### DIFF
--- a/test/io/errors/writeThisUserError.bad
+++ b/test/io/errors/writeThisUserError.bad
@@ -1,1 +1,0 @@
-SystemError

--- a/test/io/errors/writeThisUserError.chpl
+++ b/test/io/errors/writeThisUserError.chpl
@@ -17,18 +17,6 @@ record foo {
 
 proc main() {
   var x = new foo();
-  try {
-    stdout.write(x);
-  } catch err: SystemError {
-    writeln("SystemError");
-  } catch err: IllegalArgumentError {
-    writeln("IllegalArgumentError"); 
-  } catch err {}
-
-  //
-  // You have to use `clearError` here to prevent a crash when destroying
-  // the internal channel.
-  //
-  stdout.clearError();  
+  try! stdout.write(x);
 }
 

--- a/test/io/errors/writeThisUserError.future
+++ b/test/io/errors/writeThisUserError.future
@@ -1,6 +1,0 @@
-No issue number yet
-
-The machinery in `modules/standard/IO.chpl` should be able to display
-errors thrown from `readThis`/`writeThis` directly rather than throw
-a more general IOError as a workaround.
-

--- a/test/io/errors/writeThisUserError.good
+++ b/test/io/errors/writeThisUserError.good
@@ -1,1 +1,3 @@
-IllegalArgumentError
+uncaught IllegalArgumentError: User error thrown from writeThis!
+  writeThisUserError.chpl:12: thrown here
+  writeThisUserError.chpl:20: uncaught here

--- a/test/io/ferguson/read-class-reorder3.bad
+++ b/test/io/ferguson/read-class-reorder3.bad
@@ -1,5 +1,5 @@
 a is {a = 1, b = 2, x = 3, y = 4}
 writing {b=5,y=7,a=4,x=6}
-uncaught BadFormatError: bad format (in channel.read(ref a:borrowed Child) with path "test.txt" offset 9)
+uncaught BadFormatError: bad format (Failed to read field, could not skip)
   read-class-reorder3.chpl:28: thrown here
   read-class-reorder3.chpl:28: uncaught here


### PR DESCRIPTION
This PR adjusts two IO futures that had their failure modes altered in the wake of #14739. The future `writeThisUserError.chpl` now passes, so I've changed it into a regular test. The other future still fails, but the contents of the thrown error have changed.