### PR TITLE
Fix partial field internal error

### DIFF
--- a/test/types/records/generic/allParamMultiInst.bad
+++ b/test/types/records/generic/allParamMultiInst.bad
@@ -1,3 +1,0 @@
-allParamMultiInst.chpl:14: In initializer:
-allParamMultiInst.chpl:15: error: cannot assign expression of type R(4,5) to field 'r' of type R(1,2)
-allParamMultiInst.chpl:26: Initializer instantiated as: init(param x = 4, param y = 5, param z = 6)

--- a/test/types/records/generic/allParamMultiInst.future
+++ b/test/types/records/generic/allParamMultiInst.future
@@ -1,6 +1,0 @@
-bug: second instantiation of a generic record results in type mismatch
-
-This future shows that the second instantiation of a generic record
-results in a type mismatch as though the field is already hard-coded
-to be of the first instantiation type.  It seems something must be
-going wrong in the compiler.


### PR DESCRIPTION
This PR updates AggregateType to correctly identify fields with partial type expressions.

Resolves #15830 

Testing:
- [x] local + futures
- [x] gasnet + futures