### PR TITLE
Pin an older version of MPICH in cray module builds

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -284,6 +284,9 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
+
+        # pin an older version of MPICH that works with gen_version_gcc
+        load_module_version cray-mpich 7.7.13
     }
 
     function load_prgenv_cray() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -353,6 +353,9 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
+
+        # pin an older version of MPICH that works with gen_version_gcc
+        load_module_version cray-mpich 7.7.13
     }
 
     function load_prgenv_intel() {


### PR DESCRIPTION
We started to have some failures on cray-module builds recently. This PR pins a
slightly older version of MPICH that works with our backend compiler
