### PR TITLE
Add support for .first and .last on enums

### DIFF
--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -1,5 +1,7 @@
 .. _Chapter-Types:
 
+.. default-domain:: chpl
+
 Types
 =====
 
@@ -362,11 +364,17 @@ available:
 
 
 
-.. code-block:: chapel
+.. function:: proc enum.size: param int
 
-   proc enum.size: param int
+     Returns the number of constants in the given enumerated type.
 
-The number of constants in the given enumerated type.
+.. function:: proc enum.first: enum
+
+     Returns the first constant in the enumerated type.
+
+.. function:: proc enum.last: enum
+
+     Returns the last constant in the enumerated type.
 
 .. _Structured_Types:
 

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -762,6 +762,16 @@ iter type enumerated.these(){
     yield i;
 }
 
+pragma "no doc"
+proc type enumerated.first {
+  return chpl__orderToEnum(0, this);
+}
+
+pragma "no doc"
+proc type enumerated.last {
+  return chpl__orderToEnum(this.size-1, this);
+}
+
 private proc chpl_enum_minbits(type t: enumerated) param {
   if t.size <= max(uint(8)) then
     return 8;

--- a/test/types/enum/enumFirstLast.chpl
+++ b/test/types/enum/enumFirstLast.chpl
@@ -1,0 +1,7 @@
+enum color {red, green, blue};
+
+writeln(color.first);
+writeln(color.last);
+
+for i in color.first..color.last do
+  writeln(i);

--- a/test/types/enum/enumFirstLast.good
+++ b/test/types/enum/enumFirstLast.good
@@ -1,0 +1,5 @@
+red
+blue
+red
+green
+blue


### PR DESCRIPTION
This adds support for .first and .last queries on enums, supporting
the ability to write code like `for c in color.first..color.last
do...` It also adds the routines to the spec and reformats the enum
routines in the spec to use `.. function::` formatting rather than
`.. code-block::` formatting, which is much prettier (or at least,
more consistent).