### PR TITLE
using add_stylesheet with sphinx removing deprecation warning

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -49,6 +49,10 @@ for line in open('../util/nitpick_ignore'):
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['meta/templates']
 
+# Setup CSS files
+def setup(app):
+    app.add_stylesheet('style.css')
+
 # The suffix of source filenames.
 source_suffix = '.rst'
 

--- a/doc/rst/meta/templates/page.html
+++ b/doc/rst/meta/templates/page.html
@@ -1,5 +1,4 @@
 {% extends "!page.html" %}
-{% set css_files = css_files + ["_static/style.css"] %}
 
 {% block footer %}
 {{ super() }}


### PR DESCRIPTION
Closes: #15404 

Using add_stylesheet instead of deprecated css_files