### PR TITLE
Change default privacy of import statements to private

### DIFF
--- a/compiler/AST/ImportStmt.cpp
+++ b/compiler/AST/ImportStmt.cpp
@@ -29,7 +29,9 @@
 *                                                                             *
 ************************************** | *************************************/
 
-ImportStmt::ImportStmt(BaseAST* source) : VisibilityStmt(E_ImportStmt) {
+ImportStmt::ImportStmt(BaseAST* source,
+                       bool isPrivate) : VisibilityStmt(E_ImportStmt) {
+  this->isPrivate = isPrivate;
   this->modRename = astr("");
   if (Symbol* b = toSymbol(source)) {
     src = new SymExpr(b);
@@ -44,9 +46,10 @@ ImportStmt::ImportStmt(BaseAST* source) : VisibilityStmt(E_ImportStmt) {
   gImportStmts.add(this);
 }
 
-ImportStmt::ImportStmt(BaseAST* source,
-                       const char* rename) : VisibilityStmt(E_ImportStmt) {
+ImportStmt::ImportStmt(BaseAST* source, const char* rename,
+                       bool isPrivate) : VisibilityStmt(E_ImportStmt) {
 
+  this->isPrivate = isPrivate;
   this->modRename = astr(rename);
 
   if (Symbol* b = toSymbol(source)) {
@@ -63,7 +66,7 @@ ImportStmt::ImportStmt(BaseAST* source,
 }
 
 ImportStmt* ImportStmt::copyInner(SymbolMap* map) {
-  ImportStmt* _this = new ImportStmt(COPY_INT(src), modRename);
+  ImportStmt* _this = new ImportStmt(COPY_INT(src), modRename, isPrivate);
 
   return _this;
 }

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -551,7 +551,7 @@ BlockStmt* buildUseStmt(std::vector<PotentialRename*>* args, bool privateUse) {
 // Build an 'import' statement
 //
 BlockStmt* buildImportStmt(Expr* mod) {
-  ImportStmt* newImport = new ImportStmt(mod, false);
+  ImportStmt* newImport = new ImportStmt(mod, true);
   addModuleToSearchList(newImport, mod);
 
   return buildChapelStmt(newImport);
@@ -561,7 +561,7 @@ BlockStmt* buildImportStmt(Expr* mod) {
 // Build an 'import' statement
 //
 BlockStmt* buildImportStmt(Expr* mod, const char* rename) {
-  ImportStmt* newImport = new ImportStmt(mod, rename, false);
+  ImportStmt* newImport = new ImportStmt(mod, rename, true);
   addModuleToSearchList(newImport, mod);
 
   return buildChapelStmt(newImport);

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -551,7 +551,7 @@ BlockStmt* buildUseStmt(std::vector<PotentialRename*>* args, bool privateUse) {
 // Build an 'import' statement
 //
 BlockStmt* buildImportStmt(Expr* mod) {
-  ImportStmt* newImport = new ImportStmt(mod);
+  ImportStmt* newImport = new ImportStmt(mod, false);
   addModuleToSearchList(newImport, mod);
 
   return buildChapelStmt(newImport);
@@ -561,7 +561,7 @@ BlockStmt* buildImportStmt(Expr* mod) {
 // Build an 'import' statement
 //
 BlockStmt* buildImportStmt(Expr* mod, const char* rename) {
-  ImportStmt* newImport = new ImportStmt(mod, rename);
+  ImportStmt* newImport = new ImportStmt(mod, rename, false);
   addModuleToSearchList(newImport, mod);
 
   return buildChapelStmt(newImport);

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -551,7 +551,7 @@ BlockStmt* buildUseStmt(std::vector<PotentialRename*>* args, bool privateUse) {
 // Build an 'import' statement
 //
 BlockStmt* buildImportStmt(Expr* mod) {
-  ImportStmt* newImport = new ImportStmt(mod, true);
+  ImportStmt* newImport = new ImportStmt(mod, /* isPrivate =*/ true);
   addModuleToSearchList(newImport, mod);
 
   return buildChapelStmt(newImport);
@@ -561,7 +561,7 @@ BlockStmt* buildImportStmt(Expr* mod) {
 // Build an 'import' statement
 //
 BlockStmt* buildImportStmt(Expr* mod, const char* rename) {
-  ImportStmt* newImport = new ImportStmt(mod, rename, true);
+  ImportStmt* newImport = new ImportStmt(mod, rename, /* isPrivate =*/ true);
   addModuleToSearchList(newImport, mod);
 
   return buildChapelStmt(newImport);

--- a/compiler/include/ImportStmt.h
+++ b/compiler/include/ImportStmt.h
@@ -26,8 +26,8 @@ class ResolveScope;
 
 class ImportStmt: public VisibilityStmt {
  public:
-  ImportStmt(BaseAST* source);
-  ImportStmt(BaseAST* source, const char* rename);
+  ImportStmt(BaseAST* source, bool isPrivate);
+  ImportStmt(BaseAST* source, const char* rename, bool isPrivate);
 
   DECLARE_COPY(ImportStmt);
 

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -88,7 +88,6 @@ private:
 public:
   std::vector<const char*>           named;
   std::map<const char*, const char*> renamed;
-  bool isPrivate;
 
 private:
   bool                               except;

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -73,10 +73,11 @@ class VisibilityStmt: public Stmt {
                             Symbol* sym);
 
 public:
-  Expr*                              src;
+  Expr* src;
+  bool isPrivate;
 
 protected:
-  const char*                        modRename;
+  const char* modRename;
 
 };
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2164,7 +2164,8 @@ static void buildBreadthFirstModuleList(
                 SymExpr* importSE = toSymExpr(import->src);
                 INT_ASSERT(importSE);
 
-                if (!importSE->symbol()->hasFlag(FLAG_PRIVATE)) {
+                if (!import->isPrivate &&
+                    !importSE->symbol()->hasFlag(FLAG_PRIVATE)) {
                   // Imports of private modules are not transitive - the
                   // symbols in the private modules are only visible to itself
                   // and its immediate parent.  Therefore, if the symbol is
@@ -2174,7 +2175,13 @@ static void buildBreadthFirstModuleList(
                     next.add(import);
                     modules->add(import);
                   }
-                } else {
+                } else if (!import->isPrivate &&
+                           importSE->symbol()->hasFlag(FLAG_PRIVATE)) {
+                  // If we're skipping because the import was public, but the
+                  // module was private, then we shouldn't look at the module
+                  // again and should add it to the alreadySeen map.  Otherwise
+                  // there might be a later import or use that is public, so
+                  // we should allow it to be found
                   (*alreadySeen)[importSE->symbol()].push_back(import);
                 }
               } else {

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -549,14 +549,19 @@ static void getVisibleFunctions(const char*           name,
     if (block->useList != NULL) {
       // the block uses other modules
       for_actuals(expr, block->useList) {
-        UseStmt* use = toUseStmt(expr);
-
-        INT_ASSERT(use);
+        VisibilityStmt* vis = NULL;
+        if (UseStmt* use = toUseStmt(expr)) {
+          vis = use;
+        } else if (ImportStmt* import = toImportStmt(expr)) {
+          vis = import;
+        } else {
+          INT_FATAL("unexpected expr, expected ImportStmt or UseStmt");
+        }
 
         // Only traverse private use statements at this point.  Public use
         // statements will have already been handled the first time this scope
         // was seen
-        if (use->isPrivate) {
+        if (vis->isPrivate) {
           if (use->skipSymbolSearch(name) == false) {
             SymExpr* se = toSymExpr(use->src);
 

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -581,12 +581,12 @@ static void getVisibleFunctions(const char*           name,
                 }
               }
             }
-          } else if (isImportStmt(expr)) {
-            // Don't go into import statements to look for symbols, they only
-            // provide qualified access.
-          } else {
-            INT_FATAL("Expected ImportStmt or UseStmt");
           }
+        } else if (isImportStmt(expr)) {
+          // Don't go into import statements to look for symbols, they only
+          // provide qualified access.
+        } else {
+          INT_FATAL("Expected ImportStmt or UseStmt");
         }
       }
     }

--- a/test/visibility/import/importAndImport.good
+++ b/test/visibility/import/importAndImport.good
@@ -1,2 +1,2 @@
-4
-In A.foo()
+importAndImport.chpl:19: In function 'main':
+importAndImport.chpl:20: error: 'A' undeclared (first use this function)

--- a/test/visibility/import/useWithImports.good
+++ b/test/visibility/import/useWithImports.good
@@ -1,5 +1,2 @@
-false
-B.bar
-A.foo
-0
-A.foo
+useWithImports.chpl:21: In function 'main':
+useWithImports.chpl:24: error: 'A' undeclared (first use this function)

--- a/test/visibility/import/useWithImports2.chpl
+++ b/test/visibility/import/useWithImports2.chpl
@@ -1,0 +1,26 @@
+module A {
+  var x: int;
+  proc foo() {
+    writeln("A.foo");
+  }
+}
+
+module B {
+  import A;
+
+  var y: bool;
+  proc bar() {
+    writeln("B.bar");
+    A.foo();
+  }
+}
+
+module C {
+  use B;
+
+  proc main() {
+    writeln(y);
+    bar();
+    A.foo();
+  }
+}

--- a/test/visibility/import/useWithImports2.good
+++ b/test/visibility/import/useWithImports2.good
@@ -1,0 +1,2 @@
+useWithImports2.chpl:21: In function 'main':
+useWithImports2.chpl:24: error: 'A' undeclared (first use this function)

--- a/test/visibility/private/uses/qualified.chpl
+++ b/test/visibility/private/uses/qualified.chpl
@@ -1,0 +1,17 @@
+module A {
+  var x = 2;
+}
+
+module B {
+  private use A;
+
+  var y: bool;
+}
+
+module C {
+  use B;
+
+  proc main() {
+    writeln(A.x);
+  }
+}

--- a/test/visibility/private/uses/qualified.good
+++ b/test/visibility/private/uses/qualified.good
@@ -1,0 +1,2 @@
+qualified.chpl:14: In function 'main':
+qualified.chpl:15: error: 'A' undeclared (first use this function)


### PR DESCRIPTION
My initial implementation had them public, but between: 
- questions about re-exporting and interactions with use statement chains, and
- private being the default for most use statements now, and
- private -> public being a less breaking language change than public -> private
it seemed like having them be private by default was the better call.

This PR puts in some support for privacy controls on import statements, but
doesn't fully implement it.  There is now a shared `isPrivate` field on the
parent type, VisibilityStmt, and ImportStmts takes it as an argument, but build.cpp
hard-codes the value that is sent.  Eventually, the private keyword will cause
it to send true, making the decision happen in chapel.ypp.  Scope resolution
now checks the privacy of the ImportStmt before adding it to the breadth first
module list, and has support to avoid private imports of a module hiding later
public uses or public imports.

I also found another spot where I had failed to account for useLists having
ImportStmts as well as UseStmts.  Sigh.  I'm going to open an issue to start
converting `use M only;` and `use M except *;` in the standard/internal/package
modules into import statements, which will help us to catch more of these
cases (but hopefully there aren't any more).

Resolves Cray/chapel-private#788

Test changes:
Changes the expected behavior for test/visibility/import/importAndImport.chpl
and test/visibility/import/useWithImports.chpl.  Adds a second variant of
useWithImports to ensure that qualified access of functions are treated the same
as qualified access of global variables due to this change.  Also adds a test of
qualified access with private uses, since I think I had forgotten to make that a test
before.

Testing:
- [x] full standard paratest with futures