### PR TITLE
Adjust file touches done before building libfabric.

### DIFF
--- a/third-party/libfabric/Makefile
+++ b/third-party/libfabric/Makefile
@@ -49,6 +49,11 @@ configure-libfabric: FORCE
 # These first few lines touch some autoconf-oriented files in a
 # certain order to prevent autoconf from running again.
 #
+	cd $(LIBFABRIC_SUBDIR) && touch -c configure.ac
+	cd $(LIBFABRIC_SUBDIR) && find . -name "*.m4" | xargs touch 
+	sleep 1
+	cd $(LIBFABRIC_SUBDIR) && touch -c aclocal.m4
+	sleep 1
 	touch $(LIBFABRIC_SUBDIR)/configure
 	find $(LIBFABRIC_SUBDIR)/. -name Makefile.in | xargs touch
 #


### PR DESCRIPTION
I had seen a case where a third-party/libfabric build wanted to run
aclocal-1.15 a few weeks ago while first working on libfabric=libfabric,
but it didn't recur.  Now, in my first build after having merged that
PR, it did!  Here, add some more file touches to get rid of it.  This
makes the libfabric build just like the hwloc one in terms of doing file
touches to avoid autotools-related rebuilds.