### PR TITLE
Unstable warning for captures of iterators, warning of past / future diffs

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4256,10 +4256,13 @@ module ChapelArray {
     if shapeful && i < r.size then
       r = r #i;
 
-    if !shapeful then
+    if !shapeful then {
       // return 1..0 (the empty range value) if the size is 0; 0.. #i otherwise
       // (unless capturedIteratorLowBound is overridden)
       r = if i == 0 then 1..0 else capturedIteratorLowBound .. #i;
+      if chpl_warnUnstable then
+        compilerWarning("capturing expressions like this into inferred-type variables used to result in a 1D 1-based array, but now results in a 1D 0-based array.  In the future, it _may_ result in capturing the iterator expression itself.  Use an explicit type if this concerns you.");
+    }
 
     pragma "insert auto destroy"
     var D = { r };


### PR DESCRIPTION
This was a good idea but causes too much noise in standard/internal/distribution modules unfortunately.  To quiet it down safely/sanely, we'd really want `var X: [0..] = ...;` (or to have the compiler involved, but I'm not crazy about going down that road).