### PR TITLE
Only try to build compiler once with `make mason`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,7 @@ chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
 	cd tools/chplvis && $(MAKE) install
 
-mason: comprt chpldoc mason-no-chpldoc FORCE
-
-mason-no-chpldoc: comprt FORCE
+mason: chpldoc FORCE
 	cd tools/mason && $(MAKE) && $(MAKE) install
 
 c2chapel: FORCE

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
 	cd tools/chplvis && $(MAKE) install
 
-mason: chpldoc FORCE
+mason: chpldoc notcompiler FORCE
 	cd tools/mason && $(MAKE) && $(MAKE) install
 
 c2chapel: FORCE


### PR DESCRIPTION
Have `make mason` only depend on `chpldoc` and `notcompiler`, which should attempt to build the dependencies exactly once.

Closes https://github.com/chapel-lang/chapel/issues/15430