### PR TITLE
Allow 'C' to be a subtype of 'C?'

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1397,7 +1397,7 @@ bool canCoerceAsSubtype(Type*     actualType,
 
     // Check that the decorators allow coercion
     if (canCoerceDecorators(actualDecorator, formalDecorator,
-                            /*allowNonSubtypes*/ false,
+                            /*allowNonSubtypes*/ true,
                             /*implicitBang*/false)) {
       // are the decorated class types the same?
       if (actualC == formalC)

--- a/test/classes/nilability/nil-non-subtype.chpl
+++ b/test/classes/nilability/nil-non-subtype.chpl
@@ -1,0 +1,26 @@
+
+class C {
+  var x : int;
+}
+
+class G { 
+  type T;
+  var x : T;
+}
+
+class D : C {
+  var y : real;
+}
+
+proc test(type A, type B) {
+  const sub = isSubtype(A, B);
+  writeln(A:string, " subtype of ", B:string, ": ", sub);
+  assert(sub != isSubtype(B, A));
+}
+
+proc main() {
+  test(C, C?);
+  test(G, G?);
+  test(G(int), G(int)?);
+  test(D, C?);
+}

--- a/test/classes/nilability/nil-non-subtype.good
+++ b/test/classes/nilability/nil-non-subtype.good
@@ -1,0 +1,4 @@
+C subtype of C?: true
+G subtype of G?: true
+G(int(64)) subtype of G(int(64))?: true
+D subtype of C?: true


### PR DESCRIPTION
Update the compiler to allow ``C`` to be a subtype of ``C?``.

Resolves #14307 

Testing:
- [x] local + futures