### PR TITLE
Fix problem in callDestructors after 14814

### DIFF
--- a/test/types/records/expiring/bug-from-14814.chpl
+++ b/test/types/records/expiring/bug-from-14814.chpl
@@ -1,0 +1,28 @@
+record R {
+  var x:int = 0;
+  proc init() {
+    writeln("init");
+  }
+  proc deinit() {
+    assert(x == 0);
+    x = 99;
+    writeln("deinit");
+  }
+}
+
+config const option = true;
+config const error = false;
+
+proc throwsAndReturns(): R throws {
+  if error then
+    throw new Error();
+
+  var ret: R;
+  return ret;
+}
+
+proc main() {
+  if option {
+    throwsAndReturns();
+  }
+}

--- a/test/types/records/expiring/bug-from-14814.execopts
+++ b/test/types/records/expiring/bug-from-14814.execopts
@@ -1,0 +1,2 @@
+--error=false  # bug-from-14814.nothrow.good
+--error=true   # bug-from-14814.throw.good

--- a/test/types/records/expiring/bug-from-14814.nothrow.good
+++ b/test/types/records/expiring/bug-from-14814.nothrow.good
@@ -1,0 +1,6 @@
+Expiring values for function throwsAndReturns (bug-from-14814.chpl:16)
+  ret (bug-from-14814.chpl:20) expires after last mention
+Expiring values for function main (bug-from-14814.chpl:24)
+  temp (bug-from-14814.chpl:26) expires after last mention
+init
+deinit

--- a/test/types/records/expiring/bug-from-14814.throw.good
+++ b/test/types/records/expiring/bug-from-14814.throw.good
@@ -1,0 +1,7 @@
+Expiring values for function throwsAndReturns (bug-from-14814.chpl:16)
+  ret (bug-from-14814.chpl:20) expires after last mention
+Expiring values for function main (bug-from-14814.chpl:24)
+  temp (bug-from-14814.chpl:26) expires after last mention
+uncaught Error: 
+  bug-from-14814.chpl:18: thrown here
+  bug-from-14814.chpl:26: uncaught here


### PR DESCRIPTION
PR #14814 introduced some bugs into callDestructors. In certain 
return-by-arg patterns, the deinitalizer for the returned argument was
being called before a 'move' setting the argument was executed. E.g. in
test/mason/masonNewTest.chpl (under valgrind).

Additionally, this PR fixes a problem with --verify testing for the test 
split-init-try.

Reviewed by @benharsh - thanks!

- [x] full local testing
- [x] primers pass with valgrind & memleaks
- [x] test/types/records/split-init passes with --verify