### PR TITLE
Fix comm counts in assignSlice

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 40, put = 1, execute_on = 4) (get = 40, put = 1) (get = 40, put = 1)
+(execute_on = 8, execute_on_nb = 9) (get = 32, put = 1, execute_on = 4) (get = 32, put = 1) (get = 32, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.chpl
@@ -10,7 +10,7 @@ var B: [Dom4D] 4*int;
 resetCommDiagnostics();
 startCommDiagnostics();
 if doVerboseComm then startVerboseComm();
-B = A[1..n4,1..n4,1..n4,1..n4];
+{ B = A[1..n4,1..n4,1..n4,1..n4]; }
 if doVerboseComm then stopVerboseComm();
 stopCommDiagnostics();
 writeln(getCommDiagnostics());

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 67, put = 1, execute_on = 4) (get = 67, put = 1) (get = 67, put = 1)
+(execute_on = 8, execute_on_nb = 9) (get = 40, put = 1, execute_on = 4) (get = 40, put = 1) (get = 40, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_nb = 6) (get = 61, put = 1, execute_on = 2) (get = 61, put = 1) (get = 61, put = 1)
+(execute_on = 8, execute_on_nb = 9) (get = 67, put = 1, execute_on = 4) (get = 67, put = 1) (get = 67, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 4, execute_on_nb = 6) (get = 62, put = 1, execute_on = 6) (get = 62, put = 1, execute_on = 4) (get = 62, put = 1, execute_on = 4)
+(put = 12, execute_on = 8, execute_on_nb = 9) (get = 76, put = 1, execute_on = 8) (get = 76, put = 1, execute_on = 4) (get = 76, put = 1, execute_on = 4)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.na-none.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 4, execute_on_nb = 6) (get = 62, put = 1, execute_on = 6, execute_on_fast = 2) (get = 62, put = 1, execute_on = 4, execute_on_fast = 2) (get = 62, put = 1, execute_on = 4, execute_on_fast = 2)
+(put = 12, execute_on = 8, execute_on_nb = 9) (get = 76, put = 1, execute_on = 8, execute_on_fast = 3) (get = 76, put = 1, execute_on = 4, execute_on_fast = 3) (get = 76, put = 1, execute_on = 4, execute_on_fast = 3)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.block.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_nb = 9) (get = 40, put = 1, execute_on = 2) (get = 40, put = 1) (get = 40, put = 1)
+(execute_on = 4, execute_on_nb = 9) (get = 32, put = 1, execute_on = 2) (get = 32, put = 1) (get = 32, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.cyclic.good
@@ -1,1 +1,1 @@
-(execute_on = 2, execute_on_nb = 6) (get = 67, put = 1, execute_on = 1) (get = 67, put = 1) (get = 67, put = 1)
+(execute_on = 4, execute_on_nb = 9) (get = 73, put = 1, execute_on = 2) (get = 73, put = 1) (get = 73, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.cyclic.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_nb = 9) (get = 73, put = 1, execute_on = 2) (get = 73, put = 1) (get = 73, put = 1)
+(execute_on = 4, execute_on_nb = 9) (get = 46, put = 1, execute_on = 2) (get = 46, put = 1) (get = 46, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.replicated.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 2, execute_on_nb = 6) (get = 62, put = 1, execute_on = 5) (get = 62, put = 1, execute_on = 4) (get = 62, put = 1, execute_on = 4)
+(put = 12, execute_on = 4, execute_on_nb = 9) (get = 76, put = 1, execute_on = 6) (get = 76, put = 1, execute_on = 4) (get = 76, put = 1, execute_on = 4)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.replicated.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.replicated.na-none.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 2, execute_on_nb = 6) (get = 62, put = 1, execute_on = 5, execute_on_fast = 2) (get = 62, put = 1, execute_on = 4, execute_on_fast = 2) (get = 62, put = 1, execute_on = 4, execute_on_fast = 2)
+(put = 12, execute_on = 4, execute_on_nb = 9) (get = 76, put = 1, execute_on = 6, execute_on_fast = 3) (get = 76, put = 1, execute_on = 4, execute_on_fast = 3) (get = 76, put = 1, execute_on = 4, execute_on_fast = 3)


### PR DESCRIPTION
PR #15041 caused comm count changes for the assignSlice tests because a
temporary was being destroyed in the measured section. Putting curly
braces around the measured section caused the same behavior on master
before that PR.

This PR updates the comm counts to account for that PR and others
yesterday. It does so in two commits - first, it updates the test to put
curly braces around the measured section and accepts the comm count
increases (this was done with the version just before PR #15041). Then,
the 2nd commit accepts improvements from other PRs (most likely #15049
and #15044 but I did not narrow it down).

Trivial and not reviewed.

- [x] assignSlice tests pass on a ugni with replicated, cyclic, block
- [x] assignSlice tests pass on a gasnet with replicated, cyclic, block