### PR TITLE
Update HDF5 testing's .skipif script to require High-level HDF5

### DIFF
--- a/test/library/packages/HDF5.skipif
+++ b/test/library/packages/HDF5.skipif
@@ -2,7 +2,7 @@
 
 # The HDF5 package requires the hdf5 library.
 
-if h5cc -showconfig 2>&1 > /dev/null ; then
+if h5cc -showconfig 2>&1 | grep -q 'High-level library: yes' ; then
   echo 'False'
 else
   echo 'True'


### PR DESCRIPTION
Apparently HDF5 is installed on our cygwin test environment but not the
"High-level" components. Skip the HDF5 directory if the High-level components
are not available, as suggested by @ronawho.