### PR TITLE
List _collapse: remove shift arg

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -575,9 +575,8 @@ module List {
     }
 
     //
-    // Move all elements following `idx` one position left in memory
-    // so that they begin at index `idx`.  May release memory if
-    // possible.
+    // Shift all elements following "idx" one to the left.
+    // May release memory if possible.
     //
     // This method does not fire destructors, so do so before calling it.
     //

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -575,18 +575,20 @@ module List {
     }
 
     //
-    // Move all elements at and following the index `shift` left in memory
-    // so that they begin at index `idx`, possibly resizing. May release
-    // memory if possible.
+    // Move all elements following `idx` one position left in memory
+    // so that they begin at index `idx`.  May release memory if
+    // possible.
     //
     // This method does not fire destructors, so do so before calling it.
     //
     pragma "no doc"
-    proc ref _collapse(idx: int, shift: int=1) {
+    proc ref _collapse(idx: int) {
       _sanity(_withinBounds(idx));
 
-      if idx == _size-1 then
+      if idx == _size-1 {
+        on this do _maybeReleaseMem(1);
         return;
+      }
       
       on this {
         for i in idx..(_size - 2) {

--- a/test/classes/delete-free/lifetimes/bad-append-borrow.good
+++ b/test/classes/delete-free/lifetimes/bad-append-borrow.good
@@ -1,4 +1,4 @@
 bad-append-borrow.chpl:22: In function 'addone':
 bad-append-borrow.chpl:27: error: Actual argument does not meet called function lifetime constraint
-$CHPL_HOME/modules/standard/List.chpl:626: note: called function list(I,false).append(x: borrowed I)
-$CHPL_HOME/modules/standard/List.chpl:626: note: includes lifetime constraint this < x
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: called function list(I,false).append(x: borrowed I)
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: includes lifetime constraint this < x

--- a/test/classes/delete-free/lifetimes/bad-append-borrow.prediff
+++ b/test/classes/delete-free/lifetimes/bad-append-borrow.prediff
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+command='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+cp "$2" $2.tmp
+cat $2.tmp | sed "$command" > $2
+rm $2.tmp
+

--- a/test/library/standard/List/classLists/listAppendBorrow.good
+++ b/test/library/standard/List/classLists/listAppendBorrow.good
@@ -1,5 +1,5 @@
 listAppendBorrow.chpl:16: In function 'error7':
 listAppendBorrow.chpl:17: error: Actual argument does not meet called function lifetime constraint
 listAppendBorrow.chpl:16: note: consider scope of arg
-$CHPL_HOME/modules/standard/List.chpl:626: note: called function list(borrowed foo?,false).append(x: borrowed foo?)
-$CHPL_HOME/modules/standard/List.chpl:626: note: includes lifetime constraint this < x
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: called function list(borrowed foo?,false).append(x: borrowed foo?)
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: includes lifetime constraint this < x

--- a/test/library/standard/List/classLists/listAppendBorrow.prediff
+++ b/test/library/standard/List/classLists/listAppendBorrow.prediff
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+command='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+cp "$2" $2.tmp
+cat $2.tmp | sed "$command" > $2
+rm $2.tmp
+

--- a/test/library/standard/List/classLists/listAppendLifetime.good
+++ b/test/library/standard/List/classLists/listAppendLifetime.good
@@ -1,10 +1,10 @@
 listAppendLifetime.chpl:5: In function 'bad1':
 listAppendLifetime.chpl:11: error: Actual argument bb does not meet called function lifetime constraint
 listAppendLifetime.chpl:9: note: consider scope of own
-$CHPL_HOME/modules/standard/List.chpl:626: note: called function list(C,false).append(x: borrowed C)
-$CHPL_HOME/modules/standard/List.chpl:626: note: includes lifetime constraint this < x
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: called function list(C,false).append(x: borrowed C)
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: includes lifetime constraint this < x
 listAppendLifetime.chpl:18: In function 'bad2':
 listAppendLifetime.chpl:23: error: Actual argument does not meet called function lifetime constraint
 listAppendLifetime.chpl:22: note: consider scope of own
-$CHPL_HOME/modules/standard/List.chpl:626: note: called function list(C,false).append(x: borrowed C)
-$CHPL_HOME/modules/standard/List.chpl:626: note: includes lifetime constraint this < x
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: called function list(C,false).append(x: borrowed C)
+$CHPL_HOME/modules/standard/List.chpl:nnnn: note: includes lifetime constraint this < x

--- a/test/library/standard/List/classLists/listAppendLifetime.prediff
+++ b/test/library/standard/List/classLists/listAppendLifetime.prediff
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+command='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+cp "$2" $2.tmp
+cat $2.tmp | sed "$command" > $2
+rm $2.tmp
+


### PR DESCRIPTION
_collapse() ignored its shift arg, so remove it so it doesn't mislead
anyone.  None of the callers passed a non-1 value.  If anyone does
want to collapse by more than one, they'll have to implement it, but
won't be surprised by _collapse() ignoring the shift value.

While I was here, have _collapse() try to free memory for the case of
collapsing off the last element of the List, as it does for collapsing
in on an interior element.

That changed the line numbers of an error in List.chpl in a few tests,
so future-proof them with copies of the prediff file from
test/library/standard/List/listAppendLifetime, and change the
List.chpl line numbers in their .good files to nnnn.  (One of the
affected tests has the same name as the source of the prediff file,
but is in a subdirectory.)