### PR TITLE
Prevent associative arrays and maps of non-nilable classes

### DIFF
--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -163,9 +163,12 @@ proc Replicated.dsiPrivatize(privatizeData)
 
   // make private copy of targetLocales and its domain
   const privDom = otherTargetLocales.domain;
-  const privTargetLocales: [privDom] locale = otherTargetLocales;
+  const privTargetLocales: [privDom] locale? = otherTargetLocales;
+ 
+  const nonNilWrapper: [0..#privTargetLocales.size] locale =
+    for loc in otherTargetLocales do loc!; 
 
-  return new unmanaged Replicated(privTargetLocales, "used during privatization");
+  return new unmanaged Replicated(nonNilWrapper, "used during privatization");
 }
 
 

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -449,7 +449,7 @@ class ReplicatedArr : AbsBaseArr {
   // Access another locale's local array representation
   //
   proc replicand(loc: locale) ref {
-    return localArrs[loc.id].arrLocalRep;
+    return localArrs[loc.id]!.arrLocalRep;
   }
 }
 

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -276,7 +276,8 @@ proc ReplicatedDom.dsiReprivatize(other, reprivatizeData): void {
 
 proc Replicated.dsiClone(): _to_unmanaged(this.type) {
   if traceReplicatedDist then writeln("Replicated.dsiClone");
-  var nonNilWrapper: [0..#targetLocales.size] locale;
+  var nonNilWrapper: [0..#targetLocales.size] locale =
+    for loc in targetLocales do loc!;
   var idx = 0;
   for loc in targetLocales {
     nonNilWrapper[idx] = loc!;

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -278,11 +278,6 @@ proc Replicated.dsiClone(): _to_unmanaged(this.type) {
   if traceReplicatedDist then writeln("Replicated.dsiClone");
   var nonNilWrapper: [0..#targetLocales.size] locale =
     for loc in targetLocales do loc!;
-  var idx = 0;
-  for loc in targetLocales {
-    nonNilWrapper[idx] = loc!;
-    idx += 1;
-  }
   return new unmanaged Replicated(nonNilWrapper);
 }
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -634,8 +634,9 @@ module DefaultAssociative {
     // 
     proc postinit() {
       if isNonNilableClass(this.eltType) {
-        param msg = "Cannot initialize associative array with element type "
-                  + eltType:string + " because it is a non-nilable class";
+        param msg = "Cannot initialize associative array because"
+                  + " element type " + eltType:string
+                  + " is a non-nilable class";
         compilerError(msg);
       }
     }

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -627,7 +627,19 @@ module DefaultAssociative {
   
     var tmpDom = {0..(-1:chpl_table_index_type)};
     var tmpTable: [tmpDom] eltType;
-  
+
+    //
+    // #14367 - Use this as a workaround in order to detect whether or not
+    // the element type of an associative array is a non-nilable class.
+    // 
+    proc postinit() {
+      if isNonNilableClass(this.eltType) {
+        param msg = "Cannot initialize associative array with element type "
+                  + eltType:string + " because it is a non-nilable class";
+        compilerError(msg);
+      }
+    }
+
     //
     // Standard internal array interface
     // 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -628,16 +628,8 @@ module DefaultAssociative {
     var tmpDom = {0..(-1:chpl_table_index_type)};
     var tmpTable: [tmpDom] eltType;
 
-    // Don't use this for now, I don't think it's the correct answer.
-    pragma "no doc"
-    proc _isIgnoredNonNilableClass(type t) param where isNonNilableClass(t) {
-      // Make an exception for the locale type since it "lives" forever.
-      if t:unmanaged == unmanaged locale then return false;
-    }
-
     //
-    // #14367 - Blanket ban on non-nilable classes while we think of a more
-    // long term solution.
+    // #14367 - Blanket ban on non-nilable classes for the time being.
     //
     pragma "no doc"
     proc postinit() {

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -636,8 +636,8 @@ module DefaultAssociative {
     }
 
     //
-    // #14367 - Use this as a workaround in order to detect whether or not
-    // the element type of an associative array is a non-nilable class.
+    // #14367 - Blanket ban on non-nilable classes while we think of a more
+    // long term solution.
     //
     pragma "no doc"
     proc postinit() {

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -628,10 +628,18 @@ module DefaultAssociative {
     var tmpDom = {0..(-1:chpl_table_index_type)};
     var tmpTable: [tmpDom] eltType;
 
+    // Don't use this for now, I don't think it's the correct answer.
+    pragma "no doc"
+    proc _isIgnoredNonNilableClass(type t) param where isNonNilableClass(t) {
+      // Make an exception for the locale type since it "lives" forever.
+      if t:unmanaged == unmanaged locale then return false;
+    }
+
     //
     // #14367 - Use this as a workaround in order to detect whether or not
     // the element type of an associative array is a non-nilable class.
-    // 
+    //
+    pragma "no doc"
     proc postinit() {
       if isNonNilableClass(this.eltType) {
         param msg = "Cannot initialize associative array because"

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -649,8 +649,21 @@ used to recursively hold tables and respective values
       this.tag = fieldArr;
     }
 
+    pragma "no doc"
+    proc init(arr: [?dom] unmanaged Toml?) where isAssociativeDom(dom) == false  {
+      this.dom = dom;
+      this.arr = arr;
+      this.tag = fieldArr;
+    }
+
     // List
     proc init(lst: list(unmanaged Toml)) {
+      // Cheat by translating directly into an array for now.
+      this.init(lst.toArray());
+    }
+
+    pragma "no doc"
+    proc init(lst: list(unmanaged Toml?)) {
       // Cheat by translating directly into an array for now.
       this.init(lst.toArray());
     }

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -737,8 +737,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(s);
       } else {
-        t.tag = fieldString;
-        t.s = s;
+        t!.tag = fieldString;
+        t!.s = s;
       }
     }
     proc set(tbl: string, i: int) {
@@ -746,8 +746,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(i);
       } else {
-        t.tag = fieldInt;
-        t.i = i;
+        t!.tag = fieldInt;
+        t!.i = i;
       }
     }
     proc set(tbl: string, b: bool) {
@@ -755,8 +755,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(b);
       } else {
-        t.tag = fieldBool;
-        t.boo = b;
+        t!.tag = fieldBool;
+        t!.boo = b;
       }
     }
     proc set(tbl: string, r: real) {
@@ -764,8 +764,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(r);
       } else {
-        t.tag = fieldReal;
-        t.re = r;
+        t!.tag = fieldReal;
+        t!.re = r;
       }
     }
     proc set(tbl: string, ld: date) {
@@ -773,8 +773,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(ld);
       } else {
-        t.tag = fieldDate;
-        t.ld = ld;
+        t!.tag = fieldDate;
+        t!.ld = ld;
       }
     }
     proc set(tbl: string, ti: time) {
@@ -782,8 +782,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(ti);
       } else {
-        t.tag = fieldTime;
-        t.ti = ti;
+        t!.tag = fieldTime;
+        t!.ti = ti;
       }
     }
     proc set(tbl: string, dt: datetime) {
@@ -791,8 +791,8 @@ used to recursively hold tables and respective values
       if t == nil {
         t = new unmanaged Toml(dt);
       } else {
-        t.tag = fieldDateTime;
-        t.dt = dt;
+        t!.tag = fieldDateTime;
+        t!.dt = dt;
       }
     }
     proc set(tbl: string, A: [?D] unmanaged Toml?) where isAssociativeDom(D) {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -40,8 +40,6 @@ public use TomlParser;
 private use TomlReader;
 use IO;
 
-pragma "no doc"
-type TomlType = unmanaged Toml?;
 
 /* Receives a TOML file as a parameter and outputs a Toml object.
 

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -204,7 +204,7 @@ module TomlParser {
       var toke = getToken(source);
       var tablename = brackets.sub('', toke);
       var tblD: domain(string);
-      var tbl: [tblD] unmanaged Toml;
+      var tbl: [tblD] unmanaged Toml?;
       if !rootTable.pathExists(tablename) {
         rootTable.set(tablename, tbl);
       }
@@ -216,10 +216,10 @@ module TomlParser {
       var tblname = getToken(source);
       skipNext(source);
       var tblD: domain(string);
-      var tbl: [tblD] unmanaged Toml;
+      var tbl: [tblD] unmanaged Toml?;
       var (tblPath, tblLeaf) = splitTblPath(tblname);
       if !rootTable.pathExists(tblPath) then makePath(tblPath);
-      rootTable[tblPath].set(tblLeaf, tbl);
+      rootTable[tblPath]!.set(tblLeaf, tbl);
       curTable = tblname;
     }
 
@@ -232,15 +232,15 @@ module TomlParser {
       for parent in path {
         if first {
           var tblD: domain(string);
-          var tbl: [tblD] unmanaged Toml;
+          var tbl: [tblD] unmanaged Toml?;
           rootTable.set(parent, tbl);
           first = false;
         }
         else {
           var tblD: domain(string);
-          var tbl: [tblD] unmanaged Toml;
+          var tbl: [tblD] unmanaged Toml?;
           var grandParent = '.'.join(path[..firstIn+i]);
-          rootTable[grandParent].set(parent, tbl);
+          rootTable[grandParent]!.set(parent, tbl);
           i+=1;
         }
       }
@@ -249,7 +249,7 @@ module TomlParser {
     proc parseInlineTbl(key: string) {
       var tblname: string;
       var tblD: domain(string);
-      var tbl: [tblD] unmanaged Toml;
+      var tbl: [tblD] unmanaged Toml?;
       if curTable.isEmpty() {
         tblname = key;
         rootTable.set(key, tbl);
@@ -257,7 +257,7 @@ module TomlParser {
       else {
         tblname = '.'.join(curTable, key);
         var (tblPath, tblLeaf) = splitTblPath(tblname);
-        rootTable[tblPath].set(tblLeaf, tbl);
+        rootTable[tblPath]!.set(tblLeaf, tbl);
       }
       var temp = curTable;
       curTable = tblname;
@@ -282,7 +282,7 @@ module TomlParser {
         else {
           var value = parseValue();
           if curTable.isEmpty() then rootTable[key] = value;
-          else rootTable[curTable][key] = value;
+          else rootTable[curTable]![key] = value;
         }
       }
       catch e: TomlError {
@@ -595,6 +595,13 @@ used to recursively hold tables and respective values
     // Toml
     proc init(A: [?D] unmanaged Toml) where isAssociativeDom(D) {
       this.complete();
+      for i in D do this.A[i] = A[i]?;
+      this.tag = fieldToml;
+    }
+
+    pragma "no doc"
+    proc init(A: [?D] unmanaged Toml?) where isAssociativeDom(D) {
+      this.complete();
       for i in D do this.A[i] = A[i];
       this.tag = fieldToml;
     }
@@ -657,20 +664,23 @@ used to recursively hold tables and respective values
       this.i = root.i;
       this.re = root.re;
       this.dom = root.dom;
-      for idx in root.dom do this.arr[idx] = new unmanaged Toml(root.arr[idx]);
+      for idx in root.dom do this.arr[idx] = new unmanaged Toml(root.arr[idx]!)?;
       this.ld = root.ld;
       this.ti = root.ti;
       this.dt = root.dt;
       this.s = root.s;
-      for idx in root.A do this.A[idx] = new unmanaged Toml(root.A[idx]);
+      for idx in root.A do this.A[idx] = new unmanaged Toml(root.A[idx]!)?;
       this.tag = root.tag;
     }
 
 
     /* Returns the index of the table path given as a parameter */
-    proc this(tbl: string) ref : unmanaged Toml throws {
+    proc this(tbl: string) ref : unmanaged Toml? throws {
       const indx = tbl.split('.');
       var top = indx.domain.first;
+      //
+      // TODO: This is a bug, see #14861.
+      //
       if indx.size < 2 {
         return this.A[tbl];
       }
@@ -679,7 +689,7 @@ used to recursively hold tables and respective values
         if !this.A.contains(indx[top]) {
           throw new owned TomlError("No index found for " + tbl);
         }
-        return this.A[indx[top]][next];
+        return this.A[indx[top]]![next];
       }
     }
 
@@ -700,7 +710,7 @@ used to recursively hold tables and respective values
         else {
           var next = '.'.join(path[top+1..]);
           if this.A.contains(path[top]) {
-            return this.A[path[top]].pathExists(next);
+            return this.A[path[top]]!.pathExists(next);
           }
           else {
             return false;
@@ -785,23 +795,23 @@ used to recursively hold tables and respective values
         t.dt = dt;
       }
     }
-    proc set(tbl: string, A: [?D] unmanaged Toml) where isAssociativeDom(D) {
+    proc set(tbl: string, A: [?D] unmanaged Toml?) where isAssociativeDom(D) {
       ref t = this(tbl);
       if t == nil {
         t = new unmanaged Toml(A);
       } else {
-        t.tag = fieldToml;
-        for i in D do t.A[i] = A[i];
+        t!.tag = fieldToml;
+        for i in D do t!.A[i] = A[i];
       }
     }
-    proc set(tbl: string, arr: [?dom] unmanaged Toml) where !isAssociativeDom(dom) {
+    proc set(tbl: string, arr: [?dom] unmanaged Toml?) where !isAssociativeDom(dom) {
       ref t = this(tbl);
       if t == nil {
         t = new unmanaged Toml(arr);
       } else {
-        t.tag = fieldArr;
-        t.dom = dom;
-        t.arr = arr;
+        t!.tag = fieldArr;
+        t!.dom = dom;
+        t!.arr = arr;
       }
     }
 
@@ -814,7 +824,7 @@ used to recursively hold tables and respective values
     /* Write a Table to channel f in TOML format */
     proc writeTOML(f) {
       try! {
-        var flat = new map(string, unmanaged Toml);
+        var flat = new map(string, unmanaged Toml?);
         this.flatten(flat);       // Flattens containing Toml
         printValues(f, this);     // Prints key values in containing Toml
         printTables(flat, f);       // Prints tables in containing Toml
@@ -827,7 +837,7 @@ used to recursively hold tables and respective values
     /* Write a Table to channel f in JSON format */
     proc writeJSON(f) {
       try! {
-        var flat = new map(string, unmanaged Toml);
+        var flat = new map(string, unmanaged Toml?);
         this.flatten(flat);           // Flattens containing Toml
 
         var indent=0;
@@ -839,13 +849,13 @@ used to recursively hold tables and respective values
         printValuesJSON(f, this, indent=indent);
 
         if flat.contains('root') {
-          printValuesJSON(f, flat['root'], indent=indent);
+          printValuesJSON(f, flat['root']!, indent=indent);
           flat.remove('root');
         }
         for k in flat.keysToArray().sorted() {
           f.writef('%s"%s": {\n', ' '*indent, k);
           indent += tabSpace;
-          printValuesJSON(f, flat[k], indent=indent);
+          printValuesJSON(f, flat[k]!, indent=indent);
           indent -= tabSpace;
           f.writef('%s}\n', ' '*indent);
         }
@@ -861,35 +871,36 @@ used to recursively hold tables and respective values
 
     pragma "no doc"
     /* Flatten tables into flat associative array for writing */
-    proc flatten(ref flat: map(string, unmanaged Toml, false), rootKey = '') : flat.type {
+    proc flatten(ref flat: map(string, unmanaged Toml?, false), rootKey = '') : flat.type {
       for (k, v) in this.A.items() {
-        if v.tag == fieldToml {
+        if v!.tag == fieldToml {
           var fullKey = k;
           if rootKey != '' then fullKey = '.'.join(rootKey, k);
           flat[fullKey] = v;
-          v.flatten(flat, fullKey);
+          v!.flatten(flat, fullKey);
         }
       }
       return flat;
     }
 
     pragma "no doc"
-    proc printTables(ref flat: map(string, unmanaged Toml, false), f:channel) {
+    proc printTables(ref flat: map(string, unmanaged Toml?, false), f:channel) {
       if flat.contains('root') {
         f.writeln('[root]');
-        printValues(f, flat['root']);
+        printValues(f, flat['root']!);
         flat.remove('root');
       }
       for k in flat.keysToArray().sorted() {
         f.writeln('[', k, ']');
-        printValues(f, flat[k]);
+        printValues(f, flat[k]!);
       }
     }
 
     pragma "no doc"
     /* Send values from table to toString for writing  */
     proc printValues(f: channel, v: borrowed Toml) throws {
-      for (key, value) in v.A.items() {
+      for (key, val) in v.A.items() {
+        var value = val!;
         select value.tag {
           when fieldToml do continue; // Table
           when fieldBool {
@@ -904,10 +915,10 @@ used to recursively hold tables and respective values
             final += '[';
             for k in value.arr {
               if value.arr.domain.size == 1 || k == value.arr[value.arr.domain.last] {
-                final += toString(k);
+                final += toString(k!);
               }
               else {
-                final += toString(k) + ', ';
+                final += toString(k!) + ', ';
               }
             }
             final += ']';
@@ -943,7 +954,8 @@ used to recursively hold tables and respective values
     pragma "no doc"
     /* Send values from table to toString for writing  */
     proc printValuesJSON(f: channel, v: borrowed Toml, in indent=0) throws {
-      for ((key, value), i) in zip(v.A.items(), 1..v.A.size) {
+      for ((key, val), i) in zip(v.A.items(), 1..v.A.size) {
+        var value = val!;
         select value.tag {
           when fieldToml do continue; // Table
           when fieldBool {
@@ -961,7 +973,7 @@ used to recursively hold tables and respective values
             var arrayElements: string;
             for i in value.arr.domain {
               ref k = value.arr[i];
-              f.writef('%s{"type": "%s", "value": "%s"}', ' '*indent, k.tomlType, toString(k));
+              f.writef('%s{"type": "%s", "value": "%s"}', ' '*indent, k!.tomlType, toString(k!));
               if i != value.arr.domain.last {
                 f.writef(',');
               }
@@ -1013,10 +1025,10 @@ used to recursively hold tables and respective values
           final += '[';
           for k in val.arr {
             if val.arr.domain.size == 1 || k == val.arr[val.arr.domain.last] {
-              final += toString(k);
+              final += toString(k!);
             }
             else {
-              final += toString(k) + ', ';
+              final += toString(k!) + ', ';
             }
           }
           final += ']';

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -689,13 +689,16 @@ used to recursively hold tables and respective values
     proc this(tbl: string) ref : unmanaged Toml? throws {
       const indx = tbl.split('.');
       var top = indx.domain.first;
+
       //
-      // TODO: This is a bug, see #14861.
+      // TODO: This is a bug when the return type of this routine is a
+      // non-nilable class, see #14367/#14861. So for now, we have to make
+      // `Toml.this` return `Toml?`, which makes it a lot less pleasant
+      // to use.
       //
       if indx.size < 2 {
         return this.A[tbl];
-      }
-      else {
+      } else {
         var next = '.'.join(indx[top+1..]);
         if !this.A.contains(indx[top]) {
           throw new owned TomlError("No index found for " + tbl);

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -593,7 +593,7 @@ used to recursively hold tables and respective values
     // Toml
     proc init(A: [?D] unmanaged Toml) where isAssociativeDom(D) {
       this.complete();
-      for i in D do this.A[i] = A[i]?;
+      for i in D do this.A[i] = A[i];
       this.tag = fieldToml;
     }
 

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -40,6 +40,8 @@ public use TomlParser;
 private use TomlReader;
 use IO;
 
+pragma "no doc"
+type TomlType = unmanaged Toml?;
 
 /* Receives a TOML file as a parameter and outputs a Toml object.
 
@@ -93,7 +95,7 @@ proc parseToml(input: channel) : unmanaged Toml {
  /* Receives a string of TOML format as a parameter and outputs a Toml object */
 proc parseToml(input: string) : unmanaged Toml {
   var D: domain(string);
-  var table: [D] unmanaged Toml;
+  var table: [D] unmanaged Toml?;
   var rootTable = new unmanaged Toml(table);
   const source = new unmanaged Source(input);
   const parser = new unmanaged Parser(source, rootTable);
@@ -575,8 +577,8 @@ used to recursively hold tables and respective values
       ti: time,
       dt: datetime,
       dom: domain(1),
-      arr: [dom] unmanaged Toml,
-      A: map(string, unmanaged Toml, false),
+      arr: [dom] unmanaged Toml?,
+      A: map(string, unmanaged Toml?, false),
       tag: fieldtag;
 
     // Empty

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -110,6 +110,19 @@ module Map {
       }
     }
 
+    //
+    // #14861 - Blanket ban on non-nilable classes while we make API changes
+    // to map that allow it to handle !isDefaultInitializable elements
+    // comfortably.
+    //
+    pragma "no doc"
+    proc postinit() {
+      if isNonNilableClass(valType) {
+        param msg = "Cannot initialize map because element type "
+                  + valType:string + " is a non-nilable class";
+        compilerError(msg);
+      }
+    }
     /*
       Clears the contents of this map.
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -51,12 +51,13 @@ module Map {
   private use IO;
 
   pragma "no doc"
-  inline proc checkValTypeForNonNilableClass(type valType) {
-    if isNonNilableClass(valType) {
+  inline proc checkForNonNilableClass(type t) type {
+    if isNonNilableClass(t) {
       param msg = "Cannot initialize map because element type "
-                + valType:string + " is a non-nilable class";
+                + t:string + " is a non-nilable class";
       compilerError(msg, 2);
     }
+    return t;
   }
 
   record map {
@@ -64,7 +65,7 @@ module Map {
     param parSafe = false;
 
     var myKeys: domain(keyType, parSafe=parSafe);
-    var vals: [myKeys] checkValTypeForNonNilableClass(valType);
+    var vals: [myKeys] checkForNonNilableClass(valType);
 
 
     pragma "no doc"
@@ -90,14 +91,9 @@ module Map {
       :arg parSafe: If `true`, this map will use parallel safe operations.
     */
     proc init(type keyType, type valType, param parSafe=false) {
-
-
-
       this.keyType = keyType;
       this.valType = valType;
       this.parSafe = parSafe;
-
-      this.vals = [myKeys] valType;
     }
 
     /*
@@ -112,12 +108,6 @@ module Map {
     */
     proc init=(pragma "intent ref maybe const formal"
                other: map(?kt, ?vt, ?ps)) {
-      if isNonNilableClass(vt) {
-        param msg = "Cannot initialize map because element type "
-                  + vt:string + " is a non-nilable class";
-        compilerError(msg);
-      }
-
       this.keyType = kt;
       this.valType = vt;
       this.parSafe = ps;

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -50,6 +50,12 @@ module Map {
 
   private use IO;
 
+  //
+  // #14861 - For now, maps of non-nilable classes are banned. Once we
+  // resolve #13602 and #14861, we can remvoe this check. The check is on
+  // a type method instead of `map.init` because init for associative
+  // arrays (and thus their compiler error) resolves before `map.init`.
+  //
   pragma "no doc"
   inline proc checkForNonNilableClass(type t) type {
     if isNonNilableClass(t) {

--- a/test/arrays/errors/nilStorageNonNilAssocArr.0.good
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.0.good
@@ -1,0 +1,2 @@
+nilStorageNonNilAssocArr.chpl:17: In function 'main':
+nilStorageNonNilAssocArr.chpl:19: error: Cannot initialize associative array because element type owned C is a non-nilable class

--- a/test/arrays/errors/nilStorageNonNilAssocArr.1.good
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.1.good
@@ -1,0 +1,2 @@
+nilStorageNonNilAssocArr.chpl:17: In function 'main':
+nilStorageNonNilAssocArr.chpl:19: error: Cannot initialize associative array because element type shared C is a non-nilable class

--- a/test/arrays/errors/nilStorageNonNilAssocArr.2.good
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.2.good
@@ -1,0 +1,2 @@
+nilStorageNonNilAssocArr.chpl:17: In function 'main':
+nilStorageNonNilAssocArr.chpl:19: error: Cannot initialize associative array because element type unmanaged C is a non-nilable class

--- a/test/arrays/errors/nilStorageNonNilAssocArr.bad
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.bad
@@ -1,1 +1,0 @@
-nilStorageNonNilAssocArr.chpl:23: error: halt reached - argument to ! is nil

--- a/test/arrays/errors/nilStorageNonNilAssocArr.bad
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.bad
@@ -1,0 +1,1 @@
+nilStorageNonNilAssocArr.chpl:23: error: halt reached - argument to ! is nil

--- a/test/arrays/errors/nilStorageNonNilAssocArr.chpl
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.chpl
@@ -1,8 +1,7 @@
 //
-// See issue #14367. An associative array with a value type that is
-// a non-nilable class must not insert nil as the default value (as
-// it does for _nilable_ classes) when a key is added to the array's
-// domain.
+// See issue #14367. An associative array with a value type that is a
+// non-nilable class must not insert nil as the default value (as it does for
+// _nilable_ classes) when a key is added to the array's domain.
 //
 
 class C {
@@ -13,10 +12,7 @@ proc main() {
   var d: domain(string);
   var a: [d] shared C;
 
-  //
-  // We should emit some sort of error here, or prevent this action
-  // from happening in the first place.
-  //
+  // Some sort of error should have been emitted by this point.
   d += "key";
 
   // Will emit a nil error (which shouldn't be possible).

--- a/test/arrays/errors/nilStorageNonNilAssocArr.chpl
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.chpl
@@ -8,14 +8,20 @@ class C {
   var x: int;
 }
 
+type OwnedC = owned C;
+type SharedC = shared C;
+type UnmanagedC = unmanaged C;
+
+config type TestClass = OwnedC;
+
 proc main() {
   var d: domain(string);
-  var a: [d] shared C;
+  var a: [d] TestClass;
 
   // Some sort of error should have been emitted by this point.
-  d += "key";
+  a += "key";
 
-  // Will emit a nil error (which shouldn't be possible).
+  // This call will emit a nil error (which shouldn't be possible).
   writeln(a);
 }
 

--- a/test/arrays/errors/nilStorageNonNilAssocArr.chpl
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.chpl
@@ -1,0 +1,25 @@
+//
+// See issue #14367. An associative array with a value type that is
+// a non-nilable class must not insert nil as the default value (as
+// it does for _nilable_ classes) when a key is added to the array's
+// domain.
+//
+
+class C {
+  var x: int;
+}
+
+proc main() {
+  var d: domain(string);
+  var a: [d] shared C;
+
+  //
+  // We should emit some sort of error here, or prevent this action
+  // from happening in the first place.
+  //
+  d += "key";
+
+  // Will emit a nil error (which shouldn't be possible).
+  writeln(a);
+}
+

--- a/test/arrays/errors/nilStorageNonNilAssocArr.chpl
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.chpl
@@ -19,7 +19,7 @@ proc main() {
   var a: [d] TestClass;
 
   // Some sort of error should have been emitted by this point.
-  a += "key";
+  d += "key";
 
   // This call will emit a nil error (which shouldn't be possible).
   writeln(a);

--- a/test/arrays/errors/nilStorageNonNilAssocArr.compopts
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.compopts
@@ -1,0 +1,3 @@
+-sTestClass=OwnedC        # nilStorageNonNilAssocArr.0.good
+-sTestClass=SharedC       # nilStorageNonNilAssocArr.1.good
+-sTestClass=UnmanagedC    # nilStorageNonNilAssocArr.2.good

--- a/test/arrays/errors/nilStorageNonNilAssocArr.good
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.good
@@ -1,0 +1,1 @@
+No idea what this will look like yet!

--- a/test/arrays/errors/nilStorageNonNilAssocArr.good
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.good
@@ -1,1 +1,2 @@
-No idea what this will look like yet!
+nilStorageNonNilAssocArr.chpl:11: In function 'main':
+nilStorageNonNilAssocArr.chpl:13: error: Cannot initialize associative array with element type shared C because it is a non-nilable class

--- a/test/arrays/errors/nilStorageNonNilAssocArr.good
+++ b/test/arrays/errors/nilStorageNonNilAssocArr.good
@@ -1,2 +1,0 @@
-nilStorageNonNilAssocArr.chpl:11: In function 'main':
-nilStorageNonNilAssocArr.chpl:13: error: Cannot initialize associative array with element type shared C because it is a non-nilable class

--- a/test/associative/bradc/localeDom/assocLocales3.chpl
+++ b/test/associative/bradc/localeDom/assocLocales3.chpl
@@ -13,7 +13,7 @@ class C {
 
   var D: domain(locale) = targetLocs;
 
-  var A: [D] unmanaged LocC(idxType);
+  var A: [D] unmanaged LocC(idxType)?;
 
   proc postinit() {
     for (loc, locid) in zip(targetLocs, 0..) do

--- a/test/library/packages/TOML/test/UTomlTest.chpl
+++ b/test/library/packages/TOML/test/UTomlTest.chpl
@@ -9,19 +9,19 @@ proc main() {
 
   // New Table
   var tblD: domain(string);
-  var tbl: [tblD] unmanaged Toml;
+  var tbl: [tblD] unmanaged Toml?;
 
   // Table indexed into and new table added
-  tomlData["A.B"].set("C", tbl);
+  tomlData["A.B"]!.set("C", tbl);
 
   // Add elements to new table C
   var toAdd: bool = true;
-  tomlData["A.B.C"].set("new-key-added", toAdd);
+  tomlData["A.B.C"]!.set("new-key-added", toAdd);
 
   writeln("After Mutation: ", tomlData);
 
   // test toString proc
-  var strInt: string = tomlData["A.B"]["number"].toString();
+  var strInt: string = tomlData["A.B"]!["number"]!.toString();
   writeln("A.B.number = ",strInt); 
 
   writeln(); //for spacing
@@ -34,11 +34,11 @@ proc main() {
   // Test of the "copy constructor"
   // New Toml
   var tbl2D: domain(string);
-  var tbl2: [tbl2D] unmanaged Toml;
+  var tbl2: [tbl2D] unmanaged Toml?;
   var tomlData2 = new unmanaged Toml(tbl2);
 
   // copy Toml A.B in tomlData to Toml A in TomlData2
-  tomlData2["A"] = new unmanaged Toml(tomlData["A"]);
+  tomlData2["A"] = new unmanaged Toml(tomlData["A"]!);
   writeln(tomlData["A"]);
   writeln("Should be the same as");
   writeln(tomlData2["A"]);

--- a/test/library/packages/TOML/test/date.chpl
+++ b/test/library/packages/TOML/test/date.chpl
@@ -8,8 +8,8 @@ config const str: string = """[owner]
 
 proc main() {
   var TomlData = parseToml(str);
-  var dob = TomlData["owner"]["dob"];
-  writeln(dob.toString());
+  var dob = TomlData["owner"]!["dob"];
+  writeln(dob!.toString());
 
   delete TomlData;
 }

--- a/test/library/packages/TOML/test/testtime.chpl
+++ b/test/library/packages/TOML/test/testtime.chpl
@@ -12,17 +12,17 @@ config const str: string = """[owner]
 
 proc main() {
   var TomlData = parseToml(str);
-  var ts1 = TomlData["owner"]["timestamp1"];
-  var ts2 = TomlData["owner"]["timestamp2"];
-  var ts3 = TomlData["owner"]["timestamp3"];
-  var ts4 = TomlData["owner"]["timestamp4"];
-  var ts5 = TomlData["owner"]["timestamp5"];
+  var ts1 = TomlData["owner"]!["timestamp1"];
+  var ts2 = TomlData["owner"]!["timestamp2"];
+  var ts3 = TomlData["owner"]!["timestamp3"];
+  var ts4 = TomlData["owner"]!["timestamp4"];
+  var ts5 = TomlData["owner"]!["timestamp5"];
 
-  writeln(ts1.toString());
-  writeln(ts2.toString());
-  writeln(ts3.toString());
-  writeln(ts4.toString());
-  writeln(ts5.toString());
+  writeln(ts1!.toString());
+  writeln(ts2!.toString());
+  writeln(ts3!.toString());
+  writeln(ts4!.toString());
+  writeln(ts5!.toString());
 
   delete TomlData;
 }

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -265,7 +265,7 @@ module DataFrames {
           f <~> " ";
 
         for (ser, lab) in zip(d, d.labels) {
-          ser.writeElem(f, idx, lab.length);
+          ser!.writeElem(f, idx, lab.length);
           f <~> "   ";
         }
       }
@@ -761,7 +761,7 @@ module DataFrames {
 
     // TODO: array of owned Series
     //   Currently run into confusing const errors in DefaultAssociative
-    var columns: [labels] unmanaged Series;
+    var columns: [labels] unmanaged Series?;
 
     var idx: shared Index?;
 
@@ -780,13 +780,23 @@ module DataFrames {
         this.columns[lab] = s.copy().release();
     }
 
+    pragma "no doc"
+    proc init(columns: [?D] ?E) where isSubtype(E, Series?) {
+      this.labels = D;
+      this.idx = nil;
+      this.complete();
+
+      for (lab, s) in zip(labels, columns) do
+        this.columns[lab] = s!.copy().release();
+    }
+
     proc init(columns: [?D], in idx: shared Index) {
       this.labels = D;
       this.idx = idx;
       this.complete();
 
       for (lab, s) in zip(labels, columns) do
-        this.insert(lab, s);
+        this.insert(lab, s!);
     }
 
     proc deinit() {
@@ -812,13 +822,13 @@ module DataFrames {
     proc reindex(in idx: shared Index?) {
       this.idx = idx;
       for s in columns do
-        s.reindex(idx);
+        s!.reindex(idx);
     }
 
     proc nrows() {
       var nMax = 0;
       for s in this {
-        var n = s.nrows();
+        var n = s!.nrows();
         if n > nMax then nMax = n;
       }
       return nMax;
@@ -847,7 +857,7 @@ module DataFrames {
             f <~> " ";
 
           for (ser, lab) in zip(this, labels) {
-            ser.writeElemNoIndex(f, i, lab.length);
+            ser!.writeElemNoIndex(f, i, lab.length);
             f <~> "   ";
           }
         }

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -2,9 +2,9 @@ use DataFrames;
 
 var validBits = [true, false, true, false, true];
 
-var columnOne: owned Series = new owned TypedSeries(["a", "b", "c", "d", "e"], validBits);
-var columnTwo: owned Series = new owned TypedSeries([1, 2, 3, 4, 5], validBits);
-var columnThree: owned Series = new owned TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
+var columnOne: owned Series? = new owned TypedSeries(["a", "b", "c", "d", "e"], validBits);
+var columnTwo: owned Series? = new owned TypedSeries([1, 2, 3, 4, 5], validBits);
+var columnThree: owned Series? = new owned TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
 
 var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnThree" => columnThree];
 var idx = new shared TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);

--- a/test/library/standard/Map/testBanNonNilableClass.1.good
+++ b/test/library/standard/Map/testBanNonNilableClass.1.good
@@ -1,0 +1,2 @@
+testBanNonNilableClass.chpl:15: In function 'main':
+testBanNonNilableClass.chpl:16: error: Cannot initialize map because element type owned SomeClass is a non-nilable class

--- a/test/library/standard/Map/testBanNonNilableClass.chpl
+++ b/test/library/standard/Map/testBanNonNilableClass.chpl
@@ -1,0 +1,19 @@
+//
+// See issue #14861. Once `map.this` has been adjusted we can fix map so
+// that it works with non-nilable classes, and then remove this test.
+//
+
+use Map;
+
+class SomeClass { var x: int = 0; }
+
+type NilClass = owned SomeClass?;
+type NonNilClass = owned SomeClass;
+
+config type TestClass = NilClass;
+
+proc main() {
+  var m: map(int, TestClass, false);
+  return;
+}
+

--- a/test/library/standard/Map/testBanNonNilableClass.compopts
+++ b/test/library/standard/Map/testBanNonNilableClass.compopts
@@ -1,0 +1,2 @@
+-sTestClass=NilClass          # testBanNonNilableClass.0.good
+-sTestClass=NonNilClass       # testBanNonNilableClass.1.good

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_driver.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_driver.chpl
@@ -58,7 +58,7 @@ module SSCA2_driver
         largest_edges ( G, Heavy_Edge_List );
 
         if RUN_KERNEL3 {
-          var Heavy_Edge_Subgraphs : [Heavy_Edge_List] unmanaged Generated_Subgraph (vertex);
+          var Heavy_Edge_Subgraphs : [Heavy_Edge_List] unmanaged Generated_Subgraph (vertex)?;
 
           for (x,y) in Heavy_Edge_List do
             Heavy_Edge_Subgraphs ( (x, y) ) = new unmanaged Generated_Subgraph (vertex);

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -122,13 +122,13 @@ module SSCA2_kernels
 	  writeln ( " Building heavy edge subgraph from pair:", (x,y) );
 	Active_Level.add ( y );
 	Next_Level.clear ();
-	Heavy_Edge_Subgraph ( (x, y) ).nodes.clear ();
-	Heavy_Edge_Subgraph ( (x, y) ).edges.clear ();
+	Heavy_Edge_Subgraph ( (x, y) )!.nodes.clear ();
+	Heavy_Edge_Subgraph ( (x, y) )!.edges.clear ();
 	min_distance ( y ).write(0);
 
-	Heavy_Edge_Subgraph ( (x, y) ).edges.add ( (x, y) );
-	Heavy_Edge_Subgraph ( (x, y) ).nodes.add ( x );
-	Heavy_Edge_Subgraph ( (x, y) ).nodes.add ( y );
+	Heavy_Edge_Subgraph ( (x, y) )!.edges.add ( (x, y) );
+	Heavy_Edge_Subgraph ( (x, y) )!.nodes.add ( x );
+	Heavy_Edge_Subgraph ( (x, y) )!.nodes.add ( y );
   
 	for path_length in 1 .. max_path_length do {
 	    
@@ -139,11 +139,11 @@ module SSCA2_kernels
 
               if min_distance(w).compareAndSwap(-1, path_length) then {
                 Next_Level.add (w);
-                Heavy_Edge_Subgraph ( (x, y) ).nodes.add (w);
+                Heavy_Edge_Subgraph ( (x, y) )!.nodes.add (w);
 	      }
 
 	      if min_distance(w).read() == path_length then {
-		Heavy_Edge_Subgraph ( (x, y) ).edges.add ( (v, w) );
+		Heavy_Edge_Subgraph ( (x, y) )!.edges.add ( (v, w) );
 	      }
 	    }
 	  }

--- a/test/studies/590o/alaska/graph.chpl
+++ b/test/studies/590o/alaska/graph.chpl
@@ -39,6 +39,10 @@ proc <(x: borrowed Node, y: borrowed Node) {
   return x.name < y.name;
 }
 
+proc <(x: borrowed Node?, y: borrowed Node?) {
+  return x!.name < y!.name;
+}
+
 class Edge {
   var id: int;
   var src: unmanaged Node;
@@ -75,6 +79,10 @@ proc <(x: borrowed Edge, y: borrowed Edge) {
   } else {
     return (x.src.name < y.src.name);
   }
+}
+
+proc <(x: borrowed Edge?, y: borrowed Edge?) {
+  return x! < y!;
 }
 
 class MultiMap {
@@ -157,8 +165,8 @@ class Graph {
 
   const NodeDom, EdgeDom : domain(1); //= [1..NumNodes];
   //  const EdgeDom : domain(1) = [1..NumEdges];
-  var nodes : [NodeDom] unmanaged Node;
-  var edges : [EdgeDom] unmanaged Edge;
+  var nodes : [NodeDom] unmanaged Node?;
+  var edges : [EdgeDom] unmanaged Edge?;
 
   var inEdges : [NodeDom] LinkedList(unmanaged Edge);
   proc inEdges(n:borrowed Node) ref { return inEdges[n.id]; }
@@ -205,17 +213,18 @@ class Graph {
   /* Populate index structures in parallel */
   proc preprocess(){
     forall n in nodes do {
-      preprocess(n);
+      preprocess(n!);
     }
 
     writeln("preprocess done!");
     for n in nodes do {
-	writeln(n.name," :in[",inEdges[n.id],"] :out[",outEdges[n.id],"]");
+	writeln(n!.name," :in[",inEdges[n!.id],"] :out[",outEdges[n!.id],"]");
       }
   }
 
   proc preprocess(n : borrowed Node){
-    for e in edges do {
+    for edge in edges do {
+      var e = edge!;
       if( e.src == n ){
 	outEdges[n.id].append(e);
 	adjacent[n.id].append(e.dst.id);
@@ -233,27 +242,31 @@ class Graph {
     writeln("* init_rank  *");
     writeln("**************");
     // for all nodes, if not ranked, rank it 1
-    for u in nodes do {
+    for node in nodes do {
+      var u = node!; 
       var uId = u.id;
       var r = curRank(uId);
-      if(u.pred == nil){
-	curRank(uId) = 1;
-	r = 1;
-	writeln("Init rank for ",u," to ",curRank(uId));
-	propagate_rank(u);
+
+      if (u.pred == nil) {
+        curRank(uId) = 1;
+        r = 1;
+        writeln("Init rank for ",u," to ",curRank(uId));
+        propagate_rank(u);
       }
     }
   }
 
   proc propagate_rank(u:borrowed Node) {
     var r = curRank(u.id);
-    for e in inEdges[u.id] do {
+    for edge in inEdges[u.id] do {
+      var e = edge!;
       var v = e.src.id;
       if(v != u.id){
 	if(curRank(v) == -1){
 	  curRank(v) = r - 1; // it points to me
-	  writeln("\t",nodes(v).name," of rank ",r - 1,"\n\t propagate_rank(",nodes(v).name,")");
-	  propagate_rank(nodes(v));
+    var nd = nodes(v)!;
+	  writeln("\t",nd.name," of rank ",r - 1,"\n\t propagate_rank(",nd.name,")");
+	  propagate_rank(nd);
 	} else if(curRank(v) > r){
 	  halt("Edge from ",e.src," to ",u," but ranks are ",curRank(v)," -> ",r);
 	}
@@ -264,8 +277,9 @@ class Graph {
       if(v != u.id){
 	if(curRank(v) == -1){
 	  curRank(v) = r + 1; // it points to me
-	  writeln("\t",nodes(v).name," of rank ",r+1,"\n\t propagate_rank(",nodes(v).name,")");
-	  propagate_rank(nodes(v));
+    var nd = nodes(v)!;
+	  writeln("\t",nd.name," of rank ",r+1,"\n\t propagate_rank(",nd.name,")");
+	  propagate_rank(nd);
 	} else if(curRank(v) < r){
 	  halt("Edge from ",u," to ",e.dst," but ranks are ",r," -> ",curRank(v));
 	}
@@ -274,7 +288,8 @@ class Graph {
   }
 
   proc recompute_slack(){
-    forall e in edges do{
+    forall edge in edges do{
+      var e = edge!;
       if(e.kind == edgeKind.BACK){
 	slack(e.id) = curRank(e.src.id) - curRank(e.dst.id);
       } else {
@@ -332,7 +347,7 @@ class Graph {
     __treeEdges = 0;
     __treeNodes = 0;
     treeNodes(nID) = 1;
-    writeln("Finding max tight-tree containing ",nodes(nID).name);
+    writeln("Finding max tight-tree containing ",nodes(nID)!.name);
     var cnt = find_tight_tree(nID);
     //    writeln("tight_tree ",nodes(nID)," has ",cnt," edges ");
     return + reduce [i in NodeDom] treeNodes(i);
@@ -340,7 +355,7 @@ class Graph {
 
   proc find_tight_tree(nID:index(NodeDom)):int {
     var cnt = 0;
-    var node: unmanaged Node = nodes(nID);
+    var node: unmanaged Node = nodes(nID)!;
     treeNodes(nID) = 1;
 
     for edge in non_tree_inEdges(nID) do {
@@ -371,7 +386,8 @@ class Graph {
   }
 
   iter incident_non_tree_edge() : unmanaged Edge {
-    for e in edges do {
+    for edge in edges do {
+      var e = edge!;
 	if((treeEdges[e.id] == 0) &&
 	   ((treeNodes(e.src.id) == 0 && treeNodes(e.dst.id) != 0) ||
 	    (treeNodes(e.dst.id)) == 0 && treeNodes(e.src.id) != 0)){
@@ -421,7 +437,8 @@ class Graph {
 	    curRank(v) += (delta * treeNodes(v));
 	  }
 	recompute_slack();
-	for e in edges do {
+	for edge in edges do {
+    var e = edge!;
 	    writeln(e.src," @R[[",curRank(e.src.id),"]] --> ",e.dst,"@R[[",curRank(e.dst.id),"]] == ",slack(e.id));
 	  }
 	/* Try and tighten from the incident edge */
@@ -452,7 +469,8 @@ class Graph {
   }
 
   iter edgesOut(u:unmanaged Node) : unmanaged Edge {
-    for e in edges do {
+    for edge in edges do {
+      var e = edge!;
       if ((e.src == u && !e.reversed) || (e.dst == u && e.reversed)){
 	yield e;
       }
@@ -468,7 +486,8 @@ class Graph {
 
 proc DFS(G){
   G.time = 0;
-  for u in G.nodes do {
+  for node in G.nodes do {
+    var u = node!;
       if( u.color == colors.WHITE ) {
 	writeln("Starting at ",u);
 	DFS_VISIT(G,u);
@@ -519,8 +538,8 @@ proc readGraph(filename) {
 
   var ND: domain(string);
   var ED: domain((string,string));
-  var NameMap: [ND] unmanaged Node;
-  var EdgeMap: [ED] unmanaged Edge;
+  var NameMap: [ND] unmanaged Node?;
+  var EdgeMap: [ED] unmanaged Edge?;
   //
   // Read in the edge statements
   //
@@ -550,7 +569,7 @@ proc readGraph(filename) {
     // Create an Edge if needed
     if(!ED.contains((s,d))){
       ED.add((s,d));
-      EdgeMap((s,d)) = new unmanaged Edge(i,NameMap(s),NameMap(d));
+      EdgeMap((s,d)) = new unmanaged Edge(i,NameMap(s)!,NameMap(d)!);
       writeln("Added edge ",s," ",arrow," ",d);
     } else {
       halt("Duplicate edge ",s," ",arrow," ",d);
@@ -561,11 +580,11 @@ proc readGraph(filename) {
   var N: domain(1) = {1..ND.numIndices};
   var E: domain(1) = {1..ED.numIndices};
 
-  var X: [N] unmanaged Node = NameMap.sorted();
-  var Y: [E] unmanaged Edge = EdgeMap.sorted();
+  var X: [N] unmanaged Node? = NameMap.sorted();
+  var Y: [E] unmanaged Edge? = EdgeMap.sorted();
 
-  [ i in N ] X(i).id = i;
-  [ i in E ] Y(i).id = i;
+  [ i in N ] X(i)!.id = i;
+  [ i in E ] Y(i)!.id = i;
 
   writeln(ND.sorted());
   writeln(NameMap.sorted());

--- a/test/studies/590o/alaska/graph.good
+++ b/test/studies/590o/alaska/graph.good
@@ -88,4 +88,4 @@ Init rank for {A} to 1
 	 propagate_rank(C)
 	F of rank 1
 	 propagate_rank(F)
-graph.chpl:258: error: halt reached - Edge from {C} to {F} but ranks are 2 -> 1
+graph.chpl:271: error: halt reached - Edge from {C} to {F} but ranks are 2 -> 1

--- a/test/studies/amr/advection/amr/AMRBC_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/amr/AMRBC_AdvectionCTU.chpl
@@ -15,7 +15,7 @@ class ZeroInflowBC: AMRBC {
 
     //---- Assign zeros to ghost cells on the physical boundary ----
     for (grid,multidomain) in hierarchy.physical_boundaries(level_idx) {
-      for ghost_domain in multidomain do
+      for ghost_domain in multidomain! do
 	      q(grid, ghost_domain) = 0.0;
     }
   }

--- a/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl
@@ -42,7 +42,7 @@ class GradientFlagger: Flagger {
     
     for grid in level_solution.level.grids {
 
-      const ref value = current_data(grid).value;
+      const ref value = current_data(grid)!.value;
       
       for cell in grid.cells {
         

--- a/test/studies/amr/advection/level/LevelBC_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/level/LevelBC_AdvectionCTU.chpl
@@ -13,9 +13,9 @@ class ZeroInflowBC: LevelBC {
 
     for grid in level.grids {
 
-      for ghost_domain in level.boundary(grid) {
+      for ghost_domain in level.boundary(grid)! {
         forall cell in ghost_domain do
-          q(grid).value(cell) = 0.0;
+          q(grid)!.value(cell) = 0.0;
       }
 
     }

--- a/test/studies/amr/advection/level/LevelVariable_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/level/LevelVariable_AdvectionCTU.chpl
@@ -9,6 +9,6 @@ proc LevelVariable.storeCTUOperator(
 {
   
   for grid in level.grids do
-    this(grid).storeCTUOperator(q(grid), velocity, dt);
+    this(grid)!.storeCTUOperator(q(grid)!, velocity, dt);
   
 }

--- a/test/studies/amr/diffusion/level/LevelBC_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelBC_DiffusionBE.chpl
@@ -20,7 +20,7 @@ class ZeroFluxDiffusionBC: LevelBC {
         var shift = -1*loc;
         
         forall cell in ghost_domain do
-          q(grid).value(cell) = q(grid).value(cell+shift);
+          q(grid)!.value(cell) = q(grid)!.value(cell+shift);
       }
     
     } // end for grid in level.grids

--- a/test/studies/amr/diffusion/level/LevelVariable_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelVariable_DiffusionBE.chpl
@@ -64,7 +64,7 @@ proc LevelVariable.storeCGSolution(
     for grid in level.grids {
       this(grid,grid.cells) += alpha * search_dir(grid,grid.cells);
       residual(grid,grid.cells) -= alpha * residual_update(grid,grid.cells);
-      grid_res_norm_squares(grid) = +reduce( residual(grid).value(grid.cells)**2 );
+      grid_res_norm_squares(grid) = +reduce( residual(grid)!.value(grid.cells)**2 );
     }
     //<=== Update solution and residual <===
 
@@ -132,5 +132,5 @@ proc LevelVariable.storeFluxDivergence(
   q.fillOverlaps();
   
   for grid in level.grids do
-    this(grid).storeFluxDivergence(q(grid), diffusivity);
+    this(grid)!.storeFluxDivergence(q(grid)!, diffusivity);
 }

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -565,7 +565,7 @@ class PhysicalBoundary
 {
 
   const grids:        domain(unmanaged Grid);
-  const multidomains: [grids] unmanaged MultiDomain(dimension,stridable=true);
+  const multidomains: [grids] unmanaged MultiDomain(dimension,stridable=true)?;
 
 
 
@@ -854,7 +854,7 @@ proc LevelVariable.initialFill (
         unfilled_intersection.intersect( refined_coarse );
         
         for D in unfilled_intersection do
-          this(grid,D) = q_coarse(coarse_grid).refineValues(D, ref_ratio);
+          this(grid,D) = q_coarse(coarse_grid)!.refineValues(D, ref_ratio);
         
         delete unfilled_intersection;
        }

--- a/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
@@ -107,7 +107,7 @@ class LevelInvalidRegion {
   const level:      unmanaged Level;
   const fine_level: unmanaged Level;
   
-  var grid_invalid_regions: [level.grids] unmanaged GridInvalidRegion;
+  var grid_invalid_regions: [level.grids] unmanaged GridInvalidRegion?;
 
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -227,8 +227,8 @@ proc LevelVariable.fillInvalidRegion (
 
   //---- Each grid obtains coarsened values from fine neighbors ----
   for grid in this.level.grids {
-    for (f_neighbor,Domain) in level_invalid_region(grid) do
-      this(grid,Domain) = fine_level_variable(f_neighbor).coarsenValues(Domain,ref_ratio);
+    for (f_neighbor,Domain) in level_invalid_region(grid)! do
+      this(grid,Domain) = fine_level_variable(f_neighbor)!.coarsenValues(Domain,ref_ratio);
   }
 }
 // /|""""""""""""""""""""""""""""""""""""""""""""""""""""""/|

--- a/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
@@ -23,7 +23,7 @@ class GridCFGhostRegion {
 
   const grid:             unmanaged Grid;
   var coarse_neighbors: domain(unmanaged Grid);
-  var transfer_regions:  [coarse_neighbors] unmanaged MultiDomain(dimension,stridable=true);
+  var transfer_regions:  [coarse_neighbors] unmanaged MultiDomain(dimension,stridable=true)?;
   
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -62,9 +62,9 @@ class GridCFGhostRegion {
         boundary_multidomain.subtract( grid.cells );
         
 
-        //----Remove sibling ghost regions ----
+        //---- Remove sibling ghost regions ----
         
-        for (neighbor, region) in parent_level.sibling_ghost_regions(grid) {
+        for (neighbor, region) in parent_level.sibling_ghost_regions(grid)! {
           
           if fine_intersection(region).numIndices > 0 {
             boundary_multidomain.subtract(region);     
@@ -147,7 +147,7 @@ class LevelCFGhostRegion {
   
   const level:               unmanaged Level;  
   const coarse_level:        unmanaged Level;
-  var grid_cf_ghost_regions: [level.grids] unmanaged GridCFGhostRegion;
+  var grid_cf_ghost_regions: [level.grids] unmanaged GridCFGhostRegion?;
   
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -231,10 +231,10 @@ class GridCFGhostSolution {
   
   const grid_cf_ghost_region: unmanaged GridCFGhostRegion;
   
-  var old_data: [grid_cf_ghost_region.coarse_neighbors] unmanaged MultiArray(dimension,true,real);
+  var old_data: [grid_cf_ghost_region.coarse_neighbors] unmanaged MultiArray(dimension,true,real)?;
   var old_time: real;
 
-  var current_data: [grid_cf_ghost_region.coarse_neighbors] unmanaged MultiArray(dimension,true,real);
+  var current_data: [grid_cf_ghost_region.coarse_neighbors] unmanaged MultiArray(dimension,true,real)?;
   var current_time: real;
 
 
@@ -266,10 +266,10 @@ class GridCFGhostSolution {
     for c_neighbor in grid_cf_ghost_region.coarse_neighbors {
 
       old_data(c_neighbor) = new unmanaged MultiArray(dimension,true,real);
-      old_data(c_neighbor).allocate( grid_cf_ghost_region.transfer_regions(c_neighbor) );
+      old_data(c_neighbor)!.allocate( grid_cf_ghost_region.transfer_regions(c_neighbor)! );
 
       current_data(c_neighbor) = new unmanaged MultiArray(dimension,true,real);
-      current_data(c_neighbor).allocate( grid_cf_ghost_region.transfer_regions(c_neighbor) );
+      current_data(c_neighbor)!.allocate( grid_cf_ghost_region.transfer_regions(c_neighbor)! );
     }
   }
   // /|'''''''''''''''''''''''''''''''''''/|
@@ -294,7 +294,7 @@ class GridCFGhostSolution {
       //---- This is a zipper iteration over two objects ----
 
       for ( old_array,            current_array            ) 
-      in  zip( old_data(c_neighbor), current_data(c_neighbor) )
+      in  zip( old_data(c_neighbor)!, current_data(c_neighbor)! )
       do
         yield ( old_array, current_array );
     }
@@ -351,11 +351,11 @@ class GridCFGhostSolution {
       //---- Refine data from the coarse grid solution into this structure ----
 
       for ( old_array,            current_array            )
-      in  zip( old_data(c_neighbor), current_data(c_neighbor) )
+      in  zip( old_data(c_neighbor)!, current_data(c_neighbor)! )
       {
         var boundary_domain = old_array.domain;
-        old_array     = old_coarse.refineValues( boundary_domain, ref_ratio );
-        current_array = current_coarse.refineValues( boundary_domain, ref_ratio );
+        old_array     = old_coarse!.refineValues( boundary_domain, ref_ratio );
+        current_array = current_coarse!.refineValues( boundary_domain, ref_ratio );
       }
 
     }
@@ -403,7 +403,7 @@ class LevelCFGhostSolution {
   
   const level:                 unmanaged Level;
   
-  var grid_cf_ghost_solutions: [level.grids] unmanaged GridCFGhostSolution;
+  var grid_cf_ghost_solutions: [level.grids] unmanaged GridCFGhostSolution?;
 
   var old_time:     real;    
   var current_time: real;
@@ -441,7 +441,7 @@ class LevelCFGhostSolution {
            "Error: LevelCFGhostRegion.postinit: Input level must equal level_cf_ghost_region.level");
     
     for grid in level.grids do
-      grid_cf_ghost_solutions(grid) = new unmanaged GridCFGhostSolution( level_cf_ghost_region(grid) );
+      grid_cf_ghost_solutions(grid) = new unmanaged GridCFGhostSolution( level_cf_ghost_region(grid)! );
 
   }
   // /|'''''''''''''''''''''''''''''''''''/|
@@ -512,7 +512,7 @@ class LevelCFGhostSolution {
 
     //==== Fill each GridCFGhostSolution ====
     for grid in level.grids do
-      grid_cf_ghost_solutions(grid).fill( coarse_level_solution );
+      grid_cf_ghost_solutions(grid)!.fill( coarse_level_solution );
 
 
     //==== Copy times ====
@@ -601,7 +601,7 @@ proc LevelVariable.fillCFGhostRegion (
 {
 
   for grid in level.grids do
-    this(grid).fillCFGhostRegion( level_cf_ghost_solution(grid), time );
+    this(grid)!.fillCFGhostRegion( level_cf_ghost_solution(grid)!, time );
   
 }
 // /|""""""""""""""""""""""""""""""""""""""""""""""""""""""/|

--- a/test/studies/amr/lib/level/LevelVariable_def.chpl
+++ b/test/studies/amr/lib/level/LevelVariable_def.chpl
@@ -16,7 +16,7 @@ private use IO;
 class LevelVariable {
   
   const level:        unmanaged Level;
-  var grid_variables: [level.grids] unmanaged GridVariable;
+  var grid_variables: [level.grids] unmanaged GridVariable?;
 
 
 
@@ -81,7 +81,7 @@ class LevelVariable {
     grid: unmanaged Grid, 
     D: domain(dimension, stridable=true)) 
   {
-    return grid_variables(grid).value(D);
+    return grid_variables(grid)!.value(D);
   }
   // /|'''''''''''''''''''''/|
   //< |    this methods    < |
@@ -111,7 +111,7 @@ proc LevelVariable.setToFunction(
 ){
 
   for grid in level.grids do
-    grid_variables(grid).setToFunction(f);
+    grid_variables(grid)!.setToFunction(f);
 
 }
 // /|""""""""""""""""""""""""""""""""""""/|
@@ -140,7 +140,7 @@ proc LevelVariable.fillOverlaps ()
 {
   
   for grid in level.grids {
-    for (neighbor, region) in level.sibling_ghost_regions(grid) do
+    for (neighbor, region) in level.sibling_ghost_regions(grid)! do
       this(grid,region) = this(neighbor,region);
   }
   
@@ -169,7 +169,7 @@ proc LevelVariable.fillOverlaps ()
 proc LevelVariable.extrapolateGhostData () {
   
   for grid_variable in grid_variables do
-    grid_variable.extrapolateGhostData();
+    grid_variable!.extrapolateGhostData();
 
 }
 
@@ -259,7 +259,7 @@ proc LevelVariable.writeData (
 
   var grid_number = base_grid_number;
   for grid in level.ordered_grids {
-    grid_variables(grid).writeData(grid_number, AMR_level, outfile);
+    grid_variables(grid)!.writeData(grid_number, AMR_level, outfile);
     outfile.writeln("  ");
     grid_number += 1;
   }

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -54,8 +54,8 @@ class Level {
   //---------------------------------------------------------------------
 
   var grids:                 domain(unmanaged Grid);
-  var sibling_ghost_regions: [grids] unmanaged SiblingGhostRegion;
-  var boundary:              [grids] unmanaged MultiDomain(dimension,stridable=true);
+  var sibling_ghost_regions: [grids] unmanaged SiblingGhostRegion?;
+  var boundary:              [grids] unmanaged MultiDomain(dimension,stridable=true)?;
 
 
 
@@ -280,10 +280,10 @@ proc Level.complete ()
     
     boundary(grid) = new unmanaged MultiDomain(dimension,stridable=true);
 
-    for D in grid.ghost_domains do boundary(grid).add( D );
+    for D in grid.ghost_domains do boundary(grid)!.add( D );
 
-    for overlap in sibling_ghost_regions(grid).overlaps do
-      boundary(grid).subtract( overlap );
+    for overlap in sibling_ghost_regions(grid)!.overlaps do
+      boundary(grid)!.subtract( overlap );
   }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -71,10 +71,10 @@ proc initVectors(B, C) {
     on loc {
       var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
-      randlist.skipToNth(B.locArr(loc).locDom.low);
-      randlist.fillRandom(B.locArr(loc).myElems);
-      randlist.skipToNth(B.numElements + C.locArr(loc).locDom.low);
-      randlist.fillRandom(C.locArr(loc).myElems);
+      randlist.skipToNth(B.locArr(loc)!.locDom.low);
+      randlist.fillRandom(B.locArr(loc)!.myElems);
+      randlist.skipToNth(B.numElements + C.locArr(loc)!.locDom.low);
+      randlist.fillRandom(C.locArr(loc)!.myElems);
     }
   }
 

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -122,13 +122,13 @@ module SSCA2_kernels
 	  writeln ( " Building heavy edge subgraph from pair:", (x,y) );
 	Active_Level.add ( y );
 	Next_Level.clear ();
-	Heavy_Edge_Subgraph ( (x, y) ).nodes.clear ();
-	Heavy_Edge_Subgraph ( (x, y) ).edges.clear ();
+	Heavy_Edge_Subgraph ( (x, y) )!.nodes.clear ();
+	Heavy_Edge_Subgraph ( (x, y) )!.edges.clear ();
 	min_distance ( y ).write(0);
 
-	Heavy_Edge_Subgraph ( (x, y) ).edges.add ( (x, y) );
-	Heavy_Edge_Subgraph ( (x, y) ).nodes.add ( x );
-	Heavy_Edge_Subgraph ( (x, y) ).nodes.add ( y );
+	Heavy_Edge_Subgraph ( (x, y) )!.edges.add ( (x, y) );
+	Heavy_Edge_Subgraph ( (x, y) )!.nodes.add ( x );
+	Heavy_Edge_Subgraph ( (x, y) )!.nodes.add ( y );
   
 	for path_length in 1 .. max_path_length do {
 	    
@@ -139,11 +139,11 @@ module SSCA2_kernels
 
               if min_distance(w).compareAndSwap(-1, path_length) then {
                 Next_Level.add (w);
-                Heavy_Edge_Subgraph ( (x, y) ).nodes.add (w);
+                Heavy_Edge_Subgraph ( (x, y) )!.nodes.add (w);
 	      }
 
 	      if min_distance(w).read() == path_length then {
-		Heavy_Edge_Subgraph ( (x, y) ).edges.add ( (v, w) );
+		Heavy_Edge_Subgraph ( (x, y) )!.edges.add ( (v, w) );
 	      }
 	    }
 	  }

--- a/test/types/records/split-init/split-init-examples-inspired-by-ak.chpl
+++ b/test/types/records/split-init/split-init-examples-inspired-by-ak.chpl
@@ -8,13 +8,13 @@ module M {
   }
 
   class Table {
-    var tab: map(string, shared Entry);
+    var tab: map(string, shared Entry?);
 
     proc store(name: string, x: int) {
       if tab.contains(name) {
-        tab[name].x = x;
+        tab[name]!.x = x;
       } else {
-        tab.add(name, new shared Entry(x));
+        tab.add(name, new shared Entry(x)?);
       }
     }
   }
@@ -26,7 +26,7 @@ module M {
     }
 
     ref r = tab[name]; // workaround for an issue solved by 14793
-    return r.borrow();
+    return r!.borrow();
   }
 
   proc Table.tryLookup(name:string): borrowed Entry? {

--- a/test/users/ferguson/resolution-bug-this.chpl
+++ b/test/users/ferguson/resolution-bug-this.chpl
@@ -1,5 +1,5 @@
 var watDom: domain(string);
-var wat: [watDom] unmanaged WAT;
+var wat: [watDom] unmanaged WAT?;
 
 class WAT { }
 

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -244,11 +244,12 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
 proc genSourceList(lockFile: borrowed Toml) {
   var sourceList: list((string, string, string));
   for (name, package) in lockFile.A.items() {
-    if package.tag == fieldtag.fieldToml {
+    if package!.tag == fieldtag.fieldToml {
       if name == "root" || name == "system" || name == "external" then continue;
       else {
-        var version = lockFile[name]["version"].s;
-        var source = lockFile[name]["source"].s;
+        var toml = lockFile[name]!;
+        var version = toml["version"]!.s;
+        var source = toml["source"]!.s;
         sourceList.append((source, name, version));
       }
     }
@@ -303,28 +304,30 @@ proc getTomlCompopts(lock: borrowed Toml, ref compopts: list(string)) {
 
   // Checks for compilation options are present in Mason.toml
   if lock.pathExists('root.compopts') {
-    const cmpFlags = lock["root"]["compopts"].s;
+    const cmpFlags = lock["root"]!["compopts"]!.s;
     compopts.append(cmpFlags);
   }
   
   if lock.pathExists('external') {
-    const exDeps = lock['external'];
+    const exDeps = lock['external']!;
     for (name, depInfo) in exDeps.A.items() {
-      for (k,v) in allFields(depInfo) {
+      for (k,v) in allFields(depInfo!) {
+        var val = v!;
         select k {
-            when "libs" do compopts.append("-L" + v.s); 
-            when "include" do compopts.append("-I" + v.s);
-            when "other" do compopts.append("-I" + v.s);
+            when "libs" do compopts.append("-L" + val.s); 
+            when "include" do compopts.append("-I" + val.s);
+            when "other" do compopts.append("-I" + val.s);
             otherwise continue;
           }
       }
     }
   }
   if lock.pathExists('system') {
-    const pkgDeps = lock['system'];
-    for (name, depInfo) in pkgDeps.A.items() {
-      compopts.append(depInfo["libs"].s);
-      compopts.append("-I" + depInfo["include"].s);
+    const pkgDeps = lock['system']!;
+    for (name, dep) in pkgDeps.A.items() {
+      var depInfo = dep!;
+      compopts.append(depInfo["libs"]!.s);
+      compopts.append("-I" + depInfo["include"]!.s);
     }
   }
   return compopts;

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -114,7 +114,7 @@ proc masonBuild(args) throws {
 }
 
 private proc checkChplVersion(lockFile : borrowed Toml) throws {
-  const root = lockFile["root"];
+  const root = lockFile["root"]!;
   const (success, low, hi) = verifyChapelVersion(root);
 
   if success == false {
@@ -133,7 +133,7 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
     const projectHome = getProjectHome(cwd, tomlName);
     const toParse = open(projectHome + "/" + lockName, iomode.r);
     var lockFile = new owned(parseToml(toParse));
-    const projectName = lockFile["root"]["name"].s;
+    const projectName = lockFile["root"]!["name"]!.s;
     
     // --fast
     var binLoc = 'debug';
@@ -200,7 +200,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
 
   const sourceList = genSourceList(lockFile);
   const depPath = MASON_HOME + '/src/';
-  const project = lockFile["root"]["name"].s;
+  const project = lockFile["root"]!["name"]!.s;
   const pathToProj = projectHome + '/src/'+ project + '.chpl';
   const moveTo = ' -o ' + projectHome + '/target/'+ binLoc +'/'+ project;
 

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -38,7 +38,7 @@ proc masonDoc(args) throws {
     const toParse = open(projectHome + "/" + tomlName, iomode.r);
     var tomlFile = new owned(parseToml(toParse));
 
-    const projectName = tomlFile["brick"]["name"].s;
+    const projectName = tomlFile["brick"]!["name"]!.s;
     const projectFile = projectName + '.chpl';
 
     if isDir(projectHome + '/src/') {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -102,7 +102,7 @@ private proc getBuildInfo(projectHome: string) {
   // have for good performance.
   //
   getSrcCode(sourceList, false);
-  const project = lockFile["root"]["name"].s;
+  const project = lockFile["root"]!["name"]!.s;
   const projectPath = "".join(projectHome, "/src/", project, ".chpl");
   
   // get the example names from lockfile or from example directory
@@ -132,11 +132,11 @@ private proc getExampleOptions(toml: Toml, exampleNames: list(string)) {
     const exampleName = basename(stripExt(example, ".chpl"));
     exampleOptions[exampleName] = ("", "");
     if toml.pathExists("".join("examples.", exampleName, ".compopts")) {
-      var compopts = toml["".join("examples.", exampleName)]["compopts"].s;
+      var compopts = toml["".join("examples.", exampleName)]!["compopts"]!.s;
       exampleOptions[exampleName][1] = compopts;
     }
     if toml.pathExists("".join("examples.", exampleName, ".execopts")) {
-      var execopts = toml["".join("examples.", exampleName)]["execopts"].s;
+      var execopts = toml["".join("examples.", exampleName)]!["execopts"]!.s;
       exampleOptions[exampleName][2] = execopts;
     }
   }
@@ -318,7 +318,7 @@ private proc getExamples(toml: Toml, projectHome: string) {
 
   if toml.pathExists("examples.examples") {
 
-    var examples = toml["examples"]["examples"].toString();
+    var examples = toml["examples"]!["examples"]!.toString();
     var strippedExamples = examples.split(',').strip('[]');
     for example in strippedExamples {
       const t = example.strip().strip('"');

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -240,10 +240,11 @@ private proc editCompilers() {
 proc getExternalPackages(exDeps: unmanaged Toml) {
 
   var exDom: domain(string);
-  var exDepTree: [exDom] unmanaged Toml;
+  var exDepTree: [exDom] unmanaged Toml?;
 
-  for (name, spec) in exDeps.A.items() {
+  for (name, spc) in exDeps.A.items() {
     try! {
+      var spec = spc!;
       select spec.tag {
           when fieldtag.fieldToml do continue;
           otherwise {
@@ -285,7 +286,7 @@ proc getSpkgInfo(spec: string, ref dependencies: list(string)): unmanaged Toml t
   // put above try b/c compiler complains about return value
   var depList: list(unmanaged Toml);
   var spkgDom: domain(string);
-  var spkgToml: [spkgDom] unmanaged Toml;
+  var spkgToml: [spkgDom] unmanaged Toml?;
   var spkgInfo = new unmanaged Toml(spkgToml);
 
   try {

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -174,15 +174,15 @@ private proc masonAdd(toml: unmanaged Toml, toAdd: string, version: string) thro
       throw new owned MasonError("A dependency by that name already exists in Mason.toml");
     }
     else {
-      toml["dependencies"].set(toAdd, version);
+      toml["dependencies"]!.set(toAdd, version);
     }
   }
   // Create dependency table if it doesnt exist
   else {
     var tdom: domain(string);
-    var deps: [tdom] unmanaged Toml;
+    var deps: [tdom] unmanaged Toml?;
     toml.set("dependencies", deps);
-    toml["dependencies"].set(toAdd, version);
+    toml["dependencies"]!.set(toAdd, version);
   }
   return toml;
 }
@@ -191,8 +191,8 @@ private proc masonAdd(toml: unmanaged Toml, toAdd: string, version: string) thro
 private proc masonRemove(toml: unmanaged Toml, toRm: string) throws {
   if toml.pathExists("dependencies") {
     if toml.pathExists("dependencies." + toRm) {
-      var old = toml["dependencies"][toRm];
-      toml["dependencies"].A.remove(toRm);
+      var old = toml["dependencies"]![toRm]!;
+      toml["dependencies"]!.A.remove(toRm);
       delete old;
     }
     else {
@@ -213,14 +213,14 @@ private proc masonSystemAdd(toml: unmanaged Toml, toAdd: string, version: string
       throw new owned MasonError("A dependency by that name already exists in Mason.toml");
     }
     else {
-      toml["system"].set(toAdd, version);
+      toml["system"]!.set(toAdd, version);
     }
   }
   else {
     var pkgdom: domain(string);
-    var pkgdeps: [pkgdom] unmanaged Toml;
+    var pkgdeps: [pkgdom] unmanaged Toml?;
     toml.set("system", pkgdeps);
-    toml["system"].set(toAdd, version);
+    toml["system"]!.set(toAdd, version);
   }
   return toml;
 }
@@ -229,8 +229,8 @@ private proc masonSystemAdd(toml: unmanaged Toml, toAdd: string, version: string
 private proc masonSystemRemove(toml: unmanaged Toml, toRm: string) throws {
   if toml.pathExists("system") {
     if toml.pathExists("system." + toRm) {
-      var old = toml["system"][toRm];
-      toml["system"].A.remove(toRm);
+      var old = toml["system"]![toRm]!;
+      toml["system"]!.A.remove(toRm);
       delete old;
     }
     else {
@@ -250,14 +250,14 @@ private proc masonExternalAdd(toml: unmanaged Toml, toAdd: string, spec: string)
       throw new owned MasonError("An external dependency by that name already exists in Mason.toml");
     }
     else {
-      toml["external"].set(toAdd, spec);
+      toml["external"]!.set(toAdd, spec);
     }
   }
   else {
     var exdom: domain(string);
-    var exdeps: [exdom] unmanaged Toml;
+    var exdeps: [exdom] unmanaged Toml?;
     toml.set("external", exdeps);
-    toml["external"].set(toAdd, spec);
+    toml["external"]!.set(toAdd, spec);
   }
   return toml;
 }
@@ -266,8 +266,8 @@ private proc masonExternalAdd(toml: unmanaged Toml, toAdd: string, spec: string)
 private proc masonExternalRemove(toml: unmanaged Toml, toRm: string) throws {
   if toml.pathExists("external") {
     if toml.pathExists("external." + toRm) {
-      var old = toml["external"][toRm];
-      toml["external"].A.remove(toRm);
+      var old = toml["external"]![toRm]!;
+      toml["external"]!.A.remove(toRm);
       delete old;
     }
     else {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -352,7 +352,7 @@ proc getPackageName() throws {
   try! {
     const toParse = open("Mason.toml", iomode.r);
     var tomlFile = new owned(parseToml(toParse));
-    const name = tomlFile['brick']['name'].s;
+    const name = tomlFile['brick']!['name']!.s;
     return name;
   }
   catch {
@@ -368,7 +368,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
   try! {
     const toParse = open(projectLocal+ "/Mason.toml", iomode.r);
     var tomlFile = new owned(parseToml(toParse));
-    const versionNum = tomlFile['brick']['version'].s;
+    const versionNum = tomlFile['brick']!['version']!.s;
     if !isLocal {
       if !exists(safeDir + '/mason-registry/Bricks/') {
         throw new owned MasonError('Registry does not have the expected structure. Ensure your registry has a Bricks directory.');
@@ -381,7 +381,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
         var newToml = open(safeDir + "/mason-registry/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
         var tomlWriter = newToml.writer();
         const url = gitUrl();
-        baseToml["brick"].set("source", url[1..url.length-1]);
+        baseToml["brick"]!.set("source", url[1..url.length-1]);
         tomlWriter.write(baseToml);
         tomlWriter.close();
         return name + '@' + versionNum;
@@ -403,7 +403,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
         const baseToml = tomlFile;
         var newToml = open(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
         var tomlWriter = newToml.writer();
-        baseToml["brick"].set("source", projectLocal);
+        baseToml["brick"]!.set("source", projectLocal);
         tomlWriter.write(baseToml);
         tomlWriter.close();
         const gitMessageString = ('git tag -a v' + versionNum + ' -m  "' + name + '"');

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -82,7 +82,7 @@ proc runProjectBinary(show: bool, release: bool, execopts: list(string)) throws 
     const projectHome = getProjectHome(cwd);
     const toParse = open(projectHome + "/Mason.toml", iomode.r);
     const tomlFile = new owned(parseToml(toParse));
-    const project = tomlFile["brick"]["name"].s;
+    const project = tomlFile["brick"]!["name"]!.s;
  
     // Find the Binary and execute
     if isDir(joinPath(projectHome, 'target')) {

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -213,7 +213,7 @@ proc pkgExists(pkgName: string) : bool {
 proc getPkgInfo(pkgName: string, version: string) throws {
 
   var pkgDom: domain(string);
-  var pkgToml: [pkgDom] unmanaged Toml;
+  var pkgToml: [pkgDom] unmanaged Toml?;
   var pkgInfo = new unmanaged Toml(pkgToml);
 
   if pkgExists(pkgName) {
@@ -242,12 +242,12 @@ proc getPkgInfo(pkgName: string, version: string) throws {
 proc getPCDeps(exDeps: unmanaged Toml) {
 
   var exDom: domain(string);
-  var exDepTree: [exDom] unmanaged Toml;
+  var exDepTree: [exDom] unmanaged Toml?;
 
   for (name, vers) in exDeps.A.items() {
     try! {
       if pkgConfigExists() {
-        const pkgInfo = getPkgInfo(name, vers.s);
+        const pkgInfo = getPkgInfo(name, vers!.s);
         exDom += name;
         exDepTree[name] = pkgInfo;
       }

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -130,7 +130,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
     const sourceList = genSourceList(lockFile);
 
     getSrcCode(sourceList, show);
-    const project = lockFile["root"]["name"].s;
+    const project = lockFile["root"]!["name"]!.s;
     const projectPath = "".join(projectHome, "/src/", project, ".chpl");
 
     // Get system, and external compopts
@@ -270,7 +270,7 @@ private proc getTests(lock: borrowed Toml, projectHome: string) {
   const testPath = joinPath(projectHome, "test");
 
   if lock.pathExists("root.tests") {
-    var tests = lock["root"]["tests"].toString();
+    var tests = lock["root"]!["tests"]!.toString();
     var strippedTests = tests.split(',').strip('[]');
     for test in strippedTests {
       const t = test.strip().strip('"');

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -171,13 +171,15 @@ proc updateRegistry(tf: string, args: list(string)) {
   }
 }
 
-proc parseChplVersion(brick:borrowed Toml): (VersionInfo, VersionInfo) {
+proc parseChplVersion(maybeBrick: borrowed Toml?): (VersionInfo, VersionInfo) {
   use Regexp;
 
-  if brick == nil {
+  if maybeBrick == nil {
     stderr.writeln("Error: Unable to parse manifest file");
     exit(1);
   }
+
+  var brick = maybeBrick!;
 
   // Assert some expected fields are not nil
   if brick['name'] == nil || brick['version'] == nil{

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -171,29 +171,27 @@ proc updateRegistry(tf: string, args: list(string)) {
   }
 }
 
-proc parseChplVersion(maybeBrick: borrowed Toml?): (VersionInfo, VersionInfo) {
+proc parseChplVersion(brick: borrowed Toml?): (VersionInfo, VersionInfo) {
   use Regexp;
 
-  if maybeBrick == nil {
+  if brick == nil {
     stderr.writeln("Error: Unable to parse manifest file");
     exit(1);
   }
-
-  var brick = maybeBrick!;
 
   // Assert some expected fields are not nil
-  if brick['name'] == nil || brick['version'] == nil{
+  if brick!['name'] == nil || brick!['version'] == nil{
     stderr.writeln("Error: Unable to parse manifest file");
     exit(1);
   }
 
-  if brick['chplVersion'] == nil {
-    const name = brick["name"]!.s + "-" + brick["version"]!.s;
+  if brick!['chplVersion'] == nil {
+    const name = brick!["name"]!.s + "-" + brick!["version"]!.s;
     stderr.writeln("Brick '", name, "' missing required 'chplVersion' field");
     exit(1);
   }
 
-  const chplVersion = brick["chplVersion"]!.s;
+  const chplVersion = brick!["chplVersion"]!.s;
   var low, hi : VersionInfo;
 
   try {
@@ -242,7 +240,7 @@ proc parseChplVersion(maybeBrick: borrowed Toml?): (VersionInfo, VersionInfo) {
     if (low <= hi) == false then
       throw new owned MasonError("Lower bound of chplVersion must be <= upper bound: " + low.str() + " > " + hi.str());
   } catch e : Error {
-    const name = brick["name"]!.s + "-" + brick["version"]!.s;
+    const name = brick!["name"]!.s + "-" + brick!["version"]!.s;
     stderr.writeln("Invalid chplVersion in package '", name, "': ", chplVersion);
     stderr.writeln("Details: ", e.message());
     exit(1);
@@ -346,7 +344,7 @@ private proc createDepTree(root: unmanaged Toml) {
 }
 
 private proc createDepTrees(depTree: unmanaged Toml, ref deps: list(unmanaged Toml), name: string) : unmanaged Toml {
-  var depList: list(unmanaged Toml);
+  var depList: list(unmanaged Toml?);
   while deps.size > 0 {
     var dep = deps[1];
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -186,12 +186,12 @@ proc parseChplVersion(brick:borrowed Toml): (VersionInfo, VersionInfo) {
   }
 
   if brick['chplVersion'] == nil {
-    const name = brick["name"].s + "-" + brick["version"].s;
+    const name = brick["name"]!.s + "-" + brick["version"]!.s;
     stderr.writeln("Brick '", name, "' missing required 'chplVersion' field");
     exit(1);
   }
 
-  const chplVersion = brick["chplVersion"].s;
+  const chplVersion = brick["chplVersion"]!.s;
   var low, hi : VersionInfo;
 
   try {
@@ -240,7 +240,7 @@ proc parseChplVersion(brick:borrowed Toml): (VersionInfo, VersionInfo) {
     if (low <= hi) == false then
       throw new owned MasonError("Lower bound of chplVersion must be <= upper bound: " + low.str() + " > " + hi.str());
   } catch e : Error {
-    const name = brick["name"].s + "-" + brick["version"].s;
+    const name = brick["name"]!.s + "-" + brick["version"]!.s;
     stderr.writeln("Invalid chplVersion in package '", name, "': ", chplVersion);
     stderr.writeln("Details: ", e.message());
     exit(1);
@@ -276,7 +276,7 @@ proc chplVersionError(brick:borrowed Toml) {
   if info(1) == false {
     const low  = info(2);
     const hi   = info(3);
-    const name = brick["name"].s + "-" + brick["version"].s;
+    const name = brick["name"]!.s + "-" + brick["version"]!.s;
     const msg  = name + " :  expecting " + prettyVersionRange(low, hi);
     failedChapelVersion.append(msg);
   }
@@ -288,10 +288,10 @@ proc chplVersionError(brick:borrowed Toml) {
    until each dep is recorded */
 private proc createDepTree(root: unmanaged Toml) {
   var dp: domain(string);
-  var dps: [dp] unmanaged Toml;
+  var dps: [dp] unmanaged Toml?;
   var depTree = new unmanaged Toml(dps);
   if root.pathExists("brick") {
-    depTree.set("root", new unmanaged Toml(root["brick"]));
+    depTree.set("root", new unmanaged Toml(root["brick"]!));
   }
   else {
     stderr.writeln("Could not find brick; Mason cannot update");
@@ -313,7 +313,8 @@ private proc createDepTree(root: unmanaged Toml) {
   // dependency tree because IVRS may not execute in the desired order. For
   // example, we might encounter foo-0.3.0 before foo-0.2.0.
   //
-  for brick in depTree.A.values() {
+  for b in depTree.A.values() {
+    var brick = b!;
     chplVersionError(brick);
 
     // Lock in the current Chapel version
@@ -321,22 +322,22 @@ private proc createDepTree(root: unmanaged Toml) {
     brick.set("chplVersion", curVer + ".." + curVer);
 
     if brick.pathExists("dependencies") {
-      for item in brick["dependencies"].arr {
-        const brick = depTree[item.s];
-        item.s = brick["name"].s + " " + brick["version"].s + " " + brick["source"].s;
+      for item in brick["dependencies"]!.arr {
+        const brick = depTree[item!.s]!;
+        item!.s = brick["name"]!.s + " " + brick["version"]!.s + " " + brick["source"]!.s;
       }
     }
   }
 
   // Check for pkg-config dependencies
   if root.pathExists("system") {
-    const exDeps = getPCDeps(root["system"]);
+    const exDeps = getPCDeps(root["system"]!);
     depTree.set("system", exDeps);
   }
 
   // Check for non-Chapel dependencies
   if root.pathExists("external") {
-    const externals = getExternalPackages(root["external"]);
+    const externals = getExternalPackages(root["external"]!);
     depTree.set("external", externals);
   }
   return depTree;
@@ -347,31 +348,31 @@ private proc createDepTrees(depTree: unmanaged Toml, ref deps: list(unmanaged To
   while deps.size > 0 {
     var dep = deps[1];
 
-    var brick       = dep["brick"];
-    var package     = brick["name"].s;
-    var version     = brick["version"].s;
-    var chplVersion = brick["chplVersion"].s;
-    var source      = brick["source"].s;
+    var brick       = dep["brick"]!;
+    var package     = brick["name"]!.s;
+    var version     = brick["version"]!.s;
+    var chplVersion = brick["chplVersion"]!.s;
+    var source      = brick["source"]!.s;
 
     if depTree.pathExists(package) {
-      var verToUse = IVRS(brick, depTree[package]);
-      version = verToUse["version"].s;
-      chplVersion = verToUse["chplVersion"].s;
+      var verToUse = IVRS(brick, depTree[package]!);
+      version = verToUse["version"]!.s;
+      chplVersion = verToUse["chplVersion"]!.s;
     }
 
     depList.append(new unmanaged Toml(package));
 
     if depTree.pathExists(package) == false {
       var dt: domain(string);
-      var depTbl: [dt] unmanaged Toml;
+      var depTbl: [dt] unmanaged Toml?;
       depTree.set(package, depTbl);
     }
-    depTree[package].set("name", package);
-    depTree[package].set("version", version);
-    depTree[package].set("chplVersion", chplVersion);
-    depTree[package].set("source", source);
+    depTree[package]!.set("name", package);
+    depTree[package]!.set("version", version);
+    depTree[package]!.set("chplVersion", chplVersion);
+    depTree[package]!.set("source", source);
 
-    if dep.pathExists("dependencies") {
+    if dep!.pathExists("dependencies") {
       var subDeps = getDependencies(dep);
       var manifests = getManifests(subDeps);
       var dependency = createDepTrees(depTree, manifests, package);
@@ -381,7 +382,7 @@ private proc createDepTrees(depTree: unmanaged Toml, ref deps: list(unmanaged To
   }
   // Use toArray here to avoid making Toml aware of `list`, for now.
   if depList.size > 0 then
-    depTree[name].set("dependencies", depList.toArray());
+    depTree[name]!.set("dependencies", depList.toArray());
   return depTree;
 }
 
@@ -394,11 +395,11 @@ private proc createDepTrees(depTree: unmanaged Toml, ref deps: list(unmanaged To
    - Always newest minor and patch
    - in accordance with semantic versioning  */
 private proc IVRS(A: borrowed Toml, B: borrowed Toml) {
-  const name = A["name"].s;
+  const name = A["name"]!.s;
   const (okA, Alo, Ahi) = verifyChapelVersion(A);
   const (okB, Blo, Bhi) = verifyChapelVersion(B);
-  const version1 = A["version"].s;
-  const version2 = B["version"].s;
+  const version1 = A["version"]!.s;
+  const version2 = B["version"]!.s;
   if okA == false && okB == false {
     stderr.writeln("Dependency resolution error: unable to find version of '", name, "' compatible with your version of Chapel (", getChapelVersionStr(), "):");
     stderr.writeln("  v", version1, " expecting ", prettyVersionRange(Alo, Ahi));
@@ -479,7 +480,7 @@ private proc getDependencies(tomlTbl: unmanaged Toml) {
   var deps: list((string, unmanaged Toml?));
   for k in tomlTbl.A {
     if k == "dependencies" {
-      for (a,d) in allFields(tomlTbl[k]) {
+      for (a,d) in allFields(tomlTbl[k]!) {
         deps.append((a, d));
       }
     }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -487,7 +487,7 @@ proc isIdentifier(name:string) {
    TODO custom fields returned */
 iter allFields(tomlTbl: unmanaged Toml) {
   for (k,v) in tomlTbl.A.items() {
-    if v.tag == fieldtag.fieldToml then
+    if v!.tag == fieldtag.fieldToml then
       continue;
     else yield(k,v);
   }


### PR DESCRIPTION
This PR makes the initialization of associative arrays of non-nilable classes a compile-time error. It does so by adding a postinit for the `DefaultAssociativeArr` class which issues a `compilerError` if the element type of the array is a non-nilable class.

---

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [ ] `ALL` on `linux64` when `CHPL_COMM=gasnet`
