### PR TITLE
Trivial formatting updates to Engin's version of regex-redux

### DIFF
--- a/test/studies/shootout/regexdna-redux/engin/regexredux.chpl
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.chpl
@@ -1,14 +1,12 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
-   regex-dna program contributed by Ben Harshbarger
-   derived from the GNU C++ RE2 version by Alexey Zolotov
-
-   converted from regex-dna program
+   contributed by Engin Kayraklioglu
+   derived from the converted regex-dna Chapel version by Ben Harshbarger
+   which was derived from the GNU C++ RE2 version by Alexey Zolotov
 */
 
-use IO;
-use Regexp;
+use IO, Regexp;
 
 proc main(args: [] string) {
   var variants = [
@@ -24,8 +22,8 @@ proc main(args: [] string) {
   ];
 
   var subst = [
-    (b"tHa[Nt]", b"<4>"), (b"aND|caN|Ha[DS]|WaS", b"<3>"), (b"a[NSt]|BY", b"<2>"), 
-    (b"<[^>]*>", b"|"), (b"\\|[^|][^|]*\\|", b"-")
+    (b"tHa[Nt]", b"<4>"), (b"aND|caN|Ha[DS]|WaS", b"<3>"),
+    (b"a[NSt]|BY", b"<2>"), (b"<[^>]*>", b"|"), (b"\\|[^|][^|]*\\|", b"-")
   ];
 
   var data: bytes;


### PR DESCRIPTION
* updated the byline to reflect Engin's authorship and compress the history a bit
* put both `use`d modules on one line
* reformatted an array literal to fit within 80 columns