### PR TITLE
Use explicit encoding in build scripts

### DIFF
--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -46,13 +46,13 @@ def run_command(command, stdout=True, stderr=False, cmd_input=None):
     except OSError:
         error("command not found: {0}".format(command[0]), OSError)
 
-    byte_cmd_input = str.encode(cmd_input) if cmd_input else None
+    byte_cmd_input = str.encode(cmd_input, encoding="utf-8") if cmd_input else None
     output = process.communicate(input=byte_cmd_input)
     if process.returncode != 0:
         error("command failed: {0}\noutput was:\n{1}".format(
             command, output[1]), CommandError)
     else:
-        output = (output[0].decode(), output[1].decode())
+        output = (output[0].decode(encoding="utf-8"), output[1].decode(encoding="utf-8"))
         if stdout and stderr:
             return output
         elif stdout:
@@ -72,8 +72,8 @@ def run_live_command(command):
     except OSError:
         error("command not found: {0}".format(command[0]), OSError)
 
-    for stdout_char in iter(lambda: process.stdout.read(1), str.encode("")):
-        yield stdout_char.decode()
+    for stdout_char in iter(lambda: process.stdout.read(1), str.encode("", encoding="utf-8")):
+        yield stdout_char.decode(encoding="utf-8")
     process.stdout.close()
     returncode = process.wait()
 

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -102,7 +102,7 @@ def get_sys_c_types(docs=False):
     compileline_env.pop('CHPL_MAKE_CHPLENV_CACHE', None)
     compileline_proc = subprocess.Popen([compileline_cmd, '--compile'],
         stdout=subprocess.PIPE, env=compileline_env)
-    compileline = compileline_proc.communicate()[0].decode().strip();
+    compileline = compileline_proc.communicate()[0].decode(encoding="utf-8").strip();
     logging.debug('Compile line: {0}'.format(compileline))
 
     # Create temp header file with *_MAX macros, then run it through the C


### PR DESCRIPTION
Add explicit encoding where necessary in build scripts

In Python2, default encoding is `ascii` and this poses a problem when these
scripts are used in a system where `make` and other external tools can emit
non-ascii error/warning messages.

See https://github.com/chapel-lang/chapel/issues/15155
