### PR TITLE
Add perf annotations for 2020-03-27

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -407,8 +407,7 @@ all:
     - text: Optimize unorderedCopy for types larger than 8 bytes (#14255)
       config: 16 node XC
   12/04/19:
-    - text: Warm up the runtime before entering user code (#14567)
-      config: 16 node XC, 16-node-cs
+    - Warm up the runtime before entering user code (#14567)
   01/17/20:
     - Adjust point of deinitialization based on expiring value analysis (#14691)
   02/07/20:
@@ -424,6 +423,9 @@ all:
     - Add a spinlock to the atomic runtime interface. (#15015)
   03/05/20:
     - Allow bulk transfer of some wide pointer arrays (#15049)
+  03/20/20:
+    - text: Make --cache-remote readahead less aggressive (#15267)
+      config: chapcs.comm-counts
 
 
 AllCompTime: &timecomp-base
@@ -577,6 +579,8 @@ chameneos-redux:
     - Chameneos initializer updates (#7328)
   10/31/18:
     - Enable parallelism for shape-ful expressions over ranges (#11501)
+  03/20/20:
+    - Fix up chameneous benchmarks (#15250)
 
 CoMD:
   07/26/17:
@@ -643,6 +647,8 @@ distCreate-arrays-deinit.cc-perf: &distCreate-base
     -  Record-wrap `locale` (#15149)
   03/22/20:
     - Rewrite ddata_allocate() to avoid inadvertent widening of init_elts() (#15275)
+  03/26/20:
+    - Make locale-related comm improvements (#15288)
 
 distCreate-arrays-init.cc-perf:
   <<: *distCreate-base
@@ -767,6 +773,8 @@ fastaredux:
     - Disable enum->int casts for enums without values (#10114)
   07/14/18:
     - Optimize enum->int casts for concrete types (#10308)
+  01/29/20:
+    - Propagate user thrown errors out of IO routines (#14739)
 
 fft:
   05/15/19:
@@ -1223,6 +1231,18 @@ memleaksfull:
     - Use escaped strings in paths (#14907)
   02/26/20:
     - Closes memory leaks introduced by 14907 (#14959)
+  02/28/20:
+    - mason init (#14820)
+  02/29/20:
+    - Improve out intent (#14917)
+  03/01/20:
+    - Fix remote I/O error and a memory leak (#15025)
+  03/07/20:
+    - Close some memory leaks in mason init (#15099)
+  03/21/20:
+    - mason new --moduleName (#14997)
+  03/27/20:
+    - Close mason init memory leaks (#15325)
 
 meteor:
   12/18/13:
@@ -1500,7 +1520,7 @@ revcomp: &revcomp-base
   09/10/19:
     - Restore reverse-complement performance with qio hint (#14045)
   02/04/20:
-    - Improve const/ref this decorators for list methods (#14809)
+    - Improve const/ref this decorators (and update revcomp) (#14809)
 revcomp-submitted:
   <<: *revcomp-base
 

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -91,7 +91,8 @@ def check_graph_names(ann_data, graph_list):
 def check_configs(ann_data):
     """Check that all the configs used in the annotation file are 'known'"""
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
-                     '16 node XC', 'Single node XC', '16-node-cs'}
+                     '16 node XC', 'Single node XC', '16-node-cs',
+                     'chapcs.comm-counts'}
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():
             for ann in annotations:


### PR DESCRIPTION
Add annotations for:
 - cache-remote [regressions](https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2020/03/14&enddate=2020/03/27&graphs=remotearrayread) from less aggressive readahead (#15267)
 - dist domain creation comm count [regression fix](https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2020/03/14&enddate=2020/03/27&graphs=creatingdistributeddomains) (#15288)
 - slower chameneous [regressions](https://chapel-lang.org/perf/chapcs/?startdate=2020/03/12&enddate=2020/03/27&graphs=chameneosreduxshootoutbenchmarkn6000000) due to benchmark changes (#15250)
 - slower fastaredux [regression](https://chapel-lang.org/perf/chapcs/?startdate=2020/01/14&enddate=2020/02/11&graphs=fastareduxshootoutbenchmarkn25000000) due to throwing out of I/O (#14739)
 - recent memory leak regressions and fixes