### PR TITLE
Eliminate some mem leaks in collection x types tests

### DIFF
--- a/test/arrays/types/ArrayTest.chpl
+++ b/test/arrays/types/ArrayTest.chpl
@@ -7,7 +7,7 @@ proc testArray(type t) {
 
   assert(a.size == 1);
 
-  if isunmanagedclass(t) {
+  if isUnmanagedClass(t) {
     delete a;
   }
 }

--- a/test/arrays/types/ArrayTest.chpl
+++ b/test/arrays/types/ArrayTest.chpl
@@ -6,4 +6,8 @@ proc testArray(type t) {
 
 
   assert(a.size == 1);
+
+  if isunmanagedclass(t) {
+    delete a;
+  }
 }

--- a/test/associative/types/ArrayTest.chpl
+++ b/test/associative/types/ArrayTest.chpl
@@ -11,4 +11,8 @@ proc testArray(type t) {
 
 
   assert(A.size == 1);
+
+  if isUnmanagedClass(t) {
+    delete A;
+  }
 }

--- a/test/library/standard/List/types/ListTest.chpl
+++ b/test/library/standard/List/types/ListTest.chpl
@@ -16,4 +16,9 @@ proc testList(type t) {
 
   var value = l.pop();
   assert(l.size == 0);
+
+  if isUnmanagedClass(t) {
+    delete x;
+  }
+
 }

--- a/test/library/standard/Map/types/MapTest.chpl
+++ b/test/library/standard/Map/types/MapTest.chpl
@@ -27,4 +27,9 @@ proc testMap(type t) {
   ret = m.remove(1);
   assert(ret);
   assert(!m.contains(2));
+
+  if isUnmanagedClass(t) {
+    delete x;
+    delete y;
+  }
 }

--- a/test/library/standard/Set/types/SetTest.chpl
+++ b/test/library/standard/Set/types/SetTest.chpl
@@ -12,4 +12,8 @@ proc testSet(type t) {
 
   s.remove(x);
   assert(s.size == 0);
+
+  if isUnmanagedClass(t) {
+    delete x;
+  }
 }

--- a/test/sparse/types/SparseTest.chpl
+++ b/test/sparse/types/SparseTest.chpl
@@ -11,4 +11,8 @@ proc testSparse(type t) {
           else new t(1);
 
   assert(A.size == 1);
+
+  if isUnmanagedClass(t) {
+    delete A;
+  }
 }

--- a/test/types/tuple/types/TupleTest.chpl
+++ b/test/types/tuple/types/TupleTest.chpl
@@ -1,9 +1,6 @@
 proc test(type t) where isTuple(t) {
   var a = ((new t[0](1), new t[1](2)), (new t[0](3), new t[1](4)));
   assert(a.size == 2);
-  if isUnmanagedClass(t) {
-    delete a;
-  }
 }
 
 proc test(type t) {

--- a/test/types/tuple/types/TupleTest.chpl
+++ b/test/types/tuple/types/TupleTest.chpl
@@ -1,9 +1,18 @@
 proc test(type t) where isTuple(t) {
   var a = ((new t[0](1), new t[1](2)), (new t[0](3), new t[1](4)));
   assert(a.size == 2);
+  if isUnmanagedClass(t) {
+    delete a;
+  }
 }
 
 proc test(type t) {
   var a = (new t(1), new t(2));
   assert(a.size == 2);
+
+  if isUnmanagedClass(t) {
+    for i in a.indices {
+      delete a[i];
+    }
+  }
 }


### PR DESCRIPTION
The unmanaged cases were not getting cleaned up. Thanks @e-kayrakli for pointing this out to me.

- [x] Tested locally:

```sh
start_test --memleaks mem.log --futures    test/arrays/types/ test/associative/types/ test/sparse/types/ test/types/tuple/types/ test/library/standard/List/types/ test/library/standard/Map/types/ test/library/standard/Set/types/

[Summary: #Successes = 47 | #Failures = 0 | #Futures = 28 | #Warnings = 0 ]
```