### PR TITLE
Add a future test for spawn(..stderr=STDOUT)

### DIFF
--- a/test/library/standard/Spawn/redirect-stderr-stdout.bad
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.bad
@@ -1,0 +1,2 @@
+main process
+stderr

--- a/test/library/standard/Spawn/redirect-stderr-stdout.bad
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.bad
@@ -1,2 +1,3 @@
+*stdout
 main process
 stderr

--- a/test/library/standard/Spawn/redirect-stderr-stdout.chpl
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.chpl
@@ -1,5 +1,5 @@
 use Spawn;
 const cmd = ["sh", "-c", "echo stderr 1>&2; echo stdout;"];
 var sub = spawn(cmd, stdout=PIPE, stderr=STDOUT);
-writeln("main process");
 sub.wait();
+writeln("main process");

--- a/test/library/standard/Spawn/redirect-stderr-stdout.chpl
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.chpl
@@ -1,5 +1,9 @@
 use Spawn;
 const cmd = ["sh", "-c", "echo stderr 1>&2; echo stdout;"];
 var sub = spawn(cmd, stdout=PIPE, stderr=STDOUT);
+var line: string;
+while (sub.stdout.readline(line)) {
+  write('*'+line);
+}
 sub.wait();
 writeln("main process");

--- a/test/library/standard/Spawn/redirect-stderr-stdout.chpl
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.chpl
@@ -1,0 +1,5 @@
+use Spawn;
+const cmd = ["sh", "-c", "echo stderr 1>&2; echo stdout;"];
+var sub = spawn(cmd, stdout=PIPE, stderr=STDOUT);
+writeln("main process");
+sub.wait();

--- a/test/library/standard/Spawn/redirect-stderr-stdout.future
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.future
@@ -1,0 +1,3 @@
+bug: spawn(..stderr=STDOUT) not working
+
+https://github.com/chapel-lang/chapel/issues/15497

--- a/test/library/standard/Spawn/redirect-stderr-stdout.good
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.good
@@ -1,0 +1,1 @@
+main process

--- a/test/library/standard/Spawn/redirect-stderr-stdout.good
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.good
@@ -1,1 +1,3 @@
+*stderr
+*stdout
 main process


### PR DESCRIPTION
Add a future test for `spawn(..stderr=STDOUT)` since it's not working now.

Relates to https://github.com/chapel-lang/chapel/issues/15497

@bradcray Kindly review.