### PR TITLE
Warm up the comm layer, in the many-to-one test.

### DIFF
--- a/test/performance/comm/low-level/many-to-one.chpl
+++ b/test/performance/comm/low-level/many-to-one.chpl
@@ -28,7 +28,7 @@ config const runSecs = 5.0;
 config const minOpsPerTimerCheck = if opNeedsTask then 10**2 else 10**3;
 
 config const printConfig = false;
-config const doWarmupPass = (CHPL_COMM == 'ofi');
+config const doWarmupPass = true;
 config const printWarmupTiming = false;
 config const printTimings = false;
 config const printCommDiags = false;

--- a/test/performance/comm/low-level/many-to-one.chpl
+++ b/test/performance/comm/low-level/many-to-one.chpl
@@ -28,6 +28,7 @@ config const runSecs = 5.0;
 config const minOpsPerTimerCheck = if opNeedsTask then 10**2 else 10**3;
 
 config const printConfig = false;
+config const printWarmupTiming = false;
 config const printTimings = false;
 config const printCommDiags = false;
 
@@ -45,6 +46,33 @@ proc main() {
             'run for ', runSecs, ' seconds');
   }
 
+  //
+  // Warm up.  This avoids including overheads associated with the
+  // first communication transactions in the measured performance.
+  // It's particularly necessary for comm=ofi with providers that
+  // connect endpoints dynamically upon first communication, for
+  // example.
+  //
+  var tWarmup: Timer;
+  tWarmup.start();
+
+  coforall locIdx in 0..#numLocales {
+    on Locales(locIdx) {
+      coforall taskIdx in 1..numTasksPerNode {
+        if locIdx > 1 {
+          on Locales(1) do emptyFn();
+        }
+      }
+    }
+  }
+
+  if printWarmupTiming {
+    writeln('Warmup time: ', tWarmup.elapsed(), 's');
+  }
+
+  //
+  // Now do the measured operations.
+  //
   if printCommDiags {
     resetCommDiagnostics();
     startCommDiagnostics();


### PR DESCRIPTION
It turns out that comm=ofi can have significant startup overhead which
occurs at the time of the first communication.  Here, add a warm-up
phase to the many-to-one test to get this overhead out of the way before
we start on the measured part of the program.

The need for this is most significant when we're using the RxM utility
provider, which supports RDM endpoints over the verbs and tcp providers.
RxM dynamically connects each endpoint pair at the time the first SEND
transaction is initiated on it.  Many-to-one is a particularly difficult
case, because for ops that involve Active Messages, such as executeOn,
all the worker endpoints have to be connected to the single target
endpoint.  The measured warm-up time with 14 36-task worker nodes, when
the program is run on 16 Cray CS Broadwell-18 nodes, is about 4 seconds.
When this time was included in the measured section it badly affected
the reported performance.