### PR TITLE
Use `python3 -m pip` instead of `pip3` to install arkouda

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -47,7 +47,7 @@ if ! make ; then
 fi
 
 # Install Arkouda and python dependencies
-if ! pip3 install -e .[test] --user ; then
+if ! python3 -m pip install -e .[test] --user ; then
   log_fatal_error "installing arkouda"
 fi
 


### PR DESCRIPTION
This is the recommended approach and it resolves an error we have on XC
testing where a system pip is being used by mistake.

https://stackoverflow.com/a/58389148
https://github.com/chapel-lang/chapel/pull/14826#discussion_r371953304