### PR TITLE
Update .good for masonTestSome  

### DIFF
--- a/test/mason/masonTestSome/mason-test-some.good
+++ b/test/mason/masonTestSome/mason-test-some.good
@@ -1,4 +1,4 @@
-Updating mason-registry
+Updating registry
 
 ======================================================================
 FAIL test1.chpl: test1


### PR DESCRIPTION
Fixes a `.good` with conflicts from #14881

- [x] tested locally
