### PR TITLE
Unfuturize a private import test

### DIFF
--- a/test/visibility/import/private-import.bad
+++ b/test/visibility/import/private-import.bad
@@ -1,1 +1,0 @@
-private-import.chpl:9: syntax error: near 'import'

--- a/test/visibility/import/private-import.future
+++ b/test/visibility/import/private-import.future
@@ -1,2 +1,0 @@
-unimplemented feature: support public/private on imports
-#14908


### PR DESCRIPTION
We now have support for `private import` after #15192.

This PR converts a relevant future to a test.