### PR TITLE
Add `--warn-unstable` warnings for some enum features with detractors

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1231,6 +1231,14 @@ static void buildEnumIntegerCastFunctions(EnumType* et) {
       // associated integer value.  This routine throws an error.
       fn->throwsErrorInit();
 
+      if (fWarnUnstable) {
+        USR_WARN(et->symbol, "it has been suggested that support for "
+                 "semi-concrete enums like this (in which initial members "
+                 "have no integer values, but later ones do) should be "
+                 "deprecated, so this enum could be considered unstable; "
+                 "if you value such enums, please let the Chapel team know.");
+      }
+
       count = 0;
       whenstmts = buildChapelStmt();
       lastInit = NULL;

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -96,7 +96,7 @@ checkResolved() {
 
   forv_Vec(TypeSymbol, type, gTypeSymbols) {
     if (EnumType* et = toEnumType(type->type)) {
-      std::set<int> intVals;
+      std::set<std::string> enumVals;
       for_enums(def, et) {
         if (def->init) {
           SymExpr* sym = toSymExpr(def->init);
@@ -106,14 +106,15 @@ checkResolved() {
                            def->sym->name);
           } else if (fWarnUnstable) {
             Immediate* imm = toVarSymbol(sym->symbol())->immediate;
-            int64_t enumval = imm->int_value();
-            if (intVals.count(enumval) != 0) {
+            std::string enumval = imm->to_string();
+            if (enumVals.count(enumval) != 0) {
               USR_WARN(sym, "it has been suggested that support for enums "
                        "with duplicate integer values should be deprecated, "
                        "so this enum could be considered unstable; if you "
                        "value such enums, please let the Chapel team know.");
+              break;
             }
-            intVals.insert(enumval);
+            enumVals.insert(enumval);
           }
         }
       }

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -106,15 +106,15 @@ checkResolved() {
                            def->sym->name);
           } else if (fWarnUnstable) {
             Immediate* imm = toVarSymbol(sym->symbol())->immediate;
-            std::string enumval = imm->to_string();
-            if (enumVals.count(enumval) != 0) {
+            std::string enumVal = imm->to_string();
+            if (enumVals.count(enumVal) != 0) {
               USR_WARN(sym, "it has been suggested that support for enums "
                        "with duplicate integer values should be deprecated, "
                        "so this enum could be considered unstable; if you "
                        "value such enums, please let the Chapel team know.");
               break;
             }
-            enumVals.insert(enumval);
+            enumVals.insert(enumVal);
           }
         }
       }

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -96,13 +96,25 @@ checkResolved() {
 
   forv_Vec(TypeSymbol, type, gTypeSymbols) {
     if (EnumType* et = toEnumType(type->type)) {
+      std::set<int> intVals;
       for_enums(def, et) {
         if (def->init) {
           SymExpr* sym = toSymExpr(def->init);
           if (!sym || (!sym->symbol()->hasFlag(FLAG_PARAM) &&
-                       !toVarSymbol(sym->symbol())->immediate))
+                       !toVarSymbol(sym->symbol())->immediate)) {
             USR_FATAL_CONT(def, "enumerator '%s' is not an integer param value",
                            def->sym->name);
+          } else if (fWarnUnstable) {
+            Immediate* imm = toVarSymbol(sym->symbol())->immediate;
+            int64_t enumval = imm->int_value();
+            if (intVals.count(enumval) != 0) {
+              USR_WARN(sym, "it has been suggested that support for enums "
+                       "with duplicate integer values should be deprecated, "
+                       "so this enum could be considered unstable; if you "
+                       "value such enums, please let the Chapel team know.");
+            }
+            intVals.insert(enumval);
+          }
         }
       }
     }

--- a/test/unstable/enumDupValues.chpl
+++ b/test/unstable/enumDupValues.chpl
@@ -1,0 +1,10 @@
+enum color { red = 3, green = 4, blue = 3 };
+enum color2 { red = 3, green, blue, violet = 5 };
+
+writeln(color.red: int);
+writeln(color.green: int);
+writeln(color.blue: int);
+writeln(color2.red: int);
+writeln(color2.green: int);
+writeln(color2.blue: int);
+writeln(color2.violet: int);

--- a/test/unstable/enumDupValues.good
+++ b/test/unstable/enumDupValues.good
@@ -1,0 +1,9 @@
+enumDupValues.chpl:1: warning: it has been suggested that support for enums with duplicate integer values should be deprecated, so this enum could be considered unstable; if you value such enums, please let the Chapel team know.
+enumDupValues.chpl:2: warning: it has been suggested that support for enums with duplicate integer values should be deprecated, so this enum could be considered unstable; if you value such enums, please let the Chapel team know.
+3
+4
+3
+3
+4
+5
+5

--- a/test/unstable/semiConcreteEnum.chpl
+++ b/test/unstable/semiConcreteEnum.chpl
@@ -1,0 +1,4 @@
+enum color {black, red=2, green=3, blue=4};
+
+writeln(color.black);
+writeln(color.black:int);

--- a/test/unstable/semiConcreteEnum.good
+++ b/test/unstable/semiConcreteEnum.good
@@ -1,0 +1,5 @@
+semiConcreteEnum.chpl:1: warning: it has been suggested that support for semi-concrete enums like this (in which initial members have no integer values, but later ones do) should be deprecated, so this enum could be considered unstable; if you value such enums, please let the Chapel team know.
+black
+uncaught IllegalArgumentError: bad cast: enum 'color.black' has no integer value
+  semiConcreteEnum.chpl:4: thrown here
+  semiConcreteEnum.chpl:4: uncaught here


### PR DESCRIPTION
At present, we support enums that:

(a) are semi-concrete, meaning that some of the initial values don't have integer values, but later ones do

(b) have repeated integer values

I personally like both of these features just fine and don't have any immediate plans to remove them, but it's also been proposed that we _might_ want to retire both of these things.  For that reason, this PR adds `--warn-unstable` warnings for both situations so that people who are sufficiently defensive can guard against them.  The warnings also suggest advocating for them if the user likes them, as I think we could more officially embrace both features as well.

I tested this by running it over master once with the checks forced on, making sure the warnings fired appropriately for existing tests (they didn't, but I fixed those cases); and a second time with the checks in their default position to make sure there were no failures.