### PR TITLE
Do some code acrobatics to cleanup Private

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -240,15 +240,15 @@ proc PrivateArr.doiScan(op, dom) where (rank == 1) &&
 // This way we cleanup the unmanaged, module-scope variable after module
 // deinitializer, which is called before deinitializing module-scope variables
 // which would cause use-after-free during the cleanup of PrivateSpace
-var cw = new CleanupWrapper();
+var chpl_privateCW = new chpl_privateDistCleanupWrapper();
 var chpl_privateDist = new unmanaged Private();
 const PrivateSpace: domain(1) dmapped new dmap(chpl_privateDist);
 
-record CleanupWrapper {
+record chpl_privateDistCleanupWrapper {
   var val = nil : unmanaged Private?;
   proc deinit() { delete val!; }
 }
 
 proc deinit() {
-  cw.val = chpl_privateDist;
+  chpl_privateCW.val = chpl_privateDist;
 }

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -230,5 +230,25 @@ proc PrivateArr.doiScan(op, dom) where (rank == 1) &&
 }
 
 // TODO: Fix 'new Private()' leak -- Discussed in #6726
-const PrivateSpace: domain(1) dmapped Private();
+// ENGIN: below is my workaround to close the leak:
+// 1. Declare a module-scope record variable with an unmanaged nilable Private
+//    field
+//    1.a. Make sure that this variable is defined *before* PrivateSpace, so
+//         that compiler injects its cleanup *after* PrivateSpace
+// 2. In module deinitializer, set the field of this record variable to
+//    chpl_privateDist
+// This way we cleanup the unmanaged, module-scope variable after module
+// deinitializer, which is called before deinitializing module-scope variables
+// which would cause use-after-free during the cleanup of PrivateSpace
+var cw = new CleanupWrapper();
+var chpl_privateDist = new unmanaged Private();
+const PrivateSpace: domain(1) dmapped new dmap(chpl_privateDist);
 
+record CleanupWrapper {
+  var val = nil : unmanaged Private?;
+  proc deinit() { delete val!; }
+}
+
+proc deinit() {
+  cw.val = chpl_privateDist;
+}


### PR DESCRIPTION
This closes the `Private` leaks by introducing a cleanup record type that takes
the responsibility of deleting leaking variables after module deinitializer.

Comment has the details of how it's done.

Some related reading:
https://github.com/chapel-lang/chapel/pull/6695
https://github.com/chapel-lang/chapel/issues/6726
https://github.com/chapel-lang/chapel/pull/6741
https://github.com/chapel-lang/chapel/issues/12731

This is a better alternative to #15496 to close Private distribution leaks.

Test:
- [x] private leaks are closed
- [x] gasnet
- [x] standard