### PR TITLE
Fix a bug with copy elision improvements

### DIFF
--- a/test/types/records/copy-elision/copy-elision.chpl
+++ b/test/types/records/copy-elision/copy-elision.chpl
@@ -295,6 +295,103 @@ proc test11() {
 }
 test11();
 
+proc test12() {
+  writeln("test12");
+  var x = new R(1);
+  var y = x;
+  var z = y;
+}
+test12();
+
+proc test13() {
+  writeln("test13");
+  for i in 1..1 {
+    var x = new R(1);
+    var y = x;
+  }
+}
+test13();
+
+proc test14() {
+  writeln("test14");
+  coforall i in 1..1 {
+    var x = new R(1);
+    var y = x;
+  }
+}
+test14();
+
+proc test15() {
+  writeln("test15");
+  forall i in 1..1 {
+    var x = new R(1);
+    var y = x;
+  }
+}
+test15();
+
+proc test16() {
+  writeln("test16");
+  var i = 1;
+  do {
+    var x = new R(1);
+    var y = x;
+    i += 1;
+  } while (i <= 1);
+}
+test16();
+
+proc test17() {
+  writeln("test17");
+  var i = 1;
+  while (i <= 1) {
+    var x = new R(1);
+    var y = x;
+    i += 1;
+  }
+}
+test17();
+
+proc test18() {
+  writeln("test18");
+  cobegin {
+    {
+      var x = new R(1);
+      var y = x;
+    }
+    {
+      // do nothing
+    }
+  }
+}
+test18();
+
+proc test19() {
+  writeln("test19");
+  sync {
+    begin {
+      var x = new R(1);
+      var y = x;
+    }
+  }
+}
+test19();
+
+proc test20() {
+  writeln("test20");
+
+  var done$: sync int;
+
+  begin {
+    var x = new R(1);
+    var y = x;
+    done$ = 1;
+  }
+
+  done$; // wait
+}
+test20();
+
 writeln("test-public-global");
 public var global1  = globalR;
 

--- a/test/types/records/copy-elision/copy-elision.good
+++ b/test/types/records/copy-elision/copy-elision.good
@@ -140,6 +140,33 @@ init 1 1
 init= 1 1
 deinit 1 1
 deinit 1 1
+test12
+init 1 1
+deinit 1 1
+test13
+init 1 1
+deinit 1 1
+test14
+init 1 1
+deinit 1 1
+test15
+init 1 1
+deinit 1 1
+test16
+init 1 1
+deinit 1 1
+test17
+init 1 1
+deinit 1 1
+test18
+init 1 1
+deinit 1 1
+test19
+init 1 1
+deinit 1 1
+test20
+init 1 1
+deinit 1 1
 test-public-global
 init= 0 0
 test-private-global


### PR DESCRIPTION
PR #15174 changed the copy elision implementation to be more flexible and
to find more copies that can be elided. However it also inadverdently
removed legal copy elision within loops, for example:

``` chapel
for i in 1..n {
  var x = f();
  var y = x;  // should copy elide but was not
}
```

This was noticeable in a performance test showing the potential impact of
copy elision:

  https://chapel-lang.org/perf/chapcs/?startdate=2020/02/28&enddate=2020/03/13&graphs=stringtemporarycopies

This PR fixes the problem by adding a set tracking variables eligible for
elision. When traversing into a loop, the traversal uses a new empty set
of eligible variables. That prevents a copy-init from an outer variable
from turning into an elided copy within a loop but still allows copy
elision for variables declared within the loop.

Reviewed by @benharsh - thanks!

- [x] types/records/copy-elision passes with valgrind+verify and does not leak
- [x] primers pass with valgrind+verify and do not leak
- [x] full local testing
