### PR TITLE
Fix an off-by-one error in mason

### DIFF
--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -128,7 +128,7 @@ proc validateInit(path: string, name: string, isNameDiff: bool, show: bool) thro
 
   var files = [ "/Mason.toml", "/src" , "/test" , "/example", "/.git", "/.gitignore", "/src/" + moduleName ];
   var toBeCreated : list(string);
-  for idx in 1..files.size do {
+  for idx in 0..<files.size do {
     const metafile = files(idx);
     const dir = metafile;
     if dir == "/Mason.toml" || dir == "/.gitignore" {


### PR DESCRIPTION
I'm not sure how this slipped by me as part of PR #14521.  Maybe I don't normally have
mason built, so mason tests are skipped, but after building it
this morning, ones were running that hadn't been?