### PR TITLE
PRIM_CAST in compiler always makes QUAL_VAL

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -209,7 +209,8 @@ returnInfoCast(CallExpr* call) {
     if (wideRefMap.get(t1))
       t1 = wideRefMap.get(t1);
   }
-  return QualifiedType(t1); // what should qual be here?
+  INT_ASSERT(!isReferenceType(t1));
+  return QualifiedType(t1, QUAL_VAL);
 }
 
 static QualifiedType


### PR DESCRIPTION
Resolves a testing failure for types/tuple/bradc/unaryTupleOps.chpl with --verify.

Trivial and not reviewed.

- [x] primers pass with valgrind and do not leak
- [x] full local testing