### PR TITLE
Fix a 0-based tuple flaw.

### DIFF
--- a/test/studies/comd/llnl/utils/forceeam.chpl
+++ b/test/studies/comd/llnl/utils/forceeam.chpl
@@ -156,7 +156,7 @@ local {
           src = dest;
           var neighbor = ijk + nOff;
           var srcOff = (0,0,0);
-          for i in 1..3 {
+          for i in 0..2 {
             if(neighbor(i) < 0) {
               //neighbor(i) = locDom.high(i);
               //srcOff(i) = boxSpace.high(i);


### PR DESCRIPTION
This was causing a compile-time error in some XC perf testing I was
running just now.  I don't know why it hasn't popped up in nightlies; we
do run this test in a variety of nightly configurations.