### PR TITLE
Fix two futures after 15208

### DIFF
--- a/test/performance/vectorization/hintTests/vec-hint-ok-harder-zips.bad
+++ b/test/performance/vectorization/hintTests/vec-hint-ok-harder-zips.bad
@@ -1,4 +1,0 @@
-vec-hint-ok-harder-zips.chpl:18: note: Vectorization disabled -- address taken
-vec-hint-ok-harder-zips.chpl:24: note: Vectorization disabled -- address taken
-2.0 10001.0
-3.0 10002.0

--- a/test/performance/vectorization/hintTests/vec-hint-ok-harder-zips.future
+++ b/test/performance/vectorization/hintTests/vec-hint-ok-harder-zips.future
@@ -1,1 +1,0 @@
-unimplemented feature: vectorization of zippered vectorizeOnly

--- a/test/reductions/vass/extra-iter-call.bad
+++ b/test/reductions/vass/extra-iter-call.bad
@@ -1,4 +1,0 @@
-start myIter
-start myIter
-finish myIter
-5 7 9

--- a/test/reductions/vass/extra-iter-call.skipif
+++ b/test/reductions/vass/extra-iter-call.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
PR #15208 changed the behavior of two futures. This PR adjusts them:

 * test/reductions/vass/extra-iter-call.chpl (#11884) now results in 
   memory errors reported by valgrind, so run it only under valgrind.
 *  test/performance/vectorization/hintTests/vec-hint-ok-harder-zips.chpl 
    now passes, so un-future it

Future work: investigate extra-iter-call.chpl further. Note that valgrind 
testing did not show other issues after #15208.

Test changes only, not reviewed.