### PR TITLE
Close two test leaks

### DIFF
--- a/test/parallel/forall/reduce-intents/ri-6-user-instance.chpl
+++ b/test/parallel/forall/reduce-intents/ri-6-user-instance.chpl
@@ -28,10 +28,12 @@ proc main {
   writeln("n = ", n);
 
   var sumUsr1 = 35, sumUsr2 = 36, sumUsr3 = 37;
-  const userReduceInstance = new unmanaged UserReduceOp(eltType=int);
+  const userReduceInstance1 = new unmanaged UserReduceOp(eltType=int);
+  const userReduceInstance2 = new unmanaged UserReduceOp(eltType=int);
+  const userReduceInstance3 = new unmanaged UserReduceOp(eltType=int);
 
-  forall arrElm in ARR with (userReduceInstance reduce sumUsr1,
-                             new unmanaged UserReduceOp(eltType=int) reduce sumUsr2)
+  forall arrElm in ARR with (userReduceInstance1 reduce sumUsr1,
+                             userReduceInstance2 reduce sumUsr2)
   {
     sumUsr1 = sumUsr1 + arrElm;
     sumUsr2 += arrElm;
@@ -39,7 +41,7 @@ proc main {
 
   writeln("forall finished");
 
-  testFormals(sumUsr3, new unmanaged UserReduceOp(eltType=int));
+  testFormals(sumUsr3, userReduceInstance3);
 
   check("sumUsr1", 35 + n*(n+1)/2, sumUsr1);
   check("sumUsr2", 36 + n*(n+1)/2, sumUsr2);
@@ -50,6 +52,10 @@ proc main {
     writeln("NUMERRORS: ", numErrors);
   else
     writeln("success");
+
+  delete userReduceInstance1;
+  delete userReduceInstance2;
+  delete userReduceInstance3;
 }
 
 proc testFormals(ref sumUsr3: int, userOp: unmanaged UserReduceOp(int)) {

--- a/test/types/records/sungeun/classInRecord.chpl
+++ b/test/types/records/sungeun/classInRecord.chpl
@@ -4,16 +4,14 @@ class myC {
 }
 
 record myR {
-  var c: unmanaged myC;
-  proc init() { c = new unmanaged myC(); }
+  var c: shared myC;
+  proc init() { c = new shared myC(); }
   proc init=(other: myR) { c = other.c; }
-  proc deinit() { delete c; }
+  proc deinit() { }
 }
 
-inline proc chpl__autoDestroy(x: myR) { }
-
 proc =(ref a: myR, b: myR) {
-  a.c = new unmanaged myC(); // leak memory here.
+  a.c = new shared myC();
   a.c.i = b.c.i;
 }
 


### PR DESCRIPTION
1. User-defined reduction interface needs `unmanaged` classes. Cleanup after
   them in test
2. A relatively old test had `unmanaged` fields in a `record` and a no-op
   overload of `chpl__autoDestroy`. Fix both to close leaks.

Changed tests pass:
- [x] standard
- [x] gasnet
- [x] valgrind
