### PR TITLE
Update lock-free tests w.r.t. their tuple indexing

### DIFF
--- a/test/library/packages/LockFreeQueue/consistencyCheck.chpl
+++ b/test/library/packages/LockFreeQueue/consistencyCheck.chpl
@@ -17,7 +17,7 @@ forall i in 1..N {
 
 var total : int;
 forall i in 1..N with (+ reduce total) {
-    total += lfq.dequeue()[2];
+    total += lfq.dequeue()[1];
 }
 assert(total == expected, total, "!=", expected);
 timer.stop();
@@ -32,7 +32,7 @@ forall i in 1..N with (var tok = lfq.getToken()) {
 
 total = 0;
 forall i in 1..N with (var tok = lfq.getToken(), + reduce total) {
-    total += lfq.dequeue(tok)[2];
+    total += lfq.dequeue(tok)[1];
 }
 assert(total == expected, total, "!=", expected);
 lfq.tryReclaim();

--- a/test/library/packages/LockFreeStack/consistencyCheck.chpl
+++ b/test/library/packages/LockFreeStack/consistencyCheck.chpl
@@ -17,7 +17,7 @@ forall i in 1..N {
 
 var total : int;
 forall i in 1..N with (+ reduce total) {
-    total += lfs.pop()[2];
+    total += lfs.pop()[1];
 }
 assert(total == expected, total, "!=", expected);
 timer.stop();
@@ -32,7 +32,7 @@ forall i in 1..N with (var tok = lfs.getToken()) {
 
 total = 0;
 forall i in 1..N with (var tok = lfs.getToken(), + reduce total) {
-    total += lfs.pop(tok)[2];
+    total += lfs.pop(tok)[1];
 }
 assert(total == expected, total, "!=", expected);
 lfs.tryReclaim();


### PR DESCRIPTION
These are only tested with LLVM, so I'd missed them in my paratest run.