### PR TITLE
Fix hdf5 tests

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -55,7 +55,7 @@ The native HDF5 functions can be called directly by calling into the
 :mod:`C_HDF5` submodule.
 */
 module HDF5 {
-  use SysCTypes;
+  use SysCTypes, BlockDist;
 
   // This interface was generated with HDF5 1.10.1. Due to a change of the
   // `hid_t` type from 32-bit to 64-bit in this version, versions prior

--- a/test/library/packages/HDF5/parallelHdf5WriteSingleFile.execenv
+++ b/test/library/packages/HDF5/parallelHdf5WriteSingleFile.execenv
@@ -1,0 +1,1 @@
+MPICH_MAX_THREAD_SAFETY=multiple

--- a/test/library/packages/HDF5/readDistrib1D.execenv
+++ b/test/library/packages/HDF5/readDistrib1D.execenv
@@ -1,0 +1,1 @@
+MPICH_MAX_THREAD_SAFETY=multiple

--- a/test/library/packages/HDF5/readDistrib2D.execenv
+++ b/test/library/packages/HDF5/readDistrib2D.execenv
@@ -1,0 +1,1 @@
+MPICH_MAX_THREAD_SAFETY=multiple


### PR DESCRIPTION
* Added .execenc files with MPICH_MAX_THREAD_SAFETY=multiple so these tests
  will run with it set.

* Add a module-level 'use BlockDist' to work around an apparent bug.
  A function that did 'use BlockDist' inside it and then tried to create a
  block array was failing to find 'BlockDist.dsiBuildArray'. Moving the 'use'
  to module scope fixed the issue.