### PR TITLE
Fix timeout identification for Cray-CS testing

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -17,6 +17,7 @@ function loadCSModule()
 
 if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
+  export CHPL_TEST_LAUNCHCMD=$CHPL_HOME/util/test/chpl_launchcmd.py
   loadCSModule gcc
   loadCSModule python/2.7.6
   loadCSModule cray-fftw


### PR DESCRIPTION
Fix Cray-CS timeout identification by using chpl_launchcmd.py to get
batch submission of slurm jobs. To identify slurm timeouts we look for
`slurm.* CANCELLED .* DUE TO TIME LIMIT`. We do not see this text with
a plain salloc/srun because we throw `--quiet`, which we need to
suppress other messages we don't want to have to filter.

Using launchcmd switches to batch submission where we see our sentinel,
which allows us to more easily identify timeouts.

Closes https://github.com/Cray/chapel-private/issues/581