### PR TITLE
Fix format strings for linux32

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -823,7 +823,7 @@ static void checkNumArgsErrors(AggregateType* at, CallExpr* call, const char* ca
     USR_PRINT(call, "type specifier did not match: %s", typeSignature);
     USR_PRINT(call, "type was specified with %d arguments", numArgs);
     const char* plural = genericFields.size() > 1 ? "fields" : "field";
-    USR_PRINT(at, "but type '%s' only has %lu generic %s", symbol->name, genericFields.size(), plural);
+    USR_PRINT(at, "but type '%s' only has %zu generic %s", symbol->name, genericFields.size(), plural);
     USR_STOP();
   }
 }


### PR DESCRIPTION
Though I did a bunch of portability testing on PR #15450, I did not test any 32-bit systems, which led to a single failure.  This should fix it.