### PR TITLE
Decrease qio_test problem size under cygwin

### DIFF
--- a/test/io/ferguson/ctests/qio_test.compopts
+++ b/test/io/ferguson/ctests/qio_test.compopts
@@ -1,2 +1,11 @@
--DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/qio_error.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread
+#!/usr/bin/env python
 
+import os
+
+compopts = "-DCHPL_RT_UNIT_TEST $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/qio_error.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread"
+
+if (os.getenv('CHPL_TEST_VGRND_EXE') == 'on' or
+    'cygwin' in os.getenv('CHPL_HOST_PLATFORM', '')):
+    compopts = '-DLIMIT_TESTING ' + compopts
+
+print(compopts)

--- a/test/io/ferguson/ctests/qio_test.skipif
+++ b/test/io/ferguson/ctests/qio_test.skipif
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-"""For valgrind, see qio_test.valgrind.test.c. Skip test when atomics are
-implemented with locks and tasking layer is not fifo.
+"""Skip test when atomics are implemented with locks and tasking layer is not
+fifo.
 
 This test requires locks, but the appropriate header files are not available in
 non-fifo tasking layers due to how compile line is constructed. Skip the test
@@ -10,6 +10,4 @@ for now.
 
 import os
 
-print(os.getenv('CHPL_TEST_VGRND_EXE') == 'on' or
-      (os.getenv('CHPL_ATOMICS') == 'locks' and
-       os.getenv('CHPL_TASKS') != 'fifo'))
+print(os.getenv('CHPL_ATOMICS') == 'locks' and os.getenv('CHPL_TASKS') != 'fifo')

--- a/test/io/ferguson/ctests/qio_test.test.c
+++ b/test/io/ferguson/ctests/qio_test.test.c
@@ -3,10 +3,10 @@
 #include <stdio.h>
 
 
-#ifdef CHPL_VALGRIND_TEST
-int valgrind = 1;
+#ifdef LIMIT_TESTING
+int limit_testing = 1;
 #else
-int valgrind = 0;
+int limit_testing = 0;
 #endif
 
 int verbose = 0;
@@ -319,8 +319,8 @@ void check_channels(void)
   int nhints = sizeof(hints)/sizeof(qio_hint_t);
   int file_hint, ch_hint;
 
-  if( valgrind ) nlens = 4;
-  if( valgrind ) nchunkszs = 4;
+  if( limit_testing ) nlens = 4;
+  if( limit_testing ) nchunkszs = 4;
 
   for( file_hint = 0; file_hint < nhints; file_hint++ ) {
     for( ch_hint = 0; ch_hint < nhints; ch_hint++ ) {
@@ -338,9 +338,9 @@ void check_channels(void)
         }
       }
     }
-    // only test default chanel hints with valgrind
+    // only test default chanel hints with limit_testing
     // moving over file hints should still give us good coverage.
-    if( valgrind ) break;
+    if( limit_testing ) break;
   }
 
   // check with reopen/seek variations while limiting other configurations

--- a/test/io/ferguson/ctests/qio_test.timeout
+++ b/test/io/ferguson/ctests/qio_test.timeout
@@ -1,2 +1,1 @@
-# takes 10m30s on cygwin
 900

--- a/test/io/ferguson/ctests/qio_test.valgrind.compopts
+++ b/test/io/ferguson/ctests/qio_test.valgrind.compopts
@@ -1,2 +1,0 @@
--DCHPL_VALGRIND_TEST -DCHPL_RT_UNIT_TEST  $CHPL_HOME/runtime/src/qio/qio.c $CHPL_HOME/runtime/src/qio/qbuffer.c $CHPL_HOME/runtime/src/qio/sys.c $CHPL_HOME/runtime/src/qio/sys_xsi_strerror_r.c $CHPL_HOME/runtime/src/qio/qio_error.c $CHPL_HOME/runtime/src/qio/deque.c -lpthread
-

--- a/test/io/ferguson/ctests/qio_test.valgrind.good
+++ b/test/io/ferguson/ctests/qio_test.valgrind.good
@@ -1,1 +1,0 @@
-qio_test PASS

--- a/test/io/ferguson/ctests/qio_test.valgrind.skipif
+++ b/test/io/ferguson/ctests/qio_test.valgrind.skipif
@@ -1,3 +1,0 @@
-# Use this test only under valgrind.
-# Otherwise use its origin, qio_test.test.c
-CHPL_TEST_VGRND_EXE != on

--- a/test/io/ferguson/ctests/qio_test.valgrind.test.c
+++ b/test/io/ferguson/ctests/qio_test.valgrind.test.c
@@ -1,4 +1,0 @@
-// This is a duplicate of qio_test.test.c
-// with a longer timeout for valgrind.
-
-#include "qio_test.test.c"


### PR DESCRIPTION
This test has always been slow under cygwin (it had a 900 second
timeout), but it has gotten even slower recently. To speed things up,
use the smaller problem size that valgrind was using. Use an executable
compopts to simplify setting the lower problem size instead of cloning
the test.