### PR TITLE
Removed unnecessary return statements

### DIFF
--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -306,7 +306,6 @@ private proc getTests(lock: borrowed Toml, projectHome: string) {
       const t = test.strip().strip('"');
       testNames.append(t);
     }
-    return testNames;
   }
   else if isDir(testPath) {
     var tests = findfiles(startdir=testPath, recursive=true, hidden=false);
@@ -315,7 +314,6 @@ private proc getTests(lock: borrowed Toml, projectHome: string) {
         testNames.append(getTestPath(test));
       }
     }
-    return testNames;
   }
   return testNames;
 }


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/blob/f5b0f309ae954e5dd74ab36c715039c0dfe18c6f/tools/mason/MasonTest.chpl#L298-L321


In this function, `if` and `else if` statements return the same list which is also returned at the end of the function.

