### PR TITLE
Refactor String Documentation

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -37,10 +37,10 @@ Creating :record:`bytes`
   another :record:`bytes`, a `c_string` or a C pointer) you can use the
   factory functions shown below, such as :proc:`createBytesWithNewBuffer`.
 
-:record:`bytes` and :record:`~String.string`
+:record:`bytes` and :mod:`~String`
 --------------------------------------------
 
-As :record:`bytes` can store arbitrary data, any :record:`~String.string` can be
+As :record:`bytes` can store arbitrary data, any :mod:`~String` can be
 cast to :record:`bytes`. In that event, the bytes will store UTF-8 encoded
 character data. However, a :record:`bytes` can contain non-UTF-8 bytes and needs
 to be decoded to be converted to string.

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -72,6 +72,7 @@ stores the value ``1`` in ``number``.
 To learn more about handling these errors, see the
 :ref:`Error Handling technical note <readme-errorHandling>`.
 
+
 Unicode Support
 ---------------
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -53,7 +53,7 @@ within strings.
 Casts from String to a Numeric Type
 -----------------------------------
 
-This module supports casts from :record:`string` to numeric types. Such casts
+This module supports casts from :mod:`String` to numeric types. Such casts
 will convert the string to the numeric type and throw an error if the string
 is invalid. For example:
 
@@ -91,7 +91,7 @@ Non-Unicode Data and Chapel Strings
 
 For doing string operations on non-Unicode or arbitrary data, consider using
 :record:`~Bytes.bytes` instead of string. However, there may be cases where
-:record:`string` must be used with non-Unicode data. Examples of this are file
+:mod:`String` must be used with non-Unicode data. Examples of this are file
 system and path operations on systems where UTF-8 file names are not enforced.
 
 
@@ -1194,10 +1194,10 @@ module String {
   }
   
   /*
-     Gets a version of the :record:`string` that is on the currently
+     Gets a version of the :mod:`String` that is on the currently
      executing locale.
 
-     :returns: A shallow copy if the :record:`string` is already on the
+     :returns: A shallow copy if the :mod:`String` is already on the
                current locale, otherwise a deep copy is performed.
   */
   inline proc string.localize() : string {
@@ -1210,11 +1210,11 @@ module String {
   }
 
   /*
-    Get a `c_string` from a :record:`string`.
+    Get a `c_string` from a :mod:`String`.
 
     .. warning::
 
-        This can only be called safely on a :record:`string` whose home is
+        This can only be called safely on a :mod:`String` whose home is
         the current locale.  This property can be enforced by calling
         :proc:`string.localize()` before :proc:`~string.c_str()`. If the
         string is remote, the program will halt.
@@ -1230,7 +1230,7 @@ module String {
 
     :returns:
         A `c_string` that points to the underlying buffer used by this
-        :record:`string`. The returned `c_string` is only valid when used
+        :mod:`String`. The returned `c_string` is only valid when used
         on the same locale as the string.
    */
   inline proc string.c_str(): c_string {
@@ -1238,7 +1238,7 @@ module String {
   }
   
   /*
-    Returns a :record:`~Bytes.bytes` from the given :record:`string`. If the
+    Returns a :record:`~Bytes.bytes` from the given :mod:`String`. If the
     string contains some escaped non-UTF8 bytes, `policy` argument determines
     the action.
         
@@ -1328,7 +1328,7 @@ module String {
 
   /*
     Iterates over the string character by character, yielding 1-codepoint
-    strings. (A synonym for :iter:`items`)
+    strings. (A synonym for :iter:`string.items`)
 
     For example:
 
@@ -1470,7 +1470,7 @@ module String {
   }
 
   /*
-    Return the `i` th codepoint in the string. (A synonym for :proc:`item`)
+    Return the `i` th codepoint in the string. (A synonym for :proc:`string.item`)
 
     :returns: A string with the complete multibyte character starting at the
               specified codepoint index from ``0..#string.numCodepoints``
@@ -1480,7 +1480,7 @@ module String {
   }
 
   /*
-    Return the `i` th codepoint in the string. (A synonym for :proc:`item`)
+    Return the `i` th codepoint in the string. (A synonym for :proc:`string.item`)
 
     :returns: A string with the complete multibyte character starting at the
               specified codepoint index from ``1..string.numCodepoints``
@@ -2116,7 +2116,6 @@ module String {
     }
     return result;
   }
-  //FIND END
 
   //
   // Assignment functions

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -61,7 +61,7 @@ is invalid. For example:
 
   var number = "a":int;
 
-  throws an error when it is executed, but
+throws an error when it is executed, but
 
 .. code-block:: chapel
 
@@ -833,7 +833,7 @@ module String {
   pragma "ignore noinit"
   pragma "no default functions" // avoid the default (read|write)This routines
   pragma "no doc"
-  record _string { //Opening brace
+  record _string {
     var buffLen: int = 0; // length of string in bytes
     var buffSize: int = 0; // size of the buffer we own
     var buff: bufferType = nil;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -61,7 +61,7 @@ is invalid. For example:
 
   var number = "a":int;
 
-
+  throws an error when it is executed, but
 
 .. code-block:: chapel
 
@@ -80,7 +80,7 @@ subset of UTF-8 strings, because every ASCII character is a UTF-8 character with
 the same meaning.
 
 UTF-8 strings might not work properly if a UTF-8 environment is not used. See
-
+:ref:`character set environment <readme-chplenv.character_set>` for more
 information.
 
 .. _string.nonunicode:
@@ -131,8 +131,7 @@ bytes:
 .. note::
 
   Strings that contain escaped sequences cannot be directly used with
-
-
+  unformatted I/O functions such as ``writeln``. :ref:`Formatted I/O
   <about-io-formatted-io>` can be used to print such strings with binary
   formatters such as ``%|s``.
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -61,7 +61,7 @@ is invalid. For example:
 
   var number = "a":int;
 
-throws an error when it is executed, but
+
 
 .. code-block:: chapel
 
@@ -70,7 +70,6 @@ throws an error when it is executed, but
 stores the value ``1`` in ``number``.
 
 To learn more about handling these errors, see the
-:ref:`Error Handling technical note <readme-errorHandling>`.
 
 
 Unicode Support
@@ -81,7 +80,7 @@ subset of UTF-8 strings, because every ASCII character is a UTF-8 character with
 the same meaning.
 
 UTF-8 strings might not work properly if a UTF-8 environment is not used. See
-:ref:`character set environment <readme-chplenv.character_set>` for more
+
 information.
 
 .. _string.nonunicode:
@@ -132,7 +131,8 @@ bytes:
 .. note::
 
   Strings that contain escaped sequences cannot be directly used with
-  unformatted I/O functions such as ``writeln``. :ref:`Formatted I/O
+
+
   <about-io-formatted-io>` can be used to print such strings with binary
   formatters such as ``%|s``.
 
@@ -832,23 +832,17 @@ module String {
   // in when possible.
   pragma "ignore noinit"
   pragma "no default functions" // avoid the default (read|write)This routines
-  record _string {
-    pragma "no doc"
+  pragma "no doc"
+  record _string { //Opening brace
     var buffLen: int = 0; // length of string in bytes
-    pragma "no doc"
     var buffSize: int = 0; // size of the buffer we own
-    pragma "no doc"
     var buff: bufferType = nil;
-    pragma "no doc"
     var isOwned: bool = true;
-    pragma "no doc"
     var hasEscapes: bool = false;
-    pragma "no doc"
     // We use chpl_nodeID as a shortcut to get at here.id without actually constructing
     // a locale object. Used when determining if we should make a remote transfer.
     var locale_id = chpl_nodeID; // : chpl_nodeID_t
 
-    pragma "no doc"
     proc init() {
       // Let compiler insert defaults
     }
@@ -863,7 +857,6 @@ module String {
       initWithNewBuffer(this, cs:bufferType, length=cs.size, size=cs.size+1);
     }
 
-    pragma "no doc"
     proc ref deinit() {
       // Checking for size here isn't sufficient. A string may have been
       // initialized from a c_string allocated from memory but beginning with
@@ -875,8 +868,7 @@ module String {
         }
       }
     }
-
-    pragma "no doc"
+    
     proc chpl__serialize() {
       var data : chpl__inPlaceBuffer;
       if buffLen <= CHPL_SHORT_STRING_SIZE {
@@ -884,8 +876,7 @@ module String {
       }
       return new __serializeHelper(buffLen, buff, buffSize, locale_id, data);
     }
-
-    pragma "no doc"
+    
     proc type chpl__deserialize(data) {
       if data.locale_id != chpl_nodeID {
         if data.buffLen <= CHPL_SHORT_STRING_SIZE {
@@ -907,7 +898,6 @@ module String {
     }
 
     // This is assumed to be called from this.locale
-    pragma "no doc"
     proc ref reinitString(buff: bufferType, s_len: int, size: int,
                           needToCopy:bool = true, ownBuffer = false) {
       if this.isEmpty() && buff == nil then return;
@@ -957,239 +947,10 @@ module String {
       this.buffLen = s_len;
     }
 
-    /* Deprecated - please use :proc:`string.size`. */
-    inline proc length {
-      compilerWarning("'string.length' is deprecated - " +
-                      "please use 'string.size' instead");
-      return numCodepoints;
-    }
-
-    /*
-      :returns: The number of codepoints in the string.
-      */
-    inline proc size return numCodepoints;
-
-    /*
-      :returns: The indices that can be used to index into the string
-                (i.e., the range ``0..<this.size``)
-    */
-    proc indices return 0..<size;
-
-    pragma "no doc"
     proc byteIndices return 0..<this.numBytes;
 
-    /*
-      :returns: The number of bytes in the string.
-      */
-    inline proc numBytes return buffLen;
-
-    /*
-      :returns: The number of codepoints in the string, assuming the
-                string is correctly-encoded UTF-8.
-      */
-    proc numCodepoints {
-      var localThis: string = this.localize();
-      var n = 0;
-      var i = 0;
-      while i < localThis.buffLen {
-        i += 1;
-        while i < localThis.buffLen && !isInitialByte(localThis.buff[i]) do
-          i += 1;
-        n += 1;
-      }
-      return n;
-    }
-
-    /*
-       Gets a version of the :record:`string` that is on the currently
-       executing locale.
-
-       :returns: A shallow copy if the :record:`string` is already on the
-                 current locale, otherwise a deep copy is performed.
-    */
-    inline proc localize() : string {
-      if _local || this.locale_id == chpl_nodeID {
-        return createStringWithBorrowedBuffer(this);
-      } else {
-        const x:string = this; // assignment makes it local
-        return x;
-      }
-    }
-
-    /*
-      Get a `c_string` from a :record:`string`.
-
-      .. warning::
-
-          This can only be called safely on a :record:`string` whose home is
-          the current locale.  This property can be enforced by calling
-          :proc:`string.localize()` before :proc:`~string.c_str()`. If the
-          string is remote, the program will halt.
-
-      For example:
-
-      .. code-block:: chapel
-
-          var my_string = "Hello!";
-          on different_locale {
-            printf("%s", my_string.localize().c_str());
-          }
-
-      :returns:
-          A `c_string` that points to the underlying buffer used by this
-          :record:`string`. The returned `c_string` is only valid when used
-          on the same locale as the string.
-     */
-    inline proc c_str(): c_string {
-      return getCStr(this);
-    }
-
-    pragma "no doc"
     inline proc param c_str() param : c_string {
       return this:c_string; // folded out in resolution
-    }
-
-    /*
-      Returns a :record:`~Bytes.bytes` from the given :record:`string`. If the
-      string contains some escaped non-UTF8 bytes, `policy` argument determines
-      the action.
-        
-      :arg policy: `encodePolicy.pass` directly copies the (potentially escaped)
-                    data, `encodePolicy.unescape` recovers the escaped bytes
-                    back.
-
-      :returns: :record:`~Bytes.bytes`
-    */
-    proc encode(policy=encodePolicy.pass): bytes {
-      var localThis: string = this.localize();
-
-      if policy == encodePolicy.pass {  // just copy
-        return createBytesWithNewBuffer(localThis.buff, localThis.numBytes);
-      }
-      else {  // see if there is escaped data in the string
-        var (buff, size) = bufferAlloc(this.buffLen+1);
-
-        var readIdx = 0;
-        var writeIdx = 0;
-        while readIdx < localThis.buffLen {
-          var multibytes = (localThis.buff + readIdx): c_string;
-          const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                     buffLen=localThis.buffLen,
-                                                     offset=readIdx,
-                                                     allowEsc=true);
-          if (0xdc80<=cp && cp<=0xdcff) {
-            buff[writeIdx] = (cp-0xdc00):byteType;
-            writeIdx += 1;
-          }
-          else if (decodeRet != 0) {
-            // the string contains invalid data
-            // at this point this can only happen due to a failure in our
-            // implementation of string encoding/decoding
-            // simply copy the data out
-            bufferMemcpyLocal(dst=(buff+writeIdx), src=multibytes, len=nBytes);
-            writeIdx += nBytes;
-          }
-          else {
-            bufferMemcpyLocal(dst=(buff+writeIdx), src=multibytes, len=nBytes);
-            writeIdx += nBytes;
-          }
-          readIdx += nBytes;
-        }
-        buff[writeIdx] = 0;
-        return createBytesWithOwnedBuffer(buff, length=writeIdx, size=size);
-      }
-    }
-
-    /*
-      Iterates over the string character by character.
-
-      For example:
-
-      .. code-block:: chapel
-
-        var str = "abcd";
-        for c in str {
-          writeln(c);
-        }
-
-      Output::
-
-        a
-        b
-        c
-        d
-     */
-    iter items() : string {
-      var localThis: string = this.localize();
-
-      var i = 0;
-      while i < localThis.buffLen {
-        const curPos = localThis.buff+i;
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                     buffLen=localThis.buffLen,
-                                                     offset=i,
-                                                     allowEsc=true);
-        var (newBuf, newSize) = bufferCopyLocal(curPos, nBytes);
-        newBuf[nBytes] = 0;
-
-        yield chpl_createStringWithOwnedBufferNV(newBuf, nBytes, newSize);
-
-        i += nBytes;
-      }
-    }
-
-
-    /*
-      Iterates over the string character by character, yielding 1-codepoint
-      strings. (A synonym for :iter:`items`)
-
-      For example:
-
-      .. code-block:: chapel
-
-        var str = "abcd";
-        for c in str {
-          writeln(c);
-        }
-
-      Output::
-
-        a
-        b
-        c
-        d
-     */
-    iter these() : string {
-      for c in this.items() do
-        yield c;
-    }
-
-    /*
-      Iterates over the string byte by byte.
-    */
-    iter chpl_bytes(): byteType {
-      var localThis: string = this.localize();
-
-      for i in 0..#localThis.buffLen {
-        yield localThis.buff[i];
-      }
-    }
-
-    /*
-      Iterates over the string Unicode character by Unicode character.
-    */
-    iter codepoints(): int(32) {
-      var localThis: string = this.localize();
-
-      var i = 0;
-      while i < localThis.buffLen {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                   buffLen=localThis.buffLen,
-                                                   offset=i,
-                                                   allowEsc=true);
-        yield cp;
-        i += nBytes;
-      }
     }
 
     /*
@@ -1199,7 +960,6 @@ module String {
       Assume we may accidentally start in the middle of a multibyte character,
       but the string is correctly encoded UTF-8.
     */
-    pragma "no doc"
     iter _cpIndexLen(start = 0:byteIndex) {
       var localThis: string = this.localize();
 
@@ -1224,7 +984,6 @@ module String {
       Assume we may accidentally start in the middle of a multibyte character,
       but the string is correctly encoded UTF-8.
     */
-    pragma "no doc"
     iter _indexLen(start = 0:byteIndex) {
       var localThis: string = this.localize();
 
@@ -1240,207 +999,28 @@ module String {
         i = j;
       }
     }
-
-    /*
-      :returns: The value of a single-byte string as an integer.
-    */
-    proc toByte(): uint(8) {
-      if this.buffLen != 1 then
-        halt("string.toByte() only accepts single-byte strings");
-      return bufferGetByte(buf=this.buff, off=0, loc=this.locale_id);
-    }
-
-    /*
-      :returns: The value of the `i` th byte as an integer.
-    */
-    proc byte(i: int): uint(8) {
-      if boundsChecking && (i < 0 || i >= this.buffLen)
-        then halt("index ", i, " out of bounds for string with ", this.numBytes, " bytes");
-      return bufferGetByte(buf=this.buff, off=i, loc=this.locale_id);
-    }
-
-    /*
-      :returns: The value of a single-codepoint string as an integer.
-     */
-    proc toCodepoint(): int(32) {
-      // TODO: Engin: at least we can check whether the length is less than 4
-      // bytes before localizing?
-      var localThis: string = this.localize();
-
-      if localThis.isEmpty() then
-        halt("string.toCodepoint() only accepts single-codepoint strings");
-
-      const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                 buffLen=localThis.buffLen,
-                                                 offset=0,
-                                                 allowEsc=true);
-      if localThis.buffLen != nBytes:int then
-        halt("string.toCodepoint() only accepts single-codepoint strings");
-
-      return cp;
-    }
-
-    /*
-      :returns: The value of the `i` th multibyte character as an integer.
-     */
-    proc codepoint(i: int): int(32) {
-      // TODO: Engin we may need localize here
-      const idx = i: int;
-      if boundsChecking && idx < 0 then
-        halt("index ", idx, " out of bounds for string");
-
-      var j = 0;
-      for cp in this.codepoints() {
-        if j == idx then
-          return cp;
-        j += 1;
-      }
-      // We have reached the end of the string without finding our index.
-      if boundsChecking then
-        halt("index ", idx, " out of bounds for string with length ", this.size);
-      return 0: int(32);
-    }
-
-    /*
-      Return the codepoint starting at the `i` th byte in the string
-
-      :returns: A string with the complete multibyte character starting at the
-                specified byte index from ``0..#string.numBytes``
-     */
-    proc this(i: byteIndex) : string {
-      var idx = i: int;
-      if boundsChecking && (idx < 0 || idx >= this.buffLen)
-        then halt("index ", i, " out of bounds for string with ", this.buffLen, " bytes");
-
-      var ret: string;
-      var maxbytes = (this.buffLen - idx): ssize_t;
-      if maxbytes < 0 || maxbytes > 4 then
-        maxbytes = 4;
-      var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=idx,
-                                            len=maxbytes, loc=this.locale_id);
-      ret.buffSize = allocSize;
-      ret.buff = newBuff;
-      ret.isOwned = true;
-
-      const (decodeRet, cp, nBytes) = decodeHelp(buff=ret.buff,
-                                                 buffLen=maxbytes,
-                                                 offset=0,
-                                                 allowEsc=true);
-      ret.buff[nBytes] = 0;
-      ret.buffLen = nBytes;
-      return ret;
-    }
-
-    /*
-      Return the `i` th codepoint in the string. (A synonym for :proc:`item`)
-
-      :returns: A string with the complete multibyte character starting at the
-                specified codepoint index from ``0..#string.numCodepoints``
-     */
-    proc this(i: codepointIndex) : string {
-      return this.item(i);
-    }
-
-    /*
-      Return the `i` th codepoint in the string. (A synonym for :proc:`item`)
-
-      :returns: A string with the complete multibyte character starting at the
-                specified codepoint index from ``1..string.numCodepoints``
-     */
-    inline proc this(i: int) : string {
-      return this.item(i);
-    }
-
-    /*
-      Return the `i` th codepoint in the string
-
-      :returns: A string with the complete multibyte character starting at the
-                specified codepoint index from ``1..string.numCodepoints``
-     */
-    proc item(i: codepointIndex) : string {
-      if this.isEmpty() then return "";
-      const idx = i: int;
-      return codepointToString(this.codepoint(idx));
-    }
-
-    /*
-      Return the `i` th codepoint in the string
-
-      :returns: A string with the complete multibyte character starting at the
-                specified codepoint index from ``0..#string.numCodepoints``
-     */
-    inline proc item(i: int) : string {
-      return this[i: codepointIndex];
-    }
-
-    /*
-      Slice a string. Halts if r is non-empty and not completely inside the
-      range ``0..<string.size`` when compiled with `--checks`. `--fast`
-      disables this check.
-
-      :arg r: range of the indices the new string should be made from
-
-      :returns: a new string that is a substring within ``0..<string.size``. If
-                the length of `r` is zero, an empty string is returned.
-     */
-    inline proc this(r: range(?)) : string {
-      return getSlice(this, r);
-    }
-
-    pragma "no doc"
+    
     inline proc substring(i: int) {
       compilerError("substring removed: use string[index]");
     }
 
-    pragma "no doc"
     inline proc substring(r: range) {
       compilerError("substring removed: use string[range]");
     }
 
-    /*
-      :returns: * `true`  -- when the string is empty
-                * `false` -- otherwise
-     */
-    inline proc isEmpty() : bool {
-      return this.buffLen == 0; // this should be enough of a check
-    }
-
     // These should never be called (but are default functions for records)
-    pragma "no doc"
     proc writeThis(f) throws {
       compilerError("not implemented: writeThis");
     }
-    pragma "no doc"
+
     proc readThis(f) throws {
       compilerError("not implemented: readThis");
     }
-
-    /*
-      :arg needles: A varargs list of strings to match against.
-
-      :returns: * `true`  -- when the string begins with one or more of the `needles`
-                * `false` -- otherwise
-     */
-    inline proc startsWith(needles: string ...) : bool {
-      return startsEndsWith(this, needles, fromLeft=true);
-    }
-
-    /*
-      :arg needles: A varargs list of strings to match against.
-
-      :returns: * `true`  -- when the string ends with one or more of the `needles`
-                * `false` -- otherwise
-     */
-    inline proc endsWith(needles: string ...) : bool {
-      return startsEndsWith(this, needles, fromLeft=false);
-    }
-
 
     // Helper function that uses a param bool to toggle between count and find
     //TODO: this could be a much better string search
     //      (Boyer-Moore-Horspool|any thing other than brute force)
     //
-    pragma "no doc"
     inline proc _search_helper(needle: string, region: range(?),
                                param count: bool, param fromLeft: bool = true) {
       // needle.len is <= than this.buffLen, so go to the home locale
@@ -1528,217 +1108,637 @@ module String {
       return ret;
     }
 
-    /*
-      :arg needle: the string to search for
-      :arg region: an optional range defining the substring to search within,
-                   default is the whole string. Halts if the range is not
-                   within ``0..<string.size``
-
-      :returns: the index of the first occurrence of `needle` within a
-                string, or -1 if the `needle` is not in the string.
-     */
-    inline proc find(needle: string,
-                     region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
-      // TODO: better name than region?
-      return _search_helper(needle, region, count=false): byteIndex;
-    }
-
-    /*
-      :arg needle: the string to search for
-      :arg region: an optional range defining the substring to search within,
-                   default is the whole string. Halts if the range is not
-                   within ``0..<string.size``
-
-      :returns: the index of the first occurrence from the right of `needle`
-                within a string, or -1 if the `needle` is not in the string.
-     */
-    inline proc rfind(needle: string,
-                      region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
-      return _search_helper(needle, region, count=false, fromLeft=false): byteIndex;
-    }
-
-    /*
-      :arg needle: the string to search for
-      :arg region: an optional range defining the substring to search within,
-                   default is the whole string. Halts if the range is not
-                   within ``0..<string.size``
-
-      :returns: the number of times `needle` occurs in the string
-     */
-    inline proc count(needle: string, region: range(?) = this.indices) : int {
-      return _search_helper(needle, region, count=true);
-    }
-
-    /*
-      :arg needle: the string to search for
-      :arg replacement: the string to replace `needle` with
-      :arg count: an optional integer specifying the number of replacements to
-                  make, values less than zero will replace all occurrences
-
-      :returns: a copy of the string where `replacement` replaces `needle` up
-                to `count` times
-     */
-    inline proc replace(needle: string, replacement: string, count: int = -1) : string {
-      return doReplace(this, needle, replacement, count);
-    }
-
-    /*
-      Splits the string on `sep` yielding the substring between each
-      occurrence, up to `maxsplit` times.
-
-      :arg sep: The delimiter used to break the string into chunks.
-      :arg maxsplit: The number of times to split the string, negative values
-                     indicate no limit.
-      :arg ignoreEmpty: * When `true`  -- Empty strings will not be yielded,
-                                          and will not count towards `maxsplit`
-                        * When `false` -- Empty strings will be yielded when
-                                          `sep` occurs multiple times in a row.
-     */
-    iter split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) /* : string */ {
-      // TODO: specifying return type leads to un-inited string?
-      for s in doSplit(this, sep, maxsplit, ignoreEmpty) do yield s;
-    }
-
-    /*
-      Works as above, but uses runs of whitespace as the delimiter.
-
-      :arg maxsplit: The number of times to split the string, negative values
-                     indicate no limit.
-     */
-    iter split(maxsplit: int = -1) /* : string */ {
-      // note: to improve performance, this code collapses several cases into a
-      //       single yield statement, which makes it confusing to read
-      // TODO: specifying return type leads to un-inited string?
-      if !this.isEmpty() {
-        const localThis: string = this.localize();
-        var done : bool = false;
-        var yieldChunk : bool = false;
-        var chunk : string;
-
-        const noSplits : bool = maxsplit == 0;
-        const limitSplits : bool = maxsplit > 0;
-        var splitCount: int = 0;
-        const iEnd: byteIndex = localThis.buffLen - 2;
-
-        var inChunk : bool = false;
-        var chunkStart : byteIndex;
-
-        for (c, i, nBytes) in localThis._cpIndexLen() {
-          // emit whole string, unless all whitespace
-          if noSplits {
-            done = true;
-            if !localThis.isSpace() then {
-              chunk = localThis;
-              yieldChunk = true;
-            }
-          } else {
-            var cSpace = codepoint_isWhitespace(c);
-            // first char of a chunk
-            if !(inChunk || cSpace) {
-              chunkStart = i;
-              inChunk = true;
-              if i - 1 + nBytes > iEnd {
-                chunk = localThis[chunkStart..];
-                yieldChunk = true;
-                done = true;
-              }
-            } else if inChunk {
-              // first char out of a chunk
-              if cSpace {
-                splitCount += 1;
-                // last split under limit
-                if limitSplits && splitCount > maxsplit {
-                  chunk = localThis[chunkStart..];
-                  yieldChunk = true;
-                  done = true;
-                // no limit
-                } else {
-                  chunk = localThis[chunkStart..i-1];
-                  yieldChunk = true;
-                  inChunk = false;
-                }
-              // out of chars
-              } else if i - 1 + nBytes > iEnd {
-                chunk = localThis[chunkStart..];
-                yieldChunk = true;
-                done = true;
-              }
-            }
-          }
-
-          if yieldChunk {
-            yield chunk;
-            yieldChunk = false;
-          }
-          if done then
-            break;
-        }
-      }
-    }
-
-    /*
-      Returns a new string, which is the concatenation of all of the strings
-      passed in with the receiving string inserted between them.
-
-      .. code-block:: chapel
-
-          var x = "|".join("a","10","d");
-          writeln(x); // prints: "a|10|d"
-     */
-    inline proc join(const ref x: string ...) : string {
-      return _join(x);
-    }
-
-    /*
-      Same as the varargs version, but with a homogeneous tuple of strings.
-
-      .. code-block:: chapel
-
-          var x = "|".join("a","10","d");
-          writeln(x); // prints: "a|10|d"
-     */
-    inline proc join(const ref x) : string where isTuple(x) {
-      if !isHomogeneousTuple(x) || !isString(x[1]) then
-        compilerError("join() on tuples only handles homogeneous tuples of strings");
-      return _join(x);
-    }
-
     pragma "last resort"
-    pragma "no doc"
     inline proc join(const ref S) : string where isTuple(S) {
       joinArgDepr();
       return join(S);
     }
 
-    /*
-      Same as the varargs version, but with all the strings in an array.
-
-      .. code-block:: chapel
-
-          var x = "|".join(["a","10","d"]);
-          writeln(x); // prints: "a|10|d"
-     */
-    inline proc join(const ref S: [] string) : string {
-      return _join(S);
-    }
-
     pragma "last resort"
-    pragma "no doc"
     inline proc join(const ref S: [] string) : string {
       joinArgDepr();
       return join(S);
     }
 
-    pragma "no doc"
     inline proc join(ir: _iteratorRecord): string {
       return doJoinIterator(this, ir);
     }
 
     // TODO: we don't need this
-    pragma "no doc"
     inline proc _join(const ref S) : string where isTuple(S) || isArray(S) {
       return doJoin(this, S);
     }
+
+    /*
+      :returns: A new string with the first character in uppercase (if it is a
+                case character), and all other case characters in lowercase.
+                Uncased characters are copied with no changes.
+    */
+    proc capitalize() : string {
+      var result: string = this.toLower();
+      if result.isEmpty() then return result;
+      const (decodeRet, cp, nBytes) = decodeHelp(buff=result.buff,
+                                                 buffLen=result.buffLen,
+                                                 offset=0,
+                                                 allowEsc=false);
+      
+      var upCodepoint = codepoint_toUpper(cp);
+      if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
+        // Use the MacOS approach everywhere:  only change the case if
+        // the result does not change the number of encoded bytes.
+        qio_encode_char_buf(result.buff, upCodepoint);
+      }
+      return result;
+    }
+
+  } // end record string
+                                        
+  /* Deprecated - please use :proc:`string.size`. */
+  inline proc string.length {
+    compilerWarning("'string.length' is deprecated - " +
+                    "please use 'string.size' instead");
+    return numCodepoints;
+  }
+
+  /*
+    :returns: The number of codepoints in the string.
+  */
+  inline proc string.size return numCodepoints;
+
+  /*
+    :returns: The indices that can be used to index into the string
+              (i.e., the range ``0..<this.size``)
+  */
+  proc string.indices return 0..<size;
+
+  /*
+    :returns: The number of bytes in the string.
+  */
+  inline proc string.numBytes return buffLen;
+
+  /*
+    :returns: The number of codepoints in the string, assuming the
+              string is correctly-encoded UTF-8.
+  */
+  proc string.numCodepoints {
+    var localThis: string = this.localize();
+    var n = 0;
+    var i = 0;
+    while i < localThis.buffLen {
+      i += 1;
+      while i < localThis.buffLen && !isInitialByte(localThis.buff[i]) do
+        i += 1;
+      n += 1;
+    }
+    return n;
+  }
+  
+  /*
+     Gets a version of the :record:`string` that is on the currently
+     executing locale.
+
+     :returns: A shallow copy if the :record:`string` is already on the
+               current locale, otherwise a deep copy is performed.
+  */
+  inline proc string.localize() : string {
+    if _local || this.locale_id == chpl_nodeID {
+      return createStringWithBorrowedBuffer(this);
+    } else {
+      const x:string = this; // assignment makes it local
+      return x;
+    }
+  }
+
+  /*
+    Get a `c_string` from a :record:`string`.
+
+    .. warning::
+
+        This can only be called safely on a :record:`string` whose home is
+        the current locale.  This property can be enforced by calling
+        :proc:`string.localize()` before :proc:`~string.c_str()`. If the
+        string is remote, the program will halt.
+
+    For example:
+
+    .. code-block:: chapel
+
+        var my_string = "Hello!";
+        on different_locale {
+          printf("%s", my_string.localize().c_str());
+        }
+
+    :returns:
+        A `c_string` that points to the underlying buffer used by this
+        :record:`string`. The returned `c_string` is only valid when used
+        on the same locale as the string.
+   */
+  inline proc string.c_str(): c_string {
+    return getCStr(this);
+  }
+  
+  /*
+    Returns a :record:`~Bytes.bytes` from the given :record:`string`. If the
+    string contains some escaped non-UTF8 bytes, `policy` argument determines
+    the action.
+        
+    :arg policy: `encodePolicy.pass` directly copies the (potentially escaped)
+                  data, `encodePolicy.unescape` recovers the escaped bytes
+                  back.
+
+    :returns: :record:`~Bytes.bytes`
+  */
+  proc string.encode(policy=encodePolicy.pass): bytes {
+    var localThis: string = this.localize();
+
+    if policy == encodePolicy.pass {  // just copy
+      return createBytesWithNewBuffer(localThis.buff, localThis.numBytes);
+    }
+    else {  // see if there is escaped data in the string
+      var (buff, size) = bufferAlloc(this.buffLen+1);
+
+      var readIdx = 0;
+      var writeIdx = 0;
+      while readIdx < localThis.buffLen {
+        var multibytes = (localThis.buff + readIdx): c_string;
+        const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
+                                                   buffLen=localThis.buffLen,
+                                                   offset=readIdx,
+                                                   allowEsc=true);
+        if (0xdc80<=cp && cp<=0xdcff) {
+          buff[writeIdx] = (cp-0xdc00):byteType;
+          writeIdx += 1;
+        }
+        else if (decodeRet != 0) {
+          // the string contains invalid data
+          // at this point this can only happen due to a failure in our
+          // implementation of string encoding/decoding
+          // simply copy the data out
+          bufferMemcpyLocal(dst=(buff+writeIdx), src=multibytes, len=nBytes);
+          writeIdx += nBytes;
+        }
+        else {
+          bufferMemcpyLocal(dst=(buff+writeIdx), src=multibytes, len=nBytes);
+          writeIdx += nBytes;
+        }
+        readIdx += nBytes;
+      }
+      buff[writeIdx] = 0;
+      return createBytesWithOwnedBuffer(buff, length=writeIdx, size=size);
+    }
+  }
+
+  /*
+    Iterates over the string character by character.
+
+    For example:
+
+    .. code-block:: chapel
+
+      var str = "abcd";
+      for c in str {
+        writeln(c);
+      }
+
+    Output::
+
+      a
+      b
+      c
+      d
+   */
+  iter string.items() : string {
+    var localThis: string = this.localize();
+
+    var i = 0;
+    while i < localThis.buffLen {
+      const curPos = localThis.buff+i;
+      const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
+                                                   buffLen=localThis.buffLen,
+                                                   offset=i,
+                                                   allowEsc=true);
+      var (newBuf, newSize) = bufferCopyLocal(curPos, nBytes);
+      newBuf[nBytes] = 0;
+
+      yield chpl_createStringWithOwnedBufferNV(newBuf, nBytes, newSize);
+
+      i += nBytes;
+    }
+  }
+
+  /*
+    Iterates over the string character by character, yielding 1-codepoint
+    strings. (A synonym for :iter:`items`)
+
+    For example:
+
+    .. code-block:: chapel
+
+      var str = "abcd";
+      for c in str {
+        writeln(c);
+      }
+
+    Output::
+
+      a
+      b
+      c
+      d
+   */
+  iter string.these() : string {
+    for c in this.items() do
+      yield c;
+  }
+
+  /*
+    Iterates over the string byte by byte.
+  */
+  iter string.chpl_bytes(): byteType {
+    var localThis: string = this.localize();
+
+    for i in 0..#localThis.buffLen {
+      yield localThis.buff[i];
+    }
+  }
+
+  /*
+    Iterates over the string Unicode character by Unicode character.
+  */
+  iter string.codepoints(): int(32) {
+    var localThis: string = this.localize();
+
+    var i = 0;
+    while i < localThis.buffLen {
+      const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
+                                                 buffLen=localThis.buffLen,
+                                                 offset=i,
+                                                 allowEsc=true);
+      yield cp;
+      i += nBytes;
+    }
+  }
+
+  /*
+    :returns: The value of a single-byte string as an integer.
+  */
+  proc string.toByte(): uint(8) {
+    if this.buffLen != 1 then
+      halt("string.toByte() only accepts single-byte strings");
+    return bufferGetByte(buf=this.buff, off=0, loc=this.locale_id);
+  }
+
+  /*
+    :returns: The value of the `i` th byte as an integer.
+  */
+  proc string.byte(i: int): uint(8) {
+    if boundsChecking && (i < 0 || i >= this.buffLen)
+      then halt("index ", i, " out of bounds for string with ", this.numBytes, " bytes");
+    return bufferGetByte(buf=this.buff, off=i, loc=this.locale_id);
+  }
+
+  /*
+    :returns: The value of a single-codepoint string as an integer.
+   */
+  proc string.toCodepoint(): int(32) {
+    // TODO: Engin: at least we can check whether the length is less than 4
+    // bytes before localizing?
+    var localThis: string = this.localize();
+
+    if localThis.isEmpty() then
+      halt("string.toCodepoint() only accepts single-codepoint strings");
+
+    const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
+                                               buffLen=localThis.buffLen,
+                                               offset=0,
+                                               allowEsc=true);
+    if localThis.buffLen != nBytes:int then
+      halt("string.toCodepoint() only accepts single-codepoint strings");
+
+    return cp;
+  }
+
+  /*
+    :returns: The value of the `i` th multibyte character as an integer.
+   */
+  proc string.codepoint(i: int): int(32) {
+    // TODO: Engin we may need localize here
+    const idx = i: int;
+    if boundsChecking && idx < 0 then
+      halt("index ", idx, " out of bounds for string");
+
+    var j = 0;
+    for cp in this.codepoints() {
+      if j == idx then
+        return cp;
+      j += 1;
+    }
+    // We have reached the end of the string without finding our index.
+    if boundsChecking then
+      halt("index ", idx, " out of bounds for string with length ", this.size);
+    return 0: int(32);
+  }
+
+  /*
+    Return the codepoint starting at the `i` th byte in the string
+
+    :returns: A string with the complete multibyte character starting at the
+              specified byte index from ``0..#string.numBytes``
+   */
+  proc string.this(i: byteIndex) : string {
+    var idx = i: int;
+    if boundsChecking && (idx < 0 || idx >= this.buffLen)
+      then halt("index ", i, " out of bounds for string with ", this.buffLen, " bytes");
+
+    var ret: string;
+    var maxbytes = (this.buffLen - idx): ssize_t;
+    if maxbytes < 0 || maxbytes > 4 then
+      maxbytes = 4;
+    var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=idx,
+                                          len=maxbytes, loc=this.locale_id);
+    ret.buffSize = allocSize;
+    ret.buff = newBuff;
+    ret.isOwned = true;
+
+    const (decodeRet, cp, nBytes) = decodeHelp(buff=ret.buff,
+                                               buffLen=maxbytes,
+                                               offset=0,
+                                               allowEsc=true);
+    ret.buff[nBytes] = 0;
+    ret.buffLen = nBytes;
+    return ret;
+  }
+
+  /*
+    Return the `i` th codepoint in the string. (A synonym for :proc:`item`)
+
+    :returns: A string with the complete multibyte character starting at the
+              specified codepoint index from ``0..#string.numCodepoints``
+   */
+  proc string.this(i: codepointIndex) : string {
+    return this.item(i);
+  }
+
+  /*
+    Return the `i` th codepoint in the string. (A synonym for :proc:`item`)
+
+    :returns: A string with the complete multibyte character starting at the
+              specified codepoint index from ``1..string.numCodepoints``
+   */
+  inline proc string.this(i: int) : string {
+    return this.item(i);
+  }
+
+  /*
+    Return the `i` th codepoint in the string
+
+    :returns: A string with the complete multibyte character starting at the
+              specified codepoint index from ``1..string.numCodepoints``
+   */
+  proc string.item(i: codepointIndex) : string {
+    if this.isEmpty() then return "";
+    const idx = i: int;
+    return codepointToString(this.codepoint(idx));
+  }
+
+  /*
+    Return the `i` th codepoint in the string
+
+    :returns: A string with the complete multibyte character starting at the
+              specified codepoint index from ``0..#string.numCodepoints``
+   */
+  inline proc string.item(i: int) : string {
+    return this[i: codepointIndex];
+  }
+
+  /*
+    Slice a string. Halts if r is non-empty and not completely inside the
+    range ``0..<string.size`` when compiled with `--checks`. `--fast`
+    disables this check.
+
+    :arg r: range of the indices the new string should be made from
+
+    :returns: a new string that is a substring within ``0..<string.size``. If
+              the length of `r` is zero, an empty string is returned.
+   */
+  inline proc string.this(r: range(?)) : string {
+    return getSlice(this, r);
+  }
+
+  /*
+    :returns: * `true`  -- when the string is empty
+              * `false` -- otherwise
+   */
+  inline proc string.isEmpty() : bool {
+    return this.buffLen == 0; // this should be enough of a check
+  }
+
+  /*
+    :arg needles: A varargs list of strings to match against.
+
+    :returns: * `true`  -- when the string begins with one or more of the `needles`
+              * `false` -- otherwise
+   */
+  inline proc string.startsWith(needles: string ...) : bool {
+    return startsEndsWith(this, needles, fromLeft=true);
+  }
+
+  /*
+    :arg needles: A varargs list of strings to match against.
+
+    :returns: * `true`  -- when the string ends with one or more of the `needles`
+              * `false` -- otherwise
+   */
+  inline proc string.endsWith(needles: string ...) : bool {
+    return startsEndsWith(this, needles, fromLeft=false);
+  }
+
+  /*
+    :arg needle: the string to search for
+    :arg region: an optional range defining the substring to search within,
+                 default is the whole string. Halts if the range is not
+                 within ``0..<string.size``
+
+    :returns: the index of the first occurrence of `needle` within a
+              string, or -1 if the `needle` is not in the string.
+   */
+  inline proc string.find(needle: string,
+                   region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
+    // TODO: better name than region?
+    return _search_helper(needle, region, count=false): byteIndex;
+  }
+
+  /*
+    :arg needle: the string to search for
+    :arg region: an optional range defining the substring to search within,
+                 default is the whole string. Halts if the range is not
+                 within ``0..<string.size``
+
+    :returns: the index of the first occurrence from the right of `needle`
+              within a string, or -1 if the `needle` is not in the string.
+   */
+  inline proc string.rfind(needle: string,
+                    region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
+    return _search_helper(needle, region, count=false, fromLeft=false): byteIndex;
+  }
+
+  /*
+    :arg needle: the string to search for
+    :arg region: an optional range defining the substring to search within,
+                 default is the whole string. Halts if the range is not
+                 within ``0..<string.size``
+
+    :returns: the number of times `needle` occurs in the string
+   */
+  inline proc string.count(needle: string, region: range(?) = this.indices) : int {
+    return _search_helper(needle, region, count=true);
+  }
+
+  /*
+    :arg needle: the string to search for
+    :arg replacement: the string to replace `needle` with
+    :arg count: an optional integer specifying the number of replacements to
+                make, values less than zero will replace all occurrences
+
+    :returns: a copy of the string where `replacement` replaces `needle` up
+              to `count` times
+   */
+  inline proc string.replace(needle: string, replacement: string, count: int = -1) : string {
+    return doReplace(this, needle, replacement, count);
+  }
+
+  /*
+    Splits the string on `sep` yielding the substring between each
+    occurrence, up to `maxsplit` times.
+
+    :arg sep: The delimiter used to break the string into chunks.
+    :arg maxsplit: The number of times to split the string, negative values
+                   indicate no limit.
+    :arg ignoreEmpty: * When `true`  -- Empty strings will not be yielded,
+                                        and will not count towards `maxsplit`
+                      * When `false` -- Empty strings will be yielded when
+                                        `sep` occurs multiple times in a row.
+   */
+    iter string.split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) /* : string */ {
+    // TODO: specifying return type leads to un-inited string?
+    for s in doSplit(this, sep, maxsplit, ignoreEmpty) do yield s;
+  }
+
+  /*
+    Works as above, but uses runs of whitespace as the delimiter.
+
+    :arg maxsplit: The number of times to split the string, negative values
+                   indicate no limit.
+   */
+  iter string.split(maxsplit: int = -1) /* : string */ {
+    // note: to improve performance, this code collapses several cases into a
+    //       single yield statement, which makes it confusing to read
+    // TODO: specifying return type leads to un-inited string?
+    if !this.isEmpty() {
+      const localThis: string = this.localize();
+      var done : bool = false;
+      var yieldChunk : bool = false;
+      var chunk : string;
+
+      const noSplits : bool = maxsplit == 0;
+      const limitSplits : bool = maxsplit > 0;
+      var splitCount: int = 0;
+      const iEnd: byteIndex = localThis.buffLen - 2;
+
+      var inChunk : bool = false;
+      var chunkStart : byteIndex;
+
+      for (c, i, nBytes) in localThis._cpIndexLen() {
+        // emit whole string, unless all whitespace
+        if noSplits {
+          done = true;
+          if !localThis.isSpace() then {
+            chunk = localThis;
+            yieldChunk = true;
+          }
+        } else {
+          var cSpace = codepoint_isWhitespace(c);
+          // first char of a chunk
+          if !(inChunk || cSpace) {
+            chunkStart = i;
+            inChunk = true;
+            if i - 1 + nBytes > iEnd {
+              chunk = localThis[chunkStart..];
+              yieldChunk = true;
+              done = true;
+            }
+          } else if inChunk {
+            // first char out of a chunk
+            if cSpace {
+              splitCount += 1;
+              // last split under limit
+              if limitSplits && splitCount > maxsplit {
+                chunk = localThis[chunkStart..];
+                yieldChunk = true;
+                done = true;
+              // no limit
+              } else {
+                chunk = localThis[chunkStart..i-1];
+                yieldChunk = true;
+                inChunk = false;
+              }
+            // out of chars
+            } else if i - 1 + nBytes > iEnd {
+              chunk = localThis[chunkStart..];
+              yieldChunk = true;
+              done = true;
+            }
+          }
+        }
+
+        if yieldChunk {
+          yield chunk;
+          yieldChunk = false;
+        }
+        if done then
+          break;
+      }
+    }
+  }
+
+  /*
+    Returns a new string, which is the concatenation of all of the strings
+    passed in with the receiving string inserted between them.
+
+    .. code-block:: chapel
+
+        var x = "|".join("a","10","d");
+        writeln(x); // prints: "a|10|d"
+   */
+  inline proc string.join(const ref x: string ...) : string {
+    return _join(x);
+  }
+
+  /*
+    Same as the varargs version, but with a homogeneous tuple of strings.
+
+    .. code-block:: chapel
+
+        var x = "|".join("a","10","d");
+        writeln(x); // prints: "a|10|d"
+   */
+  inline proc string.join(const ref x) : string where isTuple(x) {
+    if !isHomogeneousTuple(x) || !isString(x[1]) then
+      compilerError("join() on tuples only handles homogeneous tuples of strings");
+    return _join(x);
+  }
+
+  /*
+    Same as the varargs version, but with all the strings in an array.
+
+    .. code-block:: chapel
+
+        var x = "|".join(["a","10","d"]);
+        writeln(x); // prints: "a|10|d"
+   */
+  inline proc string.join(const ref S: [] string) : string {
+    return _join(S);
+  }
 
     /*
       :arg chars: A string containing each character to remove.
@@ -1751,7 +1751,7 @@ module String {
       :returns: A new string with `leading` and/or `trailing` occurrences of
                 characters in `chars` removed as appropriate.
     */
-    proc strip(chars: string = " \t\r\n", leading=true, trailing=true) : string {
+    proc string.strip(chars: string = " \t\r\n", leading=true, trailing=true) : string {
       if this.isEmpty() then return "";
       if chars.isEmpty() then return this;
 
@@ -1798,7 +1798,7 @@ module String {
       before `sep`, `sep`, and the section after `sep`. If `sep` is not found,
       the tuple will contain the whole string, and then two empty strings.
     */
-    inline proc const partition(sep: string) : 3*string {
+    inline proc const string.partition(sep: string) : 3*string {
       return doPartition(this, sep);
     }
 
@@ -1811,7 +1811,7 @@ module String {
                              uncased characters.
                 * `false` -- otherwise
      */
-    proc isUpper() : bool {
+    proc string.isUpper() : bool {
       if this.isEmpty() then return false;
 
       var result: bool;
@@ -1838,7 +1838,7 @@ module String {
       :returns: * `true`  -- when there are no uppercase characters in the string.
                 * `false` -- otherwise
      */
-    proc isLower() : bool {
+    proc string.isLower() : bool {
       if this.isEmpty() then return false;
 
       var result: bool;
@@ -1865,7 +1865,7 @@ module String {
       :returns: * `true`  -- when all the characters are whitespace.
                 * `false` -- otherwise
      */
-    proc isSpace() : bool {
+    proc string.isSpace() : bool {
       if this.isEmpty() then return false;
       var result: bool = true;
 
@@ -1887,7 +1887,7 @@ module String {
       :returns: * `true`  -- when the characters are alphabetic.
                 * `false` -- otherwise
      */
-    proc isAlpha() : bool {
+    proc string.isAlpha() : bool {
       if this.isEmpty() then return false;
       var result: bool = true;
 
@@ -1909,7 +1909,7 @@ module String {
       :returns: * `true`  -- when the characters are digits.
                 * `false` -- otherwise
      */
-    proc isDigit() : bool {
+    proc string.isDigit() : bool {
       if this.isEmpty() then return false;
       var result: bool = true;
 
@@ -1931,7 +1931,7 @@ module String {
       :returns: * `true`  -- when the characters are alphanumeric.
                 * `false` -- otherwise
      */
-    proc isAlnum() : bool {
+    proc string.isAlnum() : bool {
       if this.isEmpty() then return false;
       var result: bool = true;
 
@@ -1953,7 +1953,7 @@ module String {
       :returns: * `true`  -- when the characters are printable.
                 * `false` -- otherwise
      */
-    proc isPrintable() : bool {
+    proc string.isPrintable() : bool {
       if this.isEmpty() then return false;
       var result: bool = true;
 
@@ -1976,7 +1976,7 @@ module String {
       :returns: * `true`  -- when the condition described above is met.
                 * `false` -- otherwise
      */
-    proc isTitle() : bool {
+    proc string.isTitle() : bool {
       if this.isEmpty() then return false;
       var result: bool = true;
 
@@ -2018,7 +2018,7 @@ module String {
         The case change operation is not currently performed on characters whose
         cases take different number of bytes to represent in Unicode mapping.
     */
-    proc toLower() : string {
+    proc string.toLower() : string {
       var result: string = this;
       if result.isEmpty() then return result;
 
@@ -2048,7 +2048,7 @@ module String {
         The case change operation is not currently performed on characters whose
         cases take different number of bytes to represent in Unicode mapping.
     */
-    proc toUpper() : string {
+    proc string.toUpper() : string {
       var result: string = this;
       if result.isEmpty() then return result;
 
@@ -2069,78 +2069,54 @@ module String {
       return result;
     }
 
-    /*
-      :returns: A new string with all cased characters following an uncased
-                character converted to uppercase, and all cased characters
-                following another cased character converted to lowercase.
+  /*
+    :returns: A new string with all cased characters following an uncased
+              character converted to uppercase, and all cased characters
+              following another cased character converted to lowercase.
 
-      .. note::
-        
-        The case change operation is not currently performed on characters whose
-        cases take different number of bytes to represent in Unicode mapping.
-     */
-    proc toTitle() : string {
-      var result: string = this;
-      if result.isEmpty() then return result;
+    .. note::
 
-      param UN = 0, LETTER = 1;
-      var last = UN;
-      var i = 0;
-      while i < result.buffLen {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=result.buff,
-                                                   buffLen=result.buffLen,
-                                                   offset=i,
-                                                   allowEsc=false);
-        if codepoint_isAlpha(cp) {
-          if last == UN {
-            last = LETTER;
-            var upCodepoint = codepoint_toUpper(cp);
-            if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
-              // Use the MacOS approach everywhere:  only change the case if
-              // the result does not change the number of encoded bytes.
-              qio_encode_char_buf(result.buff + i, upCodepoint);
-            }
-          } else { // last == LETTER
-            var lowCodepoint = codepoint_toLower(cp);
-            if lowCodepoint != cp && qio_nbytes_char(lowCodepoint) == nBytes {
-              // Use the MacOS approach everywhere:  only change the case if
-              // the result does not change the number of encoded bytes.
-              qio_encode_char_buf(result.buff + i, lowCodepoint);
-            }
-          }
-        } else {
-          // Uncased elements
-          last = UN;
-        }
-        i += nBytes;
-      }
-      return result;
-    }
+      The case change operation is not currently performed on characters whose
+      cases take different number of bytes to represent in Unicode mapping.
+   */
+  proc string.toTitle() : string {
+    var result: string = this;
+    if result.isEmpty() then return result;
 
-    /*
-      :returns: A new string with the first character in uppercase (if it is a
-                case character), and all other case characters in lowercase.
-                Uncased characters are copied with no changes.
-    */
-    pragma "no doc"
-    proc capitalize() : string {
-      var result: string = this.toLower();
-      if result.isEmpty() then return result;
+    param UN = 0, LETTER = 1;
+    var last = UN;
+    var i = 0;
+    while i < result.buffLen {
       const (decodeRet, cp, nBytes) = decodeHelp(buff=result.buff,
                                                  buffLen=result.buffLen,
-                                                 offset=0,
+                                                 offset=i,
                                                  allowEsc=false);
-      
-      var upCodepoint = codepoint_toUpper(cp);
-      if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
-        // Use the MacOS approach everywhere:  only change the case if
-        // the result does not change the number of encoded bytes.
-        qio_encode_char_buf(result.buff, upCodepoint);
+      if codepoint_isAlpha(cp) {
+        if last == UN {
+          last = LETTER;
+          var upCodepoint = codepoint_toUpper(cp);
+          if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
+            // Use the MacOS approach everywhere:  only change the case if
+            // the result does not change the number of encoded bytes.
+            qio_encode_char_buf(result.buff + i, upCodepoint);
+          }
+        } else { // last == LETTER
+          var lowCodepoint = codepoint_toLower(cp);
+          if lowCodepoint != cp && qio_nbytes_char(lowCodepoint) == nBytes {
+            // Use the MacOS approach everywhere:  only change the case if
+            // the result does not change the number of encoded bytes.
+            qio_encode_char_buf(result.buff + i, lowCodepoint);
+          }
+        }
+      } else {
+        // Uncased elements
+        last = UN;
       }
-      return result;
+      i += nBytes;
     }
-
-  } // end record string
+    return result;
+  }
+  //FIND END
 
   //
   // Assignment functions

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -70,7 +70,7 @@ is invalid. For example:
 stores the value ``1`` in ``number``.
 
 To learn more about handling these errors, see the
-
+:ref:`Error Handling technical note <readme-errorHandling>`.
 
 Unicode Support
 ---------------


### PR DESCRIPTION
String will no longer appear as a "record" in documentation and changed many string methods to secondary methods so their documentation would still appear.