### PR TITLE
Remove leftover git conflict resolution marker

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -43,7 +43,6 @@ Creating :mod:`Bytes`
 As :mod:`Bytes` can store arbitrary data, any :mod:`~String` can be
 cast to :mod:`Bytes`. In that event, the bytes will store UTF-8 encoded
 character data. However, a :mod:`Bytes` can contain non-UTF-8 bytes and needs
->>>>>>> master
 to be decoded to be converted to string.
 
 .. code-block:: chapel


### PR DESCRIPTION
Accidentally left a git conflict resolution marker in my bytes documentation refactor PR