### PR TITLE
Add perf annotations for 2020-06-26

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -476,6 +476,15 @@ AllCompTime: &timecomp-base
     - Remove calls to getUserInstantiationPoint (#15051)
   06/11/20:
     - Fix split init of const variables and update lvalue errors (#15800)
+  06/16/20:
+    - text: Support third-party CHPL_LIBFABRIC=libfabric (#15729)
+      config: 16-node-cs
+    - text: Warm up the comm layer, in the many-to-one test (#15798)
+      config: 16-node-cs
+  06/21/20:
+    - Switch the domain's list of arrays to a hashtable (#15895)
+  06/25/20:
+    - Avoid allocating memory for empty hashtables (#15918)
 
 allocate:
   06/11/20:
@@ -1892,8 +1901,7 @@ arkouda: &arkouda-base
   04/22/20:
     - Optimize coargsort for numeric arrays (mhmerrill/arkouda#330)
   04/28/20:
-    - text: Improve comm=none build and execution speed (mhmerrill/arkouda#358)
-      config: chapcs
+    - Improve comm=none build and execution speed (mhmerrill/arkouda#358)
   04/28/20:
     - text: Move XC testing from login to elogin node
       config: 16-node-xc


### PR DESCRIPTION
Add annotations for:
 - ofi [improvements](https://chapel-lang.org/perf/16-node-cs/?startdate=2020/05/16&enddate=2020/06/25&configs=ofi&graphs=hpcchplreleaseperfgflopsn255nb32,hpccrarmoperfgupsn233,remotefetchingamoperformance,remoteamoperformance,remoteunorderedamoperformance,remoteexecuteonperformance,remotefastexecuteonperformance,remotemanytomanyintgetperformance,remotemanytomany2intgetperformance,remotemanytomany16intgetperformance,remotemanytomanyintputperformance,remotemanytomany2intputperformance,remotemanytomany16intputperformance,remotemanytomanyintgetputperformance,remotemanytomany2intgetputperformance,remotemanytomany16intgetputperformance,blockdisttransfern1e6,creatingdistributeddomains,destroyingdistributeddomains,creatingdistributedarrays1elementperlocale,destroyingdistributedarrays1elementperlocale) (#15729, #15798)
 - [improvements, regressions, and fixes](https://chapel-lang.org/perf/chapcs/?startdate=2020/06/16&enddate=2020/06/27&graphs=ssca2scale8,hpccffttime,arrayviewcreation,minimdljsize10time,nbodyvariations,buildingupassociativedomains,serialreductionstyles,forallwithaoainandreduceintents) from domain list -> set (#15895, #15918)