### PR TITLE
Set dead aggregate type handles to NULL, conditionally add dtBytes and dtString to Python type map

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -266,7 +266,7 @@ void cleanAst() {
 
       //
       // If an internal aggregate type is being deleted, set its global
-      // handle to NULL.
+      // handle to NULL. See #15169.
       //
       if (!isAlive(at)) {
         if (at == dtBytes) dtBytes = NULL;

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -263,6 +263,18 @@ void cleanAst() {
           }
         }
       }
+
+      //
+      // If an internal aggregate type is being deleted, set its global
+      // handle to NULL.
+      //
+      if (!isAlive(at)) {
+        if (at == dtBytes) dtBytes = NULL;
+        if (at == dtString) dtString = NULL;
+        if (at == dtLocale) dtLocale = NULL;
+        if (at == dtOwned) dtOwned = NULL;
+        if (at == dtShared) dtShared = NULL;
+      }
     }
   }
 

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -305,8 +305,9 @@ void closeLibraryHelperFile(fileinfo* fi, bool beautifyIt) {
     beautify(fi);
 }
 
-// Populate the pythonNames map with the translation for bools, differently sized
-// integers, etc.
+// Populate the pythonNames map with the translation for bools, differently
+// sized integers, etc. Only types marked (FLAG_PRIMITIVE_TYPE) go in this
+// table.
 static void setupPythonTypeMap() {
   pythonNames[dtInt[INT_SIZE_8]->symbol] = std::make_pair("", "numpy.int8");
   pythonNames[dtInt[INT_SIZE_16]->symbol] = std::make_pair("", "numpy.int16");
@@ -320,8 +321,6 @@ static void setupPythonTypeMap() {
   pythonNames[dtReal[FLOAT_SIZE_64]->symbol] = std::make_pair("double", "float");
   pythonNames[dtBool->symbol] = std::make_pair("bint", "bint");
   pythonNames[dtStringC->symbol] = std::make_pair("const char *", "bytes");
-  pythonNames[dtString->symbol] = std::make_pair("", "object");
-  pythonNames[dtBytes->symbol] = std::make_pair("", "object");
   pythonNames[dtComplex[COMPLEX_SIZE_64]->symbol] =
               std::make_pair("float complex", "numpy.complex64");
   pythonNames[dtComplex[COMPLEX_SIZE_128]->symbol] =
@@ -343,10 +342,6 @@ std::string getPythonTypeName(Type* type, PythonFileType pxd) {
     std::string res = tNames.second;
     if (strncmp(res.c_str(), "numpy", strlen("numpy")) == 0) {
       res += "_t";
-    } else if (strcmp(res.c_str(), "object") == 0) {
-      // Types like byte and string map to Python objects that have no 1-to-1
-      // representation in C.
-      return res;
     } else {
       res = getPythonTypeName(type, C_PXD);
     }

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -330,7 +330,7 @@ static void setupPythonTypeMap() {
   }
 
   if (dtString != NULL) {
-    pythonNames[dtBytes->symbol] = std::make_pair("", "object");
+    pythonNames[dtString->symbol] = std::make_pair("", "object");
   }
 
   // TODO: Handle bigint (which should naturally match to Python's int)

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -306,8 +306,7 @@ void closeLibraryHelperFile(fileinfo* fi, bool beautifyIt) {
 }
 
 // Populate the pythonNames map with the translation for bools, differently
-// sized integers, etc. Only types marked (FLAG_PRIMITIVE_TYPE) go in this
-// table.
+// sized integers, etc.
 static void setupPythonTypeMap() {
   pythonNames[dtInt[INT_SIZE_8]->symbol] = std::make_pair("", "numpy.int8");
   pythonNames[dtInt[INT_SIZE_16]->symbol] = std::make_pair("", "numpy.int16");

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -326,6 +326,14 @@ static void setupPythonTypeMap() {
   pythonNames[dtComplex[COMPLEX_SIZE_128]->symbol] =
               std::make_pair("double complex", "numpy.complex128");
 
+  if (dtBytes != NULL) {
+    pythonNames[dtBytes->symbol] = std::make_pair("", "object");
+  }
+
+  if (dtString != NULL) {
+    pythonNames[dtBytes->symbol] = std::make_pair("", "object");
+  }
+
   // TODO: Handle bigint (which should naturally match to Python's int)
 
 }
@@ -342,6 +350,10 @@ std::string getPythonTypeName(Type* type, PythonFileType pxd) {
     std::string res = tNames.second;
     if (strncmp(res.c_str(), "numpy", strlen("numpy")) == 0) {
       res += "_t";
+    } else if (strcmp(res.c_str(), "object") == 0) {
+      // Types like byte and string map to Python objects that have no 1-to-1
+      // representation in C.
+      return res;
     } else {
       res = getPythonTypeName(type, C_PXD);
     }

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1176,12 +1176,26 @@ static std::string pythonArgToExternalArray(ArgSymbol* as) {
   std::string strname = as->cname;
 
   if (Symbol* eltType = exportedArrayElementType[as]) {
-    // The element type will be recorded in the exportedArrayElementType map
-    // if this arg's type was originally a Chapel array instead of explicitly
-    // an external array.  If we have the element type, that means we need to
-    // do a translation in the python wrapper.
-    std::string typeStr = getPythonTypeName(eltType->type, PYTHON_PYX);
-    std::string typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
+
+    std::string typeStr;
+    std::string typeStrCDefs;
+
+    //
+    // String and bytes are not considered primitive types so we cannot fetch
+    // them from the Python type map.
+    //
+    if (eltType->type == dtString || eltType->type == dtBytes) {
+      typeStr = "object";
+      typeStrCDefs = "";
+    } else {
+      // The element type will be recorded in the exportedArrayElementType
+      // map if this arg's type was originally a Chapel array instead of
+      // explicitly an external array.  If we have the element type, that
+      // means we need to do a translation in the python wrapper.
+      typeStr = getPythonTypeName(eltType->type, PYTHON_PYX);
+      typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
+    }
+
 
     // Create the memory needed to store the contents of what was passed to us
     // E.g. cdef chpl_external_array chpl_foo =

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -2335,12 +2335,12 @@ static void pythonRetExternalArray(FnSymbol* fn, std::string& funcCall,
   // String and bytes are not considered primitive types so we cannot fetch
   // them from the Python type map.
   //
-  if (eltType->type == dtString || eltType->type == dtBytes) {
+  if (eltType == dtString || eltType == dtBytes) {
     typeStr = "object";
     typeStrCDefs = "";
   } else {
-    typeStr = getPythonTypeName(eltType->type, PYTHON_PYX);
-    typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
+    typeStr = getPythonTypeName(eltType, PYTHON_PYX);
+    typeStrCDefs = getPythonTypeName(eltType, C_PYX);
   }
 
   //

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1176,26 +1176,12 @@ static std::string pythonArgToExternalArray(ArgSymbol* as) {
   std::string strname = as->cname;
 
   if (Symbol* eltType = exportedArrayElementType[as]) {
-
-    std::string typeStr;
-    std::string typeStrCDefs;
-
-    //
-    // String and bytes are not considered primitive types so we cannot fetch
-    // them from the Python type map.
-    //
-    if (eltType->type == dtString || eltType->type == dtBytes) {
-      typeStr = "object";
-      typeStrCDefs = "";
-    } else {
-      // The element type will be recorded in the exportedArrayElementType
-      // map if this arg's type was originally a Chapel array instead of
-      // explicitly an external array.  If we have the element type, that
-      // means we need to do a translation in the python wrapper.
-      typeStr = getPythonTypeName(eltType->type, PYTHON_PYX);
-      typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
-    }
-
+    // The element type will be recorded in the exportedArrayElementType map
+    // if this arg's type was originally a Chapel array instead of explicitly
+    // an external array.  If we have the element type, that means we need to
+    // do a translation in the python wrapper.
+    std::string typeStr = getPythonTypeName(eltType->type, PYTHON_PYX);
+    std::string typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
 
     // Create the memory needed to store the contents of what was passed to us
     // E.g. cdef chpl_external_array chpl_foo =
@@ -2337,7 +2323,7 @@ static void pythonRetExternalArray(FnSymbol* fn, std::string& funcCall,
   //
   if (eltType == dtString || eltType == dtBytes) {
     typeStr = "object";
-    typeStrCDefs = "";
+    typeStrCDefs = "object";
   } else {
     typeStr = getPythonTypeName(eltType, PYTHON_PYX);
     typeStrCDefs = getPythonTypeName(eltType, C_PYX);

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -2314,20 +2314,8 @@ static void pythonRetExternalArray(FnSymbol* fn, std::string& funcCall,
 
   funcCall += "cdef chpl_external_array ret_arr = ";
 
-  std::string typeStr;
-  std::string typeStrCDefs;
-
-  //
-  // String and bytes are not considered primitive types so we cannot fetch
-  // them from the Python type map.
-  //
-  if (eltType == dtString || eltType == dtBytes) {
-    typeStr = "object";
-    typeStrCDefs = "object";
-  } else {
-    typeStr = getPythonTypeName(eltType, PYTHON_PYX);
-    typeStrCDefs = getPythonTypeName(eltType, C_PYX);
-  }
+  std::string typeStr = getPythonTypeName(eltType, PYTHON_PYX);
+  std::string typeStrCDefs = getPythonTypeName(eltType, C_PYX);
 
   //
   // Create the numpy array to return. The form looks like:

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -2328,8 +2328,20 @@ static void pythonRetExternalArray(FnSymbol* fn, std::string& funcCall,
 
   funcCall += "cdef chpl_external_array ret_arr = ";
 
-  std::string typeStr = getPythonTypeName(eltType, PYTHON_PYX);
-  std::string typeStrCDefs = getPythonTypeName(eltType, C_PYX);
+  std::string typeStr;
+  std::string typeStrCDefs;
+
+  //
+  // String and bytes are not considered primitive types so we cannot fetch
+  // them from the Python type map.
+  //
+  if (eltType->type == dtString || eltType->type == dtBytes) {
+    typeStr = "object";
+    typeStrCDefs = "";
+  } else {
+    typeStr = getPythonTypeName(eltType->type, PYTHON_PYX);
+    typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
+  }
 
   //
   // Create the numpy array to return. The form looks like:


### PR DESCRIPTION
 The `dtBytes` and `dtString` types were added to the Python type map for #15453 in an attempt to treat all exported types in a uniform manner. I failed to realize that there might be situations where these types might have been pruned from the AST because they are never used.

This PR adjusts `cleanAst` to set global `AggregateType*` handles such as `dtBytes` or `dtShared` to NULL if they are not alive (and will soon be deleted).

It then adjusts the code in `setupPythonTypeMap` to only add `dtBytes` and `dtString` to the map if their handles are not NULL.

---

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `interop/python` on `linux64` when `CHPL_COMM=none`
- [x] `interop/python` on `linux64` when `CHPL_COMM=gasnet`
- [x] `interop/python/noLibFlag/pythonCompile` on `linux64` with `valgrind`