### PR TITLE
Skip linux32 testing for mason-external tests

### DIFF
--- a/test/mason/mason-external/libtomlc99/SKIPIF
+++ b/test/mason/mason-external/libtomlc99/SKIPIF
@@ -1,1 +1,14 @@
-../../SKIPIF
+#!/usr/bin/env python
+
+"""
+mason requires CHPL_COMM=none (local)
+
+mason external does not yet work on linux32 due to a bug in spack
+"""
+
+from __future__ import print_function
+from os import environ
+
+print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2' or environ['CHPL_LAUNCHER'] != 'none' or environ['CHPL_TARGET_PLATFORM'] == 'linux32')
+
+


### PR DESCRIPTION
There is an issue in Spack where it cannot infer `x86` from `i686` compiler configuration. There are work-arounds a user can employ (modifying their `compilers.yaml` or `microarchitectures.json`, but it seem kludgy to implement these fixes within mason or mason testing so we are skipping testing until spack resolves the issue.

Once linux32 testing is re-enabled, we should revert this SKIPIF back to being a symlink to the mason-wide SKIPIF.

This is a follow-on to https://github.com/chapel-lang/chapel/pull/15681

