### PR TITLE
Fix numa locale model

### DIFF
--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -154,7 +154,7 @@ module LocaleModelHelpSetup {
     dst.maxTaskPar = chpl_task_getMaxPar();
   }
 
-  proc helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, const in numSublocales, type NumaDomain) {
+  proc helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, numSublocales, type NumaDomain) {
     helpSetupLocaleFlat(dst, local_name);
 
     extern proc chpl_task_getMaxPar(): uint(32);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -154,16 +154,12 @@ module LocaleModelHelpSetup {
     dst.maxTaskPar = chpl_task_getMaxPar();
   }
 
-  proc helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, out numSublocales, type NumaDomain) {
+  proc helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, const in numSublocales, type NumaDomain) {
     helpSetupLocaleFlat(dst, local_name);
-
-    extern proc chpl_topo_getNumNumaDomains(): c_int;
-    numSublocales = chpl_topo_getNumNumaDomains();
 
     extern proc chpl_task_getMaxPar(): uint(32);
 
     if numSublocales >= 1 {
-      dst.childSpace = {0..#numSublocales};
       // These nPUs* values are estimates only; better values await
       // full hwloc support. In particular it assumes a homogeneous node
       const nPUsPhysAccPerSubloc = dst.nPUsPhysAcc/numSublocales;

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -115,7 +115,7 @@ module LocaleModel {
     const _node_id : int;
     var local_name : string; // should never be modified after first assignment
 
-    var numSublocales: int; // should never be modified after first assignment
+    const numSublocales: int;
     const childSpace: domain(1);
     // Todo: avoid the pragma by having helpSetupLocaleNUMA return this array
     // and initialize the field from it. Need childSpace to be const?
@@ -138,6 +138,7 @@ module LocaleModel {
       }
 
       this.complete();
+
       setup();
     }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -148,7 +148,8 @@ module LocaleModel {
       super.init(parent_loc);
 
       // Why doesn't this work (generates an internal error) to avoid
-      // the code duplication below?
+      // the code duplication below?  Or if it's not supposed to work,
+      // how could we make it a user error?
       //
       //      this.init();
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -116,7 +116,7 @@ module LocaleModel {
     var local_name : string; // should never be modified after first assignment
 
     var numSublocales: int; // should never be modified after first assignment
-    var childSpace: domain(1);
+    const childSpace: domain(1);
     // Todo: avoid the pragma by having helpSetupLocaleNUMA return this array
     // and initialize the field from it. Need childSpace to be const?
     pragma "unsafe"

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -147,6 +147,11 @@ module LocaleModel {
       }
       super.init(parent_loc);
 
+      // Why doesn't this work (generates an internal error) to avoid
+      // the code duplication below?
+      //
+      //      this.init();
+
       use SysCTypes;
       _node_id = chpl_nodeID: int;
       extern proc chpl_topo_getNumNumaDomains(): c_int;

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -138,9 +138,7 @@ module LocaleModel {
       }
 
       this.complete();
-      writeln("Heading into setup, childSpace is: ", childSpace);
       setup();
-      writeln("Coming out of setup, childSpace is: ", childSpace);
     }
 
     proc init(parent_loc : locale) {

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -127,14 +127,20 @@ module LocaleModel {
     // to establish the equivalence the "locale" field of the locale object
     // and the node ID portion of any wide pointer referring to it.
     proc init() {
+      use SysCTypes;
+      _node_id = chpl_nodeID: int;
+      extern proc chpl_topo_getNumNumaDomains(): c_int;
+      numSublocales = chpl_topo_getNumNumaDomains();
+      childSpace = {0..#numSublocales};
+
       if rootLocaleInitialized {
         halt("Cannot create additional LocaleModel instances");
       }
-      _node_id = chpl_nodeID: int;
 
       this.complete();
-
+      writeln("Heading into setup, childSpace is: ", childSpace);
       setup();
+      writeln("Coming out of setup, childSpace is: ", childSpace);
     }
 
     proc init(parent_loc : locale) {
@@ -143,7 +149,11 @@ module LocaleModel {
       }
       super.init(parent_loc);
 
+      use SysCTypes;
       _node_id = chpl_nodeID: int;
+      extern proc chpl_topo_getNumNumaDomains(): c_int;
+      numSublocales = chpl_topo_getNumNumaDomains();
+      childSpace = {0..#numSublocales};
 
       this.complete();
 


### PR DESCRIPTION
I broke the numa locale model yesterday when I prohibited arrays of non-nilable from being resized because it uses such an array of non-nilable to represent its children, and initializes its size not in its initializer, but a post-initializer setup routine.

Here, I refactor that code from the post-initializer setup routine into the initializers themselves, which avoids the reallocation and therefore the error message.  This also permits the number and domain of child locales to be made `const` which is attractive.

It's tempting to try and push all of the post-initializer setup() into the initializer itself to reduce some of the spaghetti involved in locale setup, but (a) my attempt to have the 1-arg initializer call the 0-arg initializer to avoid code duplication was unsuccessful (resulted in a compiler assertion failure), and I worry that the amount of code I'd need to duplicate as a result would be higher than ideal, and (b) I'm feeling short on cycles to wrestle with non-essentials for this release.

I tested this by running testing on test/release/examples/hello*.chpl and test/localeModels/numa with `CHPL_RT_NUM_NUMA_DOMAINS=2` and `QT_NUM_SHEPHERDS=2`.