### PR TITLE
Move one more one-line comment that breaks doc

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -273,6 +273,7 @@ module BytesStringCommon {
     }
   }
 
+  // TODO: I wasn't very good about caching variables locally in this one.
   proc getSlice(const ref x: ?t, r: range(?)) {
     assertArgType(t, "getSlice");
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1476,7 +1476,6 @@ module String {
       :returns: a new string that is a substring within ``0..<string.size``. If
                 the length of `r` is zero, an empty string is returned.
      */
-    // TODO: I wasn't very good about caching variables locally in this one.
     inline proc this(r: range(?)) : string {
       return getSlice(this, r);
     }


### PR DESCRIPTION
Moves the comment above the slicing `string.this` to the helper