### PR TITLE
Reduce memory in a test to avoid timeouts

### DIFF
--- a/test/runtime/configMatters/comm/misalignedComm.chpl
+++ b/test/runtime/configMatters/comm/misalignedComm.chpl
@@ -8,7 +8,8 @@
 
 use BlockDist;
 
-config var n = 600_000_001;
+// without this we are allocating way too much memory for VMs
+config var n = if CHPL_COMM=="ugni" then 600_000_001 else 60_000_001;
 
 var d1 = {0..#n} dmapped Block({0..#n});
 var a1: [d1] bool;


### PR DESCRIPTION
This test was added for a specific UGNI bug with large misaligned transfers. We
have had some issues with the large size under other configurations. This PR
uses smaller size on comm layers other than UGNI.
