### PR TITLE
Make failing enum casts throw rather than halt

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1219,7 +1219,6 @@ static void buildEnumIntegerCastFunctions(EnumType* et) {
     arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", et);
     fn->insertFormalAtTail(arg1);
     fn->insertFormalAtTail(arg2);
-    fn->throwsErrorInit();
 
     if (et->isConcrete()) {
       // If this enum is concrete, rely on the C cast and inline
@@ -1227,6 +1226,7 @@ static void buildEnumIntegerCastFunctions(EnumType* et) {
                                     new CallExpr(PRIM_CAST, arg1, arg2)));
       fn->addFlag(FLAG_INLINE);
     } else {
+      fn->throwsErrorInit();
       // Otherwise, it's semi-concrete, so we need errors for some cases.
       // Generate a select statement with when clauses for each of the
       // enumeration constants, and an otherwise clause that calls halt.

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1250,10 +1250,9 @@ static void buildEnumIntegerCastFunctions(EnumType* et) {
                                              new CallExpr("+", lastInit->copy(),
                                                           new SymExpr(new_IntSymbol(count)))));
         } else {
-          result = new CallExpr(PRIM_RETURN,
-                                new CallExpr("chpl_enum_cast_error_no_int",
-                                             new_StringSymbol(et->symbol->name),
-                                             new_StringSymbol(constant->sym->name)));
+          result = new CallExpr("chpl_enum_cast_error_no_int",
+                                new_StringSymbol(et->symbol->name),
+                                new_StringSymbol(constant->sym->name));
         }
         CondStmt* when =
           new CondStmt(new CallExpr(PRIM_WHEN, new SymExpr(constant->sym)),

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -913,13 +913,13 @@ void ErrorCheckingVisitor::checkCatches(TryStmt* tryStmt) {
   }
 }
 
-static void genThrowingFnError(FnSymbol* calledFn,
-                               CallExpr* node,
-                               implicitThrowsReasons_t* reasons,
-                               const char* problem) {
+static void issueThrowingFnError(FnSymbol* calledFn,
+                                 CallExpr* node,
+                                 implicitThrowsReasons_t* reasons,
+                                 const char* problem) {
   const char* desc = "cast";
   bool cast = true;
-  if (strcmp(calledFn->name, "_cast") != 0) {
+  if (calledFn->name != astr_cast) {
     desc = astr("function ", calledFn->name);
     cast = false;
   }
@@ -966,8 +966,8 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
 
       } else if(node->tryTag == TRY_TAG_IN_TRY) {
         if (!inThrowingFunction) {
-          genThrowingFnError(calledFn, node, reasons,
-                             "is in a try but not handled");
+          issueThrowingFnError(calledFn, node, reasons,
+                               "is in a try but not handled");
         }
 
         // Otherwise, OK, a try in a throwing function
@@ -975,11 +975,11 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
       } else {
         if (shouldEnforceStrict(node, taskFunctionDepth)) {
           if (mode == ERROR_MODE_STRICT) {
-            genThrowingFnError(calledFn, node, reasons,
-                               "without try or try! (strict mode)");
+            issueThrowingFnError(calledFn, node, reasons,
+                                 "without try or try! (strict mode)");
           } else if (mode == ERROR_MODE_RELAXED && !inThrowingFunction) {
-            genThrowingFnError(calledFn, node, reasons,
-                               "without throws, try, or try! (relaxed mode)");
+            issueThrowingFnError(calledFn, node, reasons,
+                                 "without throws, try, or try! (relaxed mode)");
           }
         }
       }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -920,7 +920,7 @@ static void genThrowingFnError(FnSymbol* calledFn,
   const char* desc = "cast";
   bool cast = true;
   if (strcmp(calledFn->name, "_cast") != 0) {
-    desc = astr("function '", calledFn->name, "'");
+    desc = astr("function ", calledFn->name);
     cast = false;
   }
   USR_FATAL_CONT(node, "call to throwing %s %s", desc, problem);

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -979,7 +979,7 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
                                "without try or try! (strict mode)");
           } else if (mode == ERROR_MODE_RELAXED && !inThrowingFunction) {
             genThrowingFnError(calledFn, node, reasons,
-                               "without try or try! (relaxed mode)");
+                               "without throws, try, or try! (relaxed mode)");
           }
         }
       }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -28,6 +28,7 @@
 #include "driver.h"
 #include "resolution.h"
 #include "stmt.h"
+#include "stringutil.h"
 #include "symbol.h"
 #include "TryStmt.h"
 #include "wellknown.h"
@@ -912,6 +913,24 @@ void ErrorCheckingVisitor::checkCatches(TryStmt* tryStmt) {
   }
 }
 
+static void genThrowingFnError(FnSymbol* calledFn,
+                               CallExpr* node,
+                               implicitThrowsReasons_t* reasons,
+                               const char* problem) {
+  const char* desc = "cast";
+  bool cast = true;
+  if (strcmp(calledFn->name, "_cast") != 0) {
+    desc = astr("function '", calledFn->name, "'");
+    cast = false;
+  }
+  USR_FATAL_CONT(node, "call to throwing %s %s", desc, problem);
+  if (!cast) {
+    USR_PRINT(calledFn, "throwing function %s defined here", calledFn->name);
+  }
+  printReason(node, reasons);
+}
+
+
 bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
   bool insideTry = (tryDepth > 0);
 
@@ -947,12 +966,8 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
 
       } else if(node->tryTag == TRY_TAG_IN_TRY) {
         if (!inThrowingFunction) {
-          USR_FATAL_CONT(node, "call to throwing function %s "
-                               "is in a try but not handled",
-                               calledFn->name);
-          USR_PRINT(calledFn, "throwing function %s defined here",
-                              calledFn->name);
-          printReason(node, reasons);
+          genThrowingFnError(calledFn, node, reasons,
+                             "is in a try but not handled");
         }
 
         // Otherwise, OK, a try in a throwing function
@@ -960,19 +975,11 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
       } else {
         if (shouldEnforceStrict(node, taskFunctionDepth)) {
           if (mode == ERROR_MODE_STRICT) {
-            USR_FATAL_CONT(node, "call to throwing function %s "
-                                 "without try or try! (strict mode)",
-                                 calledFn->name);
-            USR_PRINT(calledFn, "throwing function %s defined here",
-                                calledFn->name);
-            printReason(node, reasons);
+            genThrowingFnError(calledFn, node, reasons,
+                               "without try or try! (strict mode)");
           } else if (mode == ERROR_MODE_RELAXED && !inThrowingFunction) {
-            USR_FATAL_CONT(node, "call to throwing function %s "
-                                 "without throws, try, or try! (relaxed mode)",
-                                 calledFn->name);
-            USR_PRINT(calledFn, "throwing function %s defined here",
-                                calledFn->name);
-            printReason(node, reasons);
+            genThrowingFnError(calledFn, node, reasons,
+                               "without try or try! (relaxed mode)");
           }
         }
       }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1412,13 +1412,13 @@ module ChapelBase {
   inline proc _cast(type t:chpl_anyreal, x:chpl_anyreal)
     return __primitive("cast", t, x);
 
-  inline proc _cast(type t:chpl_anybool, x:enum)
+  inline proc _cast(type t:chpl_anybool, x:enum) throws
     return x: int: bool;
   // _cast(type t:integral, x:enum)
   // is generated for each enum in buildDefaultFunctions
   inline proc _cast(type t:enum, x:enum) where x.type == t
     return x;
-  inline proc _cast(type t:chpl_anyreal, x:enum)
+  inline proc _cast(type t:chpl_anyreal, x:enum) throws
     return x: int: real;
 
   inline proc _cast(type t:unmanaged class, x:_nilType)
@@ -1564,7 +1564,7 @@ module ChapelBase {
   inline proc _cast(type t:chpl_anycomplex, x: chpl_anycomplex)
     return (x.re, x.im):t;
 
-  inline proc _cast(type t:chpl_anycomplex, x: enum)
+  inline proc _cast(type t:chpl_anycomplex, x: enum) throws
     return (x:real, 0):t;
 
   //
@@ -1585,7 +1585,7 @@ module ChapelBase {
   inline proc _cast(type t:chpl_anyimag, x: chpl_anycomplex)
     return __primitive("cast", t, x.im);
 
-  inline proc _cast(type t:chpl_anyimag, x: enum)
+  inline proc _cast(type t:chpl_anyimag, x: enum) throws
     return x:real:imag;
 
   //

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -516,9 +516,9 @@ module ChapelError {
   pragma "always propagate line file info"
   proc chpl_enum_cast_error(casted: string, enumName: string) throws {
     if casted.isEmpty() then
-      throw new owned IllegalArgumentError("bad cast from empty string to " + enumName);
+      throw new owned IllegalArgumentError("bad cast from empty string to enum '" + enumName + "'");
     else
-      throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to '" + enumName + "'");
+      throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to enum '" + enumName + "'");
   }
 
   pragma "no doc"
@@ -532,7 +532,7 @@ module ChapelError {
   pragma "insert line file info"
   pragma "always propagate line file info"
     proc chpl_enum_cast_error_no_int(enumName: string, constName: string) throws {
-    throw new owned IllegalArgumentError("bad cast: '" + enumName + "." +
+    throw new owned IllegalArgumentError("bad cast: enum '" + enumName + "." +
                                          constName + "' has no integer value");
     return 0;
   }
@@ -545,10 +545,10 @@ module ChapelError {
   pragma "always propagate line file info"
   proc chpl_enum_cast_error(casted: bytes, enumName: string) throws {
     if casted.isEmpty() then
-      throw new owned IllegalArgumentError("bad cast from empty bytes to " + enumName);
+      throw new owned IllegalArgumentError("bad cast from empty bytes to enum '" + enumName + "'");
     else
       throw new owned IllegalArgumentError("bad cast from bytes '" +
                                            casted.decode(decodePolicy.replace) +
-                                           "' to " + enumName);
+                                           "' to enum '" + enumName + "'");
   }
 }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -528,6 +528,15 @@ module ChapelError {
     throw new owned IllegalArgumentError("bad cast from int '" + casted:string + "' to enum '" + enumName, "'");
   }
 
+  pragma "no doc"
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+    proc chpl_enum_cast_error_no_int(enumName: string, constName: string) throws {
+    throw new owned IllegalArgumentError("bad cast: '" + enumName + "." +
+                                         constName + "' has no integer value");
+    return 0;
+  }
+
 
   // The compiler generates functions to cast from bytes to enums. This
   // function helps the compiler throw errors from those generated casts.

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -521,6 +521,14 @@ module ChapelError {
       throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to " + enumName);
   }
 
+  pragma "no doc"
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_enum_cast_error(casted: int, enumName: string) throws {
+    throw new owned IllegalArgumentError("bad cast from int '" + casted:string + "' to enum '" + enumName, "'");
+  }
+
+
   // The compiler generates functions to cast from bytes to enums. This
   // function helps the compiler throw errors from those generated casts.
   pragma "no doc"

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -518,7 +518,7 @@ module ChapelError {
     if casted.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to " + enumName);
     else
-      throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to " + enumName);
+      throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to '" + enumName + "'");
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -524,7 +524,7 @@ module ChapelError {
   pragma "no doc"
   pragma "insert line file info"
   pragma "always propagate line file info"
-  proc chpl_enum_cast_error(casted: int, enumName: string) throws {
+  proc chpl_enum_cast_error(casted: integral, enumName: string) throws {
     throw new owned IllegalArgumentError("bad cast from int '" + casted:string + "' to enum '" + enumName, "'");
   }
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -344,13 +344,13 @@ module DateTime {
    */
   proc date.weekday() {
     // January 1 0001 is a Monday
-    return ((toordinal() + 6) % 7): DayOfWeek;
+    return try! ((toordinal() + 6) % 7): DayOfWeek;
   }
 
   /* Return the day of the week as an `ISODayOfWeek`.
      `Monday` == 1, `Sunday` == 7 */
   proc date.isoweekday() {
-    return (weekday(): int + 1): ISODayOfWeek;
+    return try! (weekday(): int + 1): ISODayOfWeek;
   }
 
   /* Return the ISO date as a tuple containing the ISO year, ISO week number,

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5222,17 +5222,13 @@ proc _toIntegral(x:?t) where isIntegralType(t)
   return (x, true);
 }
 private inline
-proc _toIntegral(x:?t) where _isIoPrimitiveType(t) && !isIntegralType(t)
+proc _toIntegral(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0, false);
-    else
-      ret = (x:int, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0, false);
-  }
+  else
+    ret = (x:int, true);
   return ret;
 }
 private inline
@@ -5268,17 +5264,13 @@ proc _toSigned(x:uint(64))
 }
 
 private inline
-proc _toSigned(x:?t) where _isIoPrimitiveType(t) && !isIntegralType(t)
+proc _toSigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0, false);
-    else
-      ret = (x:int, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0, false);
-  }
+  else
+    ret = (x:int, true);
   return ret;
 }
 private inline
@@ -5315,17 +5307,13 @@ proc _toUnsigned(x:int(64))
 
 
 private inline
-proc _toUnsigned(x:?t) where _isIoPrimitiveType(t) && !isIntegralType(t)
+proc _toUnsigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (uint, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0:uint, false);
-    else
-      ret = (x:uint, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0:uint, false);
-  }
+  else
+    ret = (x:uint, true);
   return ret;
 }
 private inline
@@ -5341,17 +5329,13 @@ proc _toReal(x:?t) where isRealType(t)
   return (x, true);
 }
 private inline
-proc _toReal(x:?t) where _isIoPrimitiveType(t) && !isRealType(t)
+proc _toReal(x:?t) throws where _isIoPrimitiveType(t) && !isRealType(t)
 {
   var ret: (real, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0.0, false);
-    else
-      ret = (x:real, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0.0, false);
-  }
+  else
+    ret = (x:real, true);
   return ret;
 }
 private inline
@@ -5366,17 +5350,13 @@ proc _toImag(x:?t) where isImagType(t)
   return (x, true);
 }
 private inline
-proc _toImag(x:?t) where _isIoPrimitiveType(t) && !isImagType(t)
+proc _toImag(x:?t) throws where _isIoPrimitiveType(t) && !isImagType(t)
 {
   var ret: (imag, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0.0i, false);
-    else
-      ret = (x:imag, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0.0i, false);
-  }
+  else
+    ret = (x:imag, true);
   return ret;
 }
 private inline
@@ -5392,17 +5372,13 @@ proc _toComplex(x:?t) where isComplexType(t)
   return (x, true);
 }
 private inline
-proc _toComplex(x:?t) where _isIoPrimitiveType(t) && !isComplexType(t)
+proc _toComplex(x:?t) throws where _isIoPrimitiveType(t) && !isComplexType(t)
 {
   var ret: (complex, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0.0+0.0i, false);
-    else
-      ret = (x:complex, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0.0+0.0i, false);
-  }
+  else
+    ret = (x:complex, true);
   return ret;
 }
 private inline
@@ -5438,18 +5414,14 @@ proc _toNumeric(x:?t) where isNumericType(t)
   return (x, true);
 }
 private inline
-proc _toNumeric(x:?t) where _isIoPrimitiveType(t) && !isNumericType(t)
+proc _toNumeric(x:?t) throws where _isIoPrimitiveType(t) && !isNumericType(t)
 {
   // enums, bools get cast to int.
   var ret: (int, bool);
-  try {
-    if isAbstractEnumType(t) then
-      ret = (0, false);
-    else
-      ret = (x:int, true);
-  } catch {
+  if isAbstractEnumType(t) then
     ret = (0, false);
-  }
+  else
+    ret = (x:int, true);
   return ret;
 
 }
@@ -5846,7 +5818,7 @@ proc channel._conv_sethandler(
     argtypei:c_int,
     ref style:iostyle,
     i:int, argi,
-    isReadf:bool):bool
+    isReadf:bool):bool throws
 {
   if error then return false;
   // Now, set style elements based on action
@@ -6571,11 +6543,14 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                       // someone's trying to capture a non UTF8 sequence in a
                       // string -- argument type mismatch
                       err = qio_format_error_arg_mismatch(i);
-                      
+
                       // Engin: maybe in the future we can just propagate
                       // DecodeError here?
-                    } catch {
+                    } catch e: IllegalArgumentError {
+                      stdout.writeln("Caught an illegal argument error");
                       // maybe a cast error for the enum cast
+                      throw e;
+                    } catch {
                       err = qio_format_error_bad_regexp();
                     }
                   }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6543,14 +6543,11 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
                       // someone's trying to capture a non UTF8 sequence in a
                       // string -- argument type mismatch
                       err = qio_format_error_arg_mismatch(i);
-
+                      
                       // Engin: maybe in the future we can just propagate
                       // DecodeError here?
-                    } catch e: IllegalArgumentError {
-                      stdout.writeln("Caught an illegal argument error");
-                      // maybe a cast error for the enum cast
-                      throw e;
                     } catch {
+                      // maybe a cast error for the enum cast
                       err = qio_format_error_bad_regexp();
                     }
                   }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6717,6 +6717,8 @@ proc channel.skipField() throws {
 proc string.format(args ...?k): string throws {
   try {
     return chpl_do_format(this, (...args));
+  } catch e: IllegalArgumentError {
+    throw e;
   } catch e: SystemError {
     try ioerror(e.err, "in string.format");
   } catch e: DecodeError {

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -109,7 +109,7 @@ proc getCurrentDayOfWeek() : Day {
 
   chpl_timevalue_parts(now, seconds, minutes, hours, mday, month, year, wday, yday, isdst);
 
-  return wday : Day;
+  return try! wday : Day;
 }
 
 /*

--- a/test/errhandling/psahabu/str-to-enum.good
+++ b/test/errhandling/psahabu/str-to-enum.good
@@ -1,3 +1,3 @@
 successful cast
 caught cast error
-bad cast from string 'brad' to Goal
+bad cast from string 'brad' to enum 'Goal'

--- a/test/execflags/configFile/configFileBadEnum.good
+++ b/test/execflags/configFile/configFileBadEnum.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: bad cast from string 'garlic' to ingredients
+uncaught IllegalArgumentError: bad cast from string 'garlic' to enum 'ingredients'
   <command line setting of 'gingerbread'>:0: thrown here
   <command line setting of 'gingerbread'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarBadEnum.good
+++ b/test/execflags/shannon/configs/configVarBadEnum.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: bad cast from string 'meatloaf' to ingredients
+uncaught IllegalArgumentError: bad cast from string 'meatloaf' to enum 'ingredients'
   <command line setting of 'gingerbread'>:0: thrown here
   <command line setting of 'gingerbread'>:0: uncaught here

--- a/test/expressions/casts/enumCastErrors-1.good
+++ b/test/expressions/casts/enumCastErrors-1.good
@@ -1,0 +1,1 @@
+enumCastErrors.chpl:13: error: enum cast out of bounds

--- a/test/expressions/casts/enumCastErrors-10.good
+++ b/test/expressions/casts/enumCastErrors-10.good
@@ -1,0 +1,1 @@
+enumCastErrors.chpl:49: error: can't cast from int(64) to an abstract enum type ('color3')

--- a/test/expressions/casts/enumCastErrors-2.good
+++ b/test/expressions/casts/enumCastErrors-2.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: bad cast from string 'reed' to 'color'
+uncaught IllegalArgumentError: bad cast from string 'reed' to enum 'color'
   enumCastErrors.chpl:17: thrown here
   enumCastErrors.chpl:17: uncaught here

--- a/test/expressions/casts/enumCastErrors-2.good
+++ b/test/expressions/casts/enumCastErrors-2.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: bad cast from string 'reed' to 'color'
+  enumCastErrors.chpl:17: thrown here
+  enumCastErrors.chpl:17: uncaught here

--- a/test/expressions/casts/enumCastErrors-3.good
+++ b/test/expressions/casts/enumCastErrors-3.good
@@ -1,0 +1,1 @@
+enumCastErrors.chpl:21: error: enum cast out of bounds

--- a/test/expressions/casts/enumCastErrors-4.good
+++ b/test/expressions/casts/enumCastErrors-4.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: illegal argument 'bad cast from int '7' to enum 'color': '
+  enumCastErrors.chpl:25: thrown here
+  enumCastErrors.chpl:25: uncaught here

--- a/test/expressions/casts/enumCastErrors-5.good
+++ b/test/expressions/casts/enumCastErrors-5.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: bad cast: 'color2.red' has no integer value
+uncaught IllegalArgumentError: bad cast: enum 'color2.red' has no integer value
   enumCastErrors.chpl:29: thrown here
   enumCastErrors.chpl:29: uncaught here

--- a/test/expressions/casts/enumCastErrors-5.good
+++ b/test/expressions/casts/enumCastErrors-5.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: bad cast: 'color2.red' has no integer value
+  enumCastErrors.chpl:29: thrown here
+  enumCastErrors.chpl:29: uncaught here

--- a/test/expressions/casts/enumCastErrors-6.good
+++ b/test/expressions/casts/enumCastErrors-6.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: bad cast: 'color2.red' has no integer value
+uncaught IllegalArgumentError: bad cast: enum 'color2.red' has no integer value
   enumCastErrors.chpl:33: thrown here
   enumCastErrors.chpl:33: uncaught here

--- a/test/expressions/casts/enumCastErrors-6.good
+++ b/test/expressions/casts/enumCastErrors-6.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: bad cast: 'color2.red' has no integer value
+  enumCastErrors.chpl:33: thrown here
+  enumCastErrors.chpl:33: uncaught here

--- a/test/expressions/casts/enumCastErrors-7.good
+++ b/test/expressions/casts/enumCastErrors-7.good
@@ -1,0 +1,1 @@
+enumCastErrors.chpl:37: error: enum cast out of bounds

--- a/test/expressions/casts/enumCastErrors-8.good
+++ b/test/expressions/casts/enumCastErrors-8.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: illegal argument 'bad cast from int '1' to enum 'color2': '
+  enumCastErrors.chpl:41: thrown here
+  enumCastErrors.chpl:41: uncaught here

--- a/test/expressions/casts/enumCastErrors-9.good
+++ b/test/expressions/casts/enumCastErrors-9.good
@@ -1,0 +1,1 @@
+enumCastErrors.chpl:45: error: can't cast from int(64) to an abstract enum type ('color3')

--- a/test/expressions/casts/enumCastErrors.chpl
+++ b/test/expressions/casts/enumCastErrors.chpl
@@ -1,0 +1,51 @@
+
+  enum color {red=1, green, blue};
+  enum color2 {red, green, blue=3};
+  enum color3 {red, green, blue};
+
+  config param case = 6;
+  config var badcolor = "reed";
+  config var badint = 7;
+  config var badint2 = 1;
+  config var badcolor2 = color2.red;
+
+  if case == 1 {  // cast param string to enum
+    var x = "reed": color;
+    writeln(x);
+  }
+  if case == 2 {  // cast non-param string to enum
+    var x = badcolor: color;
+    writeln(x);
+  }
+  if case == 3 {  // cast param int to enum
+    var x = 7: color;
+    writeln(x);
+  }
+  if case == 4 {  // cast non-param int to enum
+    var x = badint: color;
+    writeln(x);
+  }
+  if case == 5 {  // cast param enum to int
+    var x = color2.red: int;
+    writeln(x);
+  }
+  if case == 6 {  // cast non-param enum to int
+    var x = badcolor2: int;
+    writeln(x);
+  }
+  if case == 7 {  // cast param int to enum w/out that int
+    var x = 1: color2;
+    writeln(x);
+  }
+  if case == 8 {  // cast non-param int to enum w/out that int
+    var x = badint2: color2;
+    writeln(x);
+  }
+  if case == 9 {  // cast param int to enum w/out any ints
+    var x = 1: color3;
+    writeln(x);
+  }
+  if case == 10 {  // cast non-param int to enum w/out any ints
+    var x = badint2: color3;
+    writeln(x);
+  }

--- a/test/expressions/casts/enumCastErrors.compopts
+++ b/test/expressions/casts/enumCastErrors.compopts
@@ -1,0 +1,10 @@
+-scase=1  # enumCastErrors-1.good
+-scase=2  # enumCastErrors-2.good
+-scase=3  # enumCastErrors-3.good
+-scase=4  # enumCastErrors-4.good
+-scase=5  # enumCastErrors-5.good
+-scase=6  # enumCastErrors-6.good
+-scase=7  # enumCastErrors-7.good
+-scase=8  # enumCastErrors-8.good
+-scase=9  # enumCastErrors-9.good
+-scase=10 # enumCastErrors-10.good

--- a/test/studies/shootout/meteor/kbrady/meteor-implicit-domain.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-implicit-domain.chpl
@@ -86,12 +86,12 @@ module meteor {
 
   /* Returns the direction rotated 60 degrees clockwise */
   proc rotate(dir: direction) : direction {
-    return ((dir:int + 2) % direction.size): direction;
+    return try! ((dir:int + 2) % direction.size): direction;
   }
 
   /* Returns the direction flipped on the horizontal axis */
   proc flip(dir: direction) : direction {
-    return ((direction.size - dir:int) % direction.size): direction;
+    return try! ((direction.size - dir:int) % direction.size): direction;
   }
 
   /* Returns the new cell index from the specified cell in the

--- a/test/studies/shootout/meteor/kbrady/meteor.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor.chpl
@@ -86,12 +86,12 @@ module meteor {
 
   /* Returns the direction rotated 60 degrees clockwise */
   proc rotate(dir: direction) : direction {
-    return ((dir:int + 2) % direction.size): direction;
+    return try! ((dir:int + 2) % direction.size): direction;
   }
 
   /* Returns the direction flipped on the horizontal axis */
   proc flip(dir: direction) : direction {
-    return ((direction.size - dir:int) % direction.size): direction;
+    return try! ((direction.size - dir:int) % direction.size): direction;
   }
 
   /* Returns the new cell index from the specified cell in the

--- a/test/types/enum/deitz/test_enum4b.good
+++ b/test/types/enum/deitz/test_enum4b.good
@@ -1,1 +1,3 @@
-test_enum4b.chpl:6: error: halt reached - illegal cast: ExprTypes.ADD has no integer value
+uncaught IllegalArgumentError: bad cast: enum 'ExprTypes.ADD' has no integer value
+  test_enum4b.chpl:6: thrown here
+  test_enum4b.chpl:6: uncaught here

--- a/test/types/enum/diten/varEnumOutOfBounds.good
+++ b/test/types/enum/diten/varEnumOutOfBounds.good
@@ -2,4 +2,6 @@ A
 B
 C
 D
-varEnumOutOfBounds.chpl:10: error: halt reached - enumerated type out of bounds
+uncaught IllegalArgumentError: illegal argument 'bad cast from int '4' to enum 'myEnum': '
+  varEnumOutOfBounds.chpl:10: thrown here
+  varEnumOutOfBounds.chpl:10: uncaught here

--- a/test/types/enum/readSemiAbstractEnumAsValue.good
+++ b/test/types/enum/readSemiAbstractEnumAsValue.good
@@ -1,5 +1,5 @@
 F1
 F1
-uncaught SystemError: Invalid argument: Argument type mismatch in argument 1 (in channel.readf(fmt:string, ...) with path "readSemiAbstractEnumAsValue.stdin" offset 6)
+uncaught IllegalArgumentError: bad cast: enum 'G.F1' has no integer value
   readSemiAbstractEnumAsValue.chpl:6: thrown here
   readSemiAbstractEnumAsValue.chpl:6: uncaught here

--- a/test/types/enum/readSemiAbstractEnumAsValue.good
+++ b/test/types/enum/readSemiAbstractEnumAsValue.good
@@ -1,3 +1,5 @@
 F1
 F1
-readSemiAbstractEnumAsValue.chpl:6: error: halt reached - illegal cast: G.F1 has no integer value
+uncaught SystemError: Invalid argument: Argument type mismatch in argument 1 (in channel.readf(fmt:string, ...) with path "readSemiAbstractEnumAsValue.stdin" offset 6)
+  readSemiAbstractEnumAsValue.chpl:6: thrown here
+  readSemiAbstractEnumAsValue.chpl:6: uncaught here

--- a/test/types/enum/writeSemiAbstractEnumAsValue.good
+++ b/test/types/enum/writeSemiAbstractEnumAsValue.good
@@ -1,6 +1,6 @@
 F1
 F1
 F1
-uncaught SystemError: Invalid argument: Argument type mismatch in argument 1 (in string.format)
+uncaught IllegalArgumentError: bad cast: enum 'G.F1' has no integer value
   writeSemiAbstractEnumAsValue.chpl:6: thrown here
   writeSemiAbstractEnumAsValue.chpl:6: uncaught here

--- a/test/types/enum/writeSemiAbstractEnumAsValue.good
+++ b/test/types/enum/writeSemiAbstractEnumAsValue.good
@@ -1,4 +1,6 @@
 F1
 F1
 F1
-writeSemiAbstractEnumAsValue.chpl:6: error: halt reached - illegal cast: G.F1 has no integer value
+uncaught SystemError: Invalid argument: Argument type mismatch in argument 1 (in string.format)
+  writeSemiAbstractEnumAsValue.chpl:6: thrown here
+  writeSemiAbstractEnumAsValue.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToEnum.good
+++ b/test/types/string/cast/emptyStringToEnum.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: bad cast from empty string to color
+uncaught IllegalArgumentError: bad cast from empty string to enum 'color'
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here


### PR DESCRIPTION
This PR makes casts involving enum that _may_ fail throw, similar to what `"brad":int` would do.  So, for example `myInt:myColor` would throw because not all ints can become colors.  But `myColor:int` would not for an enum where every symbol has an integer value because there's no way it could fail.

The main work is done in buildDefaultFunctions.cpp where:
* the functions themselves are marked as being throwing when they are
* the select statements that the compiler introduces change from using halt()s to throws
* a try statement is inserted to throw any errors upward
The specific work to generate and throw the error is put in ChapelError.chpl, to permit them to be more easily modified and customized.

Other core work involved:
* making the cast functions for enums defined in ChapelBase.chpl throw as well
* putting `try!` into known-safe casts in DateTime.chpl and Time.chpl
* reworking code paths for readf/writef to throw these casting errors upwards where, by default, they would turn them into less clear errors

While here, I improved the error messages generated in errorHandling.cpp when the user fails to put a try/try!/throws around a throwing cast by specializing the error message for casts rather than mentioning the internal `_cast` routine, and I refactored a few cases of generating such error messages to reduce repetition and share more commonality.  I also reworded the error messages in ChapelError.chpl so that they consistently referred to an enum type as `enum 'color'` (say).

Test changes included updating error messages for the changes to error message wordings, and to change tests of halts into uncaught errors.  Kyle's meteor variants also needed `try!` to guard some known-safe casts.  

I also added a new test that attempts to exhaustively enumerate ways that enum casts could go wrong.