### PR TITLE
Update a few more tests on behalf of comm=ofi.

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -478,6 +478,7 @@ int chpl_launch_using_system(char* command, char* argv0) {
       printf("%s ", evList);
     }
     printf("%s\n", command);
+    fflush(stdout);
   }
   chpl_launch_sanity_checks(argv0);
   return system(command);

--- a/test/execflags/ferguson/args.prediff
+++ b/test/execflags/ferguson/args.prediff
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Throw out any --waltime argument (added by sub_test).
+sed "s/ --walltime=[^ ]*//" $2 > $2.tmp &&
+mv $2.tmp $2

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
@@ -1,0 +1,1 @@
+EVARS=vals srun --job-name=CHPL-testVFlag --quiet --nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N --exclusive --mem=0 --kill-on-bad-exit --partition=P  ./testVFlag_real -v -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -39,11 +39,11 @@ fi
 # Address program output variations peculiar to the various configuation
 # settings.
 
-# On Cray X* systems, compute node system names aren't meaningful.
+# On Cray CS and X* systems, compute node system names aren't meaningful.
 case $target in
-  cray-x*) sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
-               < $2 > $2.tmp &&
-           mv $2.tmp $2;;
+  cray-cs|cray-x*) sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
+                       < $2 > $2.tmp &&
+                   mv $2.tmp $2;;
 esac
 
 # With Qthreads, -v results in some lines of QTHREADS info we don't need.
@@ -55,6 +55,9 @@ esac
 # If we use the amudprun launcher, there's a path on the front of it.
 # If we use the aprun launcher, the depth (-d) value may vary, and also
 # there is a resource usage line with varying contents.
+# If we use the slurm-srun launcher, the depth (--cpus-per-task) and
+# partition values may vary, and there may be a --time option and some
+# some trailing white space.
 case $launcher in
   amudprun) sed -e "s/[^ ]*amudprun/amudprun/" \
                 -e "/QTHREADS/d" $2 > $2.tmp &&
@@ -63,4 +66,10 @@ case $launcher in
              -e "s/^\(Application\) .* \(resources\): .*/\1 APID \2: .../" \
              $2 > $2.tmp &&
          mv $2.tmp $2;;
+  slurm-srun) sed -e "s/ \(--cpus-per-task\)=[1-9][0-9]* / \1=N /" \
+                  -e "s/ \(--partition\)=[^ ]* / \1=P /" \
+                  -e "s/ --time=[^ ]*//" \
+                  -e 's/ *$//' \
+                  $2 > $2.tmp &&
+              mv $2.tmp $2;;
 esac

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
@@ -1,0 +1,1 @@
+EVARS=vals srun --job-name=CHPL-testVerboseFlag --quiet --nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N --exclusive --mem=0 --kill-on-bad-exit --partition=P  ./testVerboseFlag_real -v -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -39,11 +39,11 @@ fi
 # Address program output variations peculiar to the various configuation
 # settings.
 
-# On Cray X* systems, compute node system names aren't meaningful.
+# On Cray CS and X* systems, compute node system names aren't meaningful.
 case $target in
-  cray-x*) sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
-               < $2 > $2.tmp &&
-           mv $2.tmp $2;;
+  cray-cs|cray-x*) sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
+                       < $2 > $2.tmp &&
+                   mv $2.tmp $2;;
 esac
 
 # With Qthreads, -v results in some lines of QTHREADS info we don't need.
@@ -55,6 +55,9 @@ esac
 # If we use the amudprun launcher, there's a path on the front of it.
 # If we use the aprun launcher, the depth (-d) value may vary, and also
 # there is a resource usage line with varying contents.
+# If we use the slurm-srun launcher, the depth (--cpus-per-task) and
+# partition values may vary, and there may be a --time option and some
+# some trailing white space.
 case $launcher in
   amudprun) sed -e "s/[^ ]*amudprun/amudprun/" \
                 -e "/QTHREADS/d" $2 > $2.tmp &&
@@ -63,5 +66,11 @@ case $launcher in
              -e "s/^\(Application\) .* \(resources\): .*/\1 APID \2: .../" \
              $2 > $2.tmp &&
          mv $2.tmp $2;;
+  slurm-srun) sed -e "s/ \(--cpus-per-task\)=[1-9][0-9]* / \1=N /" \
+                  -e "s/ \(--partition\)=[^ ]* / \1=P /" \
+                  -e "s/ --time=[^ ]*//" \
+                  -e 's/ *$//' \
+                  $2 > $2.tmp &&
+              mv $2.tmp $2;;
 esac
 


### PR DESCRIPTION
For launchers that are initiated via system(3), flush stdout before
calling that.  If we don't do this, the verbose output showing the
launcher command line can be buffered during the shell execution and
printed after the output from the user program instead of before it.

In the 'testVFlag' and 'testVerboseFlag' tests, add support for the
slurm-srun launcher and fix flaws on Cray CS.

In the 'args' test, account for a possible '--walltime' option added by
sub_test.