### PR TITLE
Do not split-init arrays in comm count assign tests

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/assign.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assign.chpl
@@ -2,7 +2,7 @@ use driver_domains;
 private use CommDiagnostics;
 
 var A: [Dom4D] 4*int = {(...Dom4D.dims())};
-var B: [Dom4D] 4*int;
+var B: [Dom4D] 4*int = (0, 0, 0, 0);
 
 resetCommDiagnostics();
 startCommDiagnostics();

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignAlias.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignAlias.chpl
@@ -2,7 +2,7 @@ use driver_domains;
 private use CommDiagnostics;
 
 var A: [Dom4D] 4*int = {(...Dom4D.dims())};
-var B: [Dom4D] 4*int;
+var B: [Dom4D] 4*int = (0, 0, 0, 0);
 
 resetCommDiagnostics();
 startCommDiagnostics();

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.chpl
@@ -6,7 +6,7 @@ config const doVerboseComm = false;
 const bigDom4D = Dom4D.expand((1,1,1,1));
 const locBigDom = {(...bigDom4D.dims())};
 var A: [bigDom4D] 4*int = locBigDom;
-var B: [Dom4D] 4*int;
+var B: [Dom4D] 4*int = (0, 0, 0, 0);
 
 const offset = locBigDom.translate(1);
 const slice = offset.expand(-1);

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.chpl
@@ -5,7 +5,7 @@ config const doVerboseComm = false;
 
 const bigDom4D = Dom4D.expand((1,1,1,1));
 var A: [bigDom4D] 4*int = {(...bigDom4D.dims())};
-var B: [Dom4D] 4*int;
+var B: [Dom4D] 4*int = (0, 0, 0, 0);
 
 resetCommDiagnostics();
 startCommDiagnostics();


### PR DESCRIPTION
Follow-on to PR #15113 . By doing split-init, the array initialization 
moved into the measured portion of these comm counts tests. This PR just
adjusts the declaration statements to also initialize.

Test change only - not reviewed.