### PR TITLE
Map docs clean-up

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -72,7 +72,7 @@ module Map {
     /* Type of map values. */
     type valType;
 
-    /* Tracks if map is parallel safe. */
+    /* If `true`, this set will perform parallel safe operations. */
     param parSafe = false;
 
     pragma "no doc"

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -72,7 +72,7 @@ module Map {
     /* Type of map values. */
     type valType;
 
-    /* If `true`, this set will perform parallel safe operations. */
+    /* If `true`, this map will perform parallel safe operations. */
     param parSafe = false;
 
     pragma "no doc"

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -67,10 +67,17 @@ module Map {
   }
 
   record map {
-    type keyType, valType;
+    /* Type of map keys. */
+    type keyType;
+    /* Type of map values. */
+    type valType;
+
+    /* Tracks if map is parallel safe. */
     param parSafe = false;
 
+    pragma "no doc"
     var myKeys: domain(keyType, parSafe=parSafe);
+    pragma "no doc"
     var vals: [myKeys] checkForNonNilableClass(valType);
 
 


### PR DESCRIPTION
Clean up Map documentation a bit.

- `pragma "no doc"` `vals` and `keys`
- add descriptions to `valType`, `keyType`, and `parSafe`