### PR TITLE
Rewrite ddata_allocate() to avoid inadvertent widening of init_elts()

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -914,7 +914,11 @@ module ChapelBase {
     }
   }
 
-  proc init_elts(x, s, type t, lo=0:s.type) : void {
+  proc init_elts(x, s, type t): void {
+    init_elts(x, s, t, 0);
+  }
+
+  proc init_elts(x, s, type t, lo) : void {
     var initMethod = chpl_getArrayInitMethod();
 
     // no need to init an array of zeros

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1363,7 +1363,10 @@ module DefaultRectangular {
       if (isNonNilableClass(eltType)) {
         halt("Can't resize domains whose arrays' elements don't have default values");
       }
-      on this {
+      if (this.locale != here) {
+        halt("internal error: dsiReallocate() can only be called from an array's home locale");
+      }
+      {
         const reallocD = {(...bounds)};
 
         // For now, we'll use realloc for 1D, non-empty arrays when
@@ -1378,10 +1381,10 @@ module DefaultRectangular {
             writeln("reallocating in-place");
 
           sizesPerDim(1) = reallocD.dsiDim(1).size;
-          _ddata_reallocate(data,
-                            eltType,
-                            oldSize=dom.dsiNumIndices,
-                            newSize=reallocD.size);
+          data = _ddata_reallocate(data,
+                                   eltType,
+                                   oldSize=dom.dsiNumIndices,
+                                   newSize=reallocD.size);
           initShiftedData();
         } else {
           var copy = new unmanaged DefaultRectangularArr(eltType=eltType,


### PR DESCRIPTION
This fixes a performance regression for array creation that crept in
when the array reallocation PR was merged.

Prior to this change, passing a ddata by `ref` to ddata_reallocate()
and then passing it along to init_elts() caused all calls to
init_elts() to use a wide rather than narrow ddata.  Worse, this even
affected programs that did not call ddata_reallocate() or even generate it
into their generated code, I believe because of dynamic dispatch resolution. 
This seems regrettable performance-wise, and was also subtle and hard to
track down.  It makes me wonder whether we should clone such functions
more aggressively to stop such cases from creeping in (and what other
performance wins that might lead to).

Here, I work around that issue by having ddata_reallocate() behave
more like realloc() in that it takes in the old ddata and returns
the new one.

While debugging this, I also noted that we had an extraneous on-clause
in dsiReallocate().  Extraneous because the only place it's called is within
ChapelDistribution.chpl, which already contains the necessary
on-clause.  For that reason, I converted the on-clause into an assert
to reduce overheads.

TODO:
- [x] verify that this fixes performance
- [x] verify that I haven't broken ugni realloc code paths
- [x] full correctness test