### PR TITLE
Wipe mason git submodules for darwin testing

### DIFF
--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -10,7 +10,7 @@ source $CWD/common-localnode-paratest.bash
 # TODO: To be promoted to common.bash if this works
 # Work-around to remove git submodules
 #   See Cray/chapel-private#1050 for long term solution
-git clean --ffdx ${CHPL_HOME}/test/mason
+git clean -ffdx ${CHPL_HOME}/test/mason
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 

--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -7,6 +7,11 @@ source $CWD/common.bash
 source $CWD/common-darwin.bash
 source $CWD/common-localnode-paratest.bash
 
+# TODO: To be promoted to common.bash if this works
+# Work-around to remove git submodules
+#   See Cray/chapel-private#1050 for long term solution
+git clean --ffdx ${CHPL_HOME}/test/mason
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 
 $CWD/nightly -cron $(get_nightly_paratest_args)


### PR DESCRIPTION
This is an incremental change to see if we can remove git submodule from a cron script. This will be added to common.bash if it works in nightly testing. 

See https://github.com/Cray/chapel-private/issues/1050 for more background.