### PR TITLE
Optimize repeated insertions/deletions from chpl__hashtable

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -286,6 +286,7 @@ module DefaultAssociative {
           table.table[slot].status = chpl__hash_status.empty;
         }
         numEntries.write(0);
+        table.maybeShrinkAfterRemove();
         unlockTable();
       }
     }
@@ -376,6 +377,7 @@ module DefaultAssociative {
         } else {
           retval = 0;
         }
+        table.maybeShrinkAfterRemove();
       }
       return retval;
     }

--- a/test/domains/elliot/primes.chpl
+++ b/test/domains/elliot/primes.chpl
@@ -49,7 +49,7 @@ proc primePerf(type tableType) {
     timer.start();
     for p in new Primes(tableType) { if p > LIMIT then break; count += 1; }
     timer.stop();
-    writef("%16s: %7.1dr s\n", tableType:string, timer.elapsed());
+    writef("%16s: %7.2dr s\n", tableType:string, timer.elapsed());
   }
 }
 


### PR DESCRIPTION
Previously, we would only resize if the number of full slots was half
the capacity, but that still led to a lot of collisions and probing past
deleted entries for repeated insertion/deletion cycles. Change to resize
based on the number of empty slots instead. This also fixes an issue
with associative arrays where we weren't shrinking after resizing.

This improves the performance of #15874 (domains/elliot/primes):

| LIMIT       | assoc arr (before) | assoc arr (now) | custom HT  |
| ----------- | -----------------: | --------------: | ---------: |
| 1_000_000   |  0.30 s            |   0.11 s        | 0.02 s     |
| 10_000_000  |  4.29 s            |   1.12 s        | 0.21 s     |
| 100_000_000 | 72.33 s            |  11.49 s        | 2.27 s     |

We see ~4x improvement at the 10_000_000 problem size, but more
importantly this resolves some scaling issues. Before increasing the
problem size by 10x would result in a 16x increase in execution time,
but now that's just over 10.

Throwing in map numbers with this PR and bumping the problem size:

| LIMIT         | assoc arr  | map       | custom HT  |
| ------------- | ---------: | --------: | ---------: |
| 1_000_000     |   0.11 s   |  0.07 s   |  0.02 s    |
| 10_000_000    |   1.12 s   |  0.74 s   |  0.21 s    |
| 100_000_000   |  11.49 s   |  7.48 s   |  2.27 s    |
| 1_000_000_000 | 119.42 s   | 79.07 s   | 24.06 s    |

We see that map raw performance is better and scaling is still good.
map performance is ~3x off from the custom hash table, and the
associative array is roughly 5x off, but the scaling issue has
been resolved.

Closes https://github.com/cray/chapel-private/issues/1085