### PR TITLE
Add missing mason testing COMPOPTS

### DIFF
--- a/test/mason/COMPOPTS
+++ b/test/mason/COMPOPTS
@@ -1,0 +1,1 @@
+-M ${CHPL_HOME}/tools/mason/


### PR DESCRIPTION
With great power comes great responsibility. The unreviewed PR I merged over the weekend (https://github.com/chapel-lang/chapel/pull/15785) mistakenly deleted the COMPOPTS that other COMOPTS files symlink to now. This PR adds it back in.