### PR TITLE
Fix minor problems with #14921

### DIFF
--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -97,7 +97,7 @@ module LockFreeStack {
 
   class Node {
     type eltType;
-    var val : eltType?;
+    var val : toNilableIfClassType(eltType);
     var next : unmanaged Node(eltType)?;
 
     proc init(val : ?eltType) {
@@ -114,6 +114,8 @@ module LockFreeStack {
     type objType;
     var _top : AtomicObject(unmanaged Node(objType)?, hasGlobalSupport=true, hasABASupport=false);
     var _manager = new owned LocalEpochManager();
+
+    proc objTypeOpt type return toNilableIfClassType(objType);
 
     proc init(type objType) {
       this.objType = objType;
@@ -157,7 +159,7 @@ module LockFreeStack {
       return (true, retval);
     }
 
-    iter drain() : objType? {
+    iter drain() : objTypeOpt {
       var tok = getToken();
       var (hasElt, elt) = pop(tok);
       while hasElt {
@@ -167,7 +169,7 @@ module LockFreeStack {
       tryReclaim();
     }
 
-    iter drain(param tag : iterKind) : objType? where tag == iterKind.standalone {
+    iter drain(param tag : iterKind) : objTypeOpt where tag == iterKind.standalone {
       coforall tid in 1..here.maxTaskPar {
         var tok = getToken();
         var (hasElt, elt) = pop(tok);

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -568,14 +568,7 @@ proc chpl_isSyncSingleAtomic(e: single) param  return true;
 pragma "no doc"
 proc chpl_isSyncSingleAtomic(e)  param where isAtomicType(e.type)  return true;
 
-
-// Is 'sub' a subtype (or equal to) 'super'?
-/* isSubtype Returns `true` if the type `sub` is a subtype of the type `super`. */
-// isSubtype is directly handled by compiler
-
-// Is 'sub' a proper subtype of 'super'?
-// isProperSubtype returns true if so
-// isProperSubtype is directly handled by compiler.
+// isSubtype(), isProperSubtype() are now directly handled by compiler
 
 // Returns true if it is legal to coerce t1 to t2, false otherwise.
 pragma "no doc"
@@ -596,7 +589,6 @@ proc chpl__legalIntCoerce(type t1, type t2) param
   }
 }
 
-
 // Returns the type with which both s and t are compatible
 // That is, both s and t can be coerced to the returned type.
 private proc chpl__commonType(type s, type t) type
@@ -615,6 +607,15 @@ private proc chpl__commonType(type s, type t) type
 
   return s;
 }
+
+/* If the argument is a class type, returns its nilable version like `arg?`.
+   Otherwise returns the argument unchanged. */
+proc toNilableIfClassType(type arg) type {
+  if isNonNilableClassType(arg)   // btw #14920
+  then return arg?;
+  else return arg;
+}
+
 
 //
 // numBits(type) -- returns the number of bits in a type

--- a/test/compflags/sungeun/configs/type_variables/configTypeFun.chpl
+++ b/test/compflags/sungeun/configs/type_variables/configTypeFun.chpl
@@ -12,16 +12,11 @@ class cPair {
 
 config type myType = rPair;
 
-proc toNonNilableIfClassType(type arg) type {
-  if isClassType(arg) then return arg?;
-  else                     return arg;  // #14920
-}
-
-proc f(p: toNonNilableIfClassType(myType)) {
+proc f(p: toNilableIfClassType(myType)) {
   writeln("p = ", p);
 }
 
-var p: toNonNilableIfClassType(myType);
+var p: toNilableIfClassType(myType);
 
 f(p);
 writeln("numBits(myIdxType) = ", numBits(myIdxType));

--- a/test/compflags/sungeun/configs/type_variables/configTypeFunNoType.chpl
+++ b/test/compflags/sungeun/configs/type_variables/configTypeFunNoType.chpl
@@ -12,16 +12,11 @@ class cPair {
 
 config type myType = rPair;
 
-proc toNonNilableIfClassType(type arg) type {
-  if isClassType(arg) then return arg?;
-  else                     return arg;  // #14920
-}
-
 proc f(p) {
   writeln("p = ", p);
 }
 
-var p: toNonNilableIfClassType(myType);
+var p: toNilableIfClassType(myType);
 
 f(p);
 writeln("numBits(myIdxType) = ", numBits(myIdxType));

--- a/test/compflags/sungeun/configs/type_variables/configTypeUserType.chpl
+++ b/test/compflags/sungeun/configs/type_variables/configTypeUserType.chpl
@@ -10,13 +10,8 @@ class cPair {
   var y: myIdxType;
 }
 
-proc toNonNilableIfClassType(type arg) type {
-  if isClassType(arg) then return arg?;
-  else                     return arg;  // #14920
-}
-
 config type myType = rPair;
-var p: toNonNilableIfClassType(myType);
+var p: toNilableIfClassType(myType);
 
 writeln("p = ", p);
 writeln("numBits(myIdxType) = ", numBits(myIdxType));


### PR DESCRIPTION
* Adjust the package modules `LockFreeQueue` and `LockFreeStack`
  to comply with #14921 by replacing `eltType?` with
  `toNilableIfClassType(eltType)`, and likewise for `objType`.

* For that, add `proc toNilableIfClassType` to standard modules.

* Replace the mis-named `toNonNilableIfClassType()` added in #14921
  to a couple of tests with the newly-added `toNonNilableIfClassType`.

Future work: think whether `LockFreeQueue` and `LockFreeStack`
should accept only default-initializable element types.
I suspect currently they would not work on a record type
that does not provide a 0-arg initializer.

OTOH for now, until full-blown option types arrive,
we may be able to make these datatypes work properly
with non-nilable class types. Ex. we could have `drain()` (for example)
return non-nilable classes in this case.
