### PR TITLE
Fix issue 15846

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2645,6 +2645,11 @@ Type* computeDecoratedManagedType(AggregateType* canonicalClassType,
   Type* borrowType = canonicalClassType->getDecoratedClass(d);
 
   CallExpr* typeCall = new CallExpr(manager->symbol, borrowType->symbol);
+
+  // Find different insert point if ctx isn't in a list
+  if (ctx->list == NULL)
+    ctx = ctx->parentSymbol->defPoint;
+
   ctx->insertAfter(typeCall);
   resolveCall(typeCall);
   Type* ret = typeCall->typeInfo();

--- a/test/classes/nilability/issue-15846.chpl
+++ b/test/classes/nilability/issue-15846.chpl
@@ -1,0 +1,43 @@
+class C {  }
+
+record Test1 {
+  type t;
+  var field: t?;
+}
+
+proc t1() {
+  writeln("t1");
+  var tst = new Test1(shared C);
+  writeln(tst);
+  writeln(tst.t:string);
+  writeln(tst.field.type:string);
+}
+t1();
+
+record Test2 {
+  type t;
+  var field: t? = nil;
+}
+
+proc t2() {
+  writeln("t2");
+  var tst = new Test2(shared C);
+  writeln(tst);
+  writeln(tst.t:string);
+  writeln(tst.field.type:string);
+}
+t2();
+
+record Test3 {
+  type t;
+  var field: t? = nil: t?;
+}
+
+proc t3() {
+  writeln("t3");
+  var tst = new Test3(shared C);
+  writeln(tst);
+  writeln(tst.t:string);
+  writeln(tst.field.type:string);
+}
+t3();

--- a/test/classes/nilability/issue-15846.good
+++ b/test/classes/nilability/issue-15846.good
@@ -1,0 +1,12 @@
+t1
+(field = nil)
+shared C
+shared C?
+t2
+(field = nil)
+shared C
+shared C?
+t3
+(field = nil)
+shared C
+shared C?


### PR DESCRIPTION
Resolves #15846.

The compiler was running into an internal error because
it tried to call insertAfter on something not in a list.

This PR resolves the problem by inserting the call at the declaration
point for the symbol in that event.

Reviewed by @e-kayrakli - thanks!

- [x] full local testing