### PR TITLE
Improve static checks and add new static analysis for fast followers

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -56,6 +56,7 @@ ForallStmt::ForallStmt(BlockStmt* body):
 
 
   optInfo.autoLocalAccessChecked = false;
+  optInfo.confirmedFastFollower = false;
 
   gForallStmts.add(this);
 }

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -964,9 +964,16 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
                                           new_Expr("'move'(%S, %S)", T2, gFalse)));
     } else {
       leadForLoop->insertAtTail("'move'(%S, chpl__staticFastFollowCheckZip(%S))", T1, iterRec);
-      leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),
-                                          new_Expr("'move'(%S, chpl__dynamicFastFollowCheckZip(%S))", T2, iterRec),
-                                          new_Expr("'move'(%S, %S)", T2, gFalse)));
+      if (pfs->optInfo.confirmedFastFollower) {
+        leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),
+                                            new_Expr("'move'(%S, %S)", T2, gTrue),
+                                            new_Expr("'move'(%S, %S)", T2, gFalse)));
+      }
+      else {
+        leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),
+                                            new_Expr("'move'(%S, chpl__dynamicFastFollowCheckZip(%S))", T2, iterRec),
+                                            new_Expr("'move'(%S, %S)", T2, gFalse)));
+      }
     }
 
     SymbolMap map;

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -964,10 +964,10 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
                                           new_Expr("'move'(%S, %S)", T2, gFalse)));
     } else {
       leadForLoop->insertAtTail("'move'(%S, chpl__staticFastFollowCheckZip(%S))", T1, iterRec);
+
+      // override the dynamic check if the compiler can call it
       if (pfs->optInfo.confirmedFastFollower) {
-        leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),
-                                            new_Expr("'move'(%S, %S)", T2, gTrue),
-                                            new_Expr("'move'(%S, %S)", T2, gFalse)));
+        leadForLoop->insertAtTail(new_Expr("'move'(%S, %S)", T2, T1));
       }
       else {
         leadForLoop->insertAtTail(new CondStmt(new SymExpr(T1),

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -46,6 +46,9 @@ class ForallOptimizationInfo {
     std::vector<Symbol *> staticCheckSymsForDynamicCandidates;
 
     bool autoLocalAccessChecked;
+
+
+    bool confirmedFastFollower;
 };
 
 ///////////////////////////////////

--- a/compiler/include/autoLocalAccess.h
+++ b/compiler/include/autoLocalAccess.h
@@ -25,7 +25,7 @@
 #include "symbol.h"
 
 // interface for normalize
-void autoLocalAccess();
+void doPreNormalizeOptimizations();
 
 // interface for resolution
 Expr *preFoldMaybeLocalThis(CallExpr *call);

--- a/compiler/optimizations/autoLocalAccess.cpp
+++ b/compiler/optimizations/autoLocalAccess.cpp
@@ -164,10 +164,6 @@ static Symbol *getDomSym(Symbol *arrSym) {
     }
   }
 
-  if (ret == NULL) {
-    LOG("Regular domain symbol was not found for array", arrSym);
-  }
-
   return ret;
 }
 
@@ -776,6 +772,9 @@ void autoLocalAccess() {
               Symbol *domSym = getDomSym(accBaseSym);
               if (domSym != NULL) {
                 LOG("\twith domain defined at", domSym);
+              }
+              else {
+                LOG("\tregular domain symbol was not found for array", accBaseSym);
               }
 
               if (domSym != NULL) {  //  I can find the domain of the array

--- a/compiler/optimizations/autoLocalAccess.cpp
+++ b/compiler/optimizations/autoLocalAccess.cpp
@@ -731,8 +731,8 @@ static void symbolicFastFollowerAnalysis(ForallStmt *forall) {
     }
   }
   if (confirm) {
-    std::cout << "Confirming forall for static fast follower check\n";
-    std::cout << forall->stringLoc() << std::endl;
+    //std::cout << "Confirming forall for static fast follower check\n";
+    //std::cout << forall->stringLoc() << std::endl;
   }
   forall->optInfo.confirmedFastFollower = confirm;
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -124,7 +124,7 @@ static bool        firstConstructorWarning = true;
 
 void normalize() {
 
-  autoLocalAccess();
+  doPreNormalizeOptimizations();
 
   insertModuleInit();
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -509,7 +509,7 @@ module ChapelIteratorSupport {
     if x.size-1 == dim then
       return chpl__staticFastFollowCheckZip(x(dim), lead);
     else
-      return chpl__staticFastFollowCheckZip(x(dim), lead) || chpl__staticFastFollowCheckZip(x, lead, dim+1);
+      return chpl__staticFastFollowCheckZip(x(dim), lead) && chpl__staticFastFollowCheckZip(x, lead, dim+1);
   }
 
   //

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -473,19 +473,66 @@ module ChapelIteratorSupport {
     return _toStandalone(x.these(), (...args));
   }
 
+  // arrays: can lead fast followers, can produce fast followers
+  // domains: can lead fast followers, doesn't produce fast followers
+  // other iterators: cannot lead fast followers, doesn't produce fast followers
+
+  // There are three types of iterands w.r.t. fast followers:
+  // 1. Those that can have fast followers:
+  //    
+  //    We can generate fast followers for these types, and they are the only
+  //    category of types that can result in fast followers in a
+  //    non-zippered forall.
+  //    
+  //    Arrays are in this category
+  //
+  // 2. Those that can lead fast followers:
+  // 
+  //    We can generate fast followers in zippered foralls where the first
+  //    iterand is one of these types. Note that, being able to lead fast
+  //    followers doesn't mean being able to generate fast followers.
+  //
+  //    Domains and arrays are in this category
+  //    
+  // 3. Those that can appear in a fast copy of a forall as followers
+  //
+  //    Basically reverse of 1. These iterands do not break static or dynamic
+  //    check. When `toFastFollower` is called with them, we just call
+  //    `toFollow`
+  //
+  //    Domains and other iterators are in this category
+  proc chpl__canHaveFastFollowers(x) param {
+    return isArray(x);
+  }
+
+  proc chpl__canLeadFastFollowers(x) param {
+    if isDomain(x) || isArray(x) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+
+  proc chpl__hasInertFastFollowers(x) param { 
+    return !isArray(x);
+  }
 
   //
   // return true if any iterator supports fast followers
   //
   proc chpl__staticFastFollowCheck(x) param {
     pragma "no copy" const lead = x;
-    if isDomain(lead) || isArray(lead) then
+    if chpl__canHaveFastFollowers(lead) then
       return chpl__staticFastFollowCheck(x, lead);
-    else
+    else {
       return false;
+    }
   }
 
   proc chpl__staticFastFollowCheck(x, lead) param {
+    compilerWarning("Static fast follow check called with unexpected types ",
+                    x.type:string, " and ", lead.type:string);
     return false;
   }
 
@@ -495,21 +542,23 @@ module ChapelIteratorSupport {
 
   proc chpl__staticFastFollowCheckZip(x: _tuple) param {
     pragma "no copy" const lead = x(0);
-    if isDomain(lead) || isArray(lead) then
+    if chpl__canLeadFastFollowers(lead) then
       return chpl__staticFastFollowCheckZip(x, lead);
     else
       return false;
   }
 
   proc chpl__staticFastFollowCheckZip(x, lead) param {
-    return chpl__staticFastFollowCheck(x, lead);
+    return chpl__hasInertFastFollowers(x) ||
+           chpl__staticFastFollowCheck(x, lead);
   }
 
   proc chpl__staticFastFollowCheckZip(x: _tuple, lead, param dim = 0) param {
     if x.size-1 == dim then
       return chpl__staticFastFollowCheckZip(x(dim), lead);
     else
-      return chpl__staticFastFollowCheckZip(x(dim), lead) && chpl__staticFastFollowCheckZip(x, lead, dim+1);
+      return chpl__staticFastFollowCheckZip(x(dim), lead) &&
+             chpl__staticFastFollowCheckZip(x, lead, dim+1);
   }
 
   //
@@ -517,11 +566,18 @@ module ChapelIteratorSupport {
   // their fast followers
   //
   proc chpl__dynamicFastFollowCheck(x) {
-    return chpl__dynamicFastFollowCheck(x, x);
+    if chpl__canHaveFastFollowers(x) {
+      return chpl__dynamicFastFollowCheck(x, x);
+    }
+    else {
+      return false;
+    }
   }
 
   proc chpl__dynamicFastFollowCheck(x, lead) {
-    return true;
+    compilerWarning("Dynamic fast follow check called with unexpected types ",
+                    x.type:string, " and ", lead.type:string);
+    return false;
   }
 
   proc chpl__dynamicFastFollowCheck(x: [], lead) {
@@ -532,11 +588,16 @@ module ChapelIteratorSupport {
   }
 
   proc chpl__dynamicFastFollowCheckZip(x: _tuple) {
-    return chpl__dynamicFastFollowCheckZip(x, x(0));
+    if chpl__canLeadFastFollowers(x(0)) {
+      return chpl__dynamicFastFollowCheckZip(x, x(0));
+    }
+    else {
+      return false;
+    }
   }
 
   proc chpl__dynamicFastFollowCheckZip(x, lead) {
-    return chpl__dynamicFastFollowCheck(x, lead);
+    return chpl__hasInertFastFollowers(x) || chpl__dynamicFastFollowCheck(x, lead);
   }
 
   proc chpl__dynamicFastFollowCheckZip(x: _tuple, lead, param dim = 0) {
@@ -600,7 +661,7 @@ module ChapelIteratorSupport {
 
   pragma "fn returns iterator"
   inline proc _toFastFollower(x, leaderIndex) {
-    if chpl__staticFastFollowCheck(x) then
+    if chpl__canHaveFastFollowers(x) then
       return _toFastFollower(_getIterator(x), leaderIndex, fast=true);
     else
       return _toFollower(_getIterator(x), leaderIndex);
@@ -625,6 +686,7 @@ module ChapelIteratorSupport {
       return (_toFastFollowerZip(x(dim), leaderIndex),
               (..._toFastFollowerZip(x, leaderIndex, dim+1)));
   }
+
 
 
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -518,6 +518,15 @@ module ChapelIteratorSupport {
     return !isArray(x);
   }
 
+  proc chpl__hasAnIterandWithFastFollowers(x: _tuple, param dim=0) param {
+    if x.size-1 == dim then
+      return chpl__canHaveFastFollowers(x(dim));
+    else
+      return chpl__canHaveFastFollowers(x(dim)) ||
+             chpl__hasAnIterandWithFastFollowers(x, dim+1);
+
+  }
+
   //
   // return true if any iterator supports fast followers
   //
@@ -541,11 +550,16 @@ module ChapelIteratorSupport {
   }
 
   proc chpl__staticFastFollowCheckZip(x: _tuple) param {
-    pragma "no copy" const lead = x(0);
-    if chpl__canLeadFastFollowers(lead) then
-      return chpl__staticFastFollowCheckZip(x, lead);
-    else
+    if !chpl__hasAnIterandWithFastFollowers(x) {
       return false;
+    }
+    else {
+      pragma "no copy" const lead = x(0);
+      if chpl__canLeadFastFollowers(lead) then
+        return chpl__staticFastFollowCheckZip(x, lead);
+      else
+        return false;
+    }
   }
 
   proc chpl__staticFastFollowCheckZip(x, lead) param {

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -675,7 +675,8 @@ module ChapelIteratorSupport {
 
   pragma "fn returns iterator"
   inline proc _toFastFollower(x, leaderIndex) {
-    if chpl__canHaveFastFollowers(x) then
+    // ENGIN: want to call chpl__canHaveFastFollowers, but can't get it to work
+    if chpl__staticFastFollowCheck(x) then
       return _toFastFollower(_getIterator(x), leaderIndex, fast=true);
     else
       return _toFollower(_getIterator(x), leaderIndex);

--- a/test/distributions/bharshbarg/fastFollowerEquality.chpl
+++ b/test/distributions/bharshbarg/fastFollowerEquality.chpl
@@ -3,6 +3,8 @@ use BlockDist;
 use StencilDist;
 use CyclicDist;
 
+config param zipRange = true;
+
 proc test(Orig : domain) {
   var Copy = Orig;
   test(Orig, Copy);
@@ -31,14 +33,25 @@ proc test(A : [?DA], B : [?DB]) {
   DB.dist.displayRepresentation();
   writeln();
 
-  forall (a,b) in zip(A,B) do
-    a += b;
+  if !zipRange {
+    forall (a,b) in zip(A,B) do
+      a += b;
+  }
+  else {
+    forall (a,b,i) in zip(A,B, 0..) do
+      a += b+i;
+  }
   writeln("----------");
   writeln();
 
   var cur = 0;
   for i in DA {
-    assert(A[i] == cur * 2);
+    if !zipRange {
+      assert(A[i] == cur * 2);
+    }
+    else {
+      assert(A[i] == cur * 3);
+    }
     cur += 1;
   }
 }

--- a/test/distributions/bharshbarg/fastFollowerEquality.compopts
+++ b/test/distributions/bharshbarg/fastFollowerEquality.compopts
@@ -1,1 +1,2 @@
--sCyclicDist.testFastFollowerOptimization -sBlockDist.testFastFollowerOptimization -sdataParTasksPerLocale=2
+-sCyclicDist.testFastFollowerOptimization -sBlockDist.testFastFollowerOptimization -sdataParTasksPerLocale=2 -szipRange=false
+-sCyclicDist.testFastFollowerOptimization -sBlockDist.testFastFollowerOptimization -sdataParTasksPerLocale=2 -szipRange=true

--- a/test/optimizations/autoLocalAccess/allDynamicsFailStatic.good
+++ b/test/optimizations/autoLocalAccess/allDynamicsFailStatic.good
@@ -19,7 +19,7 @@ Access base's domain is the iterator
 Potential access
 	allDynamicsFailStatic.chpl:19
 
-Regular domain symbol was not found for array
+	regular domain symbol was not found for array
 	allDynamicsFailStatic.chpl:8
 
 	Marking static candidate

--- a/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.good
+++ b/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.good
@@ -19,7 +19,7 @@ Access base's domain is the iterator
 Potential access
 	allDynamicsFailStatic.chpl:19
 
-Regular domain symbol was not found for array
+	regular domain symbol was not found for array
 	allDynamicsFailStatic.chpl:8
 
 	Marking static candidate


### PR DESCRIPTION
The main goal of this PR is to eliminate loop clones as much as possible
to improve compilation speed.

Today, the fast follower optimization changes the following loop

```chapel
forall (a,b) in zip(A,B) {
  foo();
}
```

into something like

```chapel
var doFast: bool;
if (any iterator passes static check) {
  doFast = (all iterators pass dynamic check);
}
else {
  doFast = false;
}

if doFast {
  for followThis in A.these(leader) {
    for (a,b) in zip(A.these(..., fast=true), B.these(..., fast=true)) {
      foo();
    }
  }
}
else {
  for followThis in A.these(leader) {
    for (a,b) in zip(A.these(..., fast=false), B.these(..., fast=false)) {
      foo();
    }
  }
}
```

This approach is prone to leaving unused loops in the AST and generate code for
them, slowing compilation.

This PR addresses false positives and false negatives in fast follower checks.

false positives
---------------

The static check that we do today is way too lax. Because for a leader that
supports fast followers, we always have a fast loop. However that loop is unused
if any of the followers don't support fast followers and/or not of same type as
the leader.

This decision seems to be made in 2010 when fast followers were first
implemented. I assume that compiler wasn't this powerful and slow and/or there
wasn't param unfolding etc. 

The commit where this was added is 0dd8331b8903cb1e280ee69af37187997c6d77e7.

Citing part of it that alludes to this decision:

>   This optimization works as follows: When 'parsing' a forall loop, we
>   generate code that generates two loops in a conditional, a fast
>   follower loop and a normal follower loop.  The conditional is guarded
>   by or'ing the result of calling the static checks on all of the
>   followers, and then and'ing the result of calling the dynamic checks
>   on all of the followers.  That is, if any follower has a fast version
>   that may be called, let's generate the code, but we're only going to
>   run the fast loop (all fast followers) if every follower that may be
>   called should be called.

Where there is no strong argument for having this behavior.

I believe these type of false optimizations are the main reason for the
performance overhead of fast followers.

false negatives
---------------

There are also cases where we keep the slow loop although the zippered arrays
can be confirmed to be defined on the same domains. This PR adds an analysis for
that leveraging some of the logic that was added for automatic localAccess in 
https://github.com/chapel-lang/chapel/pull/15713.

With that support, if we can determine the array symbols are defined with the
same domain symbol, we override the dynamic checks and rely only on the static
check for fast followers. We still need to call that existing static check,
because the analysis added here are only based on symbols and not their types.
i.e. the compiler analysis will also confirm that two DefaultRectangulars can
use fast followers when they are zippered, but in reality they'll fail the
static check because they don't support this optimization.

As far as I can see, the benefits of this is much smaller compared to the other
optimization above.

compiler performance
--------------------

MiniMD has bunch of dynamic checks that fail, so used that with the compiler
command:

```
chpl -M helpers -sdisableAliasedBulkTransfer=false --no-local -suseBlockDist=true miniMD.chpl
```

|               | resolve | makeBinary | total |
|---------------|---------|------------|------ |
|master         | 12.714  | 17.027     | 44.717|
|master --fast  | 12.138  | 48.754     | 74.214|
|branch         | 12.363  | 16.519     | 43.117|
|branch --fast  | 11.494  | 46.398     | 70.482|


todo
----

- [x] `test/distribution/bharshbarg/fastFollowerEquality.chpl` passes on gasnet
- [x] check performance of a benchmark that benefits from fast followers
- [ ] change file names from autoLocalAccess.* to something more general
- [ ] full standard
- [ ] full gasnet





