### PR TITLE
Use --no-early-deinit in array creation/destruction benchmark

### DIFF
--- a/test/performance/array/distCreate.cc-compopts
+++ b/test/performance/array/distCreate.cc-compopts
@@ -1,0 +1,1 @@
+--no-early-deinit

--- a/test/performance/array/distCreate.compopts
+++ b/test/performance/array/distCreate.compopts
@@ -1,0 +1,1 @@
+--no-early-deinit

--- a/test/performance/array/distCreate.ml-compopts
+++ b/test/performance/array/distCreate.ml-compopts
@@ -1,0 +1,1 @@
+--no-early-deinit


### PR DESCRIPTION
This PR adds compopts file to use `--no-early-deinit` flag in the distributed
array/domain creation/destruction benchmark.

Resolves https://github.com/cray/chapel-private/issues/737

Test:
- [x] confirm correctness, ml, cc tests run locally
- [x] confirm correct comm-count values on chapcs
- [x] confirm correct multilocale perf timing on CX