### PR TITLE
Fix the requireHeader test

### DIFF
--- a/test/interop/C/makefiles/checkRequire2.c
+++ b/test/interop/C/makefiles/checkRequire2.c
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
 
   R foo;
   foo.b = 5;
-  printsArg(&foo);
+  printsArg(foo);
 
   chpl_library_finalize();
   return 0;

--- a/test/interop/C/makefiles/requireHeader.chpl
+++ b/test/interop/C/makefiles/requireHeader.chpl
@@ -4,6 +4,6 @@ extern record R {
   var b: int;
 }
 
-export proc printsArg(x: R) {
+export proc printsArg(in x: R) {
   writeln(x.b);
 }


### PR DESCRIPTION
PR #15903 required explicit intents for export routines. For some reason 
that PR neglected to update the one test:
`interop/C/makefiles/requireHeader.chpl`. This PR updates that test.

Test change only, not reviewed.