### PR TITLE
Move spec/README to new spec location

### DIFF
--- a/doc/rst/language/spec/README
+++ b/doc/rst/language/spec/README
@@ -1,8 +1,5 @@
-Please Note the spec has migrated from .tex files
-to .rst files and is now stored in $CHPL_HOME/doc/rst/language.
-
-
-
+[The following was developed back when spec was written in Latex / .tex
+however the principles still hold for the rst-formatted spec.]
 
 Each chapter on a feature (e.g. a data type) should have this structure:
 


### PR DESCRIPTION
Following the move of the spec sources to a new location in bea6d4b410 then ae75540cbf, move its README there as well.

While this README was last edited way back in 317fd09bd0, the principles presented there still apply.
