### PR TITLE
Update multilocale exportBytes test for 0-based bytes indexing

### DIFF
--- a/test/interop/python/multilocale/chapelBytes/exportBytes.chpl
+++ b/test/interop/python/multilocale/chapelBytes/exportBytes.chpl
@@ -1,9 +1,9 @@
 use Bytes;
 
 export proc getFirstNullBytePos(in b: bytes): int {
-  for i in 1..b.size do
+  for i in 0..<b.size do
     if b[i] == 0x00 then
-      return (i - 1);
+      return i;
   return -1;
 }
 


### PR DESCRIPTION
I had missed this one and...strangely...it was hanging.  Thanks to @ronawho for pointing it out.