### PR TITLE
Remove error about split init on globals

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2746,8 +2746,6 @@ static void errorIfSplitInitializationRequired(DefExpr* def, Expr* cur) {
 
   if (canDefaultInit == false) {
     const char* name = def->sym->name;
-    FnSymbol* initFn = def->getModule()->initFn;
-    bool global = (initFn && def->parentExpr == initFn->body);
 
     // Don't give errors for compiler generated functions at this time.
     FnSymbol* inFn = def->getFunction();
@@ -2787,9 +2785,7 @@ static void errorIfSplitInitializationRequired(DefExpr* def, Expr* cur) {
       }
     }
 
-    if (global) {
-      USR_FATAL_CONT(def, "split initialization is not supported for globals");
-    } else if (cur) {
+    if (cur) {
       if (def->exprType == NULL || genericType != NULL) {
         USR_PRINT(cur,
                   "'%s' use here prevents split-init from establishing the type",

--- a/test/classes/nilability/demo2.good
+++ b/test/classes/nilability/demo2.good
@@ -1,4 +1,3 @@
 demo2.chpl:11: error: variable 'a' is not initialized
 note: non-nilable class type borrowed C does not support default initialization
 note: Consider using the type borrowed C? instead
-demo2.chpl:11: error: split initialization is not supported for globals

--- a/test/parsing/vass/line-numbers-after-newline-in-string.good
+++ b/test/parsing/vass/line-numbers-after-newline-in-string.good
@@ -1,2 +1,1 @@
 line-numbers-after-newline-in-string.chpl:3: error: variable 'x' is not initialized and has no type
-line-numbers-after-newline-in-string.chpl:3: error: split initialization is not supported for globals

--- a/test/types/integral/integralvariable2.good
+++ b/test/types/integral/integralvariable2.good
@@ -1,3 +1,3 @@
 integralvariable2.chpl:1: error: variable 'r' is not initialized
 note: generic type integral does not support default initialization
-integralvariable2.chpl:1: error: split initialization is not supported for globals
+integralvariable2.chpl:2: note: 'r' use here prevents split-init from establishing the type

--- a/test/types/records/split-init/error-never-initialized.good
+++ b/test/types/records/split-init/error-never-initialized.good
@@ -30,20 +30,14 @@ note: undecorated class type C? does not support default initialization
 note: consider adding a management decorator such as 'owned', 'shared', 'borrowed', or 'unmanaged'
 error-never-initialized.chpl:25: note: 'q2' use here prevents split-init from establishing the type
 error-never-initialized.chpl:36: error: variable 'b' is not initialized and has no type
-error-never-initialized.chpl:36: error: split initialization is not supported for globals
 error-never-initialized.chpl:37: error: type alias 'tt' is not initialized
-error-never-initialized.chpl:37: error: split initialization is not supported for globals
 error-never-initialized.chpl:38: error: reference 'rr' is not initialized
-error-never-initialized.chpl:38: error: split initialization is not supported for globals
 error-never-initialized.chpl:39: error: variable 'bb' is not initialized
 note: non-nilable class type borrowed C does not support default initialization
 note: Consider using the type borrowed C? instead
-error-never-initialized.chpl:39: error: split initialization is not supported for globals
 error-never-initialized.chpl:40: error: variable 'cc' is not initialized
 note: undecorated class type C does not support default initialization
 note: consider adding a management decorator such as 'owned', 'shared', 'borrowed', or 'unmanaged'
-error-never-initialized.chpl:40: error: split initialization is not supported for globals
 error-never-initialized.chpl:41: error: variable 'qq' is not initialized
 note: undecorated class type C? does not support default initialization
 note: consider adding a management decorator such as 'owned', 'shared', 'borrowed', or 'unmanaged'
-error-never-initialized.chpl:41: error: split initialization is not supported for globals

--- a/test/variables/sungeun/refvar-compare-nil.good
+++ b/test/variables/sungeun/refvar-compare-nil.good
@@ -1,2 +1,2 @@
 refvar-compare-nil.chpl:1: error: reference 'rx' is not initialized
-refvar-compare-nil.chpl:1: error: split initialization is not supported for globals
+refvar-compare-nil.chpl:3: note: 'rx' use here prevents split-init

--- a/test/variables/sungeun/refvar-no-init-with-use.good
+++ b/test/variables/sungeun/refvar-no-init-with-use.good
@@ -1,2 +1,2 @@
 refvar-no-init-with-use.chpl:1: error: reference 'r' is not initialized
-refvar-no-init-with-use.chpl:1: error: split initialization is not supported for globals
+refvar-no-init-with-use.chpl:2: note: 'r' use here prevents split-init


### PR DESCRIPTION
Split init has been supported on module-scope variables since
PR #15113, but an error message indicated it was not supported.

This PR removes that error message and updates tests.

Reviewed by @benharsh - thanks!

- [x] full local testing