### PR TITLE
Update HDF5Preproccesors to close the file and use a better filename

### DIFF
--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -55,7 +55,6 @@ module HDF5Preprocessors {
           }
         }
 
-        f.close();
         remove(scriptName);
       }
     }

--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -22,7 +22,7 @@ module HDF5Preprocessors {
         //var f = opentmp();
         //const scriptName = f.realPath();
 
-        const scriptName = "hdf5TempScript.bash";
+        const scriptName = "./hdf5TempScript.bash";
         var f = open(scriptName, iomode.cw);
 
         // write the script to a file
@@ -32,6 +32,7 @@ module HDF5Preprocessors {
           writer.flush();
           f.fsync();
         }
+        f.close();
 
         // give the file executable permission
         chmod(scriptName, 0o755);


### PR DESCRIPTION
Closing the file and using './' in the filename gets it passing on XC. Thanks
for the tips @ronawho.