### PR TITLE
Allow string-by-def regexps with warning

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6961,7 +6961,7 @@ proc channel._ch_handle_captures(matches:_ddata(qio_regexp_string_piece_t),
 
 // documented in the error= captures version
 pragma "no doc"
-proc channel.search(re:regexp, ref error:syserr):reMatch
+proc channel.search(re:regexp(?), ref error:syserr):reMatch
 {
   var m:reMatch;
   on this.home {
@@ -7002,7 +7002,7 @@ proc channel.search(re:regexp, ref error:syserr):reMatch
 
 // documented in the error= version
 pragma "no doc"
-proc channel.search(re:regexp):reMatch throws
+proc channel.search(re:regexp(?)):reMatch throws
 {
   var e:syserr = ENOERR;
   var ret = this.search(re, error=e);
@@ -7025,7 +7025,7 @@ proc channel.search(re:regexp):reMatch throws
                    in the regular expression.
     :returns: the region of the channel that matched
  */
-proc channel.search(re:regexp, ref captures ...?k): reMatch throws
+proc channel.search(re:regexp(?), ref captures ...?k): reMatch throws
 {
   var m:reMatch;
   var err:syserr = ENOERR;
@@ -7069,7 +7069,7 @@ proc channel.search(re:regexp, ref captures ...?k): reMatch throws
 
 // documented in the capture group version
 pragma "no doc"
-proc channel.match(re:regexp, ref error:syserr):reMatch
+proc channel.match(re:regexp(?), ref error:syserr):reMatch
 {
   var m:reMatch;
   on this.home {
@@ -7109,7 +7109,7 @@ proc channel.match(re:regexp, ref error:syserr):reMatch
 
 // documented in the error= version
 pragma "no doc"
-proc channel.match(re:regexp):reMatch throws
+proc channel.match(re:regexp(?)):reMatch throws
 {
   var e:syserr = ENOERR;
   var ret = this.match(re, error=e);
@@ -7131,7 +7131,7 @@ proc channel.match(re:regexp):reMatch throws
    :returns: the region of the channel that matched
  */
 
-proc channel.match(re:regexp, ref captures ...?k, ref error:syserr):reMatch
+proc channel.match(re:regexp(?), ref captures ...?k, ref error:syserr):reMatch
 {
   var m:reMatch;
   on this.home {
@@ -7173,7 +7173,7 @@ proc channel.match(re:regexp, ref captures ...?k, ref error:syserr):reMatch
 }
 // documented in the error= version
 pragma "no doc"
-proc channel.match(re:regexp, ref captures ...?k):reMatch throws
+proc channel.match(re:regexp(?), ref captures ...?k):reMatch throws
 {
   var e:syserr = ENOERR;
   var ret = this.match(re, (...captures), error=e);
@@ -7210,7 +7210,7 @@ proc channel.match(re:regexp, ref captures ...?k):reMatch throws
    :yields: tuples of :record:`Regexp.reMatch` objects, where the first element
             is the whole pattern.  The tuples will have 1+captures elements.
  */
-iter channel.matches(re:regexp, param captures=0, maxmatches:int = max(int))
+iter channel.matches(re:regexp(?), param captures=0, maxmatches:int = max(int))
 // TODO: should be throws
 {
   var m:reMatch;

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -571,6 +571,13 @@ proc bytes.this(m:reMatch) {
 
  private use IO;
 
+pragma "no doc"
+proc warnIfNoDefArg() type {
+  compilerWarning("string-by-default regexp is deprecated. ",
+                  "Use regexp(string) or regexp(bytes) instead.");
+  return string;
+}
+
 /*  This class represents a compiled regular expression. Regular expressions
     are currently cached on a per-thread basis and are reference counted.
     To create a compiled regular expression, use the proc:`compile` function.
@@ -583,7 +590,7 @@ pragma "ignore noinit"
 record regexp {
 
   pragma "no doc"
-  type exprType;
+  type exprType = warnIfNoDefArg();
   pragma "no doc"
   var home: locale = here;
   pragma "no doc"

--- a/test/deprecated/regexpListEltType.chpl
+++ b/test/deprecated/regexpListEltType.chpl
@@ -1,0 +1,5 @@
+use List;
+use Regexp;
+
+var l: list(regexp);
+writeln(l.eltType:string);

--- a/test/deprecated/regexpListEltType.good
+++ b/test/deprecated/regexpListEltType.good
@@ -1,0 +1,2 @@
+$CHPL_HOME/modules/standard/Regexp.chpl:593: warning: string-by-default regexp is deprecated. Use regexp(string) or regexp(bytes) instead.
+regexp(string)

--- a/test/deprecated/regexpListEltType.skipif
+++ b/test/deprecated/regexpListEltType.skipif
@@ -1,0 +1,1 @@
+CHPL_REGEXP!=re2

--- a/test/deprecated/regexpType.chpl
+++ b/test/deprecated/regexpType.chpl
@@ -1,0 +1,5 @@
+use Regexp;
+
+var r: regexp;
+writeln(r.type:string);
+

--- a/test/deprecated/regexpType.good
+++ b/test/deprecated/regexpType.good
@@ -1,0 +1,2 @@
+$CHPL_HOME/modules/standard/Regexp.chpl:593: warning: string-by-default regexp is deprecated. Use regexp(string) or regexp(bytes) instead.
+regexp(string)

--- a/test/deprecated/regexpType.skipif
+++ b/test/deprecated/regexpType.skipif
@@ -1,0 +1,1 @@
+CHPL_REGEXP!=re2


### PR DESCRIPTION
This PR makes `string` default for `regexp` with a deprecation warning for 1.21

Resolves #14693
Resolves #14895

`regexp`s were string-based until #14686 made them generic to support bytes and
strings. Under #14693, we reached a consensus that generic `regexp` is what we
want going forward, but we need to support `regexp` with string-by-default type
for 1.21 with a deprecation warning.

This PR also adds deprecation tests

Test:
- [x] standard local
- [x] standard gasnet
