### PR TITLE
Add FLAG_IGNORE_RUNTIME_TYPE and use it an array function to get static type

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -165,6 +165,7 @@ symbolFlag( FLAG_GET_MODULE_NAME, ypr, "get module name", "replace calls to this
 symbolFlag( FLAG_GLOBAL_TYPE_SYMBOL, ypr, "global type symbol", "is accessible through a global type variable")
 symbolFlag( FLAG_HAS_POSTINIT , ypr, "has postinit" , "type that has a postinit method" )
 symbolFlag( FLAG_HAS_RUNTIME_TYPE , ypr, "has runtime type" , "type that has an associated runtime type" )
+symbolFlag( FLAG_IGNORE_RUNTIME_TYPE , ypr, "ignore runtime type" , "use the static type only in the return value" )
 symbolFlag( FLAG_RVV, npr, "RVV", "variable is the return value variable" )
 symbolFlag( FLAG_YVV, npr, "YVV", "variable is a yield value variable" )
 symbolFlag( FLAG_HEAP , npr, "heap" , ncm )

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -164,7 +164,8 @@ static Expr* postFoldNormal(CallExpr* call) {
   if (fn->retTag == RET_TYPE) {
     Symbol* ret = fn->getReturnSymbol();
 
-    if (ret->type->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE) == false) {
+    if (ret->type->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE) == false ||
+        fn->hasFlag(FLAG_IGNORE_RUNTIME_TYPE)) {
       retval = new SymExpr(ret->type->symbol);
 
       call->replace(retval);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -766,6 +766,7 @@ module ChapelArray {
 
   pragma "return not owned"
   proc chpl__distributionFromDomainRuntimeType(type rtt) {
+    pragma "ignore runtime type"
     proc getDomDistType() type {
       pragma "unsafe"
       var arr : rtt;
@@ -782,6 +783,7 @@ module ChapelArray {
 
   pragma "return not owned"
   proc chpl__domainFromArrayRuntimeType(type rtt) {
+    pragma "ignore runtime type"
     proc getArrDomType() type {
       pragma "unsafe"
       var arr : rtt;


### PR DESCRIPTION
Follow-up to PR #15239.

chpl__domainFromArrayRuntimeType calls getArrDomType
which is meant to return the static type of the domain.
But under --baseline, it default-initializes the array in
the process.

See for example this test under --baseline
 arrays/ferguson/array-initialization-patterns/array-initialization-patterns

Add FLAG_IGNORE_RUNTIME_TYPE to allow getArrDomType to opt
in to being treated like type/param fn (and not a runtime type fn).

See also PR #11140 for related history.

Reviewed by @benharsh - thanks!

- [x] primers pass with valgrind and do not leak
- [x] full local testing