### PR TITLE
Future-ize array-of-barriers test

### DIFF
--- a/test/parallel/taskPar/elliot/barrier/array-of-barriers.future
+++ b/test/parallel/taskPar/elliot/barrier/array-of-barriers.future
@@ -1,0 +1,2 @@
+bug: problems with memory management of barriers
+#15116

--- a/test/parallel/taskPar/elliot/barrier/array-of-barriers.skipif
+++ b/test/parallel/taskPar/elliot/barrier/array-of-barriers.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
This PR future-izes the test

    test/parallel/taskPar/elliot/barrier/array-of-barriers.chpl

for until #15116 is solved.

Trivial and not reviewed (but discussed with @daviditen ).