### PR TITLE
Fix another off-by-one in mason

### DIFF
--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -307,7 +307,7 @@ proc validatePackageNameChecks(path: string, name: string) {
     else {
       if isDir(path + '/src') {
         const files = listdir(path + '/src');
-        const file = files[1];
+        const file = files[0];
         const fileName = file.split(".");
         const nameModule = fileName[0];
         if validateNameInit(nameModule) then actualName = nameModule;


### PR DESCRIPTION
I'm befuddled why these mason test errors keep slipping by me...  It's like I only seem to see some of these when testing on linux64 and not my laptop... :(