### PR TITLE
Improve lifetime checker to consider copy elision

### DIFF
--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1947,38 +1947,6 @@ bool DeinitOrderVisitor::enterCallExpr(CallExpr* call) {
   if (lifetimes->callsToIgnore.count(call))
     return false;
 
-  /* don't consider auto-destroy calls to simplify the analysis.
-     these are added by the compiler in ways that are sometimes inconsistent
-     (e.g. reduction variables) and also can be added in many return paths
-     (e.g. throwing an error from in a loop) that are not particularly
-     important here.
-  if (FnSymbol* fn = call->resolvedFunction()) {
-    if (fn->hasFlag(FLAG_AUTO_DESTROY_FN)) {
-      SymExpr* se = toSymExpr(call->get(1));
-      Symbol* sym = lifetimes->getCanonicalSymbol(se->symbol());
-
-      if (skipEarlyDeinitsForUnconditionalReturn == 0 &&
-          isAutoDestroyedVariable(sym)) {
-        if (debugging) {
-          printOrderSummary(orderStack);
-          printf(" deinit %s[%i] in call %i\n", sym->name, sym->id, call->id);
-        }
-
-        addToDeinitOrderTree(&lifetimes->order[sym], orderStack.front());
-      } else if (debugging) {
-        printOrderSummary(orderStack);
-        printf(" skipping deinit %s[%i] in call %i\n",
-               sym->name, sym->id, call->id);
-      }
-
-      // don't advance order for auto-destroy functions themselves
-      // (so that deinitialization order is not enforced in analysis)
-
-      // no need to consider nested calls
-      return false;
-    }
-  }*/
-
   if (call->isPrimitive(PRIM_ASSIGN_ELIDED_COPY)) {
     SymExpr* se = toSymExpr(call->get(2));
     Symbol* sym = lifetimes->getCanonicalSymbol(se->symbol());

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1927,7 +1927,8 @@ bool DeinitOrderVisitor::enterCallExpr(CallExpr* call) {
       SymExpr* se = toSymExpr(call->get(1));
       Symbol* sym = lifetimes->getCanonicalSymbol(se->symbol());
 
-      if (skipEarlyDeinitsForUnconditionalReturn == 0) {
+      if (skipEarlyDeinitsForUnconditionalReturn == 0 &&
+          sym->getValType()->symbol->hasFlag(FLAG_POD) == false) {
         if (debugging) {
           printOrderSummary(orderStack);
           printf(" deinit %s[%i] in call %i\n", sym->name, sym->id, call->id);
@@ -1952,7 +1953,8 @@ bool DeinitOrderVisitor::enterCallExpr(CallExpr* call) {
     SymExpr* se = toSymExpr(call->get(2));
     Symbol* sym = lifetimes->getCanonicalSymbol(se->symbol());
 
-    if (skipEarlyDeinitsForUnconditionalReturn == 0) {
+    if (skipEarlyDeinitsForUnconditionalReturn == 0 &&
+        sym->getValType()->symbol->hasFlag(FLAG_POD) == false) {
       if (debugging) {
         printOrderSummary(orderStack);
         printf(" copy elide %s[%i] in call %i\n", sym->name, sym->id, call->id);
@@ -1964,6 +1966,9 @@ bool DeinitOrderVisitor::enterCallExpr(CallExpr* call) {
       printf(" skipping copy elide %s[%i] in call %i\n",
              sym->name, sym->id, call->id);
     }
+
+    // no need to consider nested calls
+    return false;
   }
 
   if (call->isPrimitive(PRIM_END_OF_STATEMENT)) {

--- a/test/classes/delete-free/lifetimes/borrow-escapes.chpl
+++ b/test/classes/delete-free/lifetimes/borrow-escapes.chpl
@@ -113,6 +113,7 @@ proc bad23() {
   }
   writeln(outer);
   outer = new borrowed MyClass(1);
+  writeln(outer);
 }
 
 

--- a/test/classes/delete-free/lifetimes/copy-elision-checking.chpl
+++ b/test/classes/delete-free/lifetimes/copy-elision-checking.chpl
@@ -55,3 +55,15 @@ proc test5() {
   }
 }
 test5();
+
+class C { var x: int; }
+
+proc test6() {
+  var a:owned C = new C(1);
+  var b = a.borrow();
+  {
+    var b = a; // copy elision
+    return;
+  }
+}
+test6();

--- a/test/classes/delete-free/lifetimes/copy-elision-checking.chpl
+++ b/test/classes/delete-free/lifetimes/copy-elision-checking.chpl
@@ -1,0 +1,57 @@
+record R {
+  proc deinit() { }
+}
+
+config const option = true;
+
+proc refIdentity(ref arg) ref {
+  return arg;
+}
+
+proc test1() {
+  var a:R;
+  ref r = a;
+  var b = a; // copy elision
+  writeln(r); // expect an error
+}
+test1();
+
+proc test2() {
+  var a:R;
+  ref r = refIdentity(a); 
+  var b = a; // copy elision
+  writeln(r); // expect an error
+}
+test2();
+
+proc test3() {
+  var a:R;
+  ref r = refIdentity(a); 
+  if option {
+    var b = a; // copy elision
+    return;
+  }
+  writeln(r); // this one is OK
+}
+test3();
+
+proc test4() {
+  var a:R;
+  {
+    ref r = refIdentity(a); 
+    var b = a; // copy elision
+    writeln(r);
+    return;
+  }
+}
+test4();
+
+proc test5() {
+  var a:R;
+  ref r = refIdentity(a); 
+  {
+    var b = a; // copy elision
+    writeln(r);
+  }
+}
+test5();

--- a/test/classes/delete-free/lifetimes/copy-elision-checking.good
+++ b/test/classes/delete-free/lifetimes/copy-elision-checking.good
@@ -10,3 +10,6 @@ copy-elision-checking.chpl:20: note: consider scope of a
 copy-elision-checking.chpl:38: In function 'test4':
 copy-elision-checking.chpl:41: error: Reference to scoped variable r reachable after lifetime ends
 copy-elision-checking.chpl:39: note: consider scope of a
+copy-elision-checking.chpl:61: In function 'test6':
+copy-elision-checking.chpl:63: error: Scoped variable b would outlive the value it is set to
+copy-elision-checking.chpl:62: note: consider scope of a

--- a/test/classes/delete-free/lifetimes/copy-elision-checking.good
+++ b/test/classes/delete-free/lifetimes/copy-elision-checking.good
@@ -1,0 +1,12 @@
+copy-elision-checking.chpl:11: In function 'test1':
+copy-elision-checking.chpl:15: error: Illegal use of dead value
+copy-elision-checking.chpl:15: note: 'r' refers to 'a'
+copy-elision-checking.chpl:14: note: 'a' is dead due to copy elision here
+copy-elision-checking.chpl:13: error: Reference to scoped variable r reachable after lifetime ends
+copy-elision-checking.chpl:12: note: consider scope of a
+copy-elision-checking.chpl:19: In function 'test2':
+copy-elision-checking.chpl:21: error: Reference to scoped variable r reachable after lifetime ends
+copy-elision-checking.chpl:20: note: consider scope of a
+copy-elision-checking.chpl:38: In function 'test4':
+copy-elision-checking.chpl:41: error: Reference to scoped variable r reachable after lifetime ends
+copy-elision-checking.chpl:39: note: consider scope of a

--- a/test/classes/delete-free/lifetimes/errors-dead-early.chpl
+++ b/test/classes/delete-free/lifetimes/errors-dead-early.chpl
@@ -49,6 +49,7 @@ test5();
 proc test6() {
   var a:borrowed MyClass? = nil;
   a = new borrowed MyClass();
+  writeln(a);
 }
 test6();
 

--- a/test/classes/delete-free/lifetimes/errors-dead-early.good
+++ b/test/classes/delete-free/lifetimes/errors-dead-early.good
@@ -12,6 +12,6 @@ errors-dead-early.chpl:42: In function 'test5':
 errors-dead-early.chpl:44: error: reference points to scoped variable reachable after lifetime ends
 errors-dead-early.chpl:49: In function 'test6':
 errors-dead-early.chpl:51: error: Scoped variable a would outlive the value it is set to
-errors-dead-early.chpl:113: In function 'test7':
-errors-dead-early.chpl:116: error: Scoped variable b would outlive the value it is set to
-errors-dead-early.chpl:114: note: consider scope of x
+errors-dead-early.chpl:114: In function 'test7':
+errors-dead-early.chpl:117: error: Scoped variable b would outlive the value it is set to
+errors-dead-early.chpl:115: note: consider scope of x


### PR DESCRIPTION
This PR updates the lifetime checker to use an analysis to determine
deinit points rather than to assume all variables are deinitialized at
the end of a block.

Determining the deinit point is important for issuing lifetime errors for
copy elision. When copy elision applies to some variable, the previously
applied rule (that a lifetime in a contained block is "shorter") is no
longer sufficient. For example:

``` chapel
proc f() {
  var x: R;
  var y = x; // x is copy elided; x dead after this point
  {
     var z = ...;
     // x has shorter lifetime than z
     // even though z was declared in a nested block
  }
```

As a result, the lifetime checker no longer compares block nesting to
determine which lifetime is shorter.

The new analysis numbers all statements in the function in a depth-first
traversal. It computes for each variable a DeinitOrderNode which
indicates which statement it could be deinitialized in. In order to
handle nested blocks and conditionals, a DeinitOrderNode can contain a
`nestedOrder` and an `elseOrder`. The analysis ignores
`chpl__autoDestroy` calls and only considers `PRIM_ASSIGN_ELIDED_COPY` as
a reason to consider something to be deinitialized early. Variables that
are not copy-elided have their deinit point computed from the
DeinitOrderNode saved for the last statement for the block in which they
are declared.

I had originally hoped to apply DeinitOrderNode to mark the difference
between last-mention compiler temps and end-of-block user variables/temps
in init statements. I was attempting to mark such deinit points for
last-mention temps according to their `chpl__autoDestroy` call.  That
approach did not work because not all variables will have
`chpl__autoDestroy` called and because certain compiler temp patterns
(e.g. with reductions) have unusual patterns of calling
`chpl__autoDestroy`. So this PR leaves the approach of identifying
last-mention compiler temps by a flag and considering them to have
shorter lifetime than end-of-block variables as a tie-breaker.

Also note that the new test, copy-elision-checking, should produce a
compilation error for test5 as well but it does not yet because copy
elision does not yet occur in that case. I address that in another PR.

Reviewed by @benharsh - thanks!

- [x] full local futures testing
