### PR TITLE
Update .good of test for modules parsed by default

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -65,8 +65,7 @@ module Random {
   public use NPBRandom;
   public use PCGRandom;
   import HaltWrappers;
-
-  use Set;
+  import Set;
 
 
 
@@ -315,7 +314,7 @@ module Random {
         }
       } else {
         if numElements < log2(X.size) {
-          var indices: set(int);
+          var indices: Set.set(int);
           var i: int = 0;
           while i < numElements {
             var randVal = stream.getNext(resultType=int, 0, X.size-1);

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -41,6 +41,7 @@ Parsing module files:
   $CHPL_HOME/modules/standard/List.chpl
   $CHPL_HOME/modules/standard/Random.chpl
   $CHPL_HOME/modules/dists/BlockDist.chpl
+  $CHPL_HOME/modules/standard/Set.chpl
   $CHPL_HOME/modules/standard/Time.chpl
   $CHPL_HOME/modules/layouts/LayoutCS.chpl
   $CHPL_HOME/modules/dists/SparseBlockDist.chpl


### PR DESCRIPTION
Update `.good` of a test that lists all modules that are parsed by default.

`Set.chpl` was added to this list because `Random.chpl` is parsed by default and imports as `Set` as of https://github.com/chapel-lang/chapel/pull/15154.

I have also switched the usage of `Set` to an import. Would slightly prefer `import Set.set`, but that is currently prevented by https://github.com/chapel-lang/chapel/issues/15639.