### PR TITLE
Add Arkouda annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1817,3 +1817,18 @@ topTotalTime:
   <<: *compiler-perf-base
 topPasses:
   <<: *compiler-perf-base
+
+arkouda: &arkouda-base
+  04/22/20:
+    - Optimize coargsort for numeric arrays (mhmerrill/arkouda#330)
+  04/28/20:
+    - text: Improve comm=none build and execution speed (mhmerrill/arkouda#358)
+      config: chapcs
+  04/28/20:
+    - text: Move XC testing from login to elogin node
+      config: 16-node-xc
+  05/20/20:
+    - Upgrade Arkouda release testing from 1.20 to 1.22 (#15690)
+
+arkouda-comp:
+  <<: *arkouda-base

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -75,6 +75,7 @@ test_end "make test-python"
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
   benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
 
+  benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"
   if [[ -n $CHPL_TEST_PERF_DESCRIPTION ]]; then
     benchmark_opts="${benchmark_opts} --description $CHPL_TEST_PERF_DESCRIPTION"
   fi

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -27,7 +27,7 @@ currentSha=`git rev-parse HEAD`
 # test against Chapel release
 function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release
-  export CHPL_TEST_PERF_CONFIGS="release:v,master:v"
+  export CHPL_TEST_PERF_CONFIGS="release:v,master"
   git checkout 1.22.0
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
@@ -37,7 +37,7 @@ function test_release() {
 # test against Chapel master
 function test_master() {
   export CHPL_TEST_PERF_DESCRIPTION=master
-  export CHPL_TEST_PERF_CONFIGS="release:v,master:v"
+  export CHPL_TEST_PERF_CONFIGS="release:v,master"
   git checkout $currentSha
   git clean -ffdx $CHPL_HOME
   $CWD/nightly -cron ${nightly_args}

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -85,7 +85,7 @@ def try_parsing_annotations(ann_data, graph_list):
 def check_graph_names(ann_data, graph_list):
     """Check that graph names in the annotation file are listed in GRAPHFILES"""
     for graph in ann_data:
-        if graph != 'all' and graph not in graph_list:
+        if graph != 'all' and 'arkouda' not in graph and graph not in graph_list:
             warnings.warn('Warning: no .graph file found for "{0}"'.format(graph))
 
 def check_configs(ann_data):

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -507,6 +507,13 @@ function computeGitHubLinks(text) {
     var url = "https://github.com/chapel-lang/chapel/pull/" + num;
     return "<a target='_blank' href='" + url + "'>" + m + "</a>";
   });
+
+  var ak_re = /\(mhmerrill\/arkouda#([0-9]+)\)/gi;
+  text = text.replace(ak_re, function(m, num) {
+    var url = "https://github.com/mhmerrill/arkouda/pull/" + num;
+    return "<a target='_blank' href='" + url + "'>" + m + "</a>";
+  });
+
   text = text.replace("\n", "\n<hr/>");
 
   return text;


### PR DESCRIPTION
Add support for adding Arkouda perf graph annotations and add the
annotations themselves.

Also don't make the Arkouda chapel-master perf results visible by
default. These are mostly for Chapel devs, so to make the graphs simpler
to follow for others by only having the chapel-release results visible
by default.