### PR TITLE
Update three places to use ImportStmt's providesUnqualifiedAccess method

### DIFF
--- a/compiler/AST/ImportStmt.cpp
+++ b/compiler/AST/ImportStmt.cpp
@@ -180,7 +180,7 @@ void ImportStmt::scopeResolve(ResolveScope* scope) {
             USR_FATAL(this, "Can't 'import' without naming a module");
           }
 
-          if (unqualified.size() != 0) {
+          if (providesUnqualifiedAccess()) {
             // We already have listed unqualified access for this import, which
             // means this is the last symbol prior to the curly braces (e.g.
             // this is `B` of `import A.B.{C, D};`).  This symbol is required
@@ -405,7 +405,7 @@ void ImportStmt::validateUnqualified() {
 bool ImportStmt::skipSymbolSearch(const char* name) {
   // We don't define any symbols for unqualified access, so we should skip this
   // import
-  if (unqualified.size() == 0 && renamed.size() == 0) {
+  if (!providesUnqualifiedAccess()) {
     return true;
   } else {
     // Otherwise, look through the list of unqualified symbol names to see if

--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -931,7 +931,7 @@ bool UseStmt::providesNewSymbols(const ImportStmt* other) const {
     // probably fine. (and if they did, there's no harm in including it again)
     return true;
   } else {
-    if (other->unqualified.size() == 0 && other->renamed.size() == 0) {
+    if (!other->providesUnqualifiedAccess()) {
       // Other is an import of just a module.  As long as we provided something
       // for unqualified access, we provide new symbols
       if (renamed.size() > 0) {

--- a/test/visibility/import/rename/last-before-list-not-mod.chpl
+++ b/test/visibility/import/rename/last-before-list-not-mod.chpl
@@ -1,0 +1,12 @@
+module A {
+  class B {
+    var x: int;
+  }
+}
+module User {
+  import A.B.{x as y}; // should fail, renaming shouldn't hide the error message
+
+  proc main() {
+    writeln(y);
+  }
+}

--- a/test/visibility/import/rename/last-before-list-not-mod.good
+++ b/test/visibility/import/rename/last-before-list-not-mod.good
@@ -1,0 +1,1 @@
+last-before-list-not-mod.chpl:7: error: Last symbol prior to `{` in import must be a module, symbol 'B' is not


### PR DESCRIPTION
This helper method was added rather late in the implementation, and as a
result was not used in every place it could be.

This will make the code more robust to potential changes in the future
(especially w.r.t. if we enable importing both the module and symbols in it in
the same {} list).

It also fixed a bug where we were giving a less useful error message in the case
where the last symbol before an unqualified list was not a module, but the
unqualified list only contained renames.

Add test locking in the improved error message from the previous commit,
which previously failed and now passes.

Passed a full paratest with futures