### PR TITLE
Parallelize PrivateDist scan

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -210,6 +210,24 @@ proc PrivateArr.dsiSerialWrite(x) {
   }
 }
 
+proc PrivateArr.doiScan(op, dom) where (rank == 1) &&
+                                  chpl__scanStateResTypesMatch(op) {
+  type resType = op.generate().type;
+  var res: [dom] resType;
+
+  var localArr: [0..numLocales-1] resType;
+
+  coforall loc in Locales do on loc do
+    localArr[here.id] = if _local then data else chpl_getPrivatizedCopy(this.type, this.pid).data;
+
+  var localRes = localArr._scan(op);
+
+  forall r in res do r = localRes[here.id];
+
+  // localArr deletes op
+  return res;
+}
+
 // TODO: Fix 'new Private()' leak -- Discussed in #6726
 const PrivateSpace: domain(1) dmapped Private();
 

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -218,7 +218,7 @@ proc PrivateArr.doiScan(op, dom) where (rank == 1) &&
   var localArr: [0..numLocales-1] resType;
 
   coforall loc in Locales do on loc do
-    localArr[here.id] = if _local then data else chpl_getPrivatizedCopy(this.type, this.pid).data;
+    localArr[here.id] = if _isPrivatized(this) then chpl_getPrivatizedCopy(this.type, this.pid).data else data;
 
   var localRes = localArr._scan(op);
 

--- a/test/scan/testScanOps.chpl
+++ b/test/scan/testScanOps.chpl
@@ -1,5 +1,6 @@
 
 use BlockDist;
+use PrivateDist;
 use Random;
 
 config const n = 100;
@@ -20,6 +21,10 @@ proc testType(type T) {
 
   var BL : [S] T = DR;
   test(BL);
+
+  var PR : [PrivateSpace] T = DR[1..numLocales];
+  test(PR);
+
 }
 
 proc test(A : []) {

--- a/test/scan/testScanOps.good
+++ b/test/scan/testScanOps.good
@@ -38,6 +38,26 @@ minloc scan
 ^ scan
   Success
 
+Testing type '[PrivateDom(1,int(64),false)] int(64)'
++ scan
+  Success
+min scan
+  Success
+max scan
+  Success
+* scan
+  Success
+maxloc scan
+  Success
+minloc scan
+  Success
+& scan
+  Success
+| scan
+  Success
+^ scan
+  Success
+
 Testing type '[domain(1,int(64),false)] real(64)'
 + scan
   Success
@@ -66,6 +86,20 @@ maxloc scan
 minloc scan
   Success
 
+Testing type '[PrivateDom(1,int(64),false)] real(64)'
++ scan
+  Success
+min scan
+  Success
+max scan
+  Success
+* scan
+  Success
+maxloc scan
+  Success
+minloc scan
+  Success
+
 Testing type '[domain(1,int(64),false)] bool'
 && scan
   Success
@@ -73,6 +107,12 @@ Testing type '[domain(1,int(64),false)] bool'
   Success
 
 Testing type '[BlockDom(1,int(64),false,unmanaged DefaultDist)] bool'
+&& scan
+  Success
+|| scan
+  Success
+
+Testing type '[PrivateDom(1,int(64),false)] bool'
 && scan
   Success
 || scan


### PR DESCRIPTION
Optimize and parallelize scan for PrivateDist. The implementation just
gathers the PrivateArray into a local DefaultRectangular array, performs
the scan locally, and then scatters the results to the result array.
This is significantly faster than the default serial approach. It's 100x
faster at 512 nodes. PrivateDist scans are unlikely to be a performance
bottleneck for anybody but it was causing serialization warnings for
Arkouda.

Below are scalability numbers for PrivateDist scan. Results are a rate
(scans/sec) so higher is better. I'm just running:

```chpl
for 1..trials do
  var resEnds: [PrivateSpace] int = + scan numResults;
```

| nodes | before | now    |
| ----: | -----: | -----: |
|   1   | 56,400 | 44,000 |
|   2   |  8,200 |  7,500 |
|   4   |  3,700 |  5,000 |
|   8   |  2,000 |  3,800 |
|  16   |  1,200 |  2,800 |
|  32   |    640 |  2,200 |
|  64   |     90 |  1,750 |
| 128   |     40 |  1,400 |
| 256   |     15 |  1,000 |
| 512   |      6 |    600 |

There's a slight hit for single node since we're copying around a
little, but there's a 100x improvement at 512 nodes.

Resolves https://github.com/chapel-lang/chapel/issues/14840
Closes https://github.com/Cray/chapel-private/issues/870