### PR TITLE
Fix gcc 10 incompatibilities

### DIFF
--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -316,7 +316,7 @@ Vec<C,S>::move_internal(Vec<C,S> &vv)  {
   i = vv.i;
   v = vv.v;
   if (vv.v == &vv.e[0]) { 
-    memcpy(e, &vv.e[0], sizeof(e));
+    memcpy((void*)e, &vv.e[0], sizeof(e));
     v = e;
   } else
     vv.v = 0;
@@ -333,7 +333,7 @@ Vec<C,S>::copy(const Vec<C,S> &vv)  {
   n = vv.n;
   i = vv.i;
   if (vv.v == &vv.e[0]) { 
-    memcpy(e, &vv.e[0], sizeof(e));
+    memcpy((void*)e, &vv.e[0], sizeof(e));
     v = e;
   } else {
     if (vv.v) 

--- a/runtime/include/chpl-comm-callbacks-internal.h
+++ b/runtime/include/chpl-comm-callbacks-internal.h
@@ -38,7 +38,7 @@
 //    }
 //
 
-int chpl_comm_callback_counts[chpl_comm_cb_num_event_kinds];
+extern int chpl_comm_callback_counts[chpl_comm_cb_num_event_kinds];
 
 static inline
 int chpl_comm_have_callbacks(chpl_comm_cb_event_kind_t event_kind) {

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -78,8 +78,8 @@ typedef struct _chpl_atomic_commDiagnostics {
 #undef _COMM_DIAGS_DECL_ATOMIC
 } chpl_atomic_commDiagnostics;
 
-chpl_atomic_commDiagnostics chpl_comm_diags_counters;
-atomic_int_least16_t chpl_comm_diags_disable_flag;
+extern chpl_atomic_commDiagnostics chpl_comm_diags_counters;
+extern atomic_int_least16_t chpl_comm_diags_disable_flag;
 
 static inline
 void chpl_comm_diags_init(void) {

--- a/runtime/include/chpl-tasks-callbacks-internal.h
+++ b/runtime/include/chpl-tasks-callbacks-internal.h
@@ -31,7 +31,7 @@
 // Don't refer to this directly.  It's only here in public to support
 // reducing overhead by inlining the test for >0.
 //
-int chpl_task_callback_counts[chpl_task_cb_num_event_kinds];
+extern int chpl_task_callback_counts[chpl_task_cb_num_event_kinds];
 
 
 void chpl_task_do_callbacks_internal(chpl_task_cb_event_kind_t,

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -39,6 +39,9 @@ int chpl_verbose_comm = 0;
 int chpl_comm_diagnostics = 0;
 int chpl_comm_diags_print_unstable = 0;
 
+atomic_int_least16_t chpl_comm_diags_disable_flag;
+chpl_atomic_commDiagnostics chpl_comm_diags_counters;
+
 static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
 
 

--- a/runtime/src/chpl-tasks-callbacks.c
+++ b/runtime/src/chpl-tasks-callbacks.c
@@ -28,7 +28,6 @@
 #include "chpl-tasks-callbacks.h"
 #include "chpl-tasks-callbacks-internal.h"
 
-
 //
 // Tasking callback support.
 //
@@ -38,6 +37,8 @@ static struct cb_info {
   chpl_task_cb_fn_t fns[MAX_CBS_PER_EVENT];
   chpl_task_cb_info_kind_t info_kinds[MAX_CBS_PER_EVENT];
 } cb_info[chpl_task_cb_num_event_kinds];
+
+int chpl_task_callback_counts[chpl_task_cb_num_event_kinds] = {0};
 
 
 //


### PR DESCRIPTION
Fix gcc 10 incompatibilities

- Cast some compiler memcpy's to void* to avoid -Werror=class-memaccess
  - gcc 10 is catching more cases, but we ran into this with gcc 9 too.
    See a0904cd213 for more info.

- Make globals in runtime headers extern
  - GCC 10 made -fno-common the default, and there were a couple places
    where we were relying on -fcommon behavior. Fix this by making our
    declarations in .h files extern and adding the definitions in the .c
    files. See https://gcc.gnu.org/gcc-10/porting_to.html for more info

Resolves https://github.com/chapel-lang/chapel/issues/15657
Resolves https://github.com/chapel-lang/chapel/issues/15761