### PR TITLE
Triangle iterator

### DIFF
--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -739,11 +739,11 @@ private proc adaptSplit(ref rangeToSplit:range(?), splitFactor:int, ref itLeft, 
   This iterator expects that the work to be done by the ith index
   returned is O(k-i).  That is, that it's being used in a loop like
 
-  forall j in triangle(1..n) {
-    for i in j..n {
-      constant_amount_of_work(i,j);
-    }
-  }
+  X  forall j in triangle(1..n) {
+  X    for i in j..n {
+  X      constant_amount_of_work(i,j);
+  X    }
+  X  }
 
   Essentially, we want to pair the 0th index and the nth,
   and the 1st index and the (n-1)st,


### PR DESCRIPTION
This is a draft of a parallel iterator targeting "triangular" iteration, of the form

```chapel
for i in 1..n { 
  for j in i..n {
    constant_work(i,j);
  }
}
```

Where the `i=1` iteration has `n` work, and the `i=n` iteration has `1` work.

Inspired by summing the integers from 1 to 100, it pairs up iterations 1 and 100, 2 and 99, 3 and 98, and so on.  Since each pair has 101 work, we can statically divide the total work evenly between threads.  (It actually pairs up chunks, 1..k and n-k+1..n; k+1..2k and n-2k-1..n-k, etc.)

```chapel
forall i in triangle(1..n) {
  for j in i..n {
    ...
  }
}
```



TODO
[] See if this is faster than `guided(1..n by -1)`.  On my machine, it isn't.
[] Make it support increasing work in addition to decreasing: `for i in 1..n { for j in 1..i { ...}}`
[] Add a standalone version
[] Consider `forall (i,j) in triangular_ij(1..n, triangle_type) { constant_work(i,j); }`, which might be more elegant
[] Better name?