### PR TITLE
Support escaping $ in tests

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -249,6 +249,12 @@ def PerfDirFile(s):
 def PerfTFile(test_filename, sfx):
     return test_filename + '.' + perflabel + sfx
 
+# A alternative to os.path.expandvars that treats '\$' as the escape of '$'
+def expandvarsWithEscape(path):
+    escaped = path.replace('\$', 'CHPL_EXPANDVARS_ESCAPE_DOLLAR')
+    os.path.expandvars(escaped)
+    return escaped.replace('CHPL_EXPANDVARS_ESCAPE_DOLLAR', '$')
+
 # Read a file or if the file is executable read its output. If the file is
 # executable, the current chplenv is copied into the env before executing.
 # Expands shell variables and strip out comments/whitespace. Returns a list of
@@ -291,7 +297,7 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
         else:
             if line[0] == '#': continue
         # expand shell variables
-        line = os.path.expandvars(line)
+        line = expandvarsWithEscape(line)
         mylist.append(line)
     return mylist
 


### PR DESCRIPTION
Support escaping $ in setting files of tests

spins off https://github.com/chapel-lang/chapel/pull/15137#issuecomment-597398555

The current implementation of `sub_test.py` will try to replace everything that starts with `$` when reading from settings files.
https://github.com/chapel-lang/chapel/blob/02377f302148391e7dcbc54a5697efa44811ed87/util/test/sub_test#L252-L256
There is no way to avoid this. e.g.
A test setting file `withEnv.doc.chpldocopts`
```
--author '$PATH'
```
will be read as `--author '/usr/local/sbin /usr/local/bin /usr/bin (and lots of paths)'` even though `$PATH` is quoted. This stops us from adding tests containing `$` characters.

With this PR, we can use `\$` to represent `$` when we don't want envs replacement.

@lydia-duncan  Could you please review this?
