### PR TITLE
Update Mason/TOML to handle changes from #14846

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -737,7 +737,7 @@ used to recursively hold tables and respective values
       return false;
     }
 
-    proc set(tbl: string, toml: unmanaged Toml) {
+    proc set(tbl: string, toml: unmanaged Toml?) {
       ref t = this(tbl);
       if t == nil {
         t = toml;
@@ -746,6 +746,7 @@ used to recursively hold tables and respective values
         t = toml;
       }
     }
+
     proc set(tbl: string, s: string) {
       ref t = this(tbl);
       if t == nil {


### PR DESCRIPTION
Fix conflicts between https://github.com/chapel-lang/chapel/pull/14846 and https://github.com/chapel-lang/chapel/pull/14820 that was causing `make mason` to fail.

Changes include:

- Updating `TOML.set()` to expect an nilable TOML
- Using `pathExists` instead of comparing against `nil` for the non-nilable `tomlFile` instances in `MasonInit`
- Added a few `if show` checks to output that should be verbose only
- some other small clean-ups (consistent spacing, whitespace)