### PR TITLE
Memory improvements and fixes in multilocale string/bytes interop

### DIFF
--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -428,6 +428,10 @@ std::string MLIContext::genMarshalBodyChplBytesWrapper(Type* t, bool out) {
     gen += "mem_err = (";
     gen += fieldData;
     gen += " == NULL);\n";
+
+    // if I have allocated something here, own it, too
+    gen += fieldIsOwned;
+    gen += " = true;";
   }
 
   // Push/pull possible allocation error on ACK.

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -889,12 +889,6 @@ std::string MLIContext::genServersideRPC(FnSymbol* fn) {
     }
   }
 
-  //
-  // TODO: As it stands today, the server leaks memory allocated for return
-  // values. This is _obviously_ not ideal, however uncommenting the
-  // below code causes tests related to `c_string` to fail with a segfault.
-  // So for now, knowingly leak the memory.
-  //
   if (!hasVoidReturnType && this->isTypeRequiringAlloc(fn->retType)) {
     gen += this->genMemCleanup(fn->retType, "result");
   }

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -895,11 +895,9 @@ std::string MLIContext::genServersideRPC(FnSymbol* fn) {
   // below code causes tests related to `c_string` to fail with a segfault.
   // So for now, knowingly leak the memory.
   //
-  /*
   if (!hasVoidReturnType && this->isTypeRequiringAlloc(fn->retType)) {
     gen += this->genMemCleanup(fn->retType, "result");
   }
-  */
 
   return gen;
 }
@@ -913,7 +911,7 @@ std::string MLIContext::genMemCleanup(Type* t, const char* var) {
     gen += var;
     gen += "));\n";
   } else if (t == exportTypeChplByteBuffer) {
-    gen += "chpl_byte_buffer_free(";
+    gen += "chpl_byte_buffer_free_server(";
     gen += var;
     gen += ");\n";
   } else {

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -1041,8 +1041,8 @@ bool MLIContext::isTypeRequiringAlloc(Type* t) {
   return
       // TODO: Do we just assume that all CPTRs require allocation?
       t->symbol->hasFlag(FLAG_C_PTR_CLASS) ||
-      t == dtStringC ||
       t->getValType() == exportTypeChplByteBuffer;
+  // we had dtStringC in this list, but we don't really allocate for them
 }
 
 std::string MLIContext::genNewDecl(const char* t, const char* v) {

--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -92,7 +92,7 @@ char* chpl_mli_pull_connection(void) {
   chpl_mli_debugf("Getting %s\n", "expected size");
   chpl_mli_pull(chpl_client.setup_sock, &len, sizeof(len), 0);
   chpl_mli_debugf("Expected size is %d\n", len);
-  char* conn = mli_malloc(len);
+  char* conn = mli_malloc(len+1);
   chpl_mli_debugf("Getting %s\n", "string itself");
   chpl_mli_pull(chpl_client.setup_sock, (void*)conn, len, 0);
   conn[len] = '\0';

--- a/runtime/etc/src/mli/common_code.c
+++ b/runtime/etc/src/mli/common_code.c
@@ -61,12 +61,12 @@
 
 //
 // If this code is being run on the server, mli_malloc() is a wrapper for
-// chpl_malloc(). If this code is being run on the client, then it is a
+// chpl_mem_alloc(). If this code is being run on the client, then it is a
 // wrapper for the system allocator.
 //
 #ifdef CHPL_MLI_IS_SERVER
-#   define mli_malloc(bytes) chpl_malloc(bytes)
-#   define mli_free(ptr) chpl_free(ptr)
+#   define mli_malloc(bytes) chpl_mem_alloc(bytes, CHPL_RT_MD_MLI_DATA, 0, 0)
+#   define mli_free(ptr) chpl_mem_free(ptr, 0, 0)
 #elif defined(CHPL_MLI_IS_CLIENT)
 #   define mli_malloc(bytes) sys_malloc(bytes)
 #   define mli_free(ptr) sys_free(ptr)

--- a/runtime/include/chpl-export-wrappers.h
+++ b/runtime/include/chpl-export-wrappers.h
@@ -31,6 +31,7 @@ typedef struct chpl_byte_buffer {
 } chpl_byte_buffer;
 
 void chpl_byte_buffer_free(chpl_byte_buffer cb);
+void chpl_byte_buffer_free_server(chpl_byte_buffer cb);
 
 chpl_byte_buffer chpl_byte_buffer_make(const char* data);
 chpl_byte_buffer chpl_byte_buffer_make_len(const char* data, uint64_t size);

--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -86,6 +86,7 @@
   m(OS_LAYER_TMP_DATA,    "OS layer temporary data",                  true ), \
   m(GMP,                  "gmp data",                                 true ), \
   m(GETS_PUTS_STRIDES,    "put_strd/get_strd array of strides",       true ), \
+  m(MLI_DATA,             "multilocale interop data",                 true ), \
   m(NUM,                  "*** this must be the last entry ***",      true )
 
 

--- a/runtime/src/chpl-export-wrappers.c
+++ b/runtime/src/chpl-export-wrappers.c
@@ -24,6 +24,16 @@
 
 #include <string.h>
 
+void chpl_byte_buffer_free_server(chpl_byte_buffer cb) {
+  if (!cb.isOwned) { return; }
+
+  if (cb.data != NULL) {
+    chpl_mem_free(cb.data, 0, 0);
+  }
+
+  return;
+}
+
 void chpl_byte_buffer_free(chpl_byte_buffer cb) {
   if (!cb.isOwned) { return; }
 

--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal.ml-test.c
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal.ml-test.c
@@ -1,3 +1,8 @@
+// This test currently fails sporadically. whatIsGlobal() reads a global that is
+// uninitialized. Globals are not default-value-initialized in multilocale runs
+// because they are just wide pointers to heap. See "library-init" version of
+// this test for the "correct" version of this.
+
 #include "lib/reliesOnGlobal.h"
 
 // Test of calling an exported Chapel library that relies on a global.

--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal.ml-test.c
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal.ml-test.c
@@ -1,7 +1,8 @@
 // This test currently fails sporadically. whatIsGlobal() reads a global that is
 // uninitialized. Globals are not default-value-initialized in multilocale runs
-// because they are just wide pointers to heap. See "library-init" version of
-// this test for the "correct" version of this.
+// because they are just wide pointers to heap. The correct way to do this is to
+// call the module initializer before using its globals. See "library-init"
+// version of this test
 
 #include "lib/reliesOnGlobal.h"
 


### PR DESCRIPTION
This PR fixes a few things related to memory management in string/bytes
multilocale interop.

- Adjust MLI allocators to use `chpl_mem_alloc` and `chpl_mem_free`, add
  `CHPL_RT_MD_MLI_DATA` mem descriptor to be used by the MLI allocator.

- Add `chpl_byte_buffer_free_server` to correctly capture the deallocations
  from the compiler generated MLI marshalling code (above bullet)

- Close a leak when returning Chapel strings/bytes from exported functions.
  
  This is just done by uncommenting a block of code. The comment above
  the code suggests that it was causing c_string errors, but didn't see any issue
  with that in an Address Sanitizer test.

- Own a string passed as an argument if it was remote.

   Otherwise, we are leaking the buffer we allocate for the string.

- Stop cleaning after c_strings

  This shouldn't be necessary and was causing issues. Even if we leak, I think
  `c_string` shouldn't be used in interop

- Fix an off-by-one error in a memory allocation.

  Something that ASAN complained in my initial runs

- Add a comment to the test that's somehow running successfully but should fail
  sporadically.

Test:
- [x] gasnet + Address Sanitizer on `test/interop` is clean except for the
      problematic test
- [x] gasnet multilocale only
- [x] full gasnet
- [x] full standard

