### PR TITLE
Fix line numbers in a deprecation test

### DIFF
--- a/test/deprecated/regexpListEltType.good
+++ b/test/deprecated/regexpListEltType.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/standard/Regexp.chpl:593: warning: string-by-default regexp is deprecated. Use regexp(string) or regexp(bytes) instead.
+$CHPL_HOME/modules/standard/Regexp.chpl:602: warning: string-by-default regexp is deprecated. Use regexp(string) or regexp(bytes) instead.
 regexp(string)

--- a/test/deprecated/regexpType.good
+++ b/test/deprecated/regexpType.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/standard/Regexp.chpl:593: warning: string-by-default regexp is deprecated. Use regexp(string) or regexp(bytes) instead.
+$CHPL_HOME/modules/standard/Regexp.chpl:602: warning: string-by-default regexp is deprecated. Use regexp(string) or regexp(bytes) instead.
 regexp(string)


### PR DESCRIPTION
Regexp module has changed a bit before I merged these deprecation tests.

This PR updates the line numbers for the warnings to reflect those changes.