### PR TITLE
Fix bug in Random.choice for non-numeric array types

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -390,7 +390,7 @@ module Random {
             var (found, indexChosen) = Search.binarySearch(cumulativeArr, randNum);
             if !indicesChosen.contains(indexChosen) {
               indicesChosen += indexChosen;
-              samples[i] += A[indexChosen];
+              samples[i] = A[indexChosen];
               i += 1;
             }
             P[indexChosen] = 0;

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -254,11 +254,19 @@ module Random {
         throw new owned IllegalArgumentError('choice() array arguments must have same domain');
       }
     }
+
     if !isNothingType(sizeType) {
       if isIntegralType(sizeType) {
         if size <= 0 then
-        throw new owned IllegalArgumentError('choice() size must be greater than 0');
-      } else if !isDomainType(sizeType) {
+          throw new owned IllegalArgumentError('choice() size must be greater than 0');
+        if !replace && size > arr.size then
+          throw new owned IllegalArgumentError('choice() size must be smaller than array.size when replace=false');
+      } else if isDomainType(sizeType) {
+        if size.size <= 0 then
+          throw new owned IllegalArgumentError('choice() size domain can not be empty');
+        if !replace && size.size > arr.size then
+          throw new owned IllegalArgumentError('choice() size must be smaller than array.size when replace=false');
+      } else {
         compilerError('choice() size must be integral or domain');
       }
     }

--- a/test/library/standard/Random/RandomStreamInterface/choiceTest.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTest.chpl
@@ -19,6 +19,13 @@ proc runTests(stream) {
   var real32s: [1..4] real(32) = [0.1:real(32), 0.2:real(32), 0.3:real(32), 0.4:real(32)];
   testArray(stream, real32s);
 
+  // user-defined type
+  var rArr = [new R(1), new R(2), new R(3)];
+  testArray(stream, rArr, trials=1);
+
+  var pArr = [1, 1, 2];
+  testArray(stream, rArr, prob=pArr, size=2, replace=false, trials=1);
+
   // offset & strided domain
   var strideDom = {10..#10 by 3};
   var strideArr: [strideDom] int;
@@ -70,9 +77,14 @@ proc runTests(stream) {
     writeln('error: domain reference not maintained');
 }
 
-proc testArray(stream, arr: [], size:?sizeType=none, replace=true, prob:?probType=none, trials=10000) throws {
-  var countsDom: domain(arr.eltType);
-  var counts = new map(arr.eltType, int);
+/* User-defined type */
+record R {
+  var value = 0;
+  var tag = "someValue";
+}
+
+proc testArray(stream, arr: [] ?eltType, size:?sizeType=none, replace=true, prob:?probType=none, trials=10000) throws {
+  var counts = new map(eltType, int);
 
   // Collect statistics
   if isNothingType(probType) {
@@ -113,7 +125,7 @@ proc testArray(stream, arr: [], size:?sizeType=none, replace=true, prob:?probTyp
   if isDomainType(sizeType) then m = size.size;
   else if isIntegralType(sizeType) then m = size;
 
-  var actualRatios = new map(int, real);
+  var actualRatios = new map(eltType, real);
   for (k,v) in actualRatios.items() {
     if isNothingType(sizeType) then
       actualRatios[k] = v / trials:real;
@@ -139,7 +151,7 @@ proc testArray(stream, arr: [], size:?sizeType=none, replace=true, prob:?probTyp
   var success = true;
   if replace {
     for value in actualRatios {
-      if !isClose(actualRatios[value], expectedRatios[value:arr.eltType]) {
+      if !isClose(actualRatios[value], expectedRatios[value]) {
         success = false;
       }
     }

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestErrors.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestErrors.chpl
@@ -45,4 +45,18 @@ proc main() throws {
   } catch e: IllegalArgumentError {
     if debug then writeln(e.message());
   }
+
+  try {
+    var c = stream.choice([1,2], replace=false, size=3);
+    writeln('Error: size > arr.size with replace=false did not throw error');
+  } catch e: IllegalArgumentError {
+    if debug then writeln(e.message());
+  }
+
+  try {
+    var c = stream.choice([1,2], replace=false, size={1..4});
+    writeln('Error: (size:domain).size > arr.size with replace=false did not throw error');
+  } catch e: IllegalArgumentError {
+    if debug then writeln(e.message());
+  }
 }


### PR DESCRIPTION
This PR tackles 2 issues for the `choice()` function in the `Random` module:

- Fixes a bug where using non-numeric array types  with args `choice(arr, prob, size>1, replace=false)` gave a compiler error. 
- Adds better error messages for when `size>arr.size` instead of giving an index out of bounds error.

Also added tests for these bugs and generalized the `choice` tests to not assume non-numeric array types.