### PR TITLE
Update HDF5 package w.r.t. #15320

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3466,6 +3466,7 @@ module HDF5 {
     pragma "no doc"
     module HDF5_WAR {
       require "HDF5Helper/hdf5_helper.h";
+      use C_HDF5;
 
       extern proc H5LTget_dataset_info_WAR(loc_id: hid_t,
                                            dset_name: c_string,

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -80,7 +80,7 @@ module HDF5 {
     require "hdf5_hl.h";
     require "-lhdf5", "-lhdf5_hl";
 
-    use HDF5_WAR;
+    public use HDF5_WAR;
 
     extern proc H5open() : herr_t;
 
@@ -4043,7 +4043,7 @@ module HDF5 {
       // instead of:
       // A11, A12, B11, B12
       // A21, A22, B21, B22
-      use BlockDist, CyclicDist;
+      use BlockDist, CyclicDist, C_HDF5;
       proc isBlock(D: Block) param return true;
       proc isBlock(D) param return false;
       proc isCyclic(D: Cyclic) param return true;

--- a/test/library/packages/HDF5/ex_lite1.chpl
+++ b/test/library/packages/HDF5/ex_lite1.chpl
@@ -1,10 +1,11 @@
 // This is based on:
 // https://bitbucket.hdfgroup.org/projects/HDFFV/repos/hdf5/browse/examples/h5_crtdat.c
 
+use HDF5.C_HDF5;
+
 param RANK = 2:c_int;
 
 proc main {
-  use HDF5.C_HDF5;
 
   var file_id: hid_t;
   var dims: [0..#RANK] hsize_t = [2:hsize_t, 3:hsize_t];


### PR DESCRIPTION
This adds a use to the inner WAR module within HDF5 so that it
can continue to refer to symbols in its parent module's scope
after PR #15312.  Without this, Arkouda was broken.

While here, I ran test/library/packages/hdf5 and found and fixed
some other low-hanging fruit problems that suggest that nobody's
run testing on it in ages.  There are also other cases I didn't fix due
to lack of time such as its use of array-as-vec technology.