### PR TITLE
Close a leak where RVF'ed array view instances leaked

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1159,6 +1159,9 @@ module ChapelArray {
             _delete_dist(distToFree!, _isPrivatized(inst.dist));
         }
       }
+      else {
+        // Do we need to worry about RVF'ed domain views?
+      }
     }
     pragma "no doc"
     proc deinit () {
@@ -3168,6 +3171,14 @@ module ChapelArray {
           _delete_dom(instanceDom!, domIsPrivatized);
         if distToFree != nil then
           _delete_dist(distToFree!, distIsPrivatized);
+      }
+    }
+    else {
+      // we have _unowned set, so we don't have data to free up, but our
+      // instance might be an rvf'ed array view that itself needs to be cleaned
+      // up
+      if chpl__isArrayView(_instance) {
+        delete _instance;
       }
     }
   }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1160,7 +1160,10 @@ module ChapelArray {
         }
       }
       else {
-        // Do we need to worry about RVF'ed domain views?
+        // Engin 4/14/20: We don't have any arrayview domain instances that we
+        // RVF today. If/when we do have them, we need to clean them up here.
+        // See _do_destroy_arr for a similar cleanup we do today for arrayview
+        // arrays.
       }
     }
     pragma "no doc"


### PR DESCRIPTION
This PR fixes a memory bug where we leaked RVF'ed ArrayView instances.

Such slices are wrapped in `_array`s that have `unowned=true`. This causes the
whole cleanup part of the code to be skipped. This is right, in the sense that
we don't want to free the actual array that this view refers to. However, when
the RVF'ed `_array` is deleted, we still need to delete the ArrayView instance
that it wraps.

Test:

- [x] standard
- [x] gasnet
