### PR TITLE
Adjust encode/decode related interface

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1081,6 +1081,20 @@ module Bytes {
       return decodeByteBuffer(localThis.buff, localThis.len, errors);
     }
 
+    // just to capture the deprecated decodePolicy.ignore and give a compiler
+    // warning
+    pragma "no doc"
+    proc decode(param errors=decodePolicy.strict): string throws {
+      if errors == decodePolicy.ignore then
+        compilerWarning("decodePolicy.ignore is deprecated. ",
+                        "Use decodePolicy.drop instead");
+
+      // have to repeat this as above to avoid recursion. That's the cleanest
+      // way I could think of.
+      var localThis: bytes = this.localize();
+      return decodeByteBuffer(localThis.buff, localThis.len, errors);
+    }
+
     /*
      Checks if all the characters in the :record:`bytes` are uppercase (A-Z) in
      ASCII.  Ignores uncased (not a letter) and extended ASCII characters

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1066,7 +1066,7 @@ module Bytes {
       
       :arg policy: `decodePolicy.strict` raises an error, `decodePolicy.replace`
                    replaces the malformed character with UTF-8 replacement
-                   character, `decodePolicy.ignore` drops the data silently,
+                   character, `decodePolicy.drop` drops the data silently,
                    `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
       

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1062,29 +1062,41 @@ module Bytes {
 
     /*
       Returns a UTF-8 string from the given :record:`bytes`. If the data is
-      malformed for UTF-8, `errors` argument determines the action.
+      malformed for UTF-8, `policy` argument determines the action.
       
-      :arg errors: `decodePolicy.strict` raises an error, `decodePolicy.replace`
+      :arg policy: `decodePolicy.strict` raises an error, `decodePolicy.replace`
                    replaces the malformed character with UTF-8 replacement
                    character, `decodePolicy.ignore` drops the data silently,
                    `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
       
-      :throws: `DecodeError` if `decodePolicy.strict` is passed to the `errors`
+      :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
                argument and the :record:`bytes` contains non-UTF-8 characters.
 
       :returns: A UTF-8 string.
     */
     // NOTE: In the future this could support more encodings.
-    proc decode(errors=decodePolicy.strict): string throws {
+    proc decode(policy=decodePolicy.strict): string throws {
       var localThis: bytes = this.localize();
-      return decodeByteBuffer(localThis.buff, localThis.len, errors);
+      return decodeByteBuffer(localThis.buff, localThis.len, policy);
+    }
+
+    // to capture the deprecated formal name "errors"
+    pragma "no doc"
+    pragma "last resort"
+    proc decode(errors=decodePolicy.strict): string throws {
+      compilerWarning("'errors' argument to bytes.decode is deprecated. ",
+                      "Use 'policy' instead.");
+      return this.decode(policy=errors);
     }
 
     // just to capture the deprecated decodePolicy.ignore and give a compiler
     // warning
     pragma "no doc"
+    pragma "last resort"
     proc decode(param errors=decodePolicy.strict): string throws {
+      compilerWarning("'errors' argument to bytes.decode is deprecated. ",
+                      "Use 'policy' instead.");
       if errors == decodePolicy.ignore then
         compilerWarning("decodePolicy.ignore is deprecated. ",
                         "Use decodePolicy.drop instead");
@@ -1093,6 +1105,18 @@ module Bytes {
       // way I could think of.
       var localThis: bytes = this.localize();
       return decodeByteBuffer(localThis.buff, localThis.len, errors);
+    }
+
+    pragma "no doc"
+    proc decode(param policy=decodePolicy.strict): string throws {
+      if policy == decodePolicy.ignore then
+        compilerWarning("decodePolicy.ignore is deprecated. ",
+                        "Use decodePolicy.drop instead");
+
+      // have to repeat this as above to avoid recursion. That's the cleanest
+      // way I could think of.
+      var localThis: bytes = this.localize();
+      return decodeByteBuffer(localThis.buff, localThis.len, policy);
     }
 
     /*

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1094,7 +1094,7 @@ module Bytes {
     // warning
     pragma "no doc"
     pragma "last resort"
-    proc decode(param errors=decodePolicy.strict): string throws {
+    proc decode(param errors): string throws {
       compilerWarning("'errors' argument to bytes.decode is deprecated. ",
                       "Use 'policy' instead.");
       if errors == decodePolicy.ignore then
@@ -1108,7 +1108,7 @@ module Bytes {
     }
 
     pragma "no doc"
-    proc decode(param policy=decodePolicy.strict): string throws {
+    proc decode(param policy): string throws {
       if policy == decodePolicy.ignore then
         compilerWarning("decodePolicy.ignore is deprecated. ",
                         "Use decodePolicy.drop instead");

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1094,7 +1094,7 @@ module Bytes {
     // warning
     pragma "no doc"
     pragma "last resort"
-    proc decode(param errors): string throws {
+    proc decode(param errors: decodePolicy): string throws {
       compilerWarning("'errors' argument to bytes.decode is deprecated. ",
                       "Use 'policy' instead.");
       if errors == decodePolicy.ignore then
@@ -1108,7 +1108,7 @@ module Bytes {
     }
 
     pragma "no doc"
-    proc decode(param policy): string throws {
+    proc decode(param policy: decodePolicy): string throws {
       if policy == decodePolicy.ignore then
         compilerWarning("decodePolicy.ignore is deprecated. ",
                         "Use decodePolicy.drop instead");

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -45,7 +45,7 @@ module BytesCasts {
       return false;
     } else {
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(decodePolicy.ignore) +
+                                           x.decode(decodePolicy.drop) +
                                            "' to bool");
     }
     return false;
@@ -125,7 +125,7 @@ module BytesCasts {
       }
       if numElements > 1 then
         throw new owned IllegalArgumentError("bad cast from bytes '" + 
-                                             x.decode(decodePolicy.ignore) +
+                                             x.decode(decodePolicy.drop) +
                                              "' to " + t:string);
 
       // remove underscores everywhere but the first position
@@ -159,7 +159,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(decodePolicy.ignore) +
+                                           x.decode(decodePolicy.drop) +
                                            "' to " + t:string);
 
     return retVal;
@@ -238,7 +238,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(decodePolicy.ignore) +
+                                           x.decode(decodePolicy.drop) +
                                            "' to real(" + numBits(t):string + ")");
 
     return retVal;
@@ -267,7 +267,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(decodePolicy.ignore) +
+                                           x.decode(decodePolicy.drop) +
                                            "' to imag(" + numBits(t):string + ")");
 
     return retVal;
@@ -325,7 +325,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(decodePolicy.ignore) +
+                                           x.decode(decodePolicy.drop) +
                                            "' to complex(" + numBits(t):string + ")");
 
     return retVal;

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -84,10 +84,10 @@ module BytesStringCommon {
 
    It iterates over the buffer, trying to decode codepoints out of it. If there
    is an illegal sequence that doesn't correspond to any valid codepoint, the
-   behavior is determined by the `errors` argument. See the `decodePolicy`
+   behavior is determined by the `policy` argument. See the `decodePolicy`
    documentation above for the meaning of different policies.
   */
-  proc decodeByteBuffer(buf: bufferType, length: int, errors: decodePolicy)
+  proc decodeByteBuffer(buf: bufferType, length: int, policy: decodePolicy)
       throws {
 
     pragma "fn synchronization free"
@@ -121,7 +121,7 @@ module BytesStringCommon {
                                             bufToDecode, maxbytes);
 
       if decodeRet != 0 {  //decoder returns error
-        if errors == decodePolicy.strict {
+        if policy == decodePolicy.strict {
           throw new owned DecodeError();
         }
         else {
@@ -134,7 +134,7 @@ module BytesStringCommon {
           const nInvalidBytes = if nbytes==1 then nbytes else nbytes-1;
           thisIdx += nInvalidBytes;
 
-          if errors == decodePolicy.replace {
+          if policy == decodePolicy.replace {
             param replChar: int(32) = 0xfffd;
 
             // Replacement can cause the string to be larger than initially
@@ -150,7 +150,7 @@ module BytesStringCommon {
 
             decodedIdx += 3;  // replacement character is 3 bytes in UTF8
           }
-          else if errors == decodePolicy.escape {
+          else if policy == decodePolicy.escape {
 
             // encoded escape sequence is 3 bytes. And this is per invalid byte
             expectedSize += 2*nInvalidBytes;
@@ -162,7 +162,7 @@ module BytesStringCommon {
               decodedIdx += 3;
             }
           }
-          // if errors == decodePolicy.ignore, we don't do anything and skip over
+          // if policy == decodePolicy.ignore, we don't do anything and skip over
           // the invalid sequence
         }
       }

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -29,11 +29,12 @@ module BytesStringCommon {
        
        - **strict**: default policy; raise error
        - **replace**: replace with UTF-8 replacement character
-       - **ignore**: silently drop data
+       - **drop**: silently drop data
        - **escape**: escape invalid data by replacing each byte 0xXX with
                      codepoint 0xDCXX
+       - **ignore**: silently drop data (Deprecated)
   */
-  enum decodePolicy { strict, replace, ignore, escape }
+  enum decodePolicy { strict, replace, drop, escape, ignore }
 
   /*
      ``encodePolicy`` specifies what happens when there is escaped non-UTF8

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -712,9 +712,9 @@ module String {
   pragma "last resort"
   pragma "no doc"
   inline proc createStringWithNewBuffer(s: c_string, length=s.size,
-                                        errors=decodePolicy.strict) throws {
+                                        policy=decodePolicy.strict) throws {
     stringFactoryArgDepr();
-    return createStringWithNewBuffer(x=s, length, errors);
+    return createStringWithNewBuffer(x=s, length, policy);
   }
 
   /*
@@ -737,7 +737,7 @@ module String {
   inline proc createStringWithNewBuffer(x: bufferType,
                                         length: int, size=length+1,
                                         policy=decodePolicy.strict) throws {
-    return decodeByteBuffer(x, length, errors);
+    return decodeByteBuffer(x, length, policy);
   }
 
   pragma "last resort"
@@ -746,7 +746,7 @@ module String {
                                         length: int, size=length+1,
                                         policy=decodePolicy.strict) throws {
     stringFactoryArgDepr();
-    return createStringWithNewBuffer(x=s, length, size, errors);
+    return createStringWithNewBuffer(x=s, length, size, policy);
   }
 
   pragma "no doc"

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -704,9 +704,9 @@ module String {
     :returns: A new `string`
   */
   inline proc createStringWithNewBuffer(x: c_string, length=x.size,
-                                        errors=decodePolicy.strict) throws {
+                                        policy=decodePolicy.strict) throws {
     return createStringWithNewBuffer(x: bufferType, length=length,
-                                     size=length+1, errors);
+                                     size=length+1, policy);
   }
 
   pragma "last resort"
@@ -736,7 +736,7 @@ module String {
   // consistence? Then, we can at least give it a default like length+1
   inline proc createStringWithNewBuffer(x: bufferType,
                                         length: int, size=length+1,
-                                        errors=decodePolicy.strict) throws {
+                                        policy=decodePolicy.strict) throws {
     return decodeByteBuffer(x, length, errors);
   }
 
@@ -744,7 +744,7 @@ module String {
   pragma "no doc"
   inline proc createStringWithNewBuffer(s: bufferType,
                                         length: int, size=length+1,
-                                        errors=decodePolicy.strict) throws {
+                                        policy=decodePolicy.strict) throws {
     stringFactoryArgDepr();
     return createStringWithNewBuffer(x=s, length, size, errors);
   }
@@ -978,19 +978,19 @@ module String {
 
     /*
       Returns a :record:`~Bytes.bytes` from the given :record:`string`. If the
-      string contains some escaped non-UTF8 bytes, `errors` argument determines
+      string contains some escaped non-UTF8 bytes, `policy` argument determines
       the action.
         
-      :arg errors: `encodePolicy.pass` directly copies the (potentially escaped)
+      :arg policy: `encodePolicy.pass` directly copies the (potentially escaped)
                     data, `encodePolicy.unescape` recovers the escaped bytes
                     back.
 
       :returns: :record:`~Bytes.bytes`
     */
-    proc encode(errors=encodePolicy.pass): bytes {
+    proc encode(policy=encodePolicy.pass): bytes {
       var localThis: string = this.localize();
 
-      if errors == encodePolicy.pass {  // just copy
+      if policy == encodePolicy.pass {  // just copy
         return createBytesWithNewBuffer(localThis.buff, localThis.numBytes);
       }
       else {  // see if there is escaped data in the string

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -159,7 +159,7 @@ extern const S_ISVTX: int;
    c_string to pass to extern file system operations.
 */
 private inline proc unescape(str: string) {
-  return str.encode(errors=encodePolicy.unescape);
+  return str.encode(policy=encodePolicy.unescape);
 }
 
 /* Change the current working directory of the locale in question to the
@@ -605,7 +605,7 @@ proc locale.cwd(): string throws {
     // c_strings can't cross on statements.
     err = chpl_fs_cwd(tmp);
     try! {
-      ret = createStringWithNewBuffer(tmp, errors=decodePolicy.escape);
+      ret = createStringWithNewBuffer(tmp, policy=decodePolicy.escape);
     }
     // tmp was qio_malloc'd by chpl_fs_cwd
     chpl_free_c_string(tmp);
@@ -894,7 +894,7 @@ private module GlobWrappers {
     try! {
       return createStringWithNewBuffer(chpl_glob_index(glb,
                                                        idx.safeCast(size_t)),
-                                       errors=decodePolicy.escape);
+                                       policy=decodePolicy.escape);
     }
   }
 
@@ -1203,7 +1203,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
       var filename: string;
       try! {
         filename = createStringWithNewBuffer(ent.d_name(),
-                                             errors=decodePolicy.escape);
+                                             policy=decodePolicy.escape);
       }
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1568,7 +1568,7 @@ proc file.path : string throws {
     chpl_free_c_string(tmp);
     if !err {
       ret = createStringWithNewBuffer(tmp2,
-                                      errors=decodePolicy.escape);
+                                      policy=decodePolicy.escape);
     }
     chpl_free_c_string(tmp2);
   }
@@ -1670,7 +1670,7 @@ proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
     try ioerror(ENOENT:syserr, "in open: path is the empty string");
 
   error = qio_file_open_access(ret._file_internal,
-                               path.encode(errors=encodePolicy.unescape).c_str(),
+                               path.encode(policy=encodePolicy.unescape).c_str(),
                                _modestring(mode).c_str(), hints, local_style);
   if error then
     try ioerror(error, "in open", path);
@@ -1724,7 +1724,7 @@ proc openplugin(pluginFile: QioPluginFile, mode:iomode,
       } else {
         // doesn't throw with decodePolicy.replace
         path = createStringWithNewBuffer(str, len,
-                                         errors=decodePolicy.replace);
+                                         policy=decodePolicy.replace);
       }
     }
 
@@ -1779,7 +1779,7 @@ proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE, style:iostyle = defaultIOStyle(
     var path_err = qio_file_path_for_fd(fd, path_cs);
     var path = if path_err then "unknown"
                            else createStringWithNewBuffer(path_cs,
-                                                          errors=decodePolicy.replace);
+                                                          policy=decodePolicy.replace);
     try ioerror(err, "in openfd", path);
   }
   return ret;
@@ -1822,7 +1822,7 @@ proc openfp(fp: _file, hints:iohints=IOHINT_NONE, style:iostyle = defaultIOStyle
     var path_err = qio_file_path_for_fp(fp, path_cs);
     var path = if path_err then "unknown"
                            else createStringWithNewBuffer(path_cs,
-                                                          errors=decodePolicy.replace);
+                                                          policy=decodePolicy.replace);
     chpl_free_c_string(path_cs);
     try ioerror(err, "in openfp", path);
   }
@@ -2152,7 +2152,7 @@ proc channel._ch_ioerror(error:syserr, msg:string) throws {
     if !err {
       // shouldn't throw
       path = createStringWithNewBuffer(tmp_path,
-                                       errors=decodePolicy.replace);
+                                       policy=decodePolicy.replace);
       chpl_free_c_string(tmp_path);
       offset = tmp_offset;
     }
@@ -2172,7 +2172,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
     if !err {
       // shouldn't throw
       path = createStringWithNewBuffer(tmp_path,
-                                       errors=decodePolicy.replace);
+                                       policy=decodePolicy.replace);
       chpl_free_c_string(tmp_path);
       offset = tmp_offset;
     }
@@ -3486,7 +3486,7 @@ proc stringify(const args ...?k):string {
         //decodePolicy.replace never throws
         try! {
           str += createStringWithNewBuffer(args[i],
-                                           errors=decodePolicy.replace);
+                                           policy=decodePolicy.replace);
         }
       } else if args[i].type == bytes {
         //decodePolicy.replace never throws

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -82,7 +82,7 @@ const pathSep = "/";
    c_string to pass to extern file system operations.
 */
 private inline proc unescape(str: string) {
-  return str.encode(errors=encodePolicy.unescape);
+  return str.encode(policy=encodePolicy.unescape);
 }
 
 /*
@@ -369,7 +369,7 @@ proc dirname(name: string): string {
            } else {
              try! {
                value = createStringWithNewBuffer(value_c,
-                                                 errors=decodePolicy.escape);
+                                                 policy=decodePolicy.escape);
              }
            }
            res += value;
@@ -390,7 +390,7 @@ proc dirname(name: string): string {
          } else {
            try! {
              value = createStringWithNewBuffer(value_c,
-                                               errors=decodePolicy.escape);
+                                               policy=decodePolicy.escape);
            }
          }
          res += value;
@@ -592,7 +592,7 @@ proc realPath(name: string): string throws {
   var res: c_string;
   var err = chpl_fs_realpath(unescape(name).c_str(), res);
   if err then try ioerror(err, "realPath", name);
-  const ret = createStringWithNewBuffer(res, errors=decodePolicy.escape);
+  const ret = createStringWithNewBuffer(res, policy=decodePolicy.escape);
   // res was qio_malloc'd by chpl_fs_realpath, so free it here
   chpl_free_c_string(res);
   return ret; 

--- a/test/types/bytes/decode.chpl
+++ b/test/types/bytes/decode.chpl
@@ -5,7 +5,7 @@
 
 config const testBytesDecode = false;
 
-proc createHelp(b: bytes, errors=decodePolicy.strict) throws {
+proc createHelp(b: bytes, param errors=decodePolicy.strict) throws {
   // call the string factory instead of decode to test the interface
   if testBytesDecode {
     return b.decode(errors);
@@ -25,7 +25,7 @@ writeln("Decoded string: ", createHelp(valid_utf8));
 assert(createHelp(valid_utf8) == unicodeStr);
 
 var invalid_utf8 = b"T\xc3\xbc\xffrk\xc3\xa7e"; // \xff is invalid
-const ignoredString = createHelp(invalid_utf8, errors=decodePolicy.ignore);
+const ignoredString = createHelp(invalid_utf8, errors=decodePolicy.drop);
 writeln("String with the ignore policy: ", ignoredString,
         " (length=", ignoredString.numBytes, ")");
 const replacedString = createHelp(invalid_utf8, errors=decodePolicy.replace);
@@ -90,7 +90,7 @@ writeln(createHelp(almostHwairToStringRepl:bytes));
 almostHwairToStringEscp = createHelp(almostHwairValidAscii, decodePolicy.escape);
 writeln("Should be 13: ", almostHwairToStringEscp.numBytes);
 
-var almostHwairToStringIgnr = createHelp(almostHwairValidAscii, decodePolicy.ignore);
+var almostHwairToStringIgnr = createHelp(almostHwairValidAscii, decodePolicy.drop);
 // number of bytes should be 4 -- only the last four must be in the string
 writeln("Should be 4: ", almostHwairToStringIgnr.numBytes);
 

--- a/test/types/string/validation/escapedFunc.chpl
+++ b/test/types/string/validation/escapedFunc.chpl
@@ -1,4 +1,4 @@
-var str = b"bAb\xffbAb".decode(errors=decodePolicy.escape);
+var str = b"bAb\xffbAb".decode(policy=decodePolicy.escape);
 
 // iterate over the string using indexing
 var idx = 1;
@@ -35,7 +35,7 @@ writeln();
 
 writeln("find/count");
 var strGood = "A";
-var strBad = b"\xff".decode(errors=decodePolicy.escape);
+var strBad = b"\xff".decode(policy=decodePolicy.escape);
 
 writeln("Should be 2: ", str.count(strGood));
 writeln("Should be 1: ", str.count(strBad));

--- a/test/types/string/validation/nonUTFEscape.chpl
+++ b/test/types/string/validation/nonUTFEscape.chpl
@@ -6,7 +6,7 @@ for b in myBytes.bytes() {
 }
 writeln();
 
-var myString = myBytes.decode(errors=decodePolicy.escape);
+var myString = myBytes.decode(policy=decodePolicy.escape);
 writeln("Escaped string bytes: ");
 for b in myString.bytes() {
   writef("Decimal: %u, Hexadecimal: %xu\n", b, b);
@@ -14,14 +14,14 @@ for b in myString.bytes() {
 writeln();
 
 writeln("Direct copy string bytes: ");
-var directBytes = myString.encode(errors=encodePolicy.pass);
+var directBytes = myString.encode(policy=encodePolicy.pass);
 for b in directBytes.bytes() {
   writeln(b);
 }
 writeln();
 
 writeln("Unescaped string bytes: ");
-var unescapedBytes = myString.encode(errors=encodePolicy.unescape);
+var unescapedBytes = myString.encode(policy=encodePolicy.unescape);
 for b in unescapedBytes.bytes() {
   writeln(b);
 }

--- a/test/types/string/validation/randomByteEscape.chpl
+++ b/test/types/string/validation/randomByteEscape.chpl
@@ -25,9 +25,9 @@ for i in 1..nIterations {
      randomEscapedString =
         if useFactory then
           createStringWithNewBuffer(buf, length=nBytes, size=nBytes+1,
-                                    errors=decodePolicy.escape)
+                                    policy=decodePolicy.escape)
         else
-          randomBytes.decode(errors=decodePolicy.escape);
+          randomBytes.decode(policy=decodePolicy.escape);
   }
   catch e: DecodeError {
     halt("Unexpected decode error");
@@ -37,7 +37,7 @@ for i in 1..nIterations {
   }
 
   // unescaped string must be equal to the initial `bytes`
-  if randomEscapedString.encode(errors=encodePolicy.unescape) != randomBytes {
+  if randomEscapedString.encode(policy=encodePolicy.unescape) != randomBytes {
     halt("Failed. Seed:", randomStream.seed, " Iteration:" , i);
   }
 }

--- a/test/types/string/validation/stress.chpl
+++ b/test/types/string/validation/stress.chpl
@@ -16,7 +16,7 @@ var chan = f.reader();
 
 var b: bytes;
 while chan.readbytes(b) {
-  writeln(b.decode(errors=decodePolicy.replace));
+  writeln(b.decode(policy=decodePolicy.replace));
 }
 chan.close();
 f.close();


### PR DESCRIPTION
This PR makes adjustments in encoding related function signatures:

Resolves #14554
Resolves #14796

- `decodePolicy.ignore` is deprecated in favor of `decodePolicy.drop`

  `bytes` methods that make use of this enum now have `param` overload that
  captures when these arguments are passed and issues a compiler warning.

  Some `string` factory functions also use this argument. But this was added
  post 1.20, so there is no deprecation warning for those.

- Changes the argument `errors` in `bytes.decode`, `string.encode` and some
  string factory functions to `policy`. Similarly, the `bytes` version has some
  overloads for deprecation warnings. `string` functions/methods are new, so
  there is no deprecation warning for those.

- Also adds few tests for the deprecation warnings.

Test:
- [x] standard local
- [x] standard gasnet