### PR TITLE
adding docs for compiler defined global variables

### DIFF
--- a/doc/rst/technotes/globalvars.rst
+++ b/doc/rst/technotes/globalvars.rst
@@ -5,43 +5,43 @@ Global Variables
 ==================================
 
 .. warning:: The variables defined here are not part of Chapel Standard and 
-             they can be changed, renamed or removed at any point in future.
+             they can be changed, renamed, or removed at any point in the future.
 
-Chapel Compiler define some variables that are available to all the Chapel programs. 
-These variables are used by compiler itself and standard Chapel libraries/packages 
-to provide some features/optimizations on the basis of compiler options. 
-All these variables are compile-time constants.
+The Chapel Compiler defines some variables that are available to all Chapel programs. 
+These variables are used by the compiler itself and the standard Chapel libraries/packages 
+to provide some features/optimizations based on compilation flags. 
+All of these variables are compile-time constants.
 
 Variables
 ---------
 
 **boundsChecking**
 
-    This variable can be used to check if ``bounds-checks`` is enabled or not. 
+    This variable can be used to check if ``bounds-checks`` are enabled or not. 
     It is used by libraries to enable/disable runtime bound checks while 
-    accessing ranges, arrays or domains.
+    accessing ranges, arrays, or domains.
 
 **castChecking**
 
-    This variable reflects wether ``cast-checks`` is enabled or not.
+    This variable reflects whether ``cast-checks`` are enabled or not.
     It is used to provide checks before casting a variable from one type to another.
 
 **chpl_checkNilDereferences**
 
-    When ``nil-checks`` is enabled, this variable is set to *true*. It is used to check if a object
+    When ``nil-checks`` is enabled, this variable is set to *true*. It is used to check if an object
     is nil before accessing it.
 
 **chpl_checkDivByZero**
 
-    This variable can be used to check if ``div-by-zero-checks`` is enabled. When this variable is
-    set to *true*, the runtime will check for attempt to divide by zero.
+    This variable can be used to check if ``div-by-zero-checks`` are enabled. When this variable is
+    set to *true*, the runtime will check for attempts to divide by zero.
 
 **chpl_warnUnstable**
 
-    This variable can be used to check if, ``warn-unstable`` compiler flag is enabled. When set to *true*,
-    compiler will issue warning on the use of code that can be changed in future or are not suitable for use.
+    This variable can be used to check if the ``warn-unstable`` compiler flag is enabled. When set to *true*,
+    the compiler will issue a warning about code that can be changed in the future or is not suitable for use.
 
 **_local**
 
-    This variable can be used to check if program is being compiled for singlw/multi locale excecution.
-    It is set to *true* if program is compiled for single locale excecution.
+    This variable can be used to check if a program is being compiled for single/multi locale execution.
+    It is set to *true* if the program is compiled for single locale execution.

--- a/doc/rst/technotes/globalvars.rst
+++ b/doc/rst/technotes/globalvars.rst
@@ -4,7 +4,7 @@
 Global Variables
 ==================================
 
-.. warning:: The variables defined here are not part of Chapel Standard and 
+.. warning:: The variables defined here are not part of the Chapel Standard and 
              they can be changed, renamed, or removed at any point in the future.
 
 The Chapel Compiler defines some variables that are available to all Chapel programs. 
@@ -17,28 +17,28 @@ Variables
 
 **boundsChecking**
 
-    This variable can be used to check if ``bounds-checks`` are enabled or not. 
-    It is used by libraries to enable/disable runtime bound checks while 
+    This variable is *true* when ``--bounds-checks`` is enabled. 
+    It is used by libraries to enable/disable runtime bounds checks while 
     accessing ranges, arrays, or domains.
 
 **castChecking**
 
-    This variable reflects whether ``cast-checks`` are enabled or not.
+    This variable reflects whether ``--cast-checks`` flag is enabled.
     It is used to provide checks before casting a variable from one type to another.
 
 **chpl_checkNilDereferences**
 
-    When ``nil-checks`` is enabled, this variable is set to *true*. It is used to check if an object
+    When ``--nil-checks`` is enabled, this variable is set to *true*. It is used to check if an object
     is nil before accessing it.
 
 **chpl_checkDivByZero**
 
-    This variable can be used to check if ``div-by-zero-checks`` are enabled. When this variable is
+    This variable can be used to check if ``--div-by-zero-checks`` is enabled. When this variable is
     set to *true*, the runtime will check for attempts to divide by zero.
 
 **chpl_warnUnstable**
 
-    This variable can be used to check if the ``warn-unstable`` compiler flag is enabled. When set to *true*,
+    This variable can be used to check if the ``--warn-unstable`` compiler flag is enabled. When set to *true*,
     the compiler will issue a warning about code that can be changed in the future or is not suitable for use.
 
 **_local**

--- a/doc/rst/technotes/globalvars.rst
+++ b/doc/rst/technotes/globalvars.rst
@@ -1,0 +1,47 @@
+.. _readme-globalvars:
+
+==================================
+Global Variables
+==================================
+
+.. warning:: The variables defined here are not part of Chapel Standard and 
+             they can be changed, renamed or removed at any point in future.
+
+Chapel Compiler define some variables that are available to all the Chapel programs. 
+These variables are used by compiler itself and standard Chapel libraries/packages 
+to provide some features/optimizations on the basis of compiler options. 
+All these variables are compile-time constants.
+
+Variables
+---------
+
+**boundsChecking**
+
+    This variable can be used to check if ``bounds-checks`` is enabled or not. 
+    It is used by libraries to enable/disable runtime bound checks while 
+    accessing ranges, arrays or domains.
+
+**castChecking**
+
+    This variable reflects wether ``cast-checks`` is enabled or not.
+    It is used to provide checks before casting a variable from one type to another.
+
+**chpl_checkNilDereferences**
+
+    When ``nil-checks`` is enabled, this variable is set to *true*. It is used to check if a object
+    is nil before accessing it.
+
+**chpl_checkDivByZero**
+
+    This variable can be used to check if ``div-by-zero-checks`` is enabled. When this variable is
+    set to *true*, the runtime will check for attempt to divide by zero.
+
+**chpl_warnUnstable**
+
+    This variable can be used to check if, ``warn-unstable`` compiler flag is enabled. When set to *true*,
+    compiler will issue warning on the use of code that can be changed in future or are not suitable for use.
+
+**_local**
+
+    This variable can be used to check if program is being compiled for singlw/multi locale excecution.
+    It is set to *true* if program is compiled for single locale excecution.

--- a/doc/rst/technotes/globalvars.rst
+++ b/doc/rst/technotes/globalvars.rst
@@ -17,14 +17,14 @@ Variables
 
 **boundsChecking**
 
-    This variable is *true* when ``--bounds-checks`` is enabled. 
+    This variable is *true* when the ``--bounds-checks`` flag is enabled. 
     It is used by libraries to enable/disable runtime bounds checks while 
     accessing ranges, arrays, or domains.
 
 **castChecking**
 
-    This variable reflects whether ``--cast-checks`` flag is enabled.
-    It is used to provide checks before casting a variable from one type to another.
+    This variable reflects whether the ``--cast-checks`` flag is enabled. If this flag is enabled, checks will
+    be done to prevent narrowing conversions.
 
 **chpl_checkNilDereferences**
 
@@ -43,5 +43,5 @@ Variables
 
 **_local**
 
-    This variable can be used to check if a program is being compiled for single/multi locale execution.
-    It is set to *true* if the program is compiled for single locale execution.
+    This variable can be used to check if a program is being compiled for single or multi locale execution.
+    It will be set to *true* when the program will be compiled for single locale execution.


### PR DESCRIPTION
Adding documentation for global variables defined by the compiler.

Closes #15527 