### PR TITLE
Revert the error order in a .bad file

### DIFF
--- a/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.bad
@@ -1,2 +1,2 @@
-parallel-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
 parallel-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+parallel-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
@@ -1,2 +1,2 @@
-remote-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
 remote-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+remote-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.bad
@@ -1,2 +1,2 @@
-serial-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
 serial-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+serial-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)


### PR DESCRIPTION
#15713 caused some errors to be printed in reverse order, and #15900 brought the
previous behavior as a side effect.

This PR adjust the relevant .bad files.
