### PR TITLE
Get HDF5 testing working again

### DIFF
--- a/test/library/packages/HDF5/parallelReadMultitype.chpl
+++ b/test/library/packages/HDF5/parallelReadMultitype.chpl
@@ -12,7 +12,7 @@ proc main {
 
   var t = new Timer();
 
-  for param i in 1..inputTypes.size {
+  for param i in 0..<inputTypes.size {
     type inType = inputTypes(i);
     param typeName = inType:string;
     t.start();

--- a/test/library/packages/HDF5/parallelReadMultitypePreprocess.chpl
+++ b/test/library/packages/HDF5/parallelReadMultitypePreprocess.chpl
@@ -13,7 +13,7 @@ proc main {
   var t = new Timer();
   var preprocess = new owned AddNPreprocessor(1);
 
-  for param i in 1..inputTypes.size {
+  for param i in 0..<inputTypes.size {
     type inType = inputTypes(i);
     param typeName = inType:string;
     t.start();


### PR DESCRIPTION
* Update HDF5 module for 0-based tuples.
* Update HDF5 module to use a list instead of array-as-vec in one function.
* Update two tests for 0-based tuples.

This gets all the tests passing except readChunks1DPreprocess.chpl which is
hitting internal issue #474 and getting an error pointing to that issue.