### PR TITLE
Warn unstable for "new borrowed C"

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7338,6 +7338,11 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
       if (manager == NULL && fWarnUnstable)
         // Generate an error on 'new MyClass' with fWarnUnstable
         handleUnstableNewError(newExpr, type);
+
+      if (manager == dtBorrowed && fWarnUnstable) {
+        Type* ct = canonicalClassType(type);
+        USR_WARN(newExpr, "new borrowed %s is unstable", ct->symbol->name);
+      }
     }
   }
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7342,6 +7342,12 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
       if (manager == dtBorrowed && fWarnUnstable) {
         Type* ct = canonicalClassType(type);
         USR_WARN(newExpr, "new borrowed %s is unstable", ct->symbol->name);
+        USR_PRINT(newExpr, "use 'new unmanaged %s' "
+                           "'new owned %s' or "
+                           "'new shared %s'",
+                           ct->symbol->name,
+                           ct->symbol->name,
+                           ct->symbol->name);
       }
     }
   }
@@ -7351,10 +7357,8 @@ static void handleUnstableNewError(CallExpr* newExpr, Type* newType) {
   if (isUndecoratedClassNew(newExpr, newType)) {
     USR_WARN(newExpr, "new %s is unstable", newType->symbol->name);
     USR_PRINT(newExpr, "use 'new unmanaged %s' "
-                       "'new owned %s' "
-                       "'new shared %s' or "
-                       "'new borrowed %s'",
-                       newType->symbol->name,
+                       "'new owned %s' or "
+                       "'new shared %s'",
                        newType->symbol->name,
                        newType->symbol->name,
                        newType->symbol->name);

--- a/test/unstable/newBorrowed.chpl
+++ b/test/unstable/newBorrowed.chpl
@@ -1,0 +1,8 @@
+class C { var x: int = 0; }
+
+proc test() {
+  for i in 1..8 do var c = new borrowed C(i);
+  return;
+}
+test();
+

--- a/test/unstable/newBorrowed.good
+++ b/test/unstable/newBorrowed.good
@@ -1,2 +1,3 @@
 newBorrowed.chpl:3: In function 'test':
 newBorrowed.chpl:4: warning: new borrowed C is unstable
+newBorrowed.chpl:4: note: use 'new unmanaged C' 'new owned C' or 'new shared C'

--- a/test/unstable/newBorrowed.good
+++ b/test/unstable/newBorrowed.good
@@ -1,0 +1,2 @@
+newBorrowed.chpl:3: In function 'test':
+newBorrowed.chpl:4: warning: new borrowed C is unstable


### PR DESCRIPTION
This PR adjusts the compiler to emit a warning when the `--warn-unstable` flag is thrown and the user attempts to create a new borrowed class.

It adds one new test to `test/unstable` to lock in the warning.

---

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet`
