### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,7 +7,7 @@ Chapel release:
 Contributors to the Chapel 1.21 and 1.22 releases
 -------------------------------------------------
 * Ben Albrecht, [HPE]
-* Souris Ash, invidividual contributor
+* Souris Ash, individual contributor
 * Akshansh Bhanjana, individual contributor
 * Ankush Bhardwaj, individual contributor
 * Paul Cassella, [HPE]

--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1222,8 +1222,8 @@ static long licmFn(FnSymbol* fn) {
     std::vector<SymExpr*> loopInvariants;
     std::set<Symbol*> defsInLoop;
     std::map<Symbol*, std::set<Symbol*> > aliases;
-    bool tooManyAlises = computeAliases(fn, aliases);
-    if (tooManyAlises) {
+    bool tooManyAliases = computeAliases(fn, aliases);
+    if (tooManyAliases) {
       return 0;
     }
     computeLoopInvariants(loopInvariants, defsInLoop, curLoop, localDefMap, aliases);

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -104,7 +104,7 @@ Index-neutral Features
 This experience also led to a number of new programming features in
 Chapel 1.21 designed to help write code in more of an index-neutral
 style.  Chief among these are new ``.indices`` queries on most of the
-relevent types as well as support for loops over heterogeneous tuples.
+relevant types as well as support for loops over heterogeneous tuples.
 We also introduced features that we found to be useful in updating
 code, such as support for open-interval ranges and ``.first`` and
 ``.last`` queries on enumerated types.  To this end, even though Chapel

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -868,7 +868,7 @@ The Compiler-Generated Initializer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If no user-defined initializers are supplied for a given generic class,
-the compiler generates one following in a manner similar to that for
+the compiler generates one in a manner similar to that for
 concrete classes (:ref:`The_Compiler_Generated_Initializer`).
 However, the compiler-generated initializer for a generic class or
 record (:ref:`The_Compiler_Generated_Initializer`) is generic

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -1121,7 +1121,7 @@ module DefaultAssociative {
     }
 
     override proc _deinitSlot(slot: int) {
-      // deinitalize the element at idx
+      // deinitialize the element at idx
       _deinitElement(data[slot]);
     }
 


### PR DESCRIPTION
Fix typos in generics.rst, evolution.rst, CONTRIBUTORS.md,
loopInvariantCodeMotion.chpl and DefaultAssociative.chpl.
