### PR TITLE
Remove suppressif for submitted revcomp

### DIFF
--- a/test/studies/shootout/submitted/revcomp2.suppressif
+++ b/test/studies/shootout/submitted/revcomp2.suppressif
@@ -1,2 +1,0 @@
-CHPL_LAUNCHER <= slurm
-CHPL_LAUNCHER <= aprun


### PR DESCRIPTION
I'd forgotten that this suppression file is no longer needed now
that our submitted revcomp no longer queries the size of the input
file.  Removing it.