### PR TITLE
Replace empty uses in the standard, internal, and package modules with imports

### DIFF
--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -22,7 +22,7 @@
 //
 
 private use DimensionalDist2D;
-private use RangeChunk only ;
+import RangeChunk;
 
 config const BlockCyclicDim_allowParLeader = true;
 config param BlockCyclicDim_enableArrayIterWarning = false;  // 'false' for testing

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -25,7 +25,7 @@
 //
 
 private use DimensionalDist2D;
-private use RangeChunk only ;
+import RangeChunk;
 
 /*
 This Replicated dimension specifier is for use with the

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -27,7 +27,7 @@
 module CPtr {
   private use ChapelStandard;
   private use SysBasic, SysError, SysCTypes;
-  private use HaltWrappers only;
+  import HaltWrappers;
 
   /* A Chapel version of a C NULL pointer. */
   inline proc c_nil:c_void_ptr {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -166,7 +166,7 @@ module ChapelArray {
   use ArrayViewSlice;
   use ArrayViewRankChange;
   use ArrayViewReindex;
-  private use Reflection only;
+  import Reflection;
   private use ChapelDebugPrint;
   private use SysCTypes;
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -817,7 +817,7 @@ module ChapelArray {
   // return type when the declared return type specifies a particular domain
   // but not the element type.
   proc chpl__checkDomainsMatch(a: [], b) {
-    use HaltWrappers only;
+    import HaltWrappers;
     if (boundsChecking) {
       if (a.domain != b) {
         HaltWrappers.boundsCheckHalt("domain mismatch on return");
@@ -826,7 +826,7 @@ module ChapelArray {
   }
 
   proc chpl__checkDomainsMatch(a: _iteratorRecord, b) {
-    use HaltWrappers only;
+    import HaltWrappers;
     if (boundsChecking) {
       // Should use iterator.shape here to avoid copy
       var tmp = a;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -691,7 +691,7 @@ module ChapelBase {
 
   pragma "always propagate line file info"
   private inline proc checkNotNil(x:borrowed class?) {
-    use HaltWrappers only;
+    import HaltWrappers;
     // Check only if --nil-checks is enabled
     if chpl_checkNilDereferences {
       // Add check for nilable types only.

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -67,7 +67,7 @@
 module ChapelLocale {
 
   use LocaleModel;
-  private use HaltWrappers only;
+  import HaltWrappers;
   private use SysCTypes;
 
   //

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2135,7 +2135,7 @@ module DefaultRectangular {
   // broken out into a helper function in order to be made use of by
   // distributed array scans.
   proc DefaultRectangularArr.chpl__preScan(op, res: [] ?resType, dom) {
-    use RangeChunk only;
+    import RangeChunk;
     // Compute who owns what
     const rng = dom.dim(1);
     const numTasks = if __primitive("task_get_serial") then

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -247,7 +247,7 @@ module DefaultSparse {
 
     override proc bulkAdd_help(inds: [?indsDom] index(rank, idxType),
         dataSorted=false, isUnique=false, addOn=nil:locale?){
-      use Sort only;
+      import Sort;
 
       if addOn != nil {
         if addOn != this.locale {

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -21,7 +21,7 @@
 //
 module DefaultSparse {
   private use ChapelStandard;
-  private use RangeChunk only ;
+  import RangeChunk;
 
   config param debugDefaultSparse = false;
 

--- a/modules/internal/MemConsistency.chpl
+++ b/modules/internal/MemConsistency.chpl
@@ -86,7 +86,7 @@ module MemConsistency {
   }
 
   inline proc c_memory_order(param order: memoryOrder) {
-    use HaltWrappers only;
+    import HaltWrappers;
     select order {
       when memoryOrder.relaxed do return memory_order_relaxed;
       when memoryOrder.acquire do return memory_order_acquire;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -347,7 +347,7 @@ module OwnedObject {
          ref rhs: _owned)
     where ! (isNonNilableClass(lhs) && isNilableClass(rhs))
   {
-    use HaltWrappers only;
+    import HaltWrappers;
     // Work around issues in associative arrays of owned
     // TODO: remove this workaround
     if lhs.chpl_p == nil && rhs.chpl_p == nil then

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -526,7 +526,7 @@ module OwnedObject {
   pragma "no doc"
   pragma "always propagate line file info"
   inline proc postfix!(const ref x:_owned) {
-    use HaltWrappers only;
+    import HaltWrappers;
     // Check only if --nil-checks is enabled
     if chpl_checkNilDereferences {
       // Add check for nilable types only.

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -545,7 +545,7 @@ module SharedObject {
   pragma "no doc"
   pragma "always propagate line file info"
   inline proc postfix!(x:_shared) {
-    use HaltWrappers only;
+    import HaltWrappers;
     // Check only if --nil-checks is enabled
     if chpl_checkNilDereferences {
       // Add check for nilable types only.

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -396,7 +396,7 @@ class CSDom: BaseSparseDomImpl {
 
   override proc bulkAdd_help(inds: [?indsDom] rank*idxType,
       dataSorted=false, isUnique=false, addOn=nil:locale?) {
-    use Sort only;
+    import Sort;
 
     if addOn != nil {
       if addOn != this.locale {

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-use RangeChunk only ;
+import RangeChunk;
 
 pragma "no doc"
 /* Debug flag */

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -392,8 +392,8 @@ module Curl {
   pragma "no doc"
   module CurlQioIntegration {
 
-    use Sys only ;
-    use Time only ;
+    import Sys;
+    import Time;
     private use IO;
 
     class CurlFile : QioPluginFile {

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -4108,7 +4108,7 @@ module HDF5 {
    */
   class HDF5Preprocessor {
     proc preprocess(A: []) {
-      use HaltWrappers only ;
+      import HaltWrappers;
       HaltWrappers.pureVirtualMethodHalt();
     }
   }

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -36,7 +36,7 @@ connecting to an HDFS name node.
 
 .. code-block:: chapel
 
-  use HDFS only;
+  import HDFS;
 
   fs = HDFS.connect(); // can pass a nameNode host and port here,
                        // otherwise uses HDFS default settings.

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -186,7 +186,7 @@ are supported through submodules, such ``LinearAlgebra.Sparse`` for the
 module LinearAlgebra {
 
 use Norm; // TODO -- merge Norm into LinearAlgebra
-use BLAS only;
+import BLAS;
 use LAPACK only lapack_memory_order, isLAPACKType;
 
 /* Determines if using native Chapel implementations */
@@ -576,7 +576,7 @@ proc dot(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDenseArr(A) && isDense
 
 */
 proc _array.dot(A: []) where isDenseArr(this) && isDenseArr(A) {
-  use LinearAlgebra only;
+  import LinearAlgebra;
   return LinearAlgebra.dot(this, A);
 }
 
@@ -1978,13 +1978,13 @@ module Sparse {
 
   /* Compute the dot-product */
   proc _array.dot(A: []) where isCSArr(A) || isCSArr(this) {
-    use LinearAlgebra only;
+    import LinearAlgebra;
     return LinearAlgebra.Sparse.dot(this, A);
   }
 
   /* Compute the dot-product */
   proc _array.dot(a) where isNumeric(a) && isCSArr(this) {
-    use LinearAlgebra only;
+    import LinearAlgebra;
     return LinearAlgebra.dot(this, a);
   }
 

--- a/modules/packages/Prefetch.chpl
+++ b/modules/packages/Prefetch.chpl
@@ -21,7 +21,7 @@
  *  Prefetch
  */
 module Prefetch {
-  private use Prefetch_internal only ;
+  import Prefetch_internal;
   inline proc prefetch(addr:c_ptr) {
     Prefetch_internal.chpl_prefetch(addr:c_void_ptr);
   }

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -58,7 +58,7 @@
    implemented and optimized.
 */
 module Barriers {
-  private use HaltWrappers only ;
+  import HaltWrappers;
 
   /* An enumeration of the different barrier implementations.  Used to choose
      the implementation to use when constructing a new barrier object.

--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -21,7 +21,7 @@
   Bitwise operations implemented using C intrinsics when possible.
  */
 module BitOps {
-  private use BitOps_internal only;
+  import BitOps_internal;
 
   /*
     Count leading zeros in `x`.

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -33,7 +33,7 @@
  */
 
 module DateTime {
-  private use HaltWrappers only ;
+  import HaltWrappers;
   private use SysCTypes;
 
   /* The minimum year allowed in `date` objects */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1617,7 +1617,7 @@ private param _cwr = "w+";
 
 pragma "no doc"
 proc _modestring(mode:iomode) {
-  use HaltWrappers only;
+  import HaltWrappers;
   select mode {
     when iomode.r do return _r;
     when iomode.rw do return _rw;
@@ -1669,7 +1669,7 @@ proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
 
 proc openplugin(pluginFile: QioPluginFile, mode:iomode,
                 seekable:bool, style:iostyle) throws {
-  use HaltWrappers only;
+  import HaltWrappers;
 
   extern proc qio_file_init_plugin(ref file_out:qio_file_ptr_t,
       file_info:c_void_ptr, flags:c_int, const ref style:iostyle):syserr;

--- a/modules/standard/LinkedLists.chpl
+++ b/modules/standard/LinkedLists.chpl
@@ -187,7 +187,7 @@ record LinkedList {
      It is an error to call this function on an empty list.
    */
    proc pop_front():eltType {
-     use HaltWrappers only;
+     import HaltWrappers;
      if boundsChecking && length < 1 {
        HaltWrappers.boundsCheckHalt("pop_front on empty list");
      }

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -52,7 +52,7 @@
   into a list is O(1).
 */
 module List {
-  private use ChapelLocks only;
+  import ChapelLocks;
   private use HaltWrappers;
   private use Sort;
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -27,7 +27,7 @@
   mode of its originating map.
 */
 module Map {
-  private use ChapelLocks only;
+  import ChapelLocks;
   private use HaltWrappers;
 
   // Lock code lifted from modules/standard/Lists.chpl.

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -47,7 +47,7 @@ exception will be generated.
 
 */
 module Math {
-  private use HaltWrappers only;
+  import HaltWrappers;
   private use SysCTypes;
 
   //////////////////////////////////////////////////////////////////////////

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -744,7 +744,7 @@ proc relPath(name: string, start:string=curDir): string throws {
   :throws SystemError: Upon failure to get the current working directory.
 */
 proc file.relPath(start:string=curDir): string throws {
-  use Path only;
+  import Path;
   // Have to prefix module name to avoid muddying name resolution.
   return Path.relPath(this.path, start);
 }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -318,8 +318,8 @@ module Random {
   /* _choice branch for distribution defined by probabilities array */
   proc _choiceProbabilities(stream, arr:[], size:?sizeType, replace, prob:?probType) throws
   {
-    use Search only;
-    use Sort only;
+    import Search;
+    import Sort;
 
     // If stride, offset, or size don't match, we're in trouble
     if arr.domain != prob.domain then

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -63,7 +63,7 @@ module Random {
   public use RandomSupport;
   public use NPBRandom;
   public use PCGRandom;
-  private use HaltWrappers only;
+  import HaltWrappers;
 
 
 

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -41,7 +41,7 @@ module Set {
   // Use this to restrict our secondary initializer to only resolve when the
   // "iterable" argument has a method named "these".
   //
-  private use ChapelLocks only;
+  import ChapelLocks;
   private use IO;
   private use Reflection;
 

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -29,7 +29,7 @@
 
 module Time {
   private use SysBasic;
-  private use HaltWrappers only;
+  import HaltWrappers;
 
 // Returns the number of seconds since midnight.  Has the potential for
 // microsecond resolution if supported by the runtime platform

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -25,7 +25,7 @@ Functions related to predefined types.
 
 */
 module Types {
-  private use HaltWrappers only;
+  import HaltWrappers;
 
 pragma "no doc" // joint documentation with the next one
 proc isType(type t) param return true;


### PR DESCRIPTION
This PR goes through and replaces `use M only;` with `import M;`
in the standard, internal, and package modules, to begin leaning
more heavily on import statements (and use what will be the more
recommended strategy).

There were no instances of `use M except *;` to replace.

Resolves Cray/chapel-private#822

Testing:
- [x]  full std paratest with futures
- [x] test/arrays and test/multilocale with gasnet