### PR TITLE
Add a --warn-unstable warning for casting enums to non-int values

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2002,6 +2002,14 @@ static Expr* preFoldNamed(CallExpr* call) {
           if (imm != NULL && (fromEnum || fromIntEtc) && toIntEtc) {
             Immediate coerce = getDefaultImmediate(newType);
 
+            if (fWarnUnstable && !toIntUint) {
+              if (is_bool_type(newType)) {
+                USR_WARN(call, "enum-to-bool casts are likely to be deprecated in the future");
+              } else {
+                USR_WARN(call, "enum-to-float casts are likely to be deprecated in the future");
+              }
+            }
+
             coerce_immediate(imm, &coerce);
 
             retval = new SymExpr(new_ImmediateSymbol(&coerce));

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2002,7 +2002,7 @@ static Expr* preFoldNamed(CallExpr* call) {
           if (imm != NULL && (fromEnum || fromIntEtc) && toIntEtc) {
             Immediate coerce = getDefaultImmediate(newType);
 
-            if (fWarnUnstable && !toIntUint) {
+            if (fWarnUnstable && fromEnum && !toIntUint) {
               if (is_bool_type(newType)) {
                 USR_WARN(call, "enum-to-bool casts are likely to be deprecated in the future");
               } else {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1422,14 +1422,21 @@ module ChapelBase {
   inline proc _cast(type t:chpl_anyreal, x:chpl_anyreal)
     return __primitive("cast", t, x);
 
-  inline proc _cast(type t:chpl_anybool, x:enum) throws
-    return x: int: bool;
+  inline proc _cast(type t:chpl_anybool, x:enum) throws {
+    if chpl_warnUnstable {
+      compilerWarning("enum-to-bool casts are likely to be deprecated in the future");
+    }    return x: int: bool;
+  }
   // _cast(type t:integral, x:enum)
   // is generated for each enum in buildDefaultFunctions
   inline proc _cast(type t:enum, x:enum) where x.type == t
     return x;
-  inline proc _cast(type t:chpl_anyreal, x:enum) throws
+  inline proc _cast(type t:chpl_anyreal, x:enum) throws {
+    if chpl_warnUnstable {
+      compilerWarning("enum-to-float casts are likely to be deprecated in the future");
+    }
     return x: int: real;
+  }
 
   inline proc _cast(type t:unmanaged class, x:_nilType)
   {

--- a/test/unstable/enumNumCast.chpl
+++ b/test/unstable/enumNumCast.chpl
@@ -1,0 +1,10 @@
+enum color { red = 1, green = 2, blue = 3 };
+writeln(color.red: bool);
+writeln(color.red: real);
+writeln(color.red: imag);
+writeln(color.red: complex);
+config const c = color.blue;
+writeln(c: bool);
+writeln(c: real);
+writeln(c: imag);
+writeln(c: complex);

--- a/test/unstable/enumNumCast.good
+++ b/test/unstable/enumNumCast.good
@@ -1,0 +1,16 @@
+enumNumCast.chpl:2: warning: enum-to-bool casts are likely to be deprecated in the future
+enumNumCast.chpl:3: warning: enum-to-float casts are likely to be deprecated in the future
+enumNumCast.chpl:4: warning: enum-to-float casts are likely to be deprecated in the future
+enumNumCast.chpl:5: warning: enum-to-float casts are likely to be deprecated in the future
+enumNumCast.chpl:7: warning: enum-to-bool casts are likely to be deprecated in the future
+enumNumCast.chpl:8: warning: enum-to-float casts are likely to be deprecated in the future
+enumNumCast.chpl:9: warning: enum-to-float casts are likely to be deprecated in the future
+enumNumCast.chpl:10: warning: enum-to-float casts are likely to be deprecated in the future
+true
+1.0
+1.0i
+1.0 + 0.0i
+true
+3.0
+3.0i
+3.0 + 0.0i


### PR DESCRIPTION
This adds a `--warn-unstable` warning when casting enums to bools, reals, imags, or complexes.
