### PR TITLE
Improve mason external --setup

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -547,9 +547,9 @@ through the Spack integration. The following is a workflow of finding, installin
 First, the Spack backend must be installed. Users can have mason install Spack
 or point mason to an existing spack installation.
 
-This command will install Spack into ``$MASON_HOME`` and set it up so that it
+This command will install Spack into ``$MASON_HOME/spack`` and set it up so that it
 can be used by Mason. It should be noted that this command pulls from the `master` branch of spack
-for setting up the spack registry at ``$MASON_HOME``::
+for setting up the spack registry at ``$MASON_HOME/spack-registry``::
 
   mason external --setup
 

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -548,7 +548,8 @@ First, the Spack backend must be installed. Users can have mason install Spack
 or point mason to an existing spack installation.
 
 This command will install Spack into ``$MASON_HOME`` and set it up so that it
-can be used by Mason::
+can be used by Mason. It should be noted that this command pulls from the `master` branch of spack
+for setting up the spack registry at ``$MASON_HOME``::
 
   mason external --setup
 

--- a/test/mason/mason-external/libtomlc99/mason-external.good
+++ b/test/mason/mason-external/libtomlc99/mason-external.good
@@ -1,4 +1,6 @@
+  Fetch: <time>.  Build: <time>.  Total: <time>.
 Installing Spack backend ...
+Spack installation successful
 Updating registry
 Compiling [debug] target: CToml
 Build Successful

--- a/test/mason/mason-external/libtomlc99/mason-external.good
+++ b/test/mason/mason-external/libtomlc99/mason-external.good
@@ -1,6 +1,5 @@
   Fetch: <time>.  Build: <time>.  Total: <time>.
 Installing Spack backend ...
-Spack installation successful
 Updating registry
 Compiling [debug] target: CToml
 Build Successful

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -148,7 +148,7 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
         var sourceList = genSourceList(lockFile);
 
         if lockFile.pathExists('external') {
-          spackInstalled();
+          if !spackInstalled() then throw new owned MasonError("Error!");
         }
         //
         // TODO: Temporarily use `toArray` here because `list` does not yet
@@ -159,7 +159,6 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
 
         // get compilation options including external dependencies
         const compopts = getTomlCompopts(lockFile, cmdLineCompopts);
-
         // Compile Program
         if compileSrc(lockFile, binLoc, show, release, compopts, projectHome) {
           writeln("Build Successful\n");

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -30,6 +30,7 @@ use MasonHelp;
 use MasonEnv;
 use MasonUpdate;
 use MasonSystem;
+use MasonExternal;
 use MasonExample;
 
 proc masonBuild(args) throws {
@@ -145,6 +146,10 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
 
         // generate list of dependencies and get src code
         var sourceList = genSourceList(lockFile);
+
+        if lockFile.pathExists('external') {
+          spackInstalled();
+        }
         //
         // TODO: Temporarily use `toArray` here because `list` does not yet
         // support parallel iteration, which the `getSrcCode` method _must_

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -148,7 +148,7 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
         var sourceList = genSourceList(lockFile);
 
         if lockFile.pathExists('external') {
-          if !spackInstalled() then throw new owned MasonError("Error!");
+          spackInstalled();
         }
         //
         // TODO: Temporarily use `toArray` here because `list` does not yet

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -140,9 +140,12 @@ private proc updateSpackCommandLine() {
                       ' checkout -q FETCH_HEAD -b ' + version + '-branch';
   const command = 'git ' + '-C ' + MASON_HOME + '/spack ' + ' fetch -q ' +
                   ' --depth 1 origin ' + branch;
+  const commitTagCommand = 'git ' + '-C ' + MASON_HOME + '/spack ' +
+                      'tag v0.14.2 -m "updated version"';
   const status = runWithStatus(command);
   const statusCheckOut = runWithStatus(checkOutCommand);
-  if status != 0 || statusCheckOut != 0 then return -1;
+  const statusCommitTag = runWithStatus(commitTagCommand);
+  if status != 0 || statusCheckOut != 0 || statusCommitTag != 0 then return -1;
   else return 0;
 }
 

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -47,17 +47,17 @@ proc masonExternal(args: [] string) {
       exit(0);
     }
     else if args[2] == "--setup" {
-      // if spack and spack registry is present with latest version, print message
+      // If spack and spack registry is present with latest version, print message
       if isDir(SPACK_ROOT) &&
       isDir(MASON_HOME+'/spack-registry') &&
       getSpackVersion == spackVersion &&
       SPACK_ROOT == spackDefaultPath {
         throw new owned MasonError("Spack backend is already installed");
       }
-      // if both spack and spack registry not installed then setup spack
+      // If both spack and spack registry not installed then setup spack
       if !isDir(SPACK_ROOT) && !isDir(MASON_HOME+'/spack-registry') then
         setupSpack();
-      // if spack registry is not installed then install it
+      // If spack registry is not installed then install it
       if !isDir(MASON_HOME+'/spack-registry') {
         writeln("Installing Spack Registry ...");
         const dest = MASON_HOME + '/spack-registry';
@@ -65,14 +65,14 @@ proc masonExternal(args: [] string) {
         const status = cloneSpackRepository(branch, dest);
         if status != 0 then throw new owned MasonError("Spack registry installation failed.");
       }
-      // if spack is installed and version is outdated, update it
+      // If spack is installed and version is outdated, update it
       if isDir(SPACK_ROOT) && getSpackVersion != spackVersion {
         writeln("Updating Spack backend ... ");
         const status = updateSpackCommandLine();
         if isDir(MASON_HOME + '/spack-registry') then generateYAML();
         if status != 0 then throw new owned MasonError("Spack update failed.");
       }
-      // if spack is not installed then install it
+      // If spack is not installed then install it
       if !isDir(SPACK_ROOT) {
         writeln("Installing Spack backend ... ");
         const spackLatestBranch = ' --branch ' + spackBranch + ' ';
@@ -116,15 +116,15 @@ private proc specHelp() {
 /* Checks if updated spack and spack registry is installed*/
 proc spackInstalled() throws {
   if !isDir(SPACK_ROOT) {
-    throw new owned MasonError("To use `mason external` call `mason external --setup`");
+    throw new owned MasonError("To use mason external, call : mason external --setup");
   }
   if !isDir(getSpackRegistry) {
-    throw new owned MasonError("Mason has been updated, to use `mason external` "+
-                                "call `mason external --setup`");
+    throw new owned MasonError("Mason has been updated. To use mason external, "+
+                                "call : mason external --setup");
   }
   if getSpackVersion != spackVersion && SPACK_ROOT == spackDefaultPath {
     throw new owned MasonError("Mason has been updated and requires a newer" +
-          " version of spack.\nTo use `mason external`, call `mason external --setup`");
+          " version of Spack.\nTo use mason external, call : mason external --setup");
   }
   return true;
 }
@@ -144,7 +144,7 @@ proc setupSpack() throws {
   }
 }
 
-/* clones the spack repository */
+/* Clones the Spack repository */
 proc cloneSpackRepository(branch : string, dest: string) {
   const repo = "https://github.com/spack/spack ";
   const depth = '--depth 1 ';
@@ -210,20 +210,20 @@ private proc generateYAML() {
   yamlWriter.close();
 }
 
-/* prints spack version */
+/* Prints spack version */
 private proc printSpackVersion() {
   const command = "spack --version";
   const version = runSpackCommand(command);
 }
 
-/* returns spack version */
+/* Returns spack version */
 private proc getSpackVersion : string {
   const command = "spack --version";
   const version = getSpackResult(command,true).strip();
   return version;
 }
 
-/* lists available spack packages */
+/* Lists available spack packages */
 private proc listSpkgs() {
   const command = "spack list";
   const status = runSpackCommand(command);
@@ -258,7 +258,7 @@ private proc searchSpkgs(args: [?d] string) {
   }
 }
 
-/* lists all installed spack packages for user */
+/* Lists all installed spack packages for user */
 private proc listInstalled() {
   const command = "spack find";
   const status = runSpackCommand(command);
@@ -340,7 +340,7 @@ private proc compiler(args: [?d] string) {
     }
 }
 
-/* lists available compilers on system */
+/* Lists available compilers on system */
 private proc listCompilers() {
   const command = "spack compilers";
   const status = runSpackCommand(command);

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -66,6 +66,7 @@ proc masonExternal(args: [] string) {
         when 'info' do spkgInfo(args);
         when 'find' do findSpkg(args);
         when '--spec' do specHelp();
+        when '-V' do spackVersion();
         otherwise {
           writeln('error: no such subcommand');
           writeln('try mason external --help');
@@ -144,6 +145,12 @@ private proc generateYAML() {
   var yamlWriter = yamlFile.writer();
   yamlWriter.write(reposOverride);
   yamlWriter.close();
+}
+
+private proc spackVersion() {
+  const command = "spack --version";
+  const version = runSpackCommandReturnLine(command);
+  write(version);
 }
 
 /* lists available spack packages */

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -136,8 +136,10 @@ proc setupSpack() throws {
 }
 
 private proc updateSpackCommandLine() {
-  const checkOutCommand = 'git checkout FETCH_HEAD -b ' + branch;
-  const command = 'git fetch --depth 1 origin ' + branch;
+  const checkOutCommand = 'git ' + '-C ' + MASON_HOME + '/spack ' +
+                      ' checkout -q FETCH_HEAD -b ' + version + '-branch';
+  const command = 'git ' + '-C ' + MASON_HOME + '/spack ' + ' fetch -q ' +
+                  ' --depth 1 origin ' + branch;
   const status = runWithStatus(command);
   const statusCheckOut = runWithStatus(checkOutCommand);
   if status != 0 || statusCheckOut != 0 then return -1;

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -133,7 +133,7 @@ proc spackInstalled() throws {
 proc setupSpack() throws {
   writeln("Installing Spack backend ...");
   const destCLI = MASON_HOME + "/spack/";
-  const spackLatestBranch = ' --branch ' + spackBranch + ' ';
+  const spackLatestBranch = ' --branch v' + spackVersion + ' ';
   const destPackages = MASON_HOME + "/spack-registry";
   const spackMasterBranch = ' --branch master ';
   const statusCLI = cloneSpackRepository(spackLatestBranch, destCLI);
@@ -148,16 +148,16 @@ proc setupSpack() throws {
 proc cloneSpackRepository(branch : string, dest: string) {
   const repo = "https://github.com/spack/spack ";
   const depth = '--depth 1 ';
-  const command = 'git clone -q ' + branch + depth + repo + dest;
+  const command = 'git clone -q -c advice.detachedHead=false ' + branch + depth + repo + dest;
   const statusPackages = runWithStatus(command);
   if statusPackages != 0 then return -1;
   else return 0;
 }
 
 /* git checkout command run at SPACK_ROOT */
-proc gitCheckOutSpack(version: string) {
+proc gitCheckOutSpack(tag: string) {
   const checkOutCommand = 'git ' + '-C ' + SPACK_ROOT +
-                      ' checkout -q FETCH_HEAD -b ' + version + '-branch';
+                      ' checkout -q ' + tag;
   const status = runWithStatus(checkOutCommand);
   if status != 0 then return -1;
   else return 0;
@@ -172,23 +172,14 @@ proc gitFetch(branch: string) {
   else return 0;
 }
 
-/* git tag command run at SPACK_ROOT */
-proc gitCommitTag(tag: string) {
-  const commitTagCommand = 'git ' + '-C ' + SPACK_ROOT +
-                   ' tag ' + tag + ' -f -m "updated" &> /dev/null';
-  const status = runWithStatus(commitTagCommand);
-  if status != 0 then return -1;
-  else return 0;
-
-}
-
 /* Updates the spack directory used for spack commands */
 private proc updateSpackCommandLine() {
   const releaseTag = 'v' + spackVersion;
-  const statusFetch = gitFetch(spackBranch);
-  const statusCheckOut = gitCheckOutSpack(spackVersion);
-  const statusCommitTag = gitCommitTag(releaseTag);
-  if statusFetch != 0 || statusCheckOut != 0 || statusCommitTag != 0 then return -1;
+  var tag = 'refs/tags/' + releaseTag;
+  tag = tag + ':' + tag;
+  const statusFetch = gitFetch(tag);
+  const statusCheckOut = gitCheckOutSpack(releaseTag);
+  if statusFetch != 0 || statusCheckOut != 0 then return -1;
   else return 0;
 }
 

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -114,7 +114,7 @@ private proc specHelp() {
 }
 
 /* checks if updated spack and spack registry is installed*/
-private proc spackInstalled() throws {
+proc spackInstalled() throws {
   if !isDir(SPACK_ROOT) {
     throw new owned MasonError("To use `mason external` call `mason external --setup`");
   }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -100,6 +100,7 @@ proc setupSpack() throws {
   const clonePackages = "git clone -q" + getMasterBranch + depth + repo + destPackages;
   const statusCLI = runWithStatus(cloneCLI);
   const statusPackages = runWithStatus(clonePackages);
+  generateYAML();
   // check for status
   if statusCLI != 0 && statusPackages != 0 {
     throw new owned MasonError("Spack installation failed");
@@ -108,6 +109,23 @@ proc setupSpack() throws {
   }
 }
 
+/*
+  Generate site-specific repos.yaml :-
+  Replaces package repository path of repos.yaml file at
+  /spack/etc/spack/defaults with that of spack-registry
+*/
+private proc generateYAML() {
+  const yamlFilePath = SPACK_ROOT + '/etc/spack/defaults/repos.yaml';
+  if isFile(yamlFilePath) then {
+    remove(yamlFilePath);
+  }
+  const reposOverride = 'repos:\n'+
+                        '  - ~/.mason/spack-registry/var/spack/repos/builtin \n';
+  var yamlFile = open(yamlFilePath,iomode.cw);
+  var yamlWriter = yamlFile.writer();
+  yamlWriter.write(reposOverride);
+  yamlWriter.close();
+}
 
 /* lists available spack packages */
 private proc listSpkgs() {

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -113,7 +113,7 @@ private proc specHelp() {
   const status = runSpackCommand(command);
 }
 
-/* checks if updated spack and spack registry is installed*/
+/* Checks if updated spack and spack registry is installed*/
 proc spackInstalled() throws {
   if !isDir(SPACK_ROOT) {
     throw new owned MasonError("To use `mason external` call `mason external --setup`");

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -47,6 +47,11 @@ proc masonExternal(args: [] string) {
       exit(0);
     }
     else if args[2] == "--setup" {
+      // if MASON_OFFLINE is set, then cannot install spack
+      if MASON_OFFLINE {
+        throw new owned MasonError('Cannot setup Spack when MASON_OFFLINE is set to true');
+        exit(0);
+      }
       // If spack and spack registry is present with latest version, print message
       if isDir(SPACK_ROOT) &&
       isDir(MASON_HOME+'/spack-registry') &&

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -19,7 +19,10 @@
  */
 
 const spackVersion = '0.14.2';
-const spackBranch = 'releases/v0.14';
+const v = spackVersion.split('.');
+const master = v[0];
+const minor = v[1];
+const spackBranch = 'releases/v' + '.'.join(master,minor);
 const spackDefaultPath = MASON_HOME + "/spack";
 
 private use List;

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-config const spackVersion = "releases/v0.11.2";
 
 private use List;
 private use Map;
@@ -89,13 +88,23 @@ private proc spackInstalled() throws {
 /* Spack installed to MASON_HOME/spack */
 proc setupSpack() throws {
   writeln("Installing Spack backend ...");
-  const destination = MASON_HOME + "/spack/";
-  const clone = "git clone -q https://github.com/spack/spack " + destination;
-  const checkout = "git checkout -q " + spackVersion;
-  const status = runWithStatus(clone);
-  gitC(destination, checkout);
-  if status != 0 {
+  // destination directory name for spack command line interface and registry
+  const destCLI = MASON_HOME + "/spack/";
+  const destPackages = MASON_HOME + "/spack-registry";
+  // git clone to download spack for CLI and registry
+  const depth = ' --depth 1 ';
+  const getRepoTag = ' --branch releases/v0.14 ';
+  const getMasterBranch = ' --branch master ';
+  const repo = "https://github.com/spack/spack ";
+  const cloneCLI = "git clone -q" + getRepoTag + depth + repo + destCLI;
+  const clonePackages = "git clone -q" + getMasterBranch + depth + repo + destPackages;
+  const statusCLI = runWithStatus(cloneCLI);
+  const statusPackages = runWithStatus(clonePackages);
+  // check for status
+  if statusCLI != 0 && statusPackages != 0 {
     throw new owned MasonError("Spack installation failed");
+  } else {
+    writeln("Spack installation successful");
   }
 }
 

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -121,15 +121,15 @@ private proc specHelp() {
 /* Checks if updated spack and spack registry is installed*/
 proc spackInstalled() throws {
   if !isDir(SPACK_ROOT) {
-    throw new owned MasonError("To use mason external, call : mason external --setup");
+    throw new owned MasonError("To use mason external, call: mason external --setup");
   }
   if !isDir(getSpackRegistry) {
     throw new owned MasonError("Mason has been updated. To use mason external, "+
-                                "call : mason external --setup");
+                                "call: mason external --setup");
   }
   if getSpackVersion != spackVersion && SPACK_ROOT == spackDefaultPath {
     throw new owned MasonError("Mason has been updated and requires a newer" +
-          " version of Spack.\nTo use mason external, call : mason external --setup");
+          " version of Spack.\nTo use mason external, call: mason external --setup");
   }
   return true;
 }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -208,7 +208,7 @@ private proc printSpackVersion() {
 }
 
 /* Returns spack version */
-private proc getSpackVersion : string {
+proc getSpackVersion : string {
   const command = "spack --version";
   const version = getSpackResult(command,true).strip();
   return version;

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -175,7 +175,7 @@ proc gitFetch(branch: string) {
 /* git tag command run at SPACK_ROOT */
 proc gitCommitTag(tag: string) {
   const commitTagCommand = 'git ' + '-C ' + SPACK_ROOT +
-                   ' tag ' + tag + ' -m "updated"';
+                   ' tag ' + tag + ' -f -m "updated" &> /dev/null';
   const status = runWithStatus(commitTagCommand);
   if status != 0 then return -1;
   else return 0;

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -193,6 +193,7 @@ proc masonExternalHelp() {
   writeln("    uninstall                   Uninstall an external package");
   writeln("    info                        Show information about an external package");
   writeln("    find                        Find information about installed external packages");
+  writeln("    -V                          Display Spack version");
   writeln("    -h, --help                  Display this message");
   writeln("        --setup                 Download and install Spack backend");
   writeln("        --spec                  Display Spack specification help");

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -193,7 +193,7 @@ proc masonExternalHelp() {
   writeln("    uninstall                   Uninstall an external package");
   writeln("    info                        Show information about an external package");
   writeln("    find                        Find information about installed external packages");
-  writeln("    -V                          Display Spack version");
+  writeln("    -V, --version               Display Spack version");
   writeln("    -h, --help                  Display this message");
   writeln("        --setup                 Download and install Spack backend");
   writeln("        --spec                  Display Spack specification help");

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -69,10 +69,10 @@ proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
     updateRegistry(tf, args);
     const openFile = openreader(tomlPath);
     const TomlFile = parseToml(openFile);
-    if isDir(SPACK_ROOT) {
+    if isDir(SPACK_ROOT) && TomlFile.pathExists('external') {
       if getSpackVersion != spackVersion then
-      throw new owned MasonError("Mason could not find Spack at $MASON_HOME. " +
-                  "To install Spack, use : mason external --setup.");
+      throw new owned MasonError("Mason has been updated. " +
+                  "To install Spack, call  : mason external --setup.");
     }
     const lockFile = createDepTree(TomlFile);
     if failedChapelVersion.size > 0 {

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -69,9 +69,11 @@ proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
     updateRegistry(tf, args);
     const openFile = openreader(tomlPath);
     const TomlFile = parseToml(openFile);
-    if !isDir(SPACK_ROOT) || !isDir(MASON_HOME+'/spack-registry') then
-    throw new owned MasonError("Mason could not find Spack at $MASON_HOME. " +
+    if isDir(SPACK_ROOT) {
+      if getSpackVersion != spackVersion then
+      throw new owned MasonError("Mason could not find Spack at $MASON_HOME. " +
                   "To install Spack, use : mason external --setup.");
+    }
     const lockFile = createDepTree(TomlFile);
     if failedChapelVersion.size > 0 {
       const prefix = if failedChapelVersion.size == 1

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -66,12 +66,13 @@ proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
     const tomlPath = projectHome + "/" + tf;
     const lockPath = projectHome + "/" + lf;
 
-
     updateRegistry(tf, args);
     const openFile = openreader(tomlPath);
     const TomlFile = parseToml(openFile);
+    if !isDir(SPACK_ROOT) || !isDir(MASON_HOME+'/spack-registry') then
+    throw new owned MasonError("Mason could not find Spack at $MASON_HOME. " +
+                  "To install Spack, use `mason external --setup`.");
     const lockFile = createDepTree(TomlFile);
-
     if failedChapelVersion.size > 0 {
       const prefix = if failedChapelVersion.size == 1
         then "The following package is"
@@ -81,10 +82,8 @@ proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
         stderr.writeln("  ", msg);
       exit(1);
     }
-
     // Generate Lock File
     genLock(lockFile, lockPath);
-
     // Close Memory
     openFile.close();
     delete TomlFile;
@@ -150,7 +149,6 @@ proc updateRegistry(tf: string, args: list(string)) {
     writeln('Skipping update due to MASON_OFFLINE=true');
     return;
   }
-
   checkRegistryChanged();
   for ((name, registry), registryHome) in zip(MASON_REGISTRY, MASON_CACHED_REGISTRY) {
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -72,7 +72,7 @@ proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
     if isDir(SPACK_ROOT) && TomlFile.pathExists('external') {
       if getSpackVersion != spackVersion then
       throw new owned MasonError("Mason has been updated. " +
-                  "To install Spack, call  : mason external --setup.");
+                  "To install Spack, call: mason external --setup.");
     }
     const lockFile = createDepTree(TomlFile);
     if failedChapelVersion.size > 0 {

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -71,7 +71,7 @@ proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
     const TomlFile = parseToml(openFile);
     if !isDir(SPACK_ROOT) || !isDir(MASON_HOME+'/spack-registry') then
     throw new owned MasonError("Mason could not find Spack at $MASON_HOME. " +
-                  "To install Spack, use `mason external --setup`.");
+                  "To install Spack, use : mason external --setup.");
     const lockFile = createDepTree(TomlFile);
     if failedChapelVersion.size > 0 {
       const prefix = if failedChapelVersion.size == 1

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -395,10 +395,8 @@ proc getChapelVersionStr() {
 
 proc gitC(newDir, command, quiet=false) throws {
   var ret : string;
-
   const oldDir = here.cwd();
   here.chdir(newDir);
-
   ret = runCommand(command, quiet);
 
   here.chdir(oldDir);

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -160,6 +160,10 @@ proc SPACK_ROOT : string {
   return spackRoot;
 }
 
+proc getSpackRegistry : string {
+  return MASON_HOME + "/spack-registry";
+}
+
 /* uses spawnshell and the prefix to setup Spack before
    calling the spack command. This also returns the stdout
    of the spack call.

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -159,7 +159,11 @@ proc SPACK_ROOT : string {
 
   return spackRoot;
 }
-
+/*
+This fetches the mason-installed spack registry only.
+For an user who has explicitly installed spack, will be required
+to use their own spack registry
+*/
 proc getSpackRegistry : string {
   return MASON_HOME + "/spack-registry";
 }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -161,8 +161,8 @@ proc SPACK_ROOT : string {
 }
 /*
 This fetches the mason-installed spack registry only.
-For an user who has explicitly installed spack, will be required
-to use their own spack registry
+Users that define SPACK_ROOT to their own spack installation will use 
+the registry of their spack installation.
 */
 proc getSpackRegistry : string {
   return MASON_HOME + "/spack-registry";

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -171,8 +171,6 @@ proc getSpackRegistry : string {
 proc getSpackResult(cmd, quiet=false) : string throws {
   var ret : string;
   try {
-
-
     var prefix = "export SPACK_ROOT=" + SPACK_ROOT +
     " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
@@ -214,25 +212,6 @@ proc runSpackCommand(command) {
   return sub.exit_status;
 }
 
-/*
-Returns the output of a spack command provided it is a
-single line.
-*/
-proc runSpackCommandReturnLine(command) {
-  var prefix = "export SPACK_ROOT=" + SPACK_ROOT +
-  " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
-  " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
-
-  var cmd = (prefix + command);
-  var sub = spawnshell(cmd, stderr=PIPE, executable="bash");
-  sub.wait();
-  var returnLine : string;
-  for line in sub.stderr.lines() {
-    returnLine = line;
-    break;
-  }
-  return returnLine;
-}
 
 proc hasOptions(args: list(string), const opts: string ...) {
   var ret = false;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -214,6 +214,25 @@ proc runSpackCommand(command) {
   return sub.exit_status;
 }
 
+/*
+Returns the output of a spack command provided it is a
+single line.
+*/
+proc runSpackCommandReturnLine(command) {
+  var prefix = "export SPACK_ROOT=" + SPACK_ROOT +
+  " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
+  " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
+
+  var cmd = (prefix + command);
+  var sub = spawnshell(cmd, stderr=PIPE, executable="bash");
+  sub.wait();
+  var returnLine : string;
+  for line in sub.stderr.lines() {
+    returnLine = line;
+    break;
+  }
+  return returnLine;
+}
 
 proc hasOptions(args: list(string), const opts: string ...) {
   var ret = false;


### PR DESCRIPTION
This PR makes the following improvements : 
- split `spack` installation between `spack` command line tool (pinned version) and `spack-registry` (always pulls master branch).
- implemented "shallow clone" to install `spack` and `spack-registry`, reducing time of download to under a minute.
- implemented function to update from earlier version of `spack` and mason to latest version.
- modified `repos.yaml` file to point to `spack-registry`
- added appropriate error messages.
- updated the documentation.


fixes #15616 