### PR TITLE
Add perf annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -426,6 +426,8 @@ all:
   03/20/20:
     - text: Make --cache-remote readahead less aggressive (#15267)
       config: chapcs.comm-counts
+  05/26/20:
+    - Adjust array copy initialization to avoid default-init/assign (#15239)
 
 
 AllCompTime: &timecomp-base


### PR DESCRIPTION
This week chapcs performance tests haven't run due to system issues, so we
didn't get a good picture of things. But at the same time, number of PRs that
went in was also limited.

https://github.com/chapel-lang/chapel/pull/15239 seems to be the likely
candidate for the following performance changes:

- [Stencil performance](https://chapel-lang.org/perf/16-node-xc/?startdate=2020/03/21&enddate=2020/05/27&graphs=prkstencilvariationsperf,prkoptimizedstenciltimesec,prkelegantstenciltimesec)
- [Distributed array-domain init-deinit](https://chapel-lang.org/perf/16-node-xc/?startdate=2020/04/26&enddate=2020/05/27&graphs=creatingdistributedarrays1elementperlocale,destroyingdistributedarrays1elementperlocale,creatingdistributedarrays1melements,destroyingdistributedarrays1melements,creatingdistributedarrays14ofavailablememory,destroyingdistributedarrays14ofavailablememory)
- [Small array get performance](https://chapel-lang.org/perf/16-node-xc/?startdate=2020/03/14&enddate=2020/05/27&graphs=smallarraygetperformance)
- [Comm count changes](https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2020/02/22&enddate=2020/05/27&graphs=creatingdistributedarrays,creatingdistributeddomains)
