### PR TITLE
Add PREDIFF for srun errors

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/PREDIFF
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/PREDIFF
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Filter lines like this:
+#
+#   srun: error: nid00036: task 0: Exited with exit code 1
+#   slurmstepd: Terminating job step 113904.0; task 0 exit code 1 exited without notification
+#
+# This program halts under the configurations it is run, and that appears to
+# be intentional because the .good files have the halt error messages in them.
+
+outfile=$2
+cat $outfile | \
+    grep -v -E 'srun: error: .* Exited with exit code 1' | \
+    grep -v -E 'slurmstepd: Terminating job step .* exit code 1 exited without notification' | \
+    grep -v -E 'srun: Terminating job step .*' \
+    > $outfile.tmp
+mv $outfile.tmp $outfile


### PR DESCRIPTION
Filter out srun error message when halting in XC testing for new linear algebra test.

Follow-up to #15322  
