### PR TITLE
Relax some limitations of --auto-local-access

### DIFF
--- a/compiler/optimizations/autoLocalAccess.cpp
+++ b/compiler/optimizations/autoLocalAccess.cpp
@@ -92,9 +92,9 @@ static Symbol *getDotDomBaseSym(Expr *expr) {
 static Symbol *getDomSym(Symbol *arrSym) {
   Symbol *ret = NULL;
   if(DefExpr *def = arrSym->defPoint) {
-    // check the most basic idiom `var A: [D] int`
     if (def->exprType != NULL) {
       if (CallExpr *ceOuter = toCallExpr(def->exprType)) {
+        // check the most basic idiom `var A: [D] int`
         if (ceOuter->isNamed("chpl__buildArrayRuntimeType")) {
           if (CallExpr *ceInner = toCallExpr(ceOuter->get(1))) {
             if (ceInner->isNamed("chpl__ensureDomainExpr")) {
@@ -106,6 +106,12 @@ static Symbol *getDomSym(Symbol *arrSym) {
                 ret = getDomSym(dotDomBaseSym); // recurse
               }
             }
+          }
+        }
+        // check for `B` in `var A, B: [D] int;`
+        else if (ceOuter->isPrimitive(PRIM_TYPEOF)) {
+          if (SymExpr *typeOfSymExpr = toSymExpr(ceOuter->get(1))) {
+            ret = getDomSym(typeOfSymExpr->symbol()); // recurse
           }
         }
       }

--- a/compiler/optimizations/autoLocalAccess.cpp
+++ b/compiler/optimizations/autoLocalAccess.cpp
@@ -108,15 +108,19 @@ static Symbol *getDomSym(Symbol *arrSym);
 
 // get the domain symbol from `Dom`, `?Dom` (if allowQuery) or `arr.domain`
 static Symbol *getDomSymFromDomExpr(Expr *domExpr, bool allowQuery) {
+  // we try the following cases one by one:
+  
   if (SymExpr *domSE = toSymExpr(domExpr)) {
     return domSE->symbol();
   }
-  else if (allowQuery) {
+
+  if (allowQuery) {
     if (DefExpr *domSE = toDefExpr(domExpr)) {
       return domSE->sym;
     }
   }
-  else if (Symbol *dotDomBaseSym = getDotDomBaseSym(domExpr)) {
+
+  if (Symbol *dotDomBaseSym = getDotDomBaseSym(domExpr)) {
     return getDomSym(dotDomBaseSym); // recurse
   }
   return NULL;

--- a/compiler/optimizations/autoLocalAccess.cpp
+++ b/compiler/optimizations/autoLocalAccess.cpp
@@ -308,23 +308,8 @@ static void gatherForallInfo(ForallStmt *forall) {
   }
 }
 
-static bool hasReduceIntentShadowVars(ForallStmt *forall) {
-  // We never seem to use `temp`, why is it in the interface of this macro?
-  for_shadow_vars(svar, temp, forall) {
-    if (svar->isReduce()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 static bool checkLoopSuitableForOpt(ForallStmt *forall) {
 
-  // reduce-intent variables expect some special AST form that this optimization
-  // somehow breaks
-  if (hasReduceIntentShadowVars(forall)) {
-    return false;
-  }
   if (forall->optInfo.multiDIndices.size() == 0) {
     return false;
   }

--- a/compiler/optimizations/autoLocalAccess.cpp
+++ b/compiler/optimizations/autoLocalAccess.cpp
@@ -146,15 +146,17 @@ static Symbol *getDomSym(Symbol *arrSym) {
     }
   }
 
-  // try to get the domain if the symbol was an argument
-  // e.g. `a: [d] int`, `a: [?d] int`, `a: [x.domain] int`
-  if (ArgSymbol *arrArgSym = toArgSymbol(arrSym)) {
-    if (BlockStmt *typeBlock = toBlockStmt(arrArgSym->typeExpr)) {
-      Expr *firstExpr = typeBlock->body.head;
-      Expr *domExpr = getDomExprFromTypeExprOrQuery(firstExpr);
+  if (ret == NULL) {
+    // try to get the domain if the symbol was an argument
+    // e.g. `a: [d] int`, `a: [?d] int`, `a: [x.domain] int`
+    if (ArgSymbol *arrArgSym = toArgSymbol(arrSym)) {
+      if (BlockStmt *typeBlock = toBlockStmt(arrArgSym->typeExpr)) {
+        Expr *firstExpr = typeBlock->body.head;
+        Expr *domExpr = getDomExprFromTypeExprOrQuery(firstExpr);
 
-      ret = getDomSymFromDomExpr(domExpr, /* allowQuery= */ true);
+        ret = getDomSymFromDomExpr(domExpr, /* allowQuery= */ true);
 
+      }
     }
   }
 
@@ -162,7 +164,7 @@ static Symbol *getDomSym(Symbol *arrSym) {
     LOG("Regular domain symbol was not found for array", arrSym);
   }
 
-  return NULL;
+  return ret;
 }
 
 // Return the closest parent of `ce` that can impact locality (forall or on)

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -275,21 +275,19 @@ static void workaroundForReduceIntoDetupleDecl(ForallStmt* fs, Symbol* svar) {
 static void insertFinalGenerate(ForallStmt* fs,
                                 Symbol* fiVarSym, Symbol* globalOp)
 {
-  Expr* next = fs->next; // nicer ordering of the following insertions
-  INT_ASSERT(next);
   if (fs->needsInitialAccumulate()) {
     VarSymbol* genTemp = newTemp("chpl_gentemp");
-    next->insertBefore(new DefExpr(genTemp));
-    next->insertBefore("'move'(%S, generate(%S,%S))",
-                     genTemp, gMethodToken, globalOp);
-    next->insertBefore(new CallExpr("=", fiVarSym, genTemp));
+    fs->insertAfter(new CallExpr("=", fiVarSym, genTemp));
+    fs->insertAfter("'move'(%S, generate(%S,%S))",
+                    genTemp, gMethodToken, globalOp);
+    fs->insertAfter(new DefExpr(genTemp));
     // TODO: Should we try to free chpl_gentemp right after the assignment?
     genTemp->addFlag(FLAG_INSERT_AUTO_DESTROY);
   } else {
     // Initialize, not assign. Do everything *after* 'fs'.
-    next->insertBefore(fiVarSym->defPoint->remove());
-    next->insertBefore("'move'(%S, generate(%S,%S))",
-                       fiVarSym, gMethodToken, globalOp);
+    fs->insertAfter("'move'(%S, generate(%S,%S))",
+                    fiVarSym, gMethodToken, globalOp);
+    fs->insertAfter(fiVarSym->defPoint->remove());
     fiVarSym->addFlag(FLAG_EXPR_TEMP);
     workaroundForReduceIntoDetupleDecl(fs, fiVarSym);
   }

--- a/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
@@ -8,7 +8,7 @@ var A: [D] int;
 var B = newCyclicArr({1..10}, int);
 
 // A is a static candidate, and will pass the static check
-// B is a dynamic candidate that'll fail dynamic check, in that case, we want
+// B is a dynamic candidate that'll fail static check, in that case, we want
 // the dynamic-checked loop copy to be folded out. In other words,
 // post-resolution we should have only one instance of this loop
 

--- a/test/optimizations/autoLocalAccess/commaDecl.chpl
+++ b/test/optimizations/autoLocalAccess/commaDecl.chpl
@@ -1,0 +1,13 @@
+use BlockDist;
+
+var D = newBlockDom({1..10});
+
+var A, B: [D] int;
+
+B = 10;
+
+forall i in D {
+  A[i] = B[i];
+}
+
+writeln(A);

--- a/test/optimizations/autoLocalAccess/commaDecl.good
+++ b/test/optimizations/autoLocalAccess/commaDecl.good
@@ -1,0 +1,43 @@
+**** Start forall ****
+	commaDecl.chpl:9
+
+Iterated symbol
+	commaDecl.chpl:3
+
+Loop is suitable for further analysis
+	commaDecl.chpl:9
+
+Potential access
+	commaDecl.chpl:10
+
+	with domain defined at
+	commaDecl.chpl:3
+
+Access base's domain is the iterator
+	commaDecl.chpl:10
+
+Potential access
+	commaDecl.chpl:10
+
+	with domain defined at
+	commaDecl.chpl:3
+
+Access base's domain is the iterator
+	commaDecl.chpl:10
+
+	Marking static candidate
+	commaDecl.chpl:10
+
+	Marking static candidate
+	commaDecl.chpl:10
+
+**** End forall ****
+	commaDecl.chpl:9
+
+Static check successful. Using localAccess
+	commaDecl.chpl:10
+
+Static check successful. Using localAccess
+	commaDecl.chpl:10
+
+10 10 10 10 10 10 10 10 10 10

--- a/test/optimizations/autoLocalAccess/functionArgs.chpl
+++ b/test/optimizations/autoLocalAccess/functionArgs.chpl
@@ -1,0 +1,78 @@
+use BlockDist;
+
+var D = newBlockDom({1..10});
+
+var A: [D] int;
+var B: [D] int;
+
+// all the patterns in this test must be recognized and optimized statically
+
+proc localQueriedDomain(a: [?d] int, b: [d] int){
+  forall i in a.domain {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+
+  forall i in b.domain {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+
+  forall i in d {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+}
+
+proc globalDotDomain(a: [A.domain] int, b: [A.domain] int){
+  forall i in A.domain {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+
+  forall i in B.domain {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+
+  forall i in D {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+}
+
+proc globalDomain(a: [D] int, b: [D] int){
+  forall i in A.domain {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+
+  forall i in B.domain {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+
+  forall i in D {
+    a[i] += 
+      b[i];
+  }
+  writeln(a);
+}
+
+proc main() {
+  B = 10;
+
+  localQueriedDomain(A, B);
+
+  globalDotDomain(A, B);
+
+  globalDomain(A, B);
+}

--- a/test/optimizations/autoLocalAccess/functionArgs.good
+++ b/test/optimizations/autoLocalAccess/functionArgs.good
@@ -1,0 +1,399 @@
+**** Start forall ****
+	functionArgs.chpl:11
+
+Iterated over the domain of
+	functionArgs.chpl:10
+
+, which is
+	functionArgs.chpl:10
+
+Loop is suitable for further analysis
+	functionArgs.chpl:11
+
+Potential access
+	functionArgs.chpl:12
+
+	Can optimize: Access base is the iterator's base
+	functionArgs.chpl:12
+
+Potential access
+	functionArgs.chpl:13
+
+	with domain defined at
+	functionArgs.chpl:10
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:13
+
+	Marking static candidate
+	functionArgs.chpl:12
+
+	Marking static candidate
+	functionArgs.chpl:13
+
+**** End forall ****
+	functionArgs.chpl:11
+
+**** Start forall ****
+	functionArgs.chpl:17
+
+Iterated over the domain of
+	functionArgs.chpl:10
+
+, which is
+	functionArgs.chpl:10
+
+Loop is suitable for further analysis
+	functionArgs.chpl:17
+
+Potential access
+	functionArgs.chpl:18
+
+	with domain defined at
+	functionArgs.chpl:10
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:18
+
+Potential access
+	functionArgs.chpl:19
+
+	Can optimize: Access base is the iterator's base
+	functionArgs.chpl:19
+
+	Marking static candidate
+	functionArgs.chpl:18
+
+	Marking static candidate
+	functionArgs.chpl:19
+
+**** End forall ****
+	functionArgs.chpl:17
+
+**** Start forall ****
+	functionArgs.chpl:23
+
+Iterated symbol
+	functionArgs.chpl:10
+
+Loop is suitable for further analysis
+	functionArgs.chpl:23
+
+Potential access
+	functionArgs.chpl:24
+
+	with domain defined at
+	functionArgs.chpl:10
+
+Access base's domain is the iterator
+	functionArgs.chpl:24
+
+Potential access
+	functionArgs.chpl:25
+
+	with domain defined at
+	functionArgs.chpl:10
+
+Access base's domain is the iterator
+	functionArgs.chpl:25
+
+	Marking static candidate
+	functionArgs.chpl:24
+
+	Marking static candidate
+	functionArgs.chpl:25
+
+**** End forall ****
+	functionArgs.chpl:23
+
+**** Start forall ****
+	functionArgs.chpl:31
+
+Iterated over the domain of
+	functionArgs.chpl:5
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:31
+
+Potential access
+	functionArgs.chpl:32
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:32
+
+Potential access
+	functionArgs.chpl:33
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:33
+
+	Marking static candidate
+	functionArgs.chpl:32
+
+	Marking static candidate
+	functionArgs.chpl:33
+
+**** End forall ****
+	functionArgs.chpl:31
+
+**** Start forall ****
+	functionArgs.chpl:37
+
+Iterated over the domain of
+	functionArgs.chpl:6
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:37
+
+Potential access
+	functionArgs.chpl:38
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:38
+
+Potential access
+	functionArgs.chpl:39
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:39
+
+	Marking static candidate
+	functionArgs.chpl:38
+
+	Marking static candidate
+	functionArgs.chpl:39
+
+**** End forall ****
+	functionArgs.chpl:37
+
+**** Start forall ****
+	functionArgs.chpl:43
+
+Iterated symbol
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:43
+
+Potential access
+	functionArgs.chpl:44
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:44
+
+Potential access
+	functionArgs.chpl:45
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:45
+
+	Marking static candidate
+	functionArgs.chpl:44
+
+	Marking static candidate
+	functionArgs.chpl:45
+
+**** End forall ****
+	functionArgs.chpl:43
+
+**** Start forall ****
+	functionArgs.chpl:51
+
+Iterated over the domain of
+	functionArgs.chpl:5
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:51
+
+Potential access
+	functionArgs.chpl:52
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:52
+
+Potential access
+	functionArgs.chpl:53
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:53
+
+	Marking static candidate
+	functionArgs.chpl:52
+
+	Marking static candidate
+	functionArgs.chpl:53
+
+**** End forall ****
+	functionArgs.chpl:51
+
+**** Start forall ****
+	functionArgs.chpl:57
+
+Iterated over the domain of
+	functionArgs.chpl:6
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:57
+
+Potential access
+	functionArgs.chpl:58
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:58
+
+Potential access
+	functionArgs.chpl:59
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:59
+
+	Marking static candidate
+	functionArgs.chpl:58
+
+	Marking static candidate
+	functionArgs.chpl:59
+
+**** End forall ****
+	functionArgs.chpl:57
+
+**** Start forall ****
+	functionArgs.chpl:63
+
+Iterated symbol
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:63
+
+Potential access
+	functionArgs.chpl:64
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:64
+
+Potential access
+	functionArgs.chpl:65
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:65
+
+	Marking static candidate
+	functionArgs.chpl:64
+
+	Marking static candidate
+	functionArgs.chpl:65
+
+**** End forall ****
+	functionArgs.chpl:63
+
+Static check successful. Using localAccess
+	functionArgs.chpl:12
+
+Static check successful. Using localAccess
+	functionArgs.chpl:13
+
+Static check successful. Using localAccess
+	functionArgs.chpl:18
+
+Static check successful. Using localAccess
+	functionArgs.chpl:19
+
+Static check successful. Using localAccess
+	functionArgs.chpl:24
+
+Static check successful. Using localAccess
+	functionArgs.chpl:25
+
+Static check successful. Using localAccess
+	functionArgs.chpl:32
+
+Static check successful. Using localAccess
+	functionArgs.chpl:33
+
+Static check successful. Using localAccess
+	functionArgs.chpl:38
+
+Static check successful. Using localAccess
+	functionArgs.chpl:39
+
+Static check successful. Using localAccess
+	functionArgs.chpl:44
+
+Static check successful. Using localAccess
+	functionArgs.chpl:45
+
+Static check successful. Using localAccess
+	functionArgs.chpl:52
+
+Static check successful. Using localAccess
+	functionArgs.chpl:53
+
+Static check successful. Using localAccess
+	functionArgs.chpl:58
+
+Static check successful. Using localAccess
+	functionArgs.chpl:59
+
+Static check successful. Using localAccess
+	functionArgs.chpl:64
+
+Static check successful. Using localAccess
+	functionArgs.chpl:65
+
+10 10 10 10 10 10 10 10 10 10
+20 20 20 20 20 20 20 20 20 20
+30 30 30 30 30 30 30 30 30 30
+40 40 40 40 40 40 40 40 40 40
+50 50 50 50 50 50 50 50 50 50
+60 60 60 60 60 60 60 60 60 60
+70 70 70 70 70 70 70 70 70 70
+80 80 80 80 80 80 80 80 80 80
+90 90 90 90 90 90 90 90 90 90

--- a/test/optimizations/autoLocalAccess/zipper/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/zipper/COMPOPTS
@@ -1,0 +1,1 @@
+../COMPOPTS

--- a/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.chpl
@@ -1,0 +1,20 @@
+use BlockDist;
+use CyclicDist;
+
+var D = newBlockDom({1..10});
+
+
+var A: [D] int;
+var B = newCyclicArr({1..10}, int);
+
+// A is a static candidate, and will pass the static check
+// B is a dynamic candidate that'll fail dynamic check, in that case, we want
+// the dynamic-checked loop copy to be folded out. In other words,
+// post-resolution we should have only one instance of this loop
+
+// One way to confirm that is that "Static check successful" message is shown
+// only once in the compiler logs
+forall (i, loopIdx) in zip(D, 1..) {
+  A[i] = 
+    B[i]*loopIdx;
+}

--- a/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.good
+++ b/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.good
@@ -1,0 +1,36 @@
+**** Start forall ****
+	allDynamicsFailStatic.chpl:17
+
+Iterated symbol
+	allDynamicsFailStatic.chpl:4
+
+Loop is suitable for further analysis
+	allDynamicsFailStatic.chpl:17
+
+Potential access
+	allDynamicsFailStatic.chpl:18
+
+	with domain defined at
+	allDynamicsFailStatic.chpl:4
+
+Access base's domain is the iterator
+	allDynamicsFailStatic.chpl:18
+
+Potential access
+	allDynamicsFailStatic.chpl:19
+
+Regular domain symbol was not found for array
+	allDynamicsFailStatic.chpl:8
+
+	Marking static candidate
+	allDynamicsFailStatic.chpl:18
+
+	Marking dynamic candidate
+	allDynamicsFailStatic.chpl:19
+
+**** End forall ****
+	allDynamicsFailStatic.chpl:17
+
+Static check successful. Using localAccess
+	allDynamicsFailStatic.chpl:18
+

--- a/test/optimizations/autoLocalAccess/zipper/commaDecl.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/commaDecl.chpl
@@ -1,0 +1,13 @@
+use BlockDist;
+
+var D = newBlockDom({1..10});
+
+var A, B: [D] int;
+
+B = 10;
+
+forall (i, loopIdx) in zip(D, 1..) {
+  A[i] = B[i]*loopIdx;
+}
+
+writeln(A);

--- a/test/optimizations/autoLocalAccess/zipper/commaDecl.good
+++ b/test/optimizations/autoLocalAccess/zipper/commaDecl.good
@@ -1,0 +1,43 @@
+**** Start forall ****
+	commaDecl.chpl:9
+
+Iterated symbol
+	commaDecl.chpl:3
+
+Loop is suitable for further analysis
+	commaDecl.chpl:9
+
+Potential access
+	commaDecl.chpl:10
+
+	with domain defined at
+	commaDecl.chpl:3
+
+Access base's domain is the iterator
+	commaDecl.chpl:10
+
+Potential access
+	commaDecl.chpl:10
+
+	with domain defined at
+	commaDecl.chpl:3
+
+Access base's domain is the iterator
+	commaDecl.chpl:10
+
+	Marking static candidate
+	commaDecl.chpl:10
+
+	Marking static candidate
+	commaDecl.chpl:10
+
+**** End forall ****
+	commaDecl.chpl:9
+
+Static check successful. Using localAccess
+	commaDecl.chpl:10
+
+Static check successful. Using localAccess
+	commaDecl.chpl:10
+
+10 20 30 40 50 60 70 80 90 100

--- a/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.chpl
@@ -1,0 +1,37 @@
+use BlockDist;
+
+proc foo() {
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C = newBlockArr({1..10}, int);
+
+  B = 3;
+  C = 7;
+
+  // this is the very basic case and optimzed completely
+  forall (i, loopIdx) in zip(D, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}
+
+//{
+  //var D = newBlockDom({1..10});
+
+  //var A: [D] real;
+  //var B: [D] real;
+  //var C: [D] real;
+
+  //B = 3;
+  //C = 7;
+
+  //// this only optimizes `A[i]` can do more static tracing to optimize others
+  //forall i in A.domain {
+    //A[i] = B[i] + C[i];
+  //}
+  //writeln(A);
+//}
+
+foo();

--- a/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.good
@@ -1,0 +1,61 @@
+**** Start forall ****
+	copyInitDeclaration.chpl:14
+
+Iterated symbol
+	copyInitDeclaration.chpl:4
+
+Loop is suitable for further analysis
+	copyInitDeclaration.chpl:14
+
+Potential access
+	copyInitDeclaration.chpl:15
+
+	with domain defined at
+	copyInitDeclaration.chpl:4
+
+Access base's domain is the iterator
+	copyInitDeclaration.chpl:15
+
+Potential access
+	copyInitDeclaration.chpl:15
+
+	with domain defined at
+	copyInitDeclaration.chpl:4
+
+Access base's domain is the iterator
+	copyInitDeclaration.chpl:15
+
+Potential access
+	copyInitDeclaration.chpl:15
+
+Regular domain symbol was not found for array
+	copyInitDeclaration.chpl:8
+
+	Marking static candidate
+	copyInitDeclaration.chpl:15
+
+	Marking static candidate
+	copyInitDeclaration.chpl:15
+
+	Marking dynamic candidate
+	copyInitDeclaration.chpl:15
+
+**** End forall ****
+	copyInitDeclaration.chpl:14
+
+Static check successful. Using localAccess
+	copyInitDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	copyInitDeclaration.chpl:15
+
+Static check successful. Using localAccess with dynamic check
+	copyInitDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	copyInitDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	copyInitDeclaration.chpl:15
+
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.chpl
@@ -1,0 +1,69 @@
+use BlockDist;
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [A.domain] real;
+  var C: [B.domain] real;
+
+  B = 3;
+  C = 7;
+
+  // domain information is not directly available for B and C
+  forall (i, loopIdx) in zip(D, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [A.domain] real;
+  var C: [B.domain] real;
+
+  B = 3;
+  C = 7;
+
+  // domain information is not directly available for B and C
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [A.domain] real;
+  var C: [B.domain] real;
+
+  B = 3;
+  C = 7;
+
+  // domain information is not directly available for B and C
+  forall (i, loopIdx) in zip(B.domain, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [A.domain] real;
+  var C: [B.domain] real;
+
+  B = 3;
+  C = 7;
+
+  // domain information is not directly available for B and C
+  forall (i, loopIdx) in zip(C.domain, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}

--- a/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.good
@@ -1,0 +1,232 @@
+**** Start forall ****
+	dotDomDeclaration.chpl:14
+
+Iterated symbol
+	dotDomDeclaration.chpl:4
+
+Loop is suitable for further analysis
+	dotDomDeclaration.chpl:14
+
+Potential access
+	dotDomDeclaration.chpl:15
+
+	with domain defined at
+	dotDomDeclaration.chpl:4
+
+Access base's domain is the iterator
+	dotDomDeclaration.chpl:15
+
+Potential access
+	dotDomDeclaration.chpl:15
+
+	with domain defined at
+	dotDomDeclaration.chpl:4
+
+Access base's domain is the iterator
+	dotDomDeclaration.chpl:15
+
+Potential access
+	dotDomDeclaration.chpl:15
+
+	with domain defined at
+	dotDomDeclaration.chpl:4
+
+Access base's domain is the iterator
+	dotDomDeclaration.chpl:15
+
+	Marking static candidate
+	dotDomDeclaration.chpl:15
+
+	Marking static candidate
+	dotDomDeclaration.chpl:15
+
+	Marking static candidate
+	dotDomDeclaration.chpl:15
+
+**** End forall ****
+	dotDomDeclaration.chpl:14
+
+**** Start forall ****
+	dotDomDeclaration.chpl:31
+
+Iterated over the domain of
+	dotDomDeclaration.chpl:23
+
+, which is
+	dotDomDeclaration.chpl:21
+
+Loop is suitable for further analysis
+	dotDomDeclaration.chpl:31
+
+Potential access
+	dotDomDeclaration.chpl:32
+
+	Can optimize: Access base is the iterator's base
+	dotDomDeclaration.chpl:32
+
+Potential access
+	dotDomDeclaration.chpl:32
+
+	with domain defined at
+	dotDomDeclaration.chpl:21
+
+	Can optimize: Access base has the same domain as iterator's base
+	dotDomDeclaration.chpl:32
+
+Potential access
+	dotDomDeclaration.chpl:32
+
+	with domain defined at
+	dotDomDeclaration.chpl:21
+
+	Can optimize: Access base has the same domain as iterator's base
+	dotDomDeclaration.chpl:32
+
+	Marking static candidate
+	dotDomDeclaration.chpl:32
+
+	Marking static candidate
+	dotDomDeclaration.chpl:32
+
+	Marking static candidate
+	dotDomDeclaration.chpl:32
+
+**** End forall ****
+	dotDomDeclaration.chpl:31
+
+**** Start forall ****
+	dotDomDeclaration.chpl:48
+
+Iterated over the domain of
+	dotDomDeclaration.chpl:41
+
+, which is
+	dotDomDeclaration.chpl:38
+
+Loop is suitable for further analysis
+	dotDomDeclaration.chpl:48
+
+Potential access
+	dotDomDeclaration.chpl:49
+
+	with domain defined at
+	dotDomDeclaration.chpl:38
+
+	Can optimize: Access base has the same domain as iterator's base
+	dotDomDeclaration.chpl:49
+
+Potential access
+	dotDomDeclaration.chpl:49
+
+	Can optimize: Access base is the iterator's base
+	dotDomDeclaration.chpl:49
+
+Potential access
+	dotDomDeclaration.chpl:49
+
+	with domain defined at
+	dotDomDeclaration.chpl:38
+
+	Can optimize: Access base has the same domain as iterator's base
+	dotDomDeclaration.chpl:49
+
+	Marking static candidate
+	dotDomDeclaration.chpl:49
+
+	Marking static candidate
+	dotDomDeclaration.chpl:49
+
+	Marking static candidate
+	dotDomDeclaration.chpl:49
+
+**** End forall ****
+	dotDomDeclaration.chpl:48
+
+**** Start forall ****
+	dotDomDeclaration.chpl:65
+
+Iterated over the domain of
+	dotDomDeclaration.chpl:59
+
+, which is
+	dotDomDeclaration.chpl:55
+
+Loop is suitable for further analysis
+	dotDomDeclaration.chpl:65
+
+Potential access
+	dotDomDeclaration.chpl:66
+
+	with domain defined at
+	dotDomDeclaration.chpl:55
+
+	Can optimize: Access base has the same domain as iterator's base
+	dotDomDeclaration.chpl:66
+
+Potential access
+	dotDomDeclaration.chpl:66
+
+	with domain defined at
+	dotDomDeclaration.chpl:55
+
+	Can optimize: Access base has the same domain as iterator's base
+	dotDomDeclaration.chpl:66
+
+Potential access
+	dotDomDeclaration.chpl:66
+
+	Can optimize: Access base is the iterator's base
+	dotDomDeclaration.chpl:66
+
+	Marking static candidate
+	dotDomDeclaration.chpl:66
+
+	Marking static candidate
+	dotDomDeclaration.chpl:66
+
+	Marking static candidate
+	dotDomDeclaration.chpl:66
+
+**** End forall ****
+	dotDomDeclaration.chpl:65
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:32
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:32
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:32
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:49
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:49
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:49
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:66
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:66
+
+Static check successful. Using localAccess
+	dotDomDeclaration.chpl:66
+
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.chpl
@@ -1,0 +1,21 @@
+use BlockDist;
+
+var dom = newBlockDom({1..10});
+
+var arr: [dom] real;
+
+class MyClass {
+  proc this(i) {
+    return i*2;
+  }
+}
+
+proc foo(A: arr.type, B) {
+  // A is a static candidate that should be statically confirmed,
+  // B is a dynamic candidate that should be statically reverted
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = B[i]*loopIdx;
+  }
+}
+
+foo(arr, new MyClass());

--- a/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.good
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.good
@@ -1,0 +1,39 @@
+**** Start forall ****
+	dynamicCheckInGenericFunction.chpl:16
+
+Regular domain symbol was not found for array
+	dynamicCheckInGenericFunction.chpl:13
+
+Iterated over the domain of
+	dynamicCheckInGenericFunction.chpl:13
+
+, whose domain cannot be determined statically
+	dynamicCheckInGenericFunction.chpl:13
+
+Loop is suitable for further analysis
+	dynamicCheckInGenericFunction.chpl:16
+
+Potential access
+	dynamicCheckInGenericFunction.chpl:17
+
+	Can optimize: Access base is the iterator's base
+	dynamicCheckInGenericFunction.chpl:17
+
+Potential access
+	dynamicCheckInGenericFunction.chpl:17
+
+Regular domain symbol was not found for array
+	dynamicCheckInGenericFunction.chpl:13
+
+	Marking static candidate
+	dynamicCheckInGenericFunction.chpl:17
+
+	Marking dynamic candidate
+	dynamicCheckInGenericFunction.chpl:17
+
+**** End forall ****
+	dynamicCheckInGenericFunction.chpl:16
+
+Static check successful. Using localAccess
+	dynamicCheckInGenericFunction.chpl:17
+

--- a/test/optimizations/autoLocalAccess/zipper/dynamicChecks.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicChecks.chpl
@@ -1,0 +1,36 @@
+use BlockDist;
+
+proc F(i) {
+  return i*2;
+}
+
+class MyClass {
+  proc this(i) {
+    return i;
+  }
+}
+
+{
+
+  const space = {1..10};
+  var dom = newBlockDom(space);
+
+  var A: [dom] real;
+  var B: [dom] real;
+  var C = newBlockArr(space, real);
+  var D: [space] real;
+  var E = new MyClass();
+
+
+  B = 3;
+
+  // this is the very basic case and optimzed completely
+  forall (i, loopIdx) in zip(dom, 1..) {
+    A[i] = B[i] +
+           C[i] +
+           D[i] +
+           E[i] +
+           F[i]*loopIdx;  // functions are unresolved sym exprs, so they are skipped
+  }
+  writeln(A);
+}

--- a/test/optimizations/autoLocalAccess/zipper/dynamicChecks.good
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicChecks.good
@@ -1,0 +1,79 @@
+**** Start forall ****
+	dynamicChecks.chpl:28
+
+Iterated symbol
+	dynamicChecks.chpl:16
+
+Loop is suitable for further analysis
+	dynamicChecks.chpl:28
+
+Potential access
+	dynamicChecks.chpl:29
+
+	with domain defined at
+	dynamicChecks.chpl:16
+
+Access base's domain is the iterator
+	dynamicChecks.chpl:29
+
+Potential access
+	dynamicChecks.chpl:29
+
+	with domain defined at
+	dynamicChecks.chpl:16
+
+Access base's domain is the iterator
+	dynamicChecks.chpl:29
+
+Potential access
+	dynamicChecks.chpl:30
+
+Regular domain symbol was not found for array
+	dynamicChecks.chpl:20
+
+Potential access
+	dynamicChecks.chpl:31
+
+	with domain defined at
+	dynamicChecks.chpl:15
+
+Potential access
+	dynamicChecks.chpl:32
+
+Regular domain symbol was not found for array
+	dynamicChecks.chpl:22
+
+	Marking static candidate
+	dynamicChecks.chpl:29
+
+	Marking static candidate
+	dynamicChecks.chpl:29
+
+	Marking dynamic candidate
+	dynamicChecks.chpl:30
+
+	Marking dynamic candidate
+	dynamicChecks.chpl:32
+
+**** End forall ****
+	dynamicChecks.chpl:28
+
+Static check successful. Using localAccess
+	dynamicChecks.chpl:29
+
+Static check successful. Using localAccess
+	dynamicChecks.chpl:29
+
+Static check successful. Using localAccess with dynamic check
+	dynamicChecks.chpl:30
+
+Static check failed. Reverting optimization
+	dynamicChecks.chpl:32
+
+Static check successful. Using localAccess
+	dynamicChecks.chpl:29
+
+Static check successful. Using localAccess
+	dynamicChecks.chpl:29
+
+6.0 13.0 24.0 39.0 58.0 81.0 108.0 139.0 174.0 213.0

--- a/test/optimizations/autoLocalAccess/zipper/failures
+++ b/test/optimizations/autoLocalAccess/zipper/failures
@@ -1,0 +1,21 @@
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/commaDecl]
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/copyInitDeclaration]
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/dotDomDeclaration]
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/dynamicChecks]
+[Error matching compiler output for
+optimizations/autoLocalAccess/zipper/interveningForallOrOn]
+[Error matching compiler output for
+optimizations/autoLocalAccess/zipper/nonDomainIter]
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess]
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/regularCommaDeclaration]
+[Error matching program output for
+optimizations/autoLocalAccess/zipper/regularDeclaration]
+[Error matching compiler output for
+optimizations/autoLocalAccess/zipper/regularDeclaration2D]
+

--- a/test/optimizations/autoLocalAccess/zipper/functionArgs.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/functionArgs.chpl
@@ -1,0 +1,78 @@
+use BlockDist;
+
+var D = newBlockDom({1..10});
+
+var A: [D] int;
+var B: [D] int;
+
+// all the patterns in this test must be recognized and optimized statically
+
+proc localQueriedDomain(a: [?d] int, b: [d] int){
+  forall (i, loopIdx) in zip(a.domain, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+
+  forall (i, loopIdx) in zip(b.domain, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+
+  forall (i, loopIdx) in zip(d, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+}
+
+proc globalDotDomain(a: [A.domain] int, b: [A.domain] int){
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+
+  forall (i, loopIdx) in zip(B.domain, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+
+  forall (i, loopIdx) in zip(D, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+}
+
+proc globalDomain(a: [D] int, b: [D] int){
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+
+  forall (i, loopIdx) in zip(B.domain, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+
+  forall (i, loopIdx) in zip(D, 1..) {
+    a[i] += 
+      b[i] * loopIdx;
+  }
+  writeln(a);
+}
+
+proc main() {
+  B = 10;
+
+  localQueriedDomain(A, B);
+
+  globalDotDomain(A, B);
+
+  globalDomain(A, B);
+}

--- a/test/optimizations/autoLocalAccess/zipper/functionArgs.good
+++ b/test/optimizations/autoLocalAccess/zipper/functionArgs.good
@@ -1,0 +1,399 @@
+**** Start forall ****
+	functionArgs.chpl:11
+
+Iterated over the domain of
+	functionArgs.chpl:10
+
+, which is
+	functionArgs.chpl:10
+
+Loop is suitable for further analysis
+	functionArgs.chpl:11
+
+Potential access
+	functionArgs.chpl:12
+
+	Can optimize: Access base is the iterator's base
+	functionArgs.chpl:12
+
+Potential access
+	functionArgs.chpl:13
+
+	with domain defined at
+	functionArgs.chpl:10
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:13
+
+	Marking static candidate
+	functionArgs.chpl:12
+
+	Marking static candidate
+	functionArgs.chpl:13
+
+**** End forall ****
+	functionArgs.chpl:11
+
+**** Start forall ****
+	functionArgs.chpl:17
+
+Iterated over the domain of
+	functionArgs.chpl:10
+
+, which is
+	functionArgs.chpl:10
+
+Loop is suitable for further analysis
+	functionArgs.chpl:17
+
+Potential access
+	functionArgs.chpl:18
+
+	with domain defined at
+	functionArgs.chpl:10
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:18
+
+Potential access
+	functionArgs.chpl:19
+
+	Can optimize: Access base is the iterator's base
+	functionArgs.chpl:19
+
+	Marking static candidate
+	functionArgs.chpl:18
+
+	Marking static candidate
+	functionArgs.chpl:19
+
+**** End forall ****
+	functionArgs.chpl:17
+
+**** Start forall ****
+	functionArgs.chpl:23
+
+Iterated symbol
+	functionArgs.chpl:10
+
+Loop is suitable for further analysis
+	functionArgs.chpl:23
+
+Potential access
+	functionArgs.chpl:24
+
+	with domain defined at
+	functionArgs.chpl:10
+
+Access base's domain is the iterator
+	functionArgs.chpl:24
+
+Potential access
+	functionArgs.chpl:25
+
+	with domain defined at
+	functionArgs.chpl:10
+
+Access base's domain is the iterator
+	functionArgs.chpl:25
+
+	Marking static candidate
+	functionArgs.chpl:24
+
+	Marking static candidate
+	functionArgs.chpl:25
+
+**** End forall ****
+	functionArgs.chpl:23
+
+**** Start forall ****
+	functionArgs.chpl:31
+
+Iterated over the domain of
+	functionArgs.chpl:5
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:31
+
+Potential access
+	functionArgs.chpl:32
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:32
+
+Potential access
+	functionArgs.chpl:33
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:33
+
+	Marking static candidate
+	functionArgs.chpl:32
+
+	Marking static candidate
+	functionArgs.chpl:33
+
+**** End forall ****
+	functionArgs.chpl:31
+
+**** Start forall ****
+	functionArgs.chpl:37
+
+Iterated over the domain of
+	functionArgs.chpl:6
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:37
+
+Potential access
+	functionArgs.chpl:38
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:38
+
+Potential access
+	functionArgs.chpl:39
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:39
+
+	Marking static candidate
+	functionArgs.chpl:38
+
+	Marking static candidate
+	functionArgs.chpl:39
+
+**** End forall ****
+	functionArgs.chpl:37
+
+**** Start forall ****
+	functionArgs.chpl:43
+
+Iterated symbol
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:43
+
+Potential access
+	functionArgs.chpl:44
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:44
+
+Potential access
+	functionArgs.chpl:45
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:45
+
+	Marking static candidate
+	functionArgs.chpl:44
+
+	Marking static candidate
+	functionArgs.chpl:45
+
+**** End forall ****
+	functionArgs.chpl:43
+
+**** Start forall ****
+	functionArgs.chpl:51
+
+Iterated over the domain of
+	functionArgs.chpl:5
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:51
+
+Potential access
+	functionArgs.chpl:52
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:52
+
+Potential access
+	functionArgs.chpl:53
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:53
+
+	Marking static candidate
+	functionArgs.chpl:52
+
+	Marking static candidate
+	functionArgs.chpl:53
+
+**** End forall ****
+	functionArgs.chpl:51
+
+**** Start forall ****
+	functionArgs.chpl:57
+
+Iterated over the domain of
+	functionArgs.chpl:6
+
+, which is
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:57
+
+Potential access
+	functionArgs.chpl:58
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:58
+
+Potential access
+	functionArgs.chpl:59
+
+	with domain defined at
+	functionArgs.chpl:3
+
+	Can optimize: Access base has the same domain as iterator's base
+	functionArgs.chpl:59
+
+	Marking static candidate
+	functionArgs.chpl:58
+
+	Marking static candidate
+	functionArgs.chpl:59
+
+**** End forall ****
+	functionArgs.chpl:57
+
+**** Start forall ****
+	functionArgs.chpl:63
+
+Iterated symbol
+	functionArgs.chpl:3
+
+Loop is suitable for further analysis
+	functionArgs.chpl:63
+
+Potential access
+	functionArgs.chpl:64
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:64
+
+Potential access
+	functionArgs.chpl:65
+
+	with domain defined at
+	functionArgs.chpl:3
+
+Access base's domain is the iterator
+	functionArgs.chpl:65
+
+	Marking static candidate
+	functionArgs.chpl:64
+
+	Marking static candidate
+	functionArgs.chpl:65
+
+**** End forall ****
+	functionArgs.chpl:63
+
+Static check successful. Using localAccess
+	functionArgs.chpl:12
+
+Static check successful. Using localAccess
+	functionArgs.chpl:13
+
+Static check successful. Using localAccess
+	functionArgs.chpl:18
+
+Static check successful. Using localAccess
+	functionArgs.chpl:19
+
+Static check successful. Using localAccess
+	functionArgs.chpl:24
+
+Static check successful. Using localAccess
+	functionArgs.chpl:25
+
+Static check successful. Using localAccess
+	functionArgs.chpl:32
+
+Static check successful. Using localAccess
+	functionArgs.chpl:33
+
+Static check successful. Using localAccess
+	functionArgs.chpl:38
+
+Static check successful. Using localAccess
+	functionArgs.chpl:39
+
+Static check successful. Using localAccess
+	functionArgs.chpl:44
+
+Static check successful. Using localAccess
+	functionArgs.chpl:45
+
+Static check successful. Using localAccess
+	functionArgs.chpl:52
+
+Static check successful. Using localAccess
+	functionArgs.chpl:53
+
+Static check successful. Using localAccess
+	functionArgs.chpl:58
+
+Static check successful. Using localAccess
+	functionArgs.chpl:59
+
+Static check successful. Using localAccess
+	functionArgs.chpl:64
+
+Static check successful. Using localAccess
+	functionArgs.chpl:65
+
+10 20 30 40 50 60 70 80 90 100
+20 40 60 80 100 120 140 160 180 200
+30 60 90 120 150 180 210 240 270 300
+40 80 120 160 200 240 280 320 360 400
+50 100 150 200 250 300 350 400 450 500
+60 120 180 240 300 360 420 480 540 600
+70 140 210 280 350 420 490 560 630 700
+80 160 240 320 400 480 560 640 720 800
+90 180 270 360 450 540 630 720 810 900

--- a/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.chpl
@@ -1,0 +1,31 @@
+
+use BlockDist;
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  forall (i, loopIdx) in zip(D, 1..) {
+    forall j in 1..10 {
+      A[i] = B[i] + C[j] * loopIdx;
+    }
+  }
+}
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  forall (i, loopIdx) in zip(D, 1..) {
+    on Locales[0] {
+      A[i] = B[i] + C[i] * loopIdx;
+    }
+  }
+
+}

--- a/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.good
+++ b/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.good
@@ -1,0 +1,30 @@
+**** Start forall ****
+	interveningForallOrOn.chpl:12
+
+**** End forall ****
+	interveningForallOrOn.chpl:12
+
+**** Start forall ****
+	interveningForallOrOn.chpl:11
+
+Iterated symbol
+	interveningForallOrOn.chpl:5
+
+Loop is suitable for further analysis
+	interveningForallOrOn.chpl:11
+
+**** End forall ****
+	interveningForallOrOn.chpl:11
+
+**** Start forall ****
+	interveningForallOrOn.chpl:25
+
+Iterated symbol
+	interveningForallOrOn.chpl:19
+
+Loop is suitable for further analysis
+	interveningForallOrOn.chpl:25
+
+**** End forall ****
+	interveningForallOrOn.chpl:25
+

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.chpl
@@ -1,0 +1,10 @@
+use BlockDist;
+
+var A = newBlockArr({1..10}, int);
+var B = newBlockArr({1..10}, int);
+
+// there must be only one static check, and two accesses optimized
+forall (i, loopIdx) in zip(A.domain, 1..) {
+  if i>1 && i<10 then
+    A[i] = B[i-1] + B[i] + B[i] * loopIdx + B[i+1];
+}

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.good
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.good
@@ -1,0 +1,57 @@
+**** Start forall ****
+	multipleAccessDynamic.chpl:7
+
+Regular domain symbol was not found for array
+	multipleAccessDynamic.chpl:3
+
+Iterated over the domain of
+	multipleAccessDynamic.chpl:3
+
+, whose domain cannot be determined statically
+	multipleAccessDynamic.chpl:3
+
+Loop is suitable for further analysis
+	multipleAccessDynamic.chpl:7
+
+Potential access
+	multipleAccessDynamic.chpl:9
+
+	Can optimize: Access base is the iterator's base
+	multipleAccessDynamic.chpl:9
+
+Potential access
+	multipleAccessDynamic.chpl:9
+
+Regular domain symbol was not found for array
+	multipleAccessDynamic.chpl:4
+
+Potential access
+	multipleAccessDynamic.chpl:9
+
+Regular domain symbol was not found for array
+	multipleAccessDynamic.chpl:4
+
+	Marking static candidate
+	multipleAccessDynamic.chpl:9
+
+	Marking dynamic candidate
+	multipleAccessDynamic.chpl:9
+
+	Marking dynamic candidate
+	multipleAccessDynamic.chpl:9
+
+**** End forall ****
+	multipleAccessDynamic.chpl:7
+
+Static check successful. Using localAccess
+	multipleAccessDynamic.chpl:9
+
+Static check successful. Using localAccess with dynamic check
+	multipleAccessDynamic.chpl:9
+
+Static check successful. Using localAccess with dynamic check
+	multipleAccessDynamic.chpl:9
+
+Static check successful. Using localAccess
+	multipleAccessDynamic.chpl:9
+

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.chpl
@@ -1,0 +1,11 @@
+use BlockDist;
+
+var D = newBlockDom({1..10});
+
+var A: [D] int;
+
+// there must be only one static check, and two accesses optimized
+forall (i, loopIdx) in zip(D, 1..) {
+  if i>1 && i<10 then
+    A[i] = A[i-1] + A[i] * loopIdx + A[i+1];
+}

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.good
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.good
@@ -1,0 +1,42 @@
+**** Start forall ****
+	multipleAccessStatic.chpl:8
+
+Iterated symbol
+	multipleAccessStatic.chpl:3
+
+Loop is suitable for further analysis
+	multipleAccessStatic.chpl:8
+
+Potential access
+	multipleAccessStatic.chpl:10
+
+	with domain defined at
+	multipleAccessStatic.chpl:3
+
+Access base's domain is the iterator
+	multipleAccessStatic.chpl:10
+
+Potential access
+	multipleAccessStatic.chpl:10
+
+	with domain defined at
+	multipleAccessStatic.chpl:3
+
+Access base's domain is the iterator
+	multipleAccessStatic.chpl:10
+
+	Marking static candidate
+	multipleAccessStatic.chpl:10
+
+	Marking static candidate
+	multipleAccessStatic.chpl:10
+
+**** End forall ****
+	multipleAccessStatic.chpl:8
+
+Static check successful. Using localAccess
+	multipleAccessStatic.chpl:10
+
+Static check successful. Using localAccess
+	multipleAccessStatic.chpl:10
+

--- a/test/optimizations/autoLocalAccess/zipper/nonDomainIter.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/nonDomainIter.chpl
@@ -1,0 +1,29 @@
+use BlockDist;
+
+class C {
+  var i = 10;
+    iter these() {
+      yield i;
+    }
+
+    iter these(param tag: iterKind) where tag == iterKind.standalone {
+      yield i;
+    }
+
+    iter these(param tag: iterKind) where tag == iterKind.leader {
+      yield (1..10, );
+    }
+
+    iter these(param tag: iterKind, followThis) where tag == iterKind.follower {
+      for i in followThis[0] do yield i;
+    }
+}
+
+var A = newBlockArr({1..10}, int);
+var B = newBlockArr({1..10}, int);
+
+var c = new C();
+
+forall (i, loopIdx) in zip(c, 1..) {
+  A[i] = 2 * B[i] * loopIdx;
+}

--- a/test/optimizations/autoLocalAccess/zipper/nonDomainIter.good
+++ b/test/optimizations/autoLocalAccess/zipper/nonDomainIter.good
@@ -1,0 +1,30 @@
+**** Start forall ****
+	nonDomainIter.chpl:27
+
+Iterated symbol
+	nonDomainIter.chpl:25
+
+Loop is suitable for further analysis
+	nonDomainIter.chpl:27
+
+Potential access
+	nonDomainIter.chpl:28
+
+Regular domain symbol was not found for array
+	nonDomainIter.chpl:22
+
+Potential access
+	nonDomainIter.chpl:28
+
+Regular domain symbol was not found for array
+	nonDomainIter.chpl:23
+
+	Marking dynamic candidate
+	nonDomainIter.chpl:28
+
+	Marking dynamic candidate
+	nonDomainIter.chpl:28
+
+**** End forall ****
+	nonDomainIter.chpl:27
+

--- a/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.chpl
@@ -1,0 +1,27 @@
+use BlockDist;
+
+class MyClass { proc this(i) { return i; } }
+
+// hijack these two methods to provide some output
+inline proc _array.this(i: int) ref {
+  writeln("Custom this was called");
+  return this._value.dsiAccess((i:int,));
+}
+
+inline proc _array.localAccess(i: int) ref {
+  writeln("Custom localAccess was called");
+  return this._value.dsiLocalAccess((i:int,));
+}
+
+var D = newBlockDom({1..10});
+
+var A = newBlockArr({1..10}, int); // dynamic candidate, static check is true
+var B = new MyClass(); // dynamic candidate, static check is false
+
+// we want the access to A still be through localAccess (i.e. not affected by
+// the static failure of another dynamic candidate)
+forall (i, loopIdx) in zip(D, 1..) {
+  A[i] = B[i] * loopIdx;
+}
+
+writeln(A);

--- a/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.good
+++ b/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.good
@@ -1,0 +1,47 @@
+**** Start forall ****
+	oneStaticFailOtherDynamicSuccess.chpl:23
+
+Iterated symbol
+	oneStaticFailOtherDynamicSuccess.chpl:16
+
+Loop is suitable for further analysis
+	oneStaticFailOtherDynamicSuccess.chpl:23
+
+Potential access
+	oneStaticFailOtherDynamicSuccess.chpl:24
+
+Regular domain symbol was not found for array
+	oneStaticFailOtherDynamicSuccess.chpl:18
+
+Potential access
+	oneStaticFailOtherDynamicSuccess.chpl:24
+
+Regular domain symbol was not found for array
+	oneStaticFailOtherDynamicSuccess.chpl:19
+
+	Marking dynamic candidate
+	oneStaticFailOtherDynamicSuccess.chpl:24
+
+	Marking dynamic candidate
+	oneStaticFailOtherDynamicSuccess.chpl:24
+
+**** End forall ****
+	oneStaticFailOtherDynamicSuccess.chpl:23
+
+Static check successful. Using localAccess with dynamic check
+	oneStaticFailOtherDynamicSuccess.chpl:24
+
+Static check failed. Reverting optimization
+	oneStaticFailOtherDynamicSuccess.chpl:24
+
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+Custom localAccess was called
+1 4 9 16 25 36 49 64 81 100

--- a/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.chpl
@@ -1,0 +1,31 @@
+use BlockDist;
+
+{
+  var D = newBlockDom({1..10});
+
+  var A, B, C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this is the very basic case and optimzed completely
+  forall (i, loopIdx) in zip(D, 1..) {
+    A[i] = B[i] + C[i];
+  }
+  writeln(A);
+}
+
+{
+  var D = newBlockDom({1..10});
+
+  var A, B, C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this only optimizes `A[i]` can do more static tracing to optimize others
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}

--- a/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.good
@@ -113,4 +113,4 @@ Static check successful. Using localAccess
 	regularCommaDeclaration.chpl:28
 
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
-10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration.chpl
@@ -1,0 +1,35 @@
+use BlockDist;
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this is the very basic case and optimzed completely
+  forall (i, loopIdx) in zip(D, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}
+
+{
+  var D = newBlockDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this only optimizes `A[i]` can do more static tracing to optimize others
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = B[i] + C[i] * loopIdx;
+  }
+  writeln(A);
+}

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration.good
@@ -1,0 +1,116 @@
+**** Start forall ****
+	regularDeclaration.chpl:14
+
+Iterated symbol
+	regularDeclaration.chpl:4
+
+Loop is suitable for further analysis
+	regularDeclaration.chpl:14
+
+Potential access
+	regularDeclaration.chpl:15
+
+	with domain defined at
+	regularDeclaration.chpl:4
+
+Access base's domain is the iterator
+	regularDeclaration.chpl:15
+
+Potential access
+	regularDeclaration.chpl:15
+
+	with domain defined at
+	regularDeclaration.chpl:4
+
+Access base's domain is the iterator
+	regularDeclaration.chpl:15
+
+Potential access
+	regularDeclaration.chpl:15
+
+	with domain defined at
+	regularDeclaration.chpl:4
+
+Access base's domain is the iterator
+	regularDeclaration.chpl:15
+
+	Marking static candidate
+	regularDeclaration.chpl:15
+
+	Marking static candidate
+	regularDeclaration.chpl:15
+
+	Marking static candidate
+	regularDeclaration.chpl:15
+
+**** End forall ****
+	regularDeclaration.chpl:14
+
+**** Start forall ****
+	regularDeclaration.chpl:31
+
+Iterated over the domain of
+	regularDeclaration.chpl:23
+
+, which is
+	regularDeclaration.chpl:21
+
+Loop is suitable for further analysis
+	regularDeclaration.chpl:31
+
+Potential access
+	regularDeclaration.chpl:32
+
+	Can optimize: Access base is the iterator's base
+	regularDeclaration.chpl:32
+
+Potential access
+	regularDeclaration.chpl:32
+
+	with domain defined at
+	regularDeclaration.chpl:21
+
+	Can optimize: Access base has the same domain as iterator's base
+	regularDeclaration.chpl:32
+
+Potential access
+	regularDeclaration.chpl:32
+
+	with domain defined at
+	regularDeclaration.chpl:21
+
+	Can optimize: Access base has the same domain as iterator's base
+	regularDeclaration.chpl:32
+
+	Marking static candidate
+	regularDeclaration.chpl:32
+
+	Marking static candidate
+	regularDeclaration.chpl:32
+
+	Marking static candidate
+	regularDeclaration.chpl:32
+
+**** End forall ****
+	regularDeclaration.chpl:31
+
+Static check successful. Using localAccess
+	regularDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	regularDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	regularDeclaration.chpl:15
+
+Static check successful. Using localAccess
+	regularDeclaration.chpl:32
+
+Static check successful. Using localAccess
+	regularDeclaration.chpl:32
+
+Static check successful. Using localAccess
+	regularDeclaration.chpl:32
+
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
+10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.chpl
@@ -1,0 +1,35 @@
+use BlockDist;
+
+{
+  var D = newBlockDom({1..10, 1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this is the very basic case and optimzed completely
+  forall ((i,j), loopIdx) in zip(D, {1..10, 1..10}) {
+    A[i,j] = B[i,j] + C[i,j] * loopIdx[0];
+  }
+  writeln(A);
+}
+
+{
+  var D = newBlockDom({1..10, 1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this only optimizes `A[i]` can do more static tracing to optimize others
+  forall ((i,j), loopIdx) in zip(D, {1..10, 1..10}) {
+    A[i,j] = B[i,j] + C[i,j] * loopIdx[0];
+  }
+  writeln(A);
+}

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.good
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.good
@@ -1,0 +1,134 @@
+**** Start forall ****
+	regularDeclaration2D.chpl:14
+
+Iterated symbol
+	regularDeclaration2D.chpl:4
+
+Loop is suitable for further analysis
+	regularDeclaration2D.chpl:14
+
+Potential access
+	regularDeclaration2D.chpl:15
+
+	with domain defined at
+	regularDeclaration2D.chpl:4
+
+Access base's domain is the iterator
+	regularDeclaration2D.chpl:15
+
+Potential access
+	regularDeclaration2D.chpl:15
+
+	with domain defined at
+	regularDeclaration2D.chpl:4
+
+Access base's domain is the iterator
+	regularDeclaration2D.chpl:15
+
+Potential access
+	regularDeclaration2D.chpl:15
+
+	with domain defined at
+	regularDeclaration2D.chpl:4
+
+Access base's domain is the iterator
+	regularDeclaration2D.chpl:15
+
+	Marking static candidate
+	regularDeclaration2D.chpl:15
+
+	Marking static candidate
+	regularDeclaration2D.chpl:15
+
+	Marking static candidate
+	regularDeclaration2D.chpl:15
+
+**** End forall ****
+	regularDeclaration2D.chpl:14
+
+**** Start forall ****
+	regularDeclaration2D.chpl:31
+
+Iterated symbol
+	regularDeclaration2D.chpl:21
+
+Loop is suitable for further analysis
+	regularDeclaration2D.chpl:31
+
+Potential access
+	regularDeclaration2D.chpl:32
+
+	with domain defined at
+	regularDeclaration2D.chpl:21
+
+Access base's domain is the iterator
+	regularDeclaration2D.chpl:32
+
+Potential access
+	regularDeclaration2D.chpl:32
+
+	with domain defined at
+	regularDeclaration2D.chpl:21
+
+Access base's domain is the iterator
+	regularDeclaration2D.chpl:32
+
+Potential access
+	regularDeclaration2D.chpl:32
+
+	with domain defined at
+	regularDeclaration2D.chpl:21
+
+Access base's domain is the iterator
+	regularDeclaration2D.chpl:32
+
+	Marking static candidate
+	regularDeclaration2D.chpl:32
+
+	Marking static candidate
+	regularDeclaration2D.chpl:32
+
+	Marking static candidate
+	regularDeclaration2D.chpl:32
+
+**** End forall ****
+	regularDeclaration2D.chpl:31
+
+Static check successful. Using localAccess
+	regularDeclaration2D.chpl:15
+
+Static check successful. Using localAccess
+	regularDeclaration2D.chpl:15
+
+Static check successful. Using localAccess
+	regularDeclaration2D.chpl:15
+
+Static check successful. Using localAccess
+	regularDeclaration2D.chpl:32
+
+Static check successful. Using localAccess
+	regularDeclaration2D.chpl:32
+
+Static check successful. Using localAccess
+	regularDeclaration2D.chpl:32
+
+10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
+17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0
+24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0
+31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0
+38.0 38.0 38.0 38.0 38.0 38.0 38.0 38.0 38.0 38.0
+45.0 45.0 45.0 45.0 45.0 45.0 45.0 45.0 45.0 45.0
+52.0 52.0 52.0 52.0 52.0 52.0 52.0 52.0 52.0 52.0
+59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0
+66.0 66.0 66.0 66.0 66.0 66.0 66.0 66.0 66.0 66.0
+73.0 73.0 73.0 73.0 73.0 73.0 73.0 73.0 73.0 73.0
+10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
+17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0
+24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0
+31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0
+38.0 38.0 38.0 38.0 38.0 38.0 38.0 38.0 38.0 38.0
+45.0 45.0 45.0 45.0 45.0 45.0 45.0 45.0 45.0 45.0
+52.0 52.0 52.0 52.0 52.0 52.0 52.0 52.0 52.0 52.0
+59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0
+66.0 66.0 66.0 66.0 66.0 66.0 66.0 66.0 66.0 66.0
+73.0 73.0 73.0 73.0 73.0 73.0 73.0 73.0 73.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.chpl
@@ -1,0 +1,10 @@
+use BlockDist;
+
+var A = newBlockArr({0..10}, int);
+var B = newBlockArr({1..9}, int);
+
+forall (i, loopIdx) in zip(B.domain, 1..) {
+  B[i] = A[i] * loopIdx;
+}
+
+writeln(B);

--- a/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.good
+++ b/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.good
@@ -1,0 +1,46 @@
+**** Start forall ****
+	staticSuccessDynamicFail.chpl:6
+
+Regular domain symbol was not found for array
+	staticSuccessDynamicFail.chpl:4
+
+Iterated over the domain of
+	staticSuccessDynamicFail.chpl:4
+
+, whose domain cannot be determined statically
+	staticSuccessDynamicFail.chpl:4
+
+Loop is suitable for further analysis
+	staticSuccessDynamicFail.chpl:6
+
+Potential access
+	staticSuccessDynamicFail.chpl:7
+
+	Can optimize: Access base is the iterator's base
+	staticSuccessDynamicFail.chpl:7
+
+Potential access
+	staticSuccessDynamicFail.chpl:7
+
+Regular domain symbol was not found for array
+	staticSuccessDynamicFail.chpl:3
+
+	Marking static candidate
+	staticSuccessDynamicFail.chpl:7
+
+	Marking dynamic candidate
+	staticSuccessDynamicFail.chpl:7
+
+**** End forall ****
+	staticSuccessDynamicFail.chpl:6
+
+Static check successful. Using localAccess
+	staticSuccessDynamicFail.chpl:7
+
+Static check successful. Using localAccess with dynamic check
+	staticSuccessDynamicFail.chpl:7
+
+Static check successful. Using localAccess
+	staticSuccessDynamicFail.chpl:7
+
+0 0 0 0 0 0 0 0 0

--- a/test/optimizations/autoLocalAccess/zipper/withInitializerCall.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/withInitializerCall.chpl
@@ -1,0 +1,37 @@
+use BlockDist;
+
+record R {
+  var x: int;
+}
+
+class C {
+  var x: int;
+}
+
+{
+  var A = newBlockArr({1..10}, R);
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = new R[i*loopIdx];
+  }
+}
+
+{
+  var A = newBlockArr({1..10}, unmanaged C?);
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = new unmanaged C[i*loopIdx];
+  }
+}
+
+{
+  var A = newBlockArr({1..10}, owned C?);
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = new owned C[i*loopIdx];
+  }
+}
+
+{
+  var A = newBlockArr({1..10}, shared C?);
+  forall (i, loopIdx) in zip(A.domain, 1..) {
+    A[i] = new shared C[i*loopIdx];
+  }
+}

--- a/test/optimizations/autoLocalAccess/zipper/withInitializerCall.good
+++ b/test/optimizations/autoLocalAccess/zipper/withInitializerCall.good
@@ -1,0 +1,120 @@
+**** Start forall ****
+	withInitializerCall.chpl:13
+
+Regular domain symbol was not found for array
+	withInitializerCall.chpl:12
+
+Iterated over the domain of
+	withInitializerCall.chpl:12
+
+, whose domain cannot be determined statically
+	withInitializerCall.chpl:12
+
+Loop is suitable for further analysis
+	withInitializerCall.chpl:13
+
+Potential access
+	withInitializerCall.chpl:14
+
+	Can optimize: Access base is the iterator's base
+	withInitializerCall.chpl:14
+
+	Marking static candidate
+	withInitializerCall.chpl:14
+
+**** End forall ****
+	withInitializerCall.chpl:13
+
+**** Start forall ****
+	withInitializerCall.chpl:20
+
+Regular domain symbol was not found for array
+	withInitializerCall.chpl:19
+
+Iterated over the domain of
+	withInitializerCall.chpl:19
+
+, whose domain cannot be determined statically
+	withInitializerCall.chpl:19
+
+Loop is suitable for further analysis
+	withInitializerCall.chpl:20
+
+Potential access
+	withInitializerCall.chpl:21
+
+	Can optimize: Access base is the iterator's base
+	withInitializerCall.chpl:21
+
+	Marking static candidate
+	withInitializerCall.chpl:21
+
+**** End forall ****
+	withInitializerCall.chpl:20
+
+**** Start forall ****
+	withInitializerCall.chpl:27
+
+Regular domain symbol was not found for array
+	withInitializerCall.chpl:26
+
+Iterated over the domain of
+	withInitializerCall.chpl:26
+
+, whose domain cannot be determined statically
+	withInitializerCall.chpl:26
+
+Loop is suitable for further analysis
+	withInitializerCall.chpl:27
+
+Potential access
+	withInitializerCall.chpl:28
+
+	Can optimize: Access base is the iterator's base
+	withInitializerCall.chpl:28
+
+	Marking static candidate
+	withInitializerCall.chpl:28
+
+**** End forall ****
+	withInitializerCall.chpl:27
+
+**** Start forall ****
+	withInitializerCall.chpl:34
+
+Regular domain symbol was not found for array
+	withInitializerCall.chpl:33
+
+Iterated over the domain of
+	withInitializerCall.chpl:33
+
+, whose domain cannot be determined statically
+	withInitializerCall.chpl:33
+
+Loop is suitable for further analysis
+	withInitializerCall.chpl:34
+
+Potential access
+	withInitializerCall.chpl:35
+
+	Can optimize: Access base is the iterator's base
+	withInitializerCall.chpl:35
+
+	Marking static candidate
+	withInitializerCall.chpl:35
+
+**** End forall ****
+	withInitializerCall.chpl:34
+
+Static check successful. Using localAccess
+	withInitializerCall.chpl:14
+
+Static check successful. Using localAccess
+	withInitializerCall.chpl:21
+
+Static check successful. Using localAccess
+	withInitializerCall.chpl:28
+
+Static check successful. Using localAccess
+	withInitializerCall.chpl:35
+


### PR DESCRIPTION
#15713 added an optimization to use `localAccess` automatically. This PR is a
follow up to improve few things to increase the coverage of the optimization.

- Statically optimize for `B` in `var A, B: [D] int`

  Apparently the above statement turns into something like

  ```chapel
  var A: [D] int;
  var B: A.type;
  ```

  So, this PR adds a check for `PRIM_TYPEOF` in static domain analysis.

- Cover zippered foralls

  This was literally an `if` I have added because I was scared of zippered
  foralls. Removing that seems to work nicely.

- Extend static analysis to array arguments

  There are few patterns where we can statically optimize arrays that are
  arguments to functions. This PR adds coverage for

  ```chapel
  proc foo(a: [D] int)  // domain in the outer-scope
  proc foo(a: [?D] int) // domain is assigned to a local
  proc foo(a: [otherArr.domain] int)   // queried domain of an outer array
  ```

  These patterns are recognized and acted upon similarly to array declarations
  statically

- Allow `forall`s with reduce intents to be analyzed.

  Reduce intent implementation had an assertion that checked for existence of an
  expression after the `forall` in question. However with #15713, we can create
  `forall`s that are tightly enclosed in conditionals' then/else blocks. In such
  scenerios, there are no `next` for such `forall`s.

  In the initial implementation, I came across this late in testing, and
  disabled those cases. This PR removes that assertion by changing the logic
  trivially, and removes the limitation on reduce intents.

- Add tests

  Adds some new tests and copies all the tests that were already in
  `test/optimizations/autoLocalAccess` in a subfolder `zipper` in there, and
  trivially adjusts them to use `zip`

Test:
- [x] standard with `-sdefaultRectangularSupportsAutoLocalAccess`
- [x] gasnet with `-sdefaultRectangularSupportsAutoLocalAccess`

