### PR TITLE
Remove use of --cc-warnings in 'make check' step

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -161,9 +161,6 @@ fi
 chpl_comm="$($CHPL_HOME/util/chplenv/chpl_comm.py)"
 chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 
-# Necessary to suppress warnings when WARNINGS=1 (e.g. nightly build settings)
-COMP_FLAGS="--cc-warnings"
-
 backend="C"
 if [ ${CHPL_LLVM_CODEGEN:-0} -ne 0 ]; then
   backend="LLVM"


### PR DESCRIPTION
This script, used by 'make check', has traditionally added
--cc-warnings to our 'make check' step which turns on stricter
back-end C compiler warnings (and makes them errors) than we typically
generate for users.  As a result, it makes the 'make check' less
likely to pass even though the Chapel installation may work just fine
in practice.  While we'd like to know about such issues and rely on
'--cc-warnings' to keep ourselves honest in our test system, I don't
think users should generally use it, nor that we should have a
user-run 'make check' failing over such warnings.  The historical
comment here indicating why --cc-warnings was added summarizes its
effect incorrect and likely reflects a misunderstanding on BenA's part
when he implemented this (he notes that it was during his first week
at Cray).

For these reasons, this PR removes --cc-warnings from the script.