### PR TITLE
Fix an issue with tuple containing owned passed to in intent

### DIFF
--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -542,7 +542,8 @@ static void instantiate_tuple_init(FnSymbol* fn) {
 
 // Returns the variable storing the read tuple field
 static VarSymbol* generateReadTupleField(Symbol* fromSym, Symbol* fromField,
-                                         Expr* insertBefore)
+                                         Expr* insertBefore,
+                                         BlockStmt* insertAtTail)
 {
   VarSymbol* readF = NULL;
   const char* name  = fromField->name;
@@ -552,20 +553,32 @@ static VarSymbol* generateReadTupleField(Symbol* fromSym, Symbol* fromField,
   if (isReferenceType(fromField->type)) {
     // Use PRIM_GET_MEMBER_VALUE if the element is already a reference
     readF = new VarSymbol(astr("read_", name), fromField->type);
-    insertBefore->insertBefore(new DefExpr(readF));
+    DefExpr* def = new DefExpr(readF);
+    if (insertBefore)
+      insertBefore->insertBefore(def);
+    else
+      insertAtTail->insertAtTail(def);
     get = new CallExpr(PRIM_GET_MEMBER_VALUE, fromSym, fromName);
   } else {
     // Otherwise, use PRIM_GET_MEMBER
     readF = new VarSymbol(astr("read_", name),
                           fromField->type->getRefType());
 
-    insertBefore->insertBefore(new DefExpr(readF));
+    DefExpr* def = new DefExpr(readF);
+    if (insertBefore)
+      insertBefore->insertBefore(def);
+    else
+      insertAtTail->insertAtTail(def);
 
     get   = new CallExpr(PRIM_GET_MEMBER, fromSym, fromName);
   }
 
   CallExpr* setReadF = new CallExpr(PRIM_MOVE, readF, get);
-  insertBefore->insertBefore(setReadF);
+  if (insertBefore)
+    insertBefore->insertBefore(setReadF);
+  else
+    insertAtTail->insertAtTail(setReadF);
+
   resolveCall(setReadF);
 
   return readF;
@@ -671,7 +684,7 @@ void addTupleCoercion(AggregateType* fromT, AggregateType* toT,
     VarSymbol* element = NULL;
 
 
-    readF = generateReadTupleField(fromSym, fromField, insertBefore);
+    readF = generateReadTupleField(fromSym, fromField, insertBefore, NULL);
 
     element = generateCoerce(fromField, toField, readF, insertBefore);
 
@@ -707,33 +720,15 @@ static void instantiate_tuple_cast(FnSymbol* fn, CallExpr* context) {
   for (int i=2; i<=toT->fields.length; i++) {
     Symbol* fromField = toDefExpr(fromT->fields.get(i))->sym;
     Symbol*   toField = toDefExpr(  toT->fields.get(i))->sym;
-    Symbol*  fromName = new_CStringSymbol(fromField->name);
     Symbol*    toName = new_CStringSymbol(  toField->name);
     const char* name  = toField->name;
 
     VarSymbol* readF = NULL;
     VarSymbol* element = NULL;
 
-    CallExpr* get = NULL;
+    readF = generateReadTupleField(arg, fromField, NULL, block);
 
-    if (isReferenceType(fromField->type)) {
-      // Use PRIM_GET_MEMBER_VALUE if the element is already a reference
-      readF = new VarSymbol(astr("read_", name), fromField->type);
-      block->insertAtTail(new DefExpr(readF));
-      get = new CallExpr(PRIM_GET_MEMBER_VALUE, arg, fromName);
-    } else {
-      // Otherwise, use PRIM_GET_MEMBER
-      readF = new VarSymbol(astr("read_", name),
-                            fromField->type->getRefType());
-
-      block->insertAtTail(new DefExpr(readF));
-
-      get   = new CallExpr(PRIM_GET_MEMBER, arg, fromName);
-    }
-
-    block->insertAtTail(new CallExpr(PRIM_MOVE, readF, get));
-
-    // now readF is some kind of reference
+    // now readF might be some kind of reference
     // the code below needs to handle the following 5 cases:
     //
     // fromField : t1     toField : t2       (value types differ)
@@ -808,16 +803,11 @@ instantiate_tuple_initCopy_or_autoCopy(FnSymbol* fn,
   for (int i=2; i<=ct->fields.length; i++) {
     Symbol* fromField = toDefExpr(origCt->fields.get(i))->sym;
     Symbol*   toField = toDefExpr(ct->fields.get(i))->sym;
-    Symbol*  fromName = new_CStringSymbol(fromField->name);
     Symbol*    toName = new_CStringSymbol(  toField->name);
     const char* name  = toField->name;
 
-    VarSymbol* read = new VarSymbol(astr("read_", name), fromField->type);
-    block->insertAtTail(new DefExpr(read));
+    VarSymbol* read = generateReadTupleField(arg, fromField, NULL, block);
     VarSymbol* element = NULL;
-
-    CallExpr* get = new CallExpr(PRIM_GET_MEMBER_VALUE, arg, fromName);
-    block->insertAtTail(new CallExpr(PRIM_MOVE, read, get));
 
     if (isReferenceType(fromField->type) && isReferenceType(toField->type)) {
       // If it is a reference, pass it through
@@ -828,6 +818,8 @@ instantiate_tuple_initCopy_or_autoCopy(FnSymbol* fn,
       block->insertAtTail(new DefExpr(element));
       CallExpr* copy = new CallExpr(copy_fun, read);
       block->insertAtTail(new CallExpr(PRIM_MOVE, element, copy));
+      if (recordContainingCopyMutatesField(toField->type))
+        arg->intent = INTENT_REF;
     }
     block->insertAtTail(new CallExpr(PRIM_SET_MEMBER, retv, toName, element));
   }
@@ -884,16 +876,11 @@ instantiate_tuple_unref(FnSymbol* fn)
     for (int i=2; i<=ct->fields.length; i++) {
       Symbol* fromField = toDefExpr(origCt->fields.get(i))->sym;
       Symbol*   toField = toDefExpr(    ct->fields.get(i))->sym;
-      Symbol*  fromName = new_CStringSymbol(fromField->name);
       Symbol*    toName = new_CStringSymbol(  toField->name);
       const char* name  = toField->name;
 
-      VarSymbol* read = new VarSymbol(astr("read_", name), fromField->type);
-      block->insertAtTail(new DefExpr(read));
+      VarSymbol* read = generateReadTupleField(arg, fromField, NULL, block);
       VarSymbol* element = NULL;
-
-      CallExpr* get = new CallExpr(PRIM_GET_MEMBER_VALUE, arg, fromName);
-      block->insertAtTail(new CallExpr(PRIM_MOVE, read, get));
 
       if (isReferenceType(fromField->type)) {
         // If it is a reference, copy construct it

--- a/test/classes/delete-free/owned/tuple-of-owned.chpl
+++ b/test/classes/delete-free/owned/tuple-of-owned.chpl
@@ -88,4 +88,16 @@ proc test5() {
   acceptst5( (a, b) ); // should be nil by here
 }
 test5();
+
+proc acceptsIn6(in t: (int, owned C?)) {
+  return;
 }
+
+proc test6() {
+  var t = (128, new owned C?(256));
+  acceptsIn6(t);
+  assert(t[2] == nil);
+}
+test6();
+
+} // end module


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/865

This PR resolves a problem with the compiler-generated
copy-initializer for tuples containing owned.

Reviewed by @benharsh - thanks!

- [x] primers pass with valgrind+verify and do not leak
- [x] full local testing