### PR TITLE
PRK DGEMM fix

### DIFF
--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -90,10 +90,10 @@ else {
           if here.id==0 && tid==0 && niter==1 then t.start();
 
           for (kk,jj) in {myChunk by blockSize, vecRange by blockSize} {
-            const kMax = min(jj+blockSize-1, myChunk.high);
-            const jMax = min(kk+blockSize-1, vecRange.high);
-            const jRange = 0..jMax-jj;
+            const kMax = min(kk+blockSize-1, myChunk.high);
+            const jMax = min(jj+blockSize-1, vecRange.high); 
             const kRange = 0..kMax-kk;
+            const jRange = 0..jMax-jj;
 
             // instead of unbounded ranges I was using 0..#blockSize in
             // perf tests, which was running fine with --fast, but

--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -89,9 +89,9 @@ else {
         for niter in 0..iterations {
           if here.id==0 && tid==0 && niter==1 then t.start();
 
-          for (jj,kk) in {myChunk by blockSize, vecRange by blockSize} {
-            const jMax = min(jj+blockSize-1, myChunk.high);
-            const kMax = min(kk+blockSize-1, vecRange.high);
+          for (kk,j) in {myChunk by blockSize, vecRange by blockSize} {
+            const kMax = min(jj+blockSize-1, myChunk.high);
+            const jMax = min(kk+blockSize-1, vecRange.high);
             const jRange = 0..jMax-jj;
             const kRange = 0..kMax-kk;
 

--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -89,7 +89,7 @@ else {
         for niter in 0..iterations {
           if here.id==0 && tid==0 && niter==1 then t.start();
 
-          for (kk,j) in {myChunk by blockSize, vecRange by blockSize} {
+          for (kk,jj) in {myChunk by blockSize, vecRange by blockSize} {
             const kMax = min(jj+blockSize-1, myChunk.high);
             const jMax = min(kk+blockSize-1, vecRange.high);
             const jRange = 0..jMax-jj;


### PR DESCRIPTION
Iterated indices were flipped. It was still working because we only deal with square matrices with the same ranges in each dimension.