### PR TITLE
Fix LLVM interop test that was relying on default low bound of 1

### DIFF
--- a/test/interop/C/llvm/exportArray/returningArr/returnBadArray.chpl
+++ b/test/interop/C/llvm/exportArray/returningArr/returnBadArray.chpl
@@ -1,6 +1,6 @@
 // This tests that it is an error to return an array with a different lower
 // bounds than expected
 export proc foo(): [] int {
-  var x = [1, 2, 3, 4]; // lower bounds is 1 (because that's the default)
+  var x: [1..4] int = [1, 2, 3, 4]; // explicitly make the lower bound 1
   return x;
 }


### PR DESCRIPTION
This is the symmetric change to the one made in the non-LLVM tests yesterday, reviewed by @lydia-duncan.
