### PR TITLE
Close a few multilocale string/bytes leaks

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -136,7 +136,9 @@ module ByteBufferHelpers {
   inline proc bufferGetByte(buf, off, loc) {
     if !_local && loc != chpl_nodeID {
       const newBuf = bufferCopyRemote(src_loc_id=loc, src_addr=buf+off, len=1);
-      return newBuf[0];
+      const ret = newBuf[0];
+      bufferFree(newBuf);
+      return ret;
     }
     else {
       return buf[off];
@@ -173,16 +175,23 @@ module ByteBufferHelpers {
     } 
     else if loc1 != chpl_nodeID && loc2 == chpl_nodeID {
       var locBuf1 = bufferCopyRemote(loc1, buf1, len1);
-      return _strcmp_local(locBuf1, len1, buf2, len2);
+      const ret = _strcmp_local(locBuf1, len1, buf2, len2);
+      bufferFree(locBuf1);
+      return ret;
     }
     else if loc1 == chpl_nodeID && loc2 != chpl_nodeID {
       var locBuf2 = bufferCopyRemote(loc2, buf2, len2);
-      return _strcmp_local(buf1, len1, locBuf2, len2);
+      const ret = _strcmp_local(buf1, len1, locBuf2, len2);
+      bufferFree(locBuf2);
+      return ret;
     }
     else {
       var locBuf1 = bufferCopyRemote(loc1, buf1, len1);
       var locBuf2 = bufferCopyRemote(loc2, buf2, len2);
-      return _strcmp_local(locBuf1, len1, locBuf2, len2);
+      const ret = _strcmp_local(locBuf1, len1, locBuf2, len2);
+      bufferFree(locBuf1);
+      bufferFree(locBuf2);
+      return ret;
     }
   }
 }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -382,7 +382,7 @@ module Bytes {
     // This is assumed to be called from this.locale
     pragma "no doc"
     proc ref reinitString(buf: bufferType, s_len: int, size: int,
-                          needToCopy:bool = true) {
+                          needToCopy:bool = true, ownBuffer=false) {
       if this.isEmpty() && buf == nil then return;
 
       /*const buf = _buf:bufferType; // this is different than string*/
@@ -426,6 +426,8 @@ module Bytes {
           this.buff = buf;
         }
       }
+
+      if ownBuffer then this.isowned = true;
 
       this.len = s_len;
     }

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -561,7 +561,8 @@ module BytesStringCommon {
         var remote_buf:bufferType = nil;
         if len != 0 then
           remote_buf = bufferCopyRemote(rhs.locale_id, rhs.buff, len);
-        lhs.reinitString(remote_buf, len, len+1, needToCopy=false);
+        lhs.reinitString(remote_buf, len, len+1, needToCopy=false,
+                                                 ownBuffer=true);
       }
     }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -909,7 +909,7 @@ module String {
     // This is assumed to be called from this.locale
     pragma "no doc"
     proc ref reinitString(buf: bufferType, s_len: int, size: int,
-                          needToCopy:bool = true) {
+                          needToCopy:bool = true, ownBuffer = false) {
       if this.isEmpty() && buf == nil then return;
 
       // If the this.buff is longer than buf, then reuse the buffer if we are
@@ -951,6 +951,8 @@ module String {
           this.buff = buf;
         }
       }
+
+      if ownBuffer then this.isowned = true;
 
       this.len = s_len;
     }


### PR DESCRIPTION
This PR closes few string/bytes leaks. Following used to leak when the
operation is done on a remote string:

- Equality check
- Assignment
- `string.byte()`

Resolves https://github.com/chapel-lang/chapel/issues/7549

Testing:
- [x] full gasnet
- [x] full standard
- [x] some valgrind  -- `test/types/{string,bytes}` passes
- [x] some tests with Address Sanitizer - thanks to @ronawho