### PR TITLE
Make some improvements to Arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -11,6 +11,9 @@ source $CWD/functions.bash
 
 subtest_start
 
+DFLT_TIMEOUT=${CHPL_TEST_TIMEOUT:-300}
+export ARKOUDA_CLIENT_TIMEOUT=${ARKOUDA_CLIENT_TIMEOUT:-$DFLT_TIMEOUT}
+
 # Arkouda needs chpl in PATH
 bin_subdir=$($CHPL_HOME/util/chplenv/chpl_bin_subdir.py)
 export "PATH=$CHPL_HOME/bin/$bin_subdir:$PATH"
@@ -31,6 +34,10 @@ if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-de
 fi
 
 # Compile Arkouda
+if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
+  export ARKOUDA_PRINT_PASSES_FILE="$CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION/comp-time"
+  mkdir -p $(dirname $ARKOUDA_PRINT_PASSES_FILE)
+fi
 if ! make ; then
   log_fatal_error "compiling arkouda"
 fi
@@ -52,7 +59,11 @@ test_end "make check"
 
 # Run benchmarks
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-  benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --description $CHPL_TEST_PERF_DESCRIPTION --graph-dir $CHPL_TEST_PERF_DIR/html"
+  benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+
+  if [[ -n $CHPL_TEST_PERF_DESCRIPTION ]]; then
+    benchmark_opts="${benchmark_opts} --description $CHPL_TEST_PERF_DESCRIPTION"
+  fi
   if [[ -n $CHPL_TEST_PERF_CONFIG_NAME ]]; then
     benchmark_opts="${benchmark_opts} --platform $CHPL_TEST_PERF_CONFIG_NAME"
   fi

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -2,14 +2,13 @@
 #
 # Configure environment for arkouda testing
 
-CWD=$(cd $(dirname $0) ; pwd)
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 # Perf configuration
 source $CWD/common-perf.bash
-ARKOUDA_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/arkouda
+ARKOUDA_PERF_DIR=${ARKOUDA_PERF_DIR:-/cray/css/users/chapelu/NightlyPerformance/arkouda}
 export CHPL_TEST_PERF_DIR=$ARKOUDA_PERF_DIR/$CHPL_TEST_PERF_CONFIG_NAME
 export CHPL_TEST_NUM_TRIALS=3
-export CHPL_TEST_PERF_CONFIGS="release:v,master:v"
 export CHPL_TEST_PERF_START_DATE=04/01/20
 
 # Run arkouda correctness and performance testing
@@ -27,6 +26,7 @@ currentSha=`git rev-parse HEAD`
 # test against Chapel release
 function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release
+  export CHPL_TEST_PERF_CONFIGS="release:v,master:v"
   git checkout 1.20.0
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
@@ -36,6 +36,7 @@ function test_release() {
 # test against Chapel master
 function test_master() {
   export CHPL_TEST_PERF_DESCRIPTION=master
+  export CHPL_TEST_PERF_CONFIGS="release:v,master:v"
   git checkout $currentSha
   git clean -ffdx $CHPL_HOME
   $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Set ARKOUDA_CLIENT_TIMEOUT to get reasonable testing timeouts instead of
long hangs and build failures.

Enable arkouda build/compile time tracking

Make it easier to run arkouda perf testing manually. Can now do:

    export ARKOUDA_PERF_DIR=<dir>
    source util/cron/common-arkouda.bash
    start_test test/studies/arkouda