### PR TITLE
Remove available-by-default atomic peek/poke

### DIFF
--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -56,7 +56,7 @@
    in order for record assignment to work, the read() functions
    need to be able to work with a const RHS.
 
-   To enable that, the read/peek/waitFor/writeThis functions take in `this`
+   To enable that, the read/waitFor/writeThis functions take in `this`
    with const intent. That is reasonable even if the atomic is
    implemented with a lock because the programmer can view it
    as constant, and on good hardware it really will be. If we change
@@ -334,29 +334,6 @@ module Atomics {
       return this.compareAndSwap(expected, desired, order);
     }
 
-    /*
-       Non-atomically reads the stored value.
-
-       .. note:: Default usage of `peek()` is deprecated, use :mod:`PeekPoke`.
-
-    */
-    pragma "last resort"
-    inline proc const peek(): bool {
-      compilerWarning("Default usage of peek() is deprecated, use PeekPoke");
-      return this.read(order=memoryOrder.relaxed);
-    }
-
-    /*
-       Non-atomically writes `value`.
-
-       .. note:: Default usage of `poke()` is deprecated, use :mod:`PeekPoke`.
-
-    */
-    pragma "last resort"
-    inline proc poke(value:bool): void {
-      compilerWarning("Default usage of poke() is deprecated, use PeekPoke");
-      this.write(value, order=memoryOrder.relaxed);
-    }
   }
 
   pragma "atomic type"
@@ -659,29 +636,6 @@ module Atomics {
       return this.compareAndSwap(expected, desired, order);
     }
 
-    /*
-       Non-atomically reads the stored value.
-
-       .. note:: Default usage of `peek()` is deprecated, use :mod:`PeekPoke`.
-
-    */
-    pragma "last resort"
-    inline proc const peek(): T {
-      compilerWarning("Default usage of peek() is deprecated, use PeekPoke");
-      return this.read(order=memoryOrder.relaxed);
-    }
-
-    /*
-       Non-atomically writes `value`.
-
-       .. note:: Default usage of `poke()` is deprecated, use :mod:`PeekPoke`.
-
-    */
-    pragma "last resort"
-    inline proc poke(value:T): void {
-      compilerWarning("Default usage of poke() is deprecated, use PeekPoke");
-      this.write(value, order=memoryOrder.relaxed);
-    }
   }
 
   //

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -124,17 +124,6 @@ module NetworkAtomics {
       return this.compareAndSwap(expected, desired, order);
     }
 
-    pragma "last resort"
-    inline proc const peek(): bool {
-      compilerWarning("Default usage of peek() is deprecated, use PeekPoke");
-      return _v:bool;
-    }
-
-    pragma "last resort"
-    inline proc poke(value:bool): void {
-      compilerWarning("Default usage of poke() is deprecated, use PeekPoke");
-      _v = value:int(64);
-    }
   }
 
   pragma "atomic type"
@@ -325,17 +314,6 @@ module NetworkAtomics {
       return this.compareAndSwap(expected, desired, order);
     }
 
-    pragma "last resort"
-    inline proc const peek(): T {
-      compilerWarning("Default usage of peek() is deprecated, use PeekPoke");
-      return _v;
-    }
-
-    pragma "last resort"
-    inline proc poke(value:T): void {
-      compilerWarning("Default usage of poke() is deprecated, use PeekPoke");
-      _v = value;
-    }
   }
 
 

--- a/test/deprecated/peek-poke.chpl
+++ b/test/deprecated/peek-poke.chpl
@@ -1,7 +1,0 @@
-var a: atomic int;
-a.poke(1);
-writeln(a.peek());
-
-var ab: atomic bool;
-ab.poke(true);
-writeln(ab.peek());

--- a/test/deprecated/peek-poke.good
+++ b/test/deprecated/peek-poke.good
@@ -1,6 +1,0 @@
-peek-poke.chpl:2: warning: Default usage of poke() is deprecated, use PeekPoke
-peek-poke.chpl:3: warning: Default usage of peek() is deprecated, use PeekPoke
-peek-poke.chpl:6: warning: Default usage of poke() is deprecated, use PeekPoke
-peek-poke.chpl:7: warning: Default usage of peek() is deprecated, use PeekPoke
-1
-true


### PR DESCRIPTION
They were deprecated in #13888.