### PR TITLE
update flag for compiler global boundsChecking

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -879,7 +879,7 @@ static void setupBoolGlobal(VarSymbol* globalVar, bool value) {
 void initCompilerGlobals() {
 
   gBoundsChecking = new VarSymbol("boundsChecking", dtBool);
-  gBoundsChecking->addFlag(FLAG_CONST);
+  gBoundsChecking->addFlag(FLAG_PARAM);
   setupBoolGlobal(gBoundsChecking, !fNoBoundsChecks);
 
   gCastChecking = new VarSymbol("castChecking", dtBool);


### PR DESCRIPTION
In [compiler/AST/type.cpp](https://github.com/chapel-lang/chapel/blob/master/compiler/AST/type.cpp#L881-L916), all the compiler globals are marked as param and also as all of them have an immediate value set they act as one. Only for `boundsChecking` it was marked as const instead of param. This PR updates `boundsChecking` to be param as well.