### PR TITLE
Add License field to manifest file

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -972,7 +972,7 @@ later. For example, if you are using the 1.16 release, chplVersion will be
 ``1.16.0``.
 
 The ``license`` field indicates the software license under which the package is distributed.
-Any of the licenses available at the SPDX License List can be used for Mason packages.
+Any of the licenses available at the `SPDX License List <https://spdx.org/licenses/>`_ can be used for Mason packages.
 The license field defaults to ``None``.
 
 Environment Variables

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -338,6 +338,7 @@ Tests can be listed in the ``Mason.toml`` as a TOML array of strings for the
    name = "myPackage"
    version = "0.1.0"
    chplVersion = "1.18.0"
+   license = "None"
    tests = ["test1.chpl",
             "test2.chpl",
             "test3.chpl"]
@@ -413,6 +414,7 @@ in their ``Mason.toml`` as follows:
    name = "myPackage"
    version = "0.1.0"
    chplVersion = "1.18.0"
+   license = "None"
 
    [dependencies]
 
@@ -454,6 +456,7 @@ file of the package as follows:
    name = "myPackage"
    version = "0.1.0"
    chplVersion = "1.18.0"
+   license = "None"
 
    [dependencies]
    MatrixMarket = 0.1.0
@@ -532,6 +535,7 @@ The ``Mason.toml`` now looks like:
    name = "myPackage"
    version = "0.1.0"
    chplVersion = "1.18.0"
+   license = "None"
 
    [system]
    openSSL = "0.9.8zh"
@@ -750,6 +754,7 @@ The ``Mason.toml`` now looks like:
    name = "myPackage"
    version = "0.1.0"
    chplVersion = "1.18.0"
+   license = "None"
 
    [external]
    openSSL = "1.0.2k"
@@ -808,6 +813,7 @@ Continuing the example from before, the 'registry' ``0.1.0.toml`` would include 
      name = "MyPackage"
      version = "0.1.0"
      chplVersion = "1.16.0"
+     license = "None"
      authors = ["Sam Partee <Sam@Partee.com>"]
      source = "https://github.com/Spartee/MyPackage"
 
@@ -946,6 +952,7 @@ For example, ``Mason.toml``:
     name = "MyPackage"
     version = "0.1.0"
     chplVersion = "1.16.0"
+    license = "None"
     authors = ["Sam Partee <Sam@Partee.com>"]
 
     [dependencies]
@@ -964,6 +971,9 @@ By default, ``chplVersion`` is set to represent the current Chapel release or
 later. For example, if you are using the 1.16 release, chplVersion will be
 ``1.16.0``.
 
+The ``license`` field indicates the software license under which the package is distributed.
+Any of the licenses available at the SPDX License List can be used for Mason packages.
+The license field defaults to ``None``.
 
 Environment Variables
 =====================
@@ -1071,6 +1081,7 @@ a lock file is written below as if generated from the earlier example of a ``Mas
      name = 'curl'
      version = '1.0.0'
      chplVersion = "1.16.0..1.16.0"
+     license = "None"
      source = 'https://github.com/username/curl'
 
 
@@ -1078,6 +1089,7 @@ a lock file is written below as if generated from the earlier example of a ``Mas
      name = "MyPackage"
      version = "0.1.0"
      chplVersion = "1.16.0..1.16.0"
+     license = "None"
      authors = ["Sam Partee <Sam@Partee.com>"]
      source = "https://github.com/Spartee/MyPackage"
      dependencies = ['curl 1.0.0 https://github.com/username/curl']

--- a/test/mason/chplVersion/mason-chpl-version-new.good
+++ b/test/mason/chplVersion/mason-chpl-version-new.good
@@ -3,6 +3,7 @@ Created new library project: newTest
 name = "newTest"
 version = "0.1.0"
 chplVersion = "CHPL_CUR_FULL"
+license = "None"
 
 [dependencies]
 

--- a/test/mason/init/masonInteractive.good
+++ b/test/mason/init/masonInteractive.good
@@ -4,11 +4,12 @@ create the project. Suggestions for defaults are also provided which will be
 considered if no input is given.
 
 Press ^C to quit interactive mode.
-Package name : Package version (0.1.0): Chapel version (1.23.0): 
+Package name : Package version (0.1.0): Chapel version (1.23.0): License (None): 
 [brick]
 name = "project"
 version = "1.2.3"
 chplVersion = "1.21.0"
+license = "MIT"
 
 [dependencies]
 

--- a/test/mason/init/masonInteractive.stdin
+++ b/test/mason/init/masonInteractive.stdin
@@ -1,4 +1,5 @@
 project
 1.2.3
 1.21.0
+MIT
 y

--- a/test/mason/init/project/Mason.toml
+++ b/test/mason/init/project/Mason.toml
@@ -2,6 +2,7 @@
 name = "project"
 version = "1.2.3"
 chplVersion = "1.21.0"
+license = "MIT"
 
 [dependencies]
 

--- a/test/mason/new/masonInteractive.good
+++ b/test/mason/new/masonInteractive.good
@@ -4,11 +4,12 @@ create the project. Suggestions for defaults are also provided which will be
 considered if no input is given.
 
 Press ^C to quit interactive mode.
-Package name : Package version (0.1.0): Chapel version (1.23.0): 
+Package name : Package version (0.1.0): Chapel version (1.23.0): License (None): 
 [brick]
 name = "project"
 version = "1.2.3"
 chplVersion = "1.21.0"
+license = "MIT"
 
 [dependencies]
 

--- a/test/mason/new/masonInteractive.stdin
+++ b/test/mason/new/masonInteractive.stdin
@@ -1,4 +1,5 @@
 project
 1.2.3
 1.21.0
+MIT
 y

--- a/test/mason/new/project/Mason.toml
+++ b/test/mason/new/project/Mason.toml
@@ -2,6 +2,7 @@
 name = "project"
 version = "1.2.3"
 chplVersion = "1.21.0"
+license = "MIT"
 
 [dependencies]
 

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -593,11 +593,7 @@ private proc checkLicense(projectHome: string) throws {
     var licenseList = listdir(MASON_HOME + "/spdx");
     for licenses in licenseList {
       const licenseName: string = licenses.strip('.txt', trailing=true);
-      if defaultLicense == 'None' {
-        foundValidLicense = true; 
-        break;
-      }
-      if licenseName == defaultLicense {
+      if licenseName == defaultLicense || defaultLicense == 'None' {
         foundValidLicense = true;
         break;
       }


### PR DESCRIPTION
This PR aims to regularize use of a license field in the Mason.toml manifest file.

fixes #15886 

- [x]  Modify `mason init` & `mason new` to support license field. 
- [x] Update documentation 
- [x] Validate license field at `mason publish --ci-check`
