### PR TITLE
Fix format specifiers for 32-bit systems

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -483,7 +483,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
     int64_t n = testCaptureVector.size();
     if (index <= 0 || index > n) {
-      USR_FATAL(call, "index '%i' out of bounds, expected to be between '1' and '%i'",
+      USR_FATAL(call, "index '%" PRId64 "' out of bounds, expected to be between '1' and '%" PRId64 "'",
                 index, n);
     }
 
@@ -1905,7 +1905,7 @@ static Expr* preFoldNamed(CallExpr* call) {
       }
 
       if (index < 0 || index > at->fields.length-2) {
-        USR_FATAL(call, "type index expression '%i' out of bounds (0..%d)", index, at->fields.length-2);
+        USR_FATAL(call, "type index expression '%" PRId64 "' out of bounds (0..%d)", index, at->fields.length-2);
       }
 
       sprintf(field, "x%" PRId64, index);


### PR DESCRIPTION
Failures on typeTupleOOB.chpl on linux32 last night demonstrated that
we're using some %d modifiers on 64-bit integers which isn't portable
on systems where int/%d mean 32-bit.  Here, switch to using PRId64
instead which resolves the errors and should be more portable.

Strange that gcc has never warned us about this... perhaps due to
the way our USR/INT macros are set up since they appear there
rather than in a printf?
