### PR TITLE
Add a spinlock to the atomic runtime interface.

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -82,7 +82,7 @@ typedef uint32_t qio_hint_t;
 #endif
 
 #ifdef _chplrt_H_
-#include "chpl-tasks.h"
+#include "chpl-atomics.h"
 
 // also export iohint_t and fdflag_t
 typedef qio_hint_t iohints;
@@ -91,7 +91,7 @@ typedef qio_fdflag_t fdflag_t;
 
 // make a re-entrant lock.
 typedef struct {
-  chpl_sync_aux_t sv;
+  atomic_spinlock_t lock;
   chpl_taskID_t owner; // task ID of owner.
   uint64_t count; // how many times owner has locked.
 } qio_lock_t;
@@ -108,12 +108,12 @@ void qio_unlock(qio_lock_t* x);
 static inline qioerr qio_lock_init(qio_lock_t* x) {
   x->owner = NULL_OWNER;
   x->count = 0;
-  chpl_sync_initAux(&x->sv);
+  atomic_init_spinlock_t(&x->lock);
   return 0;
 }
 
 static inline void qio_lock_destroy(qio_lock_t* x) {
-  chpl_sync_destroyAux(&x->sv);
+  atomic_destroy_spinlock_t(&x->lock);
 }
 
 #ifdef __cplusplus

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -110,7 +110,7 @@ qioerr qio_lock(qio_lock_t* x) {
   }
 
   // we have to get the mutex.
-  chpl_sync_lock(&x->sv);
+  atomic_lock_spinlock_t(&x->lock);
 
   assert( chpl_task_idEquals(x->owner, NULL_OWNER) );
   x->count = 1;
@@ -132,7 +132,7 @@ void qio_unlock(qio_lock_t* x) {
   }
 
   x->owner = NULL_OWNER;
-  chpl_sync_unlock(&x->sv);
+  atomic_unlock_spinlock_t(&x->lock);
 }
 #endif
 


### PR DESCRIPTION
Add an optimized spinlock to the runtime and use it for I/O,
privatization, and ugni CQ acquisition.

Traditionally, we've implemented locks in the runtime on top of the
atomic layer. However, we can only implement highly optimized
test-and-test-and-set spinlocks with acquire/release orderings with
`cstdlib` atomics. Performance is pretty bad for `intrinsics` where we'd
end up with a sequentially consistent test-and-set lock, that performs
poorly under contention.

Here we implement the lock directly in the atomic layer, which allows us
to implement a test-and-test-and-set lock with acquire/release ordering
in the intrinsics backend with a load, `__sync_lock_test_and_set`, and
`__sync_lock_release`. We can also use a pthread spinlock for the locks
backend. We don't care about the performance of the locks backend very
much, but this has much better performance than implementing a lock on
top of the atomic interface.

This spinlock is always faster than a sync lock both serially and under
contention. This is similar to what we've seen before with
test-and-test-and-set locks, but previously we did not have a way to
implement this for non-cstdlib atomic backends.

Here's the performance of the new spinlock compared to a sync for gnu,
intel, and cray compilers on a 28-core XC node. Note that intel and cce
still default to intrinsics, though longer term we would like them to
use cstdlib.

The test is just doing:

```chpl
for[all] i in 1..50000000 {
  lock.lock();
  a += 1;
  lock.unlock();
}
```

Serial performance:

| config           | atomic  | sync   |
| ---------------- | ------- | ------ |
| gcc (cstdlib)    |  0.50s  |  6.90s |
| icc (intrinsics) |  1.10s  |  6.90s |
| cce (intrinsics) |  0.50s  |  6.90s |

Parallel performance:

| config           | atomic  | sync   |
| ---------------- | ------- | ------ |
| gcc (cstdlib)    |  6.50s  | 25.00s |
| icc (intrinsics) |  8.95s  | 33.50s |
| cce (intrinsics) |  6.50s  | 26.90s |

So serial performance is 7-14x faster, and contended parallel
performance is 4x faster.

---

And here's the performance of the spinlock for gnu, intel, and cray compilers
across all the atomic layers:

| config         | serial  | parallel |
| -------------- | ------- | -------- |
| gcc-cstdlib    |  0.50s  |  6.50s   |
| icc-cstdlib    |  0.50s  |  6.50s   |
| cce-cstdlib    |  0.50s  |  6.50s   |
| -------------- | ------- | -------- |
| gcc-intrinsics |  0.50s  |  6.50s   |
| icc-intrinsics |  1.00s  | 11.50s   |
| cce-intrinsics |  0.50s  |  6.50s   |
| -------------- | ------- | -------- |
| gcc-locks      |  0.50s  | 30.00s   |
| icc-locks      |  0.50s  | 30.00s   |
| cce-locks      |  0.50s  | 30.00s   |

cstdlib and locks performance is identical across all compilers. intel
intrinsics performance is behind gcc/ccce, but overall is still a huge
win over a sync lock.

Closes https://github.com/chapel-lang/chapel/issues/10141