### PR TITLE
Fix RA comm counts

### DIFF
--- a/test/studies/hpcc/CommDiags/COMPOPTS
+++ b/test/studies/hpcc/CommDiags/COMPOPTS
@@ -1,1 +1,1 @@
--M../../../release/examples/benchmarks/hpcc
+-M../../../release/examples/benchmarks/hpcc --fast

--- a/test/studies/hpcc/CommDiags/ra-atomics_commDiags.compopts
+++ b/test/studies/hpcc/CommDiags/ra-atomics_commDiags.compopts
@@ -1,1 +1,1 @@
--O --main-module raAtomics
+--main-module raAtomics

--- a/test/studies/hpcc/CommDiags/ra_commDiags-LCG.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags-LCG.good
@@ -1,7 +1,0 @@
-Problem size = 1024 (2**10)
-Bytes per array = 8192
-Total memory required (GB) = 7.62939e-06
-Number of updates = 4096
-
-(execute_on = 768, execute_on_nb = 3) (execute_on = 768) (execute_on = 768) (execute_on = 768)
-Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/ra_commDiags-LCG.na-none.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags-LCG.na-none.good
@@ -1,7 +1,0 @@
-Problem size = 1024 (2**10)
-Bytes per array = 8192
-Total memory required (GB) = 7.62939e-06
-Number of updates = 4096
-
-(execute_on = 768, execute_on_nb = 3) (execute_on = 768, execute_on_fast = 1) (execute_on = 768, execute_on_fast = 1) (execute_on = 768, execute_on_fast = 1)
-Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/ra_commDiags.compopts
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.compopts
@@ -1,1 +1,1 @@
--suseOn=true --no-warnings -O --main-module ra
+-suseOn=true --no-warnings --main-module ra

--- a/test/studies/hpcc/CommDiags/ra_commDiags.compopts
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.compopts
@@ -1,3 +1,1 @@
---no-warnings -O --main-module ra -suseLCG=false
---no-warnings -O --main-module ra # ra_commDiags-LCG.good
-
+-suseOn=true --no-warnings -O --main-module ra

--- a/test/studies/hpcc/CommDiags/ra_commDiags.execopts
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.execopts
@@ -1,1 +1,1 @@
---n=10 --printStats=false
+--n=16 --N_U=4096 --printStats=false

--- a/test/studies/hpcc/CommDiags/ra_commDiags.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.good
@@ -3,5 +3,5 @@ Bytes per array = 524288
 Total memory required (GB) = 0.000488281
 Number of updates = 4096
 
-(get = 21, execute_on = 773, execute_on_nb = 3) (get = 21, execute_on = 766) (get = 21, execute_on = 780) (get = 21, execute_on = 742)
+(get = 21, execute_on_fast = 773, execute_on_nb = 3) (get = 21, execute_on_fast = 766) (get = 21, execute_on_fast = 780) (get = 21, execute_on_fast = 742)
 Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/ra_commDiags.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.good
@@ -1,7 +1,7 @@
-Problem size = 1024 (2**10)
-Bytes per array = 8192
-Total memory required (GB) = 7.62939e-06
+Problem size = 65536 (2**16)
+Bytes per array = 524288
+Total memory required (GB) = 0.000488281
 Number of updates = 4096
 
-(execute_on = 212, execute_on_nb = 3) (execute_on = 849) (execute_on = 872) (execute_on = 837)
+(get = 21, execute_on = 773, execute_on_nb = 3) (get = 21, execute_on = 766) (get = 21, execute_on = 780) (get = 21, execute_on = 742)
 Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/ra_commDiags.na-none.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.na-none.good
@@ -1,7 +1,7 @@
-Problem size = 1024 (2**10)
-Bytes per array = 8192
-Total memory required (GB) = 7.62939e-06
+Problem size = 65536 (2**16)
+Bytes per array = 524288
+Total memory required (GB) = 0.000488281
 Number of updates = 4096
 
-(execute_on = 212, execute_on_nb = 3) (execute_on = 849, execute_on_fast = 1) (execute_on = 872, execute_on_fast = 1) (execute_on = 837, execute_on_fast = 1)
+(get = 21, execute_on = 773, execute_on_nb = 3) (get = 21, execute_on = 766, execute_on_fast = 1) (get = 21, execute_on = 780, execute_on_fast = 1) (get = 21, execute_on = 742, execute_on_fast = 1)
 Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/ra_commDiags.na-none.good
+++ b/test/studies/hpcc/CommDiags/ra_commDiags.na-none.good
@@ -3,5 +3,5 @@ Bytes per array = 524288
 Total memory required (GB) = 0.000488281
 Number of updates = 4096
 
-(get = 21, execute_on = 773, execute_on_nb = 3) (get = 21, execute_on = 766, execute_on_fast = 1) (get = 21, execute_on = 780, execute_on_fast = 1) (get = 21, execute_on = 742, execute_on_fast = 1)
+(get = 21, execute_on_fast = 773, execute_on_nb = 3) (get = 21, execute_on_fast = 767) (get = 21, execute_on_fast = 781) (get = 21, execute_on_fast = 743)
 Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/stream-ep_commDiags.good
+++ b/test/studies/hpcc/CommDiags/stream-ep_commDiags.good
@@ -3,5 +3,5 @@ Bytes per array = 256
 Total memory required (GB) = 7.15256e-07
 Number of trials = 10
 
-(execute_on_nb = 3) (get = 6, put = 2) (get = 6, put = 2) (get = 6, put = 2)
+(execute_on_nb = 3) (get = 2, put = 2) (get = 2, put = 2) (get = 2, put = 2)
 Validation: SUCCESS

--- a/test/studies/hpcc/CommDiags/stream-ep_commDiags.na-none.good
+++ b/test/studies/hpcc/CommDiags/stream-ep_commDiags.na-none.good
@@ -3,5 +3,5 @@ Bytes per array = 256
 Total memory required (GB) = 7.15256e-07
 Number of trials = 10
 
-(execute_on_nb = 3) (get = 6, put = 2, execute_on_fast = 1) (get = 6, put = 2, execute_on_fast = 1) (get = 6, put = 2, execute_on_fast = 1)
+(execute_on_nb = 3) (get = 2, put = 2, execute_on_fast = 1) (get = 2, put = 2, execute_on_fast = 1) (get = 2, put = 2, execute_on_fast = 1)
 Validation: SUCCESS


### PR DESCRIPTION
Update ra_commDiags for #15001. #15001 updated RA to use localAccess and
switched `on TableDist.idxToLocale[r&indexMask]` to `on T[r&indexMask]`.
Switching the on clause added some GETs from populating the RADCache,
but we believe this code is more elegant and the number of GETs per
locale is constant.

Testing this on XC revealed that verification was failing. Increase the
table size to reduce conflicts like we did in 36c521bfab for similar
reasons and remove the non-LCG version added in 8d68e2cdc0, so
that we're testing the same config as release/examples.

While updating RA comm counts, we noticed it was still reporting
non-fast ons.  This is because we weren't throwing `--fast` and some of
our bounds checks introduce potential comm that thwarts fast-ons. Throw
--fast and update the .good files.