### PR TITLE
Make random streams use 0-based indexing

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -488,13 +488,13 @@ module Random {
 
     /*
       Advances/rewinds the stream to the `n`-th value in the sequence.
-      The first value is with n=1.  n must be > 0, otherwise an
+      The first value corresponds to n=0.  n must be >= 0, otherwise an
       IllegalArgumentError is thrown.
 
-      :arg n: The position in the stream to skip to.  Must be > 0.
+      :arg n: The position in the stream to skip to.  Must be >= 0.
       :type n: `integral`
 
-      :throws IllegalArgumentError: When called with non-positive `n` value.
+      :throws IllegalArgumentError: When called with negative `n` value.
      */
     proc skipToNth(n: integral) throws {
       compilerError("RandomStreamInterface.skipToNth called");
@@ -502,15 +502,15 @@ module Random {
 
     /*
       Advance/rewind the stream to the `n`-th value and return it
-      (advancing the stream by one).  n must be > 0, otherwise an
+      (advancing the stream by one).  n must be >= 0, otherwise an
       IllegalArgumentError is thrown.  This is equivalent to
       :proc:`skipToNth()` followed by :proc:`getNext()`.
 
-      :arg n: The position in the stream to skip to.  Must be > 0.
+      :arg n: The position in the stream to skip to.  Must be >= 0.
       :type n: `integral`
 
       :returns: The `n`-th value in the random stream as type :type:`eltType`.
-      :throws IllegalArgumentError: When called with non-positive `n` value.
+      :throws IllegalArgumentError: When called with negative `n` value.
      */
     proc getNth(n: integral): eltType throws {
       compilerError("RandomStreamInterface.getNth called");
@@ -837,8 +837,8 @@ module Random {
 
       pragma "no doc"
       proc PCGRandomStreamPrivate_skipToNth_noLock(in n: integral) {
-        PCGRandomStreamPrivate_count = n;
-        PCGRandomStreamPrivate_rngs = randlc_skipto(eltType, seed, n);
+        PCGRandomStreamPrivate_count = n+1;
+        PCGRandomStreamPrivate_rngs = randlc_skipto(eltType, seed, n+1);
       }
 
       /*
@@ -903,17 +903,17 @@ module Random {
 
       /*
         Advances/rewinds the stream to the `n`-th value in the sequence.
-        The first value is with n=1.  n must be > 0, otherwise an
+        The first value corresponds to n=0.  n must be >= 0, otherwise an
         IllegalArgumentError is thrown.
 
-        :arg n: The position in the stream to skip to.  Must be > 0.
+        :arg n: The position in the stream to skip to.  Must be >= 0.
         :type n: `integral`
 
-        :throws IllegalArgumentError: When called with non-positive `n` value.
+        :throws IllegalArgumentError: When called with negative `n` value.
        */
       proc skipToNth(n: integral) throws {
-        if n <= 0 then
-          throw new owned IllegalArgumentError("PCGRandomStream.skipToNth(n) called with non-positive 'n' value " + n:string);
+        if n < 0 then
+          throw new owned IllegalArgumentError("PCGRandomStream.skipToNth(n) called with negative 'n' value " + n:string);
         _lock();
         PCGRandomStreamPrivate_skipToNth_noLock(n);
         _unlock();
@@ -921,19 +921,19 @@ module Random {
 
       /*
         Advance/rewind the stream to the `n`-th value and return it
-        (advancing the stream by one).  n must be > 0, otherwise an
+        (advancing the stream by one).  n must be >= 0, otherwise an
         IllegalArgumentError is thrown.  This is equivalent to
         :proc:`skipToNth()` followed by :proc:`getNext()`.
 
-        :arg n: The position in the stream to skip to.  Must be > 0.
+        :arg n: The position in the stream to skip to.  Must be >= 0.
         :type n: `integral`
 
         :returns: The `n`-th value in the random stream as type :type:`eltType`.
-        :throws IllegalArgumentError: When called with non-positive `n` value.
+        :throws IllegalArgumentError: When called with negative `n` value.
        */
       proc getNth(n: integral): eltType throws {
-        if (n <= 0) then
-          throw new owned IllegalArgumentError("PCGRandomStream.getNth(n) called with non-positive 'n' value " + n:string);
+        if (n < 0) then
+          throw new owned IllegalArgumentError("PCGRandomStream.getNth(n) called with negative 'n' value " + n:string);
         _lock();
         PCGRandomStreamPrivate_skipToNth_noLock(n);
         const result = PCGRandomStreamPrivate_getNext_noLock(eltType);
@@ -1084,7 +1084,7 @@ module Random {
         _lock();
         const start = PCGRandomStreamPrivate_count;
         PCGRandomStreamPrivate_count += D.size.safeCast(int(64));
-        PCGRandomStreamPrivate_skipToNth_noLock(PCGRandomStreamPrivate_count);
+        PCGRandomStreamPrivate_skipToNth_noLock(PCGRandomStreamPrivate_count-1);
         _unlock();
         return PCGRandomPrivate_iterate(resultType, D, seed, start);
       }
@@ -2382,6 +2382,7 @@ module Random {
 
       pragma "no doc"
       proc NPBRandomStreamPrivate_skipToNth_noLock(in n: integral) {
+        n += 1;
         if eltType == complex then n = n*2 - 1;
         NPBRandomStreamPrivate_count = n;
         NPBRandomStreamPrivate_cursor = randlc_skipto(seed, n);
@@ -2404,17 +2405,17 @@ module Random {
 
       /*
         Advances/rewinds the stream to the `n`-th value in the sequence.
-        The first value is with n=1.  n must be > 0, otherwise an
+        The first value corresponds to n=0.  n must be >= 0, otherwise an
         IllegalArgumentError is thrown.
 
-        :arg n: The position in the stream to skip to.  Must be > 0.
+        :arg n: The position in the stream to skip to.  Must be >= 0.
         :type n: `integral`
 
-        :throws IllegalArgumentError: When called with non-positive `n` value.
+        :throws IllegalArgumentError: When called with negative `n` value.
        */
       proc skipToNth(n: integral) throws {
-        if n <= 0 then
-          throw new owned IllegalArgumentError("NPBRandomStream.skipToNth(n) called with non-positive 'n' value " + n:string);
+        if n < 0 then
+          throw new owned IllegalArgumentError("NPBRandomStream.skipToNth(n) called with negative 'n' value " + n:string);
         _lock();
         NPBRandomStreamPrivate_skipToNth_noLock(n);
         _unlock();
@@ -2422,19 +2423,19 @@ module Random {
 
       /*
         Advance/rewind the stream to the `n`-th value and return it
-        (advancing the stream by one).  n must be > 0, otherwise an
+        (advancing the stream by one).  n must be >= 0, otherwise an
         IllegalArgumentError is thrown.  This is equivalent to
         :proc:`skipToNth()` followed by :proc:`getNext()`.
 
-        :arg n: The position in the stream to skip to.  Must be > 0.
+        :arg n: The position in the stream to skip to.  Must be >= 0.
         :type n: `integral`
 
         :returns: The `n`-th value in the random stream as type :type:`eltType`.
-        :throws IllegalArgumentError: When called with non-positive `n` value.
+        :throws IllegalArgumentError: When called with negative `n` value.
        */
       proc getNth(n: integral): eltType throws {
-        if (n <= 0) then
-          throw new owned IllegalArgumentError("NPBRandomStream.getNth(n) called with non-positive 'n' value " + n:string);
+        if (n < 0) then
+          throw new owned IllegalArgumentError("NPBRandomStream.getNth(n) called with negative 'n' value " + n:string);
         _lock(); 
         NPBRandomStreamPrivate_skipToNth_noLock(n);
         const result = NPBRandomStreamPrivate_getNext_noLock();
@@ -2490,7 +2491,7 @@ module Random {
         _lock();
         const start = NPBRandomStreamPrivate_count;
         NPBRandomStreamPrivate_count += D.size.safeCast(int(64));
-        NPBRandomStreamPrivate_skipToNth_noLock(NPBRandomStreamPrivate_count);
+        NPBRandomStreamPrivate_skipToNth_noLock(NPBRandomStreamPrivate_count-1);
         _unlock();
         return NPBRandomPrivate_iterate(resultType, D, seed, start);
       }

--- a/test/exercises/MonteCarloPi/multiLocaleTaskParallel.chpl
+++ b/test/exercises/MonteCarloPi/multiLocaleTaskParallel.chpl
@@ -55,7 +55,7 @@ coforall loc in Locales {
             extras = locN%tasksPerLocale;
       rs.skipToNth(2*(locFirstPt + 
                       tid*locNPerTask + (if tid < extras then tid else extras))
-                   + 1);
+                   );
 
       var count = 0;
       for i in 1..locNPerTask + (tid < extras) do

--- a/test/exercises/MonteCarloPi/taskParallel.chpl
+++ b/test/exercises/MonteCarloPi/taskParallel.chpl
@@ -23,7 +23,7 @@ coforall tid in 0..#tasks {
   var rs = new owned NPBRandomStream(real, seed, parSafe=false);
   const nPerTask = n/tasks,
         extras = n%tasks;
-  rs.skipToNth(2*(tid*nPerTask + (if tid < extras then tid else extras)) + 1);
+  rs.skipToNth(2*(tid*nPerTask + (if tid < extras then tid else extras)));
 
   var count = 0;
   for i in 1..nPerTask + (tid < extras) do

--- a/test/library/standard/Random/bradc/randomAcrossTypes.chpl
+++ b/test/library/standard/Random/bradc/randomAcrossTypes.chpl
@@ -52,11 +52,11 @@ writeln(C);
 // Check getNth() method
 //
 for i in 1..8 {
-  A[i] = rs4.getNth(i);
-  B[i] = rs5.getNth(i);
+  A[i] = rs4.getNth(i-1);
+  B[i] = rs5.getNth(i-1);
 }
 for i in 1..4 {
-  C[i] = rs6.getNth(i);
+  C[i] = rs6.getNth(i-1);
 }
 writeln(A);
 writeln(B);
@@ -66,13 +66,13 @@ writeln(C);
 // Check skipToNth()/getNext() methods
 //
 for i in 1..8 {
-  rs4.skipToNth(i);
+  rs4.skipToNth(i-1);
   A[i] = rs4.getNext();
-  rs5.skipToNth(i);
+  rs5.skipToNth(i-1);
   B[i] = rs5.getNext();
 }
 for i in 1..4 {
-  rs6.skipToNth(i);
+  rs6.skipToNth(i-1);
   C[i] = rs6.getNext();
 }
 writeln(A);

--- a/test/library/standard/Random/bradc/testGetNth.chpl
+++ b/test/library/standard/Random/bradc/testGetNth.chpl
@@ -9,7 +9,7 @@ var randStr1 = createRandomStream(real, 314159265, algorithm=rtype);
 var randStr2 = createRandomStream(real, 314159265, algorithm=rtype);
 var randStr3 = createRandomStream(real, 314159265, algorithm=rtype);
 
-for i in 1..n {
+for i in 0..n-1 {
   const r1 = randStr1.getNext();
   const r2 = randStr2.getNth(i);
   const r3 = randStr3.getNth(i);

--- a/test/library/standard/Random/bradc/testGetNth2.chpl
+++ b/test/library/standard/Random/bradc/testGetNth2.chpl
@@ -14,26 +14,26 @@ var A, B: [1..n] real;
 randStr1.fillRandom(A);
 
 for i in 1..n {
-  B(i) = randStr2.getNth(i);
+  B(i) = randStr2.getNth(i-1);
 }
 
 checkArrays("1: ");
 
 for i in 1..n by -1 {
-  B(i) = randStr2.getNth(i);
+  B(i) = randStr2.getNth(i-1);
 }
 
 checkArrays("2: ");
 
 for i in 1..n by 2 {
-  B(i) = randStr2.getNth(i);
-  B(i+1) = randStr2.getNth(i+1);
+  B(i) = randStr2.getNth(i-1);
+  B(i+1) = randStr2.getNth(i);
 }
 
 checkArrays("3: ");
 
 for i in 1..n by 4 {
-  B(i) = randStr2.getNth(i);
+  B(i) = randStr2.getNth(i-1);
   B(i+1) = randStr2.getNext();
   B(i+2) = randStr2.getNext();
   B(i+3) = randStr2.getNext();
@@ -41,7 +41,7 @@ for i in 1..n by 4 {
 
 checkArrays("4: ");
 
-B(1) = randStr2.getNth(1);
+B(1) = randStr2.getNth(0);
 
 for i in 2..n {
   B(i) = randStr2.getNext();
@@ -49,7 +49,7 @@ for i in 2..n {
 
 checkArrays("5: ");
 
-randStr2.skipToNth(1);
+randStr2.skipToNth(0);
 
 for i in 1..n {
   B(i) = randStr2.getNext();
@@ -58,7 +58,7 @@ for i in 1..n {
 checkArrays("6: ");
 
 
-randStr2.skipToNth(1);
+randStr2.skipToNth(0);
 
 randStr2.fillRandom(B);
 

--- a/test/library/standard/Random/deitz/test1D2D.chpl
+++ b/test/library/standard/Random/deitz/test1D2D.chpl
@@ -16,7 +16,7 @@ config param algo = RNG.NPB;
 {
   var rs = createRandomStream(real, seed, algorithm=algo);
 
-  writeln(for i in 1..n do "%{#.#####}".format(rs.getNth(i)));
+  writeln(for i in 0..<n do "%{#.#####}".format(rs.getNth(i)));
   writeln(rs.getNext());
 }
 

--- a/test/library/standard/Random/elliot/testBadNth.npb.get.good
+++ b/test/library/standard/Random/elliot/testBadNth.npb.get.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: NPBRandomStream.getNth(n) called with non-positive 'n' value -1
+uncaught IllegalArgumentError: NPBRandomStream.getNth(n) called with negative 'n' value -1
   testBadNth.chpl:11: thrown here
   testBadNth.chpl:11: uncaught here

--- a/test/library/standard/Random/elliot/testBadNth.npb.skip.good
+++ b/test/library/standard/Random/elliot/testBadNth.npb.skip.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: NPBRandomStream.skipToNth(n) called with non-positive 'n' value -1
+uncaught IllegalArgumentError: NPBRandomStream.skipToNth(n) called with negative 'n' value -1
   testBadNth.chpl:13: thrown here
   testBadNth.chpl:13: uncaught here

--- a/test/library/standard/Random/elliot/testBadNth.pcg.get.good
+++ b/test/library/standard/Random/elliot/testBadNth.pcg.get.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: PCGRandomStream.getNth(n) called with non-positive 'n' value -1
+uncaught IllegalArgumentError: PCGRandomStream.getNth(n) called with negative 'n' value -1
   testBadNth.chpl:17: thrown here
   testBadNth.chpl:17: uncaught here

--- a/test/library/standard/Random/elliot/testBadNth.pcg.skip.good
+++ b/test/library/standard/Random/elliot/testBadNth.pcg.skip.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: PCGRandomStream.skipToNth(n) called with non-positive 'n' value -1
+uncaught IllegalArgumentError: PCGRandomStream.skipToNth(n) called with negative 'n' value -1
   testBadNth.chpl:19: thrown here
   testBadNth.chpl:19: uncaught here

--- a/test/library/standard/Random/ferguson/check-bounded-rng-fixed-offset.chpl
+++ b/test/library/standard/Random/ferguson/check-bounded-rng-fixed-offset.chpl
@@ -26,7 +26,7 @@ proc createRandomArrayParallel(nTasks:int, minimum:int, maximum:int) {
     var rng = createRandomStream(eltType=int, seed=seed);
     // Each task generates the same random values as in a serial program
     // (skipping ahead / advancing the RNG past values it would have made)
-    rng.skipToNth(1+start);
+    rng.skipToNth(start);
     for i in start..end {
       A[i] = rng.getNext(min=minimum, max=maximum);
     }

--- a/test/library/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-check.chpl
@@ -22,7 +22,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got == e32 );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
   for e32 in expect32_1 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -32,7 +32,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got == e32 );
   }
 
-  for (i, e32) in zip(1..6, expect32_1) {
+  for (i, e32) in zip(0..5, expect32_1) {
     var got = rs.getNth(i);
 
     if verbose then writef("%xu\n", got);
@@ -50,7 +50,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got:uint(32) == e32 );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
   for e32 in expect32_1 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -59,7 +59,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got:uint(32) == e32 );
   }
 
-  for (i, e32) in zip(1..6, expect32_1) {
+  for (i, e32) in zip(0..5, expect32_1) {
     var got = rs.getNth(i);
     if verbose then writef("%xu\n", got);
     assert( got:uint(32) == e32 );
@@ -79,7 +79,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got == e32 >> 24 );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
   for e32 in expect32_1 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -89,7 +89,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got == e32 >> 24 );
   }
 
-  for (i, e32) in zip(1..6, expect32_1) {
+  for (i, e32) in zip(0..5, expect32_1) {
     var got = rs.getNth(i);
 
     if verbose then writef("%xu\n", got);
@@ -110,7 +110,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got == e32 >> 16 );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
   for e32 in expect32_1 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -120,7 +120,7 @@ writeln("Checking 32-bit RNG seq 1");
     assert( got == e32 >> 16 );
   }
 
-  for (i, e32) in zip(1..6, expect32_1) {
+  for (i, e32) in zip(0..5, expect32_1) {
     var got = rs.getNth(i);
 
     if verbose then writef("%xu\n", got);
@@ -142,7 +142,7 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
     assert( got == (e32_1:uint(64) << 32) | e32_2:uint(64) );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
   for (e32_1, e32_2) in zip(expect32_1, expect32_2) {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -152,7 +152,7 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
     assert( got == (e32_1:uint(64) << 32) | e32_2:uint(64) );
   }
 
-  for (i, e32_1, e32_2) in zip(1..6, expect32_1, expect32_2) {
+  for (i, e32_1, e32_2) in zip(0..5, expect32_1, expect32_2) {
     var got = rs.getNth(i);
 
     if verbose then writef("%xu\n", got);
@@ -178,7 +178,7 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
     assert( got == expect[i] );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -188,7 +188,7 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
     assert( got == expect[i] );
   }
 
-  for i in 1..6 {
+  for i in 0..5 {
     var got = rs.getNth(i);
 
     if verbose then writef("%n\n", got);
@@ -199,13 +199,13 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
 writeln("Checking real(64)");
 // check that real(64) reproduces
 {
-  var expect:[1..6] real(64);
+  var expect:[0..5] real(64);
 
   fillRandom(expect, seed=seed, algorithm=RNG.PCG);
 
   var rs = new owned RandomStream(seed = seed, eltType = real(64));
 
-  for i in 1..6 {
+  for i in 0..5 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
 
@@ -213,9 +213,9 @@ writeln("Checking real(64)");
     assert( got == expect[i] );
   }
 
-  rs.skipToNth(1);
+  rs.skipToNth(0);
 
-  for i in 1..6 {
+  for i in 0..5 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
     var got = rs.getNext();
 
@@ -223,7 +223,7 @@ writeln("Checking real(64)");
     assert( got == expect[i] );
   }
 
-  for i in 1..6 {
+  for i in 0..5 {
     var got = rs.getNth(i);
 
     if verbose then writef("%n\n", got);

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
@@ -47,7 +47,7 @@ for i in 0..#n {
 
 writeln("Numbers with skipToNth each time");
 for i in 0..#n {
-  rs.skipToNth(1 + i);
+  rs.skipToNth(i);
   var num = rs.getNext(0, max);
   writeln(num);
   assert(num <= max);
@@ -73,20 +73,20 @@ got2[n+2] = rs2.getNext();
 
 writeln("Numbers with skipToNth each time - 64");
 for i in 0..#n {
-  rs2.skipToNth(1 + i);
+  rs2.skipToNth(i);
   var num = rs2.getNext(0, max2);
   writeln(num);
   assert(num <= max2);
   assert(got2[i] == num);
 }
-rs2.skipToNth(n + 1);
+rs2.skipToNth(n);
 var num = rs2.getNext();
 assert(got2[n] == num);
 
-rs2.skipToNth(n + 2);
+rs2.skipToNth(n + 1);
 num = rs2.getNext(0, 2**32);
 assert(got2[n+1] == num);
 
-rs2.skipToNth(n + 3);
+rs2.skipToNth(n + 2);
 num = rs2.getNext();
 assert(got2[n+2] == num);

--- a/test/npb/ep/mcahir/ep.chpl
+++ b/test/npb/ep/mcahir/ep.chpl
@@ -87,7 +87,7 @@ proc gaussPairsBatch(k: int(64), numPairs: int) {
 
 	var rs = new NPBRandomStream(real, seed=seed, parSafe=false);
 	//Find starting seed for this batch
-	rs.skipToNth(k * 2*nk + 1);
+	rs.skipToNth(k * 2*nk);
 
 	// Compute uniform pseudorandom numbers.
 	for e in x do e = rs.getNext();

--- a/test/npb/is/mcahir/intsort.mtml.chpl
+++ b/test/npb/is/mcahir/intsort.mtml.chpl
@@ -487,7 +487,7 @@ proc gen_keys () {
       var last : int = first+(nkeys/numLocales) - 1;
  
       var rs = new owned NPBRandomStream(real, seed);
-      rs.skipToNth(first*4+1);
+      rs.skipToNth(first*4);
       for i in first..last {
         rs.fillRandom(tmpreals);
         key(i) = ( (range>>2)*(+ reduce tmpreals ) ): int;

--- a/test/release/examples/primers/randomNumbers.chpl
+++ b/test/release/examples/primers/randomNumbers.chpl
@@ -27,7 +27,7 @@ fillRandom(rands);
 // To produce deterministic output, specify the starting seed to use when
 // filling the array.
 //
-var randsSeeded: [1..10] real;
+var randsSeeded: [0..9] real;
 var seed = 17;
 fillRandom(randsSeeded, seed);
 writeln("randsSeeded = ", randsSeeded); // Here the output is deterministic
@@ -62,8 +62,8 @@ randStream.fillRandom(randsFromStream);
 //
 // Or random numbers can be requested one at a a time.
 //
-var nextRand = randStreamSeeded.getNext();
-writeln(nextRand == randsSeeded[1]);
+var firstRand = randStreamSeeded.getNext();
+writeln(firstRand == randsSeeded[0]);
 
 // Note that since since we are using the same seed, the numbers generated will
 // match those generated earlier by ``fillRandom(randsSeeded, seed)``.
@@ -72,27 +72,27 @@ writeln(nextRand == randsSeeded[1]);
 // The next random number generated will follow the most
 // recent...
 //
-var secondRand = randStreamSeeded.getNext();
-writeln(secondRand == randsSeeded[2]);
+var nextRand = randStreamSeeded.getNext();
+writeln(nextRand == randsSeeded[1]);
 
 // ...unless the position to look at has been changed.
-randStreamSeeded.skipToNth(7);
-var seventhRand = randStreamSeeded.getNext();
-writeln(seventhRand == randsSeeded[7]);
+randStreamSeeded.skipToNth(6);
+var rand6 = randStreamSeeded.getNext();
+writeln(rand6 == randsSeeded[6]);
 
 //
 // A specific random number in the stream can be obtained by
 // specifying the position.  This argument must be greater
-// than ``0``.
+// than or equal to ``0``.
 //
-var secondRand2 = randStreamSeeded.getNth(2);
-writeln(secondRand2 == secondRand);
+var rand1 = randStreamSeeded.getNth(1);
+writeln(rand1 == nextRand);
 
 //
 // This position can be earlier or later than the most recent.
 //
-var fourthRand = randStreamSeeded.getNth(4);
-writeln(fourthRand == randsSeeded[4]);
+var rand3 = randStreamSeeded.getNth(3);
+writeln(rand3 == randsSeeded[3]);
 
 
 //

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -71,9 +71,9 @@ proc initVectors(B, C) {
     on loc {
       var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
-      randlist.skipToNth(B.locArr(loc)!.locDom.low);
+      randlist.skipToNth(B.locArr(loc)!.locDom.low-1);
       randlist.fillRandom(B.locArr(loc)!.myElems);
-      randlist.skipToNth(B.size + C.locArr(loc)!.locDom.low);
+      randlist.skipToNth(B.size + C.locArr(loc)!.locDom.low-1);
       randlist.fillRandom(C.locArr(loc)!.myElems);
     }
   }

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
@@ -84,9 +84,9 @@ proc initVectors(B, C) {
     on B.dom.dist.targetLocs(loc) {
       var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
-      randlist.skipToNth(B.locArr(loc)!.locDom.low);
+      randlist.skipToNth(B.locArr(loc)!.locDom.low-1);
       randlist.fillRandom(B.locArr(loc)!.myElems);
-      randlist.skipToNth(B.size + C.locArr(loc)!.locDom.low);
+      randlist.skipToNth(B.size + C.locArr(loc)!.locDom.low-1);
       randlist.fillRandom(C.locArr(loc)!.myElems);
     }
   }

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
@@ -90,9 +90,9 @@ proc initVectors(B, C) {
     on B.dom.dist.targetLocs(loc) {
       var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
-      randlist.skipToNth(B.locArr(loc)!.locDom.low);
+      randlist.skipToNth(B.locArr(loc)!.locDom.low-1);
       randlist.fillRandom(B.locArr(loc)!.myElems);
-      randlist.skipToNth(B.size + C.locArr(loc)!.locDom.low);
+      randlist.skipToNth(B.size + C.locArr(loc)!.locDom.low-1);
       randlist.fillRandom(C.locArr(loc)!.myElems);
     }
   }

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
@@ -66,9 +66,9 @@ proc printConfiguration() {
 proc initVectors(B, C, ProblemSpace, print) {
   var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
-  randlist.skipToNth(B.domain.low);
+  randlist.skipToNth(B.domain.low-1);
   randlist.fillRandom(B);
-  randlist.skipToNth(ProblemSpace.size + C.domain.low);
+  randlist.skipToNth(ProblemSpace.size + C.domain.low-1);
   randlist.fillRandom(C);
 
   if (printArrays && print) {

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
@@ -69,9 +69,9 @@ proc printConfiguration() {
 proc initVectors(B, C, ProblemSpace) {
   var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
-  randlist.skipToNth(B.domain.low);
+  randlist.skipToNth(B.domain.low-1);
   randlist.fillRandom(B);
-  randlist.skipToNth(ProblemSpace.size + C.domain.low);
+  randlist.skipToNth(ProblemSpace.size + C.domain.low-1);
   randlist.fillRandom(C);
 
   if (printArrays) {

--- a/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
+++ b/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
@@ -69,9 +69,9 @@ proc printConfiguration() {
 proc initVectors(B, C, ProblemSpace) {
   var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
-  randlist.skipToNth(B.domain.low);
+  randlist.skipToNth(B.domain.low-1);
   randlist.fillRandom(B);
-  randlist.skipToNth(ProblemSpace.size + C.domain.low);
+  randlist.skipToNth(ProblemSpace.size + C.domain.low-1);
   randlist.fillRandom(C);
 
   if (printArrays) {


### PR DESCRIPTION
This PR makes RandomStreams count from 0 rather than 1 in terms of
routines like getNth() or skipToNth().  This is largely not a
backwards-breaking change unless you happen to care what numbers
are returned for a given random stream index since we're only
expanding the set of indices for which a random number can be queried.

The approach I took here for the sake of expediency was to have the
random stream continue to store its state as before, and to just
adjust the values by 1 at the interface boundaries that refer to
a specific position.  Thus, if skipToNth() sets the index to 5, the internal
private count for the PCG or NPB streams will continue to be stored as 6.
Ultimately, we should adjust this to avoid the mismatch, but this seemed
like the quickest way to proceed.

The main work was updating the documentation and adjusting our tests
which are reasonably sensitive to which values they get from the
random streams.

Resolves #15418.