### PR TITLE
Restore lost documentation due to fix with interrupting single line comments

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -68,14 +68,15 @@ module CPtr {
 
   */
 
-  //   Similar to _ddata from ChapelBase, but differs
-  //   from _ddata because it can never be wide.
   pragma "data class"
   pragma "no object"
   pragma "no default functions"
   pragma "no wide class"
   pragma "c_ptr class"
   class c_ptr {
+    //   Similar to _ddata from ChapelBase, but differs
+    //   from _ddata because it can never be wide.
+
     /* The type that this pointer points to */
     type eltType;
     /* Retrieve the i'th element (zero based) from a pointer to an array.

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1448,11 +1448,11 @@ module ChapelArray {
     }
 
     /* Remove all indices from this domain, leaving it empty */
-
-    // For rectangular domains, create an empty domain and assign it to this
-    // one to make sure that we leverage all of the array's normal resizing
-    // machinery.
     proc clear() where isRectangularDom(this) {
+      // For rectangular domains, create an empty domain and assign it to this
+      // one to make sure that we leverage all of the array's normal resizing
+      // machinery.
+
       var emptyDom: this.type;
       this = emptyDom;
     }
@@ -2979,13 +2979,13 @@ module ChapelArray {
     /*
        Return an array of locales over which this array has been distributed.
     */
-    //
-    // TODO: Is it really appropriate that the array should provide
-    // this dsi routine rather than having this call forward to the
-    // domain[.dist] here?  Do any of the array implementations do
-    // anything other than that with it?
-    //
     proc targetLocales() {
+      //
+      // TODO: Is it really appropriate that the array should provide
+      // this dsi routine rather than having this call forward to the
+      // domain[.dist] here?  Do any of the array implementations do
+      // anything other than that with it?
+      //
       return _value.dsiTargetLocales();
     }
 

--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -107,10 +107,10 @@ use IO, Regexp, Reflection;
 
 /* A class providing the ability to read records matching a regular expression.
  */
-//   Future work is to make this be able to take in a class type as opposed to a
-//   record type.  Right now we cant take in a class type due to the future filed
-//   in test/types/typedefs/tzakian/classConstructorsFromTypes.chpl
 class RecordReader {
+  //   Future work is to make this be able to take in a class type as opposed to
+  //   a record type.  Right now we cant take in a class type due to the future
+  //   filed in test/types/typedefs/tzakian/classConstructorsFromTypes.chpl
   /* The record type to populate */
   type t;
   /* The channel to read from */

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -451,8 +451,8 @@ the sorting algorithm.
   data is sorted.
 
  */
-// TODO: This should have a flag `stable` to request a stable sort
 proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+  // TODO: This should have a flag `stable` to request a stable sort
   chpl_check_comparator(comparator, eltType);
 
   if Dom.low >= Dom.high then

--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -85,11 +85,11 @@ module UnorderedCopy {
   /*
      Unordered copy. Only supported for identical trivially copyable types.
    */
-  // Version to provide a clean signature for docs and to provide a clean error
-  // message instead of just "unresolved call". Last resort to avoid thwarting
-  // promotion for POD arrays.
   pragma "last resort"
   inline proc unorderedCopy(ref dst, src): void {
+    // Version to provide a clean signature for docs and to provide a clean error
+    // message instead of just "unresolved call". Last resort to avoid thwarting
+    // promotion for POD arrays.
     compilerError("unorderedCopy is only supported between identical trivially copyable types");
   }
 

--- a/modules/standard/LinkedLists.chpl
+++ b/modules/standard/LinkedLists.chpl
@@ -129,8 +129,8 @@ record LinkedList {
   /*
     Append all of the supplied arguments to the list.
    */
-  //TODO: merge the append overloads
   proc append(e: eltType, es: eltType ...?k) {
+    //TODO: merge the append overloads
     append(e);
     for param i in 0..k-1 do
       append(es(i));
@@ -341,8 +341,8 @@ record LinkedList {
   :type x: `T`
   :rtype: LinkedList(T)
  */
-// TODO: could just be an initializer?
 proc makeList(x ...?k) {
+  // TODO: could just be an initializer?
   var s: LinkedList(x(0).type);
   for param i in 0..k-1 do
     s.append(x(i));

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -943,9 +943,9 @@ record regexp {
      :arg global: if true, replace multiple matches
      :returns: a tuple containing (new text, number of substitutions made)
    */
-  // TODO -- move subn after sub for documentation clarity
   proc subn(repl: exprType, text: exprType, global = true ):(exprType, int)
   {
+    // TODO -- move subn after sub for documentation clarity
     var pos:byteIndex;
     var endpos:byteIndex;
 


### PR DESCRIPTION
I missed noticing that these cases dropped their documentation due to that
fix.  Restore the documentation by moving the interrupting single line
comment into the definition.

Covers:
- Regexp's [subn](http://web.us.cray.com/~lydia/restoreLost/modules/standard/Regexp.html#Regexp.regexp.subn)
- LinkedList's [append](http://web.us.cray.com/~lydia/restoreLost/modules/standard/LinkedLists.html#LinkedLists.LinkedList.append) and [makeList](http://web.us.cray.com/~lydia/restoreLost/modules/standard/LinkedLists.html#LinkedLists.makeList)
- UnorderedCopy's [unorderedCopy](http://web.us.cray.com/~lydia/restoreLost/modules/packages/UnorderedCopy.html#UnorderedCopy.unorderedCopy)
- Sort's [sort](http://web.us.cray.com/~lydia/restoreLost/modules/packages/Sort.html#Sort.sort) function
- CPtr's [c_ptr](http://web.us.cray.com/~lydia/restoreLost/builtins/CPtr.html#CPtr.c_ptr) type
- ChapelArray's [clear](http://web.us.cray.com/~lydia/restoreLost/builtins/ChapelArray.html#ChapelArray.clear) and [array.targetLocales](http://web.us.cray.com/~lydia/restoreLost/builtins/ChapelArray.html#ChapelArray.IRV)
- RecordParser's [RecordReader](http://web.us.cray.com/~lydia/restoreLost/modules/packages/RecordParser.html#RecordParser.RecordReader) class

Verified the built documentation shows the restored text (and didn't before)