### PR TITLE
Fix a multilocale python interop bytes test 

### DIFF
--- a/test/interop/python/multilocale/chapelBytes/exportBytes.chpl
+++ b/test/interop/python/multilocale/chapelBytes/exportBytes.chpl
@@ -2,7 +2,7 @@ use Bytes;
 
 export proc getFirstNullBytePos(in b: bytes): int {
   for i in 1..b.length do
-    if b[i].toByte() == 0x00 then
+    if b[i] == 0x00 then
       return (i - 1);
   return -1;
 }


### PR DESCRIPTION
I missed that there is a multilocale test that it identical to what I fixed with #14992 

This PR fixes that multilocale correctness test