### PR TITLE
Fix forall-unordered-opt for ig-variants

### DIFF
--- a/test/studies/bale/indexgather/ig-variants.comm-none.good
+++ b/test/studies/bale/indexgather/ig-variants.comm-none.good
@@ -1,3 +1,21 @@
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:82: note: Optimized assign to be unordered
+ig-variants.chpl:82: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
 17 1 4 19 14 19 7 19 11 2 12 2 14 14 9 17 0 19 3 6 10 2 3 8 6 6 8 7 13 15 9 5 5 18 15 18 1 2 0 18
 17 1 4 19 14 19 7 19 11 2 12 2 14 14 9 17 0 19 3 6 10 2 3 8 6 6 8 7 13 15 9 5 5 18 15 18 1 2 0 18
 17 1 4 19 14 19 7 19 11 2 12 2 14 14 9 17 0 19 3 6 10 2 3 8 6 6 8 7 13 15 9 5 5 18 15 18 1 2 0 18

--- a/test/studies/bale/indexgather/ig-variants.compopts
+++ b/test/studies/bale/indexgather/ig-variants.compopts
@@ -1,0 +1,1 @@
+--report-optimized-forall-unordered-ops

--- a/test/studies/bale/indexgather/ig-variants.good
+++ b/test/studies/bale/indexgather/ig-variants.good
@@ -1,3 +1,21 @@
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:82: note: Optimized assign to be unordered
+ig-variants.chpl:82: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:75: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:59: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
+ig-variants.chpl:67: note: Optimized assign to be unordered
 57 61 4 59 74 59 67 79 11 62 32 22 74 14 9 17 20 79 3 26 70 62 23 68 46 46 28 27 33 35 69 5 45 38 75 38 21 2 40 38 24 50 36 73 71 37 23 77 30 14 68 76 17 68 27 59 42 38 26 55 1 50 13 14 16 30 39 31 30 1 46 57 15 71 12 26 32 18 35 64 57 64 12 21 62 43 9 56 21 74 42 57 42 19 55 73 2 3 76 8 43 37 52 7 51 68 30 40 35 6 73 17 34 9 31 31 73 48 67 49 25 1 5 42 27 59 47 70 59 62 4 25 29 72 6 67 0 1 4 27 71 75 52 38 63 3 45 62 58 66 77 32 66 54 18 31 48 8 16 24
 57 61 4 59 74 59 67 79 11 62 32 22 74 14 9 17 20 79 3 26 70 62 23 68 46 46 28 27 33 35 69 5 45 38 75 38 21 2 40 38 24 50 36 73 71 37 23 77 30 14 68 76 17 68 27 59 42 38 26 55 1 50 13 14 16 30 39 31 30 1 46 57 15 71 12 26 32 18 35 64 57 64 12 21 62 43 9 56 21 74 42 57 42 19 55 73 2 3 76 8 43 37 52 7 51 68 30 40 35 6 73 17 34 9 31 31 73 48 67 49 25 1 5 42 27 59 47 70 59 62 4 25 29 72 6 67 0 1 4 27 71 75 52 38 63 3 45 62 58 66 77 32 66 54 18 31 48 8 16 24
 57 61 4 59 74 59 67 79 11 62 32 22 74 14 9 17 20 79 3 26 70 62 23 68 46 46 28 27 33 35 69 5 45 38 75 38 21 2 40 38 24 50 36 73 71 37 23 77 30 14 68 76 17 68 27 59 42 38 26 55 1 50 13 14 16 30 39 31 30 1 46 57 15 71 12 26 32 18 35 64 57 64 12 21 62 43 9 56 21 74 42 57 42 19 55 73 2 3 76 8 43 37 52 7 51 68 30 40 35 6 73 17 34 9 31 31 73 48 67 49 25 1 5 42 27 59 47 70 59 62 4 25 29 72 6 67 0 1 4 27 71 75 52 38 63 3 45 62 58 66 77 32 66 54 18 31 48 8 16 24


### PR DESCRIPTION
PR #14825 caused a performance regression for this test.
This commit resolves the issue and adjusts the test to use
--report-optimized-forall-unordered-ops so that the issue might
be more easily identified in the future.

Resolves https://github.com/Cray/chapel-private/issues/883

Reviewed by @ronawho - thanks!

- [x] full local testing