### PR TITLE
Change the order of errors in a .bad file

### DIFF
--- a/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
@@ -1,2 +1,2 @@
-remote-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
 remote-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
+remote-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)


### PR DESCRIPTION
#15713 clones forall loops for an optimization. This, however, can
result in some foralls to appear later in `gForallStmts` causing
the order of error messages to change.

Copying myself from a mail thread regarding this

> We create a copy of the forall from the original. ... . Then, we make the
> transformations on this original. However, the original disappears during
> resolution because the optimization is not applicable. So, the loop where this
> error is triggered is actually the clone of the original and the one that
> appears later in gForallStmts.

This PR changes a .bad file where this behavior is seen.
