### PR TITLE
Disable ugni comm/compute overlap with --cache-remote

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -51,6 +51,7 @@
 #include "chplcgfns.h"
 #include "chpl-gen-includes.h"
 #include "chplrt.h"
+#include "chpl-cache.h"
 #include "chpl-comm.h"
 #include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
@@ -1954,8 +1955,11 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
   PERFSTATS_DO_ALL(_PSV_INIT);
 #undef _PSTAT_INIT
 
+  // Yield during comm by default to allow comm/compute overlap, but
+  // disable if the user requested or if `--cache-remote` is enabled
+  // (it currently breaks when tasks switch during a GET/PUT.)
   yield_during_comm = chpl_env_rt_get_bool("COMM_UGNI_YIELD_DURING_COMM",
-                                           true);
+                                           true) && !chpl_cache_enabled();
 
   //
   // We can easily reach 16k memory regions on Aries.  We can reach a


### PR DESCRIPTION
Comm/compute overlap with `--cache-remote` is currently leading to
segfaults. We don't fully understand the source of the problem, but for
now disable comm/compute overlap to workaround the problem. This will
hurt the performance of SSCA and microbenchmarks that oversubscribe
comm, but lower performance is better than segfaulting.

We'll look to fix this in the future, but for now this puts us in a
better state and I'd feel comfortable recommending `--cache-remote` to
users.

Resolves https://github.com/Cray/chapel-private/issues/585