### PR TITLE
Avoid allocating memory for empty hashtables

### DIFF
--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -97,10 +97,6 @@ module ChapelHashtable {
 
     var initMethod = init_elts_method(size, tableEltType);
 
-    const numChunks = _computeNumChunks(size);
-    if numChunks == 1 then
-      initMethod = ArrayInit.serialInit;
-
     const sizeofElement = _ddata_sizeof_element(ret);
 
     // The memset call below needs to be able to set _array records.

--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -43,7 +43,7 @@ module ChapelHashtable {
     }
   }
 
-  private proc chpl__primes return
+  private inline proc chpl__primes return
     (0, 23, 53, 89, 191, 383, 761, 1531, 3067, 6143, 12281, 24571, 49139, 98299,
      196597, 393209, 786431, 1572853, 3145721, 6291449, 12582893, 25165813,
      50331599, 100663291, 201326557, 402653171, 805306357, 1610612711, 3221225461,
@@ -595,8 +595,7 @@ module ChapelHashtable {
             }
             if newslot < 0 {
               halt("couldn't add element during resize - got slot ", newslot,
-                   " for key ", oldEntry.key, " and old table size is ",
-                   oldSize, " and new table size is ", newSize);
+                   " for key");
             }
 
             // move the key and value from the old entry into the new one
@@ -674,11 +673,6 @@ module ChapelHashtable {
   record chpl__simpleSet {
     type eltType;
     var table: chpl__hashtable(eltType, nothing);
-
-    proc init(type eltType) {
-      this.eltType = eltType;
-      this.table = new chpl__hashtable(eltType, nothing);
-    }
 
     inline proc size {
       return table.tableNumFullSlots;

--- a/test/types/chplhashtable/check-look-for-slots.chpl
+++ b/test/types/chplhashtable/check-look-for-slots.chpl
@@ -1,13 +1,8 @@
 config const verbose = false;
 
-iter lookForSlots(hash:int, numSlots:int) {
-  const baseSlot = hash:uint;
-  for probe in 0..numSlots/2 {
-    var uprobe = probe:uint;
-    var n = numSlots:uint;
-    yield ((baseSlot + uprobe**2)%n):int;
-  }
-}
+use ChapelHashtable;
+
+var ht: chpl__hashtable(int, nothing);
 
 // How many buckets can lookForSlots check?
 // Let's find out.
@@ -17,7 +12,7 @@ iter lookForSlots(hash:int, numSlots:int) {
 for hash in (max(int)-3, max(int)-2, max(int)-1, max(int), 0, 1, 2, 3) {
   for numSlots in (3, 7, 11, 19, 23, 31, 47, 83, 191, 383) {
     var hits:[0..#numSlots] int;
-    for i in lookForSlots(hash, numSlots) {
+    for i in ht._lookForSlots(hash, numSlots) {
       if verbose then
         writeln("lookForSlots(", hash, ",", numSlots, ") yielded ", i);
       assert( 0 <= i && i < numSlots );

--- a/test/types/chplhashtable/test-chpl-hashtable.chpl
+++ b/test/types/chplhashtable/test-chpl-hashtable.chpl
@@ -1,0 +1,169 @@
+use ChapelHashtable;
+
+config var printInitDeinit = true;
+config const debug = false;
+
+
+proc printTable(h: chpl__hashtable) {
+  writeln("printing table tableSize=", h.tableSize,
+          " tableNumFullSlots=", h.tableNumFullSlots);
+  for slot in h.allSlots() {
+    ref entry = h.table[slot];
+    if entry.status == chpl__hash_status.full {
+      writeln("slot ", slot, " full. key = ", entry.key, " val = ", entry.val);
+    } else {
+      writeln("slot ", slot, " ", entry.status:string, ".");
+    }
+  }
+}
+
+proc test1() {
+  writeln("test1");
+  var h = new chpl__hashtable(int, int);
+
+  var foundFullSlot: bool;
+  var slotNum: int;
+
+  (foundFullSlot, slotNum) = h.findAvailableSlot(1);
+  assert(!foundFullSlot);
+  assert(slotNum > 0);
+  h.fillSlot(slotNum, 1, 10);
+
+  for slot in h.allSlots() {
+    if h.isSlotFull(slot) {
+      ref entry = h.table[slot];
+      writeln("key = ", entry.key, " val = ", entry.val);
+    }
+  }
+
+  (foundFullSlot, slotNum) = h.findFullSlot(1);
+  assert(foundFullSlot);
+  assert(slotNum > 0);
+
+  var gotKey: int;
+  var gotVal: int;
+  h.clearSlot(slotNum, gotKey, gotVal);
+  assert(gotKey == 1);
+  assert(gotVal == 10);
+  h.maybeShrinkAfterRemove();
+}
+test1();
+
+class C {
+  var xx: int = 0;
+}
+
+record R {
+  var x: int = 0;
+  var ptr: shared C = new shared C(0);
+  proc init() {
+    this.x = 0;
+    this.ptr = new shared C(0);
+    if printInitDeinit then writeln("init (default)");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    this.ptr = new shared C(arg);
+    if printInitDeinit then writeln("init ", arg, " ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    this.ptr = new shared C(other.ptr.xx);
+    if printInitDeinit then writeln("init= ", other.x, " ", other.ptr.xx);
+  }
+  proc deinit() {
+    if printInitDeinit then writeln("deinit ", x, " ", ptr.xx);
+  }
+  proc toString() {
+    return "(" + this.x:string + " " + this.ptr.xx:string + ")";
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  if printInitDeinit then writeln("lhs", lhs.toString(), " = rhs", rhs.toString());
+  lhs.x = rhs.x;
+  lhs.ptr = new shared C(rhs.ptr.xx);
+}
+proc ==(const ref lhs: R, const ref rhs: R) {
+  return lhs.x == rhs.x && lhs.ptr.xx == rhs.ptr.xx;
+}
+proc chpl__defaultHash(o: R) {
+  return chpl__defaultHashCombine(chpl__defaultHash(o.x),
+                                  chpl__defaultHash(o.ptr.xx),
+                                  1);
+}
+
+
+printInitDeinit = false;
+var globalRone = new R(1);
+var globalRten = new R(10);
+var globalRoneCopy = globalRone;
+assert(globalRoneCopy == globalRone);
+printInitDeinit = true;
+
+proc test2() {
+  writeln("test2");
+  var h = new chpl__hashtable(R, R);
+
+  var foundFullSlot: bool;
+  var slotNum: int;
+
+  writeln("adding ", globalRone);
+  {
+    var key = globalRone;
+    var val = globalRten;
+    (foundFullSlot, slotNum) = h.findAvailableSlot(key);
+    assert(!foundFullSlot);
+    assert(slotNum > 0);
+    h.fillSlot(slotNum, key, val);
+  }
+
+  if debug then
+    printTable(h);
+
+  writeln("iterating");
+  for slot in h.allSlots() {
+    if h.isSlotFull(slot) {
+      ref entry = h.table[slot];
+      writeln("key = ", entry.key, " val = ", entry.val);
+    }
+  }
+
+  if debug then
+    printTable(h);
+
+  writeln("finding");
+  (foundFullSlot, slotNum) = h.findFullSlot(globalRone);
+  if debug then
+    writeln("found slot ", slotNum);
+  assert(foundFullSlot);
+  assert(slotNum > 0);
+
+  writeln("requestCapacity");
+  h.requestCapacity(100);
+  if debug then
+    printTable(h);
+
+  writeln("finding");
+  (foundFullSlot, slotNum) = h.findFullSlot(globalRone);
+  if debug then
+    writeln("found slot ", slotNum);
+  assert(foundFullSlot);
+  assert(slotNum > 0);
+
+  writeln("clearing");
+  var gotKey: R;
+  var gotVal: R;
+  h.clearSlot(slotNum, gotKey, gotVal);
+  assert(gotKey.x == 1);
+  assert(gotVal.x == 10);
+  h.maybeShrinkAfterRemove();
+}
+test2();
+
+proc test3() {
+  writeln("test3");
+  var h = new chpl__hashtable(R, R);
+}
+test3();
+
+printInitDeinit = false;

--- a/test/types/chplhashtable/test-chpl-hashtable.good
+++ b/test/types/chplhashtable/test-chpl-hashtable.good
@@ -1,0 +1,15 @@
+test1
+key = 1 val = 10
+test2
+adding (x = 1, ptr = {xx = 1})
+init= 1 1
+init= 10 10
+iterating
+key = (x = 1, ptr = {xx = 1}) val = (x = 10, ptr = {xx = 10})
+finding
+requestCapacity
+finding
+clearing
+deinit 10 10
+deinit 1 1
+test3

--- a/test/types/string/StringImpl/common/memTrackSupport.chpl
+++ b/test/types/string/StringImpl/common/memTrackSupport.chpl
@@ -8,7 +8,7 @@ var totalMemLeaked = 0:uint(64);
 proc computeMemTrackOverhead() {
   const m0 = memoryUsed();
   {
-    var mu: [LocaleSpace] uint(64);
+    var mu: [0..#numLocales] uint(64);
     const m1 = memoryUsed();
     mu; // keep it alive
     return m1-m0;
@@ -26,7 +26,7 @@ proc allMemoryUsed(first=true) {
     if !first && verboseMemLeaks then printMemAllocsByType();
     return memoryUsed();
   } else {
-    var mu: [LocaleSpace] uint(64);
+    var mu: [0..#numLocales] uint(64);
     for loc in Locales do on loc do mu[here.id] = memoryUsed();
     if first && verboseMem then startVerboseMem();
     if !first && verboseMemLeaks then


### PR DESCRIPTION
Switching the domain's list of arrays to a hashtable (#15895) hurt the
performance of creating array views. The root cause of this was extra
memory allocations.

There are no allocations for a new/empty linkedlist, but previously
there were 2 allocations for a new/empty hashtable. We'd allocate space
for some initial capacity, and we'd create the rehashHelpers.

These allocations hurt performance in cases like array views where
hashtables are created, but never added to. Remove the extra allocations
by starting with an initial capacity of zero, and only allocate the
rehashHelpers when they're actually needed (associative arrays). This
will restore the performance of creating array views, and fix some comm
count regressions.

This also eliminates initialization comms that were added by switching
to a hashtable.  The hashtable was using `_computeNumChunks()` in it's
init, but that calls `here`, which is a dummyLocale on locale 0 early in
set up, which incurs comm.  Just remove this call since it would only
serialize initialization when the size was 0/1, and `init_elts_method`
will already do that (and it's careful to use serial init before the
locales are replicated to avoid comm -- #10541).

Resolves https://github.com/Cray/chapel-private/issues/1080