### PR TITLE
Filter out extra messages for writeThisUsingOn

### DIFF
--- a/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
+++ b/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import sys
+
+outfile = sys.argv[2]
+
+with open (outfile, 'r') as f:
+    lines = f.readlines()
+
+with open (outfile, 'w') as f:
+    for line in lines:
+        if 'halt reached - Timed out' in line:
+            f.write(line)


### PR DESCRIPTION
multilocale/bradc/needMultiLocales/writeThisUsingOn has been sporadically
getting warnings like `GASNET WARNING(Node 0): AMUDP_DrainNetwork(ep_t)`
`returning an error code: AM_ERR_RESOURCE requested resource)`. This test
is a future that hangs. It has a halt to provide a fast failure instead of
timing out. Halting while we're hung can introduce this warning, so just
filter them out. Similar to https://github.com/chapel-lang/chapel/pull/12937