### PR TITLE
Add a statement saying that assignment overloads aren't supported for classes

### DIFF
--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1132,6 +1132,8 @@ The arity and precedence of the operator must be maintained when it is
 overloaded. Operator resolution follows the same algorithm as function
 resolution.
 
+Assignment overloads are not supported for class types.
+
 .. _Function_Resolution:
 
 Function Resolution


### PR DESCRIPTION
Somehow I snuck #14180 past @vasslitvinov and @mppf without documenting it.