### PR TITLE
added SPACK_ROOT env to MasonEnv

### DIFF
--- a/test/mason/env/mason-env.good
+++ b/test/mason/env/mason-env.good
@@ -1,18 +1,22 @@
 MASON_HOME: $PWD *
 MASON_REGISTRY: mason-registry|https://github.com/chapel-lang/mason-registry
 MASON_OFFLINE: false
+SPACK_ROOT: $PWD/spack
 ----------
 MASON_HOME: $PWD *
 MASON_REGISTRY: foobar|foobar *
 MASON_OFFLINE: false
+SPACK_ROOT: $PWD/spack
 ----------
 MASON_HOME: $PWD *
 MASON_REGISTRY: mason-registry|https://github.com/chapel-lang/mason-registry
 MASON_OFFLINE: true *
+SPACK_ROOT: $PWD/spack
 ---------
 MASON_HOME: $PWD *
 MASON_REGISTRY: mason-registry|https://github.com/chapel-lang/mason-registry
 MASON_OFFLINE: false
+SPACK_ROOT: $PWD/spack
 MASON_CACHED_REGISTRY: $PWD/mason-registry
 ----------
 Print environment variables recognized by mason

--- a/test/mason/env/mason-registry.good
+++ b/test/mason/env/mason-registry.good
@@ -1,6 +1,7 @@
 MASON_HOME: $PWD/tempHome *
 MASON_REGISTRY: myRegistry|$PWD/tempHome/uncached/myRegistry *
 MASON_OFFLINE: false
+SPACK_ROOT: $PWD/tempHome/spack
 Updating myRegistry
 multiple (0.2.0)
 simple (0.1.0)

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -25,7 +25,6 @@ public use MasonHelp;
 proc MASON_HOME : string {
   const envHome = getEnv("MASON_HOME");
   const default = getEnv('HOME') + "/.mason";
-
   const masonHome = if envHome != "" then envHome else default;
 
   return masonHome;
@@ -112,6 +111,14 @@ proc MASON_REGISTRY {
   return registries;
 }
 
+proc getSpackRoot() : string {
+  const envSpack = getEnv('SPACK_ROOT');
+  const default = getEnv('HOME') + "/.spack";
+  const spackRoot = if envSpack != "" then envSpack else default;
+
+  return spackRoot;
+}
+
 proc masonEnv(args) {
   if hasOptions(args, "-h", "--help") {
     masonEnvHelp();
@@ -161,6 +168,7 @@ proc masonEnv(args) {
   printVar("MASON_HOME", MASON_HOME);
   printVar("MASON_REGISTRY", MASON_REGISTRY);
   printVar('MASON_OFFLINE', offlineString);
+  printVar('SPACK_ROOT', getSpackRoot());
 
   if debug {
     printVar("MASON_CACHED_REGISTRY", MASON_CACHED_REGISTRY);

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -111,14 +111,6 @@ proc MASON_REGISTRY {
   return registries;
 }
 
-proc getSpackRoot() : string {
-  const envSpack = getEnv('SPACK_ROOT');
-  const default = getEnv('HOME') + "/.spack";
-  const spackRoot = if envSpack != "" then envSpack else default;
-
-  return spackRoot;
-}
-
 proc masonEnv(args) {
   if hasOptions(args, "-h", "--help") {
     masonEnvHelp();
@@ -168,7 +160,7 @@ proc masonEnv(args) {
   printVar("MASON_HOME", MASON_HOME);
   printVar("MASON_REGISTRY", MASON_REGISTRY);
   printVar('MASON_OFFLINE', offlineString);
-  printVar('SPACK_ROOT', getSpackRoot());
+  printVar("SPACK_ROOT", SPACK_ROOT);
 
   if debug {
     printVar("MASON_CACHED_REGISTRY", MASON_CACHED_REGISTRY);


### PR DESCRIPTION
This PR adds a feature to MasonEnv to display `SPACK_ROOT` environment variable as it affects Mason. 

fixes #15535 