### PR TITLE
Workaround a --verify error for DistributedFFT

### DIFF
--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -434,7 +434,7 @@ prototype module DistributedFFT {
 
     // See if we already have wisdom for this plan. If we do, we avoid an
     // allocation.
-    var arr: c_ptr(arrType) = c_nil;
+    var arr: c_ptr(arrType);
     var plan = new FFTWplan(ftType, rank, nnp, howmany, arr,
                             nnp, stride, idist,
                             arr, nnp, stride, idist,


### PR DESCRIPTION
We just added ft_transposed_comp_only.chpl and it is failing under
verify with:

```
./DistributedFFT.chpl:405: In function 'setupPlan':
./DistributedFFT.chpl:438: internal error: actual formal type mismatch for init: c_void_ptr != c_ptr(complex(128)) [main/checks.cpp:890]
```

Where we're doing `var arr: c_ptr(arrType) = c_nil;` and passing that to
the FFTWplan init that's expecting a `c_ptr(arrType)`. However, that
c_nil is getting copy-propagated and we end up passing in a c_void_ptr
c_nil, which is fine as far as the backend is concerned, but fails the
exact type match required by `--verify`. I'm not sure if this is a bug
in copy propagation, or if the verify check is too aggressive. So far
I'm having trouble coming up with a smaller reproducer, but dropping the
`= c_nil` and relying on the default nil seems to work to quiet the
failure.