### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -411,7 +411,7 @@ all:
   01/17/20:
     - Adjust point of deinitialization based on expiring value analysis (#14691)
   02/07/20:
-    - text: machine update
+    - text: machine update (McAfee)
       config: chapcs
   02/19/20:
     - text:  Serialize calls to gasnet_AMPoll for IBV/Aries (#14912)
@@ -428,6 +428,9 @@ all:
       config: chapcs.comm-counts
   05/26/20:
     - Adjust array copy initialization to avoid default-init/assign (#15239)
+  05/28/20:
+    - text: machine update (McAfee)
+      config: chapcs
 
 
 AllCompTime: &timecomp-base
@@ -663,6 +666,8 @@ distCreate-arrays-deinit.cc-perf: &distCreate-base
     - Rewrite ddata_allocate() to avoid inadvertent widening of init_elts() (#15275)
   03/26/20:
     - Make locale-related comm improvements (#15288)
+  06/02/20:
+    - Address performance issues with stencil and block-cyclic array init (#15741)
 
 distCreate-arrays-init.cc-perf:
   <<: *distCreate-base
@@ -968,6 +973,8 @@ LCALS-parallel-long:
 listBenchmark1:
   05/04/20:
     - Change lists to use 0-based indexing (#14684)
+  06/03/20:
+    - List _collapse remove shift arg (#15693)
 
 lulesh:
   03/15/14:
@@ -1371,6 +1378,14 @@ nbody:
 no-op:
   02/24/17:
     - upgrade hwloc to 1.11.6 (#5411)
+
+one-locale-parallel-amos.ml-perf:
+  06/02/20:
+    - Improve MCM enforcement for AM-mediated nonfetching AMOs (#15712)
+
+one-locale-serial-amos.ml-perf:
+  06/02/20:
+    - Improve MCM enforcement for AM-mediated nonfetching AMOs (#15712)
 
 parOpEquals:
   09/06/13:


### PR DESCRIPTION
Adds the following annotations:

- [Stencil and BlockCyc performance improvements](https://chapel-lang.org/perf/16-node-xc/?startdate=2020/05/07&enddate=2020/06/02&graphs=creatingdistributeddomains,creatingdistributedarrays1elementperlocale,creatingdistributedarrays1melements,creatingdistributedarrays14ofavailablememory)

- [List PopBack regression](https://chapel-lang.org/perf/chapcs/?startdate=2020/05/19&enddate=2020/06/04&graphs=listoperations)

- [AMO improvements on OFI](https://chapel-lang.org/perf/16-node-cs/?startdate=2020/04/12&enddate=2020/06/04&graphs=serial1localeremoteamoperformance,parallel1localeremoteamoperformance)

- Also adds a new McAfee annotation and marks an existing annotation with
  `(McAfee)`
