### PR TITLE
Update Sort module to number parts in keyPart from 0

### DIFF
--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -13,15 +13,15 @@ record UselessKeyPartComparator {
   proc keyPart(x, i:int) {
     if isTuple(x) {
       type tt = x(0).type;
-      if i <= x.size then
-        return (0, x(i-1));  // JUST CHANGED THIS
+      if i < x.size then
+        return (0, x(i));
       else
         return (-1, 0:tt);
 
     } else if x.type == string {
       return defaultComparator.keyPart(x, i);
     } else if isNumericType(x.type) {
-      if i == 1 then
+      if i == 0 then
         return (0, x);
       else
         return (-1, x);

--- a/test/library/packages/Sort/correctness/keyPartEnding.chpl
+++ b/test/library/packages/Sort/correctness/keyPartEnding.chpl
@@ -45,9 +45,9 @@ proc stringToTwoRepeated(arg:string) {
 record MyComparator {
   proc keyPart(arg:TwoRepeated, i:int) {
     var sum = arg.nFirst + arg.nSecond;
-    if i <= arg.nFirst then
+    if i < arg.nFirst then
       return (0, arg.first);
-    else if i <= sum then
+    else if i < sum then
       return (0, arg.second);
     else
       return (-1, 0);
@@ -70,7 +70,7 @@ proc testSort(arr) {
   // Then, sort the array as records
   var c = for s in arr do stringToTwoRepeated(s);
   var cc = new MyComparator();
-  cc.keyPart(c[1], 1);
+  cc.keyPart(c[0], 0);
   sort(c, new MyComparator());
   writeln(c);
   assert(isSorted(c, new MyComparator()));

--- a/test/library/packages/Sort/correctness/testMsbRadixSort.chpl
+++ b/test/library/packages/Sort/correctness/testMsbRadixSort.chpl
@@ -10,8 +10,8 @@ use BitOps;
  record uintCriterion8 {
    inline
    proc keyPart(x, start:int):(int(8),uint(8)) {
-     if start > 8 then return (-1:int(8), 0:uint(8));
-     var key:uint = (x:uint) >> (64 - 8*start);
+     if start >= 8 then return (-1:int(8), 0:uint(8));
+     var key:uint = (x:uint) >> (64 - 8*(start+1));
      //writef("in keyPart8(%016xu, %u)\n", x, start);
      return (0:int(8), (key & 0xff):uint(8));
    }
@@ -19,8 +19,8 @@ use BitOps;
  record uintCriterion16 {
    inline
    proc keyPart(x, start:int):(int(8),uint(16)) {
-     if start > 4 then return (-1:int(8), 0:uint(8));
-     var key:uint = (x:uint) >> (64 - 16*start);
+     if start >= 4 then return (-1:int(8), 0:uint(8));
+     var key:uint = (x:uint) >> (64 - 16*(start+1));
      //writef("in keyPart16(%016xu, %u)\n", x, start);
      return (0:int(8), (key & 0xffff):uint(16));
    }
@@ -28,8 +28,8 @@ use BitOps;
  record uintCriterion32 {
    inline
    proc keyPart(x, start:int):(int, uint(32)) {
-     if start > 2 then return (-1:int, 0:uint(32));
-     var key:uint = (x:uint) >> (64 - 32*start);
+     if start >= 2 then return (-1:int, 0:uint(32));
+     var key:uint = (x:uint) >> (64 - 32*(start+1));
      //writef("in keyPart32(%016xu, %u)\n", x, start);
      return (0:int, (key & 0xffffffff):uint(32));
    }
@@ -37,7 +37,7 @@ use BitOps;
  record uintCriterion64 {
    inline
    proc keyPart(x, start:int):(int(8), uint(64)) {
-     if start > 1 then return (-1:int(8), 0:uint(64));
+     if start >= 1 then return (-1:int(8), 0:uint(64));
      var key:uint = x:uint;
      //writef("in keyPart64(%016xu, %u)\n", x, start);
      return (0:int(8), key);
@@ -46,7 +46,7 @@ use BitOps;
  record intCriterion {
    inline
    proc keyPart(x, start:int):(int, int) {
-     if start > 1 then return (-1:int, 0:int);
+     if start >= 1 then return (-1:int, 0:int);
      //writef("in intCriterion64(%016xu, %u)\n", x, start);
      return (0:int, x);
    }
@@ -54,11 +54,11 @@ use BitOps;
  record intTupleCriterion {
    inline
    proc keyPart(x:2*int, start:int):(int, int) {
-     if start > 2 then
+     if start >= 2 then
        return (-1, 0);
 
      //writef("in intTupleCriterion(%016xu %016xu %u)\n", x(1), x(2), start);
-     return (0, x(start-1));
+     return (0, x(start));
    }
  }
  record stringCriterion {
@@ -66,8 +66,8 @@ use BitOps;
    proc keyPart(x:string, start:int):(int(8), uint(8)) {
      var ptr = x.c_str():c_ptr(uint(8));
      var len = x.numBytes;
-     var section = if start <= len then 0:int(8)     else -1:int(8);
-     var part =    if start <= len then ptr[start-1] else  0:uint(8);
+     var section = if start < len then 0:int(8)     else -1:int(8);
+     var part =    if start < len then ptr[start]   else  0:uint(8);
      return (section, part);
    }
  }

--- a/test/library/packages/Sort/errors/errors-keyPart.tIntReal.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.tIntReal.good
@@ -1,2 +1,2 @@
 errors-keyPart.chpl:9: In function 'main':
-errors-keyPart.chpl:17: error: The keyPart method in tIntReal must return a tuple with 2nd element int(?) or uint(?) when used with int(64) elements
+errors-keyPart.chpl:17: error: The keyPart method in tIntReal must return a tuple with element 1 of type  int(?) or uint(?) when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-keyPart.tStrStr.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.tStrStr.good
@@ -1,2 +1,2 @@
 errors-keyPart.chpl:9: In function 'main':
-errors-keyPart.chpl:17: error: The keyPart method in tStrStr must return a tuple with 1st element int(?) when used with int(64) elements
+errors-keyPart.chpl:17: error: The keyPart method in tStrStr must return a tuple with element 0 of type int(?) when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-keyPart.tUintInt.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.tUintInt.good
@@ -1,2 +1,2 @@
 errors-keyPart.chpl:9: In function 'main':
-errors-keyPart.chpl:17: error: The keyPart method in tUintInt must return a tuple with 1st element int(?) when used with int(64) elements
+errors-keyPart.chpl:17: error: The keyPart method in tUintInt must return a tuple with element 0 of type int(?) when used with int(64) elements


### PR DESCRIPTION
This PR updates the Sort module to number parts in the keyPart functions from 0 rather than 1. After this change, code implementing keyPart methods needs to change.

Resolves #15419.

Reviewed by @ben-albrecht - thanks!

- [x] full local futures testing