### PR TITLE
Update for-expr-owned-bug.bad

### DIFF
--- a/test/types/records/split-init/for-expr-owned-bug.bad
+++ b/test/types/records/split-init/for-expr-owned-bug.bad
@@ -1,4 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:4215: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
-for-expr-owned-bug.chpl:6: In function 'main':
-for-expr-owned-bug.chpl:7: error: Cannot copy array with element type that cannot be assigned
-$CHPL_HOME/modules/internal/ChapelArray.chpl:4299: note: in function called here
+$CHPL_HOME/modules/internal/ChapelArray.chpl:4296: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()


### PR DESCRIPTION
This updates for-expr-owned-bug.bad, whose behavior seems to have changed
today, yet is still apparently not working as intended.