### PR TITLE
Fix typos

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -713,7 +713,7 @@ initPrimitive() {
 
   // dst, src. PRIM_ASSIGN with reference dst sets *dst
   prim_def(PRIM_ASSIGN, "=", returnInfoVoid, true);
-  // like PRIM_ASSIGN but indicates an elidided copy
+  // like PRIM_ASSIGN but indicates an elided copy
   // which means that the RHS cannot be used again after this call.
   prim_def(PRIM_ASSIGN_ELIDED_COPY, "elided-copy=", returnInfoVoid, true);
   // like PRIM_ASSIGN but the operation can be put off until end of

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -351,7 +351,7 @@ static BlockStmt* buildResetUnionField(Symbol* _this,
                                                   ct->symbol,
                                                   newFieldNameSym)));
 
-    // Next, initialize the requsted field.
+    // Next, initialize the requested field.
     VarSymbol* tmp = newTemp("union_reset_init");
     tmp->addFlag(FLAG_NO_AUTO_DESTROY); // will transfer to the field.
     block->insertAtTail(new DefExpr(tmp));

--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -139,7 +139,7 @@ void AutoDestroyScope::addInitialization(VarSymbol* var) {
   // Note: this will be called redundantly.
   for (AutoDestroyScope* scope = this; scope != NULL; scope = scope->mParent) {
     if (scope->mInitedVars.insert(var).second) {
-      // An insertion occured, meaning this was the first
+      // An insertion occurred, meaning this was the first
       // thing that looked like initialization for this variable.
 
       if (scope->mDeclaredVars.count(var) > 0) {
@@ -217,7 +217,7 @@ void AutoDestroyScope::forgetOuterVariableInitializations() {
 
   // iterate through DeinitedVars
   for_set (VarSymbol, var, mDeinitedVars) {
-    // clear it from any parent scopes, stoping at the declaration point
+    // clear it from any parent scopes, stopping at the declaration point
     for (AutoDestroyScope* s = this->mParent; s != NULL; s = s->mParent) {
       s->mDeinitedVars.erase(var);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3560,9 +3560,9 @@ static Type* finalArrayElementType(AggregateType* arrayType) {
   return eltType;
 }
 
-// Is it OK to defalt-initialize an array with this element type?
+// Is it OK to default-initialize an array with this element type?
 // Once #14854 is resolved, this should be simply
-//   isDefaultInitializeable(eltType)
+//   isDefaultInitializable(eltType)
 static bool okForDefaultInitializedArray(Type* eltType) {
   // Exclude locales. Remove this exception once #15149 is merged.
   return eltType == dtLocale || ! isNonNilableClassType(eltType);

--- a/compiler/resolution/nilChecking.cpp
+++ b/compiler/resolution/nilChecking.cpp
@@ -382,7 +382,7 @@ static void checkForNilDereferencesInCall(
 
   // For records and non-nilable class types, check that any argument
   // to a user function is not dead.
-  // Also check for transfering ownership out of an unknown reference
+  // Also check for transferring ownership out of an unknown reference
   // to a non-nilable owned.
   FnSymbol* inFn = call->getFunction();
   if (FnSymbol* calledFn = call->resolvedOrVirtualFunction()) {
@@ -433,7 +433,7 @@ static void checkForNilDereferencesInCall(
             }
           }
 
-          // check for transfering ownership out of unk ref to non-nilable
+          // check for transferring ownership out of unk ref to non-nilable
           if (formal->hasFlag(FLAG_LEAVES_ARG_NIL)) {
             Symbol* actualSym = argSym;
             if (referent != NULL)

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -381,7 +381,7 @@ static void setRecordDefaultValueFlags(AggregateType* at) {
   }
 }
 
-static bool isDefaultInitializeable(Type* t) {
+static bool isDefaultInitializable(Type* t) {
   bool val = true;
   if (isRecord(t)) {
     AggregateType* at = toAggregateType(t);
@@ -1063,7 +1063,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
   case PRIM_HAS_DEFAULT_VALUE: {
     Type* t = call->get(1)->typeInfo();
 
-    bool val = isDefaultInitializeable(t);
+    bool val = isDefaultInitializable(t);
 
     if (val)
       retval = new SymExpr(gTrue);

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -930,7 +930,7 @@ static FnSymbol* getOverrideCandidate(FnSymbol* fn) {
   }
 
   //
-  // TODO: Merging these code paths triggers weird forwaring errors for
+  // TODO: Merging these code paths triggers weird forwarding errors for
   // OwnedObject code. Might be because we discard "owned" in places
   // we should not?
   //

--- a/compiler/util/astlocs.cpp
+++ b/compiler/util/astlocs.cpp
@@ -169,7 +169,7 @@ astlocT getUserInstantiationPoint(const BaseAST* ast) {
           cur = instantiationPoint;
       }
     } else if (TypeSymbol* ts = toTypeSymbol(cur)) {
-      // Find the first use of the TypeSymbol at the type's instantation point
+      // Find the first use of the TypeSymbol at the type's instantiation point
       // so we can have a better error message line number.
       BlockStmt* instantiationPoint = ts->instantiationPoint;
 

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -128,7 +128,7 @@ module BytesStringCommon {
         else {
           // if nbytes is 1, then we must have read a single byte and found
           // that it was invalid, if nbytes is >1 then we must have read
-          // multible bytes where the last one broke the sequence. But it can
+          // multiple bytes where the last one broke the sequence. But it can
           // be a valid byte itself. So we rewind by 1 in that case
           // we use nInvalidBytes to store how many bytes we are ignoring or
           // replacing

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4325,7 +4325,7 @@ module ChapelArray {
         i += 1;
       }
     } catch e {
-      // Deinitialize any elements that have been iniitalized.
+      // Deinitialize any elements that have been initialized.
       for j in 0..i-1 {
         chpl__autoDestroy(data[j]);
       }

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -52,7 +52,7 @@ module Map {
 
   //
   // #14861 - For now, maps of non-nilable classes are banned. Once we
-  // resolve #13602 and #14861, we can remvoe this check. The check is on
+  // resolve #13602 and #14861, we can remove this check. The check is on
   // a type method instead of `map.init` because init for associative
   // arrays (and thus their compiler error) resolves before `map.init`.
   //

--- a/runtime/include/encoding/encoding-support.h
+++ b/runtime/include/encoding/encoding-support.h
@@ -211,7 +211,7 @@ int chpl_enc_validate_buf(const char *buf, ssize_t buflen) {
   int offset = 0;
 
   while (offset<buflen) {
-    // you can create a chapel string with a codepoint that represens and
+    // you can create a chapel string with a codepoint that represents an
     // escaped byte, so the last argument is true
     if (chpl_enc_decode_char_buf_utf8(&cp, &nbytes, buf+offset,
                                       buflen-offset, true) != 0) {


### PR DESCRIPTION
Fix typos in

BytesStringCommon.chpl ChapelArray.chpl     Map.chpl
astlocs.cpp            AutoDestroyScope.cpp buildDefaultFunctions.cpp
functionResolution.cpp nilChecking.cpp      preFold.cpp
primitive.cpp          virtualDispatch.cpp  encoding-support.h
