### PR TITLE
Continue to pin to an older crape for xc-aarch64 module

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -268,6 +268,8 @@ else
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
+    # Also, the next time this gets updated, try removing the craype pin in
+    # load_prgenv_cray
     gen_version_cce=9.0.0-classic
 
     target_cpu_module=craype-arm-thunderx2
@@ -297,6 +299,8 @@ else
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
+        # Try removing this line the next time we update compiler versions
+        load_module_version craype 2.6.1.9
         load_module_version $target_compiler $target_version
     }
 


### PR DESCRIPTION
We see hangs with the default craype and cce. I was hopeful we could
remove this workaround with a newer cce (#15410), but that does not
seem to be the case so re-pin.

For more info see https://github.com/Cray/chapel-private/issues/442