### PR TITLE
Add "import" to our syntax highlighters

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -87,7 +87,7 @@ not the type face."
   chpl '("as"
          "const" "config"
          "except" "export" "extern"
-         "inline" "iter"
+         "import" "inline" "iter"
          "module"
          "only" "override"
          "param" "private" "proc" "public"
@@ -152,7 +152,7 @@ be mutually exclusive with `c-type-list-kwds'.
 
 Note: Use `c-typeless-decl-kwds' for keywords followed by a function
 or variable identifier (that's being defined)."
-  chpl '("as" "except" "only" "use"))
+  chpl '("as" "except" "import" "only" "use"))
 
 (c-lang-defconst c-block-stmt-1-kwds
   "Statement keywords followed directly by a substatement."

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -18,7 +18,7 @@ Keywords={
          "delete", "dmapped", "do",
          "else", "enum", "except", "export", "extern",
          "false", "for", "forall",
-         "if", "in", "index", "inline", "inout", "iter",
+         "if", "import", "in", "index", "inline", "inout", "iter",
          "label", "lambda", "let", "lifetime", "local",
          "module",
          "new", "nil", "noinit",

--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -24,7 +24,7 @@ number = '\<([[:digit:]]([[:digit:]]|_)*)\>'
 string delim "\"" "\"" escape "\\"
 
 # double-quotes mean that parens are interpreted literally
-keyword = "align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|config|const|continue||deinit|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|init|init=|inline|inout|iter|label|lambda|let|lifetime|local|locale|module|new|nil|noinit|none|on|only|otherwise|out|override|owned|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|shared|sparse|subdomain|sync|then|these|this|throw|throws|true|try|type|union|unmanaged|use|var|when|where|while|with|yield|zip"
+keyword = "align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|config|const|continue||deinit|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|import|in|index|init|init=|inline|inout|iter|label|lambda|let|lifetime|local|locale|module|new|nil|noinit|none|on|only|otherwise|out|override|owned|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|shared|sparse|subdomain|sync|then|these|this|throw|throws|true|try|type|union|unmanaged|use|var|when|where|while|with|yield|zip"
 
 
 # double-quotes mean that parens are interpreted literally

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -258,7 +258,7 @@ endif
 
 " Chapel extentions
 syn keyword chplStatement	break return continue compilerWarning delete
-syn keyword chplStatement	new delete this these use except only require
+syn keyword chplStatement	new delete this these use except only require import
 syn keyword chplStatement	noinit init
 syn keyword chplStatement	as module yield compilerError zip
 syn keyword chplIntent		param type in out inout ref


### PR DESCRIPTION
Covers:
- emacs
- vim
- highlight (used for the Computer Language Benchmarks Game)
- source-highlight

The following require updates to separate repos:
- pygments (someone else owns)
- tmbundle (we own)

And the latex directory led to a dead-end.

I tested three of these - I did not install source-highlight to test it but I have no
reason to believe it will not work.