### PR TITLE
Add runtime/configMatters to atomic test configs

### DIFF
--- a/util/cron/test-linux64-cstdlib-atomics.bash
+++ b/util/cron/test-linux64-cstdlib-atomics.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test cstdlib atomics configuration on examples only, on linux64
+# Test cstdlib atomics configuration on examples/configMatters
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
@@ -9,4 +9,5 @@ export CHPL_ATOMICS=cstdlib
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-cstdlib-atomics"
 
-$CWD/nightly -cron -examples ${nightly_args}
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/ runtime/configMatters/"
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-linux64-locks-atomics.bash
+++ b/util/cron/test-linux64-locks-atomics.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test locks atomics configuration on examples only, on linux64
+# Test locks atomics configuration on examples/configMatters
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
@@ -9,4 +9,5 @@ export CHPL_ATOMICS=locks
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-locks-atomics"
 
-$CWD/nightly -cron -examples ${nightly_args}
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/ runtime/configMatters/"
+$CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
runtime/configMatters includes our atomics API tests and soon some other
atomic stress test that will be worth testing under intrinsics/locks
atomic backends.