### PR TITLE
Extend python interoperability skipif for when CHPL_LIB_PIC not set

### DIFF
--- a/test/interop/python/SKIPIF
+++ b/test/interop/python/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM != none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 elif command -v python3 >/dev/null; then
   # Python3 is required for building with Cython (we would need to change our
   # output of certain types and that isn't particularly worth it)

--- a/test/interop/python/chapelBytes/SKIPIF
+++ b/test/interop/python/chapelBytes/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM != none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 elif command -v python3 >/dev/null; then
   # Python3 is required for building with Cython (we would need to change our
   # output of certain types and that isn't particularly worth it)

--- a/test/interop/python/chapelStrings/SKIPIF
+++ b/test/interop/python/chapelStrings/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM != none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 elif command -v python3 >/dev/null; then
   # Python3 is required for building with Cython (we would need to change our
   # output of certain types and that isn't particularly worth it)

--- a/test/interop/python/multilocale/SKIPIF
+++ b/test/interop/python/multilocale/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM == none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 elif command -v python3 >/dev/null; then
   # Python3 is required for building with Cython (we would need to change our
   # output of certain types and that isn't particularly worth it)

--- a/test/interop/python/multilocale/chapelBytes/SKIPIF
+++ b/test/interop/python/multilocale/chapelBytes/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM == none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 elif command -v python3 >/dev/null; then
   # Python3 is required for building with Cython (we would need to change our
   # output of certain types and that isn't particularly worth it)

--- a/test/interop/python/multilocale/chapelStrings/SKIPIF
+++ b/test/interop/python/multilocale/chapelStrings/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM == none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 elif command -v python3 >/dev/null; then
   # Python3 is required for building with Cython (we would need to change our
   # output of certain types and that isn't particularly worth it)

--- a/test/interop/python/noLibFlag/SKIPIF
+++ b/test/interop/python/noLibFlag/SKIPIF
@@ -2,4 +2,6 @@
 
 if [[ $CHPL_COMM != none ]] ; then
   echo True
+elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
+  echo True
 fi


### PR DESCRIPTION
@ronawho was encountering test failures with cython and numpy installed on a
linux system due to not having CHPL_LIB_PIC set.  This avoids those
failures while not preventing testing from running.

Verified behavior on:
- darwin
- linux64 without CHPL_LIB_PIC and without cython & numpy installed
- linux64 with CHPL_LIB_PIC
- linux64 without CHPL_LIB_PIC
- linux64 and gasnet with CHPL_LIB_PIC
- linux64 and gasnet without CHPL_LIB_PIC