### PR TITLE
Don't check the provider when single-node.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -407,6 +407,10 @@ static providerSet_t providerInUseSet;
 
 static
 void init_providerInUse(void) {
+  if (chpl_numNodes <= 1) {
+    return;
+  }
+
   //
   // We can be using only one primary provider.
   //


### PR DESCRIPTION
The unilateral exit control flow includes a provider check, which in
single-node execution will cause a segfault because we haven't set up
the provider info.  Fix that here, by making provider checks behave
as expected no matter what the node count is.

This fixes https://github.com/Cray/chapel-private/issues/916.