### PR TITLE
Have gasnet-smp docker image use SystemV shared memory

### DIFF
--- a/util/dockerfiles/gasnet-smp/Dockerfile
+++ b/util/dockerfiles/gasnet-smp/Dockerfile
@@ -4,6 +4,11 @@ ENV CHPL_COMM gasnet
 ENV CHPL_COMM_SUBSTRATE smp
 ENV CHPL_RT_OVERSUBSCRIBED yes
 
+# By default GASNet will use POSIX shared memory, whose memory allocations
+# reside in /dev/shm. The default /dev/shm size for docker is only 64MB, which
+# is far too small for us, so use the SystemV implementation instead.
+ENV CHPL_GASNET_MORE_CFG_OPTIONS "--disable-pshm-posix --enable-pshm-sysv"
+
 RUN make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall


### PR DESCRIPTION
By default GASNet will use POSIX shared memory, whose memory allocations
reside in /dev/shm. The default /dev/shm size for docker is only 64MB,
which is far too small for us, so use the SystemV implementation
instead.

The default /dev/shm size is documented at:
https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources

Prior to this even `./hello -nl 1` was running out of memory because
64MB wasn't enough for our task stacks and other startup memory. With
SystemV all memory should be available to use.

The top level GASNet README has much more information about the shared
memory implementations, but here's some relevant snippets:

"""
On most systems, the default implementation of PSHM uses POSIX shared
memory. On many operating systems the amount of available POSIX shared
memory is controlled by the sizing of a pseudo-filesystem... If this
filesystem is not large enough, it can limit the amount of POSIX shared
memory which can be allocated for the GASNet segment.

On most modern Linux distribution, POSIX shared memory allocations
reside in the /dev/shm filesystem.

SystemV shared memory is the second most widely used implementation of
PSHM after POSIX shared memory... and is recommended on most other
systems when POSIX does not work for any reason.
"""