### PR TITLE
Fix my nbody variations

### DIFF
--- a/test/studies/shootout/nbody/bradc/nbody-blc-ref.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc-ref.chpl
@@ -115,8 +115,9 @@ record NBodySystem {
   
 }
 
+config const n = 10000;
+
 proc main(args: [] string) {
-  const n = args[1]:int;
 
   var bodies: NBodySystem;
 

--- a/test/studies/shootout/nbody/bradc/nbody-blc-slice.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc-slice.chpl
@@ -99,9 +99,9 @@ record NBodySystem {
   }
 }
 
-proc main(args: [] string) {
-  const n = args[1]:int;
+config const n = 10000;
 
+proc main(args: [] string) {
   var bodies: NBodySystem;
 
   writef("%.9r\n", bodies.energy());

--- a/test/studies/shootout/nbody/bradc/nbody-blc-zip.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc-zip.chpl
@@ -103,8 +103,9 @@ record NBodySystem {
   }
 }
 
+config const n = 10000;
+
 proc main(args: [] string) {
-  const n = args[1]:int;
 
   var bodies: NBodySystem;
 


### PR DESCRIPTION
I accidentally broke these yesterday when bringing my nbody-blc version
up-to-date with our submitted version because all four of these tests
used to parse an argument from main (old-style) and then I changed the
new one to a config const, forgetting that there were other tests that
shared [PERF]EXECOPTS with it.

[Worse, I ran a full test against master before bed yesterday to make
sure I hadn't broken anything, but had a bad file in my local repo, so I
didn't get good results and then didn't take the time to run it again from
a clean repo.  Sloppy!