### PR TITLE
Add another slurm message to filter out.

### DIFF
--- a/util/test/prediff-for-slurm-srun
+++ b/util/test/prediff-for-slurm-srun
@@ -11,6 +11,8 @@ msgs = (
 """,
 """srun: error: .+: task [0-9]+: Terminated
 """,
+"""srun: Force Terminated job step [0-9.]+
+""",
 """srun: Terminating job step [0-9.]+
 """,
 """slurmstepd: error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ \*\*\*


### PR DESCRIPTION
This one hadn't been seen until now, on a Cray XC system with srun
version 19.05.4.