### PR TITLE
Add error message when a module is listed multiple times in a row in a use/import

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -698,6 +698,10 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
 
     ResolveScope* scope = getScopeFor(outerMod->block);
     if (Symbol* symbol = scope->getField(rhsName)) {
+      if (retval == symbol) {
+        USR_FATAL(expr, "duplicate mention of the same module '%s'",
+                  symbol->name);
+      }
       retval = symbol;
 
     } else if (Symbol *symbol =

--- a/test/visibility/duplicateMod.chpl
+++ b/test/visibility/duplicateMod.chpl
@@ -1,0 +1,12 @@
+module Library {
+  module Sub {
+    var x = 1;
+  }
+}
+
+module Program {
+  use Library.Sub.Sub;
+  proc main() {
+    writeln(x);
+  }
+}

--- a/test/visibility/duplicateMod.good
+++ b/test/visibility/duplicateMod.good
@@ -1,0 +1,1 @@
+duplicateMod.chpl:8: error: duplicate mention of the same module 'Sub'

--- a/test/visibility/import/duplicateMod.chpl
+++ b/test/visibility/import/duplicateMod.chpl
@@ -1,0 +1,12 @@
+module Library {
+  module Sub {
+    var x = 1;
+  }
+}
+
+module Program {
+  import Library.Sub.Sub;
+  proc main() {
+    writeln(Sub.x);
+  }
+}

--- a/test/visibility/import/duplicateMod.good
+++ b/test/visibility/import/duplicateMod.good
@@ -1,0 +1,1 @@
+duplicateMod.chpl:8: error: duplicate mention of the same module 'Sub'


### PR DESCRIPTION
Prior to this change, you could write `use Foo.Bar.Bar;` or `import Foo.Bar.Bar;`
even if Bar did not have a submodule named Bar.  We discovered this because a
duplicate module was accidentally used in a longer module path - we believe
most instances of this would be an accident and that no value is provided by
supporting it.  To that end, this PR removes the ability to list a duplicate module,
only allowing `Foo.Bar.Bar` if Foo.Bar has a submodule that shares its name.

Resolves #15265 

Adds two new tests to lock in this behavior - one for use statements and one
for import statements.  I believe we already have tests where a module shares
a name with a submodule (I wrote one locally and it worked).

Passed a full paratest with futures