### PR TITLE
Don't GET domain's dimensions unless needed

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1857,9 +1857,11 @@ module DefaultRectangular {
 
     if blk(rank-1) != 1 then return false;
 
-    const domDims = dom.dsiDims();
-    for param dim in 0..(rank-2) by -1 do
-      if blk(dim) != blk(dim+1)*domDims(dim+1).size then return false;
+    if rank >= 2 {
+      const domDims = dom.dsiDims();
+      for param dim in 0..(rank-2) by -1 do
+        if blk(dim) != blk(dim+1)*domDims(dim+1).size then return false;
+    }
 
     if debugDefaultDistBulkTransfer then
       chpl_debug_writeln("\tYES!");

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.na-none.good
@@ -1,5 +1,5 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 13, put = 1, execute_on = 2, execute_on_fast = 2) (get = 13, put = 1, execute_on_fast = 2) (get = 13, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 12, put = 1, execute_on = 2, execute_on_fast = 2) (get = 12, put = 1, execute_on_fast = 2) (get = 12, put = 1, execute_on_fast = 2)
 Dom2D
 (execute_on = 4, execute_on_nb = 6) (get = 19, put = 1, execute_on = 2, execute_on_fast = 2) (get = 19, put = 1, execute_on_fast = 2) (get = 19, put = 1, execute_on_fast = 2)
 Dom3D

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.na-none.good
@@ -1,5 +1,5 @@
 Dom1D
-(get = 39, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 39, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 39, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 39, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 36, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 36, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D
 (get = 57, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 57, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 57, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 57, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom3D


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/15239

As an optimization, that PR started storing dimensions of the domain in a local
variable in `DefaultRectangular.isDataContiguous`, but that's not needed unless
the domain is multidimensional.

This is the cause of the comm count increase in

https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2020/03/02&enddate=2020/06/04&graphs=arrayassignget

This may also impact other perf tests, but I don't expect a huge change in
performance, but maybe only reduced communication in some.

Test:
- [x] standard
- [x] gasnet
