### PR TITLE
Decrease number of trials for CS arkouda testing

### DIFF
--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -11,6 +11,9 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.arkouda"
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+# limit to 1 trial to limit memory fragmentation
+export CHPL_TEST_NUM_TRIALS=1
+
 # setup for CS perf (gasnet-large, gnu, 36-core Broadwell)
 source $CWD/common-cray-cs.bash
 source $CWD/common-perf-cray-cs.bash


### PR DESCRIPTION
This should avoid some out of memory errors. See
https://github.com/Cray/chapel-private/issues/1093 for more info