### PR TITLE
Fix import iterator bug

### DIFF
--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -133,8 +133,7 @@ void findVisibleFunctions(CallInfo&       info,
   } else {
     // Methods, fields, and type helper functions should ignore the privacy and
     // limitations on use statements.  All other symbols should respect them.
-    if (call->numActuals() >=2 && isSymExpr(call->get(1)) &&
-        toSymExpr(call->get(1))->symbol() == gMethodToken) {
+    if (call->numActuals() >=2 && call->get(1)->typeInfo() == dtMethodToken) {
 
       getVisibleMethods(info.name, call, visibleFns);
 

--- a/test/library/standard/Set/destructors/setDestructors.bad
+++ b/test/library/standard/Set/destructors/setDestructors.bad
@@ -1,1 +1,0 @@
-setDestructors.chpl:20: error: assert failed

--- a/test/library/standard/Set/destructors/setDestructors.future
+++ b/test/library/standard/Set/destructors/setDestructors.future
@@ -1,3 +1,0 @@
-The set is currently implemented with an associative domain, which default
-initializes and fires destructors on _all_ of its backing store, regardless
-of whether or not it is being used.

--- a/test/visibility/import/edgeCases/typeAndIteratorCall.chpl
+++ b/test/visibility/import/edgeCases/typeAndIteratorCall.chpl
@@ -1,0 +1,32 @@
+module TestImportTheseFollower {
+  // Import the type `set` from the submodule `MySet`.
+  import this.MySet.set;
+
+  proc test() {
+    var s1 = new set();
+    var s2 = new set();
+
+    forall (x, y) in zip(s1, s2) do
+      var tmp = x + y;
+
+    return;
+  }
+  test();
+
+  module MySet {
+
+    // Define a simple "set" type.
+    record set {
+      iter these() { for i in 0..#100 do yield i; }
+
+      iter these(param tag) where tag == iterKind.leader {
+        var space = 0..#100;
+        for followThis in space.these(tag) do yield followThis;
+      }
+
+      iter these(param tag, followThis) where tag == iterKind.follower {
+        for idx in followThis(0) do yield idx;
+      }
+    }
+  }
+}


### PR DESCRIPTION
David L discovered that we were failing to find `these` methods when importing
a type directly (at least, in certain valid circumstances).  It turns out this was
due to being too specific when checking if a function call was to a method.
Generalize that check so that it also detects this case.

Resolves #15823 

Also adds the code David used when reporting the issue as a test.

While here, remove the .bad and .future for a passing future that turned up
in my paratest run (which looks to be due to #15772)

Passed a full paratest with futures