### PR TITLE
Fix compatibility with old sed in the test script

### DIFF
--- a/test/chpldoc/compflags/author/withoutAuthor/withoutAuthor.doc.prediff
+++ b/test/chpldoc/compflags/author/withoutAuthor/withoutAuthor.doc.prediff
@@ -1,5 +1,5 @@
 #!/bin/sh
 grep Copyright $2 > $2.prediff.tmp
-sed -E 's/[0-9]{4}/n/' $2.prediff.tmp > $2
+sed 's/[0-9][0-9][0-9][0-9]/n/' $2.prediff.tmp > $2
 rm $2.prediff.tmp
 


### PR DESCRIPTION
Fix compatibility with old sed in the test script that is added earlier.
https://github.com/chapel-lang/chapel/pull/15151#issuecomment-600409912

No options of `sed` are used this time. I suppose this would work on most setups.
@bradcray @lydia-duncan 