### PR TITLE
Fix associative domain ^= to avoid removing while iterating

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3491,8 +3491,8 @@ module ChapelArray {
      added to the LHS.
   */
   proc ^=(ref a :domain, b: domain) where (a.type == b.type) && isAssociativeDom(a) {
-    for e in a do
-      if b.contains(e) then
+    for e in b do
+      if a.contains(e) then
         a.remove(e);
       else
         a.add(e);


### PR DESCRIPTION
Fix a bug in the associative domain ^= implementation where we were
removing elements while iterating over it. Similar to #15957 and #15962