### PR TITLE
Refactor code that gets outer scope for visibleFunctions.cpp

### DIFF
--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -323,13 +323,7 @@ static void getVisibleMethods(const char* name, CallExpr* call,
     }
 
     if (block != rootModule->block) {
-      BlockStmt* next  = getVisibilityScope(block);
-
-      ModuleSymbol* blockMod = block->getModule();
-      ModuleSymbol* nextMod = next->getModule();
-      if (blockMod != nextMod && nextMod != theProgram && nextMod != rootModule) {
-        next = standardModule->block;
-      }
+      BlockStmt* next  = getVisibilityScopeNoParentModule(block);
 
       // Recurse in the enclosing block
       getVisibleMethods(name, call, next, visited, visibleFns);
@@ -541,13 +535,7 @@ static void getVisibleFunctions(const char*           name,
     }
 
     if (block != rootModule->block) {
-      BlockStmt* next  = getVisibilityScope(block);
-
-      ModuleSymbol* blockMod = block->getModule();
-      ModuleSymbol* nextMod = next->getModule();
-      if (blockMod != nextMod && nextMod != theProgram && nextMod != rootModule) {
-        next = standardModule->block;
-      }
+      BlockStmt* next  = getVisibilityScopeNoParentModule(block);
 
       // Recurse in the enclosing block
       getVisibleFunctions(name, call, next, visited, visibleFns, inUseChain);
@@ -653,13 +641,7 @@ static void getVisibleFunctions(const char*           name,
     // Need to continue going up in case our parent scopes also had private
     // uses that were skipped.
     if (block != rootModule->block) {
-      BlockStmt* next  = getVisibilityScope(block);
-
-      ModuleSymbol* blockMod = block->getModule();
-      ModuleSymbol* nextMod = next->getModule();
-      if (blockMod != nextMod && nextMod != theProgram && nextMod != rootModule) {
-        next = standardModule->block;
-      }
+      BlockStmt* next  = getVisibilityScopeNoParentModule(block);
 
       // Recurse in the enclosing block
       getVisibleFunctions(name, call, next, visited, visibleFns, inUseChain);
@@ -761,6 +743,27 @@ BlockStmt* getVisibilityScope(Expr* expr) {
 
   return NULL;
 }
+
+
+/* This function returns the next BlockStmt enclosing `expr` that
+   should be searched for function definitions when getting visible
+   functions.  Unlike getVisibilityScope() above, it will skip over
+   inner module's parent (ancestor) modules since we don't consider
+   those symbols to be lexically visible as of PR #15312.
+ */
+BlockStmt* getVisibilityScopeNoParentModule(Expr* expr) {
+  BlockStmt* next = getVisibilityScope(expr);
+
+  ModuleSymbol* blockMod = block->getModule();
+  ModuleSymbol* nextMod = next->getModule();
+  if (blockMod != nextMod && nextMod != theProgram && nextMod != rootModule) {
+    next = standardModule->block;
+  }
+
+  return next;
+}
+
+
 
 
 /************************************* | **************************************


### PR DESCRIPTION
This is an IOU cleanup Lydia requested on PR #15312.  To avoid the
repeated code that I introduced, I added a helper routine that gets
the enclosing scope, but skipping over any enclosing parent modules.
Additional effort could be put in to replace pre-existing repeated
code at these callsites, but I didn't undertake that here.