### PR TITLE
Don't deinit formal temps before end of block

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1126,6 +1126,7 @@ static void markTempsDeadLastMention(std::set<VarSymbol*>& temps) {
         v->hasFlag(FLAG_INDEX_VAR) ||
         v->hasFlag(FLAG_CHPL__ITER) ||
         v->hasFlag(FLAG_CHPL__ITER_NEWSTYLE) ||
+        v->hasFlag(FLAG_FORMAL_TEMP) ||
         v->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
       // index vars, iterator records are always end-of-block
       // but shouldn't be global variables.


### PR DESCRIPTION
Formal temps are more like user variables than normal temps.
It makes sense not to deinit them early since they will be used
throughout the function, generally speaking.

Resolves valgrind failures with
 test/types/records/intents/out-intent.chpl

after PR #15041.

Trivial and not reviewed.

- [x] full local testing
- [x] primers pass under valgrind+verify and do not leak