### PR TITLE
Update common launcher to find the _real in the same directory as the launcher

### DIFF
--- a/runtime/make/Makefile.runtime.head
+++ b/runtime/make/Makefile.runtime.head
@@ -46,7 +46,8 @@ LAUNCHER_CFLAGS = $(RUNTIME_CFLAGS) -DLAUNCHER
 LAUNCHER_INCLS = \
         -I$(RUNTIME_ROOT)/include/comm/$(CHPL_MAKE_COMM) \
         -I$(RUNTIME_ROOT)/include/comm \
-        -I$(RUNTIME_ROOT)/include
+        -I$(RUNTIME_ROOT)/include \
+        -I$(THIRD_PARTY_DIR)/whereami/whereami-src
 
 ifeq ($(CHPL_MAKE_HWLOC),none)
   CHPL_MAKE_TOPO = none

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -33,6 +33,7 @@
 #include "chpl-mem.h"
 #include "chpltypes.h"
 #include "error.h"
+#include "whereami.c"
 
 // used in get_enviro_keys
 extern char** environ;
@@ -649,7 +650,8 @@ void chpl_compute_real_binary_name(const char* argv0) {
       real_suffix = launcher_real_suffix;
     }
 
-    length = strlen(argv0);
+    length = wai_getExecutablePath(NULL, 0, NULL);
+
     if (length + strlen(launcher_real_suffix) >= BIN_NAME_SIZE)
       chpl_internal_error("Real executable name is too long.");
 
@@ -660,7 +662,7 @@ void chpl_compute_real_binary_name(const char* argv0) {
       length -= exe_length;
 
     // Copy the filename sans exe suffix.
-    strncpy(cursor, argv0, length);
+    wai_getExecutablePath(cursor, length, NULL);
     cursor += length;
     strcpy(cursor, launcher_real_suffix);
   }

--- a/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.chpl
+++ b/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.chpl
@@ -1,0 +1,1 @@
+writeln("Success!");

--- a/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.good
+++ b/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.good
@@ -1,0 +1,1 @@
+Success!

--- a/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.noexec
+++ b/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.noexec
@@ -1,0 +1,2 @@
+# The test system expects the binary to be in the current directory,
+# not moved somewhere else in the $PATH.

--- a/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.prediff
+++ b/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.prediff
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Test that launcher can find its _real binary when
+# both are buried somewhere in $PATH.
+
+mkdir hidefiles 
+export PATH="`pwd`/hidefiles:$PATH"
+
+basefile=testHiddenLauncher
+if [[ -e $basefile ]] ; then
+  mv $basefile hidefiles
+fi
+
+if [[ -e ${basefile}_real ]] ; then
+  mv ${basefile}_real hidefiles
+fi
+
+$basefile -nl1 > ${basefile}.comp.out.tmp 2>&1
+
+rm -r hidefiles

--- a/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.prediff
+++ b/test/multilocale/diten/oneOrMoreLocales/testHiddenLauncher.prediff
@@ -15,6 +15,6 @@ if [[ -e ${basefile}_real ]] ; then
   mv ${basefile}_real hidefiles
 fi
 
-$basefile -nl1 > ${basefile}.comp.out.tmp 2>&1
+$basefile -nl1 >> ${basefile}.comp.out.tmp 2>&1
 
 rm -r hidefiles


### PR DESCRIPTION
Use the whereami library to find the directory the launcher is running from
and assume the _real binary will be in the same location.

Add a test that moves itself to a new directory and adds that directory to
PATH before running itself.