### PR TITLE
Fall back to plain -lpkg, when third-party 'pkg.la' doesn't satisfy.

### DIFF
--- a/util/chplenv/chpl_3p_libunwind_configs.py
+++ b/util/chplenv/chpl_3p_libunwind_configs.py
@@ -29,6 +29,6 @@ def get_link_args(unwind):
       # it doesn't include -lzma when it probably should.
       # So try to get the libraries out of libunwind.la.
       libs = third_party_utils.default_get_link_args(
-                       'libunwind', libs=['libunwind.la'])
+                       'libunwind', libs=['libunwind.la', 'libunwind-x86_64.la'])
 
     return libs

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -15,10 +15,7 @@ def get_uniq_cfg_path():
 def get_link_args():
     link_args = \
         third_party_utils.default_get_link_args('qthread',
-                                                ucp=get_uniq_cfg_path(),
-                                                libs=['libqthread_chpl.la',
-                                                      '-lchpl',
-                                                      'libqthread.la'])
+                                                ucp=get_uniq_cfg_path())
     compiler_val = chpl_compiler.get('target')
     if compiler_val == 'cray-prgenv-cray':
         link_args.append('-lrt')

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -149,4 +149,6 @@ def default_get_link_args(pkg, ucp='', libs=[]):
             all_args.extend(handle_la(la))
         else:
             all_args.append(lib_arg)
+    if all_args == []:
+        all_args.append('-l' + pkg)
     return all_args


### PR DESCRIPTION
By default when looking for third-party package libraries we search for
a `libpkg.la` libtool(1) description file, since that's what most of our
package builds produce and using it gives us not only the library itself
but also anything it depends on.  However, one user has reported that a
Chapel `make install` build didn't produce the expected .la files for
some of the third-party packages.  Undefined symbols when linking user
programs resulted.  Here, adjust the default third-party package link
argument creation to add a fallback reference to `-lpkg.a` whenever the
initial library search doesn't find anything at all.

While here, I also removed an unused library from the ones added for
CHPL_TASKS=qthreads, and got CHPL_UNWIND=libunwind working again.

This resolves https://github.com/Cray/chapel-private/issues/778.