### PR TITLE
Handle runtime's chpl-env-gen.h better in Makefiles

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -35,15 +35,15 @@ all: $(CHPL_ENV_HEADER) third-party-pkgs all.helpme
 depend:
 
 clean: clean.helpme
-	rm -f tags TAGS
+	rm -f tags TAGS $(CHPL_ENV_HEADER)
 
 cleanall: cleanall.helpme
-	rm -f tags TAGS
+	rm -f tags TAGS $(CHPL_ENV_HEADER)
 
 cleandeps: cleandeps.helpme
 
 clobber: clobber.helpme
-	rm -f tags TAGS
+	rm -f tags TAGS $(CHPL_ENV_HEADER)
 
 %.helpme:
 	@$(MAKE) -f Makefile.help MAKE_LAUNCHER=0 CHPL_MAKE_RULE=$* $*

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -51,7 +51,7 @@ ifneq ($(CHPL_MAKE_LAUNCHER),none)
 	@$(MAKE) -f Makefile.help MAKE_LAUNCHER=1 CHPL_MAKE_RULE=$* $*
 endif
 
-$(CHPL_ENV_HEADER):
+$(CHPL_ENV_HEADER): $(CHPL_MAKE_HOME)/util/printchplenv $(CHPL_MAKE_HOME)/util/chplenv/*
 	@mkdir -p $(CHPL_ENV_HEADER_DIR)
 	@echo "Generating $(CHPL_ENV_HEADER)"
 	@cp $(CHPL_ENV_HEADER_TEMPLATE) $(CHPL_ENV_HEADER)


### PR DESCRIPTION
This header has apparently caused problems when the set of things put
into it change, and (as I understand it), this was exacerbated by
`make clean` not removing the header.  So this makes `make clean`
do that.

Probably a better way of dealing with this issue would be to have the
Makefile be smarter about when the header needs to be re-generated in
its list of dependences.  Currently, that list is empty which means
that as long as the header exists, we won't regenerate it.  For
example, we could re-generate it whenever printchplenv or any of its
helper scripts change...?

Resolves #15926.