### PR TITLE
Update performance graphs with release 1.21 and 1.22.

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -138,6 +138,14 @@ export CHPL_TEST_PERF_DATE="09/11/19"
 export CHPL_HOME=$chpl_release_home/chapel-1.20.0
 testReleasePerformance
 
+export CHPL_TEST_PERF_DATE="03/31/20"
+export CHPL_HOME=$chpl_release_home/chapel-1.21.0
+testReleasePerformance
+
+export CHPL_TEST_PERF_DATE="04/07/20"
+export CHPL_HOME=$chpl_release_home/chapel-1.22.0
+testReleasePerformance
+
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -110,7 +110,7 @@ var branchInfo = [
                   { "release" : "1.22",
                     "releaseDate": "2020-04-16",
                     "branchDate" : "2020-04-07",
-  "revision" : -1}
+                    "revision" : -1}
                   ];
 
 

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -102,7 +102,15 @@ var branchInfo = [
                   { "release" : "1.20",
                     "releaseDate": "2019-09-19",
                     "branchDate" : "2019-09-11",
-                    "revision" : -1}
+                    "revision" : -1},
+                  { "release" : "1.21",
+                    "releaseDate": "2020-04-09",
+                    "branchDate" : "2020-03-31",
+                    "revision" : -1},
+                  { "release" : "1.22",
+                    "releaseDate": "2020-04-16",
+                    "branchDate" : "2020-04-07",
+  "revision" : -1}
                   ];
 
 


### PR DESCRIPTION
Update dates with the branch and the release dates of our latest releases.