### PR TITLE
Fortify mason testing

### DIFF
--- a/test/mason/EXECENV
+++ b/test/mason/EXECENV
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
+# Ensure mason in PATH
 bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
 echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
+
+# Mason envs
 echo "MASON_HOME=\$PWD/mason_home"
 # Note, this registry should only ever be used by mason update tests
 echo "MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry"
 echo "MASON_OFFLINE=false"
-
+echo "SPACK_ROOT=\$PWD/mason_home/spack"

--- a/test/mason/env/COMPOPTS
+++ b/test/mason/env/COMPOPTS
@@ -1,1 +1,1 @@
--M ../../../tools/mason/
+../COMPOPTS

--- a/test/mason/env/EXECENV
+++ b/test/mason/env/EXECENV
@@ -1,4 +1,1 @@
-#!/usr/bin/env bash
-
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
+../EXECENV

--- a/test/mason/env/mason-env.good
+++ b/test/mason/env/mason-env.good
@@ -1,22 +1,22 @@
 MASON_HOME: $PWD *
 MASON_REGISTRY: mason-registry|https://github.com/chapel-lang/mason-registry
 MASON_OFFLINE: false
-SPACK_ROOT: $PWD/spack
+SPACK_ROOT: $PWD/mason_home/spack *
 ----------
 MASON_HOME: $PWD *
 MASON_REGISTRY: foobar|foobar *
 MASON_OFFLINE: false
-SPACK_ROOT: $PWD/spack
+SPACK_ROOT: $PWD/mason_home/spack *
 ----------
 MASON_HOME: $PWD *
 MASON_REGISTRY: mason-registry|https://github.com/chapel-lang/mason-registry
 MASON_OFFLINE: true *
-SPACK_ROOT: $PWD/spack
+SPACK_ROOT: $PWD/mason_home/spack *
 ---------
 MASON_HOME: $PWD *
 MASON_REGISTRY: mason-registry|https://github.com/chapel-lang/mason-registry
 MASON_OFFLINE: false
-SPACK_ROOT: $PWD/spack
+SPACK_ROOT: $PWD/mason_home/spack *
 MASON_CACHED_REGISTRY: $PWD/mason-registry
 ----------
 Print environment variables recognized by mason

--- a/test/mason/env/mason-registry.good
+++ b/test/mason/env/mason-registry.good
@@ -1,7 +1,7 @@
 MASON_HOME: $PWD/tempHome *
 MASON_REGISTRY: myRegistry|$PWD/tempHome/uncached/myRegistry *
 MASON_OFFLINE: false
-SPACK_ROOT: $PWD/tempHome/spack
+SPACK_ROOT: $PWD/mason_home/spack *
 Updating myRegistry
 multiple (0.2.0)
 simple (0.1.0)

--- a/test/mason/mason-external/libtomlc99/COMPOPTS
+++ b/test/mason/mason-external/libtomlc99/COMPOPTS
@@ -1,1 +1,1 @@
--M ../../../../tools/mason/
+../../COMPOPTS

--- a/test/mason/mason-external/masonExternalRanges/COMPOPTS
+++ b/test/mason/mason-external/masonExternalRanges/COMPOPTS
@@ -1,1 +1,1 @@
--M ../../../../tools/mason/
+../../COMPOPTS


### PR DESCRIPTION
This PR fixes recent nightly testing failures by updating the `EXECENV` files to set `SPACK_ROOT` as well. This is necessary now because our testing machines are now using Spack outside of mason and have `SPACK_ROOT` set by default.

It also makes a few related changes to improve maintainability of mason testing:

- Switches `EXECENV` files to symlinks to the main `EXECENV` when possible.
- Switches `COMPOPTS` files to symlink to main `COMPOPTS` when possible.
- Utilizes `CHPL_HOME` instead of relative paths in `COMPOPTS`  (allowing us to use a symlink)
- Adds `mason_home.notest` files to avoid the verbose listing of every `mason_home` subdirectory in the test output.

Testing:

- [x] `start_test test/mason` (local OS X)