### PR TITLE
Fix an off-by-one error in list test that was silently ignored

### DIFF
--- a/test/library/standard/List/perf/listBenchmark1.chpl
+++ b/test/library/standard/List/perf/listBenchmark1.chpl
@@ -79,7 +79,7 @@ class InsertFront: Test {
   override proc name() return "InsertFront";
   override proc setup() { _lst = createList(1); }
   override proc test() {
-    while _lst.size < n1 do _lst.insert(1, (_lst.size & 127):byte);
+    while _lst.size < n1 do _lst.insert(0, (_lst.size & 127):byte);
   }
 }
 


### PR DESCRIPTION
On the night that #14684 was merged, when lists were changed from 1- to 0-based indexing, we saw an uptick in this test for the popFront case:


https://chapel-lang.org/perf/chapcs/?startdate=2020/03/29&enddate=2020/04/06&graphs=listoperations

Inspecting the code, I wasn't able to find anything about that operation that was incorrect or would explain the slowdown, though I did find another missed update that caused a number of list inserts to be silently dropped on the floor.  I'm wondering whether this could somehow indirectly have affected the performance by changing the memory footprint of the benchmark in some way (?).  It seems worth fixing in any case.