### PR TITLE
Add project to mason gitignore

### DIFF
--- a/test/mason/.gitignore
+++ b/test/mason/.gitignore
@@ -1,1 +1,2 @@
 mason_home
+project


### PR DESCRIPTION
Lots of mason tests create a directory called `project`, so lets ignore that.