### PR TITLE
Make `mason doc` respect authors field

### DIFF
--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -43,7 +43,7 @@ proc masonDoc(args) throws {
     const projectAuthors = tomlFile["brick"]!["authors"]!.toString();
 
     const strippedAuthors = projectAuthors.split(',').strip('[]');
-    var authorsString:string;
+    var authorsString: string;
     for author in strippedAuthors {
       authorsString += author.strip('"') + ',';
     }

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -40,13 +40,21 @@ proc masonDoc(args) throws {
 
     const projectName = tomlFile["brick"]!["name"]!.s;
     const projectFile = projectName + '.chpl';
+    const projectAuthors = tomlFile["brick"]!["authors"]!.toString();
+
+    const strippedAuthors = projectAuthors.split(',').strip('[]');
+    var authorsString:string;
+    for author in strippedAuthors {
+      authorsString += author.strip('"') + ',';
+    }
+    authorsString = '--author "' + authorsString.strip(',') + '"';
 
     if isDir(projectHome + '/src/') {
       if isFile(projectHome + '/src/' + projectFile) {
         // Must use relative paths with chpldoc to prevent baking in abs paths
         here.chdir(projectHome);
 
-        const command = 'chpldoc src/' + projectFile + ' -o doc/ --process-used-modules';
+        const command = 'chpldoc src/' + projectFile + ' -o doc/ --process-used-modules' + ' ' + authorsString;
         writeln(command);
         runCommand(command);
       }


### PR DESCRIPTION
Make `mason doc` respect authors field
resolves https://github.com/chapel-lang/chapel/issues/15152

However, this can be buggy due to https://github.com/chapel-lang/chapel/issues/15152#issuecomment-597106651 and should be hold back until `runCommand` gets fixed.