### PR TITLE
Add criteria to override section of classes spec

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -622,10 +622,19 @@ Overriding Base Class Methods
 
 If a method in a derived class is declared with a signature identical to
 that of a method in a base class, then it is said to override the base
-class’s method. Such methods are considered for dynamic dispatch. In
-particular, dynamic dispatch will be used when the method receiver has a
-static type of the base class but refers to an instance of a derived
-class type.
+class’s method. Such methods may be considered for dynamic dispatch if
+certain criteria are met. In particular, dynanmic dispatch will be used
+when the method receiver has a static type of the base class but refers
+to an instance of a derived class type. Additionally, a method eligible
+for dynamic dispatch must not be a class method (see :ref:`Class_Methods`,
+must not return `type`, and must not return `param`.
+
+   *Rationale*.
+
+   Class methods, methods that return `type`, and methods that return
+   `param` are not considered as candidates for dynamic dispatch because
+   they are resolved at compile-time based on the static type of the
+   method receiver.
 
 In order to have identical signatures, two methods must have the same
 the names, intents, types, and order of formal arguments. The return

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -623,7 +623,7 @@ Overriding Base Class Methods
 If a method in a derived class is declared with a signature identical to
 that of a method in a base class, then it is said to override the base
 class’s method. Such methods may be considered for dynamic dispatch if
-certain criteria are met. In particular, dynanmic dispatch will be used
+certain criteria are met. In particular, dynamic dispatch will be used
 when the method receiver has a static type of the base class but refers
 to an instance of a derived class type. Additionally, a method eligible
 for dynamic dispatch must not be a class method (see :ref:`Class_Methods`),
@@ -637,10 +637,12 @@ must not return ``type``, and must not return ``param``.
    method receiver.
 
 In order to have identical signatures, two methods must have the same
-the names, intents, types, and order of formal arguments. The return
-type of the overriding method must either be the same as the return type
-of the base class’s method or be a subclass of the base class method’s
-return type.
+names, and their formal arguments must have the same names, intents, types,
+and order.
+
+The return type of the overriding method must either be the same as the
+return type of the base class’s method or be a subclass of the base class
+method’s return type.
 
 Methods that override a base class method must be marked with the
 ``override`` keyword in the ``procedure-kind``. Additionally, methods

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -626,13 +626,13 @@ class’s method. Such methods may be considered for dynamic dispatch if
 certain criteria are met. In particular, dynanmic dispatch will be used
 when the method receiver has a static type of the base class but refers
 to an instance of a derived class type. Additionally, a method eligible
-for dynamic dispatch must not be a class method (see :ref:`Class_Methods`,
-must not return `type`, and must not return `param`.
+for dynamic dispatch must not be a class method (see :ref:`Class_Methods`),
+must not return ``type``, and must not return ``param``.
 
    *Rationale*.
 
-   Class methods, methods that return `type`, and methods that return
-   `param` are not considered as candidates for dynamic dispatch because
+   Class methods, methods that return ``type``, and methods that return
+   ``param`` are not considered as candidates for dynamic dispatch because
    they are resolved at compile-time based on the static type of the
    method receiver.
 


### PR DESCRIPTION
This PR rewrites part of the override section of the classes spec to mention that class methods, methods that return `type`, and methods that return `param` are not eligible for dynamic dispatch.

---

Testing:

- [x] Generate docs locally and make sure links work