### PR TITLE
Add perf annotations for 2020-02-28

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -417,6 +417,11 @@ all:
   02/19/20:
     - text:  Serialize calls to gasnet_AMPoll for IBV/Aries (#14912)
       config: 16 node XC, 16-node-cs
+  02/21/20:
+    - text: Poll for AMs on every call to gasnet_AMPoll for Aries (#14938)
+      config: 16 node XC
+  02/28/20:
+    - Add a spinlock to the atomic runtime interface. (#15015)
 
 
 AllCompTime:
@@ -633,6 +638,32 @@ create-views:
 cs-resize:
   03/05/19:
     - Add radix sort to Sort package module (#12452)
+
+distCreate-arrays-deinit.cc-perf: &distCreate-base
+  02/12/20:
+    - Use --no-early-deinit in array creation/destruction benchmark (#14876)
+distCreate-arrays-init.cc-perf:
+  <<: *distCreate-base
+distCreate-domains-deinit.cc-perf:
+  <<: *distCreate-base
+distCreate-domains-deinit.ml-perf:
+  <<: *distCreate-base
+distCreate-domains-init.cc-perf:
+  <<: *distCreate-base
+distCreate-domains-init.ml-perf:
+  <<: *distCreate-base
+distCreate-large-deinit.ml-perf:
+  <<: *distCreate-base
+distCreate-large-init.ml-perf:
+  <<: *distCreate-base
+distCreate-small-deinit.ml-perf:
+  <<: *distCreate-base
+distCreate-small-init.ml-perf:
+  <<: *distCreate-base
+distCreate-tiny-deinit.ml-perf:
+  <<: *distCreate-base
+distCreate-tiny-init.ml-perf:
+  <<: *distCreate-base
 
 domainAssignment-similar: &domainAssign-base
   10/26/19:
@@ -1179,8 +1210,10 @@ memleaksfull:
     - Propagate user thrown errors out of IO routines (#14739)
   01/30/20:
     - Adjust split init to allow some try, if with returns (#14814)
-  02/19/20:
-    -  Use escaped strings in paths (#14907)
+  02/20/20:
+    - Use escaped strings in paths (#14907)
+  02/26/20:
+    - Closes memory leaks introduced by 14907 (#14959)
 
 meteor:
   12/18/13:
@@ -1362,6 +1395,8 @@ ra:
 ra.ml-perf:
   09/19/17:
     - machine changes, cannot reproduce old numbers
+  02/28/20:
+    - Use localAccess for ra-on (#15001)
 
 ra-atomics.ml-perf:
   10/03/17:


### PR DESCRIPTION
Add annotations for:
 - [I/O improvements](https://chapel-lang.org/perf/chapcs/?startdate=2018/06/08&enddate=2020/03/11&graphs=parboilbfsexecutiontime,parboilsadserialexecutiontime,timetotreepaircount,cvschplwritingsinglenewlinestostdout) from optimized runtime spinlock (#15015)
 - [RA-on improvement](https://chapel-lang.org/perf/16-node-xc/?startdate=2020/02/22&enddate=2020/03/01&graphs=hpccraonperfgupsn233) from switching to localAccess (#15001)
 - [gasnet-aries AM improvements](https://chapel-lang.org/perf/16-node-xc/?startdate=2020/02/17&enddate=2020/02/24&graphs=hpcchplreleaseperfgflopsn255nb32,emptyremotetaskspawntime,remotetaskspawntime) from AM optimization (#14938)
 - [memory leak fix](https://chapel-lang.org/perf/chapcs/?startdate=2020/02/15&enddate=2020/02/28&graphs=memoryleaksforalltests,numberoftestswithleaks) (#14959)
 - [domain destruction](https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2019/12/31&enddate=2020/02/26&suite=domainarraycreation) test fix (#14876)