### PR TITLE
Require 'use' statements to use absolute path or explicit relative path

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -412,7 +412,7 @@ static void ensureRequiredStandardModulesAreParsed() {
       UnresolvedSymExpr* oldModNameExpr = toUnresolvedSymExpr(moduleExpr);
 
       if (oldModNameExpr == NULL) {
-        INT_FATAL("It seems an internal module is using a mod.submod form");
+        continue;
       }
 
       const char* modName  = oldModNameExpr->unresolved;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -665,7 +665,8 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
       USR_PRINT(expr, "please specify the full path to the module");
       USR_PRINT(expr, "or use a relative %s e.g. '%s this.M' or '%s super.M'",
                       stmtType, stmtType, stmtType);
-      USR_STOP();
+      // Try to continue compilation
+      retval = badCloserModule;
     }
   }
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -625,10 +625,6 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
           // if we're not in the root module scope or using relative import,
           // this is an improper match
           badCloserModule = mod;
-          if (isUse) { // TODO: remove this to disable relative use
-            retval = sym;
-            break;
-          }
         } else {
           // if we are in the root module scope, then it is a proper match.
           retval = sym;

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -208,7 +208,7 @@ module BLAS {
                    else 'cblas.h'
                  else blasHeader;
 
-  use C_BLAS;
+  use this.C_BLAS;
 
   public use SysCTypes;
 

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -80,7 +80,7 @@
 
 module Crypto {
 
-  use C_OpenSSL;
+  use this.C_OpenSSL;
   use SysError;
 
   private use IO;

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -121,7 +121,7 @@ module Curl {
      :proc:`URL.openUrlReader` or :proc:`URL.openUrlWriter`.
    */
   proc getCurlHandle(ch:channel):c_ptr(CURL) throws {
-    use CurlQioIntegration;
+    use this.CurlQioIntegration;
 
     if ch.home != here {
       throw SystemError.fromSyserr(EINVAL, "getCurlHandle only functions with local channels");
@@ -146,7 +146,7 @@ module Curl {
      :type arg: `int`, `string`, `bool`, or `slist`
   */
   proc setopt(ch:channel, opt:c_int, arg):bool throws {
-    use CurlQioIntegration;
+    use this.CurlQioIntegration;
 
     var err:syserr = ENOERR;
 

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -502,9 +502,9 @@ module EpochManager {
 
   }
 
-  private use LockFreeLinkedListModule;
-  private use LockFreeQueueModule;
-  private use LimboListModule;
+  private use this.LockFreeLinkedListModule;
+  private use this.LockFreeQueueModule;
+  private use this.LimboListModule;
 
   /*
     :class:`LocalEpochManager` manages reclamation of objects, ensuring
@@ -753,7 +753,7 @@ module EpochManager {
     }
   }
 
-  private use VectorModule;
+  private use this.VectorModule;
 
   /*
     :record:`EpochManager` manages reclamation of objects, ensuring

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1879,7 +1879,7 @@ module SequentialInPlacePartitioning {
 pragma "no doc"
 module TwoArrayPartitioning {
   private use BlockDist;
-  private use MSBRadixSort;
+  private use super.MSBRadixSort;
 
   private param debug = false;
   param maxBuckets = 512;
@@ -2655,8 +2655,8 @@ module TwoArrayPartitioning {
 
 pragma "no doc"
 module TwoArrayRadixSort {
-  private use TwoArrayPartitioning;
-  private use RadixSortHelp;
+  private use super.TwoArrayPartitioning;
+  private use super.RadixSortHelp;
 
   proc twoArrayRadixSort(Data:[], comparator:?rec=defaultComparator) {
 
@@ -2702,9 +2702,9 @@ module TwoArrayRadixSort {
 
 pragma "no doc"
 module TwoArraySampleSort {
-  private use TwoArrayPartitioning;
-  private use SampleSortHelp;
-  private use RadixSortHelp;
+  private use super.TwoArrayPartitioning;
+  private use super.SampleSortHelp;
+  private use super.RadixSortHelp;
 
   proc twoArraySampleSort(Data:[], comparator:?rec=defaultComparator) {
 
@@ -2751,7 +2751,7 @@ module InPlacePartitioning {
 pragma "no doc"
 module MSBRadixSort {
 
-  private use RadixSortHelp;
+  private use super.RadixSortHelp;
 
   // This structure tracks configuration for the radix sorter.
   record MSBRadixSortSettings {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -36,8 +36,8 @@ module TOML {
 
 private use List;
 private use Map;
-public use TomlParser;
-private use TomlReader;
+public use this.TomlParser;
+private use this.TomlReader;
 use IO;
 
 

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -238,7 +238,7 @@ Output:
 */
 module UnitTest {
   use Reflection;
-  use TestError;
+  use this.TestError;
   use List, Map;
   private use IO;
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -915,7 +915,7 @@ private module GlobWrappers {
    :yield: The matching filenames as strings
 */
 iter glob(pattern: string = "*"): string {
-  use GlobWrappers;
+  use this.GlobWrappers;
   var glb : glob_t;
 
   glob_w(pattern, glb);
@@ -931,7 +931,7 @@ iter glob(pattern: string = "*"): string {
 pragma "no doc"
 iter glob(pattern: string = "*", param tag: iterKind): string
        where tag == iterKind.standalone {
-  use GlobWrappers;
+  use this.GlobWrappers;
   var glb : glob_t;
 
   glob_w(pattern, glb);
@@ -955,7 +955,7 @@ iter glob(pattern: string = "*", param tag: iterKind): string
 pragma "no doc"
 iter glob(pattern: string = "*", param tag: iterKind)
        where tag == iterKind.leader {
-  use GlobWrappers;
+  use this.GlobWrappers;
   var glb : glob_t;
 
   glob_w(pattern, glb);
@@ -972,7 +972,7 @@ iter glob(pattern: string = "*", param tag: iterKind)
 pragma "no doc"
 iter glob(pattern: string = "*", followThis, param tag: iterKind): string
        where tag == iterKind.follower {
-  use GlobWrappers;
+  use this.GlobWrappers;
   var glb : glob_t;
   if (followThis.size != 1) then
     compilerError("glob() iterator can only be zipped with 1D iterators");

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -60,9 +60,9 @@
 */
 module Random {
 
-  public use RandomSupport;
-  public use NPBRandom;
-  public use PCGRandom;
+  public use this.RandomSupport;
+  public use this.NPBRandom;
+  public use this.PCGRandom;
   import HaltWrappers;
 
 
@@ -679,8 +679,8 @@ module Random {
   */
   module PCGRandom {
 
-    use RandomSupport;
-    public use PCGRandomLib;
+    use super.RandomSupport;
+    public use super.PCGRandomLib;
     private use ChapelLocks;
 
     // How many generators do we need for this type?
@@ -2283,7 +2283,7 @@ module Random {
   */
   module NPBRandom {
 
-    use RandomSupport;
+    use super.RandomSupport;
     private use ChapelLocks;
 
     /*

--- a/test/arrays/ferguson/semantic-examples/4-global-slice-alias.chpl
+++ b/test/arrays/ferguson/semantic-examples/4-global-slice-alias.chpl
@@ -7,7 +7,7 @@ module OuterModule {
     // slice freed here
   }
 
-  use bar;
+  use this.bar;
 
   proc main() {
     writeln("Setting A[1,1] to 1");

--- a/test/classes/deitz/inherit-class-record/inherit1.chpl
+++ b/test/classes/deitz/inherit-class-record/inherit1.chpl
@@ -11,7 +11,7 @@ module OuterModule {
     }
   }
 
-  use M1;
+  use this.M1;
 
   class D: C {
     var i: int;

--- a/test/classes/diten/breakList.chpl
+++ b/test/classes/diten/breakList.chpl
@@ -19,7 +19,7 @@ module OuterModule {
   }
 
   proc bar() {
-    use LibGL;
+    use this.LibGL;
     var li = new LinkedList(real);
     li.append(3);
   }

--- a/test/classes/initializers/qualified/qualifiedNew.chpl
+++ b/test/classes/initializers/qualified/qualifiedNew.chpl
@@ -9,7 +9,7 @@ module OuterModule {
     }
   }
 
-  use A;
+  use this.A;
   var r = new A.R(1);
   writeln(r); // {a = 2}
 }

--- a/test/classes/initializers/qualified/qualifiedTypeAndNew.chpl
+++ b/test/classes/initializers/qualified/qualifiedTypeAndNew.chpl
@@ -9,7 +9,7 @@ module OuterModule {
     }
   }
 
-  use A;
+  use this.A;
   var r: A.R = new A.R(1); // Doesn't work.
   /* var r: R = new R(1); // Works. */
   writeln(r); // {a = 2}

--- a/test/classes/nilability/error-with-bang-suggestion.chpl
+++ b/test/classes/nilability/error-with-bang-suggestion.chpl
@@ -1,5 +1,5 @@
 module OuterModule {
-  use M;
+  use this.M;
   var test = new Test();
 
   class Test {

--- a/test/errhandling/modes/implicit-relaxed-try-inner.chpl
+++ b/test/errhandling/modes/implicit-relaxed-try-inner.chpl
@@ -16,6 +16,6 @@ module mymodule {
   }
 }
 
-use mymodule;
+use this.mymodule;
 writeln("In outer implicit module");
 test();

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.chpl
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.chpl
@@ -17,6 +17,6 @@ module mymodule {
   }
 }
 
-use mymodule;
+use this.mymodule;
 writeln("In outer implicit module");
 test();

--- a/test/errhandling/modes/strict-nested-try.chpl
+++ b/test/errhandling/modes/strict-nested-try.chpl
@@ -15,5 +15,5 @@ module OuterModule {
     }
   }
 
-  use InnerModule;
+  use this.InnerModule;
 }

--- a/test/errhandling/parallel/begin-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/begin-calls-throwing-fn.chpl
@@ -14,6 +14,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/begin-on-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/begin-on-calls-throwing-fn.chpl
@@ -14,6 +14,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/cobegin-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/cobegin-calls-throwing-fn.chpl
@@ -15,6 +15,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/cobegin-on-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/cobegin-on-calls-throwing-fn.chpl
@@ -23,6 +23,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/coforall-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/coforall-calls-throwing-fn.chpl
@@ -11,6 +11,6 @@ prototype module OuterModule {
           }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/coforall-on-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/coforall-on-calls-throwing-fn.chpl
@@ -11,6 +11,6 @@ prototype module OuterModule {
           }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/for-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/for-calls-throwing-fn.chpl
@@ -15,6 +15,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   test();
 }

--- a/test/errhandling/parallel/forall-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/forall-calls-throwing-fn.chpl
@@ -16,6 +16,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   test();
 }

--- a/test/errhandling/parallel/sync-around-bad-throws-call.chpl
+++ b/test/errhandling/parallel/sync-around-bad-throws-call.chpl
@@ -11,6 +11,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   badFn();
 }

--- a/test/errhandling/parallel/try-sync-throws.chpl
+++ b/test/errhandling/parallel/try-sync-throws.chpl
@@ -13,6 +13,6 @@ prototype module OuterModule {
     }
   }
 
-  use M;
+  use this.M;
   goodFn();
 }

--- a/test/extern/ferguson/externblock/struct-inmodule.chpl
+++ b/test/extern/ferguson/externblock/struct-inmodule.chpl
@@ -7,7 +7,7 @@ module OuterModule {
     }
   }
 
-  use C;
+  use this.C;
   var td_strct: C.td_struct;
   td_strct.d = 7.5;
 

--- a/test/extern/jjueckstock/ptr.chpl
+++ b/test/extern/jjueckstock/ptr.chpl
@@ -40,7 +40,7 @@ module OuterModule {
     }
   } }
 
-  use C;
+  use this.C;
 
   var a: C.st;
   a.c = "a string".c_str();

--- a/test/extern/jjueckstock/types.chpl
+++ b/test/extern/jjueckstock/types.chpl
@@ -27,7 +27,7 @@ module OuterModule {
     typedef int my_int;
   } }
 
-  use C;
+  use this.C;
 
   //NOTE: either C.my_struct or my_struct will work with the use C; statement.
   var strct: C.my_struct = new my_struct(42, "bar".c_str());

--- a/test/functions/cwailes/disambiguation/dbm_case_Q.chpl
+++ b/test/functions/cwailes/disambiguation/dbm_case_Q.chpl
@@ -9,7 +9,7 @@ module OuterModule {
     writeln("foo2");
   }
 
-  use Bar;
+  use this.Bar;
 
   foo(42);
 }

--- a/test/functions/default-arguments/default-argument-best-function.chpl
+++ b/test/functions/default-arguments/default-argument-best-function.chpl
@@ -1,5 +1,5 @@
 module OuterModule {
-  use A;
+  use this.A;
 
   module A {
     proc foo() : int {

--- a/test/functions/default-arguments/default-argument-function-not-in-scope.chpl
+++ b/test/functions/default-arguments/default-argument-function-not-in-scope.chpl
@@ -1,5 +1,5 @@
 module OuterModule {
-  use A;
+  use this.A;
 
   module A {
     proc foo() : int {

--- a/test/functions/deitz/test_resolve_best_shadowed2.chpl
+++ b/test/functions/deitz/test_resolve_best_shadowed2.chpl
@@ -6,12 +6,12 @@ module OuterModule {
       f();
     }
 
-    public use M2;
+    public use this.M2;
     proc g() { } // shadows other g based on call to g
     g();
 
-    public use M3;
-    public use M4;
+    public use this.M3;
+    public use this.M4;
     h();
   }
 
@@ -20,13 +20,13 @@ module OuterModule {
   }
 
   module M3 {
-    public use M5;
+    public use super.M5;
     proc h() { } // does not shadow other h based on call to h since
     // there is another path (through M4) to the other h
   }
 
   module M4 {
-    public use M5;
+    public use super.M5;
   }
 
   module M5 {

--- a/test/functions/jturner/fun_as_value_crossmodule.chpl
+++ b/test/functions/jturner/fun_as_value_crossmodule.chpl
@@ -8,7 +8,7 @@ module OuterModule {
   }
 
   module mod2 {
-    use mod1;
+    use super.mod1;
 
     proc main {
       proc add1(x: int) {

--- a/test/functions/vass/best-fns-in-diff-modules.chpl
+++ b/test/functions/vass/best-fns-in-diff-modules.chpl
@@ -22,7 +22,7 @@ module OuterModule {
     }
   }
   proc main {
-    use M, P, Q;
+    use this.M, this.P, this.Q;
     ref r = access();
     const ref c = access();
     var v = access();

--- a/test/interop/C/errorMessage/multiMod/multipleModules.chpl
+++ b/test/interop/C/errorMessage/multiMod/multipleModules.chpl
@@ -8,6 +8,6 @@ module MultipleModules {
     export proc baz() { writeln("in B.baz"); }
   }
 
-  use A, B, C; // to prevent them from being removed,
-               // and to make their module init fns run
+  use this.A, this.B, C; // to prevent them from being removed,
+                         // and to make their module init fns run
 }

--- a/test/modules/cassella/new-explicit.chpl
+++ b/test/modules/cassella/new-explicit.chpl
@@ -40,43 +40,43 @@ module OuterModule {
   }
 
   proc printThing(x) {
-    use A; // get 'writeThis'
+    use this.A; // get 'writeThis'
     writeln(x);
   }
 
   writeln("Concrete Record");
   {         var x : A.CR = new A.CR(1); printThing(x); }
-  { use A;  var x :   CR = new A.CR(1); printThing(x); }
-  { use A;  var x        = new A.CR(1); printThing(x); }
+  { use this.A;  var x :   CR = new A.CR(1); printThing(x); }
+  { use this.A;  var x        = new A.CR(1); printThing(x); }
   {         var x        = new A.CR(1); printThing(x); }
-  { use A;  var x : A.CR = new   CR(1); printThing(x); }
-  { use A;  var x :   CR = new   CR(1); printThing(x); }
-  { use A;  var x        = new   CR(1); printThing(x); }
+  { use this.A;  var x : A.CR = new   CR(1); printThing(x); }
+  { use this.A;  var x :   CR = new   CR(1); printThing(x); }
+  { use this.A;  var x        = new   CR(1); printThing(x); }
 
   writeln("\nConcrete Class");
   {         var x : owned A.CC = new owned A.CC(1); printThing(x); }
-  { use A;  var x : owned   CC = new owned A.CC(1); printThing(x); }
-  { use A;  var x              = new owned A.CC(1); printThing(x); }
+  { use this.A;  var x : owned   CC = new owned A.CC(1); printThing(x); }
+  { use this.A;  var x              = new owned A.CC(1); printThing(x); }
   {         var x              = new owned A.CC(1); printThing(x); }
-  { use A;  var x : owned A.CC = new owned   CC(1); printThing(x); }
-  { use A;  var x : owned CC   = new owned   CC(1); printThing(x); }
-  { use A;  var x              = new owned   CC(1); printThing(x); }
+  { use this.A;  var x : owned A.CC = new owned   CC(1); printThing(x); }
+  { use this.A;  var x : owned CC   = new owned   CC(1); printThing(x); }
+  { use this.A;  var x              = new owned   CC(1); printThing(x); }
 
   writeln("\nGeneric Record");
   {         var x : A.GR(int) = new A.GR(int, 1); printThing(x); }
-  { use A;  var x :   GR(int) = new A.GR(int, 1); printThing(x); }
-  { use A;  var x             = new A.GR(int, 1); printThing(x); }
+  { use this.A;  var x :   GR(int) = new A.GR(int, 1); printThing(x); }
+  { use this.A;  var x             = new A.GR(int, 1); printThing(x); }
   {         var x             = new A.GR(int, 1); printThing(x); }
-  { use A;  var x : A.GR(int) = new   GR(int, 1); printThing(x); }
-  { use A;  var x :   GR(int) = new   GR(int, 1); printThing(x); }
-  { use A;  var x             = new   GR(int, 1); printThing(x); }
+  { use this.A;  var x : A.GR(int) = new   GR(int, 1); printThing(x); }
+  { use this.A;  var x :   GR(int) = new   GR(int, 1); printThing(x); }
+  { use this.A;  var x             = new   GR(int, 1); printThing(x); }
 
   writeln("\nGeneric Class");
   {         var x : owned A.GC(int) = new owned A.GC(int, 1); printThing(x); }
-  { use A;  var x : owned   GC(int) = new owned A.GC(int, 1); printThing(x); }
-  { use A;  var x                   = new owned A.GC(int, 1); printThing(x); }
+  { use this.A;  var x : owned   GC(int) = new owned A.GC(int, 1); printThing(x); }
+  { use this.A;  var x                   = new owned A.GC(int, 1); printThing(x); }
   {         var x                   = new owned A.GC(int, 1); printThing(x); }
-  { use A;  var x : owned A.GC(int) = new owned   GC(int, 1); printThing(x); }
-  { use A;  var x : owned   GC(int) = new owned   GC(int, 1); printThing(x); }
-  { use A;  var x                   = new owned   GC(int, 1); printThing(x); }
+  { use this.A;  var x : owned A.GC(int) = new owned   GC(int, 1); printThing(x); }
+  { use this.A;  var x : owned   GC(int) = new owned   GC(int, 1); printThing(x); }
+  { use this.A;  var x                   = new owned   GC(int, 1); printThing(x); }
 }

--- a/test/modules/cassella/use-module-as.chpl
+++ b/test/modules/cassella/use-module-as.chpl
@@ -2,6 +2,6 @@ module JohannGambolputtyDeVonAusfernSchplendenSchlitterAppleBangerVonHautkopftOf
   var k = 7;
 }
 
-use JohannGambolputtyDeVonAusfernSchplendenSchlitterAppleBangerVonHautkopftOfUlm as J;
+use this.JohannGambolputtyDeVonAusfernSchplendenSchlitterAppleBangerVonHautkopftOfUlm as J;
 
 writeln(J.k);

--- a/test/modules/deitz/test_module_access1.chpl
+++ b/test/modules/deitz/test_module_access1.chpl
@@ -5,7 +5,7 @@ module OuterModule {
     var y = 2;
   }
 
-  use M;
+  use this.M;
 
   writeln((M.x, M.y));
 }

--- a/test/modules/deitz/test_module_access2.chpl
+++ b/test/modules/deitz/test_module_access2.chpl
@@ -4,11 +4,11 @@ module OuterModule {
   }
 
   module M {
-    use N;
+    use super.N;
     var y = 2;
   }
 
-  use M;
+  use this.M;
 
   writeln((M.x, M.y));
 }

--- a/test/modules/deitz/test_module_access5.chpl
+++ b/test/modules/deitz/test_module_access5.chpl
@@ -6,7 +6,7 @@ module OuterModule {
   }
 
   {
-    use M;
+    use this.M;
     M.foo(3);
   }
   foo(3);

--- a/test/modules/deitz/test_module_use3.chpl
+++ b/test/modules/deitz/test_module_use3.chpl
@@ -9,7 +9,7 @@ module red {
 
   proc foo(i : int) {
     writeln(i);
-    use green;
+    use this.green;
     bar();
   }
 }

--- a/test/modules/deitz/test_nested_modules2.chpl
+++ b/test/modules/deitz/test_nested_modules2.chpl
@@ -3,7 +3,7 @@ module OuterModule {
     var x: int = 2;
   }
 
-  use M1;
+  use this.M1;
 
   module M2 {
     proc main {

--- a/test/modules/dinan/module_reused_without_main.chpl
+++ b/test/modules/dinan/module_reused_without_main.chpl
@@ -3,7 +3,7 @@ module OuterModule {
     proc getString() return "Hello World";
   }
 
-  use test;
+  use this.test;
 
   writeln(getString());
 }

--- a/test/modules/dinan/use_module_in_same_file.chpl
+++ b/test/modules/dinan/use_module_in_same_file.chpl
@@ -2,7 +2,7 @@ module foo {
   var x = 5;
 }
 
-use foo;
+use this.foo;
 
 proc main() {
   writeln(x);

--- a/test/modules/diten/moduleNotInitialized.chpl
+++ b/test/modules/diten/moduleNotInitialized.chpl
@@ -22,12 +22,12 @@ module OuterModule {
     proc main {
       var b, c: sync borrowed object?;
       begin {
-        use M1;
+        use super.M1;
         M1.init();
         b = a;
       }
       lock1;
-      use M1;
+      use super.M1;
       M1.init();
       c = a;
       lock2 = false;

--- a/test/modules/diten/moduleNotInitialized2.chpl
+++ b/test/modules/diten/moduleNotInitialized2.chpl
@@ -19,12 +19,12 @@ module OuterModule {
     proc main {
       var b, c: sync int;
       begin {
-        use M1;
+        use super.M1;
         M1.init();
         b = a;
       }
       lock1;
-      use M1;
+      use super.M1;
       M1.init();
       c = a;
       lock2 = false;

--- a/test/modules/diten/module_overloaded_function.chpl
+++ b/test/modules/diten/module_overloaded_function.chpl
@@ -11,7 +11,7 @@ module OuterModule {
   }
 
   proc main() {
-    use color;
+    use this.color;
 
     g = 1;
 

--- a/test/modules/diten/nested_module_collision.chpl
+++ b/test/modules/diten/nested_module_collision.chpl
@@ -8,11 +8,11 @@ module OuterModule {
   module b { writeln("b"); }
 
   proc main() {
-    use a.b;
+    use this.a.b;
     foo();
   }
 
   proc foo() {
-    use b;
+    use this.b;
   }
 }

--- a/test/modules/diten/nested_modules_no_main.chpl
+++ b/test/modules/diten/nested_modules_no_main.chpl
@@ -5,7 +5,7 @@ module M1 {
       writeln(x);
     }
   }
-  use M2;
+  use this.M2;
   f();
 }
 

--- a/test/modules/diten/nesting.chpl
+++ b/test/modules/diten/nesting.chpl
@@ -8,13 +8,13 @@ module m1 {
     }
   }
   proc foo() {
-    use m2;
+    use this.m2;
     writeln(ccc);
   }
 }
 module m3 {
   proc main() {
-    use m1;
+    use super.m1;
     foo();
   }
 }

--- a/test/modules/diten/testOpaqueClass.chpl
+++ b/test/modules/diten/testOpaqueClass.chpl
@@ -14,14 +14,14 @@ module M1 {
     }
   }
   proc retCs() {
-    use M1Inner;
+    use this.M1Inner;
     return new unmanaged C();
   }
 }
 
 module M2 {
   proc main {
-    use M1;
+    use super.M1;
     var c = retCs();
     writeln(c);
     writeln(c.a);

--- a/test/modules/diten/testOpaqueClass2.chpl
+++ b/test/modules/diten/testOpaqueClass2.chpl
@@ -14,14 +14,14 @@ module M1 {
     }
   }
   proc retCs() {
-    use M1Inner;
+    use this.M1Inner;
     return new unmanaged C();
   }
 }
 
 module M2 {
   proc main {
-    use M1;
+    use super.M1;
     var c = retCs();
     //writeln(c);
     writeln(c.a);

--- a/test/modules/diten/usemodule/check_symbol_accesses.chpl
+++ b/test/modules/diten/usemodule/check_symbol_accesses.chpl
@@ -14,12 +14,12 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.middlemost.innermost;
+    use this.outermost.middlemost.innermost;
     bar(); foo(); bar();
   }
 
   proc bar() {
-    use outermost;
+    use this.outermost;
     writeln(a);
   }
 }

--- a/test/modules/diten/usemodule/check_symbol_accesses2.chpl
+++ b/test/modules/diten/usemodule/check_symbol_accesses2.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.middlemost.innermost;
+    use this.outermost.middlemost.innermost;
     bar(); foo(); bar();
   }
 

--- a/test/modules/diten/usemodule/inner_uses_all_outer.chpl
+++ b/test/modules/diten/usemodule/inner_uses_all_outer.chpl
@@ -1,6 +1,6 @@
 module OuterModule {
   module outermost {
-    use useMe;
+    use super.useMe;
     module middlemost {
       module innermost {
         proc f() {
@@ -21,7 +21,7 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.middlemost.innermost;
+    use this.outermost.middlemost.innermost;
     f();
   }
 }

--- a/test/modules/diten/usemodule/test_nested_use1.chpl
+++ b/test/modules/diten/usemodule/test_nested_use1.chpl
@@ -10,6 +10,6 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.middlemost.innermost;
+    use this.outermost.middlemost.innermost;
   }
 }

--- a/test/modules/diten/usemodule/test_nested_use2.chpl
+++ b/test/modules/diten/usemodule/test_nested_use2.chpl
@@ -10,6 +10,6 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.middlemost.notinnermost;
+    use this.outermost.middlemost.notinnermost;
   }
 }

--- a/test/modules/diten/usemodule/test_nested_use3.chpl
+++ b/test/modules/diten/usemodule/test_nested_use3.chpl
@@ -10,6 +10,6 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.notmiddlemost.innermost;
+    use this.outermost.notmiddlemost.innermost;
   }
 }

--- a/test/modules/diten/usemodule/test_nested_use_outer.chpl
+++ b/test/modules/diten/usemodule/test_nested_use_outer.chpl
@@ -23,13 +23,13 @@ module OuterModule {
   }
 
   proc main() {
-    use outermost.middlemost.innermost;
+    use this.outermost.middlemost.innermost;
     f(3);
     foo(4);
   }
 
   proc foo(a: int) {
-    use outermost;
+    use this.outermost;
     writeln("foo");
     f(a);
   }

--- a/test/modules/errors/useMissingModule3.chpl
+++ b/test/modules/errors/useMissingModule3.chpl
@@ -1,4 +1,4 @@
-use Goober.Peas;
+use this.Goober.Peas;
 
 module Goober {
 }

--- a/test/modules/noakes/mod-explicit-1.chpl
+++ b/test/modules/noakes/mod-explicit-1.chpl
@@ -15,7 +15,7 @@ module OuterModule {
 
   // This function needs to 'use' M1 to access writeThis etc
   proc showIt(s) {
-    use M1;
+    use this.M1;
 
     writeln('s = ', s);
   }

--- a/test/modules/noakes/mod-explicit-2.chpl
+++ b/test/modules/noakes/mod-explicit-2.chpl
@@ -34,7 +34,7 @@ module OuterModule {
 
 
 
-  use M1;
+  use this.M1;
 
   proc main() {
     testMod1();

--- a/test/modules/noakes/mod-init-fails.chpl
+++ b/test/modules/noakes/mod-init-fails.chpl
@@ -16,7 +16,7 @@ module Main {
 
 
 module M1 {
-  use M2;
+  use this.M2;
   use M3;
   use M4;
 
@@ -31,7 +31,7 @@ module M1 {
 
 
 module M2 {
-  use M1;
+  use this.M1;
   use M3;
   use M4;
 
@@ -46,7 +46,7 @@ module M2 {
 
 module M3 {
   use M1;
-  use M2;
+  use this.M2;
   use M4;
 
   writeln('1.5: Module M3');
@@ -61,7 +61,7 @@ module M3 {
 module M4 {
   use M1;
   use M2;
-  use M3;
+  use this.M3;
 
   writeln('1.4: Module M4');
 

--- a/test/modules/noakes/mod-init-order-works.chpl
+++ b/test/modules/noakes/mod-init-order-works.chpl
@@ -1,5 +1,5 @@
 module M2 {
-  use M3;
+  use this.M3;
 
   module M3 {
     module M4 {

--- a/test/modules/noakes/mod-init-works.chpl
+++ b/test/modules/noakes/mod-init-works.chpl
@@ -16,7 +16,7 @@ module Main {
 
 
 module M1 {
-  use M2;
+  use this.M2;
   use M3;
   use M4;
 
@@ -31,7 +31,7 @@ module M1 {
 
 
 module M2 {
-  use M1;
+  use this.M1;
   use M3;
   use M4;
 
@@ -46,7 +46,7 @@ module M2 {
 
 module M3 {
   use M1;
-  use M2;
+  use this.M2;
   use M4;
 
   writeln('1.5: Module M3');
@@ -61,7 +61,7 @@ module M3 {
 module M4 {
   use M1;
   use M2;
-  use M3;
+  use this.M3;
 
   writeln('1.4: Module M4');
 

--- a/test/modules/use/topLevel/subVsTop.chpl
+++ b/test/modules/use/topLevel/subVsTop.chpl
@@ -10,8 +10,8 @@ module OuterModule {
   }
 
   {
-    use N only;
-    use M;
+    use this.N only;
+    use this.M;
     N.fn();
   }
 }

--- a/test/modules/use/topLevel/subVsTop1a.chpl
+++ b/test/modules/use/topLevel/subVsTop1a.chpl
@@ -10,8 +10,8 @@ module OuterModule {
   }
 
   {
-    use M;
-    use N only;
+    use this.M;
+    use this.N only;
     N.fn();
   }
 }

--- a/test/modules/use/topLevel/subVsTop2.chpl
+++ b/test/modules/use/topLevel/subVsTop2.chpl
@@ -10,8 +10,8 @@ module OuterModule {
   }
 
   {
-    use N only;
-    use M;
+    use this.N only;
+    use this.M;
     writeln(N.x);
   }
 }

--- a/test/modules/use/topLevel/subVsTop2a.chpl
+++ b/test/modules/use/topLevel/subVsTop2a.chpl
@@ -10,8 +10,8 @@ module OuterModule {
   }
 
   {
-    use M;
-    use N only;
+    use this.M;
+    use this.N only;
     writeln(N.x);
   }
 }

--- a/test/modules/use/topLevel/subVsTop3.chpl
+++ b/test/modules/use/topLevel/subVsTop3.chpl
@@ -10,8 +10,8 @@ module OuterModule {
   }
 
   {
-    use M only N as N2;
-    use N only;
+    use this.M only N as N2;
+    use this.N only;
     writeln(N.x);
     writeln(N2.x);
   }

--- a/test/modules/use/topLevel/topVsSub.chpl
+++ b/test/modules/use/topLevel/topVsSub.chpl
@@ -5,7 +5,7 @@ module M {
     }
   }
 
-  use N;
+  use this.N;
   proc main() {
     foo();
   }

--- a/test/modules/use/topLevel/topVsSub2.chpl
+++ b/test/modules/use/topLevel/topVsSub2.chpl
@@ -6,7 +6,7 @@ module M {
   }
 
   proc main() {
-    use N;
+    use this.N;
     foo();
   }
 }

--- a/test/modules/use/topLevel/topVsSub3.chpl
+++ b/test/modules/use/topLevel/topVsSub3.chpl
@@ -6,7 +6,7 @@ module M {
   }
 
   proc main() {
-    use NNNNN;
+    use this.NNNNN;
     foo();
   }
 }

--- a/test/modules/use/topLevel/topVsSub4.chpl
+++ b/test/modules/use/topLevel/topVsSub4.chpl
@@ -5,6 +5,6 @@ module OuterModule {
     }
   }
 
-  use NNNNN;
+  use this.NNNNN;
   foo();
 }

--- a/test/modules/vass/multiply-defined-error-with-fn.chpl
+++ b/test/modules/vass/multiply-defined-error-with-fn.chpl
@@ -2,9 +2,9 @@ module OuterModule {
   // extract from test/users/npadmana/mpi/ring.chpl
   // which uses MPI and Barriers (just once)
 
-  use MPIvass;
-  use BarriersVass;
-  use BarriersVass2;
+  use this.MPIvass;
+  use this.BarriersVass;
+  use this.BarriersVass2;
 
   proc main() {
     var sendBarrier = new Barrier(numLocales);

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -968,7 +968,7 @@ module OurModule {
 
 // Using ``OurModule`` also uses all the modules it uses.
 // Since ``OurModule`` uses ``Time``, we also use ``Time``.
-use OurModule;
+use this.OurModule;
 
 // At this point we have not used ``ChildModule`` or ``SiblingModule`` so
 // their symbols (i.e. ``foo``) are not available to us. However, the module

--- a/test/trivial/jturner/module_class_name_clash.chpl
+++ b/test/trivial/jturner/module_class_name_clash.chpl
@@ -11,8 +11,8 @@ module OuterModule {
     }
   }
 
-  use M1;
-  use M2;
+  use this.M1;
+  use this.M2;
 
   var m1 = new owned M1.MyType(x=1);
   var m2 = new owned M2.MyType(y=2);

--- a/test/types/records/bharshbarger/nestedRecordInClass1.chpl
+++ b/test/types/records/bharshbarger/nestedRecordInClass1.chpl
@@ -4,7 +4,7 @@ module OuterModule {
   }
 
   module MyModule {
-          use MyTypes;
+          use super.MyTypes;
           class Bar {
                   var thing : real;
                   record myR {

--- a/test/types/records/bharshbarger/nestedRecordInClass2.chpl
+++ b/test/types/records/bharshbarger/nestedRecordInClass2.chpl
@@ -4,7 +4,7 @@ module OuterModule {
   }
 
   module MyModule {
-          use MyTypes;
+          use super.MyTypes;
           class Bar {
                   var thing : Foo;
                   record myR {

--- a/test/types/records/init/copy/localUseNoCopy.chpl
+++ b/test/types/records/init/copy/localUseNoCopy.chpl
@@ -27,7 +27,7 @@ module OuterModule {
   }
 
   proc main() {
-    use Bar;
+    use this.Bar;
 
     // For 's = r' below, the compiler does actually insert the default copy
     // initializer.

--- a/test/types/records/init/copy/localUseNoCopyD.chpl
+++ b/test/types/records/init/copy/localUseNoCopyD.chpl
@@ -29,7 +29,7 @@ module OuterModule {
   }
 
   proc main() {
-    use Bar;
+    use this.Bar;
 
     // For 's = r' below, the compiler does actually insert the default copy
     // initializer.

--- a/test/users/ferguson/bug-zhao.chpl
+++ b/test/users/ferguson/bug-zhao.chpl
@@ -31,7 +31,7 @@ module OuterModule {
       }
     }
   } // end OurModule
-  use OurModule;
+  use this.OurModule;
 
   // At this point we have not used ChildModule or SiblingModule so their symbols
   // (i.e. foo ) are not available to us.

--- a/test/users/ferguson/histogram/reductionex_module.chpl
+++ b/test/users/ferguson/histogram/reductionex_module.chpl
@@ -52,7 +52,7 @@ module OuterModule {
   param NBUCKETS = 16;
   param PER = 16000/NBUCKETS;
 
-  use Test;
+  use this.Test;
 
   var counts = myhisto reduce array;
 

--- a/test/users/ferguson/histogram/reductionex_module2.chpl
+++ b/test/users/ferguson/histogram/reductionex_module2.chpl
@@ -52,7 +52,7 @@ module OuterModule {
   param NBUCKETS = 16;
   var per:uint(64) = 16000/NBUCKETS;
 
-  use Test;
+  use this.Test;
 
   var counts = myhisto reduce array;
 

--- a/test/users/ferguson/histogram/reductionex_module3.chpl
+++ b/test/users/ferguson/histogram/reductionex_module3.chpl
@@ -55,7 +55,7 @@ module OuterModule {
   var min:uint(64) = 0;
   var max:uint(64) = 16000;
 
-  use Test;
+  use this.Test;
 
   var counts = myhisto reduce array;
 

--- a/test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
+++ b/test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
@@ -1,6 +1,6 @@
 module OuterModule {
   use ReplicatedVar, ReplicatedDist;
-  use Utils;
+  use this.Utils;
 
   module Utils {
 

--- a/test/visibility/empty/defaultValues.chpl
+++ b/test/visibility/empty/defaultValues.chpl
@@ -6,7 +6,7 @@ module OuterModule {
   }
 
   proc main() {
-    use A only;
+    use this.A only;
     var r: A.R(int);
     writeln(r.type: string);
   }

--- a/test/visibility/empty/exceptEverything.chpl
+++ b/test/visibility/empty/exceptEverything.chpl
@@ -8,7 +8,7 @@ module OuterModule {
   }
 
   module M2 {
-    use M except *;  // require all symbols in M to be fully-qualified.
+    use super.M except *;  // require all symbols in M to be fully-qualified.
 
     proc main() {
       if qualifiedAccess then

--- a/test/visibility/empty/exceptEverythingField.chpl
+++ b/test/visibility/empty/exceptEverythingField.chpl
@@ -1,5 +1,5 @@
 proc main() {
-  use bash except *;
+  use this.bash except *;
 
   var p = bash.ls();
 
@@ -7,7 +7,7 @@ proc main() {
 }
 
 module bash {
-  public use Other;
+  public use super.Other;
 
   proc ls(args='') {
     var p = Other.makeFoo();

--- a/test/visibility/empty/methodAndFuncShareName.chpl
+++ b/test/visibility/empty/methodAndFuncShareName.chpl
@@ -12,7 +12,7 @@ module OuterModule {
   }
 
   proc main() {
-    use M only;
+    use this.M only;
 
     sameName();
   }

--- a/test/visibility/empty/onlyNothing.chpl
+++ b/test/visibility/empty/onlyNothing.chpl
@@ -8,7 +8,7 @@ module OuterModule {
   }
 
   module M2 {
-    use M only ;   // require all symbols in M to be fully-qualified
+    use super.M only ;   // require all symbols in M to be fully-qualified
 
     proc main() {
       if qualifiedAccess then

--- a/test/visibility/empty/onlyNothingField.chpl
+++ b/test/visibility/empty/onlyNothingField.chpl
@@ -1,5 +1,5 @@
 proc main() {
-  use bash only;
+  use this.bash only;
 
   var p = bash.ls();
 
@@ -7,7 +7,7 @@ proc main() {
 }
 
 module bash {
-  public use Other;
+  public use super.Other;
 
   proc ls(args='') {
     var p = Other.makeFoo();

--- a/test/visibility/empty/qualifiedTypeAccess-except.chpl
+++ b/test/visibility/empty/qualifiedTypeAccess-except.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   }
 
   module M2 {
-    use M except *; // require all symbols in M to be fully-qualified
+    use super.M except *; // require all symbols in M to be fully-qualified
 
     proc main() {
       var foo = new borrowed M.Foo();

--- a/test/visibility/empty/qualifiedTypeAccess-field-except.chpl
+++ b/test/visibility/empty/qualifiedTypeAccess-field-except.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   }
 
   proc test() {
-    use C except *;
+    use this.C except *;
 
     var tmp = C.make_struct();
     var f = tmp.my_field;

--- a/test/visibility/empty/qualifiedTypeAccess-field.chpl
+++ b/test/visibility/empty/qualifiedTypeAccess-field.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   }
 
   proc test() {
-    use C only;
+    use this.C only;
 
     var tmp = C.make_struct();
     var f = tmp.my_field;

--- a/test/visibility/empty/qualifiedTypeAccess.chpl
+++ b/test/visibility/empty/qualifiedTypeAccess.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   }
 
   module M2 {
-    use M only; // require all symbols in M to be fully-qualified
+    use super.M only; // require all symbols in M to be fully-qualified
 
     proc main() {
       var foo = new borrowed M.Foo();

--- a/test/visibility/except/exceptModuleItself.chpl
+++ b/test/visibility/except/exceptModuleItself.chpl
@@ -4,6 +4,6 @@ module OuterModule {
   }
 
   proc main() {
-    use Toolbox except Toolbox; // This should not compile
+    use this.Toolbox except Toolbox; // This should not compile
   }
 }

--- a/test/visibility/import/privateModuleMethodAccess.chpl
+++ b/test/visibility/import/privateModuleMethodAccess.chpl
@@ -1,5 +1,5 @@
 module A {
-  private use Inner;
+  private use this.Inner;
 
   class Foo {
     var x: int;

--- a/test/visibility/import/privateModuleMethodAccessBad.chpl
+++ b/test/visibility/import/privateModuleMethodAccessBad.chpl
@@ -1,5 +1,5 @@
 module A {
-  private use Inner;
+  private use this.Inner;
 
   class Foo {
     var x: int;

--- a/test/visibility/only/canSeeSecondaryMethod2.chpl
+++ b/test/visibility/only/canSeeSecondaryMethod2.chpl
@@ -1,6 +1,6 @@
 module OuterModule {
   use secondaryMethod only Foo;
-  use Extender only Foo;
+  use this.Extender only Foo;
   // Verifies that you can define a method in a module outside of the original
   // type definition, and by specifying that type in your 'only' list, access
   // it.

--- a/test/visibility/only/innerModuleSharesName-topLevel-MdotM-useInDiffScope.chpl
+++ b/test/visibility/only/innerModuleSharesName-topLevel-MdotM-useInDiffScope.chpl
@@ -7,6 +7,6 @@ module M {
 }
 
 {
-  use M only;
+  use this.M only;
   M.M.whatev();
 }

--- a/test/visibility/only/innerModuleSharesName-topLevel-MdotM.chpl
+++ b/test/visibility/only/innerModuleSharesName-topLevel-MdotM.chpl
@@ -7,6 +7,6 @@ module OuterModule {
     }
   }
 
-  use M only;
+  use this.M only;
   M.M.whatev();
 }

--- a/test/visibility/only/innerModuleSharesName-topLevel-doubleUse.chpl
+++ b/test/visibility/only/innerModuleSharesName-topLevel-doubleUse.chpl
@@ -7,7 +7,7 @@ module OuterModule {
     }
   }
 
-  use M;
-  use M.M;
+  use this.M;
+  use this.M.M;
   writeln(a);
 }

--- a/test/visibility/only/innerModuleSharesName-topLevel-useInDiffScope.chpl
+++ b/test/visibility/only/innerModuleSharesName-topLevel-useInDiffScope.chpl
@@ -7,6 +7,6 @@ module M {
 }
 
 {
-  use M only M;
+  use this.M only M;
   M.whatev();
 }

--- a/test/visibility/only/innerModuleSharesName-topLevel.chpl
+++ b/test/visibility/only/innerModuleSharesName-topLevel.chpl
@@ -7,6 +7,6 @@ module OuterModule {
     }
   }
 
-  use M only M;
+  use this.M only M;
   M.whatev();
 }

--- a/test/visibility/only/innerModuleSharesName.chpl
+++ b/test/visibility/only/innerModuleSharesName.chpl
@@ -9,6 +9,6 @@ module OuterModule {
     }
   }
 
-  use EvenMoreOuter.M only M;
+  use this.EvenMoreOuter.M only M;
   M.whatev();
 }

--- a/test/visibility/only/onlyModuleItself.chpl
+++ b/test/visibility/only/onlyModuleItself.chpl
@@ -4,6 +4,6 @@ module OuterModule {
   }
 
   proc main() {
-    use Toolbox only Toolbox; // This should not compile
+    use this.Toolbox only Toolbox; // This should not compile
   }
 }

--- a/test/visibility/only/onlyOuterModule.chpl
+++ b/test/visibility/only/onlyOuterModule.chpl
@@ -6,6 +6,6 @@ module OuterModule {
   }
 
   proc main() {
-    use Outer.Toolbox only Outer; // This should not compile
+    use this.Outer.Toolbox only Outer; // This should not compile
   }
 }

--- a/test/visibility/only/pointOfInstantiation.chpl
+++ b/test/visibility/only/pointOfInstantiation.chpl
@@ -4,7 +4,7 @@ module OuterModule {
   // At one point we failed to resolve the call to 'bar' because we were looking
   // for it via foo's callsite, which was limited by the 'only foo' clause.
 
-  use B only foo;
+  use this.B only foo;
   foo('hello');
 
   module B {

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew.chpl
@@ -7,12 +7,12 @@ module grandparent {
       }
     }
 
-    use child;
+    use this.child;
     // Valid, because this module is the direct parent of the private module
   }
 
   module sibling {
-    use parent;
+    use super.parent;
 
     proc main() {
       writeln(parent.child.secretFunction(11));

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew2.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew2.chpl
@@ -7,12 +7,12 @@ module grandparent {
       }
     }
 
-    use child;
+    use this.child;
     // Valid, because this module is the direct parent of the private module
   }
 
   module sibling {
-    use parent;
+    use super.parent;
 
     proc main() {
       writeln(child.secretFunction(11));

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew3.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew3.chpl
@@ -7,12 +7,12 @@ module grandparent {
       }
     }
 
-    use child;
+    use this.child;
     // Valid, because this module is the direct parent of the private module
   }
 
   module sibling {
-    use parent;
+    use super.parent;
 
     proc main() {
       writeln(secretFunction(11));

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedSibling.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedSibling.chpl
@@ -5,7 +5,7 @@ module parent {
     }
   }
 
-  use child;
+  use this.child;
   // Valid, because this module is the direct parent of the private module
 
 

--- a/test/visibility/private/moduleSymbols/siblingSubmodule.chpl
+++ b/test/visibility/private/moduleSymbols/siblingSubmodule.chpl
@@ -6,7 +6,7 @@ module parent {
   }
 
   module sibling {
-    use child;
+    use super.child;
 
     proc main() {
       writeln(secretFunction(11));

--- a/test/visibility/private/moduleSymbols/submodule.chpl
+++ b/test/visibility/private/moduleSymbols/submodule.chpl
@@ -6,7 +6,7 @@ module parent {
   }
 
   proc main() {
-    use child;
+    use this.child;
     writeln(secretFunction(11)); // Should return 33;
   }
 }

--- a/test/visibility/private/uses/definesMultiUse.chpl
+++ b/test/visibility/private/uses/definesMultiUse.chpl
@@ -23,7 +23,7 @@ module definesMultiUse {
     }
   }
 
-  private use Inner1, Inner2, Inner3;
+  private use this.Inner1, this.Inner2, this.Inner3;
 
   // Ensures that a private use doesn't interfere with our ability to access the
   // used modules' symbols

--- a/test/visibility/private/uses/weirdEnumHiding.chpl
+++ b/test/visibility/private/uses/weirdEnumHiding.chpl
@@ -5,7 +5,7 @@ module weirdEnumHiding {
   }
 
   module B {
-    public use A;
+    public use super.A;
 
     proc checkFoo() {
       writeln(foo.b);
@@ -13,7 +13,7 @@ module weirdEnumHiding {
   }
 
   module C {
-    private use A;
+    private use super.A;
 
     proc checkFoo() {
       writeln(foo.b);
@@ -21,8 +21,8 @@ module weirdEnumHiding {
   }
 
   module D {
-    public use C;
-    public use B;
+    public use super.C;
+    public use super.B;
 
     proc checkFoo() {
       writeln(foo.b);

--- a/test/visibility/relative-use/require-relative-use.chpl
+++ b/test/visibility/relative-use/require-relative-use.chpl
@@ -1,0 +1,11 @@
+module M {
+  
+  module SubM {
+    var x: int;
+  }
+  
+  use SubM;
+  proc main() {
+    writeln(x);
+  }
+}

--- a/test/visibility/relative-use/require-relative-use.good
+++ b/test/visibility/relative-use/require-relative-use.good
@@ -1,0 +1,5 @@
+require-relative-use.chpl:7: error: Cannot import module 'SubM'
+require-relative-use.chpl:3: note: a module named 'SubM' is defined here
+require-relative-use.chpl:7: note: full path or explicit relative import required
+require-relative-use.chpl:7: note: please specify the full path to the module
+require-relative-use.chpl:7: note: or use a relative import e.g. 'import this.M' or 'import super.M'

--- a/test/visibility/relative-use/require-relative-use.good
+++ b/test/visibility/relative-use/require-relative-use.good
@@ -1,5 +1,5 @@
-require-relative-use.chpl:7: error: Cannot import module 'SubM'
+require-relative-use.chpl:7: error: Cannot use module 'SubM'
 require-relative-use.chpl:3: note: a module named 'SubM' is defined here
-require-relative-use.chpl:7: note: full path or explicit relative import required
+require-relative-use.chpl:7: note: full path or explicit relative use required
 require-relative-use.chpl:7: note: please specify the full path to the module
-require-relative-use.chpl:7: note: or use a relative import e.g. 'import this.M' or 'import super.M'
+require-relative-use.chpl:7: note: or use a relative use e.g. 'use this.M' or 'use super.M'

--- a/test/visibility/rename/renameModuleViaOnly.chpl
+++ b/test/visibility/rename/renameModuleViaOnly.chpl
@@ -4,6 +4,6 @@ module OuterModule {
   }
 
   proc main() {
-    use Toolbox only Toolbox as tb; // This should not compile
+    use this.Toolbox only Toolbox as tb; // This should not compile
   }
 }

--- a/test/visibility/rename/renameUsedMod/renamePrivateModuleOnUse.chpl
+++ b/test/visibility/rename/renameUsedMod/renamePrivateModuleOnUse.chpl
@@ -3,7 +3,7 @@ module Outer {
     var x: int;
   }
 
-  public use Inner as In;
+  public use this.Inner as In;
 }
 
 module User {

--- a/test/visibility/rename/renameUsedMod/renamePrivateModuleOnUse2.chpl
+++ b/test/visibility/rename/renameUsedMod/renamePrivateModuleOnUse2.chpl
@@ -3,7 +3,7 @@ module Outer {
     var x: int;
   }
 
-  public use Inner as In;
+  public use this.Inner as In;
 }
 
 module User {

--- a/test/visibility/shadow.chpl
+++ b/test/visibility/shadow.chpl
@@ -24,7 +24,7 @@ module OuterModule {
 
 
   proc main() {
-    use A;
+    use this.A;
     var r = new R();
 
     r.shadow();

--- a/test/visibility/type-shadow.chpl
+++ b/test/visibility/type-shadow.chpl
@@ -6,7 +6,7 @@ module X {
     }
   }
 
-  use M;
+  use this.M;
 
   record R { // X.R
     var r : R(int); // 'R' should refer to X.R, not M.R


### PR DESCRIPTION
Adjusts lookupForImport to remove the code enabling relative `use` without opt-in so that `use` will now behave like `import`:
 * `use M` refers to a top-level module or a module already available from earlier use/import
 * `use this.M` refers to a submodule

- [x] full local testing