### PR TITLE
Restore previous Qthreads-related linking behavior.

### DIFF
--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -15,7 +15,9 @@ def get_uniq_cfg_path():
 def get_link_args():
     link_args = \
         third_party_utils.default_get_link_args('qthread',
-                                                ucp=get_uniq_cfg_path())
+                                                ucp=get_uniq_cfg_path(),
+                                                libs=['-lchpl',
+                                                      'libqthread.la'])
     compiler_val = chpl_compiler.get('target')
     if compiler_val == 'cray-prgenv-cray':
         link_args.append('-lrt')


### PR DESCRIPTION
In PR 15000 I made a seemingly minor ("while here") change to the
Qthreads-related link argument handling, which now turns out to have
been broken in two ways, one obvious and one not all so.  The obvious
breakage was that I effectively replaced the Qthreads-specific unique
config path with the default one for the purposes of finding libqthread.
Here, undo that change.

The not-nearly-so-obvious breakage was that in addition to removing a
reference to the nonexistent and unused libqthread_chpl library, I also
removed a "-lchpl" link argument immediately following that, which
should have had no effect at all.  Surprise!  It seems that this mention
of libchpl is the only one that precedes the -lqthread and -lgasnet on
the linker command line.  The only other -lchpl follows those two, and
thus adds the runtime's global references to Qthreads and GASNet symbols
to the linker's set of undefined symbols only after those libraries have
been searched.  (The linker processes each library to satisfy undefs
just once, at the time it is encountered in a left-to-right scan of its
command line.)  Here, restore that "-lchpl" also.

As a side observation this is also the reason some tests such as
interop/python/multilocale/boolFunctions won't even link with
CHPL_TASKS=fifo: without the -lchpl that chpl_3p_qthreads_configs.py
adds "early", the runtime's references to GASNet symbols don't get put
into the linker's set of undefs until after libgasnet has already been
searched.

I'll make a followup issue to look into our library ordering on the
linking command line.