### PR TITLE
Fix fatal error logging for arkouda testing

### DIFF
--- a/test/studies/arkouda/functions.bash
+++ b/test/studies/arkouda/functions.bash
@@ -3,17 +3,6 @@
 # Helper functions for logging and marking test start/stop. Formats output in
 # the way the testing infrastructure expects.
 
-function log_error() {
-  local msg=$@
-  echo "[Error ${msg}]"
-  exit 0
-}
-
-function log_success() {
-  local msg=$@
-  echo "[Success matching ${msg}]"
-}
-
 function subtest_start() {
   subtest_start_time=$(date +%s)
   echo "[Starting subtest - $(date)]"
@@ -23,6 +12,23 @@ function subtest_end() {
   local subtest_end_time=$(date +%s)
   local elapsed=$(( $subtest_end_time - $subtest_start_time ))
   echo "[Finished subtest \"studies/arkouda\" - $elapsed seconds"
+}
+
+function log_error() {
+  local msg=$@
+  echo "[Error ${msg}]"
+}
+
+function log_fatal_error() {
+  local msg=$@
+  echo "[Error ${msg}]"
+  subtest_end
+  exit 0
+}
+
+function log_success() {
+  local msg=$@
+  echo "[Success matching ${msg}]"
 }
 
 function test_start() {

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -21,23 +21,23 @@ rm -rf ${ARKOUDA_HOME}
 
 # Clone Arkouda 
 if ! git clone --depth=1 ${ARKOUDA_URL} --branch=${ARKOUDA_BRANCH} ; then
-  log_error "cloning Arkouda"
+  log_fatal_error "cloning Arkouda"
 fi
 cd ${ARKOUDA_HOME}
 
 # Install dependencies
 if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
-  log_error "installing dependencies"
+  log_fatal_error "installing dependencies"
 fi
 
 # Compile Arkouda
 if ! make ; then
-  log_error "compiling arkouda"
+  log_fatal_error "compiling arkouda"
 fi
 
 # Install Arkouda and python dependencies
 if ! pip3 install -e .[test] --user ; then
-  log_error "installing arkouda"
+  log_fatal_error "installing arkouda"
 fi
 
 # Check installation
@@ -45,14 +45,13 @@ test_start "make check"
 if make check ; then
   log_success "make check output"
 else
-  log_error "running make check"
+  test_end "make check"
+  log_fatal_error "running make check"
 fi
 test_end "make check"
 
 # Run benchmarks
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-  test_start "benchmarks"
-
   benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --description $CHPL_TEST_PERF_DESCRIPTION --graph-dir $CHPL_TEST_PERF_DIR/html"
   if [[ -n $CHPL_TEST_PERF_CONFIG_NAME ]]; then
     benchmark_opts="${benchmark_opts} --platform $CHPL_TEST_PERF_CONFIG_NAME"
@@ -67,6 +66,7 @@ if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
     benchmark_opts="${benchmark_opts} --configs $CHPL_TEST_PERF_CONFIGS"
   fi
 
+  test_start "benchmarks"
   if ./benchmarks/run_benchmarks.py ${benchmark_opts} ; then
     log_success "benchmark output"
   else


### PR DESCRIPTION
We need to print test/subtest end messages so that our junit processing
works. Previously, we would just exit and not report test/subtest ends,
which led to hangs in the junit processing script.