### PR TITLE
Fix problems with isDefaultInitializable

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1878,7 +1878,7 @@ static Expr* unrollHetTupleLoop(CallExpr* call, Expr* tupExpr, Type* iterType) {
     tmp->addFlag(FLAG_REF_VAR);
 
     // create the AST for 'tupleTemp = tuple.field'
-    // 
+    //
     VarSymbol* field = new_CStringSymbol(tupType->getField(i)->name);
     noop->insertBefore(new DefExpr(tmp));
     noop->insertBefore(new CallExpr(PRIM_MOVE, tmp,

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -253,21 +253,6 @@ static bool recordContainsOwned(Type* t) {
 
   return false;
 }
-static bool recordContainsNonNilable(Type* t) {
-  if (isNonNilableClassType(t))
-    return true;
-
-  if (isRecord(t)) {
-    AggregateType* at = toAggregateType(t);
-
-    for_fields(field, at) {
-      if (recordContainsNonNilable(field->getValType()))
-        return true;
-    }
-  }
-
-  return false;
-}
 
 static bool isNonNilableOwned(Type* t) {
   return isManagedPtrType(t) &&
@@ -380,63 +365,7 @@ static void setRecordAssignableFlags(AggregateType* at) {
   }
 }
 
-static void setRecordDefaultValueFlags(AggregateType* at) {
-  TypeSymbol* ts = at->symbol;
-
-  if (!ts->hasFlag(FLAG_TYPE_DEFAULT_VALUE) &&
-      !ts->hasFlag(FLAG_TYPE_NO_DEFAULT_VALUE)) {
-
-    if (isNonNilableClassType(at)) {
-      ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
-    } else if (isNilableClassType(at)) {
-      ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-    } else if (at->symbol->hasFlag(FLAG_TUPLE)) {
-      Flag flag = FLAG_TYPE_DEFAULT_VALUE;
-      for_fields(field, at) {
-        if (field->isRef()) continue;
-        if (AggregateType* at = toAggregateType(field->getValType())) {
-          setRecordDefaultValueFlags(at);
-          if (at->symbol->hasFlag(FLAG_TYPE_NO_DEFAULT_VALUE)) {
-            flag = FLAG_TYPE_NO_DEFAULT_VALUE;
-            break;
-          }
-        }
-      }
-      ts->addFlag(flag);
-    } else if (Type* eltType = arrayElementType(at)) {
-      if (AggregateType* eltTypeAt = toAggregateType(eltType)) {
-        setRecordAssignableFlags(eltTypeAt);
-
-        if (eltType->symbol->hasFlag(FLAG_TYPE_DEFAULT_VALUE))
-          at->symbol->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-        else if (eltType->symbol->hasFlag(FLAG_TYPE_NO_DEFAULT_VALUE))
-          at->symbol->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
-      } else {
-         at->symbol->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-      }
-
-
-    } else if (at->symbol->hasFlag(FLAG_EXTERN)) {
-      // Currently extern records aren't initialized at all by default.
-      // But it's not necessarily reasonable to expect them to have
-      // initializers. See issue #7992.
-      ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-    } else {
-      // Try resolving a test init() to set the flags
-      FnSymbol* initZero = findZeroArgInitFn(at);
-      if (initZero == NULL) {
-        ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
-      } else if (initZero->hasFlag(FLAG_COMPILER_GENERATED)) {
-        if (recordContainsNonNilable(at))
-          ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
-        else
-          ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-      } else {
-        ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-      }
-    }
-  }
-}
+static void setRecordDefaultValueFlags(AggregateType* at);
 
 static bool isDefaultInitializable(Type* t) {
   bool val = true;
@@ -455,6 +384,66 @@ static bool isDefaultInitializable(Type* t) {
 
   return val;
 }
+
+static void setRecordDefaultValueFlags(AggregateType* at) {
+  TypeSymbol* ts = at->symbol;
+
+  if (!ts->hasFlag(FLAG_TYPE_DEFAULT_VALUE) &&
+      !ts->hasFlag(FLAG_TYPE_NO_DEFAULT_VALUE)) {
+
+    if (isNonNilableClassType(at)) {
+      ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
+    } else if (isNilableClassType(at)) {
+      ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
+    } else if (Type* eltType = arrayElementType(at)) {
+      if (isDefaultInitializable(eltType)) {
+        ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
+      } else {
+        ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
+      }
+
+    } else if (at->symbol->hasFlag(FLAG_EXTERN)) {
+      // Currently extern records aren't initialized at all by default.
+      // But it's not necessarily reasonable to expect them to have
+      // initializers. See issue #7992.
+      ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
+    } else {
+
+      if (at->hasUserDefinedInit == false ||
+          at->symbol->hasFlag(FLAG_TUPLE)) {
+        // For records with compiler-generated default init,
+        // or for tuples, first consider the fields.
+        // If any of the fields prohibit
+        // default initialization, return before trying
+        // to resolve the init() function.
+        bool failsDefaultInit = false;
+        for_fields(field, at) {
+          Type* fieldType = field->getValType(); // val type for tuples
+          if (isDefaultInitializable(fieldType) == false) {
+            // check for default value
+            if (field->defPoint->init == NULL) {
+              failsDefaultInit = true;
+              break;
+            }
+          }
+        }
+        if (failsDefaultInit) {
+          ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
+          return;
+        }
+      }
+
+      // Try resolving a test init() to set the flags
+      FnSymbol* initZero = findZeroArgInitFn(at);
+      if (initZero == NULL) {
+        ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
+      } else {
+        ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
+      }
+    }
+  }
+}
+
 
 static Expr* preFoldPrimOp(CallExpr* call) {
   Expr* retval = NULL;

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -390,7 +390,19 @@ static void setRecordDefaultValueFlags(AggregateType* at) {
       ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
     } else if (isNilableClassType(at)) {
       ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
-
+    } else if (at->symbol->hasFlag(FLAG_TUPLE)) {
+      Flag flag = FLAG_TYPE_DEFAULT_VALUE;
+      for_fields(field, at) {
+        if (field->isRef()) continue;
+        if (AggregateType* at = toAggregateType(field->getValType())) {
+          setRecordDefaultValueFlags(at);
+          if (at->symbol->hasFlag(FLAG_TYPE_NO_DEFAULT_VALUE)) {
+            flag = FLAG_TYPE_NO_DEFAULT_VALUE;
+            break;
+          }
+        }
+      }
+      ts->addFlag(flag);
     } else if (Type* eltType = arrayElementType(at)) {
       if (AggregateType* eltTypeAt = toAggregateType(eltType)) {
         setRecordAssignableFlags(eltTypeAt);

--- a/test/library/standard/Types/copyable-nonnilable-records.bad
+++ b/test/library/standard/Types/copyable-nonnilable-records.bad
@@ -1,3 +1,0 @@
-copyable-nonnilable-records.chpl:76: error: Cannot default-initialize z: owned C
-note: non-nil class types do not support default initialization
-note: Consider using the type owned C? instead

--- a/test/library/standard/Types/copyable-nonnilable-records.future
+++ b/test/library/standard/Types/copyable-nonnilable-records.future
@@ -1,2 +1,0 @@
-bug: isDefaultInitializable not working with record of non-nilable owned
-#14854

--- a/test/library/standard/Types/is-default-initializable-arrays.bad
+++ b/test/library/standard/Types/is-default-initializable-arrays.bad
@@ -1,0 +1,3 @@
+is-default-initializable-arrays.chpl:5: error: Cannot default-initialize z: owned C
+note: non-nil class types do not support default initialization
+note: Consider using the type owned C? instead

--- a/test/library/standard/Types/is-default-initializable-arrays.chpl
+++ b/test/library/standard/Types/is-default-initializable-arrays.chpl
@@ -1,0 +1,17 @@
+use Types;
+
+class C { var x: int; }
+record ContainingNonNilableOwned {
+  var z: owned C;
+}
+if isDefaultInitializable(ContainingNonNilableOwned) != false {
+  compilerError("error matching ContainingNonNilableOwned");
+}
+
+proc testArrays() {
+  var A3:[1..1] ContainingNonNilableOwned = [new ContainingNonNilableOwned(new C(1))];
+  if isDefaultInitializable(A3.type) != false {
+    compilerError("error matching array of ContainingNonNilableOwned");
+  }
+}
+testArrays();

--- a/test/library/standard/Types/is-default-initializable-arrays.future
+++ b/test/library/standard/Types/is-default-initializable-arrays.future
@@ -1,0 +1,2 @@
+bug: cannot create array of non-default-initializable record
+#15233

--- a/test/library/standard/Types/is-default-initializable.chpl
+++ b/test/library/standard/Types/is-default-initializable.chpl
@@ -1,0 +1,100 @@
+use Types;
+
+class C { var x: int; }
+record ContainingNonNilableOwned {
+  var z: owned C;
+}
+if isDefaultInitializable(ContainingNonNilableOwned) != false {
+  compilerError("error matching ContainingNonNilableOwned");
+}
+
+record ContainingNonNilableOwnedAndInit {
+  var z: owned C;
+  proc init() {
+    this.z = new owned C(1);
+  }
+}
+if isDefaultInitializable(ContainingNonNilableOwnedAndInit) != true {
+  compilerError("error matching ContainingNonNilableOwnedAndInit");
+}
+
+record GenericContainingNonNilableOwnedAndInit {
+  type t;
+  var z: t;
+  proc init(type t) {
+    this.t = t;
+    this.z = new owned C(1);
+  }
+}
+if isDefaultInitializable(GenericContainingNonNilableOwnedAndInit(owned C)) != true {
+  compilerError("error matching GenericContainingNonNilableOwnedAndInit(owned C)");
+}
+
+record ContainingNonNilableWithFieldDefault {
+  var c: unmanaged object = new	unmanaged object();
+}
+if isDefaultInitializable(ContainingNonNilableWithFieldDefault) != true {
+  compilerError("error matching ContainingNonNilableWithFieldDefault");
+}
+
+record ContainingRecordWithInit {
+  var z: ContainingNonNilableOwnedAndInit;
+}
+if isDefaultInitializable(ContainingRecordWithInit) != true {
+  compilerError("error matching ContainingRecordWithInit");
+}
+
+record ContainingContainingNonNilableOwned {
+  var z: ContainingNonNilableOwned;
+}
+if isDefaultInitializable(ContainingContainingNonNilableOwned) != false {
+  compilerError("error matching ContainingContainingNonNilableOwned");
+}
+
+record ContainingDefaultContainingNonNilableOwned {
+  var z: ContainingNonNilableOwned = new ContainingNonNilableOwned(new C(1));
+}
+if isDefaultInitializable(ContainingDefaultContainingNonNilableOwned) != true {
+  compilerError("error matching ContainingDefaultContainingNonNilableOwned");
+}
+
+record NoZeroArgInit {
+  var x: int;
+  proc init(arg: int) {
+    this.x = arg;
+  }
+}
+if isDefaultInitializable(NoZeroArgInit) != false {
+  compilerError("error matching NoZeroArgInit");
+}
+
+
+if isDefaultInitializable((owned C, owned C)) != false {
+  compilerError("error matching tuple of owned");
+}
+
+if isDefaultInitializable((ContainingNonNilableOwned, ContainingNonNilableOwned)) != false {
+  compilerError("error matching tuple of ContainingNonNilableOwned");
+}
+
+if isDefaultInitializable((ContainingNonNilableWithFieldDefault, ContainingNonNilableOwnedAndInit)) != true {
+  compilerError("error matching tuple of ContainingNonNilableWithFieldDefault, ContainingNonNilableOwnedAndInit");
+}
+
+proc testArrays() {
+  var A0:[1..1] owned C? = [new owned C?(1)];
+  if isDefaultInitializable(A0.type) != true {
+    compilerError("error matching array of owned C?");
+  }
+
+  var A1:[1..1] owned C = [new owned C(1)];
+  if isDefaultInitializable(A1.type) != false {
+    compilerError("error matching array of owned C");
+  }
+
+  var A2:[1..1] ContainingNonNilableOwnedAndInit = [new ContainingNonNilableOwnedAndInit()];
+  if isDefaultInitializable(A2.type) != true {
+    compilerError("error matching array of ContainingNonNilableOwnedAndInit");
+  }
+}
+testArrays();


### PR DESCRIPTION
For #14854.

Resolves several problems with isDefaultInitializable and adds testing for the trickier cases.

- [x] primers pass with valgrind and do not leak
- [x] full local testing

Reviewed by @vasslitvinov - thanks!

Future Work:
 * Extend array checking to non-default-initializable elements #15233
 * Update conditional in ` modules/internal/ChapelArray.chpl` from [here](https://github.com/chapel-lang/chapel/pull/15571/files#diff-a0be501f0990849134d41079d80affd0R1421)
 * update call added in #15571
 * update checks related to `Can't resize domains whose arrays' elements` errors 