### PR TITLE
Skip ig-variants under baseline testing

### DIFF
--- a/test/studies/bale/indexgather/ig-variants.skipif
+++ b/test/studies/bale/indexgather/ig-variants.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
Follow-up to PR #15286.

Now that ig-variants.chpl prints out optimization info,
when the optimization doesn't run due to --baseline the test fails.
So skip it in that configuration.

Trivial and not reviewed.