### PR TITLE
Update Mason Run error message 

### DIFF
--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -289,7 +289,9 @@ private proc runExampleBinary(projectHome: string, exampleName: string,
 
   const exampleResult = runWithStatus(command, true);
   if exampleResult != 0 {
-    throw new owned MasonError("Mason failed to find and run compiled example: " + exampleName + ".chpl");
+    throw new owned MasonError("Example has not been compiled: " + exampleName + ".chpl\n" +
+    "Try running: mason build --example " + exampleName + ".chpl\n" +
+    "         or: mason run --example " + exampleName + ".chpl --build");
   }
 }  
 


### PR DESCRIPTION
Updates the error message on Mason run (when mason run used without build) and closes #15009