### PR TITLE
More additions/adjustments to prediff-for-slurm-srun.

### DIFF
--- a/util/test/prediff-for-slurm-srun
+++ b/util/test/prediff-for-slurm-srun
@@ -9,11 +9,11 @@ import sys, re
 msgs = (
 """srun: error: .+: task [0-9]+: Exited with exit code [0-9]+
 """,
-"""srun: error: .+: task [0-9]+: Terminated
+"""srun: error: .+: task [0-9]+: (Killed|Terminated)
 """,
-"""srun: Force Terminated job step [0-9.]+
+"""srun: (Force Terminated|Terminating) job step [0-9.]+
 """,
-"""srun: Terminating job step [0-9.]+
+"""srun: Job step aborted: Waiting up to [0-9]+ seconds for job step .*
 """,
 """slurmstepd: error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ \*\*\*
 """,


### PR DESCRIPTION
Either slurm has a pretty high rate of churn on its diagnostic messages
or it just has a lot of different messages it can print, I can't tell
which.