### PR TITLE
Fix array/dom creation commcount graphs

### DIFF
--- a/test/performance/array/distCreate-arrays-init.cc-perf.graph
+++ b/test/performance/array/distCreate-arrays-init.cc-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: arrInit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:, arrDeinit-GETS:, arrDeinit-PUTS:, arrDeinit-ONS:
-graphkeys: blockArrInit-GETS:, blockArrDeinit-PUTS:, blockArrDeinit-ONS:, cyclicArrDeinit-GETS:, cyclicArrDeinit-PUTS:, cyclicArrDeinit-ONS:, blockCycArrDeinit-GETS:, blockCycArrDeinit-PUTS:, blockCycArrDeinit-ONS:, stencilArrDeinit-GETS:, stencilArrDeinit-PUTS:, stencilArrDeinit-ONS:
+perfkeys: arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:, arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:, arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:, arrInit-GETS:, arrInit-PUTS:, arrInit-ONS:
+graphkeys: blockArrInit-GETS:, blockArrInit-PUTS:, blockArrInit-ONS:, cyclicArrInit-GETS:, cyclicArrInit-PUTS:, cyclicArrInit-ONS:, blockCycArrInit-GETS:, blockCycArrInit-PUTS:, blockCycArrInit-ONS:, stencilArrInit-GETS:, stencilArrInit-PUTS:, stencilArrInit-ONS:
 repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Creating distributed arrays

--- a/test/performance/array/distCreate-domains-init.cc-perf.graph
+++ b/test/performance/array/distCreate-domains-init.cc-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: domInit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:, domDeinit-GETS:, domDeinit-PUTS:, domDeinit-ONS:
-graphkeys: blockDomInit-GETS:, blockDomDeinit-PUTS:, blockDomDeinit-ONS:, cyclicDomDeinit-GETS:, cyclicDomDeinit-PUTS:, cyclicDomDeinit-ONS:, blockCycDomDeinit-GETS:, blockCycDomDeinit-PUTS:, blockCycDomDeinit-ONS:, stencilDomDeinit-GETS:, stencilDomDeinit-PUTS:, stencilDomDeinit-ONS:
+perfkeys: domInit-GETS:, domInit-PUTS:, domInit-ONS:, domInit-GETS:, domInit-PUTS:, domInit-ONS:, domInit-GETS:, domInit-PUTS:, domInit-ONS:, domInit-GETS:, domInit-PUTS:, domInit-ONS:
+graphkeys: blockDomInit-GETS:, blockDomInit-PUTS:, blockDomInit-ONS:, cyclicDomInit-GETS:, cyclicDomInit-PUTS:, cyclicDomInit-ONS:, blockCycDomInit-GETS:, blockCycDomInit-PUTS:, blockCycDomInit-ONS:, stencilDomInit-GETS:, stencilDomInit-PUTS:, stencilDomInit-ONS:
 repeat-files: distCreate-cc-block.dat, distCreate-cc-cyclic.dat, distCreate-cc-blockCyc.dat, distCreate-cc-stencil.dat
 ylabel: Count
 graphtitle: Creating distributed domains


### PR DESCRIPTION
We were using wrong keys in the commcount graphs for array and domain creation
benchmarks. This PR fixes that.
