### PR TITLE
Distribution improvements for automatic localAccess

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -905,6 +905,8 @@ override proc BlockCyclicArr.dsiDestroyArr(param deinitElts:bool) {
   }
 }
 
+override proc BlockCyclicDom.dsiSupportsAutoLocalAccess() param { return true; }
+
 proc BlockCyclicArr.chpl__serialize() {
   return pid;
 }
@@ -934,6 +936,10 @@ proc BlockCyclicArr.dsiPrivatize(privatizeData) {
   return c;
 }
 
+inline proc BlockCyclicArr.dsiLocalAccess(i: idxType) ref {
+  return _to_nonnil(myLocArr).this(i);
+}
+
 //
 // the global accessor for the array
 //
@@ -949,6 +955,13 @@ proc BlockCyclicArr.dsiAccess(i: idxType) ref where rank == 1 {
   //  var desc = locArr(loci);
   //  return locArr(loci)(i);
   return locArr(dom.dist.idxToLocaleInd(i))(i);
+}
+
+inline proc BlockCyclicArr.dsiLocalAccess(i: rank*idxType) ref {
+  if rank == 1 then
+    return _to_nonnil(myLocArr).this(i[0]);
+  else
+    return _to_nonnil(myLocArr).this(i);
 }
 
 proc BlockCyclicArr.dsiAccess(i: rank*idxType) ref {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -310,6 +310,8 @@ override proc Cyclic.dsiDisplayRepresentation() {
     writeln("locDist[", tli, "].myChunk = ", locDist[tli].myChunk);
 }
 
+override proc CyclicDom.dsiSupportsAutoLocalAccess() param { return true; }
+
 proc Cyclic.init(other: Cyclic, privateData,
                  param rank = other.rank,
                  type idxType = other.idxType) {
@@ -860,6 +862,10 @@ inline proc _remoteAccessData.getDataIndex(
     }
   }
   return sum;
+}
+
+inline proc CyclicArr.dsiLocalAccess(i: rank*idxType) ref {
+  return _to_nonnil(myLocArr).this(i);
 }
 
 proc CyclicArr.dsiAccess(i:rank*idxType) ref {

--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -526,6 +526,8 @@ class UserMapAssocDom: BaseAssociativeDom {
 
   }
 
+  override proc dsiSupportsAutoLocalAccess() param { return true; }
+
   override proc dsiSupportsPrivatization() param return true;
   proc dsiGetPrivatizeData() return dist.pid;
   proc dsiGetReprivatizeData() return 0;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1740,6 +1740,8 @@ inline proc LocStencilArr.this(i) ref {
   return myElems(i);
 }
 
+override proc StencilDom.dsiSupportsAutoLocalAccess() param { return true; }
+
 //
 // Privatization
 //

--- a/test/optimizations/autoLocalAccess/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/COMPOPTS
@@ -1,1 +1,1 @@
---report-auto-local-access
+--report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess

--- a/test/optimizations/autoLocalAccess/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/COMPOPTS
@@ -1,1 +1,2 @@
---report-auto-local-access
+-sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/COMPOPTS
@@ -1,3 +1,5 @@
 -sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=BlockCyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Cyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
 -sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
 -sdistType=Hashed --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/COMPOPTS
@@ -1,5 +1,1 @@
--sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=BlockCyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=Cyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=Hashed --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+--report-auto-local-access

--- a/test/optimizations/autoLocalAccess/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/COMPOPTS
@@ -1,2 +1,3 @@
 -sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
 -sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Hashed --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 use CyclicDist;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 
 var A: [D] int;

--- a/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
@@ -1,5 +1,5 @@
 use common;
-use CyclicDist;
+
 
 var D = createDom({1..10});
 

--- a/test/optimizations/autoLocalAccess/commaDecl.chpl
+++ b/test/optimizations/autoLocalAccess/commaDecl.chpl
@@ -1,6 +1,6 @@
 use common;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 var A, B: [D] int;
 

--- a/test/optimizations/autoLocalAccess/commaDecl.chpl
+++ b/test/optimizations/autoLocalAccess/commaDecl.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 var D = newBlockDom({1..10});
 

--- a/test/optimizations/autoLocalAccess/common.chpl
+++ b/test/optimizations/autoLocalAccess/common.chpl
@@ -7,6 +7,10 @@ use StencilDist;
 config type distType = Block;
 
 proc createDom(space) {
+  if space.rank > 2 {
+    compilerError("Only 1 and 2 dimensional domains");
+  }
+
   if distType == Block {
     return newBlockDom(space);
   }
@@ -14,17 +18,19 @@ proc createDom(space) {
     return newCyclicDom(space);
   }
   else if distType == BlockCyclic {
-    return newBlockCycDom(space);
+    if space.rank == 1 {
+      return space dmapped BlockCyclic(startIdx=(space.low,), blocksize=(2,));
+    }
+    else {
+      return space dmapped BlockCyclic(startIdx=space.low, blocksize=(2,2));
+    }
   }
   else if distType == Stencil {
     if space.rank == 1 {
       return space dmapped Stencil(space, fluff=(1,));
     }
-    else if space.rank == 2 {
-      return space dmapped Stencil(space, fluff=(1,1));
-    }
     else {
-      compilerError("Only 1 and 2 dimensional domains");
+      return space dmapped Stencil(space, fluff=(1,1));
     }
   }
   else if distType == Hashed {

--- a/test/optimizations/autoLocalAccess/common.chpl
+++ b/test/optimizations/autoLocalAccess/common.chpl
@@ -33,7 +33,6 @@ proc createDom(space) {
       return space dmapped Stencil(space, fluff=(1,1));
     }
   }
-  /*
   else if distType == Hashed {
     var D: domain(int) dmapped Hashed(idxType=int);
     for i in space {
@@ -41,7 +40,6 @@ proc createDom(space) {
     }
     return D;
   }
-   */
   else {
     compilerError("Unrecognized distribution type");
   }

--- a/test/optimizations/autoLocalAccess/common.chpl
+++ b/test/optimizations/autoLocalAccess/common.chpl
@@ -1,8 +1,8 @@
-use BlockDist;
-use CyclicDist;
-use BlockCycDist;
-use HashedDist;
-use StencilDist;
+public use BlockDist;
+public use CyclicDist;
+public use BlockCycDist;
+public use HashedDist;
+public use StencilDist;
 
 config type distType = Block;
 

--- a/test/optimizations/autoLocalAccess/common.chpl
+++ b/test/optimizations/autoLocalAccess/common.chpl
@@ -33,13 +33,15 @@ proc createDom(space) {
       return space dmapped Stencil(space, fluff=(1,1));
     }
   }
+  /*
   else if distType == Hashed {
-    var D: domain(string) dmapped Hashed(idxType=string);
+    var D: domain(int) dmapped Hashed(idxType=int);
     for i in space {
-      D += i:string;
+      D += i;
     }
     return D;
   }
+   */
   else {
     compilerError("Unrecognized distribution type");
   }

--- a/test/optimizations/autoLocalAccess/common.chpl
+++ b/test/optimizations/autoLocalAccess/common.chpl
@@ -1,0 +1,47 @@
+use BlockDist;
+use CyclicDist;
+use BlockCycDist;
+use HashedDist;
+use StencilDist;
+
+config type distType = Block;
+
+proc createDom(space) {
+  if distType == Block {
+    return newBlockDom(space);
+  }
+  else if distType == Cyclic {
+    return newCyclicDom(space);
+  }
+  else if distType == BlockCyclic {
+    return newBlockCycDom(space);
+  }
+  else if distType == Stencil {
+    if space.rank == 1 {
+      return space dmapped Stencil(space, fluff=(1,));
+    }
+    else if space.rank == 2 {
+      return space dmapped Stencil(space, fluff=(1,1));
+    }
+    else {
+      compilerError("Only 1 and 2 dimensional domains");
+    }
+  }
+  else if distType == Hashed {
+    var D: domain(string) dmapped Hashed(idxType=string);
+    for i in space {
+      D += i:string;
+    }
+    return D;
+  }
+  else {
+    compilerError("Unrecognized distribution type");
+  }
+}
+
+proc createArr(space, type t) {
+  var D = createDom(space);
+  var A: [D] t;
+  return A;
+}
+

--- a/test/optimizations/autoLocalAccess/copyInitDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/copyInitDeclaration.chpl
@@ -1,11 +1,11 @@
-use BlockDist;
+use common;
 
 proc foo() {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;
-  var C = newBlockArr({1..10}, int);
+  var C = createArr({1..10}, int);
 
   B = 3;
   C = 7;
@@ -18,7 +18,7 @@ proc foo() {
 }
 
 //{
-  //var D = newBlockDom({1..10});
+  //var D = createDom({1..10});
 
   //var A: [D] real;
   //var B: [D] real;

--- a/test/optimizations/autoLocalAccess/dotDomDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/dotDomDeclaration.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;
@@ -18,7 +18,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;
@@ -35,7 +35,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;
@@ -52,7 +52,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;

--- a/test/optimizations/autoLocalAccess/dynamicCheckInGenericFunction.chpl
+++ b/test/optimizations/autoLocalAccess/dynamicCheckInGenericFunction.chpl
@@ -1,6 +1,6 @@
-use BlockDist;
+use common;
 
-var dom = newBlockDom({1..10});
+var dom = createDom({1..10});
 
 var arr: [dom] real;
 

--- a/test/optimizations/autoLocalAccess/dynamicChecks.chpl
+++ b/test/optimizations/autoLocalAccess/dynamicChecks.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 proc F(i) {
   return i*2;
@@ -13,11 +13,11 @@ class MyClass {
 {
 
   const space = {1..10};
-  var dom = newBlockDom(space);
+  var dom = createDom(space);
 
   var A: [dom] real;
   var B: [dom] real;
-  var C = newBlockArr(space, real);
+  var C = createArr(space, real);
   var D: [space] real;
   var E = new MyClass();
 

--- a/test/optimizations/autoLocalAccess/functionArgs.chpl
+++ b/test/optimizations/autoLocalAccess/functionArgs.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 var D = newBlockDom({1..10});
 

--- a/test/optimizations/autoLocalAccess/functionArgs.chpl
+++ b/test/optimizations/autoLocalAccess/functionArgs.chpl
@@ -1,6 +1,6 @@
 use common;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 var A: [D] int;
 var B: [D] int;

--- a/test/optimizations/autoLocalAccess/interveningForallOrOn.chpl
+++ b/test/optimizations/autoLocalAccess/interveningForallOrOn.chpl
@@ -1,8 +1,8 @@
 
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;
@@ -16,7 +16,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;

--- a/test/optimizations/autoLocalAccess/multipleAccessDynamic.chpl
+++ b/test/optimizations/autoLocalAccess/multipleAccessDynamic.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
-var A = newBlockArr({1..10}, int);
-var B = newBlockArr({1..10}, int);
+var A = createArr({1..10}, int);
+var B = createArr({1..10}, int);
 
 // there must be only one static check, and two accesses optimized
 forall i in A.domain {

--- a/test/optimizations/autoLocalAccess/multipleAccessStatic.chpl
+++ b/test/optimizations/autoLocalAccess/multipleAccessStatic.chpl
@@ -1,6 +1,6 @@
-use BlockDist;
+use common;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 var A: [D] int;
 

--- a/test/optimizations/autoLocalAccess/nonDomainIter.chpl
+++ b/test/optimizations/autoLocalAccess/nonDomainIter.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 class C {
   var i = 10;
@@ -11,8 +11,8 @@ class C {
     }
 }
 
-var A = newBlockArr({1..10}, int);
-var B = newBlockArr({1..10}, int);
+var A = createArr({1..10}, int);
+var B = createArr({1..10}, int);
 
 var c = new C();
 

--- a/test/optimizations/autoLocalAccess/oneStaticFailOtherDynamicSuccess.chpl
+++ b/test/optimizations/autoLocalAccess/oneStaticFailOtherDynamicSuccess.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 class MyClass { proc this(i) { return i; } }
 
@@ -13,9 +13,9 @@ inline proc _array.localAccess(i: int) ref {
   return this._value.dsiLocalAccess((i:int,));
 }
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
-var A = newBlockArr({1..10}, int); // dynamic candidate, static check is true
+var A = createArr({1..10}, int); // dynamic candidate, static check is true
 var B = new MyClass(); // dynamic candidate, static check is false
 
 // we want the access to A still be through localAccess (i.e. not affected by

--- a/test/optimizations/autoLocalAccess/regularCommaDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/regularCommaDeclaration.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A, B, C: [D] real;
 
@@ -16,7 +16,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A, B, C: [D] real;
 

--- a/test/optimizations/autoLocalAccess/regularDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/regularDeclaration.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;
@@ -18,7 +18,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;

--- a/test/optimizations/autoLocalAccess/regularDeclaration.compopts
+++ b/test/optimizations/autoLocalAccess/regularDeclaration.compopts
@@ -1,0 +1,5 @@
+-sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=BlockCyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Cyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Hashed --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/regularDeclaration2D.chpl
+++ b/test/optimizations/autoLocalAccess/regularDeclaration2D.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10, 1..10});
+  var D = createDom({1..10, 1..10});
 
   var A: [D] real;
   var B: [D] real;
@@ -18,7 +18,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10, 1..10});
+  var D = createDom({1..10, 1..10});
 
   var A: [D] real;
   var B: [D] real;

--- a/test/optimizations/autoLocalAccess/staticSuccessDynamicFail.chpl
+++ b/test/optimizations/autoLocalAccess/staticSuccessDynamicFail.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
-var A = newBlockArr({0..10}, int);
-var B = newBlockArr({1..9}, int);
+var A = createArr({0..10}, int);
+var B = createArr({1..9}, int);
 
 forall i in B.domain {
   B[i] = A[i];

--- a/test/optimizations/autoLocalAccess/withInitializerCall.chpl
+++ b/test/optimizations/autoLocalAccess/withInitializerCall.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 record R {
   var x: int;
@@ -9,14 +9,14 @@ class C {
 }
 
 {
-  var A = newBlockArr({1..10}, R);
+  var A = createArr({1..10}, R);
   forall i in A.domain {
     A[i] = new R[i];
   }
 }
 
 {
-  var A = newBlockArr({1..10}, unmanaged C?);
+  var A = createArr({1..10}, unmanaged C?);
   forall i in A.domain {
     A[i] = new unmanaged C[i];
   }
@@ -25,14 +25,14 @@ class C {
 }
 
 {
-  var A = newBlockArr({1..10}, owned C?);
+  var A = createArr({1..10}, owned C?);
   forall i in A.domain {
     A[i] = new owned C[i];
   }
 }
 
 {
-  var A = newBlockArr({1..10}, shared C?);
+  var A = createArr({1..10}, shared C?);
   forall i in A.domain {
     A[i] = new shared C[i];
   }

--- a/test/optimizations/autoLocalAccess/zipper/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/zipper/COMPOPTS
@@ -1,1 +1,2 @@
-../COMPOPTS
+-sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/zipper/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/zipper/COMPOPTS
@@ -1,4 +1,1 @@
--sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=BlockCyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=Cyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
--sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+../COMPOPTS

--- a/test/optimizations/autoLocalAccess/zipper/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/zipper/COMPOPTS
@@ -1,2 +1,4 @@
 -sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=BlockCyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Cyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
 -sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 use CyclicDist;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 
 var A: [D] int;

--- a/test/optimizations/autoLocalAccess/zipper/commaDecl.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/commaDecl.chpl
@@ -1,6 +1,6 @@
-use BlockDist;
+use common;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 var A, B: [D] int;
 

--- a/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.chpl
@@ -1,11 +1,11 @@
-use BlockDist;
+use common;
 
 proc foo() {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;
-  var C = newBlockArr({1..10}, int);
+  var C = createArr({1..10}, int);
 
   B = 3;
   C = 7;
@@ -18,7 +18,7 @@ proc foo() {
 }
 
 //{
-  //var D = newBlockDom({1..10});
+  //var D = createDom({1..10});
 
   //var A: [D] real;
   //var B: [D] real;

--- a/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;
@@ -18,7 +18,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;
@@ -35,7 +35,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;
@@ -52,7 +52,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [A.domain] real;

--- a/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.chpl
@@ -1,6 +1,6 @@
-use BlockDist;
+use common;
 
-var dom = newBlockDom({1..10});
+var dom = createDom({1..10});
 
 var arr: [dom] real;
 

--- a/test/optimizations/autoLocalAccess/zipper/dynamicChecks.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicChecks.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 proc F(i) {
   return i*2;
@@ -13,11 +13,11 @@ class MyClass {
 {
 
   const space = {1..10};
-  var dom = newBlockDom(space);
+  var dom = createDom(space);
 
   var A: [dom] real;
   var B: [dom] real;
-  var C = newBlockArr(space, real);
+  var C = createArr(space, real);
   var D: [space] real;
   var E = new MyClass();
 

--- a/test/optimizations/autoLocalAccess/zipper/functionArgs.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/functionArgs.chpl
@@ -1,6 +1,6 @@
-use BlockDist;
+use common;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 var A: [D] int;
 var B: [D] int;

--- a/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.chpl
@@ -1,8 +1,8 @@
 
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;
@@ -16,7 +16,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
-var A = newBlockArr({1..10}, int);
-var B = newBlockArr({1..10}, int);
+var A = createArr({1..10}, int);
+var B = createArr({1..10}, int);
 
 // there must be only one static check, and two accesses optimized
 forall (i, loopIdx) in zip(A.domain, 1..) {

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.chpl
@@ -1,6 +1,6 @@
-use BlockDist;
+use common;
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
 var A: [D] int;
 

--- a/test/optimizations/autoLocalAccess/zipper/nonDomainIter.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/nonDomainIter.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 class C {
   var i = 10;
@@ -19,8 +19,8 @@ class C {
     }
 }
 
-var A = newBlockArr({1..10}, int);
-var B = newBlockArr({1..10}, int);
+var A = createArr({1..10}, int);
+var B = createArr({1..10}, int);
 
 var c = new C();
 

--- a/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 class MyClass { proc this(i) { return i; } }
 
@@ -13,9 +13,9 @@ inline proc _array.localAccess(i: int) ref {
   return this._value.dsiLocalAccess((i:int,));
 }
 
-var D = newBlockDom({1..10});
+var D = createDom({1..10});
 
-var A = newBlockArr({1..10}, int); // dynamic candidate, static check is true
+var A = createArr({1..10}, int); // dynamic candidate, static check is true
 var B = new MyClass(); // dynamic candidate, static check is false
 
 // we want the access to A still be through localAccess (i.e. not affected by

--- a/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A, B, C: [D] real;
 
@@ -16,7 +16,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A, B, C: [D] real;
 

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;
@@ -18,7 +18,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10});
+  var D = createDom({1..10});
 
   var A: [D] real;
   var B: [D] real;

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration.compopts
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration.compopts
@@ -1,0 +1,4 @@
+-sdistType=Block --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=BlockCyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Cyclic --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/
+-sdistType=Stencil --report-auto-local-access -M$CHPL_HOME/test/optimizations/autoLocalAccess/

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
 {
-  var D = newBlockDom({1..10, 1..10});
+  var D = createDom({1..10, 1..10});
 
   var A: [D] real;
   var B: [D] real;
@@ -18,7 +18,7 @@ use BlockDist;
 }
 
 {
-  var D = newBlockDom({1..10, 1..10});
+  var D = createDom({1..10, 1..10});
 
   var A: [D] real;
   var B: [D] real;

--- a/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.chpl
@@ -1,7 +1,7 @@
-use BlockDist;
+use common;
 
-var A = newBlockArr({0..10}, int);
-var B = newBlockArr({1..9}, int);
+var A = createArr({0..10}, int);
+var B = createArr({1..9}, int);
 
 forall (i, loopIdx) in zip(B.domain, 1..) {
   B[i] = A[i] * loopIdx;

--- a/test/optimizations/autoLocalAccess/zipper/withInitializerCall.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/withInitializerCall.chpl
@@ -1,4 +1,4 @@
-use BlockDist;
+use common;
 
 record R {
   var x: int;
@@ -9,28 +9,28 @@ class C {
 }
 
 {
-  var A = newBlockArr({1..10}, R);
+  var A = createArr({1..10}, R);
   forall (i, loopIdx) in zip(A.domain, 1..) {
     A[i] = new R[i*loopIdx];
   }
 }
 
 {
-  var A = newBlockArr({1..10}, unmanaged C?);
+  var A = createArr({1..10}, unmanaged C?);
   forall (i, loopIdx) in zip(A.domain, 1..) {
     A[i] = new unmanaged C[i*loopIdx];
   }
 }
 
 {
-  var A = newBlockArr({1..10}, owned C?);
+  var A = createArr({1..10}, owned C?);
   forall (i, loopIdx) in zip(A.domain, 1..) {
     A[i] = new owned C[i*loopIdx];
   }
 }
 
 {
-  var A = newBlockArr({1..10}, shared C?);
+  var A = createArr({1..10}, shared C?);
   forall (i, loopIdx) in zip(A.domain, 1..) {
     A[i] = new shared C[i*loopIdx];
   }


### PR DESCRIPTION
This PR does several changes in distributions to increase the coverage of
`--auto-local-access`. The original PR (#15713) only supported Block
distrubution.

Change summary:
- Add `dsiLocalAccess` to `BlockCyclic` and `Cyclic`
- Have the following dists support automatic localAccess optimization
  - `BlockCyclic`
  - `Cyclic`
  - `Stencil`
  - `Hashed`
- Adjust tests under `optimizations/autoLocalAccess` to test new dists
  - This is currently only done with a single test to keep the testing time at bay

Test status:
- [x] standard `-sdefaultRectangularSupportsAutoLocalAccess`
- [x] gasnet `-sdefaultRectangularSupportsAutoLocalAccess`

