### PR TITLE
Remove test's reliance on string + value support

### DIFF
--- a/test/interop/C/llvm/exportArray/exportFuncWithRealArr.chpl
+++ b/test/interop/C/llvm/exportArray/exportFuncWithRealArr.chpl
@@ -2,7 +2,7 @@ export proc foo(x: [] real) {
   for i in x.domain {
     // Note: this assumes x will have initial contents
     if ((x[i] <= i+2) && (x[i] > i)) {
-      writeln("x[" + i + "] in expected range");
+      writeln("x[" + i:string + "] in expected range");
     }
   }
   for i in x.domain {


### PR DESCRIPTION
(This is one of a number of tests that drop the 'chpl' compiler output
on the floor such that new warnings don't trigger failures, so it
never got updated when string+value overloads were deprecated.  I
missed it in my testing because I didn't test LLVM-only tests).