### PR TITLE
Fix double free in comm=ofi.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -197,7 +197,11 @@ int chpl_comm_ofi_abort_on_error;
 
 #define CHPL_CALLOC(p, n) CHPL_CALLOC_SZ(p, n, sizeof(*(p)))
 
-#define CHPL_FREE(p) chpl_mem_free((p), 0, 0)
+#define CHPL_FREE(p)                                                    \
+  do {                                                                  \
+    chpl_mem_free((p), 0, 0);                                           \
+    p = NULL;                                                           \
+  } while (0)
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1816,8 +1816,6 @@ void fini_ofi(void) {
 
   CHPL_FREE(memTabMap);
 
-  CHPL_FREE(memTabMap);
-
   CHPL_FREE(amLZs);
 
   CHPL_FREE(ofi_rxAddrs);


### PR DESCRIPTION
There has been a double free in comm=ofi for the last 1.5 years.
Fix it.  While here, also arrange to NULL pointers in comm=ofi when
we free them.