### PR TITLE
Set CHPL_RT_OVERSUBSCRIBED in gasnet dockerfile

### DIFF
--- a/util/dockerfiles/gasnet/Dockerfile
+++ b/util/dockerfiles/gasnet/Dockerfile
@@ -1,6 +1,7 @@
 FROM chapel/chapel:latest
 
 ENV CHPL_COMM gasnet
+ENV CHPL_RT_OVERSUBSCRIBED yes
 
 RUN make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \


### PR DESCRIPTION
This is a dockerfile for local testing. Set `CHPL_RT_OVERSUBSCRIBED=yes`
to reduce overheads from concurrent Chapel instances running on a single
node.