### PR TITLE
add "make mason" check for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ compiler:
 matrix:
   include:
     - name: "make check"
-      env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
+      env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SKIP_MAKE_MASON=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
+
+    - name: "make mason"
+      env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SKIP_MAKE_CHECK=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
 
     - name: "make check-chpldoc && make docs"
-      env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true TEST_COMMAND="./util/buildRelease/smokeTest"
+      env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true CHPL_SKIP_MAKE_MASON=true TEST_COMMAND="./util/buildRelease/smokeTest"
 
     - name: "check annotations"
       env: TEST_COMMAND="make test-venv && CHPL_HOME=$PWD ./util/run-in-venv.bash ./util/test/check_annotations.py"

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -88,7 +88,10 @@ source $CHPL_HOME/util/cron/common.bash
 
 # Disable GMP and re2 to speed up build.
 export CHPL_GMP=none
-export CHPL_REGEXP=none
+
+if [ "${CHPL_SKIP_MAKE_MASON}" == "true" ] ; then
+  export CHPL_REGEXP=none
+fi
 
 echo ""
 
@@ -128,3 +131,10 @@ if [ "${CHPL_SMOKE_SKIP_DOC}" != "true" ] ; then
         make $chpl_make_args check-chpldoc && \
         make docs || exit 2
 fi
+
+if [ "${CHPL_SKIP_MAKE_MASON}" != "true" ] ; then
+    # Build Mason 
+    make -j${num_procs} $chpl_make_args && \
+        make $chpl_make_args mason || exit 2 
+fi
+


### PR DESCRIPTION
part of #6758 
There were several instances when mason broke on master. Therefore, adding a Travis job for "make mason".