### PR TITLE
Allow no-op AMs from the AM handler.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2571,7 +2571,6 @@ void amRequestFree(c_nodeid_t node, void* p) {
 
 static inline
 void amRequestNop(c_nodeid_t node, chpl_bool blocking) {
-  assert(!isAmHandler);
   amRequest_t req = { .b = { .op = am_opNop,
                              .node = chpl_nodeID, }, };
   amRequestCommon(node, &req, sizeof(req.b),


### PR DESCRIPTION
Liveness checks are implemented using no-op AMs initiated from the AM
handler itself.  But there's an assertion that we're not the AM handler
in the no-op AM function!  Remove it.  (This hasn't caused problems in
regular testing because the assert is effectively compiled out in a
non-debug build.)