### PR TITLE
Add nightly gcc 10.1 testing

### DIFF
--- a/util/cron/test-linux64-gcc101.bash
+++ b/util/cron/test-linux64-gcc101.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with compiler gcc-10.1
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+source /data/cf/chapel/setup_gcc101.bash     # host-specific setup for target compiler
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc101"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
We had a number of incompatibilities with gcc 10. Now that they're
fixed (#15763), add nightly testing to lock this in.

Closes https://github.com/Cray/chapel-private/issues/1018