### PR TITLE
Document open-interval ranges

### DIFF
--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -374,7 +374,9 @@ Precedence and Associativity
 | | ``-``            |                | | subtraction                        |
 |                    |                |                                      |
 +--------------------+----------------+--------------------------------------+
-| ``..``             | left           | range initialization                 |
+| | ``..``           | | left         | | range initialization               |
+| | ``..<``          | | left         | | open-interval range initialization |
+|                    |                |                                      |
 +--------------------+----------------+--------------------------------------+
 | | ``<=``           | left           | | less-than-or-equal-to comparison   |
 | | ``>=``           |                | | greater-than-or-equal-to comparison|

--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -506,7 +506,7 @@ language:
 ``+=`` ``-=`` ``*=`` ``/=`` ``**=`` ``%=`` ``&=`` ``|=`` ``^=`` ``&&=`` ``||=`` ``<<=`` ``>>=``     compound assignment
 ``<=>``                                                                                             swap
 ``<~>``                                                                                             I/O
-``..``                                                                                              range specifier
+``..`` ``..<``                                                                                      range specifier
 ``by``                                                                                              range/domain stride specifier
 ``#``                                                                                               range count operator
 ``...``                                                                                             variable argument lists

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -287,7 +287,9 @@ Range literals are specified with the following syntax.
 
 The expressions to the left and to the right of ``..`` or ``..<``,
 when given, are called the `lower bound expression` and the `upper
-bound expression`, respectively.
+bound expression`, respectively.  The ``..`` operator defines a
+closed-interval range, whereas the ``..<`` operator defines a
+half-open interval.
 
 The type of a range literal is a range with the following parameters:
 
@@ -323,16 +325,15 @@ The type of a range literal is a range with the following parameters:
 
 The value of a range literal is as follows:
 
--  The low bound is given by the lower bound expression, if present, and
-   is -:math:`\infty` otherwise.
+- The low bound is given by the lower bound expression, if present, and
+  is -:math:`\infty` otherwise.
 
-- For ranges constructed with ``..``, the high bound is given by the
-  upper bound expression, if present, and is +\ :math:`\infty`
-  otherwise.
-
-- For ranges constructed with ``..<``, the high bound is one less than
-  the upper bound expression, if present, and is +\ :math:`\infty`
-  otherwise.
+- When the range has an upper bound expression, a closed-interval
+  range (``..``) takes the expression's value as its high bound;
+  whereas the high bound of a half-open interval range (``..<``)
+  excludes the upper bound and is therefore one less than the upper
+  bound expression.  If there is no upper bound expression, the high
+  bound is +\ :math:`\infty`.
 
 -  The stride is 1.
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -279,21 +279,24 @@ Range literals are specified with the following syntax.
 
    range-literal:
      expression .. expression
+     expression ..< expression
      expression ..
      .. expression
+     ..< expression
      ..
 
-The expressions to the left and to the right of ``..``, when given, are
-called the low bound and the high bound expression, respectively.
+The expressions to the left and to the right of ``..`` or ``..<``,
+when given, are called the `lower bound expression` and the `upper
+bound expression`, respectively.
 
 The type of a range literal is a range with the following parameters:
 
 -  ``idxType`` is determined as follows:
 
-   -  If both the low bound and the high bound expressions are given and
+   -  If both the lower bound and the upper bound expressions are given and
       have the same type, then ``idxType`` is that type.
 
-   -  If both the low bound and the high bound expressions are given and
+   -  If both the lower bound and the upper bound expressions are given and
       an implicit conversion is allowed from one expression’s type to
       the other’s, then ``idxType`` is that type.
 
@@ -307,12 +310,12 @@ The type of a range literal is a range with the following parameters:
 -  ``boundedType`` is a value of the type ``BoundedRangeType`` that is
    determined as follows:
 
-   -  ``bounded``, if both the low bound and the high bound expressions
+   -  ``bounded``, if both the lower bound and the upper bound expressions
       are given,
 
-   -  ``boundedLow``, if only the high bound expression is given,
+   -  ``boundedLow``, if only the upper bound expression is given,
 
-   -  ``boundedHigh``, if only the low bound expression is given,
+   -  ``boundedHigh``, if only the lower bound expression is given,
 
    -  ``boundedNone``, if neither bound expression is given.
 
@@ -320,11 +323,16 @@ The type of a range literal is a range with the following parameters:
 
 The value of a range literal is as follows:
 
--  The low bound is given by the low bound expression, if present, and
+-  The low bound is given by the lower bound expression, if present, and
    is -:math:`\infty` otherwise.
 
--  The high bound is given by the upper bound expression, if present,
-   and is +\ :math:`\infty` otherwise.
+- For ranges constructed with ``..``, the high bound is given by the
+  upper bound expression, if present, and is +\ :math:`\infty`
+  otherwise.
+
+- For ranges constructed with ``..<``, the high bound is one less than
+  the upper bound expression, if present, and is +\ :math:`\infty`
+  otherwise.
 
 -  The stride is 1.
 

--- a/test/release/examples/primers/ranges.chpl
+++ b/test/release/examples/primers/ranges.chpl
@@ -20,6 +20,16 @@ writeln("Basic range r");
 const r = 1..10;
 writeRange(r);
 
+// Ranges can also be defined using an `open-interval` form using the
+// ``..<`` operator which causes the upper bound to be omitted.  For
+// example, the range ``3..<10`` is equivalent to ``3..9``.
+writeln("Open interval range rOpen");
+const rOpen = 3..<10;
+writeRange(rOpen);
+
+// This form can be convenient when iterating over a 0-based
+// data structure using ranges like ``lo..<data.size``.
+
 //
 // Ranges are a basic building block for iteration.  Here we use a
 // for-loop to iterate over the sequence represented by ``r`` and

--- a/test/release/examples/primers/ranges.good
+++ b/test/release/examples/primers/ranges.good
@@ -1,5 +1,7 @@
 Basic range r
 Range 1..10 = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+Open interval range rOpen
+Range 3..9 = 3, 4, 5, 6, 7, 8, 9
 The sum of the values in 1..10 is 55
 The sum of the values in 1..10 as computed by reduce is also 55
 


### PR DESCRIPTION
This adds a description of open-interval ranges to the language specification and the ranges primer.  While working on the spec, I also did some minor wordsmithing and updated the terms used to describe "lo" and "hi" in `lo..hi` from "low bound expression" and "high bound expression" to "lower bound expression" and "upper bound expression."