### PR TITLE
Fix definition of chpl_internal_error for CHPL_RT_UNIT_TEST

### DIFF
--- a/runtime/include/error.h
+++ b/runtime/include/error.h
@@ -71,8 +71,6 @@ void chpl_internal_error_v(const char *restrict format, ...)
     exit(1);                                                                   \
   } while (0)
 
-#define chpl_internal_error(message) chpl_internal_error_v("%s", message)
-
 static inline
 void chpl_internal_error_v(const char *restrict, ...)
     __attribute__((format(printf, 1, 2)));
@@ -88,6 +86,11 @@ void chpl_internal_error_v(const char *restrict format, ...) {
   va_end(ap);
 
   exit(1);
+}
+
+static inline
+void chpl_internal_error(const char*message) {
+  chpl_internal_error_v("%s", message);
 }
 #endif
 


### PR DESCRIPTION
Under `CHPL_RT_UNIT_TEST`, the definition of `chpl_internal_error` was
wrong, but it wasn't getting called before so we didn't notice. Calls to
it were introduced as a result of different `#include`'s in 15015, which
exposed the problem.