### PR TITLE
Reduce number of iterations in a stress test

### DIFF
--- a/test/types/string/validation/randomByteEscape.chpl
+++ b/test/types/string/validation/randomByteEscape.chpl
@@ -1,7 +1,7 @@
 use Random;
 
 config const nBytes = 100000;
-config const nIterations = 100;
+config const nIterations = 25;
 config const useFactory = false;
 
 var randomStream = createRandomStream(eltType=uint(8));


### PR DESCRIPTION
This test caused timeouts in nightly valgrind testing. It timed out while the system was heavily loaded, but the execopt that finished took more than 10 minutes, too.

This PR reduces the number of iterations from 100 to 25.