### PR TITLE
Lifetime check copy elision

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -49,6 +49,7 @@ symbolFlag( FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO , ypr, "always propagate line f
 symbolFlag( FLAG_ALWAYS_RVF, ypr, "always RVF", "attach to a type to force RVF for objects of that type" )
 symbolFlag( FLAG_DEAD_END_OF_BLOCK , ypr, "dead at end of block" , ncm )
 symbolFlag( FLAG_DEAD_LAST_MENTION , ypr, "dead after last mention" , ncm )
+symbolFlag( FLAG_DEAD_COPY_ELISION , npr, "dead after copy elision" , ncm )
 symbolFlag( FLAG_DONT_ALLOW_REF , ypr, "do not allow ref" , ncm )
 symbolFlag( FLAG_ARG_THIS, npr, "arg this", "the hidden object argument")
 symbolFlag( FLAG_ARRAY , ypr, "array" , ncm )

--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -388,6 +388,7 @@ static void deinitializeOrCopyElide(Expr* before, Expr* after, VarSymbol* var) {
       // Change the copy into a move and don't destroy the variable.
       copyToElide->convertToNoop();
       copyToElide->insertBefore(new CallExpr(PRIM_ASSIGN_ELIDED_COPY, copyToLhs, var));
+      var->addFlag(FLAG_DEAD_COPY_ELISION);
     }
   }
 }

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1312,8 +1312,6 @@ void callDestructors() {
 
   insertCopiesForYields();
 
-  checkLifetimes();
-
   lateConstCheck(NULL);
 
   addAutoDestroyCalls();
@@ -1322,7 +1320,7 @@ void callDestructors() {
 
   checkForErroneousInitCopies();
 
-  findNilDereferences();
+  checkLifetimesAndNilDereferences();
 
   convertClassTypesToCanonical();
 

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -360,7 +360,13 @@ static void checkFunction(FnSymbol* fn);
 static bool isCallToFunctionReturningNotOwned(CallExpr* call);
 static bool isUser(BaseAST* ast);
 
-void checkLifetimes() {
+void checkLifetimesAndNilDereferences() {
+  // Clear last error location so we get errors from nil checking
+  // even if previous compiler code raised error on the same line.
+  // This is necessary due to the use of printsSameLocationAsLastError
+  // to hide multiple nil-checking errors from the same line.
+  clearLastErrorLocation();
+
   // Mark all arguments with FLAG_SCOPE or FLAG_RETURN_SCOPE.
   // This needs to be done for all functions before the next
   // loop since it affects how calls are handled.
@@ -369,8 +375,10 @@ void checkLifetimes() {
     adjustSignatureForNilChecking(fn);
   }
 
-  // Perform lifetime checking on each function
   forv_Vec(FnSymbol, fn, gFnSymbols) {
+    // Perform nil checking on each function
+    checkNilDereferencesInFn(fn);
+    // Perform lifetime checking on each function
     checkFunction(fn);
   }
 

--- a/compiler/resolution/lifetime.h
+++ b/compiler/resolution/lifetime.h
@@ -23,13 +23,14 @@
 class FnSymbol;
 class Type;
 
-void checkLifetimes();
+void adjustSignatureForNilChecking(FnSymbol* fn);
+
+void checkNilDereferencesInFn(FnSymbol* fn);
 
 void checkLifetimesInFunction(FnSymbol* fn);
 
-void adjustSignatureForNilChecking(FnSymbol* fn);
 bool isOrContainsBorrowedClass(Type* type);
 
-void findNilDereferences();
+void checkLifetimesAndNilDereferences();
 
 #endif

--- a/compiler/resolution/nilChecking.cpp
+++ b/compiler/resolution/nilChecking.cpp
@@ -1392,20 +1392,12 @@ static void findNilDereferencesInFn(FnSymbol* fn) {
   }
 }
 
-void findNilDereferences() {
+void checkNilDereferencesInFn(FnSymbol* fn) {
   if (fCompileTimeNilChecking) {
-    // Clear last error location so we get errors from nil checking
-    // even if previous compiler code raised error on the same line.
-    // This is necessary due to the use of printsSameLocationAsLastError
-    // to hide multiple nil-checking errors from the same line.
-    clearLastErrorLocation();
-    forv_Vec(FnSymbol, fn, gFnSymbols) {
-      findNilDereferencesInFn(fn);
-      findNonNilableStoringNil(fn);
-    }
+    findNilDereferencesInFn(fn);
+    findNonNilableStoringNil(fn);
   }
 }
-
 
 void adjustSignatureForNilChecking(FnSymbol* fn) {
   if (fn->_this != NULL) {

--- a/test/classes/delete-free/lifetimes/borrow-escapes.good
+++ b/test/classes/delete-free/lifetimes/borrow-escapes.good
@@ -23,5 +23,4 @@ borrow-escapes.chpl:97: note: consider scope of r
 borrow-escapes.chpl:106: In function 'bad23':
 borrow-escapes.chpl:111: error: Scoped variable would outlive the value it is set to
 borrow-escapes.chpl:109: note: consider scope of r
-borrow-escapes.chpl:111: error: Scoped variable outer reachable after lifetime ends
-borrow-escapes.chpl:109: note: consider scope of r
+borrow-escapes.chpl:115: error: Scoped variable outer would outlive the value it is set to

--- a/test/classes/delete-free/lifetimes/deinit-uses-borrow.chpl
+++ b/test/classes/delete-free/lifetimes/deinit-uses-borrow.chpl
@@ -1,0 +1,14 @@
+class MyClassBorrows {
+  var x: int;
+  var b: borrowed MyClassBorrows?;
+  proc deinit() {
+    writeln("in deinit, b is ", b);
+  }
+}
+
+proc test2() {
+  var x = new MyClassBorrows(1);
+  var y = new MyClassBorrows(2);
+  x.b = y.borrow();
+}
+test2();

--- a/test/classes/delete-free/lifetimes/deinit-uses-borrow.future
+++ b/test/classes/delete-free/lifetimes/deinit-uses-borrow.future
@@ -1,0 +1,2 @@
+feature request: lifetime checking considering deinitialization order
+#15065

--- a/test/classes/delete-free/lifetimes/deinit-uses-borrow.good
+++ b/test/classes/delete-free/lifetimes/deinit-uses-borrow.good
@@ -1,0 +1,3 @@
+deinit-uses-borrow.chpl:9: In function 'test2':
+deinit-uses-borrow.chpl:12: error: Scoped variable would outlive the value it is set to
+deinit-uses-borrow.chpl:11: note: consider scope of y

--- a/test/classes/delete-free/lifetimes/errors-dead-early.chpl
+++ b/test/classes/delete-free/lifetimes/errors-dead-early.chpl
@@ -1,0 +1,126 @@
+class MyClass { var x: int; }
+
+proc test1() {
+  var x: borrowed MyClass? = nil;
+  x = (new owned MyClass()).borrow();
+  // owned class deinited here
+  writeln(x); // use after free
+}
+test1();
+
+proc acceptsIn(in arg) { }
+
+proc identity(arg) { return arg; }
+proc test2() {
+  var x = new MyClass(1);
+  var b = identity(x.borrow());
+  acceptsIn(x); // copy elided
+  writeln(b);
+}
+test2();
+
+proc refIdentity(ref arg) ref { return arg; }
+proc test3() {
+  var x = new MyClass(1);
+  ref r = refIdentity(x);
+  acceptsIn(x); // copy elided
+  writeln(r);
+}
+test3();
+
+proc test4() {
+  var arr: [1..1] borrowed MyClass?;
+  arr[1] = new MyClass(1);
+  writeln(arr);
+}
+test4();
+
+record MyRecord {
+  var c: borrowed MyClass?;
+}
+
+proc test5() {
+  var x: MyRecord;
+  x.c = new borrowed MyClass(1);
+  writeln(x);
+}
+test5();
+
+proc test6() {
+  var a:borrowed MyClass? = nil;
+  a = new borrowed MyClass();
+}
+test6();
+
+config param printInitDeinit = true;
+
+class C {
+  var xx: int = 0;
+}
+
+record R {
+  var x: int = 0;
+  var ptr: shared C = new shared C(0);
+  proc init() {
+    this.x = 0;
+    this.ptr = new shared C(0);
+    if printInitDeinit then writeln("init (default)");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    this.ptr = new shared C(arg);
+    if printInitDeinit then writeln("init ", arg, " ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    this.ptr = new shared C(other.ptr.xx);
+    if printInitDeinit then writeln("init= ", other.x, " ", other.ptr.xx);
+  }
+  proc deinit() {
+    if printInitDeinit then writeln("deinit ", x, " ", ptr.xx);
+  }
+  proc toString() {
+    return "(" + this.x:string + " " + this.ptr.xx:string + ")";
+  }
+  proc ref set1() ref {
+    this.x = 1;
+    this.ptr.xx = 1;
+    return this;
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  if printInitDeinit then writeln("lhs", lhs.toString(), " = rhs", rhs.toString());
+  lhs.x = rhs.x;
+  lhs.ptr = new shared C(rhs.ptr.xx);
+}
+
+proc concatenate(a: R, b: R): string {
+  return a.toString() + " " + b.toString();
+}
+
+proc concatenate(a: R, b: borrowed C): string {
+  return a.toString() + " " + b.xx:string;
+}
+
+proc concatenate(a: R, b: int): string {
+  return a.toString() + " " + b:string;
+}
+
+proc copy(in arg) {
+  return arg;
+}
+
+proc test7() {
+  var x = new R(1);
+  writeln("test5b.a");
+  var b = x.ptr.borrow();
+  writeln(concatenate(copy(x), b));
+}
+test7();
+
+proc test8() { // should be an error too, one day
+  var x = new R(1);
+  const ref rx = x.ptr.xx;
+  writeln(concatenate(copy(x), rx));
+}
+test8();

--- a/test/classes/delete-free/lifetimes/errors-dead-early.good
+++ b/test/classes/delete-free/lifetimes/errors-dead-early.good
@@ -1,0 +1,17 @@
+errors-dead-early.chpl:3: In function 'test1':
+errors-dead-early.chpl:5: error: Scoped variable x would outlive the value it is set to
+errors-dead-early.chpl:14: In function 'test2':
+errors-dead-early.chpl:16: error: Scoped variable b would outlive the value it is set to
+errors-dead-early.chpl:15: note: consider scope of x
+errors-dead-early.chpl:23: In function 'test3':
+errors-dead-early.chpl:25: error: Reference to scoped variable r reachable after lifetime ends
+errors-dead-early.chpl:24: note: consider scope of x
+errors-dead-early.chpl:31: In function 'test4':
+errors-dead-early.chpl:33: error: Scoped variable would outlive the value it is set to
+errors-dead-early.chpl:42: In function 'test5':
+errors-dead-early.chpl:44: error: reference points to scoped variable reachable after lifetime ends
+errors-dead-early.chpl:49: In function 'test6':
+errors-dead-early.chpl:51: error: Scoped variable a would outlive the value it is set to
+errors-dead-early.chpl:113: In function 'test7':
+errors-dead-early.chpl:116: error: Scoped variable b would outlive the value it is set to
+errors-dead-early.chpl:114: note: consider scope of x

--- a/test/classes/delete-free/nil-checking/nilcheck-empty-refs.good
+++ b/test/classes/delete-free/nil-checking/nilcheck-empty-refs.good
@@ -16,6 +16,8 @@ nilcheck-empty-refs.chpl:40: In function 'badSetNilByRefXAssign':
 nilcheck-empty-refs.chpl:45: error: applying postfix-! to dead value
 nilcheck-empty-refs.chpl:45: note: 'r' refers to 'x'
 nilcheck-empty-refs.chpl:44: note: 'x' is dead due to copy elision here
+nilcheck-empty-refs.chpl:43: error: Reference to scoped variable r reachable after lifetime ends
+nilcheck-empty-refs.chpl:41: note: consider scope of x
 nilcheck-empty-refs.chpl:51: In function 'badRefToNilOwned2':
 nilcheck-empty-refs.chpl:55: error: applying postfix-! to nil
 nilcheck-empty-refs.chpl:55: note: 'r' refers to 'x'
@@ -34,3 +36,7 @@ nilcheck-empty-refs.chpl:87: In function 'badSetNilByRefXAssign2':
 nilcheck-empty-refs.chpl:93: error: applying postfix-! to dead value
 nilcheck-empty-refs.chpl:93: note: 'r' refers to 'x'
 nilcheck-empty-refs.chpl:92: note: 'x' is dead due to copy elision here
+nilcheck-empty-refs.chpl:90: error: Reference to scoped variable q reachable after lifetime ends
+nilcheck-empty-refs.chpl:88: note: consider scope of x
+nilcheck-empty-refs.chpl:91: error: Reference to scoped variable r reachable after lifetime ends
+nilcheck-empty-refs.chpl:88: note: consider scope of x

--- a/test/classes/delete-free/owned/owned-transfer-from-nonnil-tuple.bad
+++ b/test/classes/delete-free/owned/owned-transfer-from-nonnil-tuple.bad
@@ -1,3 +1,1 @@
 $CHPL_HOME/modules/internal/ChapelBase.chpl:1647: error: Cannot transfer ownership from this non-nilable reference variable
-$CHPL_HOME/modules/internal/ChapelBase.chpl:1647: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
-$CHPL_HOME/modules/internal/ChapelBase.chpl:1647: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias

--- a/test/classes/delete-free/tests-from-design-overview/lifetime-checking.good
+++ b/test/classes/delete-free/tests-from-design-overview/lifetime-checking.good
@@ -1,5 +1,5 @@
 lifetime-checking.chpl:11: In function 'test':
-lifetime-checking.chpl:16: error: Scoped variable c cannot be returned
-lifetime-checking.chpl:12: note: consider scope of a
 lifetime-checking.chpl:11: error: Illegal return of dead value
 lifetime-checking.chpl:16: note: 'a' is dead due to deinitialization here
+lifetime-checking.chpl:16: error: Scoped variable c cannot be returned
+lifetime-checking.chpl:12: note: consider scope of a

--- a/test/classes/delete-free/undecorated-generic/factory-new-borrowed.good
+++ b/test/classes/delete-free/undecorated-generic/factory-new-borrowed.good
@@ -6,7 +6,7 @@ factory-new-borrowed.chpl:19: warning: factory(MyClass) : owned MyClass
 factory-new-borrowed.chpl:21: warning: factory(owned MyClass) : owned MyClass
 factory-new-borrowed.chpl:23: warning: factory(borrowed MyClass) : borrowed MyClass
 factory-new-borrowed.chpl:3: In function 'factory':
-factory-new-borrowed.chpl:6: error: Scoped variable y cannot be returned
-factory-new-borrowed.chpl:4: note: consider result here
 factory-new-borrowed.chpl:3: error: Illegal return of dead value
 factory-new-borrowed.chpl:6: note: value is dead due to deinitialization here
+factory-new-borrowed.chpl:6: error: Scoped variable y cannot be returned
+factory-new-borrowed.chpl:4: note: consider result here

--- a/test/types/records/copy-elision/copy-elision-behavior.chpl
+++ b/test/types/records/copy-elision/copy-elision-behavior.chpl
@@ -187,6 +187,7 @@ proc test5a() {
 }
 test5a();
 
+pragma "unsafe" // avoid lifetime checker errors here
 proc test5b() {
   writeln("test5b");
   var x = new R(1);

--- a/test/types/records/copy-elision/copy-elision-checking.good
+++ b/test/types/records/copy-elision/copy-elision-checking.good
@@ -5,63 +5,95 @@ copy-elision-checking.chpl:25: note: 'x' is dead due to copy elision here
 copy-elision-checking.chpl:27: error: Illegal use of dead value
 copy-elision-checking.chpl:27: note: 'r' refers to 'x'
 copy-elision-checking.chpl:25: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:24: error: Reference to scoped variable r reachable after lifetime ends
+copy-elision-checking.chpl:23: note: consider scope of x
 copy-elision-checking.chpl:32: In function 'test2':
 copy-elision-checking.chpl:36: error: Illegal use of dead value
 copy-elision-checking.chpl:36: note: 'r' refers to 'x'
 copy-elision-checking.chpl:35: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:34: error: Reference to scoped variable r reachable after lifetime ends
+copy-elision-checking.chpl:33: note: consider scope of x
 copy-elision-checking.chpl:43: In function 'test10':
 copy-elision-checking.chpl:47: error: Illegal use of dead value
 copy-elision-checking.chpl:47: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:46: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:45: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:44: note: consider scope of x
 copy-elision-checking.chpl:51: In function 'test10a':
 copy-elision-checking.chpl:55: error: Illegal use of dead value
 copy-elision-checking.chpl:55: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:54: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:53: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:52: note: consider scope of x
 copy-elision-checking.chpl:59: In function 'test11':
 copy-elision-checking.chpl:63: error: Illegal use of dead value
 copy-elision-checking.chpl:63: note: 'y' refers to 'x'
 copy-elision-checking.chpl:62: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:61: error: Scoped variable y would outlive the value it is set to
+copy-elision-checking.chpl:60: note: consider scope of x
 copy-elision-checking.chpl:67: In function 'test11a':
 copy-elision-checking.chpl:71: error: Illegal use of dead value
 copy-elision-checking.chpl:71: note: 'y' refers to 'x'
 copy-elision-checking.chpl:70: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:69: error: Scoped variable y would outlive the value it is set to
+copy-elision-checking.chpl:68: note: consider scope of x
 copy-elision-checking.chpl:75: In function 'test12':
 copy-elision-checking.chpl:79: error: applying postfix-! to dead value
 copy-elision-checking.chpl:79: note: 'y' refers to 'x'
 copy-elision-checking.chpl:78: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:77: error: Scoped variable y would outlive the value it is set to
+copy-elision-checking.chpl:76: note: consider scope of x
 copy-elision-checking.chpl:83: In function 'test12a':
 copy-elision-checking.chpl:87: error: applying postfix-! to dead value
 copy-elision-checking.chpl:87: note: 'y' refers to 'x'
 copy-elision-checking.chpl:86: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:85: error: Scoped variable y would outlive the value it is set to
+copy-elision-checking.chpl:84: note: consider scope of x
 copy-elision-checking.chpl:160: In function 'test2a':
 copy-elision-checking.chpl:167: error: Illegal use of dead value
 copy-elision-checking.chpl:167: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:165: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:163: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:162: note: consider scope of x
 copy-elision-checking.chpl:171: In function 'test2b':
 copy-elision-checking.chpl:178: error: Illegal use of dead value
 copy-elision-checking.chpl:178: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:176: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:174: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:173: note: consider scope of x
 copy-elision-checking.chpl:182: In function 'test2c':
 copy-elision-checking.chpl:189: error: Illegal use of dead value
 copy-elision-checking.chpl:189: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:187: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:185: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:184: note: consider scope of x
 copy-elision-checking.chpl:193: In function 'test2d':
 copy-elision-checking.chpl:200: error: Illegal use of dead value
 copy-elision-checking.chpl:200: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:198: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:196: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:195: note: consider scope of x
 copy-elision-checking.chpl:263: In function 'test2aD':
 copy-elision-checking.chpl:270: error: Illegal use of dead value
 copy-elision-checking.chpl:270: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:268: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:266: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:265: note: consider scope of x
 copy-elision-checking.chpl:274: In function 'test2bD':
 copy-elision-checking.chpl:281: error: Illegal use of dead value
 copy-elision-checking.chpl:281: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:279: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:277: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:276: note: consider scope of x
 copy-elision-checking.chpl:285: In function 'test2cD':
 copy-elision-checking.chpl:292: error: Illegal use of dead value
 copy-elision-checking.chpl:292: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:290: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:288: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:287: note: consider scope of x
 copy-elision-checking.chpl:296: In function 'test2dD':
 copy-elision-checking.chpl:303: error: Illegal use of dead value
 copy-elision-checking.chpl:303: note: 'rx' refers to 'x'
 copy-elision-checking.chpl:301: note: 'x' is dead due to copy elision here
+copy-elision-checking.chpl:299: error: Reference to scoped variable rx reachable after lifetime ends
+copy-elision-checking.chpl:298: note: consider scope of x

--- a/test/types/records/copy-elision/copy-elision-default-behavior.chpl
+++ b/test/types/records/copy-elision/copy-elision-default-behavior.chpl
@@ -187,6 +187,7 @@ proc test5a() {
 }
 test5a();
 
+pragma "unsafe" // avoid lifetime checker errors for this test
 proc test5b() {
   writeln("test5b");
   var x = new R(1);

--- a/test/types/records/copy-elision/copy-elision-default.chpl
+++ b/test/types/records/copy-elision/copy-elision-default.chpl
@@ -187,6 +187,7 @@ proc test5a() {
 }
 test5a();
 
+pragma "unsafe" // avoid lifetime checking errors here
 proc test5b() {
   writeln("test5b");
   var x = new R(1);

--- a/test/types/records/copy-elision/copy-elision.chpl
+++ b/test/types/records/copy-elision/copy-elision.chpl
@@ -191,6 +191,7 @@ proc test5a() {
 }
 test5a();
 
+pragma "unsafe" // avoid lifetime errors for this function
 proc test5b() {
   writeln("test5b");
   var x = new R(1);

--- a/test/types/records/expiring/ex-errors.chpl
+++ b/test/types/records/expiring/ex-errors.chpl
@@ -14,6 +14,7 @@ proc setit(ref lhs, rhs) lifetime lhs < rhs {
 proc ownedExample2EOB() {
   writeln("ownedExample2EOB");
   var b: borrowed C?;
+  b; // no split init please
   b = (new owned C(1)).borrow();
   // point 1
   writeln(b);

--- a/test/types/records/expiring/ex-errors.future
+++ b/test/types/records/expiring/ex-errors.future
@@ -1,2 +1,0 @@
-feature request: compilation error for this pattern
-#11534

--- a/test/types/records/expiring/ex-errors.good
+++ b/test/types/records/expiring/ex-errors.good
@@ -1,1 +1,6 @@
-compilation error
+ex-errors.chpl:14: In function 'ownedExample2EOB':
+ex-errors.chpl:18: error: Scoped variable b would outlive the value it is set to
+ex-errors.chpl:26: In function 'ownedExample3EOB':
+ex-errors.chpl:29: error: Actual argument does not meet called function lifetime constraint
+ex-errors.chpl:10: note: called function setit(lhs: borrowed C?, rhs: borrowed C)
+ex-errors.chpl:10: note: includes lifetime constraint lhs < rhs

--- a/test/types/records/split-init/split-init-borrow-lifetime-error.good
+++ b/test/types/records/split-init/split-init-borrow-lifetime-error.good
@@ -2,6 +2,9 @@ split-init-borrow-lifetime-error.chpl:11: In function 'testCborrowedCQassign':
 split-init-borrow-lifetime-error.chpl:15: error: Scoped variable c would outlive the value it is set to
 split-init-borrow-lifetime-error.chpl:14: note: consider scope of inner
 split-init-borrow-lifetime-error.chpl:21: In function 'testCborrowedC':
+split-init-borrow-lifetime-error.chpl:27: error: Illegal use of dead value
+split-init-borrow-lifetime-error.chpl:27: note: 'c' refers to 'inner'
+split-init-borrow-lifetime-error.chpl:25: note: 'inner' is dead due to deinitialization here
 split-init-borrow-lifetime-error.chpl:25: error: Scoped variable c would outlive the value it is set to
 split-init-borrow-lifetime-error.chpl:24: note: consider scope of inner
 split-init-borrow-lifetime-error.chpl:31: In function 'testCborrowedCQ':
@@ -10,6 +13,9 @@ split-init-borrow-lifetime-error.chpl:34: note: consider scope of inner
 split-init-borrow-lifetime-error.chpl:35: error: Scoped variable c reachable after lifetime ends
 split-init-borrow-lifetime-error.chpl:34: note: consider scope of inner
 split-init-borrow-lifetime-error.chpl:41: In function 'testCNoType':
+split-init-borrow-lifetime-error.chpl:47: error: Illegal use of dead value
+split-init-borrow-lifetime-error.chpl:47: note: 'c' refers to 'inner'
+split-init-borrow-lifetime-error.chpl:45: note: 'inner' is dead due to deinitialization here
 split-init-borrow-lifetime-error.chpl:45: error: Scoped variable c would outlive the value it is set to
 split-init-borrow-lifetime-error.chpl:44: note: consider scope of inner
 split-init-borrow-lifetime-error.chpl:51: In function 'testRassign':
@@ -30,11 +36,3 @@ split-init-borrow-lifetime-error.chpl:95: note: consider scope of myC
 split-init-borrow-lifetime-error.chpl:102: In function 'testRQsplitNoType':
 split-init-borrow-lifetime-error.chpl:106: error: Scoped variable x reachable after lifetime ends
 split-init-borrow-lifetime-error.chpl:105: note: consider scope of myC
-split-init-borrow-lifetime-error.chpl:21: In function 'testCborrowedC':
-split-init-borrow-lifetime-error.chpl:27: error: Illegal use of dead value
-split-init-borrow-lifetime-error.chpl:27: note: 'c' refers to 'inner'
-split-init-borrow-lifetime-error.chpl:25: note: 'inner' is dead due to deinitialization here
-split-init-borrow-lifetime-error.chpl:41: In function 'testCNoType':
-split-init-borrow-lifetime-error.chpl:47: error: Illegal use of dead value
-split-init-borrow-lifetime-error.chpl:47: note: 'c' refers to 'inner'
-split-init-borrow-lifetime-error.chpl:45: note: 'inner' is dead due to deinitialization here

--- a/test/users/engin/retInnerFunction.bad
+++ b/test/users/engin/retInnerFunction.bad
@@ -1,4 +1,4 @@
-retInnerFunction.chpl:5: internal error: RES-LIF-IME-3074 chpl version 1.21.0 pre-release (f6474ce083)
+retInnerFunction.chpl:5: internal error: RES-ADD-LLS-0719 chpl version 1.21.0 pre-release (3b498c4d5f)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/npadmana/twopt/do_smu_soa-error.bad
+++ b/test/users/npadmana/twopt/do_smu_soa-error.bad
@@ -1,6 +1,3 @@
 do_smu_soa-error.chpl:294: In function 'doPairs':
-do_smu_soa-error.chpl:299: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
-do_smu_soa-error.chpl:299: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
+do_smu_soa-error.chpl:299: error: Cannot transfer ownership from this non-nilable reference variable
 $CHPL_HOME/modules/internal/ChapelBase.chpl:1647: error: Cannot transfer ownership from this non-nilable reference variable
-$CHPL_HOME/modules/internal/ChapelBase.chpl:2248: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias
-$CHPL_HOME/modules/internal/ChapelBase.chpl:2248: error: Cannot transfer ownership from a non-nilable variable with a potentially captured alias


### PR DESCRIPTION
This PR adjusts the lifetime checker to use a very simple 
control-flow-independent test to estimate when a variable has smaller
scope due to early deinit or copy elision. This is a first step - in the
future, it should compare blocks & deinit points. However this starting
point checking helps find real errors.

In order to allow the lifetime checker to check `PRIM_ELIDED_COPY`, it
moves lifetime checking later in callDestructors. Along the way, it makes
lifetime checking and nil-checking run together on each function, to keep
more AST in cache.

Reviewed by @benharsh - thanks!

- [x] full local futures testing