### PR TITLE
Close new file system and path memleaks

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -607,6 +607,8 @@ proc locale.cwd(): string throws {
     try! {
       ret = createStringWithNewBuffer(tmp, errors=decodePolicy.escape);
     }
+    // tmp was qio_malloc'd by chpl_fs_cwd
+    chpl_free_c_string(tmp);
   }
   if err != ENOERR then try ioerror(err, "in cwd");
   return ret;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3534,9 +3534,10 @@ proc stringify(const args ...?k):string {
       // Add the terminating NULL byte to make C string conversion easy.
       buf[offset] = 0;
 
-      return try! createStringWithNewBuffer(buf, offset, offset+1,
+      const ret = createStringWithNewBuffer(buf, offset, offset+1,
                                             decodePolicy.replace);
       c_free(buf);
+      return ret;
     }
   }
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1568,6 +1568,7 @@ proc file.path : string throws {
       ret = createStringWithNewBuffer(tmp2,
                                       errors=decodePolicy.escape);
     }
+    chpl_free_c_string(tmp2);
   }
   if err then try ioerror(err, "in file.path");
   return ret;
@@ -1829,6 +1830,7 @@ proc openfp(fp: _file, hints:iohints=IOHINT_NONE, style:iostyle = defaultIOStyle
     var path = if path_err then "unknown"
                            else createStringWithNewBuffer(path_cs,
                                                           errors=decodePolicy.replace);
+    chpl_free_c_string(path_cs);
     try ioerror(err, "in openfp", path);
   }
   return ret;
@@ -2158,6 +2160,7 @@ proc channel._ch_ioerror(error:syserr, msg:string) throws {
       // shouldn't throw
       path = createStringWithNewBuffer(tmp_path,
                                        errors=decodePolicy.replace);
+      chpl_free_c_string(tmp_path);
       offset = tmp_offset;
     }
   }
@@ -2178,6 +2181,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
       // shouldn't throw
       path = createStringWithNewBuffer(tmp_path,
                                        errors=decodePolicy.replace);
+      chpl_free_c_string(tmp_path);
       offset = tmp_offset;
     }
   }
@@ -3532,6 +3536,7 @@ proc stringify(const args ...?k):string {
 
       return try! createStringWithNewBuffer(buf, offset, offset+1,
                                             decodePolicy.replace);
+      c_free(buf);
     }
   }
 }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -362,6 +362,7 @@ proc dirname(name: string): string {
            var env_var: string = path_p(..(ind-1));
            var value: string;
            var value_c: c_string;
+           // buffer received from sys_getenv, shouldn't be freed
            var h: int = sys_getenv(unescape(env_var).c_str(), value_c);
            if (h != 1) {
              value = "${" + env_var + "}";
@@ -369,7 +370,6 @@ proc dirname(name: string): string {
              try! {
                value = createStringWithNewBuffer(value_c,
                                                  errors=decodePolicy.escape);
-               chpl_free_c_string(value_c);
              }
            }
            res += value;
@@ -383,6 +383,7 @@ proc dirname(name: string): string {
          }
          var value: string;
          var value_c: c_string;
+         // buffer received from sys_getenv, shouldn't be freed
          var h: int = sys_getenv(unescape(env_var).c_str(), value_c);
          if (h != 1) {
            value = "$" + env_var;
@@ -390,7 +391,6 @@ proc dirname(name: string): string {
            try! {
              value = createStringWithNewBuffer(value_c,
                                                errors=decodePolicy.escape);
-             chpl_free_c_string(value_c);
            }
          }
          res += value;

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -369,6 +369,7 @@ proc dirname(name: string): string {
              try! {
                value = createStringWithNewBuffer(value_c,
                                                  errors=decodePolicy.escape);
+               chpl_free_c_string(value_c);
              }
            }
            res += value;
@@ -389,6 +390,7 @@ proc dirname(name: string): string {
            try! {
              value = createStringWithNewBuffer(value_c,
                                                errors=decodePolicy.escape);
+             chpl_free_c_string(value_c);
            }
          }
          res += value;
@@ -590,7 +592,10 @@ proc realPath(name: string): string throws {
   var res: c_string;
   var err = chpl_fs_realpath(unescape(name).c_str(), res);
   if err then try ioerror(err, "realPath", name);
-  return createStringWithNewBuffer(res, errors=decodePolicy.escape);
+  const ret = createStringWithNewBuffer(res, errors=decodePolicy.escape);
+  // res was qio_malloc'd by chpl_fs_realpath, so free it here
+  chpl_free_c_string(res);
+  return ret; 
 }
 
 pragma "no doc"


### PR DESCRIPTION
Closes memory leaks introduced by #14907

That PR started to create new buffers while creating Chapel strings instead of
transferring the ownership of the c_string. In part because of my confusion
about c_strings I didn't add some needed frees. This PR adds those, and adds
some comments where they seem to be necessary from the Chapel code, but they
aren't.

Test:
- [x] quickstart valgrind in `library/standard/{FileSystem, Path, IO}`
- [x] local memleaks in `library/standard/{FileSystem, Path, IO}`
- [x] local correctness
- [x] gasnet correctness