### PR TITLE
Set PYTHONUSERBASE for arkouda install during testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -46,7 +46,8 @@ if ! make ; then
   log_fatal_error "compiling arkouda"
 fi
 
-# Install Arkouda and python dependencies
+# Install Arkouda and python dependencies to a python-deps subdir
+export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
 if ! python3 -m pip install --force-reinstall -e .[test] --user ; then
   log_fatal_error "installing arkouda"
 fi


### PR DESCRIPTION
Previously, we were just doing a `pip --user` install, which would
install Arkouda in $HOME. We don't really want to be installing Arkouda
for the current user, we just want to be able to test it. Install to
subdir in the arkouda checkout so it's not a permanent install.