### PR TITLE
Change chpl__unalias on arrays to ignore _unowned

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4153,9 +4153,8 @@ module ChapelArray {
     param isview = (x._value.isSliceArrayView() ||
                     x._value.isRankChangeArrayView() ||
                     x._value.isReindexArrayView());
-    const isalias = x._unowned;
 
-    if isview || isalias {
+    if isview {
       // Intended to call chpl__initCopy
       pragma "no auto destroy" var ret = x;
       // Since chpl__unalias replaces a initCopy(auto/initCopy()) the

--- a/test/analysis/alias/array-of-classes-variant.compgood
+++ b/test/analysis/alias/array-of-classes-variant.compgood
@@ -13,8 +13,6 @@ noAliasSets: no-aliases for function acceptsArrays:
 noAliasSets: no-aliases for function acceptsClasses:
 noAliasSets: no-aliases for function acceptsIntRefs:
   A may alias ret
-  A may alias ret
-  B may alias ret
   B may alias ret
 LICM: may-alias report for a loop in function acceptsArrays:
 LICM: may-alias report for a loop in function acceptsClasses:

--- a/test/analysis/alias/array-of-classes.compgood
+++ b/test/analysis/alias/array-of-classes.compgood
@@ -12,8 +12,6 @@ noAliasSets: no-aliases for function acceptsArrays:
 noAliasSets: no-aliases for function acceptsClasses:
 noAliasSets: no-aliases for function acceptsIntRefs:
   A may alias ret
-  A may alias ret
-  B may alias ret
   B may alias ret
 LICM: may-alias report for a loop in function acceptsArrays:
 LICM: may-alias report for a loop in function acceptsClasses:

--- a/test/arrays/ferguson/array-of-owned-return.bad
+++ b/test/arrays/ferguson/array-of-owned-return.bad
@@ -1,4 +1,0 @@
-array-of-owned-return.chpl:9: In function 'main':
-array-of-owned-return.chpl:10: error: invalid implicit copy-initialization
-array-of-owned-return.chpl:10: error: Cannot copy array with element type that cannot be assigned
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2248: note: [domain(1,int(64),false)] owned C does not have a valid init=

--- a/test/arrays/ferguson/array-of-owned-return.future
+++ b/test/arrays/ferguson/array-of-owned-return.future
@@ -1,2 +1,0 @@
-bug: should be able to return array of owned
-#14896


### PR DESCRIPTION
The _unowned field on _arrays is unused in user-facing code.
Checking for it in chpl__unalias and then calling initCopy caused errors for the
code in issue #14896. By leaving out _unowned from consideration
and changing the check to be only compile-time, this issue is avoided.

Resolves #14896.

Reviewed by @benharsh - thanks!

- [x] full local testing
- [x] primers pass with valgrind+verify and do not leak