### PR TITLE
Move libunwind into alphabetical order

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -47,11 +47,11 @@ The Chapel implementation is composed of two categories of code:
      hwloc            portable NUMA compute node utilities         new BSD
      jemalloc         alternative memory allocator                 BSD-like
      libfabric        portable networking library                  BSD
+     libunwind        used for runtime stack tracing               MIT
      llvm             CLANG C parsing/optional back-end compiler   U of I/NCSA
      qthread          alternative lightweight tasking option       new BSD
      re2              optional regular expression parsing library  new BSD
      utf8-decoder     used for runtime UTF-8 string decoding       MIT
-     libunwind        used for runtime stack tracing               MIT
      whereami         for locating the _real binary in launchers   MIT
 
    For a more complete introduction to these packages and their
@@ -75,11 +75,11 @@ The Chapel implementation is composed of two categories of code:
      gmp              only used when CHPL_GMP is 'gmp'
      hwloc            only used when CHPL_HWLOC is 'hwloc'
      jemalloc         only used when CHPL_MEM is 'jemalloc'
+     libunwind        only used when CHPL_UNWIND is 'libunwind'
      llvm             only used when CHPL_LLVM is 'llvm'
      qthread          only used when CHPL_TASKS is 'qthreads'
      re2              only used when CHPL_REGEXP is 're2'
      utf8-decoder     bundled into the Chapel runtime to decode UTF-8 strings
-     libunwind        only used when CHPL_UNWIND is 'libunwind'
      whereami         used when starting a program with a launcher
 
    For packages that are used based on a CHPL_* setting, note that this

--- a/third-party/README
+++ b/third-party/README
@@ -82,6 +82,18 @@ libfabric/
   See also: libfabric/README and libfabric/libfabric-src/README
 
 
+libunwind/
+  Summary: libunwind is a portable and efficient C programming
+           interface (API) to determine the call-chain of a program
+
+  License: MIT (see libunwind/libunwind-<version>/COPYING and
+           libunwind/libunwind-<version>/LICENSE)
+
+  Website: https://www.nongnu.org/libunwind/
+
+  See also: libunwind/README and libunwind/libunwind-<version>/README
+
+
 llvm/
   Summary: This directory holds LLVM and Clang.  LLVM is provided as
            an optional back-end target in place of C (see
@@ -132,18 +144,6 @@ utf8-decoder/
   Website: http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
 
   See also: utf8-decoder/README
-
-
-libunwind/
-  Summary: libunwind is a portable and efficient C programming
-           interface (API) to determine the call-chain of a program
-
-  License: MIT (see libunwind/libunwind-<version>/COPYING and
-           libunwind/libunwind-<version>/LICENSE)
-
-  Website: https://www.nongnu.org/libunwind/
-
-  See also: libunwind/README and libunwind/libunwind-<version>/README
 
 
 whereami/


### PR DESCRIPTION
In reviewing the recent libfabric / whereami changes to LICENSE and README, I noticed that libunwind was the only package that wasn't in alphabetical order for no reason that I could see.  Alphabetize it.