### PR TITLE
We don't necessarily need FI_MULTI_RECV for _all_ receives.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -767,8 +767,8 @@ void init_ofiFabricDomain(void) {
 
   hints->addr_format = FI_FORMAT_UNSPEC;
 
-  hints->tx_attr->op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
-  hints->rx_attr->op_flags = FI_MULTI_RECV        | FI_COMPLETION;
+  hints->tx_attr->op_flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
+  hints->rx_attr->op_flags = FI_COMPLETION;
 
   hints->ep_attr->type = FI_EP_RDM;
 


### PR DESCRIPTION
We have been asserting `FI_MULTI_RECV` in the `hints->rx_attr->op_flags`
input to `fi_getinfo()`.  This basically says we want that flag on every
receive operation we do.  That's not necessarily so.  Although it is
true that we throw it on all our `fi_recvmsg()` calls now, we may not do
so forever, and everything works fine without it being in the hints.
Therefore, remove it.

(I just happened to run across this while working on something else.)