### PR TITLE
Few more minor fixes in record comparison docs

### DIFF
--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -523,11 +523,12 @@ Other comparison operator overloads (namely ``<``, ``<=``, ``>``, and ``>=``)
 have similar signatures but their where clauses also check whether the relevant
 operator is supported by each field.
 
-Record comparisons have a similar behavior to tuple comparisons :ref:`tuple comparisons <Tuple_Relational_Operators>`.
-The operators >, >=, <, and <= check the corresponding lexicographical order based 
-on pair-wise comparisons between the arguments' fields.
-The operators == and != check whether the two arguments are pair-wise equal or not.
-The fields are compared in the order they are declared in the record definition.
+Record comparisons have a similar behavior to :ref:`tuple comparisons
+<Tuple_Relational_Operators>`.  The operators ``>``, ``>=``, ``<``, and ``<=``
+check the corresponding lexicographical order based on pair-wise comparisons
+between the arguments' fields.  The operators ``==`` and ``!=`` check whether
+the two arguments are pair-wise equal or not.  The fields are compared in the
+order they are declared in the record definition.
 
 .. _Class_and_Record_Differences:
 


### PR DESCRIPTION
I noticed the "tuple comparison" phrase was repeated right after merging #15036.

This PR fixes that, reflows the paragraph, formats the operators to be consistent
with the rest of the section.

With #15036 resolves #14833 