### PR TITLE
Fix another misaligned GET bug in ugni

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5910,7 +5910,7 @@ void do_remote_get(void* tgt_addr, c_nodeid_t locale, void* src_addr,
     //
     // The transfer will fit in a single trampoline buffer.
     //
-    tgt_addr_xmit = get_buf_alloc(size);
+    tgt_addr_xmit = get_buf_alloc(xmit_size);
 
     do_nic_get(tgt_addr_xmit, locale, remote_mr,
                src_addr_xmit, xmit_size, gnr_mreg);

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.chpl
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.chpl
@@ -9,7 +9,10 @@ config const printStats = true,
 config const oversubscription = 1,
              tasksPerLocale = here.maxTaskPar * oversubscription;
 
-config type copyType = int;
+config type componentType = int;
+config param numComponents = 1;
+type copyType = if numComponents > 1 then numComponents*componentType else componentType;
+
 config param useUnorderedCopy = true;
 config const concurrentFencing = false;
 config param commDiags = false;
@@ -22,8 +25,8 @@ const D = space dmapped Block(space, dataParTasksPerLocale=tasksPerLocale);
 var A, reversedA: [D] copyType;
 
 forall (a, r, d) in zip(A, reversedA, D) {
-  a += d;
-  r += d;
+  a += d:componentType;
+  r += d:componentType;
 }
 
 inline proc assign(ref dst, ref src) {
@@ -57,7 +60,7 @@ proc stop(opType: string) {
   if verify then
     forall (rA, i) in zip(reversedA, D) {
       var expected: copyType;
-      expected += size-i;
+      expected += (size-i):componentType;
       assert(rA == expected);
     }
 }

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.compopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.compopts
@@ -1,3 +1,5 @@
---no-checks --no-optimize-forall-unordered-ops -scopyType=int
---no-checks --no-optimize-forall-unordered-ops -scopyType=2*int
---no-checks --no-optimize-forall-unordered-ops -scopyType=512*int
+--no-checks --no-optimize-forall-unordered-ops -scomponentType=int(8) -snumComponents=1
+--no-checks --no-optimize-forall-unordered-ops -scomponentType=int(8) -snumComponents=7
+--no-checks --no-optimize-forall-unordered-ops -scomponentType=int    -snumComponents=1
+--no-checks --no-optimize-forall-unordered-ops -scomponentType=int    -snumComponents=1
+--no-checks --no-optimize-forall-unordered-ops -scomponentType=int    -snumComponents=512


### PR DESCRIPTION
Under ugni, the size and addresses of a GET have to be 4-byte aligned.
If they aren't, we use bounce buffers and over-GET in order to meet
those alignment requirements. We had a bug in this code, where we could
end up requesting too small of a bounce buffer and overflow it,
corrupting the bounce buffer data structures.

For a 7-byte GET with a 7-byte aligned address, we'd end up doing a
16-byte GET, but we were only asking for an 8-byte buffer. We'd overflow
that buffer, corrupting the locks and other data structures around it.
Here we ensure that we ask for a bounce buffer that's at least as large
as the aligned transmission size, not the original size.

It was pretty rare to trigger this bug because you needed the GET size
to be < 8, and the aligned GET size to be > 8. That requires a 2,3,5,6,
or 7 byte GET with wrong alignment. Most of our codes end up doing 1, 4,
or 8 byte GETs, all of which worked correctly.

This is the cause of https://github.com/mhmerrill/arkouda/issues/301