### PR TITLE
Accept duplicate chpl_after_forall_fence() for check-fence-after-forall

### DIFF
--- a/test/runtime/configMatters/forall-unordered-opt/check-fence/check-fence-after-forall.good
+++ b/test/runtime/configMatters/forall-unordered-opt/check-fence/check-fence-after-forall.good
@@ -2,3 +2,5 @@
 ../needsFenceSerial.chpl:16: note: Optimized atomic call to be unordered
 chpl_after_forall_fence();
 chpl_after_forall_fence();
+chpl_after_forall_fence();
+chpl_after_forall_fence();


### PR DESCRIPTION
Since #14691, there are duplicate/consecutive `chpl_after_forall_fence()`
calls for check-fence-after-forall. For now we're accepting them to
quiet the test since it's going to run under ugni nightly testing again.

See https://github.com/Cray/chapel-private/issues/745 for more info.