### PR TITLE
Remove BUG where return in serial block serializes all subsequent code

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -884,8 +884,8 @@ BlockStmt* buildSerialStmt(Expr* cond, BlockStmt* body) {
   VarSymbol *serial_state = newTemp();
   sbody->insertAtTail(new DefExpr(serial_state, new CallExpr(PRIM_GET_SERIAL)));
   sbody->insertAtTail(new CondStmt(cond, new CallExpr(PRIM_SET_SERIAL, gTrue)));
+  sbody->insertAtTail(new DeferStmt(new CallExpr(PRIM_SET_SERIAL, serial_state)));
   sbody->insertAtTail(body);
-  sbody->insertAtTail(new CallExpr(PRIM_SET_SERIAL, serial_state));
   return sbody;
 }
 

--- a/test/statements/serial/serialReturn.chpl
+++ b/test/statements/serial/serialReturn.chpl
@@ -9,14 +9,16 @@ proc test() {
   
   serialWithReturn();
 
-  begin{
-    x$; 
-    writeln("Begin 1");
-  }
+  sync{
+    begin{
+      x$; 
+      writeln("Begin 1");
+    }
 
-  begin{
-    writeln("Begin 2");
-    x$ = 1;
+    begin{
+      writeln("Begin 2");
+      x$ = 1;
+    }
   }
 }
 

--- a/test/statements/serial/serialReturn.chpl
+++ b/test/statements/serial/serialReturn.chpl
@@ -5,16 +5,18 @@ proc serialWithReturn() {
 }
 
 proc test() {
-
+  var x$: sync int;
+  
   serialWithReturn();
 
   begin{
-    sleep(1);
+    x$; 
     writeln("Begin 1");
   }
 
   begin{
-    writeln("Begin 2");  
+    writeln("Begin 2");
+    x$ = 1;
   }
 }
 

--- a/test/statements/serial/serialReturn.chpl
+++ b/test/statements/serial/serialReturn.chpl
@@ -1,0 +1,21 @@
+use Time;
+
+proc serialWithReturn() {
+    serial do return 1;
+}
+
+proc test() {
+
+  serialWithReturn();
+
+  begin{
+    sleep(1);
+    writeln("Begin 1");
+  }
+
+  begin{
+    writeln("Begin 2");  
+  }
+}
+
+test();

--- a/test/statements/serial/serialReturn.good
+++ b/test/statements/serial/serialReturn.good
@@ -1,0 +1,2 @@
+Begin 2
+Begin 1


### PR DESCRIPTION
Fixes #15438

Returning from serial block made the cleanup call to ```chpl_task_data_setSerial``` unreachable. Simple fix includes using a defer statement