### PR TITLE
Update sub_test filtering for common system error modes

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -557,7 +557,9 @@ def translateOutput(output):
               ('Fatal MPP reservation error on create',
                'Jira 329 -- Fatal MPP reservation error for'),
               ('Text file busy',
-               'private issue #474 -- Text file busy for'))
+               'private issue #474 -- Text file busy for'),
+              ('slurm_receive_msgs: Socket timed out on send/recv',
+               'private issue #579 -- Slurm socket timed out on send/recv'))
 
     known_error = ''
     was_timeout = False

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -543,7 +543,7 @@ def translateOutput(output):
     xlates = (('slurmstepd: Munge decode failed: Expired credential',
                'Jira 18 -- Expired slurm credential for'),
               ('output file from job .* does not exist',
-               'Jira 17 -- Missing output file for'),
+               'private issue #906 -- Missing output file for'),
               ('aprun: Unexpected close of the apsys control connection',
                'Jira 193 -- Unexpected close of apsys for'),
               ('qsub: cannot connect to server sdb',

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -558,7 +558,7 @@ def translateOutput(output):
                'Jira 329 -- Fatal MPP reservation error for'),
               ('Text file busy',
                'private issue #474 -- Text file busy for'),
-              ('slurm_receive_msgs: Socket timed out on send/recv',
+              ('Socket timed out on send/recv operation',
                'private issue #579 -- Slurm socket timed out on send/recv'))
 
     known_error = ''


### PR DESCRIPTION
Replace a reference to old Jira issue # with new Github chapel-private issue #.
Also add tracking for "slurm socket timed out on send/recv operation".