### PR TITLE
Handle edge case for 1 char filename in MasonUtils

### DIFF
--- a/test/mason/mason-test/Mason.toml
+++ b/test/mason/mason-test/Mason.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 chplVersion = "1.17.0"
 tests = ["sampletest.chpl",
          "sampletest2.chpl",
+         "x.chpl",
          "dependencytest.chpl",
          "nomodule.chpl",
          "testdir/subdirectorytest.chpl",

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -10,7 +10,7 @@ FAIL shallnotpass.chpl: shallnotpass
 ----------------------------------------------------------------------
 shallnotpass returned exitCode = 255
 ----------------------------------------------------------------------
-Ran 8 tests in n seconds
+Ran 9 tests in n seconds
 
-FAILED (passed = 6 failures = 1 errors = 1 )
+FAILED (passed = 7 failures = 1 errors = 1 )
 compilation failed for compileerror.chpl

--- a/test/mason/mason-test/test/x.chpl
+++ b/test/mason/mason-test/test/x.chpl
@@ -1,0 +1,6 @@
+
+proc test() {
+  writeln("Test for single character test file name passed");
+}
+
+test();

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -86,6 +86,7 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
 
 proc stripExt(toStrip: string, ext: string) : string {
   if toStrip.endsWith(ext) {
+    if (toStrip.size - ext.size) == 1 then return toStrip[0];
     var stripped = toStrip[..<(toStrip.size - ext.size)];
     return stripped;
   }


### PR DESCRIPTION
Handles edge case when the passed filename is of a single char.

Fixes https://github.com/chapel-lang/chapel/issues/15522