### PR TITLE
Fix problem in BlockCyclicArr.dsiDestroyArr

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -888,7 +888,7 @@ override proc BlockCyclicArr.dsiDestroyArr(param deinitElts:bool) {
       if deinitElts {
         for subdom in do_dsiLocalSubdomains(arr!.indexDom) {
           forall j in subdom {
-            chpl__autoDestroy(dsiAccess(j));
+            chpl__autoDestroy(arr(j));
           }
         }
       }


### PR DESCRIPTION
Follow-up to PR #15239.

Addresses a sporadic failure in
 ./test/distributions/bharshbarg/arrOfArrDmap.chpl

(and valgrind was reporting invalid memory access for that test).

Trivial and not reviewed.

- [x] full local testing