### PR TITLE
Fix an off-by-one tuple index error in tree paircount test to fix perf regression

### DIFF
--- a/test/users/npadmana/twopt/do_smu_aos.chpl
+++ b/test/users/npadmana/twopt/do_smu_aos.chpl
@@ -188,7 +188,7 @@ proc BuildTree(pp : []WeightedParticle3D, scr : []WeightedParticle3D, id : int) 
   dx = pmax - pmin; 
   var splitDim = 1;
   for idim in Ddim {
-    if (dx(idim-1) > dx(splitDim)) then splitDim=idim;
+    if (dx(idim-1) > dx(splitDim-1)) then splitDim=idim;
   }
 
   // Split


### PR DESCRIPTION
In #14522 when tuple indexing was changed to be 0-based, I failed to update an index in this test that did not affect its correctness (at least according to the test system), but did hurt its performance:

https://chapel-lang.org/perf/chapcs/?startdate=2020/03/24&enddate=2020/04/10&graphs=timetotreepaircount

This restores the intended indexing, which should hopefully make the performance go back to normal (it definitely helped in my local runs).

If rewriting this test from scratch, it'd probably make sense to change its domain/array indexing to be 0-based as well to avoid some +/-1 expressions, but having messed it up once, I'm nervous about making a change that dramatic to it now.