### PR TITLE
Update CoMD w.r.t. 0-based indexing, --checks

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -948,6 +948,9 @@ inline proc AccumStencilArr.dsiAccess(i: idxType...rank) const ref
 where shouldReturnRvalueByConstRef(eltType)
   return dsiAccess(i);
 
+inline proc AccumStencilArr.dsiBoundsCheck(i: rank*idxType) {
+  return dom.wholeFluff.contains(i);
+}
 
 iter AccumStencilArr.these() ref {
   for i in dom do

--- a/test/studies/comd/llnl/CoMD.chpl
+++ b/test/studies/comd/llnl/CoMD.chpl
@@ -30,7 +30,7 @@ proc initGrid(latticeConstant: real, const ref force: unmanaged Force) {
 
   assert(locDom.size <= numLocales);
   const targetLocales : [locDom] locale =
-          for (_,l) in zip(0..#locDom.size, Locales) do l;
+          for l in Locales[0..#locDom.size] do l;
 
   const boxSpace = {1..numBoxes(0), 1..numBoxes(1), 1..numBoxes(2)};
   const distSpace = boxSpace dmapped Block(boundingBox=boxSpace, targetLocales=targetLocales);
@@ -445,7 +445,7 @@ tArray[timerEnum.ATOMHALO].start();
   for i in 1..6 by 2 {
     coforall ijk in locDom {
       on locGrid[ijk] {
-        if Grid[ijk]!.localDom.dim((i/2):int+1).size > 1 {
+        if Grid[ijk]!.localDom.dim((i/2):int).size > 1 {
           exchangeDataTwo(Grid[ijk]!, i);
         } else {
           exchangeData(Grid[ijk]!, i);

--- a/test/studies/comd/llnl/utils/forceeam.chpl
+++ b/test/studies/comd/llnl/utils/forceeam.chpl
@@ -156,7 +156,7 @@ local {
           src = dest;
           var neighbor = ijk + nOff;
           var srcOff = (0,0,0);
-          for i in 1..3 {
+          for i in 0..2 {
             if(neighbor(i) < 0) {
               //neighbor(i) = locDom.high(i);
               //srcOff(i) = boxSpace.high(i);


### PR DESCRIPTION
@gbtitus found that CoMD was causing some compilation errors when using CHPL_TARGET_COMPILER=cray-prgenv-gnu with gcc 9.3.0 due to a loop not having been updated from 1- to 0-based indexing.  I originally thought that this was due to the test being compiled with `--checks`, though it seems that the code is never actually executed in our test configurations, so that's probably the real reason.

While debugging the issue, I turned on `--checks` and found a few other things that wouldn't work when compiled with checks on, so fixed those as well.