### PR TITLE
Remove workaround in FileSystem submodule due to bug tracked by #15308

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -875,10 +875,7 @@ private module GlobWrappers {
 
   // glob wrapper that takes care of casting and error checking
   inline proc glob_w(pattern: string, ref ret_glob:glob_t): void {
-    // want:
-    //  import FileSystem.unescape;
-    // but see issue #15308, so:
-    use FileSystem;
+    import FileSystem.unescape;
     extern proc chpl_glob(pattern: c_string, flags: c_int,
                           ref ret_glob: glob_t): c_int;
 


### PR DESCRIPTION
This issue has been solved for a little bit, so we can now import the symbol we
need directly, instead of using the parent module as a whole.

Noticed when looking back at #15312 