### PR TITLE
Remove 'new borrowed' from examples in spec

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -373,8 +373,8 @@ concrete* for the purpose of function resolution.
 
    .. BLOCK-test-chapelpost
 
-      var cc = new borrowed Container(int);
-      var c = new borrowed C(real, int, cc.type);
+      var cc = new Container(int);
+      var c = new C(real, int, cc.type);
       f(c);
       g(c);
 

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -335,7 +335,7 @@ be declared with parentheses even if the argument list is empty.
 
    .. BLOCK-test-chapelpost
 
-      var ta = new borrowed ThreeArray();
+      var ta = new ThreeArray();
       ta(1) = 1;
       ta(2) = 2;
       ta(3) = 3;


### PR DESCRIPTION
Since we're not really promoting 'new borrowed' anymore and these
tests don't rely on them, remove the uses.  These didn't show up in
the rendered spec, I believe, but would show up in the
release/examples directory for anyone browsing the spec examples.