### PR TITLE
Minor fixes after PRs 15044 and 15084

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1114,8 +1114,8 @@ class GatherGlobalsReferredTo : public AstVisitorTraverse {
 
     // this is global state storing results of analysis
     std::set<FnSymbol*> visited;
-    std::map<FnSymbol*, std::set<VarSymbol*>> directGlobalMentions;
-    std::map<FnSymbol*, std::set<FnSymbol*>> callGraph;
+    std::map<FnSymbol*, std::set<VarSymbol*> > directGlobalMentions;
+    std::map<FnSymbol*, std::set<FnSymbol*> > callGraph;
 
     GatherGlobalsReferredTo()
       : thisFunction(NULL)
@@ -1304,9 +1304,9 @@ bool computeIntersection(std::set<VarSymbol*>& a, std::set<VarSymbol*>& b,
 
 // This function is intended to be relatively optimized
 bool FindInvalidGlobalUses::checkIfFnUsesInvalid(FnSymbol* startFn) {
-  std::map<FnSymbol*, std::set<VarSymbol*>>& directGlobalMentions =
+  std::map<FnSymbol*, std::set<VarSymbol*> >& directGlobalMentions =
     gatherVisitor.directGlobalMentions;
-  std::map<FnSymbol*, std::set<FnSymbol*>>& callGraph =
+  std::map<FnSymbol*, std::set<FnSymbol*> >& callGraph =
     gatherVisitor.callGraph;
 
   std::set<FnSymbol*> everBeenInWork;
@@ -1350,9 +1350,9 @@ bool FindInvalidGlobalUses::checkIfFnUsesInvalid(FnSymbol* startFn) {
 // to be reported. In that event it gives a stack trace.
 bool FindInvalidGlobalUses::errorIfFnUsesInvalid(FnSymbol* fn, BaseAST* loc,
                                                  std::set<FnSymbol*>& visited) {
-  std::map<FnSymbol*, std::set<VarSymbol*>>& directGlobalMentions =
+  std::map<FnSymbol*, std::set<VarSymbol*> >& directGlobalMentions =
     gatherVisitor.directGlobalMentions;
-  std::map<FnSymbol*, std::set<FnSymbol*>>& callGraph =
+  std::map<FnSymbol*, std::set<FnSymbol*> >& callGraph =
     gatherVisitor.callGraph;
   std::vector<VarSymbol*> inV;
 

--- a/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.chpl
+++ b/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.chpl
@@ -11,7 +11,7 @@ class LocC {
 }
 
 class C {
-  var locCs: [LocaleSpace] unmanaged LocC;
+  var locCs: [LocaleSpace] unmanaged LocC?;
 
   proc postinit() {
     for loc in LocaleSpace {


### PR DESCRIPTION
* In the compiler, add a space in `>>` in nested templates such as
`std::map<FnSymbol*, std::set<VarSymbol*>>`, as required by gcc 4.8.

* In a test, switch the array element type as nilable.
The compiler error about it was masked by the test's prediff.