### PR TITLE
Add __attribute__((printf)) to handleError, adjust callsites

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -823,7 +823,7 @@ static void checkNumArgsErrors(AggregateType* at, CallExpr* call, const char* ca
     USR_PRINT(call, "type specifier did not match: %s", typeSignature);
     USR_PRINT(call, "type was specified with %d arguments", numArgs);
     const char* plural = genericFields.size() > 1 ? "fields" : "field";
-    USR_PRINT(at, "but type '%s' only has %d generic %s", symbol->name, genericFields.size(), plural);
+    USR_PRINT(at, "but type '%s' only has %lu generic %s", symbol->name, genericFields.size(), plural);
     USR_STOP();
   }
 }

--- a/compiler/AST/AstPrintDocs.cpp
+++ b/compiler/AST/AstPrintDocs.cpp
@@ -120,8 +120,8 @@ bool AstPrintDocs::enterModSym(ModuleSymbol* node) {
     static const int dirPerms = S_IRWXU | S_IRWXG | S_IRWXO;
     int result = mkdir(this->pathWithoutPostfix.c_str(), dirPerms);
     if (result != 0 && errno != 0 && errno != EEXIST) {
-      USR_FATAL(astr("Failed to create directory: ", this->pathWithoutPostfix.c_str(),
-                   " due to: ", strerror(errno)));
+      USR_FATAL("Failed to create directory: %s due to: %s",
+                this->pathWithoutPostfix.c_str(), strerror(errno));
     }
 
     std::string parent = "";

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -250,7 +250,7 @@ void computeNonvirtualCallSites(FnSymbol* fn) {
       } else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
         FnSymbol* vFn = toFnSymbol(toSymExpr(call->get(1))->symbol());
         if (vFn == fn) {
-          INT_FATAL(call, "unexpected case calling %d", fn->name);
+          INT_FATAL(call, "unexpected case calling %s", fn->name);
         }
       }
     }

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -91,9 +91,9 @@ const char* cleanFilename(const char*    name);
 
 void        setupError(const char* subdir, const char* filename, int lineno, int tag);
 
-void        handleError(const char* fmt, ...);
-void        handleError(const BaseAST* ast, const char* fmt, ...);
-void        handleError(astlocT astloc, const char* fmt, ...);
+void        handleError(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void        handleError(const BaseAST* ast, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
+void        handleError(astlocT astloc, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 
 void        exitIfFatalErrorsEncountered();
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1453,11 +1453,7 @@ static void checkMLDebugAndLibmode(void) {
 
   if (!strcmp(CHPL_COMM, "none")) {
     fMultiLocaleLibraryDebug = false;
-
-    const char* warning =
-        "Compiling a single locale library because CHPL_COMM is none.";
-
-    USR_WARN(warning);
+    USR_WARN("Compiling a single locale library because CHPL_COMM is none.");
   }
 
   return;

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -262,8 +262,8 @@ static void makeDir(const char* dirpath) {
   static const int dirPerms = S_IRWXU | S_IRWXG | S_IRWXO;
   int result = mkdir(dirpath, dirPerms);
   if (result != 0 && errno != 0 && errno != EEXIST) {
-    USR_FATAL(astr("Failed to create directory: ", dirpath,
-                   " due to: ", strerror(errno)));
+    USR_FATAL("Failed to create directory: %s due to: %s",
+              dirpath, strerror(errno));
   }
 }
 
@@ -366,8 +366,7 @@ static char * checkProjectVersion(char * projectVersion) {
   if(check) {
     return projectVersion;
   } else {
-    USR_FATAL(astr("Invalid version format: ", projectVersion,
-                    " due to: ", error));
+    USR_FATAL("Invalid version format: %s due to: %s", projectVersion, error);
   }
   return NULL;
 }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -477,7 +477,7 @@ static bool canForallStmtThrow(ForallStmt* fs) {
       if (canBlockStmtThrow(DB))
         // Error handling for the deinit blocks may be unimplemented.
         USR_FATAL_CONT(DB, "the deinitializer of the task-private variable '%s'"
-                       " throws - this is currently not supported");
+                       " throws - this is currently not supported", svar->name);
     }
   }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1445,7 +1445,7 @@ static void printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym,
                   another->name, nameUsed, renameLoc->filename,
                   renameLoc->lineno);
       } else {
-        USR_PRINT(another, "also defined here", another->name);
+        USR_PRINT(another, "also defined here");
       }
     }
   }

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -462,8 +462,8 @@ static void checkSplitInitOrder(CondStmt* cond,
         elseMsg += "]";
       }
     }
-    USR_PRINT(cond->thenStmt, thenMsg.c_str());
-    USR_PRINT(cond->elseStmt, elseMsg.c_str());
+    USR_PRINT(cond->thenStmt, "%s", thenMsg.c_str());
+    USR_PRINT(cond->elseStmt, "%s", elseMsg.c_str());
   }
 }
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -108,9 +108,9 @@ explainInstantiation(FnSymbol* fn) {
   }
   sprintf(msg+len, ")");
   if (callStack.n) {
-    USR_PRINT(callStack.v[callStack.n-1], msg);
+    USR_PRINT(callStack.v[callStack.n-1], "%s", msg);
   } else {
-    USR_PRINT(fn, msg);
+    USR_PRINT(fn, "%s", msg);
   }
 }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -767,7 +767,7 @@ static void makeActualsVector(const CallInfo&          info,
       // Fail if no matching formal is found.
       if (!match) {
         INT_FATAL(call,
-                  "Compilation should have already ensured this action ",
+                  "Compilation should have already ensured this action "
                   "would be valid");
       }
     }

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -2507,16 +2507,12 @@ static void emitError(Expr* inExpr,
                       Lifetime relevantLifetime,
                       LifetimeState* lifetimes) {
 
-  char buf[256];
-
   BaseAST* place = findUserPlace(inExpr);
 
   if (relevantSymbol && !relevantSymbol->hasFlag(FLAG_TEMP)) {
-    snprintf(buf, sizeof(buf), "%s %s %s", msg1, relevantSymbol->name, msg2);
-    USR_FATAL_CONT(place, buf);
+    USR_FATAL_CONT(place, "%s %s %s", msg1, relevantSymbol->name, msg2);
   } else {
-    snprintf(buf, sizeof(buf), "%s %s", msg1, msg2);
-    USR_FATAL_CONT(place, buf);
+    USR_FATAL_CONT(place, "%s %s", msg1, msg2);
   }
 
   Symbol* fromSym = relevantLifetime.fromSymbolScope;

--- a/compiler/resolution/nilChecking.cpp
+++ b/compiler/resolution/nilChecking.cpp
@@ -257,7 +257,7 @@ static void issueNilError(const char* message, Expr* ref,
   if (printsSameLocationAsLastError(ref))
     return;
 
-  USR_FATAL_CONT(ref, message);
+  USR_FATAL_CONT(ref, "%s", message);
 
   Symbol* v  = var;
   if (referent != NULL) {

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2186,14 +2186,14 @@ static Expr* resolveTupleIndexing(CallExpr* call, Symbol* baseVar) {
   if (get_int(call->get(3), &index)) {
     sprintf(field, "x%" PRId64, index);
     if (index < 0 || index >= baseType->fields.length-1) {
-      USR_FATAL_CONT(call, "tuple index %ld is out of bounds", index);
+      USR_FATAL_CONT(call, "tuple index %" PRId64 " is out of bounds", index);
       if (index < 0) zero_error = true;
       error = true;
     }
   } else if (get_uint(call->get(3), &uindex)) {
     sprintf(field, "x%" PRIu64, uindex);
     if (uindex >= (unsigned long)baseType->fields.length-1) {
-      USR_FATAL_CONT(call, "tuple index %lu is out of bounds", uindex);
+      USR_FATAL_CONT(call, "tuple index %" PRIu64 " is out of bounds", uindex);
       error = true;
     }
   } else {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -310,13 +310,8 @@ FILE* openfile(const char* filename,
   FILE* newfile = fopen(filename, mode);
 
   if (newfile == NULL) {
-    const char* errorstr = "opening ";
-    const char* errormsg = astr(errorstr,
-                                filename, ": ",
-                                strerror(errno));
-
     if (fatal == true) {
-      USR_FATAL(errormsg);
+      USR_FATAL("opening %s: %s", filename, strerror(errno));
     }
   }
 
@@ -326,10 +321,7 @@ FILE* openfile(const char* filename,
 
 void closefile(FILE* thefile) {
   if (fclose(thefile) != 0) {
-    const char* errorstr = "closing file: ";
-    const char* errormsg = astr(errorstr, strerror(errno));
-
-    USR_FATAL(errormsg);
+    USR_FATAL("closing file: %s", strerror(errno));
   }
 }
 
@@ -441,17 +433,14 @@ void addSourceFiles(int numNewFilenames, const char* filename[]) {
 
   for (int i = 0; i < numNewFilenames; i++) {
     if (!isRecognizedSource(filename[i])) {
-      USR_FATAL(astr("file '",
-                     filename[i],
-                     "' does not have a recognized suffix"));
+      USR_FATAL("file '%s' does not have a recognized suffix", filename[i]);
     }
     // WE SHOULDN"T TRY TO OPEN .h files, just .c and .chpl and .o
     if (!isCHeader(filename[i])) {
       FILE* testfile = openInputFile(filename[i]);
       if (fscanf(testfile, "%c", &achar) != 1) {
-        USR_FATAL(astr("source file '",
-                       filename[i],
-                       "' is either empty or a directory"));
+        USR_FATAL("source file '%s' is either empty or a directory",
+                  filename[i]);
       }
 
       closeInputFile(testfile);
@@ -543,8 +532,8 @@ const char* createDebuggerFile(const char* debugger, int argc, char* argv[]) {
   } else if (strcmp(debugger, "lldb") == 0) {
     fprintf(dbgfile, "settings set -- target.run-args");
   } else {
-      INT_FATAL(astr("createDebuggerFile doesn't know how to handle the given "
-                     "debugger: '", debugger, "'"));
+      INT_FATAL("createDebuggerFile doesn't know how to handle the given "
+                "debugger: '%s'", debugger);
   }
   for (i=1; i<argc; i++) {
     if (strcmp(argv[i], astr("--", debugger)) != 0) {
@@ -598,13 +587,11 @@ std::string runCommand(std::string& command) {
   // Run arbitrary command and return result
   char buffer[256];
   std::string result = "";
-  std::string error = "";
 
   // Call command
   FILE* pipe = popen(command.c_str(), "r");
   if (!pipe) {
-    error = "running " + command;
-    USR_FATAL(error.c_str());
+    USR_FATAL("running %s", command.c_str());
   }
 
   // Read output of command into result via buffer
@@ -615,8 +602,7 @@ std::string runCommand(std::string& command) {
   }
 
   if (pclose(pipe)) {
-    error = command + " did not run successfully";
-    USR_FATAL(error.c_str());
+    USR_FATAL("%s did not run successfully", command.c_str());
   }
 
   return result;

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -52,7 +52,7 @@ int mysystem(const char* command,
     USR_FATAL("system() fork failed: %s", strerror(errno));
 
   } else if (status != 0 && ignoreStatus == false) {
-    USR_FATAL(description);
+    USR_FATAL("%s", description);
   }
 
   return status;


### PR DESCRIPTION
Follow up #15441 by setting __attribute__((printf)) on handleError(),
and cleaning up the INT_FATAL/USR_FATAL calls to adapt.  This will
allow g++ to complain about mismatched args and format strings.


This fixes four actual bugs.  None of the tests trigger them:

Two are internal errors: one in astutil.cpp computeNonvirtualCallSites()

```diff
-          INT_FATAL(call, "unexpected case calling %d", fn->name);
+          INT_FATAL(call, "unexpected case calling %s", fn->name);
```

The other in initializerResolution.cpp makeActualsVector()

```diff
-                  "Compilation should have already ensured this action ",
+                  "Compilation should have already ensured this action "
                   "would be valid");
```

The third's in errorHandling.cpp canForallStmtThrow():

```diff
         // Error handling for the deinit blocks may be unimplemented.
         USR_FATAL_CONT(DB, "the deinitializer of the task-private variable '%s'"
-                       " throws - this is currently not supported");
+                       " throws - this is currently not supported", svar->name);
```

But deinitializers can't throw to start with, which is caught before
this error is considered.

The fourth is AggregateType.cpp checkNumArgsErrors():

```diff
     USR_PRINT(call, "type specifier did not match: %s", typeSignature);
     USR_PRINT(call, "type was specified with %d arguments", numArgs);
     const char* plural = genericFields.size() > 1 ? "fields" : "field";
-    USR_PRINT(at, "but type '%s' only has %d generic %s", symbol->name, genericFields.size(), plural);
+    USR_PRINT(at, "but type '%s' only has %lu generic %s", symbol->name, genericFields.size(), plural);
     USR_STOP();
```

Which would be a problem if a record contained at least `2**32` generic
fields, and someone declared it with a static type containing at least
`2**32 + 1` args.  (It would take at least 12 GB of source code to
define such a record and declare a variable with the explicit type.)

The other changes are because gcc doesn't like the condition:

```shell
  format not a string literal and no format arguments [-Wformat-security]
```

(e.g., `USR_PRINT(msg)`)

Where a string was constructed in the
preceding lines just to pass to the `USR/INT_FATAL`, I opted to have the
`USR/INT_FATAL` call construct the string.  (I also didn't think
`INT_FATAL(astr(...)`) made sense, so I removed those in lines I was
modifying anyway.)

Otherwise, I used `USR_PRINT("%s", msg)`.

I also checked that the error fixed by #15441 is caught.