### PR TITLE
Tidy a few things in resolution

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2504,6 +2504,7 @@ void AggregateType::buildCopyInitializer() {
     fn->addFlag(FLAG_COMPILER_GENERATED);
     fn->addFlag(FLAG_LAST_RESORT);
     fn->addFlag(FLAG_COPY_INIT);
+    fn->addFlag(FLAG_SUPPRESS_LVALUE_ERRORS);
 
     _this->addFlag(FLAG_ARG_THIS);
 

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -909,7 +909,7 @@ bool FnSymbol::isDefaultInit() const {
 }
 
 bool FnSymbol::isCopyInit() const {
-  return isMethod() && strcmp(name, astrInitEquals) == 0;
+  return isMethod() && name == astrInitEquals;
 }
 
 // This function or method is an iterator (as opposed to a procedure).

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1995,6 +1995,7 @@ const char* astr_forexpr = NULL;
 const char* astr_loopexpr_iter = NULL;
 const char* astrPostfixBang = NULL;
 const char* astrBorrow = NULL;
+const char* astr_init_coerce_tmp = NULL;
 
 void initAstrConsts() {
   astrSassign = astr("=");
@@ -2027,6 +2028,7 @@ void initAstrConsts() {
   astrPostfixBang = astr("postfix!");
 
   astrBorrow = astr("borrow");
+  astr_init_coerce_tmp = astr("init_coerce_tmp");
 }
 
 /************************************* | **************************************

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -43,9 +43,6 @@ extern SymbolMap                        paramMap;
 
 extern Vec<CallExpr*>                   callStack;
 
-extern char                             arrayUnrefName[];
-extern char                             primCoerceTmpName[];
-
 extern Map<Type*,     FnSymbol*>        autoDestroyMap;
 
 extern Map<Type*,     FnSymbol*>        valueToRuntimeTypeMap;

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -226,6 +226,7 @@ FnSymbol* getUnalias(Type* t);
 
 
 bool isPOD(Type* t);
+bool recordContainingCopyMutatesField(Type* at);
 
 // resolution errors and warnings
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -705,6 +705,7 @@ extern const char* astr_forexpr;
 extern const char* astr_loopexpr_iter;
 extern const char* astrPostfixBang;
 extern const char* astrBorrow;
+extern const char* astr_init_coerce_tmp;
 
 void initAstrConsts();
 

--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -96,8 +96,7 @@ bool CallInfo::isWellFormed(CallExpr* callExpr) {
 
     } else if (t->symbol->hasFlag(FLAG_GENERIC) == true) {
       // The _this actual to an initializer may be generic
-      bool isInit = strcmp(name, "init") == 0 ||
-                    strcmp(name, astrInitEquals) == 0;
+      bool isInit = name == astrInit || name == astrInitEquals;
       if (isInit && i == 2) {
         actuals.add(sym);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2993,7 +2993,7 @@ static bool isGenericRecordInit(CallExpr* call) {
   bool retval = false;
 
   if (UnresolvedSymExpr* ures = toUnresolvedSymExpr(call->baseExpr)) {
-    if ((strcmp(ures->unresolved, "init") == 0 || strcmp(ures->unresolved, astrInitEquals) == 0) &&
+    if ((ures->unresolved == astrInit || ures->unresolved == astrInitEquals) &&
         call->numActuals()               >= 2) {
       Type* t1 = call->get(1)->typeInfo();
       Type* t2 = call->get(2)->typeInfo();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -101,11 +101,6 @@ typedef std::map<int, SymbolMap*> CapturedValueMap;
 //# Global Variables
 //#
 
-// TODO -- can we remove this global now? at least it shouldn't be array.
-char                               arrayUnrefName[] = "array_unref_ret_tmp";
-
-char                               primCoerceTmpName[] = "init_coerce_tmp";
-
 bool                               resolved                  = false;
 int                                explainCallLine           = 0;
 
@@ -520,7 +515,7 @@ isLegalLvalueActualArg(ArgSymbol* formal, Expr* actual) {
       formalTS = formal->getValType()->symbol;
       formalCopyMutates = formalTS->hasFlag(FLAG_COPY_MUTATES);
     }
-    bool isInitCoerceTmp = (0 == strcmp(sym->name, primCoerceTmpName));
+    bool isInitCoerceTmp = sym->name == astr_init_coerce_tmp;
 
     if ((actualExprTmp && !formalCopyMutates && !isInitCoerceTmp) ||
         (actualConst && !(formal && formal->hasFlag(FLAG_ARG_THIS))) ||
@@ -6017,7 +6012,7 @@ static void resolveInitVar(CallExpr* call) {
       if (mismatch)
         checkMoveIntoClass(call, targetType->getValType(), src->getValType());
 
-      VarSymbol* tmp = newTemp(primCoerceTmpName, targetType);
+      VarSymbol* tmp = newTemp(astr_init_coerce_tmp, targetType);
       tmp->addFlag(FLAG_EXPR_TEMP);
       if (dst->hasFlag(FLAG_PARAM))
         tmp->addFlag(FLAG_PARAM);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -500,6 +500,15 @@ static bool fixupDefaultInitCopy(FnSymbol* fn,
         // above code adds a call that would be considered already resolved.
         resolveCallAndCallee(initCall);
 
+        // Workaround: setting init= argument to ref in case
+        // the fields were not resolved yet
+        if (recordContainingCopyMutatesField(ct)) {
+          FnSymbol* fn = initCall->resolvedFunction();
+          INT_ASSERT(fn->numFormals() == 3);
+          ArgSymbol* arg = fn->getFormal(3);
+          arg->intent = INTENT_REF;
+          arg->originalIntent = INTENT_REF;
+        }
         if (ct->hasPostInitializer() == true) {
           CallExpr* post = new CallExpr("postinit", gMethodToken, thisTmp);
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -100,8 +100,6 @@ static bool needRefFormal(FnSymbol* fn, ArgSymbol* formal, bool* needRefIntent);
 
 static bool shouldUpdateAtomicFormalToRef(FnSymbol* fn, ArgSymbol* formal);
 
-static bool recordContainingCopyMutatesField(Type* at);
-
 static void handleParamCNameFormal(FnSymbol* fn, ArgSymbol* formal);
 
 static void storeDefaultValuesForPython(FnSymbol* fn, ArgSymbol* formal);
@@ -357,7 +355,7 @@ static bool shouldUpdateAtomicFormalToRef(FnSymbol* fn, ArgSymbol* formal) {
          fn->hasFlag(FLAG_BUILD_TUPLE)         == false;
 }
 
-static bool recordContainingCopyMutatesField(Type* t) {
+bool recordContainingCopyMutatesField(Type* t) {
   AggregateType* at = toAggregateType(t);
   if (at == NULL) return false;
   if (!isRecord(at)) return false;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -672,7 +672,7 @@ static void insertUnrefForArrayOrTupleReturn(FnSymbol* fn) {
 
           SET_LINENO(call);
           Expr*      rhs       = call->get(2)->remove();
-          VarSymbol* tmp       = newTemp(arrayUnrefName, rhsType);
+          VarSymbol* tmp       = newTemp("array_unref_ret_tmp", rhsType);
           CallExpr*  initTmp   = new CallExpr(PRIM_MOVE,     tmp, rhs);
           CallExpr*  unrefCall = new CallExpr("chpl__unref", tmp);
           CallExpr*  shapeSet  = findSetShape(call, ret);

--- a/test/types/records/init/copy/contains-owned-not-mentioned.chpl
+++ b/test/types/records/init/copy/contains-owned-not-mentioned.chpl
@@ -1,0 +1,3 @@
+class C { }
+record ContainingNilableOwned { var zq: owned C?; }
+record ContainingNonNilableOwned { var z: owned C; }


### PR DESCRIPTION
I noticed that the following program was not compiling due to an 
order-of-resolution issue:

``` chapel
class C { }
record ContainingNilableOwned { var zq: owned C?; }
record ContainingNonNilableOwned { var z: owned C; }
```

This PR adjusts resolution to handle the event that the resolution steps 
occur in a different order so that the above program will compile. While 
there, it updates a few `strcmp` calls to instead use pointer comparison
and removes one an unused global variable.

Reviewed by @benharsh - thanks!

- [x] full local testing