### PR TITLE
Change getField*() numbering from 1-based to 0-based

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -648,7 +648,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     if (name == NULL) {
       USR_FATAL(call,
                 "'%d' is not a valid field number for %s",
-                fieldNum,
+                fieldNum-1,
                 toString(classType));
     }
 
@@ -720,7 +720,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
       // specified.  This is the user's error.
       USR_FATAL(call,
                 "'%d' is not a valid field number for %s",
-                fieldNum,
+                fieldNum-1,
                 toString(classType));
     }
 

--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -165,7 +165,7 @@ class RecordReader {
     // data is very nice... (but hey, the programmer wasn't willing to give us a
     // regex..)
     var accum: string = "\\s*";
-    for param n in 1..num_fields {
+    for param n in 0..<num_fields {
       accum = accum + getFieldName(t, n) + "\\s*(.*?)" + "\\s*";
     }
     return accum;
@@ -232,11 +232,11 @@ class RecordReader {
         // Then break and dont return any record
         return (rec, false);
       }
-      for param n in 1..num_fields {
+      for param n in 0..<num_fields {
         var tmp = getField(rec, n);
         var s: string;
         ref dst = getFieldRef(rec, n);
-        myReader.extractMatch(m(n), s);
+        myReader.extractMatch(m(n+1), s);
         if s == "" then
           dst = tmp;
         else if tmp.type == string then

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -966,10 +966,10 @@ module ZMQ {
       on classRef.home {
         var copy = data;
         param N = numFields(T);
-        for param i in 1..(N-1) do
+        for param i in 0..<(N-1) do
           try send(getField(copy,i), ZMQ_SNDMORE | flags);
 
-        try send(getField(copy,N), flags);
+        try send(getField(copy,N-1), flags);
       }
     }
 
@@ -1064,7 +1064,7 @@ module ZMQ {
       var ret: T;
       on classRef.home {
         var data: T;
-        for param i in 1..numFields(T) do
+        for param i in 0..<numFields(T) do
           getFieldRef(data,i) = try recv(getField(data,i).type);
         ret = data;
       }

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -238,7 +238,7 @@ module CommDiagnostics
 
       var first = true;
       c <~> "(";
-      for param i in 1..numFields(chpl_commDiagnostics) {
+      for param i in 0..<numFields(chpl_commDiagnostics) {
         param name = getFieldName(this.type, i);
         const val = getField(this, i);
         if val != 0 {

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -51,51 +51,51 @@ proc numFields(type t) param : int
   return __primitive("num fields", checkQueryT(t));
 
 /* Get the name of the ith field in a class or record.
-   Causes a compilation error if `i` is not in 1..numFields(t).
+   Causes a compilation error if `i` is not in 0..<numFields(t).
 
    :arg t: a class or record type
    :arg i: which field to get the name of
    :returns: the name of the field, as a param string
  */
 proc getFieldName(type t, param i:int) param : string
-  return __primitive("field num to name", checkQueryT(t), i);
+  return __primitive("field num to name", checkQueryT(t), i+1);
 
 // Note, since this version has a where clause, it is preferred
 // over the const ref one.
 /* Get the ith field in a class or record. When the ith field is
    a `param` this overload will be chosen to return a `param`.
-   Causes a compilation error if `i` is not in 1..numFields(t).
+   Causes a compilation error if `i` is not in 0..<numFields(t).
 
    :arg x: a class or record
    :arg i: which field to get
    :returns: the `param` that field represents
 */
 proc getField(const ref x:?t, param i: int) param
-  where i > 0 && i <= numFields(t) &&
-        isParam(__primitive("field by num", x, i)) {
+  where i >= 0 && i < numFields(t) &&
+        isParam(__primitive("field by num", x, i+1)) {
 
-  return __primitive("field by num", x, i);
+  return __primitive("field by num", x, i+1);
 }
 
 // Note, since this version has a where clause, it is preferred
 // over the const ref one.
 /* Get the ith field in a class or record. When the ith field is
    a `type` variable this overload will be chosen to return a type.
-   Causes a compilation error if `i` is not in 1..numFields(t).
+   Causes a compilation error if `i` is not in 0..<numFields(t).
 
    :arg x: a class or record
    :arg i: which field to get
    :returns: the type that field represents
 */
 proc getField(const ref x:?t, param i: int) type
-  where i > 0 && i <= numFields(t) &&
-        isType(__primitive("field by num", x, i)) {
+  where i >= 0 && i < numFields(t) &&
+        isType(__primitive("field by num", x, i+1)) {
 
-  return __primitive("field by num", x, i);
+  return __primitive("field by num", x, i+1);
 }
 
 /* Get the ith field in a class or record.
-   Causes a compilation error if `i` is not in 1..numFields(t).
+   Causes a compilation error if `i` is not in 0..<numFields(t).
 
    :arg x: a class or record
    :arg i: which field to get
@@ -104,7 +104,7 @@ proc getField(const ref x:?t, param i: int) type
 pragma "unsafe"
 inline
 proc getField(const ref x:?t, param i:int) const ref
-  return __primitive("field by num", x, i);
+  return __primitive("field by num", x, i+1);
 
 /* Get a field in a class or record by name. When the named
    field is a `param` this overload will be chosen to return a
@@ -116,7 +116,7 @@ proc getField(const ref x:?t, param i:int) const ref
    :returns: the `param` that field represents
  */
 proc getField(const ref x:?t, param s: string) param
-  where getFieldIndex(t, s) != 0 && isParam(getField(x, getFieldIndex(t, s))) {
+  where getFieldIndex(t, s) != -1 && isParam(getField(x, getFieldIndex(t, s))) {
 
   return getField(x, getFieldIndex(t, s));
 }
@@ -131,7 +131,7 @@ proc getField(const ref x:?t, param s: string) param
    :returns: the type that field represents
  */
 proc getField(const ref x:?t, param s: string) type
-  where getFieldIndex(t, s) != 0 && isType(getField(x, getFieldIndex(t, s))) {
+  where getFieldIndex(t, s) != -1 && isType(getField(x, getFieldIndex(t, s))) {
 
   return getField(x, getFieldIndex(t, s));
 }
@@ -192,7 +192,7 @@ proc getImplementationField(const ref x:?t, param i:int) const ref {
 }
 
 /* Get a mutable ref to the ith field in a class or record.
-   Causes a compilation error if `i` is not in 1..numFields(t)
+   Causes a compilation error if `i` is not in 0..<numFields(t)
    or if the argument is not mutable.
 
    :arg x: a class or record
@@ -202,7 +202,7 @@ proc getImplementationField(const ref x:?t, param i:int) const ref {
 pragma "unsafe"
 inline
 proc getFieldRef(ref x:?t, param i:int) ref
-  return __primitive("field by num", x, i);
+  return __primitive("field by num", x, i+1);
 
 /* Get a mutable ref to a field in a class or record by name.
    Will generate a compilation error if a field with that name
@@ -220,15 +220,15 @@ proc getFieldRef(ref x:?t, param s:string) ref {
   return __primitive("field by num", x, i);
 }
 
-/* Get a field index in a class or record, or 0 if
+/* Get a field index in a class or record, or -1 if
    the field is not found.
 
    :arg t: a class or record type
    :arg s: the name of a field
-   :returns: an index `i` usable in getField, or 0 if the field was not found.
+   :returns: an index `i` usable in getField, or -1 if the field was not found.
  */
 proc getFieldIndex(type t, param s:string) param : int
-  return __primitive("field name to num", checkQueryT(t), s);
+  return __primitive("field name to num", checkQueryT(t), s)-1;
 
 /* Returns `true` if a class or record has a field named `s`,
    or `false` otherwise.
@@ -239,7 +239,7 @@ proc getFieldIndex(type t, param s:string) param : int
  */
 
 proc hasField(type t, param s:string) param : bool
-  return getFieldIndex(t, s) > 0;
+  return getFieldIndex(t, s) >= 0;
 
 /* Returns `true` if the given class or record's ith field
    has been instantiated.

--- a/test/library/packages/csv/CSV.chpl
+++ b/test/library/packages/csv/CSV.chpl
@@ -58,7 +58,7 @@ module CSV {
           continue;
         const vals = line.split(sep);
         for param i in 0..numFields(t)-1 {
-          getFieldRef(r, i+1) = vals[i]: getField(r, i+1).type;
+          getFieldRef(r, i) = vals[i]: getField(r, i).type;
         }
         if skipHeader {
           skipHeader = false;
@@ -143,9 +143,9 @@ module CSV {
       use Reflection;
       if !ch.writing then compilerError("writing to a reading channel");
 
-      for param i in 1..numFields(t) {
+      for param i in 0..<numFields(t) {
         ch.write(getField(r, i));
-        if i < numFields(t) then
+        if i != numFields(t)-1 then
           ch.write(sep);
       }
       ch.writeln();

--- a/test/library/standard/Reflection/field-queries-ok.chpl
+++ b/test/library/standard/Reflection/field-queries-ok.chpl
@@ -5,10 +5,10 @@ use Reflection;
 proc test(type tp) {
   compilerWarning("===== ", tp:string);
   compilerWarning("  numFields       ", numFields(tp)            :string);
-  compilerWarning("  getFieldName    ", getFieldName(tp, 6)             );
+  compilerWarning("  getFieldName    ", getFieldName(tp, 5)             );
   compilerWarning("  hasField        ", hasField(tp, "f6")       :string);
   compilerWarning("  getFieldIndex   ", getFieldIndex(tp, "f6")  :string);
-  compilerWarning("  isFieldBound 6  ", isFieldBound(tp, 6)      :string);
+  compilerWarning("  isFieldBound 5  ", isFieldBound(tp, 5)      :string);
   compilerWarning("  isFieldBound f6 ", isFieldBound(tp, "f6")   :string);
 }
 

--- a/test/library/standard/Reflection/field-queries-ok.good
+++ b/test/library/standard/Reflection/field-queries-ok.good
@@ -2,154 +2,154 @@ field-queries-ok.chpl:20: warning: ===== CCon
 field-queries-ok.chpl:20: warning:   numFields       6
 field-queries-ok.chpl:20: warning:   getFieldName    f6
 field-queries-ok.chpl:20: warning:   hasField        true
-field-queries-ok.chpl:20: warning:   getFieldIndex   6
-field-queries-ok.chpl:20: warning:   isFieldBound 6  true
+field-queries-ok.chpl:20: warning:   getFieldIndex   5
+field-queries-ok.chpl:20: warning:   isFieldBound 5  true
 field-queries-ok.chpl:20: warning:   isFieldBound f6 true
 field-queries-ok.chpl:21: warning: ===== owned CCon
 field-queries-ok.chpl:21: warning:   numFields       6
 field-queries-ok.chpl:21: warning:   getFieldName    f6
 field-queries-ok.chpl:21: warning:   hasField        true
-field-queries-ok.chpl:21: warning:   getFieldIndex   6
-field-queries-ok.chpl:21: warning:   isFieldBound 6  true
+field-queries-ok.chpl:21: warning:   getFieldIndex   5
+field-queries-ok.chpl:21: warning:   isFieldBound 5  true
 field-queries-ok.chpl:21: warning:   isFieldBound f6 true
 field-queries-ok.chpl:22: warning: ===== owned CCon?
 field-queries-ok.chpl:22: warning:   numFields       6
 field-queries-ok.chpl:22: warning:   getFieldName    f6
 field-queries-ok.chpl:22: warning:   hasField        true
-field-queries-ok.chpl:22: warning:   getFieldIndex   6
-field-queries-ok.chpl:22: warning:   isFieldBound 6  true
+field-queries-ok.chpl:22: warning:   getFieldIndex   5
+field-queries-ok.chpl:22: warning:   isFieldBound 5  true
 field-queries-ok.chpl:22: warning:   isFieldBound f6 true
 field-queries-ok.chpl:23: warning: ===== shared CCon
 field-queries-ok.chpl:23: warning:   numFields       6
 field-queries-ok.chpl:23: warning:   getFieldName    f6
 field-queries-ok.chpl:23: warning:   hasField        true
-field-queries-ok.chpl:23: warning:   getFieldIndex   6
-field-queries-ok.chpl:23: warning:   isFieldBound 6  true
+field-queries-ok.chpl:23: warning:   getFieldIndex   5
+field-queries-ok.chpl:23: warning:   isFieldBound 5  true
 field-queries-ok.chpl:23: warning:   isFieldBound f6 true
 field-queries-ok.chpl:24: warning: ===== shared CCon?
 field-queries-ok.chpl:24: warning:   numFields       6
 field-queries-ok.chpl:24: warning:   getFieldName    f6
 field-queries-ok.chpl:24: warning:   hasField        true
-field-queries-ok.chpl:24: warning:   getFieldIndex   6
-field-queries-ok.chpl:24: warning:   isFieldBound 6  true
+field-queries-ok.chpl:24: warning:   getFieldIndex   5
+field-queries-ok.chpl:24: warning:   isFieldBound 5  true
 field-queries-ok.chpl:24: warning:   isFieldBound f6 true
 field-queries-ok.chpl:25: warning: ===== borrowed CCon
 field-queries-ok.chpl:25: warning:   numFields       6
 field-queries-ok.chpl:25: warning:   getFieldName    f6
 field-queries-ok.chpl:25: warning:   hasField        true
-field-queries-ok.chpl:25: warning:   getFieldIndex   6
-field-queries-ok.chpl:25: warning:   isFieldBound 6  true
+field-queries-ok.chpl:25: warning:   getFieldIndex   5
+field-queries-ok.chpl:25: warning:   isFieldBound 5  true
 field-queries-ok.chpl:25: warning:   isFieldBound f6 true
 field-queries-ok.chpl:26: warning: ===== borrowed CCon?
 field-queries-ok.chpl:26: warning:   numFields       6
 field-queries-ok.chpl:26: warning:   getFieldName    f6
 field-queries-ok.chpl:26: warning:   hasField        true
-field-queries-ok.chpl:26: warning:   getFieldIndex   6
-field-queries-ok.chpl:26: warning:   isFieldBound 6  true
+field-queries-ok.chpl:26: warning:   getFieldIndex   5
+field-queries-ok.chpl:26: warning:   isFieldBound 5  true
 field-queries-ok.chpl:26: warning:   isFieldBound f6 true
 field-queries-ok.chpl:27: warning: ===== unmanaged CCon
 field-queries-ok.chpl:27: warning:   numFields       6
 field-queries-ok.chpl:27: warning:   getFieldName    f6
 field-queries-ok.chpl:27: warning:   hasField        true
-field-queries-ok.chpl:27: warning:   getFieldIndex   6
-field-queries-ok.chpl:27: warning:   isFieldBound 6  true
+field-queries-ok.chpl:27: warning:   getFieldIndex   5
+field-queries-ok.chpl:27: warning:   isFieldBound 5  true
 field-queries-ok.chpl:27: warning:   isFieldBound f6 true
 field-queries-ok.chpl:28: warning: ===== unmanaged CCon?
 field-queries-ok.chpl:28: warning:   numFields       6
 field-queries-ok.chpl:28: warning:   getFieldName    f6
 field-queries-ok.chpl:28: warning:   hasField        true
-field-queries-ok.chpl:28: warning:   getFieldIndex   6
-field-queries-ok.chpl:28: warning:   isFieldBound 6  true
+field-queries-ok.chpl:28: warning:   getFieldIndex   5
+field-queries-ok.chpl:28: warning:   isFieldBound 5  true
 field-queries-ok.chpl:28: warning:   isFieldBound f6 true
 field-queries-ok.chpl:35: warning: ===== CGen
 field-queries-ok.chpl:35: warning:   numFields       6
 field-queries-ok.chpl:35: warning:   getFieldName    f6
 field-queries-ok.chpl:35: warning:   hasField        true
-field-queries-ok.chpl:35: warning:   getFieldIndex   6
-field-queries-ok.chpl:35: warning:   isFieldBound 6  false
+field-queries-ok.chpl:35: warning:   getFieldIndex   5
+field-queries-ok.chpl:35: warning:   isFieldBound 5  false
 field-queries-ok.chpl:35: warning:   isFieldBound f6 false
 field-queries-ok.chpl:36: warning: ===== owned CGen
 field-queries-ok.chpl:36: warning:   numFields       6
 field-queries-ok.chpl:36: warning:   getFieldName    f6
 field-queries-ok.chpl:36: warning:   hasField        true
-field-queries-ok.chpl:36: warning:   getFieldIndex   6
-field-queries-ok.chpl:36: warning:   isFieldBound 6  false
+field-queries-ok.chpl:36: warning:   getFieldIndex   5
+field-queries-ok.chpl:36: warning:   isFieldBound 5  false
 field-queries-ok.chpl:36: warning:   isFieldBound f6 false
 field-queries-ok.chpl:37: warning: ===== owned CGen?
 field-queries-ok.chpl:37: warning:   numFields       6
 field-queries-ok.chpl:37: warning:   getFieldName    f6
 field-queries-ok.chpl:37: warning:   hasField        true
-field-queries-ok.chpl:37: warning:   getFieldIndex   6
-field-queries-ok.chpl:37: warning:   isFieldBound 6  false
+field-queries-ok.chpl:37: warning:   getFieldIndex   5
+field-queries-ok.chpl:37: warning:   isFieldBound 5  false
 field-queries-ok.chpl:37: warning:   isFieldBound f6 false
 field-queries-ok.chpl:38: warning: ===== shared CGen
 field-queries-ok.chpl:38: warning:   numFields       6
 field-queries-ok.chpl:38: warning:   getFieldName    f6
 field-queries-ok.chpl:38: warning:   hasField        true
-field-queries-ok.chpl:38: warning:   getFieldIndex   6
-field-queries-ok.chpl:38: warning:   isFieldBound 6  false
+field-queries-ok.chpl:38: warning:   getFieldIndex   5
+field-queries-ok.chpl:38: warning:   isFieldBound 5  false
 field-queries-ok.chpl:38: warning:   isFieldBound f6 false
 field-queries-ok.chpl:39: warning: ===== shared CGen?
 field-queries-ok.chpl:39: warning:   numFields       6
 field-queries-ok.chpl:39: warning:   getFieldName    f6
 field-queries-ok.chpl:39: warning:   hasField        true
-field-queries-ok.chpl:39: warning:   getFieldIndex   6
-field-queries-ok.chpl:39: warning:   isFieldBound 6  false
+field-queries-ok.chpl:39: warning:   getFieldIndex   5
+field-queries-ok.chpl:39: warning:   isFieldBound 5  false
 field-queries-ok.chpl:39: warning:   isFieldBound f6 false
 field-queries-ok.chpl:40: warning: ===== borrowed CGen
 field-queries-ok.chpl:40: warning:   numFields       6
 field-queries-ok.chpl:40: warning:   getFieldName    f6
 field-queries-ok.chpl:40: warning:   hasField        true
-field-queries-ok.chpl:40: warning:   getFieldIndex   6
-field-queries-ok.chpl:40: warning:   isFieldBound 6  false
+field-queries-ok.chpl:40: warning:   getFieldIndex   5
+field-queries-ok.chpl:40: warning:   isFieldBound 5  false
 field-queries-ok.chpl:40: warning:   isFieldBound f6 false
 field-queries-ok.chpl:41: warning: ===== borrowed CGen?
 field-queries-ok.chpl:41: warning:   numFields       6
 field-queries-ok.chpl:41: warning:   getFieldName    f6
 field-queries-ok.chpl:41: warning:   hasField        true
-field-queries-ok.chpl:41: warning:   getFieldIndex   6
-field-queries-ok.chpl:41: warning:   isFieldBound 6  false
+field-queries-ok.chpl:41: warning:   getFieldIndex   5
+field-queries-ok.chpl:41: warning:   isFieldBound 5  false
 field-queries-ok.chpl:41: warning:   isFieldBound f6 false
 field-queries-ok.chpl:42: warning: ===== unmanaged CGen
 field-queries-ok.chpl:42: warning:   numFields       6
 field-queries-ok.chpl:42: warning:   getFieldName    f6
 field-queries-ok.chpl:42: warning:   hasField        true
-field-queries-ok.chpl:42: warning:   getFieldIndex   6
-field-queries-ok.chpl:42: warning:   isFieldBound 6  false
+field-queries-ok.chpl:42: warning:   getFieldIndex   5
+field-queries-ok.chpl:42: warning:   isFieldBound 5  false
 field-queries-ok.chpl:42: warning:   isFieldBound f6 false
 field-queries-ok.chpl:43: warning: ===== unmanaged CGen?
 field-queries-ok.chpl:43: warning:   numFields       6
 field-queries-ok.chpl:43: warning:   getFieldName    f6
 field-queries-ok.chpl:43: warning:   hasField        true
-field-queries-ok.chpl:43: warning:   getFieldIndex   6
-field-queries-ok.chpl:43: warning:   isFieldBound 6  false
+field-queries-ok.chpl:43: warning:   getFieldIndex   5
+field-queries-ok.chpl:43: warning:   isFieldBound 5  false
 field-queries-ok.chpl:43: warning:   isFieldBound f6 false
 field-queries-ok.chpl:50: warning: ===== RCon
 field-queries-ok.chpl:50: warning:   numFields       6
 field-queries-ok.chpl:50: warning:   getFieldName    f6
 field-queries-ok.chpl:50: warning:   hasField        true
-field-queries-ok.chpl:50: warning:   getFieldIndex   6
-field-queries-ok.chpl:50: warning:   isFieldBound 6  true
+field-queries-ok.chpl:50: warning:   getFieldIndex   5
+field-queries-ok.chpl:50: warning:   isFieldBound 5  true
 field-queries-ok.chpl:50: warning:   isFieldBound f6 true
 field-queries-ok.chpl:57: warning: ===== RGen
 field-queries-ok.chpl:57: warning:   numFields       6
 field-queries-ok.chpl:57: warning:   getFieldName    f6
 field-queries-ok.chpl:57: warning:   hasField        true
-field-queries-ok.chpl:57: warning:   getFieldIndex   6
-field-queries-ok.chpl:57: warning:   isFieldBound 6  false
+field-queries-ok.chpl:57: warning:   getFieldIndex   5
+field-queries-ok.chpl:57: warning:   isFieldBound 5  false
 field-queries-ok.chpl:57: warning:   isFieldBound f6 false
 field-queries-ok.chpl:64: warning: ===== UCon
 field-queries-ok.chpl:64: warning:   numFields       6
 field-queries-ok.chpl:64: warning:   getFieldName    f6
 field-queries-ok.chpl:64: warning:   hasField        true
-field-queries-ok.chpl:64: warning:   getFieldIndex   6
-field-queries-ok.chpl:64: warning:   isFieldBound 6  true
+field-queries-ok.chpl:64: warning:   getFieldIndex   5
+field-queries-ok.chpl:64: warning:   isFieldBound 5  true
 field-queries-ok.chpl:64: warning:   isFieldBound f6 true
 field-queries-ok.chpl:71: warning: ===== UGen
 field-queries-ok.chpl:71: warning:   numFields       6
 field-queries-ok.chpl:71: warning:   getFieldName    f6
 field-queries-ok.chpl:71: warning:   hasField        true
-field-queries-ok.chpl:71: warning:   getFieldIndex   6
-field-queries-ok.chpl:71: warning:   isFieldBound 6  false
+field-queries-ok.chpl:71: warning:   getFieldIndex   5
+field-queries-ok.chpl:71: warning:   isFieldBound 5  false
 field-queries-ok.chpl:71: warning:   isFieldBound f6 false
 field-queries-ok.chpl:74: error: === done ===

--- a/test/library/standard/Reflection/fielderator-concrete.chpl
+++ b/test/library/standard/Reflection/fielderator-concrete.chpl
@@ -2,7 +2,7 @@ use Reflection;
 
 proc parse(ref data: ?t) {
   param numfield = numFields(t);
-  for param i in 1..numfield {
+  for param i in 0..<numfield {
     type vtype = getField(data, i).type;
     writeln(getFieldName(t, i));
     if isRecordType(vtype) || isClassType(vtype) {

--- a/test/library/standard/Reflection/fielderator-generic.chpl
+++ b/test/library/standard/Reflection/fielderator-generic.chpl
@@ -2,7 +2,7 @@ use Reflection;
 
 proc parse(ref data: ?t) {
   param numfield = numFields(t);
-  for param i in 1..numfield {
+  for param i in 0..<numfield {
     type vtype = if isType(getField(data, i)) then getField(data, i)
                                               else getField(data, i).type;
     writeln(getFieldName(t, i));

--- a/test/library/standard/Reflection/reflectOnTypesParams.chpl
+++ b/test/library/standard/Reflection/reflectOnTypesParams.chpl
@@ -8,7 +8,7 @@ record R {
 
 var r = new R();
 
-for param i in 1..numFields(r.type) {
+for param i in 0..<numFields(r.type) {
   if isParam(getField(r, i)) {
     param f = getField(r,i);
     writeln("field ", i, " = ", f, " is a param");
@@ -21,7 +21,7 @@ for param i in 1..numFields(r.type) {
   }
 }
 
-for param i in 1..numFields(r.type) {
+for param i in 0..<numFields(r.type) {
   param fName = getFieldName(R, i);
   if isParam(getField(r, fName)) {
     param f = getField(r, fName);

--- a/test/library/standard/Reflection/reflectOnTypesParams.good
+++ b/test/library/standard/Reflection/reflectOnTypesParams.good
@@ -1,6 +1,6 @@
-field 1 = real(64) is a type
-field 2 = 1 is a param
-field 3 = 0.0 is not a param or type
+field 0 = real(64) is a type
+field 1 = 1 is a param
+field 2 = 0.0 is not a param or type
 field t = real(64) is a type
 field p = 1 is a param
 field a = 0.0 is not a param or type

--- a/test/param/bharshbarg/refToGetFieldType.chpl
+++ b/test/param/bharshbarg/refToGetFieldType.chpl
@@ -14,7 +14,7 @@ const x = new R(int, real, 42);
 const ref q = x.A;
 writeln("q = ", q);
 
-for param i in 1..numFields(x.type) {
+for param i in 0..<numFields(x.type) {
   param name = getFieldName(x.type, i);
   const ref val = getField(x, i);
 

--- a/test/param/ferguson/field-name-not-in-range.chpl
+++ b/test/param/ferguson/field-name-not-in-range.chpl
@@ -4,5 +4,5 @@ record R {
   var x:int;
 }
 
-var s = getFieldName(R, 2);
+var s = getFieldName(R, 1);
 

--- a/test/param/ferguson/field-name-not-in-range.good
+++ b/test/param/ferguson/field-name-not-in-range.good
@@ -1,3 +1,3 @@
 $CHPL_HOME/modules/standard/Reflection.chpl:: In function 'getFieldName':
-$CHPL_HOME/modules/standard/Reflection.chpl:: error: '2' is not a valid field number for R
-field-name-not-in-range.chpl:: Function 'getFieldName' instantiated as: getFieldName(type t = R, param i = 2)
+$CHPL_HOME/modules/standard/Reflection.chpl:: error: '1' is not a valid field number for R
+field-name-not-in-range.chpl:: Function 'getFieldName' instantiated as: getFieldName(type t = R, param i = 1)

--- a/test/param/ferguson/field-value-not-in-range.chpl
+++ b/test/param/ferguson/field-value-not-in-range.chpl
@@ -5,5 +5,5 @@ record R {
 }
 
 var r:R;
-var i = getField(r, 2);
+var i = getField(r, 1);
 

--- a/test/param/ferguson/field-value-not-in-range.good
+++ b/test/param/ferguson/field-value-not-in-range.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/Reflection.chpl:: error: '2' is not a valid field number for R
+$CHPL_HOME/modules/standard/Reflection.chpl:: error: '1' is not a valid field number for R

--- a/test/param/ferguson/field-value-not-in-range2.chpl
+++ b/test/param/ferguson/field-value-not-in-range2.chpl
@@ -5,5 +5,5 @@ record R {
 }
 
 var r:R;
-var i = getFieldRef(r, 2);
+var i = getFieldRef(r, 1);
 

--- a/test/param/ferguson/field-value-not-in-range2.good
+++ b/test/param/ferguson/field-value-not-in-range2.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/Reflection.chpl:: error: '2' is not a valid field number for R
+$CHPL_HOME/modules/standard/Reflection.chpl:: error: '1' is not a valid field number for R

--- a/test/param/ferguson/fielderator-user-class.chpl
+++ b/test/param/ferguson/fielderator-user-class.chpl
@@ -7,11 +7,11 @@ class R {
 
 
 assert(numFields(R) == 2);
-assert(getFieldName(R, 1) == "x");
+assert(getFieldName(R, 0) == "x");
 
-assert(getFieldIndex(R, "x") == 1);
-assert(getFieldIndex(R, "y") == 2);
-assert(getFieldIndex(R, "z") == 0); // no field z.
+assert(getFieldIndex(R, "x") == 0);
+assert(getFieldIndex(R, "y") == 1);
+assert(getFieldIndex(R, "z") == -1); // no field z.
 assert(hasField(R, "x") == true);
 assert(hasField(R, "y") == true);
 assert(hasField(R, "z") == false);
@@ -20,14 +20,14 @@ assert(hasField(R, "z") == false);
 {
   var r = new unmanaged R(10,20);
 
-  assert(getField(r, 1) == 10);
-  assert(getField(r, 2) == 20);
+  assert(getField(r, 0) == 10);
+  assert(getField(r, 1) == 20);
 
   assert(getField(r, "x") == 10);
   assert(getField(r, "y") == 20);
 
 
-  getFieldRef(r, 1) = 100;
+  getFieldRef(r, 0) = 100;
   getFieldRef(r, "y") = 200;
 
   assert(getFieldRef(r, "x") == 100);
@@ -42,14 +42,14 @@ assert(hasField(R, "z") == false);
 {
   var r = new borrowed R(10,20);
 
-  assert(getField(r, 1) == 10);
-  assert(getField(r, 2) == 20);
+  assert(getField(r, 0) == 10);
+  assert(getField(r, 1) == 20);
 
   assert(getField(r, "x") == 10);
   assert(getField(r, "y") == 20);
 
 
-  getFieldRef(r, 1) = 100;
+  getFieldRef(r, 0) = 100;
   getFieldRef(r, "y") = 200;
 
   assert(getFieldRef(r, "x") == 100);

--- a/test/param/ferguson/fielderator-user.chpl
+++ b/test/param/ferguson/fielderator-user.chpl
@@ -7,11 +7,11 @@ record R {
 
 
 assert(numFields(R) == 2);
-assert(getFieldName(R, 1) == "x");
+assert(getFieldName(R, 0) == "x");
 
-assert(getFieldIndex(R, "x") == 1);
-assert(getFieldIndex(R, "y") == 2);
-assert(getFieldIndex(R, "z") == 0); // no field z.
+assert(getFieldIndex(R, "x") == 0);
+assert(getFieldIndex(R, "y") == 1);
+assert(getFieldIndex(R, "z") == -1); // no field z.
 assert(hasField(R, "x") == true);
 assert(hasField(R, "y") == true);
 assert(hasField(R, "z") == false);
@@ -19,14 +19,14 @@ assert(hasField(R, "z") == false);
 
 var r = new R(10,20);
 
-assert(getField(r, 1) == 10);
-assert(getField(r, 2) == 20);
+assert(getField(r, 0) == 10);
+assert(getField(r, 1) == 20);
 
 assert(getField(r, "x") == 10);
 assert(getField(r, "y") == 20);
 
 
-getFieldRef(r, 1) = 100;
+getFieldRef(r, 0) = 100;
 getFieldRef(r, "y") = 200;
 
 assert(getFieldRef(r, "x") == 100);

--- a/test/param/ferguson/getfieldref.chpl
+++ b/test/param/ferguson/getfieldref.chpl
@@ -14,10 +14,10 @@ proc getFieldRef(x:?t, param i:int) ref {
   return __primitive("field by num", x, i);
 }
 
-getFieldRef(r, 1) = 10;
+getFieldRef(r, 0) = 10;
 writeln(r.x);
 
-var i = getFieldRef(r, 1);
+var i = getFieldRef(r, 0);
 writeln(i);
 
 

--- a/test/param/ferguson/getfieldref.chpl
+++ b/test/param/ferguson/getfieldref.chpl
@@ -11,7 +11,7 @@ var r:R;
 // If const checking is improved, I expect it
 // to become a compile error.
 proc getFieldRef(x:?t, param i:int) ref {
-  return __primitive("field by num", x, i);
+  return __primitive("field by num", x, i+1);
 }
 
 getFieldRef(r, 0) = 10;

--- a/test/types/partial/isFieldBound.chpl
+++ b/test/types/partial/isFieldBound.chpl
@@ -11,7 +11,7 @@ record R {
 proc main() {
   type T = R(int, U=real);
 
-  for param i in 1..numFields(T) {
+  for param i in 0..<numFields(T) {
     param name = getFieldName(T, i);
     writeln("T.", name, ": ", isFieldBound(T, name));
   }

--- a/test/users/lydia/fieldNumToNameError.good
+++ b/test/users/lydia/fieldNumToNameError.good
@@ -1,1 +1,1 @@
-fieldNumToNameError.chpl:7: error: '4' is not a valid field number for R
+fieldNumToNameError.chpl:7: error: '3' is not a valid field number for R


### PR DESCRIPTION
This updates the getField*() routines in Reflection.chpl to number the
fields from 0 rather than 1, to match what we do for tuple indexing.
It also updates tests of these routines, and uses of them in modules.

This PR takes the lame approach of updating the user interfaces, but
not the underlying primitives (so those are still 1-based).  I did this for
the sake of expediency, but really, we'll want to update the underlying
primitives as well for consistency / simplicity before long (if not today).
A few tests were calling the primitives directly (not expected of users)
and those tests in particularly are a bit goofy in this "halfway converted"
world.

Resolves #15427 