### PR TITLE
Add a deinit back in a test

### DIFF
--- a/test/studies/hpcc/RA/diten/buckets.chpl
+++ b/test/studies/hpcc/RA/diten/buckets.chpl
@@ -48,6 +48,10 @@ class Buckets {
   var heap = new owned MaxHeap(numLocs);
   var updateManager = new owned UpdateManager();
 
+  proc deinit() {
+    delete BucketArray;
+  }
+
   proc insertUpdate(ran: uint(64), loc: int) {
     local {
       var bucket = BucketArray(loc);


### PR DESCRIPTION
#15044 removed a work around in this test, but I believe it overshot
and removed a deinit that wasn't part of the workaround. That was
causing leaks in this test.

Test:
- [x] valgrind