### PR TITLE
improved mason search

### DIFF
--- a/test/mason/search/no-pattern.good
+++ b/test/mason/search/no-pattern.good
@@ -1,3 +1,3 @@
-multiVersion (1.0.0)
 WithCaps (0.1.0)
 capsize (0.1.0)
+multiVersion (1.0.0)

--- a/test/mason/search/no-pattern.good
+++ b/test/mason/search/no-pattern.good
@@ -1,3 +1,3 @@
-capsize (0.1.0)
 multiVersion (1.0.0)
 WithCaps (0.1.0)
+capsize (0.1.0)

--- a/test/mason/search/no-pattern.good
+++ b/test/mason/search/no-pattern.good
@@ -1,3 +1,3 @@
-WithCaps (0.1.0)
 capsize (0.1.0)
 multiVersion (1.0.0)
+WithCaps (0.1.0)

--- a/test/mason/search/show.good
+++ b/test/mason/search/show.good
@@ -1,4 +1,4 @@
-WithCaps (0.1.0)
 capsize (0.1.0)
+WithCaps (0.1.0)
 "caps"  returned more than one package.
 --show requires the search to return one package.

--- a/test/mason/search/substring.good
+++ b/test/mason/search/substring.good
@@ -1,2 +1,2 @@
-WithCaps (0.1.0)
 capsize (0.1.0)
+WithCaps (0.1.0)

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -89,18 +89,7 @@ proc masonSearch(ref args: list(string)) {
       }
     }
   }
-  // Sort the results in a order such that results that startWith needle
-  // are displayed first 
-  use Sort;
-  record Comparator { }
-  proc Comparator.compare(a, b) {
-    if a.toLower().startsWith(query) && !b.toLower().startsWith(query) then return -1;
-    else if !a.toLower().startsWith(query) && b.toLower().startsWith(query) then return 1;
-    else return -1;
-  }
-  var cmp : Comparator;
-  var res = results.toArray();
-  sort(res, comparator = cmp);
+  var res = rankResults(results, query);
   for r in res do writeln(r);
   
   // Handle --show flag
@@ -128,6 +117,23 @@ proc masonSearch(ref args: list(string)) {
   if results.size == 0 {
     exit(1);
   }
+}
+
+
+// Sort the results in a order such that results that startWith needle
+// are displayed first 
+proc rankResults(results, query) {
+  use Sort;
+  record Comparator { }
+  proc Comparator.compare(a, b) {
+    if a.toLower().startsWith(query) && !b.toLower().startsWith(query) then return -1;
+    else if !a.toLower().startsWith(query) && b.toLower().startsWith(query) then return 1;
+    else return -1;
+  }
+  var cmp : Comparator;
+  var res = results.toArray();
+  sort(res, comparator = cmp);
+  return res;
 }
 
 proc isHidden(name : string) : bool {

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -133,7 +133,9 @@ proc rankResults(results, query) {
   var cmp : Comparator;
   var res = results.toArray();
   sort(res, comparator = cmp);
-  return res;
+  if query != ".*" then
+    return res;
+  else return res.sorted();
 }
 
 proc isHidden(name : string) : bool {

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -120,8 +120,8 @@ proc masonSearch(ref args: list(string)) {
 }
 
 
-// Sort the results in a order such that results that startWith needle
-// are displayed first 
+/* Sort the results in a order such that results that startWith needle
+   are displayed first */
 proc rankResults(results, query) {
   use Sort;
   record Comparator { }

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -122,7 +122,7 @@ proc masonSearch(ref args: list(string)) {
 
 /* Sort the results in a order such that results that startWith needle
    are displayed first */
-proc rankResults(results, query) {
+proc rankResults(results: list(string), query: string): [] string {
   use Sort;
   record Comparator { }
   proc Comparator.compare(a, b) {
@@ -132,10 +132,9 @@ proc rankResults(results, query) {
   }
   var cmp : Comparator;
   var res = results.toArray();
-  sort(res, comparator = cmp);
-  if query != ".*" then
-    return res;
-  else return res.sorted();
+  if query == ".*" then sort(res);
+  else sort(res, comparator=cmp);
+  return res;
 }
 
 proc isHidden(name : string) : bool {

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -128,7 +128,7 @@ proc rankResults(results, query) {
   proc Comparator.compare(a, b) {
     if a.toLower().startsWith(query) && !b.toLower().startsWith(query) then return -1;
     else if !a.toLower().startsWith(query) && b.toLower().startsWith(query) then return 1;
-    else return -1;
+    else return 1;
   }
   var cmp : Comparator;
   var res = results.toArray();

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -53,7 +53,6 @@ proc masonSearch(ref args: list(string)) {
 
   const show = hasOptions(args, "--show");
   const debug = hasOptions(args, "--debug");
-
   updateRegistry("", args);
 
   consumeArgs(args);
@@ -62,7 +61,6 @@ proc masonSearch(ref args: list(string)) {
   const query = if args.size > 0 then args[args.size-1].toLower()
                 else ".*";
   const pattern = compile(query, ignoreCase=true);
-
   var results: list(string);
   var packages: list(string);
   var versions: list(string);
@@ -73,7 +71,6 @@ proc masonSearch(ref args: list(string)) {
 
     for dir in listdir(searchDir, files=false, dirs=true) {
       const name = dir.replace("/", "");
-
       if pattern.search(name) {
         if isHidden(name) {
           if debug {
@@ -92,8 +89,19 @@ proc masonSearch(ref args: list(string)) {
       }
     }
   }
-
-  for r in results.toArray().sorted() do writeln(r);
+  // Sort the results in a order such that results that startWith needle
+  // are displayed first 
+  use Sort;
+  record Comparator { }
+  proc Comparator.compare(a, b) {
+    if a.toLower().startsWith(query) && !b.toLower().startsWith(query) then return -1;
+    else if !a.toLower().startsWith(query) && b.toLower().startsWith(query) then return 1;
+    else return -1;
+  }
+  var cmp : Comparator;
+  var res = results.toArray();
+  sort(res, comparator = cmp);
+  for r in res do writeln(r);
   
   // Handle --show flag
   if show {


### PR DESCRIPTION
fixes #15788

Improved search command to show package names in proper order to a corresponding query. 
```
$ > mason search lo
Logging (0.1.0)
LocalAtomics (0.1.0)
Gnuplot (0.1.0)
```