### PR TITLE
Fix isDefaultInitializable for domains

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -402,6 +402,11 @@ static void setRecordDefaultValueFlags(AggregateType* at) {
         ts->addFlag(FLAG_TYPE_NO_DEFAULT_VALUE);
       }
 
+    } else if (isRecordWrappedType(at)) {
+      // domain or distribution
+      // these have default values today
+      ts->addFlag(FLAG_TYPE_DEFAULT_VALUE);
+
     } else if (at->symbol->hasFlag(FLAG_EXTERN)) {
       // Currently extern records aren't initialized at all by default.
       // But it's not necessarily reasonable to expect them to have

--- a/test/library/standard/Types/is-default-initializable.chpl
+++ b/test/library/standard/Types/is-default-initializable.chpl
@@ -98,3 +98,18 @@ proc testArrays() {
   }
 }
 testArrays();
+
+proc test11() {
+  var d = {1..10};
+  assert(isDefaultInitializable(d.type));
+  assert(isDefaultInitializable(d));
+  var dd: d.type;
+}
+test11();
+
+proc test12() {
+  assert(isDefaultInitializable(defaultDist.type));
+  assert(isDefaultInitializable(defaultDist));
+  var dd: defaultDist.type;
+}
+test11();


### PR DESCRIPTION
Domains don't currently support initialization with `init()`, so adjust
isDefaultInitializable support in the compiler to treat domains
specially. Also considers distributions specially, so that all the
record-wrapped types (arrays, domains, distributions) are handled
directly in isDefaultInitializable. Resolves problems with a case that is
added to the test is-default-initializable.chpl.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local futures testing
