### PR TITLE
Futures requesting better errors for 'owned' applied to non-classes

### DIFF
--- a/test/classes/delete-free/owned/errors/owned-class-instance.bad
+++ b/test/classes/delete-free/owned/errors/owned-class-instance.bad
@@ -1,0 +1,3 @@
+owned-class-instance.chpl:5: error: invalid type specifier '_owned(owned C)'
+owned-class-instance.chpl:5: note: type specifier did not match: _owned(type chpl_t)
+owned-class-instance.chpl:5: note: cannot instantiate type field 'chpl_t' with non-type

--- a/test/classes/delete-free/owned/errors/owned-class-instance.chpl
+++ b/test/classes/delete-free/owned/errors/owned-class-instance.chpl
@@ -1,0 +1,5 @@
+class C {}
+
+var myC = new C();
+
+writeln(owned myC);

--- a/test/classes/delete-free/owned/errors/owned-class-instance.future
+++ b/test/classes/delete-free/owned/errors/owned-class-instance.future
@@ -1,0 +1,4 @@
+error message: 'owned <non-class type>' results in confusing error messages
+
+This series of tests shows that when 'owned' is applied to something other
+than a class type, the resulting error messages are confusing.

--- a/test/classes/delete-free/owned/errors/owned-class-instance.good
+++ b/test/classes/delete-free/owned/errors/owned-class-instance.good
@@ -1,0 +1,2 @@
+owned-class-instance.chpl:5: error: 'owned' can only be applied to class types
+owned-class-instance.chpl:5: note: here it is applied to a class value

--- a/test/classes/delete-free/owned/errors/owned-int-type.bad
+++ b/test/classes/delete-free/owned/errors/owned-int-type.bad
@@ -1,0 +1,3 @@
+$CHPL_HOME/modules/internal/OwnedObject.chpl:417: error: ambiguous call 'owned.init(owned int(64))'
+$CHPL_HOME/modules/internal/OwnedObject.chpl:175: note: candidates are: owned.init(p: borrowed)
+$CHPL_HOME/modules/internal/OwnedObject.chpl:242: note:                 owned.init(src: owned)

--- a/test/classes/delete-free/owned/errors/owned-int-type.chpl
+++ b/test/classes/delete-free/owned/errors/owned-int-type.chpl
@@ -1,0 +1,1 @@
+writeln(owned int:string);

--- a/test/classes/delete-free/owned/errors/owned-int-type.future
+++ b/test/classes/delete-free/owned/errors/owned-int-type.future
@@ -1,0 +1,4 @@
+error message: 'owned <non-class type>' results in confusing error messages
+
+This series of tests shows that when 'owned' is applied to something other
+than a class type, the resulting error messages are confusing.

--- a/test/classes/delete-free/owned/errors/owned-int-type.good
+++ b/test/classes/delete-free/owned/errors/owned-int-type.good
@@ -1,0 +1,2 @@
+owned-class-instance.chpl:1: error: 'owned' can only be applied to class types
+owned-class-instance.chpl:1: note: here it is applied to type 'int'

--- a/test/classes/delete-free/owned/errors/owned-int-value.bad
+++ b/test/classes/delete-free/owned/errors/owned-int-value.bad
@@ -1,0 +1,3 @@
+owned-int-value.chpl:1: error: invalid type specifier '_owned(3)'
+owned-int-value.chpl:1: note: type specifier did not match: _owned(type chpl_t)
+owned-int-value.chpl:1: note: cannot instantiate type field 'chpl_t' with non-type

--- a/test/classes/delete-free/owned/errors/owned-int-value.chpl
+++ b/test/classes/delete-free/owned/errors/owned-int-value.chpl
@@ -1,0 +1,2 @@
+writeln(owned 3);
+

--- a/test/classes/delete-free/owned/errors/owned-int-value.future
+++ b/test/classes/delete-free/owned/errors/owned-int-value.future
@@ -1,0 +1,4 @@
+error message: 'owned <non-class type>' results in confusing error messages
+
+This series of tests shows that when 'owned' is applied to something other
+than a class type, the resulting error messages are confusing.

--- a/test/classes/delete-free/owned/errors/owned-int-value.good
+++ b/test/classes/delete-free/owned/errors/owned-int-value.good
@@ -1,0 +1,2 @@
+owned-class-instance.chpl:1: error: 'owned' can only be applied to class types
+owned-class-instance.chpl:1: note: here it is applied to type an 'int' value


### PR DESCRIPTION
While working on some test cases yesterday, I wrote some patterns
incorrectly, and felt that the error messages were not particularly
helpful or user friendly.  These futures capture some of those cases,
requesting a better error message (I'm not tied to the specific
proposals in the .good files, and am just offering them up as a
possibility).