### PR TITLE
Adds renaming a module when using it to the spec and modules primer

### DIFF
--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -720,7 +720,7 @@ The syntax of the use statement is given by:
      module-or-enum-name , module-or-enum-name-list
 
    module-or-enum-name:
-     identifier
+     rename-base
      identifier . module-or-enum-name
 
    limitation-clause:
@@ -820,6 +820,11 @@ An error is signaled if multiple enumeration constants or public
 module-level symbols would be inserted into this enclosing scope with
 the same name, and that name is referenced by other statements in the
 same scope as the use.
+
+A module or enum being used may optionally be given a new name using the ``as``
+keyword.  This new name will be usable from the scope of the use in place of the
+old name.  This new name does not affect uses of that module from other
+contexts.
 
 Use statements may be explicitly delared ``public`` or ``private``.
 By default, uses are ``private``.  Making a use ``public`` causes its

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -171,6 +171,21 @@ module MainModule {
       writeln(bazBarFoo);
     }
 
+    /* Modules that are being used can be given a different name than the ones
+       they were declared with.  In this example, ``modToUse.bar`` can be
+       accessed using the new name, ``other``, as the module prefix.  The old
+       name is not visible in that scope, though, so writing just
+       ``modToUse.bar`` will not work.  However, unprefixed access to the
+       module's symbols remains unchanged.
+    */
+    {
+      use modToUse as other;
+
+      writeln(other.bar);
+      // writeln(modToUse.bar);
+      writeln(bar);
+    }
+
 
     /* The symbols provided by a ``use`` statement are only considered when
        the name in question cannot be resolved directly within the local

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -182,7 +182,7 @@ module MainModule {
       use modToUse as other;
 
       writeln(other.bar);
-      // writeln(modToUse.bar);
+      // writeln(modToUse.bar); // would be an error, modToUse not visible
       writeln(bar);
     }
 

--- a/test/release/examples/primers/modules.good
+++ b/test/release/examples/primers/modules.good
@@ -1,6 +1,8 @@
 Access from outside a module
 28
 28
+2
+2
 4.0
 2
 12


### PR DESCRIPTION
Updates the syntax block for use statements, and adds a brief paragraph about it
prior to the descriptions of `public` and `private` in the spec.  This paragraph is
basically a reduced version of the description for symbols that are renamed
within an `only` list.

Also adds a short example and description paragraph to the modules primer,
extending the .good output for the additional output.

Resolves Cray/chapel-private#661

The updated primer passed a fresh checkout, and paratest over release/examples.
The built docs look good for the primer and spec