### PR TITLE
Fix off-by-one errors in UnitTest

### DIFF
--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -651,11 +651,11 @@ module UnitTest {
         if seq_type_name == "Array" {
           tmpString += "'[";
           for i in seq1.indices {
-            if i != seq1.size then tmpString+= seq1[i]:string+", ";
+            if i != seq1.size-1 then tmpString+= seq1[i]:string+", ";
             else tmpString += seq1[i]:string+"]'"+symbol+ "'[";
           }
           for i in seq2.indices {
-            if i != seq2.size then tmpString+= seq2[i]:string+", ";
+            if i != seq2.size-1 then tmpString+= seq2[i]:string+", ";
             else tmpString += seq2[i]:string+"]'";
           }
         }
@@ -855,11 +855,11 @@ module UnitTest {
         if seq_type_name == "Array" {
           tmpString += "'[";
           for i in seq1.indices {
-            if i != seq1.size then tmpString+= seq1[i]:string+", ";
+            if i != seq1.size-1 then tmpString+= seq1[i]:string+", ";
             else tmpString += seq1[i]:string+"]'"+symbol+ "'[";
           }
           for i in seq2.indices {
-            if i != seq2.size then tmpString+= seq2[i]:string+", ";
+            if i != seq2.size-1 then tmpString+= seq2[i]:string+", ";
             else tmpString += seq2[i]:string+"]'";
           }
         }


### PR DESCRIPTION
Somehow these slipped by me, but... one of my previous commits broke
the way < and > unit tests print out their output without my
noticing.  The cause was that the check to see whether we were at the
end of the array or not was comparing whether the index (now 0-based)
was equal to the size, but now needed to compare to size-1.