### PR TITLE
Fix problems with --llvm-wide-opt

### DIFF
--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -62,6 +62,7 @@ FnSymbol *gChplForallError;
 FnSymbol *gAtomicFenceFn;
 FnSymbol *gChplAfterForallFence;
 FnSymbol *gChplCreateStringWithLiteral;
+FnSymbol *gChplBuildLocaleId;
 
 /************************************* | **************************************
 *                                                                             *
@@ -353,6 +354,11 @@ static WellKnownFn sWellKnownFns[] = {
     FLAG_UNKNOWN
   },
 
+  {
+    "chpl_buildLocaleID",
+    &gChplBuildLocaleId,
+    FLAG_UNKNOWN
+  },
 };
 
 void gatherWellKnownFns() {

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2386,8 +2386,7 @@ GenRet codegenCallExpr(GenRet function,
         chapelRetTy = fn->retType->codegen().type;
         chplRetTySigned = is_signed(fn->retType);
       }
-    } else if(FD) {
-      INT_ASSERT(FD != NULL);
+    } else if (FD) {
       clang::QualType retTy = FD->getCallResultType();
       if (retTy->isVoidType()) {
         chapelRetTy = llvm::Type::getVoidTy(ctx);

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -44,6 +44,7 @@ namespace llvm {
 namespace clang {
   class Decl;
   class FunctionDecl;
+  class QualType;
   class TypeDecl;
   class ValueDecl;
 
@@ -65,6 +66,7 @@ void cleanupExternC();
 #ifdef HAVE_LLVM
 // should support TypedefDecl,EnumDecl,RecordDecl
 llvm::Type* codegenCType(const clang::TypeDecl* td);
+llvm::Type* codegenCType(const clang::QualType& qType);
 // should support FunctionDecl,VarDecl,EnumConstantDecl
 GenRet codegenCValue(const clang::ValueDecl *vd);
 

--- a/compiler/include/llvmGlobalToWide.h
+++ b/compiler/include/llvmGlobalToWide.h
@@ -168,7 +168,11 @@ struct GlobalToWideInfo {
   GlobalToWideInfo()
     : globalSpace(0), wideSpace(0), globalPtrBits(0),
       localeIdType(NULL), nodeIdType(NULL), gTypes(), specialFunctions(),
-      hasPreservingFn(false) { }
+      getFn(NULL), getFnType(NULL),
+      putFn(NULL), putFnType(NULL),
+      getPutFn(NULL), getPutFnType(NULL),
+      memsetFn(NULL), memsetFnType(NULL),
+      hasPreservingFn(false), preservingFn(NULL) { }
 };
 
 llvm::ModulePass *createGlobalToWide(GlobalToWideInfo* info,

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -74,5 +74,6 @@ extern FnSymbol *gChplForallError;
 extern FnSymbol *gAtomicFenceFn;
 extern FnSymbol *gChplAfterForallFence;
 extern FnSymbol *gChplCreateStringWithLiteral;
+extern FnSymbol *gChplBuildLocaleId;
 
 #endif

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2663,14 +2663,25 @@ void setupForGlobalToWide(void) {
   info->nodeIdType = ginfo->lvt->getType("c_nodeid_t");
   assert(info->nodeIdType);
 
-  info->getFn = getFunctionLLVM("chpl_gen_comm_get_ctl");
-  INT_ASSERT(info->getFn);
-  info->putFn = getFunctionLLVM("chpl_gen_comm_put_ctl");
-  INT_ASSERT(info->putFn);
-  info->getPutFn = getFunctionLLVM("chpl_gen_comm_getput");
-  INT_ASSERT(info->getPutFn);
-  info->memsetFn = getFunctionLLVM("chpl_gen_comm_memset");
-  INT_ASSERT(info->memsetFn);
+  llvm::Function* getFn = getFunctionLLVM("chpl_gen_comm_get_ctl");
+  INT_ASSERT(getFn);
+  info->getFn = getFn;
+  info->getFnType = getFn->getFunctionType();
+
+  llvm::Function* putFn = getFunctionLLVM("chpl_gen_comm_put_ctl");
+  INT_ASSERT(putFn);
+  info->putFn = putFn;
+  info->putFnType = putFn->getFunctionType();
+
+  llvm::Function* getPutFn = getFunctionLLVM("chpl_gen_comm_getput");
+  INT_ASSERT(getPutFn);
+  info->getPutFn = getPutFn;
+  info->getPutFnType = getPutFn->getFunctionType();
+
+  llvm::Function* memsetFn = getFunctionLLVM("chpl_gen_comm_memset");
+  INT_ASSERT(memsetFn);
+  info->memsetFn = memsetFn;
+  info->memsetFnType = memsetFn->getFunctionType();
 
   // Call these functions in a dummy externally visible
   // function which GlobalToWide should remove. We need to do that

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2001,6 +2001,18 @@ llvm::Type* codegenCType(const TypeDecl* td)
   return clang::CodeGen::convertTypeForMemory(cCodeGen->CGM(), qType);
 }
 
+llvm::Type* codegenCType(const clang::QualType& qType)
+{
+  GenInfo* info = gGenInfo;
+  INT_ASSERT(info);
+  ClangInfo* clangInfo = info->clangInfo;
+  INT_ASSERT(clangInfo);
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+  INT_ASSERT(cCodeGen);
+
+  return clang::CodeGen::convertTypeForMemory(cCodeGen->CGM(), qType);
+}
+
 // should support FunctionDecl,VarDecl,EnumConstantDecl
 GenRet codegenCValue(const ValueDecl *vd)
 {

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1229,10 +1229,6 @@ namespace {
 
         Type* nodeTy = info->nodeIdType;
 
-        // TODO -- update these
-        // gdb /home/mppf/w/llvm-debug/third-party/llvm/install/linux64-gnu/bin/opt
-        // run --load /home/mppf/w/llvm-debug/compiler/llvm/llvm-global-to-wide/build/lib/llvm-pgas.so  -global-to-wide -S < /home/mppf/w/llvm-debug/compiler/llvm/llvm-global-to-wide/test/e.ll
-
         auto getFn = M.getOrInsertFunction("chpl_gen_comm_get_ctl_sym", voidTy,
                                            voidPtrTy, nodeTy, voidPtrTy,
                                            sizeTy, i64Ty);
@@ -1366,6 +1362,17 @@ namespace {
           }
         }
       }
+
+      assert(info->getFn);
+      assert(info->putFn);
+      assert(info->getPutFn);
+      assert(info->memsetFn);
+#if HAVE_LLVM_VER >= 90
+      assert(info->getFnType);
+      assert(info->putFnType);
+      assert(info->getPutFnType);
+      assert(info->memsetFnType);
+#endif
 
       assert(info->globalSpace > 0);
       assert(info->localeIdType);


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/1131

After recent work improving LLVM ABI support (most recently PR #15990),
there are problems with `--llvm-wide-opt` functioning. These problems are
due in large part to the case where an `export proc` referring to a C
function returning a structure was not being handled with the new ABI
support.

This PR:
 * makes `chpl_buildLocaleID` a well-known function, so calls to it can
   more easily use the ABI support
 * adjusts codegenCallExpr to convert the result to the appropriate type
 * removes such a conversion from CallExpr::codegen
 * fixes a problem where `getFnType` etc were not being initialized
   correctly for the global-to-wide pass

Reviewed by @e-kayrakli - thanks!

- [x] full local --llvm testing
- [x] full local testing
