### PR TITLE
Capture multilocale and examples memory leaks as correctness errors

### DIFF
--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -557,8 +557,16 @@ printMemAllocs(chpl_mem_descInt_t description, int64_t threshold,
   }
 
   totalWidth = filenameWidth+numberWidth*4+descWidth+20;
-  for (i = 0; i < totalWidth; i++)
+  const int headerWidth = strlen(" Memory Leaks ");
+  const int leftHeaderWidth = (totalWidth-headerWidth)/2;
+  const int rightHeaderWidth = totalWidth-leftHeaderWidth-headerWidth;
+
+  for (i = 0; i < leftHeaderWidth; i++)
     fprintf(memLogFile, "=");
+  fprintf(memLogFile, "%s", " Memory Leaks ");
+  for (i = 0; i < rightHeaderWidth; i++)
+    fprintf(memLogFile, "=");
+
   fprintf(memLogFile, "\n");
   fprintf(memLogFile, "%-*s%-*s%-*s%-*s%-*s%-*s\n",
          filenameWidth+numberWidth, "Allocated Memory (Bytes)",

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -53,7 +53,8 @@ $verify = 0;
 $retaintree = 0;
 $dist = "";
 $llvm = 0;
-$memleaks = "";
+$memleaks = 0;
+$memleakslog = "";
 $multilocale = 0;
 $svnrevopt = "";
 $compopts = "";
@@ -120,7 +121,9 @@ while (@ARGV) {
     } elsif ($flag eq "-fast") {
         $fast = 1;
     } elsif ($flag eq "-memleaks") {
-        $memleaks = shift @ARGV;
+        $memleaks = 1;
+    } elsif ($flag eq "-memleakslog") {
+        $memleakslog = shift @ARGV;
     } elsif ($flag eq "-componly") {
         $componly = 1;
     } elsif ($flag eq "-futures") {
@@ -201,7 +204,8 @@ if ($printusage == 1) {
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
     print "\t-llvm                          : run tests using --llvm\n";
     print "\t-mason                         : build mason before running tests\n";
-    print "\t-memleaks <log>                : run memleaks tests\n";
+    print "\t-memleaks <log>                : run testes with --memLeaks\n";
+    print "\t-memleakslog <log>             : run memleakslog testing\n";
     print "\t-multilocale                   : run multilocale tests only\n";
     print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
     print "\t-no-futures                    : do not run future tests\n";
@@ -327,7 +331,7 @@ if (! (-r $logdir and -w $logdir and -d $logdir)) {
 
 $memleaksdir = $ENV{'CHPL_NIGHTLY_MEMLEAKS_DIR'};
 
-if ($memleaks ne "") {
+if ($memleakslog ne "") {
     # Default to known file share.
     if ($debug == 1 && $memleaksdir eq "") {
         $memleaksdir = $logdir;
@@ -339,7 +343,7 @@ if ($memleaks ne "") {
         mkpath $memleaksdir;
     }
 
-    # Check that memleaks dir is accessible.
+    # Check that memleakslog dir is accessible.
     if (! (-r $memleaksdir and -w $memleaksdir and -d $memleaksdir)) {
         print "Error: CHPL_NIGHTLY_MEMLEAKS_DIR ($memleaksdir) not accessible\n";
         exit 1;
@@ -672,8 +676,11 @@ if (!($dist eq "")) {
 if ($fast == 1) {
     $testflags = "$testflags -compopts --fast";
 }
-if (!($memleaks eq "")) {
-    $testflags = "$testflags -memleaks $basetmpdir/$memleaks";
+if ($memleak == 1) {
+    $testflags = "$testflags -memleaks";
+}
+if (!($memleakslog eq "")) {
+    $testflags = "$testflags -memleakslog $basetmpdir/$memleaks";
 }
 if ($nolocal == 1) {
     $testflags = "$testflags -compopts --no-local";
@@ -844,8 +851,8 @@ if ($runtests == 0) {
 #
 # analyze memory leaks tests
 #
-    if (!($memleaks eq "")) {
-        mysystem("$chplhomedir/util/devel/analyzeMemLeaksLog $basetmpdir/$memleaks > $memleaksdir/$memleaks", "analyzeMemLeaksLog", 1, 0, 0);
+    if (!($memleakslog eq "")) {
+        mysystem("$chplhomedir/util/devel/analyzeMemLeaksLog $basetmpdir/$memleakslog > $memleaksdir/$memleakslog", "analyzeMemLeaksLog", 1, 0, 0);
 
         # Update the memory leaks status for performance testing runs to
         #  generate graphs for the memory leaks data
@@ -862,7 +869,7 @@ if ($runtests == 0) {
             }
         }
 
-        mysystem("cd $testdir && cp $memleaksdir/$memleaks ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir", "memLeak computePerfStats", 1, 0, 0);
+        mysystem("cd $testdir && cp $memleaksdir/$memleakslog ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir", "memLeak computePerfStats", 1, 0, 0);
     }
 }
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -204,8 +204,8 @@ if ($printusage == 1) {
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
     print "\t-llvm                          : run tests using --llvm\n";
     print "\t-mason                         : build mason before running tests\n";
-    print "\t-memleaks <log>                : run testes with --memLeaks\n";
-    print "\t-memleakslog <log>             : run memleakslog testing\n";
+    print "\t-memleaks <log>                : run tests with --memLeaks\n";
+    print "\t-memleakslog <log>             : run tests with --memLeaksLog\n";
     print "\t-multilocale                   : run multilocale tests only\n";
     print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
     print "\t-no-futures                    : do not run future tests\n";

--- a/util/cron/test-memleaks.bash
+++ b/util/cron/test-memleaks.bash
@@ -9,5 +9,5 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks"
 
-$CWD/nightly -cron -memleaks $(memleaks_log full) -no-futures $(get_nightly_paratest_args)
+$CWD/nightly -cron -memleakslog $(memleaks_log full) -no-futures $(get_nightly_paratest_args)
 save_memleaks_log full

--- a/util/cron/test-memleaks.examples.bash
+++ b/util/cron/test-memleaks.examples.bash
@@ -8,5 +8,5 @@ source $CWD/common-memleaks.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks.examples"
 
-$CWD/nightly -cron -memleaks $(memleaks_log examples) -examples
+$CWD/nightly -cron -memleaks -examples
 save_memleaks_log examples

--- a/util/cron/test-ml-memleaks.bash
+++ b/util/cron/test-ml-memleaks.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -futures -multilocale -memleaks $(memleaks_log ml)
+$CWD/nightly -cron -futures -multilocale -memleaks

--- a/util/start_test
+++ b/util/start_test
@@ -678,6 +678,11 @@ def set_up_environment():
     else:
         args.execopts = ""
 
+    # memory leak
+    if args.mem_leaks:
+        os.environ["CHPL_MEM_LEAK_TESTING"] = "true"
+        args.execopts += " --memLeaks"
+
     # memory leak log
     if args.mem_leaks_log:
         os.environ["CHPL_MEM_LEAK_TESTING"] = "true"
@@ -1299,10 +1304,13 @@ def parser_setup():
     # log_file
     parser.add_argument("-logfile", "--logfile", action="store",
             dest="log_file", help="set alternate log file")
+    # mem leaks
+    parser.add_argument("-memleaks", "-memleaks", "-memLeaks", "--memLeaks",
+            action="store_true", dest="mem_leaks", help="run with --memLeaks")
     # mem leaks log
-    parser.add_argument("-memleaks", "--memleaks", action="store",
-            dest="mem_leaks_log", help=("set location for memLeaks log, "
-                "and run with the --memLeaksLog flag"))
+    parser.add_argument("-memleakslog", "--memleakslog", "-memLeaksLog",
+            "--memLeaksLog", action="store", dest="mem_leaks_log", help=("set"
+            " location for memLeaks log, and run with --memLeaksLog"))
     # valgrind
     parser.add_argument("-valgrind", "--valgrind", action="store_true",
             dest="valgrind", help="run everything using valgrind")

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -53,7 +53,7 @@ sub main {
 
     if ($#ARGV < 6) {
         fatal("insufficient arguments: '@ARGV'\n" .
-	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks [compopts [execopts]]");
+	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks memleakslog [compopts [execopts]]");
     }
 
     $id = $ARGV[0];
@@ -66,11 +66,11 @@ sub main {
     $valgrind = "-valgrindexe" if ($ARGV[5] == 2);
 
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
-    if ($#ARGV>=7) {
-        $compopts = "-compopts \"" . $ARGV[7] . "\"";
-    }
     if ($#ARGV>=8) {
-        $execopts = "-execopts \"" . $ARGV[8] . "\"";
+        $compopts = "-compopts \"" . $ARGV[8] . "\"";
+    }
+    if ($#ARGV>=9) {
+        $execopts = "-execopts \"" . $ARGV[9] . "\"";
     }
 
     $synchfile = "$synchdir/$node.$id";
@@ -97,7 +97,8 @@ sub main {
     $logfile = "$logdir/$dirfname.$node.log";
     unlink $logfile if (-e $logfile);
 
-    $memleaks = ($ARGV[6] == 1) ? "-memleaks $logdir/tmp.$dirfname.$node.memleaks" : "";
+    $memleaks = ($ARGV[6] == 1) ? "-memleaks" : "";
+    $memleakslog = ($ARGV[7] == 1) ? "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" : "";
 
     $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks";
     $testarg = "$testarg $testdir -norecurse";

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -11,7 +11,7 @@
 #  chplenv - Chapel environment variables
 #  futures-mode - include .futures (0=no, 1=all, 2=futures only, 3=futures with skipifs)
 #  valgrind - run valgrind (0=no, 1=both compiler and executable, 2=executable only)
-#  memleaks - check for memleaks (1=yes, else no)
+#  memleaks - check for memleaks (0=no, 1=use -memleaks, 2=use -memleakslog)
 #  compopts - optional Chapel compiler options
 #  execopts - optional test execution options
 #
@@ -53,24 +53,30 @@ sub main {
 
     if ($#ARGV < 6) {
         fatal("insufficient arguments: '@ARGV'\n" .
-	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks memleakslog [compopts [execopts]]");
+	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks [compopts [execopts]]");
     }
 
     $id = $ARGV[0];
     $workingdir = $ARGV[1];
     $testdir = $ARGV[2];
     $chplenv = $ARGV[3];
+
     $futures_mode = "-futures-mode \"" . $ARGV[4] . "\"";
+
     $valgrind = "";
     $valgrind = "-valgrind" if ($ARGV[5] == 1);
     $valgrind = "-valgrindexe" if ($ARGV[5] == 2);
 
+    $memleaks = "";
+    $memleaks = "-memleaks" if ($ARGV[6] == 1);
+    $memleaks = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[6] == 2);
+
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
-    if ($#ARGV>=8) {
-        $compopts = "-compopts \"" . $ARGV[8] . "\"";
+    if ($#ARGV>=7) {
+        $compopts = "-compopts \"" . $ARGV[7] . "\"";
     }
-    if ($#ARGV>=9) {
-        $execopts = "-execopts \"" . $ARGV[9] . "\"";
+    if ($#ARGV>=8) {
+        $execopts = "-execopts \"" . $ARGV[8] . "\"";
     }
 
     $synchfile = "$synchdir/$node.$id";
@@ -96,9 +102,6 @@ sub main {
     $dirfname =~ s/\//-/g;
     $logfile = "$logdir/$dirfname.$node.log";
     unlink $logfile if (-e $logfile);
-
-    $memleaks = ($ARGV[6] == 1) ? "-memleaks" : "";
-    $memleakslog = ($ARGV[7] == 1) ? "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" : "";
 
     $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks";
     $testarg = "$testarg $testdir -norecurse";

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -44,7 +44,8 @@ $filedist = 0;
 $dirs = "";
 $node_para = 1;                        # the number of tasks to run on each node
 $valgrind = 0;
-$memleaks = "/dev/null";
+$memleaks = 0;
+$memleakslog = "/dev/null";
 $memleaksflag = 0;
 $show_all_errors = 0;
 $junit_xml = 0;
@@ -355,8 +356,8 @@ sub feed_nodes {
       $endtime = `date`; chomp $endtime;
       print "\n";
       if ($memleaksflag) {
-          print "Collecting memleaks logs to $memleaks\n";
-          systemd("cat $logdir/tmp.*.memleaks > $memleaks");
+          print "Collecting memleaks logs to $memleakslog\n";
+          systemd("cat $logdir/tmp.*.memleaks > $memleakslog");
           # Keep the individual logs upon failure.
           !$? or die "Could not collect memleaks logs: $?\n";
           systemd("rm -f $logdir/tmp.*.memleaks");
@@ -509,7 +510,7 @@ sub find_files {
 
 
 sub print_help {
-    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-futures-only] [-logfile l] [-memleaks f] [-multilocale-only] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
+    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-futures-only] [-logfile l] [-memleaks] [-memleakslog f] [-multilocale-only] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
     print "    -compopts s: s is a string that is passed with -compopts to start_test.\n";
     print "    -dirfile  d: d is a file listing directories to test. Default is the current diretory.\n";
     print "    -dirs     d: d is a space separated list of directories to recursively search for directories to test\n";
@@ -519,7 +520,8 @@ sub print_help {
     print "    -futures   : include .future tests (default is none).\n";
     print "    -futures-only : only run .future tests, not regular ones.\n";
     print "    -logfile  l: l is the output log file. Default is \"user\".\"platform\".log. in the Logs subdirectory.\n";
-    print "    -memleaks f: pass -memleaks to start_test; aggregate all output.\n";
+    print "    -memleaks  : pass -memleaks to start_test. \n";
+    print "    -memleakslog f: pass -memleakslog to start_test; aggregate all output.\n";
     print "    -multilocale-only: pass -multilocale-only to start_test if comm!=none\n";
     print "    -nodefile n: n is a file listing nodes to run on. Default is current node.\n";
     print "    -nodepara m: Run m paratest.client tasks on each node.\n";

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -47,6 +47,7 @@ $valgrind = 0;
 $memleaks = 0;
 $memleakslog = "/dev/null";
 $memleaksflag = 0;
+$memleakslogflag = 0;
 $show_all_errors = 0;
 $junit_xml = 0;
 $junit_xml_file = "";
@@ -277,7 +278,7 @@ sub feed_nodes {
                       $execopts = "\\\"$execopts\\\"";
                   }
                   # If the command line gets too long, consider using xargs
-                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $compopts $execopts";
+                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $memleakslogflag $compopts $execopts";
                   if ($verbose) {
                       systemd ($rem_cmd);
                   } else {
@@ -355,7 +356,7 @@ sub feed_nodes {
 
       $endtime = `date`; chomp $endtime;
       print "\n";
-      if ($memleaksflag) {
+      if ($memleakslogflag) {
           print "Collecting memleaks logs to $memleakslog\n";
           systemd("cat $logdir/tmp.*.memleaks > $memleakslog");
           # Keep the individual logs upon failure.
@@ -634,12 +635,14 @@ sub main {
                 exit(8);
             }
         } elsif (/^-memleaks$/) {
+            $memleaksflag = 1;
+        } elsif (/^-memleakslog$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
-                $memleaks = $ARGV[0];
-                $memleaksflag = 1;
+                $memleakslog = $ARGV[0];
+                $memleakslogflag = 1;
             } else {
-                print "missing -memleaks arg\n";
+                print "missing -memleakslog arg\n";
                 exit (8);
             }
         } elsif (/^-multilocale-only$/) {

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -47,7 +47,6 @@ $valgrind = 0;
 $memleaks = 0;
 $memleakslog = "/dev/null";
 $memleaksflag = 0;
-$memleakslogflag = 0;
 $show_all_errors = 0;
 $junit_xml = 0;
 $junit_xml_file = "";
@@ -278,7 +277,7 @@ sub feed_nodes {
                       $execopts = "\\\"$execopts\\\"";
                   }
                   # If the command line gets too long, consider using xargs
-                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $memleakslogflag $compopts $execopts";
+                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $compopts $execopts";
                   if ($verbose) {
                       systemd ($rem_cmd);
                   } else {
@@ -356,7 +355,7 @@ sub feed_nodes {
 
       $endtime = `date`; chomp $endtime;
       print "\n";
-      if ($memleakslogflag) {
+      if ($memleaksflag == 2) {
           print "Collecting memleaks logs to $memleakslog\n";
           systemd("cat $logdir/tmp.*.memleaks > $memleakslog");
           # Keep the individual logs upon failure.
@@ -640,7 +639,7 @@ sub main {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $memleakslog = $ARGV[0];
-                $memleakslogflag = 1;
+                $memleaksflag = 2;
             } else {
                 print "missing -memleakslog arg\n";
                 exit (8);

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -634,6 +634,12 @@ def filter_errors(output, pre_exec_output, execgoodfile, execlog):
             extra_msg = '(possible private issue #398) '
             break
 
+    err_strings = ['=* Memory Leaks =*']
+    for s in err_strings:
+        if (re.search(s, output, re.IGNORECASE) != None):
+            extra_msg = '(memory leak) '
+            break
+
     return extra_msg
 
 


### PR DESCRIPTION
This PR adds the ability to use the executable flags `--memLeaks` and
`--memLeaksLog` in the testing system, and uses that to report multilocale and
example leaks as a special correctness failure.

Co-developed by @ronawho

- Adds a ` Memory Leaks ` header to the runtime's leak report to be able to
  capture that in a filter in sub_test
- Adds a filter to `sub_test` to mark memory leaks as special errors, similar to
  private issues, JIRAs etc.
- Adjusts the following scripts to be able to use both `-memleaks` and
  `memleakslog`.
  - `start_test`
  - `paratest.server`
  - `paratest.client`
  - `nightly`

  They are now more consistent and map directly to their corresponding
  executable flags.

- Sets the single-locale memleaks' cron script to use `memleakslog` instead of
  `memleaks`.

  In these scripts, `memleaks` will only produce "raw" output, where the other
  will produce the output that can be used by `analyzeMemLeaksLog`. So, using
  `memleakslog` will allow us to track single-locale memory leaks as we have
  been doing.

  OTOH, other memleaks nightlies (multilocale and example only) still use
  `-memleaks` which prints the raw leak report and that output will be captured
  to print

  ```
  Error (memory leak) matching program output
  ```

  So, we'll be seeing new leaks on those two as errors.

Test:
- [x] paratest -memleaks
- [x] paratest -memleakslog
- [x] paratest -memleaks -multilocale-only
