### PR TITLE
Add spaces required by gcc 4.9

### DIFF
--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -60,7 +60,7 @@ public:
                                         VisibleFunctionBlock();
 
   Map<const char*, Vec<FnSymbol*>*>     visibleFunctions;
-  std::map<const char*, std::pair<bool, std::vector<FnSymbol*>*>> reexports;
+  std::map<const char*, std::pair<bool, std::vector<FnSymbol*>*> > reexports;
 };
 
 static Map<BlockStmt*, VisibleFunctionBlock*> visibleFunctionMap;
@@ -904,7 +904,7 @@ void visibleFunctionsClear() {
     }
 
     for(std::map<const char*, std::pair<bool,
-          std::vector<FnSymbol*>*>>::iterator it = vfb->reexports.begin();
+          std::vector<FnSymbol*>*> >::iterator it = vfb->reexports.begin();
         it != vfb->reexports.end(); ++it) {
       std::pair<bool, std::vector<FnSymbol*>*> val = it->second;
       delete val.second;


### PR DESCRIPTION
Verified that the compiler built with 4.9 with this change and
hello.chpl compiled and ran correctly.  Running a paratest over
the examples directory with our usual gcc version