### PR TITLE
Adjust Fortran array wrapper generation to avoid compiler error

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3328,6 +3328,7 @@ static void fixupExportedArrayFormals(FnSymbol* fn) {
           formal->typeExpr->replace(
             new BlockStmt(new SymExpr(dtCFI_cdesc_t->symbol)));
           formal->intent = INTENT_REF;
+          formal->originalIntent = INTENT_REF;
         }
       } else {
         // Create a representation of the array argument that is accessible


### PR DESCRIPTION
Follow-up to PR #15903 which required explicit intents for export 
routines.

This PR adjusts the compiler's generation of wrapper functions for
Fortran for array arguments to avoid an error about explicit intent being
required.

Trivial and not reviewed.

- [x] test/interop/fortran passes with cray-prgenv-intel