### PR TITLE
Optimize blc version of fasta

### DIFF
--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -117,10 +117,9 @@ proc randomMake(desc, nuclInfo: [?nuclInds], n) {
   // compute the cumulative probabilities of the nucleotides
   var cumulProb: [nuclInds] randType,
       p = 0.0;
-  for i in nuclInds {
-    const (_,prob) = nuclInfo[i];
+  for (cp, (_,prob)) in zip(cumulProb, nuclInfo) {
     p += prob;
-    cumulProb[i] = 1 + (p*IM):randType;
+    cp = 1 + (p*IM): randType;
   }
 
   // guard when tasks can access the random numbers or output stream

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -148,7 +148,9 @@ proc randomMake(desc, nuclInfo: [?nuclInds], n) {
           off = 0;
 
       for r in myRands[..<nBytes] {
-        const nid = + reduce for p in cumulProb do (r >= p);
+        var nid = 0;
+        for p in cumulProb do
+          nid += (r >= p);
         const (nucl,_) = nuclInfo[nid];
 
         myBuff[off] = nucl: int(8);

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -148,7 +148,7 @@ proc randomMake(desc, nuclInfo: [?nuclInds], n) {
           off = 0;
 
       for r in myRands[..<nBytes] {
-        const nid = + reduce (r >= cumulProb);
+        const nid = + reduce for p in cumulProb do (r >= p);
         const (nucl,_) = nuclInfo[nid];
 
         myBuff[off] = nucl: int(8);


### PR DESCRIPTION
Yesterday, I was overly optimistic about the overhead of a new use of a reduction; here, I back that out, revert to more manual ways of computing the reduction and put in some nice style changes to boot.
