### PR TITLE
Add additional constraint to shift expressions in spec

### DIFF
--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -1072,6 +1072,12 @@ otherwise the new high-order bits are set to zero.
 
 The value of ``b`` must be non-negative.
 
+The value of ``b`` must be less than the number of bits in ``a``.
+
+Conforming implementations may add both compile-time and run-time
+checks to ensure that the value of the second actual argument ``b``
+meets the above constraints.
+
 .. _Logical_Operators:
 
 Logical Operators

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -1074,10 +1074,6 @@ The value of ``b`` must be non-negative.
 
 The value of ``b`` must be less than the number of bits in ``a``.
 
-Conforming implementations may add both compile-time and run-time
-checks to ensure that the value of the second actual argument ``b``
-meets the above constraints.
-
 .. _Logical_Operators:
 
 Logical Operators


### PR DESCRIPTION
This PR updates the bitshift section of the spec to reflect changes made in #14391. 

It adds a constraint that "restricts that value of the second operand to be less than the number of bits required by the type of the first".

--- 

Testing:

- [x] Make sure docs render locally