### PR TITLE
Add compareExchange version that takes success and failure memory orders

### DIFF
--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -567,7 +567,7 @@ memoryOrder.seqCst.
 
 ::
 
-   proc (atomic T).read(order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).read(param order:memoryOrder = memoryOrder.seqCst): T
 
 Reads and returns the stored value. Defined for all atomic types.
 
@@ -575,7 +575,7 @@ Reads and returns the stored value. Defined for all atomic types.
 
 ::
 
-   proc (atomic T).write(v: T, order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic T).write(v: T, param order:memoryOrder = memoryOrder.seqCst)
 
 Stores ``v`` as the new value. Defined for all atomic types.
 
@@ -583,16 +583,30 @@ Stores ``v`` as the new value. Defined for all atomic types.
 
 ::
 
-   proc (atomic T).exchange(v: T, order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).exchange(v: T, param order:memoryOrder = memoryOrder.seqCst): T
 
 Stores ``v`` as the new value and returns the original value. Defined
 for all atomic types.
+
+::
+
+   proc (atomic T).compareExchange(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
+   proc (atomic T).compareExchange(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
+   proc (atomic T).compareExchangeWeak(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
+   proc (atomic T).compareExchangeWeak(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
+
+Stores ``v`` as the new value, if and only if the original value is
+equal to ``e``. Returns ``true`` if ``v`` was stored, otherwise
+returns ``false`` and updates ``e`` to the old value.  The weak
+version is allowed to spuriously fail, but when using
+``compareExchange`` in a loop anyways, it can can offer better
+performance on some platforms. Defined for all atomic types.
 
 
 
 ::
 
-   proc (atomic T).compareAndSwap(e: t, v: T, order:memoryOrder = memoryOrder.seqCst): bool
+   proc (atomic T).compareAndSwap(e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
 
 Stores ``v`` as the new value, if and only if the original value is
 equal to ``e``. Returns ``true`` if ``v`` was stored, ``false``
@@ -602,11 +616,11 @@ otherwise. Defined for all atomic types.
 
 ::
 
-   proc (atomic T).add(v: T, order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).sub(v: T, order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).or(v: T, order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).and(v: T, order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).xor(v: T, order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic T).add(v: T, param order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic T).sub(v: T, param order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic T).or(v: T, param order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic T).and(v: T, param order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic T).xor(v: T, param order:memoryOrder = memoryOrder.seqCst)
 
 Applies the appropriate operator (``+``, ``-``, ``|``, ``&``, ``^``) to
 the original value and ``v`` and stores the result. All of the methods
@@ -623,11 +637,11 @@ for the ``bool`` atomic type.
 
 ::
 
-   proc (atomic T).fetchAdd(v: T, order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchSub(v: T, order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchOr(v: T, order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchAnd(v: T, order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchXor(v: T, order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).fetchAdd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).fetchSub(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).fetchOr(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).fetchAnd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+   proc (atomic T).fetchXor(v: T, param order:memoryOrder = memoryOrder.seqCst): T
 
 Applies the appropriate operator (``+``, ``-``, ``|``, ``&``, ``^``) to
 the original value and ``v``, stores the result, and returns the original
@@ -639,7 +653,7 @@ methods are defined for the ``bool`` atomic type.
 
 ::
 
-   proc (atomic bool).testAndSet(order:memoryOrder = memoryOrder.seqCst): bool
+   proc (atomic bool).testAndSet(param order:memoryOrder = memoryOrder.seqCst): bool
 
 Stores ``true`` as the new value and returns the old value. Equivalent
 to ``exchange(true)``. Only defined for the ``bool`` atomic type.
@@ -648,7 +662,7 @@ to ``exchange(true)``. Only defined for the ``bool`` atomic type.
 
 ::
 
-   proc (atomic bool).clear(order:memoryOrder = memoryOrder.seqCst)
+   proc (atomic bool).clear(param order:memoryOrder = memoryOrder.seqCst)
 
 Stores ``false`` as the new value. Equivalent to ``write(false)``. Only
 defined for the ``bool`` atomic type.

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -255,13 +255,16 @@ module Atomics {
        updates `expected` to the original value.
      */
     inline proc compareExchange(ref expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
+      return this.compareExchange(expected, desired, order, readableOrder(order));
+    }
+    inline proc compareExchange(ref expected:bool, desired:bool, param success: memoryOrder, param failure: memoryOrder): bool {
       extern externFunc("compare_exchange_strong", bool)
         proc atomic_compare_exchange_strong(ref obj:externT(bool), ref expected:bool, desired:bool, succ:memory_order, fail:memory_order): bool;
 
       var ret:bool;
       on this {
         var localizedExpected = expected;
-        ret = atomic_compare_exchange_strong(_v, localizedExpected, desired, c_memory_order(order), c_memory_order(readableOrder(order)));
+        ret = atomic_compare_exchange_strong(_v, localizedExpected, desired, c_memory_order(success), c_memory_order(failure));
         if !ret then expected = localizedExpected;
       }
       return ret;
@@ -273,13 +276,16 @@ module Atomics {
        may happen if the value could not be updated atomically.
     */
     inline proc compareExchangeWeak(ref expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
+      return this.compareExchangeWeak(expected, desired, order, readableOrder(order));
+    }
+    inline proc compareExchangeWeak(ref expected:bool, desired:bool, param success: memoryOrder, param failure: memoryOrder) {
       extern externFunc("compare_exchange_weak", bool)
         proc atomic_compare_exchange_weak(ref obj:externT(bool), ref expected:bool, desired:bool, succ:memory_order, fail:memory_order): bool;
 
       var ret:bool;
       on this {
         var localizedExpected = expected;
-        ret = atomic_compare_exchange_weak(_v, localizedExpected, desired, c_memory_order(order), c_memory_order(readableOrder(order)));
+        ret = atomic_compare_exchange_weak(_v, localizedExpected, desired, c_memory_order(success), c_memory_order(failure));
         if !ret then expected = localizedExpected;
       }
       return ret;
@@ -426,13 +432,16 @@ module Atomics {
        updates `expected` to the original value.
      */
     inline proc compareExchange(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
+      return this.compareExchange(expected, desired, order, readableOrder(order));
+    }
+    inline proc compareExchange(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
       extern externFunc("compare_exchange_strong", T)
         proc atomic_compare_exchange_strong(ref obj:externT(T), ref expected:T, desired:T, succ:memory_order, fail:memory_order): bool;
 
       var ret:bool;
       on this {
         var localizedExpected = expected;
-        ret = atomic_compare_exchange_strong(_v, localizedExpected, desired, c_memory_order(order), c_memory_order(readableOrder(order)));
+        ret = atomic_compare_exchange_strong(_v, localizedExpected, desired, c_memory_order(success), c_memory_order(failure));
         if !ret then expected = localizedExpected;
       }
       return ret;
@@ -444,13 +453,16 @@ module Atomics {
        may happen if the value could not be updated atomically.
     */
     inline proc compareExchangeWeak(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
+      return this.compareExchangeWeak(expected, desired, order, readableOrder(order));
+    }
+    inline proc compareExchangeWeak(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
       extern externFunc("compare_exchange_weak", T)
         proc atomic_compare_exchange_weak(ref obj:externT(T), ref expected:T, desired:T, succ:memory_order, fail:memory_order): bool;
 
       var ret:bool;
       on this {
         var localizedExpected = expected;
-        ret = atomic_compare_exchange_weak(_v, localizedExpected, desired, c_memory_order(order), c_memory_order(readableOrder(order)));
+        ret = atomic_compare_exchange_weak(_v, localizedExpected, desired, c_memory_order(success), c_memory_order(failure));
         if !ret then expected = localizedExpected;
       }
       return ret;

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -77,19 +77,25 @@ module NetworkAtomics {
     }
 
     inline proc compareExchange(ref expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
+      return this.compareExchange(expected, desired, order, readableOrder(order));
+    }
+    inline proc compareExchange(ref expected:bool, desired:bool, param success: memoryOrder, param failure: memoryOrder): bool {
       pragma "insert line file info" extern externFunc("cmpxchg", int(64))
         proc atomic_cmpxchg(ref expected:int(64), ref desired:int(64), l:int(32), obj:c_void_ptr, ref result:bool(32), succ:memory_order, fail:memory_order): void;
 
       var ret:bool(32);
       var te = expected:int(64);
       var td = desired:int(64);
-      atomic_cmpxchg(te, td, _localeid(), _addr(), ret, c_memory_order(order), c_memory_order(readableOrder(order)));
+      atomic_cmpxchg(te, td, _localeid(), _addr(), ret, c_memory_order(success), c_memory_order(failure));
       if !ret then expected = te:bool;
       return ret:bool;
     }
 
     inline proc compareExchangeWeak(ref expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchange(expected, desired, order);
+    }
+    inline proc compareExchangeWeak(ref expected:bool, desired:bool, param success: memoryOrder, param failure: memoryOrder): bool {
+      return this.compareExchange(expected, desired, success, failure);
     }
 
     inline proc compareAndSwap(expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
@@ -178,20 +184,25 @@ module NetworkAtomics {
     }
 
     inline proc compareExchange(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
+      return this.compareExchange(expected, desired, order, readableOrder(order));
+    }
+    inline proc compareExchange(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
       pragma "insert line file info" extern externFunc("cmpxchg", T)
         proc atomic_cmpxchg(ref expected:T, ref desired:T, l:int(32), obj:c_void_ptr, ref result:bool(32), succ:memory_order, fail:memory_order): void;
 
       var te = expected;
       var ret:bool(32);
       var td = desired;
-      atomic_cmpxchg(te, td, _localeid(), _addr(), ret, c_memory_order(order), c_memory_order(readableOrder(order)));
+      atomic_cmpxchg(te, td, _localeid(), _addr(), ret, c_memory_order(success), c_memory_order(failure));
       if !ret then expected = te;
       return ret:bool;
-
     }
 
     inline proc compareExchangeWeak(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchange(expected, desired, order);
+    }
+    inline proc compareExchangeWeak(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
+      return this.compareExchange(expected, desired, success, failure);
     }
 
     inline proc compareAndSwap(expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {

--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -46,24 +46,28 @@ proc testOrderAtomicBool(a, ref i, ref b, param o: memoryOrder) {
   param t = true, f = false;
 
   writeln("Testing 'atomic bool' with order '", o, "':");
-                                                                writea  ("init    ", a);
-                var initval : a.type = true;                    writeai ("init=   ", a, initval);
-                var initval2 : a.type = initval;                writeai ("init=(v)", a, initval2);
-                var initval3 = initval;                         writeai ("init=(v)", a, initval3);
+                                                                     writea  ("init    ", a);
+                var initval : a.type = true;                         writeai ("init=   ", a, initval);
+                var initval2 : a.type = initval;                     writeai ("init=(v)", a, initval2);
+                var initval3 = initval;                              writeai ("init=(v)", a, initval3);
                 assert(initval3.type == atomic bool);
-                i = a.read(o);                                  writeai ("read    ", a, i);
-                    a.write(t, o);                              writea  ("write   ", a);
-                i = a.exchange(f, o);                           writeai ("xchg    ", a, i);
-                var x = true;                                   writex  ("expected", x);
-                b = a.compareExchange(x, t, o);                 writeabx("cmpxchg ", a, b, x);
-                b = a.compareExchange(x, t, o);                 writeabx("cmpxchg ", a, b, x);
-                b = a.compareExchangeWeak(x, f, o);             writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, f, o); while n(b); writeabx("cmpxchgW", a, b, x);
-                b = a.compareAndSwap(t, t, o);                  writeab ("cas     ", a, b);
-                b = a.compareAndSwap(f, t, o);                  writeab ("cas     ", a, b);
-                i = a.testAndSet(o);                            writeai ("test&Set", a, i);
-                    a.clear(o);                                 writea  ("clear   ", a);
-  asyncSet(a);      a.waitFor(true, o);                         writea  ("waitFor ", a);
+                i = a.read(o);                                       writeai ("read    ", a, i);
+                    a.write(t, o);                                   writea  ("write   ", a);
+                i = a.exchange(f, o);                                writeai ("xchg    ", a, i);
+                var x = true;                                        writex  ("expected", x);
+                b = a.compareExchange(x, t, o);                      writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchange(x, t, o);                      writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchange(x, f, o, o);                   writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchange(x, f, o, o);                   writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchangeWeak(x, t, o);                  writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, t, o); while n(b);      writeabx("cmpxchgW", a, b, x);
+                b = a.compareExchangeWeak(x, f, o, o);               writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, f, o, o); while n(b);   writeabx("cmpxchgW", a, b, x);
+                b = a.compareAndSwap(t, t, o);                       writeab ("cas     ", a, b);
+                b = a.compareAndSwap(f, t, o);                       writeab ("cas     ", a, b);
+                i = a.testAndSet(o);                                 writeai ("test&Set", a, i);
+                    a.clear(o);                                      writea  ("clear   ", a);
+  asyncSet(a);      a.waitFor(true, o);                              writea  ("waitFor ", a);
   writeln();
 }
 
@@ -109,34 +113,38 @@ proc testOrderAtomicT(a, ref i, ref b, type basetype, param o: memoryOrder) {
   type xType = if isArray(a) then [a.domain] basetype else basetype;
 
   writeln("Testing 'atomic ", basetype:string, "' with order '", o, "':");
-                                                                writea  ("init    ", a);
+                                                                     writea  ("init    ", a);
                 if isArray(a) == false {
-                  var initval : a.type = 1;                     writeai ("init=   ", a, initval);
-                  var initval2 : a.type = initval;              writeai ("init=(v)", a, initval2);
-                  var initval3 = initval;                       writeai ("init=(v)", a, initval3);
+                  var initval : a.type = 1;                          writeai ("init=   ", a, initval);
+                  var initval2 : a.type = initval;                   writeai ("init=(v)", a, initval2);
+                  var initval3 = initval;                            writeai ("init=(v)", a, initval3);
                   assert(initval3.type == atomic basetype);     
                 }
-                i = a.read(o);                                  writeai ("read    ", a, i);
-                    a.write(1, o);                              writea  ("write   ", a);
-                i = a.exchange(2, o);                           writeai ("xchg    ", a, i);
-                var x: xType = 3:basetype;                      writex  ("expected", x);
-                b = a.compareExchange(x, 4, o);                 writeabx("cmpxchg ", a, b, x);
-                b = a.compareExchange(x, 4, o);                 writeabx("cmpxchg ", a, b, x);
-                b = a.compareExchangeWeak(x, 2, o);             writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, 2, o); while n(b); writeabx("cmpxchgW", a, b, x);
-                b = a.compareAndSwap(1, 5, o);                  writeab ("cas     ", a, b);
-                b = a.compareAndSwap(2, 5, o);                  writeab ("cas     ", a, b);
-                i = a.fetchAdd(1, o);                           writeai ("fetchAdd", a, i);
-                    a.add(1, o);                                writea  ("add     ", a);
-                i = a.fetchSub(1, o);                           writeai ("fetchSub", a, i);
-                    a.sub(1, o);                                writea  ("sub     ", a);
-  if isInt {    i = a.fetchOr(8, o);                            writeai ("fetchOr ", a, i);   }
-  if isInt {        a.or(10, o);                                writea  ("or      ", a);      }
-  if isInt {    i = a.fetchAnd(7, o);                           writeai ("fetchAnd", a, i);   }
-  if isInt {        a.and(5, o);                                writea  ("and     ", a);      }
-  if isInt {    i = a.fetchXor(5, o);                           writeai ("fetchXor", a, i);   }
-  if isInt {        a.xor(5, o);                                writea  ("xor     ", a);      }
-  asyncAdd(a);      a.waitFor(6, o);                            writea  ("waitFor ", a);
+                i = a.read(o);                                       writeai ("read    ", a, i);
+                    a.write(1, o);                                   writea  ("write   ", a);
+                i = a.exchange(2, o);                                writeai ("xchg    ", a, i);
+                var x: xType = 3:basetype;                           writex  ("expected", x);
+                b = a.compareExchange(x, 4, o);                      writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchange(x, 4, o);                      writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchange(x, 2, o, o);                   writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchange(x, 2, o, o);                   writeabx("cmpxchg ", a, b, x);
+                b = a.compareExchangeWeak(x, 4, o, o);               writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, 4, o, o); while n(b);   writeabx("cmpxchgW", a, b, x);
+                b = a.compareExchangeWeak(x, 2, o);                  writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, 2, o); while n(b);      writeabx("cmpxchgW", a, b, x);
+                b = a.compareAndSwap(1, 5, o);                       writeab ("cas     ", a, b);
+                b = a.compareAndSwap(2, 5, o);                       writeab ("cas     ", a, b);
+                i = a.fetchAdd(1, o);                                writeai ("fetchAdd", a, i);
+                    a.add(1, o);                                     writea  ("add     ", a);
+                i = a.fetchSub(1, o);                                writeai ("fetchSub", a, i);
+                    a.sub(1, o);                                     writea  ("sub     ", a);
+  if isInt {    i = a.fetchOr(8, o);                                 writeai ("fetchOr ", a, i);   }
+  if isInt {        a.or(10, o);                                     writea  ("or      ", a);      }
+  if isInt {    i = a.fetchAnd(7, o);                                writeai ("fetchAnd", a, i);   }
+  if isInt {        a.and(5, o);                                     writea  ("and     ", a);      }
+  if isInt {    i = a.fetchXor(5, o);                                writeai ("fetchXor", a, i);   }
+  if isInt {        a.xor(5, o);                                     writea  ("xor     ", a);      }
+  asyncAdd(a);      a.waitFor(6, o);                                 writea  ("waitFor ", a);
   writeln();
 }
 

--- a/test/runtime/configMatters/comm/atomics-api.good
+++ b/test/runtime/configMatters/comm/atomics-api.good
@@ -28,6 +28,10 @@ Testing 'atomic bool' with order 'seqCst':
   expected    x=true
   cmpxchg     a=false, b=false, x=false
   cmpxchg     a=true, b=true, x=false
+  cmpxchg     a=true, b=false, x=true
+  cmpxchg     a=false, b=true, x=true
+  cmpxchgW    a=false, b=false, x=false
+  cmpxchgW    a=true, b=true, x=false
   cmpxchgW    a=true, b=false, x=true
   cmpxchgW    a=false, b=true, x=true
   cas         a=false, b=false
@@ -74,6 +78,10 @@ Testing 'atomic int(8)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -128,6 +136,10 @@ Testing 'atomic int(16)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -182,6 +194,10 @@ Testing 'atomic int(32)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -236,6 +252,10 @@ Testing 'atomic int(64)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -290,6 +310,10 @@ Testing 'atomic int(64)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -344,6 +368,10 @@ Testing 'atomic uint(8)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -398,6 +426,10 @@ Testing 'atomic uint(16)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -452,6 +484,10 @@ Testing 'atomic uint(32)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -506,6 +542,10 @@ Testing 'atomic uint(64)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -560,6 +600,10 @@ Testing 'atomic uint(64)' with order 'seqCst':
   expected    x=3
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
+  cmpxchg     a=4, b=false, x=4
+  cmpxchg     a=2, b=true, x=4
+  cmpxchgW    a=2, b=false, x=2
+  cmpxchgW    a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
   cmpxchgW    a=2, b=true, x=4
   cas         a=2, b=false
@@ -608,6 +652,10 @@ Testing 'atomic real(32)' with order 'seqCst':
   expected    x=3.0
   cmpxchg     a=2.0, b=false, x=2.0
   cmpxchg     a=4.0, b=true, x=2.0
+  cmpxchg     a=4.0, b=false, x=4.0
+  cmpxchg     a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=false, x=2.0
+  cmpxchgW    a=4.0, b=true, x=2.0
   cmpxchgW    a=4.0, b=false, x=4.0
   cmpxchgW    a=2.0, b=true, x=4.0
   cas         a=2.0, b=false
@@ -650,6 +698,10 @@ Testing 'atomic real(64)' with order 'seqCst':
   expected    x=3.0
   cmpxchg     a=2.0, b=false, x=2.0
   cmpxchg     a=4.0, b=true, x=2.0
+  cmpxchg     a=4.0, b=false, x=4.0
+  cmpxchg     a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=false, x=2.0
+  cmpxchgW    a=4.0, b=true, x=2.0
   cmpxchgW    a=4.0, b=false, x=4.0
   cmpxchgW    a=2.0, b=true, x=4.0
   cas         a=2.0, b=false
@@ -692,6 +744,10 @@ Testing 'atomic real(64)' with order 'seqCst':
   expected    x=3.0
   cmpxchg     a=2.0, b=false, x=2.0
   cmpxchg     a=4.0, b=true, x=2.0
+  cmpxchg     a=4.0, b=false, x=4.0
+  cmpxchg     a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=false, x=2.0
+  cmpxchgW    a=4.0, b=true, x=2.0
   cmpxchgW    a=4.0, b=false, x=4.0
   cmpxchgW    a=2.0, b=true, x=4.0
   cas         a=2.0, b=false
@@ -734,6 +790,10 @@ Testing 'atomic int(64)' with order 'seqCst':
   expected    x=3 3 3
   cmpxchg     a=2 2 2, b=false false false, x=2 2 2
   cmpxchg     a=4 4 4, b=true true true, x=2 2 2
+  cmpxchg     a=4 4 4, b=false false false, x=4 4 4
+  cmpxchg     a=2 2 2, b=true true true, x=4 4 4
+  cmpxchgW    a=2 2 2, b=false false false, x=2 2 2
+  cmpxchgW    a=4 4 4, b=true true true, x=2 2 2
   cmpxchgW    a=4 4 4, b=false false false, x=4 4 4
   cmpxchgW    a=2 2 2, b=true true true, x=4 4 4
   cas         a=2 2 2, b=false false false


### PR DESCRIPTION
Most atomic methods just take a single memory order, but compareExchange
can benefit from using different memory orders on success and failure.
Add an overload that takes two memory orders, which matches C++.

Update the spec to include compareExchange now that we've finalized the
API. While doing that I noticed the spec was missing `param` on the
memory orders.

Closes https://github.com/chapel-lang/chapel/issues/14953