### PR TITLE
Toml Parser: Misleading "line number" on error

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -321,7 +321,9 @@ module TomlParser {
               skipNext(source);
             }
             else if comment.match(top(source)) {
-              skipLine(source);
+              while top(source) != "\n" {
+                skipNext(source);
+              }
             }
             else {
               var toParse = parseValue();
@@ -399,7 +401,9 @@ module TomlParser {
         }
         // Comments within arrays
         else if val == '#' {
-          skipLine(source);
+          while top(source) != "\n" {
+            skipNext(source);
+          }
           return parseValue();
         }
         else if corner.match(val) {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -169,7 +169,6 @@ module TomlParser {
         if !source.isEmpty() {
           while(readLine(source)) {
             var token = top(source);
-         
             if comment.match(token) {
               parseComment();
             }
@@ -617,7 +616,7 @@ used to recursively hold tables and respective values
     // Time
     proc init(ti: time) {
        this.ti = ti;
-       this.tag = fieldTime; 
+       this.tag = fieldTime;
     }
 
     // Datetime
@@ -1201,7 +1200,7 @@ module TomlReader {
     }
 
     proc splitLine(line) {
-      var idx = 0; 
+      var idx = 0;
       var linetokens: list(string);
       var nonEmptyChar: bool = false;
 
@@ -1230,7 +1229,6 @@ module TomlReader {
             writeln('Tokenized: ', '(', strippedToken, ')');
           }
           nonEmptyChar = true;
-          
           var isComment = strippedToken.match(compile(comments));
           if isComment.matched && idx <= 1 {
             linetokens.append(strippedToken);

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -1211,7 +1211,10 @@ module TomlReader {
             comments = "(\\#)",                 // #
             commas = "(\\,)",                   // ,
             equals = "(\\=)",                   // =
-            curly = "(\\{)|(\\})";              // {}
+            curly = "(\\{)|(\\})",              // {}
+            dt = "^\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}",
+            ld = "^\\d{4}-\\d{2}-\\d{2}",
+            ti = "^\\d{2}:\\d{2}:\\d{2}(.\\d{6,})?";
 
       const pattern = compile('|'.join(doubleQuotes,
                                        singleQuotes,
@@ -1219,7 +1222,10 @@ module TomlReader {
                                        brackets,
                                        commas,
                                        curly,
-                                       equals));
+                                       equals,
+                                       dt,
+                                       ti,
+                                       ld));
 
       for token in pattern.split(line) {
         idx += 1;
@@ -1229,6 +1235,12 @@ module TomlReader {
             writeln('Tokenized: ', '(', strippedToken, ')');
           }
           nonEmptyChar = true;
+          // check for date/time in a line and avoid comment
+          const toke = strippedToken;
+          const isWhiteSpace = compile("\\s");
+          var dateTimeToken = isWhiteSpace.split(toke);
+          if strippedToken.match(compile('|'.join(dt,ti,ld))).matched then
+            strippedToken = dateTimeToken[0];
           var isComment = strippedToken.match(compile(comments));
           if isComment.matched && idx <= 1 {
             linetokens.append(strippedToken);

--- a/test/library/packages/TOML/test/commentTest.chpl
+++ b/test/library/packages/TOML/test/commentTest.chpl
@@ -2,8 +2,8 @@
 use TOML;
 
 config const str: string = """[owner]
-                            name = ["Foo Bar"] #something 
-                            # Another comment 
+                            name = ["Foo Bar"] # something
+                            # Another comment
                             dob = 2000-30-04-23
                             """;
 
@@ -12,10 +12,9 @@ proc main() {
     var TomlData = parseToml(str);
     var dob = TomlData["owner"]!["name"];
 
-    delete TomlData;  
+    delete TomlData;
   } catch e: TomlError{
     writeln(e.message());
     exit(1);
   }
-  
 }

--- a/test/library/packages/TOML/test/commentTest.chpl
+++ b/test/library/packages/TOML/test/commentTest.chpl
@@ -1,0 +1,21 @@
+
+use TOML;
+
+config const str: string = """[owner]
+                            name = ["Foo Bar"] #something 
+                            # Another comment 
+                            dob = 2000-30-04-23
+                            """;
+
+proc main() {
+  try! {
+    var TomlData = parseToml(str);
+    var dob = TomlData["owner"]!["name"];
+
+    delete TomlData;  
+  } catch e: TomlError{
+    writeln(e.message());
+    exit(1);
+  }
+  
+}

--- a/test/library/packages/TOML/test/commentTest.compopts
+++ b/test/library/packages/TOML/test/commentTest.compopts
@@ -1,1 +1,2 @@
 -M ../../../modules/packages/
+

--- a/test/library/packages/TOML/test/commentTest.compopts
+++ b/test/library/packages/TOML/test/commentTest.compopts
@@ -1,2 +1,0 @@
--M ../../../modules/packages/
-

--- a/test/library/packages/TOML/test/commentTest.compopts
+++ b/test/library/packages/TOML/test/commentTest.compopts
@@ -1,0 +1,1 @@
+-M ../../../modules/packages/

--- a/test/library/packages/TOML/test/commentTest.good
+++ b/test/library/packages/TOML/test/commentTest.good
@@ -1,0 +1,1 @@
+Line 4: Illegal Value -> 2000-30-04-23

--- a/test/library/packages/TOML/test/testtime.chpl
+++ b/test/library/packages/TOML/test/testtime.chpl
@@ -2,7 +2,7 @@
 use TOML;
 
 config const str: string = """[owner]
-                            name = "Foo Bar"
+                            name = "Foo Bar" # a name
                             timestamp1 = 06:30:30
                             timestamp2 = 06:30:30.123456
                             timestamp3 = 06:30:30.1234567 # rounding up


### PR DESCRIPTION
This PR aims to resolve the issue where inline comments are treated as new lines in the toml parser, which sometimes results in a wrong line number in TOML parse errors. 

The previous implementation did not differentiate between inline and full line comments. As a fix, we ignore inline comments and avoid adding them to the token list. 

fixes #12843 