### PR TITLE
Extend nonnilable-array-eltType check to arrays of arrays

### DIFF
--- a/test/classes/deleting/deleteArrays.chpl
+++ b/test/classes/deleting/deleteArrays.chpl
@@ -17,7 +17,7 @@ writeln("---");
 }
 writeln("---");
 {
-  var A: [1..3] [1..3] unmanaged C;
+  var A: [1..3] [1..3] unmanaged C?;
   for i in 1..3 do
     for j in 1..3 do
       A[i][j] = new unmanaged C();
@@ -30,7 +30,7 @@ writeln("---");
   var myC = new unmanaged C();
   var B: [1..4] unmanaged C = [1..4] new unmanaged C();
   var myC2 = new unmanaged C();
-  var D: [1..2] [1..3] unmanaged C;
+  var D: [1..2] [1..3] unmanaged C?;
   for i in 1..2 do
     for j in 1..3 do
       D[i][j] = new unmanaged C();

--- a/test/classes/nilability/array-with-nonnilable-elttype.chpl
+++ b/test/classes/nilability/array-with-nonnilable-elttype.chpl
@@ -24,3 +24,29 @@ class C2 {
 }
 
 var c2 = new C2();
+
+/// adding arrays of arrays
+
+// ... a variable declaration
+var y1: [1..3] [1..2] owned object;
+var y2: [1..3] [1..2] shared object;
+var y3: [1..3] [1..2] borrowed object;
+var y4: [1..3] [1..2] unmanaged object;
+
+// ... a field; compiler-generated initializer
+class D1 {
+  var B1: [1..3] [1..2] borrowed object;
+}
+
+var d1 = new D1();
+
+// ... a field; user-defined initializer
+class D2 {
+  var B2: [1..3] [1..2] borrowed object;
+  proc init() {
+    // B2 is default-initialized here
+    this.complete();
+  }
+}
+
+var d2 = new D2();

--- a/test/classes/nilability/array-with-nonnilable-elttype.good
+++ b/test/classes/nilability/array-with-nonnilable-elttype.good
@@ -1,7 +1,14 @@
 array-with-nonnilable-elttype.chpl:15: error: cannot default-initialize the array field A1 because it has a non-nilable element type 'borrowed object'
 array-with-nonnilable-elttype.chpl:20: In initializer:
 array-with-nonnilable-elttype.chpl:22: error: cannot default-initialize the array field A2 because it has a non-nilable element type 'borrowed object'
+array-with-nonnilable-elttype.chpl:41: error: cannot default-initialize the array field B1 because it has a non-nilable element type 'borrowed object'
+array-with-nonnilable-elttype.chpl:46: In initializer:
+array-with-nonnilable-elttype.chpl:48: error: cannot default-initialize the array field B2 because it has a non-nilable element type 'borrowed object'
 array-with-nonnilable-elttype.chpl:5: error: cannot default-initialize the array x1 because it has a non-nilable element type 'owned object'
 array-with-nonnilable-elttype.chpl:6: error: cannot default-initialize the array x2 because it has a non-nilable element type 'shared object'
 array-with-nonnilable-elttype.chpl:7: error: cannot default-initialize the array x3 because it has a non-nilable element type 'borrowed object'
 array-with-nonnilable-elttype.chpl:8: error: cannot default-initialize the array x4 because it has a non-nilable element type 'unmanaged object'
+array-with-nonnilable-elttype.chpl:31: error: cannot default-initialize the array y1 because it has a non-nilable element type 'owned object'
+array-with-nonnilable-elttype.chpl:32: error: cannot default-initialize the array y2 because it has a non-nilable element type 'shared object'
+array-with-nonnilable-elttype.chpl:33: error: cannot default-initialize the array y3 because it has a non-nilable element type 'borrowed object'
+array-with-nonnilable-elttype.chpl:34: error: cannot default-initialize the array y4 because it has a non-nilable element type 'unmanaged object'


### PR DESCRIPTION
Extend the check introduced in #15044 to arrays of arrays
(and arrays of arrays of arrays and ....).