### PR TITLE
added wrapper for qio_decode_char_buf

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -79,6 +79,50 @@ module BytesStringCommon {
   }
 
   /*
+   This function qio_decode is used to create a wrapper for 
+   qio_decode_char_buf* and qio_decode_char_buf_esc and return 
+   the value of syserr , cp and nbytes.
+   asks for buffer , size of buffer , starting index to read buffer,
+   and choice between "qio_decode_char_buf" 
+   and "qio_decode_char_buf_esc" for escape statement
+   */
+
+   proc qio_decode(buf:c_ptr(uint(8)), buflen:int, 
+                  bufstart:int, esc: bool ):
+                  (syserr,int(32),c_int){
+    
+    pragma "fn synchronization free"
+    extern proc qio_decode_char_buf(ref chr:int(32), 
+                                    ref nbytes:c_int,
+                                    buf:c_string,
+                                    buflen:ssize_t): syserr;
+    pragma "fn synchronization free"
+    extern proc qio_decode_char_buf_esc(ref chr:int(32),
+                                        ref nbytes:c_int,
+                                        buf:c_string,
+                                        buflen:ssize_t): syserr;
+    // esc chooses between qio_decode_char_buf_esc and
+    // qio_decode_char_buf as a single wrapper function 
+    if(esc){
+    var chr: int(32);
+    var nbytes: c_int;
+    var start = bufstart:c_int;
+    var multibytes = (buf + start): c_string;
+    var maxbytes = (buflen - start): ssize_t;
+    var decodeRet = qio_decode_char_buf_esc(chr, nbytes, multibytes,maxbytes);
+    return (decodeRet,chr,nbytes);
+    }
+    else{
+    var chr: int(32);
+    var nbytes: c_int;
+    var start = bufstart:c_int;
+    var multibytes = (buf + start): c_string;
+    var maxbytes = (buflen - start): ssize_t;
+    var decodeRet = qio_decode_char_buf(chr, nbytes, multibytes,maxbytes);
+    return (decodeRet,chr,nbytes);
+    }
+  }
+  /*
    This function is called by `bytes.decode` and string factory functions that
    take a C array as the buffer.
 

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -56,12 +56,15 @@ export PE_CHAPEL_PKGCONFIG_LIBS=`$CHPL_HOME/util/config/gather-pe-chapel-pkgconf
 # Note that the GCC option -### causes the compiler to not actually
 # compile anything but just print out what it would do to stderr.
 #
+# Note that the first /dev/null (before the stderr redirection) is
+# actually an "input file" for the compilation.
+#
 # -lchpl_lib_token allows the Chapel compiler to know
 # where to put additional arguments (they replace that argument).
 if [[ "$2" == "cray-shasta" ]] ; then
-  COMMANDS=`cc -craype-verbose -### -lchpl_lib_token 2>/dev/null`
+  COMMANDS=`cc -craype-verbose -### -lchpl_lib_token /dev/null 2>/dev/null`
 else
-  COMMANDS=`cc -craype-verbose -### -lhugetlbfs -lchpl_lib_token 2>/dev/null`
+  COMMANDS=`cc -craype-verbose -### -lhugetlbfs -lchpl_lib_token /dev/null 2>/dev/null`
 fi
 
   for arg in $COMMANDS


### PR DESCRIPTION
Working as example for  #15216
(wrapper function in BytesStringCommon.chpl).

 wrapper function 
```chapel
proc qio_decode(buf:c_string,
                buflen:ssize_t, 
                esc: bool ): (syserror,int(32),c_int)
```