### PR TITLE
Support CHPL_LAUNCHER_REAL_WRAPPER for slurm-gasnetrun* launchers

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -258,7 +258,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     propagate_environment(envProp);
     fprintf(slurmFile, "%s", envProp);
 
-    fprintf(slurmFile, " %s ", chpl_get_real_binary_name());
+    fprintf(slurmFile, " %s %s", chpl_get_real_binary_wrapper(), chpl_get_real_binary_name());
 
     for (i=1; i<argc; i++) {
       fprintf(slurmFile, " '%s'", argv[i]);
@@ -291,7 +291,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
                    CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH),
                    GASNETRUN_LAUNCHER, numLocales, numLocales);
     len += propagate_environment(iCom+len);
-    len += sprintf(iCom+len, " %s ", chpl_get_real_binary_name());
+    len += sprintf(iCom+len, " %s %s", chpl_get_real_binary_wrapper(), chpl_get_real_binary_name());
     for (i=1; i<argc; i++) {
       len += sprintf(iCom+len, " %s", argv[i]);
     }

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1884,7 +1884,8 @@ for testname in testsrc:
             # binary for launchers that use a queue so we don't include the
             # time to get the reservation. These are the launchers known to
             # support timing the _real using CHPL_LAUNCHER_REAL_WRAPPER.
-            timereal = chpllauncher in ['pbs-aprun', 'aprun', 'slurm-srun']
+            timereal = (chpllauncher in ['pbs-aprun', 'aprun', 'slurm-srun'] or
+                        'slurm-gasnetrun' in chpllauncher)
 
             args=list()
             if timer and timereal:


### PR DESCRIPTION
This is required for the no-op/startup performance test for Cray-CS testing
after 14838. That test wants to time how long the real binary runs for and on
systems with a job scheduler, CHPL_LAUNCHER_REAL_WRAPPER is the way to do that.
We were actually timing the launcher before and just didn't realize it, so this
will also give us a more accurate time.