### PR TITLE
Document that 'use' statements are now 'private' by default and wordsmith

### DIFF
--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -816,8 +816,8 @@ symbols to be transitively visible: if module A uses module B, and
 module B contains a public use of a module or enumerated type C, then
 C’s public symbols will also be visible to A unless they are shadowed
 by symbols of the same name in B.  Conversely, if B's use of C is
-``private`` then A will not be able to see C's symbols by virtue of
-that ``use``.
+``private`` then A will not be able to see C's symbols due to that
+``use``.
 
 This notion of transitivity extends to the case in which a scope
 imports symbols from multiple modules or constants from multiple

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -810,21 +810,23 @@ module-level symbols would be inserted into this enclosing scope with
 the same name, and that name is referenced by other statements in the
 same scope as the use.
 
-Use statements are transitive by default: if a module A uses a module B,
-and module B contains a use of a module or enumerated type C, then C’s
-public symbols may also be visible within A. The exception to this
-occurs when B has public symbols that shadow symbols with the same name
-in C, or when the use of C has been declared explicitly ``private``. If
-a use statement is declared to be ``private``, then the symbols it makes
-visible will only be visible to the scope containing the use.
+Use statements may be explicitly delared ``public`` or ``private``.
+By default, uses are ``private``.  Making a use ``public`` causes its
+symbols to be transitively visible: if module A uses module B, and
+module B contains a public use of a module or enumerated type C, then
+C’s public symbols will also be visible to A unless they are shadowed
+by symbols of the same name in B.  Conversely, if B's use of C is
+``private`` then A will not be able to see C's symbols by virtue of
+that ``use``.
 
-This notion of transitivity extends to the case in which a scope imports
-symbols from multiple modules or constants from multiple enumeration
-types. For example if a module A uses modules B1, B2, B3 and modules B1,
-B2, B3 use modules C1, C2, C3 respectively, then all of the public
-symbols in B1, B2, B3 have the potential to shadow the public symbols of
-C1, C2, and C3. However an error is signaled if C1, C2, C3 have public
-module level definitions of the same symbol.
+This notion of transitivity extends to the case in which a scope
+imports symbols from multiple modules or constants from multiple
+enumeration types. For example if a module A uses modules B1, B2, B3
+and modules B1, B2, B3 publicly use modules C1, C2, C3 respectively,
+then all of the public symbols in B1, B2, B3 have the potential to
+shadow the public symbols of C1, C2, and C3. However an error is
+signaled if C1, C2, C3 have conflicting public module-level
+definitions of the same symbol.
 
 An optional ``limitation-clause`` may be provided to limit the symbols
 made available by a given use statement. If an ``except`` list is

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -455,16 +455,16 @@ module OuterNested {
   }
 } // end of OuterNested module
 
-/* Private Uses
-   ------------
+/* Public vs. Private Uses
+   -----------------------
 
-   It is important to note that a module with a ``use`` of other modules will
-   by default make those symbols available to scopes that ``use`` it.
-   Considering the following pair of modules:
+   Use statements can be labeled as being either ``public`` or ``private``.
+   By default ``use`` statements are ``private``.  This means that if one
+   module uses a second, it will only see the symbols defined by that module,
+   not by other modules that it happens to use.  For example, consider the
+   following library module:
 */
-module UserModule {
-  use ModuleThatIsUsed;
-}
+
 
 module ModuleThatIsUsed {
   proc publiclyAvailableProc() {
@@ -472,30 +472,41 @@ module ModuleThatIsUsed {
   }
 }
 
-/* A scope with a ``use`` of ``UserModule`` will also be able to see the
-   symbols defined by ``ModuleThatIsUsed``.
+/* And a module that uses it:
+ */
+module UserModule {
+  use ModuleThatIsUsed;  // or `private use ModuleThatIsUsed`
+}
+
+/* When a scope has a ``use`` of ``UserModule``, the symbols from
+   ``ModuleThatIsUsed`` will not be available due to the ``private`` nature of
+   ``UserModule`` 's ``use``, so the following code would not compile.
 */
+
 module UsesTheUser {
   proc func1() {
+    use UserModule;
+    // publiclyAvailableProc(); // Won't compile, since ``UserModule``'s ``use`` is ``private``
+  }
+}
+
+/* By contrast, a ``public use`` will permit symbols used by one module to
+   be seen by those that use it.  For example, consider the following
+   variation of the previous example:
+*/
+module UserModule2 {
+  public use ModuleThatIsUsed;
+}
+
+
+/* Since its use is ``public``, A scope with a ``use`` of ``UserModule2`` will 
+   also be able to see the symbols defined by ``ModuleThatIsUsed``.
+*/
+module UsesTheUser2 {
+  proc func2() {
     use UserModule;
     publiclyAvailableProc(); // available due to ``use`` of ModuleThatIsUsed
   }
 }
 
-/* To avoid this, ``use`` statements can be declared as ``private``:
- */
-module UserModule2 {
-  private use ModuleThatIsUsed;
-}
 
-/* When a scope has a ``use`` of ``UserModule2``, the symbols from
-   ``ModuleThatIsUsed`` will not be available due to the ``private`` modifier on
-   ``UserModule2`` 's ``use`` of it, so the following code would not compile.
-*/
-
-module UsesTheUser2 {
-  proc func2() {
-    use UserModule2;
-    //publiclyAvailableProc(); // Won't compile, the ``use`` is ``private``
-  }
-}

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -504,7 +504,7 @@ module UserModule2 {
 */
 module UsesTheUser2 {
   proc func2() {
-    use UserModule;
+    use UserModule2;
     publiclyAvailableProc(); // available due to ``use`` of ModuleThatIsUsed
   }
 }


### PR DESCRIPTION
Update the `use` statement documentation in the spec and modules primer to reflect that it's now private by default and wordsmith the paragraphs relating to this a bit.