### PR TITLE
Removes workarounds for isDefaultInitializable

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -230,6 +230,7 @@ FnSymbol* getCoerceMoveFromCoerceCopy(FnSymbol* coerceCopyFn);
 const char* getErroneousCopyError(FnSymbol* fn);
 void markCopyErroneous(FnSymbol* fn, const char* err);
 
+bool isDefaultInitializable(Type* t);
 
 bool isPOD(Type* t);
 bool recordContainingCopyMutatesField(Type* at);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -367,7 +367,7 @@ static void setRecordAssignableFlags(AggregateType* at) {
 
 static void setRecordDefaultValueFlags(AggregateType* at);
 
-static bool isDefaultInitializable(Type* t) {
+bool isDefaultInitializable(Type* t) {
   bool val = true;
   if (isRecord(t)) {
     AggregateType* at = toAggregateType(t);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1503,11 +1503,12 @@ module ChapelArray {
         }
         compilerError("array element type cannot currently be generic");
         // In the future we might support it if the array is not default-inited
-      } else if isSparseDom(this) && isNonNilableClass(eltType) {
-        // TODO: The second half of this test should really be
-        // isDefaultInitializable, but we can't rely on that yet
-        // due to #14854.
-        compilerError("sparse arrays of non-nilable classes are not currently supported");
+      } else if isSparseDom(this) && !isDefaultInitializable(eltType) {
+        if isNonNilableClass(eltType) {
+          compilerError("sparse arrays of non-nilable classes are not currently supported");
+        } else {
+          compilerError("sparse arrays of non-default-initializable types are not currently supported");
+        }
       }
 
       if chpl_warnUnstable then

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -459,11 +459,18 @@ module DefaultAssociative {
       this.tmpData = nil;
       this.complete();
 
-      if initElts && isNonNilableClass(this.eltType) {
-        param msg = "Cannot default initialize associative array because"
-                  + " element type " + eltType:string
-                  + " is a non-nilable class";
-        compilerError(msg);
+      if initElts {
+        if isNonNilableClass(this.eltType) {
+          param msg = "Cannot default initialize associative array because"
+                    + " element type " + eltType:string
+                    + " is a non-nilable class";
+          compilerError(msg);
+        } else if !isDefaultInitializable(this.eltType) {
+          param msg = "Cannot default initialize associative array because"
+                    + " element type " + eltType:string
+                    + " cannot be default initialized";
+          compilerError(msg);
+        }
       }
 
       // Initialize array elements for any full slots

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -968,6 +968,7 @@ module DefaultRectangular {
     type idxType;
     param stridable: bool;
     var targetLocDom: domain(rank);
+    pragma "unsafe"
     var RAD: [targetLocDom] _remoteAccessData(eltType, rank, idxType,
                                               stridable);
     var RADLocks: [targetLocDom] chpl_LocalSpinlock;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1405,12 +1405,7 @@ module DefaultRectangular {
       if !actuallyResizing then
         return;
 
-      // This should really be isDefaultInitializable(eltType), but that
-      // doesn't always work / give correct answers yet.  The following
-      // check won't catch cases such as records with non-nilable class
-      // fields that don't have default initializers (that initialize
-      // them).
-      if (isNonNilableClass(eltType)) {
+      if (!isDefaultInitializable(eltType)) {
         halt("Can't resize domains whose arrays' elements don't have default values");
       }
       if (this.locale != here) {

--- a/test/associative/types/testTuple.bad
+++ b/test/associative/types/testTuple.bad
@@ -1,1 +1,3 @@
-./AssocTest.chpl:8: error: halt reached - Can't default initialize associative arrays whose elements have no default value
+./AssocTest.chpl:1: In function 'testAssoc':
+./AssocTest.chpl:8: error: Cannot default initialize associative array because element type 2*shared T cannot be default initialized
+testTuple.chpl:8: Function 'testAssoc' instantiated as: testAssoc(type t = 2*shared T)

--- a/test/library/standard/Map/types/testTuple.bad
+++ b/test/library/standard/Map/types/testTuple.bad
@@ -1,1 +1,3 @@
-./MapTest.chpl:10: error: halt reached - Can't resize domains whose arrays' elements don't have default values
+$CHPL_HOME/modules/standard/Map.chpl:100: In initializer:
+$CHPL_HOME/modules/standard/Map.chpl:75: error: Cannot default initialize associative array because element type 2*shared T cannot be default initialized
+./MapTest.chpl:5: Initializer instantiated as: init(type keyType = int(64), type valType = 2*shared T, param parSafe = 0)

--- a/test/sparse/types/testTuple.bad
+++ b/test/sparse/types/testTuple.bad
@@ -1,8 +1,3 @@
 ./SparseTest.chpl:1: In function 'testSparse':
-./SparseTest.chpl:9: error: Cannot default-initialize a tuple component of the type shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
-./SparseTest.chpl:9: error: Cannot default-initialize a tuple component of the type shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
+./SparseTest.chpl:9: error: sparse arrays of non-default-initializable types are not currently supported
 testTuple.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = 2*shared T)


### PR DESCRIPTION
Follow-up to #15774.
Related to #14854.

Removes several workarounds for problems with isDefaultInitializable 
(issue #14854) that were added in PRs #15233 #15571 and a few others.

Future work: It's unclear if the check for sync variables added in #13691 
is what we need it to be; it prevents sync variables of non-nilable
classes (why?) but not say `owned C?` or a non-default-initable record.
However this was not a workaround for problems with
isDefaultInitializable and so this PR leaves it alone.

Reviewed by @vasslitvinov - thanks!

- [x] primers pass with valgrind and do not leak
- [x] full local futures testing