### PR TITLE
Overloaded INT_ASSERT

### DIFF
--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -70,7 +70,7 @@
 #define USR_STOP       exitIfFatalErrorsEncountered
 
 // INT_ASSERT is intended to become no-op in production builds of compiler
-#define SELECT_ASSERT(_1, _2, NAME) NAME
+#define SELECT_ASSERT(_1, _2, NAME, ...) NAME
 #define INT_ASSERT(...) SELECT_ASSERT(__VA_ARGS__, INT_ASSERT2, INT_ASSERT1)(__VA_ARGS__)
 #define INT_ASSERT1(x) do { if (!(x)) INT_FATAL("assertion error"); } while (0)
 #define INT_ASSERT2(s, x) do { if (!(x)) INT_FATAL((s), "assertion error"); } while (0)

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -70,7 +70,10 @@
 #define USR_STOP       exitIfFatalErrorsEncountered
 
 // INT_ASSERT is intended to become no-op in production builds of compiler
-#define INT_ASSERT(x) do { if (!(x)) INT_FATAL("assertion error"); } while (0)
+#define SELECT_ASSERT(_1, _2, NAME) NAME
+#define INT_ASSERT(...) SELECT_ASSERT(__VA_ARGS__, INT_ASSERT2, INT_ASSERT1)(__VA_ARGS__)
+#define INT_ASSERT1(x) do { if (!(x)) INT_FATAL("assertion error"); } while (0)
+#define INT_ASSERT2(x, s) do { if (!(x)) INT_FATAL((s), "assertion error"); } while (0)
 
 #define iterKindTypename          "iterKind"
 #define iterKindLeaderTagname     "leader"

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -73,7 +73,7 @@
 #define SELECT_ASSERT(_1, _2, NAME) NAME
 #define INT_ASSERT(...) SELECT_ASSERT(__VA_ARGS__, INT_ASSERT2, INT_ASSERT1)(__VA_ARGS__)
 #define INT_ASSERT1(x) do { if (!(x)) INT_FATAL("assertion error"); } while (0)
-#define INT_ASSERT2(x, s) do { if (!(x)) INT_FATAL((s), "assertion error"); } while (0)
+#define INT_ASSERT2(s, x) do { if (!(x)) INT_FATAL((s), "assertion error"); } while (0)
 
 #define iterKindTypename          "iterKind"
 #define iterKindLeaderTagname     "leader"


### PR DESCRIPTION
Added a variadic selector for different number of parameters for INT_ASSERT.

[chapel-lang/10152](https://github.com/chapel-lang/chapel/issues/10152)

Resolves #10152.