### PR TITLE
Add .prediff scripts for a few tests that are printing an absolute path now

### DIFF
--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -73,3 +73,9 @@ case $launcher in
                   $2 > $2.tmp &&
               mv $2.tmp $2;;
 esac
+
+sed -e "s;`pwd`;.;" $2 > $2.tmp
+cat $2.tmp
+echo ---
+cat $2
+mv $2.tmp $2

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -74,3 +74,5 @@ case $launcher in
               mv $2.tmp $2;;
 esac
 
+sed -e "s;`pwd`;.;" $2 > $2.tmp
+mv $2.tmp $2

--- a/test/trivial/bradc/entrypoint/argv0.prediff
+++ b/test/trivial/bradc/entrypoint/argv0.prediff
@@ -1,5 +1,5 @@
 #!/bin/sh
-rm b.out_real
+
 outfile=$2
 
 sed -e "s;`pwd`;.;" $outfile > $outfile.2


### PR DESCRIPTION
Add .prediff scripts that strip the path out of the output leaving the
previously expected output.