### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -474,6 +474,12 @@ AllCompTime: &timecomp-base
     - Improve handling for tryResolve and errors to handle a bad init= (#14887)
   03/03/20:
     - Remove calls to getUserInstantiationPoint (#15051)
+  06/11/20:
+    - Fix split init of const variables and update lvalue errors (#15800)
+
+allocate:
+  06/11/20:
+    - Add a field to the string record to store a cached size (#15758)
 
 arguments:
   09/20/17:
@@ -507,6 +513,8 @@ array-of-strings-read:
     - Rework the helper for string/bytes slicing (#15615)
   05/20/20:
     - Remove string.indices from getView (#15653)
+  06/11/20:
+    - Add a field to the string record to store a cached size (#15758)
 
 arr-forall:
   03/24/15:
@@ -1281,6 +1289,10 @@ memleaksfull:
     - Close some multilocale test leaks (#15406)
   04/19/20:
     - no new leaks, multiple tests used to be registered as one
+  06/16/20:
+    - Use `localAccess` automatically (#15713)
+  06/18/20:
+    - Close a trivial test leak (#15871)
 
 meteor:
   12/18/13:
@@ -1518,6 +1530,8 @@ regexdna: &regexdna-base
     - Add UTF8 validation for strings (#14384)
   01/23/20:
     - Add support for escaping non-UTF8 sequences in strings (#14743)
+  06/11/20:
+    - Add a field to the string record to store a cached size (#15758)
 regexdna-redux:
   <<: *regexdna-base
 regexdna-submitted:
@@ -1583,6 +1597,10 @@ revcomp: &revcomp-base
 revcomp-submitted:
   <<: *revcomp-base
 
+ri-a2-AoA:
+  06/05/20:
+    - Remove unnecessary array temporaries for arrays-of-arrays (#15767)
+
 sad:
   05/03/16:
     - inconclusive due to noise
@@ -1626,6 +1644,8 @@ spectral-norm-specify-step:
 split-whitespace-perf:
   11/02/16:
     - fix bugs when reading null bytes (#4806)
+  06/11/20:
+    - Add a field to the string record to store a cached size (#15758)
 
 SSCA2_main:
   06/12/13:
@@ -1691,6 +1711,8 @@ substring:
     - Rework the helper for string/bytes slicing (#15615)
   05/20/20:
     - Remove string.indices from getView (#15653)
+  06/11/20:
+    - Add a field to the string record to store a cached size (#15758)
 
 taskSpawn:
   07/24/16:
@@ -1715,6 +1737,8 @@ temporary-copies:
     - Rework the helper for string/bytes slicing (#15615)
   05/20/20:
     - Remove string.indices from getView (#15653)
+  06/11/20:
+    - Add a field to the string record to store a cached size (#15758)
 
 twopt-paircount:
   06/22/17:


### PR DESCRIPTION
- String regressions

  Caused by: https://github.com/chapel-lang/chapel/pull/15758
  Likely fix: https://github.com/chapel-lang/chapel/pull/15870

  [Plots](https://chapel-lang.org/perf/chapcs/?startdate=2020/05/25&enddate=2020/06/18&graphs=regexdnashootoutbenchmark,regexdnareduxshootoutbenchmark,submittedregexdnashootoutbenchmark,submittedregexdnareduxshootoutbenchmark,arrayofstringelementaccess,stringtemporarycopies,splittingastringonwhitespace,allocatingstringoperations,searchwithinastring)

- Trivial leak

  Caused by: https://github.com/chapel-lang/chapel/pull/15713
  Fixed by: https://github.com/chapel-lang/chapel/pull/15871

  [Plots](https://chapel-lang.org/perf/chapcs/?startdate=2020/05/22&enddate=2020/06/18&graphs=memoryleaksforexamplestests,numberoftestswithleaksexamplesonly,memoryusageforalltests,memoryleaksforalltests,numberoftestswithleaks,memoryusageformultilocaletests,memoryleaksformultilocaletests,numberofmultilocaletestswithleaks)

- AoA Forall Intent Improvement

  Caused by: https://github.com/chapel-lang/chapel/pull/15767

  [Plots](https://chapel-lang.org/perf/chapcs/?startdate=2020/05/19&enddate=2020/06/18&graphs=forallwithaoainandreduceintents)

- Sampler compile time regression

  Likely caused by: https://github.com/chapel-lang/chapel/pull/15800

  [Plots](https://chapel-lang.org/perf/chapcs/?startdate=2020/06/09&enddate=2020/06/12&suite=compilerperformance)

