### PR TITLE
Use in intent instead of blank intent in c2chapel

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -216,16 +216,18 @@ def computeArgs(pl):
             (intent, typeName, ptrTypeName) = getIntentInfo(arg.type)
             argName = computeArgName(arg)
             if typeName != "":
-                if intent != "":
+                if intent == "":
+                    intent = "in "
+                else:
                     intent += " "
                 if argName == "":
                     argName = "arg" + str(i)
                 formals.append(intent + argName + " : " + typeName)
 
                 if ptrTypeName != "":
-                    ptrFormals.append(argName + " : " + ptrTypeName)
+                    ptrFormals.append("in " + argName + " : " + ptrTypeName)
                 else:
-                    ptrFormals.append(argName + " : " + typeName)
+                    ptrFormals.append("in " + argName + " : " + typeName)
     return (", ".join(formals), ", ".join(ptrFormals))
 
 def isPointerTo(ty, text):


### PR DESCRIPTION
PR #15903 requires `extern proc` with `extern record` arguments to use an 
explicit intent. Since C typically uses pass by value, the explicit
intent most common is `in`. This PR adjusts c2chapel to emit arguments
with `in` intent in `extern proc`s (unless they are `ref` intent as an
alternative pointer interface).

Reviewed by @daviditen - thanks!

- [x] passing test/c2chapel