### PR TITLE
Add errors for certain confusing initialization patterns

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1991,10 +1991,15 @@ buildFunctionFormal(FnSymbol* fn, DefExpr* def) {
     return fn;
   ArgSymbol* arg = toArgSymbol(def->sym);
   INT_ASSERT(arg);
+
+  int countFormals = fn->numFormals();
+
   fn->insertFormalAtTail(def);
   if (!strcmp(arg->name, "chpl__tuple_arg_temp")) {
     destructureTupleGroupedArgs(fn, arg->variableExpr, new SymExpr(arg));
     arg->variableExpr = NULL;
+    // append countFormals to the argument name so it is unique
+    arg->name = astr(arg->name, istr(countFormals));
   }
   return fn;
 }

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -187,9 +187,11 @@ static void checkParallelIterator(FnSymbol* serial, Expr* call,
   CallExpr* repCall = new CallExpr(new UnresolvedSymExpr(serial->name));
 
   // Use the formals of 'serial', for the purposes of resolution.
-  for_formals(formal, serial)
-    repCall->insertAtTail(
-      new NamedExpr(formal->name, createSymExprPropagatingParam(formal)) );
+  for_formals(formal, serial) {
+    if (formal->name != astrTag)
+      repCall->insertAtTail(
+        new NamedExpr(formal->name, createSymExprPropagatingParam(formal)) );
+  }
 
   // Add the tag argument.
   repCall->insertAtTail(new NamedExpr(astrTag, new SymExpr(iterKindTag)));

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2631,14 +2631,13 @@ static void normalizeVariableDefinition(DefExpr* defExpr) {
         tt->addFlag(FLAG_MAYBE_TYPE);
 
         DefExpr* def = new DefExpr(tt);
-        CallExpr* mv = new CallExpr(PRIM_MOVE, tt, defExpr->exprType->remove());
 
         // after the def, put
         //   declare type_tmp
         //   move type_tmp, type-expr
         //   PRIM_INIT_VAR_SPLIT_DECL var type_tmp
         defExpr->insertAfter(new CallExpr(PRIM_INIT_VAR_SPLIT_DECL, var, tt));
-        defExpr->insertAfter(mv);
+        emitTypeAliasInit(defExpr, tt, defExpr->exprType->remove());
         defExpr->insertAfter(def);
 
         typeTemp = tt;

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -165,7 +165,12 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
       bool match = false;
       int  j    = 0;
       for_formals(formal, fn) {
-        if (strcmp(info.actualNames.v[i], formal->name) == 0) {
+        if (info.actualNames.v[i] == formal->name) {
+
+          if (formalIdxToActual[j] != NULL)
+            USR_FATAL(info.call, "named argument '%s' provided twice",
+                      formal->name);
+
           match                = true;
           actualIdxToFormal[i] = formal;
           formalIdxToActual[j] = info.actuals.v[i];

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2492,6 +2492,7 @@ void resolveCall(CallExpr* call) {
 
     case PRIM_INIT_VAR:
     case PRIM_INIT_VAR_SPLIT_INIT:
+      resolveGenericActuals(call);
       resolveInitVar(call);
       break;
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -289,6 +289,14 @@ static CallExpr* buildInitCall(CallExpr* newExpr,
       USR_FATAL(call, "initialization requires an argument for %s", arg->name);
   }
 
+  // check that the type created by init is compatible with the requested
+  // type (e.g. for `type t = C(int); var x = new t(real);`).
+  if (isSubtypeOrInstantiation(tmp->type, at, call) == false) {
+    USR_FATAL_CONT(call, "initializer produces a different type");
+    USR_PRINT(call, "new was provided type '%s'", toString(at));
+    USR_PRINT(call, "init resulted in type '%s'", toString(tmp->type));
+  }
+
   return call;
 }
 

--- a/test/classes/initializers/records/generics/bug-14945.bad
+++ b/test/classes/initializers/records/generics/bug-14945.bad
@@ -1,1 +1,0 @@
-Foo(bool)

--- a/test/classes/initializers/records/generics/bug-14945.future
+++ b/test/classes/initializers/records/generics/bug-14945.future
@@ -1,2 +1,0 @@
-bug: missing compilation error for record initializer changing type
-#14945

--- a/test/classes/initializers/records/generics/bug-14945.good
+++ b/test/classes/initializers/records/generics/bug-14945.good
@@ -1,1 +1,3 @@
-some sort of compilation error
+bug-14945.chpl:8: error: initializer produces a different type
+bug-14945.chpl:8: note: when default-initializing 'foo1' of type 'Foo(bool)'
+bug-14945.chpl:8: note: init resulted in type 'Foo(int(64))'

--- a/test/classes/initializers/records/generics/varArgDefaultValue.bad
+++ b/test/classes/initializers/records/generics/varArgDefaultValue.bad
@@ -1,7 +1,0 @@
-varArgDefaultValue.chpl:18: internal error: MAI-CHE-CKS-nnnn chpl version mmmm
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/initializers/records/generics/varArgDefaultValue.compopts
+++ b/test/classes/initializers/records/generics/varArgDefaultValue.compopts
@@ -1,1 +1,0 @@
---no-codegen --verify

--- a/test/classes/initializers/records/generics/varArgDefaultValue.future
+++ b/test/classes/initializers/records/generics/varArgDefaultValue.future
@@ -1,2 +1,0 @@
-bug: missing checking of type mismatch produced by init
-#8499

--- a/test/classes/initializers/records/generics/varArgDefaultValue.good
+++ b/test/classes/initializers/records/generics/varArgDefaultValue.good
@@ -1,3 +1,3 @@
-Foo(bool)
-(v = false)
-(v = 0)
+varArgDefaultValue.chpl:12: error: initializer produces a different type
+varArgDefaultValue.chpl:12: note: when default-initializing 'foo1' of type 'Foo(bool)'
+varArgDefaultValue.chpl:12: note: init resulted in type 'Foo(int(64))'

--- a/test/library/packages/Itertools/repeat/check_Parallel_Standalone.chpl
+++ b/test/library/packages/Itertools/repeat/check_Parallel_Standalone.chpl
@@ -4,7 +4,7 @@ var test_case_1: [1..5] real = [2.3, -3.4, 8.91, 12.04, 2.8];
 
 var test_case_2: string = 'This is a test sentence.';
 
-var test_case_3: range = -3..21 by 3;
+var test_case_3: range(?) = -3..21 by 3;
 
 
 //  Testing with an integer array

--- a/test/library/packages/Itertools/repeat/check_Parallel_zippered.chpl
+++ b/test/library/packages/Itertools/repeat/check_Parallel_zippered.chpl
@@ -4,7 +4,7 @@ var test_case_1: [1..5] real = [2.3, -3.4, 8.91, 12.04, 2.8];
 
 var test_case_2: string = 'This is a test sentence.';
 
-var test_case_3: range = -3..21 by 3;
+var test_case_3: range(?) = -3..21 by 3;
 
 var test_case_4_dictDomain: domain(string) = {'Second', 'Third', 'First'};
 var test_case_4_dict: [test_case_4_dictDomain] int;

--- a/test/library/packages/Itertools/repeat/check_Serial.chpl
+++ b/test/library/packages/Itertools/repeat/check_Serial.chpl
@@ -4,7 +4,7 @@ var test_case_1: [1..5] real = [2.3, -3.4, 8.91, 12.04, 2.8];
 
 var test_case_2: string = 'This is a test sentence.';
 
-var test_case_3: range = -3..21 by 3;
+var test_case_3: range(?) = -3..21 by 3;
 
 
 //  Testing with an integer array

--- a/test/types/range/ferguson/range-split-inits.chpl
+++ b/test/types/range/ferguson/range-split-inits.chpl
@@ -17,15 +17,12 @@ proc test1() {
 }
 test1();
 
-// If these become errors, split them into a separate test.
-// Here a variable declared with type `range` is initialized
-// to a non-default range.
 proc test2() {
   writeln("test2");
-  var a:range = 4..40 by 2;
+  var a:range(?) = 4..40 by 2;
   writeln(a.type:string, " ", a);
   
-  var b:range;
+  var b:range(?);
   b = 5..50 by 2;
   writeln(b.type:string, " ", b);
 }

--- a/test/types/records/bad-change-type/init-changes-type.chpl
+++ b/test/types/records/bad-change-type/init-changes-type.chpl
@@ -1,0 +1,12 @@
+record R {
+  type t;
+  var field: t;
+}
+
+proc R.init(type t) {
+  this.t = real;
+  field = 1.0;
+}
+
+var x: R(int);
+writeln(x.type:string, " ", x);

--- a/test/types/records/bad-change-type/init-changes-type.good
+++ b/test/types/records/bad-change-type/init-changes-type.good
@@ -1,0 +1,3 @@
+init-changes-type.chpl:11: error: initializer produces a different type
+init-changes-type.chpl:11: note: when default-initializing 'x' of type 'R(int(64))'
+init-changes-type.chpl:11: note: init resulted in type 'R(real(64))'

--- a/test/types/records/bad-change-type/init-new-arg-changes-type1.chpl
+++ b/test/types/records/bad-change-type/init-new-arg-changes-type1.chpl
@@ -1,0 +1,13 @@
+record R {
+  type t;
+  var field: t;
+}
+
+proc R.init(type t) {
+  this.t = t;
+  field = 1.0;
+}
+
+type tt = R(int);
+var yy = new tt(t=real);
+writeln(yy.type:string, " ", yy);

--- a/test/types/records/bad-change-type/init-new-arg-changes-type1.good
+++ b/test/types/records/bad-change-type/init-new-arg-changes-type1.good
@@ -1,0 +1,1 @@
+init-new-arg-changes-type1.chpl:12: error: named argument 't' provided twice

--- a/test/types/records/bad-change-type/init-new-arg-changes-type2.chpl
+++ b/test/types/records/bad-change-type/init-new-arg-changes-type2.chpl
@@ -1,0 +1,13 @@
+class C {
+  type t;
+  var field: t;
+}
+
+proc C.init(type t) {
+  this.t = t;
+  field = 1.0;
+}
+
+type t = C(int);
+var y = new t(t=real);
+writeln(y.type:string, " ", y);

--- a/test/types/records/bad-change-type/init-new-arg-changes-type2.good
+++ b/test/types/records/bad-change-type/init-new-arg-changes-type2.good
@@ -1,0 +1,1 @@
+init-new-arg-changes-type2.chpl:12: error: named argument 't' provided twice

--- a/test/types/records/bad-change-type/init-new-changes-type.chpl
+++ b/test/types/records/bad-change-type/init-new-changes-type.chpl
@@ -1,0 +1,27 @@
+class C {
+  type t;
+  var field: t;
+}
+
+proc C.init(type t) {
+  this.t = real;
+  field = 1.0;
+}
+
+type t = C(int);
+var y = new t();
+writeln(y.type:string, " ", y);
+
+record R {
+  type t;
+  var field: t;
+}
+
+proc R.init(type t) {
+  this.t = real;
+  field = 1.0;
+}
+
+type tt = R(int);
+var yy = new tt();
+writeln(yy.type:string, " ", yy);

--- a/test/types/records/bad-change-type/init-new-changes-type.good
+++ b/test/types/records/bad-change-type/init-new-changes-type.good
@@ -1,0 +1,6 @@
+init-new-changes-type.chpl:12: error: initializer produces a different type
+init-new-changes-type.chpl:12: note: new was provided type 'borrowed C(int(64))'
+init-new-changes-type.chpl:12: note: init resulted in type 'borrowed C(real(64))'
+init-new-changes-type.chpl:26: error: initializer produces a different type
+init-new-changes-type.chpl:26: note: new was provided type 'R(int(64))'
+init-new-changes-type.chpl:26: note: init resulted in type 'R(real(64))'

--- a/test/types/records/bad-change-type/init-uses-default.chpl
+++ b/test/types/records/bad-change-type/init-uses-default.chpl
@@ -1,0 +1,12 @@
+record R {
+  type t;
+  var field: t;
+}
+
+proc R.init(type t=real) {
+  this.t = t;
+  field = 1.0;
+}
+
+var xx: R;
+writeln(xx.type:string, " ", xx);

--- a/test/types/records/bad-change-type/init-uses-default.good
+++ b/test/types/records/bad-change-type/init-uses-default.good
@@ -1,0 +1,2 @@
+init-uses-default.chpl:11: error: Cannot default-initialize a variable with generic type
+init-uses-default.chpl:11: note: 'xx' has generic type 'R'

--- a/test/types/records/bad-change-type/range-init1.chpl
+++ b/test/types/records/bad-change-type/range-init1.chpl
@@ -1,0 +1,6 @@
+proc test() {
+  var ok: range(?) = 1..10 by 2;
+
+  var err: range = 1..10 by 2;
+}
+test();

--- a/test/types/records/bad-change-type/range-init1.good
+++ b/test/types/records/bad-change-type/range-init1.good
@@ -1,0 +1,2 @@
+range-init1.chpl:1: In function 'test':
+range-init1.chpl:4: error: cannot initialize a non-stridable range from a stridable range

--- a/test/types/records/bad-change-type/range-init2.chpl
+++ b/test/types/records/bad-change-type/range-init2.chpl
@@ -1,0 +1,8 @@
+proc test() {
+  var ok: range(?);
+  ok = 1..10 by 2;
+
+  var err: range;
+  err = 1..10 by 2;
+}
+test();

--- a/test/types/records/bad-change-type/range-init2.good
+++ b/test/types/records/bad-change-type/range-init2.good
@@ -1,0 +1,2 @@
+range-init2.chpl:1: In function 'test':
+range-init2.chpl:6: error: cannot initialize a non-stridable range from a stridable range

--- a/test/types/records/generic/partial-instantiation-equivalence.bad
+++ b/test/types/records/generic/partial-instantiation-equivalence.bad
@@ -1,3 +1,6 @@
+partial-instantiation-equivalence.chpl:24: error: initializer produces a different type
+partial-instantiation-equivalence.chpl:24: note: new was provided type 'R(1,1)'
+partial-instantiation-equivalence.chpl:24: note: init resulted in type 'R(1,1)'
 partial-instantiation-equivalence.chpl:32: error: unresolved call 'oof(R(1,1))'
 partial-instantiation-equivalence.chpl:27: note: this candidate did not match: oof(rr: Ryx)
 partial-instantiation-equivalence.chpl:32: note: because call actual argument #1 with type R(1,1)

--- a/test/types/tuple/diten/overload_destructure_args.good
+++ b/test/types/tuple/diten/overload_destructure_args.good
@@ -1,3 +1,3 @@
 overload_destructure_args.chpl:14: error: ambiguous call 'foo(1, (int(64),2*int(64)))'
-overload_destructure_args.chpl:6: note: candidates are: foo(a: int(64), chpl__tuple_arg_temp: _tuple)
-overload_destructure_args.chpl:10: note:                 foo(a: int(64), chpl__tuple_arg_temp: _tuple)
+overload_destructure_args.chpl:6: note: candidates are: foo(a: int(64), chpl__tuple_arg_temp1: _tuple)
+overload_destructure_args.chpl:10: note:                 foo(a: int(64), chpl__tuple_arg_temp1: _tuple)


### PR DESCRIPTION
This PR adds missing error checking for several patterns of 
initialization that would be confusing. These patterns are discussed in
issues #8499 and #13566 and shown in the new tests added by this PR.

Resolves #8499.
Resolves #13566.
Resolves #14945.

Reviewed by @benharsh - thanks!

- [x] primers pass with valgrind+verify
- [x] full local futures testing