### PR TITLE
Stop trying to save the raw log of examples memory leaks

### DIFF
--- a/util/cron/test-memleaks.examples.bash
+++ b/util/cron/test-memleaks.examples.bash
@@ -9,4 +9,3 @@ source $CWD/common-memleaks.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks.examples"
 
 $CWD/nightly -cron -memleaks -examples
-save_memleaks_log examples


### PR DESCRIPTION
I have forgotten one post-run call that saved raw output of examples memory
leaks to a separate directory. We no longer need to do that, and trying to do it
caused the test to fail at the very end.

Looks like I hadn't added that call to multilocale memory leaks in the first
place, I also confirmed that we don't have raw outputs from multilocale leaks.
So, I don't expect a similar failure on that.
