### PR TITLE
Add design guidelines to ContributorInfo.rst

### DIFF
--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -15,6 +15,12 @@ feature, and submitting pull requests.
 Overview:
 
 #. `Choosing a task`_
+
+#. `Design`_
+
+    #. `Creating a design issue`_
+    #. `Leading a design discussion`_
+
 #. `Development`_
 
     #. `Get set up`_
@@ -23,10 +29,6 @@ Overview:
 
        #. `Add new tests`_
 
-#. `Design`_
-
-    #. `Creating a design issue`_
-    #. `Leading a design discussion`_
 
 #. `Contributing changes`_
 
@@ -45,7 +47,7 @@ Overview:
 
 
 
-.. _Choosing a task
+.. _Choosing a task:
 
 Choosing a task
 ---------------
@@ -53,21 +55,114 @@ Choosing a task
 If you do not already know what task to work on, the `Contributing`_ page has
 some tips for finding a task.
 
-It is important to communicate with other people who might be working on the
-same area. For small tasks, this can be as simple as commenting on an issue.
-For larger projects, you should discuss the approach in a design issue on
-GitHub. See the `Design`_ section for guidance on creating a design issue.
+It is important to communicate with other people before working on a task. This
+will help address design questions before starting implementation and will
+avoid multiple people working on the same task simultaneously.
+If an issue exists for the task you are working on, you should always comment
+on that issue to let others know you are working on it. If an issue does not
+exist for the task you have chosen, you should open an issue first. In many
+cases, you will need to discuss the design of the interface or implementation
+before starting development.  See the `Design`_ section for more details on
+this.
 
-Any user-facing change to the language or standard library interface will
-require design review. It is helpful to start the design review discussion as
-early as possible.  All code changes will require code review.
 
 .. _Contributing: https://chapel-lang.org/contributing.html
 
-.. _Get set up:
+.. _Design:
+
+Design
+------
+
+.. When design discussion is needed
+
+When design discussion is needed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Design discussion is needed when changes impact:
+
+- language or standard library
+- software architecture
+
+In many cases it is reasonable to start development without a full design
+review, but such efforts should be open to changing once the design is being
+discussed.
+
+If your task does require a design issue, you may skip ahead to the
+`Development`_ section.
+
+
+.. _Creating a design issue:
+
+Creating a design issue
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The design issue should aim to clearly and concisely present some design
+decisions. Here are some strategies to make a good design issue:
+
+- Summarize issue at the top, preferably include concise code example(s).
+- Try not to make initial issue too long in order to lower the barrier for
+  someone getting involved.
+- Clearly define the problem this proposal aims to solve.
+- It can be useful to consider alternative solutions to the problem and
+  describe the trade-offs among them.
+- A design issue should have two developers not involved in the effort to review.
+- To find reviewers, send an email to chapel-developers_.
+
+  * Use a prefix of ``[Design]`` in the subject header.
+  * Include a short summary of the topic, potentially including motivation
+    and/or an example.
+      - This should not be a copy/paste of the issue contents.
+  * Include a link to your issue.
+  * Ask for people to volunteer to be involved in design discussions.
+
+    .. code-block:: text
+
+        Subject: [Design] Add feature A to module M
+
+        Hello,
+
+        I would like to add feature A to module M. This feature is motivated by
+        X, Y, and Z. For example, this would enable:
+
+          var result = M.A(args);
+
+        See the issue here: https://github.com/chapel-lang/chapel/issues/<number>
+
+        I need 2 developers to identify themselves as API reviewers for this design
+        issue.
+
+        Thanks,
+        Contributor
+
+.. _Leading a design discussion:
+
+Leading a design discussion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many design choices require a consensus among community members.
+It can be helpful to reach a consensus on a design decision quicker by making
+an effort to lead that discussion.
+
+Here are some ways to progress the discussion:
+
+- Ask people involved what they need to know to make a decision
+- Summarize the different solutions that were brought up in the discussion and
+  list their pros and cons
+- Compare with other languages, libraries, previous work in area
+
+It is common for new design questions to emerge during design discussion
+(or less commonly, in code review).
+It can be helpful to spin off new issues for design questions that generate a
+lot of discussion or design questions that are not completely on-topic.
+This will help keep the discussion focused and the goals of the current design
+issue clear.
+
+.. _Development:
 
 Development
 -----------
+
+.. _Get set up:
 
 Get set up
 ~~~~~~~~~~
@@ -147,71 +242,6 @@ test/directory is run with ``start_test`` (and performance tests should also
 pass testing for ``start_test -performance``).
 
 .. _Creating a Simple Test: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/TestSystem.rst#creating-a-simple-test
-
-.. _Design
-
-Design
-------
-
-.. _Creating a design issue
-
-Creating a design issue
-~~~~~~~~~~~~~~~~~~~~~~~
-
-The design issue should aim to clearly and concisely present some design
-decisions. Here are some strategies to make a good design issue:
-
-- Summarize issue at the top, preferably include concise code example(s).
-- Try not to make initial issue too long in order to lower the barrier for
-  someone getting involved.
-- Clearly define the problem this proposal aims to solve.
-- It can be useful to consider alternative solutions to the problem and
-  describe the trade-offs among them.
-- A design issue should have two developers not involved in the effort to review.
-- To find reviewers, send an email to chapel-developers_.
-
-  * Use a prefix of ``[Design]`` in the subject header.
-  * Include a short summary of the topic, potentially including motivation and/or an example.
-  * Include a link to your issue.
-  * Ask for people to volunteer to be involved in design discussions.
-
-    .. code-block:: text
-
-        Subject: [Design] Add feature A to module M
-
-        Hello,
-
-        I would like to add feature A to module M. This feature is motivated by
-        X, Y, and Z. For example, this would enable:
-
-          var result = M.A(args);
-
-        See the issue here: https://github.com/chapel-lang/chapel/issues/<number>
-
-        I need 2 developers to identify themselves as API reviewers for this design
-        issue.
-
-        Thanks,
-        Contributor
-
-.. _Leading a design discussion
-
-Leading a design discussion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Many design choices require a consensus among community members.
-It can be helpful to reach a consensus on a design decision quicker by making
-an effort to lead that discussion.
-
-Here are some ways to progress the discussion:
-
-- Ask people involved what they need to know to make a decision
-- Summarize the different solutions that were brought up in the discussion and
-  list their pros and cons
-- Compare with other languages, libraries, previous work in area
-
-GitHub does not have nested thread comments, so it can be helpful to create
-new issues for design elements generating a lot of discussion.
 
 
 .. _Contributing changes

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -18,6 +18,7 @@ Overview:
 
 #. `Design`_
 
+    #. `When design discussion is needed`_
     #. `Creating a design issue`_
     #. `Leading a design discussion`_
 
@@ -73,15 +74,13 @@ this.
 Design
 ------
 
-.. When design discussion is needed
+.. When design discussion is needed:
 
 When design discussion is needed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Design discussion is needed when changes impact:
-
-- language or standard library
-- software architecture
+Design discussion is necessary when proposing language or standard library
+changes. It is also necessary for any large or architectural changes.
 
 In many cases it is reasonable to start development without a full design
 review, but such efforts should be open to changing once the design is being

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -86,7 +86,7 @@ In many cases it is reasonable to start development without a full design
 review, but such efforts should be open to changing once the design is being
 discussed.
 
-If your task does require a design issue, you may skip ahead to the
+If your task does not require a design issue, you may skip ahead to the
 `Development`_ section.
 
 

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -59,6 +59,7 @@ some tips for finding a task.
 It is important to communicate with other people before working on a task. This
 will help address design questions before starting implementation and will
 avoid multiple people working on the same task simultaneously.
+
 If an issue exists for the task you are working on, you should always comment
 on that issue to let others know you are working on it. If an issue does not
 exist for the task you have chosen, you should open an issue first. In many
@@ -74,7 +75,7 @@ this.
 Design
 ------
 
-.. When design discussion is needed:
+.. _When design discussion is needed:
 
 When design discussion is needed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -1,9 +1,6 @@
 Contributor Info
 ================
 
-Repository
-----------
-
 The git repository for the project is hosted on Github at
 `chapel-lang/chapel`_. Anyone can read the repository. It is open source!
 
@@ -15,45 +12,62 @@ feature, and submitting pull requests.
 
 .. note:: A `contributor license agreement`_ must be signed before any contributing pull requests can be merged.
 
-Developer Workflow
-------------------
-
 Overview:
 
-#. `Discuss design changes or big development efforts`_
-#. `Get set up`_
-#. `Create new branch`_
-#. `Develop and test contributions locally`_
+#. `Choosing a task`_
+#. `Development`_
 
-   #. `Add new tests`_
+    #. `Get set up`_
+    #. `Create new branch`_
+    #. `Develop and test contributions locally`_
 
-#. `Request feedback on your changes`_
+       #. `Add new tests`_
+
+#. `Design`_
+
+    #. `Creating a design issue`_
+    #. `Leading a design discussion`_
+
+#. `Contributing changes`_
 
    #. `Push your work to your feature branch`_
    #. `Ask for feedback on your branch early (optional)`_
    #. `Submit pull request`_
    #. `Find a reviewer`_
    #. `Work with your reviewers`_
+   #. `Before merging`_
+   #. `After merging`_
 
-#. `Get ready to merge`_
-#. `Watch automatic testing and address issues`_
+#. `Other useful information`_
 
-`HOWTO and Git details`_
+   #. `Chapel git workflow`_
+   #. `Policy details`_
 
-`Policy details`_
 
-.. _Discuss design changes or big development efforts:
 
-Discuss design changes or big development efforts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _Choosing a task
 
-Before embarking on a big project, please open an issue on the GitHub page
-and/or send an email to chapel-developers_ with a prefix of ``[Design]`` in the
-subject header for discussion with the community and to ensure that you are
-aware of any parallel efforts in that area.  It may also be a good idea to ask
-for input from the user community via the chapel-users_ mailing list.
+Choosing a task
+---------------
+
+If you do not already know what task to work on, the `Contributing`_ page has
+some tips for finding a task.
+
+It is important to communicate with other people who might be working on the
+same area. For small tasks, this can be as simple as commenting on an issue.
+For larger projects, you should discuss the approach in a design issue on
+GitHub. See the `Design`_ section for guidance on creating a design issue.
+
+Any user-facing change to the language or standard library interface will
+require design review. It is helpful to start the design review discussion as
+early as possible.  All code changes will require code review.
+
+.. _Contributing: https://chapel-lang.org/contributing.html
 
 .. _Get set up:
+
+Development
+-----------
 
 Get set up
 ~~~~~~~~~~
@@ -134,16 +148,81 @@ pass testing for ``start_test -performance``).
 
 .. _Creating a Simple Test: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/TestSystem.rst#creating-a-simple-test
 
+.. _Design
 
-.. _Request feedback on your changes:
+Design
+------
 
-Request feedback on your changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _Creating a design issue
+
+Creating a design issue
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The design issue should aim to clearly and concisely present some design
+decisions. Here are some strategies to make a good design issue:
+
+- Summarize issue at the top, preferably include concise code example(s).
+- Try not to make initial issue too long in order to lower the barrier for
+  someone getting involved.
+- Clearly define the problem this proposal aims to solve.
+- It can be useful to consider alternative solutions to the problem and
+  describe the trade-offs among them.
+- A design issue should have two developers not involved in the effort to review.
+- To find reviewers, send an email to chapel-developers_.
+
+  * Use a prefix of ``[Design]`` in the subject header.
+  * Include a short summary of the topic, potentially including motivation and/or an example.
+  * Include a link to your issue.
+  * Ask for people to volunteer to be involved in design discussions.
+
+    .. code-block:: text
+
+        Subject: [Design] Add feature A to module M
+
+        Hello,
+
+        I would like to add feature A to module M. This feature is motivated by
+        X, Y, and Z. For example, this would enable:
+
+          var result = M.A(args);
+
+        See the issue here: https://github.com/chapel-lang/chapel/issues/<number>
+
+        I need 2 developers to identify themselves as API reviewers for this design
+        issue.
+
+        Thanks,
+        Contributor
+
+.. _Leading a design discussion
+
+Leading a design discussion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many design choices require a consensus among community members.
+It can be helpful to reach a consensus on a design decision quicker by making
+an effort to lead that discussion.
+
+Here are some ways to progress the discussion:
+
+- Ask people involved what they need to know to make a decision
+- Summarize the different solutions that were brought up in the discussion and
+  list their pros and cons
+- Compare with other languages, libraries, previous work in area
+
+GitHub does not have nested thread comments, so it can be helpful to create
+new issues for design elements generating a lot of discussion.
+
+
+.. _Contributing changes
+
+Contributing changes
+--------------------
 
 .. _Push your work to your feature branch:
 
 Push your work to your feature branch
-+++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Push your changes to your feature branch on GitHub to enable others to see your
 work (see `How to push`_ for command details).  Note that if you have already
@@ -153,7 +232,7 @@ branch will update the pull request.
 .. _Ask for feedback on your branch early (optional):
 
 Ask for feedback on your branch early (optional)
-++++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Not ready to merge your changes, but still want to see if your work is going in
 the right direction?  Feel free to ask for early feedback!  Exposing the code is
@@ -175,7 +254,7 @@ Discussion can take place in:
 .. _Submit pull request:
 
 Submit pull request
-+++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~
 
 See `How to open a PR`_ for the sequence of steps necessary.
 
@@ -193,7 +272,7 @@ Please follow the `Pull request guidance`_ and keep PRs reasonably sized.
 .. _Find a reviewer:
 
 Find a reviewer
-+++++++++++++++
+~~~~~~~~~~~~~~~
 
 * Once your PR is ready, you'll need to request a review.  If you know who you'd
   like to review it, @ mention them in a comment on the PR and ask them to have
@@ -213,7 +292,7 @@ Find a reviewer
 .. _Work with your reviewers:
 
 Work with your reviewers
-++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Iterate with the reviewer until you're both satisfied.  One should generally
   try to do whatever their reviewer asks.  Sometimes, a reviewer will ask for
@@ -225,10 +304,10 @@ Work with your reviewers
   other developers, or to bring those developers into the conversation if they
   feel unqualified to do so.
 
-.. _Get ready to merge:
+.. _Before merging:
 
-Get ready to merge
-~~~~~~~~~~~~~~~~~~
+Before merging
+~~~~~~~~~~~~~~
 
 Before the change can be merged, go through this checklist to ensure:
 
@@ -258,10 +337,13 @@ After the final version of the change has been agreed upon, the person making
 the merge should follow the steps for `How to merge a PR`_.
 
 
-.. _Watch automatic testing and address issues:
+.. _After merging:
 
-Watch automatic testing and address issues
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+After merging
+~~~~~~~~~~~~~
+
+After merging, a good contributor should watch automatic testing results for
+failures that they may need to address:
 
 * In short order, a smoke-test will be run against the commit to make sure that
   nothing basic has been broken by it.  Monitor the
@@ -275,10 +357,13 @@ Watch automatic testing and address issues
   diagnosing any testing failures on any given night, but it's nice when
   developers notice the issue first themselves to save wasted effort).
 
-.. _HOWTO and Git details:
+.. _Chapel git workflow:
 
-HOWTO and Git details
-~~~~~~~~~~~~~~~~~~~~~
+Chapel git workflow
+~~~~~~~~~~~~~~~~~~~~
+
+The following section walks through some basics of git and GitHub that
+are helpful in contributing to Chapel.
 
 .. _initial git setup:
 


### PR DESCRIPTION
Add design guidelines to `ContributorInfo.rst`.

Also shuffle and rename some sections to improve document flow and consistency.