### PR TITLE
Fix some failures from record-wrapped locale changes

### DIFF
--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -697,7 +697,7 @@ module ChapelIO {
   pragma "no doc"
   proc locale.writeThis(f) throws {
     // FIXME this doesn't resolve without `this`
-    f <~> new ioLiteral("LOCALE") <~> this.chpl_id();
+    f <~> this._instance;
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -327,6 +327,10 @@ module ChapelLocale {
       return hname;
     }
 
+    override proc writeThis(f) throws {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+
     /*
       Get the name of this locale.  In practice, this is often the
       same as the hostname, though in some cases (like when using

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -201,7 +201,7 @@ module LocaleModel {
     }
 
     proc getChildArray() {
-      return childLocales;
+      return [loc in childLocales] loc;
     }
 
     //------------------------------------------------------------------------{

--- a/test/localeModels/numa/basics/bad_children.chpl
+++ b/test/localeModels/numa/basics/bad_children.chpl
@@ -1,3 +1,3 @@
-var myNumaDomain = (here:LocaleModel).getChild(0):NumaDomain;
+var myNumaDomain = here.getChild(0)._value:NumaDomain;
 for child in myNumaDomain.getChildren() do
   writeln(child);

--- a/test/localeModels/numa/basics/checkSubloc.chpl
+++ b/test/localeModels/numa/basics/checkSubloc.chpl
@@ -6,11 +6,12 @@ for loc in Locales do on loc {
             "] Wrong subloc (wanted ", c_sublocid_any,
             ", got ", chpl_getSubloc(), ")");
 
-  for i in 0..#(here:LocaleModel).numSublocales do
-    on (here:LocaleModel).getChild(i) do
+  for i in 0..#here.getChildCount() {
+    on here.getChild(i) do
       if i!=chpl_getSubloc() then
         writeln("[", here.id,
                 "] Wrong subloc (wanted ", i,
                 ", got ", chpl_getSubloc(), ")");
+  }
 }
 

--- a/test/localeModels/numa/basics/coforall_on.chpl
+++ b/test/localeModels/numa/basics/coforall_on.chpl
@@ -1,30 +1,30 @@
 inline proc writestuff(newLine=true) {
-  writeln((here, here:LocaleModel?, here:NumaDomain?));
+  writeln((here, here._instance:LocaleModel?, here._instance:NumaDomain?));
   if newLine then writeln();
 }
 
 writestuff();
 
-coforall i in 0..#(here:LocaleModel).numSublocales do
-  on (here:LocaleModel).getChild(i) do writestuff(false);
+coforall i in 0..#here.getChildCount() do
+  on here.getChild(i) do writestuff(false);
 
 writeln("==========");
 writestuff();
 
-coforall subloc in (here:LocaleModel).getChildren() do
+coforall subloc in (here._value:LocaleModel).getChildren() do
   on subloc do writestuff(false);
 
 writeln("==========");
 writestuff();
 
-coforall subloc in (here:LocaleModel).getChildren() do
+coforall subloc in (here._value:LocaleModel).getChildren() do
   on subloc do writestuff(false);
 
 writeln("==========");
 writestuff();
 
 config const dummy = true; // to break up the coforall+on optimization
-coforall subloc in (here:LocaleModel).getChildren() {
+coforall subloc in (here._value:LocaleModel).getChildren() {
   if dummy then on subloc do writestuff(false);
   else writestuff(false);
 }

--- a/test/localeModels/numa/basics/hello7-taskpar-sublocs.chpl
+++ b/test/localeModels/numa/basics/hello7-taskpar-sublocs.chpl
@@ -32,7 +32,7 @@ coforall loc in Locales {
   // locale's memory).
   //
   on loc {
-    const numSublocales = (here:LocaleModel).numSublocales;
+    const numSublocales = here.getChildCount();
 
     //
     // Now create a number of tasks as specified by the tasksPerLocale
@@ -43,7 +43,7 @@ coforall loc in Locales {
     // 'on' clauses, all tasks will remain local to the current locale
     // by default.
     //
-    coforall subloc in (here:LocaleModel).getChildren() {
+    coforall subloc in (here._value:LocaleModel).getChildren() {
       on subloc {
         //
         // Start creating the message
@@ -55,7 +55,7 @@ coforall loc in Locales {
         // the message according to the task ID.
         //
         if (numSublocales > 1) then
-          message += (here:NumaDomain).sid:string + " of " + numSublocales:string + " named " + here.name + " on ";
+          message += (here._value:NumaDomain).sid:string + " of " + numSublocales:string + " named " + here.name + " on ";
 
         //
         // Specialize the message based on the locale we're running on:
@@ -65,8 +65,8 @@ coforall loc in Locales {
         // - '.name' queries its name (similar to UNIX `hostname`)
         // - 'numLocales' refers to the number of locales (as specified by -nl)
         //
-        message += "locale " + here.parent!.id:string + " of " + numLocales:string;
-        if (printLocaleName) then message += " named " + here.parent!.name;
+        message += "locale " + here.parent.id:string + " of " + numLocales:string;
+        if (printLocaleName) then message += " named " + here.parent.name;
 
         //
         // Terminate the message

--- a/test/localeModels/numa/basics/on.chpl
+++ b/test/localeModels/numa/basics/on.chpl
@@ -1,5 +1,5 @@
 inline proc writestuff(newLine=true) {
-  writeln((here, here:LocaleModel?, here:NumaDomain?));
+  writeln((here, here._instance:LocaleModel?, here._instance:NumaDomain?));
   if newLine then writeln();
 }
 
@@ -12,16 +12,16 @@ on (Locales[numLocales-1]) {
 
 writestuff();
 
-const subloc = (Locales[numLocales-1]:LocaleModel).numSublocales-1;
-writeln((Locales[numLocales-1]:LocaleModel).getChild(subloc));
-on (Locales[numLocales-1]:LocaleModel).getChild(subloc) {
+const subloc = Locales[numLocales-1].getChildCount()-1;
+writeln(Locales[numLocales-1].getChild(subloc));
+on Locales[numLocales-1].getChild(subloc) {
   writestuff();
 }
 
 writestuff();
 
-writeln((here:LocaleModel).getChild(subloc));
-on (here:LocaleModel).getChild(subloc) {
+writeln(here.getChild(subloc));
+on here.getChild(subloc) {
   writestuff();
 }
 

--- a/test/localeModels/numa/dataParallel/forall.chpl
+++ b/test/localeModels/numa/dataParallel/forall.chpl
@@ -2,7 +2,7 @@ config const beNoisy = false;
 {
   writeln("Locales array iteration");
   for loc in Locales {
-    const A = (loc:LocaleModel).getChildArray();
+    const A = (loc._value:LocaleModel).getChildArray();
     forall a in A do
       if beNoisy then writeln((a, chpl_getSubloc()));
   }


### PR DESCRIPTION
We have seen some failures in NUMA that I have missed because of
misconfiguring my local NUMA setup. This PR adjusts those tests.

Fixes mostly cleanup the test implementations, but there are some cases
where the NUMA interface differs from the `locale` interface. In such
cases, there are still some ugly usages.

Test: 
- [x] gasnet