### PR TITLE
Possible Fix for failing tests on a 32 bit machine for Endian module

### DIFF
--- a/test/library/standard/Endian/Endian.chpl
+++ b/test/library/standard/Endian/Endian.chpl
@@ -38,10 +38,10 @@ module Endian {
   private extern proc le32toh(x: c_uint): c_uint;
   private extern proc htobe32(x: c_uint): c_uint;
   private extern proc be32toh(x: c_uint): c_uint;
-  private extern proc htole64(x: c_ulong): c_ulong;
-  private extern proc le64toh(x: c_ulong): c_ulong;
-  private extern proc htobe64(x: c_ulong): c_ulong;
-  private extern proc be64toh(x: c_ulong): c_ulong;
+  private extern proc htole64(x: c_ulonglong): c_ulonglong;
+  private extern proc le64toh(x: c_ulonglong): c_ulonglong;
+  private extern proc htobe64(x: c_ulonglong): c_ulonglong;
+  private extern proc be64toh(x: c_ulonglong): c_ulonglong;
 
   /*
     Has value ``true`` if the host system is little-endian type.

--- a/test/library/standard/Endian/Endian.chpl
+++ b/test/library/standard/Endian/Endian.chpl
@@ -30,18 +30,18 @@
 module Endian {
   use SysCTypes;
 
-  private extern proc htole16(x: c_uint): c_uint;
-  private extern proc le16toh(x: c_uint): c_uint;
-  private extern proc htobe16(x: c_uint): c_uint;
-  private extern proc be16toh(x: c_uint): c_uint;
-  private extern proc htole32(x: c_uint): c_uint;
-  private extern proc le32toh(x: c_uint): c_uint;
-  private extern proc htobe32(x: c_uint): c_uint;
-  private extern proc be32toh(x: c_uint): c_uint;
-  private extern proc htole64(x: c_ulonglong): c_ulonglong;
-  private extern proc le64toh(x: c_ulonglong): c_ulonglong;
-  private extern proc htobe64(x: c_ulonglong): c_ulonglong;
-  private extern proc be64toh(x: c_ulonglong): c_ulonglong;
+  private extern proc htole16(x: uint(16)): uint(16);
+  private extern proc le16toh(x: uint(16)): uint(16);
+  private extern proc htobe16(x: uint(16)): uint(16);
+  private extern proc be16toh(x: uint(16)): uint(16);
+  private extern proc htole32(x: uint(32)): uint(32);
+  private extern proc le32toh(x: uint(32)): uint(32);
+  private extern proc htobe32(x: uint(32)): uint(32);
+  private extern proc be32toh(x: uint(32)): uint(32);
+  private extern proc htole64(x: uint(64)): uint(64);
+  private extern proc le64toh(x: uint(64)): uint(64);
+  private extern proc htobe64(x: uint(64)): uint(64);
+  private extern proc be64toh(x: uint(64)): uint(64);
 
   /*
     Has value ``true`` if the host system is little-endian type.


### PR DESCRIPTION
On a 32-bit machine `private extern proc htole64(x: c_ulong): c_ulong;` is expecting x of 4 bytes, while we are sending 8 bytes in case of `int(64)`, resulting in an unresolved call. Changing `c_ulong`(4 bytes on a 32-bit machine) to `c_ulonglong`(8 bytes) should work for both 32-bit(not tested) and 64-bit machine(tested).

I don't have access to a 32-bit machine currently, it would be great if someone tests this change :)