### PR TITLE
removed --list

### DIFF
--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -36,9 +36,9 @@ proc masonHelp() {
   writeln('    -h, --help          Display this message');
   writeln('    -V, --version       Print version info and exit');
   writeln();
-  writeln('Some common mason commands are:');
+  writeln('Mason commands:');
   writeln('    new         Create a new mason project');
-  writeln('    init        Initializes a library project inside a given directory or path.');
+  writeln('    init        Initialize a mason project inside an existing directory');
   writeln('    add         Add a dependency to Mason.toml');
   writeln('    rm          Remove a dependency from Mason.toml');
   writeln('    update      Update/Generate Mason.lock');

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -35,10 +35,10 @@ proc masonHelp() {
   writeln('Options:');
   writeln('    -h, --help          Display this message');
   writeln('    -V, --version       Print version info and exit');
-  writeln('    --list              List installed commands');
   writeln();
-  writeln('Some common mason commands are (see all commands with --list):');
+  writeln('Some common mason commands are:');
   writeln('    new         Create a new mason project');
+  writeln('    init        Initializes a library project inside a given directory or path.');
   writeln('    add         Add a dependency to Mason.toml');
   writeln('    rm          Remove a dependency from Mason.toml');
   writeln('    update      Update/Generate Mason.lock');
@@ -53,27 +53,6 @@ proc masonHelp() {
   writeln('    external    Integrate external dependencies into mason packages');
   writeln('    publish     Publish package to mason-registry');
 }
-
-proc masonList() {
-  writeln('Installed Mason Commands:');
-  writeln('      add                ');
-  writeln('      rm                 ');
-  writeln('      new                ');
-  writeln('      update             ');
-  writeln('      build              ');
-  writeln('      run                ');
-  writeln('      test               ');
-  writeln('      external           ');
-  writeln('      search             ');
-  writeln('      env                ');
-  writeln('      clean              ');
-  writeln('      doc                ');
-  writeln('      help               ');
-  writeln('      version            ');
-  writeln('      system             ');
-  writeln('      publish            ');
-}
-
 
 proc masonRunHelp() {
   writeln('Run the compiled project and output to standard output');

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -96,7 +96,6 @@ proc main(args: [] string) throws {
       when 'clean' do masonClean(args);
       when 'help' do masonHelp();
       when 'version' do printVersion();
-      when '--list' do masonList();
       when '-h' do masonHelp();
       when '--help' do masonHelp();
       when '-V' do printVersion();


### PR DESCRIPTION
Removed `--list` flag because its function was the same as `--help` or `mason`. 
Added `mason init` to `--help`

fixes #15550 