### PR TITLE
Minor tweaks to improve VisualDebug / chplvis

### DIFF
--- a/modules/packages/VisualDebug.chpl
+++ b/modules/packages/VisualDebug.chpl
@@ -110,6 +110,7 @@ private proc VDebugTree (what: vis_op, name: string, time: real, tagno: int,
 }
 
 
+ private var Vdebugstarted = false;
 /*
   Start logging events for VisualDebug.  Open a new set of data
   files, one for each locale, for :ref:`chplvis`.  This routine should be
@@ -121,6 +122,16 @@ private proc VDebugTree (what: vis_op, name: string, time: real, tagno: int,
   :arg rootname:  Directory name and rootname for files.
 */
   proc startVdebug ( rootname : string ) {
+    // startVdebug() currently can't be called multiple times, so
+    // issue an error if it is (calling it multiple times causes all
+    // locales other than #0 to report no stats, and locale #0's
+    // results may be bogus too).
+    if Vdebugstarted then
+      halt("Calling startVdebug() multiple times is not currently supported; "
+           + "try using the [pause/tag]Vdebug() routines instead");
+    else
+      Vdebugstarted = true;
+
     var now = chpl_now_time();
     if (VisualDebugOn) {
       tagno.write(0);
@@ -151,7 +162,7 @@ private proc VDebugTree (what: vis_op, name: string, time: real, tagno: int,
   }
 
 /*
-  Suspend collection of VisualDebug data.
+  Suspend collection of VisualDebug data.  Use :proc:`tagVdebug` to resume.
 */
   proc pauseVdebug () {
     if (VisualDebugOn) {

--- a/modules/packages/VisualDebug.chpl
+++ b/modules/packages/VisualDebug.chpl
@@ -110,7 +110,7 @@ private proc VDebugTree (what: vis_op, name: string, time: real, tagno: int,
 }
 
 
- private var Vdebugstarted = false;
+ private var Vdebugstarted: atomic bool = false;
 /*
   Start logging events for VisualDebug.  Open a new set of data
   files, one for each locale, for :ref:`chplvis`.  This routine should be
@@ -126,11 +126,9 @@ private proc VDebugTree (what: vis_op, name: string, time: real, tagno: int,
     // issue an error if it is (calling it multiple times causes all
     // locales other than #0 to report no stats, and locale #0's
     // results may be bogus too).
-    if Vdebugstarted then
+    if Vdebugstarted.testAndSet() then
       halt("Calling startVdebug() multiple times is not currently supported; "
            + "try using the [pause/tag]Vdebug() routines instead");
-    else
-      Vdebugstarted = true;
 
     var now = chpl_now_time();
     if (VisualDebugOn) {

--- a/test/chplvis/startTwice.chpl
+++ b/test/chplvis/startTwice.chpl
@@ -1,0 +1,19 @@
+use VisualDebug;
+
+config const secondName = "hi";
+
+var count: atomic int;
+
+startVdebug("hi");
+coforall loc in Locales do
+  count.add(1);
+stopVdebug();
+
+assert(count.read() == numLocales);
+
+startVdebug(secondName);
+coforall loc in Locales do
+  count.add(1);
+stopVdebug();
+
+writeln("Success!");

--- a/test/chplvis/startTwice.execopts
+++ b/test/chplvis/startTwice.execopts
@@ -1,0 +1,2 @@
+                     # startTwice.good
+--secondName="bye"   # startTwice.good

--- a/test/chplvis/startTwice.good
+++ b/test/chplvis/startTwice.good
@@ -1,0 +1,1 @@
+startTwice.chpl:14: error: halt reached - Calling startVdebug() multiple times is not currently supported; try using the [pause/tag]Vdebug() routines instead


### PR DESCRIPTION
* Prior to this change, chplvis couldn't be started twice, though it
  didn't prevent a user from attempting to do so; it just resulted in
  garbage data making it look like no locales other than #0 did
  anything.  The documentation said that its start routine could only
  be called once, but was easy to overlook.  This changes the start
  interface to only permit it to be called once, causing a halt() to
  be generated on subsequent calls.  A test locks in this behavior,
  making sure it's consistent whether the same start call is used or a
  different one.

* I also tweaked the documentation for the pause routine to indicate
  how to unpause it (it wasn't clear to me from the documentation and
  I had to look at the source and existing tests to figure it out)

Both of these changes suggest to me that we could make the API for
this module much more ergonomic, but for now I'm just tackling the
low-hanging fruit.