### PR TITLE
Allow fast followers for Block and Cyclic regardless of element type

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1083,9 +1083,18 @@ iter BlockArr.these(param tag: iterKind) where tag == iterKind.leader {
     yield followThis;
 }
 
-override proc BlockArr.dsiStaticFastFollowCheck(type leadType) param
-  return _to_borrowed(leadType) == _to_borrowed(this.type) ||
-         _to_borrowed(leadType) == _to_borrowed(this.dom.type);
+override proc BlockArr.dsiStaticFastFollowCheck(type leadType) param {
+  if isSubtype(leadType, BlockArr) {
+    // Comparing domains for rank/idxType/stride/sparseLayout, which allows for
+    // fast followers regardless of eltType.
+    //
+    // TODO: Remove once 'typeExpr.field' results in a type
+    var x : leadType?;
+    return _to_borrowed(x!.dom.type) == _to_borrowed(this.dom.type);
+  } else {
+    return _to_borrowed(leadType) == _to_borrowed(this.dom.type);
+  }
+}
 
 proc BlockArr.dsiDynamicFastFollowCheck(lead: [])
   return this.dsiDynamicFastFollowCheck(lead.domain);

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -919,9 +919,14 @@ iter CyclicArr.these(param tag: iterKind) where tag == iterKind.leader {
     yield followThis;
 }
 
-override proc CyclicArr.dsiStaticFastFollowCheck(type leadType) param
-  return _to_borrowed(leadType) == _to_borrowed(this.type) ||
-         _to_borrowed(leadType) == _to_borrowed(this.dom.type);
+override proc CyclicArr.dsiStaticFastFollowCheck(type leadType) param {
+  if isSubtype(leadType, CyclicArr) {
+    var x : leadType?;
+    return _to_borrowed(x!.dom.type) == _to_borrowed(this.dom.type);
+  } else {
+    return _to_borrowed(leadType) == _to_borrowed(this.dom.type);
+  }
+}
 
 proc CyclicArr.dsiDynamicFastFollowCheck(lead: [])
   return this.dsiDynamicFastFollowCheck(lead.domain);

--- a/test/distributions/bharshbarg/fastFollowerEquality.chpl
+++ b/test/distributions/bharshbarg/fastFollowerEquality.chpl
@@ -8,8 +8,8 @@ proc test(Orig : domain) {
   test(Orig, Copy);
 }
 
-proc makeArray(D : domain) {
-  var ret : [D] int;
+proc makeArray(D : domain, type eltType = int) {
+  var ret : [D] eltType;
   var cur = 0;
   for i in D {
     ret[i] = cur;
@@ -21,8 +21,11 @@ proc makeArray(D : domain) {
 proc test(DA : domain, DB : domain) {
   var A = makeArray(DA);
   var B = makeArray(DB);
+  test(A,B);
+}
 
-  writeln("--- ", DA.type:string, " vs. ", DB.type:string, " ---");
+proc test(A : [?DA], B : [?DB]) {
+  writeln("--- ", A.type:string, " vs. ", B.type:string, " ---");
   DA.dist.displayRepresentation();
   writeln();
   DB.dist.displayRepresentation();
@@ -85,4 +88,8 @@ proc main() {
 
   // - different startIdx
   test(make(cyclic,one),make(cyclic,one,startIdx=(2,)));
+
+  // - different eltTypes
+  test(makeArray(make(block,one), real), makeArray(make(block,one), int));
+  test(makeArray(make(cyclic,one), real), makeArray(make(cyclic,one), int));
 }

--- a/test/distributions/bharshbarg/fastFollowerEquality.good
+++ b/test/distributions/bharshbarg/fastFollowerEquality.good
@@ -1,4 +1,4 @@
---- BlockDom(1,int(64),false,unmanaged DefaultDist) vs. BlockDom(1,int(64),false,unmanaged DefaultDist) ---
+--- [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) vs. [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..3}
 targetLocales = 0 1 2 3
@@ -39,7 +39,7 @@ fast follower invoked for Block array
 fast follower invoked for Block array
 ----------
 
---- StencilDom(1,int(64),false,false) vs. StencilDom(1,int(64),false,false) ---
+--- [StencilDom(1,int(64),false,false)] int(64) vs. [StencilDom(1,int(64),false,false)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..3}
 targetLocales = 0 1 2 3
@@ -80,7 +80,7 @@ fast follower invoked for Stencil array
 fast follower invoked for Stencil array
 ----------
 
---- CyclicDom(1,int(64),false) vs. CyclicDom(1,int(64),false) ---
+--- [CyclicDom(1,int(64),false)] int(64) vs. [CyclicDom(1,int(64),false)] int(64) ---
 startIdx = (1)
 targetLocDom = {0..3}
 targetLocs = 0 1 2 3
@@ -121,7 +121,7 @@ fast follower invoked for Cyclic array
 fast follower invoked for Cyclic array
 ----------
 
---- BlockDom(1,int(64),false,unmanaged DefaultDist) vs. BlockDom(1,int(64),false,unmanaged DefaultDist) ---
+--- [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) vs. [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..1}
 targetLocales = 0 1
@@ -150,7 +150,7 @@ regular follower invoked for Block array
 regular follower invoked for Block array
 ----------
 
---- StencilDom(1,int(64),false,false) vs. StencilDom(1,int(64),false,false) ---
+--- [StencilDom(1,int(64),false,false)] int(64) vs. [StencilDom(1,int(64),false,false)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..1}
 targetLocales = 0 1
@@ -179,7 +179,7 @@ regular follower invoked for Stencil array
 regular follower invoked for Stencil array
 ----------
 
---- CyclicDom(1,int(64),false) vs. CyclicDom(1,int(64),false) ---
+--- [CyclicDom(1,int(64),false)] int(64) vs. [CyclicDom(1,int(64),false)] int(64) ---
 startIdx = (1)
 targetLocDom = {0..1}
 targetLocs = 0 1
@@ -208,7 +208,7 @@ regular follower invoked for Cyclic array
 regular follower invoked for Cyclic array
 ----------
 
---- BlockDom(1,int(64),false,unmanaged DefaultDist) vs. BlockDom(1,int(64),false,unmanaged DefaultDist) ---
+--- [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) vs. [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..3}
 targetLocales = 0 1 2 3
@@ -249,7 +249,7 @@ regular follower invoked for Block array
 regular follower invoked for Block array
 ----------
 
---- StencilDom(1,int(64),false,false) vs. StencilDom(1,int(64),false,false) ---
+--- [StencilDom(1,int(64),false,false)] int(64) vs. [StencilDom(1,int(64),false,false)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..3}
 targetLocales = 0 1 2 3
@@ -290,7 +290,7 @@ regular follower invoked for Stencil array
 regular follower invoked for Stencil array
 ----------
 
---- CyclicDom(1,int(64),false) vs. CyclicDom(1,int(64),false) ---
+--- [CyclicDom(1,int(64),false)] int(64) vs. [CyclicDom(1,int(64),false)] int(64) ---
 startIdx = (1)
 targetLocDom = {0..3}
 targetLocs = 0 1 2 3
@@ -331,7 +331,7 @@ regular follower invoked for Cyclic array
 regular follower invoked for Cyclic array
 ----------
 
---- BlockDom(1,int(64),false,unmanaged DefaultDist) vs. BlockDom(1,int(64),false,unmanaged DefaultDist) ---
+--- [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) vs. [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) ---
 boundingBox = {0..99}
 targetLocDom = {0..3}
 targetLocales = 0 1 2 3
@@ -360,7 +360,7 @@ regular follower invoked for Block array
 regular follower invoked for Block array
 ----------
 
---- StencilDom(1,int(64),false,false) vs. StencilDom(1,int(64),false,false) ---
+--- [StencilDom(1,int(64),false,false)] int(64) vs. [StencilDom(1,int(64),false,false)] int(64) ---
 boundingBox = {0..99}
 targetLocDom = {0..3}
 targetLocales = 0 1 2 3
@@ -389,7 +389,7 @@ regular follower invoked for Stencil array
 regular follower invoked for Stencil array
 ----------
 
---- CyclicDom(1,int(64),false) vs. CyclicDom(1,int(64),false) ---
+--- [CyclicDom(1,int(64),false)] int(64) vs. [CyclicDom(1,int(64),false)] int(64) ---
 startIdx = (1)
 targetLocDom = {0..3}
 targetLocs = 0 1 2 3
@@ -428,5 +428,87 @@ regular follower invoked for Cyclic array
 regular follower invoked for Cyclic array
 regular follower invoked for Cyclic array
 regular follower invoked for Cyclic array
+----------
+
+--- [BlockDom(1,int(64),false,unmanaged DefaultDist)] real(64) vs. [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64) ---
+boundingBox = {1..10}
+targetLocDom = {0..3}
+targetLocales = 0 1 2 3
+dataParTasksPerLocale = 2
+dataParIgnoreRunningTasks = false
+dataParMinGranularity = 1
+locDist[0].myChunk = {-9223372036854775808..3}
+locDist[1].myChunk = {4..5}
+locDist[2].myChunk = {6..8}
+locDist[3].myChunk = {9..9223372036854775807}
+
+boundingBox = {1..10}
+targetLocDom = {0..3}
+targetLocales = 0 1 2 3
+dataParTasksPerLocale = 2
+dataParIgnoreRunningTasks = false
+dataParMinGranularity = 1
+locDist[0].myChunk = {-9223372036854775808..3}
+locDist[1].myChunk = {4..5}
+locDist[2].myChunk = {6..8}
+locDist[3].myChunk = {9..9223372036854775807}
+
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+fast follower invoked for Block array
+----------
+
+--- [CyclicDom(1,int(64),false)] real(64) vs. [CyclicDom(1,int(64),false)] int(64) ---
+startIdx = (1)
+targetLocDom = {0..3}
+targetLocs = 0 1 2 3
+dataParTasksPerLocale = 2
+dataParIgnoreRunningTasks = false
+dataParMinGranularity = 1
+locDist[0].myChunk = {-9223372036854775807..9223372036854775805 by 4}
+locDist[1].myChunk = {-9223372036854775806..9223372036854775806 by 4}
+locDist[2].myChunk = {-9223372036854775805..9223372036854775807 by 4}
+locDist[3].myChunk = {-9223372036854775808..9223372036854775804 by 4}
+
+startIdx = (1)
+targetLocDom = {0..3}
+targetLocs = 0 1 2 3
+dataParTasksPerLocale = 2
+dataParIgnoreRunningTasks = false
+dataParMinGranularity = 1
+locDist[0].myChunk = {-9223372036854775807..9223372036854775805 by 4}
+locDist[1].myChunk = {-9223372036854775806..9223372036854775806 by 4}
+locDist[2].myChunk = {-9223372036854775805..9223372036854775807 by 4}
+locDist[3].myChunk = {-9223372036854775808..9223372036854775804 by 4}
+
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
+fast follower invoked for Cyclic array
 ----------
 


### PR DESCRIPTION
This PR updates the static fast-follower checks for Block and Cyclic to only check the domain's static type. This allows for fast-followers to trigger even when element types differ. In these classes, the only additional compile-time information contained by the array classes is the element type, so it's safe to just compare the domain types.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] dist-cyclic