### PR TITLE
Improve mason update output

### DIFF
--- a/test/mason/env/mason-registry.good
+++ b/test/mason/env/mason-registry.good
@@ -1,6 +1,6 @@
 MASON_HOME: $PWD/tempHome *
 MASON_REGISTRY: myRegistry|$PWD/tempHome/uncached/myRegistry *
 MASON_OFFLINE: false
-Updating mason-registry
+Updating myRegistry
 multiple (0.2.0)
 simple (0.1.0)

--- a/test/mason/mason-example-with-opts/mason-example.good
+++ b/test/mason/mason-example-with-opts/mason-example.good
@@ -1,4 +1,4 @@
-Updating mason-registry
+Updating registry
 Downloading dependency: _MasonTest1-0.2.0
 compiled depExample.chpl successfully
 compiled withOpts.chpl successfully

--- a/test/mason/mason-example/mason-example.good
+++ b/test/mason/mason-example/mason-example.good
@@ -1,4 +1,4 @@
-Updating mason-registry
+Updating registry
 Downloading dependency: _MasonTest1-0.2.0
 compiled depExample.chpl successfully
 compiled example.chpl successfully

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -1,4 +1,4 @@
-Updating mason-registry
+Updating registry
 Downloading dependency: _MasonTest1-0.2.0
 
 ======================================================================

--- a/test/mason/run/mason-run.good
+++ b/test/mason/run/mason-run.good
@@ -1,4 +1,4 @@
-Updating mason-registry
+Updating registry
 Compiling [debug] target: FizzBuzz
 Build Successful
 

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,4 +1,4 @@
-Updating mason-registry
+Updating registry
 Compiling [debug] target: FizzBuzz
 Build Successful
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -165,7 +165,7 @@ proc updateRegistry(tf: string, args: list(string)) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Updating ", registry, "-registry");
+      writeln("Updating ", registry);
       gitC(localRegistry, cloneRegistry);
     }
   }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -153,10 +153,17 @@ proc updateRegistry(tf: string, args: list(string)) {
   checkRegistryChanged();
   for ((name, registry), registryHome) in zip(MASON_REGISTRY, MASON_CACHED_REGISTRY) {
 
+    const env = getEnv("MASON_REGISTRY");
+    const regPath = env.split(',');
+    const masonUrl = regPath[1].split('|');
+    const localUrl = regPath[2].split('|');
+    const mRegistry = masonUrl[1];
+    const lRegistry = localUrl[1];
+
     if isDir(registryHome) {
       var pullRegistry = 'git pull -q origin master';
       if tf == "Mason.toml" then
-        writeln("Updating mason-registry");
+        writeln("Updating ", mRegistry);
       gitC(registryHome, pullRegistry);
     }
     // Registry has moved or does not exist
@@ -165,7 +172,7 @@ proc updateRegistry(tf: string, args: list(string)) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Updating ", registry);
+      writeln("Updating ", lRegistry);
       gitC(localRegistry, cloneRegistry);
     }
   }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -165,7 +165,7 @@ proc updateRegistry(tf: string, args: list(string)) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Updating mason-registry");
+      writeln("Updating ", registry, "-registry");
       gitC(localRegistry, cloneRegistry);
     }
   }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -153,17 +153,10 @@ proc updateRegistry(tf: string, args: list(string)) {
   checkRegistryChanged();
   for ((name, registry), registryHome) in zip(MASON_REGISTRY, MASON_CACHED_REGISTRY) {
 
-    const env = getEnv("MASON_REGISTRY");
-    const regPath = env.split(',');
-    const masonUrl = regPath[1].split('|');
-    const localUrl = regPath[2].split('|');
-    const mRegistry = masonUrl[1];
-    const lRegistry = localUrl[1];
-
     if isDir(registryHome) {
       var pullRegistry = 'git pull -q origin master';
       if tf == "Mason.toml" then
-        writeln("Updating ", mRegistry);
+        writeln("Updating ", name);
       gitC(registryHome, pullRegistry);
     }
     // Registry has moved or does not exist
@@ -172,7 +165,7 @@ proc updateRegistry(tf: string, args: list(string)) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Updating ", lRegistry);
+      writeln("Updating ", name);
       gitC(localRegistry, cloneRegistry);
     }
   }


### PR DESCRIPTION
Modifies the "Updating mason-registry" message to specify the registry name, for example:

Using the chapel-lang registry and a custom registry changes from this:

```
Updating mason-registry
Updating mason-registry
```

to this:

```
Updating registry
Updating myRegistry
```
Fixes https://github.com/chapel-lang/chapel/issues/13336