### PR TITLE
Fix a .bad file after PR #14843.

### DIFF
--- a/test/classes/initializers/records/array-from-for-expr.bad
+++ b/test/classes/initializers/records/array-from-for-expr.bad
@@ -1,7 +1,6 @@
-array-from-for-expr.chpl:15: error: non-lvalue actual is passed to a 'ref' formal of init=()
-$CHPL_HOME/modules/internal/ChapelArray.chpl:4413: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
+$CHPL_HOME/modules/internal/ChapelArray.chpl:4204: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
 array-from-for-expr.chpl:35: In function 'main':
 array-from-for-expr.chpl:36: error: unresolved call 'RRR.init()'
 array-from-for-expr.chpl:19: note: this candidate did not match: RRR.init(idx: int)
-$CHPL_HOME/modules/internal/ChapelBase.chpl:870: note: because call does not supply enough arguments
+$CHPL_HOME/modules/internal/ChapelBase.chpl:970: note: because call does not supply enough arguments
 array-from-for-expr.chpl:19: note: it is missing a value for formal 'idx: int(64)'


### PR DESCRIPTION
Follow-on to PR #14843. Test change only. Not reviewed.

Fixes a .bad file mismatch for classes/initializers/records/array-from-for-expr.chpl.