### PR TITLE
Fix associative domain contains() race

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -291,6 +291,7 @@ module DefaultAssociative {
     }
 
     proc dsiMember(idx: idxType): bool {
+      lockTable(); defer { unlockTable(); }
       var (foundFullSlot, slotNum) = table.findFullSlot(idx);
       return foundFullSlot;
     }

--- a/test/domains/sungeun/assoc/parSafeMember.skipif
+++ b/test/domains/sungeun/assoc/parSafeMember.skipif
@@ -1,1 +1,1 @@
-CHPL_ATOMICS!=intrinsics
+CHPL_ATOMICS==locks


### PR DESCRIPTION
Grab the lock when calling contains/dsiMember for associative domains.
This was originally fixed in 2dc2051892, but was reintroduced in #15739
when splitting the hashtable out of DefaultAssociative. This race was
exacerbated by #15918, which caused failures for parSafeMember.chpl.

Fix the race by grabbing the lock, and update parSafeMember to run with
cstdlib atomics too (it was skipped when intrinsics weren't used before
because locks were too slow, but that was back when intrinsics and locks
were the only options.)