### PR TITLE
Revert XC module build to cce 8 compiler

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -270,7 +270,7 @@ else
     gen_version_gcc=7.3.0
     # Also, the next time this gets updated, try removing the craype pin in
     # load_prgenv_cray
-    gen_version_cce=9.0.0-classic
+    gen_version_cce=8.7.8
 
     target_cpu_module=craype-arm-thunderx2
 
@@ -302,6 +302,10 @@ else
         # Try removing this line the next time we update compiler versions
         load_module_version craype 2.6.1.9
         load_module_version $target_compiler $target_version
+
+        # pin to mpich/libsci versions compatible with the gen compiler
+        load_module_version cray-mpich 7.7.7
+        load_module_version cray-libsci 18.07.1
     }
 
     function load_target_cpu() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -337,7 +337,7 @@ else
     # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
     gen_version_intel=16.0.3.210
-    gen_version_cce=9.0.0-classic
+    gen_version_cce=8.7.11
 
     target_cpu_module=craype-sandybridge
 
@@ -381,6 +381,10 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
+
+        # pin to mpich/libsci versions compatible with the gen compiler
+        load_module_version cray-mpich 7.7.7
+        load_module_version cray-libsci 18.07.1
     }
 
     function load_target_cpu() {


### PR DESCRIPTION
We're running into problems with 9, so fall back to versions of 8 that
are available.