### PR TITLE
Add CLEANFILES to mason init tests

### DIFF
--- a/test/mason/masonInit/CLEANFILES
+++ b/test/mason/masonInit/CLEANFILES
@@ -1,0 +1,1 @@
+testSrc


### PR DESCRIPTION
This prevents test failures from breaking other tests in the same directory due to leaving `testSrc` packages lying around. (Follow-up to #14820)