### PR TITLE
Fix typos

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -807,7 +807,7 @@ ModuleSymbol* parseIncludedSubmodule(const char* name) {
   // save parser global variables to restore after parsing the submodule
   BlockStmt*  s_yyblock = yyblock;
   const char* s_yyfilename = yyfilename;
-  int         s_yystarlineno = yystartlineno;
+  int         s_yystartlineno = yystartlineno;
   ModTag      s_currentModuleType = currentModuleType;
   const char* s_currentModuleName = currentModuleName;
   int         s_chplLineno = chplLineno;
@@ -836,7 +836,7 @@ ModuleSymbol* parseIncludedSubmodule(const char* name) {
   // restore parser global variables
   yyblock = s_yyblock;
   yyfilename = s_yyfilename;
-  yystartlineno = s_yystarlineno;
+  yystartlineno = s_yystartlineno;
   currentModuleType = s_currentModuleType;
   currentModuleName = s_currentModuleName;
   chplLineno = s_chplLineno;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -545,7 +545,7 @@ static const char* getNameFrom(Expr* e) {
 
 // Finds the first name (other than this/super) in the Expr
 //   name is that name
-//   call is the call contaning the name on the left branch or NULL
+//   call is the call containing the name on the left branch or NULL
 //     (which is the call requiring further processing)
 //   scope is the scope indicated by any this. / super. or NULL
 void ResolveScope::firstImportedModuleName(Expr* expr,

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -320,7 +320,7 @@ within it available for reference within a given scope.  For top-level modules,
 an ``import`` or ``use`` statement is required before referring to the module's
 name or the symbols it contains within a given lexical scope.
 
-Import statements can also rename the set of symbols that it makes available
+Import statements can also rename the set of symbols that they make available
 within the scope.  For further information about ``import`` statements, see
 :ref:`The_Import_Statement`.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -421,7 +421,7 @@ argument is initialized to its default value if one is supplied, or to
 its type’s default value otherwise. The formal argument can be modified
 within the function.
 
-The assigment implementing the ``out`` intent is a candidate for
+The assignment implementing the ``out`` intent is a candidate for
 :ref:`Split_Initialization`. As a result, an actual argument might be
 initialized by a call passing the actual by ``out`` intent.
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -827,7 +827,7 @@ keyword.  This new name will be usable from the scope of the use in place of the
 old name.  This new name does not affect uses or imports of that module from
 other contexts.
 
-Use statements may be explicitly delared ``public`` or ``private``.
+Use statements may be explicitly declared ``public`` or ``private``.
 By default, uses are ``private``.  Making a use ``public`` causes its
 symbols to be transitively visible: if module A uses module B, and
 module B contains a public use of a module or enumerated type C, then
@@ -1061,7 +1061,7 @@ scope has no effect on its behavior.  If a scope includes multiple ``import``
 statements, or a combination of ``import`` and ``use`` statements, then the
 newly-visible names are inserted into a common enclosing scope.
 
-An error is signalled if multiple public module-level symbols would be inserted
+An error is signaled if multiple public module-level symbols would be inserted
 into this enclosing scope with the same name, and that name is referenced by
 other statements in the same scope as the import.
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -759,12 +759,12 @@ capture elements.
 
 Tuple expressions or tuple arguments with default argument intent are two
 examples of referential tuples. They store elements by reference where it
-makes sense to do so. Referential tuples may be viewed as analagous to a
+makes sense to do so. Referential tuples may be viewed as analogous to a
 group of function arguments that each have default argument intent.
 
 Tuple variables or tuple arguments with ``in`` intent are two examples of
 value tuples. They store all elements by value and may store elements copy
-initialized from another tuple. Value tuples may be viewed as analagous to
+initialized from another tuple. Value tuples may be viewed as analogous to
 a group of function arguments that each have the ``in`` intent.
 
 In short, some or all of the elements of a referential tuple may be

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -667,7 +667,7 @@ The compiler adds temporary local variables to contain the result of
 nested call expressions. ``g()`` in the statement ``f(g());`` is an
 example of a nested call expression. If the containing statement is an
 initialization expression for some variable, such as ``var x = f(g());``,
-then the tempory local variables for that statement are deinitialized at
+then the temporary local variables for that statement are deinitialized at
 the end of the containing block. Otherwise, the temporary local variables
 are deinitialized at the end of the containing statement.
 
@@ -975,7 +975,7 @@ Copy elision does not apply:
  * when the copy statement is in one branch of a conditional but not in
    the other, or when the other branch does not always ``return`` or
    ``throw``.
- * when the copy statament is in a ``try`` or ``try!`` block which has
+ * when the copy statement is in a ``try`` or ``try!`` block which has
    ``catch`` clauses that mention the variable or which has ``catch``
    clauses that do not always ``throw`` or ``return``.
 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -567,7 +567,7 @@ module ChapelRange {
     if ! isBoundedRange(this) then
       compilerError("'size' is not defined on unbounded ranges");
 
-    // assumes alignedHigh/alignLow always work, even for an empty range
+    // assumes alignedHigh/alignedLow always work, even for an empty range
     const ah = this.alignedHighAsInt,
           al = this.alignedLowAsInt;
     if al > ah then return 0: intIdxType;

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -580,7 +580,7 @@ chameneos-redux:
   10/31/18:
     - Enable parallelism for shape-ful expressions over ranges (#11501)
   03/20/20:
-    - Fix up chameneous benchmarks (#15250)
+    - Fix up chameneos benchmarks (#15250)
 
 CoMD:
   07/26/17:


### PR DESCRIPTION
Fix typos in ChapelRange.chpl, parser.cpp, ResolveScope.cpp,
the spec, and ANNOTATIONS.yaml
