### PR TITLE
Adjust the CPU type for Shasta systems.

### DIFF
--- a/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
@@ -344,7 +344,11 @@ else
     #[TODO] gen_version_intel=
     #[TODO] gen_version_cce=
 
-    target_cpu_module=craype-sandybridge
+    if [ "$CRAYPE_NETWORK_TARGET" == slingshot* ]; then
+        target_cpu_module=craype-x86-rome
+    else
+        target_cpu_module=craype-sandybridge
+    fi
 
     function load_prgenv_gnu() {
 

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -488,11 +488,20 @@ class InvalidLocationError(ValueError):
 # cpu architecture is actually loaded. Note that this MUST be kept in sync with
 # what we have in the module build script.
 def get_module_lcd_cpu(platform_val, cpu):
-    if platform_val == "cray-xc" or platform_val == "cray-shasta":
+    if platform_val == "cray-xc":
         if is_known_arm(cpu):
             return "arm-thunderx2"
         else:
             return "sandybridge"
+    elif platform_val == "cray-shasta":
+        if is_known_arm(cpu):
+            return "none"    # we don't know what we need here yet
+        else:
+            cray_network = os.environ.get('CRAYPE_NETWORK_TARGET', 'none')
+            if cray_network.startswith("slingshot"):
+                return "x86-rome"       # We're building on a Shasta system!
+            else:
+                return "sandybridge"    # We're still building on an XC.
     elif platform_val == "cray-xe" or platform_val == "cray-xk":
         return "barcelona"
     elif platform_val == "aarch64":


### PR DESCRIPTION
The introductory product information for the Shasta public announcement
says that the CPUs in the first systems will be "AMD® EPYC® 7002".
These seem to be equivalent to the "rome" codename, and indeed the
default CPU module on one Shasta system I checked is craype-x86-rome.
Here, take this is the least-common-denominator CPU type for Shasta, at
least when we're on a Shasta system and can make use of it.  (When on
other system types, notably for ongoing module builds, we'll still use
sandybridge.)

I've tested this on an XC, which is where we're currently building Shasta
modules, and it works as before.  I haven't tested it on a Shasta system
yet, but we're not building on one anyway.