### PR TITLE
Set: op= in-place, write some op in terms of op= for terseness

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -496,28 +496,21 @@ module Set {
   proc |(const ref a: set(?t, ?), const ref b: set(t, ?)): set(t) {
     var result: set(t, (a.parSafe || b.parSafe));
 
-    for x in a do
-      result.add(x);
-
-    for x in b do
-      result.add(x);
+    result = a;
+    result |= b;
 
     return result;
   }
 
   /*
-    Assign to the set `lhs` the set that is the union of `lhs` and `rhs`.
-
-    .. warning::
-
-      This will invalidate any references to elements previously contained in
-      the set `lhs`.
+    Add to the set `lhs` all the elements of `rhs`.
 
     :arg lhs: A set to take the union of and then assign to.
     :arg rhs: A set to take the union of.
   */
   proc |=(ref lhs: set(?t, ?), const ref rhs: set(t, ?)) {
-    lhs = lhs | rhs;
+    for x in rhs do
+      lhs.add(x);
   }
 
   /*
@@ -535,18 +528,13 @@ module Set {
   }
 
   /*
-    Assign to the set `lhs` the set that is the union of `lhs` and `rhs`.
-
-    .. warning::
-
-      This will invalidate any references to elements previously contained in
-      the set `lhs`.
+    Add to the set `lhs` all the elements of `rhs`.
 
     :arg lhs: A set to take the union of and then assign to.
     :arg rhs: A set to take the union of.
   */
   proc +=(ref lhs: set(?t, ?), const ref rhs: set(t, ?)) {
-    lhs = lhs + rhs;
+    lhs |= rhs;
   }
 
   /*
@@ -575,7 +563,7 @@ module Set {
   }
 
   /*
-    Assign to the set `lhs` the set that is the difference of `lhs` and `rhs`.
+    Remove from the set `lhs` the elements of `rhs`.
 
     .. warning::
 
@@ -586,7 +574,13 @@ module Set {
     :arg rhs: A set to take the difference of.
   */
   proc -=(ref lhs: set(?t, ?), const ref rhs: set(t, ?)) {
-    lhs = lhs - rhs;
+    if lhs.parSafe && rhs.parSafe {
+      forall x in rhs do
+        lhs.remove(x);
+    } else {
+      for x in rhs do
+        lhs.remove(x);
+    }
   }
 
   /*
@@ -601,14 +595,27 @@ module Set {
   proc &(const ref a: set(?t, ?), const ref b: set(t, ?)): set(t) {
     var result: set(t, (a.parSafe || b.parSafe));
 
-    if a.parSafe && b.parSafe {
-      forall x in a do
-        if b.contains(x) then
-          result.add(x);
+    /* Iterate over the smaller set */
+    if a.size <= b.size {
+      if a.parSafe && b.parSafe {
+        forall x in a do
+          if b.contains(x) then
+            result.add(x);
+      } else {
+        for x in a do
+          if b.contains(x) then
+            result.add(x);
+      }
     } else {
-      for x in a do
-        if b.contains(x) then
-          result.add(x);
+      if a.parSafe && b.parSafe {
+        forall x in b do
+          if a.contains(x) then
+            result.add(x);
+      } else {
+        for x in b do
+          if a.contains(x) then
+            result.add(x);
+      }
     }
 
     return result;
@@ -627,7 +634,31 @@ module Set {
     :arg rhs: A set to take the intersection of.
   */
   proc &=(ref lhs: set(?t, ?), const ref rhs: set(t, ?)) {
-    lhs = lhs & rhs;
+    /* Iterate over the smaller set.  But we can't remove things from
+       lhs while iterating over it.  So use a temporary if lhs is
+       significantly smaller than rhs; otherwise just iterate over rhs. */
+    if lhs.size < 2 * rhs.size {
+      var result: set(t, (lhs.parSafe || rhs.parSafe));
+
+      if lhs.parSafe && rhs.parSafe {
+        forall x in lhs do
+          if rhs.contains(x) then
+            result.add(x);
+      } else {
+        for x in lhs do
+          if rhs.contains(x) then
+            result.add(x);
+      }
+      lhs = result;
+    } else {
+      if lhs.parSafe && rhs.parSafe {
+        forall x in rhs do
+          lhs.remove(x);
+      } else {
+        for x in rhs do
+          lhs.remove(x);
+      }
+    }
   }
 
   /*
@@ -642,20 +673,14 @@ module Set {
   proc ^(const ref a: set(?t, ?), const ref b: set(t, ?)): set(t) {
     var result: set(t, (a.parSafe || b.parSafe));
 
-    if a.parSafe && b.parSafe {
-      forall x in a do
-        if !b.contains(x) then
-          result.add(x);
-      forall x in b do
-        if !a.contains(x) then
-          result.add(x);
+    /* Expect the loop in ^= to be more expensive than the loop in =,
+       so arrange for the rhs of the ^= to be the smaller set. */
+    if a.size <= b.size {
+      result = b;
+      result ^= a;
     } else {
-      for x in a do
-        if !b.contains(x) then
-          result.add(x);
-      for x in b do
-        if !a.contains(x) then
-          result.add(x);
+      result = a;
+      result ^= b;
     }
 
     return result;
@@ -674,7 +699,23 @@ module Set {
     :arg rhs: A set to take the symmetric difference of.
   */
   proc ^=(ref lhs: set(?t, ?), const ref rhs: set(t, ?)) {
-    lhs = lhs ^ rhs;
+    if lhs.parSafe && rhs.parSafe {
+      forall x in rhs {
+        if lhs.contains(x) {
+          lhs.remove(x);
+        } else {
+          lhs.add(x);
+        }
+      }
+    } else {
+      for x in rhs {
+        if lhs.contains(x) {
+          lhs.remove(x);
+        } else {
+          lhs.add(x);
+        }
+      }
+    }
   }
 
   /*
@@ -806,5 +847,4 @@ module Set {
     return result;
   }
 
-} // End module "Sets".
-
+} // End module "Set".

--- a/test/library/standard/Set/difference/setDifference.chpl
+++ b/test/library/standard/Set/difference/setDifference.chpl
@@ -39,6 +39,9 @@ proc doTest(type eltType) {
   assert(s1.size == testIters);
   assert(s2.size == (testIters * 2));
   assert(s3.size == testIters);
+
+  s2 -= s1;
+  assert(s2 == s3);
 }
 
 doTest(int);

--- a/test/library/standard/Set/intersection/setIntersection.chpl
+++ b/test/library/standard/Set/intersection/setIntersection.chpl
@@ -33,6 +33,8 @@ proc doTest(type eltType) {
   assert(s2.size == (testIters * 2));
 
   s3 = s1 & s2;
+
+  var s2copy = s2;
   
   assert(s3 == s1);
 
@@ -45,6 +47,9 @@ proc doTest(type eltType) {
   s4 = s2 & s3;
 
   assert(s4.size == 0 && s4.isEmpty());
+
+  s1 &= s2copy; // replicate s3 = s1 & s2 above
+  assert(s1 == s3);
 }
 
 doTest(int);

--- a/test/library/standard/Set/symmetricDifference/setSymmetricDifference.chpl
+++ b/test/library/standard/Set/symmetricDifference/setSymmetricDifference.chpl
@@ -39,6 +39,9 @@ proc doTest(type eltType) {
 
   for x in s3 do
     assert(!s1.contains(x) && s2.contains(x));
+
+  s1 ^= s2;
+  assert(s1 == s3);
 }
 
 doTest(int);

--- a/test/library/standard/Set/union/setUnion.chpl
+++ b/test/library/standard/Set/union/setUnion.chpl
@@ -41,6 +41,9 @@ proc doTest(type eltType) {
 
   assert(s4.size == s2.size);
 
+  s1 |= s3;
+  assert(s1 == s4);
+
   for x in s4 do
     assert(s2.contains(x));
 }


### PR DESCRIPTION
Write the |=, +=, -=, and ^= to operate on lhs in-place rather than
using a temporary and replacing all of lhs with the temporary.  (The
temporary they were using was inside the |, +, -, or ^ operator they
invoked.)

This allows |= / += to not invalidate references to existing elements.
The other operations still do since they necessarily remove elements
from lhs.

Rewrite &= to be in-place when it's efficient to do so.  It still
invalidates references due to .remove().

Write | and ^ in terms of |= and ^= to reduce code duplication.

& and - weren't as amenable to writing in terms of &= and -=, for
efficiency reasons.

Since & is symmetric, and only has to iterate over one of its
arguments, choose to iterate over the smaller argument.

Add a test of each op= to the test of its op.

Correct name of module in module-ending comment.
