### PR TITLE
Wipe mason git submodules for all testing 

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -112,3 +112,8 @@ fi
 if [ -z "$CHPL_TEST_COMP_PERF_DIR" ]; then
     export CHPL_TEST_COMP_PERF_DIR=$PERF_LOGDIR_PREFIX/NightlyPerformance/$CHPL_TEST_PERF_CONFIG_NAME
 fi
+
+# Work-around to remove git submodules
+#   See Cray/chapel-private#1050 for long term solution
+log_info "Clearing out git submodules in test/mason/"
+git clean -ffdx ${CHPL_HOME}/test/mason

--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -7,11 +7,6 @@ source $CWD/common.bash
 source $CWD/common-darwin.bash
 source $CWD/common-localnode-paratest.bash
 
-# TODO: To be promoted to common.bash if this works
-# Work-around to remove git submodules
-#   See Cray/chapel-private#1050 for long term solution
-git clean -ffdx ${CHPL_HOME}/test/mason
-
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 
 $CWD/nightly -cron $(get_nightly_paratest_args)


### PR DESCRIPTION
The `git clean -ffdx` worked as expected in darwin testing, so now we are
promoting the git clean command to common.bash so that all test configs
will clear out any mason git submodules before starting.

Also added a log message.

Follow-up to #15852 

See Cray/chapel-private#1050 for more background.

