### PR TITLE
Prevent escaped strings from being printed

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -107,6 +107,7 @@ module BytesStringCommon {
     ret.buff = newBuff;
     ret._size = allocSize;
     ret.isowned = true;
+    ret.hasEscapes = false;
 
     var expectedSize = ret._size;
 
@@ -152,6 +153,7 @@ module BytesStringCommon {
           }
           else if policy == decodePolicy.escape {
 
+            ret.hasEscapes = true;
             // encoded escape sequence is 3 bytes. And this is per invalid byte
             expectedSize += 2*nInvalidBytes;
             (ret.buff, ret._size) = bufferEnsureSize(ret.buff, ret._size,
@@ -184,6 +186,7 @@ module BytesStringCommon {
     assertArgType(t, "initWithBorrowedBuffer");
 
     x.isowned = false;
+    if t == string then x.hasEscapes = other.hasEscapes;
 
     const otherRemote = other.locale_id != chpl_nodeID;
     const otherLen = other.numBytes;
@@ -234,6 +237,7 @@ module BytesStringCommon {
     const otherRemote = other.locale_id != chpl_nodeID;
     const otherLen = other.numBytes;
     x.isowned = true;
+    if t == string then x.hasEscapes = other.hasEscapes;
 
     if otherLen > 0 {
       x.len = otherLen;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -776,6 +776,8 @@ module String {
     pragma "no doc"
     var isowned: bool = true;
     pragma "no doc"
+    var hasEscapes: bool = false;
+    pragma "no doc"
     // We use chpl_nodeID as a shortcut to get at here.id without actually constructing
     // a locale object. Used when determining if we should make a remote transfer.
     var locale_id = chpl_nodeID; // : chpl_nodeID_t

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2827,6 +2827,10 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t,
   } else if t == string {
     // handle string
     const local_x = x.localize();
+    // check if the string has escapes
+    if local_x.hasEscapes {
+      return EINVAL;
+    }
     return qio_channel_print_string(false, _channel_internal, local_x.c_str(), local_x.numBytes:ssize_t);
   } else if t == bytes {
     // handle bytes
@@ -2990,6 +2994,10 @@ private inline proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, 
     return err;
   } else if t == string {
     var local_x = x.localize();
+    // check if the string has escapes
+    if local_x.hasEscapes {
+      return EINVAL;
+    }
     return qio_channel_write_string(false, byteorder:c_int, qio_channel_str_style(_channel_internal), _channel_internal, local_x.c_str(), local_x.numBytes: ssize_t);
   } else if t == bytes {
     var local_x = x.localize();

--- a/test/types/string/validation/escapeNoIO.chpl
+++ b/test/types/string/validation/escapeNoIO.chpl
@@ -1,4 +1,29 @@
+use IO;
+
 var b = b"\xff";
 var s = b.decode(policy=decodePolicy.escape);
 
-writeln("String is :", s);
+try {
+  stdout.writeln(s);
+  writeln("writeln shouldn't have been successful");
+}
+catch e {
+  writeln(e);
+}
+
+try {
+  stdout.writef("%s\n", s);
+  writeln("writef('%s') shouldn't have been successful");
+}
+catch e {
+  writeln(e);
+}
+
+try {
+  stdout.writef("%|*s\n", s.numBytes, s);
+  writeln("writef('%|s') should be successful");
+}
+catch e {
+  writeln(e);
+}
+

--- a/test/types/string/validation/escapeNoIO.chpl
+++ b/test/types/string/validation/escapeNoIO.chpl
@@ -1,0 +1,4 @@
+var b = b"\xff";
+var s = b.decode(policy=decodePolicy.escape);
+
+writeln("String is :", s);

--- a/test/types/string/validation/escapeNoIO.chpl
+++ b/test/types/string/validation/escapeNoIO.chpl
@@ -7,23 +7,29 @@ try {
   stdout.writeln(s);
   writeln("writeln shouldn't have been successful");
 }
-catch e {
-  writeln(e);
+catch e: SystemError {
+  writeln("Correct error was caught");
+}
+catch {
+  writeln("Unexpected error");
 }
 
 try {
   stdout.writef("%s\n", s);
   writeln("writef('%s') shouldn't have been successful");
 }
-catch e {
-  writeln(e);
+catch e: SystemError {
+  writeln("Correct error was caught");
+}
+catch {
+  writeln("Unexpected error");
 }
 
 try {
   stdout.writef("%|*s\n", s.numBytes, s);
   writeln("writef('%|s') should be successful");
 }
-catch e {
-  writeln(e);
+catch {
+  writeln("Unexpected error");
 }
 

--- a/test/types/string/validation/escapeNoIO.good
+++ b/test/types/string/validation/escapeNoIO.good
@@ -1,3 +1,4 @@
-String is :uncaught SystemError: Illegal byte sequence (Strings with escaped non-UTF8 bytes cannot be used with I/O. Try using string.encode(encodePolicy.unescape) first.while writing string with path "unknown" offset -1)
-  escapeNoIO.chpl:4: thrown here
-  escapeNoIO.chpl:4: uncaught here
+SystemError: Illegal byte sequence (Strings with escaped non-UTF8 bytes cannot be used with I/O. Try using string.encode(encodePolicy.unescape) first.while writing string with path "unknown" offset -1)
+SystemError: Illegal byte sequence (Strings with escaped non-UTF8 bytes cannot be used with I/O. Try using string.encode(encodePolicy.unescape) first.while writing string with path "unknown" offset -1)
+í³¿
+writef('%|s') should be successful

--- a/test/types/string/validation/escapeNoIO.good
+++ b/test/types/string/validation/escapeNoIO.good
@@ -1,0 +1,3 @@
+String is :uncaught SystemError: Illegal byte sequence (Strings with escaped non-UTF8 bytes cannot be used with I/O. Try using string.encode(encodePolicy.unescape) first.while writing string with path "unknown" offset -1)
+  escapeNoIO.chpl:4: thrown here
+  escapeNoIO.chpl:4: uncaught here

--- a/test/types/string/validation/escapeNoIO.good
+++ b/test/types/string/validation/escapeNoIO.good
@@ -1,4 +1,4 @@
-SystemError: Illegal byte sequence (Strings with escaped non-UTF8 bytes cannot be used with I/O. Try using string.encode(encodePolicy.unescape) first.while writing string with path "unknown" offset -1)
-SystemError: Illegal byte sequence (Strings with escaped non-UTF8 bytes cannot be used with I/O. Try using string.encode(encodePolicy.unescape) first.while writing string with path "unknown" offset -1)
+Correct error was caught
+Correct error was caught
 í³¿
 writef('%|s') should be successful


### PR DESCRIPTION
String buffers can have special escapes to represent bytes that don't
correspond to a part of a valid UTF8 sequence. This is used mainly to
store file names in systems that do not enforce UTF8 filenames.

Printing these strings probably is not a useful thing to have and can
cause confusion on a UTF8 terminal because those special escapes
cannot be represented with any character. Python does the same thing,
too.

This PR prevents escaped strings to be printed by adding a `hasEscapes`
field to the string record and checking that while writing/printing strings.
This restriction doesn't apply to binary formatters.

Resolves #14879 

In the future, we may relax this restriction if there is a compelling case.

Test:
- [x] standard
