### PR TITLE
Tunnel Arkouda Cray-XC testing through the login node

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -27,6 +27,9 @@ nightly_args="${nightly_args} -no-buildcheck"
 # XC has new enough python, but missing pip
 source /cray/css/users/chapelu/setup_python36.bash
 
+# Run on an elogin node, so we have to tunnel to the login
+export ARKOUDA_TUNNEL_SERVER=$EPROXY_LOGIN
+
 test_release
 test_master
 sync_graphs


### PR DESCRIPTION
The job has been moved to an elogin node, which doesn't have direct ssh
access to the compute nodes, so we need to tunnel through the login
node.