### PR TITLE
Add a workaround for PrivateDist leaks

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -230,5 +230,5 @@ proc PrivateArr.doiScan(op, dom) where (rank == 1) &&
 }
 
 // TODO: Fix 'new Private()' leak -- Discussed in #6726
-const PrivateSpace: domain(1) dmapped Private();
-
+const chpl_privateDist = new unmanaged Private();
+const PrivateSpace: domain(1) dmapped new dmap(chpl_privateDist);

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -180,4 +180,10 @@ module ChapelUtil {
 
     chpl_moduleDeinitFuns = nil;
   }
+
+  // TODO: Fix 'new Private()' leak -- Discussed in #6726
+  use PrivateDist;
+  proc deinit() {
+    delete chpl_privateDist;
+  }
 }


### PR DESCRIPTION
This PR separates the distribution of `PrivateSpace` to clean it up, which is done in ChapelUtil.

This is a workaround to close the memory leak in the short term, until we have a better approach for implementing PrivateDist/PrivateSpace.

Some related reading:
https://github.com/chapel-lang/chapel/pull/6695
https://github.com/chapel-lang/chapel/issues/6726
https://github.com/chapel-lang/chapel/pull/6741
https://github.com/chapel-lang/chapel/issues/12731

This is currently draft because it causes the following changes:
- 2 more ONs in `modules/sungeun/init/printInitCommCounts`
- 56 byte allocated (and freed) in `runtime/configMatters/comm/commArrayMemStats`

They seem innocent to me, but I definitely need a second opinion before I accept those changes.

Test:
- [x] valgrind in release/examples
- [ ] standard
- [ ] gasnet