### PR TITLE
fixed mason example doc

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -408,8 +408,8 @@ in their ``Mason.toml`` as follows:
    examples = ["myPackageExample.chpl"]
 
    [examples.myPackageExample]
-   execopts = ["--count=20"]
-   compopts = ["--savec tmp"]
+   execopts = "--count=20"
+   compopts = "--savec tmp"
 
 
 Documenting a Package


### PR DESCRIPTION
Modified the Mason example doc, from 
```
execopts = ["--count=20"]
compopts = ["--savec tmp"]
```
to 
```
execopts = "--count=20"
compopts = "--savec tmp"
```
fixes #15485 