### PR TITLE
Don't use default values in the compiler code to keep gcc 4.9 happy

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -36,6 +36,7 @@ UseStmt::UseStmt(BaseAST* source, const char* modRename,
   src    = NULL;
   this->modRename = astr(modRename);
   except = false;
+  canReexport = true;
 
   if (Symbol* b = toSymbol(source)) {
     src = new SymExpr(b);
@@ -48,6 +49,7 @@ UseStmt::UseStmt(BaseAST* source, const char* modRename,
   }
 
   gUseStmts.add(this);
+
 }
 
 UseStmt::UseStmt(BaseAST*                            source,
@@ -62,6 +64,7 @@ UseStmt::UseStmt(BaseAST*                            source,
   src    = NULL;
   this->modRename = astr(modRename);
   except = exclude;
+  canReexport = true;
 
   if (Symbol* b = toSymbol(source)) {
     src = new SymExpr(b);

--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -49,7 +49,6 @@ UseStmt::UseStmt(BaseAST* source, const char* modRename,
   }
 
   gUseStmts.add(this);
-
 }
 
 UseStmt::UseStmt(BaseAST*                            source,

--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -108,7 +108,7 @@ public:
 
   void                  describe()                                       const;
 
-  bool                  canReexport = true;
+  bool                  canReexport;
 
 private:
   typedef std::vector<VisibilityStmt*>   UseImportList;

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -68,7 +68,7 @@ public:
 
   void            writeListPredicate(FILE* mFP)                          const;
 
-  bool            canReexport = true;
+  bool            canReexport;
 
 private:
   bool            isEnum(const Symbol* sym)                              const;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -138,6 +138,8 @@ ResolveScope::ResolveScope(ModuleSymbol*       modSymbol,
   // Use modSymbol->block for sScopeMap
   INT_ASSERT(getScopeFor(modSymbol->block) == NULL);
   sScopeMap[modSymbol->block] = this;
+
+  canReexport = true;
 }
 
 ResolveScope::ResolveScope(BaseAST*            ast,
@@ -147,6 +149,8 @@ ResolveScope::ResolveScope(BaseAST*            ast,
 
   INT_ASSERT(getScopeFor(ast) == NULL);
   sScopeMap[ast] = this;
+
+  canReexport = true;
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
This PR is a follow up to #15517 which added few fields with default values in the compiler code. Apparently gcc 4.9 does not like that. This removes default values and assigns those fields in respective constructors:

Test:
- [x] Compiler builds with gcc 4.9 cleanly
- [ ] release/examples out of paranoia