### PR TITLE
Change 'new owned C()' to 'new C()' in released examples

### DIFF
--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -88,7 +88,7 @@ The receiver-clause (or its absence) specifies the method’s receiver
         var name: string;
         var age: uint;
       }
-      var anActor = new owned Actor(name="Tommy", age=27);
+      var anActor = new Actor(name="Tommy", age=27);
       writeln(anActor);
 
    
@@ -148,7 +148,7 @@ method-call-expression as specified in :ref:`Method_Calls`.
 
    .. BLOCK-test-chapelpost
 
-      var c1: C = new owned C();
+      var c1: C = new C();
       c1.foo();
 
    
@@ -384,7 +384,7 @@ controlled by the ``these`` iterator.
 
    .. BLOCK-test-chapelpost
 
-      var ta = new owned ThreeArray();
+      var ta = new ThreeArray();
       for (i, j) in zip(ta, 1..) do
         i = j;
 

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -45,7 +45,7 @@ module LCALSDataTypes {
     var num_suite_passes: int;
     var loop_samp_frac: real;
 
-    const ref_loop_stat = new owned LoopStat();
+    const ref_loop_stat = new LoopStat();
 
     var loop_weights: [weight_group_dom] real;
 
@@ -81,7 +81,7 @@ module LCALSDataTypes {
     var loop_chksum: [loop_length_dom] real;
 
     proc init() {
-      loop_run_time = for i in loop_length_dom do new owned vector(real);
+      loop_run_time = for i in loop_length_dom do new vector(real);
     }
   }
 
@@ -259,7 +259,7 @@ module LCALSDataTypes {
     // class implements the same pattern used in the LCALS reference.
     //
     // var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays][0..#2, 0..#aligned_chunksize, 0..#4] real;
-    var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays] owned LCALS_Overlapping_Array_3D(real) = [i in 0..#s_num_3D_2xNx4_Real_arrays] new owned LCALS_Overlapping_Array_3D(real, 2*4*aligned_chunksize); // 2 X loop_length X 4 array size
+    var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays] owned LCALS_Overlapping_Array_3D(real) = [i in 0..#s_num_3D_2xNx4_Real_arrays] new LCALS_Overlapping_Array_3D(real, 2*4*aligned_chunksize); // 2 X loop_length X 4 array size
 
     var RealArray_scalars: [0..#s_num_Real_scalars] real;
   }

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -382,7 +382,7 @@ module LCALSLoops {
     var loop_data = getLoopData();
     var len: int = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
-    var ltimer = new owned LoopTimer();
+    var ltimer = new LoopTimer();
 
     loopInit(LoopKernelID.REF_LOOP, lstat);
 
@@ -404,7 +404,7 @@ module LCALSLoops {
 
     var len = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
-    var ltimer = new owned LoopTimer();
+    var ltimer = new LoopTimer();
 
     loopInit(LoopKernelID.REF_LOOP, lstat);
 

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -1145,6 +1145,6 @@ proc defineLoopSuiteRunInfo(run_variants, run_loop,
     }
   }
   defineReferenceLoopRunInfo();
-  s_loop_data = new owned LoopData(max(max_loop_length, suite_info.ref_loop_stat!.loop_length[LoopLength.LONG]));
+  s_loop_data = new LoopData(max(max_loop_length, suite_info.ref_loop_stat!.loop_length[LoopLength.LONG]));
 
 }

--- a/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
@@ -2,7 +2,7 @@ module LCALSStatic {
   use LCALSDataTypes;
 
   var s_loop_data: owned LoopData?;
-  var s_loop_suite_run_info = new owned LoopSuiteRunInfo();
+  var s_loop_suite_run_info = new LoopSuiteRunInfo();
 
   proc getLoopSuiteRunInfo() {
     return s_loop_suite_run_info.borrow();

--- a/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
@@ -11,7 +11,7 @@ module RunARawLoops {
         var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new owned LoopTimer();
+        var ltimer = new LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
@@ -17,7 +17,7 @@ module RunBRawLoops {
         var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new owned LoopTimer();
+        var ltimer = new LoopTimer();
 
         select iloop {
           when LoopKernelID.INIT3 {

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -10,7 +10,7 @@ module RunCRawLoops {
         var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new owned LoopTimer();
+        var ltimer = new LoopTimer();
 
         select iloop {
           when LoopKernelID.HYDRO_1D {

--- a/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
@@ -11,7 +11,7 @@ module RunParallelRawLoops {
         var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new owned LoopTimer();
+        var ltimer = new LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -29,7 +29,7 @@ module RunSPMDRawLoops {
         var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new owned LoopTimer();
+        var ltimer = new LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -11,7 +11,7 @@ module RunVectorizeOnlyRawLoops {
         var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new owned LoopTimer();
+        var ltimer = new LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -74,14 +74,14 @@ module Timer {
 
     proc init(timerType: TimerType = defaultTimerType) {
       if timerType == TimerType.Chapel {
-        t = new owned ChapelTimer();
+        t = new ChapelTimer();
       } else if timerType == TimerType.Clock then {
-        t = new owned ClockTimer();
+        t = new ClockTimer();
       } else if timerType == TimerType.Cycle then {
-        t = new owned CycleTimer();
+        t = new CycleTimer();
       } else {
         halt("Unknown timer type");
-        t = new owned TimerImpl(); //dummy
+        t = new TimerImpl(); //dummy
       }
     }
 

--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -47,7 +47,7 @@ class ForceEAM : Force  {
 
   var FP: [DistSpace] [perBinSpace] real;
               
-  var funcfl = new owned Funcfl();
+  var funcfl = new Funcfl();
 
   proc init(cf : real) {
     this.complete();

--- a/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
@@ -244,8 +244,8 @@ var Dest, Src: [NeighDom] domain(3);
 setupComms();
 
 var fobj : owned Force =
-  if force == "lj" then new owned ForceLJ(force_cut): owned Force
-                   else new owned ForceEAM(force_cut);
+  if force == "lj" then new ForceLJ(force_cut): owned Force
+                   else new ForceEAM(force_cut);
 
 if force != "lj" then
   mass = fobj.mass;

--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
@@ -25,8 +25,8 @@ const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 proc main() {
   printColorEquations();
 
-  const group1 = [i in 1..popSize1] new owned Chameneos(i, ((i-1)%3):Color);
-  const group2 = [i in 1..popSize2] new owned Chameneos(i, colors10[i]);
+  const group1 = [i in 1..popSize1] new Chameneos(i, ((i-1)%3):Color);
+  const group2 = [i in 1..popSize2] new Chameneos(i, colors10[i]);
 
   cobegin {
     holdMeetings(group1, n);

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -64,8 +64,8 @@ record Population {
   // an array of chameneos objects representing the population
   //
   var chameneos = [i in 1..size]
-                   new owned Chameneos?(i, if size == 10 then colors10[i]
-                                                         else ((i-1)%3): Color);
+                   new Chameneos?(i, if size == 10 then colors10[i]
+                                                   else ((i-1)%3): Color);
 
   //
   // Print the colors of the current population.

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
@@ -271,9 +271,9 @@ NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+4*delta)) {
     // Random Numbers return in the range [0.0, 1.0)
 
     var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
-                     new owned NPBRandomStream (real, seed = 0556707007)
+                     new NPBRandomStream (real, seed = 0556707007)
                    else
-                     new owned NPBRandomStream (real);
+                     new NPBRandomStream (real);
 
     var   Noisy_a     : [edge_domain] real,
           Noisy_b     : [edge_domain] real,

--- a/test/release/examples/primers/classes.chpl
+++ b/test/release/examples/primers/classes.chpl
@@ -23,11 +23,13 @@ class C {
 // initializer has an argument for each field in the class. Once a class
 // has been initialized, its methods can be called.
 //
-// Class types include a strategy for freeing them. We'll discuss this
-// more below.
+// Classes have various memory management strategies that determine how
+// they are freed.  We'll discuss these more below, but for now, know
+// that ``new C(...)`` is equivalent to writing out ``new owned C(...)``
+// where ``owned`` is one of these memory management strategies.
 //
 // A class variable can refer to an *instance* of a class.
-var foo = new owned C(1, 3);
+var foo = new C(1, 3);
 foo.printFields();
 
 //
@@ -84,7 +86,7 @@ class D: C {
 //
 // Note that since ``foo`` is an ``owned C``, assigning to it
 // will delete the previous instance "owned" by that variable.
-foo = new owned D(3, 4);
+foo = new D(3, 4);
 foo.printFields();
 
 
@@ -97,12 +99,14 @@ delete unm;
 
 var own: owned C = new owned C(1, 10);
 // The instance referred to by ``own`` is deleted when it is no longer in scope.
-// Only one ``owned C`` can refer to a given instance at a time but the
+// Only one ``owned C`` can refer to a given instance at a time, but the
 // ownership can be transferred to another variable.
+
 var own2 = new C(1, 10);
 assert(own.type == own2.type);
-// The example above shows that the default behavior makes ``new C`` equivalent
-// to ``new owned C``.
+// The example above shows that ``new C(...)`` can be used as a
+// shorthand for ``new owned C(...)`` because ``owned`` is the default
+// memory management strategy for classes.
 
 var share: shared C = new shared C(1, 10);
 // The instance referred to by ``share`` is reference counted -- that is,
@@ -155,7 +159,7 @@ x = b2; // converting from borrowed C to borrowed C?
 // is not ``nil`` and return it as a non-nilable type. This operator
 // will halt if the value is actually ``nil``.
 //
-// Note that when applied to an ``owned`` or ``shared` variable, ``!`` will
+// Note that when applied to an ``owned`` or ``shared`` variable, ``!`` will
 // result in a borrow from that variable.
 x!.printFields();
 

--- a/test/release/examples/primers/errorHandling.chpl
+++ b/test/release/examples/primers/errorHandling.chpl
@@ -73,7 +73,7 @@ class EmptyFilenameError : Error {
 
 proc checkFilename(f_name: string) throws {
   if f_name.isEmpty() then
-    throw new owned EmptyFilenameError();
+    throw new EmptyFilenameError();
 }
 
 proc openFilename(f_name: string) throws {

--- a/test/release/examples/primers/genericClasses.chpl
+++ b/test/release/examples/primers/genericClasses.chpl
@@ -32,16 +32,16 @@ record UntypedField {
 // instantiated using the types of the arguments representing the
 // generic fields in the default constructor.
 //
-var taf  = new owned TypeAliasField(real, 1.0, 2.0);
-var taf2 = new owned TypeAliasField(int, 3, 4);
+var taf  = new TypeAliasField(real, 1.0, 2.0);
+var taf2 = new TypeAliasField(int, 3, 4);
 writeln("taf = ", taf, ", taf2 = ", taf2);
 
-var pf  = new owned ParamField(3);
-var pf2 = new owned ParamField(2);
+var pf  = new ParamField(3);
+var pf2 = new ParamField(2);
 writeln("pf = ", pf, ", pf2 = ", pf2);
 
 var uf  = new UntypedField(3.14 + 2.72i);
-var uf2 = new UntypedField(new owned ParamField(2));
+var uf2 = new UntypedField(new ParamField(2));
 writeln("uf = ", uf, ", uf2 = ", uf2);
 
 //

--- a/test/release/examples/primers/iterators.chpl
+++ b/test/release/examples/primers/iterators.chpl
@@ -154,11 +154,11 @@ iter postorder(tree: borrowed Tree?): borrowed Tree {
          / \
         d   e
 */
-var tree = new owned Tree( "a",
-  new owned Tree("b"),
-  new owned Tree("c",
-    new owned Tree("d"),
-    new owned Tree("e")));
+var tree = new Tree( "a",
+  new Tree("b"),
+  new Tree("c",
+    new Tree("d"),
+    new Tree("e")));
 
 //
 // This method uses the postorder iterator to print out each node.

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -816,18 +816,18 @@ class MyClass {
 
 // Call compiler-generated initializer, using default value for memberBool.
 {
-  var myObject = new owned MyClass(10);
-      myObject = new owned MyClass(memberInt = 10); // Equivalent
+  var myObject = new MyClass(10);
+      myObject = new MyClass(memberInt = 10); // Equivalent
   writeln(myObject.getMemberInt());
 
   // Same, but provide a memberBool value explicitly.
-  var myDiffObject = new owned MyClass(-1, true);
-      myDiffObject = new owned MyClass(memberInt = -1,
+  var myDiffObject = new MyClass(-1, true);
+      myDiffObject = new MyClass(memberInt = -1,
                                        memberBool = true); // Equivalent
   writeln(myDiffObject);
 
   // Similar, but rely on the default value of memberInt, passing in memberBool.
-  var myThirdObject = new owned MyClass(memberBool = true);
+  var myThirdObject = new MyClass(memberBool = true);
   writeln(myThirdObject);
 
   // If the user-defined initializer above had been uncommented, we could
@@ -844,16 +844,16 @@ class MyClass {
   // the definition has to be outside the class definition.
   proc +(A : MyClass, B : MyClass) : owned MyClass {
     return
-      new owned MyClass(memberInt = A.getMemberInt() + B.getMemberInt(),
-                        memberBool = A.getMemberBool() || B.getMemberBool());
+      new MyClass(memberInt = A.getMemberInt() + B.getMemberInt(),
+                  memberBool = A.getMemberBool() || B.getMemberBool());
   }
 
   var plusObject = myObject + myDiffObject;
   writeln(plusObject);
 
   // Destruction of an object: calls the deinit() routine and frees its memory.
-  // ``unmanaged`` variables should have ``delete`` called on them.
-  // ``owned`` variables are destroyed when they go out of scope.
+  // ``unmanaged`` objects should have ``delete`` called on them.
+  // ``owned`` objects (the default) are destroyed when they go out of scope.
 }
 
 // Classes can inherit from one or more parent classes
@@ -903,7 +903,7 @@ class GenericClass {
 } // end GenericClass
 
 // Allocate an owned instance of our class
-var realList = new owned GenericClass(real, 10);
+var realList = new GenericClass(real, 10);
 
 // We can assign to the member array of the object using the bracket
 // notation that we defined.
@@ -915,12 +915,12 @@ for value in realList do write(value, ", ");
 writeln();
 
 // Make a copy of realList using the copy initializer.
-var copyList = new owned GenericClass(realList);
+var copyList = new GenericClass(realList);
 for value in copyList do write(value, ", ");
 writeln();
 
 // Make a copy of realList and change the type, also using the copy initializer.
-var copyNewTypeList = new owned GenericClass(realList, int);
+var copyNewTypeList = new GenericClass(realList, int);
 for value in copyNewTypeList do write(value, ", ");
 writeln();
 

--- a/test/release/examples/primers/procedures.chpl
+++ b/test/release/examples/primers/procedures.chpl
@@ -134,7 +134,7 @@ class Circle {
 //
 proc create_circle(x = 0.0, y = 0.0, diameter = 0.0)
 {
-  var result = new owned Circle();
+  var result = new Circle();
 
   result.radius = diameter / 2;
   result.center.x = x;

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -49,8 +49,8 @@ writeln();
 // type of the elements that the instance should generate. If a particular seed
 // is desired, it should be specified upon creation of this instance.
 //
-var randStream = new owned RandomStream(real);
-var randStreamSeeded = new owned RandomStream(real, seed);
+var randStream = new RandomStream(real);
+var randStreamSeeded = new RandomStream(real, seed);
 
 //
 // Then the instance can be used to obtain the numbers.  This can be done in a
@@ -109,14 +109,14 @@ for i in randStreamSeeded.iterate({5..10}, real) {
 // stream during class creation.  As a result, two parallel accesses or updates
 // to the position from which reading is intended may conflict.
 //
-var parallelUnsafe       = new owned RandomStream(real, parSafe=false);
-var parallelSeededUnsafe = new owned RandomStream(real, seed, false);
+var parallelUnsafe       = new RandomStream(real, parSafe=false);
+var parallelSeededUnsafe = new RandomStream(real, seed, false);
 
 // Now :class:`~PCGRandom.PCGRandomStream` functions, such as
 // ``parallelUnsafe.getNext()`` and ``parallelSeededUnsafe.getNext()`` can be
 // called.
 
 //
-// The ``RandomStream`` instances above were created with ``new owned``
+// The ``RandomStream`` instances above were created with ``new [owned]``
 // and so are automatically deleted when they go out of scope.
 //


### PR DESCRIPTION
Now that 'new C()' is the same as 'new owned C()', it seems like
we should typically use the short form whenever we're not trying
to emphasize a point about owned classes, particularly in codes
that are part of the release/examples directory.  I thought to look
for and address this when I saw people submitting examples using
'new owned ...' in issues / PRs recently and wondered "Why are they
bothering to do that?"  Our examples should lead by example.

As part of this effort, I did a little bit of wordsmithing and
formatting clean-up to the classes primer.  I also found one case
in the spec that seemed like it should obviously use a simple `new`,
many cases in the spec that should probably continue to use `new owned`
for clarity / precision, and others that I was unsure about, so left alone.