### PR TITLE
Fix a KNL and APU locale models after 14998

### DIFF
--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -83,7 +83,10 @@ module LocaleModel {
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
     }
-    override proc getChild(idx:int) : locale { return nil; }
+    override proc getChild(idx:int) : locale {
+      halt("requesting a child from a CPULocale locale");
+      return this;
+    }
   }
 
   class GPULocale : AbstractLocaleModel {
@@ -127,7 +130,10 @@ module LocaleModel {
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
     }
-    override proc getChild(idx:int) : locale { return nil; }
+    override proc getChild(idx:int) : locale {
+      halt("requesting a child from a GPULocale locale");
+      return this;
+    }
   }
 
   const chpl_emptyLocaleSpace: domain(1) = {1..0};

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -235,7 +235,7 @@ module LocaleModel {
 
     override proc getChild(idx:int) : locale {
       halt("requesting a child from a MemoryLocale locale");
-      return new locale(); //dummy
+      return this;
     }
   }
 
@@ -326,7 +326,7 @@ module LocaleModel {
 
     override proc getChild(idx:int) : locale {
       halt("requesting a child from a NumaDomain locale");
-      return new locale(); //dummy
+      return this;
     }
 
     iter getChildren() : locale {


### PR DESCRIPTION
PR #14998 introduced additional checking that these locale
models are running into.

This PR resolves problems in nightly testing by returning `this` as
the dummy value after the halt.

Verified that hello now compiles on a KNL configuration.

Trivial and not reviewed.