### PR TITLE
Address performance issues with stencil and block-cyclic array init

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -1032,10 +1032,10 @@ private
 iter do_dsiLocalSubdomains(indexDom) {
   param rank = indexDom.rank;
   type idxType = indexDom.idxType;
+  const blockSizes = indexDom.globDom.dist.blocksize;
+  const globDims = indexDom.globDom.whole.dims();
   for i in indexDom.myStarts {
     var temp : rank*range(idxType);
-    const blockSizes = indexDom.globDom.dist.blocksize;
-    const globDims = indexDom.globDom.whole.dims();
     for param j in 0..rank-1 {
       var lo: idxType;
       if rank == 1 then lo = i;

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -1208,16 +1208,6 @@ proc LocBlockCyclicArr.mdInd2FlatInd(i) {
       idx += localIdx * sizes(d+1);
     }
 
-    /*writeln(" whole= ", allocDom.globDom.whole,
-            " localeIndex= ", localeIndex,
-            " blocksize= ", blocksize,
-            " low= ", low,
-            " locsize= ", locsize,
-            " numblocks= ", numblocks,
-            " sizes= ", sizes,
-            " globalIndex= ", i,
-            " flatIndex= ", idx);*/
-
     return idx;
   }
 }

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -616,6 +616,7 @@ proc BlockCyclicDom.dsiBuildArray(type eltType, param initElts:bool) {
                                                    idxType, stridable,
                                                    dom.locDoms(localeIdx),
                                                    dom.locDoms(localeIdx),
+                                                   localeIdx,
                                                    initElts=initElts);
       locArrTemp(localeIdx) = LBCA;
       if here == creationLocale then
@@ -886,9 +887,16 @@ override proc BlockCyclicArr.dsiDestroyArr(param deinitElts:bool) {
     on dom.dist.targetLocales(localeIdx) {
       var arr = locArr(localeIdx);
       if deinitElts {
-        for subdom in do_dsiLocalSubdomains(arr!.indexDom) {
-          forall j in subdom {
-            chpl__autoDestroy(arr(j));
+        param needsDestroy = __primitive("needs auto destroy", eltType);
+        if needsDestroy {
+          const wholeCopy = {(...arr.allocDom.globDom.dsiDims())};
+          // only deinitialize non-padding elements
+          // padding is always deinited in the LocArr deinit
+          forall flatIndex in arr.allocDom.myFlatInds {
+            var globalIndex = arr.flatInd2mdInd(flatIndex);
+            if wholeCopy.contains(globalIndex) {
+              chpl__autoDestroy(arr.myElems[flatIndex]);
+            }
           }
         }
       }
@@ -1102,6 +1110,7 @@ class LocBlockCyclicArr {
   const numblocks : rank*int = allocDom._lens;
 
   const sizes : (rank+1)*int = allocDom._sizes;
+  const localeIndex: if rank == 1 then int else rank*int;
 
   proc init(type eltType,
             param rank: int,
@@ -1109,6 +1118,7 @@ class LocBlockCyclicArr {
             param stridable: bool,
             allocDom: unmanaged LocBlockCyclicDom(rank, idxType, stridable),
             indexDom: unmanaged LocBlockCyclicDom(rank, idxType, stridable),
+            localeIndex,
             param initElts: bool) {
     this.eltType = eltType;
     this.rank = rank;
@@ -1116,22 +1126,53 @@ class LocBlockCyclicArr {
     this.stridable = stridable;
     this.allocDom = allocDom;
     this.indexDom = indexDom;
-    this.myElems = this.allocDom.myFlatInds.buildArray(eltType, initElts=false);
+    this.myElems = this.allocDom.myFlatInds.buildArray(eltType, initElts=initElts);
+    this.localeIndex = localeIndex;
     this.complete();
 
-    // Initialize only those elements referring to valid indices
-    // since these are the only ones that will be deinitialized.
-    if initElts {
-      for subdom in do_dsiLocalSubdomains(indexDom) {
-        forall j in subdom {
+    // BlockCyclic arrays are currently represented in a way that
+    // stores additional padding elements.
+    //
+    // For example, consider the following 2D array, with 2x2 blocks,
+    // which shows numbers indicating the locale number owning the element:
+    //
+    //   0 0 1 1 0      // note: 3 elements on locale 0 in this row
+    //   0 0 1 1 0
+    //   1 1 0 0 1      // note: 2 elements on locale 0 in this row
+    //   1 1 0 0 1
+    //   0 0 1 1 0
+    //
+    // These padding elements need to be initialized even if the
+    // array is not being default initialized.
+
+    // Even if the array elements don't need to be initialized now,
+    // do initialize the padding elements.
+    if initElts == false {
+      const wholeCopy = {(...allocDom.globDom.dsiDims())};
+      forall flatIndex in this.allocDom.myFlatInds {
+        var globalIndex = flatInd2mdInd(flatIndex);
+        if !wholeCopy.contains(globalIndex) {
           pragma "no auto destroy" pragma "unsafe"
           var def: eltType;
-          __primitive("=", this.this(j), def);
+          __primitive("=", this.myElems[flatIndex], def);
         }
       }
     }
   }
   proc deinit() {
+    // Even if the array elements don't need to be de-initialized now,
+    // do de-initialize the padding.
+    param needsDestroy = __primitive("needs auto destroy", eltType);
+    if needsDestroy {
+      const wholeCopy = {(...allocDom.globDom.dsiDims())};
+      forall flatIndex in this.allocDom.myFlatInds {
+        var globalIndex = flatInd2mdInd(flatIndex);
+        if !wholeCopy.contains(globalIndex) {
+          chpl__autoDestroy(myElems[flatIndex]);
+        }
+      }
+    }
+
     // Elements in myElems are deinited in dsiDestroyArr if necessary.
     // Here we need to clean up the rest of the array.
     _do_destroy_array(myElems, deinitElts=false);
@@ -1139,63 +1180,86 @@ class LocBlockCyclicArr {
 }
 
 
-proc LocBlockCyclicArr.mdInd2FlatInd(i: ?t, dim = 0) where t == idxType {
-  //  writeln("blksize");
-  const blksize = blocksize(dim);
-  //  writeln("ind0");
-  const ind0 = (i - low): int;
-  //  writeln("blkNum");
-  const blkNum = ind0 / (blksize * locsize(dim));
-  //  writeln("blkOff");
-  const blkOff = ind0 % blksize;
-  //  writeln("returning");
-  return  blkNum * blksize + blkOff;
-}
+proc LocBlockCyclicArr.mdInd2FlatInd(i) {
+  // note: draft CMO implementation available in history of this comment
 
-proc LocBlockCyclicArr.mdInd2FlatInd(i: ?t) where t == rank*idxType {
-  if (false) {  // CMO
-    var blkmults = * scan [d in 0..rank-1] blocksize(d);
-    //    writeln("blkmults = ", blkmults);
-    var numwholeblocks = 0;
-    var blkOff = 0;
-    for param d in 0..rank-1 by -1 {
-      const blksize = blocksize(d);
-      const ind0 = (i(d) - low(d)): int;
-      const blkNum = ind0 / (blksize * locsize(d));
-      const blkDimOff = ind0 % blksize;
-      if (d != rank) {
-        numwholeblocks *= numblocks(rank-d);
-        blkOff *= blkmults(rank-d);
-      }
-      numwholeblocks += blkNum;
-      blkOff += blkDimOff;
-    }
-    return (numwholeblocks * blocksize(rank)) + blkOff;
-  } else { // RMO
+  if rank == 1 {
+    param d = 0;
+    const blksize = blocksize(d);
+    const base = (i - low): int;
+    const localBlockNum = base / (blksize * locsize(d));
+    const localBlockStart = localBlockNum * blksize;
+    const localBlockOff = base % blksize;
 
+    const localIdx = localBlockStart + localBlockOff;
+
+    return localIdx;
+  } else {
     var idx = 0;
-
     for param d in 0..rank-1 {
-      const bs              = blocksize(d);  // cache for performance
+      const blksize         = blocksize(d);  // cache for performance
       const base            = i(d) - low(d); // zero-based index
-      const localBlockNum   = base / (bs * locsize(d));
-      const localBlockStart = localBlockNum * bs;
-      const remainder       = base % bs;
+      const localBlockNum   = base / (blksize * locsize(d));
+      const localBlockStart = localBlockNum * blksize;
+      const localBlockOff   = base % blksize;
 
-      const locIdx = localBlockStart + remainder;
+      const localIdx = localBlockStart + localBlockOff;
 
-      idx += locIdx * sizes(d+1);
+      idx += localIdx * sizes(d+1);
     }
+
+    /*writeln(" whole= ", allocDom.globDom.whole,
+            " localeIndex= ", localeIndex,
+            " blocksize= ", blocksize,
+            " low= ", low,
+            " locsize= ", locsize,
+            " numblocks= ", numblocks,
+            " sizes= ", sizes,
+            " globalIndex= ", i,
+            " flatIndex= ", idx);*/
 
     return idx;
   }
 }
+
+proc LocBlockCyclicArr.flatInd2mdInd(in idx:int) {
+  if rank == 1 {
+    param d = 0;
+    const blksize = blocksize(d);
+    const localIdx = idx;
+    const localBlockNum = localIdx / blksize;
+    const localBlockOff = localIdx % blksize;
+    const globalBlockNum = localBlockNum * locsize(d) + localeIndex;
+    const globalBlockStart = globalBlockNum * blksize;
+    return low + globalBlockStart + localBlockOff;
+  } else {
+    var i: rank*idxType;
+    for param d in 0..rank-1 {
+      const blksize = blocksize(d);
+      const localIdx = idx / sizes(d+1);
+      idx -= localIdx * sizes(d+1);
+      const localBlockNum = localIdx / blksize;
+      const localBlockOff = localIdx % blksize;
+      const globalBlockNum = localBlockNum * locsize(d) + localeIndex(d);
+      const globalBlockStart = globalBlockNum * blksize;
+      i(d) = low(d) + globalBlockStart + localBlockOff;
+    }
+    return i;
+  }
+}
+
+
 
 //
 // the accessor for the local array -- assumes the index is local
 //
 proc LocBlockCyclicArr.this(i) ref {
   const flatInd = mdInd2FlatInd(i);
+  if debugBlockCyclicDist {
+    // check flatInd2mdInd as well
+    const globalIndex = flatInd2mdInd(flatInd);
+    assert(globalIndex == i);
+  }
   //writeln(i, " --> ", flatInd);
   return myElems(flatInd);
 }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -380,11 +380,15 @@ class LocStencilArr {
 
     // Even if the array elements don't need to be initialized now,
     // do initialize the fluff.
-    for i in this.locDom.myFluff {
-      if !this.locDom.contains(i) {
-        pragma "no auto destroy" pragma "unsafe"
-        var def: eltType;
-        __primitive("=", myElems[i], def);
+    if initElts == false {
+      if this.locDom.myBlock != this.locDom.myFluff {
+        for fluffDom in this.locDom.recvDest {
+          forall i in fluffDom {
+            pragma "no auto destroy" pragma "unsafe"
+            var def: eltType;
+            __primitive("=", myElems[i], def);
+          }
+        }
       }
     }
   }
@@ -392,9 +396,14 @@ class LocStencilArr {
   proc deinit() {
     // Even if the array elements don't need to be de-initialized now,
     // do de-initialize the fluff.
-    for i in this.locDom.myFluff {
-      if !this.locDom.contains(i) {
-        chpl__autoDestroy(myElems[i]);
+    param needsDestroy = __primitive("needs auto destroy", eltType);
+    if needsDestroy {
+      if this.locDom.myBlock != this.locDom.myFluff {
+        for fluffDom in this.locDom.recvDest {
+          forall i in fluffDom {
+            chpl__autoDestroy(myElems[i]);
+          }
+        }
       }
     }
 

--- a/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.blockcyclic.comm-none.good
+++ b/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.blockcyclic.comm-none.good
@@ -20,25 +20,51 @@ test8
 1
 testrDefault
 init (default)
+init (default)
+init (default)
 (x = 0, ptr = {xx = 0})
+deinit 0 0
+deinit 0 0
 deinit 0 0
 -
 globalA is (x = 1, ptr = {xx = 1})
 -
 testr0
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr1 (copy required)
+init (default)
+init (default)
 init= 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr2
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr3
 in makeTuple
@@ -46,11 +72,17 @@ init 1 1
 init= 1 1
 deinit 1 1
 done makeTuple
+init (default)
+init (default)
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr4
 init 1 1
+init (default)
+init (default)
 init= 1 1
 init= 1 1
 init= 1 1
@@ -58,55 +90,117 @@ deinit 1 1
 deinit 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 deinit 1 1
 -
 testr5
+init (default)
+init (default)
 init 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr6 (copy required)
+init (default)
+init (default)
 init= 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC1
+init (default)
+init (default)
 init 1 1
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC2
+init (default)
+init (default)
 init 1 1
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC3
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC4
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR1
+init (default)
+init (default)
 init 1 1
 (AA = (x = 1, ptr = {xx = 1}))
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR2
+init (default)
+init (default)
 init 1 1
 (AA = (x = 1, ptr = {xx = 1}))
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR3
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 (AA = (x = 1, ptr = {xx = 1}))
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR4
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -

--- a/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.blockcyclic.good
+++ b/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.blockcyclic.good
@@ -20,25 +20,51 @@ test8
 1
 testrDefault
 init (default)
+init (default)
+init (default)
 (x = 0, ptr = {xx = 0})
+deinit 0 0
+deinit 0 0
 deinit 0 0
 -
 globalA is (x = 1, ptr = {xx = 1})
 -
 testr0
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr1 (copy required)
+init (default)
+init (default)
 init= 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr2
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr3
 in makeTuple
@@ -46,11 +72,17 @@ init 1 1
 init= 1 1
 deinit 1 1
 done makeTuple
+init (default)
+init (default)
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr4
 init 1 1
+init (default)
+init (default)
 init= 1 1
 init= 1 1
 init= 1 1
@@ -60,55 +92,117 @@ deinit 1 1
 deinit 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 deinit 1 1
 -
 testr5
+init (default)
+init (default)
 init 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testr6 (copy required)
+init (default)
+init (default)
 init= 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC1
+init (default)
+init (default)
 init 1 1
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC2
+init (default)
+init (default)
 init 1 1
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC3
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testC4
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR1
+init (default)
+init (default)
 init 1 1
 (AA = (x = 1, ptr = {xx = 1}))
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR2
+init (default)
+init (default)
 init 1 1
 (AA = (x = 1, ptr = {xx = 1}))
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR3
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 (AA = (x = 1, ptr = {xx = 1}))
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -
 testR4
+in makeA
+init (default)
+init (default)
+init (default)
 init 1 1
+lhs(0 0) = rhs(1 1)
+deinit 1 1
+leaving makeA
 {AA = (x = 1, ptr = {xx = 1})}
 deinit 1 1
+deinit 0 0
+deinit 0 0
 -

--- a/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.chpl
+++ b/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.chpl
@@ -3,8 +3,10 @@ use BlockDist, CyclicDist, BlockCycDist, ReplicatedDist, StencilDist;
 enum DistType { default, block, cyclic, blockcyclic, replicated, stencil };
 config param distType: DistType = DistType.block;
 
+config param makeAHidesInit = true;
+
 config var printInitDeinit = true;
-  
+
 class C {
   var xx: int = 0;
 }
@@ -114,7 +116,7 @@ proc test4() {
 }
 A = 0;
 test4();
-  
+
 proc test5() {
   writeln("test5");
   var B:[A.domain] int = [i in 1..1] i;
@@ -157,12 +159,24 @@ writeln("-");
 
 proc makeA() {
   var savePrint = printInitDeinit;
-  printInitDeinit = false;
+  if makeAHidesInit {
+    printInitDeinit = false;
+  } else if printInitDeinit {
+    writeln("in makeA");
+  }
+
   var ret: [A.domain] R;
-  ret[1] = new R(1);
-  printInitDeinit = savePrint;
-  if printInitDeinit then
-    writeln("init 1 1");
+  {
+    ret[1] = new R(1);
+    printInitDeinit = savePrint;
+  }
+  if printInitDeinit {
+    if makeAHidesInit {
+      writeln("init 1 1");
+    } else {
+      writeln("leaving makeA");
+    }
+  }
   return ret;
 }
 

--- a/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.compopts
+++ b/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.compopts
@@ -1,6 +1,6 @@
 -sdistType=DistType.default # array-initialization-patterns-dists.default.good
 -sdistType=DistType.block   # array-initialization-patterns-dists.block.good
 -sdistType=DistType.cyclic  # array-initialization-patterns-dists.cyclic.good
--sdistType=DistType.blockcyclic # array-initialization-patterns-dists.blockcyclic.good
+-sdistType=DistType.blockcyclic -smakeAHidesInit=false # array-initialization-patterns-dists.blockcyclic.good
 -sdistType=DistType.replicated # array-initialization-patterns-dists.replicated.good
 -sdistType=DistType.stencil # array-initialization-patterns-dists.stencil.good

--- a/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.replicated.good
+++ b/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.replicated.good
@@ -1,15 +1,15 @@
-array-initialization-patterns-dists.chpl:191: In function 'testr2':
-array-initialization-patterns-dists.chpl:193: error: invalid copy-initialization
-array-initialization-patterns-dists.chpl:193: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
-array-initialization-patterns-dists.chpl:270: In initializer:
-array-initialization-patterns-dists.chpl:271: error: invalid copy-initialization
-array-initialization-patterns-dists.chpl:271: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
-array-initialization-patterns-dists.chpl:287: In function 'testC4':
-array-initialization-patterns-dists.chpl:289: error: invalid copy-initialization
-array-initialization-patterns-dists.chpl:289: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
-array-initialization-patterns-dists.chpl:326: In initializer:
-array-initialization-patterns-dists.chpl:327: error: invalid copy-initialization
-array-initialization-patterns-dists.chpl:327: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
-array-initialization-patterns-dists.chpl:343: In function 'testR4':
-array-initialization-patterns-dists.chpl:345: error: invalid copy-initialization
-array-initialization-patterns-dists.chpl:345: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
+array-initialization-patterns-dists.chpl:205: In function 'testr2':
+array-initialization-patterns-dists.chpl:207: error: invalid copy-initialization
+array-initialization-patterns-dists.chpl:207: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
+array-initialization-patterns-dists.chpl:284: In initializer:
+array-initialization-patterns-dists.chpl:285: error: invalid copy-initialization
+array-initialization-patterns-dists.chpl:285: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
+array-initialization-patterns-dists.chpl:301: In function 'testC4':
+array-initialization-patterns-dists.chpl:303: error: invalid copy-initialization
+array-initialization-patterns-dists.chpl:303: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
+array-initialization-patterns-dists.chpl:340: In initializer:
+array-initialization-patterns-dists.chpl:341: error: invalid copy-initialization
+array-initialization-patterns-dists.chpl:341: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array
+array-initialization-patterns-dists.chpl:357: In function 'testR4':
+array-initialization-patterns-dists.chpl:359: error: invalid copy-initialization
+array-initialization-patterns-dists.chpl:359: error: ReplicatedDist array initialization is not currently supported for element type R - please default-initialize the array

--- a/test/arrays/ferguson/array-initialization-patterns/post-alloc-dists.blockcyclic.good
+++ b/test/arrays/ferguson/array-initialization-patterns/post-alloc-dists.blockcyclic.good
@@ -1,26 +1,33 @@
 alloc int test begins
 alloc int test0
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR calling dealloc int(64)
 alloc int test1
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR calling dealloc int(64)
 *** DR calling dealloc int(64)
 alloc int test2
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR calling dealloc int(64)
 alloc int test3
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR calling dealloc int(64)
 alloc int test4
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR alloc int(64) 3
 *** DR calling postalloc int(64) 3
 *** DR calling dealloc int(64)
 *** DR calling dealloc int(64)
 alloc int test5
 *** DR alloc int(64) 3
+*** DR calling postalloc int(64) 3
 *** DR alloc int(64) 3
 *** DR calling postalloc int(64) 3
 *** DR calling dealloc int(64)

--- a/test/distributions/bradc/blkCyc/blkCyc2d.chpl
+++ b/test/distributions/bradc/blkCyc/blkCyc2d.chpl
@@ -28,6 +28,17 @@ forall (i,j) in D2 do
 writeln("A is: ", A);
 writeln("A2 is: ", A2);
 
+{
+  // check copy/move initialization of 2d array
+  var AA = A;
+  var AAA = AA;
+  assert(A.equals(AAA));
+
+  var AA2 = A2;
+  var AAA2 = AA2;
+  assert(A2.equals(AAA2));
+}
+
 forall ((i,j), a) in zip(D, A) do
   a = j + i/100.0;
 

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -177,11 +177,15 @@ class LocAccumStencilArr {
 
     // Even if the array elements don't need to be initialized now,
     // do initialize the fluff.
-    for i in this.locDom.myFluff {
-      if !this.locDom.contains(i) {
-        pragma "no auto destroy" pragma "unsafe"
-        var def: eltType;
-        __primitive("=", myElems[i], def);
+    if initElts == false {
+      if this.locDom.myBlock != this.locDom.myFluff {
+        forall i in this.locDom.myFluff {
+          if !this.locDom.contains(i) {
+            pragma "no auto destroy" pragma "unsafe"
+            var def: eltType;
+            __primitive("=", myElems[i], def);
+          }
+        }
       }
     }
   }
@@ -200,9 +204,14 @@ class LocAccumStencilArr {
   proc deinit() {
     // Even if the array elements don't need to be de-initialized now,
     // do de-initialize the fluff.
-    for i in this.locDom.myFluff {
-      if !this.locDom.contains(i) {
-        chpl__autoDestroy(myElems[i]);
+    param needsDestroy = __primitive("needs auto destroy", eltType);
+    if needsDestroy {
+      if this.locDom.myBlock != this.locDom.myFluff {
+        forall i in this.locDom.myFluff {
+          if !this.locDom.contains(i) {
+            chpl__autoDestroy(myElems[i]);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Follow-up to PR #15239.
Related to https://github.com/Cray/chapel-private/issues/992

The array initialization improvements (PR #15239) introduced performance
regressions for StencilDist and BlockCyclicDist arrays. Some of these
were due to increased communication. The reason that Stencil and
BlockCyclic arrays are affected is that they both allocate elements that
are not initialized by array initialization (in the case of initializing
from another same-distribution array, say). For Stencil these are
fluff/ghost cell elements. For BlockCyclic they are padding.

See the test performance/array/distCreate.chpl run for example with
    
```
$ ./distCreate --size=arraySize.small --dist=distType.blockCyc -nl 2
```

This PR resolves these problems by:
 * initializing the padding/fluff elements along with the original data
   when default initializing
 * initializing the padding/fluff elements always (because they won't be
   initialized by an initialization expression e.g.) and deinitializing
   them always (because they won't be moved out of when move-initializing
   arrays either)
 * using more efficient means to identify elements that are fluff/padding 

- [x] full local gasnet testing
- [x] full local testing

Reviewed by @e-kayrakli - thanks!