### PR TITLE
De-future map of tuple .future

### DIFF
--- a/test/library/standard/Map/types/testTuple.bad
+++ b/test/library/standard/Map/types/testTuple.bad
@@ -1,3 +1,0 @@
-$CHPL_HOME/modules/standard/Map.chpl:100: In initializer:
-$CHPL_HOME/modules/standard/Map.chpl:75: error: Cannot default initialize associative array because element type 2*shared T cannot be default initialized
-./MapTest.chpl:5: Initializer instantiated as: init(type keyType = int(64), type valType = 2*shared T, param parSafe = 0)

--- a/test/library/standard/Map/types/testTuple.future
+++ b/test/library/standard/Map/types/testTuple.future
@@ -1,1 +1,0 @@
-tuples of non-nilable class types are not supported


### PR DESCRIPTION
This test started passing after changing map to use chpl__hashtable.