### PR TITLE
Fix Fortran interop tests which had not been updated to 0-based tupling

### DIFF
--- a/modules/internal/ISO_Fortran_binding.chpl
+++ b/modules/internal/ISO_Fortran_binding.chpl
@@ -194,9 +194,9 @@ module ISO_Fortran_binding {
     }
 
     var dims: rank*range;
-    for param i in 1..rank {
-      assert(FA.dim[i-1].lower_bound == 0);
-      dims[i] = 1..#FA.dim[i-1].extent;
+    for param i in 0..<rank {
+      assert(FA.dim[i].lower_bound == 0);
+      dims[i] = 1..#FA.dim[i].extent;
     }
     var D = {(...dims)};
     var A = D.buildArrayWith(eltType,

--- a/test/interop/fortran/multidimArray/chapelProcs.chpl
+++ b/test/interop/fortran/multidimArray/chapelProcs.chpl
@@ -19,8 +19,8 @@ export proc chpl_library_init_ftn() {
 proc CFI_cdesc_t.this(idx:int...?rank) ref {
   assert(this.rank == rank);
   var subscripts: [0..#rank] CFI_index_t;
-  for param i in 1..rank {
-    subscripts[i-1] = idx[i]: CFI_index_t;
+  for param i in 0..<rank {
+    subscripts[i] = idx[i]: CFI_index_t;
   }
   var x = CFI_address(this, c_ptrTo(subscripts)): c_ptr(real);
   return x.deref();


### PR DESCRIPTION
Apparently the one (?) test configuration that runs these hasn't
completed since March 25th?