### PR TITLE
Add error messages for generic types in list and map

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -148,6 +148,15 @@ module List {
       :type parSafe: `param bool`
     */
     proc init(type eltType, param parSafe=false) {
+      if isGenericType(eltType) {
+        compilerWarning("creating a list with element type " +
+                        eltType:string);
+        if isClassType(eltType) && !isGenericType(borrowed eltType) {
+          compilerWarning("which now means class type with generic management");
+        }
+        compilerError("list element type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
+      }
       this.eltType = eltType;
       this.parSafe = parSafe;
       this.complete();

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -98,6 +98,24 @@ module Map {
       :arg parSafe: If `true`, this map will use parallel safe operations.
     */
     proc init(type keyType, type valType, param parSafe=false) {
+      if isGenericType(keyType) {
+        compilerWarning("creating a map with key type " +
+                        keyType:string);
+        if isClassType(keyType) && !isGenericType(borrowed keyType) {
+          compilerWarning("which now means class type with generic management");
+        }
+        compilerError("map key type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
+      }
+      if isGenericType(valType) {
+        compilerWarning("creating a map with value type " +
+                        valType:string);
+        if isClassType(valType) && !isGenericType(borrowed valType) {
+          compilerWarning("which now means class type with generic management");
+        }
+        compilerError("map value type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
+      }
       this.keyType = keyType;
       this.valType = valType;
       this.parSafe = parSafe;
@@ -112,6 +130,24 @@ module Map {
       if isBorrowedClass(valType) {
         compilerError("maps of non-nilable borrowed values are",
                       " not currently supported");
+      }
+      if isGenericType(keyType) {
+        compilerWarning("creating a map with key type " +
+                        keyType:string);
+        if isClassType(keyType) && !isGenericType(borrowed keyType) {
+          compilerWarning("which now means class type with generic management");
+        }
+        compilerError("map key type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
+      }
+      if isGenericType(valType) {
+        compilerWarning("creating a map with value type " +
+                        valType:string);
+        if isClassType(valType) && !isGenericType(borrowed valType) {
+          compilerWarning("which now means class type with generic management");
+        }
+        compilerError("map value type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
       }
 
       this.keyType = keyType;

--- a/test/library/standard/List/init/listInitGenericError.chpl
+++ b/test/library/standard/List/init/listInitGenericError.chpl
@@ -1,0 +1,8 @@
+use List;
+
+class C {
+  var x = 10;
+}
+
+var l = new list(C);  // C has generic management
+writeln(l);

--- a/test/library/standard/List/init/listInitGenericError.good
+++ b/test/library/standard/List/init/listInitGenericError.good
@@ -1,0 +1,3 @@
+listInitGenericError.chpl:7: warning: creating a list with element type C
+listInitGenericError.chpl:7: warning: which now means class type with generic management
+listInitGenericError.chpl:7: error: list element type cannot currently be generic

--- a/test/library/standard/Map/testInitGenericError.chpl
+++ b/test/library/standard/Map/testInitGenericError.chpl
@@ -1,0 +1,8 @@
+use Map;
+
+class C {
+  var x = 10;
+}
+
+var l = new map(C, int);  // C has generic management
+writeln(l);

--- a/test/library/standard/Map/testInitGenericError.good
+++ b/test/library/standard/Map/testInitGenericError.good
@@ -1,0 +1,3 @@
+testInitGenericError.chpl:7: warning: creating a map with key type C
+testInitGenericError.chpl:7: warning: which now means class type with generic management
+testInitGenericError.chpl:7: error: map key type cannot currently be generic

--- a/test/library/standard/Map/testInitGenericError2.chpl
+++ b/test/library/standard/Map/testInitGenericError2.chpl
@@ -1,0 +1,8 @@
+use Map;
+
+class C {
+  var x = 10;
+}
+
+var l = new map(int, C);  // C has generic management
+writeln(l);

--- a/test/library/standard/Map/testInitGenericError2.good
+++ b/test/library/standard/Map/testInitGenericError2.good
@@ -1,0 +1,3 @@
+testInitGenericError2.chpl:7: warning: creating a map with value type C
+testInitGenericError2.chpl:7: warning: which now means class type with generic management
+testInitGenericError2.chpl:7: error: map value type cannot currently be generic


### PR DESCRIPTION
This PR adds checking for generic types in list and map initializers.

Lack of these checks were causing confusing error messages coming from the
internal implementation of these data structures.

Resolves https://github.com/chapel-lang/chapel/issues/14974

Test:
- [x] standard with futures
