### PR TITLE
Use prebuilt hdf5 and zeromq for Arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -28,9 +28,13 @@ if ! git clone --depth=1 ${ARKOUDA_URL} --branch=${ARKOUDA_BRANCH} ; then
 fi
 cd ${ARKOUDA_HOME}
 
-# Install dependencies
-if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
-  log_fatal_error "installing dependencies"
+# Install dependencies if needed
+if make check-deps ; then
+  export ARKOUDA_SKIP_CHECK_DEPS=true
+else
+  if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
+    log_fatal_error "installing dependencies"
+  fi
 fi
 
 # Compile Arkouda

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -16,6 +16,12 @@ export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 export CHPL_TEST_ARKOUDA_PERF=true
 
+ARKOUDA_DEP_DIR=/cray/css/users/chapelu/arkouda-deps
+if [ -d "$ARKOUDA_DEP_DIR" ]; then
+  export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}
+  export ARKOUDA_HDF5_PATH=${ARKOUDA_HDF5_PATH:-$ARKOUDA_DEP_DIR/hdf5-install}
+fi
+
 # Use personal branch (just as we get perf testing up and running to make sure
 # things are working before upstream'ing.)
 export ARKOUDA_URL=https://github.com/ronawho/arkouda.git


### PR DESCRIPTION
Don't waste time building hdf5/zeromq each time, just use prebuilt ones.

Closes https://github.com/Cray/chapel-private/issues/900