### PR TITLE
Accept the changes to the comm counts for this test

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice2.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice2.chpl
@@ -4,17 +4,14 @@ module testWrapper {
 }
 
 // This test is essentially a clone of reduceSlice.chpl, but one that
-// demonstrates something surprising: When the `use` in
-// helper/reduceSlicePrivate.chpl is `private`, comm counts go up
+// demonstrated something surprising: When the `use` in
+// helper/reduceSlicePrivate.chpl was `private`, comm counts went up
 // relative to when it's `public` because the calls to:
 //
 //   canResolveMethod(dom, "chpl__serialize")
 //   canResolveMethod(arr, "chpl__serialize")
 //
-// within chpl__rvfMe() in modules/internal/ArrayViewSlice.chpl return
-// false rather than true, disabling the slice serialization
-// optimization.  The reason is that we don't resolve methods across
-// `private use` statements even if we have an object reference that
-// we've obtained legally (issue #14407).  Compare the comm counts for
-// this test to that of reduceSlice.chpl in this same directory to see
-// the difference.
+// within chpl__rvfMe() in modules/internal/ArrayViewSlice.chpl returned false
+// rather than true, disabling the slice serialization optimization.  We used to
+// not resolve methods across `private use` statements even if we had an object
+// reference that we'd obtained legally (issue #14407).

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice2.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice2.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 2, execute_on_nb = 6) (get = 44, put = 1, execute_on = 2, execute_on_fast = 2) (get = 44, put = 1, execute_on = 1, execute_on_fast = 2) (get = 44, put = 1, execute_on = 1, execute_on_fast = 2)
+(get = 3, execute_on = 2, execute_on_nb = 6) (get = 38, put = 1, execute_on = 2, execute_on_fast = 2) (get = 38, put = 1, execute_on = 1, execute_on_fast = 2) (get = 38, put = 1, execute_on = 1, execute_on_fast = 2)


### PR DESCRIPTION
This test was added in #14353 to track that private uses caused an increase in
comm counts for slices, due to preventing the resolution of methods across
`private use` statements.  Now that methods are resolved across `private use`
statements, the behavior is now in step with public uses again.