### PR TITLE
Extend ast traversals for Import statements to handle missing functionality

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -425,6 +425,17 @@ void AstDump::visitImportStmt(ImportStmt* node) {
 
   node->src->accept(this);
 
+  if (node->isARename()) {
+    fprintf(mFP, " 'as' %s", node->getRename());
+  }
+
+  if (node->providesUnqualifiedAccess()) {
+    fprintf(mFP, ".{");
+    bool first = outputVector(mFP, node->unqualified);
+    outputRenames(mFP, node->renamed, first);
+    fprintf(mFP, "}");
+  }
+
   write(false, ")", true);
 }
 

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -495,6 +495,17 @@ void AstDumpToHtml::visitImportStmt(ImportStmt* node) {
 
   node->src->accept(this);
 
+  if (node->isARename()) {
+    fprintf(mFP, " 'as' %s", node->getRename());
+  }
+
+  if (node->providesUnqualifiedAccess()) {
+    fprintf(mFP, ".{");
+    bool first = outputVector(mFP, node->unqualified);
+    outputRenames(mFP, node->renamed, first);
+    fprintf(mFP, "}");
+  }
+
   fprintf(mFP, ")");
 
   if (isBlockStmt(node->parentExpr)) {

--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1146,6 +1146,25 @@ void AstDumpToNode::visitImportStmt(ImportStmt* node)
   newline();
   node->src->accept(this);
 
+  if (node->isARename()) {
+    fprintf(mFP, " 'as' %s", node->getRename());
+  }
+
+  if (node->providesUnqualifiedAccess()) {
+    fprintf(mFP, ".{");
+
+    for_vector(const char, str, node->unqualified) {
+      newline();
+      fprintf(mFP, "%s", str);
+    }
+
+    for (std::map<const char*, const char*>::iterator it = node->renamed.begin();
+         it != node->renamed.end(); ++it) {
+      newline();
+      fprintf(mFP, "%s 'as' %s", it->second, it->first);
+    }
+  }
+
   mOffset = mOffset - 2;
   newline();
   exitNode(node);

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -205,6 +205,37 @@ static void usePostamble(UseStmt* use, int indent) {
   printf("\n");
 }
 
+static void importPostamble(ImportStmt* import, int indent) {
+  if (import->isARename()) {
+    printf("as %s ", import->getRename());
+  }
+
+  if (import->providesUnqualifiedAccess()) {
+    printf(". {");
+    bool first = true;
+
+    for_vector(const char, str, import->unqualified) {
+      if (first) {
+        first = false;
+      } else {
+        printf(", ");
+      }
+      printf("%s", str);
+    }
+
+    for (std::map<const char*, const char*>::iterator it =
+           import->renamed.begin(); it != import->renamed.end(); ++it) {
+      if (first) {
+        first = false;
+      } else {
+        printf(", ");
+      }
+      printf("%s as %s", it->second, it->first);
+    }
+    printf("}\n");
+  }
+}
+
 static bool
 list_line(Expr* expr, BaseAST* parentAst) {
   if (expr->isStmt())
@@ -218,7 +249,7 @@ list_line(Expr* expr, BaseAST* parentAst) {
       return false;
   }
   if (Expr* pExpr = toExpr(parentAst))
-    if (pExpr->isStmt() && !isUseStmt(pExpr))
+    if (pExpr->isStmt() && !isUseStmt(pExpr) && !isImportStmt(pExpr))
       return true;
   if (isSymbol(parentAst))
     return true;
@@ -331,6 +362,8 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       else         printf("} ");
     } else if (UseStmt* use = toUseStmt(expr)) {
       usePostamble(use, indent);
+    } else if (ImportStmt* import = toImportStmt(expr)) {
+      importPostamble(import, indent);
     } else if (CondStmt* cond = toCondStmt(parentAst)) {
       if (cond->condExpr == expr)
         printf("\n");


### PR DESCRIPTION
I had accidentally missed updating the ast traversal patterns for renaming,
lists of unqualified symbols, and renaming within those lists.  This change
adds that support.

Checked generated logs, generated html, and lview in lldb for:
- test/visibility/import/nested.chpl
- test/visibility/import/enablesUnqualified/multipleImports2.chpl
- test/visibility/import/enablesUnqualified/multipleUnqualified/allButOne.chpl
- test/visibility/import/rename/new_name.chpl
- test/visibility/import/rename/renameInMultiImport.chpl
- test/visibility/import/rename/renameMiddle.chpl

Also passed a full paratest with futures, but that's out of superstition, I
think.