### PR TITLE
Speed up nightly testing

### DIFF
--- a/util/cron/test-gasnet-everything.bash
+++ b/util/cron/test-gasnet-everything.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -futures $(get_nightly_paratest_args 3)
+$CWD/nightly -cron -futures $(get_nightly_paratest_args 6)

--- a/util/cron/test-gasnet-fast.bash
+++ b/util/cron/test-gasnet-fast.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the fast segment
 export CHPL_GASNET_SEGMENT=fast
 
-$CWD/nightly -cron -multilocale $(get_nightly_paratest_args 3)
+$CWD/nightly -cron -multilocale $(get_nightly_paratest_args 6)

--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -4,7 +4,8 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
+source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
-$CWD/nightly -cron
+$CWD/nightly -cron $(get_nightly_paratest_args)

--- a/util/cron/test-llvm.system.bash
+++ b/util/cron/test-llvm.system.bash
@@ -8,6 +8,8 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-llvm.bash system
+source $CWD/common-localnode-paratest.bash
+
 
 # common-llvm restricts us to extern/ferguson, but we want all the tests
 unset CHPL_NIGHTLY_TEST_DIRS
@@ -15,5 +17,5 @@ unset CHPL_NIGHTLY_TEST_DIRS
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="llvm.system"
 
 log_info START nightly -cron ${nightly_args}
-$CWD/nightly -cron ${nightly_args}
+$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args)
 log_info nightly EXIT status $?

--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -12,4 +12,4 @@ unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
-$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 16)
+$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 20)

--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -10,23 +10,9 @@ source $CWD/common-localnode-paratest.bash
 # Whitebox testing runs multiple paratests concurrently. We limit the number of
 # running executables, but some configs run on shared machines and we don't
 # want to interfere with others too much so run in an "oversubscribed" manner.
-# Note that we don't disable affinity under PGI since we've seen that disabling
-# affinity combined with its lack of atomics has led to timeouts.
 source $CWD/common-oversubscribed.bash
-if [ "${COMPILER}" == "pgi" ] ; then
-  export QT_AFFINITY=yes
-fi
 
-if [ "${COMPILER}" == "cray" ] ; then
-  oversub=6
-fi
-
-if [ "${COMPILER}" == "intel" ] ; then
-  oversub=3
-fi
-
-# Run the tests!
-nightly_args="${nightly_args} -cron $(get_nightly_paratest_args $oversub)"
+nightly_args="${nightly_args} -cron $(get_nightly_paratest_args 4)"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
Some of our configurations are taking over 24 hours and others are
running long on the machines that we do paratesting on. Speed up these
jobs by either using paratest or increasing the amount of paratest
oversubscription we do. This should get whitebox, linux32, and
llvm-system jobs under 24 hours and get the gasnet tests finishing
faster on our development machines.

Part of https://github.com/cray/chapel-private/issues/1024