### PR TITLE
Fix LLVM+linux64-only dedup test

### DIFF
--- a/test/studies/dedup/dedup-externblock.chpl
+++ b/test/studies/dedup/dedup-externblock.chpl
@@ -34,12 +34,13 @@ proc main(args:[] string)
         paths.append(path);
   }
 
-  // Create an array of hashes and file ids
-  // a file id is just the index into the paths array.
-  var hashAndFileId:[1..paths.size] (Hash, int);
-
   // Compute the SHA1 sums using the extern calls
   var pathsArray = paths.toArray();
+
+  // Create an array of hashes and file ids
+  // a file id is just the index into the paths array.
+  var hashAndFileId:[pathsArray.domain] (Hash, int);
+
   forall (id,path) in zip(pathsArray.domain, pathsArray) {
     var mdArray:[0..19] uint(8);
     var data:string;


### PR DESCRIPTION
This test had an assumption baked into it that a list.toArray() would
generate a 1-based array.  Remove that assumption and use the returned
array's domain rather than hard-coding a domain value in.