### PR TITLE
Add skipif for old versions of suse on masonTestSome

### DIFF
--- a/test/mason/masonTestSome.skipif
+++ b/test/mason/masonTestSome.skipif
@@ -1,0 +1,1 @@
+suseSkipif


### PR DESCRIPTION
Mason tests that utilize github queries (`mason update`) should be skipped on older versions os suse