### PR TITLE
Allow asking for per-task runtime-related info from any context.

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -81,7 +81,7 @@ extern pthread_t chpl_qthread_comm_pthread;
 extern chpl_qthread_tls_t chpl_qthread_process_tls;
 extern chpl_qthread_tls_t chpl_qthread_comm_task_tls;
 
-// Wrap qthread_get_tasklocal() and assert that it is always available.
+// Wrap qthread_get_tasklocal().
 static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
 {
     chpl_qthread_tls_t* tls;
@@ -96,7 +96,6 @@ static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
             else if (pthread_equal(me, chpl_qthread_process_pthread))
                 tls = &chpl_qthread_process_tls;
         }
-        assert(tls);
     }
     else
         tls = NULL;
@@ -115,7 +114,6 @@ static inline chpl_task_infoRuntime_t* chpl_task_getInfoRuntime(void)
     if (data) {
         return &data->infoRuntime;
     }
-    assert(data);
     return NULL;
 }
 
@@ -147,7 +145,7 @@ static inline
 c_sublocid_t chpl_task_getRequestedSubloc(void)
 {
     chpl_qthread_tls_t * data = chpl_qthread_get_tasklocal();
-    if (data) {
+    if (data && data->bundle) {
         return data->bundle->requestedSubloc;
     }
     return c_sublocid_any;
@@ -192,7 +190,7 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
         chpl_qthread_tls_t * data = chpl_qthread_get_tasklocal();
         c_sublocid_t execution_subloc =
           chpl_localeModel_sublocToExecutionSubloc(full_subloc);
-        if (data) {
+        if (data && data->bundle) {
             data->bundle->requestedSubloc = full_subloc;
         }
 

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2688,6 +2688,7 @@ static
 chpl_cache_taskPrvData_t* task_private_cache_data(void)
 {
   chpl_task_infoRuntime_t* infoRuntime = chpl_task_getInfoRuntime();
+  assert(infoRuntime);
   return &infoRuntime->comm_data.cache_data;
 }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -598,17 +598,17 @@ void bitmapSet(struct bitmap_t* b, size_t i) {
 
 static inline
 chpl_comm_taskPrvData_t* get_comm_taskPrvdata(void) {
-  chpl_task_infoRuntime_t* infoRuntime = chpl_task_getInfoRuntime();
-  chpl_comm_taskPrvData_t* prvData;
-  if (infoRuntime == NULL) {
-    assert(isAmHandler);
-    static __thread chpl_comm_taskPrvData_t amHandlerCommData;
-    prvData = &amHandlerCommData;
-  } else {
-    prvData = &infoRuntime->comm_data;
+  chpl_task_infoRuntime_t* infoRuntime;
+  if ((infoRuntime = chpl_task_getInfoRuntime()) != NULL) {
+    return &infoRuntime->comm_data;
   }
 
-  return prvData;
+  if (isAmHandler) {
+    static __thread chpl_comm_taskPrvData_t amHandlerCommData;
+    return &amHandlerCommData;
+  }
+
+  return NULL;
 }
 
 


### PR DESCRIPTION
In certain runtime configurations built with `DEBUG=1`, calling
`chpl_task_getinfoRuntime()` from something that was not a Chapel task
context would cause an assertion failure or internal error.  In all the
cases seen so far, the calls that failed were for legitimate purposes.
Unless we're going to require callers of that function to somehow first
check to see if they're in a task context before making the call, it
needs to work without halting in all cases.  Here, make it return NULL
in both tasking layers when it is called from other than a task.

As part of this, adjust other code so that in all other cases where the
internal checks in question would have caused halts they still do.  Also
while here, adjust comm=ofi so that it no longer assumes that if there
is no `infoRuntime` data for the calling context then this must be the
AM handler.  It might be some other thread instead.

This resolves Cray/chapel-private#956.