### PR TITLE
Move cleanup to module deinit to avoid race in test

### DIFF
--- a/test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
+++ b/test/multilocale/diten/needMultiLocales/DijkstraTermination.chpl
@@ -178,7 +178,9 @@ proc main {
     writeln("successfully");
   else
     writeln("unsuccessfully: a is ", aa);
+}
 
+proc deinit() {
   for l in Locales do on l {
     delete wakeup;
     delete endCount;


### PR DESCRIPTION
The deletions in this test that I added in #15406 sometimes triggered before
all the threads in a locale were done before using them, causing sporadic
`pthread_mutex_lock` failures,

This PR moves these deletions to module `deinit` to make sure that all the
threads are sync'ed before deleting these variables. Thanks @ronawho for
the suggestion.

Test passes 100 times locally with gasnet.