### PR TITLE
Rework the helper for string/bytes slicing

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -631,24 +631,6 @@ module Bytes {
       return getSlice(this, r);
     }
 
-    // Checks to see if r is inside the bounds of this and returns a finite
-    // range that can be used to iterate over a section of the string
-    // TODO: move into the public interface in some form? better name if so?
-    pragma "no doc"
-    proc _getView(r:range(?)) where r.idxType == int || r.idxType == byteIndex {
-
-      // cast the argument r to `int` to make sure that we are not dealing with
-      // byteIndex
-      const intR = r:range(int, r.boundedType, r.stridable);
-      if boundsChecking {
-        if !this.byteIndices.boundsCheck(intR) {
-          halt("range ", r, " out of bounds for string with ",
-               this.numBytes, " bytes");
-        }
-      }
-      return intR[byteIndices];
-    }
-
     /*
       Checks if the :record:`bytes` is empty.
 
@@ -748,7 +730,7 @@ module Bytes {
         // used because we cant break out of an on-clause early
         var localRet: int = -2;
         const nLen = needle.buffLen;
-        const view = this._getView(region);
+        const view = getView(this, region);
         const thisLen = view.size;
 
         // Edge cases

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -276,12 +276,17 @@ module BytesStringCommon {
   // Checks to see if r is inside the bounds of this and returns a finite
   // range that can be used to iterate over a section of the string
   //
-  // This function handles ranges of codepointIndex or of numeric types,
-  // both of which signify positions in the string measured in codepoints.
+  // This function handles ranges of codepointIndex, byteIndex or numeric types.
+  // codepointIndex only makes sense for string, whereas the others can be used
+  // with both bytes and string
   //
-  // Converts from codepointIndex range to byte index range in the process.
+  // If codepointIndex range was given, converts that to byte index range in the
+  // process.
   proc getView(const ref x: ?t, r: range(?)) {
     assertArgType(t, "getView");
+    if t == bytes && r.idxType == codepointIndex {
+      compilerError("codepointIndex ranges cannot be used with bytes in getView");
+    }
 
     if t == bytes || r.idxType == byteIndex {
       // cast the argument r to `int` to make sure that we are not dealing with
@@ -335,7 +340,6 @@ module BytesStringCommon {
       }
       return byteLow..byteHigh;
     }
-
   }
 
   // TODO: I wasn't very good about caching variables locally in this one.

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -273,6 +273,71 @@ module BytesStringCommon {
     }
   }
 
+  // Checks to see if r is inside the bounds of this and returns a finite
+  // range that can be used to iterate over a section of the string
+  //
+  // This function handles ranges of codepointIndex or of numeric types,
+  // both of which signify positions in the string measured in codepoints.
+  //
+  // Converts from codepointIndex range to byte index range in the process.
+  proc getView(const ref x: ?t, r: range(?)) {
+    assertArgType(t, "getView");
+
+    if t == bytes || r.idxType == byteIndex {
+      // cast the argument r to `int` to make sure that we are not dealing with
+      // byteIndex
+      const intR = r:range(int, r.boundedType, r.stridable);
+      if boundsChecking {
+        if !x.byteIndices.boundsCheck(intR) {
+          halt("range ", r, " out of bounds for " + t:string + " with ",
+               x.numBytes, " bytes");
+        }
+      }
+      return intR[x.byteIndices];
+    }
+    else {  // string with codepoint indexing
+      if r.stridable {
+        // Slicing by stridable codepoint ranges is unsupported because it
+        // creates an irregular sequence of bytes.  We could add support in the
+        // future by refactoring the callers of _getView() to add a slow path,
+        // or by storing an array of indices marking the beginning of each
+        // codepoint alongside the string.
+        compilerError("string slicing doesn't support stridable codepoint ranges");
+      }
+
+      // cast the argument r to `int` to make sure that we are not dealing with
+      // codepointIdx
+      const intR = r:range(int, r.boundedType, r.stridable);
+      if boundsChecking {
+        if !x.indices.boundsCheck(intR) {
+          halt("range ", r, " out of bounds for string with length ", x.size);
+        }
+      }
+
+      // find the byte range of the given codepoint range
+      const cpRange = intR[x.indices];
+      var cpCount = 0;
+      var byteLow = x.buffLen;  // empty range if bounds outside string
+      var byteHigh = x.buffLen - 1;
+      if cpRange.high >= 0 {
+        for (i, nBytes) in x._indexLen() {
+          if cpCount == cpRange.low {
+            byteLow = i:int;
+            if !r.hasHighBound() then
+              break;
+          }
+          if cpCount == cpRange.high {
+            byteHigh = i:int + nBytes-1;
+            break;
+          }
+          cpCount += 1;
+        }
+      }
+      return byteLow..byteHigh;
+    }
+
+  }
+
   // TODO: I wasn't very good about caching variables locally in this one.
   proc getSlice(const ref x: ?t, r: range(?)) {
     assertArgType(t, "getSlice");
@@ -280,7 +345,7 @@ module BytesStringCommon {
     var ret: t;
     if x.isEmpty() then return ret;
 
-    const r2 = x._getView(r);
+    const r2 = getView(x, r);
     if r2.size <= 0 {
       // TODO: I can't just return "" (ret var gets freed for some reason)
       ret = "";

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1449,10 +1449,7 @@ module String {
           cpCount += 1;
         }
       }
-      const r1 = byteLow..byteHigh;
-      // do we need to do this slice?
-      const ret = r1[0..#(this.buffLen)];
-      return ret;
+      return byteLow..byteHigh;
     }
 
     /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -394,11 +394,6 @@ module String {
     return (x + y: int): t;
 
   pragma "no doc"
-  inline proc +(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return (x:int + y:int): t;
-
-  pragma "no doc"
   inline proc +(x: bufferType, y: byteIndex) {
     return x+(y:int);
   }

--- a/test/types/string/slices/sliceRanges.chpl
+++ b/test/types/string/slices/sliceRanges.chpl
@@ -1,0 +1,27 @@
+// This was the snippet in the bug report
+// https://github.com/chapel-lang/chapel/issues/15543
+
+var s = 'string indexing is "fun"';
+
+// These should all be true
+writeln(s[0] == s[..0]);    // used to be false
+writeln(s[0] == s[0..0]);   // used to be false
+
+// Some other checks
+writeln(s[0..1] == s[..1]); // true
+writeln(s[1] == s[1..1]);   // true
+writeln(s[1] == s[1..1]);   // true
+
+writeln(s[..5] == s[0..5]); // true
+writeln(s[2..2] == s[2]);   // true
+
+// Sanity check to confirm it's only strings
+var A = [1,2,3,4];
+
+writeln(A[0] == A[..0]);   // true
+writeln(A[0] == A[0..0]);  // true
+
+
+writeln(s[0] == s[..0:byteIndex]);              // used to be false
+writeln(s[0] == s[0:byteIndex..0:byteIndex]);   // used to be false
+

--- a/test/types/string/slices/sliceRanges.good
+++ b/test/types/string/slices/sliceRanges.good
@@ -1,0 +1,11 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/test/types/string/slices/slices.chpl
+++ b/test/types/string/slices/slices.chpl
@@ -1,0 +1,7 @@
+config type dataType = string;
+
+var s = "01234":dataType;
+
+writeln(s[..(-1):byteIndex] == "":dataType);
+writeln(s[..(-2):byteIndex] == "":dataType);  // this used to be OOB
+

--- a/test/types/string/slices/slices.compopts
+++ b/test/types/string/slices/slices.compopts
@@ -1,0 +1,2 @@
+-sdataType=string
+-sdataType=bytes

--- a/test/types/string/slices/slices.good
+++ b/test/types/string/slices/slices.good
@@ -1,0 +1,2 @@
+true
+true

--- a/test/types/string/slices/slices.prediff
+++ b/test/types/string/slices/slices.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed "s/.*\(halt reached\).*\(out of bounds\).*/\1 \2/" <$2 >$2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Most importantly, this PR makes `string` and `bytes` implementations rely more
on range API to do bounds checking on range-based operations rather than doing
some math internally that was confusing and error-prone.

Some of this confusion came up in @bradcray's 0-based indexing work:
https://github.com/chapel-lang/chapel/pull/14671/files#r377230710
https://github.com/chapel-lang/chapel/pull/14671/files#r403129851

The points made in the comments above caused
```chapel
s[..(-1):byteIndex] == "" // this was fine
s[..(-2):byteIndex] == "" // this was OOB
```
which is fixed by this PR.

Resolves https://github.com/Cray/chapel-private/issues/919

Summary of changes:
- Add `string.byteIndices` and `bytes.byteIndices` as alternatives to
  `indices`. Use those in internal implementation but `pragma "no doc"` them for
  now.

- Remove `string._getView` and `bytes._getView` in favor of `getView` helper in
  `BytesStringCommon`

- Use unbounded ranges a little less in the public interface.

  (Arguably optional, but makes the interface cleaner IMO)

- Resolves https://github.com/chapel-lang/chapel/issues/15543

  Thanks @ram-nad for the suggested fix!

Test:
- [x] valgrind in types/string and types/bytes
- [x] standard
- [x] gasnet
