### PR TITLE
Update test comm counts for comm=ofi, ugni.

### DIFF
--- a/test/arrays/slices/commCounts/sliceBlockWithRanges.good
+++ b/test/arrays/slices/commCounts/sliceBlockWithRanges.good
@@ -1,7 +1,7 @@
 
 Creating B (a normal slice)
 ---------------------------
-(execute_on = 4, execute_on_nb = 3) (get = 33, put = 1, execute_on = 2, execute_on_fast = 1) (get = 33, put = 1, execute_on_fast = 1) (get = 33, put = 1, execute_on_fast = 1)
+(execute_on = 4, execute_on_nb = 3) (get = 24, put = 1, execute_on = 2) (get = 24, put = 1) (get = 24, put = 1)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0
@@ -17,7 +17,7 @@ A is:
 
 Incrementing B via access
 -------------------------
-(execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
+(execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0
@@ -33,7 +33,7 @@ A is:
 
 Incrementing B via iteration
 ----------------------------
-(execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
+(execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0
@@ -50,7 +50,7 @@ A is:
 Incrementing B via routine:
 Incrementing in routine by access
 ---------------------------------
-(execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
+(execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0
@@ -67,7 +67,7 @@ A is:
 Incrementing B via routine:
 Incrementing in routine by iteration
 ------------------------------------
-(execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
+(execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 21, put = 1, execute_on = 2) (get = 21, put = 1) (get = 21, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 14, put = 1, execute_on = 2) (get = 14, put = 1) (get = 14, put = 1)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 28, put = 1, execute_on = 2) (get = 28, put = 1) (get = 28, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 20, put = 1, execute_on = 2) (get = 20, put = 1) (get = 20, put = 1)
 Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 35, put = 1, execute_on = 2) (get = 35, put = 1) (get = 35, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 26, put = 1, execute_on = 2) (get = 26, put = 1) (get = 26, put = 1)
 Dom4D
-(execute_on = 4, execute_on_nb = 6) (get = 42, put = 1, execute_on = 2) (get = 42, put = 1) (get = 42, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 32, put = 1, execute_on = 2) (get = 32, put = 1) (get = 32, put = 1)
 Dom2D32
-(execute_on = 4, execute_on_nb = 6) (get = 28, put = 1, execute_on = 2) (get = 28, put = 1) (get = 28, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 20, put = 1, execute_on = 2) (get = 20, put = 1) (get = 20, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 40, put = 1, execute_on = 2) (get = 40, put = 1) (get = 40, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 24, put = 1, execute_on = 2) (get = 24, put = 1) (get = 24, put = 1)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 47, put = 1, execute_on = 2) (get = 47, put = 1) (get = 47, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 32, put = 1, execute_on = 2) (get = 32, put = 1) (get = 32, put = 1)
 Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 62, put = 1, execute_on = 2) (get = 62, put = 1) (get = 62, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 42, put = 1, execute_on = 2) (get = 42, put = 1) (get = 42, put = 1)
 Dom4D
-(execute_on = 4, execute_on_nb = 6) (get = 77, put = 1, execute_on = 2) (get = 77, put = 1) (get = 77, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 52, put = 1, execute_on = 2) (get = 52, put = 1) (get = 52, put = 1)
 Dom2D32
-(execute_on = 4, execute_on_nb = 6) (get = 47, put = 1, execute_on = 2) (get = 47, put = 1) (get = 47, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 32, put = 1, execute_on = 2) (get = 32, put = 1) (get = 32, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 63, put = 6, execute_on = 16, execute_on_nb = 9) (get = 63, put = 3, execute_on = 11, execute_on_nb = 6) (get = 63, put = 3, execute_on = 3, execute_on_nb = 6) (get = 63, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 42, put = 6, execute_on = 16, execute_on_nb = 9) (get = 42, put = 3, execute_on = 11, execute_on_nb = 6) (get = 42, put = 3, execute_on = 3, execute_on_nb = 6) (get = 42, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D
-(get = 84, put = 6, execute_on = 16, execute_on_nb = 9) (get = 84, put = 3, execute_on = 11, execute_on_nb = 6) (get = 84, put = 3, execute_on = 3, execute_on_nb = 6) (get = 84, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 60, put = 6, execute_on = 16, execute_on_nb = 9) (get = 60, put = 3, execute_on = 11, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom3D
-(get = 105, put = 6, execute_on = 16, execute_on_nb = 9) (get = 105, put = 3, execute_on = 11, execute_on_nb = 6) (get = 105, put = 3, execute_on = 3, execute_on_nb = 6) (get = 105, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 78, put = 6, execute_on = 16, execute_on_nb = 9) (get = 78, put = 3, execute_on = 11, execute_on_nb = 6) (get = 78, put = 3, execute_on = 3, execute_on_nb = 6) (get = 78, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom4D
-(get = 126, put = 6, execute_on = 16, execute_on_nb = 9) (get = 126, put = 3, execute_on = 11, execute_on_nb = 6) (get = 126, put = 3, execute_on = 3, execute_on_nb = 6) (get = 126, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 96, put = 6, execute_on = 16, execute_on_nb = 9) (get = 96, put = 3, execute_on = 11, execute_on_nb = 6) (get = 96, put = 3, execute_on = 3, execute_on_nb = 6) (get = 96, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D32
-(get = 84, put = 6, execute_on = 16, execute_on_nb = 9) (get = 84, put = 3, execute_on = 11, execute_on_nb = 6) (get = 84, put = 3, execute_on = 3, execute_on_nb = 6) (get = 84, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 60, put = 6, execute_on = 16, execute_on_nb = 9) (get = 60, put = 3, execute_on = 11, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.cyclic.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 120, put = 6, execute_on = 16, execute_on_nb = 9) (get = 120, put = 3, execute_on = 11, execute_on_nb = 6) (get = 120, put = 3, execute_on = 3, execute_on_nb = 6) (get = 120, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 72, put = 6, execute_on = 16, execute_on_nb = 9) (get = 72, put = 3, execute_on = 11, execute_on_nb = 6) (get = 72, put = 3, execute_on = 3, execute_on_nb = 6) (get = 72, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D
-(get = 141, put = 6, execute_on = 16, execute_on_nb = 9) (get = 141, put = 3, execute_on = 11, execute_on_nb = 6) (get = 141, put = 3, execute_on = 3, execute_on_nb = 6) (get = 141, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 96, put = 6, execute_on = 16, execute_on_nb = 9) (get = 96, put = 3, execute_on = 11, execute_on_nb = 6) (get = 96, put = 3, execute_on = 3, execute_on_nb = 6) (get = 96, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom3D
-(get = 186, put = 6, execute_on = 16, execute_on_nb = 9) (get = 186, put = 3, execute_on = 11, execute_on_nb = 6) (get = 186, put = 3, execute_on = 3, execute_on_nb = 6) (get = 186, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 126, put = 6, execute_on = 16, execute_on_nb = 9) (get = 126, put = 3, execute_on = 11, execute_on_nb = 6) (get = 126, put = 3, execute_on = 3, execute_on_nb = 6) (get = 126, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom4D
-(get = 231, put = 6, execute_on = 16, execute_on_nb = 9) (get = 231, put = 3, execute_on = 11, execute_on_nb = 6) (get = 231, put = 3, execute_on = 3, execute_on_nb = 6) (get = 231, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 156, put = 6, execute_on = 16, execute_on_nb = 9) (get = 156, put = 3, execute_on = 11, execute_on_nb = 6) (get = 156, put = 3, execute_on = 3, execute_on_nb = 6) (get = 156, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D32
-(get = 141, put = 6, execute_on = 16, execute_on_nb = 9) (get = 141, put = 3, execute_on = 11, execute_on_nb = 6) (get = 141, put = 3, execute_on = 3, execute_on_nb = 6) (get = 141, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 96, put = 6, execute_on = 16, execute_on_nb = 9) (get = 96, put = 3, execute_on = 11, execute_on_nb = 6) (get = 96, put = 3, execute_on = 3, execute_on_nb = 6) (get = 96, put = 3, execute_on = 3, execute_on_nb = 6)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 101, put = 1, execute_on = 7) (get = 101, put = 1) (get = 101, put = 1)
+(execute_on = 14, execute_on_nb = 6) (get = 81, put = 1, execute_on = 7) (get = 81, put = 1) (get = 81, put = 1)
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 166, put = 1, execute_on = 7) (get = 166, put = 1) (get = 166, put = 1)
+(execute_on = 14, execute_on_nb = 6) (get = 93, put = 1, execute_on = 7) (get = 93, put = 1) (get = 93, put = 1)
 (execute_on_nb = 3) (get = 96) (get = 96) (get = 168)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 38, put = 1, execute_on = 3) (get = 38, put = 1, execute_on = 1) (get = 38, put = 1, execute_on = 1)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 26, put = 1, execute_on = 3) (get = 26, put = 1, execute_on = 1) (get = 26, put = 1, execute_on = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 61, put = 1, execute_on = 3) (get = 61, put = 1, execute_on = 1) (get = 61, put = 1, execute_on = 1)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 34, put = 1, execute_on = 3) (get = 34, put = 1, execute_on = 1) (get = 34, put = 1, execute_on = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignReindex.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignReindex.block.good
@@ -1,2 +1,2 @@
-(execute_on = 12, execute_on_nb = 6) (get = 101, put = 1, execute_on = 6) (get = 101, put = 1) (get = 101, put = 1)
+(execute_on = 12, execute_on_nb = 6) (get = 81, put = 1, execute_on = 6) (get = 81, put = 1) (get = 81, put = 1)
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignReindex.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignReindex.cyclic.good
@@ -1,2 +1,2 @@
-(execute_on = 12, execute_on_nb = 6) (get = 166, put = 1, execute_on = 6) (get = 166, put = 1) (get = 166, put = 1)
+(execute_on = 12, execute_on_nb = 6) (get = 93, put = 1, execute_on = 6) (get = 93, put = 1) (get = 93, put = 1)
 (execute_on_nb = 3) (get = 102) (get = 102) (get = 174)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.block.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 2, execute_on_nb = 6) (get = 38, put = 1, execute_on = 2) (get = 38, put = 1, execute_on = 1) (get = 38, put = 1, execute_on = 1)
+(get = 3, execute_on = 2, execute_on_nb = 6) (get = 26, put = 1, execute_on = 2) (get = 26, put = 1, execute_on = 1) (get = 26, put = 1, execute_on = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.cyclic.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 2, execute_on_nb = 6) (get = 61, put = 1, execute_on = 2) (get = 61, put = 1, execute_on = 1) (get = 61, put = 1, execute_on = 1)
+(get = 3, execute_on = 2, execute_on_nb = 6) (get = 34, put = 1, execute_on = 2) (get = 34, put = 1, execute_on = 1) (get = 34, put = 1, execute_on = 1)

--- a/test/performance/sungeun/multilocale/syncsingle.good
+++ b/test/performance/sungeun/multilocale/syncsingle.good
@@ -1,2 +1,2 @@
-(put = 3, execute_on_nb = 3) (get = 1, execute_on = 1) (get = 1, execute_on = 1) (get = 1, execute_on = 2)
-(put = 3, execute_on_nb = 3) (get = 1, execute_on = 1) (get = 1, execute_on = 1) (get = 1, execute_on = 2)
+(put = 3, execute_on_nb = 3) (execute_on = 1) (execute_on = 1) (execute_on = 2)
+(put = 3, execute_on_nb = 3) (execute_on = 1) (execute_on = 1) (execute_on = 2)


### PR DESCRIPTION
Comm counts have improved for some tests when they're built with the ofi
or ugni comm layers, which support network atomics, and use the block or
cyclic distributions.  We hadn't noticed only because we don't do
regular full testing with ofi or ugni.  Here, update those comm counts.