### PR TITLE
Remove isManagedPointerInit

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7152,8 +7152,6 @@ static void           resolveNewWithInitializer(CallExpr* newExpr,
 
 static SymExpr*       resolveNewFindTypeExpr(CallExpr* newExpr);
 
-static bool isManagedPointerInit(SymExpr* typeExpr);
-
 static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager);
 
 static void handleUnstableNewError(CallExpr* newExpr, Type* newType);
@@ -7317,7 +7315,7 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
 
         // Use the class type inside a owned/shared/etc
         // unless we are initializing Owned/Shared itself
-        if (isManagedPtrType(type) && !isManagedPointerInit(typeExpr)) {
+        if (isManagedPtrType(type)) {
           Type* subtype = getManagedPtrBorrowType(type);
           // rule out dtUnknown
           if (isAggregateType(subtype) || isDecoratedClassType(subtype))
@@ -7406,32 +7404,6 @@ static bool isUndecoratedClassNew(CallExpr* newExpr, Type* newType) {
   }
 
   return isUndecorated;
-}
-
-static bool isManagedPointerInit(SymExpr* typeExpr) {
-
-  // Managed pointer init methods are:
-  //  - accepting a single unmanaged class pointer
-  //  - accepting a single managed class pointer
-
-  // everything else is forwarded
-
-  if (typeExpr->next == NULL)
-    return false;
-
-  if (typeExpr->next->next != NULL)
-    return false;
-
-  Type* singleArgumentType = typeExpr->next->getValType();
-
-  if (isManagedPtrType(singleArgumentType))
-    return true;
-
-  if (DecoratedClassType* dt = toDecoratedClassType(singleArgumentType))
-    if (dt->isUnmanaged())
-      return true;
-
-  return false;
 }
 
 static void resolveNewWithInitializer(CallExpr* newExpr, Type* manager) {

--- a/test/classes/delete-free/owned/bug-15204.chpl
+++ b/test/classes/delete-free/owned/bug-15204.chpl
@@ -1,0 +1,17 @@
+class C {
+  proc init() {
+    writeln("in class C init()");
+  }
+  proc init(arg: owned C) {
+    writeln("in class C init(owned C)");
+  }
+}
+
+proc foo(type t) {
+  var own = new owned C();
+  var x = new t(own);
+}
+
+proc main() {
+  foo(owned C);
+}

--- a/test/classes/delete-free/owned/bug-15204.good
+++ b/test/classes/delete-free/owned/bug-15204.good
@@ -1,0 +1,2 @@
+in class C init()
+in class C init(owned C)


### PR DESCRIPTION
Removes isManagedPointerInit which should no longer be necessary after PR #15119.

Resolves #15204.

Reviewed by @benharsh - thanks!

- [x] primers pass with valgrind+verify and do not leak
- [x] full local futures testing