### PR TITLE
Update language spec to avoid referring to global variables

### DIFF
--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -239,7 +239,8 @@ directly.
    variable ``r`` is a record and has value semantics. It exists on
    ``Locales(1)`` even though it is assigned a value on a remote locale.
 
-Global (non-distributed) constants are replicated across all locales.
+Module-scope constants that are not distributed in nature are
+replicated across all locales.
 
    *Example*.
 

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -447,8 +447,8 @@ deinitialization:
 -  If the module contains a deinitializer, which is a module-scope
    function named ``deinit()``, it is executed first.
 
--  If the module declares global variables, they are deinitialized in
-   the reverse declaration order.
+-  If the module declares module-scope variables, they are deinitialized in
+   the reverse order of their declaration.
 
 Module deinitialization order is discussed
 in :ref:`Module_Deinitialization_Order`.

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -11,8 +11,8 @@ record type is associated with only one piece of storage and has only
 one type throughout its lifetime. Storage is allocated for a variable of
 record type when the variable declaration is executed, and the record
 variable is also initialized at that time. When the record variable goes
-out of scope, or at the end of the program if it is a global, it is
-deinitialized and its storage is deallocated.
+out of scope, or at the end of the program if it is declared at module
+scope, it is deinitialized and its storage is deallocated.
 
 A record declaration statement creates a record
 type :ref:`Record_Declarations`. A variable of record type

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -574,7 +574,7 @@ Parameter constants and expressions cannot be aliased.
    .. code-block:: chapel
 
       var myInt = 51;
-      ref refInt = myInt;                   // alias of a local or global variable
+      ref refInt = myInt;                   // alias of the previous variable
       myInt = 62;
       writeln("refInt = ", refInt);
       refInt = 73;


### PR DESCRIPTION
This modifies some references to "global" variables / symbols in the
language spec, as I hold that Chapel doesn't have globals so much as
module-scope variables (that may seem global if the module is `use`d
from all other modules).  Did a slight bit of wordsmithing in one case
while here.