### PR TITLE
Use fast in ra_commDiags test and update comm counts

### DIFF
--- a/test/studies/hpcc/CommDiags/ra_commDiags-LCG.na-none.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags-LCG.na-none.good
@@ -3,5 +3,5 @@ Bytes per array = 8192
 Total memory required (GB) = 7.62939e-06
 Number of updates = 4096
 
-(execute_on = 768, execute_on_nb = 3) (execute_on = 768, execute_on_fast = 1) (execute_on = 768, execute_on_fast = 1) (execute_on = 768, execute_on_fast = 1)
+(get = 21, execute_on_fast = 768, execute_on_nb = 3) (get = 21, execute_on_fast = 769) (get = 21, execute_on_fast = 769) (get = 21, execute_on_fast = 769)
 Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/ra_commDiags.compopts
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.compopts
@@ -1,3 +1,3 @@
---no-warnings -O --main-module ra -suseLCG=false
---no-warnings -O --main-module ra # ra_commDiags-LCG.good
+--fast --no-warnings -O --main-module ra -suseLCG=false
+--fast --no-warnings -O --main-module ra # ra_commDiags-LCG.good
 

--- a/test/studies/hpcc/CommDiags/ra_commDiags.na-none.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.na-none.good
@@ -3,5 +3,5 @@ Bytes per array = 8192
 Total memory required (GB) = 7.62939e-06
 Number of updates = 4096
 
-(execute_on = 212, execute_on_nb = 3) (execute_on = 849, execute_on_fast = 1) (execute_on = 872, execute_on_fast = 1) (execute_on = 837, execute_on_fast = 1)
+(get = 21, execute_on_fast = 212, execute_on_nb = 3) (get = 21, execute_on_fast = 850) (get = 21, execute_on_fast = 873) (get = 21, execute_on_fast = 838)
 Validation: SUCCESS


### PR DESCRIPTION
This test started to see different comm counts. As per @ronawho and @bradcray's suggestion this PR adds the `--fast` flag to the test and updates the comm counts.