### PR TITLE
Adjust testTuple future for fixed size arrays

### DIFF
--- a/test/arrays/types-fixed-array/testTuple.bad
+++ b/test/arrays/types-fixed-array/testTuple.bad
@@ -1,8 +1,12 @@
-./ArrayTest.chpl:1: In function 'testArray':
-./ArrayTest.chpl:4: error: Cannot default-initialize a tuple component of the type shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
-./ArrayTest.chpl:4: error: Cannot default-initialize a tuple component of the type shared T
-note: non-nil class types do not support default initialization
-note: Consider using the type shared T? instead
-testTuple.chpl:8: Function 'testArray' instantiated as: testArray(type t = 2*shared T)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: In function 'init_elts':
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: error: cannot default initialize the tuple y
+note: element 0 of type shared T has no default value
+note: because it is a non-nilable class - consider the type shared T? instead
+note: element 1 of type shared T has no default value
+note: because it is a non-nilable class - consider the type shared T? instead
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: error: cannot default initialize the tuple y
+note: element 0 of type shared T has no default value
+note: because it is a non-nilable class - consider the type shared T? instead
+note: element 1 of type shared T has no default value
+note: because it is a non-nilable class - consider the type shared T? instead
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: Function 'init_elts' instantiated as: init_elts(x: _ddata(2*shared T), s: int(64), type t = 2*shared T)

--- a/test/arrays/types-fixed-array/testTuple.future
+++ b/test/arrays/types-fixed-array/testTuple.future
@@ -1,0 +1,2 @@
+Test for fixed size array of tuples should execute but issues tuple
+related default initialization errors in internal module code

--- a/test/arrays/types-fixed-array/testTuple.prediff
+++ b/test/arrays/types-fixed-array/testTuple.prediff
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+command='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+cp "$2" $2.tmp
+cat $2.tmp | sed "$command" > $2
+rm $2.tmp
+


### PR DESCRIPTION
This PR adjusts a failing future I did not touch in #15912.

Adjust `arrays/types-fixed-array/testTuple.chpl` future so that it mirrors the future for resized arrays. New failure mode points into internal module code but line numbers are removed. Add a note to the `.future` file explaining what is broken and why.