### PR TITLE
Remove string.indices from getView

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -320,18 +320,25 @@ module BytesStringCommon {
       }
 
       // find the byte range of the given codepoint range
-      const cpRange = intR[x.indices];
       var cpCount = 0;
+      const cpIdxLow = if intR.hasLowBound() && intR.alignedLow:int >= 0
+                          then intR.alignedLow:int
+                          else 0;
+      const cpIdxHigh = if intR.hasHighBound()
+                           then intR.alignedHigh:int
+                           else x.buffLen;
+
       var byteLow = x.buffLen;  // empty range if bounds outside string
       var byteHigh = x.buffLen - 1;
-      if cpRange.high >= 0 {
+
+      if cpIdxHigh >= 0 {
         for (i, nBytes) in x._indexLen() {
-          if cpCount == cpRange.low {
+          if cpCount == cpIdxLow {
             byteLow = i:int;
             if !r.hasHighBound() then
               break;
           }
-          if cpCount == cpRange.high {
+          if cpCount == cpIdxHigh {
             byteHigh = i:int + nBytes-1;
             break;
           }


### PR DESCRIPTION
This PR avoids using `this.indices` in `string.getView` to avoid the performance
cost associated with it. I added those in
https://github.com/chapel-lang/chapel/pull/15615 but they caused performanc
 regressions.

There are better solutions to improve the performance of some of the string
queries, but this small fix is basically reverting a small subset of changes I
made in #15615, and probably a good idea until we have faster queries on things
like `string.indices`.

Test:
- [x] standard
- [x] gasnet
