### PR TITLE
With the slurm-srun launcher, automatically use prediff-for-slurm-srun.

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1101,9 +1101,9 @@ def set_up_executables():
             chpl_system_prediff.append(prediff)
     if launcher == "slurm-srun":
         # With Slurm-based launcher, auto-run prediff-for-slurm-srun.
-        pdSlurm = os.path.join(util_dir, "test", "prediff-for-slurm-srun")
-        if not any(pdSlurm in csp for csp in chpl_system_prediff):
-            chpl_system_prediff.append(pdSlurm)
+        prediff_for_slurm = os.path.join(util_dir, "test", "prediff-for-slurm-srun")
+        if prediff_for_slurm not in chpl_system_prediff:
+            chpl_system_prediff.append(prediff_for_slurm)
     if chpl_system_prediff:
         os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(chpl_system_prediff)
 

--- a/util/start_test
+++ b/util/start_test
@@ -1088,8 +1088,8 @@ def set_up_executables():
 
 
     # pre-diff
+    chpl_system_prediff = []
     if args.prediff:
-        chpl_system_prediff = []
         for prediff in args.prediff:
             if os.path.isfile(prediff) and os.access(prediff, os.X_OK):
                 prediff = os.path.abspath(prediff)
@@ -1099,6 +1099,12 @@ def set_up_executables():
                         "{0}".format(prediff))
                 finish()
             chpl_system_prediff.append(prediff)
+    if launcher == "slurm-srun":
+        # With Slurm-based launcher, auto-run prediff-for-slurm-srun.
+        pdSlurm = os.path.join(util_dir, "test", "prediff-for-slurm-srun")
+        if not any(pdSlurm in csp for csp in chpl_system_prediff):
+            chpl_system_prediff.append(pdSlurm)
+    if chpl_system_prediff:
         os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(chpl_system_prediff)
 
 


### PR DESCRIPTION
We know we need the `prediff-for-slurm-srun` system prediff script to
get clean testing if we're using the slurm-srun launcher, so
`start_test` might as well use it automatically.