### PR TITLE
Update LCALS to use .size rather than .numElements

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -21,7 +21,7 @@ module LCALSDataTypes {
     proc push_back(e: eltType) {
       A.append(e);
     }
-    proc numElements {
+    proc size {
       return A.size;
     }
     iter these() {


### PR DESCRIPTION
In my push to convert calls to .numElements over to .size, I'd missed
that one such call in LCALS was using an LCALS-specific data structure
that was still providing numElements, and for some reason this didn't
turn up in correctness testing, only performance testing.  Here, I'm
changing that private data structure to use .size as well for
consistency with other types.