### PR TITLE
Put param conditionals before others in domain record initialization

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1064,12 +1064,17 @@ module ChapelArray {
 
       // the below check is necessary for iterator records that have domain
       // shapes would create another set of privatized instances otherwise
-      if value.pid == nullPid then
-        this._pid = if _isPrivatized(value)
-                        then _newPrivatizedClass(value)
-                        else nullPid;
-      else
-        this._pid = value.pid;
+      if _isPrivatized(value) {
+        if value.pid == nullPid {
+          this._pid = _newPrivatizedClass(value);
+        }
+        else {
+          this._pid = value.pid;
+        }
+      }
+      else {
+        this._pid = nullPid;
+      }
 
       this._instance = value;
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1062,9 +1062,9 @@ module ChapelArray {
       if _to_unmanaged(value.type) != value.type then
         compilerError("Domain on borrow created");
 
-      // the below check is necessary for iterator records that have domain
-      // shapes would create another set of privatized instances otherwise
       if _isPrivatized(value) {
+        // the below check is necessary for iterator records that have domain
+        // shapes would create another set of privatized instances otherwise
         if value.pid == nullPid {
           this._pid = _newPrivatizedClass(value);
         }


### PR DESCRIPTION
This PR is motivated by the performance regressions we have seen after #15512.

https://chapel-lang.org/perf/chapcs/?startdate=2019/12/04&enddate=2020/04/23&graphs=arrayviewcreation,nbodyvariations

The gist of the change is to check `_isPrivatized` first as it is a `param`
function. This way the runtime check introduced in #15512 is folded out in local
runs.

Although I didn't reproduce the exact numbers, this change makes noticeable
improvements that is around the same magnitude.

Test:
- [x] standard
- [x] gasnet
