### PR TITLE
Bump ugni from 4K to 16K memory regions

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -580,14 +580,14 @@ The ugni communication layer maintains information about every memory
 region it registers with the Gemini or Aries NIC.  Roughly speaking there
 are a few memory regions for each tasking layer thread, plus one for each
 array larger than 2 hugepages allocated and registered separately from the
-heap.  By default the comm layer can handle up to 4k (2**12) total memory
+heap.  By default the comm layer can handle up to 16k (2**14) total memory
 regions on Cray XC systems or 2k on XE systems, which is plenty under
 normal circumstances.  In the event a program needs more than this, a
 message like the following will be printed:
 
   .. code-block:: sh
 
-    warning: no more registered memory region table entries (max is 4096).
+    warning: no more registered memory region table entries (max is 16384).
              Change using CHPL_RT_COMM_UGNI_MAX_MEM_REGIONS.
 
 To provide for more registered regions, set the
@@ -596,7 +596,7 @@ indicating how many you want to allow.  For example:
 
   .. code-block:: sh
 
-    export CHPL_RT_COMM_UGNI_MAX_MEM_REGIONS=10000
+    export CHPL_RT_COMM_UGNI_MAX_MEM_REGIONS=30000
 
 Note that there are certain comm layer overheads that are proportional to
 the number of registered memory regions, so allowing a very high number of

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1949,7 +1949,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
 #undef _PSTAT_INIT
 
   //
-  // We can easily reach 4k memory regions on Aries.  We can reach a
+  // We can easily reach 16k memory regions on Aries.  We can reach a
   // bit more than 3500 memory regions on Gemini but getting there is
   // tricky because we start bumping up against a number of limits
   // all at once (node memory sizes, limits on number of registered
@@ -1958,7 +1958,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
   //
   max_mem_regions =
     chpl_env_rt_get_int("COMM_UGNI_MAX_MEM_REGIONS",
-                        (nic_type == GNI_DEVICE_GEMINI) ? 2048 : 4096);
+                        (nic_type == GNI_DEVICE_GEMINI) ? 2048 : 16384);
 
   //
   // We have to create the local memory region table before the first


### PR DESCRIPTION
We have had users in the field run out of memory regions on 256GB nodes.
Assuming 16M hugepages, 16K memory regions is the most that could
possibly be needed on 256GB nodes, so bump our default to be safe.

Each node maintains a list of every other nodes memory regions, so we
use `num_memory_regions * sizeof(memory_region) (32 bytes) * num_nodes`
bytes of memory for memory regions. At 1024 nodes this increases the
per-node memory usage for mem regions from 128MB to 512MB. That's a
non-trivial amount of memory, but realistically 1-2K nodes is probably
the largest that anybody will run Chapel at on an XC.

Resolves https://github.com/mhmerrill/arkouda/issues/271
Closes https://github.com/cray/chapel-private/issues/742 