### PR TITLE
Optimize distributions for when postfix! runtime checks are enabled

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -24,6 +24,8 @@ module ChapelBase {
   use ChapelStandard;
   private use ChapelEnv, SysCTypes;
 
+  config param enablePostfixBangChecks = false;
+
   // These two are called by compiler-generated code.
   extern proc chpl_config_has_value(name:c_string, module_name:c_string): bool;
   extern proc chpl_config_get_value(name:c_string, module_name:c_string): c_string;
@@ -692,8 +694,8 @@ module ChapelBase {
   pragma "always propagate line file info"
   private inline proc checkNotNil(x:borrowed class?) {
     import HaltWrappers;
-    // Check only if --nil-checks is enabled
-    if chpl_checkNilDereferences {
+    // Check only if --nil-checks is enabled or user requested
+    if chpl_checkNilDereferences || enablePostfixBangChecks {
       // Add check for nilable types only.
       if x == nil {
         HaltWrappers.nilCheckHalt("argument to ! is nil");

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -370,8 +370,8 @@ module OwnedObject {
     if lhs.chpl_p == nil && rhs.chpl_p == nil then
         return;
 
-    // Check only if --nil-checks is enabled
-    if chpl_checkNilDereferences {
+    // Check only if --nil-checks is enabled or user requested
+    if chpl_checkNilDereferences || enablePostfixBangChecks {
       // Add check for lhs non-nilable.
       // Do it even if rhs non-nilable, as for now static checking has holes.
       if isNonNilableClass(lhs.chpl_t) {

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -574,8 +574,8 @@ module SharedObject {
   pragma "always propagate line file info"
   inline proc postfix!(x:_shared) {
     import HaltWrappers;
-    // Check only if --nil-checks is enabled
-    if chpl_checkNilDereferences {
+    // Check only if --nil-checks is enabled or user requested
+    if chpl_checkNilDereferences || enablePostfixBangChecks {
       // Add check for nilable types only.
       if _to_nilable(x.chpl_t) == x.chpl_t {
         if x.chpl_p == nil {


### PR DESCRIPTION
Optimize distributions for when `postfix!` checks are enabled (no
`--fast` or if a user requested them with `-senablePostfixBangChecks`

In most distribution code we're already doing a nil-check so we can
eliminate subsequent ones. These are cases that really want optional
chaining, or something like it. For localAccess we know that the
localArr will not be nil because of implementation specifics. #14660
added some compiler optimizations to eliminate runtime `!` checks, but
those don't help the distribution code much since we're mostly looking
at field accesses, which were not optimized.

With this I don't see any performance regressions running with
`-senablePostfixBangChecks` for our benchmarks or for Arkouda.

Closes https://github.com/Cray/chapel-private/issues/761
Related to https://github.com/chapel-lang/chapel/issues/13603