### PR TITLE
Deprecate `channel.error` and friends

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3340,6 +3340,8 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
      Return any saved error code.
    */
   proc channel.error():syserr {
+    compilerWarning("The channel.error method is deprecated. " +
+                    "Catch errors instead.");
     var ret:syserr;
     on this.home {
       var local_error:syserr;
@@ -3355,6 +3357,8 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
      Save an error code.
    */
   proc channel.setError(e:syserr) {
+    compilerWarning("The channel.setError method is deprecated. " +
+                    "Throw errors instead.");
     on this.home {
       var error = e;
       try! this.lock();
@@ -3367,6 +3371,8 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
      Clear any saved error code.
    */
   proc channel.clearError() {
+    compilerWarning("The channel.clearError method is deprecated. " +
+                    "Throw and catch errors instead.");
     on this.home {
       try! this.lock();
       qio_channel_clear_error(_channel_internal);

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -1018,20 +1018,17 @@ record regexp {
     var litOne = new ioLiteral("new regexp(\"");
     var litTwo = new ioLiteral("\")");
 
-    try {
-      if (f.read(litOne, pattern, litTwo)) {
-        on this.home {
-          var localPattern = pattern.localize();
-          var opts:qio_regexp_options_t;
-          qio_regexp_init_default_options(opts);
-          qio_regexp_create_compile(localPattern.c_str(), localPattern.numBytes, opts, this._regexp);
-        }
+    if (f.read(litOne, pattern, litTwo)) then
+      on this.home {
+        var localPattern = pattern.localize();
+        var opts: qio_regexp_options_t;
+
+        qio_regexp_init_default_options(opts);
+        qio_regexp_create_compile(localPattern.c_str(),
+                                  localPattern.numBytes,
+                                  opts,
+                                  this._regexp);
       }
-    } catch e: SystemError {
-      f.setError(e.err);
-    } catch {
-      f.setError(EINVAL:syserr);
-    }
   }
 }
 

--- a/test/deprecated/channelError.chpl
+++ b/test/deprecated/channelError.chpl
@@ -1,0 +1,11 @@
+use IO;
+
+proc main() {
+  if stdout.error() then writeln("Impossible!");
+
+  var error: syserr = EEOF;
+  stdout.setError(error);
+
+  stdout.clearError();
+}
+

--- a/test/deprecated/channelError.good
+++ b/test/deprecated/channelError.good
@@ -1,0 +1,4 @@
+channelError.chpl:3: In function 'main':
+channelError.chpl:4: warning: The channel.error method is deprecated. Catch errors instead.
+channelError.chpl:7: warning: The channel.setError method is deprecated. Throw errors instead.
+channelError.chpl:9: warning: The channel.clearError method is deprecated. Throw and catch errors instead.


### PR DESCRIPTION
This PR deprecates routines that were used to check for channel errors in the world before #14739. These routines are no longer used internally by IO code. The Regexp module had one use of `channel.setError` that had to be removed.

Adds one small test in `test/deprecated` to lock in the deprecation warnings.

---

Test:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet`