### PR TITLE
Update mason external skipifs

### DIFF
--- a/test/mason/mason-external.skipif
+++ b/test/mason/mason-external.skipif
@@ -1,0 +1,1 @@
+suseSkipif

--- a/test/mason/mason-external/SKIPIF
+++ b/test/mason/mason-external/SKIPIF
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+"""
+mason requires CHPL_COMM=none (local)
+
+mason external does not yet work on linux32 due to a bug in spack
+"""
+
+from __future__ import print_function
+from os import environ
+
+print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2' or environ['CHPL_LAUNCHER'] != 'none' or environ['CHPL_TARGET_PLATFORM'] == 'linux32')
+
+

--- a/test/mason/mason-external/libtomlc99/SKIPIF
+++ b/test/mason/mason-external/libtomlc99/SKIPIF
@@ -1,14 +1,1 @@
-#!/usr/bin/env python
-
-"""
-mason requires CHPL_COMM=none (local)
-
-mason external does not yet work on linux32 due to a bug in spack
-"""
-
-from __future__ import print_function
-from os import environ
-
-print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2' or environ['CHPL_LAUNCHER'] != 'none' or environ['CHPL_TARGET_PLATFORM'] == 'linux32')
-
-
+../SKIPIF

--- a/test/mason/mason-external/libtomlc99/mason-external.skipif
+++ b/test/mason/mason-external/libtomlc99/mason-external.skipif
@@ -1,1 +1,0 @@
-../../suseSkipif

--- a/test/mason/mason-external/masonExternalRanges/SKIPIF
+++ b/test/mason/mason-external/masonExternalRanges/SKIPIF
@@ -1,14 +1,1 @@
-#!/usr/bin/env python
-
-"""
-mason requires CHPL_COMM=none (local)
-
-mason external does not yet work on linux32 due to a bug in spack
-"""
-
-from __future__ import print_function
-from os import environ
-
-print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2' or environ['CHPL_LAUNCHER'] != 'none' or environ['CHPL_TARGET_PLATFORM'] == 'linux32')
-
-
+../SKIPIF

--- a/test/mason/suseSkipif
+++ b/test/mason/suseSkipif
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#
+# This file serves as a template for other SKIPIFs and .skipifs to symlink
+#
+
 # Skip this test for SuSE 11 and earlier. It requires an OpenSSL version that
 # is newer than is available on SuSe 11 due to github requirements.
 if [ -f /etc/SuSE-release ] ; then


### PR DESCRIPTION
- Skip all mason external tests if SSL is outdated
- Have all mason external tests symlink to the same SKIPIF to improve maintainability

This should resolve the ongoing whitebox failure for `mason-external/masonExternalRanges` test.