### PR TITLE
LinkedList: Remove superfluous ref this intent from append() and remove()

### DIFF
--- a/modules/standard/LinkedLists.chpl
+++ b/modules/standard/LinkedLists.chpl
@@ -109,7 +109,7 @@ record LinkedList {
   /*
     Append `e` to the list.
    */
-  proc ref append(e : eltType) {
+  proc append(e : eltType) {
     if _last {
       _last!.next = new unmanaged listNode(eltType, e);
       _last = _last!.next;
@@ -166,7 +166,7 @@ record LinkedList {
     Remove the first encountered instance of `x` from the list.
     Does nothing if `x` is not present in the list.
    */
-  proc ref remove(x: eltType) {
+  proc remove(x: eltType) {
     var tmp = _first,
         prev: _first.type = nil;
     while tmp != nil && tmp!.data != x {


### PR DESCRIPTION
These methods modify this, so have ref this intent by default.

None of the other methods in the module have an explicit ref intent,
including the ones that modify this, such as the other versions of
append().  So remove these two for consistency, and so readers don't
think they're necessary.