### PR TITLE
Don't use native qthread sync vars under aarch64

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -971,10 +971,11 @@ private module SyncVarRuntimeSupport {
   // Native qthreads sync var helpers and externs
   //
 
-  // native qthreads aligned_t sync vars only work on 64-bit platforms right
-  // now, and we only support casting between certain types and aligned_t
+  // native qthreads aligned_t sync vars only work on non-ARM 64-bit platform,
+  // and we only support casting between certain types and aligned_t
   proc supportsNativeSyncVar(type t) param {
-    return CHPL_TASKS == "qthreads"    &&
+    return CHPL_TASKS == "qthreads" &&
+           CHPL_TARGET_ARCH != "aarch64" &&
            castableToAlignedT(t) &&
            numBits(c_uintptr) == 64;
   }


### PR DESCRIPTION
There is some MCM issue with native qthread sync vars under 64-bit arm
systems. We have not had time to really look into this, so for now use
non-native sync vars, which do not appear to have this issue.

test/runtime/configMatters/comm/cache-remote/acqrel-sync* passed 500
trials with this (was failing 1/25 before.)

Closes https://github.com/chapel-lang/chapel/issues/11106
Closes https://github.com/Cray/chapel-private/issues/653
Closes https://github.com/Cray/chapel-private/issues/888