### PR TITLE
Require submodules to be used/imported

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -412,7 +412,7 @@ static void ensureRequiredStandardModulesAreParsed() {
       UnresolvedSymExpr* oldModNameExpr = toUnresolvedSymExpr(moduleExpr);
 
       if (oldModNameExpr == NULL) {
-        INT_FATAL("It seems an internal module is using a mod.submod form");
+        continue;
       }
 
       const char* modName  = oldModNameExpr->unresolved;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -822,8 +822,8 @@ Symbol* ResolveScope::lookupNameLocally(const char* name, bool isUse) const {
   if (it != mBindings.end()) {
     Symbol* sym = it->second;
 
-    // don't consider top-level modules to be visible unless this is a use
-    if (toModuleSymbol(sym) == NULL || this != rootScope || isUse) {
+    // don't consider modules to be visible unless this is a use
+    if (toModuleSymbol(sym) == NULL || isUse) {
       retval = sym;
     }
   }

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -248,6 +248,7 @@ module FFTW {
   private proc plan_dft_help(input: [] complex(128), output: [] complex(128),
                              sign: FFTW_Direction, flags: FFTW_Flag) : fftw_plan
   {
+    import FFTW.C_FFTW;
     param rank = input.rank;
 
     var dims: c_array(c_int,rank);
@@ -280,6 +281,7 @@ module FFTW {
   proc plan_dft_r2c(input : [?Din] real(64), output : [?Dout] complex(128), 
                     flags : FFTW_Flag) : fftw_plan
   {
+    import FFTW.C_FFTW;
     param rank = input.rank: c_int;
 
     if !noFFTWsizeChecks {
@@ -321,6 +323,7 @@ module FFTW {
   proc plan_dft_r2c(realDom : domain, arr : [?D] ?t, flags : FFTW_Flag) : fftw_plan
     where t == real || t == complex
   {
+    import FFTW.C_FFTW;
     if !noFFTWsizeChecks then
       if checkInPlaceDimMismatch(realDom, D, "plan_dft_r2c()", t == real) then
         halt("Incorrect array sizes in plan_dft_r2c()");
@@ -360,6 +363,7 @@ module FFTW {
   proc plan_dft_c2r(input : [?Din] complex(128), output : [?Dout] real(64), 
                     flags : FFTW_Flag) : fftw_plan
   {
+    import FFTW.C_FFTW;
     param rank = output.rank: c_int; // The dimensions are that of the real array
 
     if !noFFTWsizeChecks {
@@ -398,6 +402,7 @@ module FFTW {
   proc plan_dft_c2r(realDom : domain, arr: [?D] ?t, flags : FFTW_Flag) : fftw_plan 
     where t == real || t == complex
   {
+    import FFTW.C_FFTW;
     if !noFFTWsizeChecks then
       if checkInPlaceDimMismatch(realDom, D, "plan_dft_c2r()", t == real) then
         halt("Incorrect array sizes in plan_dft_c2r()");
@@ -427,7 +432,8 @@ module FFTW {
     :type plan: `fftw_plan`
   */
   proc execute(const plan: fftw_plan) {
-   C_FFTW.fftw_execute(plan);
+    import FFTW.C_FFTW;
+    C_FFTW.fftw_execute(plan);
   }
 
   /*
@@ -437,6 +443,7 @@ module FFTW {
     :type plan: `fftw_plan`
   */
   proc destroy_plan(plan: fftw_plan) {
+    import FFTW.C_FFTW;
     C_FFTW.fftw_destroy_plan(plan);
   }
 
@@ -445,6 +452,7 @@ module FFTW {
     Clean up FFTW overall.
   */
   proc cleanup() {
+    import FFTW.C_FFTW;
     C_FFTW.fftw_cleanup();
   }
 
@@ -644,6 +652,7 @@ module FFTW {
     locales, halting the Chapel program if any of the calls generate an error.
   */
   proc init_FFTW_MT() {
+    import FFTW.C_FFTW;
     coforall loc in Locales {
       on loc do {
         if (C_FFTW.fftw_init_threads() == 0) then
@@ -669,6 +678,7 @@ module FFTW {
     :type nthreads: `int`
   */
   proc plan_with_nthreads(nthreads: int = 0) {
+    import FFTW.C_FFTW;
     coforall loc in Locales {
       on loc do {
         const myNThreads = if nthreads < 1 then here.maxTaskPar else nthreads;
@@ -682,6 +692,7 @@ module FFTW {
     Clean up the memory used by FFTW threads on all locales.
   */
   proc cleanup_threads() {
+    import FFTW.C_FFTW;
     coforall loc in Locales {
       on loc do {
         C_FFTW.fftw_cleanup_threads();

--- a/modules/packages/LAPACK.chpl
+++ b/modules/packages/LAPACK.chpl
@@ -19092,6 +19092,7 @@ Wrapped procedure of LAPACKE_sbdsdc for the type real(32).
  */
 inline proc bdsdc(matrix_order : lapack_memory_order, uplo : string, compq : string, n : c_int, d : [] real(32), e : [] real(32), u : [] real(32), vt : [] real(32), q : [] real(32), iq : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sbdsdc(matrix_order, uplo.toByte() : c_char, compq.toByte() : c_char, n, d, e, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int, q, iq);
 }
 
@@ -19100,6 +19101,7 @@ Wrapped procedure of LAPACKE_dbdsdc for the type real(64).
  */
 inline proc bdsdc(matrix_order : lapack_memory_order, uplo : string, compq : string, n : c_int, d : [] real(64), e : [] real(64), u : [] real(64), vt : [] real(64), q : [] real(64), iq : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dbdsdc(matrix_order, uplo.toByte() : c_char, compq.toByte() : c_char, n, d, e, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int, q, iq);
 }
 
@@ -19108,6 +19110,7 @@ Wrapped procedure of LAPACKE_sbdsqr for the type real(32).
  */
 inline proc bdsqr(matrix_order : lapack_memory_order, uplo : string, d : [] real(32), e : [] real(32), vt : [] real(32), u : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sbdsqr(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then vt.domain.dim(2).size else vt.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then u.domain.dim(1).size else u.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, d, e, vt, (vt.domain.dim(2).size) : c_int, u, (u.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19116,6 +19119,7 @@ Wrapped procedure of LAPACKE_dbdsqr for the type real(64).
  */
 inline proc bdsqr(matrix_order : lapack_memory_order, uplo : string, d : [] real(64), e : [] real(64), vt : [] real(64), u : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dbdsqr(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then vt.domain.dim(2).size else vt.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then u.domain.dim(1).size else u.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, d, e, vt, (vt.domain.dim(2).size) : c_int, u, (u.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19124,6 +19128,7 @@ Wrapped procedure of LAPACKE_cbdsqr for the type complex(64).
  */
 inline proc bdsqr(matrix_order : lapack_memory_order, uplo : string, d : [] real(32), e : [] real(32), vt : [] complex(64), u : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cbdsqr(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then vt.domain.dim(2).size else vt.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then u.domain.dim(1).size else u.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, d, e, vt, (vt.domain.dim(2).size) : c_int, u, (u.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19132,6 +19137,7 @@ Wrapped procedure of LAPACKE_zbdsqr for the type complex(128).
  */
 inline proc bdsqr(matrix_order : lapack_memory_order, uplo : string, d : [] real(64), e : [] real(64), vt : [] complex(128), u : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zbdsqr(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then vt.domain.dim(2).size else vt.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then u.domain.dim(1).size else u.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, d, e, vt, (vt.domain.dim(2).size) : c_int, u, (u.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19140,6 +19146,7 @@ Wrapped procedure of LAPACKE_sdisna for the type real(32).
  */
 inline proc disna(job : string, m : c_int, n : c_int, d : [] real(32), sep : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sdisna(job.toByte() : c_char, m, n, d, sep);
 }
 
@@ -19148,6 +19155,7 @@ Wrapped procedure of LAPACKE_ddisna for the type real(64).
  */
 inline proc disna(job : string, m : c_int, n : c_int, d : [] real(64), sep : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ddisna(job.toByte() : c_char, m, n, d, sep);
 }
 
@@ -19156,6 +19164,7 @@ Wrapped procedure of LAPACKE_sgbbrd for the type real(32).
  */
 inline proc gbbrd(matrix_order : lapack_memory_order, vect : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), d : [] real(32), e : [] real(32), q : [] real(32), pt : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbbrd(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, n, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, kl, ku, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int, pt, (pt.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19164,6 +19173,7 @@ Wrapped procedure of LAPACKE_dgbbrd for the type real(64).
  */
 inline proc gbbrd(matrix_order : lapack_memory_order, vect : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), d : [] real(64), e : [] real(64), q : [] real(64), pt : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbbrd(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, n, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, kl, ku, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int, pt, (pt.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19172,6 +19182,7 @@ Wrapped procedure of LAPACKE_cgbbrd for the type complex(64).
  */
 inline proc gbbrd(matrix_order : lapack_memory_order, vect : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), d : [] real(32), e : [] real(32), q : [] complex(64), pt : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbbrd(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, n, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, kl, ku, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int, pt, (pt.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19180,6 +19191,7 @@ Wrapped procedure of LAPACKE_zgbbrd for the type complex(128).
  */
 inline proc gbbrd(matrix_order : lapack_memory_order, vect : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), d : [] real(64), e : [] real(64), q : [] complex(128), pt : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbbrd(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, n, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, kl, ku, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int, pt, (pt.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -19188,6 +19200,7 @@ Wrapped procedure of LAPACKE_sgbcon for the type real(32).
  */
 inline proc gbcon(matrix_order : lapack_memory_order, norm : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbcon(matrix_order, norm.toByte() : c_char, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -19196,6 +19209,7 @@ Wrapped procedure of LAPACKE_dgbcon for the type real(64).
  */
 inline proc gbcon(matrix_order : lapack_memory_order, norm : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbcon(matrix_order, norm.toByte() : c_char, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -19204,6 +19218,7 @@ Wrapped procedure of LAPACKE_cgbcon for the type complex(64).
  */
 inline proc gbcon(matrix_order : lapack_memory_order, norm : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbcon(matrix_order, norm.toByte() : c_char, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -19212,6 +19227,7 @@ Wrapped procedure of LAPACKE_zgbcon for the type complex(128).
  */
 inline proc gbcon(matrix_order : lapack_memory_order, norm : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbcon(matrix_order, norm.toByte() : c_char, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -19220,6 +19236,7 @@ Wrapped procedure of LAPACKE_sgbequ for the type real(32).
  */
 inline proc gbequ(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbequ(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19228,6 +19245,7 @@ Wrapped procedure of LAPACKE_dgbequ for the type real(64).
  */
 inline proc gbequ(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbequ(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19236,6 +19254,7 @@ Wrapped procedure of LAPACKE_cgbequ for the type complex(64).
  */
 inline proc gbequ(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbequ(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19244,6 +19263,7 @@ Wrapped procedure of LAPACKE_zgbequ for the type complex(128).
  */
 inline proc gbequ(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbequ(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19252,6 +19272,7 @@ Wrapped procedure of LAPACKE_sgbequb for the type real(32).
  */
 inline proc gbequb(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbequb(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19260,6 +19281,7 @@ Wrapped procedure of LAPACKE_dgbequb for the type real(64).
  */
 inline proc gbequb(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbequb(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19268,6 +19290,7 @@ Wrapped procedure of LAPACKE_cgbequb for the type complex(64).
  */
 inline proc gbequb(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbequb(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19276,6 +19299,7 @@ Wrapped procedure of LAPACKE_zgbequb for the type complex(128).
  */
 inline proc gbequb(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbequb(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19284,6 +19308,7 @@ Wrapped procedure of LAPACKE_sgbrfs for the type real(32).
  */
 inline proc gbrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), afb : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbrfs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -19292,6 +19317,7 @@ Wrapped procedure of LAPACKE_dgbrfs for the type real(64).
  */
 inline proc gbrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), afb : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbrfs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -19300,6 +19326,7 @@ Wrapped procedure of LAPACKE_cgbrfs for the type complex(64).
  */
 inline proc gbrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), afb : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbrfs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -19308,6 +19335,7 @@ Wrapped procedure of LAPACKE_zgbrfs for the type complex(128).
  */
 inline proc gbrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), afb : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbrfs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -19316,6 +19344,7 @@ Wrapped procedure of LAPACKE_sgbrfsx for the type real(32).
  */
 inline proc gbrfsx(matrix_order : lapack_memory_order, trans : string, equed : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), afb : [] real(32), ipiv : [] c_int, r : [] real(32), c : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbrfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19324,6 +19353,7 @@ Wrapped procedure of LAPACKE_dgbrfsx for the type real(64).
  */
 inline proc gbrfsx(matrix_order : lapack_memory_order, trans : string, equed : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), afb : [] real(64), ipiv : [] c_int, r : [] real(64), c : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbrfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19332,6 +19362,7 @@ Wrapped procedure of LAPACKE_cgbrfsx for the type complex(64).
  */
 inline proc gbrfsx(matrix_order : lapack_memory_order, trans : string, equed : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), afb : [] complex(64), ipiv : [] c_int, r : [] real(32), c : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbrfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19340,6 +19371,7 @@ Wrapped procedure of LAPACKE_zgbrfsx for the type complex(128).
  */
 inline proc gbrfsx(matrix_order : lapack_memory_order, trans : string, equed : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), afb : [] complex(128), ipiv : [] c_int, r : [] real(64), c : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbrfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19348,6 +19380,7 @@ Wrapped procedure of LAPACKE_sgbsv for the type real(32).
  */
 inline proc gbsv(matrix_order : lapack_memory_order, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbsv(matrix_order, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19356,6 +19389,7 @@ Wrapped procedure of LAPACKE_dgbsv for the type real(64).
  */
 inline proc gbsv(matrix_order : lapack_memory_order, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbsv(matrix_order, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19364,6 +19398,7 @@ Wrapped procedure of LAPACKE_cgbsv for the type complex(64).
  */
 inline proc gbsv(matrix_order : lapack_memory_order, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbsv(matrix_order, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19372,6 +19407,7 @@ Wrapped procedure of LAPACKE_zgbsv for the type complex(128).
  */
 inline proc gbsv(matrix_order : lapack_memory_order, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbsv(matrix_order, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19380,6 +19416,7 @@ Wrapped procedure of LAPACKE_sgbsvx for the type real(32).
  */
 inline proc gbsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), afb : [] real(32), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32), rpivot : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -19388,6 +19425,7 @@ Wrapped procedure of LAPACKE_dgbsvx for the type real(64).
  */
 inline proc gbsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), afb : [] real(64), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64), rpivot : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -19396,6 +19434,7 @@ Wrapped procedure of LAPACKE_cgbsvx for the type complex(64).
  */
 inline proc gbsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), afb : [] complex(64), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32), rpivot : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -19404,6 +19443,7 @@ Wrapped procedure of LAPACKE_zgbsvx for the type complex(128).
  */
 inline proc gbsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), afb : [] complex(128), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64), rpivot : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -19412,6 +19452,7 @@ Wrapped procedure of LAPACKE_sgbsvxx for the type real(32).
  */
 inline proc gbsvxx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), afb : [] real(32), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbsvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19420,6 +19461,7 @@ Wrapped procedure of LAPACKE_dgbsvxx for the type real(64).
  */
 inline proc gbsvxx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), afb : [] real(64), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbsvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19428,6 +19470,7 @@ Wrapped procedure of LAPACKE_cgbsvxx for the type complex(64).
  */
 inline proc gbsvxx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), afb : [] complex(64), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbsvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19436,6 +19479,7 @@ Wrapped procedure of LAPACKE_zgbsvxx for the type complex(128).
  */
 inline proc gbsvxx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), afb : [] complex(128), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbsvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -19444,6 +19488,7 @@ Wrapped procedure of LAPACKE_sgbtrf for the type real(32).
  */
 inline proc gbtrf(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbtrf(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -19452,6 +19497,7 @@ Wrapped procedure of LAPACKE_dgbtrf for the type real(64).
  */
 inline proc gbtrf(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbtrf(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -19460,6 +19506,7 @@ Wrapped procedure of LAPACKE_cgbtrf for the type complex(64).
  */
 inline proc gbtrf(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbtrf(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -19468,6 +19515,7 @@ Wrapped procedure of LAPACKE_zgbtrf for the type complex(128).
  */
 inline proc gbtrf(matrix_order : lapack_memory_order, m : c_int, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbtrf(matrix_order, m, n, kl, ku, ab, (ab.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -19476,6 +19524,7 @@ Wrapped procedure of LAPACKE_sgbtrs for the type real(32).
  */
 inline proc gbtrs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgbtrs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19484,6 +19533,7 @@ Wrapped procedure of LAPACKE_dgbtrs for the type real(64).
  */
 inline proc gbtrs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgbtrs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19492,6 +19542,7 @@ Wrapped procedure of LAPACKE_cgbtrs for the type complex(64).
  */
 inline proc gbtrs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgbtrs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19500,6 +19551,7 @@ Wrapped procedure of LAPACKE_zgbtrs for the type complex(128).
  */
 inline proc gbtrs(matrix_order : lapack_memory_order, trans : string, n : c_int, kl : c_int, ku : c_int, ab : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgbtrs(matrix_order, trans.toByte() : c_char, n, kl, ku, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19508,6 +19560,7 @@ Wrapped procedure of LAPACKE_sgebak for the type real(32).
  */
 inline proc gebak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, scale : [] real(32), v : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgebak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, scale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -19516,6 +19569,7 @@ Wrapped procedure of LAPACKE_dgebak for the type real(64).
  */
 inline proc gebak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, scale : [] real(64), v : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgebak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, scale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -19524,6 +19578,7 @@ Wrapped procedure of LAPACKE_cgebak for the type complex(64).
  */
 inline proc gebak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, scale : [] real(32), v : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgebak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, scale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -19532,6 +19587,7 @@ Wrapped procedure of LAPACKE_zgebak for the type complex(128).
  */
 inline proc gebak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, scale : [] real(64), v : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgebak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, scale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -19540,6 +19596,7 @@ Wrapped procedure of LAPACKE_sgebal for the type real(32).
  */
 inline proc gebal(matrix_order : lapack_memory_order, job : string, a : [] real(32), ref ilo : c_int, ref ihi : c_int, scale : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgebal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ilo, ihi, scale);
 }
 
@@ -19548,6 +19605,7 @@ Wrapped procedure of LAPACKE_dgebal for the type real(64).
  */
 inline proc gebal(matrix_order : lapack_memory_order, job : string, a : [] real(64), ref ilo : c_int, ref ihi : c_int, scale : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgebal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ilo, ihi, scale);
 }
 
@@ -19556,6 +19614,7 @@ Wrapped procedure of LAPACKE_cgebal for the type complex(64).
  */
 inline proc gebal(matrix_order : lapack_memory_order, job : string, a : [] complex(64), ref ilo : c_int, ref ihi : c_int, scale : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgebal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ilo, ihi, scale);
 }
 
@@ -19564,6 +19623,7 @@ Wrapped procedure of LAPACKE_zgebal for the type complex(128).
  */
 inline proc gebal(matrix_order : lapack_memory_order, job : string, a : [] complex(128), ref ilo : c_int, ref ihi : c_int, scale : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgebal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ilo, ihi, scale);
 }
 
@@ -19572,6 +19632,7 @@ Wrapped procedure of LAPACKE_sgebrd for the type real(32).
  */
 inline proc gebrd(matrix_order : lapack_memory_order, a : [] real(32), d : [] real(32), e : [] real(32), tauq : [] real(32), taup : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgebrd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tauq, taup);
 }
 
@@ -19580,6 +19641,7 @@ Wrapped procedure of LAPACKE_dgebrd for the type real(64).
  */
 inline proc gebrd(matrix_order : lapack_memory_order, a : [] real(64), d : [] real(64), e : [] real(64), tauq : [] real(64), taup : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgebrd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tauq, taup);
 }
 
@@ -19588,6 +19650,7 @@ Wrapped procedure of LAPACKE_cgebrd for the type complex(64).
  */
 inline proc gebrd(matrix_order : lapack_memory_order, a : [] complex(64), d : [] real(32), e : [] real(32), tauq : [] complex(64), taup : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgebrd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tauq, taup);
 }
 
@@ -19596,6 +19659,7 @@ Wrapped procedure of LAPACKE_zgebrd for the type complex(128).
  */
 inline proc gebrd(matrix_order : lapack_memory_order, a : [] complex(128), d : [] real(64), e : [] real(64), tauq : [] complex(128), taup : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgebrd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tauq, taup);
 }
 
@@ -19604,6 +19668,7 @@ Wrapped procedure of LAPACKE_sgecon for the type real(32).
  */
 inline proc gecon(matrix_order : lapack_memory_order, norm : string, a : [] real(32), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgecon(matrix_order, norm.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -19612,6 +19677,7 @@ Wrapped procedure of LAPACKE_dgecon for the type real(64).
  */
 inline proc gecon(matrix_order : lapack_memory_order, norm : string, a : [] real(64), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgecon(matrix_order, norm.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -19620,6 +19686,7 @@ Wrapped procedure of LAPACKE_cgecon for the type complex(64).
  */
 inline proc gecon(matrix_order : lapack_memory_order, norm : string, a : [] complex(64), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgecon(matrix_order, norm.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -19628,6 +19695,7 @@ Wrapped procedure of LAPACKE_zgecon for the type complex(128).
  */
 inline proc gecon(matrix_order : lapack_memory_order, norm : string, a : [] complex(128), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgecon(matrix_order, norm.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -19636,6 +19704,7 @@ Wrapped procedure of LAPACKE_sgeequ for the type real(32).
  */
 inline proc geequ(matrix_order : lapack_memory_order, a : [] real(32), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeequ(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19644,6 +19713,7 @@ Wrapped procedure of LAPACKE_dgeequ for the type real(64).
  */
 inline proc geequ(matrix_order : lapack_memory_order, a : [] real(64), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeequ(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19652,6 +19722,7 @@ Wrapped procedure of LAPACKE_cgeequ for the type complex(64).
  */
 inline proc geequ(matrix_order : lapack_memory_order, a : [] complex(64), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeequ(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19660,6 +19731,7 @@ Wrapped procedure of LAPACKE_zgeequ for the type complex(128).
  */
 inline proc geequ(matrix_order : lapack_memory_order, a : [] complex(128), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeequ(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19668,6 +19740,7 @@ Wrapped procedure of LAPACKE_sgeequb for the type real(32).
  */
 inline proc geequb(matrix_order : lapack_memory_order, a : [] real(32), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeequb(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19676,6 +19749,7 @@ Wrapped procedure of LAPACKE_dgeequb for the type real(64).
  */
 inline proc geequb(matrix_order : lapack_memory_order, a : [] real(64), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeequb(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19684,6 +19758,7 @@ Wrapped procedure of LAPACKE_cgeequb for the type complex(64).
  */
 inline proc geequb(matrix_order : lapack_memory_order, a : [] complex(64), r : [] real(32), c : [] real(32), ref rowcnd : real(32), ref colcnd : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeequb(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19692,6 +19767,7 @@ Wrapped procedure of LAPACKE_zgeequb for the type complex(128).
  */
 inline proc geequb(matrix_order : lapack_memory_order, a : [] complex(128), r : [] real(64), c : [] real(64), ref rowcnd : real(64), ref colcnd : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeequb(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, r, c, rowcnd, colcnd, amax);
 }
 
@@ -19700,6 +19776,7 @@ Wrapped procedure of LAPACKE_sgees for the type real(32).
  */
 inline proc gees(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_S_SELECT2, a : [] real(32), ref sdim : c_int, wr : [] real(32), wi : [] real(32), vs : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgees(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, wr, wi, vs, (vs.domain.dim(2).size) : c_int);
 }
 
@@ -19708,6 +19785,7 @@ Wrapped procedure of LAPACKE_dgees for the type real(64).
  */
 inline proc gees(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_D_SELECT2, a : [] real(64), ref sdim : c_int, wr : [] real(64), wi : [] real(64), vs : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgees(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, wr, wi, vs, (vs.domain.dim(2).size) : c_int);
 }
 
@@ -19716,6 +19794,7 @@ Wrapped procedure of LAPACKE_cgees for the type complex(64).
  */
 inline proc gees(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_C_SELECT1, a : [] complex(64), ref sdim : c_int, w : [] complex(64), vs : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgees(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, w, vs, (vs.domain.dim(2).size) : c_int);
 }
 
@@ -19724,6 +19803,7 @@ Wrapped procedure of LAPACKE_zgees for the type complex(128).
  */
 inline proc gees(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_Z_SELECT1, a : [] complex(128), ref sdim : c_int, w : [] complex(128), vs : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgees(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, w, vs, (vs.domain.dim(2).size) : c_int);
 }
 
@@ -19732,6 +19812,7 @@ Wrapped procedure of LAPACKE_sgeesx for the type real(32).
  */
 inline proc geesx(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_S_SELECT2, sense : string, a : [] real(32), ref sdim : c_int, wr : [] real(32), wi : [] real(32), vs : [] real(32), ref rconde : real(32), ref rcondv : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeesx(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, wr, wi, vs, (vs.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -19740,6 +19821,7 @@ Wrapped procedure of LAPACKE_dgeesx for the type real(64).
  */
 inline proc geesx(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_D_SELECT2, sense : string, a : [] real(64), ref sdim : c_int, wr : [] real(64), wi : [] real(64), vs : [] real(64), ref rconde : real(64), ref rcondv : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeesx(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, wr, wi, vs, (vs.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -19748,6 +19830,7 @@ Wrapped procedure of LAPACKE_cgeesx for the type complex(64).
  */
 inline proc geesx(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_C_SELECT1, sense : string, a : [] complex(64), ref sdim : c_int, w : [] complex(64), vs : [] complex(64), ref rconde : real(32), ref rcondv : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeesx(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, w, vs, (vs.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -19756,6 +19839,7 @@ Wrapped procedure of LAPACKE_zgeesx for the type complex(128).
  */
 inline proc geesx(matrix_order : lapack_memory_order, jobvs : string, sort : string, chlapack_select : LAPACK_Z_SELECT1, sense : string, a : [] complex(128), ref sdim : c_int, w : [] complex(128), vs : [] complex(128), ref rconde : real(64), ref rcondv : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeesx(matrix_order, jobvs.toByte() : c_char, sort.toByte() : c_char, chlapack_select, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sdim, w, vs, (vs.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -19764,6 +19848,7 @@ Wrapped procedure of LAPACKE_sgeev for the type real(32).
  */
 inline proc geev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] real(32), wr : [] real(32), wi : [] real(32), vl : [] real(32), vr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, wr, wi, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -19772,6 +19857,7 @@ Wrapped procedure of LAPACKE_dgeev for the type real(64).
  */
 inline proc geev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] real(64), wr : [] real(64), wi : [] real(64), vl : [] real(64), vr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, wr, wi, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -19780,6 +19866,7 @@ Wrapped procedure of LAPACKE_cgeev for the type complex(64).
  */
 inline proc geev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] complex(64), w : [] complex(64), vl : [] complex(64), vr : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -19788,6 +19875,7 @@ Wrapped procedure of LAPACKE_zgeev for the type complex(128).
  */
 inline proc geev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] complex(128), w : [] complex(128), vl : [] complex(128), vr : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -19796,6 +19884,7 @@ Wrapped procedure of LAPACKE_sgeevx for the type real(32).
  */
 inline proc geevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] real(32), wr : [] real(32), wi : [] real(32), vl : [] real(32), vr : [] real(32), ref ilo : c_int, ref ihi : c_int, scale : [] real(32), ref abnrm : real(32), rconde : [] real(32), rcondv : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, wr, wi, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, scale, abnrm, rconde, rcondv);
 }
 
@@ -19804,6 +19893,7 @@ Wrapped procedure of LAPACKE_dgeevx for the type real(64).
  */
 inline proc geevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] real(64), wr : [] real(64), wi : [] real(64), vl : [] real(64), vr : [] real(64), ref ilo : c_int, ref ihi : c_int, scale : [] real(64), ref abnrm : real(64), rconde : [] real(64), rcondv : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, wr, wi, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, scale, abnrm, rconde, rcondv);
 }
 
@@ -19812,6 +19902,7 @@ Wrapped procedure of LAPACKE_cgeevx for the type complex(64).
  */
 inline proc geevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] complex(64), w : [] complex(64), vl : [] complex(64), vr : [] complex(64), ref ilo : c_int, ref ihi : c_int, scale : [] real(32), ref abnrm : real(32), rconde : [] real(32), rcondv : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, scale, abnrm, rconde, rcondv);
 }
 
@@ -19820,6 +19911,7 @@ Wrapped procedure of LAPACKE_zgeevx for the type complex(128).
  */
 inline proc geevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] complex(128), w : [] complex(128), vl : [] complex(128), vr : [] complex(128), ref ilo : c_int, ref ihi : c_int, scale : [] real(64), ref abnrm : real(64), rconde : [] real(64), rcondv : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, scale, abnrm, rconde, rcondv);
 }
 
@@ -19828,6 +19920,7 @@ Wrapped procedure of LAPACKE_sgehrd for the type real(32).
  */
 inline proc gehrd(matrix_order : lapack_memory_order, ilo : c_int, ihi : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgehrd(matrix_order, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19836,6 +19929,7 @@ Wrapped procedure of LAPACKE_dgehrd for the type real(64).
  */
 inline proc gehrd(matrix_order : lapack_memory_order, ilo : c_int, ihi : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgehrd(matrix_order, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19844,6 +19938,7 @@ Wrapped procedure of LAPACKE_cgehrd for the type complex(64).
  */
 inline proc gehrd(matrix_order : lapack_memory_order, ilo : c_int, ihi : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgehrd(matrix_order, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19852,6 +19947,7 @@ Wrapped procedure of LAPACKE_zgehrd for the type complex(128).
  */
 inline proc gehrd(matrix_order : lapack_memory_order, ilo : c_int, ihi : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgehrd(matrix_order, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19860,6 +19956,7 @@ Wrapped procedure of LAPACKE_sgejsv for the type real(32).
  */
 inline proc gejsv(matrix_order : lapack_memory_order, joba : string, jobu : string, jobv : string, jobr : string, jobt : string, jobp : string, a : [] real(32), sva : [] real(32), u : [] real(32), v : [] real(32), stat : [] real(32), istat : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgejsv(matrix_order, joba.toByte() : c_char, jobu.toByte() : c_char, jobv.toByte() : c_char, jobr.toByte() : c_char, jobt.toByte() : c_char, jobp.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sva, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, stat, istat);
 }
 
@@ -19868,6 +19965,7 @@ Wrapped procedure of LAPACKE_dgejsv for the type real(64).
  */
 inline proc gejsv(matrix_order : lapack_memory_order, joba : string, jobu : string, jobv : string, jobr : string, jobt : string, jobp : string, a : [] real(64), sva : [] real(64), u : [] real(64), v : [] real(64), stat : [] real(64), istat : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgejsv(matrix_order, joba.toByte() : c_char, jobu.toByte() : c_char, jobv.toByte() : c_char, jobr.toByte() : c_char, jobt.toByte() : c_char, jobp.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sva, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, stat, istat);
 }
 
@@ -19876,6 +19974,7 @@ Wrapped procedure of LAPACKE_sgelq2 for the type real(32).
  */
 inline proc gelq2(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgelq2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19884,6 +19983,7 @@ Wrapped procedure of LAPACKE_dgelq2 for the type real(64).
  */
 inline proc gelq2(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgelq2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19892,6 +19992,7 @@ Wrapped procedure of LAPACKE_cgelq2 for the type complex(64).
  */
 inline proc gelq2(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgelq2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19900,6 +20001,7 @@ Wrapped procedure of LAPACKE_zgelq2 for the type complex(128).
  */
 inline proc gelq2(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgelq2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19908,6 +20010,7 @@ Wrapped procedure of LAPACKE_sgelqf for the type real(32).
  */
 inline proc gelqf(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgelqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19916,6 +20019,7 @@ Wrapped procedure of LAPACKE_dgelqf for the type real(64).
  */
 inline proc gelqf(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgelqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19924,6 +20028,7 @@ Wrapped procedure of LAPACKE_cgelqf for the type complex(64).
  */
 inline proc gelqf(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgelqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19932,6 +20037,7 @@ Wrapped procedure of LAPACKE_zgelqf for the type complex(128).
  */
 inline proc gelqf(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgelqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -19940,6 +20046,7 @@ Wrapped procedure of LAPACKE_sgels for the type real(32).
  */
 inline proc gels(matrix_order : lapack_memory_order, trans : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgels(matrix_order, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19948,6 +20055,7 @@ Wrapped procedure of LAPACKE_dgels for the type real(64).
  */
 inline proc gels(matrix_order : lapack_memory_order, trans : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgels(matrix_order, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19956,6 +20064,7 @@ Wrapped procedure of LAPACKE_cgels for the type complex(64).
  */
 inline proc gels(matrix_order : lapack_memory_order, trans : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgels(matrix_order, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19964,6 +20073,7 @@ Wrapped procedure of LAPACKE_zgels for the type complex(128).
  */
 inline proc gels(matrix_order : lapack_memory_order, trans : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgels(matrix_order, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -19972,6 +20082,7 @@ Wrapped procedure of LAPACKE_sgelsd for the type real(32).
  */
 inline proc gelsd(matrix_order : lapack_memory_order, a : [] real(32), b : [] real(32), s : [] real(32), rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgelsd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -19980,6 +20091,7 @@ Wrapped procedure of LAPACKE_dgelsd for the type real(64).
  */
 inline proc gelsd(matrix_order : lapack_memory_order, a : [] real(64), b : [] real(64), s : [] real(64), rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgelsd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -19988,6 +20100,7 @@ Wrapped procedure of LAPACKE_cgelsd for the type complex(64).
  */
 inline proc gelsd(matrix_order : lapack_memory_order, a : [] complex(64), b : [] complex(64), s : [] real(32), rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgelsd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -19996,6 +20109,7 @@ Wrapped procedure of LAPACKE_zgelsd for the type complex(128).
  */
 inline proc gelsd(matrix_order : lapack_memory_order, a : [] complex(128), b : [] complex(128), s : [] real(64), rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgelsd(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20004,6 +20118,7 @@ Wrapped procedure of LAPACKE_sgelss for the type real(32).
  */
 inline proc gelss(matrix_order : lapack_memory_order, a : [] real(32), b : [] real(32), s : [] real(32), rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgelss(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20012,6 +20127,7 @@ Wrapped procedure of LAPACKE_dgelss for the type real(64).
  */
 inline proc gelss(matrix_order : lapack_memory_order, a : [] real(64), b : [] real(64), s : [] real(64), rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgelss(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20020,6 +20136,7 @@ Wrapped procedure of LAPACKE_cgelss for the type complex(64).
  */
 inline proc gelss(matrix_order : lapack_memory_order, a : [] complex(64), b : [] complex(64), s : [] real(32), rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgelss(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20028,6 +20145,7 @@ Wrapped procedure of LAPACKE_zgelss for the type complex(128).
  */
 inline proc gelss(matrix_order : lapack_memory_order, a : [] complex(128), b : [] complex(128), s : [] real(64), rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgelss(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, s, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20036,6 +20154,7 @@ Wrapped procedure of LAPACKE_sgelsy for the type real(32).
  */
 inline proc gelsy(matrix_order : lapack_memory_order, a : [] real(32), b : [] real(32), jpvt : [] c_int, rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgelsy(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, jpvt, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20044,6 +20163,7 @@ Wrapped procedure of LAPACKE_dgelsy for the type real(64).
  */
 inline proc gelsy(matrix_order : lapack_memory_order, a : [] real(64), b : [] real(64), jpvt : [] c_int, rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgelsy(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, jpvt, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20052,6 +20172,7 @@ Wrapped procedure of LAPACKE_cgelsy for the type complex(64).
  */
 inline proc gelsy(matrix_order : lapack_memory_order, a : [] complex(64), b : [] complex(64), jpvt : [] c_int, rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgelsy(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, jpvt, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20060,6 +20181,7 @@ Wrapped procedure of LAPACKE_zgelsy for the type complex(128).
  */
 inline proc gelsy(matrix_order : lapack_memory_order, a : [] complex(128), b : [] complex(128), jpvt : [] c_int, rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgelsy(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, jpvt, rcond, (a.domain.dim(1).size) : c_int);
 }
 
@@ -20068,6 +20190,7 @@ Wrapped procedure of LAPACKE_sgeqlf for the type real(32).
  */
 inline proc geqlf(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqlf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20076,6 +20199,7 @@ Wrapped procedure of LAPACKE_dgeqlf for the type real(64).
  */
 inline proc geqlf(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqlf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20084,6 +20208,7 @@ Wrapped procedure of LAPACKE_cgeqlf for the type complex(64).
  */
 inline proc geqlf(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqlf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20092,6 +20217,7 @@ Wrapped procedure of LAPACKE_zgeqlf for the type complex(128).
  */
 inline proc geqlf(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqlf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20100,6 +20226,7 @@ Wrapped procedure of LAPACKE_sgeqp3 for the type real(32).
  */
 inline proc geqp3(matrix_order : lapack_memory_order, a : [] real(32), jpvt : [] c_int, tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqp3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20108,6 +20235,7 @@ Wrapped procedure of LAPACKE_dgeqp3 for the type real(64).
  */
 inline proc geqp3(matrix_order : lapack_memory_order, a : [] real(64), jpvt : [] c_int, tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqp3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20116,6 +20244,7 @@ Wrapped procedure of LAPACKE_cgeqp3 for the type complex(64).
  */
 inline proc geqp3(matrix_order : lapack_memory_order, a : [] complex(64), jpvt : [] c_int, tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqp3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20124,6 +20253,7 @@ Wrapped procedure of LAPACKE_zgeqp3 for the type complex(128).
  */
 inline proc geqp3(matrix_order : lapack_memory_order, a : [] complex(128), jpvt : [] c_int, tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqp3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20132,6 +20262,7 @@ Wrapped procedure of LAPACKE_sgeqpf for the type real(32).
  */
 inline proc geqpf(matrix_order : lapack_memory_order, a : [] real(32), jpvt : [] c_int, tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqpf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20140,6 +20271,7 @@ Wrapped procedure of LAPACKE_dgeqpf for the type real(64).
  */
 inline proc geqpf(matrix_order : lapack_memory_order, a : [] real(64), jpvt : [] c_int, tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqpf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20148,6 +20280,7 @@ Wrapped procedure of LAPACKE_cgeqpf for the type complex(64).
  */
 inline proc geqpf(matrix_order : lapack_memory_order, a : [] complex(64), jpvt : [] c_int, tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqpf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20156,6 +20289,7 @@ Wrapped procedure of LAPACKE_zgeqpf for the type complex(128).
  */
 inline proc geqpf(matrix_order : lapack_memory_order, a : [] complex(128), jpvt : [] c_int, tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqpf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, jpvt, tau);
 }
 
@@ -20164,6 +20298,7 @@ Wrapped procedure of LAPACKE_sgeqr2 for the type real(32).
  */
 inline proc geqr2(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqr2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20172,6 +20307,7 @@ Wrapped procedure of LAPACKE_dgeqr2 for the type real(64).
  */
 inline proc geqr2(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqr2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20180,6 +20316,7 @@ Wrapped procedure of LAPACKE_cgeqr2 for the type complex(64).
  */
 inline proc geqr2(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqr2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20188,6 +20325,7 @@ Wrapped procedure of LAPACKE_zgeqr2 for the type complex(128).
  */
 inline proc geqr2(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqr2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20196,6 +20334,7 @@ Wrapped procedure of LAPACKE_sgeqrf for the type real(32).
  */
 inline proc geqrf(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20204,6 +20343,7 @@ Wrapped procedure of LAPACKE_dgeqrf for the type real(64).
  */
 inline proc geqrf(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20212,6 +20352,7 @@ Wrapped procedure of LAPACKE_cgeqrf for the type complex(64).
  */
 inline proc geqrf(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20220,6 +20361,7 @@ Wrapped procedure of LAPACKE_zgeqrf for the type complex(128).
  */
 inline proc geqrf(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20228,6 +20370,7 @@ Wrapped procedure of LAPACKE_sgeqrfp for the type real(32).
  */
 inline proc geqrfp(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqrfp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20236,6 +20379,7 @@ Wrapped procedure of LAPACKE_dgeqrfp for the type real(64).
  */
 inline proc geqrfp(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqrfp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20244,6 +20388,7 @@ Wrapped procedure of LAPACKE_cgeqrfp for the type complex(64).
  */
 inline proc geqrfp(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqrfp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20252,6 +20397,7 @@ Wrapped procedure of LAPACKE_zgeqrfp for the type complex(128).
  */
 inline proc geqrfp(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqrfp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20260,6 +20406,7 @@ Wrapped procedure of LAPACKE_sgerfs for the type real(32).
  */
 inline proc gerfs(matrix_order : lapack_memory_order, trans : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgerfs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -20268,6 +20415,7 @@ Wrapped procedure of LAPACKE_dgerfs for the type real(64).
  */
 inline proc gerfs(matrix_order : lapack_memory_order, trans : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgerfs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -20276,6 +20424,7 @@ Wrapped procedure of LAPACKE_cgerfs for the type complex(64).
  */
 inline proc gerfs(matrix_order : lapack_memory_order, trans : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgerfs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -20284,6 +20433,7 @@ Wrapped procedure of LAPACKE_zgerfs for the type complex(128).
  */
 inline proc gerfs(matrix_order : lapack_memory_order, trans : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgerfs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -20292,6 +20442,7 @@ Wrapped procedure of LAPACKE_sgerfsx for the type real(32).
  */
 inline proc gerfsx(matrix_order : lapack_memory_order, trans : string, equed : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, r : [] real(32), c : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgerfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20300,6 +20451,7 @@ Wrapped procedure of LAPACKE_dgerfsx for the type real(64).
  */
 inline proc gerfsx(matrix_order : lapack_memory_order, trans : string, equed : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, r : [] real(64), c : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgerfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20308,6 +20460,7 @@ Wrapped procedure of LAPACKE_cgerfsx for the type complex(64).
  */
 inline proc gerfsx(matrix_order : lapack_memory_order, trans : string, equed : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, r : [] real(32), c : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgerfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20316,6 +20469,7 @@ Wrapped procedure of LAPACKE_zgerfsx for the type complex(128).
  */
 inline proc gerfsx(matrix_order : lapack_memory_order, trans : string, equed : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, r : [] real(64), c : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgerfsx(matrix_order, trans.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20324,6 +20478,7 @@ Wrapped procedure of LAPACKE_sgerqf for the type real(32).
  */
 inline proc gerqf(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgerqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20332,6 +20487,7 @@ Wrapped procedure of LAPACKE_dgerqf for the type real(64).
  */
 inline proc gerqf(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgerqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20340,6 +20496,7 @@ Wrapped procedure of LAPACKE_cgerqf for the type complex(64).
  */
 inline proc gerqf(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgerqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20348,6 +20505,7 @@ Wrapped procedure of LAPACKE_zgerqf for the type complex(128).
  */
 inline proc gerqf(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgerqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -20356,6 +20514,7 @@ Wrapped procedure of LAPACKE_sgesdd for the type real(32).
  */
 inline proc gesdd(matrix_order : lapack_memory_order, jobz : string, a : [] real(32), s : [] real(32), u : [] real(32), vt : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgesdd(matrix_order, jobz.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int);
 }
 
@@ -20364,6 +20523,7 @@ Wrapped procedure of LAPACKE_dgesdd for the type real(64).
  */
 inline proc gesdd(matrix_order : lapack_memory_order, jobz : string, a : [] real(64), s : [] real(64), u : [] real(64), vt : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgesdd(matrix_order, jobz.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int);
 }
 
@@ -20372,6 +20532,7 @@ Wrapped procedure of LAPACKE_cgesdd for the type complex(64).
  */
 inline proc gesdd(matrix_order : lapack_memory_order, jobz : string, a : [] complex(64), s : [] real(32), u : [] complex(64), vt : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgesdd(matrix_order, jobz.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int);
 }
 
@@ -20380,6 +20541,7 @@ Wrapped procedure of LAPACKE_zgesdd for the type complex(128).
  */
 inline proc gesdd(matrix_order : lapack_memory_order, jobz : string, a : [] complex(128), s : [] real(64), u : [] complex(128), vt : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgesdd(matrix_order, jobz.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int);
 }
 
@@ -20388,6 +20550,7 @@ Wrapped procedure of LAPACKE_sgesv for the type real(32).
  */
 inline proc gesv(matrix_order : lapack_memory_order, a : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgesv(matrix_order, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20396,6 +20559,7 @@ Wrapped procedure of LAPACKE_dgesv for the type real(64).
  */
 inline proc gesv(matrix_order : lapack_memory_order, a : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgesv(matrix_order, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20404,6 +20568,7 @@ Wrapped procedure of LAPACKE_cgesv for the type complex(64).
  */
 inline proc gesv(matrix_order : lapack_memory_order, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgesv(matrix_order, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20412,6 +20577,7 @@ Wrapped procedure of LAPACKE_zgesv for the type complex(128).
  */
 inline proc gesv(matrix_order : lapack_memory_order, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgesv(matrix_order, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20420,6 +20586,7 @@ Wrapped procedure of LAPACKE_dsgesv for the type real(64).
  */
 inline proc gesv(matrix_order : lapack_memory_order, a : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ref chlapack_iter : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsgesv(matrix_order, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, chlapack_iter);
 }
 
@@ -20428,6 +20595,7 @@ Wrapped procedure of LAPACKE_zcgesv for the type complex(128).
  */
 inline proc gesv(matrix_order : lapack_memory_order, a : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ref chlapack_iter : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zcgesv(matrix_order, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, chlapack_iter);
 }
 
@@ -20436,6 +20604,7 @@ Wrapped procedure of LAPACKE_sgesvd for the type real(32).
  */
 inline proc gesvd(matrix_order : lapack_memory_order, jobu : string, jobvt : string, a : [] real(32), s : [] real(32), u : [] real(32), vt : [] real(32), superb : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgesvd(matrix_order, jobu.toByte() : c_char, jobvt.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int, superb);
 }
 
@@ -20444,6 +20613,7 @@ Wrapped procedure of LAPACKE_dgesvd for the type real(64).
  */
 inline proc gesvd(matrix_order : lapack_memory_order, jobu : string, jobvt : string, a : [] real(64), s : [] real(64), u : [] real(64), vt : [] real(64), superb : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgesvd(matrix_order, jobu.toByte() : c_char, jobvt.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int, superb);
 }
 
@@ -20452,6 +20622,7 @@ Wrapped procedure of LAPACKE_cgesvd for the type complex(64).
  */
 inline proc gesvd(matrix_order : lapack_memory_order, jobu : string, jobvt : string, a : [] complex(64), s : [] real(32), u : [] complex(64), vt : [] complex(64), superb : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgesvd(matrix_order, jobu.toByte() : c_char, jobvt.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int, superb);
 }
 
@@ -20460,6 +20631,7 @@ Wrapped procedure of LAPACKE_zgesvd for the type complex(128).
  */
 inline proc gesvd(matrix_order : lapack_memory_order, jobu : string, jobvt : string, a : [] complex(128), s : [] real(64), u : [] complex(128), vt : [] complex(128), superb : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgesvd(matrix_order, jobu.toByte() : c_char, jobvt.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, u, (u.domain.dim(2).size) : c_int, vt, (vt.domain.dim(2).size) : c_int, superb);
 }
 
@@ -20468,6 +20640,7 @@ Wrapped procedure of LAPACKE_sgesvj for the type real(32).
  */
 inline proc gesvj(matrix_order : lapack_memory_order, joba : string, jobu : string, jobv : string, a : [] real(32), sva : [] real(32), mv : c_int, v : [] real(32), stat : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgesvj(matrix_order, joba.toByte() : c_char, jobu.toByte() : c_char, jobv.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sva, mv, v, (v.domain.dim(2).size) : c_int, stat);
 }
 
@@ -20476,6 +20649,7 @@ Wrapped procedure of LAPACKE_dgesvj for the type real(64).
  */
 inline proc gesvj(matrix_order : lapack_memory_order, joba : string, jobu : string, jobv : string, a : [] real(64), sva : [] real(64), mv : c_int, v : [] real(64), stat : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgesvj(matrix_order, joba.toByte() : c_char, jobu.toByte() : c_char, jobv.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sva, mv, v, (v.domain.dim(2).size) : c_int, stat);
 }
 
@@ -20484,6 +20658,7 @@ Wrapped procedure of LAPACKE_sgesvx for the type real(32).
  */
 inline proc gesvx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32), rpivot : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgesvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -20492,6 +20667,7 @@ Wrapped procedure of LAPACKE_dgesvx for the type real(64).
  */
 inline proc gesvx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64), rpivot : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgesvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -20500,6 +20676,7 @@ Wrapped procedure of LAPACKE_cgesvx for the type complex(64).
  */
 inline proc gesvx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32), rpivot : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgesvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -20508,6 +20685,7 @@ Wrapped procedure of LAPACKE_zgesvx for the type complex(128).
  */
 inline proc gesvx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64), rpivot : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgesvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr, rpivot);
 }
 
@@ -20516,6 +20694,7 @@ Wrapped procedure of LAPACKE_sgesvxx for the type real(32).
  */
 inline proc gesvxx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgesvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20524,6 +20703,7 @@ Wrapped procedure of LAPACKE_dgesvxx for the type real(64).
  */
 inline proc gesvxx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgesvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20532,6 +20712,7 @@ Wrapped procedure of LAPACKE_cgesvxx for the type complex(64).
  */
 inline proc gesvxx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, ref equed : string, r : [] real(32), c : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgesvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20540,6 +20721,7 @@ Wrapped procedure of LAPACKE_zgesvxx for the type complex(128).
  */
 inline proc gesvxx(matrix_order : lapack_memory_order, fact : string, trans : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, ref equed : string, r : [] real(64), c : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgesvxx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, r, c, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -20548,6 +20730,7 @@ Wrapped procedure of LAPACKE_sgetf2 for the type real(32).
  */
 inline proc getf2(matrix_order : lapack_memory_order, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgetf2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20556,6 +20739,7 @@ Wrapped procedure of LAPACKE_dgetf2 for the type real(64).
  */
 inline proc getf2(matrix_order : lapack_memory_order, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgetf2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20564,6 +20748,7 @@ Wrapped procedure of LAPACKE_cgetf2 for the type complex(64).
  */
 inline proc getf2(matrix_order : lapack_memory_order, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgetf2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20572,6 +20757,7 @@ Wrapped procedure of LAPACKE_zgetf2 for the type complex(128).
  */
 inline proc getf2(matrix_order : lapack_memory_order, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgetf2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20580,6 +20766,7 @@ Wrapped procedure of LAPACKE_sgetrf for the type real(32).
  */
 inline proc getrf(matrix_order : lapack_memory_order, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgetrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20588,6 +20775,7 @@ Wrapped procedure of LAPACKE_dgetrf for the type real(64).
  */
 inline proc getrf(matrix_order : lapack_memory_order, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgetrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20596,6 +20784,7 @@ Wrapped procedure of LAPACKE_cgetrf for the type complex(64).
  */
 inline proc getrf(matrix_order : lapack_memory_order, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgetrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20604,6 +20793,7 @@ Wrapped procedure of LAPACKE_zgetrf for the type complex(128).
  */
 inline proc getrf(matrix_order : lapack_memory_order, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgetrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20612,6 +20802,7 @@ Wrapped procedure of LAPACKE_sgetri for the type real(32).
  */
 inline proc getri(matrix_order : lapack_memory_order, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgetri(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20620,6 +20811,7 @@ Wrapped procedure of LAPACKE_dgetri for the type real(64).
  */
 inline proc getri(matrix_order : lapack_memory_order, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgetri(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20628,6 +20820,7 @@ Wrapped procedure of LAPACKE_cgetri for the type complex(64).
  */
 inline proc getri(matrix_order : lapack_memory_order, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgetri(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20636,6 +20829,7 @@ Wrapped procedure of LAPACKE_zgetri for the type complex(128).
  */
 inline proc getri(matrix_order : lapack_memory_order, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgetri(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -20644,6 +20838,7 @@ Wrapped procedure of LAPACKE_sgetrs for the type real(32).
  */
 inline proc getrs(matrix_order : lapack_memory_order, trans : string, a : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgetrs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20652,6 +20847,7 @@ Wrapped procedure of LAPACKE_dgetrs for the type real(64).
  */
 inline proc getrs(matrix_order : lapack_memory_order, trans : string, a : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgetrs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20660,6 +20856,7 @@ Wrapped procedure of LAPACKE_cgetrs for the type complex(64).
  */
 inline proc getrs(matrix_order : lapack_memory_order, trans : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgetrs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20668,6 +20865,7 @@ Wrapped procedure of LAPACKE_zgetrs for the type complex(128).
  */
 inline proc getrs(matrix_order : lapack_memory_order, trans : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgetrs(matrix_order, trans.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -20676,6 +20874,7 @@ Wrapped procedure of LAPACKE_sggbak for the type real(32).
  */
 inline proc ggbak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, lscale : [] real(32), rscale : [] real(32), v : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggbak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -20684,6 +20883,7 @@ Wrapped procedure of LAPACKE_dggbak for the type real(64).
  */
 inline proc ggbak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, lscale : [] real(64), rscale : [] real(64), v : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggbak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -20692,6 +20892,7 @@ Wrapped procedure of LAPACKE_cggbak for the type complex(64).
  */
 inline proc ggbak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, lscale : [] real(32), rscale : [] real(32), v : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggbak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -20700,6 +20901,7 @@ Wrapped procedure of LAPACKE_zggbak for the type complex(128).
  */
 inline proc ggbak(matrix_order : lapack_memory_order, job : string, side : string, ilo : c_int, ihi : c_int, lscale : [] real(64), rscale : [] real(64), v : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggbak(matrix_order, job.toByte() : c_char, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(1).size else v.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, (if matrix_order == lapack_memory_order.row_major then v.domain.dim(2).size else v.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int);
 }
 
@@ -20708,6 +20910,7 @@ Wrapped procedure of LAPACKE_sggbal for the type real(32).
  */
 inline proc ggbal(matrix_order : lapack_memory_order, job : string, a : [] real(32), b : [] real(32), ref ilo : c_int, ref ihi : c_int, lscale : [] real(32), rscale : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggbal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale);
 }
 
@@ -20716,6 +20919,7 @@ Wrapped procedure of LAPACKE_dggbal for the type real(64).
  */
 inline proc ggbal(matrix_order : lapack_memory_order, job : string, a : [] real(64), b : [] real(64), ref ilo : c_int, ref ihi : c_int, lscale : [] real(64), rscale : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggbal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale);
 }
 
@@ -20724,6 +20928,7 @@ Wrapped procedure of LAPACKE_cggbal for the type complex(64).
  */
 inline proc ggbal(matrix_order : lapack_memory_order, job : string, a : [] complex(64), b : [] complex(64), ref ilo : c_int, ref ihi : c_int, lscale : [] real(32), rscale : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggbal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale);
 }
 
@@ -20732,6 +20937,7 @@ Wrapped procedure of LAPACKE_zggbal for the type complex(128).
  */
 inline proc ggbal(matrix_order : lapack_memory_order, job : string, a : [] complex(128), b : [] complex(128), ref ilo : c_int, ref ihi : c_int, lscale : [] real(64), rscale : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggbal(matrix_order, job.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale);
 }
 
@@ -20740,6 +20946,7 @@ Wrapped procedure of LAPACKE_sgges for the type real(32).
  */
 inline proc gges(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_S_SELECT3, a : [] real(32), b : [] real(32), ref sdim : c_int, alphar : [] real(32), alphai : [] real(32), beta : [] real(32), vsl : [] real(32), vsr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgges(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alphar, alphai, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int);
 }
 
@@ -20748,6 +20955,7 @@ Wrapped procedure of LAPACKE_dgges for the type real(64).
  */
 inline proc gges(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_D_SELECT3, a : [] real(64), b : [] real(64), ref sdim : c_int, alphar : [] real(64), alphai : [] real(64), beta : [] real(64), vsl : [] real(64), vsr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgges(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alphar, alphai, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int);
 }
 
@@ -20756,6 +20964,7 @@ Wrapped procedure of LAPACKE_cgges for the type complex(64).
  */
 inline proc gges(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_C_SELECT2, a : [] complex(64), b : [] complex(64), ref sdim : c_int, alpha : [] complex(64), beta : [] complex(64), vsl : [] complex(64), vsr : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgges(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alpha, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int);
 }
 
@@ -20764,6 +20973,7 @@ Wrapped procedure of LAPACKE_zgges for the type complex(128).
  */
 inline proc gges(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_Z_SELECT2, a : [] complex(128), b : [] complex(128), ref sdim : c_int, alpha : [] complex(128), beta : [] complex(128), vsl : [] complex(128), vsr : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgges(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alpha, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int);
 }
 
@@ -20772,6 +20982,7 @@ Wrapped procedure of LAPACKE_sggesx for the type real(32).
  */
 inline proc ggesx(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_S_SELECT3, sense : string, a : [] real(32), b : [] real(32), ref sdim : c_int, alphar : [] real(32), alphai : [] real(32), beta : [] real(32), vsl : [] real(32), vsr : [] real(32), rconde : [] real(32), rcondv : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggesx(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alphar, alphai, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -20780,6 +20991,7 @@ Wrapped procedure of LAPACKE_dggesx for the type real(64).
  */
 inline proc ggesx(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_D_SELECT3, sense : string, a : [] real(64), b : [] real(64), ref sdim : c_int, alphar : [] real(64), alphai : [] real(64), beta : [] real(64), vsl : [] real(64), vsr : [] real(64), rconde : [] real(64), rcondv : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggesx(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alphar, alphai, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -20788,6 +21000,7 @@ Wrapped procedure of LAPACKE_cggesx for the type complex(64).
  */
 inline proc ggesx(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_C_SELECT2, sense : string, a : [] complex(64), b : [] complex(64), ref sdim : c_int, alpha : [] complex(64), beta : [] complex(64), vsl : [] complex(64), vsr : [] complex(64), rconde : [] real(32), rcondv : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggesx(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alpha, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -20796,6 +21009,7 @@ Wrapped procedure of LAPACKE_zggesx for the type complex(128).
  */
 inline proc ggesx(matrix_order : lapack_memory_order, jobvsl : string, jobvsr : string, sort : string, selctg : LAPACK_Z_SELECT2, sense : string, a : [] complex(128), b : [] complex(128), ref sdim : c_int, alpha : [] complex(128), beta : [] complex(128), vsl : [] complex(128), vsr : [] complex(128), rconde : [] real(64), rcondv : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggesx(matrix_order, jobvsl.toByte() : c_char, jobvsr.toByte() : c_char, sort.toByte() : c_char, selctg, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, sdim, alpha, beta, vsl, (vsl.domain.dim(2).size) : c_int, vsr, (vsr.domain.dim(2).size) : c_int, rconde, rcondv);
 }
 
@@ -20804,6 +21018,7 @@ Wrapped procedure of LAPACKE_sggev for the type real(32).
  */
 inline proc ggev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] real(32), b : [] real(32), alphar : [] real(32), alphai : [] real(32), beta : [] real(32), vl : [] real(32), vr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alphar, alphai, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -20812,6 +21027,7 @@ Wrapped procedure of LAPACKE_dggev for the type real(64).
  */
 inline proc ggev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] real(64), b : [] real(64), alphar : [] real(64), alphai : [] real(64), beta : [] real(64), vl : [] real(64), vr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alphar, alphai, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -20820,6 +21036,7 @@ Wrapped procedure of LAPACKE_cggev for the type complex(64).
  */
 inline proc ggev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] complex(64), b : [] complex(64), alpha : [] complex(64), beta : [] complex(64), vl : [] complex(64), vr : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -20828,6 +21045,7 @@ Wrapped procedure of LAPACKE_zggev for the type complex(128).
  */
 inline proc ggev(matrix_order : lapack_memory_order, jobvl : string, jobvr : string, a : [] complex(128), b : [] complex(128), alpha : [] complex(128), beta : [] complex(128), vl : [] complex(128), vr : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggev(matrix_order, jobvl.toByte() : c_char, jobvr.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int);
 }
 
@@ -20836,6 +21054,7 @@ Wrapped procedure of LAPACKE_sggevx for the type real(32).
  */
 inline proc ggevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] real(32), b : [] real(32), alphar : [] real(32), alphai : [] real(32), beta : [] real(32), vl : [] real(32), vr : [] real(32), ref ilo : c_int, ref ihi : c_int, lscale : [] real(32), rscale : [] real(32), ref abnrm : real(32), ref bbnrm : real(32), rconde : [] real(32), rcondv : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alphar, alphai, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, abnrm, bbnrm, rconde, rcondv);
 }
 
@@ -20844,6 +21063,7 @@ Wrapped procedure of LAPACKE_dggevx for the type real(64).
  */
 inline proc ggevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] real(64), b : [] real(64), alphar : [] real(64), alphai : [] real(64), beta : [] real(64), vl : [] real(64), vr : [] real(64), ref ilo : c_int, ref ihi : c_int, lscale : [] real(64), rscale : [] real(64), ref abnrm : real(64), ref bbnrm : real(64), rconde : [] real(64), rcondv : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alphar, alphai, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, abnrm, bbnrm, rconde, rcondv);
 }
 
@@ -20852,6 +21072,7 @@ Wrapped procedure of LAPACKE_cggevx for the type complex(64).
  */
 inline proc ggevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] complex(64), b : [] complex(64), alpha : [] complex(64), beta : [] complex(64), vl : [] complex(64), vr : [] complex(64), ref ilo : c_int, ref ihi : c_int, lscale : [] real(32), rscale : [] real(32), ref abnrm : real(32), ref bbnrm : real(32), rconde : [] real(32), rcondv : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, abnrm, bbnrm, rconde, rcondv);
 }
 
@@ -20860,6 +21081,7 @@ Wrapped procedure of LAPACKE_zggevx for the type complex(128).
  */
 inline proc ggevx(matrix_order : lapack_memory_order, balanc : string, jobvl : string, jobvr : string, sense : string, a : [] complex(128), b : [] complex(128), alpha : [] complex(128), beta : [] complex(128), vl : [] complex(128), vr : [] complex(128), ref ilo : c_int, ref ihi : c_int, lscale : [] real(64), rscale : [] real(64), ref abnrm : real(64), ref bbnrm : real(64), rconde : [] real(64), rcondv : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggevx(matrix_order, balanc.toByte() : c_char, jobvl.toByte() : c_char, jobvr.toByte() : c_char, sense.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, ilo, ihi, lscale, rscale, abnrm, bbnrm, rconde, rcondv);
 }
 
@@ -20868,6 +21090,7 @@ Wrapped procedure of LAPACKE_sggglm for the type real(32).
  */
 inline proc ggglm(matrix_order : lapack_memory_order, a : [] real(32), b : [] real(32), d : [] real(32), x : [] real(32), y : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggglm(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, d, x, y);
 }
 
@@ -20876,6 +21099,7 @@ Wrapped procedure of LAPACKE_dggglm for the type real(64).
  */
 inline proc ggglm(matrix_order : lapack_memory_order, a : [] real(64), b : [] real(64), d : [] real(64), x : [] real(64), y : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggglm(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, d, x, y);
 }
 
@@ -20884,6 +21108,7 @@ Wrapped procedure of LAPACKE_cggglm for the type complex(64).
  */
 inline proc ggglm(matrix_order : lapack_memory_order, a : [] complex(64), b : [] complex(64), d : [] complex(64), x : [] complex(64), y : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggglm(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, d, x, y);
 }
 
@@ -20892,6 +21117,7 @@ Wrapped procedure of LAPACKE_zggglm for the type complex(128).
  */
 inline proc ggglm(matrix_order : lapack_memory_order, a : [] complex(128), b : [] complex(128), d : [] complex(128), x : [] complex(128), y : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggglm(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, d, x, y);
 }
 
@@ -20900,6 +21126,7 @@ Wrapped procedure of LAPACKE_sgghrd for the type real(32).
  */
 inline proc gghrd(matrix_order : lapack_memory_order, compq : string, compz : string, ilo : c_int, ihi : c_int, a : [] real(32), b : [] real(32), q : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgghrd(matrix_order, compq.toByte() : c_char, compz.toByte() : c_char, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -20908,6 +21135,7 @@ Wrapped procedure of LAPACKE_dgghrd for the type real(64).
  */
 inline proc gghrd(matrix_order : lapack_memory_order, compq : string, compz : string, ilo : c_int, ihi : c_int, a : [] real(64), b : [] real(64), q : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgghrd(matrix_order, compq.toByte() : c_char, compz.toByte() : c_char, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -20916,6 +21144,7 @@ Wrapped procedure of LAPACKE_cgghrd for the type complex(64).
  */
 inline proc gghrd(matrix_order : lapack_memory_order, compq : string, compz : string, ilo : c_int, ihi : c_int, a : [] complex(64), b : [] complex(64), q : [] complex(64), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgghrd(matrix_order, compq.toByte() : c_char, compz.toByte() : c_char, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -20924,6 +21153,7 @@ Wrapped procedure of LAPACKE_zgghrd for the type complex(128).
  */
 inline proc gghrd(matrix_order : lapack_memory_order, compq : string, compz : string, ilo : c_int, ihi : c_int, a : [] complex(128), b : [] complex(128), q : [] complex(128), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgghrd(matrix_order, compq.toByte() : c_char, compz.toByte() : c_char, (a.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -20932,6 +21162,7 @@ Wrapped procedure of LAPACKE_sgglse for the type real(32).
  */
 inline proc gglse(matrix_order : lapack_memory_order, a : [] real(32), b : [] real(32), c : [] real(32), d : [] real(32), x : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgglse(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, d, x);
 }
 
@@ -20940,6 +21171,7 @@ Wrapped procedure of LAPACKE_dgglse for the type real(64).
  */
 inline proc gglse(matrix_order : lapack_memory_order, a : [] real(64), b : [] real(64), c : [] real(64), d : [] real(64), x : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgglse(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, d, x);
 }
 
@@ -20948,6 +21180,7 @@ Wrapped procedure of LAPACKE_cgglse for the type complex(64).
  */
 inline proc gglse(matrix_order : lapack_memory_order, a : [] complex(64), b : [] complex(64), c : [] complex(64), d : [] complex(64), x : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgglse(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, d, x);
 }
 
@@ -20956,6 +21189,7 @@ Wrapped procedure of LAPACKE_zgglse for the type complex(128).
  */
 inline proc gglse(matrix_order : lapack_memory_order, a : [] complex(128), b : [] complex(128), c : [] complex(128), d : [] complex(128), x : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgglse(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, d, x);
 }
 
@@ -20964,6 +21198,7 @@ Wrapped procedure of LAPACKE_sggqrf for the type real(32).
  */
 inline proc ggqrf(matrix_order : lapack_memory_order, a : [] real(32), taua : [] real(32), b : [] real(32), taub : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -20972,6 +21207,7 @@ Wrapped procedure of LAPACKE_dggqrf for the type real(64).
  */
 inline proc ggqrf(matrix_order : lapack_memory_order, a : [] real(64), taua : [] real(64), b : [] real(64), taub : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -20980,6 +21216,7 @@ Wrapped procedure of LAPACKE_cggqrf for the type complex(64).
  */
 inline proc ggqrf(matrix_order : lapack_memory_order, a : [] complex(64), taua : [] complex(64), b : [] complex(64), taub : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -20988,6 +21225,7 @@ Wrapped procedure of LAPACKE_zggqrf for the type complex(128).
  */
 inline proc ggqrf(matrix_order : lapack_memory_order, a : [] complex(128), taua : [] complex(128), b : [] complex(128), taub : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggqrf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -20996,6 +21234,7 @@ Wrapped procedure of LAPACKE_sggrqf for the type real(32).
  */
 inline proc ggrqf(matrix_order : lapack_memory_order, a : [] real(32), taua : [] real(32), b : [] real(32), taub : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggrqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -21004,6 +21243,7 @@ Wrapped procedure of LAPACKE_dggrqf for the type real(64).
  */
 inline proc ggrqf(matrix_order : lapack_memory_order, a : [] real(64), taua : [] real(64), b : [] real(64), taub : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggrqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -21012,6 +21252,7 @@ Wrapped procedure of LAPACKE_cggrqf for the type complex(64).
  */
 inline proc ggrqf(matrix_order : lapack_memory_order, a : [] complex(64), taua : [] complex(64), b : [] complex(64), taub : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggrqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -21020,6 +21261,7 @@ Wrapped procedure of LAPACKE_zggrqf for the type complex(128).
  */
 inline proc ggrqf(matrix_order : lapack_memory_order, a : [] complex(128), taua : [] complex(128), b : [] complex(128), taub : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggrqf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, taua, b, (b.domain.dim(2).size) : c_int, taub);
 }
 
@@ -21028,6 +21270,7 @@ Wrapped procedure of LAPACKE_sggsvd for the type real(32).
  */
 inline proc ggsvd(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, ref k : c_int, ref l : c_int, a : [] real(32), b : [] real(32), alpha : [] real(32), beta : [] real(32), u : [] real(32), v : [] real(32), q : [] real(32), iwork : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggsvd(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, iwork);
 }
 
@@ -21036,6 +21279,7 @@ Wrapped procedure of LAPACKE_dggsvd for the type real(64).
  */
 inline proc ggsvd(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, ref k : c_int, ref l : c_int, a : [] real(64), b : [] real(64), alpha : [] real(64), beta : [] real(64), u : [] real(64), v : [] real(64), q : [] real(64), iwork : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggsvd(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, iwork);
 }
 
@@ -21044,6 +21288,7 @@ Wrapped procedure of LAPACKE_cggsvd for the type complex(64).
  */
 inline proc ggsvd(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, ref k : c_int, ref l : c_int, a : [] complex(64), b : [] complex(64), alpha : [] real(32), beta : [] real(32), u : [] complex(64), v : [] complex(64), q : [] complex(64), iwork : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggsvd(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, iwork);
 }
 
@@ -21052,6 +21297,7 @@ Wrapped procedure of LAPACKE_zggsvd for the type complex(128).
  */
 inline proc ggsvd(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, ref k : c_int, ref l : c_int, a : [] complex(128), b : [] complex(128), alpha : [] real(64), beta : [] real(64), u : [] complex(128), v : [] complex(128), q : [] complex(128), iwork : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggsvd(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, iwork);
 }
 
@@ -21060,6 +21306,7 @@ Wrapped procedure of LAPACKE_sggsvp for the type real(32).
  */
 inline proc ggsvp(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, a : [] real(32), b : [] real(32), tola : real(32), tolb : real(32), ref k : c_int, ref l : c_int, u : [] real(32), v : [] real(32), q : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sggsvp(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, k, l, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -21068,6 +21315,7 @@ Wrapped procedure of LAPACKE_dggsvp for the type real(64).
  */
 inline proc ggsvp(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, a : [] real(64), b : [] real(64), tola : real(64), tolb : real(64), ref k : c_int, ref l : c_int, u : [] real(64), v : [] real(64), q : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dggsvp(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, k, l, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -21076,6 +21324,7 @@ Wrapped procedure of LAPACKE_cggsvp for the type complex(64).
  */
 inline proc ggsvp(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, a : [] complex(64), b : [] complex(64), tola : real(32), tolb : real(32), ref k : c_int, ref l : c_int, u : [] complex(64), v : [] complex(64), q : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cggsvp(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, k, l, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -21084,6 +21333,7 @@ Wrapped procedure of LAPACKE_zggsvp for the type complex(128).
  */
 inline proc ggsvp(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, a : [] complex(128), b : [] complex(128), tola : real(64), tolb : real(64), ref k : c_int, ref l : c_int, u : [] complex(128), v : [] complex(128), q : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zggsvp(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, k, l, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -21092,6 +21342,7 @@ Wrapped procedure of LAPACKE_sgtcon for the type real(32).
  */
 inline proc gtcon(norm : string, n : c_int, dl : [] real(32), d : [] real(32), du : [] real(32), du2 : [] real(32), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgtcon(norm.toByte() : c_char, n, dl, d, du, du2, ipiv, anorm, rcond);
 }
 
@@ -21100,6 +21351,7 @@ Wrapped procedure of LAPACKE_dgtcon for the type real(64).
  */
 inline proc gtcon(norm : string, n : c_int, dl : [] real(64), d : [] real(64), du : [] real(64), du2 : [] real(64), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgtcon(norm.toByte() : c_char, n, dl, d, du, du2, ipiv, anorm, rcond);
 }
 
@@ -21108,6 +21360,7 @@ Wrapped procedure of LAPACKE_cgtcon for the type complex(64).
  */
 inline proc gtcon(norm : string, n : c_int, dl : [] complex(64), d : [] complex(64), du : [] complex(64), du2 : [] complex(64), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgtcon(norm.toByte() : c_char, n, dl, d, du, du2, ipiv, anorm, rcond);
 }
 
@@ -21116,6 +21369,7 @@ Wrapped procedure of LAPACKE_zgtcon for the type complex(128).
  */
 inline proc gtcon(norm : string, n : c_int, dl : [] complex(128), d : [] complex(128), du : [] complex(128), du2 : [] complex(128), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgtcon(norm.toByte() : c_char, n, dl, d, du, du2, ipiv, anorm, rcond);
 }
 
@@ -21124,6 +21378,7 @@ Wrapped procedure of LAPACKE_sgtrfs for the type real(32).
  */
 inline proc gtrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] real(32), d : [] real(32), du : [] real(32), dlf : [] real(32), df : [] real(32), duf : [] real(32), du2 : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgtrfs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21132,6 +21387,7 @@ Wrapped procedure of LAPACKE_dgtrfs for the type real(64).
  */
 inline proc gtrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] real(64), d : [] real(64), du : [] real(64), dlf : [] real(64), df : [] real(64), duf : [] real(64), du2 : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgtrfs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21140,6 +21396,7 @@ Wrapped procedure of LAPACKE_cgtrfs for the type complex(64).
  */
 inline proc gtrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] complex(64), d : [] complex(64), du : [] complex(64), dlf : [] complex(64), df : [] complex(64), duf : [] complex(64), du2 : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgtrfs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21148,6 +21405,7 @@ Wrapped procedure of LAPACKE_zgtrfs for the type complex(128).
  */
 inline proc gtrfs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] complex(128), d : [] complex(128), du : [] complex(128), dlf : [] complex(128), df : [] complex(128), duf : [] complex(128), du2 : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgtrfs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21156,6 +21414,7 @@ Wrapped procedure of LAPACKE_sgtsv for the type real(32).
  */
 inline proc gtsv(matrix_order : lapack_memory_order, dl : [] real(32), d : [] real(32), du : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgtsv(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21164,6 +21423,7 @@ Wrapped procedure of LAPACKE_dgtsv for the type real(64).
  */
 inline proc gtsv(matrix_order : lapack_memory_order, dl : [] real(64), d : [] real(64), du : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgtsv(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21172,6 +21432,7 @@ Wrapped procedure of LAPACKE_cgtsv for the type complex(64).
  */
 inline proc gtsv(matrix_order : lapack_memory_order, n : c_int, dl : [] complex(64), d : [] complex(64), du : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgtsv(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21180,6 +21441,7 @@ Wrapped procedure of LAPACKE_zgtsv for the type complex(128).
  */
 inline proc gtsv(matrix_order : lapack_memory_order, n : c_int, dl : [] complex(128), d : [] complex(128), du : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgtsv(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21188,6 +21450,7 @@ Wrapped procedure of LAPACKE_sgtsvx for the type real(32).
  */
 inline proc gtsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, dl : [] real(32), d : [] real(32), du : [] real(32), dlf : [] real(32), df : [] real(32), duf : [] real(32), du2 : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgtsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21196,6 +21459,7 @@ Wrapped procedure of LAPACKE_dgtsvx for the type real(64).
  */
 inline proc gtsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, dl : [] real(64), d : [] real(64), du : [] real(64), dlf : [] real(64), df : [] real(64), duf : [] real(64), du2 : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgtsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21204,6 +21468,7 @@ Wrapped procedure of LAPACKE_cgtsvx for the type complex(64).
  */
 inline proc gtsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, dl : [] complex(64), d : [] complex(64), du : [] complex(64), dlf : [] complex(64), df : [] complex(64), duf : [] complex(64), du2 : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgtsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21212,6 +21477,7 @@ Wrapped procedure of LAPACKE_zgtsvx for the type complex(128).
  */
 inline proc gtsvx(matrix_order : lapack_memory_order, fact : string, trans : string, n : c_int, dl : [] complex(128), d : [] complex(128), du : [] complex(128), dlf : [] complex(128), df : [] complex(128), duf : [] complex(128), du2 : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgtsvx(matrix_order, fact.toByte() : c_char, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, dlf, df, duf, du2, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21220,6 +21486,7 @@ Wrapped procedure of LAPACKE_sgttrf for the type real(32).
  */
 inline proc gttrf(n : c_int, dl : [] real(32), d : [] real(32), du : [] real(32), du2 : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgttrf(n, dl, d, du, du2, ipiv);
 }
 
@@ -21228,6 +21495,7 @@ Wrapped procedure of LAPACKE_dgttrf for the type real(64).
  */
 inline proc gttrf(n : c_int, dl : [] real(64), d : [] real(64), du : [] real(64), du2 : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgttrf(n, dl, d, du, du2, ipiv);
 }
 
@@ -21236,6 +21504,7 @@ Wrapped procedure of LAPACKE_cgttrf for the type complex(64).
  */
 inline proc gttrf(n : c_int, dl : [] complex(64), d : [] complex(64), du : [] complex(64), du2 : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgttrf(n, dl, d, du, du2, ipiv);
 }
 
@@ -21244,6 +21513,7 @@ Wrapped procedure of LAPACKE_zgttrf for the type complex(128).
  */
 inline proc gttrf(n : c_int, dl : [] complex(128), d : [] complex(128), du : [] complex(128), du2 : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgttrf(n, dl, d, du, du2, ipiv);
 }
 
@@ -21252,6 +21522,7 @@ Wrapped procedure of LAPACKE_sgttrs for the type real(32).
  */
 inline proc gttrs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] real(32), d : [] real(32), du : [] real(32), du2 : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgttrs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, du2, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21260,6 +21531,7 @@ Wrapped procedure of LAPACKE_dgttrs for the type real(64).
  */
 inline proc gttrs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] real(64), d : [] real(64), du : [] real(64), du2 : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgttrs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, du2, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21268,6 +21540,7 @@ Wrapped procedure of LAPACKE_cgttrs for the type complex(64).
  */
 inline proc gttrs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] complex(64), d : [] complex(64), du : [] complex(64), du2 : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgttrs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, du2, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21276,6 +21549,7 @@ Wrapped procedure of LAPACKE_zgttrs for the type complex(128).
  */
 inline proc gttrs(matrix_order : lapack_memory_order, trans : string, n : c_int, dl : [] complex(128), d : [] complex(128), du : [] complex(128), du2 : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgttrs(matrix_order, trans.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, dl, d, du, du2, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21284,6 +21558,7 @@ Wrapped procedure of LAPACKE_chbev for the type complex(64).
  */
 inline proc hbev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21292,6 +21567,7 @@ Wrapped procedure of LAPACKE_zhbev for the type complex(128).
  */
 inline proc hbev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21300,6 +21576,7 @@ Wrapped procedure of LAPACKE_chbevd for the type complex(64).
  */
 inline proc hbevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21308,6 +21585,7 @@ Wrapped procedure of LAPACKE_zhbevd for the type complex(128).
  */
 inline proc hbevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21316,6 +21594,7 @@ Wrapped procedure of LAPACKE_chbevx for the type complex(64).
  */
 inline proc hbevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), q : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21324,6 +21603,7 @@ Wrapped procedure of LAPACKE_zhbevx for the type complex(128).
  */
 inline proc hbevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), q : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21332,6 +21612,7 @@ Wrapped procedure of LAPACKE_chbgst for the type complex(64).
  */
 inline proc hbgst(matrix_order : lapack_memory_order, vect : string, uplo : string, ka : c_int, kb : c_int, ab : [] complex(64), bb : [] complex(64), x : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbgst(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int);
 }
 
@@ -21340,6 +21621,7 @@ Wrapped procedure of LAPACKE_zhbgst for the type complex(128).
  */
 inline proc hbgst(matrix_order : lapack_memory_order, vect : string, uplo : string, ka : c_int, kb : c_int, ab : [] complex(128), bb : [] complex(128), x : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbgst(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int);
 }
 
@@ -21348,6 +21630,7 @@ Wrapped procedure of LAPACKE_chbgv for the type complex(64).
  */
 inline proc hbgv(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] complex(64), bb : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbgv(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21356,6 +21639,7 @@ Wrapped procedure of LAPACKE_zhbgv for the type complex(128).
  */
 inline proc hbgv(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] complex(128), bb : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbgv(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21364,6 +21648,7 @@ Wrapped procedure of LAPACKE_chbgvd for the type complex(64).
  */
 inline proc hbgvd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] complex(64), bb : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbgvd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21372,6 +21657,7 @@ Wrapped procedure of LAPACKE_zhbgvd for the type complex(128).
  */
 inline proc hbgvd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] complex(128), bb : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbgvd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21380,6 +21666,7 @@ Wrapped procedure of LAPACKE_chbgvx for the type complex(64).
  */
 inline proc hbgvx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, ka : c_int, kb : c_int, ab : [] complex(64), bb : [] complex(64), q : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbgvx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then q.domain.dim(2).size else q.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21388,6 +21675,7 @@ Wrapped procedure of LAPACKE_zhbgvx for the type complex(128).
  */
 inline proc hbgvx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, ka : c_int, kb : c_int, ab : [] complex(128), bb : [] complex(128), q : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbgvx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then q.domain.dim(2).size else q.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21396,6 +21684,7 @@ Wrapped procedure of LAPACKE_chbtrd for the type complex(64).
  */
 inline proc hbtrd(matrix_order : lapack_memory_order, vect : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), d : [] real(32), e : [] real(32), q : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chbtrd(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -21404,6 +21693,7 @@ Wrapped procedure of LAPACKE_zhbtrd for the type complex(128).
  */
 inline proc hbtrd(matrix_order : lapack_memory_order, vect : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), d : [] real(64), e : [] real(64), q : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhbtrd(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -21412,6 +21702,7 @@ Wrapped procedure of LAPACKE_checon for the type complex(64).
  */
 inline proc hecon(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_checon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -21420,6 +21711,7 @@ Wrapped procedure of LAPACKE_zhecon for the type complex(128).
  */
 inline proc hecon(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhecon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -21428,6 +21720,7 @@ Wrapped procedure of LAPACKE_cheequb for the type complex(64).
  */
 inline proc heequb(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cheequb(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -21436,6 +21729,7 @@ Wrapped procedure of LAPACKE_zheequb for the type complex(128).
  */
 inline proc heequb(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zheequb(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -21444,6 +21738,7 @@ Wrapped procedure of LAPACKE_cheev for the type complex(64).
  */
 inline proc heev(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] complex(64), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cheev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -21452,6 +21747,7 @@ Wrapped procedure of LAPACKE_zheev for the type complex(128).
  */
 inline proc heev(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] complex(128), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zheev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -21460,6 +21756,7 @@ Wrapped procedure of LAPACKE_cheevd for the type complex(64).
  */
 inline proc heevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] complex(64), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cheevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -21468,6 +21765,7 @@ Wrapped procedure of LAPACKE_zheevd for the type complex(128).
  */
 inline proc heevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] complex(128), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zheevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -21476,6 +21774,7 @@ Wrapped procedure of LAPACKE_cheevr for the type complex(64).
  */
 inline proc heevr(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cheevr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -21484,6 +21783,7 @@ Wrapped procedure of LAPACKE_zheevr for the type complex(128).
  */
 inline proc heevr(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zheevr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -21492,6 +21792,7 @@ Wrapped procedure of LAPACKE_cheevx for the type complex(64).
  */
 inline proc heevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cheevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21500,6 +21801,7 @@ Wrapped procedure of LAPACKE_zheevx for the type complex(128).
  */
 inline proc heevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zheevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21508,6 +21810,7 @@ Wrapped procedure of LAPACKE_chegst for the type complex(64).
  */
 inline proc hegst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chegst(matrix_order, itype, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21516,6 +21819,7 @@ Wrapped procedure of LAPACKE_zhegst for the type complex(128).
  */
 inline proc hegst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhegst(matrix_order, itype, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21524,6 +21828,7 @@ Wrapped procedure of LAPACKE_chegv for the type complex(64).
  */
 inline proc hegv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] complex(64), b : [] complex(64), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chegv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -21532,6 +21837,7 @@ Wrapped procedure of LAPACKE_zhegv for the type complex(128).
  */
 inline proc hegv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] complex(128), b : [] complex(128), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhegv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -21540,6 +21846,7 @@ Wrapped procedure of LAPACKE_chegvd for the type complex(64).
  */
 inline proc hegvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] complex(64), b : [] complex(64), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chegvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -21548,6 +21855,7 @@ Wrapped procedure of LAPACKE_zhegvd for the type complex(128).
  */
 inline proc hegvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] complex(128), b : [] complex(128), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhegvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -21556,6 +21864,7 @@ Wrapped procedure of LAPACKE_chegvx for the type complex(64).
  */
 inline proc hegvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, a : [] complex(64), b : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chegvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21564,6 +21873,7 @@ Wrapped procedure of LAPACKE_zhegvx for the type complex(128).
  */
 inline proc hegvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, a : [] complex(128), b : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhegvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21572,6 +21882,7 @@ Wrapped procedure of LAPACKE_cherfs for the type complex(64).
  */
 inline proc herfs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cherfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21580,6 +21891,7 @@ Wrapped procedure of LAPACKE_zherfs for the type complex(128).
  */
 inline proc herfs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zherfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21588,6 +21900,7 @@ Wrapped procedure of LAPACKE_cherfsx for the type complex(64).
  */
 inline proc herfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cherfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -21596,6 +21909,7 @@ Wrapped procedure of LAPACKE_zherfsx for the type complex(128).
  */
 inline proc herfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zherfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -21604,6 +21918,7 @@ Wrapped procedure of LAPACKE_chesv for the type complex(64).
  */
 inline proc hesv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chesv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21612,6 +21927,7 @@ Wrapped procedure of LAPACKE_zhesv for the type complex(128).
  */
 inline proc hesv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhesv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21620,6 +21936,7 @@ Wrapped procedure of LAPACKE_chesvx for the type complex(64).
  */
 inline proc hesvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chesvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21628,6 +21945,7 @@ Wrapped procedure of LAPACKE_zhesvx for the type complex(128).
  */
 inline proc hesvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhesvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21636,6 +21954,7 @@ Wrapped procedure of LAPACKE_chesvxx for the type complex(64).
  */
 inline proc hesvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, ref equed : string, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chesvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -21644,6 +21963,7 @@ Wrapped procedure of LAPACKE_zhesvxx for the type complex(128).
  */
 inline proc hesvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, ref equed : string, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhesvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -21652,6 +21972,7 @@ Wrapped procedure of LAPACKE_chetrd for the type complex(64).
  */
 inline proc hetrd(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), d : [] real(32), e : [] real(32), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetrd(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tau);
 }
 
@@ -21660,6 +21981,7 @@ Wrapped procedure of LAPACKE_zhetrd for the type complex(128).
  */
 inline proc hetrd(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), d : [] real(64), e : [] real(64), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetrd(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tau);
 }
 
@@ -21668,6 +21990,7 @@ Wrapped procedure of LAPACKE_chetrf for the type complex(64).
  */
 inline proc hetrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -21676,6 +21999,7 @@ Wrapped procedure of LAPACKE_zhetrf for the type complex(128).
  */
 inline proc hetrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -21684,6 +22008,7 @@ Wrapped procedure of LAPACKE_chetri for the type complex(64).
  */
 inline proc hetri(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -21692,6 +22017,7 @@ Wrapped procedure of LAPACKE_zhetri for the type complex(128).
  */
 inline proc hetri(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -21700,6 +22026,7 @@ Wrapped procedure of LAPACKE_chetrs for the type complex(64).
  */
 inline proc hetrs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21708,6 +22035,7 @@ Wrapped procedure of LAPACKE_zhetrs for the type complex(128).
  */
 inline proc hetrs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21716,6 +22044,7 @@ Wrapped procedure of LAPACKE_chfrk for the type complex(64).
  */
 inline proc hfrk(matrix_order : lapack_memory_order, transr : string, uplo : string, trans : string, alpha : real(32), a : [] complex(64), beta : real(32), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chfrk(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (c.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, a, (a.domain.dim(2).size) : c_int, beta, c);
 }
 
@@ -21724,6 +22053,7 @@ Wrapped procedure of LAPACKE_zhfrk for the type complex(128).
  */
 inline proc hfrk(matrix_order : lapack_memory_order, transr : string, uplo : string, trans : string, alpha : real(64), a : [] complex(128), beta : real(64), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhfrk(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (c.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, a, (a.domain.dim(2).size) : c_int, beta, c);
 }
 
@@ -21732,6 +22062,7 @@ Wrapped procedure of LAPACKE_shgeqz for the type real(32).
  */
 inline proc hgeqz(matrix_order : lapack_memory_order, job : string, compq : string, compz : string, ilo : c_int, ihi : c_int, h : [] real(32), t : [] real(32), alphar : [] real(32), alphai : [] real(32), beta : [] real(32), q : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_shgeqz(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, alphar, alphai, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21740,6 +22071,7 @@ Wrapped procedure of LAPACKE_dhgeqz for the type real(64).
  */
 inline proc hgeqz(matrix_order : lapack_memory_order, job : string, compq : string, compz : string, ilo : c_int, ihi : c_int, h : [] real(64), t : [] real(64), alphar : [] real(64), alphai : [] real(64), beta : [] real(64), q : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dhgeqz(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, alphar, alphai, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21748,6 +22080,7 @@ Wrapped procedure of LAPACKE_chgeqz for the type complex(64).
  */
 inline proc hgeqz(matrix_order : lapack_memory_order, job : string, compq : string, compz : string, ilo : c_int, ihi : c_int, h : [] complex(64), t : [] complex(64), alpha : [] complex(64), beta : [] complex(64), q : [] complex(64), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chgeqz(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, alpha, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21756,6 +22089,7 @@ Wrapped procedure of LAPACKE_zhgeqz for the type complex(128).
  */
 inline proc hgeqz(matrix_order : lapack_memory_order, job : string, compq : string, compz : string, ilo : c_int, ihi : c_int, h : [] complex(128), t : [] complex(128), alpha : [] complex(128), beta : [] complex(128), q : [] complex(128), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhgeqz(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, alpha, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21764,6 +22098,7 @@ Wrapped procedure of LAPACKE_chpcon for the type complex(64).
  */
 inline proc hpcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpcon(matrix_order, uplo.toByte() : c_char, n, ap, ipiv, anorm, rcond);
 }
 
@@ -21772,6 +22107,7 @@ Wrapped procedure of LAPACKE_zhpcon for the type complex(128).
  */
 inline proc hpcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpcon(matrix_order, uplo.toByte() : c_char, n, ap, ipiv, anorm, rcond);
 }
 
@@ -21780,6 +22116,7 @@ Wrapped procedure of LAPACKE_chpev for the type complex(64).
  */
 inline proc hpev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21788,6 +22125,7 @@ Wrapped procedure of LAPACKE_zhpev for the type complex(128).
  */
 inline proc hpev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21796,6 +22134,7 @@ Wrapped procedure of LAPACKE_chpevd for the type complex(64).
  */
 inline proc hpevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21804,6 +22143,7 @@ Wrapped procedure of LAPACKE_zhpevd for the type complex(128).
  */
 inline proc hpevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21812,6 +22152,7 @@ Wrapped procedure of LAPACKE_chpevx for the type complex(64).
  */
 inline proc hpevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, ap : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21820,6 +22161,7 @@ Wrapped procedure of LAPACKE_zhpevx for the type complex(128).
  */
 inline proc hpevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, ap : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21828,6 +22170,7 @@ Wrapped procedure of LAPACKE_chpgst for the type complex(64).
  */
 inline proc hpgst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, n : c_int, ap : [] complex(64), bp : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpgst(matrix_order, itype, uplo.toByte() : c_char, n, ap, bp);
 }
 
@@ -21836,6 +22179,7 @@ Wrapped procedure of LAPACKE_zhpgst for the type complex(128).
  */
 inline proc hpgst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, n : c_int, ap : [] complex(128), bp : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpgst(matrix_order, itype, uplo.toByte() : c_char, n, ap, bp);
 }
 
@@ -21844,6 +22188,7 @@ Wrapped procedure of LAPACKE_chpgv for the type complex(64).
  */
 inline proc hpgv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] complex(64), bp : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpgv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21852,6 +22197,7 @@ Wrapped procedure of LAPACKE_zhpgv for the type complex(128).
  */
 inline proc hpgv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] complex(128), bp : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpgv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21860,6 +22206,7 @@ Wrapped procedure of LAPACKE_chpgvd for the type complex(64).
  */
 inline proc hpgvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] complex(64), bp : [] complex(64), w : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpgvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21868,6 +22215,7 @@ Wrapped procedure of LAPACKE_zhpgvd for the type complex(128).
  */
 inline proc hpgvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] complex(128), bp : [] complex(128), w : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpgvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -21876,6 +22224,7 @@ Wrapped procedure of LAPACKE_chpgvx for the type complex(64).
  */
 inline proc hpgvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, n : c_int, ap : [] complex(64), bp : [] complex(64), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpgvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21884,6 +22233,7 @@ Wrapped procedure of LAPACKE_zhpgvx for the type complex(128).
  */
 inline proc hpgvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, n : c_int, ap : [] complex(128), bp : [] complex(128), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpgvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -21892,6 +22242,7 @@ Wrapped procedure of LAPACKE_chprfs for the type complex(64).
  */
 inline proc hprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), afp : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21900,6 +22251,7 @@ Wrapped procedure of LAPACKE_zhprfs for the type complex(128).
  */
 inline proc hprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), afp : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -21908,6 +22260,7 @@ Wrapped procedure of LAPACKE_chpsv for the type complex(64).
  */
 inline proc hpsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21916,6 +22269,7 @@ Wrapped procedure of LAPACKE_zhpsv for the type complex(128).
  */
 inline proc hpsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21924,6 +22278,7 @@ Wrapped procedure of LAPACKE_chpsvx for the type complex(64).
  */
 inline proc hpsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] complex(64), afp : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chpsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21932,6 +22287,7 @@ Wrapped procedure of LAPACKE_zhpsvx for the type complex(128).
  */
 inline proc hpsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] complex(128), afp : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhpsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -21940,6 +22296,7 @@ Wrapped procedure of LAPACKE_chptrd for the type complex(64).
  */
 inline proc hptrd(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), d : [] real(32), e : [] real(32), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chptrd(matrix_order, uplo.toByte() : c_char, n, ap, d, e, tau);
 }
 
@@ -21948,6 +22305,7 @@ Wrapped procedure of LAPACKE_zhptrd for the type complex(128).
  */
 inline proc hptrd(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), d : [] real(64), e : [] real(64), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhptrd(matrix_order, uplo.toByte() : c_char, n, ap, d, e, tau);
 }
 
@@ -21956,6 +22314,7 @@ Wrapped procedure of LAPACKE_chptrf for the type complex(64).
  */
 inline proc hptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chptrf(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -21964,6 +22323,7 @@ Wrapped procedure of LAPACKE_zhptrf for the type complex(128).
  */
 inline proc hptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhptrf(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -21972,6 +22332,7 @@ Wrapped procedure of LAPACKE_chptri for the type complex(64).
  */
 inline proc hptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chptri(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -21980,6 +22341,7 @@ Wrapped procedure of LAPACKE_zhptri for the type complex(128).
  */
 inline proc hptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhptri(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -21988,6 +22350,7 @@ Wrapped procedure of LAPACKE_chptrs for the type complex(64).
  */
 inline proc hptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -21996,6 +22359,7 @@ Wrapped procedure of LAPACKE_zhptrs for the type complex(128).
  */
 inline proc hptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22004,6 +22368,7 @@ Wrapped procedure of LAPACKE_shsein for the type real(32).
  */
 inline proc hsein(matrix_order : lapack_memory_order, job : string, eigsrc : string, initv : string, chlapack_select : [] c_int, h : [] real(32), wr : [] real(32), wi : [] real(32), vl : [] real(32), vr : [] real(32), mm : c_int, ref m : c_int, ifaill : [] c_int, ifailr : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_shsein(matrix_order, job.toByte() : c_char, eigsrc.toByte() : c_char, initv.toByte() : c_char, chlapack_select, (h.domain.dim(1).size) : c_int, h, (h.domain.dim(2).size) : c_int, wr, wi, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m, ifaill, ifailr);
 }
 
@@ -22012,6 +22377,7 @@ Wrapped procedure of LAPACKE_dhsein for the type real(64).
  */
 inline proc hsein(matrix_order : lapack_memory_order, job : string, eigsrc : string, initv : string, chlapack_select : [] c_int, h : [] real(64), wr : [] real(64), wi : [] real(64), vl : [] real(64), vr : [] real(64), mm : c_int, ref m : c_int, ifaill : [] c_int, ifailr : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dhsein(matrix_order, job.toByte() : c_char, eigsrc.toByte() : c_char, initv.toByte() : c_char, chlapack_select, (h.domain.dim(1).size) : c_int, h, (h.domain.dim(2).size) : c_int, wr, wi, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m, ifaill, ifailr);
 }
 
@@ -22020,6 +22386,7 @@ Wrapped procedure of LAPACKE_chsein for the type complex(64).
  */
 inline proc hsein(matrix_order : lapack_memory_order, job : string, eigsrc : string, initv : string, chlapack_select : [] c_int, h : [] complex(64), w : [] complex(64), vl : [] complex(64), vr : [] complex(64), mm : c_int, ref m : c_int, ifaill : [] c_int, ifailr : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chsein(matrix_order, job.toByte() : c_char, eigsrc.toByte() : c_char, initv.toByte() : c_char, chlapack_select, (h.domain.dim(1).size) : c_int, h, (h.domain.dim(2).size) : c_int, w, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m, ifaill, ifailr);
 }
 
@@ -22028,6 +22395,7 @@ Wrapped procedure of LAPACKE_zhsein for the type complex(128).
  */
 inline proc hsein(matrix_order : lapack_memory_order, job : string, eigsrc : string, initv : string, chlapack_select : [] c_int, h : [] complex(128), w : [] complex(128), vl : [] complex(128), vr : [] complex(128), mm : c_int, ref m : c_int, ifaill : [] c_int, ifailr : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhsein(matrix_order, job.toByte() : c_char, eigsrc.toByte() : c_char, initv.toByte() : c_char, chlapack_select, (h.domain.dim(1).size) : c_int, h, (h.domain.dim(2).size) : c_int, w, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m, ifaill, ifailr);
 }
 
@@ -22036,6 +22404,7 @@ Wrapped procedure of LAPACKE_shseqr for the type real(32).
  */
 inline proc hseqr(matrix_order : lapack_memory_order, job : string, compz : string, ilo : c_int, ihi : c_int, h : [] real(32), wr : [] real(32), wi : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_shseqr(matrix_order, job.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, wr, wi, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -22044,6 +22413,7 @@ Wrapped procedure of LAPACKE_dhseqr for the type real(64).
  */
 inline proc hseqr(matrix_order : lapack_memory_order, job : string, compz : string, ilo : c_int, ihi : c_int, h : [] real(64), wr : [] real(64), wi : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dhseqr(matrix_order, job.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, wr, wi, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -22052,6 +22422,7 @@ Wrapped procedure of LAPACKE_chseqr for the type complex(64).
  */
 inline proc hseqr(matrix_order : lapack_memory_order, job : string, compz : string, ilo : c_int, ihi : c_int, h : [] complex(64), w : [] complex(64), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chseqr(matrix_order, job.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -22060,6 +22431,7 @@ Wrapped procedure of LAPACKE_zhseqr for the type complex(128).
  */
 inline proc hseqr(matrix_order : lapack_memory_order, job : string, compz : string, ilo : c_int, ihi : c_int, h : [] complex(128), w : [] complex(128), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhseqr(matrix_order, job.toByte() : c_char, compz.toByte() : c_char, (h.domain.dim(1).size) : c_int, ilo, ihi, h, (h.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -22068,6 +22440,7 @@ Wrapped procedure of LAPACKE_clacgv for the type complex(64).
  */
 inline proc lacgv(n : c_int, x : [] complex(64), incx : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clacgv(n, x, incx);
 }
 
@@ -22076,6 +22449,7 @@ Wrapped procedure of LAPACKE_zlacgv for the type complex(128).
  */
 inline proc lacgv(n : c_int, x : [] complex(128), incx : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlacgv(n, x, incx);
 }
 
@@ -22084,6 +22458,7 @@ Wrapped procedure of LAPACKE_slacn2 for the type real(32).
  */
 inline proc lacn2(n : c_int, v : [] real(32), x : [] real(32), isgn : [] c_int, ref est : real(32), ref kase : c_int, isave : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slacn2(n, v, x, isgn, est, kase, isave);
 }
 
@@ -22092,6 +22467,7 @@ Wrapped procedure of LAPACKE_dlacn2 for the type real(64).
  */
 inline proc lacn2(n : c_int, v : [] real(64), x : [] real(64), isgn : [] c_int, ref est : real(64), ref kase : c_int, isave : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlacn2(n, v, x, isgn, est, kase, isave);
 }
 
@@ -22100,6 +22476,7 @@ Wrapped procedure of LAPACKE_clacn2 for the type complex(64).
  */
 inline proc lacn2(n : c_int, v : [] complex(64), x : [] complex(64), ref est : real(32), ref kase : c_int, isave : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clacn2(n, v, x, est, kase, isave);
 }
 
@@ -22108,6 +22485,7 @@ Wrapped procedure of LAPACKE_zlacn2 for the type complex(128).
  */
 inline proc lacn2(n : c_int, v : [] complex(128), x : [] complex(128), ref est : real(64), ref kase : c_int, isave : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlacn2(n, v, x, est, kase, isave);
 }
 
@@ -22116,6 +22494,7 @@ Wrapped procedure of LAPACKE_slacpy for the type real(32).
  */
 inline proc lacpy(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slacpy(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22124,6 +22503,7 @@ Wrapped procedure of LAPACKE_dlacpy for the type real(64).
  */
 inline proc lacpy(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlacpy(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22132,6 +22512,7 @@ Wrapped procedure of LAPACKE_clacpy for the type complex(64).
  */
 inline proc lacpy(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clacpy(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22140,6 +22521,7 @@ Wrapped procedure of LAPACKE_zlacpy for the type complex(128).
  */
 inline proc lacpy(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlacpy(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22148,6 +22530,7 @@ Wrapped procedure of LAPACKE_clacp2 for the type complex(64).
  */
 inline proc lacp2(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clacp2(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22156,6 +22539,7 @@ Wrapped procedure of LAPACKE_zlacp2 for the type complex(128).
  */
 inline proc lacp2(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlacp2(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -22164,6 +22548,7 @@ Wrapped procedure of LAPACKE_zlag2c for the type complex(128).
  */
 inline proc lag2c(matrix_order : lapack_memory_order, a : [] complex(128), sa : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlag2c(matrix_order, (if matrix_order == lapack_memory_order.row_major then sa.domain.dim(1).size else sa.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sa, (sa.domain.dim(2).size) : c_int);
 }
 
@@ -22172,6 +22557,7 @@ Wrapped procedure of LAPACKE_slag2d for the type real(32).
  */
 inline proc lag2d(matrix_order : lapack_memory_order, sa : [] real(32), a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slag2d(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, sa, (sa.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22180,6 +22566,7 @@ Wrapped procedure of LAPACKE_dlag2s for the type real(64).
  */
 inline proc lag2s(matrix_order : lapack_memory_order, a : [] real(64), sa : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlag2s(matrix_order, (if matrix_order == lapack_memory_order.row_major then sa.domain.dim(1).size else sa.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, sa, (sa.domain.dim(2).size) : c_int);
 }
 
@@ -22188,6 +22575,7 @@ Wrapped procedure of LAPACKE_clag2z for the type complex(64).
  */
 inline proc lag2z(matrix_order : lapack_memory_order, sa : [] complex(64), a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clag2z(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, sa, (sa.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22196,6 +22584,7 @@ Wrapped procedure of LAPACKE_slagge for the type real(32).
  */
 inline proc lagge(matrix_order : lapack_memory_order, kl : c_int, ku : c_int, d : [] real(32), a : [] real(32), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slagge(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, kl, ku, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -22204,6 +22593,7 @@ Wrapped procedure of LAPACKE_dlagge for the type real(64).
  */
 inline proc lagge(matrix_order : lapack_memory_order, kl : c_int, ku : c_int, d : [] real(64), a : [] real(64), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlagge(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, kl, ku, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -22212,6 +22602,7 @@ Wrapped procedure of LAPACKE_clagge for the type complex(64).
  */
 inline proc lagge(matrix_order : lapack_memory_order, kl : c_int, ku : c_int, d : [] real(32), a : [] complex(64), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clagge(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, kl, ku, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -22220,6 +22611,7 @@ Wrapped procedure of LAPACKE_zlagge for the type complex(128).
  */
 inline proc lagge(matrix_order : lapack_memory_order, kl : c_int, ku : c_int, d : [] real(64), a : [] complex(128), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlagge(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, kl, ku, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -22228,6 +22620,7 @@ Wrapped procedure of LAPACKE_slamch for the type real(32).
  */
 inline proc lamch(cmach : string): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slamch(cmach.toByte() : c_char);
 }
 
@@ -22236,6 +22629,7 @@ Wrapped procedure of LAPACKE_dlamch for the type real(64).
  */
 inline proc lamch(cmach : string): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlamch(cmach.toByte() : c_char);
 }
 
@@ -22244,6 +22638,7 @@ Wrapped procedure of LAPACKE_slange for the type real(32).
  */
 inline proc lange(matrix_order : lapack_memory_order, norm : string, a : [] real(32)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slange(matrix_order, norm.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22252,6 +22647,7 @@ Wrapped procedure of LAPACKE_dlange for the type real(64).
  */
 inline proc lange(matrix_order : lapack_memory_order, norm : string, a : [] real(64)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlange(matrix_order, norm.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22260,6 +22656,7 @@ Wrapped procedure of LAPACKE_clange for the type complex(64).
  */
 inline proc lange(matrix_order : lapack_memory_order, norm : string, a : [] complex(64)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clange(matrix_order, norm.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22268,6 +22665,7 @@ Wrapped procedure of LAPACKE_zlange for the type complex(128).
  */
 inline proc lange(matrix_order : lapack_memory_order, norm : string, a : [] complex(128)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlange(matrix_order, norm.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22276,6 +22674,7 @@ Wrapped procedure of LAPACKE_clanhe for the type complex(64).
  */
 inline proc lanhe(matrix_order : lapack_memory_order, norm : string, uplo : string, a : [] complex(64)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clanhe(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22284,6 +22683,7 @@ Wrapped procedure of LAPACKE_zlanhe for the type complex(128).
  */
 inline proc lanhe(matrix_order : lapack_memory_order, norm : string, uplo : string, a : [] complex(128)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlanhe(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22292,6 +22692,7 @@ Wrapped procedure of LAPACKE_slansy for the type real(32).
  */
 inline proc lansy(matrix_order : lapack_memory_order, norm : string, uplo : string, a : [] real(32)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slansy(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22300,6 +22701,7 @@ Wrapped procedure of LAPACKE_dlansy for the type real(64).
  */
 inline proc lansy(matrix_order : lapack_memory_order, norm : string, uplo : string, a : [] real(64)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlansy(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22308,6 +22710,7 @@ Wrapped procedure of LAPACKE_clansy for the type complex(64).
  */
 inline proc lansy(matrix_order : lapack_memory_order, norm : string, uplo : string, a : [] complex(64)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clansy(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22316,6 +22719,7 @@ Wrapped procedure of LAPACKE_zlansy for the type complex(128).
  */
 inline proc lansy(matrix_order : lapack_memory_order, norm : string, uplo : string, a : [] complex(128)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlansy(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22324,6 +22728,7 @@ Wrapped procedure of LAPACKE_slantr for the type real(32).
  */
 inline proc lantr(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] real(32)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slantr(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22332,6 +22737,7 @@ Wrapped procedure of LAPACKE_dlantr for the type real(64).
  */
 inline proc lantr(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] real(64)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlantr(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22340,6 +22746,7 @@ Wrapped procedure of LAPACKE_clantr for the type complex(64).
  */
 inline proc lantr(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] complex(64)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clantr(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22348,6 +22755,7 @@ Wrapped procedure of LAPACKE_zlantr for the type complex(128).
  */
 inline proc lantr(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] complex(128)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlantr(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22356,6 +22764,7 @@ Wrapped procedure of LAPACKE_slarfb for the type real(32).
  */
 inline proc larfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, v : [] real(32), t : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slarfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22364,6 +22773,7 @@ Wrapped procedure of LAPACKE_dlarfb for the type real(64).
  */
 inline proc larfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, v : [] real(64), t : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlarfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22372,6 +22782,7 @@ Wrapped procedure of LAPACKE_clarfb for the type complex(64).
  */
 inline proc larfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, v : [] complex(64), t : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clarfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22380,6 +22791,7 @@ Wrapped procedure of LAPACKE_zlarfb for the type complex(128).
  */
 inline proc larfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, v : [] complex(128), t : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlarfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22388,6 +22800,7 @@ Wrapped procedure of LAPACKE_slarfg for the type real(32).
  */
 inline proc larfg(n : c_int, ref alpha : real(32), x : [] real(32), incx : c_int, ref tau : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slarfg(n, alpha, x, incx, tau);
 }
 
@@ -22396,6 +22809,7 @@ Wrapped procedure of LAPACKE_dlarfg for the type real(64).
  */
 inline proc larfg(n : c_int, ref alpha : real(64), x : [] real(64), incx : c_int, ref tau : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlarfg(n, alpha, x, incx, tau);
 }
 
@@ -22404,6 +22818,7 @@ Wrapped procedure of LAPACKE_clarfg for the type complex(64).
  */
 inline proc larfg(n : c_int, ref alpha : complex(64), x : [] complex(64), incx : c_int, ref tau : complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clarfg(n, alpha, x, incx, tau);
 }
 
@@ -22412,6 +22827,7 @@ Wrapped procedure of LAPACKE_zlarfg for the type complex(128).
  */
 inline proc larfg(n : c_int, ref alpha : complex(128), x : [] complex(128), incx : c_int, ref tau : complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlarfg(n, alpha, x, incx, tau);
 }
 
@@ -22420,6 +22836,7 @@ Wrapped procedure of LAPACKE_slarft for the type real(32).
  */
 inline proc larft(matrix_order : lapack_memory_order, direct : string, storev : string, n : c_int, k : c_int, v : [] real(32), tau : [] real(32), t : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slarft(matrix_order, direct.toByte() : c_char, storev.toByte() : c_char, n, k, v, (v.domain.dim(2).size) : c_int, tau, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -22428,6 +22845,7 @@ Wrapped procedure of LAPACKE_dlarft for the type real(64).
  */
 inline proc larft(matrix_order : lapack_memory_order, direct : string, storev : string, n : c_int, k : c_int, v : [] real(64), tau : [] real(64), t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlarft(matrix_order, direct.toByte() : c_char, storev.toByte() : c_char, n, k, v, (v.domain.dim(2).size) : c_int, tau, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -22436,6 +22854,7 @@ Wrapped procedure of LAPACKE_clarft for the type complex(64).
  */
 inline proc larft(matrix_order : lapack_memory_order, direct : string, storev : string, n : c_int, k : c_int, v : [] complex(64), tau : [] complex(64), t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clarft(matrix_order, direct.toByte() : c_char, storev.toByte() : c_char, n, k, v, (v.domain.dim(2).size) : c_int, tau, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -22444,6 +22863,7 @@ Wrapped procedure of LAPACKE_zlarft for the type complex(128).
  */
 inline proc larft(matrix_order : lapack_memory_order, direct : string, storev : string, n : c_int, k : c_int, v : [] complex(128), tau : [] complex(128), t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlarft(matrix_order, direct.toByte() : c_char, storev.toByte() : c_char, n, k, v, (v.domain.dim(2).size) : c_int, tau, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -22452,6 +22872,7 @@ Wrapped procedure of LAPACKE_slarfx for the type real(32).
  */
 inline proc larfx(matrix_order : lapack_memory_order, side : string, v : [] real(32), tau : real(32), c : [] real(32), work : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slarfx(matrix_order, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, v, tau, c, (c.domain.dim(2).size) : c_int, work);
 }
 
@@ -22460,6 +22881,7 @@ Wrapped procedure of LAPACKE_dlarfx for the type real(64).
  */
 inline proc larfx(matrix_order : lapack_memory_order, side : string, v : [] real(64), tau : real(64), c : [] real(64), work : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlarfx(matrix_order, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, v, tau, c, (c.domain.dim(2).size) : c_int, work);
 }
 
@@ -22468,6 +22890,7 @@ Wrapped procedure of LAPACKE_clarfx for the type complex(64).
  */
 inline proc larfx(matrix_order : lapack_memory_order, side : string, v : [] complex(64), tau : complex(64), c : [] complex(64), work : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clarfx(matrix_order, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, v, tau, c, (c.domain.dim(2).size) : c_int, work);
 }
 
@@ -22476,6 +22899,7 @@ Wrapped procedure of LAPACKE_zlarfx for the type complex(128).
  */
 inline proc larfx(matrix_order : lapack_memory_order, side : string, v : [] complex(128), tau : complex(128), c : [] complex(128), work : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlarfx(matrix_order, side.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, v, tau, c, (c.domain.dim(2).size) : c_int, work);
 }
 
@@ -22484,6 +22908,7 @@ Wrapped procedure of LAPACKE_slarnv for the type real(32).
  */
 inline proc larnv(idist : c_int, iseed : [] c_int, n : c_int, x : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slarnv(idist, iseed, n, x);
 }
 
@@ -22492,6 +22917,7 @@ Wrapped procedure of LAPACKE_dlarnv for the type real(64).
  */
 inline proc larnv(idist : c_int, iseed : [] c_int, n : c_int, x : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlarnv(idist, iseed, n, x);
 }
 
@@ -22500,6 +22926,7 @@ Wrapped procedure of LAPACKE_clarnv for the type complex(64).
  */
 inline proc larnv(idist : c_int, iseed : [] c_int, n : c_int, x : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clarnv(idist, iseed, n, x);
 }
 
@@ -22508,6 +22935,7 @@ Wrapped procedure of LAPACKE_zlarnv for the type complex(128).
  */
 inline proc larnv(idist : c_int, iseed : [] c_int, n : c_int, x : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlarnv(idist, iseed, n, x);
 }
 
@@ -22516,6 +22944,7 @@ Wrapped procedure of LAPACKE_slaset for the type real(32).
  */
 inline proc laset(matrix_order : lapack_memory_order, uplo : string, alpha : real(32), beta : real(32), a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slaset(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, beta, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22524,6 +22953,7 @@ Wrapped procedure of LAPACKE_dlaset for the type real(64).
  */
 inline proc laset(matrix_order : lapack_memory_order, uplo : string, alpha : real(64), beta : real(64), a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlaset(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, beta, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22532,6 +22962,7 @@ Wrapped procedure of LAPACKE_claset for the type complex(64).
  */
 inline proc laset(matrix_order : lapack_memory_order, uplo : string, alpha : complex(64), beta : complex(64), a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_claset(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, beta, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22540,6 +22971,7 @@ Wrapped procedure of LAPACKE_zlaset for the type complex(128).
  */
 inline proc laset(matrix_order : lapack_memory_order, uplo : string, alpha : complex(128), beta : complex(128), a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlaset(matrix_order, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, beta, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22548,6 +22980,7 @@ Wrapped procedure of LAPACKE_slasrt for the type real(32).
  */
 inline proc lasrt(id : string, n : c_int, d : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slasrt(id.toByte() : c_char, n, d);
 }
 
@@ -22556,6 +22989,7 @@ Wrapped procedure of LAPACKE_dlasrt for the type real(64).
  */
 inline proc lasrt(id : string, n : c_int, d : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlasrt(id.toByte() : c_char, n, d);
 }
 
@@ -22564,6 +22998,7 @@ Wrapped procedure of LAPACKE_slaswp for the type real(32).
  */
 inline proc laswp(matrix_order : lapack_memory_order, a : [] real(32), k1 : c_int, k2 : c_int, ipiv : [] c_int, incx : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slaswp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, k1, k2, ipiv, incx);
 }
 
@@ -22572,6 +23007,7 @@ Wrapped procedure of LAPACKE_dlaswp for the type real(64).
  */
 inline proc laswp(matrix_order : lapack_memory_order, a : [] real(64), k1 : c_int, k2 : c_int, ipiv : [] c_int, incx : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlaswp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, k1, k2, ipiv, incx);
 }
 
@@ -22580,6 +23016,7 @@ Wrapped procedure of LAPACKE_claswp for the type complex(64).
  */
 inline proc laswp(matrix_order : lapack_memory_order, a : [] complex(64), k1 : c_int, k2 : c_int, ipiv : [] c_int, incx : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_claswp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, k1, k2, ipiv, incx);
 }
 
@@ -22588,6 +23025,7 @@ Wrapped procedure of LAPACKE_zlaswp for the type complex(128).
  */
 inline proc laswp(matrix_order : lapack_memory_order, a : [] complex(128), k1 : c_int, k2 : c_int, ipiv : [] c_int, incx : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlaswp(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, k1, k2, ipiv, incx);
 }
 
@@ -22596,6 +23034,7 @@ Wrapped procedure of LAPACKE_slatms for the type real(32).
  */
 inline proc latms(matrix_order : lapack_memory_order, dist : string, iseed : [] c_int, sym : string, d : [] real(32), mode : c_int, cond : real(32), dmax : real(32), kl : c_int, ku : c_int, pack : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slatms(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, dist.toByte() : c_char, iseed, sym.toByte() : c_char, d, mode, cond, dmax, kl, ku, pack.toByte() : c_char, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22604,6 +23043,7 @@ Wrapped procedure of LAPACKE_dlatms for the type real(64).
  */
 inline proc latms(matrix_order : lapack_memory_order, dist : string, iseed : [] c_int, sym : string, d : [] real(64), mode : c_int, cond : real(64), dmax : real(64), kl : c_int, ku : c_int, pack : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlatms(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, dist.toByte() : c_char, iseed, sym.toByte() : c_char, d, mode, cond, dmax, kl, ku, pack.toByte() : c_char, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22612,6 +23052,7 @@ Wrapped procedure of LAPACKE_clatms for the type complex(64).
  */
 inline proc latms(matrix_order : lapack_memory_order, dist : string, iseed : [] c_int, sym : string, d : [] real(32), mode : c_int, cond : real(32), dmax : real(32), kl : c_int, ku : c_int, pack : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clatms(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, dist.toByte() : c_char, iseed, sym.toByte() : c_char, d, mode, cond, dmax, kl, ku, pack.toByte() : c_char, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22620,6 +23061,7 @@ Wrapped procedure of LAPACKE_zlatms for the type complex(128).
  */
 inline proc latms(matrix_order : lapack_memory_order, dist : string, iseed : [] c_int, sym : string, d : [] real(64), mode : c_int, cond : real(64), dmax : real(64), kl : c_int, ku : c_int, pack : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlatms(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, dist.toByte() : c_char, iseed, sym.toByte() : c_char, d, mode, cond, dmax, kl, ku, pack.toByte() : c_char, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22628,6 +23070,7 @@ Wrapped procedure of LAPACKE_slauum for the type real(32).
  */
 inline proc lauum(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slauum(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22636,6 +23079,7 @@ Wrapped procedure of LAPACKE_dlauum for the type real(64).
  */
 inline proc lauum(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlauum(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22644,6 +23088,7 @@ Wrapped procedure of LAPACKE_clauum for the type complex(64).
  */
 inline proc lauum(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clauum(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22652,6 +23097,7 @@ Wrapped procedure of LAPACKE_zlauum for the type complex(128).
  */
 inline proc lauum(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlauum(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -22660,6 +23106,7 @@ Wrapped procedure of LAPACKE_sopgtr for the type real(32).
  */
 inline proc opgtr(matrix_order : lapack_memory_order, uplo : string, ap : [] real(32), tau : [] real(32), q : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sopgtr(matrix_order, uplo.toByte() : c_char, (q.domain.dim(1).size) : c_int, ap, tau, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -22668,6 +23115,7 @@ Wrapped procedure of LAPACKE_dopgtr for the type real(64).
  */
 inline proc opgtr(matrix_order : lapack_memory_order, uplo : string, ap : [] real(64), tau : [] real(64), q : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dopgtr(matrix_order, uplo.toByte() : c_char, (q.domain.dim(1).size) : c_int, ap, tau, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -22676,6 +23124,7 @@ Wrapped procedure of LAPACKE_sopmtr for the type real(32).
  */
 inline proc opmtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, ap : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sopmtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ap, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22684,6 +23133,7 @@ Wrapped procedure of LAPACKE_dopmtr for the type real(64).
  */
 inline proc opmtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, ap : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dopmtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ap, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22692,6 +23142,7 @@ Wrapped procedure of LAPACKE_sorgbr for the type real(32).
  */
 inline proc orgbr(matrix_order : lapack_memory_order, vect : string, k : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorgbr(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22700,6 +23151,7 @@ Wrapped procedure of LAPACKE_dorgbr for the type real(64).
  */
 inline proc orgbr(matrix_order : lapack_memory_order, vect : string, k : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorgbr(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22708,6 +23160,7 @@ Wrapped procedure of LAPACKE_sorghr for the type real(32).
  */
 inline proc orghr(matrix_order : lapack_memory_order, n : c_int, ilo : c_int, ihi : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorghr(matrix_order, n, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22716,6 +23169,7 @@ Wrapped procedure of LAPACKE_dorghr for the type real(64).
  */
 inline proc orghr(matrix_order : lapack_memory_order, n : c_int, ilo : c_int, ihi : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorghr(matrix_order, n, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22724,6 +23178,7 @@ Wrapped procedure of LAPACKE_sorglq for the type real(32).
  */
 inline proc orglq(matrix_order : lapack_memory_order, k : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorglq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22732,6 +23187,7 @@ Wrapped procedure of LAPACKE_dorglq for the type real(64).
  */
 inline proc orglq(matrix_order : lapack_memory_order, k : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorglq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22740,6 +23196,7 @@ Wrapped procedure of LAPACKE_sorgql for the type real(32).
  */
 inline proc orgql(matrix_order : lapack_memory_order, k : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorgql(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22748,6 +23205,7 @@ Wrapped procedure of LAPACKE_dorgql for the type real(64).
  */
 inline proc orgql(matrix_order : lapack_memory_order, k : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorgql(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22756,6 +23214,7 @@ Wrapped procedure of LAPACKE_sorgqr for the type real(32).
  */
 inline proc orgqr(matrix_order : lapack_memory_order, k : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorgqr(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22764,6 +23223,7 @@ Wrapped procedure of LAPACKE_dorgqr for the type real(64).
  */
 inline proc orgqr(matrix_order : lapack_memory_order, k : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorgqr(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22772,6 +23232,7 @@ Wrapped procedure of LAPACKE_sorgrq for the type real(32).
  */
 inline proc orgrq(matrix_order : lapack_memory_order, k : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorgrq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22780,6 +23241,7 @@ Wrapped procedure of LAPACKE_dorgrq for the type real(64).
  */
 inline proc orgrq(matrix_order : lapack_memory_order, k : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorgrq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22788,6 +23250,7 @@ Wrapped procedure of LAPACKE_sorgtr for the type real(32).
  */
 inline proc orgtr(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorgtr(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22796,6 +23259,7 @@ Wrapped procedure of LAPACKE_dorgtr for the type real(64).
  */
 inline proc orgtr(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorgtr(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -22804,6 +23268,7 @@ Wrapped procedure of LAPACKE_sormbr for the type real(32).
  */
 inline proc ormbr(matrix_order : lapack_memory_order, vect : string, side : string, trans : string, k : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormbr(matrix_order, vect.toByte() : c_char, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22812,6 +23277,7 @@ Wrapped procedure of LAPACKE_dormbr for the type real(64).
  */
 inline proc ormbr(matrix_order : lapack_memory_order, vect : string, side : string, trans : string, k : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormbr(matrix_order, vect.toByte() : c_char, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22820,6 +23286,7 @@ Wrapped procedure of LAPACKE_sormhr for the type real(32).
  */
 inline proc ormhr(matrix_order : lapack_memory_order, side : string, trans : string, ilo : c_int, ihi : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormhr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22828,6 +23295,7 @@ Wrapped procedure of LAPACKE_dormhr for the type real(64).
  */
 inline proc ormhr(matrix_order : lapack_memory_order, side : string, trans : string, ilo : c_int, ihi : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormhr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22836,6 +23304,7 @@ Wrapped procedure of LAPACKE_sormlq for the type real(32).
  */
 inline proc ormlq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormlq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22844,6 +23313,7 @@ Wrapped procedure of LAPACKE_dormlq for the type real(64).
  */
 inline proc ormlq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormlq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22852,6 +23322,7 @@ Wrapped procedure of LAPACKE_sormql for the type real(32).
  */
 inline proc ormql(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormql(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22860,6 +23331,7 @@ Wrapped procedure of LAPACKE_dormql for the type real(64).
  */
 inline proc ormql(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormql(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22868,6 +23340,7 @@ Wrapped procedure of LAPACKE_sormqr for the type real(32).
  */
 inline proc ormqr(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormqr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22876,6 +23349,7 @@ Wrapped procedure of LAPACKE_dormqr for the type real(64).
  */
 inline proc ormqr(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormqr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22884,6 +23358,7 @@ Wrapped procedure of LAPACKE_sormrq for the type real(32).
  */
 inline proc ormrq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormrq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22892,6 +23367,7 @@ Wrapped procedure of LAPACKE_dormrq for the type real(64).
  */
 inline proc ormrq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormrq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22900,6 +23376,7 @@ Wrapped procedure of LAPACKE_sormrz for the type real(32).
  */
 inline proc ormrz(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, l : c_int, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormrz(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22908,6 +23385,7 @@ Wrapped procedure of LAPACKE_dormrz for the type real(64).
  */
 inline proc ormrz(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, l : c_int, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormrz(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22916,6 +23394,7 @@ Wrapped procedure of LAPACKE_sormtr for the type real(32).
  */
 inline proc ormtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, a : [] real(32), tau : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sormtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22924,6 +23403,7 @@ Wrapped procedure of LAPACKE_dormtr for the type real(64).
  */
 inline proc ormtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, a : [] real(64), tau : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dormtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -22932,6 +23412,7 @@ Wrapped procedure of LAPACKE_spbcon for the type real(32).
  */
 inline proc pbcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(32), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbcon(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -22940,6 +23421,7 @@ Wrapped procedure of LAPACKE_dpbcon for the type real(64).
  */
 inline proc pbcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(64), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbcon(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -22948,6 +23430,7 @@ Wrapped procedure of LAPACKE_cpbcon for the type complex(64).
  */
 inline proc pbcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbcon(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -22956,6 +23439,7 @@ Wrapped procedure of LAPACKE_zpbcon for the type complex(128).
  */
 inline proc pbcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbcon(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -22964,6 +23448,7 @@ Wrapped procedure of LAPACKE_spbequ for the type real(32).
  */
 inline proc pbequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(32), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbequ(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -22972,6 +23457,7 @@ Wrapped procedure of LAPACKE_dpbequ for the type real(64).
  */
 inline proc pbequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(64), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbequ(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -22980,6 +23466,7 @@ Wrapped procedure of LAPACKE_cpbequ for the type complex(64).
  */
 inline proc pbequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbequ(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -22988,6 +23475,7 @@ Wrapped procedure of LAPACKE_zpbequ for the type complex(128).
  */
 inline proc pbequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbequ(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -22996,6 +23484,7 @@ Wrapped procedure of LAPACKE_spbrfs for the type real(32).
  */
 inline proc pbrfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(32), afb : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbrfs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23004,6 +23493,7 @@ Wrapped procedure of LAPACKE_dpbrfs for the type real(64).
  */
 inline proc pbrfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(64), afb : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbrfs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23012,6 +23502,7 @@ Wrapped procedure of LAPACKE_cpbrfs for the type complex(64).
  */
 inline proc pbrfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), afb : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbrfs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23020,6 +23511,7 @@ Wrapped procedure of LAPACKE_zpbrfs for the type complex(128).
  */
 inline proc pbrfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), afb : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbrfs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23028,6 +23520,7 @@ Wrapped procedure of LAPACKE_spbstf for the type real(32).
  */
 inline proc pbstf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kb : c_int, bb : [] real(32), ldbb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbstf(matrix_order, uplo.toByte() : c_char, n, kb, bb, ldbb);
 }
 
@@ -23036,6 +23529,7 @@ Wrapped procedure of LAPACKE_dpbstf for the type real(64).
  */
 inline proc pbstf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kb : c_int, bb : [] real(64), ldbb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbstf(matrix_order, uplo.toByte() : c_char, n, kb, bb, ldbb);
 }
 
@@ -23044,6 +23538,7 @@ Wrapped procedure of LAPACKE_cpbstf for the type complex(64).
  */
 inline proc pbstf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kb : c_int, bb : [] complex(64), ldbb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbstf(matrix_order, uplo.toByte() : c_char, n, kb, bb, ldbb);
 }
 
@@ -23052,6 +23547,7 @@ Wrapped procedure of LAPACKE_zpbstf for the type complex(128).
  */
 inline proc pbstf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kb : c_int, bb : [] complex(128), ldbb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbstf(matrix_order, uplo.toByte() : c_char, n, kb, bb, ldbb);
 }
 
@@ -23060,6 +23556,7 @@ Wrapped procedure of LAPACKE_spbsv for the type real(32).
  */
 inline proc pbsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbsv(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23068,6 +23565,7 @@ Wrapped procedure of LAPACKE_dpbsv for the type real(64).
  */
 inline proc pbsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbsv(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23076,6 +23574,7 @@ Wrapped procedure of LAPACKE_cpbsv for the type complex(64).
  */
 inline proc pbsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbsv(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23084,6 +23583,7 @@ Wrapped procedure of LAPACKE_zpbsv for the type complex(128).
  */
 inline proc pbsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbsv(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23092,6 +23592,7 @@ Wrapped procedure of LAPACKE_spbsvx for the type real(32).
  */
 inline proc pbsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, kd : c_int, ab : [] real(32), afb : [] real(32), ref equed : string, s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23100,6 +23601,7 @@ Wrapped procedure of LAPACKE_dpbsvx for the type real(64).
  */
 inline proc pbsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, kd : c_int, ab : [] real(64), afb : [] real(64), ref equed : string, s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23108,6 +23610,7 @@ Wrapped procedure of LAPACKE_cpbsvx for the type complex(64).
  */
 inline proc pbsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), afb : [] complex(64), ref equed : string, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23116,6 +23619,7 @@ Wrapped procedure of LAPACKE_zpbsvx for the type complex(128).
  */
 inline proc pbsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), afb : [] complex(128), ref equed : string, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, afb, (afb.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23124,6 +23628,7 @@ Wrapped procedure of LAPACKE_spbtrf for the type real(32).
  */
 inline proc pbtrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbtrf(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int);
 }
 
@@ -23132,6 +23637,7 @@ Wrapped procedure of LAPACKE_dpbtrf for the type real(64).
  */
 inline proc pbtrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbtrf(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int);
 }
 
@@ -23140,6 +23646,7 @@ Wrapped procedure of LAPACKE_cpbtrf for the type complex(64).
  */
 inline proc pbtrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbtrf(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int);
 }
 
@@ -23148,6 +23655,7 @@ Wrapped procedure of LAPACKE_zpbtrf for the type complex(128).
  */
 inline proc pbtrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbtrf(matrix_order, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int);
 }
 
@@ -23156,6 +23664,7 @@ Wrapped procedure of LAPACKE_spbtrs for the type real(32).
  */
 inline proc pbtrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spbtrs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23164,6 +23673,7 @@ Wrapped procedure of LAPACKE_dpbtrs for the type real(64).
  */
 inline proc pbtrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpbtrs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23172,6 +23682,7 @@ Wrapped procedure of LAPACKE_cpbtrs for the type complex(64).
  */
 inline proc pbtrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpbtrs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23180,6 +23691,7 @@ Wrapped procedure of LAPACKE_zpbtrs for the type complex(128).
  */
 inline proc pbtrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, kd : c_int, ab : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpbtrs(matrix_order, uplo.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23188,6 +23700,7 @@ Wrapped procedure of LAPACKE_spftrf for the type real(32).
  */
 inline proc pftrf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spftrf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23196,6 +23709,7 @@ Wrapped procedure of LAPACKE_dpftrf for the type real(64).
  */
 inline proc pftrf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpftrf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23204,6 +23718,7 @@ Wrapped procedure of LAPACKE_cpftrf for the type complex(64).
  */
 inline proc pftrf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpftrf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23212,6 +23727,7 @@ Wrapped procedure of LAPACKE_zpftrf for the type complex(128).
  */
 inline proc pftrf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpftrf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23220,6 +23736,7 @@ Wrapped procedure of LAPACKE_spftri for the type real(32).
  */
 inline proc pftri(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23228,6 +23745,7 @@ Wrapped procedure of LAPACKE_dpftri for the type real(64).
  */
 inline proc pftri(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23236,6 +23754,7 @@ Wrapped procedure of LAPACKE_cpftri for the type complex(64).
  */
 inline proc pftri(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23244,6 +23763,7 @@ Wrapped procedure of LAPACKE_zpftri for the type complex(128).
  */
 inline proc pftri(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -23252,6 +23772,7 @@ Wrapped procedure of LAPACKE_spftrs for the type real(32).
  */
 inline proc pftrs(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spftrs(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23260,6 +23781,7 @@ Wrapped procedure of LAPACKE_dpftrs for the type real(64).
  */
 inline proc pftrs(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpftrs(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23268,6 +23790,7 @@ Wrapped procedure of LAPACKE_cpftrs for the type complex(64).
  */
 inline proc pftrs(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpftrs(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23276,6 +23799,7 @@ Wrapped procedure of LAPACKE_zpftrs for the type complex(128).
  */
 inline proc pftrs(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpftrs(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23284,6 +23808,7 @@ Wrapped procedure of LAPACKE_spocon for the type real(32).
  */
 inline proc pocon(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spocon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -23292,6 +23817,7 @@ Wrapped procedure of LAPACKE_dpocon for the type real(64).
  */
 inline proc pocon(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpocon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -23300,6 +23826,7 @@ Wrapped procedure of LAPACKE_cpocon for the type complex(64).
  */
 inline proc pocon(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpocon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -23308,6 +23835,7 @@ Wrapped procedure of LAPACKE_zpocon for the type complex(128).
  */
 inline proc pocon(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpocon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, anorm, rcond);
 }
 
@@ -23316,6 +23844,7 @@ Wrapped procedure of LAPACKE_spoequ for the type real(32).
  */
 inline proc poequ(matrix_order : lapack_memory_order, a : [] real(32), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spoequ(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23324,6 +23853,7 @@ Wrapped procedure of LAPACKE_dpoequ for the type real(64).
  */
 inline proc poequ(matrix_order : lapack_memory_order, a : [] real(64), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpoequ(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23332,6 +23862,7 @@ Wrapped procedure of LAPACKE_cpoequ for the type complex(64).
  */
 inline proc poequ(matrix_order : lapack_memory_order, a : [] complex(64), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpoequ(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23340,6 +23871,7 @@ Wrapped procedure of LAPACKE_zpoequ for the type complex(128).
  */
 inline proc poequ(matrix_order : lapack_memory_order, a : [] complex(128), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpoequ(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23348,6 +23880,7 @@ Wrapped procedure of LAPACKE_spoequb for the type real(32).
  */
 inline proc poequb(matrix_order : lapack_memory_order, a : [] real(32), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spoequb(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23356,6 +23889,7 @@ Wrapped procedure of LAPACKE_dpoequb for the type real(64).
  */
 inline proc poequb(matrix_order : lapack_memory_order, a : [] real(64), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpoequb(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23364,6 +23898,7 @@ Wrapped procedure of LAPACKE_cpoequb for the type complex(64).
  */
 inline proc poequb(matrix_order : lapack_memory_order, a : [] complex(64), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpoequb(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23372,6 +23907,7 @@ Wrapped procedure of LAPACKE_zpoequb for the type complex(128).
  */
 inline proc poequb(matrix_order : lapack_memory_order, a : [] complex(128), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpoequb(matrix_order, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -23380,6 +23916,7 @@ Wrapped procedure of LAPACKE_sporfs for the type real(32).
  */
 inline proc porfs(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), af : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sporfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23388,6 +23925,7 @@ Wrapped procedure of LAPACKE_dporfs for the type real(64).
  */
 inline proc porfs(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), af : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dporfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23396,6 +23934,7 @@ Wrapped procedure of LAPACKE_cporfs for the type complex(64).
  */
 inline proc porfs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), af : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cporfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23404,6 +23943,7 @@ Wrapped procedure of LAPACKE_zporfs for the type complex(128).
  */
 inline proc porfs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), af : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zporfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23412,6 +23952,7 @@ Wrapped procedure of LAPACKE_sporfsx for the type real(32).
  */
 inline proc porfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] real(32), af : [] real(32), s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sporfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23420,6 +23961,7 @@ Wrapped procedure of LAPACKE_dporfsx for the type real(64).
  */
 inline proc porfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] real(64), af : [] real(64), s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dporfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23428,6 +23970,7 @@ Wrapped procedure of LAPACKE_cporfsx for the type complex(64).
  */
 inline proc porfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] complex(64), af : [] complex(64), s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cporfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23436,6 +23979,7 @@ Wrapped procedure of LAPACKE_zporfsx for the type complex(128).
  */
 inline proc porfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] complex(128), af : [] complex(128), s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zporfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23444,6 +23988,7 @@ Wrapped procedure of LAPACKE_sposv for the type real(32).
  */
 inline proc posv(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sposv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23452,6 +23997,7 @@ Wrapped procedure of LAPACKE_dposv for the type real(64).
  */
 inline proc posv(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dposv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23460,6 +24006,7 @@ Wrapped procedure of LAPACKE_cposv for the type complex(64).
  */
 inline proc posv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cposv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23468,6 +24015,7 @@ Wrapped procedure of LAPACKE_zposv for the type complex(128).
  */
 inline proc posv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zposv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23476,6 +24024,7 @@ Wrapped procedure of LAPACKE_dsposv for the type real(64).
  */
 inline proc posv(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), b : [] real(64), x : [] real(64), ref chlapack_iter : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsposv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, chlapack_iter);
 }
 
@@ -23484,6 +24033,7 @@ Wrapped procedure of LAPACKE_zcposv for the type complex(128).
  */
 inline proc posv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), b : [] complex(128), x : [] complex(128), ref chlapack_iter : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zcposv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, chlapack_iter);
 }
 
@@ -23492,6 +24042,7 @@ Wrapped procedure of LAPACKE_sposvx for the type real(32).
  */
 inline proc posvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(32), af : [] real(32), ref equed : string, s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sposvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23500,6 +24051,7 @@ Wrapped procedure of LAPACKE_dposvx for the type real(64).
  */
 inline proc posvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(64), af : [] real(64), ref equed : string, s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dposvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23508,6 +24060,7 @@ Wrapped procedure of LAPACKE_cposvx for the type complex(64).
  */
 inline proc posvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(64), af : [] complex(64), ref equed : string, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cposvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23516,6 +24069,7 @@ Wrapped procedure of LAPACKE_zposvx for the type complex(128).
  */
 inline proc posvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(128), af : [] complex(128), ref equed : string, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zposvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23524,6 +24078,7 @@ Wrapped procedure of LAPACKE_sposvxx for the type real(32).
  */
 inline proc posvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(32), af : [] real(32), ref equed : string, s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sposvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23532,6 +24087,7 @@ Wrapped procedure of LAPACKE_dposvxx for the type real(64).
  */
 inline proc posvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(64), af : [] real(64), ref equed : string, s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dposvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23540,6 +24096,7 @@ Wrapped procedure of LAPACKE_cposvxx for the type complex(64).
  */
 inline proc posvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(64), af : [] complex(64), ref equed : string, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cposvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23548,6 +24105,7 @@ Wrapped procedure of LAPACKE_zposvxx for the type complex(128).
  */
 inline proc posvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(128), af : [] complex(128), ref equed : string, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zposvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -23556,6 +24114,7 @@ Wrapped procedure of LAPACKE_spotrf for the type real(32).
  */
 inline proc potrf(matrix_order : lapack_memory_order, uplo : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spotrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23564,6 +24123,7 @@ Wrapped procedure of LAPACKE_dpotrf for the type real(64).
  */
 inline proc potrf(matrix_order : lapack_memory_order, uplo : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpotrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23572,6 +24132,7 @@ Wrapped procedure of LAPACKE_cpotrf for the type complex(64).
  */
 inline proc potrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpotrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23580,6 +24141,7 @@ Wrapped procedure of LAPACKE_zpotrf for the type complex(128).
  */
 inline proc potrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpotrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23588,6 +24150,7 @@ Wrapped procedure of LAPACKE_spotri for the type real(32).
  */
 inline proc potri(matrix_order : lapack_memory_order, uplo : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spotri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23596,6 +24159,7 @@ Wrapped procedure of LAPACKE_dpotri for the type real(64).
  */
 inline proc potri(matrix_order : lapack_memory_order, uplo : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpotri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23604,6 +24168,7 @@ Wrapped procedure of LAPACKE_cpotri for the type complex(64).
  */
 inline proc potri(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpotri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23612,6 +24177,7 @@ Wrapped procedure of LAPACKE_zpotri for the type complex(128).
  */
 inline proc potri(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpotri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -23620,6 +24186,7 @@ Wrapped procedure of LAPACKE_spotrs for the type real(32).
  */
 inline proc potrs(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spotrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23628,6 +24195,7 @@ Wrapped procedure of LAPACKE_dpotrs for the type real(64).
  */
 inline proc potrs(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpotrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23636,6 +24204,7 @@ Wrapped procedure of LAPACKE_cpotrs for the type complex(64).
  */
 inline proc potrs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpotrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23644,6 +24213,7 @@ Wrapped procedure of LAPACKE_zpotrs for the type complex(128).
  */
 inline proc potrs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpotrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23652,6 +24222,7 @@ Wrapped procedure of LAPACKE_sppcon for the type real(32).
  */
 inline proc ppcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sppcon(matrix_order, uplo.toByte() : c_char, n, ap, anorm, rcond);
 }
 
@@ -23660,6 +24231,7 @@ Wrapped procedure of LAPACKE_dppcon for the type real(64).
  */
 inline proc ppcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dppcon(matrix_order, uplo.toByte() : c_char, n, ap, anorm, rcond);
 }
 
@@ -23668,6 +24240,7 @@ Wrapped procedure of LAPACKE_cppcon for the type complex(64).
  */
 inline proc ppcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cppcon(matrix_order, uplo.toByte() : c_char, n, ap, anorm, rcond);
 }
 
@@ -23676,6 +24249,7 @@ Wrapped procedure of LAPACKE_zppcon for the type complex(128).
  */
 inline proc ppcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zppcon(matrix_order, uplo.toByte() : c_char, n, ap, anorm, rcond);
 }
 
@@ -23684,6 +24258,7 @@ Wrapped procedure of LAPACKE_sppequ for the type real(32).
  */
 inline proc ppequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sppequ(matrix_order, uplo.toByte() : c_char, n, ap, s, scond, amax);
 }
 
@@ -23692,6 +24267,7 @@ Wrapped procedure of LAPACKE_dppequ for the type real(64).
  */
 inline proc ppequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dppequ(matrix_order, uplo.toByte() : c_char, n, ap, s, scond, amax);
 }
 
@@ -23700,6 +24276,7 @@ Wrapped procedure of LAPACKE_cppequ for the type complex(64).
  */
 inline proc ppequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cppequ(matrix_order, uplo.toByte() : c_char, n, ap, s, scond, amax);
 }
 
@@ -23708,6 +24285,7 @@ Wrapped procedure of LAPACKE_zppequ for the type complex(128).
  */
 inline proc ppequ(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zppequ(matrix_order, uplo.toByte() : c_char, n, ap, s, scond, amax);
 }
 
@@ -23716,6 +24294,7 @@ Wrapped procedure of LAPACKE_spprfs for the type real(32).
  */
 inline proc pprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), afp : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23724,6 +24303,7 @@ Wrapped procedure of LAPACKE_dpprfs for the type real(64).
  */
 inline proc pprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), afp : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23732,6 +24312,7 @@ Wrapped procedure of LAPACKE_cpprfs for the type complex(64).
  */
 inline proc pprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), afp : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23740,6 +24321,7 @@ Wrapped procedure of LAPACKE_zpprfs for the type complex(128).
  */
 inline proc pprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), afp : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -23748,6 +24330,7 @@ Wrapped procedure of LAPACKE_sppsv for the type real(32).
  */
 inline proc ppsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sppsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23756,6 +24339,7 @@ Wrapped procedure of LAPACKE_dppsv for the type real(64).
  */
 inline proc ppsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dppsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23764,6 +24348,7 @@ Wrapped procedure of LAPACKE_cppsv for the type complex(64).
  */
 inline proc ppsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cppsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23772,6 +24357,7 @@ Wrapped procedure of LAPACKE_zppsv for the type complex(128).
  */
 inline proc ppsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zppsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23780,6 +24366,7 @@ Wrapped procedure of LAPACKE_sppsvx for the type real(32).
  */
 inline proc ppsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] real(32), afp : [] real(32), ref equed : string, s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sppsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23788,6 +24375,7 @@ Wrapped procedure of LAPACKE_dppsvx for the type real(64).
  */
 inline proc ppsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] real(64), afp : [] real(64), ref equed : string, s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dppsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23796,6 +24384,7 @@ Wrapped procedure of LAPACKE_cppsvx for the type complex(64).
  */
 inline proc ppsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] complex(64), afp : [] complex(64), ref equed : string, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cppsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23804,6 +24393,7 @@ Wrapped procedure of LAPACKE_zppsvx for the type complex(128).
  */
 inline proc ppsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] complex(128), afp : [] complex(128), ref equed : string, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zppsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -23812,6 +24402,7 @@ Wrapped procedure of LAPACKE_spptrf for the type real(32).
  */
 inline proc pptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spptrf(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23820,6 +24411,7 @@ Wrapped procedure of LAPACKE_dpptrf for the type real(64).
  */
 inline proc pptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpptrf(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23828,6 +24420,7 @@ Wrapped procedure of LAPACKE_cpptrf for the type complex(64).
  */
 inline proc pptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpptrf(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23836,6 +24429,7 @@ Wrapped procedure of LAPACKE_zpptrf for the type complex(128).
  */
 inline proc pptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpptrf(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23844,6 +24438,7 @@ Wrapped procedure of LAPACKE_spptri for the type real(32).
  */
 inline proc pptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spptri(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23852,6 +24447,7 @@ Wrapped procedure of LAPACKE_dpptri for the type real(64).
  */
 inline proc pptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpptri(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23860,6 +24456,7 @@ Wrapped procedure of LAPACKE_cpptri for the type complex(64).
  */
 inline proc pptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpptri(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23868,6 +24465,7 @@ Wrapped procedure of LAPACKE_zpptri for the type complex(128).
  */
 inline proc pptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpptri(matrix_order, uplo.toByte() : c_char, n, ap);
 }
 
@@ -23876,6 +24474,7 @@ Wrapped procedure of LAPACKE_spptrs for the type real(32).
  */
 inline proc pptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23884,6 +24483,7 @@ Wrapped procedure of LAPACKE_dpptrs for the type real(64).
  */
 inline proc pptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23892,6 +24492,7 @@ Wrapped procedure of LAPACKE_cpptrs for the type complex(64).
  */
 inline proc pptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23900,6 +24501,7 @@ Wrapped procedure of LAPACKE_zpptrs for the type complex(128).
  */
 inline proc pptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -23908,6 +24510,7 @@ Wrapped procedure of LAPACKE_spstrf for the type real(32).
  */
 inline proc pstrf(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), piv : [] c_int, ref rank : c_int, tol : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spstrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, piv, rank, tol);
 }
 
@@ -23916,6 +24519,7 @@ Wrapped procedure of LAPACKE_dpstrf for the type real(64).
  */
 inline proc pstrf(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), piv : [] c_int, ref rank : c_int, tol : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpstrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, piv, rank, tol);
 }
 
@@ -23924,6 +24528,7 @@ Wrapped procedure of LAPACKE_cpstrf for the type complex(64).
  */
 inline proc pstrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), piv : [] c_int, ref rank : c_int, tol : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpstrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, piv, rank, tol);
 }
 
@@ -23932,6 +24537,7 @@ Wrapped procedure of LAPACKE_zpstrf for the type complex(128).
  */
 inline proc pstrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), piv : [] c_int, ref rank : c_int, tol : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpstrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, piv, rank, tol);
 }
 
@@ -23940,6 +24546,7 @@ Wrapped procedure of LAPACKE_sptcon for the type real(32).
  */
 inline proc ptcon(n : c_int, d : [] real(32), e : [] real(32), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sptcon(n, d, e, anorm, rcond);
 }
 
@@ -23948,6 +24555,7 @@ Wrapped procedure of LAPACKE_dptcon for the type real(64).
  */
 inline proc ptcon(n : c_int, d : [] real(64), e : [] real(64), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dptcon(n, d, e, anorm, rcond);
 }
 
@@ -23956,6 +24564,7 @@ Wrapped procedure of LAPACKE_cptcon for the type complex(64).
  */
 inline proc ptcon(n : c_int, d : [] real(32), e : [] complex(64), anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cptcon(n, d, e, anorm, rcond);
 }
 
@@ -23964,6 +24573,7 @@ Wrapped procedure of LAPACKE_zptcon for the type complex(128).
  */
 inline proc ptcon(n : c_int, d : [] real(64), e : [] complex(128), anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zptcon(n, d, e, anorm, rcond);
 }
 
@@ -23972,6 +24582,7 @@ Wrapped procedure of LAPACKE_spteqr for the type real(32).
  */
 inline proc pteqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -23980,6 +24591,7 @@ Wrapped procedure of LAPACKE_dpteqr for the type real(64).
  */
 inline proc pteqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -23988,6 +24600,7 @@ Wrapped procedure of LAPACKE_cpteqr for the type complex(64).
  */
 inline proc pteqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -23996,6 +24609,7 @@ Wrapped procedure of LAPACKE_zpteqr for the type complex(128).
  */
 inline proc pteqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24004,6 +24618,7 @@ Wrapped procedure of LAPACKE_sptrfs for the type real(32).
  */
 inline proc ptrfs(matrix_order : lapack_memory_order, n : c_int, d : [] real(32), e : [] real(32), df : [] real(32), ef : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sptrfs(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24012,6 +24627,7 @@ Wrapped procedure of LAPACKE_dptrfs for the type real(64).
  */
 inline proc ptrfs(matrix_order : lapack_memory_order, n : c_int, d : [] real(64), e : [] real(64), df : [] real(64), ef : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dptrfs(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24020,6 +24636,7 @@ Wrapped procedure of LAPACKE_cptrfs for the type complex(64).
  */
 inline proc ptrfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, d : [] real(32), e : [] complex(64), df : [] real(32), ef : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cptrfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24028,6 +24645,7 @@ Wrapped procedure of LAPACKE_zptrfs for the type complex(128).
  */
 inline proc ptrfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, d : [] real(64), e : [] complex(128), df : [] real(64), ef : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zptrfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24036,6 +24654,7 @@ Wrapped procedure of LAPACKE_sptsv for the type real(32).
  */
 inline proc ptsv(matrix_order : lapack_memory_order, n : c_int, d : [] real(32), e : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sptsv(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24044,6 +24663,7 @@ Wrapped procedure of LAPACKE_dptsv for the type real(64).
  */
 inline proc ptsv(matrix_order : lapack_memory_order, n : c_int, d : [] real(64), e : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dptsv(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24052,6 +24672,7 @@ Wrapped procedure of LAPACKE_cptsv for the type complex(64).
  */
 inline proc ptsv(matrix_order : lapack_memory_order, n : c_int, d : [] real(32), e : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cptsv(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24060,6 +24681,7 @@ Wrapped procedure of LAPACKE_zptsv for the type complex(128).
  */
 inline proc ptsv(matrix_order : lapack_memory_order, n : c_int, d : [] real(64), e : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zptsv(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24068,6 +24690,7 @@ Wrapped procedure of LAPACKE_sptsvx for the type real(32).
  */
 inline proc ptsvx(matrix_order : lapack_memory_order, fact : string, n : c_int, d : [] real(32), e : [] real(32), df : [] real(32), ef : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sptsvx(matrix_order, fact.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24076,6 +24699,7 @@ Wrapped procedure of LAPACKE_dptsvx for the type real(64).
  */
 inline proc ptsvx(matrix_order : lapack_memory_order, fact : string, n : c_int, d : [] real(64), e : [] real(64), df : [] real(64), ef : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dptsvx(matrix_order, fact.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24084,6 +24708,7 @@ Wrapped procedure of LAPACKE_cptsvx for the type complex(64).
  */
 inline proc ptsvx(matrix_order : lapack_memory_order, fact : string, n : c_int, d : [] real(32), e : [] complex(64), df : [] real(32), ef : [] complex(64), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cptsvx(matrix_order, fact.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24092,6 +24717,7 @@ Wrapped procedure of LAPACKE_zptsvx for the type complex(128).
  */
 inline proc ptsvx(matrix_order : lapack_memory_order, fact : string, n : c_int, d : [] real(64), e : [] complex(128), df : [] real(64), ef : [] complex(128), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zptsvx(matrix_order, fact.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, df, ef, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24100,6 +24726,7 @@ Wrapped procedure of LAPACKE_spttrf for the type real(32).
  */
 inline proc pttrf(n : c_int, d : [] real(32), e : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spttrf(n, d, e);
 }
 
@@ -24108,6 +24735,7 @@ Wrapped procedure of LAPACKE_dpttrf for the type real(64).
  */
 inline proc pttrf(n : c_int, d : [] real(64), e : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpttrf(n, d, e);
 }
 
@@ -24116,6 +24744,7 @@ Wrapped procedure of LAPACKE_cpttrf for the type complex(64).
  */
 inline proc pttrf(n : c_int, d : [] real(32), e : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpttrf(n, d, e);
 }
 
@@ -24124,6 +24753,7 @@ Wrapped procedure of LAPACKE_zpttrf for the type complex(128).
  */
 inline proc pttrf(n : c_int, d : [] real(64), e : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpttrf(n, d, e);
 }
 
@@ -24132,6 +24762,7 @@ Wrapped procedure of LAPACKE_spttrs for the type real(32).
  */
 inline proc pttrs(matrix_order : lapack_memory_order, n : c_int, d : [] real(32), e : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_spttrs(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24140,6 +24771,7 @@ Wrapped procedure of LAPACKE_dpttrs for the type real(64).
  */
 inline proc pttrs(matrix_order : lapack_memory_order, n : c_int, d : [] real(64), e : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dpttrs(matrix_order, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24148,6 +24780,7 @@ Wrapped procedure of LAPACKE_cpttrs for the type complex(64).
  */
 inline proc pttrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, d : [] real(32), e : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cpttrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24156,6 +24789,7 @@ Wrapped procedure of LAPACKE_zpttrs for the type complex(128).
  */
 inline proc pttrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, d : [] real(64), e : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zpttrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, d, e, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24164,6 +24798,7 @@ Wrapped procedure of LAPACKE_ssbev for the type real(32).
  */
 inline proc sbev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24172,6 +24807,7 @@ Wrapped procedure of LAPACKE_dsbev for the type real(64).
  */
 inline proc sbev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24180,6 +24816,7 @@ Wrapped procedure of LAPACKE_ssbevd for the type real(32).
  */
 inline proc sbevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24188,6 +24825,7 @@ Wrapped procedure of LAPACKE_dsbevd for the type real(64).
  */
 inline proc sbevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, kd : c_int, ab : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24196,6 +24834,7 @@ Wrapped procedure of LAPACKE_ssbevx for the type real(32).
  */
 inline proc sbevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, kd : c_int, ab : [] real(32), q : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24204,6 +24843,7 @@ Wrapped procedure of LAPACKE_dsbevx for the type real(64).
  */
 inline proc sbevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, kd : c_int, ab : [] real(64), q : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24212,6 +24852,7 @@ Wrapped procedure of LAPACKE_ssbgst for the type real(32).
  */
 inline proc sbgst(matrix_order : lapack_memory_order, vect : string, uplo : string, ka : c_int, kb : c_int, ab : [] real(32), bb : [] real(32), x : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbgst(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int);
 }
 
@@ -24220,6 +24861,7 @@ Wrapped procedure of LAPACKE_dsbgst for the type real(64).
  */
 inline proc sbgst(matrix_order : lapack_memory_order, vect : string, uplo : string, ka : c_int, kb : c_int, ab : [] real(64), bb : [] real(64), x : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbgst(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int);
 }
 
@@ -24228,6 +24870,7 @@ Wrapped procedure of LAPACKE_ssbgv for the type real(32).
  */
 inline proc sbgv(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] real(32), bb : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbgv(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24236,6 +24879,7 @@ Wrapped procedure of LAPACKE_dsbgv for the type real(64).
  */
 inline proc sbgv(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] real(64), bb : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbgv(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24244,6 +24888,7 @@ Wrapped procedure of LAPACKE_ssbgvd for the type real(32).
  */
 inline proc sbgvd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] real(32), bb : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbgvd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24252,6 +24897,7 @@ Wrapped procedure of LAPACKE_dsbgvd for the type real(64).
  */
 inline proc sbgvd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ka : c_int, kb : c_int, ab : [] real(64), bb : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbgvd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24260,6 +24906,7 @@ Wrapped procedure of LAPACKE_ssbgvx for the type real(32).
  */
 inline proc sbgvx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, ka : c_int, kb : c_int, ab : [] real(32), bb : [] real(32), q : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbgvx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then q.domain.dim(2).size else q.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24268,6 +24915,7 @@ Wrapped procedure of LAPACKE_dsbgvx for the type real(64).
  */
 inline proc sbgvx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, ka : c_int, kb : c_int, ab : [] real(64), bb : [] real(64), q : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbgvx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then q.domain.dim(2).size else q.domain.dim(1).size) : c_int, ka, kb, ab, (ab.domain.dim(2).size) : c_int, bb, (bb.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24276,6 +24924,7 @@ Wrapped procedure of LAPACKE_ssbtrd for the type real(32).
  */
 inline proc sbtrd(matrix_order : lapack_memory_order, vect : string, uplo : string, n : c_int, kd : c_int, ab : [] real(32), d : [] real(32), e : [] real(32), q : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssbtrd(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -24284,6 +24933,7 @@ Wrapped procedure of LAPACKE_dsbtrd for the type real(64).
  */
 inline proc sbtrd(matrix_order : lapack_memory_order, vect : string, uplo : string, n : c_int, kd : c_int, ab : [] real(64), d : [] real(64), e : [] real(64), q : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsbtrd(matrix_order, vect.toByte() : c_char, uplo.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, d, e, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -24292,6 +24942,7 @@ Wrapped procedure of LAPACKE_ssfrk for the type real(32).
  */
 inline proc sfrk(matrix_order : lapack_memory_order, transr : string, uplo : string, trans : string, alpha : real(32), a : [] real(32), beta : real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssfrk(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (c.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, a, (a.domain.dim(2).size) : c_int, beta, c);
 }
 
@@ -24300,6 +24951,7 @@ Wrapped procedure of LAPACKE_dsfrk for the type real(64).
  */
 inline proc sfrk(matrix_order : lapack_memory_order, transr : string, uplo : string, trans : string, alpha : real(64), a : [] real(64), beta : real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsfrk(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (c.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, alpha, a, (a.domain.dim(2).size) : c_int, beta, c);
 }
 
@@ -24308,6 +24960,7 @@ Wrapped procedure of LAPACKE_sspcon for the type real(32).
  */
 inline proc spcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspcon(matrix_order, uplo.toByte() : c_char, n, ap, ipiv, anorm, rcond);
 }
 
@@ -24316,6 +24969,7 @@ Wrapped procedure of LAPACKE_dspcon for the type real(64).
  */
 inline proc spcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspcon(matrix_order, uplo.toByte() : c_char, n, ap, ipiv, anorm, rcond);
 }
 
@@ -24324,6 +24978,7 @@ Wrapped procedure of LAPACKE_cspcon for the type complex(64).
  */
 inline proc spcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cspcon(matrix_order, uplo.toByte() : c_char, n, ap, ipiv, anorm, rcond);
 }
 
@@ -24332,6 +24987,7 @@ Wrapped procedure of LAPACKE_zspcon for the type complex(128).
  */
 inline proc spcon(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zspcon(matrix_order, uplo.toByte() : c_char, n, ap, ipiv, anorm, rcond);
 }
 
@@ -24340,6 +24996,7 @@ Wrapped procedure of LAPACKE_sspev for the type real(32).
  */
 inline proc spev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24348,6 +25005,7 @@ Wrapped procedure of LAPACKE_dspev for the type real(64).
  */
 inline proc spev(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24356,6 +25014,7 @@ Wrapped procedure of LAPACKE_sspevd for the type real(32).
  */
 inline proc spevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24364,6 +25023,7 @@ Wrapped procedure of LAPACKE_dspevd for the type real(64).
  */
 inline proc spevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, n : c_int, ap : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24372,6 +25032,7 @@ Wrapped procedure of LAPACKE_sspevx for the type real(32).
  */
 inline proc spevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, ap : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24380,6 +25041,7 @@ Wrapped procedure of LAPACKE_dspevx for the type real(64).
  */
 inline proc spevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, n : c_int, ap : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24388,6 +25050,7 @@ Wrapped procedure of LAPACKE_sspgst for the type real(32).
  */
 inline proc spgst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, n : c_int, ap : [] real(32), bp : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspgst(matrix_order, itype, uplo.toByte() : c_char, n, ap, bp);
 }
 
@@ -24396,6 +25059,7 @@ Wrapped procedure of LAPACKE_dspgst for the type real(64).
  */
 inline proc spgst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, n : c_int, ap : [] real(64), bp : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspgst(matrix_order, itype, uplo.toByte() : c_char, n, ap, bp);
 }
 
@@ -24404,6 +25068,7 @@ Wrapped procedure of LAPACKE_sspgv for the type real(32).
  */
 inline proc spgv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] real(32), bp : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspgv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24412,6 +25077,7 @@ Wrapped procedure of LAPACKE_dspgv for the type real(64).
  */
 inline proc spgv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] real(64), bp : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspgv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24420,6 +25086,7 @@ Wrapped procedure of LAPACKE_sspgvd for the type real(32).
  */
 inline proc spgvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] real(32), bp : [] real(32), w : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspgvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24428,6 +25095,7 @@ Wrapped procedure of LAPACKE_dspgvd for the type real(64).
  */
 inline proc spgvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, n : c_int, ap : [] real(64), bp : [] real(64), w : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspgvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, w, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24436,6 +25104,7 @@ Wrapped procedure of LAPACKE_sspgvx for the type real(32).
  */
 inline proc spgvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, n : c_int, ap : [] real(32), bp : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspgvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24444,6 +25113,7 @@ Wrapped procedure of LAPACKE_dspgvx for the type real(64).
  */
 inline proc spgvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, n : c_int, ap : [] real(64), bp : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspgvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, ap, bp, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24452,6 +25122,7 @@ Wrapped procedure of LAPACKE_ssprfs for the type real(32).
  */
 inline proc sprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), afp : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24460,6 +25131,7 @@ Wrapped procedure of LAPACKE_dsprfs for the type real(64).
  */
 inline proc sprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), afp : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24468,6 +25140,7 @@ Wrapped procedure of LAPACKE_csprfs for the type complex(64).
  */
 inline proc sprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), afp : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24476,6 +25149,7 @@ Wrapped procedure of LAPACKE_zsprfs for the type complex(128).
  */
 inline proc sprfs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), afp : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsprfs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -24484,6 +25158,7 @@ Wrapped procedure of LAPACKE_sspsv for the type real(32).
  */
 inline proc spsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24492,6 +25167,7 @@ Wrapped procedure of LAPACKE_dspsv for the type real(64).
  */
 inline proc spsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24500,6 +25176,7 @@ Wrapped procedure of LAPACKE_cspsv for the type complex(64).
  */
 inline proc spsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cspsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24508,6 +25185,7 @@ Wrapped procedure of LAPACKE_zspsv for the type complex(128).
  */
 inline proc spsv(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zspsv(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24516,6 +25194,7 @@ Wrapped procedure of LAPACKE_sspsvx for the type real(32).
  */
 inline proc spsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] real(32), afp : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sspsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24524,6 +25203,7 @@ Wrapped procedure of LAPACKE_dspsvx for the type real(64).
  */
 inline proc spsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] real(64), afp : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dspsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24532,6 +25212,7 @@ Wrapped procedure of LAPACKE_cspsvx for the type complex(64).
  */
 inline proc spsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] complex(64), afp : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cspsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24540,6 +25221,7 @@ Wrapped procedure of LAPACKE_zspsvx for the type complex(128).
  */
 inline proc spsvx(matrix_order : lapack_memory_order, fact : string, uplo : string, n : c_int, ap : [] complex(128), afp : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zspsvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, afp, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -24548,6 +25230,7 @@ Wrapped procedure of LAPACKE_ssptrd for the type real(32).
  */
 inline proc sptrd(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), d : [] real(32), e : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssptrd(matrix_order, uplo.toByte() : c_char, n, ap, d, e, tau);
 }
 
@@ -24556,6 +25239,7 @@ Wrapped procedure of LAPACKE_dsptrd for the type real(64).
  */
 inline proc sptrd(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), d : [] real(64), e : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsptrd(matrix_order, uplo.toByte() : c_char, n, ap, d, e, tau);
 }
 
@@ -24564,6 +25248,7 @@ Wrapped procedure of LAPACKE_ssptrf for the type real(32).
  */
 inline proc sptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssptrf(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24572,6 +25257,7 @@ Wrapped procedure of LAPACKE_dsptrf for the type real(64).
  */
 inline proc sptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsptrf(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24580,6 +25266,7 @@ Wrapped procedure of LAPACKE_csptrf for the type complex(64).
  */
 inline proc sptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csptrf(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24588,6 +25275,7 @@ Wrapped procedure of LAPACKE_zsptrf for the type complex(128).
  */
 inline proc sptrf(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsptrf(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24596,6 +25284,7 @@ Wrapped procedure of LAPACKE_ssptri for the type real(32).
  */
 inline proc sptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssptri(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24604,6 +25293,7 @@ Wrapped procedure of LAPACKE_dsptri for the type real(64).
  */
 inline proc sptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsptri(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24612,6 +25302,7 @@ Wrapped procedure of LAPACKE_csptri for the type complex(64).
  */
 inline proc sptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csptri(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24620,6 +25311,7 @@ Wrapped procedure of LAPACKE_zsptri for the type complex(128).
  */
 inline proc sptri(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsptri(matrix_order, uplo.toByte() : c_char, n, ap, ipiv);
 }
 
@@ -24628,6 +25320,7 @@ Wrapped procedure of LAPACKE_ssptrs for the type real(32).
  */
 inline proc sptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24636,6 +25329,7 @@ Wrapped procedure of LAPACKE_dsptrs for the type real(64).
  */
 inline proc sptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24644,6 +25338,7 @@ Wrapped procedure of LAPACKE_csptrs for the type complex(64).
  */
 inline proc sptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24652,6 +25347,7 @@ Wrapped procedure of LAPACKE_zsptrs for the type complex(128).
  */
 inline proc sptrs(matrix_order : lapack_memory_order, uplo : string, n : c_int, ap : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsptrs(matrix_order, uplo.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -24660,6 +25356,7 @@ Wrapped procedure of LAPACKE_sstebz for the type real(32).
  */
 inline proc stebz(range : string, order : string, n : c_int, vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), d : [] real(32), e : [] real(32), ref m : c_int, ref nsplit : c_int, w : [] real(32), iblock : [] c_int, isplit : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstebz(range.toByte() : c_char, order.toByte() : c_char, n, vl, vu, il, iu, abstol, d, e, m, nsplit, w, iblock, isplit);
 }
 
@@ -24668,6 +25365,7 @@ Wrapped procedure of LAPACKE_dstebz for the type real(64).
  */
 inline proc stebz(range : string, order : string, n : c_int, vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), d : [] real(64), e : [] real(64), ref m : c_int, ref nsplit : c_int, w : [] real(64), iblock : [] c_int, isplit : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstebz(range.toByte() : c_char, order.toByte() : c_char, n, vl, vu, il, iu, abstol, d, e, m, nsplit, w, iblock, isplit);
 }
 
@@ -24676,6 +25374,7 @@ Wrapped procedure of LAPACKE_sstedc for the type real(32).
  */
 inline proc stedc(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstedc(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24684,6 +25383,7 @@ Wrapped procedure of LAPACKE_dstedc for the type real(64).
  */
 inline proc stedc(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstedc(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24692,6 +25392,7 @@ Wrapped procedure of LAPACKE_cstedc for the type complex(64).
  */
 inline proc stedc(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cstedc(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24700,6 +25401,7 @@ Wrapped procedure of LAPACKE_zstedc for the type complex(128).
  */
 inline proc stedc(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zstedc(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24708,6 +25410,7 @@ Wrapped procedure of LAPACKE_sstegr for the type real(32).
  */
 inline proc stegr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(32), e : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstegr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -24716,6 +25419,7 @@ Wrapped procedure of LAPACKE_dstegr for the type real(64).
  */
 inline proc stegr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(64), e : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstegr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -24724,6 +25428,7 @@ Wrapped procedure of LAPACKE_cstegr for the type complex(64).
  */
 inline proc stegr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(32), e : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] complex(64), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cstegr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -24732,6 +25437,7 @@ Wrapped procedure of LAPACKE_zstegr for the type complex(128).
  */
 inline proc stegr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(64), e : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] complex(128), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zstegr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -24740,6 +25446,7 @@ Wrapped procedure of LAPACKE_sstein for the type real(32).
  */
 inline proc stein(matrix_order : lapack_memory_order, n : c_int, d : [] real(32), e : [] real(32), m : c_int, w : [] real(32), iblock : [] c_int, isplit : [] c_int, z : [] real(32), ifailv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstein(matrix_order, n, d, e, m, w, iblock, isplit, z, (z.domain.dim(2).size) : c_int, ifailv);
 }
 
@@ -24748,6 +25455,7 @@ Wrapped procedure of LAPACKE_dstein for the type real(64).
  */
 inline proc stein(matrix_order : lapack_memory_order, n : c_int, d : [] real(64), e : [] real(64), m : c_int, w : [] real(64), iblock : [] c_int, isplit : [] c_int, z : [] real(64), ifailv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstein(matrix_order, n, d, e, m, w, iblock, isplit, z, (z.domain.dim(2).size) : c_int, ifailv);
 }
 
@@ -24756,6 +25464,7 @@ Wrapped procedure of LAPACKE_cstein for the type complex(64).
  */
 inline proc stein(matrix_order : lapack_memory_order, n : c_int, d : [] real(32), e : [] real(32), m : c_int, w : [] real(32), iblock : [] c_int, isplit : [] c_int, z : [] complex(64), ifailv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cstein(matrix_order, n, d, e, m, w, iblock, isplit, z, (z.domain.dim(2).size) : c_int, ifailv);
 }
 
@@ -24764,6 +25473,7 @@ Wrapped procedure of LAPACKE_zstein for the type complex(128).
  */
 inline proc stein(matrix_order : lapack_memory_order, n : c_int, d : [] real(64), e : [] real(64), m : c_int, w : [] real(64), iblock : [] c_int, isplit : [] c_int, z : [] complex(128), ifailv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zstein(matrix_order, n, d, e, m, w, iblock, isplit, z, (z.domain.dim(2).size) : c_int, ifailv);
 }
 
@@ -24772,6 +25482,7 @@ Wrapped procedure of LAPACKE_sstemr for the type real(32).
  */
 inline proc stemr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(32), e : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, ref m : c_int, w : [] real(32), z : [] real(32), nzc : c_int, isuppz : [] c_int, ref tryrac : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstemr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, m, w, z, (z.domain.dim(2).size) : c_int, nzc, isuppz, tryrac);
 }
 
@@ -24780,6 +25491,7 @@ Wrapped procedure of LAPACKE_dstemr for the type real(64).
  */
 inline proc stemr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(64), e : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, ref m : c_int, w : [] real(64), z : [] real(64), nzc : c_int, isuppz : [] c_int, ref tryrac : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstemr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, m, w, z, (z.domain.dim(2).size) : c_int, nzc, isuppz, tryrac);
 }
 
@@ -24788,6 +25500,7 @@ Wrapped procedure of LAPACKE_cstemr for the type complex(64).
  */
 inline proc stemr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(32), e : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, ref m : c_int, w : [] real(32), z : [] complex(64), nzc : c_int, isuppz : [] c_int, ref tryrac : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cstemr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, m, w, z, (z.domain.dim(2).size) : c_int, nzc, isuppz, tryrac);
 }
 
@@ -24796,6 +25509,7 @@ Wrapped procedure of LAPACKE_zstemr for the type complex(128).
  */
 inline proc stemr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(64), e : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, ref m : c_int, w : [] real(64), z : [] complex(128), nzc : c_int, isuppz : [] c_int, ref tryrac : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zstemr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, m, w, z, (z.domain.dim(2).size) : c_int, nzc, isuppz, tryrac);
 }
 
@@ -24804,6 +25518,7 @@ Wrapped procedure of LAPACKE_ssteqr for the type real(32).
  */
 inline proc steqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24812,6 +25527,7 @@ Wrapped procedure of LAPACKE_dsteqr for the type real(64).
  */
 inline proc steqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24820,6 +25536,7 @@ Wrapped procedure of LAPACKE_csteqr for the type complex(64).
  */
 inline proc steqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24828,6 +25545,7 @@ Wrapped procedure of LAPACKE_zsteqr for the type complex(128).
  */
 inline proc steqr(matrix_order : lapack_memory_order, compz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsteqr(matrix_order, compz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24836,6 +25554,7 @@ Wrapped procedure of LAPACKE_ssterf for the type real(32).
  */
 inline proc sterf(n : c_int, d : [] real(32), e : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssterf(n, d, e);
 }
 
@@ -24844,6 +25563,7 @@ Wrapped procedure of LAPACKE_dsterf for the type real(64).
  */
 inline proc sterf(n : c_int, d : [] real(64), e : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsterf(n, d, e);
 }
 
@@ -24852,6 +25572,7 @@ Wrapped procedure of LAPACKE_sstev for the type real(32).
  */
 inline proc stev(matrix_order : lapack_memory_order, jobz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstev(matrix_order, jobz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24860,6 +25581,7 @@ Wrapped procedure of LAPACKE_dstev for the type real(64).
  */
 inline proc stev(matrix_order : lapack_memory_order, jobz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstev(matrix_order, jobz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24868,6 +25590,7 @@ Wrapped procedure of LAPACKE_sstevd for the type real(32).
  */
 inline proc stevd(matrix_order : lapack_memory_order, jobz : string, n : c_int, d : [] real(32), e : [] real(32), z : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstevd(matrix_order, jobz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24876,6 +25599,7 @@ Wrapped procedure of LAPACKE_dstevd for the type real(64).
  */
 inline proc stevd(matrix_order : lapack_memory_order, jobz : string, n : c_int, d : [] real(64), e : [] real(64), z : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstevd(matrix_order, jobz.toByte() : c_char, n, d, e, z, (z.domain.dim(2).size) : c_int);
 }
 
@@ -24884,6 +25608,7 @@ Wrapped procedure of LAPACKE_sstevr for the type real(32).
  */
 inline proc stevr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(32), e : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstevr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -24892,6 +25617,7 @@ Wrapped procedure of LAPACKE_dstevr for the type real(64).
  */
 inline proc stevr(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(64), e : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstevr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -24900,6 +25626,7 @@ Wrapped procedure of LAPACKE_sstevx for the type real(32).
  */
 inline proc stevx(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(32), e : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sstevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24908,6 +25635,7 @@ Wrapped procedure of LAPACKE_dstevx for the type real(64).
  */
 inline proc stevx(matrix_order : lapack_memory_order, jobz : string, range : string, n : c_int, d : [] real(64), e : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dstevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, n, d, e, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -24916,6 +25644,7 @@ Wrapped procedure of LAPACKE_ssycon for the type real(32).
  */
 inline proc sycon(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssycon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -24924,6 +25653,7 @@ Wrapped procedure of LAPACKE_dsycon for the type real(64).
  */
 inline proc sycon(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsycon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -24932,6 +25662,7 @@ Wrapped procedure of LAPACKE_csycon for the type complex(64).
  */
 inline proc sycon(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, anorm : real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csycon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -24940,6 +25671,7 @@ Wrapped procedure of LAPACKE_zsycon for the type complex(128).
  */
 inline proc sycon(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, anorm : real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsycon(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, anorm, rcond);
 }
 
@@ -24948,6 +25680,7 @@ Wrapped procedure of LAPACKE_ssyequb for the type real(32).
  */
 inline proc syequb(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyequb(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -24956,6 +25689,7 @@ Wrapped procedure of LAPACKE_dsyequb for the type real(64).
  */
 inline proc syequb(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyequb(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -24964,6 +25698,7 @@ Wrapped procedure of LAPACKE_csyequb for the type complex(64).
  */
 inline proc syequb(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), s : [] real(32), ref scond : real(32), ref amax : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csyequb(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -24972,6 +25707,7 @@ Wrapped procedure of LAPACKE_zsyequb for the type complex(128).
  */
 inline proc syequb(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), s : [] real(64), ref scond : real(64), ref amax : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsyequb(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, s, scond, amax);
 }
 
@@ -24980,6 +25716,7 @@ Wrapped procedure of LAPACKE_ssyev for the type real(32).
  */
 inline proc syev(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] real(32), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -24988,6 +25725,7 @@ Wrapped procedure of LAPACKE_dsyev for the type real(64).
  */
 inline proc syev(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] real(64), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyev(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -24996,6 +25734,7 @@ Wrapped procedure of LAPACKE_ssyevd for the type real(32).
  */
 inline proc syevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] real(32), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -25004,6 +25743,7 @@ Wrapped procedure of LAPACKE_dsyevd for the type real(64).
  */
 inline proc syevd(matrix_order : lapack_memory_order, jobz : string, uplo : string, a : [] real(64), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyevd(matrix_order, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, w);
 }
 
@@ -25012,6 +25752,7 @@ Wrapped procedure of LAPACKE_ssyevr for the type real(32).
  */
 inline proc syevr(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyevr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -25020,6 +25761,7 @@ Wrapped procedure of LAPACKE_dsyevr for the type real(64).
  */
 inline proc syevr(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), isuppz : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyevr(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, isuppz);
 }
 
@@ -25028,6 +25770,7 @@ Wrapped procedure of LAPACKE_ssyevx for the type real(32).
  */
 inline proc syevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -25036,6 +25779,7 @@ Wrapped procedure of LAPACKE_dsyevx for the type real(64).
  */
 inline proc syevx(matrix_order : lapack_memory_order, jobz : string, range : string, uplo : string, a : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyevx(matrix_order, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -25044,6 +25788,7 @@ Wrapped procedure of LAPACKE_ssygst for the type real(32).
  */
 inline proc sygst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssygst(matrix_order, itype, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25052,6 +25797,7 @@ Wrapped procedure of LAPACKE_dsygst for the type real(64).
  */
 inline proc sygst(matrix_order : lapack_memory_order, itype : c_int, uplo : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsygst(matrix_order, itype, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25060,6 +25806,7 @@ Wrapped procedure of LAPACKE_ssygv for the type real(32).
  */
 inline proc sygv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] real(32), b : [] real(32), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssygv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -25068,6 +25815,7 @@ Wrapped procedure of LAPACKE_dsygv for the type real(64).
  */
 inline proc sygv(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] real(64), b : [] real(64), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsygv(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -25076,6 +25824,7 @@ Wrapped procedure of LAPACKE_ssygvd for the type real(32).
  */
 inline proc sygvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] real(32), b : [] real(32), w : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssygvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -25084,6 +25833,7 @@ Wrapped procedure of LAPACKE_dsygvd for the type real(64).
  */
 inline proc sygvd(matrix_order : lapack_memory_order, itype : c_int, jobz : string, uplo : string, a : [] real(64), b : [] real(64), w : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsygvd(matrix_order, itype, jobz.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, w);
 }
 
@@ -25092,6 +25842,7 @@ Wrapped procedure of LAPACKE_ssygvx for the type real(32).
  */
 inline proc sygvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, n : c_int, a : [] real(32), b : [] real(32), vl : real(32), vu : real(32), il : c_int, iu : c_int, abstol : real(32), ref m : c_int, w : [] real(32), z : [] real(32), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssygvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -25100,6 +25851,7 @@ Wrapped procedure of LAPACKE_dsygvx for the type real(64).
  */
 inline proc sygvx(matrix_order : lapack_memory_order, itype : c_int, jobz : string, range : string, uplo : string, n : c_int, a : [] real(64), b : [] real(64), vl : real(64), vu : real(64), il : c_int, iu : c_int, abstol : real(64), ref m : c_int, w : [] real(64), z : [] real(64), ifail : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsygvx(matrix_order, itype, jobz.toByte() : c_char, range.toByte() : c_char, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, vu, il, iu, abstol, m, w, z, (z.domain.dim(2).size) : c_int, ifail);
 }
 
@@ -25108,6 +25860,7 @@ Wrapped procedure of LAPACKE_ssyrfs for the type real(32).
  */
 inline proc syrfs(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyrfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25116,6 +25869,7 @@ Wrapped procedure of LAPACKE_dsyrfs for the type real(64).
  */
 inline proc syrfs(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyrfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25124,6 +25878,7 @@ Wrapped procedure of LAPACKE_csyrfs for the type complex(64).
  */
 inline proc syrfs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csyrfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25132,6 +25887,7 @@ Wrapped procedure of LAPACKE_zsyrfs for the type complex(128).
  */
 inline proc syrfs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsyrfs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25140,6 +25896,7 @@ Wrapped procedure of LAPACKE_ssyrfsx for the type real(32).
  */
 inline proc syrfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyrfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25148,6 +25905,7 @@ Wrapped procedure of LAPACKE_dsyrfsx for the type real(64).
  */
 inline proc syrfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyrfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25156,6 +25914,7 @@ Wrapped procedure of LAPACKE_csyrfsx for the type complex(64).
  */
 inline proc syrfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csyrfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25164,6 +25923,7 @@ Wrapped procedure of LAPACKE_zsyrfsx for the type complex(128).
  */
 inline proc syrfsx(matrix_order : lapack_memory_order, uplo : string, equed : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsyrfsx(matrix_order, uplo.toByte() : c_char, equed.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25172,6 +25932,7 @@ Wrapped procedure of LAPACKE_ssysv for the type real(32).
  */
 inline proc sysv(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssysv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25180,6 +25941,7 @@ Wrapped procedure of LAPACKE_dsysv for the type real(64).
  */
 inline proc sysv(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsysv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25188,6 +25950,7 @@ Wrapped procedure of LAPACKE_csysv for the type complex(64).
  */
 inline proc sysv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csysv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25196,6 +25959,7 @@ Wrapped procedure of LAPACKE_zsysv for the type complex(128).
  */
 inline proc sysv(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsysv(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25204,6 +25968,7 @@ Wrapped procedure of LAPACKE_ssysvx for the type real(32).
  */
 inline proc sysvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, b : [] real(32), x : [] real(32), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssysvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -25212,6 +25977,7 @@ Wrapped procedure of LAPACKE_dsysvx for the type real(64).
  */
 inline proc sysvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, b : [] real(64), x : [] real(64), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsysvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -25220,6 +25986,7 @@ Wrapped procedure of LAPACKE_csysvx for the type complex(64).
  */
 inline proc sysvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, b : [] complex(64), x : [] complex(64), ref rcond : real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csysvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -25228,6 +25995,7 @@ Wrapped procedure of LAPACKE_zsysvx for the type complex(128).
  */
 inline proc sysvx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, b : [] complex(128), x : [] complex(128), ref rcond : real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsysvx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, ferr, berr);
 }
 
@@ -25236,6 +26004,7 @@ Wrapped procedure of LAPACKE_ssysvxx for the type real(32).
  */
 inline proc sysvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(32), af : [] real(32), ipiv : [] c_int, ref equed : string, s : [] real(32), b : [] real(32), x : [] real(32), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssysvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25244,6 +26013,7 @@ Wrapped procedure of LAPACKE_dsysvxx for the type real(64).
  */
 inline proc sysvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] real(64), af : [] real(64), ipiv : [] c_int, ref equed : string, s : [] real(64), b : [] real(64), x : [] real(64), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsysvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25252,6 +26022,7 @@ Wrapped procedure of LAPACKE_csysvxx for the type complex(64).
  */
 inline proc sysvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(64), af : [] complex(64), ipiv : [] c_int, ref equed : string, s : [] real(32), b : [] complex(64), x : [] complex(64), ref rcond : real(32), ref rpvgrw : real(32), berr : [] real(32), n_err_bnds : c_int, err_bnds_norm : [] real(32), err_bnds_comp : [] real(32), nparams : c_int, params : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csysvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25260,6 +26031,7 @@ Wrapped procedure of LAPACKE_zsysvxx for the type complex(128).
  */
 inline proc sysvxx(matrix_order : lapack_memory_order, fact : string, uplo : string, a : [] complex(128), af : [] complex(128), ipiv : [] c_int, ref equed : string, s : [] real(64), b : [] complex(128), x : [] complex(128), ref rcond : real(64), ref rpvgrw : real(64), berr : [] real(64), n_err_bnds : c_int, err_bnds_norm : [] real(64), err_bnds_comp : [] real(64), nparams : c_int, params : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsysvxx(matrix_order, fact.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, af, (af.domain.dim(2).size) : c_int, ipiv, equed.toByte() : c_char, s, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, rcond, rpvgrw, berr, n_err_bnds, err_bnds_norm, err_bnds_comp, nparams, params);
 }
 
@@ -25268,6 +26040,7 @@ Wrapped procedure of LAPACKE_ssytrd for the type real(32).
  */
 inline proc sytrd(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), d : [] real(32), e : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytrd(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tau);
 }
 
@@ -25276,6 +26049,7 @@ Wrapped procedure of LAPACKE_dsytrd for the type real(64).
  */
 inline proc sytrd(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), d : [] real(64), e : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytrd(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, d, e, tau);
 }
 
@@ -25284,6 +26058,7 @@ Wrapped procedure of LAPACKE_ssytrf for the type real(32).
  */
 inline proc sytrf(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25292,6 +26067,7 @@ Wrapped procedure of LAPACKE_dsytrf for the type real(64).
  */
 inline proc sytrf(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25300,6 +26076,7 @@ Wrapped procedure of LAPACKE_csytrf for the type complex(64).
  */
 inline proc sytrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csytrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25308,6 +26085,7 @@ Wrapped procedure of LAPACKE_zsytrf for the type complex(128).
  */
 inline proc sytrf(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsytrf(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25316,6 +26094,7 @@ Wrapped procedure of LAPACKE_ssytri for the type real(32).
  */
 inline proc sytri(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25324,6 +26103,7 @@ Wrapped procedure of LAPACKE_dsytri for the type real(64).
  */
 inline proc sytri(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25332,6 +26112,7 @@ Wrapped procedure of LAPACKE_csytri for the type complex(64).
  */
 inline proc sytri(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csytri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25340,6 +26121,7 @@ Wrapped procedure of LAPACKE_zsytri for the type complex(128).
  */
 inline proc sytri(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsytri(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -25348,6 +26130,7 @@ Wrapped procedure of LAPACKE_ssytrs for the type real(32).
  */
 inline proc sytrs(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25356,6 +26139,7 @@ Wrapped procedure of LAPACKE_dsytrs for the type real(64).
  */
 inline proc sytrs(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25364,6 +26148,7 @@ Wrapped procedure of LAPACKE_csytrs for the type complex(64).
  */
 inline proc sytrs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csytrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25372,6 +26157,7 @@ Wrapped procedure of LAPACKE_zsytrs for the type complex(128).
  */
 inline proc sytrs(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsytrs(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25380,6 +26166,7 @@ Wrapped procedure of LAPACKE_stbcon for the type real(32).
  */
 inline proc tbcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, kd : c_int, ab : [] real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stbcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -25388,6 +26175,7 @@ Wrapped procedure of LAPACKE_dtbcon for the type real(64).
  */
 inline proc tbcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, kd : c_int, ab : [] real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtbcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -25396,6 +26184,7 @@ Wrapped procedure of LAPACKE_ctbcon for the type complex(64).
  */
 inline proc tbcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, kd : c_int, ab : [] complex(64), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctbcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -25404,6 +26193,7 @@ Wrapped procedure of LAPACKE_ztbcon for the type complex(128).
  */
 inline proc tbcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, kd : c_int, ab : [] complex(128), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztbcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, kd, ab, (ab.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -25412,6 +26202,7 @@ Wrapped procedure of LAPACKE_stbrfs for the type real(32).
  */
 inline proc tbrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stbrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25420,6 +26211,7 @@ Wrapped procedure of LAPACKE_dtbrfs for the type real(64).
  */
 inline proc tbrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtbrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25428,6 +26220,7 @@ Wrapped procedure of LAPACKE_ctbrfs for the type complex(64).
  */
 inline proc tbrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctbrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25436,6 +26229,7 @@ Wrapped procedure of LAPACKE_ztbrfs for the type complex(128).
  */
 inline proc tbrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztbrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25444,6 +26238,7 @@ Wrapped procedure of LAPACKE_stbtrs for the type real(32).
  */
 inline proc tbtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stbtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25452,6 +26247,7 @@ Wrapped procedure of LAPACKE_dtbtrs for the type real(64).
  */
 inline proc tbtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtbtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25460,6 +26256,7 @@ Wrapped procedure of LAPACKE_ctbtrs for the type complex(64).
  */
 inline proc tbtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctbtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25468,6 +26265,7 @@ Wrapped procedure of LAPACKE_ztbtrs for the type complex(128).
  */
 inline proc tbtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, kd : c_int, ab : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztbtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, kd, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ab, (ab.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25476,6 +26274,7 @@ Wrapped procedure of LAPACKE_stfsm for the type real(32).
  */
 inline proc tfsm(matrix_order : lapack_memory_order, transr : string, side : string, uplo : string, trans : string, diag : string, alpha : real(32), a : [] real(32), b : [] real(32), ldb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stfsm(matrix_order, transr.toByte() : c_char, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, alpha, a, b, ldb);
 }
 
@@ -25484,6 +26283,7 @@ Wrapped procedure of LAPACKE_dtfsm for the type real(64).
  */
 inline proc tfsm(matrix_order : lapack_memory_order, transr : string, side : string, uplo : string, trans : string, diag : string, alpha : real(64), a : [] real(64), b : [] real(64), ldb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtfsm(matrix_order, transr.toByte() : c_char, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, alpha, a, b, ldb);
 }
 
@@ -25492,6 +26292,7 @@ Wrapped procedure of LAPACKE_ctfsm for the type complex(64).
  */
 inline proc tfsm(matrix_order : lapack_memory_order, transr : string, side : string, uplo : string, trans : string, diag : string, alpha : complex(64), a : [] complex(64), b : [] complex(64), ldb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctfsm(matrix_order, transr.toByte() : c_char, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, alpha, a, b, ldb);
 }
 
@@ -25500,6 +26301,7 @@ Wrapped procedure of LAPACKE_ztfsm for the type complex(128).
  */
 inline proc tfsm(matrix_order : lapack_memory_order, transr : string, side : string, uplo : string, trans : string, diag : string, alpha : complex(128), a : [] complex(128), b : [] complex(128), ldb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztfsm(matrix_order, transr.toByte() : c_char, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, alpha, a, b, ldb);
 }
 
@@ -25508,6 +26310,7 @@ Wrapped procedure of LAPACKE_stftri for the type real(32).
  */
 inline proc tftri(matrix_order : lapack_memory_order, transr : string, uplo : string, diag : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -25516,6 +26319,7 @@ Wrapped procedure of LAPACKE_dtftri for the type real(64).
  */
 inline proc tftri(matrix_order : lapack_memory_order, transr : string, uplo : string, diag : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -25524,6 +26328,7 @@ Wrapped procedure of LAPACKE_ctftri for the type complex(64).
  */
 inline proc tftri(matrix_order : lapack_memory_order, transr : string, uplo : string, diag : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -25532,6 +26337,7 @@ Wrapped procedure of LAPACKE_ztftri for the type complex(128).
  */
 inline proc tftri(matrix_order : lapack_memory_order, transr : string, uplo : string, diag : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztftri(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a);
 }
 
@@ -25540,6 +26346,7 @@ Wrapped procedure of LAPACKE_stfttp for the type real(32).
  */
 inline proc tfttp(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, arf : [] real(32), ap : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stfttp(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, arf, ap);
 }
 
@@ -25548,6 +26355,7 @@ Wrapped procedure of LAPACKE_dtfttp for the type real(64).
  */
 inline proc tfttp(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, arf : [] real(64), ap : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtfttp(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, arf, ap);
 }
 
@@ -25556,6 +26364,7 @@ Wrapped procedure of LAPACKE_ctfttp for the type complex(64).
  */
 inline proc tfttp(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, arf : [] complex(64), ap : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctfttp(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, arf, ap);
 }
 
@@ -25564,6 +26373,7 @@ Wrapped procedure of LAPACKE_ztfttp for the type complex(128).
  */
 inline proc tfttp(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, arf : [] complex(128), ap : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztfttp(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, arf, ap);
 }
 
@@ -25572,6 +26382,7 @@ Wrapped procedure of LAPACKE_stfttr for the type real(32).
  */
 inline proc tfttr(matrix_order : lapack_memory_order, transr : string, uplo : string, arf : [] real(32), a : [] real(32), lda : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stfttr(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (arf.domain.dim(1).size) : c_int, arf, a, lda);
 }
 
@@ -25580,6 +26391,7 @@ Wrapped procedure of LAPACKE_dtfttr for the type real(64).
  */
 inline proc tfttr(matrix_order : lapack_memory_order, transr : string, uplo : string, arf : [] real(64), a : [] real(64), lda : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtfttr(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (arf.domain.dim(1).size) : c_int, arf, a, lda);
 }
 
@@ -25588,6 +26400,7 @@ Wrapped procedure of LAPACKE_ctfttr for the type complex(64).
  */
 inline proc tfttr(matrix_order : lapack_memory_order, transr : string, uplo : string, arf : [] complex(64), a : [] complex(64), lda : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctfttr(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, arf, a, lda);
 }
 
@@ -25596,6 +26409,7 @@ Wrapped procedure of LAPACKE_ztfttr for the type complex(128).
  */
 inline proc tfttr(matrix_order : lapack_memory_order, transr : string, uplo : string, arf : [] complex(128), a : [] complex(128), lda : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztfttr(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, arf, a, lda);
 }
 
@@ -25604,6 +26418,7 @@ Wrapped procedure of LAPACKE_stgevc for the type real(32).
  */
 inline proc tgevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, s : [] real(32), p : [] real(32), vl : [] real(32), vr : [] real(32), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stgevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (s.domain.dim(1).size) : c_int, s, (s.domain.dim(2).size) : c_int, p, (p.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -25612,6 +26427,7 @@ Wrapped procedure of LAPACKE_dtgevc for the type real(64).
  */
 inline proc tgevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, s : [] real(64), p : [] real(64), vl : [] real(64), vr : [] real(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtgevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (s.domain.dim(1).size) : c_int, s, (s.domain.dim(2).size) : c_int, p, (p.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -25620,6 +26436,7 @@ Wrapped procedure of LAPACKE_ctgevc for the type complex(64).
  */
 inline proc tgevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, s : [] complex(64), p : [] complex(64), vl : [] complex(64), vr : [] complex(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctgevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (s.domain.dim(1).size) : c_int, s, (s.domain.dim(2).size) : c_int, p, (p.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -25628,6 +26445,7 @@ Wrapped procedure of LAPACKE_ztgevc for the type complex(128).
  */
 inline proc tgevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, s : [] complex(128), p : [] complex(128), vl : [] complex(128), vr : [] complex(128), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztgevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (s.domain.dim(1).size) : c_int, s, (s.domain.dim(2).size) : c_int, p, (p.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -25636,6 +26454,7 @@ Wrapped procedure of LAPACKE_stgexc for the type real(32).
  */
 inline proc tgexc(matrix_order : lapack_memory_order, wantq : c_int, wantz : c_int, a : [] real(32), b : [] real(32), q : [] real(32), z : [] real(32), ref ifst : c_int, ref ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stgexc(matrix_order, wantq, wantz, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -25644,6 +26463,7 @@ Wrapped procedure of LAPACKE_dtgexc for the type real(64).
  */
 inline proc tgexc(matrix_order : lapack_memory_order, wantq : c_int, wantz : c_int, a : [] real(64), b : [] real(64), q : [] real(64), z : [] real(64), ref ifst : c_int, ref ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtgexc(matrix_order, wantq, wantz, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -25652,6 +26472,7 @@ Wrapped procedure of LAPACKE_ctgexc for the type complex(64).
  */
 inline proc tgexc(matrix_order : lapack_memory_order, wantq : c_int, wantz : c_int, a : [] complex(64), b : [] complex(64), q : [] complex(64), z : [] complex(64), ifst : c_int, ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctgexc(matrix_order, wantq, wantz, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -25660,6 +26481,7 @@ Wrapped procedure of LAPACKE_ztgexc for the type complex(128).
  */
 inline proc tgexc(matrix_order : lapack_memory_order, wantq : c_int, wantz : c_int, a : [] complex(128), b : [] complex(128), q : [] complex(128), z : [] complex(128), ifst : c_int, ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztgexc(matrix_order, wantq, wantz, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -25668,6 +26490,7 @@ Wrapped procedure of LAPACKE_stgsen for the type real(32).
  */
 inline proc tgsen(matrix_order : lapack_memory_order, ijob : c_int, wantq : c_int, wantz : c_int, chlapack_select : [] c_int, a : [] real(32), b : [] real(32), alphar : [] real(32), alphai : [] real(32), beta : [] real(32), q : [] real(32), z : [] real(32), ref m : c_int, ref pl : real(32), ref pr : real(32), dif : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stgsen(matrix_order, ijob, wantq, wantz, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alphar, alphai, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, m, pl, pr, dif);
 }
 
@@ -25676,6 +26499,7 @@ Wrapped procedure of LAPACKE_dtgsen for the type real(64).
  */
 inline proc tgsen(matrix_order : lapack_memory_order, ijob : c_int, wantq : c_int, wantz : c_int, chlapack_select : [] c_int, a : [] real(64), b : [] real(64), alphar : [] real(64), alphai : [] real(64), beta : [] real(64), q : [] real(64), z : [] real(64), ref m : c_int, ref pl : real(64), ref pr : real(64), dif : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtgsen(matrix_order, ijob, wantq, wantz, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alphar, alphai, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, m, pl, pr, dif);
 }
 
@@ -25684,6 +26508,7 @@ Wrapped procedure of LAPACKE_ctgsen for the type complex(64).
  */
 inline proc tgsen(matrix_order : lapack_memory_order, ijob : c_int, wantq : c_int, wantz : c_int, chlapack_select : [] c_int, a : [] complex(64), b : [] complex(64), alpha : [] complex(64), beta : [] complex(64), q : [] complex(64), z : [] complex(64), ref m : c_int, ref pl : real(32), ref pr : real(32), dif : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctgsen(matrix_order, ijob, wantq, wantz, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, m, pl, pr, dif);
 }
 
@@ -25692,6 +26517,7 @@ Wrapped procedure of LAPACKE_ztgsen for the type complex(128).
  */
 inline proc tgsen(matrix_order : lapack_memory_order, ijob : c_int, wantq : c_int, wantz : c_int, chlapack_select : [] c_int, a : [] complex(128), b : [] complex(128), alpha : [] complex(128), beta : [] complex(128), q : [] complex(128), z : [] complex(128), ref m : c_int, ref pl : real(64), ref pr : real(64), dif : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztgsen(matrix_order, ijob, wantq, wantz, chlapack_select, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, alpha, beta, q, (q.domain.dim(2).size) : c_int, z, (z.domain.dim(2).size) : c_int, m, pl, pr, dif);
 }
 
@@ -25700,6 +26526,7 @@ Wrapped procedure of LAPACKE_stgsja for the type real(32).
  */
 inline proc tgsja(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, k : c_int, l : c_int, a : [] real(32), b : [] real(32), tola : real(32), tolb : real(32), alpha : [] real(32), beta : [] real(32), u : [] real(32), v : [] real(32), q : [] real(32), ref ncycle : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stgsja(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ncycle);
 }
 
@@ -25708,6 +26535,7 @@ Wrapped procedure of LAPACKE_dtgsja for the type real(64).
  */
 inline proc tgsja(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, k : c_int, l : c_int, a : [] real(64), b : [] real(64), tola : real(64), tolb : real(64), alpha : [] real(64), beta : [] real(64), u : [] real(64), v : [] real(64), q : [] real(64), ref ncycle : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtgsja(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ncycle);
 }
 
@@ -25716,6 +26544,7 @@ Wrapped procedure of LAPACKE_ctgsja for the type complex(64).
  */
 inline proc tgsja(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, k : c_int, l : c_int, a : [] complex(64), b : [] complex(64), tola : real(32), tolb : real(32), alpha : [] real(32), beta : [] real(32), u : [] complex(64), v : [] complex(64), q : [] complex(64), ref ncycle : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctgsja(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ncycle);
 }
 
@@ -25724,6 +26553,7 @@ Wrapped procedure of LAPACKE_ztgsja for the type complex(128).
  */
 inline proc tgsja(matrix_order : lapack_memory_order, jobu : string, jobv : string, jobq : string, k : c_int, l : c_int, a : [] complex(128), b : [] complex(128), tola : real(64), tolb : real(64), alpha : [] real(64), beta : [] real(64), u : [] complex(128), v : [] complex(128), q : [] complex(128), ref ncycle : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztgsja(matrix_order, jobu.toByte() : c_char, jobv.toByte() : c_char, jobq.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, tola, tolb, alpha, beta, u, (u.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ncycle);
 }
 
@@ -25732,6 +26562,7 @@ Wrapped procedure of LAPACKE_stgsna for the type real(32).
  */
 inline proc tgsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, n : c_int, a : [] real(32), b : [] real(32), vl : [] real(32), vr : [] real(32), s : [] real(32), dif : [] real(32), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stgsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, n, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, dif, mm, m);
 }
 
@@ -25740,6 +26571,7 @@ Wrapped procedure of LAPACKE_dtgsna for the type real(64).
  */
 inline proc tgsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, n : c_int, a : [] real(64), b : [] real(64), vl : [] real(64), vr : [] real(64), s : [] real(64), dif : [] real(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtgsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, n, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, dif, mm, m);
 }
 
@@ -25748,6 +26580,7 @@ Wrapped procedure of LAPACKE_ctgsna for the type complex(64).
  */
 inline proc tgsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, n : c_int, a : [] complex(64), b : [] complex(64), vl : [] complex(64), vr : [] complex(64), s : [] real(32), dif : [] real(32), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctgsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, n, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, dif, mm, m);
 }
 
@@ -25756,6 +26589,7 @@ Wrapped procedure of LAPACKE_ztgsna for the type complex(128).
  */
 inline proc tgsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, n : c_int, a : [] complex(128), b : [] complex(128), vl : [] complex(128), vr : [] complex(128), s : [] real(64), dif : [] real(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztgsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, n, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, dif, mm, m);
 }
 
@@ -25764,6 +26598,7 @@ Wrapped procedure of LAPACKE_stgsyl for the type real(32).
  */
 inline proc tgsyl(matrix_order : lapack_memory_order, trans : string, ijob : c_int, a : [] real(32), b : [] real(32), c : [] real(32), d : [] real(32), e : [] real(32), f : [] real(32), ref scale : real(32), ref dif : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stgsyl(matrix_order, trans.toByte() : c_char, ijob, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, d, (d.domain.dim(2).size) : c_int, e, (e.domain.dim(2).size) : c_int, f, (f.domain.dim(2).size) : c_int, scale, dif);
 }
 
@@ -25772,6 +26607,7 @@ Wrapped procedure of LAPACKE_dtgsyl for the type real(64).
  */
 inline proc tgsyl(matrix_order : lapack_memory_order, trans : string, ijob : c_int, a : [] real(64), b : [] real(64), c : [] real(64), d : [] real(64), e : [] real(64), f : [] real(64), ref scale : real(64), ref dif : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtgsyl(matrix_order, trans.toByte() : c_char, ijob, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, d, (d.domain.dim(2).size) : c_int, e, (e.domain.dim(2).size) : c_int, f, (f.domain.dim(2).size) : c_int, scale, dif);
 }
 
@@ -25780,6 +26616,7 @@ Wrapped procedure of LAPACKE_ctgsyl for the type complex(64).
  */
 inline proc tgsyl(matrix_order : lapack_memory_order, trans : string, ijob : c_int, a : [] complex(64), b : [] complex(64), c : [] complex(64), d : [] complex(64), e : [] complex(64), f : [] complex(64), ref scale : real(32), ref dif : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctgsyl(matrix_order, trans.toByte() : c_char, ijob, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, d, (d.domain.dim(2).size) : c_int, e, (e.domain.dim(2).size) : c_int, f, (f.domain.dim(2).size) : c_int, scale, dif);
 }
 
@@ -25788,6 +26625,7 @@ Wrapped procedure of LAPACKE_ztgsyl for the type complex(128).
  */
 inline proc tgsyl(matrix_order : lapack_memory_order, trans : string, ijob : c_int, a : [] complex(128), b : [] complex(128), c : [] complex(128), d : [] complex(128), e : [] complex(128), f : [] complex(128), ref scale : real(64), ref dif : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztgsyl(matrix_order, trans.toByte() : c_char, ijob, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, d, (d.domain.dim(2).size) : c_int, e, (e.domain.dim(2).size) : c_int, f, (f.domain.dim(2).size) : c_int, scale, dif);
 }
 
@@ -25796,6 +26634,7 @@ Wrapped procedure of LAPACKE_stpcon for the type real(32).
  */
 inline proc tpcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, ap : [] real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stpcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap, rcond);
 }
 
@@ -25804,6 +26643,7 @@ Wrapped procedure of LAPACKE_dtpcon for the type real(64).
  */
 inline proc tpcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, ap : [] real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtpcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap, rcond);
 }
 
@@ -25812,6 +26652,7 @@ Wrapped procedure of LAPACKE_ctpcon for the type complex(64).
  */
 inline proc tpcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, ap : [] complex(64), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctpcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap, rcond);
 }
 
@@ -25820,6 +26661,7 @@ Wrapped procedure of LAPACKE_ztpcon for the type complex(128).
  */
 inline proc tpcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, n : c_int, ap : [] complex(128), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztpcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap, rcond);
 }
 
@@ -25828,6 +26670,7 @@ Wrapped procedure of LAPACKE_stprfs for the type real(32).
  */
 inline proc tprfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stprfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25836,6 +26679,7 @@ Wrapped procedure of LAPACKE_dtprfs for the type real(64).
  */
 inline proc tprfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtprfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25844,6 +26688,7 @@ Wrapped procedure of LAPACKE_ctprfs for the type complex(64).
  */
 inline proc tprfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctprfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25852,6 +26697,7 @@ Wrapped procedure of LAPACKE_ztprfs for the type complex(128).
  */
 inline proc tprfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztprfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -25860,6 +26706,7 @@ Wrapped procedure of LAPACKE_stptri for the type real(32).
  */
 inline proc tptri(matrix_order : lapack_memory_order, uplo : string, diag : string, n : c_int, ap : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stptri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap);
 }
 
@@ -25868,6 +26715,7 @@ Wrapped procedure of LAPACKE_dtptri for the type real(64).
  */
 inline proc tptri(matrix_order : lapack_memory_order, uplo : string, diag : string, n : c_int, ap : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtptri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap);
 }
 
@@ -25876,6 +26724,7 @@ Wrapped procedure of LAPACKE_ctptri for the type complex(64).
  */
 inline proc tptri(matrix_order : lapack_memory_order, uplo : string, diag : string, n : c_int, ap : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctptri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap);
 }
 
@@ -25884,6 +26733,7 @@ Wrapped procedure of LAPACKE_ztptri for the type complex(128).
  */
 inline proc tptri(matrix_order : lapack_memory_order, uplo : string, diag : string, n : c_int, ap : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztptri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, n, ap);
 }
 
@@ -25892,6 +26742,7 @@ Wrapped procedure of LAPACKE_stptrs for the type real(32).
  */
 inline proc tptrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stptrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25900,6 +26751,7 @@ Wrapped procedure of LAPACKE_dtptrs for the type real(64).
  */
 inline proc tptrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtptrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25908,6 +26760,7 @@ Wrapped procedure of LAPACKE_ctptrs for the type complex(64).
  */
 inline proc tptrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctptrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25916,6 +26769,7 @@ Wrapped procedure of LAPACKE_ztptrs for the type complex(128).
  */
 inline proc tptrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, n : c_int, ap : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztptrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, n, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, ap, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -25924,6 +26778,7 @@ Wrapped procedure of LAPACKE_stpttf for the type real(32).
  */
 inline proc tpttf(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, ap : [] real(32), arf : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stpttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, ap, arf);
 }
 
@@ -25932,6 +26787,7 @@ Wrapped procedure of LAPACKE_dtpttf for the type real(64).
  */
 inline proc tpttf(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, ap : [] real(64), arf : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtpttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, ap, arf);
 }
 
@@ -25940,6 +26796,7 @@ Wrapped procedure of LAPACKE_ctpttf for the type complex(64).
  */
 inline proc tpttf(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, ap : [] complex(64), arf : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctpttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, ap, arf);
 }
 
@@ -25948,6 +26805,7 @@ Wrapped procedure of LAPACKE_ztpttf for the type complex(128).
  */
 inline proc tpttf(matrix_order : lapack_memory_order, transr : string, uplo : string, n : c_int, ap : [] complex(128), arf : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztpttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, n, ap, arf);
 }
 
@@ -25956,6 +26814,7 @@ Wrapped procedure of LAPACKE_stpttr for the type real(32).
  */
 inline proc tpttr(matrix_order : lapack_memory_order, uplo : string, ap : [] real(32), a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stpttr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, ap, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -25964,6 +26823,7 @@ Wrapped procedure of LAPACKE_dtpttr for the type real(64).
  */
 inline proc tpttr(matrix_order : lapack_memory_order, uplo : string, ap : [] real(64), a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtpttr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, ap, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -25972,6 +26832,7 @@ Wrapped procedure of LAPACKE_ctpttr for the type complex(64).
  */
 inline proc tpttr(matrix_order : lapack_memory_order, uplo : string, ap : [] complex(64), a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctpttr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, ap, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -25980,6 +26841,7 @@ Wrapped procedure of LAPACKE_ztpttr for the type complex(128).
  */
 inline proc tpttr(matrix_order : lapack_memory_order, uplo : string, ap : [] complex(128), a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztpttr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, ap, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -25988,6 +26850,7 @@ Wrapped procedure of LAPACKE_strcon for the type real(32).
  */
 inline proc trcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] real(32), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -25996,6 +26859,7 @@ Wrapped procedure of LAPACKE_dtrcon for the type real(64).
  */
 inline proc trcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] real(64), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -26004,6 +26868,7 @@ Wrapped procedure of LAPACKE_ctrcon for the type complex(64).
  */
 inline proc trcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] complex(64), ref rcond : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -26012,6 +26877,7 @@ Wrapped procedure of LAPACKE_ztrcon for the type complex(128).
  */
 inline proc trcon(matrix_order : lapack_memory_order, norm : string, uplo : string, diag : string, a : [] complex(128), ref rcond : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrcon(matrix_order, norm.toByte() : c_char, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, rcond);
 }
 
@@ -26020,6 +26886,7 @@ Wrapped procedure of LAPACKE_strevc for the type real(32).
  */
 inline proc trevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, t : [] real(32), vl : [] real(32), vr : [] real(32), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -26028,6 +26895,7 @@ Wrapped procedure of LAPACKE_dtrevc for the type real(64).
  */
 inline proc trevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, t : [] real(64), vl : [] real(64), vr : [] real(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -26036,6 +26904,7 @@ Wrapped procedure of LAPACKE_ctrevc for the type complex(64).
  */
 inline proc trevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, t : [] complex(64), vl : [] complex(64), vr : [] complex(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -26044,6 +26913,7 @@ Wrapped procedure of LAPACKE_ztrevc for the type complex(128).
  */
 inline proc trevc(matrix_order : lapack_memory_order, side : string, howmny : string, chlapack_select : [] c_int, t : [] complex(128), vl : [] complex(128), vr : [] complex(128), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrevc(matrix_order, side.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, mm, m);
 }
 
@@ -26052,6 +26922,7 @@ Wrapped procedure of LAPACKE_strexc for the type real(32).
  */
 inline proc trexc(matrix_order : lapack_memory_order, compq : string, t : [] real(32), q : [] real(32), ref ifst : c_int, ref ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strexc(matrix_order, compq.toByte() : c_char, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -26060,6 +26931,7 @@ Wrapped procedure of LAPACKE_dtrexc for the type real(64).
  */
 inline proc trexc(matrix_order : lapack_memory_order, compq : string, t : [] real(64), q : [] real(64), ref ifst : c_int, ref ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrexc(matrix_order, compq.toByte() : c_char, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -26068,6 +26940,7 @@ Wrapped procedure of LAPACKE_ctrexc for the type complex(64).
  */
 inline proc trexc(matrix_order : lapack_memory_order, compq : string, t : [] complex(64), q : [] complex(64), ifst : c_int, ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrexc(matrix_order, compq.toByte() : c_char, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -26076,6 +26949,7 @@ Wrapped procedure of LAPACKE_ztrexc for the type complex(128).
  */
 inline proc trexc(matrix_order : lapack_memory_order, compq : string, t : [] complex(128), q : [] complex(128), ifst : c_int, ilst : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrexc(matrix_order, compq.toByte() : c_char, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, ifst, ilst);
 }
 
@@ -26084,6 +26958,7 @@ Wrapped procedure of LAPACKE_strrfs for the type real(32).
  */
 inline proc trrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] real(32), b : [] real(32), x : [] real(32), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -26092,6 +26967,7 @@ Wrapped procedure of LAPACKE_dtrrfs for the type real(64).
  */
 inline proc trrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] real(64), b : [] real(64), x : [] real(64), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -26100,6 +26976,7 @@ Wrapped procedure of LAPACKE_ctrrfs for the type complex(64).
  */
 inline proc trrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] complex(64), b : [] complex(64), x : [] complex(64), ferr : [] real(32), berr : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -26108,6 +26985,7 @@ Wrapped procedure of LAPACKE_ztrrfs for the type complex(128).
  */
 inline proc trrfs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] complex(128), b : [] complex(128), x : [] complex(128), ferr : [] real(64), berr : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrrfs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, x, (x.domain.dim(2).size) : c_int, ferr, berr);
 }
 
@@ -26116,6 +26994,7 @@ Wrapped procedure of LAPACKE_strsen for the type real(32).
  */
 inline proc trsen(matrix_order : lapack_memory_order, job : string, compq : string, chlapack_select : [] c_int, t : [] real(32), q : [] real(32), wr : [] real(32), wi : [] real(32), ref m : c_int, ref s : real(32), ref sep : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strsen(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, wr, wi, m, s, sep);
 }
 
@@ -26124,6 +27003,7 @@ Wrapped procedure of LAPACKE_dtrsen for the type real(64).
  */
 inline proc trsen(matrix_order : lapack_memory_order, job : string, compq : string, chlapack_select : [] c_int, t : [] real(64), q : [] real(64), wr : [] real(64), wi : [] real(64), ref m : c_int, ref s : real(64), ref sep : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrsen(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, wr, wi, m, s, sep);
 }
 
@@ -26132,6 +27012,7 @@ Wrapped procedure of LAPACKE_ctrsen for the type complex(64).
  */
 inline proc trsen(matrix_order : lapack_memory_order, job : string, compq : string, chlapack_select : [] c_int, t : [] complex(64), q : [] complex(64), w : [] complex(64), ref m : c_int, ref s : real(32), ref sep : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrsen(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, w, m, s, sep);
 }
 
@@ -26140,6 +27021,7 @@ Wrapped procedure of LAPACKE_ztrsen for the type complex(128).
  */
 inline proc trsen(matrix_order : lapack_memory_order, job : string, compq : string, chlapack_select : [] c_int, t : [] complex(128), q : [] complex(128), w : [] complex(128), ref m : c_int, ref s : real(64), ref sep : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrsen(matrix_order, job.toByte() : c_char, compq.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, q, (q.domain.dim(2).size) : c_int, w, m, s, sep);
 }
 
@@ -26148,6 +27030,7 @@ Wrapped procedure of LAPACKE_strsna for the type real(32).
  */
 inline proc trsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, t : [] real(32), vl : [] real(32), vr : [] real(32), s : [] real(32), sep : [] real(32), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, sep, mm, m);
 }
 
@@ -26156,6 +27039,7 @@ Wrapped procedure of LAPACKE_dtrsna for the type real(64).
  */
 inline proc trsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, t : [] real(64), vl : [] real(64), vr : [] real(64), s : [] real(64), sep : [] real(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, sep, mm, m);
 }
 
@@ -26164,6 +27048,7 @@ Wrapped procedure of LAPACKE_ctrsna for the type complex(64).
  */
 inline proc trsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, t : [] complex(64), vl : [] complex(64), vr : [] complex(64), s : [] real(32), sep : [] real(32), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, sep, mm, m);
 }
 
@@ -26172,6 +27057,7 @@ Wrapped procedure of LAPACKE_ztrsna for the type complex(128).
  */
 inline proc trsna(matrix_order : lapack_memory_order, job : string, howmny : string, chlapack_select : [] c_int, t : [] complex(128), vl : [] complex(128), vr : [] complex(128), s : [] real(64), sep : [] real(64), mm : c_int, ref m : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrsna(matrix_order, job.toByte() : c_char, howmny.toByte() : c_char, chlapack_select, (t.domain.dim(1).size) : c_int, t, (t.domain.dim(2).size) : c_int, vl, (vl.domain.dim(2).size) : c_int, vr, (vr.domain.dim(2).size) : c_int, s, sep, mm, m);
 }
 
@@ -26180,6 +27066,7 @@ Wrapped procedure of LAPACKE_strsyl for the type real(32).
  */
 inline proc trsyl(matrix_order : lapack_memory_order, trana : string, tranb : string, isgn : c_int, a : [] real(32), b : [] real(32), c : [] real(32), ref scale : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strsyl(matrix_order, trana.toByte() : c_char, tranb.toByte() : c_char, isgn, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, scale);
 }
 
@@ -26188,6 +27075,7 @@ Wrapped procedure of LAPACKE_dtrsyl for the type real(64).
  */
 inline proc trsyl(matrix_order : lapack_memory_order, trana : string, tranb : string, isgn : c_int, a : [] real(64), b : [] real(64), c : [] real(64), ref scale : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrsyl(matrix_order, trana.toByte() : c_char, tranb.toByte() : c_char, isgn, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, scale);
 }
 
@@ -26196,6 +27084,7 @@ Wrapped procedure of LAPACKE_ctrsyl for the type complex(64).
  */
 inline proc trsyl(matrix_order : lapack_memory_order, trana : string, tranb : string, isgn : c_int, a : [] complex(64), b : [] complex(64), c : [] complex(64), ref scale : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrsyl(matrix_order, trana.toByte() : c_char, tranb.toByte() : c_char, isgn, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, scale);
 }
 
@@ -26204,6 +27093,7 @@ Wrapped procedure of LAPACKE_ztrsyl for the type complex(128).
  */
 inline proc trsyl(matrix_order : lapack_memory_order, trana : string, tranb : string, isgn : c_int, a : [] complex(128), b : [] complex(128), c : [] complex(128), ref scale : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrsyl(matrix_order, trana.toByte() : c_char, tranb.toByte() : c_char, isgn, (a.domain.dim(1).size) : c_int, (b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int, scale);
 }
 
@@ -26212,6 +27102,7 @@ Wrapped procedure of LAPACKE_strtri for the type real(32).
  */
 inline proc trtri(matrix_order : lapack_memory_order, uplo : string, diag : string, a : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strtri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -26220,6 +27111,7 @@ Wrapped procedure of LAPACKE_dtrtri for the type real(64).
  */
 inline proc trtri(matrix_order : lapack_memory_order, uplo : string, diag : string, a : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrtri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -26228,6 +27120,7 @@ Wrapped procedure of LAPACKE_ctrtri for the type complex(64).
  */
 inline proc trtri(matrix_order : lapack_memory_order, uplo : string, diag : string, a : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrtri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -26236,6 +27129,7 @@ Wrapped procedure of LAPACKE_ztrtri for the type complex(128).
  */
 inline proc trtri(matrix_order : lapack_memory_order, uplo : string, diag : string, a : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrtri(matrix_order, uplo.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int);
 }
 
@@ -26244,6 +27138,7 @@ Wrapped procedure of LAPACKE_strtrs for the type real(32).
  */
 inline proc trtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26252,6 +27147,7 @@ Wrapped procedure of LAPACKE_dtrtrs for the type real(64).
  */
 inline proc trtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26260,6 +27156,7 @@ Wrapped procedure of LAPACKE_ctrtrs for the type complex(64).
  */
 inline proc trtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26268,6 +27165,7 @@ Wrapped procedure of LAPACKE_ztrtrs for the type complex(128).
  */
 inline proc trtrs(matrix_order : lapack_memory_order, uplo : string, trans : string, diag : string, a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrtrs(matrix_order, uplo.toByte() : c_char, trans.toByte() : c_char, diag.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26276,6 +27174,7 @@ Wrapped procedure of LAPACKE_strttf for the type real(32).
  */
 inline proc trttf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(32), lda : c_int, arf : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, lda, arf);
 }
 
@@ -26284,6 +27183,7 @@ Wrapped procedure of LAPACKE_dtrttf for the type real(64).
  */
 inline proc trttf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] real(64), lda : c_int, arf : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, lda, arf);
 }
 
@@ -26292,6 +27192,7 @@ Wrapped procedure of LAPACKE_ctrttf for the type complex(64).
  */
 inline proc trttf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(64), lda : c_int, arf : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, lda, arf);
 }
 
@@ -26300,6 +27201,7 @@ Wrapped procedure of LAPACKE_ztrttf for the type complex(128).
  */
 inline proc trttf(matrix_order : lapack_memory_order, transr : string, uplo : string, a : [] complex(128), lda : c_int, arf : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrttf(matrix_order, transr.toByte() : c_char, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, lda, arf);
 }
 
@@ -26308,6 +27210,7 @@ Wrapped procedure of LAPACKE_strttp for the type real(32).
  */
 inline proc trttp(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ap : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_strttp(matrix_order, uplo.toByte() : c_char, (ap.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ap);
 }
 
@@ -26316,6 +27219,7 @@ Wrapped procedure of LAPACKE_dtrttp for the type real(64).
  */
 inline proc trttp(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ap : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtrttp(matrix_order, uplo.toByte() : c_char, (ap.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ap);
 }
 
@@ -26324,6 +27228,7 @@ Wrapped procedure of LAPACKE_ctrttp for the type complex(64).
  */
 inline proc trttp(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ap : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctrttp(matrix_order, uplo.toByte() : c_char, (ap.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ap);
 }
 
@@ -26332,6 +27237,7 @@ Wrapped procedure of LAPACKE_ztrttp for the type complex(128).
  */
 inline proc trttp(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ap : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztrttp(matrix_order, uplo.toByte() : c_char, (ap.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ap);
 }
 
@@ -26340,6 +27246,7 @@ Wrapped procedure of LAPACKE_stzrzf for the type real(32).
  */
 inline proc tzrzf(matrix_order : lapack_memory_order, a : [] real(32), tau : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stzrzf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26348,6 +27255,7 @@ Wrapped procedure of LAPACKE_dtzrzf for the type real(64).
  */
 inline proc tzrzf(matrix_order : lapack_memory_order, a : [] real(64), tau : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtzrzf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26356,6 +27264,7 @@ Wrapped procedure of LAPACKE_ctzrzf for the type complex(64).
  */
 inline proc tzrzf(matrix_order : lapack_memory_order, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctzrzf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26364,6 +27273,7 @@ Wrapped procedure of LAPACKE_ztzrzf for the type complex(128).
  */
 inline proc tzrzf(matrix_order : lapack_memory_order, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztzrzf(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26372,6 +27282,7 @@ Wrapped procedure of LAPACKE_cungbr for the type complex(64).
  */
 inline proc ungbr(matrix_order : lapack_memory_order, vect : string, k : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cungbr(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26380,6 +27291,7 @@ Wrapped procedure of LAPACKE_zungbr for the type complex(128).
  */
 inline proc ungbr(matrix_order : lapack_memory_order, vect : string, k : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zungbr(matrix_order, vect.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26388,6 +27300,7 @@ Wrapped procedure of LAPACKE_cunghr for the type complex(64).
  */
 inline proc unghr(matrix_order : lapack_memory_order, n : c_int, ilo : c_int, ihi : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunghr(matrix_order, n, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26396,6 +27309,7 @@ Wrapped procedure of LAPACKE_zunghr for the type complex(128).
  */
 inline proc unghr(matrix_order : lapack_memory_order, n : c_int, ilo : c_int, ihi : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunghr(matrix_order, n, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26404,6 +27318,7 @@ Wrapped procedure of LAPACKE_cunglq for the type complex(64).
  */
 inline proc unglq(matrix_order : lapack_memory_order, k : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunglq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26412,6 +27327,7 @@ Wrapped procedure of LAPACKE_zunglq for the type complex(128).
  */
 inline proc unglq(matrix_order : lapack_memory_order, k : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunglq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26420,6 +27336,7 @@ Wrapped procedure of LAPACKE_cungql for the type complex(64).
  */
 inline proc ungql(matrix_order : lapack_memory_order, k : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cungql(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26428,6 +27345,7 @@ Wrapped procedure of LAPACKE_zungql for the type complex(128).
  */
 inline proc ungql(matrix_order : lapack_memory_order, k : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zungql(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26436,6 +27354,7 @@ Wrapped procedure of LAPACKE_cungqr for the type complex(64).
  */
 inline proc ungqr(matrix_order : lapack_memory_order, k : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cungqr(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26444,6 +27363,7 @@ Wrapped procedure of LAPACKE_zungqr for the type complex(128).
  */
 inline proc ungqr(matrix_order : lapack_memory_order, k : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zungqr(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26452,6 +27372,7 @@ Wrapped procedure of LAPACKE_cungrq for the type complex(64).
  */
 inline proc ungrq(matrix_order : lapack_memory_order, k : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cungrq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26460,6 +27381,7 @@ Wrapped procedure of LAPACKE_zungrq for the type complex(128).
  */
 inline proc ungrq(matrix_order : lapack_memory_order, k : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zungrq(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26468,6 +27390,7 @@ Wrapped procedure of LAPACKE_cungtr for the type complex(64).
  */
 inline proc ungtr(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] complex(64), tau : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cungtr(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26476,6 +27399,7 @@ Wrapped procedure of LAPACKE_zungtr for the type complex(128).
  */
 inline proc ungtr(matrix_order : lapack_memory_order, uplo : string, n : c_int, a : [] complex(128), tau : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zungtr(matrix_order, uplo.toByte() : c_char, n, a, (a.domain.dim(2).size) : c_int, tau);
 }
 
@@ -26484,6 +27408,7 @@ Wrapped procedure of LAPACKE_cunmbr for the type complex(64).
  */
 inline proc unmbr(matrix_order : lapack_memory_order, vect : string, side : string, trans : string, k : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmbr(matrix_order, vect.toByte() : c_char, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26492,6 +27417,7 @@ Wrapped procedure of LAPACKE_zunmbr for the type complex(128).
  */
 inline proc unmbr(matrix_order : lapack_memory_order, vect : string, side : string, trans : string, k : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmbr(matrix_order, vect.toByte() : c_char, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26500,6 +27426,7 @@ Wrapped procedure of LAPACKE_cunmhr for the type complex(64).
  */
 inline proc unmhr(matrix_order : lapack_memory_order, side : string, trans : string, ilo : c_int, ihi : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmhr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26508,6 +27435,7 @@ Wrapped procedure of LAPACKE_zunmhr for the type complex(128).
  */
 inline proc unmhr(matrix_order : lapack_memory_order, side : string, trans : string, ilo : c_int, ihi : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmhr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ilo, ihi, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26516,6 +27444,7 @@ Wrapped procedure of LAPACKE_cunmlq for the type complex(64).
  */
 inline proc unmlq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmlq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26524,6 +27453,7 @@ Wrapped procedure of LAPACKE_zunmlq for the type complex(128).
  */
 inline proc unmlq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmlq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26532,6 +27462,7 @@ Wrapped procedure of LAPACKE_cunmql for the type complex(64).
  */
 inline proc unmql(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmql(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26540,6 +27471,7 @@ Wrapped procedure of LAPACKE_zunmql for the type complex(128).
  */
 inline proc unmql(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmql(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26548,6 +27480,7 @@ Wrapped procedure of LAPACKE_cunmqr for the type complex(64).
  */
 inline proc unmqr(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmqr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26556,6 +27489,7 @@ Wrapped procedure of LAPACKE_zunmqr for the type complex(128).
  */
 inline proc unmqr(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmqr(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26564,6 +27498,7 @@ Wrapped procedure of LAPACKE_cunmrq for the type complex(64).
  */
 inline proc unmrq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmrq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26572,6 +27507,7 @@ Wrapped procedure of LAPACKE_zunmrq for the type complex(128).
  */
 inline proc unmrq(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmrq(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26580,6 +27516,7 @@ Wrapped procedure of LAPACKE_cunmrz for the type complex(64).
  */
 inline proc unmrz(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, l : c_int, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmrz(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26588,6 +27525,7 @@ Wrapped procedure of LAPACKE_zunmrz for the type complex(128).
  */
 inline proc unmrz(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, l : c_int, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmrz(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, l, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26596,6 +27534,7 @@ Wrapped procedure of LAPACKE_cunmtr for the type complex(64).
  */
 inline proc unmtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, a : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunmtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26604,6 +27543,7 @@ Wrapped procedure of LAPACKE_zunmtr for the type complex(128).
  */
 inline proc unmtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, a : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunmtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26612,6 +27552,7 @@ Wrapped procedure of LAPACKE_cupgtr for the type complex(64).
  */
 inline proc upgtr(matrix_order : lapack_memory_order, uplo : string, ap : [] complex(64), tau : [] complex(64), q : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cupgtr(matrix_order, uplo.toByte() : c_char, (q.domain.dim(1).size) : c_int, ap, tau, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -26620,6 +27561,7 @@ Wrapped procedure of LAPACKE_zupgtr for the type complex(128).
  */
 inline proc upgtr(matrix_order : lapack_memory_order, uplo : string, ap : [] complex(128), tau : [] complex(128), q : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zupgtr(matrix_order, uplo.toByte() : c_char, (q.domain.dim(1).size) : c_int, ap, tau, q, (q.domain.dim(2).size) : c_int);
 }
 
@@ -26628,6 +27570,7 @@ Wrapped procedure of LAPACKE_cupmtr for the type complex(64).
  */
 inline proc upmtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, ap : [] complex(64), tau : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cupmtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ap, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26636,6 +27579,7 @@ Wrapped procedure of LAPACKE_zupmtr for the type complex(128).
  */
 inline proc upmtr(matrix_order : lapack_memory_order, side : string, uplo : string, trans : string, ap : [] complex(128), tau : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zupmtr(matrix_order, side.toByte() : c_char, uplo.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, ap, tau, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -26644,6 +27588,7 @@ Wrapped procedure of LAPACKE_claghe for the type complex(64).
  */
 inline proc laghe(matrix_order : lapack_memory_order, k : c_int, d : [] real(32), a : [] complex(64), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_claghe(matrix_order, (a.domain.dim(1).size) : c_int, k, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -26652,6 +27597,7 @@ Wrapped procedure of LAPACKE_zlaghe for the type complex(128).
  */
 inline proc laghe(matrix_order : lapack_memory_order, k : c_int, d : [] real(64), a : [] complex(128), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlaghe(matrix_order, (a.domain.dim(1).size) : c_int, k, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -26660,6 +27606,7 @@ Wrapped procedure of LAPACKE_slagsy for the type real(32).
  */
 inline proc lagsy(matrix_order : lapack_memory_order, k : c_int, d : [] real(32), a : [] real(32), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slagsy(matrix_order, (a.domain.dim(1).size) : c_int, k, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -26668,6 +27615,7 @@ Wrapped procedure of LAPACKE_dlagsy for the type real(64).
  */
 inline proc lagsy(matrix_order : lapack_memory_order, k : c_int, d : [] real(64), a : [] real(64), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlagsy(matrix_order, (a.domain.dim(1).size) : c_int, k, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -26676,6 +27624,7 @@ Wrapped procedure of LAPACKE_clagsy for the type complex(64).
  */
 inline proc lagsy(matrix_order : lapack_memory_order, k : c_int, d : [] real(32), a : [] complex(64), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clagsy(matrix_order, (a.domain.dim(1).size) : c_int, k, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -26684,6 +27633,7 @@ Wrapped procedure of LAPACKE_zlagsy for the type complex(128).
  */
 inline proc lagsy(matrix_order : lapack_memory_order, k : c_int, d : [] real(64), a : [] complex(128), iseed : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlagsy(matrix_order, (a.domain.dim(1).size) : c_int, k, d, a, (a.domain.dim(2).size) : c_int, iseed);
 }
 
@@ -26692,6 +27642,7 @@ Wrapped procedure of LAPACKE_slapmr for the type real(32).
  */
 inline proc lapmr(matrix_order : lapack_memory_order, forwrd : c_int, x : [] real(32), k : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slapmr(matrix_order, forwrd, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(1).size else x.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, x, (x.domain.dim(2).size) : c_int, k);
 }
 
@@ -26700,6 +27651,7 @@ Wrapped procedure of LAPACKE_dlapmr for the type real(64).
  */
 inline proc lapmr(matrix_order : lapack_memory_order, forwrd : c_int, x : [] real(64), k : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlapmr(matrix_order, forwrd, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(1).size else x.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, x, (x.domain.dim(2).size) : c_int, k);
 }
 
@@ -26708,6 +27660,7 @@ Wrapped procedure of LAPACKE_clapmr for the type complex(64).
  */
 inline proc lapmr(matrix_order : lapack_memory_order, forwrd : c_int, x : [] complex(64), k : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_clapmr(matrix_order, forwrd, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(1).size else x.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, x, (x.domain.dim(2).size) : c_int, k);
 }
 
@@ -26716,6 +27669,7 @@ Wrapped procedure of LAPACKE_zlapmr for the type complex(128).
  */
 inline proc lapmr(matrix_order : lapack_memory_order, forwrd : c_int, x : [] complex(128), k : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zlapmr(matrix_order, forwrd, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(1).size else x.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x.domain.dim(2).size else x.domain.dim(1).size) : c_int, x, (x.domain.dim(2).size) : c_int, k);
 }
 
@@ -26724,6 +27678,7 @@ Wrapped procedure of LAPACKE_slapy2 for the type real(32).
  */
 inline proc lapy2(x : real(32), y : real(32)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slapy2(x, y);
 }
 
@@ -26732,6 +27687,7 @@ Wrapped procedure of LAPACKE_dlapy2 for the type real(64).
  */
 inline proc lapy2(x : real(64), y : real(64)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlapy2(x, y);
 }
 
@@ -26740,6 +27696,7 @@ Wrapped procedure of LAPACKE_slapy3 for the type real(32).
  */
 inline proc lapy3(x : real(32), y : real(32), z : real(32)): c_float{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slapy3(x, y, z);
 }
 
@@ -26748,6 +27705,7 @@ Wrapped procedure of LAPACKE_dlapy3 for the type real(64).
  */
 inline proc lapy3(x : real(64), y : real(64), z : real(64)): c_double{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlapy3(x, y, z);
 }
 
@@ -26756,6 +27714,7 @@ Wrapped procedure of LAPACKE_slartgp for the type real(32).
  */
 inline proc lartgp(f : real(32), g : real(32), ref cs : real(32), ref sn : real(32), ref r : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slartgp(f, g, cs, sn, r);
 }
 
@@ -26764,6 +27723,7 @@ Wrapped procedure of LAPACKE_dlartgp for the type real(64).
  */
 inline proc lartgp(f : real(64), g : real(64), ref cs : real(64), ref sn : real(64), ref r : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlartgp(f, g, cs, sn, r);
 }
 
@@ -26772,6 +27732,7 @@ Wrapped procedure of LAPACKE_slartgs for the type real(32).
  */
 inline proc lartgs(x : real(32), y : real(32), sigma : real(32), ref cs : real(32), ref sn : real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_slartgs(x, y, sigma, cs, sn);
 }
 
@@ -26780,6 +27741,7 @@ Wrapped procedure of LAPACKE_dlartgs for the type real(64).
  */
 inline proc lartgs(x : real(64), y : real(64), sigma : real(64), ref cs : real(64), ref sn : real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dlartgs(x, y, sigma, cs, sn);
 }
 
@@ -26788,6 +27750,7 @@ Wrapped procedure of LAPACKE_cbbcsd for the type complex(64).
  */
 inline proc bbcsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, m : c_int, theta : [] real(32), phi : [] real(32), u1 : [] complex(64), u2 : [] complex(64), v1t : [] complex(64), v2t : [] complex(64), b11d : [] real(32), b11e : [] real(32), b12d : [] real(32), b12e : [] real(32), b21d : [] real(32), b21e : [] real(32), b22d : [] real(32), b22e : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cbbcsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(2).size else u1.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(2).size else v1t.domain.dim(1).size) : c_int, theta, phi, u1, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(1).size else u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(1).size else v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int, b11d, b11e, b12d, b12e, b21d, b21e, b22d, b22e);
 }
 
@@ -26796,6 +27759,7 @@ Wrapped procedure of LAPACKE_cheswapr for the type complex(64).
  */
 inline proc heswapr(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), i1 : c_int, i2 : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cheswapr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, i1, i2);
 }
 
@@ -26804,6 +27768,7 @@ Wrapped procedure of LAPACKE_chetri2 for the type complex(64).
  */
 inline proc hetri2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetri2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26812,6 +27777,7 @@ Wrapped procedure of LAPACKE_chetri2x for the type complex(64).
  */
 inline proc hetri2x(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, nb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetri2x(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, nb);
 }
 
@@ -26820,6 +27786,7 @@ Wrapped procedure of LAPACKE_chetrs2 for the type complex(64).
  */
 inline proc hetrs2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_chetrs2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26828,6 +27795,7 @@ Wrapped procedure of LAPACKE_csyconv for the type complex(64).
  */
 inline proc syconv(matrix_order : lapack_memory_order, uplo : string, way : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csyconv(matrix_order, uplo.toByte() : c_char, way.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26836,6 +27804,7 @@ Wrapped procedure of LAPACKE_csyswapr for the type complex(64).
  */
 inline proc syswapr(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), i1 : c_int, i2 : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csyswapr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, i1, i2);
 }
 
@@ -26844,6 +27813,7 @@ Wrapped procedure of LAPACKE_csytri2 for the type complex(64).
  */
 inline proc sytri2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csytri2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26852,6 +27822,7 @@ Wrapped procedure of LAPACKE_csytri2x for the type complex(64).
  */
 inline proc sytri2x(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, nb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csytri2x(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, nb);
 }
 
@@ -26860,6 +27831,7 @@ Wrapped procedure of LAPACKE_csytrs2 for the type complex(64).
  */
 inline proc sytrs2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csytrs2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26868,6 +27840,7 @@ Wrapped procedure of LAPACKE_cunbdb for the type complex(64).
  */
 inline proc unbdb(matrix_order : lapack_memory_order, trans : string, signs : string, m : c_int, x11 : [] complex(64), x12 : [] complex(64), x21 : [] complex(64), x22 : [] complex(64), theta : [] real(32), phi : [] real(32), taup1 : [] complex(64), taup2 : [] complex(64), tauq1 : [] complex(64), tauq2 : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cunbdb(matrix_order, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, phi, taup1, taup2, tauq1, tauq2);
 }
 
@@ -26876,6 +27849,7 @@ Wrapped procedure of LAPACKE_cuncsd for the type complex(64).
  */
 inline proc uncsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, signs : string, m : c_int, x11 : [] complex(64), x12 : [] complex(64), x21 : [] complex(64), x22 : [] complex(64), theta : [] real(32), u1 : [] complex(64), u2 : [] complex(64), v1t : [] complex(64), v2t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cuncsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, u1, (u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int);
 }
 
@@ -26884,6 +27858,7 @@ Wrapped procedure of LAPACKE_dbbcsd for the type real(64).
  */
 inline proc bbcsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, m : c_int, theta : [] real(64), phi : [] real(64), u1 : [] real(64), u2 : [] real(64), v1t : [] real(64), v2t : [] real(64), b11d : [] real(64), b11e : [] real(64), b12d : [] real(64), b12e : [] real(64), b21d : [] real(64), b21e : [] real(64), b22d : [] real(64), b22e : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dbbcsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(2).size else u1.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(2).size else v1t.domain.dim(1).size) : c_int, theta, phi, u1, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(1).size else u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(1).size else v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int, b11d, b11e, b12d, b12e, b21d, b21e, b22d, b22e);
 }
 
@@ -26892,6 +27867,7 @@ Wrapped procedure of LAPACKE_dorbdb for the type real(64).
  */
 inline proc orbdb(matrix_order : lapack_memory_order, trans : string, signs : string, m : c_int, x11 : [] real(64), x12 : [] real(64), x21 : [] real(64), x22 : [] real(64), theta : [] real(64), phi : [] real(64), taup1 : [] real(64), taup2 : [] real(64), tauq1 : [] real(64), tauq2 : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorbdb(matrix_order, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, phi, taup1, taup2, tauq1, tauq2);
 }
 
@@ -26900,6 +27876,7 @@ Wrapped procedure of LAPACKE_dorcsd for the type real(64).
  */
 inline proc orcsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, signs : string, m : c_int, x11 : [] real(64), x12 : [] real(64), x21 : [] real(64), x22 : [] real(64), theta : [] real(64), u1 : [] real(64), u2 : [] real(64), v1t : [] real(64), v2t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dorcsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, u1, (u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int);
 }
 
@@ -26908,6 +27885,7 @@ Wrapped procedure of LAPACKE_dsyconv for the type real(64).
  */
 inline proc syconv(matrix_order : lapack_memory_order, uplo : string, way : string, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyconv(matrix_order, uplo.toByte() : c_char, way.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26916,6 +27894,7 @@ Wrapped procedure of LAPACKE_dsyswapr for the type real(64).
  */
 inline proc syswapr(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), i1 : c_int, i2 : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsyswapr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, i1, i2);
 }
 
@@ -26924,6 +27903,7 @@ Wrapped procedure of LAPACKE_dsytri2 for the type real(64).
  */
 inline proc sytri2(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytri2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26932,6 +27912,7 @@ Wrapped procedure of LAPACKE_dsytri2x for the type real(64).
  */
 inline proc sytri2x(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int, nb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytri2x(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, nb);
 }
 
@@ -26940,6 +27921,7 @@ Wrapped procedure of LAPACKE_dsytrs2 for the type real(64).
  */
 inline proc sytrs2(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsytrs2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -26948,6 +27930,7 @@ Wrapped procedure of LAPACKE_sbbcsd for the type real(32).
  */
 inline proc bbcsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, m : c_int, theta : [] real(32), phi : [] real(32), u1 : [] real(32), u2 : [] real(32), v1t : [] real(32), v2t : [] real(32), b11d : [] real(32), b11e : [] real(32), b12d : [] real(32), b12e : [] real(32), b21d : [] real(32), b21e : [] real(32), b22d : [] real(32), b22e : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sbbcsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(2).size else u1.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(2).size else v1t.domain.dim(1).size) : c_int, theta, phi, u1, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(1).size else u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(1).size else v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int, b11d, b11e, b12d, b12e, b21d, b21e, b22d, b22e);
 }
 
@@ -26956,6 +27939,7 @@ Wrapped procedure of LAPACKE_sorbdb for the type real(32).
  */
 inline proc orbdb(matrix_order : lapack_memory_order, trans : string, signs : string, m : c_int, x11 : [] real(32), x12 : [] real(32), x21 : [] real(32), x22 : [] real(32), theta : [] real(32), phi : [] real(32), taup1 : [] real(32), taup2 : [] real(32), tauq1 : [] real(32), tauq2 : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorbdb(matrix_order, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, phi, taup1, taup2, tauq1, tauq2);
 }
 
@@ -26964,6 +27948,7 @@ Wrapped procedure of LAPACKE_sorcsd for the type real(32).
  */
 inline proc orcsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, signs : string, m : c_int, x11 : [] real(32), x12 : [] real(32), x21 : [] real(32), x22 : [] real(32), theta : [] real(32), u1 : [] real(32), u2 : [] real(32), v1t : [] real(32), v2t : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sorcsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, u1, (u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int);
 }
 
@@ -26972,6 +27957,7 @@ Wrapped procedure of LAPACKE_ssyconv for the type real(32).
  */
 inline proc syconv(matrix_order : lapack_memory_order, uplo : string, way : string, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyconv(matrix_order, uplo.toByte() : c_char, way.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26980,6 +27966,7 @@ Wrapped procedure of LAPACKE_ssyswapr for the type real(32).
  */
 inline proc syswapr(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), i1 : c_int, i2 : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssyswapr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, i1, i2);
 }
 
@@ -26988,6 +27975,7 @@ Wrapped procedure of LAPACKE_ssytri2 for the type real(32).
  */
 inline proc sytri2(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytri2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -26996,6 +27984,7 @@ Wrapped procedure of LAPACKE_ssytri2x for the type real(32).
  */
 inline proc sytri2x(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int, nb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytri2x(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, nb);
 }
 
@@ -27004,6 +27993,7 @@ Wrapped procedure of LAPACKE_ssytrs2 for the type real(32).
  */
 inline proc sytrs2(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssytrs2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27012,6 +28002,7 @@ Wrapped procedure of LAPACKE_zbbcsd for the type complex(128).
  */
 inline proc bbcsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, m : c_int, theta : [] real(64), phi : [] real(64), u1 : [] complex(128), u2 : [] complex(128), v1t : [] complex(128), v2t : [] complex(128), b11d : [] real(64), b11e : [] real(64), b12d : [] real(64), b12e : [] real(64), b21d : [] real(64), b21e : [] real(64), b22d : [] real(64), b22e : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zbbcsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(2).size else u1.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(2).size else v1t.domain.dim(1).size) : c_int, theta, phi, u1, (if matrix_order == lapack_memory_order.row_major then u1.domain.dim(1).size else u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (if matrix_order == lapack_memory_order.row_major then v1t.domain.dim(1).size else v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int, b11d, b11e, b12d, b12e, b21d, b21e, b22d, b22e);
 }
 
@@ -27020,6 +28011,7 @@ Wrapped procedure of LAPACKE_zheswapr for the type complex(128).
  */
 inline proc heswapr(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), i1 : c_int, i2 : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zheswapr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, i1, i2);
 }
 
@@ -27028,6 +28020,7 @@ Wrapped procedure of LAPACKE_zhetri2 for the type complex(128).
  */
 inline proc hetri2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetri2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -27036,6 +28029,7 @@ Wrapped procedure of LAPACKE_zhetri2x for the type complex(128).
  */
 inline proc hetri2x(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, nb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetri2x(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, nb);
 }
 
@@ -27044,6 +28038,7 @@ Wrapped procedure of LAPACKE_zhetrs2 for the type complex(128).
  */
 inline proc hetrs2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zhetrs2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27052,6 +28047,7 @@ Wrapped procedure of LAPACKE_zsyconv for the type complex(128).
  */
 inline proc syconv(matrix_order : lapack_memory_order, uplo : string, way : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsyconv(matrix_order, uplo.toByte() : c_char, way.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -27060,6 +28056,7 @@ Wrapped procedure of LAPACKE_zsyswapr for the type complex(128).
  */
 inline proc syswapr(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), i1 : c_int, i2 : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsyswapr(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, i1, i2);
 }
 
@@ -27068,6 +28065,7 @@ Wrapped procedure of LAPACKE_zsytri2 for the type complex(128).
  */
 inline proc sytri2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsytri2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv);
 }
 
@@ -27076,6 +28074,7 @@ Wrapped procedure of LAPACKE_zsytri2x for the type complex(128).
  */
 inline proc sytri2x(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, nb : c_int): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsytri2x(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, nb);
 }
 
@@ -27084,6 +28083,7 @@ Wrapped procedure of LAPACKE_zsytrs2 for the type complex(128).
  */
 inline proc sytrs2(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsytrs2(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27092,6 +28092,7 @@ Wrapped procedure of LAPACKE_zunbdb for the type complex(128).
  */
 inline proc unbdb(matrix_order : lapack_memory_order, trans : string, signs : string, m : c_int, x11 : [] complex(128), x12 : [] complex(128), x21 : [] complex(128), x22 : [] complex(128), theta : [] real(64), phi : [] real(64), taup1 : [] complex(128), taup2 : [] complex(128), tauq1 : [] complex(128), tauq2 : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zunbdb(matrix_order, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, phi, taup1, taup2, tauq1, tauq2);
 }
 
@@ -27100,6 +28101,7 @@ Wrapped procedure of LAPACKE_zuncsd for the type complex(128).
  */
 inline proc uncsd(matrix_order : lapack_memory_order, jobu1 : string, jobu2 : string, jobv1t : string, jobv2t : string, trans : string, signs : string, m : c_int, x11 : [] complex(128), x12 : [] complex(128), x21 : [] complex(128), x22 : [] complex(128), theta : [] real(64), u1 : [] complex(128), u2 : [] complex(128), v1t : [] complex(128), v2t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zuncsd(matrix_order, jobu1.toByte() : c_char, jobu2.toByte() : c_char, jobv1t.toByte() : c_char, jobv2t.toByte() : c_char, trans.toByte() : c_char, signs.toByte() : c_char, m, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(1).size else x11.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then x11.domain.dim(2).size else x11.domain.dim(1).size) : c_int, x11, (x11.domain.dim(2).size) : c_int, x12, (x12.domain.dim(2).size) : c_int, x21, (x21.domain.dim(2).size) : c_int, x22, (x22.domain.dim(2).size) : c_int, theta, u1, (u1.domain.dim(2).size) : c_int, u2, (u2.domain.dim(2).size) : c_int, v1t, (v1t.domain.dim(2).size) : c_int, v2t, (v2t.domain.dim(2).size) : c_int);
 }
 
@@ -27108,6 +28110,7 @@ Wrapped procedure of LAPACKE_sgemqrt for the type real(32).
  */
 inline proc gemqrt(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, v : [] real(32), t : [] real(32), c : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgemqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -27116,6 +28119,7 @@ Wrapped procedure of LAPACKE_dgemqrt for the type real(64).
  */
 inline proc gemqrt(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, v : [] real(64), t : [] real(64), c : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgemqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -27124,6 +28128,7 @@ Wrapped procedure of LAPACKE_cgemqrt for the type complex(64).
  */
 inline proc gemqrt(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, v : [] complex(64), t : [] complex(64), c : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgemqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -27132,6 +28137,7 @@ Wrapped procedure of LAPACKE_zgemqrt for the type complex(128).
  */
 inline proc gemqrt(matrix_order : lapack_memory_order, side : string, trans : string, k : c_int, v : [] complex(128), t : [] complex(128), c : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgemqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(1).size else c.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then c.domain.dim(2).size else c.domain.dim(1).size) : c_int, k, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, c, (c.domain.dim(2).size) : c_int);
 }
 
@@ -27140,6 +28146,7 @@ Wrapped procedure of LAPACKE_sgeqrt for the type real(32).
  */
 inline proc geqrt(matrix_order : lapack_memory_order, nb : c_int, a : [] real(32), t : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, nb, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27148,6 +28155,7 @@ Wrapped procedure of LAPACKE_dgeqrt for the type real(64).
  */
 inline proc geqrt(matrix_order : lapack_memory_order, nb : c_int, a : [] real(64), t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, nb, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27156,6 +28164,7 @@ Wrapped procedure of LAPACKE_cgeqrt for the type complex(64).
  */
 inline proc geqrt(matrix_order : lapack_memory_order, nb : c_int, a : [] complex(64), t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, nb, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27164,6 +28173,7 @@ Wrapped procedure of LAPACKE_zgeqrt for the type complex(128).
  */
 inline proc geqrt(matrix_order : lapack_memory_order, nb : c_int, a : [] complex(128), t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, nb, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27172,6 +28182,7 @@ Wrapped procedure of LAPACKE_sgeqrt2 for the type real(32).
  */
 inline proc geqrt2(matrix_order : lapack_memory_order, a : [] real(32), t : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27180,6 +28191,7 @@ Wrapped procedure of LAPACKE_dgeqrt2 for the type real(64).
  */
 inline proc geqrt2(matrix_order : lapack_memory_order, a : [] real(64), t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27188,6 +28200,7 @@ Wrapped procedure of LAPACKE_cgeqrt2 for the type complex(64).
  */
 inline proc geqrt2(matrix_order : lapack_memory_order, a : [] complex(64), t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27196,6 +28209,7 @@ Wrapped procedure of LAPACKE_zgeqrt2 for the type complex(128).
  */
 inline proc geqrt2(matrix_order : lapack_memory_order, a : [] complex(128), t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27204,6 +28218,7 @@ Wrapped procedure of LAPACKE_sgeqrt3 for the type real(32).
  */
 inline proc geqrt3(matrix_order : lapack_memory_order, a : [] real(32), t : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_sgeqrt3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27212,6 +28227,7 @@ Wrapped procedure of LAPACKE_dgeqrt3 for the type real(64).
  */
 inline proc geqrt3(matrix_order : lapack_memory_order, a : [] real(64), t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dgeqrt3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27220,6 +28236,7 @@ Wrapped procedure of LAPACKE_cgeqrt3 for the type complex(64).
  */
 inline proc geqrt3(matrix_order : lapack_memory_order, a : [] complex(64), t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_cgeqrt3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27228,6 +28245,7 @@ Wrapped procedure of LAPACKE_zgeqrt3 for the type complex(128).
  */
 inline proc geqrt3(matrix_order : lapack_memory_order, a : [] complex(128), t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zgeqrt3(matrix_order, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(1).size else a.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27236,6 +28254,7 @@ Wrapped procedure of LAPACKE_stpmqrt for the type real(32).
  */
 inline proc tpmqrt(matrix_order : lapack_memory_order, side : string, trans : string, l : c_int, v : [] real(32), t : [] real(32), a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stpmqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, l, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27244,6 +28263,7 @@ Wrapped procedure of LAPACKE_dtpmqrt for the type real(64).
  */
 inline proc tpmqrt(matrix_order : lapack_memory_order, side : string, trans : string, l : c_int, v : [] real(64), t : [] real(64), a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtpmqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, l, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27252,6 +28272,7 @@ Wrapped procedure of LAPACKE_ctpmqrt for the type complex(64).
  */
 inline proc tpmqrt(matrix_order : lapack_memory_order, side : string, trans : string, l : c_int, v : [] complex(64), t : [] complex(64), a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctpmqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, l, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27260,6 +28281,7 @@ Wrapped procedure of LAPACKE_ztpmqrt for the type complex(128).
  */
 inline proc tpmqrt(matrix_order : lapack_memory_order, side : string, trans : string, l : c_int, v : [] complex(128), t : [] complex(128), a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztpmqrt(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then a.domain.dim(2).size else a.domain.dim(1).size) : c_int, l, (if matrix_order == lapack_memory_order.row_major then t.domain.dim(1).size else t.domain.dim(2).size) : c_int, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27268,6 +28290,7 @@ Wrapped procedure of LAPACKE_dtpqrt for the type real(64).
  */
 inline proc tpqrt(matrix_order : lapack_memory_order, l : c_int, nb : c_int, a : [] real(64), b : [] real(64), t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtpqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, nb, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27276,6 +28299,7 @@ Wrapped procedure of LAPACKE_ctpqrt for the type complex(64).
  */
 inline proc tpqrt(matrix_order : lapack_memory_order, l : c_int, nb : c_int, a : [] complex(64), b : [] complex(64), t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctpqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, nb, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27284,6 +28308,7 @@ Wrapped procedure of LAPACKE_ztpqrt for the type complex(128).
  */
 inline proc tpqrt(matrix_order : lapack_memory_order, l : c_int, nb : c_int, a : [] complex(128), b : [] complex(128), t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztpqrt(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, nb, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27292,6 +28317,7 @@ Wrapped procedure of LAPACKE_stpqrt2 for the type real(32).
  */
 inline proc tpqrt2(matrix_order : lapack_memory_order, l : c_int, a : [] real(32), b : [] real(32), t : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stpqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27300,6 +28326,7 @@ Wrapped procedure of LAPACKE_dtpqrt2 for the type real(64).
  */
 inline proc tpqrt2(matrix_order : lapack_memory_order, l : c_int, a : [] real(64), b : [] real(64), t : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtpqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27308,6 +28335,7 @@ Wrapped procedure of LAPACKE_ctpqrt2 for the type complex(64).
  */
 inline proc tpqrt2(matrix_order : lapack_memory_order, l : c_int, a : [] complex(64), b : [] complex(64), t : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctpqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27316,6 +28344,7 @@ Wrapped procedure of LAPACKE_ztpqrt2 for the type complex(128).
  */
 inline proc tpqrt2(matrix_order : lapack_memory_order, l : c_int, a : [] complex(128), b : [] complex(128), t : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztpqrt2(matrix_order, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, l, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int);
 }
 
@@ -27324,6 +28353,7 @@ Wrapped procedure of LAPACKE_stprfb for the type real(32).
  */
 inline proc tprfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, l : c_int, v : [] real(32), t : [] real(32), a : [] real(32), b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_stprfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, l, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27332,6 +28362,7 @@ Wrapped procedure of LAPACKE_dtprfb for the type real(64).
  */
 inline proc tprfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, l : c_int, v : [] real(64), t : [] real(64), a : [] real(64), b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dtprfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, l, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27340,6 +28371,7 @@ Wrapped procedure of LAPACKE_ctprfb for the type complex(64).
  */
 inline proc tprfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, l : c_int, v : [] complex(64), t : [] complex(64), a : [] complex(64), b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ctprfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, l, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27348,6 +28380,7 @@ Wrapped procedure of LAPACKE_ztprfb for the type complex(128).
  */
 inline proc tprfb(matrix_order : lapack_memory_order, side : string, trans : string, direct : string, storev : string, l : c_int, v : [] complex(128), t : [] complex(128), a : [] complex(128), b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ztprfb(matrix_order, side.toByte() : c_char, trans.toByte() : c_char, direct.toByte() : c_char, storev.toByte() : c_char, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(1).size else b.domain.dim(2).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, (t.domain.dim(1).size) : c_int, l, v, (v.domain.dim(2).size) : c_int, t, (t.domain.dim(2).size) : c_int, a, (a.domain.dim(2).size) : c_int, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27356,6 +28389,7 @@ Wrapped procedure of LAPACKE_ssysv_rook for the type real(32).
  */
 inline proc sysv_rook(matrix_order : lapack_memory_order, uplo : string, a : [] real(32), ipiv : [] c_int, b : [] real(32)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_ssysv_rook(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27364,6 +28398,7 @@ Wrapped procedure of LAPACKE_dsysv_rook for the type real(64).
  */
 inline proc sysv_rook(matrix_order : lapack_memory_order, uplo : string, a : [] real(64), ipiv : [] c_int, b : [] real(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_dsysv_rook(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27372,6 +28407,7 @@ Wrapped procedure of LAPACKE_csysv_rook for the type complex(64).
  */
 inline proc sysv_rook(matrix_order : lapack_memory_order, uplo : string, a : [] complex(64), ipiv : [] c_int, b : [] complex(64)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_csysv_rook(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 
@@ -27380,6 +28416,7 @@ Wrapped procedure of LAPACKE_zsysv_rook for the type complex(128).
  */
 inline proc sysv_rook(matrix_order : lapack_memory_order, uplo : string, a : [] complex(128), ipiv : [] c_int, b : [] complex(128)): c_int{
   require header;
+  import LAPACK.ClassicLAPACK;
   return ClassicLAPACK.LAPACKE_zsysv_rook(matrix_order, uplo.toByte() : c_char, (a.domain.dim(1).size) : c_int, (if matrix_order == lapack_memory_order.row_major then b.domain.dim(2).size else b.domain.dim(1).size) : c_int, a, (a.domain.dim(2).size) : c_int, ipiv, b, (b.domain.dim(2).size) : c_int);
 }
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -188,6 +188,7 @@ module LinearAlgebra {
 use Norm; // TODO -- merge Norm into LinearAlgebra
 import BLAS;
 use LAPACK only lapack_memory_order, isLAPACKType;
+import LinearAlgebra.Sparse;
 
 /* Determines if using native Chapel implementations */
 private param usingBLAS = BLAS.header != '';
@@ -1978,8 +1979,8 @@ module Sparse {
 
   /* Compute the dot-product */
   proc _array.dot(A: []) where isCSArr(A) || isCSArr(this) {
-    import LinearAlgebra;
-    return LinearAlgebra.Sparse.dot(this, A);
+    import LinearAlgebra.Sparse;
+    return Sparse.dot(this, A);
   }
 
   /* Compute the dot-product */

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -189,6 +189,7 @@ MPI Module Documentation
 
 */
 module MPI {
+  import MPI.C_MPI;
   public use SysCTypes;
   require "mpi.h";
 
@@ -277,6 +278,7 @@ module MPI {
      processes (world size)
      */
   proc initialize() {
+    import MPI.C_Env;
     // If we are running using the uGNI layer, then the following hack
     // appears to be necessary in order to run MPI, as well as Chapel
     // See : https://hpcrdm.lbl.gov/pipermail/upc-users/2014-May/002061.html

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -908,7 +908,7 @@ module QuickSort {
                  lo: int, pivIdx: int, hi: int,
                  comparator)
   {
-    use ShallowCopy;
+    import Sort.ShallowCopy;
 
     // The following section categorizes array elements as follows:
     //
@@ -1421,6 +1421,7 @@ module SampleSortHelp {
                                    in numSamples:int,
                                    seed=1) {
     private use Random;
+    import Sort.ShallowCopy;
     var Tmp:[1..1] A.eltType;
     var randNums = createRandomStream(seed=seed, eltType=int, parSafe=false);
     while numSamples > 0 {
@@ -2014,6 +2015,7 @@ module TwoArrayPartitioning {
   proc bucketize(start_n: int, end_n: int, dst:[], src:[],
                  ref state: TwoArrayBucketizerSharedState,
                  criterion, startbit:int) {
+    import Sort.ShallowCopy;
 
     if debug then
       writeln("bucketize ", start_n..end_n, " startbit=", startbit);
@@ -2132,6 +2134,8 @@ module TwoArrayPartitioning {
           start_n:int, end_n:int, A:[], Scratch:[],
           ref state: TwoArrayBucketizerSharedState,
           criterion, startbit:int):void {
+    import Sort.SampleSortHelp;
+    import Sort.RadixSortHelp;
     // If we are doing a sample sort, we need to gather a fresh sample.
     // (Otherwise we'll never be able to solve recursive subproblems,
     //  as if in quicksort we never chose a new pivot).
@@ -2189,7 +2193,9 @@ module TwoArrayPartitioning {
           start_n:int, end_n:int, A:[], Scratch:[],
           ref state: TwoArrayBucketizerSharedState,
           criterion, startbit:int):void {
-
+    import Sort.ShallowCopy;
+    import Sort.ShellSort;
+    import Sort.RadixSortHelp;
 
     if startbit > state.endbit then
       return;
@@ -2331,6 +2337,9 @@ module TwoArrayPartitioning {
           start_n:int, end_n:int, A:[], Scratch:[],
           ref state: TwoArrayDistributedBucketizerSharedState,
           criterion, startbit:int):void {
+    import Sort.ShallowCopy;
+    import Sort.RadixSortHelp;
+    import Sort.ShellSort;
 
     if startbit > state.endbit then
       return;
@@ -2378,6 +2387,8 @@ module TwoArrayPartitioning {
           start_n:int, end_n:int, A:[], Scratch:[],
           ref state: TwoArrayDistributedBucketizerSharedState,
           criterion, startbit:int):void {
+    import Sort.RadixSortHelp;
+    import Sort.SampleSortHelp;
     // If we are doing a sample sort, we need to gather a fresh sample.
     // (Otherwise we'll never be able to solve recursive subproblems,
     //  as if in quicksort we never chose a new pivot).
@@ -2437,6 +2448,8 @@ module TwoArrayPartitioning {
           start_n:int, end_n:int, A:[], Scratch:[],
           ref state: TwoArrayDistributedBucketizerSharedState,
           criterion, startbit:int): void {
+    import Sort.ShallowCopy;
+    import Sort.ShellSort;
 
     //use BlockDist only;
 
@@ -2787,11 +2800,11 @@ module MSBRadixSort {
                     startbit:int, endbit:int,
                     settings /* MSBRadixSortSettings */)
   {
+    import Sort.ShellSort;
     if startbit > endbit then
       return;
 
     if( end_n - start_n < settings.sortSwitch ) {
-      use ShellSort;
       ShellSort.shellSort(A, criterion, start=start_n, end=end_n);
       if settings.CHECK_SORTS then checkSorted(start_n, end_n, A, criterion);
       return;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -458,8 +458,10 @@ proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
     return;
 
   if radixSortOk(Data, comparator) {
+    use MSBRadixSort;
     MSBRadixSort.msbRadixSort(Data, comparator=comparator);
   } else {
+    use QuickSort;
     QuickSort.quickSort(Data, comparator=comparator);
   }
 }
@@ -906,6 +908,8 @@ module QuickSort {
                  lo: int, pivIdx: int, hi: int,
                  comparator)
   {
+    use ShallowCopy;
+
     // The following section categorizes array elements as follows:
     //
     //   |  =  |  <  |  ?  |  >  |  =   |
@@ -1078,6 +1082,7 @@ module QuickSort {
     var piv = mid;
 
     if hi - lo < minlen {
+      use InsertionSort;
       // base case -- use insertion sort
       InsertionSort.insertionSort(Data, comparator=comparator, lo, hi);
       return;
@@ -2786,6 +2791,7 @@ module MSBRadixSort {
       return;
 
     if( end_n - start_n < settings.sortSwitch ) {
+      use ShellSort;
       ShellSort.shellSort(A, criterion, start=start_n, end=end_n);
       if settings.CHECK_SORTS then checkSorted(start_n, end_n, A, criterion);
       return;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -803,6 +803,7 @@ module MergeSort {
    */
   private proc _MergeSort(Data: [?Dom], Scratch: [], lo:int, hi:int, minlen=16, comparator:?rec=defaultComparator, depth: int)
     where Dom.rank == 1 {
+    import Sort.InsertionSort;
 
     const stride = if Dom.stridable then abs(Dom.stride) else 1,
           size = (hi - lo) / stride,
@@ -1074,6 +1075,7 @@ module QuickSort {
                      minlen=16,
                      comparator:?rec=defaultComparator,
                      start:int = Dom.low, end:int = Dom.high) {
+    import Sort.InsertionSort;
 
     // grab obvious indices
     const lo = start,

--- a/test/classes/ferguson/module-call-returns-type.chpl
+++ b/test/classes/ferguson/module-call-returns-type.chpl
@@ -13,6 +13,7 @@ module OuterModule {
   }
 
   proc test() {
+    import OuterModule.C;
     var tmp = C.make_struct();
     var f = tmp.my_field;
     writeln(f);

--- a/test/classes/moduleScope/mod-init-borrowed.chpl
+++ b/test/classes/moduleScope/mod-init-borrowed.chpl
@@ -1,5 +1,8 @@
 module OuterModule {
   proc main() {
+    import OuterModule.M1;
+    import OuterModule.M2;
+
     var a   = new borrowed A(10);
 
     writeln();

--- a/test/classes/moduleScope/mod-init-owned.chpl
+++ b/test/classes/moduleScope/mod-init-owned.chpl
@@ -1,5 +1,8 @@
 module OuterModule {
   proc main() {
+    import OuterModule.M1;
+    import OuterModule.M2;
+
     var a   = new owned A(10);
 
     writeln();

--- a/test/classes/moduleScope/mod-init-unmanaged.chpl
+++ b/test/classes/moduleScope/mod-init-unmanaged.chpl
@@ -1,5 +1,8 @@
 module OuterModule {
   proc main() {
+    import OuterModule.M1;
+    import OuterModule.M2;
+
     var a   = new unmanaged A(10);
 
     writeln();

--- a/test/classes/moduleScope/mod-init.chpl
+++ b/test/classes/moduleScope/mod-init.chpl
@@ -1,5 +1,8 @@
 module OuterModule {
   proc main() {
+    import OuterModule.M1;
+    import OuterModule.M2;
+
     var a   = new A(10);
 
     writeln();

--- a/test/compflags/configs/ambiguousNestedModule-setAmbig.good
+++ b/test/compflags/configs/ambiguousNestedModule-setAmbig.good
@@ -1,12 +1,12 @@
-ambiguousNestedModule.chpl:8: error: ambiguous config name (p)
-ambiguousNestedModule.chpl:3: note: also defined here
-ambiguousNestedModule.chpl:3: note: (disambiguate using -s<modulename>.p...)
-ambiguousNestedModule.chpl:9: error: ambiguous config name (c)
+ambiguousNestedModule.chpl:9: error: ambiguous config name (p)
 ambiguousNestedModule.chpl:4: note: also defined here
-ambiguousNestedModule.chpl:4: note: (disambiguate using -s<modulename>.c...)
-ambiguousNestedModule.chpl:10: error: ambiguous config name (v)
+ambiguousNestedModule.chpl:4: note: (disambiguate using -s<modulename>.p...)
+ambiguousNestedModule.chpl:10: error: ambiguous config name (c)
 ambiguousNestedModule.chpl:5: note: also defined here
-ambiguousNestedModule.chpl:5: note: (disambiguate using -s<modulename>.v...)
-ambiguousNestedModule.chpl:11: error: ambiguous config name (t)
+ambiguousNestedModule.chpl:5: note: (disambiguate using -s<modulename>.c...)
+ambiguousNestedModule.chpl:11: error: ambiguous config name (v)
 ambiguousNestedModule.chpl:6: note: also defined here
-ambiguousNestedModule.chpl:6: note: (disambiguate using -s<modulename>.t...)
+ambiguousNestedModule.chpl:6: note: (disambiguate using -s<modulename>.v...)
+ambiguousNestedModule.chpl:12: error: ambiguous config name (t)
+ambiguousNestedModule.chpl:7: note: also defined here
+ambiguousNestedModule.chpl:7: note: (disambiguate using -s<modulename>.t...)

--- a/test/compflags/configs/ambiguousNestedModule.chpl
+++ b/test/compflags/configs/ambiguousNestedModule.chpl
@@ -1,4 +1,5 @@
 module ambiguousNestedModule {
+  import ambiguousNestedModule.M;
   module M {
     config param p = 1;
     config const c = 2;

--- a/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
@@ -3,6 +3,12 @@
 use driver_real_arrays;
 use Random;
 use Sort;
+import Sort.BubbleSort;
+import Sort.InsertionSort;
+import Sort.MergeSort;
+import Sort.SelectionSort;
+import Sort.QuickSort;
+import Sort.HeapSort;
 
 var rng = new owned RandomStream(real, 314159265);
 

--- a/test/errhandling/psahabu/defer-throw-relaxed.chpl
+++ b/test/errhandling/psahabu/defer-throw-relaxed.chpl
@@ -37,6 +37,7 @@ prototype module OuterModule {
     }
   }
 
+  import OuterModule.A;
   A.deferThrow();
   A.deferTry();
   A.deferTryComplete();

--- a/test/execflags/configs/ambiguousNestedModules.chpl
+++ b/test/execflags/configs/ambiguousNestedModules.chpl
@@ -1,17 +1,18 @@
 module M1 {
+  public import M1.Helper;
   module Helper {
     config const debug = false;
   }
 }
 
 module M2 {
-  module Helper {
+  public import M2.Helper;
+  public module Helper {
     config const debug = false;
   }
 
   proc main() {
     use M1;
-    use M1.Helper;
     writeln((M1.Helper.debug, M2.Helper.debug));
   }
 }

--- a/test/expressions/new-expr/has-arg-list.chpl
+++ b/test/expressions/new-expr/has-arg-list.chpl
@@ -44,6 +44,7 @@ module OuterModule {
       var b = new borrowed GI;
     }
     {
+      import OuterModule.M;
       var q = new M.Q;
     }
   }

--- a/test/expressions/new-expr/has-arg-list.good
+++ b/test/expressions/new-expr/has-arg-list.good
@@ -12,4 +12,4 @@ has-arg-list.chpl:41: error: type in 'new' expression is missing its argument li
 has-arg-list.chpl:42: error: type in 'new' expression is missing its argument list
 has-arg-list.chpl:43: error: type in 'new' expression is missing its argument list
 has-arg-list.chpl:44: error: type in 'new' expression is missing its argument list
-has-arg-list.chpl:47: error: type in 'new' expression is missing its argument list
+has-arg-list.chpl:48: error: type in 'new' expression is missing its argument list

--- a/test/library/packages/MPI/multilocale/hello-chapel/hello.chpl
+++ b/test/library/packages/MPI/multilocale/hello-chapel/hello.chpl
@@ -1,4 +1,5 @@
 use MPI;
+import MPI.C_MPI;
 
 coforall loc in Locales do on loc {
   var rank = commRank(CHPL_COMM_WORLD),

--- a/test/library/packages/Sort/RadixSort/RadixMSB.chpl
+++ b/test/library/packages/Sort/RadixSort/RadixMSB.chpl
@@ -14,6 +14,7 @@
    }
   
    private proc __radixSortMSB(array:[] int, place: int, startIndex: int, endIndex: int, auxArray:[] int) {
+     import Sort.InsertionSort;
 
      // comparison sorting for <=100 elements
      if(array.size<=100) {

--- a/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
+++ b/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
@@ -3,6 +3,7 @@ use BlockDist;
 use Time;
 use Sort;
 use CommDiagnostics;
+import Sort.TwoArrayRadixSort;
 
 config param debug = false;
 config const timing = true;

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -2,6 +2,8 @@ config const size = 100000;
 config const verbose = false;
 
 use Sort;
+import Sort.MSBRadixSort;
+import Sort.QuickSort;
 
 record UselessKeyComparator {
   proc key(x) {

--- a/test/library/packages/Sort/correctness/correctness.chpl
+++ b/test/library/packages/Sort/correctness/correctness.chpl
@@ -4,6 +4,12 @@
 
 use Sort;
 use Random;
+import Sort.BubbleSort;
+import Sort.InsertionSort;
+import Sort.MergeSort;
+import Sort.SelectionSort;
+import Sort.QuickSort;
+import Sort.HeapSort;
 
 proc main() {
 

--- a/test/library/packages/Sort/correctness/correctness.chpl
+++ b/test/library/packages/Sort/correctness/correctness.chpl
@@ -10,6 +10,7 @@ import Sort.MergeSort;
 import Sort.SelectionSort;
 import Sort.QuickSort;
 import Sort.HeapSort;
+import Sort.BinaryInsertionSort;
 
 proc main() {
 

--- a/test/library/packages/Sort/correctness/quickSort-constArr.chpl
+++ b/test/library/packages/Sort/correctness/quickSort-constArr.chpl
@@ -5,6 +5,7 @@
 
 use Sort;
 use Random;
+import Sort.QuickSort;
 
 config const size = 4096;
 

--- a/test/library/packages/Sort/correctness/sortByteCombinations.chpl
+++ b/test/library/packages/Sort/correctness/sortByteCombinations.chpl
@@ -1,6 +1,8 @@
 config const size = 100000;
 
 use Sort;
+import Sort.MSBRadixSort;
+import Sort.QuickSort;
 
 proc checkSorts(arr) {
   // check default sorter

--- a/test/library/packages/Sort/correctness/sortClz.chpl
+++ b/test/library/packages/Sort/correctness/sortClz.chpl
@@ -1,5 +1,6 @@
 use Sort;
 use BitOps;
+import Sort.RadixSortHelp;
 
 proc test(x) {
   var count = RadixSortHelp.radixSortClz(x);

--- a/test/library/packages/Sort/correctness/sorty.chpl
+++ b/test/library/packages/Sort/correctness/sorty.chpl
@@ -13,6 +13,12 @@ if debug then writeln("n=", n);
 use Time;
 use Random;
 use Sort;
+import Sort.BubbleSort;
+import Sort.InsertionSort;
+import Sort.MergeSort;
+import Sort.SelectionSort;
+import Sort.QuickSort;
+import Sort.HeapSort;
 config const seed = 13579;
 
 enum SortType { BUBBLE=0, INSERTION, MERGE, SELECTION, QUICK, HEAP };

--- a/test/library/packages/Sort/correctness/test-radix-bucketizer.chpl
+++ b/test/library/packages/Sort/correctness/test-radix-bucketizer.chpl
@@ -1,6 +1,10 @@
 use Sort;
 use RadixSortHelp;
 use Random;
+import Sort.TwoArrayPartitioning;
+import Sort.SequentialInPlacePartitioning;
+import Sort.TwoArrayRadixSort;
+
 
 config const debug = false;
 config var seed = SeedGenerator.oddCurrentTime;

--- a/test/library/packages/Sort/correctness/test-sample-bucketizer.chpl
+++ b/test/library/packages/Sort/correctness/test-sample-bucketizer.chpl
@@ -43,6 +43,8 @@ proc makeBucketizerTest(in nBuckets:int, equalBuckets:bool, A, criterion) {
 }
 
 proc testBucketizer(nBuckets:int, equalBuckets:bool) {
+  import Sort.TwoArrayPartitioning;
+  import Sort.TwoArraySampleSort;
   var A = [0x1234567800000000:uint,
            0x1111111111111111:uint,
            0x2222222222222222:uint,
@@ -159,6 +161,8 @@ proc testBucketizer() {
 testBucketizer();
 
 proc testBucketizerRandomized(nelts:int, nBuckets:int, equalBuckets:bool) {
+  import Sort.TwoArrayPartitioning;
+  import Sort.TwoArraySampleSort;
 
   if debug then
     writeln("testBucketizerRandomized(",

--- a/test/library/packages/Sort/correctness/testMsbRadixSort.chpl
+++ b/test/library/packages/Sort/correctness/testMsbRadixSort.chpl
@@ -3,6 +3,7 @@ use BitOps;
  use MSBRadixSort;
  use Random;
  use Time;
+import Sort.ShellSort;
 
  config const printStats = false;
  config const size = 10000;

--- a/test/library/packages/Sort/correctness/two-array-radix-sort-bug.chpl
+++ b/test/library/packages/Sort/correctness/two-array-radix-sort-bug.chpl
@@ -2,6 +2,7 @@ use Random;
 use Sort;
 use Math;
 use BlockDist;
+import Sort.TwoArrayRadixSort;
 
 config const n = 1000000;
 config const seed = 17;

--- a/test/library/packages/Sort/performance/dist-performance.chpl
+++ b/test/library/packages/Sort/performance/dist-performance.chpl
@@ -4,6 +4,7 @@ use Memory;
 use Random;
 use Sort;
 use Time;
+import Sort.TwoArrayRadixSort;
 
 type elemType = int;
 

--- a/test/library/packages/Sort/performance/performance.chpl
+++ b/test/library/packages/Sort/performance/performance.chpl
@@ -8,6 +8,12 @@
 use Sort;
 use Random;
 use Time;
+import Sort.BubbleSort;
+import Sort.InsertionSort;
+import Sort.MergeSort;
+import Sort.SelectionSort;
+import Sort.QuickSort;
+import Sort.HeapSort;
 
 config const M: int = 6,                    // 2**M bytes
              correctness: bool = true,      // Disables output

--- a/test/library/packages/Sort/performance/performance.chpl
+++ b/test/library/packages/Sort/performance/performance.chpl
@@ -14,6 +14,7 @@ import Sort.MergeSort;
 import Sort.SelectionSort;
 import Sort.QuickSort;
 import Sort.HeapSort;
+import Sort.BinaryInsertionSort;
 
 config const M: int = 6,                    // 2**M bytes
              correctness: bool = true,      // Disables output

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -10,6 +10,9 @@ import Sort.MergeSort;
 import Sort.SelectionSort;
 import Sort.QuickSort;
 import Sort.HeapSort;
+import Sort.MSBRadixSort;
+import Sort.TwoArraySampleSort;
+import Sort.TwoArrayRadixSort;
 
 config const printStats = true;
 config const minSize = 1;

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -4,6 +4,12 @@
 use Sort;
 use Random;
 use Time;
+import Sort.BubbleSort;
+import Sort.InsertionSort;
+import Sort.MergeSort;
+import Sort.SelectionSort;
+import Sort.QuickSort;
+import Sort.HeapSort;
 
 config const printStats = true;
 config const minSize = 1;

--- a/test/library/standard/FileSystem/bharshbarg/filer.chpl
+++ b/test/library/standard/FileSystem/bharshbarg/filer.chpl
@@ -112,9 +112,9 @@ iter listdir(path: string, hidden=false, dirs=true, files=true,
  neither follow dotfile directories nor symbolic links.  It will not
  sort the directories by default.
  */
-
 iter walkdirs(path: string=".", topdown=true, depth=max(int), hidden=false, 
     followlinks=false, sort=false): string {
+  import Sort.QuickSort;
 
   if (topdown) then
     yield path;

--- a/test/modules/cassella/new-explicit.chpl
+++ b/test/modules/cassella/new-explicit.chpl
@@ -44,6 +44,8 @@ module OuterModule {
     writeln(x);
   }
 
+  import OuterModule.A;
+
   writeln("Concrete Record");
   {         var x : A.CR = new A.CR(1); printThing(x); }
   { use A;  var x :   CR = new A.CR(1); printThing(x); }

--- a/test/modules/deitz/test_module_access3.chpl
+++ b/test/modules/deitz/test_module_access3.chpl
@@ -6,6 +6,7 @@ module OuterModule {
   }
 
   proc bar() {
+    import OuterModule.M;
     M.foo(3);
   }
   bar();

--- a/test/modules/deitz/test_module_access4.chpl
+++ b/test/modules/deitz/test_module_access4.chpl
@@ -5,6 +5,8 @@ module OuterModule {
     proc foo(i: int) { writeln(i); }
   }
 
+  import OuterModule.M;
+
   M.foo(3.0);
   foo(3.0);
 }

--- a/test/modules/deitz/test_module_access4.good
+++ b/test/modules/deitz/test_module_access4.good
@@ -1,4 +1,4 @@
-test_module_access4.chpl:8: error: unresolved call 'M.foo(3.0)'
+test_module_access4.chpl:10: error: unresolved call 'M.foo(3.0)'
 test_module_access4.chpl:5: note: this candidate did not match: foo(i: int)
-test_module_access4.chpl:8: note: because call actual argument #1 with type real(64)
+test_module_access4.chpl:10: note: because call actual argument #1 with type real(64)
 test_module_access4.chpl:5: note: is passed to formal 'i: int(64)'

--- a/test/modules/deitz/test_module_shadows.good
+++ b/test/modules/deitz/test_module_shadows.good
@@ -1,2 +1,2 @@
 test_module_shadows.chpl:10: In function 'foo':
-test_module_shadows.chpl:11: error: modules (like 'M2' here) cannot be called like procedures
+test_module_shadows.chpl:12: error: modules (like 'M2' here) cannot be called like procedures

--- a/test/modules/deitz/test_module_shadows2.chpl
+++ b/test/modules/deitz/test_module_shadows2.chpl
@@ -8,12 +8,11 @@ module OuterModule {
     }
 
     proc foo() {
-      import OuterModule.M1.M2;
       M2();
     }
   }
 
   proc M2() {
-    writeln("this should be shadowed");
+    writeln("this needs an import to be shadowed");
   }
 }

--- a/test/modules/deitz/test_module_shadows2.good
+++ b/test/modules/deitz/test_module_shadows2.good
@@ -1,0 +1,1 @@
+this needs an import to be shadowed

--- a/test/modules/noakes/mod-explicit-1.chpl
+++ b/test/modules/noakes/mod-explicit-1.chpl
@@ -5,8 +5,8 @@ module OuterModule {
       var y : real;
     }
   }
-
   proc main() {
+    import OuterModule.M1;
     var s = new M1.Something();
 
     showIt(s);

--- a/test/modules/noakes/mod-explicit-2.chpl
+++ b/test/modules/noakes/mod-explicit-2.chpl
@@ -58,6 +58,7 @@ module OuterModule {
 
 
   proc testMod2() {
+    import OuterModule.M2;
     var (A, B, C) = M2.version1;
     var (D, E, F) = M2.version2();
     var (G, H, I) = M2.version3(17, 18, 19);

--- a/test/param/config/threeModsSameParamName.chpl
+++ b/test/param/config/threeModsSameParamName.chpl
@@ -11,5 +11,8 @@ module OuterModule {
     config param flag = false;
   }
 
+  import OuterModule.M1;
+  import OuterModule.M2;
+  import OuterModule.M3;
   writeln((M1.flag, M2.flag, M3.flag));
 }

--- a/test/users/ferguson/bug-zhao.chpl
+++ b/test/users/ferguson/bug-zhao.chpl
@@ -17,6 +17,7 @@ module OuterModule {
       }
     }
 
+    public import OuterModule.OurModule.ChildModule;
     // Submodules of OurModule
     // It is possible to create arbitrarily deep module nests.
     module ChildModule {
@@ -25,13 +26,15 @@ module OuterModule {
       }
     }
 
+    public import OuterModule.OurModule.SiblingModule;
     module SiblingModule {
       proc foo(){
         writeln( "SiblingModule.foo()" );
       }
     }
   } // end OurModule
-  use OurModule;
+  import OuterModule.OurModule;
+  import OuterModule.OurModule.SiblingModule;
 
   // At this point we have not used ChildModule or SiblingModule so their symbols
   // (i.e. foo ) are not available to us.

--- a/test/visibility/private/config/constants/accessesOther.chpl
+++ b/test/visibility/private/config/constants/accessesOther.chpl
@@ -3,7 +3,7 @@ module OuterModule {
     private config const foo = 10;
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo);
   // Ensures that the private module level constant foo is not visible
   // via explicit naming.

--- a/test/visibility/private/config/params/accessesOther.chpl
+++ b/test/visibility/private/config/params/accessesOther.chpl
@@ -3,7 +3,7 @@ module OuterModule {
     private config param foo = 10;
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo);
   // Ensures that the private module level param foo is not visible
   // via explicit naming.

--- a/test/visibility/private/config/variables/accessesOther.chpl
+++ b/test/visibility/private/config/variables/accessesOther.chpl
@@ -1,9 +1,9 @@
 module OuterModule {
-    module M1 {
+  module M1 {
     private config var foo = 10;
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo);
   // Ensures that the private module level variable foo is not visible
   // via explicit naming.

--- a/test/visibility/private/constants/accessesOther.chpl
+++ b/test/visibility/private/constants/accessesOther.chpl
@@ -3,7 +3,7 @@ module OuterModule {
     private const foo = 10;
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo);
   // Ensures that the private module level constant foo is not visible
   // via explicit naming.

--- a/test/visibility/private/functions/accessesOther.chpl
+++ b/test/visibility/private/functions/accessesOther.chpl
@@ -6,7 +6,7 @@ module OuterModule {
     }
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo(3));
   // Ensures that the private module level variable foo is not visible
   // via explicit naming.

--- a/test/visibility/private/iters/accessesOther.chpl
+++ b/test/visibility/private/iters/accessesOther.chpl
@@ -7,7 +7,7 @@ module OuterModule {
     }
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo(3));
   // Ensures that the private module level variable foo is not visible
   // via explicit naming.

--- a/test/visibility/private/moduleSymbols/accessPrivateSiblingSubmodule.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateSiblingSubmodule.chpl
@@ -4,9 +4,9 @@ module parent {
       return a*3;
     }
   }
-
   module sibling {
     proc main() {
+      import parent.child;
       writeln(child.secretFunction(11));
     }
   }

--- a/test/visibility/private/params/accessesOther.chpl
+++ b/test/visibility/private/params/accessesOther.chpl
@@ -1,9 +1,9 @@
 module OuterModule {
-    module M1 {
+  module M1 {
     private param foo = 10;
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo);
   // Ensures that the private module level param foo is not visible
   // via explicit naming.

--- a/test/visibility/private/uses/weirdEnumHiding.chpl
+++ b/test/visibility/private/uses/weirdEnumHiding.chpl
@@ -30,6 +30,9 @@ module weirdEnumHiding {
   }
 
   proc main() {
+    import weirdEnumHiding.B;
+    import weirdEnumHiding.C;
+    import weirdEnumHiding.D;
     B.checkFoo();
     C.checkFoo();
     D.checkFoo();

--- a/test/visibility/private/variables/accessesOther.chpl
+++ b/test/visibility/private/variables/accessesOther.chpl
@@ -3,7 +3,7 @@ module OuterModule {
     private var foo = 10;
 
   }
-
+  import OuterModule.M1;
   writeln(M1.foo);
   // Ensures that the private module level variable foo is not visible
   // via explicit naming.


### PR DESCRIPTION
Issue #13536 asks whether it should be required to `use`/`import` a sub-module prior to referring to its name.  This PR takes a stab at that change to see what would the effect would be.  This is still a work-in-progress as there are a number of tests that are testing corner cases of visibility and module access which I wasn't sure how to update.

One thing to note about this PR is that I believe it requires submodules to be used or imported regardless of whether they are a submodule of the current scope or a submodule that's a cousin of sorts.  We may want to treat these cases differently.