### PR TITLE
Cache whether a ResolveScope or UseStmt can reexport

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -85,20 +85,20 @@ public:
   Symbol*               lookupPublicImports(const char* name)            const;
 
   Symbol*               lookupPublicUnqualAccessSyms(const char* name,
-                                                     BaseAST *context)   const;
+                                                     BaseAST *context);
 
   Symbol*               lookupPublicUnqualAccessSyms(const char* name,
                           BaseAST *context,
-                          std::map<Symbol *, astlocT *>& renameLocs)      const;
+                          std::map<Symbol *, astlocT *>& renameLocs);
 
   Symbol*               lookupPublicUnqualAccessSyms(const char* name,
                           ModuleSymbol*& modArg,
-                          BaseAST *context)                              const;
+                          BaseAST *context);
 
   Symbol*               lookupPublicUnqualAccessSyms(const char* name,
                           ModuleSymbol*& modArg,
                           BaseAST *context,
-                          std::map<Symbol *, astlocT *>& renameLocs)      const;
+                          std::map<Symbol *, astlocT *>& renameLocs);
 
   // Support for UseStmt with only/except
   // Has the potential to return multiple fields
@@ -107,6 +107,8 @@ public:
                                   std::vector<Symbol*>& symbols)         const;
 
   void                  describe()                                       const;
+
+  bool                  canReexport = true;
 
 private:
   typedef std::vector<VisibilityStmt*>   UseImportList;

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -68,6 +68,8 @@ public:
 
   void            writeListPredicate(FILE* mFP)                          const;
 
+  bool            canReexport = true;
+
 private:
   bool            isEnum(const Symbol* sym)                              const;
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -950,10 +950,9 @@ Symbol* ResolveScope::lookupNameLocally(const char* name, bool isUse) const {
 }
 
 Symbol* ResolveScope::lookupPublicImports(const char* name) const {
-  UseImportList useImportList = mUseImportList;
   Symbol *retval = NULL;
 
-  for_vector_allowing_0s(VisibilityStmt, visStmt, useImportList) {
+  for_vector_allowing_0s(VisibilityStmt, visStmt, mUseImportList) {
     if (ImportStmt *is = toImportStmt(visStmt)) {
       if (!is->isPrivate) {
         if (Symbol *importSym = visStmt->checkIfModuleNameMatches(name)) {
@@ -971,7 +970,9 @@ Symbol* ResolveScope::lookupPublicImports(const char* name) const {
 
 // This version is used in resolving the calls in an import statement
 Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
-                                                   BaseAST *context) const {
+                                                   BaseAST *context) {
+  if (!this->canReexport) return NULL;
+
   std::map<Symbol *, astlocT *> renameLocs;
   ModuleSymbol *ms = NULL;
   Symbol *retval = lookupPublicUnqualAccessSyms(name, ms, context, renameLocs);
@@ -981,7 +982,9 @@ Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
 // This version is used in resolveModuleCall in scope resolution
 Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
                                                    ModuleSymbol*& modArg,
-                                                   BaseAST *context) const {
+                                                   BaseAST *context) {
+  if (!this->canReexport) return NULL;
+
   std::map<Symbol *, astlocT *> renameLocs;
   Symbol *retval = lookupPublicUnqualAccessSyms(name, modArg, context,
                                                 renameLocs);
@@ -991,7 +994,9 @@ Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
 
 // This version is used in regular unresolvedsymexpr scope resolution
 Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
-            BaseAST *context, std::map<Symbol*, astlocT*>& renameLocs) const {
+            BaseAST *context, std::map<Symbol*, astlocT*>& renameLocs) {
+  if (!this->canReexport) return NULL;
+
   ModuleSymbol *ms = NULL;
   Symbol *retval = lookupPublicUnqualAccessSyms(name, ms, context, renameLocs);
   return retval;
@@ -999,15 +1004,17 @@ Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
 
 Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
          ModuleSymbol*& modArg, BaseAST *context,
-         std::map<Symbol*, astlocT*>& renameLocs) const {
+         std::map<Symbol*, astlocT*>& renameLocs) {
+  if (!this->canReexport) return NULL;
 
-  UseImportList useImportList = mUseImportList;
   std::vector<Symbol *> symbols;
 
   bool traversedRenames = false;
-  for_vector_allowing_0s(VisibilityStmt, visStmt, useImportList) {
+  bool hasPublicImport = false;
+  for_vector_allowing_0s(VisibilityStmt, visStmt, mUseImportList) {
     if (ImportStmt *impStmt = toImportStmt(visStmt)) {
       if (!impStmt->isPrivate) {
+        hasPublicImport = true;
         if (!impStmt->skipSymbolSearch(name)) {
           const char *nameToUse = name;
           const bool isSymRenamed = impStmt->isARenamedSym(name);
@@ -1030,6 +1037,10 @@ Symbol* ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
         }
       }
     }
+  }
+
+  if (!hasPublicImport) {
+    this->canReexport = false;
   }
 
   if (symbols.size() == 1) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1722,10 +1722,14 @@ static bool lookupThisScopeAndUses(const char*           name,
               BaseAST* scopeToUse = use->getSearchScope();
 
               Symbol* sym = inSymbolTable(nameToUse, scopeToUse);
-              if (!sym) {
+              if (!sym && use->canReexport) {
                 if (ResolveScope* rs = ResolveScope::getScopeFor(scopeToUse)) {
                   sym = rs->lookupPublicUnqualAccessSyms(nameToUse, context,
                                                          renameLocs);
+                  // propagate this information to the UseStmt
+                  if (!rs->canReexport) {
+                    use->canReexport = false;
+                  }
                 }
               }
               if (sym) {


### PR DESCRIPTION
This PR adds a `canReexport` field to `ResolveScope` and `UseStmt` to track
whether they contain a `public import`.

This is motivated by mitigating a [compiler performance regression](https://chapel-lang.org/perf/chap01/?startdate=2019/12/19&enddate=2020/04/14&graphs=topaveragecompilationtimeperpass)
in scopeResolve noted by @ronawho.

On `hello.chpl` I see scopeResolve time improving by about 1.25x. This number is
close to the regression we observe. I can spend more time if this doesn't put us
back where we were before.

Test:
- [x] standard
