### PR TITLE
Simplify spack spec parser in mason

### DIFF
--- a/test/mason/spec-parser/test-spec-parser.good
+++ b/test/mason/spec-parser/test-spec-parser.good
@@ -59,7 +59,7 @@ Spec: ncurses@6.0.0%clang@9.0.0-apple patches=f84b2708a42777aadcc7f502a261afe10c
 Package: ncurses
 Version: 6.0.0
 Compiler: ----
-Variants: patches=f84b2708a42777aadcc7f502a261afe10ca5646a51c1ef8b5e60d2070d926b57 ~symlinks arch=darwin-sierra-x86_64 ^pkg @0.29.2 %clang @9.0.0 +internal_glib arch=darwin-sierra-x86_64
+Variants: patches=f84b2708a42777aadcc7f502a261afe10ca5646a51c1ef8b5e60d2070d926b57 ~symlinks arch=darwin-sierra-x86_64 ^pkg -config@0.29.2 %clang@9.0.0-apple +internal_glib arch=darwin-sierra-x86_64
 ----------
 
 ---------
@@ -67,6 +67,6 @@ Spec: hdf5@1.10.1%clang@9.0.0-apple~cxx~debug~fortran~hl~mpi+pic+shared~szip~thr
 Package: hdf5
 Version: 1.10.1
 Compiler: ----
-Variants: ~cxx ~debug ~fortran ~hl ~mpi +pic +shared ~szip ~threadsafe arch=darwin-sierra-x86_64 ^hwloc @1.11.8 %clang @9.0.0 ~cuda +libxml2 ~pci arch=darwin-sierra-x86_64 ^libxml2 @2.9.4 %clang @9.0.0 ~python arch=darwin-sierra-x86_64 ^xz @5.2.3 %clang @9.0.0 arch=darwin-sierra-x86_64 ^zlib @1.2.11 %clang @9.0.0 +optimize +pic +shared arch=darwin-sierra-x86_64
+Variants: ~cxx ~debug ~fortran ~hl ~mpi +pic +shared ~szip ~threadsafe arch=darwin-sierra-x86_64 ^hwloc @1.11.8 %clang@9.0.0-apple ~cuda +libxml2 ~pci arch=darwin-sierra-x86_64 ^libxml2 @2.9.4 %clang@9.0.0-apple ~python arch=darwin-sierra-x86_64 ^xz @5.2.3 %clang@9.0.0-apple arch=darwin-sierra-x86_64 ^zlib @1.2.11 %clang@9.0.0-apple +optimize +pic +shared arch=darwin-sierra-x86_64
 ----------
 

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -237,8 +237,8 @@ private proc editCompilers() {
 
 
 /* Given a toml of external dependencies returns
-   the dependencies in a toml */
-proc getExternalPackages(exDeps: unmanaged Toml) {
+   the dependencies in a toml in lock file format */
+proc getExternalPackages(exDeps: unmanaged Toml) /* [domain(string)] unmanaged Toml? */ {
 
   var exDom: domain(string);
   var exDepTree: [exDom] unmanaged Toml?;
@@ -250,21 +250,16 @@ proc getExternalPackages(exDeps: unmanaged Toml) {
           when fieldtag.fieldToml do continue;
           otherwise {
             // Take key from toml file if not present in spec
-            var tempSpec = spec.s;
+            var fullSpec = spec.s;
+            // TODO: Should it be an error if TOML value includes name?
             if !spec.s.startsWith(name) {
-              tempSpec = "@".join(name, spec.s);
+              fullSpec = "@".join(name, spec.s);
             }
-            const specFields = getSpecFields(tempSpec);
-            var version = specFields[1];
-            var compiler = specFields[2];
-            //var variants = specFields[3];
 
-            // TODO: Add spaces between spec to allow version ranges
-            // TODO: allow dependency search to include variants
-            var fullSpec = "%".join("@".join(name, version), compiler);
+            const resolvedSpec = resolveSpec(fullSpec);
 
-            var dependencies = getSpkgDependencies(fullSpec);
-            const pkgInfo = getSpkgInfo(fullSpec, dependencies);
+            var dependencies = getSpkgDependencies(resolvedSpec);
+            const pkgInfo = getSpkgInfo(resolvedSpec, dependencies);
 
             if !exDom.contains(name) then
               exDom += name;
@@ -285,7 +280,6 @@ proc getExternalPackages(exDeps: unmanaged Toml) {
 /* Retrieves build information for MasonUpdate */
 proc getSpkgInfo(spec: string, ref dependencies: list(string)): unmanaged Toml throws {
 
-  // put above try b/c compiler complains about return value
   var depList: list(unmanaged Toml);
   var spkgDom: domain(string);
   var spkgToml: [spkgDom] unmanaged Toml?;
@@ -297,8 +291,11 @@ proc getSpkgInfo(spec: string, ref dependencies: list(string)): unmanaged Toml t
     var version = specFields[1];
     var compiler = specFields[2];
 
-    if spkgInstalled(spec) {
-      const spkgPath = getSpkgPath(spec);
+    // Remove variants from spec
+    var simpleSpec = pkgName + '@' + version + '%' + compiler;
+
+    if spkgInstalled(simpleSpec) {
+      const spkgPath = getSpkgPath(simpleSpec);
       const libs = joinPath(spkgPath, "lib");
       const includePath = joinPath(spkgPath, "include");
       const other = joinPath(spkgPath, "other");
@@ -346,7 +343,7 @@ proc getSpkgInfo(spec: string, ref dependencies: list(string)): unmanaged Toml t
 }
 
 /* Returns spack package path for build information */
-proc getSpkgPath(spec: string) throws {
+proc getSpkgPath(spec: string): string throws {
   const command = "spack location -i " + spec;
   const pkgPath = getSpackResult(command, quiet=true);
   if pkgPath == "" {
@@ -355,16 +352,16 @@ proc getSpkgPath(spec: string) throws {
   return pkgPath.strip();
 }
 
-// TODO: allow for versions to be of the form 6.0 (without bug fix)
-proc getSpkgDependencies(spec: string) throws {
+/* Find dependencies of package that are installed on machine */
+proc getSpkgDependencies(spec: string): list(string) throws {
+  const name = specName(spec);
   const command = "spack find -df --show-full-compiler " + spec;
   const pkgInfo = getSpackResult(command, quiet=true);
   var found = false;
   var dependencies: list(string);
   for item in pkgInfo.split() {
 
-    // TODO: This does not work if spec contains a version range
-    if item.rfind(spec) != -1 {
+    if item.rfind(name) != -1 {
       found = true;
     }
     else if found {
@@ -376,6 +373,32 @@ proc getSpkgDependencies(spec: string) throws {
     throw new owned MasonError("Mason could not find dependency: " + spec);
   }
   return dependencies;
+}
+
+
+/* Get package name from spec */
+private proc specName(spec: string): string throws {
+  const fields = spec.split('%');
+  const subfields = fields[0].split('@');
+  const name = subfields[0];
+  return name;
+}
+
+
+/* Resolve spec, pinning to the installed version and eliminating ranges */
+private proc resolveSpec(spec: string): string throws {
+  const command = "spack spec %s".format(spec);
+  const output = getSpackResult(command, quiet=true);
+  var lines = output.split('\n');
+
+  // Package on 7th line
+  var ret = lines[6].strip();
+
+  if ret == '' {
+    throw new owned MasonError("Package not found: " + spec);
+  }
+
+  return ret;
 }
 
 

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -119,8 +119,11 @@ proc modifyToml(add: bool, spec: string, external: bool, system: bool,
       const split = spec.split('@');
       const dependency = split[0];
       const version = split[1];
-      checkDepName(dependency);
-      checkVersion(version);
+      // Name and version checks are only valid for mason packages
+      if !external && !system {
+        checkDepName(dependency);
+        checkVersion(version);
+      }
 
       if system && add {
         writeln(" ".join("Adding system dependency", dependency, "version", version));

--- a/tools/mason/SpecParser.chpl
+++ b/tools/mason/SpecParser.chpl
@@ -33,6 +33,9 @@ config const debugSpecParser=false;
   retrieve information from the spec listed in the
   Mason.toml file under the [external] table.
 
+  This parser expects a resolved spec, such that there
+  are no version ranges.
+
   This parser is not meant to retrieve all information
   from the spec as we only need the following to use
   packages from Spack
@@ -76,31 +79,24 @@ private proc inferCompiler() throws {
 }
 
 
-proc readSpec(spec: string) {
-  const pkg = "([A-Za-z0-9\\-]+)",
-        vers = "(\\@.[^%]+)",
-        compiler = "(\\%[A-Za-z0-9\\-\\_]+[\\-a-zA-Z]*)",
+/* Tokenize spec into list of tokens */
+private proc readSpec(spec: string): list(string) {
+  const pkgVersion = "([A-Za-z0-9\\-\\@\\.\\:]+)",
+        compilerVersion = "(\\%[A-Za-z0-9\\_\\@\\.\\-]+)",
         variantInclude = "(\\+[A-Za-z0-9\\-\\_]+)",
         variantExclude = "(\\~[A-Za-z0-9\\-\\_]+)",
         dependency = "(\\^[a-zA-Z]*?[0-9]*?)",
         arch = "([A-Za-z0-9\\-\\_]+\\=[A-Za-z0-9\\-\\_]+)",
-        emptyArch = "([A-Za-z0-9\\-\\_]+\\=)",
-        versRange = "(\\@.+\\:{1}\\.[^%]+)",
-        minVers = "(\\@.+\\:)",
-        maxVers = "(\\@\\:.[^%]+)";
+        emptyArch = "([A-Za-z0-9\\-\\_]+\\=)";
 
   var tokenList: list(string);
-  const pattern = compile("|".join(versRange,
-                                   vers,
-                                   minVers,
-                                   maxVers,
-                                   compiler,
+  const pattern = compile("|".join(pkgVersion,
+                                   compilerVersion,
                                    variantInclude,
                                    variantExclude,
                                    dependency,
                                    emptyArch,
-                                   arch,
-                                   pkg));
+                                   arch));
 
 
   if debugSpecParser then writeln(spec);
@@ -117,21 +113,18 @@ proc readSpec(spec: string) {
 }
 
 
-proc parseSpec(ref tokenList: list(string)) throws {
+private proc parseSpec(ref tokenList: list(string)): 4*string throws {
 
-  const rVers = compile("(\\@.+)");
-  const rCompiler = compile("(\\%[A-Za-z0-9\\-\\_]+[\\-a-zA-Z]*)");
-  const rMinVers = compile("(\\@.+\\:)");
-  const rMaxVers = compile("(\\@\\:.[^%]+)");
-  const rVersRange = compile("(\\@.+\\:{1}\\.[^%]+)");
+  const reCompilerVersion = compile("(\\%[A-Za-z0-9\\_\\@\\.\\-]+)");
 
   // required fields
   //   - package name
   //   - version
   var package: string;
-  var pkgVersion: string;
+  var packageVersion: string;
   var compiler: string;
-  var compVersion: string;
+  var compilerVersion: string;
+
   // This includes more than just variants
   // variants, arch, dependencies etc...
   var variants: list(string);
@@ -142,51 +135,25 @@ proc parseSpec(ref tokenList: list(string)) throws {
   while tokenList.size > 0 {
     var toke = tokenList.pop(1);
 
-    // get package name (should always be first token)
-    if package.size < 1 {
-      package = toke;
-    }
-    // Match a package, compiler or dep version
-    // could be version, version range, min version or max version
-    else if rVers.match(toke).matched == true
-      || rVersRange.match(toke).matched == true
-      || rMinVers.match(toke).matched == true
-      || rMaxVers.match(toke).matched == true {
-
-      if pkgVersion.size < 1 {
-        pkgVersion = toke.strip("@");
-      }
-      else if compVersion.size < 1 {
-        compVersion = toke;
-        compiler = "".join(compiler, compVersion);
-      }
-      else {
-        variants.append(toke);
-      }
-    }
-    else if rCompiler.match(toke) {
-      // throw an error if we reach a compiler without seeing
-      // a package version.
-      if pkgVersion.size < 1 {
-        throw new owned MasonError("No package version found in spec");
-      }
-      // Match package compiler if one hasnt been matched
-      if compiler.size < 1 {
-        compiler = toke.strip("%");
-      }
-      else {
-        variants.append(toke);
+    // Package should be first token
+    if package == '' {
+      const pkgSplit = toke.split('@');
+      package = pkgSplit[0];
+      packageVersion = pkgSplit[1];
+    } else if reCompilerVersion.match(toke).matched && compilerVersion == '' {
+      const strippedToke = toke.strip('%');
+      const compilerSplit = strippedToke.split('@');
+      compiler = compilerSplit[0];
+      if compilerSplit.size > 1 {
+        // Note: This is currently unused
+        compilerVersion = compilerSplit[1];
       }
     }
     else {
-      // catch corner case where some compilers like "-"
-      // include non-spec characters e.g. clang@9.0.0-apple
-      if !toke.startsWith("-") {
-        variants.append(toke);
-      }
+      variants.append(toke);
     }
   }
-  return (package, pkgVersion, compiler, " ".join(variants.these()).strip());
+  return (package, packageVersion, compiler, " ".join(variants.these()).strip());
 }
 
 


### PR DESCRIPTION
This PR simplifies the spack spec parser in mason to handle only the token types mason cares about (package, version, compiler+version). The spec parser now requires a resolved spec (no version ranges), which helps simplify the implementation.

#15422 fixed a bug where the spec parser had the wrong format for package versions, but also caused some other parser issues. This PR maintains the fix from #15422 while addressing other parser issues.

This PR also removes the version format checks for `mason add` on external/system packages, which was a bug with a no-brainer fix encountered during development (see `MasonModify.chpl` change).

- [x] `test/mason`
- [x] `test/mason/mason-external` (skipped on most configurations)