### PR TITLE
 Add future for het. loop over varargs tuple with string and --baseline

### DIFF
--- a/test/release/examples/primers/procedures.suppressif
+++ b/test/release/examples/primers/procedures.suppressif
@@ -1,0 +1,3 @@
+# unrolling heterogeneous tuples caused by varargs doesn't work with
+# --baseline yet; see issue #
+COMPOPTS <= --baseline

--- a/test/release/examples/primers/procedures.suppressif
+++ b/test/release/examples/primers/procedures.suppressif
@@ -1,3 +1,3 @@
 # unrolling heterogeneous tuples caused by varargs doesn't work with
-# --baseline yet; see issue #
+# --baseline yet; see issue #15443
 COMPOPTS <= --baseline

--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.bad
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.bad
@@ -1,0 +1,8 @@
+varargsHetTuple.chpl:16: internal error: COD-EXP-5628 chpl version 1.22.0.0ce16d314b
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.chpl
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.chpl
@@ -1,0 +1,22 @@
+record R {
+  var x = 42;
+
+  proc init=(other: R) {
+    writeln("In copy init");
+    this.x = other.x + 1;
+  }
+}
+
+proc =(ref lhs: R, rhs: R) {
+  writeln("In assignment");
+  lhs.x = rhs.x + 5;
+}
+
+proc foo(args...) {
+  for a in args do
+    writeln(a);
+}
+
+var tup = (1, 2.3, "hi", new R());
+
+foo(1, 2.3, "hi", new R());

--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.compopts
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.compopts
@@ -1,0 +1,1 @@
+--baseline

--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.future
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.future
@@ -1,0 +1,3 @@
+bug: loops over varargs-created heterogeneous tuples fail with --baseline
+
+Specifically, the string component seems to cause problems.

--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.good
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.good
@@ -1,0 +1,5 @@
+In copy init
+1
+2.3
+hi
+(x = 42)


### PR DESCRIPTION
This adds a future showing that a loop over a heterogeneous varargs
tuple containing a string fails when compiled with --baseline, where
our normal tests of loops over heterogeneous tuples don't.  This
showed up when the procedures.chpl primer was rewritten to use that
idiom under nightly --baseline testing.  So here, I'm suppressing that
test for --baseline along with filing the future.
