### PR TITLE
Allow the gdb and lldb lview command for Chapel AST nodes to accept consts

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -290,6 +290,14 @@ ForallStmt* isForallLoopBody(Expr* expr) {
   return NULL;
 }
 
+// Return a const ForallStmt* if 'expr' is its loopBody.
+const ForallStmt* isConstForallLoopBody(const Expr* expr) {
+  if (const ForallStmt* pfs = toConstForallStmt(expr->parentExpr))
+    if (expr == pfs->loopBody())
+      return pfs;
+  return NULL;
+}
+
 // Return a ForallStmt* if 'expr' is one of its fRecIter* helpers.
 ForallStmt* isForallRecIterHelper(Expr* expr) {
   if (expr->list == NULL)

--- a/compiler/AST/ImportStmt.cpp
+++ b/compiler/AST/ImportStmt.cpp
@@ -363,7 +363,7 @@ void ImportStmt::noRepeats() const {
 }
 
 void ImportStmt::validateUnqualified() {
-    BaseAST*            scopeToUse = getSearchScope();
+  BaseAST*            scopeToUse = getSearchScope();
   const ResolveScope* scope      = ResolveScope::getScopeFor(scopeToUse);
 
   for_vector(const char, name, unqualified) {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -900,7 +900,7 @@ const char* retTagDescrString(RetTag retTag) {
 
 
 // describes this argument's intent (for use in an English sentence)
-const char* ArgSymbol::intentDescrString() {
+const char* ArgSymbol::intentDescrString() const {
   switch (intent) {
     case INTENT_BLANK: return "default intent";
     case INTENT_IN: return "'in'";

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -33,7 +33,9 @@ class ForallStmt : public Stmt
 public:
   bool       zippered()       const; // 'zip' keyword used and >1 index var
   AList&     inductionVariables();   // DefExprs, one per iterated expr
+  const AList& constInductionVariables() const; // const counterpart
   AList&     iteratedExpressions();  // Exprs, one per iterated expr
+  const AList& constIteratedExpressions() const;  // const counterpart
   AList&     shadowVariables();      // DefExprs of ShadowVarSymbols
   BlockStmt* loopBody()       const; // the body of the forall loop
   std::vector<BlockStmt*> loopBodies() const; // body or bodies of followers
@@ -135,7 +137,13 @@ Same idea as fFromForLoop.
 
 inline bool   ForallStmt::zippered()         const { return fZippered;   }
 inline AList& ForallStmt::inductionVariables()     { return fIterVars;   }
+inline const AList& ForallStmt::constInductionVariables() const {
+  return fIterVars;
+}
 inline AList& ForallStmt::iteratedExpressions()    { return fIterExprs;  }
+inline const AList& ForallStmt::constIteratedExpressions() const {
+  return fIterExprs;
+}
 inline AList& ForallStmt::shadowVariables()        { return fShadowVars; }
 inline BlockStmt* ForallStmt::loopBody()     const { return fLoopBody;   }
 
@@ -173,6 +181,7 @@ ForallStmt* isForallIterVarDef(Expr* expr);
 ForallStmt* isForallIterExpr(Expr* expr);
 ForallStmt* isForallRecIterHelper(Expr* expr);
 ForallStmt* isForallLoopBody(Expr* expr);
+const ForallStmt* isConstForallLoopBody(const Expr* expr);
 VarSymbol*  parIdxVar(ForallStmt* fs);
 
 QualifiedType fsIterYieldType(Expr* ref, FnSymbol* iterFn);

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -556,47 +556,45 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
   case E_ImportStmt:                                                    \
     AST_CALL_CHILD(_a, ImportStmt, src, call, __VA_ARGS__);             \
     break;                                                              \
-                                                                               \
-  case E_BlockStmt: {                                                          \
-    BlockStmt* stmt = toBlockStmt(_a);                                         \
-                                                                               \
-    if (stmt->isWhileDoStmt() == true) {                                       \
-      AST_CALL_LIST (stmt, WhileStmt,    body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, WhileStmt,    condExprGet(),  call, __VA_ARGS__);   \
-                                                                               \
-    } else if (stmt->isDoWhileStmt()  == true) {                               \
-      AST_CALL_LIST (stmt, WhileStmt,    body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, WhileStmt,    condExprGet(),  call, __VA_ARGS__);   \
-                                                                               \
-    } else if (stmt->isForLoop()      == true) {                               \
-      AST_CALL_LIST (stmt, ForLoop,      body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, ForLoop,      indexGet(),     call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, ForLoop,      iteratorGet(),  call, __VA_ARGS__);   \
-                                                                               \
-    } else if (stmt->isCoforallLoop() == true) {                               \
-      AST_CALL_LIST (stmt, ForLoop,      body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, ForLoop,      indexGet(),     call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, ForLoop,      iteratorGet(),  call, __VA_ARGS__);   \
-                                                                               \
-    } else if (stmt->isCForLoop()     == true) {                               \
-      AST_CALL_LIST (stmt, CForLoop,     body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, CForLoop,     initBlockGet(), call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, CForLoop,     testBlockGet(), call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, CForLoop,     incrBlockGet(), call, __VA_ARGS__);   \
-                                                                               \
-    } else if (stmt->isParamForLoop() == true) {                               \
-      AST_CALL_LIST (stmt, ParamForLoop, body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, ParamForLoop, resolveInfo(),  call, __VA_ARGS__);   \
-                                                                               \
-    } else  {                                                                  \
-      AST_CALL_LIST (stmt, BlockStmt,    body,           call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, BlockStmt,    blockInfoGet(), call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, BlockStmt,    useList,        call, __VA_ARGS__);   \
-      AST_CALL_CHILD(stmt, BlockStmt,    byrefVars,      call, __VA_ARGS__);   \
-    }                                                                          \
-    break;                                                                     \
-  }                                                                            \
-                                                                               \
+                                                                           \
+  case E_BlockStmt: {                                                      \
+    if (isWhileDoStmt(_a) == true) {                                       \
+      AST_CALL_LIST (_a, WhileStmt,    body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, WhileStmt,    condExprGet(),  call, __VA_ARGS__); \
+                                                                           \
+    } else if (isDoWhileStmt(_a)  == true) {                               \
+      AST_CALL_LIST (_a, WhileStmt,    body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, WhileStmt,    condExprGet(),  call, __VA_ARGS__); \
+                                                                           \
+    } else if (isForLoop(_a)      == true) {                               \
+      AST_CALL_LIST (_a, ForLoop,      body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, ForLoop,      indexGet(),     call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, ForLoop,      iteratorGet(),  call, __VA_ARGS__); \
+                                                                           \
+    } else if (isCoforallLoop(_a) == true) {                               \
+      AST_CALL_LIST (_a, ForLoop,      body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, ForLoop,      indexGet(),     call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, ForLoop,      iteratorGet(),  call, __VA_ARGS__); \
+                                                                           \
+    } else if (isCForLoop(_a)     == true) {                               \
+      AST_CALL_LIST (_a, CForLoop,     body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, CForLoop,     initBlockGet(), call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, CForLoop,     testBlockGet(), call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, CForLoop,     incrBlockGet(), call, __VA_ARGS__); \
+                                                                           \
+    } else if (isParamForLoop(_a) == true) {                               \
+      AST_CALL_LIST (_a, ParamForLoop, body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, ParamForLoop, resolveInfo(),  call, __VA_ARGS__); \
+                                                                           \
+    } else  {                                                              \
+      AST_CALL_LIST (_a, BlockStmt,    body,           call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, BlockStmt,    blockInfoGet(), call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, BlockStmt,    useList,        call, __VA_ARGS__); \
+      AST_CALL_CHILD(_a, BlockStmt,    byrefVars,      call, __VA_ARGS__); \
+    }                                                                      \
+    break;                                                                 \
+  }                                                                        \
+                                                                           \
   case E_CondStmt:                                                      \
     AST_CALL_CHILD(_a, CondStmt, condExpr, call, __VA_ARGS__);          \
     AST_CALL_CHILD(_a, CondStmt, thenStmt, call, __VA_ARGS__);          \

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -162,7 +162,7 @@ class SymExpr : public Expr {
 
   virtual Expr*   getFirstExpr();
 
-  Symbol* symbol() {
+  Symbol* symbol() const {
     return var;
   }
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -387,7 +387,7 @@ public:
   virtual bool    isVisible(BaseAST* scope)                 const;
 
   bool            requiresCPtr();
-  const char*     intentDescrString();
+  const char*     intentDescrString() const;
 
   GenRet          codegenType();
 

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -35,7 +35,7 @@ Expr*    aidExpr(int id);
 BaseAST* aid(BaseAST* ast);
 Expr*    aidExpr(BaseAST* ast);
 
-void        list_view_noline(BaseAST* ast);
+void        list_view_noline(const BaseAST* ast);
 void        nprint_view(BaseAST* ast);
 
 // defined in codegen/codegen.cpp
@@ -65,7 +65,7 @@ void        nprint_view_noline(BaseAST* ast);
 void        mark_view(BaseAST* ast, int id);
 
 void        list_view(int id);
-void        list_view(BaseAST* ast);
+void        list_view(const BaseAST* ast);
 
 void        astDump_view(int id);
 void        astDump_view(BaseAST* ast);


### PR DESCRIPTION
Prior to this change, lview/list_view would accept non-const versions and print
the contents of the AST node nicely, but would throw up its hands if it was
passed a const version of the same node.  This was noticed when trying to print
the argument for ImportStmt::providesNewSymbols.

By its definition, lview/list_view should never modify the contents of the nodes
that were passed to it, so it should be safe to change list_view and its helpers
to accept const arguments (where non-const value would just be const for the
duration of the function).  Based on checking const and non-const AST nodes
with this change, this appears to be accurate.

Details:
--------
In order for this update to work, I had to make a couple of related AST changes.

- a copy of isForallLoopBody was made specifically for const arguments, named
isConstForallLoopBody.  It is otherwise identical to isForallLoopBody - I was
concerned that returning a const ForallStmt would have wider consequences in the
compiler, so sidestepped the issue.

- There are some slight whitespace changes

- I marked ArgSymbol's intentDescString method as const, since it does not
change the contents of the node, and did the same for SymExpr's symbol method.

- list_sym now takes a const symbol and uses toConst* instead of to*.  I also
changed some uses of to* where the result was dropped on the floor to instead
rely on is* (e.g. a toFnSymbol call which did not save the result was turned
into isFnSymbol).

- Similarly, block_explanation, forall_explanation_start, forallPreamble, and
list_line now take a const and use toConst* instead of to*

- forallPostamble required const versions of ForallStmt's inductionVariables and
iteratedExpressions methods.  As with isForallLoopBody, I was similarly
concerned about the wider consequences of returning a const AList& to other
places in the compiler.

- usePostamble and importPostamble needed to use const_iterators instead of just
iterators in addition to const arguments.

- list_ast was updated similarly to list_sym - const arguments, uses of toConst*
instead of to*, and uses of is* when the result of to* would be dropped on the
floor.  This function also needed an update to conditionally set a variable's
value that will now be const.

- list_view(int id) now saves the result of aidWithError as a const, and
list_view(BaseAST* ast) and list_view_noline now take a const and use is*
instead of dropping the result of to*.

- AST_CHILDREN_CALL needed to be updated due to code in the BlockStmt branch
that forced it to not accept const BlockStmt*.  Thankfully, the work was mostly
done to allow this conversion to occur - headers for functions that wrap the
needed BlockStmt method calls were already present in the file, it was just a
matter of using them instead of the methods and removing the local variable that
was causing problems.

Testing:
- verified the behavior of const UseStmts, non-const UnresolvedSymExprs,
non-const BlockStmts and non-const TypeSymbol DefExprs.

Passed a full paratest with futures to be certain there weren't unintended
consequences.