### PR TITLE
Apply workaround for not split-initing sync variable

### DIFF
--- a/test/parallel/taskPool/figueroa/TooManyThreads.chpl
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.chpl
@@ -25,6 +25,8 @@ var total: int,
     count: int = numThreads,
      done: sync bool,
     ready: sync bool;
+ensureDefaultInit(ready);
+proc ensureDefaultInit(arg) { }
 
 proc foo (x) {
 

--- a/test/users/ferguson/sync-in-loop.chpl
+++ b/test/users/ferguson/sync-in-loop.chpl
@@ -32,6 +32,9 @@ proc dobegin() {
       // Run another begin
       order$ = true;
       if debug then writeln("after writes");
+
+      // wait for order$ to be empty again
+      order$ = true;
     }
     if debug then writeln("end of loop");
   }

--- a/test/users/ferguson/sync-in-loop.future
+++ b/test/users/ferguson/sync-in-loop.future
@@ -1,3 +1,0 @@
-bug: sync variable in loop
-
-This program crashes with a pthreads error.

--- a/test/users/ferguson/sync-in-loop.skipif
+++ b/test/users/ferguson/sync-in-loop.skipif
@@ -1,1 +1,0 @@
-CHPL_TASKS!=fifo


### PR DESCRIPTION
This PR includes two test changes:

 * Applies a workaround to 
   test/parallel/taskPool/figueroa/TooManyThreads.chpl - see also issue
   #15756
 * Un-futures test/users/ferguson/sync-in-loop.chpl after fixing an error
   in the program

Tests change only, not reviewed.
