### PR TITLE
Optimize chpl_comm_diags_verbose_* calls

### DIFF
--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -120,23 +120,14 @@ int chpl_comm_diags_is_enabled(void) {
   return (atomic_load_int_least16_t(&chpl_comm_diags_disable_flag) <= 0);
 }
 
-static inline
-void chpl_comm_diags_verbose_printf(chpl_bool, const char*, ...)
-  __attribute__((format(printf, 2, 3)));
-static inline
-void chpl_comm_diags_verbose_printf(chpl_bool is_unstable,
-                                    const char* format, ...) {
-  if (chpl_verbose_comm
-      && chpl_comm_diags_is_enabled()
-      && (!is_unstable || chpl_comm_diags_print_unstable)) {
-    char myFmt[100];
-    snprintf(myFmt, sizeof(myFmt), "%d: %s\n", chpl_nodeID, format);
-    va_list ap;
-    va_start(ap, format);
-    vfprintf(stdout, myFmt, ap);
-    va_end(ap);
-  }
-}
+#define chpl_comm_diags_verbose_printf(is_unstable, format, ...)   \
+  do {                                                             \
+    if (chpl_verbose_comm                                          \
+        && chpl_comm_diags_is_enabled()                            \
+        && (!is_unstable || chpl_comm_diags_print_unstable)) {     \
+      printf("%d: " format "\n", chpl_nodeID, __VA_ARGS__);        \
+    }                                                              \
+  } while(0)
 
 #define chpl_comm_diags_verbose_rdma(op, node, size, ln, fn, commid)     \
   chpl_comm_diags_verbose_printf(false,                                  \


### PR DESCRIPTION
Optimize calls to `chpl_comm_diags_verbose_*`. Previously, these macros
would always call `chpl_comm_diags_verbose_printf()`. That function is
normally a no-op, but it was a varags function, which can't be inlined
(https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10980) and we also
performed a filename lookup before making the call.

Here just make `chpl_comm_diags_verbose_printf()` a macro to avoid
function call overhead and the filename lookup.

The function call and filename lookup overhead are relatively small, so
the time doesn't really matter when actually doing comm. However, it
could impact fast paths when we do local operations. For example, this
improves local atomics in ofi and ugni when the network/provider don't
support NIC atomics and we fall back to processor atomics by ~20%.