### PR TITLE
Add new tests to lock in import behavior

### DIFF
--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/badName.chpl
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/badName.chpl
@@ -1,0 +1,10 @@
+module Foo {
+  var bar: int;
+}
+module User {
+  import Foo.{baz}; // Should fail, baz not defined in Foo
+
+  proc main() {
+    writeln(baz);
+  }
+}

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/badName.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/badName.good
@@ -1,0 +1,1 @@
+badName.chpl:5: error: Bad identifier, no known 'baz' defined in 'Foo'

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/repeats.chpl
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/repeats.chpl
@@ -1,0 +1,11 @@
+module Foo {
+  var bar: int;
+  var baz = "blah";
+}
+module User {
+  import Foo.{bar, bar}; // Should work but warn, can't repeat
+
+  proc main() {
+    writeln(bar);
+  }
+}

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/repeats.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/repeats.good
@@ -1,0 +1,2 @@
+repeats.chpl:6: warning: identifier 'bar' is repeated
+0

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/unqualifiedPrivate.chpl
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/unqualifiedPrivate.chpl
@@ -1,0 +1,10 @@
+module M {
+  private var x: bool;
+}
+module User {
+  import M.{x};
+
+  proc main() {
+    writeln(x);
+  }
+}

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/unqualifiedPrivate.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/unqualifiedPrivate.good
@@ -1,0 +1,1 @@
+unqualifiedPrivate.chpl:5: error: Bad identifier, 'x' is private

--- a/test/visibility/import/enablesUnqualified/unqualifiedPrivate.chpl
+++ b/test/visibility/import/enablesUnqualified/unqualifiedPrivate.chpl
@@ -1,0 +1,10 @@
+module M {
+  private var x: bool;
+}
+module User {
+  import M.x;
+
+  proc main() {
+    writeln(x);
+  }
+}

--- a/test/visibility/import/enablesUnqualified/unqualifiedPrivate.good
+++ b/test/visibility/import/enablesUnqualified/unqualifiedPrivate.good
@@ -1,0 +1,1 @@
+unqualifiedPrivate.chpl:5: error: Bad identifier, 'x' is private

--- a/test/visibility/import/rename/badNewName.chpl
+++ b/test/visibility/import/rename/badNewName.chpl
@@ -1,0 +1,14 @@
+module M {
+  var x: int;
+}
+module User {
+  import M.{x as foo()}; // Should fail, only identifiers allowed as new names
+
+  proc main() {
+    writeln(blah);
+  }
+
+  proc foo() param {
+    return "blah";
+  }
+}

--- a/test/visibility/import/rename/badNewName.good
+++ b/test/visibility/import/rename/badNewName.good
@@ -1,0 +1,1 @@
+badNewName.chpl:5: error: incorrect expression in 'import' list rename, identifier expected

--- a/test/visibility/import/rename/badOldName.chpl
+++ b/test/visibility/import/rename/badOldName.chpl
@@ -1,0 +1,10 @@
+module M {
+  var x: int;
+}
+module User {
+  import M.{"x" as foo}; // Should fail, only identifiers allowed as old names
+
+  proc main() {
+    writeln(foo);
+  }
+}

--- a/test/visibility/import/rename/badOldName.good
+++ b/test/visibility/import/rename/badOldName.good
@@ -1,0 +1,1 @@
+badOldName.chpl:5: error: incorrect expression in 'import' list rename, identifier expected

--- a/test/visibility/import/rename/ensureRightSymbolRenamed.chpl
+++ b/test/visibility/import/rename/ensureRightSymbolRenamed.chpl
@@ -1,0 +1,10 @@
+module M {
+  var x: int;
+}
+module User {
+  import M.x as foo;
+
+  proc main() {
+    writeln(foo.x); // Ensures that we don't accidentally replace M with Foo
+  }
+}

--- a/test/visibility/import/rename/ensureRightSymbolRenamed.good
+++ b/test/visibility/import/rename/ensureRightSymbolRenamed.good
@@ -1,0 +1,3 @@
+ensureRightSymbolRenamed.chpl:7: In function 'main':
+ensureRightSymbolRenamed.chpl:8: error: unresolved call 'int(64).x'
+ensureRightSymbolRenamed.chpl:8: note: because no functions named x found in scope

--- a/test/visibility/import/rename/noSuchOldName.chpl
+++ b/test/visibility/import/rename/noSuchOldName.chpl
@@ -1,0 +1,10 @@
+module M {
+  var bar: bool;
+}
+module User {
+  import M.{baz as foo}; // Should fail, baz doesn't exist!
+
+  proc main() {
+    writeln(foo);
+  }
+}

--- a/test/visibility/import/rename/noSuchOldName.good
+++ b/test/visibility/import/rename/noSuchOldName.good
@@ -1,0 +1,1 @@
+noSuchOldName.chpl:5: error: Bad identifier in rename, no known 'baz' in 'M'

--- a/test/visibility/import/rename/renameAndUnrenamed.chpl
+++ b/test/visibility/import/rename/renameAndUnrenamed.chpl
@@ -1,0 +1,12 @@
+module A {
+  var x: int;
+  var y = "blah";
+}
+module User {
+  import A.{x, x as y}; // works but warns user in case they didn't intend to
+
+  proc main() {
+    writeln(x); // A.x
+    writeln(y); // A.x
+  }
+}

--- a/test/visibility/import/rename/renameAndUnrenamed.good
+++ b/test/visibility/import/rename/renameAndUnrenamed.good
@@ -1,0 +1,3 @@
+renameAndUnrenamed.chpl:6: warning: identifier 'x' is repeated
+0
+0

--- a/test/visibility/import/rename/renameChain.chpl
+++ b/test/visibility/import/rename/renameChain.chpl
@@ -1,0 +1,11 @@
+module M {
+  var foo: bool;
+}
+module User {
+  import M.{foo as bar, bar as baz}; // Should fail
+
+  proc main() {
+    writeln(bar);
+    writeln(baz);
+  }
+}

--- a/test/visibility/import/rename/renameChain.good
+++ b/test/visibility/import/rename/renameChain.good
@@ -1,0 +1,3 @@
+renameChain.chpl:5: warning: identifier 'bar' is repeated
+note: Did you mean to rename 'foo' to 'baz'?
+renameChain.chpl:5: error: Bad identifier in rename, no known 'bar' in 'M'

--- a/test/visibility/import/rename/renameNoLeak.chpl
+++ b/test/visibility/import/rename/renameNoLeak.chpl
@@ -1,0 +1,11 @@
+module M {
+  var x: int;
+  var y: bool;
+}
+module User {
+  import M.{x as foo};
+
+  proc main() {
+    writeln(y); // Ensures the renaming doesn't enable other symbols to be found
+  }
+}

--- a/test/visibility/import/rename/renameNoLeak.good
+++ b/test/visibility/import/rename/renameNoLeak.good
@@ -1,0 +1,2 @@
+renameNoLeak.chpl:8: In function 'main':
+renameNoLeak.chpl:9: error: 'y' undeclared (first use this function)

--- a/test/visibility/import/rename/renamePrivate.chpl
+++ b/test/visibility/import/rename/renamePrivate.chpl
@@ -1,0 +1,10 @@
+module M {
+  private var bar: bool;
+}
+module User {
+  import M.{bar as foo}; // Should fail, bar is private
+
+  proc main() {
+    writeln(foo);
+  }
+}

--- a/test/visibility/import/rename/renamePrivate.good
+++ b/test/visibility/import/rename/renamePrivate.good
@@ -1,0 +1,1 @@
+renamePrivate.chpl:5: error: Bad identifier in rename, 'bar' is private

--- a/test/visibility/import/rename/renameToAlreadyImported.chpl
+++ b/test/visibility/import/rename/renameToAlreadyImported.chpl
@@ -1,0 +1,11 @@
+module A {
+  var x: int;
+  var y = "blah";
+}
+module User {
+  import A.{x, y as x}; // should fail, these conflict
+
+  proc main() {
+    writeln(x);
+  }
+}

--- a/test/visibility/import/rename/renameToAlreadyImported.good
+++ b/test/visibility/import/rename/renameToAlreadyImported.good
@@ -1,0 +1,1 @@
+renameToAlreadyImported.chpl:6: error: symbol 'x' multiply defined

--- a/test/visibility/import/rename/renameTwice.chpl
+++ b/test/visibility/import/rename/renameTwice.chpl
@@ -1,0 +1,11 @@
+module M {
+  var foo: bool;
+}
+module User {
+  import M.{foo as bar, foo as baz}; // Should work, but warn just in case
+
+  proc main() {
+    writeln(bar);
+    writeln(baz);
+  }
+}

--- a/test/visibility/import/rename/renameTwice.good
+++ b/test/visibility/import/rename/renameTwice.good
@@ -1,0 +1,3 @@
+renameTwice.chpl:5: warning: identifier 'foo' is repeated
+false
+false


### PR DESCRIPTION
These are tests that I meant to get to prior to the release but did not have
time for.  Thankfully, they all work as expected.

- Ensures that we can't rename a symbol brought in for unqualified access to
another name in the unqualified access list of that import
- Ensures that we can rename a symbol and bring it in with its original name,
but that we get a warning
- Ensures that we don't accidentally rename the module for single symbol
unqualified access
- Ensures we can't use non-identifiers as old names when renaming
- Ensures we can't use non-identifiers as new names when renaming
- Ensures we get an appropriate error message when we can't find the old name
- Ensures we get an appropriate error message when the old name is a private
symbol
- Ensures we can rename a symbol two different times, but that we get a warning
- Ensures we can't rename a symbol and rename that new name in
the same import statement
- Ensures that renaming doesn't accidentally enable other symbols
- Ensures that we can't list a private symbol as the last of a single
unqualified import if we aren't in scope
- Ensures that we can't list a private symbol as the last of a multiple
unqualified import if we aren't in scope
- Ensures we give an appropriate error message when a symbol in an import's
unqualified access list can't be found
- Ensures we can repeat a name in an unqualified list, but that we get a warning
for doing so

Ran a fresh checkout of the test/visibility/import directory with futures to ensure
I committed everything