### PR TITLE
Restore accidentally deleted skipif for pidigits[3]

### DIFF
--- a/test/studies/shootout/submitted/pidigits3.skipif
+++ b/test/studies/shootout/submitted/pidigits3.skipif
@@ -1,0 +1,1 @@
+CHPL_GMP == none


### PR DESCRIPTION
This should've been renamed from pidigits.skipif in PR #15666, but I
accidentally removed it instead.