### PR TITLE
Fix a bug that seems as though it was preventing tuple casting

### DIFF
--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -328,7 +328,7 @@ module ChapelTuple {
   //
   pragma "tuple cast fn"
   pragma "unsafe"
-  inline proc _cast(type t:_tuple, x: _tuple) {
+  inline proc _cast(type t:_tuple, x: _tuple) throws {
     // body filled in during resolution
   }
 

--- a/test/types/tuple/castTupleResult.chpl
+++ b/test/types/tuple/castTupleResult.chpl
@@ -1,0 +1,22 @@
+proc string.splitStringToTuple(param numChunks: int) {
+  var tup: numChunks*string;
+  var count = 0;
+
+  // fill in the initial tuple elements defined by split()                  
+  for s in this.split(numChunks-1) {
+    tup(count) = s;
+    count += 1;
+  }
+  // if split() had fewer items than the tuple, fill in the rest            
+  if (count < numChunks) {
+    for i in count..numChunks-1 {
+      tup(i) = "";
+    }
+  }
+  return tup;
+}
+
+var (i, r, s) = "1 2.3 'hi'".splitStringToTuple(3): (int,real,string);
+writeln(i, ":", i.type:string);
+writeln(r, ":", r.type:string);
+writeln(s, ":", s.type:string);

--- a/test/types/tuple/castTupleResult.good
+++ b/test/types/tuple/castTupleResult.good
@@ -1,0 +1,3 @@
+1:int(64)
+2.3:real(64)
+'hi':string


### PR DESCRIPTION
It seems that tuple casts haven't been working, at least in some cases.  I stumbled into this right before 1.22, but didn't manage to investigate or fix it in time.... :(