### PR TITLE
Pin our cray-libsci version for the gnu module build

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -285,8 +285,9 @@ else
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
 
-        # pin an older version of MPICH that works with gen_version_gcc
+        # pin to versions of mpich/libsci that work with gen_version_gcc
         load_module_version cray-mpich 7.7.13
+        load_module_version cray-libsci 19.06.1
     }
 
     function load_prgenv_cray() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -354,8 +354,9 @@ else
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
 
-        # pin an older version of MPICH that works with gen_version_gcc
+        # pin to versions of mpich/libsci that work with gen_version_gcc
         load_module_version cray-mpich 7.7.13
+        load_module_version cray-libsci 19.06.1
     }
 
     function load_prgenv_intel() {


### PR DESCRIPTION
Pin to 19.06.1 to remain compatible with our current gen compiler