### PR TITLE
Add a note about restricted support for non-nilable arrays in spec

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -345,6 +345,10 @@ class type.
 
 The default value of a concrete nilable class type is ``nil``. Generic
 class types and non-nilable class types do not have a default value.
+For this reason, rectangular arrays of non-nilable classes cannot be
+resized, since the new array values don't have a logical default
+value.  For similar reasons, associative and sparse arrays of
+non-nilable classes are not currently supported.
 
    *Example (declaration.chpl)*.
 


### PR DESCRIPTION
I forgot to make a documentation change when I made arrays of non-nilable classes non-resizeable.  Doing that here within the spec in the section that talks about default values for classes.  While here, I added a similar note regarding associative/sparse arrays of non-nilable not being supported.
