### PR TITLE
Hide a function used only in debug builds.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2203,10 +2203,12 @@ typedef enum {
   am_opShutdown,                           // signal main process for shutdown
 } amOp_t;
 
+#ifdef CHPL_COMM_DEBUG
 static inline
 chpl_bool op_uses_on_bundle(amOp_t op) {
   return op == am_opExecOn || op == am_opExecOnLrg;
 }
+#endif
 
 //
 // Members are packed, potentially differently, in each AM request type


### PR DESCRIPTION
Without CHPL_COMM_DEBUG there are no calls to op_uses_on_bundle(), and
then with -Werror,-Wunused-function we get gripes about it as an unused
function.  To prevent this, ifdef it out.