### PR TITLE
Ensure newer dependencies are used for Arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -48,7 +48,7 @@ fi
 
 # Install Arkouda and python dependencies to a python-deps subdir
 export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
-if ! python3 -m pip install --force-reinstall -e .[test] --user ; then
+if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir -e .[test] --user ; then
   log_fatal_error "installing arkouda"
 fi
 


### PR DESCRIPTION
Some very old versions of numpy/pandas were getting pulled in from the
pip cache. Just bypass the cache to avoid this