### PR TITLE
Split deprecation test into two due to REGEXP sensitivity

### DIFF
--- a/test/deprecated/length-regex.chpl
+++ b/test/deprecated/length-regex.chpl
@@ -1,0 +1,5 @@
+use Regexp;
+
+var re = "foobar".match(compile(".*oob.*"));
+
+writeln(re.length);

--- a/test/deprecated/length-regex.good
+++ b/test/deprecated/length-regex.good
@@ -1,0 +1,2 @@
+length-regex.chpl:5: warning: 'reMatch.length' is deprecated - please use 'reMatch.size' instead
+6

--- a/test/deprecated/length-regex.skipif
+++ b/test/deprecated/length-regex.skipif
@@ -1,0 +1,2 @@
+# this test only works if Regexp.chpl is supported
+CHPL_REGEXP!=re2

--- a/test/deprecated/length.chpl
+++ b/test/deprecated/length.chpl
@@ -1,4 +1,4 @@
-use IO, Collection, Regexp;
+use IO, Collection;
 
 param bp = b"brad";
 var b = b"brad";
@@ -10,8 +10,8 @@ var a: c_array(int, 20);
 var r = 1..10;
 const stdin = openfd(0);
 var l = new LinkedList(int);
-var re = "foobar".match(compile(".*oob.*"));
 var c = new CollectionImpl(int);
+
 
 
 
@@ -28,5 +28,5 @@ writeln(a.length);
 writeln(r.length);
 writeln(stdin.length());
 writeln(l.length);
-writeln(re.length);
+
 writeln(c.length);

--- a/test/deprecated/length.good
+++ b/test/deprecated/length.good
@@ -9,7 +9,6 @@ length.chpl:27: warning: 'c_array.length' is deprecated - please use 'c_array.si
 length.chpl:28: warning: 'range.length' is deprecated - please use 'range.size' instead
 length.chpl:29: warning: 'file.length()' is deprecated - please use 'file.size' instead
 length.chpl:30: warning: 'LinkedList.length' is deprecated - please use 'LinkedList.size' instead
-length.chpl:31: warning: 'reMatch.length' is deprecated - please use 'reMatch.size' instead
 length.chpl:32: warning: 'CollectionImpl.length' is deprecated - please use 'CollectionImpl.size' instead
 4
 4
@@ -22,5 +21,4 @@ length.chpl:32: warning: 'CollectionImpl.length' is deprecated - please use 'Col
 10
 0
 0
-6
 length.chpl:32: error: halt reached - 'proc size() : int' is not supported...


### PR DESCRIPTION
I failed to consider that my test of `.length` deprecations relied
on CHPL_REGEXP=re2 which meant it would fail under baseline.  This
splits the test into two, forking the reMatch.length check into its
own test which is .skipif'd in the event that CHPL_REGEXP isn't
available.