### PR TITLE
Un-do array init copy change

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1448,7 +1448,7 @@ module ChapelArray {
     }
 
     /*
-     Creates an index buffer which can be used for faster index addition. 
+     Creates an index buffer which can be used for faster index addition.
 
      For example, instead of:
 
@@ -4016,19 +4016,12 @@ module ChapelArray {
   }
 
   pragma "init copy fn"
-  proc chpl__initCopy(a: []) {
+  proc chpl__initCopy(const ref a: []) {
     var b : [a._dom] a.eltType;
 
-    if !isConstAssignableType(a.eltType) {
-      if !isAssignableType(a.eltType) {
-        compilerError("Cannot copy array with element type that cannot be assigned");
-      } else {
-        // Make sure this function uses ref argument intent for a
-        // TODO: use a where clause instead to make this less strange
-        // provided that does not significantly slow compiles
-        ref r = a;
-      }
-    }
+    // TODO: handle !isConstAssignableType(a.eltType)
+    if !isAssignableType(a.eltType) then
+      compilerError("Cannot copy array with element type that cannot be assigned");
 
     chpl__uncheckedArrayTransfer(b, a);
     return b;

--- a/test/parallel/forall/reduce-intents/ri-a2-AoA.skipif
+++ b/test/parallel/forall/reduce-intents/ri-a2-AoA.skipif
@@ -1,2 +1,0 @@
-# This test is not doing anything correctness-check-worthy.
-CHPL_TEST_PERF != on


### PR DESCRIPTION
Changes in array initCopy from PR #14887 caused failures for the test
test/parallel/forall/reduce-intents/ri-a2-AoA.chpl in performance runs.
The problem is related to const-checking of shadow variables that I'm not
quite sure how to resolve at the moment.

This PR removes the intent changes for array initCopy.

Issue #14923 tracks the future work of fixing it (along with the new
future test/types/records/const-checking/array-of-owned-const.chpl)

While there, run the test that failed in performance testing in regular
testing too. Since full testing passed with the PR before it was merged,
this test is testing something different from others.

Trivial and not reviewed.

- [x] full local testing
