### PR TITLE
Fix find()-related bug in sort test logic

### DIFF
--- a/test/library/packages/Sort/performance/performance-insert-select.good
+++ b/test/library/packages/Sort/performance/performance-insert-select.good
@@ -1,0 +1,4 @@
+default
+Time taken to sort 64 bytes (8 int(64)s)
+insertionSort (seconds): x.xxx
+selectionSort (seconds): x.xxx

--- a/test/library/packages/Sort/performance/performance-quicksort-only.good
+++ b/test/library/packages/Sort/performance/performance-quicksort-only.good
@@ -1,0 +1,3 @@
+default
+Time taken to sort 64 bytes (8 int(64)s)
+quickSort (seconds): x.xxx

--- a/test/library/packages/Sort/performance/performance.chpl
+++ b/test/library/packages/Sort/performance/performance.chpl
@@ -47,7 +47,7 @@ proc stride(N) {
 proc gatherTimings(const ref A) {
   var t = new Timer();
   print('Time taken to sort ', 2**M, ' bytes (', A.size, ' ', T:string, 's)');
-  if sorts.find('q')
+  if sorts.find('q') != -1
   {
     var B = A;
     t.start();
@@ -59,7 +59,7 @@ proc gatherTimings(const ref A) {
       print('quickSort (seconds): ', t.elapsed());
     t.clear();
   }
-  if sorts.find('h')
+  if sorts.find('h') != -1
   {
     var B = A;
     t.start();
@@ -71,7 +71,7 @@ proc gatherTimings(const ref A) {
       print('heapSort (seconds): ', t.elapsed());
     t.clear();
   }
-  if sorts.find('i')
+  if sorts.find('i') != -1
   {
     var B = A;
     t.start();
@@ -83,7 +83,7 @@ proc gatherTimings(const ref A) {
       print('insertionSort (seconds): ', t.elapsed());
     t.clear();
   }
-  if sorts.find('r')
+  if sorts.find('r') != -1
   {
     var B = A;
     t.start();
@@ -95,7 +95,7 @@ proc gatherTimings(const ref A) {
       print('binaryInsertionSort (seconds): ', t.elapsed());
     t.clear();
   }
-  if sorts.find('m')
+  if sorts.find('m') != -1
   {
     var B = A;
     t.start();
@@ -107,7 +107,7 @@ proc gatherTimings(const ref A) {
       print('mergeSort (seconds): ', t.elapsed());
     t.clear();
   }
-  if sorts.find('s')
+  if sorts.find('s') != -1
   {
     var B = A;
     t.start();
@@ -119,7 +119,7 @@ proc gatherTimings(const ref A) {
       print('selectionSort (seconds): ', t.elapsed());
     t.clear();
   }
-  if sorts.find('b')
+  if sorts.find('b') != -1
   {
     var B = A;
     t.start();
@@ -134,6 +134,8 @@ proc gatherTimings(const ref A) {
 }
 
 proc print(args...) {
-  if !correctness then
+  if correctness && args.size == 2 then
+    writeln(args(0), "x.xxx");
+  else
     writeln((...args));
 }

--- a/test/library/packages/Sort/performance/performance.execopts
+++ b/test/library/packages/Sort/performance/performance.execopts
@@ -1,0 +1,3 @@
+             # performance.good
+--sorts='q'  # performance-quicksort-only.good
+--sorts='is' # performance-insert-select.good

--- a/test/library/packages/Sort/performance/performance.good
+++ b/test/library/packages/Sort/performance/performance.good
@@ -1,0 +1,8 @@
+default
+Time taken to sort 64 bytes (8 int(64)s)
+quickSort (seconds): x.xxx
+heapSort (seconds): x.xxx
+insertionSort (seconds): x.xxx
+binaryInsertionSort (seconds): x.xxx
+mergeSort (seconds): x.xxx
+selectionSort (seconds): x.xxx


### PR DESCRIPTION
The sort performance test had a subtle bug in which it relied on
'if find(...)' idioms to determine which sorts to run.  With strings
and bytes going to 0-based indexing, and find returning -1 on
no-match finds, this caused all sorts to be run rather than just one
in performance runs, causing timeouts and bad data.  Here, I'm
switching the find calls to compare to -1 and also updating the
correctness tests to make sure the output works correctly by only
squashing timing output, not all output.