### PR TITLE
Avoid a gcc error by copying a string with strcpy instead of strncpy

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -638,7 +638,7 @@ void chpl_compute_real_binary_name(const char* argv0) {
     chpl_real_binary_name = chpl_mem_alloc(length+1,
                                            CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
 
-    snprintf(chpl_real_binary_name, length, "%s", launcher_mli_real_name);
+    strcpy(chpl_real_binary_name, launcher_mli_real_name);
     chpl_real_binary_name[length] = '\0';
 
   } else {

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -638,7 +638,7 @@ void chpl_compute_real_binary_name(const char* argv0) {
     chpl_real_binary_name = chpl_mem_alloc(length+1,
                                            CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
 
-    strncpy(chpl_real_binary_name, launcher_mli_real_name, length);
+    snprintf(chpl_real_binary_name, length, "%s", launcher_mli_real_name);
     chpl_real_binary_name[length] = '\0';
 
   } else {


### PR DESCRIPTION
Switch from strncpy to strcpy with no length argument to avoid a
gcc warning/error when copying a string.