### PR TITLE
Update a .bad file

### DIFF
--- a/test/users/npadmana/twopt/do_smu_soa-error.bad
+++ b/test/users/npadmana/twopt/do_smu_soa-error.bad
@@ -1,2 +1,5 @@
+do_smu_soa-error.chpl:294: In function 'doPairs':
+do_smu_soa-error.chpl:299: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
+do_smu_soa-error.chpl:299: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
 do_smu_soa-error.chpl:303: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
 do_smu_soa-error.chpl:303: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias


### PR DESCRIPTION
PR #14835 added `test/users/npadmana/twopt/do_smu_soa-error.bad`
(for issue #14942) but didn't quite have the current output in
the .bad file. This PR fixes that.

Trivial and not reviewed.