### PR TITLE
Fix oversight where import statements were not handled in isMoreVisible

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -39,6 +39,7 @@
 #include "fixupExports.h"
 #include "ForallStmt.h"
 #include "ForLoop.h"
+#include "ImportStmt.h"
 #include "initializerResolution.h"
 #include "initializerRules.h"
 #include "iterator.h"
@@ -1697,9 +1698,12 @@ isMoreVisibleInternal(BlockStmt* block, FnSymbol* fn1, FnSymbol* fn2,
   //
   if (block && block->useList) {
     for_actuals(expr, block->useList) {
-      UseStmt* use = toUseStmt(expr);
-      INT_ASSERT(use);
-      SymExpr* se = toSymExpr(use->src);
+      SymExpr* se = NULL;
+      if (UseStmt* use = toUseStmt(expr)) {
+        se = toSymExpr(use->src);
+      } else if (ImportStmt* import = toImportStmt(expr)) {
+        se = toSymExpr(import->src);
+      }
       INT_ASSERT(se);
       // We only care about uses of modules during function resolution, not
       // uses of enums.


### PR DESCRIPTION
If this code had ever been exercised in the right way, we would encounter
an internal compiler error due to useLists containing ImportStmts as well
as UseStmts.

This wasn't noticed before because isMoreVisible is only used when other
disambiguation strategies have failed (and also there's a bug in it where we
don't follow closer use and import statements if we find a match via ones in
outer scopes, so we were never getting to scopes that had imports)

Passed full standard paratest with futures