### PR TITLE
Revert changes to `list._commonInitFromIterable` to fix test comm count regressions

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -325,7 +325,7 @@ module List {
     }
 
     pragma "no doc"
-    proc _commonInitFromIterable(iterable) {
+    proc _commonInitFromIterable(iterable) lifetime this < iterable {
       this._firstTimeInitializeArrays();
       for x in iterable do
         append(x);

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -327,12 +327,8 @@ module List {
     pragma "no doc"
     proc _commonInitFromIterable(iterable) {
       this._firstTimeInitializeArrays();
-
-      for x in iterable do {
-        pragma "no auto destroy"
-        var cpy = x;
-        _appendByRef(cpy);
-      }
+      for x in iterable do
+        append(x);
     }
 
     pragma "no doc"


### PR DESCRIPTION
In #15575 I decided to modify `list._commonInitFromIterable` to append elements without taking a lock. Such a small optimization seemed reasonable since that method is only called by initializers. The change ended up causing a fairly large increase (30270 -> 34410) in GETs for `test/library/packages/Sort/performance/dist-performance.chpl`, so revert it.

---

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none` (probably overkill, but w/e)