### PR TITLE
Fix c2chapel again

### DIFF
--- a/test/c2chapel/c2chapel-tester.chpl
+++ b/test/c2chapel/c2chapel-tester.chpl
@@ -1,0 +1,10 @@
+import Spawn;
+
+var testdir = CHPL_HOME + "/tools/c2chapel/test/";
+var command = "cd %s; ./tester.sh".format(testdir);
+var sub = Spawn.spawnshell(command);
+sub.communicate();
+if sub.exit_status==0 then
+  writeln("OK");
+else
+  writeln("Test Failure");

--- a/test/c2chapel/c2chapel-tester.good
+++ b/test/c2chapel/c2chapel-tester.good
@@ -1,0 +1,25 @@
+Testing c2chapel...\n
+No arguments: OK
+--help: OK
+File not found: OK
+arrayDecl: OK
+chapelKeywords: OK
+chapelVarargs: OK
+cstrvoid: OK
+dashEye: OK
+enum: OK
+enumVar: OK
+fileGlobals: OK
+fnPointers: OK
+fnints: OK
+intDefines: OK
+invalidC: OK
+miscTypedef: OK
+nestedStruct: OK
+opaqueStruct: OK
+simpleRecords: OK
+sysCTypes: OK
+.c file: OK
+
+SUCCESS
+OK

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -13,7 +13,7 @@ extern record simpleStruct {
   var e : my_string;
 }
 
-extern proc retStruct(a : my_int, b : my_int, r : renamedStruct) : fancyStruct;
+extern proc retStruct(a : my_int, b : my_int, in r : renamedStruct) : fancyStruct;
 
 extern proc tdPointer(ref a : fancyStruct, ref b : c_ptr(renamedStruct)) : void;
 

--- a/tools/c2chapel/test/no-args.2.good
+++ b/tools/c2chapel/test/no-args.2.good
@@ -1,0 +1,4 @@
+usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
+                [--no-comments] [-V]
+                file [cppFlags [cppFlags ...]]
+c2chapel: error: the following arguments are required: file, cppFlags

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -23,9 +23,9 @@ extern record composition {
   var i : c_ptr(allInts);
 }
 
-extern proc structArgs(a : misc, b : misc) : void;
+extern proc structArgs(in a : misc, in b : misc) : void;
 
-extern proc retStruct(a : misc) : allInts;
+extern proc retStruct(in a : misc) : allInts;
 
 extern proc structPointer(ref a : misc) : void;
 

--- a/tools/c2chapel/test/tester.sh
+++ b/tools/c2chapel/test/tester.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # This script must be run within c2chapel/test
 
@@ -25,14 +25,21 @@ function helper() {
   msg=$1
   args=$2
   good=$3
+  good2=$4
 
   outFile=out.c2chapel.tmp
   diffFile=diff.c2chapel.tmp
 
+  if [ -z "$good2" ]; then
+    # it will just diff against the one good file twice, harmlessly
+    good2=$good
+  fi
 
   printf "%s: " "$msg"
   c2chapel $args > $outFile 2>&1
   if diff $outFile $good > $diffFile 2>&1; then
+    printf "${GREEN}OK${NORMAL}\n"
+  elif diff $outFile $good2 > $diffFile 2>&1; then
     printf "${GREEN}OK${NORMAL}\n"
   else
     printf "${RED}ERROR${NORMAL}\n"
@@ -49,7 +56,7 @@ function helper() {
 
 echo "Testing c2chapel...\n"
 
-helper "No arguments" "" "no-args.good"
+helper "No arguments" "" "no-args.good" "no-args.2.good"
 helper "--help" "--help" "help.good"
 helper "File not found" "notFound.h" "notFound.good"
 


### PR DESCRIPTION
Retry / adjustment to PR #15927.

PR #15903 requires `extern proc` with `extern record` arguments to use an 
explicit intent. Since C typically uses pass by value, the explicit
intent most common is `in`. This PR adjusts c2chapel to emit
structure-typed arguments with `in` intent in `extern proc`s. (PR #15927
did that too, but also emitted the `in` intent for integer/pointer
arguments, which this PR avoids).

Reviewed by @daviditen - thanks!

- [x] passing test/c2chapel