### PR TITLE
Adjust file touching to be just like hwloc and qthreads (surprise).

### DIFF
--- a/third-party/libfabric/Makefile
+++ b/third-party/libfabric/Makefile
@@ -55,7 +55,7 @@ configure-libfabric: FORCE
 	cd $(LIBFABRIC_SUBDIR) && touch -c aclocal.m4
 	sleep 1
 	touch $(LIBFABRIC_SUBDIR)/configure
-	find $(LIBFABRIC_SUBDIR)/. -name Makefile.in | xargs touch
+	find $(LIBFABRIC_SUBDIR)/. -name "*.in" | xargs touch
 #
 # Then configure
 #


### PR DESCRIPTION
This gets rid of the "missing autoheader" messages we were seeing on some
systems and thus allows building with `CHPL_LIBFABRIC=libfabric`.