### PR TITLE
Fix off-by-one error in LCALS due to lists switching to 0-based indexing

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -11,12 +11,10 @@ module LCALSDataTypes {
     var A: list(eltType);
 
     //
-    // Previously, this vector used an array with a domain that started at 0,
-    // but list indexes starting at 1. So we should add 1 to the index to
-    // prevent a logical error.
+    // This vector supports 0-based indexing.
     //
     proc this(i: int) ref {
-      return A[i + 1];
+      return A[i];
     }
     proc push_back(e: eltType) {
       A.append(e);


### PR DESCRIPTION
This fixes an error pointed out by @ronawho in which LCALS testing seemed to complete instantaneously this weekend.
