### PR TITLE
Merge Norm into LinearAlgebra and deprecate Norm

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1202,7 +1202,6 @@ private proc _lu (in A: [?Adom] ?eltType) {
 
   `ipiv` contains the pivot indices such that row i of `A`
   was interchanged with row `ipiv(i)`.
-
 */
 proc lu (A: [?Adom] ?eltType) {
   if Adom.rank != 2 then
@@ -1341,7 +1340,7 @@ proc _norm(x: [?D], param p: normType) where x.rank == 2 {
     return max reduce forall j in D.dim(1) do (+ reduce abs(x[D.dim(0), j..j]));
 
   when normType.norm2 {
-    halt("2-norm for 2D arrays are not yet implemented");
+    compilerError("2-norm for 2D arrays are not yet implemented");
     // TODO: Add implementation:
     //var (U, s, Vh) = svd(x);
     //return max(s)

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -186,7 +186,6 @@ are supported through submodules, such ``LinearAlgebra.Sparse`` for the
 
 module LinearAlgebra {
 
-use Norm; // TODO -- merge Norm into LinearAlgebra
 import BLAS;
 use LAPACK only lapack_memory_order, isLAPACKType;
 

--- a/modules/packages/Norm.chpl
+++ b/modules/packages/Norm.chpl
@@ -21,6 +21,10 @@
 /*
   Matrix and Vector Norms
 
+.. warning::
+
+    This module has been deprecated - please use :mod:`LinearAlgebra` instead.
+
   The Norm module currently defines:
 
     * 1-norm, 2-norm, infinity norm and Frobenius norm for 1D arrays
@@ -33,6 +37,8 @@
   which case the default norm for that array rank will be used.
  */
 module Norm {
+
+compilerWarning("Norm module is deprecated - please use LinearAlgebra instead");
 
 /*
   Indicates the different types of norms supported by this module:

--- a/test/chplvis/benchmarks-hpcc/hpl-vdb.chpl
+++ b/test/chplvis/benchmarks-hpcc/hpl-vdb.chpl
@@ -5,7 +5,7 @@ use VisualDebug;
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/deprecated/norm-module.chpl
+++ b/test/deprecated/norm-module.chpl
@@ -1,0 +1,5 @@
+use Norm;
+
+var x = [1,2,3];
+
+writeln(norm(x));

--- a/test/deprecated/norm-module.good
+++ b/test/deprecated/norm-module.good
@@ -1,0 +1,2 @@
+$CHPL_HOME/modules/packages/Norm.chpl:41: warning: Norm module is deprecated - please use LinearAlgebra instead
+3.74166

--- a/test/distributions/robust/arithmetic/kernels/hpl.chpl
+++ b/test/distributions/robust/arithmetic/kernels/hpl.chpl
@@ -9,7 +9,7 @@ use driver;
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
@@ -2,7 +2,7 @@
 
 use driver_real_arrays;
 use Random;
-use Norm;
+use LinearAlgebra;
 
 config const is2D2Norm = false;
 

--- a/test/modules/engin/pkg_module_res.chpl
+++ b/test/modules/engin/pkg_module_res.chpl
@@ -2,10 +2,10 @@ use Math; //doesn't make a difference -- works either way
 writeln(Math.pi);
 writeln(pi);
 
-use Norm;
+use LinearAlgebra;
 var arr: [{0..10}] int;
 writeln(norm(arr));
-writeln(Norm.norm(arr)); //works 
+writeln(LinearAlgebra.norm(arr)); //works 
 
 use Sort;
 writeln(isSorted(arr));

--- a/test/release/examples/benchmarks/hpcc/hpl.chpl
+++ b/test/release/examples/benchmarks/hpcc/hpl.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/release/examples/primers/LinearAlgebralib.chpl
+++ b/test/release/examples/primers/LinearAlgebralib.chpl
@@ -7,7 +7,7 @@
   .. contents:: Table of Contents
 
 */
-use LinearAlgebra, Norm;
+use LinearAlgebra;
 
 /*
 

--- a/test/studies/hpcc/HPL/bradc/hpl-blc+vass-dimensional.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc+vass-dimensional.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/studies/hpcc/HPL/bradc/hpl-blc.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/studies/hpcc/HPL/stonea/errors/writelnCausesError.chpl
+++ b/test/studies/hpcc/HPL/stonea/errors/writelnCausesError.chpl
@@ -2,7 +2,7 @@
 // ranges).
 
 use Random;
-use Norm;
+use LinearAlgebra;
 
 // calculate C = C - A * B.
 proc dgemm(

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
@@ -2,7 +2,7 @@
 // ranges).
 
 use Random;
-use Norm;
+use LinearAlgebra;
 
 // calculate C = C - A * B.
 proc dgemm(

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample3.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample3.chpl
@@ -6,7 +6,7 @@
 //    step process of extracting ranges and defining regions with these).
 
 use Random;
-use Norm;
+use LinearAlgebra;
 
 config const n = 100;
 config const trials = 3;

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample4.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample4.chpl
@@ -11,7 +11,7 @@
 //   ugly code.
 
 use Random;
-use Norm;
+use LinearAlgebra;
 
 config const n = 100;
 config const seed = 3145;

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample5.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample5.chpl
@@ -6,7 +6,7 @@
 // - Calculates flops/sec
 
 use Random;
-use Norm;
+use LinearAlgebra;
 use Time;
 
 config const n = 100;

--- a/test/studies/hpcc/HPL/vass/chpl-seq-vs-c/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/chpl-seq-vs-c/hpl.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Time;
+use LinearAlgebra, Time;
 
 // compile with stdlib.h
 extern proc rand(): int;

--- a/test/studies/hpcc/HPL/vass/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/studies/hpcc/HPL/vass/hpl.performance.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.performance.chpl
@@ -2,7 +2,7 @@
 // Use standard modules for vector and matrix Norms, Random numbers
 // and Timing routines
 //
-use Norm, Random, Time;
+use LinearAlgebra, Random, Time;
 
 //
 // Use the user module for computing HPCC problem sizes

--- a/test/studies/hpcc/PTRANS/PTRANS.chpl
+++ b/test/studies/hpcc/PTRANS/PTRANS.chpl
@@ -19,7 +19,7 @@ module HPCC_PTRANS {
 
   param zero = 0.0, one = 1.0, epsilon = 2.2E-16;
 
-  use Norm, 
+  use LinearAlgebra, 
       Time,
       BlockDist;
 

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
@@ -20,7 +20,7 @@ module HPCC_PTRANS {
 
   param zero = 0.0, one = 1.0, epsilon = 2.2E-16;
 
-  use Norm, 
+  use LinearAlgebra, 
       Time,
       BlockCycDist;
  

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
@@ -20,7 +20,7 @@ module HPCC_PTRANS {
 
   param zero = 0.0, one = 1.0, epsilon = 2.2E-16;
 
-  use Norm, 
+  use LinearAlgebra, 
       Time,
       BlockDist;
  

--- a/test/studies/lammps/shemmy/m-lammps.chpl
+++ b/test/studies/lammps/shemmy/m-lammps.chpl
@@ -6,7 +6,7 @@
 // Sandia National Laboratory.
 //
 
-use Norm, Time, BlockDist;
+use LinearAlgebra, Time, BlockDist;
 config const perfTest:bool = false;
 config const numAtoms:int = 3200;
 config const numSteps:int = 20;

--- a/test/studies/lammps/shemmy/s-lammps.chpl
+++ b/test/studies/lammps/shemmy/s-lammps.chpl
@@ -6,7 +6,7 @@
 // Sandia National Laboratory.
 //
 
-use Norm, Time;
+use LinearAlgebra, Time;
 config const perfTest:bool = false;
 const numAtoms:int = 3200;
 const numSteps:int = 20;


### PR DESCRIPTION
Merge Norm into LinearAlgebra and deprecate Norm module.

Some slight interface modifications have been made to the Norm module:

- `p: normType` argument is now a param
  - This is required to ensure LAPACK will only be required when using norm-2 with 2D arrays when we add this implementation.
- Added a `default` value to the `normType` enum
  - This eliminates the need for multiple overloads in the interface and better follows patterns in other linear algebra libraries.

Other changes include:

- Norm module has been properly deprecated (warning in documentation, compiler warning, deprecation test added).
- All tests using Norm now use LinearAlgebra instead.

Future work includes:

- Consolidating Norm tests and migrating them to the LinearAlgebra testing directory
- Implementing the 2-norm for 2D arrays - I have added a commented out implementation, which I would like to pursue as a follow-up effort.


**Testing**

- [x] linux64 testing