### PR TITLE
File future showing incorrect ownership transfer line number

### DIFF
--- a/test/classes/delete-free/owned/errors/transferInBegin.bad
+++ b/test/classes/delete-free/owned/errors/transferInBegin.bad
@@ -1,0 +1,5 @@
+transferInBegin.chpl:5: error: Cannot transfer ownership from a non-nilable outer variable
+transferInBegin.chpl:11: error: Illegal use of dead value
+transferInBegin.chpl:5: note: 'myC' is dead due to ownership transfer here
+transferInBegin.chpl:11: error: mention of non-nilable variable after ownership is transferred out of it
+transferInBegin.chpl:5: note: ownership transfer occurred here

--- a/test/classes/delete-free/owned/errors/transferInBegin.chpl
+++ b/test/classes/delete-free/owned/errors/transferInBegin.chpl
@@ -1,0 +1,11 @@
+class C {
+  var x: int;
+}
+
+var myC = new C();
+
+begin with (in myC) {
+  writeln(myC.x);
+}
+
+writeln(myC.x);

--- a/test/classes/delete-free/owned/errors/transferInBegin.future
+++ b/test/classes/delete-free/owned/errors/transferInBegin.future
@@ -1,0 +1,6 @@
+error message: ownership transfer points to wrong line
+
+This test should generate an error similar to the one it is, but
+the ownership transfer here is pointing to the wrong line; its
+declaration rather than where the ownership transfer actually
+occurs (in a task intent).

--- a/test/classes/delete-free/owned/errors/transferInBegin.good
+++ b/test/classes/delete-free/owned/errors/transferInBegin.good
@@ -1,0 +1,5 @@
+transferInBegin.chpl:5: error: Cannot transfer ownership from a non-nilable outer variable
+transferInBegin.chpl:11: error: Illegal use of dead value
+transferInBegin.chpl:7: note: 'myC' is dead due to ownership transfer here
+transferInBegin.chpl:11: error: mention of non-nilable variable after ownership is transferred out of it
+transferInBegin.chpl:5: note: ownership transfer occurred here


### PR DESCRIPTION
This test correctly generates an error indicating that ownership
transfer has taken place for a non-nilable owned, but incorrectly
reports the line number where that transfer took place, referring
to the variable's declaration point rather than the task intent
line where the transfer occurred.