### PR TITLE
Warn about negatively-strided arrays with `--warn-unstable`

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1388,6 +1388,18 @@ module ChapelArray {
         compilerError("array element type cannot currently be generic");
         // In the future we might support it if the array is not default-inited
       }
+
+      if chpl_warnUnstable then
+        if this.stridable then
+          if rank == 1 {
+            if this.stride < 0 then
+              warning("arrays with negatively strided dimensions are not particularly stable");
+          } else {
+            for s in this.stride do
+              if s < 0 then
+                warning("arrays with negatively strided dimensions are not particularly stable");
+          }
+
       var x = _value.dsiBuildArray(eltType);
       pragma "dont disable remote value forwarding"
       proc help() {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1390,7 +1390,7 @@ module ChapelArray {
       }
 
       if chpl_warnUnstable then
-        if this.stridable then
+        if isRectangularDom(this) && this.stridable then
           if rank == 1 {
             if this.stride < 0 then
               warning("arrays with negatively strided dimensions are not particularly stable");

--- a/test/unstable/negStrideArr.chpl
+++ b/test/unstable/negStrideArr.chpl
@@ -1,0 +1,4 @@
+var A: [1..10 by -1] real;
+var B: [1..10, 1..10 by -2] int;
+writeln(A);
+writeln(B);

--- a/test/unstable/negStrideArr.good
+++ b/test/unstable/negStrideArr.good
@@ -1,0 +1,13 @@
+0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+0 0 0 0 0
+negStrideArr.chpl:1: warning: arrays with negatively strided dimensions are not particularly stable
+negStrideArr.chpl:2: warning: arrays with negatively strided dimensions are not particularly stable


### PR DESCRIPTION
Negatively strided arrays have generally resulted in questions and issues from users, generally giving the sense that they may not be defined correctly, or if they are, don't always work as expected.  For example, see issues #13174, #15159, #12106, #12989.

For this reason, I think it makes sense to warn sufficiently cautious users away from using negatively strided arrays for the time being until we have a chance to make sure we agree on their definition and bolster their implementation.

This PR provides a way to do that by inserting a check into the routine that builds arrays from a user-provided domain to see whether any of the strides are negative, and issuing a warning if so.  However, the check is only performed when the program was compiled with `--warn-unstable` (to prevent adding overhead for other cases) and can only generate the warning at execution time (since we don't know the sign of strides at compile-time, at least currently).

I tested this PR by removing the check that `--warn-unstable` was thrown and running it across the test suite and only saw 13 failures, suggesting that not much code is actually relying on negatively strided arrays today.  All 13 failures were in tests that were specifically testing or locking in behavior for negatively strided arrays, and some stemmed from earlier user questions or bug reports about the feature.