### PR TITLE
Enable HDF5 testing on Cray systems when cray-hdf5-parallel is loaded

### DIFF
--- a/test/library/packages/HDF5.skipif
+++ b/test/library/packages/HDF5.skipif
@@ -1,13 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env bash
 
-# The HDF5 package requires the hdf5 library.
-#
-# Installation of the HDF5 library is detected with the find_library function,
-# which looks for the appropriate dynamic library (e.g. libhdf5.so).
-# Note that if the dynamic library is found, this test assumes that the
-# header and static library are available.
+# The HDF5 package requires the hdf5 library. Check for the cray-hdf5-parallel
+# library for now.
 
-from __future__ import print_function
-from ctypes.util import find_library
-
-print(find_library('hdf5') is None)
+if [ -z $CRAY_HDF5_PARALLEL_VERSION ] ; then
+  echo 'True'
+else
+  echo 'False'
+fi

--- a/test/library/packages/HDF5.skipif
+++ b/test/library/packages/HDF5.skipif
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-# The HDF5 package requires the hdf5 library. Check for the cray-hdf5-parallel
-# library for now.
+# The HDF5 package requires the hdf5 library.
 
-if [ -z $CRAY_HDF5_PARALLEL_VERSION ] ; then
-  echo 'True'
-else
+if h5cc -showconfig 2>&1 > /dev/null ; then
   echo 'False'
+else
+  echo 'True'
 fi

--- a/test/library/packages/HDF5/NOTEST
+++ b/test/library/packages/HDF5/NOTEST
@@ -1,7 +1,0 @@
-These tests are supposed to be skipped if the HDF5 library is not available,
-but on some of our test systems the .skipif file reports that it is available
-even though the module that would make it available is not loaded.
-
-After loading that module, I found that there are differences between it and
-the version I had been using from homebrew.  This file will silence these
-tests until I'm able to investigate the differences further.

--- a/test/library/packages/HDF5/parallelHdf5WriteSingleFile.skipif
+++ b/test/library/packages/HDF5/parallelHdf5WriteSingleFile.skipif
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if h5cc -showconfig 2>/dev/null | grep -q -i "parallel hdf5: yes"; then
+    echo "False"
+else
+    echo "True"
+fi

--- a/test/library/packages/HDF5/readDistrib1D.skipif
+++ b/test/library/packages/HDF5/readDistrib1D.skipif
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if h5cc -showconfig 2>/dev/null | grep -q -i "parallel hdf5: yes"; then
+    echo "False"
+else
+    echo "True"
+fi

--- a/test/library/packages/HDF5/readDistrib2D.skipif
+++ b/test/library/packages/HDF5/readDistrib2D.skipif
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if h5cc -showconfig 2>/dev/null | grep -q -i "parallel hdf5: yes"; then
+    echo "False"
+else
+    echo "True"
+fi


### PR DESCRIPTION
Enable HDF5 testing on Cray systems when the module cray-hdf5-parallel is
loaded. Skip the directory otherwise. Use the presence of the environment
variable CRAY_HDF5_PARALLEL_VERSION as the indicator.