### PR TITLE
Fix a few futures after PR 15895

### DIFF
--- a/test/users/rohanbadlani/bugs/bug2.bad
+++ b/test/users/rohanbadlani/bugs/bug2.bad
@@ -1,1 +1,1 @@
-bug2.chpl:8: error: unresolved access of 'LinkedList(int(64))' by '(2)'
+bug2.chpl:10: error: unresolved access of 'LinkedList(int(64))' by '(2)'

--- a/test/users/rohanbadlani/bugs/bug2.chpl
+++ b/test/users/rohanbadlani/bugs/bug2.chpl
@@ -1,3 +1,5 @@
+use LinkedLists;
+
 var mylist:LinkedList(int);
 
 mylist.append(10);

--- a/test/users/rohanbadlani/bugs/bug3.bad
+++ b/test/users/rohanbadlani/bugs/bug3.bad
@@ -1,1 +1,1 @@
-bug3.chpl:16: error: unresolved call 'LinkedList(int(64)).these(2)'
+bug3.chpl:18: error: unresolved call 'LinkedList(int(64)).these(2)'

--- a/test/users/rohanbadlani/bugs/bug3.chpl
+++ b/test/users/rohanbadlani/bugs/bug3.chpl
@@ -1,3 +1,5 @@
+use LinkedLists;
+
 var mylist:LinkedList(int);
 
 mylist.append(10);

--- a/test/users/rohanbadlani/bugs/bug3.good
+++ b/test/users/rohanbadlani/bugs/bug3.good
@@ -1,1 +1,1 @@
-bug3.chpl:16: Accessing elements of list 'mylist' is not allowed using these iterator
+bug3.chpl:18: Accessing elements of list 'mylist' is not allowed using these iterator


### PR DESCRIPTION
Follow-up to PR #15895

Updates 2 futures to add `use LinkedLists`.

Test change only - not reviewed.