### PR TITLE
Skip this test on a platform other than linux64

### DIFF
--- a/test/chpldoc/compflags/version/SKIPIF
+++ b/test/chpldoc/compflags/version/SKIPIF
@@ -1,1 +1,2 @@
+# Avoids an issue where the lack of a trailing newline is not respected on darwin
 CHPL_HOST_PLATFORM != linux64

--- a/test/chpldoc/compflags/version/SKIPIF
+++ b/test/chpldoc/compflags/version/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_HOST_PLATFORM != linux64


### PR DESCRIPTION
I know something is up with darwin, but due to testing weirdness can't
verify that it doesn't impact cygwin as well, so just limit this
directory to linux64 where I know it works until we figure out how
to fix it.

I wasn't able to easily determine what was going on in sub_test itself, but
the file being included due to the .catfiles is identical on both systems,
and is generated by Sphinx rather than the Chapel compiler (so not within
our control).  Additionally, the other generated files with the information
were ones that will vary in the future depending on third-party version
stuff, so using them instead of that file is not reasonable.  The final option
I considered was writing a prediff to limit the output to only the part of
the file that we care about - this is the best solution (other than fixing
sub_test), but not one I have time for right now.