### PR TITLE
Doc fixes for a few package and internal modules

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -523,10 +523,10 @@ module ChapelRange {
       return _low + chpl__diffMod(_alignment, _low, stride);
   }
 
+  // TODO: Add back example?
   /* Returns the range's aligned high bound. If the aligned high bound is
      undefined, the behavior is undefined.
    */
-  // TODO: Add back example?
   inline proc range.alignedHigh : idxType {
     return chpl_intToIdx(this.alignedHighAsInt);
   }

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -225,11 +225,11 @@ module DistributedBag {
   record DistBag {
     type eltType;
 
+    // This is unused, and merely for documentation purposes. See '_value'.
     /*
       The implementation of the Bag is forwarded. See :class:`DistributedBagImpl` for
       documentation.
     */
-    // This is unused, and merely for documentation purposes. See '_value'.
     var _impl : unmanaged DistributedBagImpl(eltType)?;
 
     // Privatized id...

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -206,11 +206,12 @@ module DistributedDeque {
   pragma "always RVF"
   record DistDeque {
     type eltType;
+
+    // This is unused, and merely for documentation purposes. See '_value'.
     /*
       The implementation of the Deque is forwarded. See :class:`DistributedDequeImpl` for
       documentation.
     */
-    // This is unused, and merely for documentation purposes. See '_value'.
     var _impl : unmanaged DistributedDequeImpl(eltType)?;
 
     // Privatization id

--- a/modules/packages/DistributedIters.chpl
+++ b/modules/packages/DistributedIters.chpl
@@ -49,6 +49,7 @@ config param timeDistributedIters:bool = false;
 config const infoDistributedIters:bool = false;
 
 // Distributed Dynamic Iterator.
+// Serial version.
 /*
   :arg c: The range (or domain) to iterate over. The range (domain) size must
     be positive.
@@ -97,7 +98,6 @@ config const infoDistributedIters:bool = false;
 
   Available for serial and zippered contexts.
 */
-// Serial version.
 iter distributedDynamic(c,
                         chunkSize:int=1,
                         numTasks:int=0,
@@ -323,6 +323,7 @@ where tag == iterKind.follower
 }
 
 // Distributed Guided Iterator.
+// Serial version.
 /*
   :arg c: The range (or domain) to iterate over. The range (domain) size must
     be positive.
@@ -368,7 +369,6 @@ where tag == iterKind.follower
 
   Available for serial and zippered contexts.
 */
-// Serial version.
 iter distributedGuided(c,
                        numTasks:int=0,
                        parDim:int=0,


### PR DESCRIPTION
Fixes a few docstrings in package and internal modules following the guidelines in #15477. Includes fixes for:

- ChapelRange
- DistributedBag
- DistributedDeque
- DistributedIters