### PR TITLE
Add a stability warning about het. tuple loop index intents

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1785,6 +1785,11 @@ static Expr* unrollHetTupleLoop(CallExpr* call, Expr* tupExpr, Type* iterType) {
     // modifications to tuples rather than allowing modifications
     // to tuple elements that shouldn't be modified.
     //
+    if (fWarnUnstable) {
+      USR_WARN(theloop, "index variables for loops over heterogeneous tuples "
+               "are currently `const ref` but are likely to change to `const` "
+               "and/or `ref` in some cases in the future");
+    }
     Expr* firstStmt = theloop->body.first();
     if (DefExpr* defexp = toDefExpr(firstStmt)) {
       if (VarSymbol* loopVar = toVarSymbol(defexp->sym)) {

--- a/test/unstable/hetTupleLoopIntent.chpl
+++ b/test/unstable/hetTupleLoopIntent.chpl
@@ -1,0 +1,4 @@
+const tup = (1, 2.3, "hi");
+
+for t in tup do
+  writeln(t);

--- a/test/unstable/hetTupleLoopIntent.good
+++ b/test/unstable/hetTupleLoopIntent.good
@@ -1,0 +1,4 @@
+hetTupleLoopIntent.chpl:3: warning: index variables for loops over heterogeneous tuples are currently `const ref` but are likely to change to `const` and/or `ref` in some cases in the future
+1
+2.3
+hi


### PR DESCRIPTION
This adds a `--warn-unstable` warning about the intent of a heterogeneous tuple loop's index variable potentially changing away from `const ref` in the future.