### PR TITLE
Close a trivial test leak

### DIFF
--- a/test/optimizations/autoLocalAccess/withInitializerCall.chpl
+++ b/test/optimizations/autoLocalAccess/withInitializerCall.chpl
@@ -20,6 +20,8 @@ class C {
   forall i in A.domain {
     A[i] = new unmanaged C[i];
   }
+
+  for a in A do delete a;
 }
 
 {


### PR DESCRIPTION
I introduced an obvious leak in one of the tests in #15713 by creating an
array of `unmanaged`s. This test deletes them.