### PR TITLE
Fix up chameneous benchmarks and patterns of returning array of non-nilable

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1560,7 +1560,9 @@ static void checkForErroneousInitCopies() {
           if (FnSymbol* callInFn = se->getFunction()) {
             bool inCopyIsh = callInFn->hasFlag(FLAG_INIT_COPY_FN) ||
                              callInFn->hasFlag(FLAG_AUTO_COPY_FN) ||
-                             callInFn->hasFlag(FLAG_UNALIAS_FN);
+                             callInFn->hasFlag(FLAG_UNALIAS_FN) ||
+                             (callInFn->hasFlag(FLAG_COPY_INIT) &&
+                              callInFn->hasFlag(FLAG_COMPILER_GENERATED));
             if (inCopyIsh && !callInFn->hasFlag(FLAG_ERRONEOUS_COPY)) {
               callInFn->addFlag(FLAG_ERRONEOUS_COPY);
               changed = true;
@@ -1582,7 +1584,9 @@ static void checkForErroneousInitCopies() {
         if (FnSymbol* callInFn = se->getFunction()) {
           bool inCopyIsh = callInFn->hasFlag(FLAG_INIT_COPY_FN) ||
                            callInFn->hasFlag(FLAG_AUTO_COPY_FN) ||
-                           callInFn->hasFlag(FLAG_UNALIAS_FN);
+                           callInFn->hasFlag(FLAG_UNALIAS_FN) ||
+                           (callInFn->hasFlag(FLAG_COPY_INIT) &&
+                            callInFn->hasFlag(FLAG_COMPILER_GENERATED));
           if (inCopyIsh == false) {
 
             if (callInFn->hasFlag(FLAG_INIT_COPY_FN)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3741,8 +3741,21 @@ void resolveNormalCallCompilerWarningStuff(CallExpr* call,
     } else {
       BaseAST* from = it->second.first;
       const char* err = it->second.second;
-      USR_FATAL_CONT(from, "%s", err);
-      USR_PRINT(call, "in function called here");
+      FnSymbol* inFn = call->getFunction();
+      bool inCopyIsh = false;
+      if (inFn != NULL) {
+        inCopyIsh = inFn->hasFlag(FLAG_INIT_COPY_FN) ||
+                    inFn->hasFlag(FLAG_AUTO_COPY_FN) ||
+                    inFn->hasFlag(FLAG_UNALIAS_FN) ||
+                    inFn->name == astrInitEquals;
+      }
+      if (inCopyIsh) {
+        inFn->addFlag(FLAG_ERRONEOUS_COPY);
+        tryResolveErrors[inFn] = std::make_pair(from,err);
+      } else {
+        USR_FATAL_CONT(from, "%s", err);
+        USR_PRINT(call, "in function called here");
+      }
     }
   }
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3735,6 +3735,9 @@ void resolveNormalCallCompilerWarningStuff(CallExpr* call,
     if (inTryResolve > 0 && tryResolveFunctions.size() > 0) {
       FnSymbol* fn = tryResolveFunctions.back();
       tryResolveErrors[fn] = it->second;
+    } else if (resolvedFn && resolvedFn->hasFlag(FLAG_ERRONEOUS_COPY)) {
+      // error will be reported later (in callDestructors) if
+      // copy is not eliminated by then.
     } else {
       BaseAST* from = it->second.first;
       const char* err = it->second.second;

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -64,15 +64,15 @@ record Population {
   // an array of chameneos objects representing the population
   //
   var chameneos = [i in 1..size]
-                   new Chameneos?(i, if size == 10 then colors10[i]
-                                                   else ((i-1)%3): Color);
+                   new Chameneos(i, if size == 10 then colors10[i]
+                                                  else ((i-1)%3): Color);
 
   //
   // Print the colors of the current population.
   //
   proc printColors() {
     for c in chameneos do
-      write(" ", c!.color);
+      write(" ", c.color);
     writeln();
   }
 
@@ -84,7 +84,7 @@ record Population {
     const place = new MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
-      c!.haveMeetings(place, chameneos);
+      c.haveMeetings(place, chameneos);
   }
 
   //
@@ -95,11 +95,11 @@ record Population {
   //
   proc printNotes() {
     for c in chameneos {
-      write(c!.meetings);
-      spellInt(c!.meetingsWithSelf);
+      write(c.meetings);
+      spellInt(c.meetingsWithSelf);
     }
     
-    spellInt(+ reduce chameneos!.meetings);
+    spellInt(+ reduce chameneos.meetings);
     writeln();
   }
 }
@@ -149,7 +149,7 @@ class Chameneos {
           if firstToArrive then
             waitForMeetingToEnd();
           else
-            meetWith(chameneos[peerID]!);
+            meetWith(chameneos[peerID]);
         }
       }
     } while (meetingsLeft);

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -53,7 +53,7 @@ record Population {
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors: [] Color) {
-    chameneos = [i in colors.domain] new owned Chameneos?(i, colors[i]);
+    chameneos = [i in colors.domain] new owned Chameneos(i, colors[i]);
   }
 
   //
@@ -64,7 +64,7 @@ record Population {
     const place = new MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
-      c!.haveMeetings(place, chameneos);
+      c.haveMeetings(place, chameneos);
   }
 
   //
@@ -74,15 +74,15 @@ record Population {
   //
   proc print() {
     for c in chameneos do
-      write(" ", c!.initialColor);
+      write(" ", c.initialColor);
     writeln();
 
     for c in chameneos {
-      write(c!.meetings);
-      spellInt(c!.meetingsWithSelf);
+      write(c.meetings);
+      spellInt(c.meetingsWithSelf);
     }
 
-    spellInt(+ reduce chameneos!.meetings);
+    spellInt(+ reduce chameneos.meetings);
     writeln();
   }
 }
@@ -133,7 +133,7 @@ class Chameneos {
           if firstToArrive then
             waitForMeetingToEnd();
           else
-            meetWith(chameneos[peerID]!);
+            meetWith(chameneos[peerID]);
         }
       }
     } while (meetingsLeft);

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -155,7 +155,7 @@ proc populate (size : int(32)) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int(32)) = {1..size};
-  var population : [D] owned Chameneos;
+  var population : [D] owned Chameneos?;
 
   if (size == 10) {
     for i in D {
@@ -166,7 +166,7 @@ proc populate (size : int(32)) {
       population(i) = new owned Chameneos(i, ((i-1) % 3):Color);
     }
   }
-  return population;
+  return try! population:owned Chameneos;
 }
 
 /* run takes a population of Chameneos and a MeetingPlace, then allows the

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -86,7 +86,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] owned Chameneos?, meetingPlace: MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp : uint(32);
     var peer_idx : uint(32);
     var xchg : uint(32);
@@ -111,7 +111,7 @@ class Chameneos {
             is_same = 1;
             halt("halt: chameneos met with self");
           }
-          const peer = population[peer_idx:int(32)]!;
+          const peer = population[peer_idx:int(32)].borrow();
           newColor = getComplement(color, peer.color);
           peer.color = newColor;
           peer.meetings += 1;
@@ -155,7 +155,7 @@ proc populate (size : int(32)) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int(32)) = {1..size};
-  var population : [D] owned Chameneos?;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
@@ -174,26 +174,26 @@ proc populate (size : int(32)) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] owned Chameneos?, meetingPlace : MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
-    write(" ", i!.color);
+    write(" ", i.color);
   }
   writeln();
 
   coforall i in population {
-    i!.start(population, meetingPlace);
+    i.start(population, meetingPlace);
   }
   meetingPlace.reset();
 }
 
-proc runQuiet(population : [] owned Chameneos?, meetingPlace : MeetingPlace) {
+proc runQuiet(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   coforall i in population {
-    i!.start(population, meetingPlace);
+    i.start(population, meetingPlace);
   }
   meetingPlace.reset();
 
-  const totalMeetings = + reduce population!.meetings;
-  const totalMeetingsWithSelf = + reduce population!.meetingsWithSelf;
+  const totalMeetings = + reduce population.meetings;
+  const totalMeetingsWithSelf = + reduce population.meetingsWithSelf;
   if (totalMeetings == numMeetings*2) {
     writeln("total meetings PASS");
   } else {
@@ -209,12 +209,12 @@ proc runQuiet(population : [] owned Chameneos?, meetingPlace : MeetingPlace) {
   writeln();
 }
 
-proc printInfo(population : [] owned Chameneos?) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
-    write(i!.meetings);
-    spellInt(i!.meetingsWithSelf);
+    write(i.meetings);
+    spellInt(i.meetingsWithSelf);
   }
-  const totalMeetings = + reduce population!.meetings;
+  const totalMeetings = + reduce population.meetings;
   spellInt(totalMeetings);
   writeln();
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -86,7 +86,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] owned Chameneos?, meetingPlace: MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp, peer_idx, xchg : int;
 
     stateTemp = meetingPlace.state.read(memoryOrder.acquire);
@@ -119,13 +119,13 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] owned Chameneos?, peer_idx) {
+  proc runMeeting (population : [] owned Chameneos, peer_idx) {
     var newColor : Color;
     var is_same : int;
     if (id == peer_idx) {
       is_same = 1;
     }
-    const peer = population[peer_idx:int(32)]!;
+    const peer = population[peer_idx:int(32)].borrow();
     newColor = getComplement(color, peer.color);
     peer.color = newColor;
     peer.meetings += 1;
@@ -178,7 +178,7 @@ proc populate (size) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] owned Chameneos?;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
@@ -197,25 +197,25 @@ proc populate (size) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] owned Chameneos?, meetingPlace : MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
-    write(" ", i!.color);
+    write(" ", i.color);
   }
   writeln();
 
   coforall i in population {
-    i!.start(population, meetingPlace);
+    i.start(population, meetingPlace);
   }
 
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] owned Chameneos?) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
-    write(i!.meetings);
-    spellInt(i!.meetingsWithSelf);
+    write(i.meetings);
+    spellInt(i.meetingsWithSelf);
   }
-  const totalMeetings = + reduce population!.meetings;
+  const totalMeetings = + reduce population.meetings;
   spellInt(totalMeetings);
   writeln();
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -178,7 +178,7 @@ proc populate (size) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] owned Chameneos;
+  var population : [D] owned Chameneos?;
 
   if (size == 10) {
     for i in D {
@@ -189,7 +189,7 @@ proc populate (size) {
       population(i) = new owned Chameneos(i, ((i-1) % numColors):Color);
     }
   }
-  return population;
+  return try! population:owned Chameneos;
 }
 
 /* run takes a population of Chameneos and a MeetingPlace, then allows the

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -155,7 +155,7 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] owned Chameneos;
+  var population : [D] owned Chameneos?;
 
   if (size == 10) {
     for i in D {
@@ -166,7 +166,7 @@ proc populate (size : int) {
       population(i) = new owned Chameneos(i, ((i-1) % numColors):Color);
     }
   }
-  return population;
+  return try! population:owned Chameneos;
 }
 
 /* run takes a population of Chameneos and a MeetingPlace, then allows the

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -82,7 +82,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] owned Chameneos?, meetingPlace: MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp, peer_idx, xchg : int;
 
     stateTemp = meetingPlace.state.read(memoryOrder.acquire);
@@ -116,13 +116,13 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] owned Chameneos?, peer_idx) {
+  proc runMeeting (population : [] owned Chameneos, peer_idx) {
     var is_same : int;
     var newColor : Color;
     if (id == peer_idx) {
       is_same = 1;
     }
-    const peer = population[peer_idx:int(32)]!;
+    const peer = population[peer_idx:int(32)].borrow();
     newColor = getComplement(color, peer.color);
     peer.color = newColor;
     peer.meetings += 1;
@@ -155,7 +155,7 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] owned Chameneos?;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
@@ -174,25 +174,25 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] owned Chameneos?, meetingPlace : MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
-    write(" ", i!.color);
+    write(" ", i.color);
   }
   writeln();
 
   coforall i in population {
-    i!.start(population, meetingPlace);
+    i.start(population, meetingPlace);
   }
 
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] owned Chameneos?) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
-    write(i!.meetings);
-    spellInt(i!.meetingsWithSelf);
+    write(i.meetings);
+    spellInt(i.meetingsWithSelf);
   }
-  const totalMeetings = + reduce population!.meetings;
+  const totalMeetings = + reduce population.meetings;
   spellInt(totalMeetings);
   writeln();
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
@@ -84,7 +84,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] owned Chameneos?, meetingPlace: MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp, peer_idx, xchg: int;
 
     stateTemp = meetingPlace.state.read(memoryOrder.acquire);
@@ -120,13 +120,13 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] owned Chameneos?, peer_idx) {
+  proc runMeeting (population : [] owned Chameneos, peer_idx) {
     var is_same : int;
     var newColor : Color;
     if (id == peer_idx) {
       is_same = 1;
     }
-    const peer = population[peer_idx:int(32)]!;
+    const peer = population[peer_idx:int(32)].borrow();
     newColor = getComplement(color, peer.color);
     peer.color = newColor;
     peer.meetings += 1;
@@ -164,7 +164,7 @@ proc populate (size : int) {
     for i in D do
       let ithColor = if size == 10 then colorsDefault10(i)
                                    else ((i-1) % numColors):Color
-        in new owned Chameneos?(i, ithColor);
+        in new owned Chameneos(i, ithColor);
 
   return population;
 }
@@ -174,25 +174,25 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] owned Chameneos?, meetingPlace : MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
-    write(" ", i!.color);
+    write(" ", i.color);
   }
   writeln();
 
   coforall i in population {
-    i!.start(population, meetingPlace);
+    i.start(population, meetingPlace);
   }
 
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] owned Chameneos?) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
-    write(i!.meetings);
-    spellInt(i!.meetingsWithSelf);
+    write(i.meetings);
+    spellInt(i.meetingsWithSelf);
   }
-  const totalMeetings = + reduce (population!.meetings);
+  const totalMeetings = + reduce (population.meetings);
   spellInt(totalMeetings);
   writeln();
 }


### PR DESCRIPTION
Related: PR #14887, issue #14896, PR #15240.

This PR reverts some changes to chameneos tests now that issue #14896 is 
solved. Once the changes were reverted, the tests uncovered additional
problems with the erroneous-initializer logic that this PR fixes.

Reviewed by @benharsh - thanks!

- [x] full local testing
