### PR TITLE
Explicitly cast string length to uint to avoid a backend error

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -133,7 +133,7 @@ module ByteBufferHelpers {
 
   inline proc bufferMemcpyLocal(dst: bufferType, src, len: int,
                                 dst_off: int=0, src_off: int=0) {
-    c_memcpy(dst:bufferType+dst_off, src:bufferType+src_off, len);
+    c_memcpy(dst:bufferType+dst_off, src:bufferType+src_off, len:uint(64));
   }
 
   inline proc bufferMemmoveLocal(dst: bufferType, src, len: int,


### PR DESCRIPTION
When we call `c_memcpy` in the string/bytes internals, we pass the length
(an `int`) directly. This is `safeCast` to `uint(64)` by the `c_memcpy`
implementation. However, this causes backend failures when trying to
`make DEBUG=0 WARNINGS=1 OPTIMIZE=1 mason`. This causes
smoketest failures.

I have tried calling `safeCast` in this module here, but it also causes the same
failures. I hope to take another look at this soon, but until then, this should
clear the error.

Test:
- [x] `make DEBUG=0 WARNINGS=1 OPTIMIZE=1 mason` with gcc 8.3
- [x] standard