### PR TITLE
Fix a race condition a copy-elision test

### DIFF
--- a/test/types/records/copy-elision/copy-elision.chpl
+++ b/test/types/records/copy-elision/copy-elision.chpl
@@ -383,8 +383,10 @@ proc test20() {
   var done$: sync int;
 
   begin {
-    var x = new R(1);
-    var y = x;
+    {
+      var x = new R(1);
+      var y = x;
+    }
     done$ = 1;
   }
 


### PR DESCRIPTION
PR #15208 added a new test of copy elision involving begin but the test 
code had a problem where the deinit could print out in 2 different
locations depending on a race. This PR adjusts the test to avoid the
race.

Test change only, not reviewed.