### PR TITLE
Really fix the args and testVerboseFlag tests for slurm-srun launcher.

### DIFF
--- a/test/execflags/ferguson/args.prediff
+++ b/test/execflags/ferguson/args.prediff
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Throw out any --waltime argument (added by sub_test).
-sed "s/ --walltime=[^ ]*//" $2 > $2.tmp &&
+grep -v "^--walltime=" $2 > $2.tmp &&
 mv $2.tmp $2

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
@@ -1,1 +1,1 @@
-EVARS=vals srun --job-name=CHPL-testVerboseFlag --quiet --nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N --exclusive --mem=0 --kill-on-bad-exit --partition=P  ./testVerboseFlag_real -v -nl 1 EXECOPTS
+EVARS=vals srun --job-name=CHPL-testVerbos --quiet --nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N --exclusive --mem=0 --kill-on-bad-exit --partition=P  ./testVerboseFlag_real --verbose -nl 1 EXECOPTS


### PR DESCRIPTION
My "fixes" in #14919 for running the args and testVerboseFlag tests with
the slurm-srun launcher were quite broken.  I'm not sure what happened,
but I suspect I tested them with a different launcher configured and so
didn't really exercise them at all.  Here, fix them for real (I hope).