### PR TITLE
Fix off-by-one errors in tests exporting bytes and strings

### DIFF
--- a/test/interop/python/chapelBytes/exportBytes.chpl
+++ b/test/interop/python/chapelBytes/exportBytes.chpl
@@ -1,9 +1,9 @@
 use Bytes;
 
 export proc getFirstNullBytePos(in b: bytes): int {
-  for i in 1..b.size do
+  for i in b.indices do
     if b[i] == 0x00 then
-      return (i - 1);
+      return i;
   return -1;
 }
 

--- a/test/interop/python/chapelStrings/exportStrings.chpl
+++ b/test/interop/python/chapelStrings/exportStrings.chpl
@@ -1,9 +1,9 @@
 use Bytes;
 
 export proc getFirstNullCodepointPos(in s: string): int {
-  for i in 1..s.size do
+  for i in s.indices do
     if s[i].toCodepoint() == 0x00 then
-      return (i - 1);
+      return i;
   return -1;
 }
 


### PR DESCRIPTION
This updates some Python-interop-only tests that make sure bytes and strings are exported correctly to address some obvious off-by-one errors due to the switch to 0-based indexing.