### PR TITLE
Remove warning for string.format

### DIFF
--- a/modules/internal/LastResortIO.chpl
+++ b/modules/internal/LastResortIO.chpl
@@ -448,9 +448,3 @@ proc readf(fmt:string):bool throws {
   compilerWarning("readf will no longer be available by default,\nplease insert a use of the IO module to continue calling it.");
   return readf(fmt);
 }
-
-pragma "last resort"
-proc string.format(args ...?k): string throws {
-  compilerWarning("string.format will no longer be available by default,\nplease insert a use of the IO module to continue calling it.");
-  return format((...args));
-}

--- a/test/deprecated/io/warnings.chpl
+++ b/test/deprecated/io/warnings.chpl
@@ -43,7 +43,7 @@ f5 = readln(f3);
 writeln(f5);
 f5 = readf("%i", f4);
 writeln(f5);
-"My favorite %s is %i".format("number", 9);
+
 
 stdinInit();    // TODO: document?
 stdoutInit();   // TODO: document?

--- a/test/deprecated/io/warnings.good
+++ b/test/deprecated/io/warnings.good
@@ -44,8 +44,6 @@ warnings.chpl:42: warning: readln will no longer be available by default,
 please insert a use of the IO module to continue calling it.
 warnings.chpl:44: warning: readf will no longer be available by default,
 please insert a use of the IO module to continue calling it.
-warnings.chpl:46: warning: string.format will no longer be available by default,
-please insert a use of the IO module to continue calling it.
 warnings.chpl:48: warning: stdinInit will no longer be available by default,
 please insert a use of the IO module to continue calling it.
 warnings.chpl:49: warning: stdoutInit will no longer be available by default,


### PR DESCRIPTION
With the change to resolution of methods that I made last week, this warning
is no longer necessary because we will still follow private use statements to
find it.

Running full std paratest with futures, but the test that broke is fixed so it's
probably fine.