### PR TITLE
Issue a --warn-unstable message about using .domain

### DIFF
--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -2131,7 +2131,12 @@ call_expr:
 dot_expr:
   expr TDOT ident_use          { $$ = buildDotExpr($1, $3); }
 | expr TDOT TTYPE              { $$ = new CallExpr(PRIM_TYPEOF, $1); }
-| expr TDOT TDOMAIN            { $$ = buildDotExpr($1, "_dom"); }
+| expr TDOT TDOMAIN            { if (fWarnUnstable &&
+                                     currentModuleType == MOD_USER) {
+                                   USR_WARN($1, "'.domain' may be deprecated in the future in favor of '.indices'");
+                                 }
+                                 $$ = buildDotExpr($1, "_dom");
+                               }
 | expr TDOT TLOCALE            { $$ = buildDotExpr($1, "locale"); }
 | expr TDOT TBYTES TLP TRP     { $$ = new CallExpr(buildDotExpr($1, "chpl_bytes")); }
 ;

--- a/test/unstable/domainVsIndices.chpl
+++ b/test/unstable/domainVsIndices.chpl
@@ -1,0 +1,2 @@
+var A: [1..10] real;
+writeln(A.domain);

--- a/test/unstable/domainVsIndices.good
+++ b/test/unstable/domainVsIndices.good
@@ -1,0 +1,2 @@
+domainVsIndices.chpl:2: warning: '.domain' may be deprecated in the future in favor of '.indices'
+{1..10}


### PR DESCRIPTION
This adds a warning for those who use --warn-unstable, letting them
know that there's a chance we may deprecate it in favor of .indices in
the future.

TODO:
- [ ] check in generated flex/bison files