### PR TITLE
Issue warnings for some unstable language features when --warn-unstable

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1684,7 +1684,7 @@ FnSymbol* buildLambda(FnSymbol *fn) {
    * is better to guard against this behavior then leaving someone wondering
    * why we didn't.
    */
-  if (snprintf(buffer, 100, "_chpl_lambda_%i", nextId++) >= 100) {
+  if (snprintf(buffer, 100, "chpl_lambda_%i", nextId++) >= 100) {
     INT_FATAL("Too many lambdas.");
   }
 

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -762,6 +762,9 @@ CallExpr* buildLetExpr(BlockStmt* decls, Expr* expr) {
   fn->addFlag(FLAG_INLINE);
   fn->insertAtTail(decls);
   fn->insertAtTail(new CallExpr(PRIM_RETURN, expr));
+  if (fWarnUnstable) {
+    USR_WARN(decls, "Let expressions are currently unstable and are expected to change in ways that will break their current uses.");
+  }
   return new CallExpr(new DefExpr(fn));
 }
 

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -757,7 +757,7 @@ CallExpr* buildPrimitiveExpr(CallExpr* exprs) {
 
 CallExpr* buildLetExpr(BlockStmt* decls, Expr* expr) {
   static int uid = 1;
-  FnSymbol* fn = new FnSymbol(astr("_let_fn", istr(uid++)));
+  FnSymbol* fn = new FnSymbol(astr("chpl_let_fn", istr(uid++)));
   fn->addFlag(FLAG_COMPILER_NESTED_FUNCTION);
   fn->addFlag(FLAG_INLINE);
   fn->insertAtTail(decls);

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -531,7 +531,8 @@ static void warnUnstableLeadingUnderscores() {
   if (fWarnUnstable) {
     forv_Vec(VarSymbol, var, gVarSymbols) {
       if (var->name[0] == '_' &&
-          var->defPoint->getModule()->modTag == MOD_USER) {
+          var->defPoint->getModule()->modTag == MOD_USER &&
+          !var->hasFlag(FLAG_TEMP)) {
         USR_WARN(var->defPoint,
                  "Symbol names with leading underscores (%s) are unstable.", var->name);
       }

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -42,6 +42,7 @@ static void checkModule(ModuleSymbol* mod);
 static void checkRecordInheritance(AggregateType* at);
 static void setupForCheckExplicitDeinitCalls();
 static void warnUnstableUnions(AggregateType* at);
+static void warnUnstableLeadingUnderscores();
 
 void
 checkParsed() {
@@ -132,6 +133,8 @@ checkParsed() {
 
     warnUnstableUnions(at);
   }
+
+  warnUnstableLeadingUnderscores();
 
   checkExportedNames();
 
@@ -521,5 +524,30 @@ checkExportedNames()
 static void warnUnstableUnions(AggregateType* at) {
   if (fWarnUnstable && at->isUnion()) {
     USR_WARN(at, "Unions are currently unstable and are expected to change in ways that will break their current uses.");
+  }
+}
+
+static void warnUnstableLeadingUnderscores() {
+  if (fWarnUnstable) {
+    forv_Vec(VarSymbol, var, gVarSymbols) {
+      if (var->name[0] == '_' &&
+          var->defPoint->getModule()->modTag == MOD_USER) {
+        USR_WARN(var->defPoint,
+                 "Symbol names with leading underscores (%s) are unstable.", var->name);
+      }
+    }
+    forv_Vec(FnSymbol, fn, gFnSymbols) {
+      if (fn->name[0] == '_' &&
+          fn->defPoint->getModule()->modTag == MOD_USER) {
+        USR_WARN(fn->defPoint,
+                 "Symbol names with leading underscores (%s) are unstable.", fn->name);
+      }
+    }
+    forv_Vec(ModuleSymbol, mod, gModuleSymbols) {
+      if (mod->name[0] == '_' && mod->modTag == MOD_USER) {
+        USR_WARN(mod->defPoint,
+                 "Symbol names with leading underscores (%s) are unstable.", mod->name);
+      }
+    }
   }
 }

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -529,25 +529,14 @@ static void warnUnstableUnions(AggregateType* at) {
 
 static void warnUnstableLeadingUnderscores() {
   if (fWarnUnstable) {
-    forv_Vec(VarSymbol, var, gVarSymbols) {
-      if (var->name[0] == '_' &&
-          var->defPoint->getModule()->modTag == MOD_USER &&
-          !var->hasFlag(FLAG_TEMP)) {
-        USR_WARN(var->defPoint,
-                 "Symbol names with leading underscores (%s) are unstable.", var->name);
-      }
-    }
-    forv_Vec(FnSymbol, fn, gFnSymbols) {
-      if (fn->name[0] == '_' &&
-          fn->defPoint->getModule()->modTag == MOD_USER) {
-        USR_WARN(fn->defPoint,
-                 "Symbol names with leading underscores (%s) are unstable.", fn->name);
-      }
-    }
-    forv_Vec(ModuleSymbol, mod, gModuleSymbols) {
-      if (mod->name[0] == '_' && mod->modTag == MOD_USER) {
-        USR_WARN(mod->defPoint,
-                 "Symbol names with leading underscores (%s) are unstable.", mod->name);
+    forv_Vec(DefExpr, def, gDefExprs) {
+      const char* name = def->name();
+      
+      if (name && name[0] == '_' &&
+          def->getModule()->modTag == MOD_USER &&
+          !def->sym->hasFlag(FLAG_TEMP)) {
+        USR_WARN(def,
+                 "Symbol names with leading underscores (%s) are unstable.", name);
       }
     }
   }

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -41,6 +41,7 @@ static void nestedName(ModuleSymbol* mod);
 static void checkModule(ModuleSymbol* mod);
 static void checkRecordInheritance(AggregateType* at);
 static void setupForCheckExplicitDeinitCalls();
+static void warnUnstableUnions(AggregateType* at);
 
 void
 checkParsed() {
@@ -128,6 +129,8 @@ checkParsed() {
 
   forv_Vec(AggregateType, at, gAggregateTypes) {
     checkRecordInheritance(at);
+
+    warnUnstableUnions(at);
   }
 
   checkExportedNames();
@@ -512,5 +515,11 @@ checkExportedNames()
     if (names.get(name))
       USR_FATAL_CONT(fn, "The name %s cannot be exported twice from the same compilation unit.", name);
     names.put(name, true);
+  }
+}
+
+static void warnUnstableUnions(AggregateType* at) {
+  if (fWarnUnstable && at->isUnion()) {
+    USR_WARN(at, "Unions are currently unstable and are expected to change in ways that will break their current uses.");
   }
 }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2205,7 +2205,9 @@ static Expr* createFunctionAsValue(CallExpr *call) {
   //
   // Otherwise, we need to create a Chapel first-class function (fcf)...
   //
-
+  if (fWarnUnstable) {
+    USR_WARN(call, "First class functions are unstable.");
+  }
   AggregateType* parent;
   FnSymbol*      thisParentMethod;
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -380,14 +380,16 @@ module ChapelBase {
 
   inline proc /(a: real(?w), b: imag(w)) return _r2i(-a/_i2r(b));
   inline proc /(a: imag(?w), b: real(w)) return _r2i(_i2r(a)/b);
-  inline proc /(a: real(?w), b: complex(w*2))
-    return let d = abs(b) in
-    ((a/d)*(b.re/d), (-a/d)*(b.im/d)):complex(w*2);
+  inline proc /(a: real(?w), b: complex(w*2)) {
+    const d = abs(b);
+    return ((a/d)*(b.re/d), (-a/d)*(b.im/d)):complex(w*2);
+  }
   inline proc /(a: complex(?w), b: real(w/2))
     return (a.re/b, a.im/b):complex(w);
-  inline proc /(a: imag(?w), b: complex(w*2))
-    return let d = abs(b) in
-    ((_i2r(a)/d)*(b.im/d), (_i2r(a)/d)*(b.re/d)):complex(w*2);
+  inline proc /(a: imag(?w), b: complex(w*2)) {
+    const d = abs(b);
+    return ((_i2r(a)/d)*(b.im/d), (_i2r(a)/d)*(b.re/d)):complex(w*2);
+  }
   inline proc /(a: complex(?w), b: imag(w/2))
     return (a.im/_i2r(b), -a.re/_i2r(b)):complex(w);
 
@@ -496,22 +498,27 @@ module ChapelBase {
   proc **(param a: uint(?w), param b: uint(w)) param return __primitive("**", a, b);
 
   inline proc _expHelp(a, param b: integral) {
-    if b == 0 then
+    if b == 0 {
       return 1:a.type;
-    else if b == 1 then
+    } else if b == 1 {
       return a;
-    else if b == 2 then
+    } else if b == 2 {
       return a*a;
-    else if b == 3 then
+    } else if b == 3 {
       return a*a*a;
-    else if b == 4 then
-      return let t=a*a in t*t;
-    else if b == 5 then
-      return let t=a*a in t*t*a;
-    else if b == 6 then
-      return let t=a*a in t*t*t;
-    else if b == 8 then
-      return let t=a*a, u=t*t in u*u;
+    } else if b == 4 {
+      const t = a*a;
+      return t*t;
+    } else if b == 5 {
+      const t = a*a;
+      return t*t*a;
+    } else if b == 6 {
+      const t = a*a;
+      return t*t*t;
+    } else if b == 8 {
+      const t = a*a, u = t*t;
+      return u*u;
+    }
     else
       compilerError("unexpected case in exponentiation optimization");
   }
@@ -1538,7 +1545,7 @@ module ChapelBase {
     return __primitive("cast", t, x);
 
   inline proc _cast(type t:chpl_anyimag, x: chpl_anycomplex)
-    return let xim = x.im in __primitive("cast", t, xim);
+    return __primitive("cast", t, x.im);
 
   inline proc _cast(type t:chpl_anyimag, x: enumerated)
     return x:real:imag;

--- a/test/unstable/COMPOPTS
+++ b/test/unstable/COMPOPTS
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable/declareUnion.chpl
+++ b/test/unstable/declareUnion.chpl
@@ -1,0 +1,8 @@
+union U {
+  var a: int;
+  var r: real;
+}
+
+proc main {
+  writeln("Hello");
+}

--- a/test/unstable/declareUnion.good
+++ b/test/unstable/declareUnion.good
@@ -1,0 +1,2 @@
+declareUnion.chpl:1: warning: Unions are currently unstable and are expected to change in ways that will break their current uses.
+Hello

--- a/test/unstable/first-class-functions.chpl
+++ b/test/unstable/first-class-functions.chpl
@@ -1,0 +1,11 @@
+proc foo() {
+  writeln("In foo");
+}
+
+var f = foo;
+
+f();
+
+var g = lambda() { writeln("In anon"); };
+
+g();

--- a/test/unstable/first-class-functions.good
+++ b/test/unstable/first-class-functions.good
@@ -1,0 +1,4 @@
+first-class-functions.chpl:5: warning: First class functions are unstable.
+first-class-functions.chpl:9: warning: First class functions are unstable.
+In foo
+In anon

--- a/test/unstable/leadingUnderscore.chpl
+++ b/test/unstable/leadingUnderscore.chpl
@@ -1,0 +1,10 @@
+module _MyHiddenModule {
+  config const _t: int;
+
+  proc _myPrivateFn() {
+    var _doNotLookAtMe: int;
+    type _nope = real;
+    const _____a: int;
+    param _____b: int;
+  }
+}

--- a/test/unstable/leadingUnderscore.chpl
+++ b/test/unstable/leadingUnderscore.chpl
@@ -7,4 +7,7 @@ module _MyHiddenModule {
     const _____a: int;
     param _____b: int;
   }
+
+  class _Underscore_ {
+  }
 }

--- a/test/unstable/leadingUnderscore.good
+++ b/test/unstable/leadingUnderscore.good
@@ -1,0 +1,8 @@
+leadingUnderscore.chpl:1: warning: Symbol names with leading underscores (_MyHiddenModule) are unstable.
+leadingUnderscore.chpl:2: warning: Symbol names with leading underscores (_t) are unstable.
+leadingUnderscore.chpl:4: In function '_myPrivateFn':
+leadingUnderscore.chpl:4: warning: Symbol names with leading underscores (_myPrivateFn) are unstable.
+leadingUnderscore.chpl:5: warning: Symbol names with leading underscores (_doNotLookAtMe) are unstable.
+leadingUnderscore.chpl:6: warning: Symbol names with leading underscores (_nope) are unstable.
+leadingUnderscore.chpl:7: warning: Symbol names with leading underscores (_____a) are unstable.
+leadingUnderscore.chpl:8: warning: Symbol names with leading underscores (_____b) are unstable.

--- a/test/unstable/leadingUnderscore.good
+++ b/test/unstable/leadingUnderscore.good
@@ -1,4 +1,4 @@
-leadingUnderscore.chpl:1: warning: Symbol names with leading underscores (_MyHiddenModule) are unstable.
+leadingUnderscore.chpl:11: warning: Symbol names with leading underscores (_Underscore_) are unstable.
 leadingUnderscore.chpl:2: warning: Symbol names with leading underscores (_t) are unstable.
 leadingUnderscore.chpl:4: In function '_myPrivateFn':
 leadingUnderscore.chpl:4: warning: Symbol names with leading underscores (_myPrivateFn) are unstable.

--- a/test/unstable/leadingUnderscore.prediff
+++ b/test/unstable/leadingUnderscore.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+outfile=$2
+sort $outfile > $outfile.tmp
+mv $outfile.tmp $outfile

--- a/test/unstable/letExpr.chpl
+++ b/test/unstable/letExpr.chpl
@@ -1,0 +1,5 @@
+var b = 1, c = 2;
+var result = let a1 = b * c,
+                 a2 = b + c in c*c;
+
+writeln(result);

--- a/test/unstable/letExpr.good
+++ b/test/unstable/letExpr.good
@@ -1,0 +1,2 @@
+letExpr.chpl:2: warning: Let expressions are currently unstable and are expected to change in ways that will break their current uses.
+4


### PR DESCRIPTION
Issue --warn-unstable warnings for let expressions, user-symbol names beginning with '_',
first class functions, and unions.

Add tests for each new warning type.

I ran Linux64 testing with and without --warn-unstable. Without was clean. With
--warn-unstable there were about 350 errors, but the sample of about 25 that I picked
randomly to look closer at were all valid warnings about user-code with no false positives.