### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -637,6 +637,13 @@ cs-resize:
 distCreate-arrays-deinit.cc-perf: &distCreate-base
   02/12/20:
     - Use --no-early-deinit in array creation/destruction benchmark (#14876)
+  03/13/20:
+    - Reallocate 1D arrays in place, when possible (#15177)
+  03/18/20:
+    -  Record-wrap `locale` (#15149)
+  03/22/20:
+    - Rewrite ddata_allocate() to avoid inadvertent widening of init_elts() (#15275)
+
 distCreate-arrays-init.cc-perf:
   <<: *distCreate-base
 distCreate-domains-deinit.cc-perf:
@@ -798,6 +805,11 @@ hpl_performance:
     - text: Improvements to inferConstRefs (#4904)
       config: 16 node XC
 
+ig-variants.ml-perf:
+  01/30/20:
+    - Address deinit point and param loops and conditionals (#14825)
+  03/23/20:
+    - Fix forall-unordered-opt for ig-variants (#15286)
 init:
   05/03/16:
     - Fix ref-return intent bugs (#3795)
@@ -1233,6 +1245,9 @@ mg: &mg-base
     -  Move strided bulk transfer into common code (#11197)
   09/21/18:
     -  Restore comm=none performance lost in PR 11197 (#11206)
+  03/13/20:
+    -  Reallocate 1D arrays in place, when possible (#15177)
+
 mg-b:
   <<: *mg-base
 
@@ -1267,6 +1282,8 @@ miniMD:
     - Update miniMD problem size (#9296)
   04/18/19:
     - Enable bulk-transfer for BlockDist by default (#12797)
+  03/13/20:
+    -  Reallocate 1D arrays in place, when possible (#15177)
 
 miniMD.ml-time:
   09/14/17:


### PR DESCRIPTION
Adds annotations for the following PRs that changed performance

- Address deinit point and param loops and conditionals (#14825)
- Reallocate 1D arrays in place, when possible (#15177)
- Record-wrap `locale` (#15149)
- Rewrite ddata_allocate() to avoid inadvertent widening of init_elts() (#15275)
- Fix forall-unordered-opt for ig-variants (#15286)