### PR TITLE
Enable string methods to use escaped strings

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -966,7 +966,7 @@ module String {
         var cp: int(32);
         var nBytes: c_int;
         var maxBytes = (localThis.len - i): ssize_t;
-        qio_decode_char_buf(cp, nBytes, curPos:c_string, maxBytes);
+        qio_decode_char_buf_esc(cp, nBytes, curPos:c_string, maxBytes);
 
         var (newBuf, newSize) = bufferCopyLocal(curPos, nBytes);
         newBuf[nBytes] = 0;
@@ -1000,7 +1000,7 @@ module String {
         var nbytes: c_int;
         var multibytes = (localThis.buff + i): c_string;
         var maxbytes = (localThis.len - i): ssize_t;
-        qio_decode_char_buf(cp, nbytes, multibytes, maxbytes);
+        qio_decode_char_buf_esc(cp, nbytes, multibytes, maxbytes);
         yield cp;
         i += nbytes;
       }
@@ -1026,7 +1026,7 @@ module String {
         var nbytes: c_int;
         var multibytes = (localThis.buff + i): c_string;
         var maxbytes = (localThis.len - i): ssize_t;
-        qio_decode_char_buf(cp, nbytes, multibytes, maxbytes);
+        qio_decode_char_buf_esc(cp, nbytes, multibytes, maxbytes);
         yield (cp:int(32), (i + 1):byteIndex, nbytes:int);
         i += nbytes;
       }
@@ -1089,7 +1089,7 @@ module String {
       var nbytes: c_int;
       var multibytes = localThis.buff: c_string;
       var maxbytes = localThis.len: ssize_t;
-      qio_decode_char_buf(cp, nbytes, multibytes, maxbytes);
+      qio_decode_char_buf_esc(cp, nbytes, multibytes, maxbytes);
 
       if localThis.len != nbytes:int then
         halt("string.toCodepoint() only accepts single-codepoint strings");
@@ -1142,7 +1142,7 @@ module String {
       var multibytes = ret.buff;
       var cp: int(32);
       var nbytes: c_int;
-      qio_decode_char_buf(cp, nbytes, multibytes:c_string, maxbytes);
+      qio_decode_char_buf_esc(cp, nbytes, multibytes:c_string, maxbytes);
       ret.buff[nbytes] = 0;
       ret.len = nbytes;
 
@@ -1352,7 +1352,7 @@ module String {
                   var nbytes: c_int;
                   var multibytes = (this.buff + i-1): c_string;
                   var maxbytes = (this.len - (i-1)): ssize_t;
-                  qio_decode_char_buf(cp, nbytes, multibytes, maxbytes);
+                  qio_decode_char_buf_esc(cp, nbytes, multibytes, maxbytes);
                   nextIdx = i-1 + nbytes;
                 }
               }

--- a/runtime/include/encoding/encoding-support.h
+++ b/runtime/include/encoding/encoding-support.h
@@ -211,8 +211,10 @@ int chpl_enc_validate_buf(const char *buf, ssize_t buflen) {
   int offset = 0;
 
   while (offset<buflen) {
+    // you can create a chapel string with a codepoint that represens and
+    // escaped byte, so the last argument is true
     if (chpl_enc_decode_char_buf_utf8(&cp, &nbytes, buf+offset,
-                                      buflen-offset, false) != 0) {
+                                      buflen-offset, true) != 0) {
       return -1;  // invalid : return EILSEQ
     }
     offset += nbytes;

--- a/test/types/string/validation/escapedFunc.chpl
+++ b/test/types/string/validation/escapedFunc.chpl
@@ -1,0 +1,60 @@
+var str = b"bAb\xffbAb".decode(errors=decodePolicy.escape);
+
+// iterate over the string using indexing
+var idx = 1;
+while idx <= str.length {
+  writeln("Char: ", str[idx]);
+  // we get all replacement characters here. we should be getting the actual
+  // escape codepoint
+  writef("codepoint: %xu\n", str.codepoint[idx]);
+  writef("repr: %ht\n", str[idx].encode(encodePolicy.unescape));
+  idx += 1;
+
+}
+
+writeln("default iterations");
+for s in str {
+  writef("codepoint: %xu\n", s.toCodepoint());
+  writef("repr: %ht\n", s.encode(encodePolicy.unescape));
+}
+writeln();
+
+writeln("codepoint iterations");
+for cp in str.codepoints() {
+  writef("codepoint: %xu\n", cp);
+}
+writeln();
+
+var strLower = str.toLower();
+writeln("codepoint iterations for lower");
+for cp in strLower.codepoints() {
+  writef("codepoint: %xu\n", cp);
+}
+writeln();
+
+
+writeln("find/count");
+var strGood = "A";
+var strBad = b"\xff".decode(errors=decodePolicy.escape);
+
+writeln("Should be 2: ", str.count(strGood));
+writeln("Should be 1: ", str.count(strBad));
+
+writeln("Should be 2: ", str.find(strGood));
+writeln("Should be 4: ", str.find(strBad));
+
+writeln("Should be 8: ", str.rfind(strGood));
+writeln("Should be 4: ", str.rfind(strBad));
+writeln();
+
+writeln("split");
+for s in str.split(strBad) {
+  writef("repr: %ht\n", s.encode(encodePolicy.unescape));
+}
+writeln();
+
+for s in str.split(strGood) {
+  writef("repr: %ht\n", s.encode(encodePolicy.unescape));
+}
+writeln();
+

--- a/test/types/string/validation/escapedFunc.good
+++ b/test/types/string/validation/escapedFunc.good
@@ -1,0 +1,71 @@
+Char: b
+codepoint: 62
+repr: b"b"
+Char: A
+codepoint: 41
+repr: b"A"
+Char: b
+codepoint: 62
+repr: b"b"
+Char: í³¿
+codepoint: dcff
+repr: b"\xFF"
+Char: b
+codepoint: 62
+repr: b"b"
+Char: A
+codepoint: 41
+repr: b"A"
+Char: b
+codepoint: 62
+repr: b"b"
+default iterations
+codepoint: 62
+repr: b"b"
+codepoint: 41
+repr: b"A"
+codepoint: 62
+repr: b"b"
+codepoint: dcff
+repr: b"\xFF"
+codepoint: 62
+repr: b"b"
+codepoint: 41
+repr: b"A"
+codepoint: 62
+repr: b"b"
+
+codepoint iterations
+codepoint: 62
+codepoint: 41
+codepoint: 62
+codepoint: dcff
+codepoint: 62
+codepoint: 41
+codepoint: 62
+
+codepoint iterations for lower
+codepoint: 62
+codepoint: 61
+codepoint: 62
+codepoint: dcff
+codepoint: 62
+codepoint: 61
+codepoint: 62
+
+find/count
+Should be 2: 2
+Should be 1: 1
+Should be 2: 2
+Should be 4: 4
+Should be 8: 8
+Should be 4: 4
+
+split
+repr: b"bAb"
+repr: b"bAb"
+
+repr: b"b"
+repr: b"b\xFFb"
+repr: b"b"
+


### PR DESCRIPTION
This PR enables string methods to use escaped strings.

This is a prerequisite for supporting escaped strings in Path for files with
non-UTF8 names.

Note that methods like `toLower` etc are unchanged, because they do not do
anything for the codepoints they don't recognize.

Test:
- [x] local
- [x] gasnet