### PR TITLE
Avoid running tests that failed to compile and show them in results

### DIFF
--- a/test/library/packages/UnitTest/Launcher_Test.execopts
+++ b/test/library/packages/UnitTest/Launcher_Test.execopts
@@ -6,3 +6,4 @@ LauncherTest/ #launcher_Test.folder.good
 test_locales.chpl #launcher_Test.numLocales.good
 test_dependency.chpl #launcher_Test.dependency.good
 test_WithModule.chpl #launcher_Test.WithModule.good
+test_CompileFail.chpl #launcher_Test.CompileFail.good

--- a/test/library/packages/UnitTest/launcher_Test.CompileFail.good
+++ b/test/library/packages/UnitTest/launcher_Test.CompileFail.good
@@ -1,0 +1,10 @@
+
+======================================================================
+ERROR test_CompileFail.chpl: test_CompileFail
+----------------------------------------------------------------------
+test_CompileFail.chpl failed to compile
+----------------------------------------------------------------------
+Ran 1 test in n seconds
+
+FAILED (errors = 1 )
+compilation failed for test_CompileFail.chpl

--- a/test/library/packages/UnitTest/test_CompileFail.chpl
+++ b/test/library/packages/UnitTest/test_CompileFail.chpl
@@ -1,0 +1,8 @@
+use UnitTest;
+
+proc test1(test: borrowed Test) throws {
+  writeln(shall not compile)
+}
+
+
+UnitTest.main();

--- a/test/mason/mason-test/Mason.toml
+++ b/test/mason/mason-test/Mason.toml
@@ -9,7 +9,8 @@ tests = ["sampletest.chpl",
          "nomodule.chpl",
          "testdir/subdirectorytest.chpl",
          "shallnotpass.chpl",
-         "docs/exampletest.chpl"]
+         "docs/exampletest.chpl",
+         "shallskip.chpl"]
 
 [dependencies]
 _MasonTest1 = "0.2.0"

--- a/test/mason/mason-test/Mason.toml
+++ b/test/mason/mason-test/Mason.toml
@@ -10,7 +10,7 @@ tests = ["sampletest.chpl",
          "testdir/subdirectorytest.chpl",
          "shallnotpass.chpl",
          "docs/exampletest.chpl",
-         "shallskip.chpl"]
+         "compileerror.chpl"]
 
 [dependencies]
 _MasonTest1 = "0.2.0"

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -13,5 +13,4 @@ shallnotpass returned exitCode = 255
 Ran 8 tests in n seconds
 
 FAILED (passed = 6 failures = 1 errors = 1 )
-PATH/compileerror.chpl:1: syntax error: near 'test'
 compilation failed for compileerror.chpl

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -4,7 +4,7 @@ Downloading dependency: _MasonTest1-0.2.0
 ======================================================================
 ERROR compileerror.chpl: compileerror
 ----------------------------------------------------------------------
-compileerror failed to compile
+compileerror.chpl failed to compile
 ======================================================================
 FAIL shallnotpass.chpl: shallnotpass
 ----------------------------------------------------------------------

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -2,12 +2,16 @@ Updating registry
 Downloading dependency: _MasonTest1-0.2.0
 
 ======================================================================
+ERROR compileerror.chpl: compileerror
+----------------------------------------------------------------------
+compileerror failed to compile
+======================================================================
 FAIL shallnotpass.chpl: shallnotpass
 ----------------------------------------------------------------------
 shallnotpass returned exitCode = 255
 ----------------------------------------------------------------------
-Ran 7 tests in n seconds
+Ran 8 tests in n seconds
 
-FAILED (passed = 6 failures = 1 )
-PATH/shallskip.chpl:1: syntax error: near 'test'
-compilation failed for shallskip.chpl
+FAILED (passed = 6 failures = 1 errors = 1 )
+PATH/compileerror.chpl:1: syntax error: near 'test'
+compilation failed for compileerror.chpl

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -9,3 +9,5 @@ shallnotpass returned exitCode = 255
 Ran 7 tests in n seconds
 
 FAILED (passed = 6 failures = 1 )
+PATH/shallskip.chpl:1: syntax error: near 'test'
+compilation failed for shallskip.chpl

--- a/test/mason/mason-test/mason-test.prediff
+++ b/test/mason/mason-test/mason-test.prediff
@@ -8,9 +8,6 @@ with open(tmp_file, 'w') as tf:
   with open(out_file) as outf:
       for line in outf:
         line = re.sub(r'[0-9]+([.][0-9]+)? seconds', 'n seconds', line)
-        if '/compileerror.chpl:' in line:
-          pos = line.find('/compileerror.chpl:')
-          line = 'PATH' + line[pos:]
         tf.write(line)
 
 shutil.move(tmp_file, out_file)

--- a/test/mason/mason-test/mason-test.prediff
+++ b/test/mason/mason-test/mason-test.prediff
@@ -8,6 +8,9 @@ with open(tmp_file, 'w') as tf:
   with open(out_file) as outf:
       for line in outf:
         line = re.sub(r'[0-9]+([.][0-9]+)? seconds', 'n seconds', line)
+        if '/compileerror.chpl:' in line:
+          pos = line.find('/compileerror.chpl:')
+          line = 'PATH' + line[pos:]
         tf.write(line)
 
 shutil.move(tmp_file, out_file)

--- a/test/mason/mason-test/test/compileerror.chpl
+++ b/test/mason/mason-test/test/compileerror.chpl
@@ -1,0 +1,1 @@
+this test shall fail to compile and be skipped;

--- a/test/mason/mason-test/test/shallskip.chpl
+++ b/test/mason/mason-test/test/shallskip.chpl
@@ -1,0 +1,1 @@
+this test shall failed to compile and be skipped;

--- a/test/mason/mason-test/test/shallskip.chpl
+++ b/test/mason/mason-test/test/shallskip.chpl
@@ -1,1 +1,0 @@
-this test shall failed to compile and be skipped;

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -193,7 +193,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         const outputLoc = projectHome + "/target/test/" + stripExt(testTemp, ".chpl");
         const moveTo = "-o " + outputLoc;
         const compCommand = " ".join("chpl",testPath, projectPath, moveTo, allCompOpts);
-        const compilation = runWithStatus(compCommand);
+        const compilation = runWithStatus(compCommand, show);
         
         if compilation != 0 {
           stderr.writeln("compilation failed for " + test);

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -197,7 +197,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         
         if compilation != 0 {
           stderr.writeln("compilation failed for " + test);
-          const errMsg = test: string +" failed to compile";
+          const errMsg = test +" failed to compile";
           result.addError(testName, test,  errMsg);
         }
         else {
@@ -434,7 +434,7 @@ proc testFile(file, ref result, show: bool) throws {
 
   if compilation != 0 {
     stderr.writeln("compilation failed for " + fileName);
-    const errMsg = fileName: string +" failed to compile";
+    const errMsg = fileName +" failed to compile";
     result.addError(executable, fileName,  errMsg);
   }
   else {

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -197,7 +197,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         
         if compilation != 0 {
           stderr.writeln("compilation failed for " + test);
-          const errMsg = testName: string +" failed to compile";
+          const errMsg = test: string +" failed to compile";
           result.addError(testName, test,  errMsg);
         }
         else {
@@ -430,10 +430,12 @@ proc testFile(file, ref result, show: bool) throws {
   const moveTo = "-o " + executable;
   const allCompOpts = "--comm " + comm;
   const compCommand = " ".join("chpl",file, moveTo, allCompOpts);
-  const compilation = runWithStatus(compCommand);
+  const compilation = runWithStatus(compCommand, show);
 
   if compilation != 0 {
     stderr.writeln("compilation failed for " + fileName);
+    const errMsg = fileName: string +" failed to compile";
+    result.addError(executable, fileName,  errMsg);
   }
   else {
     if show then writeln("\nCompiled '", fileName, "' successfully");

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -209,7 +209,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         }
       }
       if run && !parallel {
-        runTestBinaries(projectHome, testsCompiled, testsCompiled.size, result, show);
+        runTestBinaries(projectHome, testsCompiled, result, show);
       }
       timeElapsed.stop();
       if run {
@@ -254,7 +254,7 @@ private proc runTestBinary(projectHome: string, outputLoc: string, testName: str
 
 
 private proc runTestBinaries(projectHome: string, testNames: list(string),
-                             numTests: int, ref result, show: bool) {
+                            ref result, show: bool) {
 
   const cwd = getEnv("PWD");
   for test in testNames {

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -197,6 +197,8 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         
         if compilation != 0 {
           stderr.writeln("compilation failed for " + test);
+          const errMsg = testName: string +" failed to compile";
+          result.addError(testName, test,  errMsg);
         }
         else {
           if show || !run then writeln("Compiled '", test, "' successfully");

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -123,11 +123,12 @@ proc runWithStatus(command, show=true): int {
 
   try {
     var cmd = command.split();
-    var sub = spawn(cmd, stdout=PIPE, stderr=STDOUT);
+    var sub = spawn(cmd, stdout=PIPE, stderr=PIPE);
 
     var line:string;
     if show {
       while sub.stdout.readline(line) do write(line);
+      while sub.stderr.readline(line) do write(line);
     }
     sub.wait();
     return sub.exit_status;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -123,7 +123,7 @@ proc runWithStatus(command, show=true): int {
 
   try {
     var cmd = command.split();
-    var sub = spawn(cmd, stdout=PIPE);
+    var sub = spawn(cmd, stdout=PIPE, stderr=STDOUT);
 
     var line:string;
     if show {


### PR DESCRIPTION
Avoid running tests that failed to compile and show them in results as errors.

`mason test` will try to run tests that failed to compile, resulting in `uncaught FileNotFoundError`, which may confuse users.

This PR will avoid running such tests and print errors in results. Also, the testing process will not be aborted by compilation errors as before. Check out `test/mason/mason-test/mason-test.good` for the output format.

Resolves https://github.com/chapel-lang/chapel/issues/15403
- - -
- [x] Skip tests
- [x] Show compilation failures in results
- [x] Improve tests
- [x] Update code related to UnitTest