### PR TITLE
Update array move init to consider runtime type for elements

### DIFF
--- a/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.chpl
+++ b/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.chpl
@@ -1,0 +1,111 @@
+// simple test
+proc test1() {
+  writeln("test1");
+  var A:[0..1] real = [1.0, 2.0];
+  var AA: [1..2][1..2] real = [ A, A ];
+  writeln(AA[1].domain); // this should be {1..2}
+  writeln(AA[2].domain); // this should be {1..2}
+}
+test1();
+
+proc test2() {
+  writeln("test2");
+  var AA: [1..2][1..2] real = [ [1.0, 2.0], [3.0, 4.0] ];
+  writeln(AA[1].domain); // this should be {1..2}
+  writeln(AA[2].domain); // this should be {1..2}
+}
+test2();
+
+proc test3() {
+  writeln("test3");
+  var B:[0..1] real = [1.0, 2.0];
+  var BB: [1..2][0..1] real = [ B, B ];
+  var AA: [1..2][1..2] real = BB; // check copy eliding
+  writeln(AA[1].domain); // this should be {1..2}
+  writeln(AA[2].domain); // this should be {1..2}
+}
+test3();
+
+proc test3a() {
+  writeln("test3a");
+  var B:[0..1] real = [1.0, 2.0];
+  var BB: [1..2][0..1] real = [ B, B ];
+  var AA: [1..2][1..2] real = BB; // check not copy eliding
+  writeln(AA[1].domain); // this should be {1..2}
+  writeln(AA[2].domain); // this should be {1..2}
+  BB; // not copy eliding
+}
+test3a();
+
+proc makeBB() {
+  var B:[0..1] real = [1.0, 2.0];
+  var BB: [1..2][0..1] real = [ B, B ];
+  return BB;
+}
+
+proc test4() {
+  writeln("test4");
+  var AA: [1..2][1..2] real = makeBB(); // check copy eliding
+  writeln(AA[1].domain); // this should be {1..2}
+  writeln(AA[2].domain); // this should be {1..2}
+}
+test4();
+
+
+
+// The below is a reproducer for part of LAPACK_Matrix_test.
+writeln("reproducer");
+
+proc putInto2D( arrayOfArrays: [?D1] ?t, twoArray: [?D2] ?o): void{
+  writeln("in putInto2D");
+  writeln("D1 is ", D1);
+  writeln("arrayOfArrays is ", arrayOfArrays);
+  writeln("arrayOfArrays[D1.dim(0).low].domain is ", arrayOfArrays[D1.dim(0).low].domain);
+  writeln("arrayOfArrays[D1.dim(0).low] is ", arrayOfArrays[D1.dim(0).low]);
+  writeln("arrayOfArrays[D1.dim(0).high].domain is ", arrayOfArrays[D1.dim(0).high].domain);
+  writeln("arrayOfArrays[D1.dim(0).high] is ", arrayOfArrays[D1.dim(0).high]);
+  writeln("D2 is ", D2);
+  writeln("twoArray is ", twoArray);
+  // no check. Cannot have ragged array literals
+  assert( D1.rank == 1 && D2.rank == 2  );
+  var formed: domain(2) = {D1.dim(0), arrayOfArrays[D1.dim(0).low].domain.dim(0)};
+  writeln("formed is ", formed);
+  assert( formed.dim(0).size == D2.dim(0).size && formed.dim(1).size == D2.dim(1).size );
+  var trans = ( D2.dim(0).low - formed.dim(0).low, D2.dim(1).low - formed.dim(1).low ); 
+  writeln("trans is ", trans);
+
+  for (i,j) in D2 {
+    writeln("assigning ", (i,j)); 
+    const ref rhs1 = arrayOfArrays[i+trans[0]];
+    var rhs2 = rhs1[j+trans[1]];
+    ref lhs = twoArray[i,j];
+    lhs = rhs2;
+  }
+
+}
+
+writeln( "1D row input => row" );
+var input_1_row: [1..4] real = 
+  [ 3.0, 1.0, 
+    4.0, 2.0 ];
+
+writeln( "1D col input => col" );
+var input_1_col: [1..4] real  = 
+  [ 3.0, 4.0,   // tranpose of [ 3.0, 1.0,
+    1.0, 2.0 ]; //                 4.0, 2.0 ];
+
+// 1.5D data
+var input_1_5_row: [1..2][1..2] real =
+  [ [3.0, 1.0], 
+    [4.0, 2.0] ];
+
+var input_1_5_col: [1..2][1..2] real =
+  [ [3.0, 4.0], 
+    [1.0, 2.0] ];
+
+
+// 2D data
+writeln( "2D row input => row" );
+var input_2_row: [1..2,1..2] real;
+putInto2D( input_1_5_row, input_2_row );
+writeln(input_2_row);

--- a/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.compopts
+++ b/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.compopts
@@ -1,0 +1,2 @@
+-suseBulkTransfer=false
+-suseBulkTransfer=true

--- a/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.execopts
+++ b/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.good
+++ b/test/arrays/ferguson/array-initialization-patterns/array-of-arrays-init-check-domain.good
@@ -1,0 +1,43 @@
+test1
+{1..2}
+{1..2}
+test2
+{1..2}
+{1..2}
+test3
+{1..2}
+{1..2}
+test3a
+{1..2}
+{1..2}
+test4
+{1..2}
+{1..2}
+reproducer
+1D row input => row
+1D col input => col
+2D row input => row
+in putInto2D
+D1 is {1..2}
+arrayOfArrays is 3.0 1.0 4.0 2.0
+arrayOfArrays[D1.dim(0).low].domain is {1..2}
+arrayOfArrays[D1.dim(0).low] is 3.0 1.0
+arrayOfArrays[D1.dim(0).high].domain is {1..2}
+arrayOfArrays[D1.dim(0).high] is 4.0 2.0
+D2 is {1..2, 1..2}
+twoArray is 0.0 0.0
+0.0 0.0
+formed is {1..2, 1..2}
+trans is (0, 0)
+assigning (1, 1)
+assigning (1, 2)
+assigning (2, 1)
+assigning (2, 2)
+3.0 1.0
+4.0 2.0
+
+=================================================================================================================
+Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
+=================================================================================================================
+=================================================================================================================
+

--- a/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
+++ b/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
@@ -38,14 +38,18 @@ var A_1_col_f_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.col
 writeln( A_1_col_f_row.data, "\n", A_1_col_f_row.toString(), "\n" );
 
 // 1.5D data
+var input_1_5_row1: [1..2] real = [3.0, 1.0];
+var input_1_5_row2: [1..2] real = [4.0, 2.0];
 var input_1_5_row: [1..2][1..2] real =
-  [ [3.0, 1.0], 
-    [4.0, 2.0] ];
+  [ input_1_5_row1,
+    input_1_5_row2 ];
 //var A_1_5_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_5_row  ); 
 
+var input_1_5_col1: [1..2] real = [3.0, 4.0];
+var input_1_5_col2: [1..2] real = [1.0, 2.0];
 var input_1_5_col: [1..2][1..2] real =
-  [ [3.0, 4.0], 
-    [1.0, 2.0] ];
+  [ input_1_5_col1,
+    input_1_5_col2 ];
 //var A_1_5_col = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_5_col  ); 
 
 


### PR DESCRIPTION
Follow-on to PR #15239

Addresses a problem with `LAPACK_Matrix_test`.

 * Factors the problematic part of `LAPACK_Matrix_test` into a new test
   arrays-init-check-domain.chpl  and applies a workaround to
   `LAPACK_Matrix_test` (since it should be focused on testing matrix
   operations rather than corners of array types).
 * Fixes the problem with initializing arrays of arrays. When an
   array-of-arrays was declared with a type, the inner arrays were not
   getting the runtime component of the type set to match the
   declaration. Fixes that with a `fixRuntimeType` which is passed the
   desired element type and a reference to the element that was
   move-initialized.

Reviewed by @benharsh - thanks!

- [x] full local testing
- [x] primers pass with valgrind and do not leak