### PR TITLE
Add error message for generic types in set

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -137,7 +137,7 @@ module Set {
         compilerWarning("creating a set with element type " +
                         eltType:string);
         compilerError("set element type cannot currently be generic");
-        // In the future we might support it if the list is not default-inited
+        // In the future we might support it if the set is not default-inited
       }
       this.eltType = eltType;
       this.parSafe = parSafe;
@@ -162,7 +162,7 @@ module Set {
         compilerWarning("creating a set with element type " +
                         eltType:string);
         compilerError("set element type cannot currently be generic");
-        // In the future we might support it if the list is not default-inited
+        // In the future we might support it if the set is not default-inited
       }
       this.eltType = eltType;
       this.parSafe = parSafe;

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -133,6 +133,12 @@ module Set {
       }
       if isTuple(eltType) then
         compilerError('Sets do not support tuple types');
+      if isGenericType(eltType) {
+        compilerWarning("creating a set with element type " +
+                        eltType:string);
+        compilerError("set element type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
+      }
       this.eltType = eltType;
       this.parSafe = parSafe;
     }
@@ -152,6 +158,12 @@ module Set {
         compilerError('Sets do not support class types');
       if isTuple(eltType) then
         compilerError('Sets do not support tuple types');
+      if isGenericType(eltType) {
+        compilerWarning("creating a set with element type " +
+                        eltType:string);
+        compilerError("set element type cannot currently be generic");
+        // In the future we might support it if the list is not default-inited
+      }
       this.eltType = eltType;
       this.parSafe = parSafe;
       this.complete();

--- a/test/library/standard/Set/init/setInitGenericError.chpl
+++ b/test/library/standard/Set/init/setInitGenericError.chpl
@@ -1,0 +1,9 @@
+use Set;
+
+record R {
+  var x;
+  var y = 10;
+}
+
+var s = new set(R);
+writeln(s);

--- a/test/library/standard/Set/init/setInitGenericError.good
+++ b/test/library/standard/Set/init/setInitGenericError.good
@@ -1,0 +1,2 @@
+setInitGenericError.chpl:8: warning: creating a set with element type R
+setInitGenericError.chpl:8: error: set element type cannot currently be generic


### PR DESCRIPTION
#15368 added error messages for generic types in list and map, but it missed
set. This PR adds a similar error message for the set type and an associated
test.

Test:
- [x] standard
