### PR TITLE
Remove a mason workaround added for a string bug

### DIFF
--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -86,7 +86,6 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
 
 proc stripExt(toStrip: string, ext: string) : string {
   if toStrip.endsWith(ext) {
-    if (toStrip.size - ext.size) == 1 then return toStrip[0];
     var stripped = toStrip[..<(toStrip.size - ext.size)];
     return stripped;
   }


### PR DESCRIPTION
Removes the workaround added in https://github.com/chapel-lang/chapel/pull/15529.

This workaround was added to avoid https://github.com/chapel-lang/chapel/issues/15543, and that bug is fixed with https://github.com/chapel-lang/chapel/pull/15615.

Test:
- [x] `test/mason/` passes with standard config