### PR TITLE
Additional check for `make mason` in smokeTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ compiler:
 matrix:
   include:
     - name: "make check"
-      env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SKIP_MAKE_MASON=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
+      env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SMOKE_SKIP_MAKE_MASON=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
 
     - name: "make mason"
       env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SKIP_MAKE_CHECK=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
 
     - name: "make check-chpldoc && make docs"
-      env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true CHPL_SKIP_MAKE_MASON=true TEST_COMMAND="./util/buildRelease/smokeTest"
+      env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true CHPL_SMOKE_SKIP_MAKE_MASON=true TEST_COMMAND="./util/buildRelease/smokeTest"
 
     - name: "check annotations"
       env: TEST_COMMAND="make test-venv && CHPL_HOME=$PWD ./util/run-in-venv.bash ./util/test/check_annotations.py"

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -89,6 +89,12 @@ source $CHPL_HOME/util/cron/common.bash
 # Disable GMP and re2 to speed up build.
 export CHPL_GMP=none
 
+# mason currently requires CHPL_COMM=none -- https://github.com/chapel-lang/chapel/issues/12626
+COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
+if [ "$COMM" != "none" ]; then
+  CHPL_SMOKE_SKIP_MAKE_MASON=${CHPL_SMOKE_SKIP_MAKE_MASON:-true}
+fi
+
 if [ "${CHPL_SMOKE_SKIP_MAKE_MASON}" == "true" ] ; then
   export CHPL_REGEXP=none
 fi
@@ -117,12 +123,6 @@ num_procs=$($CHPL_HOME/util/buildRelease/chpl-make-cpu_count)
 # If make check fails, store the log file in CHPL_HOME. Also, create a temp dir
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.
 export CHPL_CHECK_INSTALL_DIR=$CHPL_HOME
-
-# mason currently requires CHPL_COMM=none -- https://github.com/chapel-lang/chapel/issues/12626
-COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
-if [ "$COMM" != "none" ]; then
-  CHPL_SMOKE_SKIP_MAKE_MASON=${CHPL_SMOKE_SKIP_MAKE_MASON:-true}
-fi
 
 if [ "${CHPL_SMOKE_SKIP_MAKE_CHECK}" != "true" ] ; then
     # Compile chapel and make sure `make check` works. Compile first with parallel

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -89,7 +89,7 @@ source $CHPL_HOME/util/cron/common.bash
 # Disable GMP and re2 to speed up build.
 export CHPL_GMP=none
 
-if [ "${CHPL_SKIP_MAKE_MASON}" == "true" ] ; then
+if [ "${CHPL_SMOKE_SKIP_MAKE_MASON}" == "true" ] ; then
   export CHPL_REGEXP=none
 fi
 
@@ -118,6 +118,12 @@ num_procs=$($CHPL_HOME/util/buildRelease/chpl-make-cpu_count)
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.
 export CHPL_CHECK_INSTALL_DIR=$CHPL_HOME
 
+# mason currently requires CHPL_COMM=none -- https://github.com/chapel-lang/chapel/issues/12626
+COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
+if [ "$COMM" != "none" ]; then
+  CHPL_SMOKE_SKIP_MAKE_MASON=${CHPL_SMOKE_SKIP_MAKE_MASON:-true}
+fi
+
 if [ "${CHPL_SMOKE_SKIP_MAKE_CHECK}" != "true" ] ; then
     # Compile chapel and make sure `make check` works. Compile first with parallel
     # execution, but call `make check` without it.
@@ -132,7 +138,7 @@ if [ "${CHPL_SMOKE_SKIP_DOC}" != "true" ] ; then
         make docs || exit 2
 fi
 
-if [ "${CHPL_SKIP_MAKE_MASON}" != "true" ] ; then
+if [ "${CHPL_SMOKE_SKIP_MAKE_MASON}" != "true" ] ; then
     # Build Mason 
     make -j${num_procs} $chpl_make_args && \
         make $chpl_make_args mason || exit 2 


### PR DESCRIPTION
follow up of #15787 
added a check to disable mason testing if `CHPL_COMM!=none` 