### PR TITLE
future requesting error on secondary init= with 0 or 2 args

### DIFF
--- a/test/classes/initializers/initequals/wrongRecordArgCount.chpl
+++ b/test/classes/initializers/initequals/wrongRecordArgCount.chpl
@@ -1,0 +1,5 @@
+record R {
+  proc init=() { }  // should give an error
+  proc init=(a1: R) { }
+  proc init=(a1: R, a2: R) { }  // should give an error
+}

--- a/test/classes/initializers/initequals/wrongRecordArgCount.good
+++ b/test/classes/initializers/initequals/wrongRecordArgCount.good
@@ -1,0 +1,2 @@
+wrongRecordArgCount.chpl:2: error: R.init= must have exactly one argument
+wrongRecordArgCount.chpl:4: error: R.init= must have exactly one argument

--- a/test/classes/initializers/initequals/wrongSecondaryArgCount.chpl
+++ b/test/classes/initializers/initequals/wrongSecondaryArgCount.chpl
@@ -1,0 +1,6 @@
+record R {
+}
+
+proc R.init=() { }  // should give an error
+proc R.init=(a1: R) { }
+proc R.init=(a1: R, a2: R) { }  // should give an error

--- a/test/classes/initializers/initequals/wrongSecondaryArgCount.future
+++ b/test/classes/initializers/initequals/wrongSecondaryArgCount.future
@@ -1,0 +1,5 @@
+bug: secondary init=() with 0 or 2 args isn't an error
+#15963
+
+These cases should be reported as compiler errors, as they are when
+defined as primary init=().

--- a/test/classes/initializers/initequals/wrongSecondaryArgCount.good
+++ b/test/classes/initializers/initequals/wrongSecondaryArgCount.good
@@ -1,0 +1,2 @@
+wrongSecondaryArgCount.chpl:4: error: R.init= must have exactly one argument
+wrongSecondaryArgCount.chpl:6: error: R.init= must have exactly one argument


### PR DESCRIPTION
Add a future for #15963 requesting a compilation error for record
secondary init= that have 0 or 2 (or more) arguments, as is the case
for such init= defined as primary.

While I'm here,  add a test of record primary init= with wrong number of arguments

This is a copy of the wrongArgCount.chpl test with a record instead of
a class.  I want to lock in the behavior for records.

