### PR TITLE
Update .bad file for `test/associative/types/testTuple`

### DIFF
--- a/test/associative/types/testTuple.bad
+++ b/test/associative/types/testTuple.bad
@@ -1,8 +1,1 @@
-./AssocTest.chpl:1: In function 'testAssoc':
-./AssocTest.chpl:8: error: Cannot default-initialize a tuple component of the type shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
-./AssocTest.chpl:8: error: Cannot default-initialize a tuple component of the type shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
-testTuple.chpl:8: Function 'testAssoc' instantiated as: testAssoc(type t = 2*shared T)
+./AssocTest.chpl:8: error: halt reached - Can't default initialize associative arrays whose elements have no default value


### PR DESCRIPTION
Update `.bad` file for future `test/associative/types/testTuple.chpl` that was missed in #15747.