### PR TITLE
Fix testing for new --lldb flag

### DIFF
--- a/test/execflags/bradc/moduleHelp.good
+++ b/test/execflags/bradc/moduleHelp.good
@@ -6,6 +6,7 @@ FLAGS:
                            (equivalent to setting the numLocales config const)
   -v, --verbose          : run program in verbose mode
   --gdb                  : run program in gdb
+  --lldb                 : run program in lldb
 
 CONFIG VAR FLAGS:
 =================

--- a/test/execflags/configs/privateconfigs-help-set.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help-set.comm-none.good
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:

--- a/test/execflags/configs/privateconfigs-help-set.good
+++ b/test/execflags/configs/privateconfigs-help-set.good
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:

--- a/test/execflags/configs/privateconfigs-help.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help.comm-none.good
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:

--- a/test/execflags/configs/privateconfigs-help.good
+++ b/test/execflags/configs/privateconfigs-help.good
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:

--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:

--- a/test/execflags/lldbddash/SKIPIF
+++ b/test/execflags/lldbddash/SKIPIF
@@ -1,5 +1,7 @@
-#!/usr/bin/env python
+#!/bin/bash
 
-from shutil import which
-
-print(which("lldb") is None)
+if which lldb >/dev/null 2>/dev/null; then
+  echo False
+else
+  echo True
+fi

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -10,6 +10,7 @@ FLAGS:
   -b, --blockreport     : report location of blocked threads on SIGINT
   -t, --taskreport      : report list of pending and executing tasks on SIGINT
   --gdb                 : run program in gdb
+  --lldb                : run program in lldb
   -E<envVar>=<val>      : set the value of an environment variable
 
 CONFIG VAR FLAGS:


### PR DESCRIPTION
This fixes a few test problems that I failed to detect before merging
the newly contributed support for a --lldb flag on our generated
executables in PR #15031.  Specifically it:

* adds --lldb to the .good files of tests that are sensitive to the
  output of --help (what a rookie mistake, Brad!)

* adds +x permissions to the SKIPIF file and rewrites it to use bash
  rather than Python, as the Python did not seem portable.