### PR TITLE
Avoid postinit in SparseBlockDom that was causing unnecessary allocations

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -576,11 +576,13 @@ override proc Block.dsiNewRectangularDom(param rank: int, type idxType,
 
 override proc Block.dsiNewSparseDom(param rank: int, type idxType,
                                     dom: domain) {
-  return new unmanaged SparseBlockDom(rank=rank, idxType=idxType,
+  var ret =  new unmanaged SparseBlockDom(rank=rank, idxType=idxType,
                             sparseLayoutType=sparseLayoutType,
                             stridable=dom.stridable,
                             dist=_to_unmanaged(this), whole=dom._value.whole,
                             parentDom=dom);
+  ret.setup();
+  return ret;
 }
 
 //

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -91,13 +91,7 @@ class SparseBlockDom: BaseSparseDomImpl {
   var myLocDom: unmanaged LocSparseBlockDom(rank, idxType, stridable,
                                             sparseLayoutType)?;
 
-  // TODO: move towards init and away from postinit
-  // and remove nilable types
-
-  proc postinit() {
-    setup();
-    //    writeln("Exiting initialize");
-  }
+  // TODO: move towards init and away from nilable types
 
   proc setup() {
     //    writeln("In setup");


### PR DESCRIPTION
This PR closes a leak with SparseBlockDom.

We used to have `SparseBlockDom.postinit` that calls the `setup` method.
This `setup` method allocates `LocSparseBlockDom` instances on each locale.
However, during privatization we initialize `SparseBlockDom` instances on each
locale, and because of that `postinit` we were allocating new
`LocSparseBlockDom` instances on each privatized instance, too. All we need at
that point is to point to the original instances of that class in each locale
and not allocate new stuff. Those newly allocated instances were leaking.

Test:
- [x] gasnet
- [x] standard
