### PR TITLE
Don't expand CHPL_HOME immediately, in common-cray-cs.bash.

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -17,7 +17,7 @@ function loadCSModule()
 
 if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
-  export CHPL_TEST_LAUNCHCMD=$CHPL_HOME/util/test/chpl_launchcmd.py
+  export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
   loadCSModule gcc
   loadCSModule python/2.7.6
   loadCSModule cray-fftw


### PR DESCRIPTION
The common-cray-cs.bash script was evaluating `CHPL_HOME` at the time it
set `CHPL_TEST_LAUNCHCMD`.  That's not right.  We're not assured that
`CHPL_HOME` is set yet, when this script is run.  (Among the things it
does is to set `CHPL_HOST_PLATFORM`, something that's typically done
before evaluating a `setchplenv` script which would set `CHPL_HOME`.)  So
here, escape the dollar sign so that `CHPL_HOME` will be expanded later,
when `CHPL_TEST_LAUNCHCMD` is used.