### PR TITLE
Make --cache-remote readahead less aggressive

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2795,7 +2795,7 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
                "from %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn, commID);
+  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn, commID);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2823,7 +2823,7 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                "%d:%p to %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn, commID);
+  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn, commID);
 
 #ifdef DUMP
   chpl_cache_print();

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2216,10 +2216,10 @@ int should_readahead_extend(uint64_t* valid,
                             uintptr_t skip, uintptr_t len )
 {
   if(count_valid_before(valid, skip,
-        CACHE_LINES_PER_PAGE_BITMASK_WORDS) > 1)
+        CACHE_LINES_PER_PAGE_BITMASK_WORDS) > 2)
     return 1;
   if(count_valid_at_after(valid, skip+len,
-        CACHE_LINES_PER_PAGE_BITMASK_WORDS) > 1)
+        CACHE_LINES_PER_PAGE_BITMASK_WORDS) > 2)
     return -1;
   return 0;
 }


### PR DESCRIPTION
We have seen some sporadic comm count failures where too many GETs have
occurred when `--cache-remote` is enabled. These extra GETs are coming
from the cache's readahead feature, and in this case it was GET'ing data
that will never be used. Make it less aggressive to avoid these extra
comms.

I did not see any regressions for patterns that actually want readahead,
like a microbenchmark that reverses an array one element at a time.