### PR TITLE
Fix chpldoc comments for '.create(:unowned)' on owned/shared objects

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -265,8 +265,9 @@ module OwnedObject {
 
        It is an error to directly delete the class instance
        after passing it to `owned.create()`. */
-    pragma "unsafe" // 'result' may have a non-nilable type
+    pragma "unsafe"
     inline proc type create(pragma "nil from arg" p : unmanaged) {
+      // 'result' may have a non-nilable type
       var result: (p.type : owned);
       result.retain(p);
       return result;

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -345,8 +345,9 @@ module SharedObject {
 
        It is an error to directly delete the class instance
        after passing it to `shared.create()`. */
-    pragma "unsafe" // 'result' may have a non-nilable type
+    pragma "unsafe"
     inline proc type create(pragma "nil from arg" p : unmanaged) {
+      // 'result' may have a non-nilable type
       var result: (p.type : shared);
       result.retain(p);
       return result;


### PR DESCRIPTION
This fixes some chpldoc comments that were squashed due to an intervening single-line comment by pushing the comment into the routine itself.