### PR TITLE
Fix SKIPIF error for masonTestSome

### DIFF
--- a/test/mason/masonTestSome/SKIPIF
+++ b/test/mason/masonTestSome/SKIPIF
@@ -1,10 +1,1 @@
-#!/usr/bin/env python
-
-"""
-mason requires CHPL_COMM=none (local)
-"""
-
-from __future__ import print_function
-from os import environ
-
-print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2')
+../SKIPIF


### PR DESCRIPTION
Fixes a SKIPIF with bad permissions in #14037 to use a symlink like all the other mason SKIPIFs