### PR TITLE
Upgrade module gen compiler to cce 9.0.0-classic

### DIFF
--- a/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
@@ -340,12 +340,9 @@ else
     fi
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
-    #[TODO] gen_version_gcc=7.3.0
-    #[TODO] gen_version_intel=16.0.3.210
-    #[TODO] gen_version_cce=8.6.3
-    #[TODO] if [ "$CHPL_LOCALE_MODEL" == knl ]; then
-    #[TODO]     gen_version_cce=8.7.3
-    #[TODO] fi
+    #[TODO] gen_version_gcc=
+    #[TODO] gen_version_intel=
+    #[TODO] gen_version_cce=
 
     target_cpu_module=craype-sandybridge
 
@@ -389,9 +386,6 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         #[TODO] load_module_version $target_compiler $target_version
-
-        # pin to an mpich version compatible with the gen compiler
-        #[TODO] load_module_version cray-mpich 7.7.7
     }
 
     function load_target_cpu() {

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -268,9 +268,7 @@ else
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
-    # Also, the next time this gets updated, try removing the craype pin in
-    # load_prgenv_cray
-    gen_version_cce=8.7.8
+    gen_version_cce=9.0.0-classic
 
     target_cpu_module=craype-arm-thunderx2
 
@@ -299,13 +297,7 @@ else
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        # Try removing this line the next time we update compiler versions
-        load_module_version craype 2.6.1.9
         load_module_version $target_compiler $target_version
-
-        # pin to mpich/libsci versions compatible with the gen compiler
-        load_module_version cray-mpich 7.7.7
-        load_module_version cray-libsci 18.07.1
     }
 
     function load_target_cpu() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -337,10 +337,7 @@ else
     # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
     gen_version_intel=16.0.3.210
-    gen_version_cce=8.7.8
-    if [ "$CHPL_LOCALE_MODEL" == knl ]; then
-        gen_version_cce=8.7.8
-    fi
+    gen_version_cce=9.0.0-classic
 
     target_cpu_module=craype-sandybridge
 
@@ -384,10 +381,6 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
-
-        # pin to mpich/libsci versions compatible with the gen compiler
-        load_module_version cray-mpich 7.7.7
-        load_module_version cray-libsci 18.07.1
     }
 
     function load_target_cpu() {


### PR DESCRIPTION
Our old version is gone, and this is a recommended gen compiler. This
also lets us get rid of pinning to specific craype/mpich/libsci modules.