### PR TITLE
Rephrase contributors text to reflect this month's two-release nature

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,9 +4,10 @@ Chapel Contributors
 The following people have contributed to the implementation of the
 Chapel release:
 
-Contributors to the current release
------------------------------------
+Contributors to the Chapel 1.21 and 1.22 releases
+-------------------------------------------------
 * Ben Albrecht, [HPE]
+* Sourish Ash, invidividual contributor
 * Akshansh Bhanjana, individual contributor
 * Ankush Bhardwaj, individual contributor
 * Paul Cassella, [HPE]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,7 +7,7 @@ Chapel release:
 Contributors to the Chapel 1.21 and 1.22 releases
 -------------------------------------------------
 * Ben Albrecht, [HPE]
-* Sourish Ash, invidividual contributor
+* Souris Ash, invidividual contributor
 * Akshansh Bhanjana, individual contributor
 * Ankush Bhardwaj, individual contributor
 * Paul Cassella, [HPE]


### PR DESCRIPTION
Since 1.21 and 1.22 are quite similar, I'm combining their contributor sections for 1.22.

Also, add Souris Ash as a recent contributor.