### PR TITLE
Fix a python interop bytes test

### DIFF
--- a/test/interop/python/chapelBytes/exportBytes.chpl
+++ b/test/interop/python/chapelBytes/exportBytes.chpl
@@ -2,7 +2,7 @@ use Bytes;
 
 export proc getFirstNullBytePos(in b: bytes): int {
   for i in 1..b.length do
-    if b[i].toByte() == 0x00 then
+    if b[i] == 0x00 then
       return (i - 1);
   return -1;
 }


### PR DESCRIPTION
This test failed because bytes indexing no longer returns another bytes after #14878. This PR fixes that in the test.