### PR TITLE
Fix array-assign-block.chpl

### DIFF
--- a/test/performance/ferguson/array-assign-block.chpl
+++ b/test/performance/ferguson/array-assign-block.chpl
@@ -5,12 +5,8 @@ config const n = 100000;
 
 const Space = {1..n};
 const D = Space dmapped Block(boundingBox=Space);
-var A: [D] int;
-var B: [D] int;
-
-for i in 1..n {
-  A[i] = i;
-}
+var A: [D] int = 1..n;
+var B: [D] int = 0;
 
 start();
 


### PR DESCRIPTION
Apply the same fix as in #15134 as a follow-up to #15113.

Trivial and not reviewed.