### PR TITLE
Add tests from 15261 and fix it

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -652,7 +652,7 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
       //    look for the symbols defined in the used
       //    or if the module being imported matches
       //    and if not, keep following the public use chains
-      retval = followImportUseChains(name);
+      retval = ptr->followImportUseChains(name);
 
       if (relativeScope != NULL)
         break; // only consider the one scope when doing relative imports

--- a/test/visibility/bug-15261/bug-15261-1.chpl
+++ b/test/visibility/bug-15261/bug-15261-1.chpl
@@ -1,0 +1,33 @@
+module MHDF5 {
+  use SysCTypes;
+
+  public import this.C_HDF5;
+  module C_HDF5 {
+    public use SysCTypes;
+
+    use HDF5_WAR;
+
+    module HDF5_WAR {
+      proc H5LTmake_dataset_WAR() {
+        writeln("in H5LTmake_dataset_WAR");
+      }
+    }
+  }
+}
+
+module GenSymIO {
+  use MHDF5;
+
+  proc write1DDistArray() throws {
+    coforall i in 1..1 {
+      use C_HDF5.HDF5_WAR;
+      H5LTmake_dataset_WAR();
+    }
+  }
+
+  proc main() {
+    try! {
+      write1DDistArray();
+    }
+  }
+}

--- a/test/visibility/bug-15261/bug-15261-1.good
+++ b/test/visibility/bug-15261/bug-15261-1.good
@@ -1,0 +1,1 @@
+in H5LTmake_dataset_WAR

--- a/test/visibility/bug-15261/bug-15261-2.chpl
+++ b/test/visibility/bug-15261/bug-15261-2.chpl
@@ -1,0 +1,33 @@
+module MHDF5 {
+  import SysCTypes;
+
+  public import this.C_HDF5;
+  module C_HDF5 {
+    import SysCTypes;
+
+    public import this.HDF5_WAR;
+    module HDF5_WAR {
+      proc H5LTmake_dataset_WAR() {
+        writeln("in H5LTmake_dataset_WAR");
+      }
+    }
+  }
+}
+
+module GenSymIO {
+  import MHDF5;
+  import MHDF5.C_HDF5;
+
+  proc write1DDistArray() throws {
+    coforall i in 1..1 {
+      import C_HDF5.HDF5_WAR;
+      HDF5_WAR.H5LTmake_dataset_WAR();
+    }
+  }
+
+  proc main() {
+    try! {
+      write1DDistArray();
+    }
+  }
+}

--- a/test/visibility/bug-15261/bug-15261-2.good
+++ b/test/visibility/bug-15261/bug-15261-2.good
@@ -1,0 +1,1 @@
+in H5LTmake_dataset_WAR

--- a/test/visibility/bug-15261/bug-15261-3.chpl
+++ b/test/visibility/bug-15261/bug-15261-3.chpl
@@ -19,7 +19,7 @@ module GenSymIO {
 
   proc write1DDistArray() throws {
     coforall i in 1..1 {
-      import C_HDF5.HDF5_WAR.HDF5_WAR.H5LTmake_dataset_WAR;
+      import C_HDF5.HDF5_WAR.H5LTmake_dataset_WAR;
       H5LTmake_dataset_WAR();
     }
   }

--- a/test/visibility/bug-15261/bug-15261-3.chpl
+++ b/test/visibility/bug-15261/bug-15261-3.chpl
@@ -1,0 +1,32 @@
+module MHDF5 {
+  import SysCTypes;
+
+  public import this.C_HDF5;
+  module C_HDF5 {
+    import SysCTypes;
+
+    public import this.HDF5_WAR;
+    module HDF5_WAR {
+      proc H5LTmake_dataset_WAR() {
+        writeln("in H5LTmake_dataset_WAR");
+      }
+    }
+  }
+}
+
+module GenSymIO {
+  use MHDF5;
+
+  proc write1DDistArray() throws {
+    coforall i in 1..1 {
+      import C_HDF5.HDF5_WAR.HDF5_WAR.H5LTmake_dataset_WAR;
+      H5LTmake_dataset_WAR();
+    }
+  }
+
+  proc main() {
+    try! {
+      write1DDistArray();
+    }
+  }
+}

--- a/test/visibility/bug-15261/bug-15261-3.good
+++ b/test/visibility/bug-15261/bug-15261-3.good
@@ -1,0 +1,1 @@
+in H5LTmake_dataset_WAR


### PR DESCRIPTION
Resolves #15261

The call to followImportUseChains in lookupForImport needs to use
the current scope rather than always using `this`.

Adds 3 variants of the problematic pattern to increase test coverage in this area.

Reviewed by @lydia-duncan - thanks!

- [x] full local testing