### PR TITLE
Date time token in Toml source

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -165,8 +165,8 @@ module TomlParser {
         if !source.isEmpty() {
           while(readLine(source)) {
             var token = top(source);
-
-            if token == '#' {
+         
+            if comment.match(token) {
               parseComment();
             }
             else if inBrackets.match(token) {
@@ -317,9 +317,7 @@ module TomlParser {
               skipNext(source);
             }
             else if comment.match(top(source)) {
-              while top(source) != "\n" {
-                skipNext(source);
-              }
+              skipNext(source);
             }
             else {
               var toParse = parseValue();
@@ -397,9 +395,7 @@ module TomlParser {
         }
         // Comments within arrays
         else if val == '#' {
-          while top(source) != "\n" {
-            skipNext(source);
-          }
+          skipLine(source);
           return parseValue();
         }
         else if corner.match(val) {
@@ -1199,6 +1195,7 @@ module TomlReader {
     }
 
     proc splitLine(line) {
+      var idx = 0; 
       var linetokens: list(string);
       var nonEmptyChar: bool = false;
 
@@ -1215,20 +1212,25 @@ module TomlReader {
                                        singleQuotes,
                                        bracketContents,
                                        brackets,
-                                       comments,
                                        commas,
                                        curly,
                                        equals));
 
       for token in pattern.split(line) {
+        idx += 1;
         var strippedToken = token.strip(" \t");
         if strippedToken.size != 0 {
           if debugTomlReader {
             writeln('Tokenized: ', '(', strippedToken, ')');
           }
-
           nonEmptyChar = true;
-          linetokens.append(strippedToken);
+          
+          var isComment = strippedToken.match(compile(comments));
+          if isComment.matched && idx <= 1 {
+            linetokens.append(strippedToken);
+          } else if !isComment.matched {
+            linetokens.append(strippedToken);
+          }
         }
       }
 

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -1206,7 +1206,10 @@ module TomlReader {
             comments = "(\\#)",                 // #
             commas = "(\\,)",                   // ,
             equals = "(\\=)",                   // =
-            curly = "(\\{)|(\\})";              // {}
+            curly = "(\\{)|(\\})",              // {}
+            dt = "^\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}",
+            ld = "^\\d{4}-\\d{2}-\\d{2}",
+            ti = "^\\d{2}:\\d{2}:\\d{2}(.\\d{6,})?";
 
       const pattern = compile('|'.join(doubleQuotes,
                                        singleQuotes,
@@ -1214,7 +1217,10 @@ module TomlReader {
                                        brackets,
                                        commas,
                                        curly,
-                                       equals));
+                                       equals,
+                                       dt,
+                                       ti,
+                                       ld));
 
       for token in pattern.split(line) {
         idx += 1;
@@ -1224,7 +1230,12 @@ module TomlReader {
             writeln('Tokenized: ', '(', strippedToken, ')');
           }
           nonEmptyChar = true;
-          
+          // check for date/time in a line and avoid comment        
+          var toke = strippedToken; 
+          var isWhiteSpace = compile("\\s");
+          var dateTimeToken = isWhiteSpace.split(toke);
+          if strippedToken.match(compile('|'.join(dt,ti,ld))).matched then 
+          strippedToken = dateTimeToken[1];
           var isComment = strippedToken.match(compile(comments));
           if isComment.matched && idx <= 1 {
             linetokens.append(strippedToken);

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -317,7 +317,9 @@ module TomlParser {
               skipNext(source);
             }
             else if comment.match(top(source)) {
-              skipLine(source);
+              while top(source) != "\n" {
+                skipNext(source);
+              }
             }
             else {
               var toParse = parseValue();
@@ -395,7 +397,9 @@ module TomlParser {
         }
         // Comments within arrays
         else if val == '#' {
-          skipLine(source);
+          while top(source) != "\n" {
+            skipNext(source);
+          }
           return parseValue();
         }
         else if corner.match(val) {

--- a/test/library/packages/TOML/test/commentTest.chpl
+++ b/test/library/packages/TOML/test/commentTest.chpl
@@ -1,0 +1,21 @@
+
+use TOML;
+
+config const str: string = """[owner]
+                            name = ["Foo Bar"] #something 
+                            # Another comment 
+                            dob = 2000-30-04-23
+                            """;
+
+proc main() {
+  try! {
+    var TomlData = parseToml(str);
+    var dob = TomlData["owner"]!["name"];
+
+    delete TomlData;  
+  } catch e: TomlError{
+    writeln(e.message());
+    exit(1);
+  }
+  
+}

--- a/test/library/packages/TOML/test/commentTest.chpl
+++ b/test/library/packages/TOML/test/commentTest.chpl
@@ -2,7 +2,7 @@
 use TOML;
 
 config const str: string = """[owner]
-                            name = ["Foo Bar"] #something 
+                            name = "Foo Bar" # something new
                             # Another comment 
                             dob = 2000-30-04-23
                             """;

--- a/test/library/packages/TOML/test/commentTest.compopts
+++ b/test/library/packages/TOML/test/commentTest.compopts
@@ -1,0 +1,1 @@
+-M ../../../modules/packages/

--- a/test/library/packages/TOML/test/commentTest.good
+++ b/test/library/packages/TOML/test/commentTest.good
@@ -1,0 +1,1 @@
+Line 4: Illegal Value -> 2000-30-04-23

--- a/test/library/packages/TOML/test/testtime.chpl
+++ b/test/library/packages/TOML/test/testtime.chpl
@@ -2,8 +2,8 @@
 use TOML;
 
 config const str: string = """[owner]
-                            name = "Foo Bar"
-                            timestamp1 = 06:30:30
+                            name = "Foo Bar" # a name 
+                            timestamp1 = 06:30:30 #some
                             timestamp2 = 06:30:30.123456
                             timestamp3 = 06:30:30.1234567 # rounding up
                             timestamp4 = 06:30:30.1234564 # rounding down


### PR DESCRIPTION
Added a check in class `Source` of TOML module to create separate tokens for date/time. 
Earlier, for a line `timestamp3 = 06:30:30.1234567 # rounding up` the token created was `(06:30:30.1234567 # rounding up)` which is an invalid token, after merge of #15228 .
Now, token created would be `(06:30:30.1234567)` which is a valid token.

fixes #15364 