### PR TITLE
Adjust channel.readf overload to throw EFORMAT errors

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6341,7 +6341,7 @@ proc channel.writef(fmtStr:?t): bool throws
    :arg fmt: the format as string or bytes
    :arg args: the arguments to read
    :returns: true if all arguments were read according to the format string,
-             false on EOF or if the format did not match the input.
+             false on EOF.
 
    :throws SystemError: Thrown if the arguments could not be read.
  */
@@ -6608,11 +6608,6 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
   if !err {
     return true;
   } else if err == EEOF {
-
-    //
-    // TODO: Since we don't return false for EFORMAT, should the docstring be
-    // updated to reflect that?
-    //
     return false;
   } else {
     try this._ch_ioerror(err, "in channel.readf(fmt:string, ...)");
@@ -6669,7 +6664,7 @@ proc channel.readf(fmtStr:?t) throws
 
   if !err {
     return true;
-  } else if err == EEOF || err == EFORMAT {
+  } else if err == EEOF {
     return false;
   } else {
     try this._ch_ioerror(err, "in channel.readf(fmt:string)");

--- a/test/regexp/ferguson/readfre.chpl
+++ b/test/regexp/ferguson/readfre.chpl
@@ -13,7 +13,14 @@ var str:t;
 var ok:bool;
 
 writeln("#1 not match");
-ok = r.readf("%/[a-z]/":t);
+try {
+  ok = r.readf("%/[a-z]/":t);
+} catch err: BadFormatError {
+  ok = false;
+} catch err {
+  writeln(err);
+  halt();
+}
 writeln(r.offset(), " ", ok);
 writeln("#2 passes B, should match");
 ok = r.readf("%/[A-Z]/":t);


### PR DESCRIPTION
This PR adjusts an overload of channel.readf so that it does not return false when an EFORMAT error is encountered. It adjusts the docstring for channel.readf so that it only returns false when the channel hits EOF.

Resolves #14816.

---

I fail to see how returning false for `EFORMAT` is of any use. It makes `channel.readf` differ from the rest of the "read" family of channel routines which only return false for `EEOF`. It also overloads the meaning of returning false in a way that is now impossible to disambiguate (Did I hit EEOF? Or was the format string bad? No way to tell, errors aren't stored in channels anymore...).

---

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet`
