### PR TITLE
Make a "friendly" error for sparse arrays of non-nilable classes

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1418,6 +1418,11 @@ module ChapelArray {
         }
         compilerError("array element type cannot currently be generic");
         // In the future we might support it if the array is not default-inited
+      } else if isSparseDom(this) && isNonNilableClass(eltType) {
+        // TODO: The second half of this test should really be
+        // isDefaultInitializable, but we can't rely on that yet
+        // due to #14854.
+        compilerError("sparse arrays of non-nilable classes are not currently supported");
       }
 
       if chpl_warnUnstable then

--- a/test/sparse/types/testBorrowed.bad
+++ b/test/sparse/types/testBorrowed.bad
@@ -1,9 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelDistribution.chpl:887: error: Cannot default-initialize irv: borrowed T
-note: non-nil class types do not support default initialization
-note: Consider using the type borrowed T? instead
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:50: In function 'dsiBuildArray':
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:51: error: cannot default-initialize the array field data because it has a non-nilable element type 'borrowed T'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1404: Function 'dsiBuildArray' instantiated as: dsiBuildArray(this: borrowed DefaultSparseDom(1,int(64),domain(1,int(64),false)), type eltType = borrowed T)
-./SparseTest.chpl:1: In function 'testSparse':
-./SparseTest.chpl:9: error: cannot default-initialize the array A because it has a non-nilable element type 'borrowed T'
-testBorrowed.chpl:9: Function 'testSparse' instantiated as: testSparse(type t = borrowed T)

--- a/test/sparse/types/testBorrowed.future
+++ b/test/sparse/types/testBorrowed.future
@@ -1,1 +1,0 @@
-borrowed type not supported

--- a/test/sparse/types/testBorrowed.good
+++ b/test/sparse/types/testBorrowed.good
@@ -1,0 +1,3 @@
+./SparseTest.chpl:1: In function 'testSparse':
+./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
+testBorrowed.chpl:9: Function 'testSparse' instantiated as: testSparse(type t = borrowed T)

--- a/test/sparse/types/testOwned.bad
+++ b/test/sparse/types/testOwned.bad
@@ -1,9 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelDistribution.chpl:887: error: Cannot default-initialize irv: owned T
-note: non-nil class types do not support default initialization
-note: Consider using the type owned T? instead
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:50: In function 'dsiBuildArray':
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:51: error: cannot default-initialize the array field data because it has a non-nilable element type 'owned T'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1404: Function 'dsiBuildArray' instantiated as: dsiBuildArray(this: borrowed DefaultSparseDom(1,int(64),domain(1,int(64),false)), type eltType = owned T)
-./SparseTest.chpl:1: In function 'testSparse':
-./SparseTest.chpl:9: error: cannot default-initialize the array A because it has a non-nilable element type 'owned T'
-testOwned.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = owned T)

--- a/test/sparse/types/testOwned.future
+++ b/test/sparse/types/testOwned.future
@@ -1,1 +1,0 @@
-owned type not supported

--- a/test/sparse/types/testOwned.good
+++ b/test/sparse/types/testOwned.good
@@ -1,0 +1,3 @@
+./SparseTest.chpl:1: In function 'testSparse':
+./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
+testOwned.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = owned T)

--- a/test/sparse/types/testShared.bad
+++ b/test/sparse/types/testShared.bad
@@ -1,9 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelDistribution.chpl:887: error: Cannot default-initialize irv: shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:50: In function 'dsiBuildArray':
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:51: error: cannot default-initialize the array field data because it has a non-nilable element type 'shared T'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1404: Function 'dsiBuildArray' instantiated as: dsiBuildArray(this: borrowed DefaultSparseDom(1,int(64),domain(1,int(64),false)), type eltType = shared T)
-./SparseTest.chpl:1: In function 'testSparse':
-./SparseTest.chpl:9: error: cannot default-initialize the array A because it has a non-nilable element type 'shared T'
-testShared.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = shared T)

--- a/test/sparse/types/testShared.future
+++ b/test/sparse/types/testShared.future
@@ -1,1 +1,0 @@
-shared type not supported

--- a/test/sparse/types/testShared.good
+++ b/test/sparse/types/testShared.good
@@ -1,0 +1,3 @@
+./SparseTest.chpl:1: In function 'testSparse':
+./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
+testShared.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = shared T)

--- a/test/sparse/types/testUnmanaged.bad
+++ b/test/sparse/types/testUnmanaged.bad
@@ -1,9 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelDistribution.chpl:887: error: Cannot default-initialize irv: unmanaged T
-note: non-nil class types do not support default initialization
-note: Consider using the type unmanaged T? instead
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:50: In function 'dsiBuildArray':
-$CHPL_HOME/modules/internal/DefaultSparse.chpl:51: error: cannot default-initialize the array field data because it has a non-nilable element type 'unmanaged T'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1404: Function 'dsiBuildArray' instantiated as: dsiBuildArray(this: borrowed DefaultSparseDom(1,int(64),domain(1,int(64),false)), type eltType = unmanaged T)
-./SparseTest.chpl:1: In function 'testSparse':
-./SparseTest.chpl:9: error: cannot default-initialize the array A because it has a non-nilable element type 'unmanaged T'
-testUnmanaged.chpl:9: Function 'testSparse' instantiated as: testSparse(type t = unmanaged T)

--- a/test/sparse/types/testUnmanaged.future
+++ b/test/sparse/types/testUnmanaged.future
@@ -1,1 +1,0 @@
-unmanaged type not supported

--- a/test/sparse/types/testUnmanaged.good
+++ b/test/sparse/types/testUnmanaged.good
@@ -1,0 +1,3 @@
+./SparseTest.chpl:1: In function 'testSparse':
+./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
+testUnmanaged.chpl:9: Function 'testSparse' instantiated as: testSparse(type t = unmanaged T)


### PR DESCRIPTION
Sparse arrays are (typically) so dynamic by nature that elements are
added (as well as removed), which poses a problem for our current
implementations when the element type is non-nilable since the new
array values need a default value up until the time they are assigned.
Previously, the internal implementations of sparse arrays would generate
an error; here, I'm adding an explicit check and error for this case.

In reality, this check should not be looking merely for a non-nilable
class eltType, but any eltType that doesn't have a default value; but
due to issue #14854, this isn't possible at present, so I'm taking the
cheap / lazy approach instead.  Once #14854 is resolved, this check
for isNonNilableClass() should be updated to !isDefaultInitializable().

As a result of this change, I turned most of the sparse/type futures
that BenA filed into working tests, as I believe the current behavior
represents reasonable behavior, at least for the forseeable future.