### PR TITLE
Only mark processor atomics as safe for fast-ons

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -230,7 +230,7 @@ symbolFlag( FLAG_LOCALE_PRIVATE , ypr, "locale private" , ncm )
 // narrow return value.
 symbolFlag( FLAG_LOCAL_ARGS , ypr, "local args" , "arguments and return value are narrow" )
 symbolFlag( FLAG_LOCAL_FIELD, ypr, "local field", "field is local to aggregate type" )
-symbolFlag( FLAG_LOCAL_FN , npr, "local fn" , "function is completely local (no communication)" )
+symbolFlag( FLAG_LOCAL_FN , ypr, "local fn" , "function is completely local (no communication)" )
 symbolFlag( FLAG_LOCAL_ON, npr, "local on", ncm)
 symbolFlag( FLAG_LOOP_BODY_ARGUMENT_CLASS , npr, "loop body argument class" , ncm )
 symbolFlag( FLAG_MANAGED_POINTER , ypr, "managed pointer" , "e.g. Owned and Shared" )

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -570,23 +570,6 @@ optimizeOnClauses(void) {
     return;
   }
 
-  // If we're not using locks, the extern functions in
-  // atomics are local and safe for fast on.
-  if (0 != strcmp(CHPL_ATOMICS, "locks")) {
-    forv_Vec(ModuleSymbol, module, gModuleSymbols) {
-      if( module->hasFlag(FLAG_ATOMIC_MODULE) ) {
-        std::vector<FnSymbol*> moduleFunctions =
-          module->getTopLevelFunctions(true);
-        for_vector(FnSymbol, fn, moduleFunctions) {
-          if( fn->hasFlag(FLAG_EXTERN) ) {
-            fn->addFlag(FLAG_FAST_ON_SAFE_EXTERN);
-            fn->addFlag(FLAG_LOCAL_FN);
-          }
-        }
-      }
-    }
-  }
-
   compute_call_sites();
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -87,6 +87,7 @@ module Atomics {
   use ChapelEnv;
 
   pragma "no doc"
+  pragma "local fn" pragma "fast-on safe extern function"
   extern proc chpl_atomic_thread_fence(order:memory_order);
 
   // non user-facing fence that is called by the compiler
@@ -181,6 +182,7 @@ module Atomics {
     pragma "no doc"
     proc init_helper(value:bool) {
       pragma "fn synchronization free"
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("init", bool, explicit=false)
         proc atomic_init(ref obj:externT(bool), value:bool): void;
 
@@ -209,6 +211,7 @@ module Atomics {
     pragma "no doc"
     proc deinit() {
       pragma "fn synchronization free"
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("destroy", bool, explicit=false)
         proc atomic_destroy(ref obj:externT(bool)): void;
 
@@ -219,6 +222,7 @@ module Atomics {
        :returns: The stored value.
     */
     inline proc const read(param order: memoryOrder = memoryOrder.seqCst): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("load", bool)
         proc atomic_load(const ref obj:externT(bool), order:memory_order): bool;
 
@@ -231,6 +235,7 @@ module Atomics {
        Stores `value` as the new value.
     */
     inline proc write(value:bool, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("store", bool)
         proc atomic_store(ref obj:externT(bool), value:bool, order:memory_order): void;
 
@@ -241,6 +246,7 @@ module Atomics {
        Stores `value` as the new value and returns the original value.
     */
     inline proc exchange(value:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("exchange", bool)
         proc atomic_exchange(ref obj:externT(bool), value:bool, order:memory_order): bool;
 
@@ -258,6 +264,7 @@ module Atomics {
       return this.compareExchange(expected, desired, order, readableOrder(order));
     }
     inline proc compareExchange(ref expected:bool, desired:bool, param success: memoryOrder, param failure: memoryOrder): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_strong", bool)
         proc atomic_compare_exchange_strong(ref obj:externT(bool), ref expected:bool, desired:bool, succ:memory_order, fail:memory_order): bool;
 
@@ -279,6 +286,7 @@ module Atomics {
       return this.compareExchangeWeak(expected, desired, order, readableOrder(order));
     }
     inline proc compareExchangeWeak(ref expected:bool, desired:bool, param success: memoryOrder, param failure: memoryOrder) {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_weak", bool)
         proc atomic_compare_exchange_weak(ref obj:externT(bool), ref expected:bool, desired:bool, succ:memory_order, fail:memory_order): bool;
 
@@ -296,6 +304,7 @@ module Atomics {
        equal to `expected`. Returns `true` if `desired` was stored.
     */
     inline proc compareAndSwap(expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_strong", bool)
         proc atomic_compare_exchange_strong(ref obj:externT(bool), ref expected:bool, desired:bool, succ:memory_order, fail:memory_order): bool;
 
@@ -355,6 +364,7 @@ module Atomics {
     pragma "no doc"
     proc init_helper(value:T) {
       pragma "fn synchronization free"
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("init", T, explicit=false)
         proc atomic_init(ref obj:externT(T), value:T): void;
 
@@ -386,6 +396,7 @@ module Atomics {
     pragma "no doc"
     proc deinit() {
       pragma "fn synchronization free"
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("destroy", T, explicit=false)
         proc atomic_destroy(ref obj:externT(T)): void;
 
@@ -396,6 +407,7 @@ module Atomics {
        :returns: The stored value.
     */
     inline proc const read(param order: memoryOrder = memoryOrder.seqCst): T {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("load", T)
         proc atomic_load(const ref obj:externT(T), order:memory_order): T;
 
@@ -408,6 +420,7 @@ module Atomics {
        Stores `value` as the new value.
     */
     inline proc write(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("store", T)
         proc atomic_store(ref obj:externT(T), value:T, order:memory_order): void;
 
@@ -418,6 +431,7 @@ module Atomics {
        Stores `value` as the new value and returns the original value.
     */
     inline proc exchange(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("exchange", T)
         proc atomic_exchange(ref obj:externT(T), value:T, order:memory_order): T;
 
@@ -435,6 +449,7 @@ module Atomics {
       return this.compareExchange(expected, desired, order, readableOrder(order));
     }
     inline proc compareExchange(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_strong", T)
         proc atomic_compare_exchange_strong(ref obj:externT(T), ref expected:T, desired:T, succ:memory_order, fail:memory_order): bool;
 
@@ -456,6 +471,7 @@ module Atomics {
       return this.compareExchangeWeak(expected, desired, order, readableOrder(order));
     }
     inline proc compareExchangeWeak(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_weak", T)
         proc atomic_compare_exchange_weak(ref obj:externT(T), ref expected:T, desired:T, succ:memory_order, fail:memory_order): bool;
 
@@ -473,6 +489,7 @@ module Atomics {
        equal to `expected`. Returns `true` if `desired` was stored.
     */
     inline proc compareAndSwap(expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_strong", T)
         proc atomic_compare_exchange_strong(ref obj:externT(T), ref expected:T, desired:T, succ:memory_order, fail:memory_order): bool;
 
@@ -491,6 +508,7 @@ module Atomics {
        integer and real atomic types.
     */
     inline proc fetchAdd(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_add", T)
         proc atomic_fetch_add(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -504,6 +522,7 @@ module Atomics {
        integer and real atomic types.
     */
     inline proc add(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_add", T)
         proc atomic_fetch_add(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -517,6 +536,7 @@ module Atomics {
        for integer and real atomic types.
     */
     inline proc fetchSub(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_sub", T)
         proc atomic_fetch_sub(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -530,6 +550,7 @@ module Atomics {
        for integer and real atomic types.
     */
     inline proc sub(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_sub", T)
         proc atomic_fetch_sub(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -546,6 +567,7 @@ module Atomics {
     */
     inline proc fetchOr(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
       if !isIntegral(T) then compilerError("fetchOr is only defined for integer atomic types");
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_or", T)
         proc atomic_fetch_or(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -562,6 +584,7 @@ module Atomics {
     */
     inline proc or(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
       if !isIntegral(T) then compilerError("or is only defined for integer atomic types");
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_or", T)
         proc atomic_fetch_or(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -578,6 +601,7 @@ module Atomics {
     */
     inline proc fetchAnd(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
       if !isIntegral(T) then compilerError("fetchAnd is only defined for integer atomic types");
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_and", T)
         proc atomic_fetch_and(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -594,6 +618,7 @@ module Atomics {
     */
     inline proc and(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
       if !isIntegral(T) then compilerError("and is only defined for integer atomic types");
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_and", T)
         proc atomic_fetch_and(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -610,6 +635,7 @@ module Atomics {
     */
     inline proc fetchXor(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
       if !isIntegral(T) then compilerError("fetchXor is only defined for integer atomic types");
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_xor", T)
         proc atomic_fetch_xor(ref obj:externT(T), operand:T, order:memory_order): T;
 
@@ -626,6 +652,7 @@ module Atomics {
     */
     inline proc xor(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
       if !isIntegral(T) then compilerError("xor is only defined for integer atomic types");
+      pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("fetch_xor", T)
         proc atomic_fetch_xor(ref obj:externT(T), operand:T, order:memory_order): T;
 


### PR DESCRIPTION
In #4008, we had the compiler mark extern functions in the atomic modules
as safe for fast-ons so that downEndCount could run in the AM-handler
for network-atomics=none. The notion was that processor atomic calls are
safe for fast-ons and that is true, but previously this compiler code
also considered network atomics as safe for fast-ons, which isn't true
since network atomics may use arbitrary comm.

Instead of having the compiler automatically mark functions that are
safe, just manually mark them in the processor atomic module code. Note
that previously we didn't consider locks-atomics as safe for fast on,
but now that we're using pthread mutexes for them it should be ok to run
them in the am handler. It may limit the rate of AMs for atomics=locks
in some cases, but that's not an important configuration anyways.

Resolves https://github.com/Cray/chapel-private/issues/821