### PR TITLE
Quiet python interop warnings about unrecognized command line option

### DIFF
--- a/test/interop/python/PREDIFF
+++ b/test/interop/python/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/chapelBytes/PREDIFF
+++ b/test/interop/python/chapelBytes/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 sed '/^clang: warning: argument unused/d' $2 > $2.tmp
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' $2.tmp > $2
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/chapelStrings/PREDIFF
+++ b/test/interop/python/chapelStrings/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/initFile/PREDIFF
+++ b/test/interop/python/initFile/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/multilocale/PREDIFF
+++ b/test/interop/python/multilocale/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/multilocale/chapelBytes/PREDIFF
+++ b/test/interop/python/multilocale/chapelBytes/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/multilocale/chapelStrings/PREDIFF
+++ b/test/interop/python/multilocale/chapelStrings/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/multilocale/initFile/PREDIFF
+++ b/test/interop/python/multilocale/initFile/PREDIFF
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/noLibFlag/checkDiffPythonModname.prediff
+++ b/test/interop/python/noLibFlag/checkDiffPythonModname.prediff
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture

--- a/test/interop/python/noLibFlag/pythonCompile.prediff
+++ b/test/interop/python/noLibFlag/pythonCompile.prediff
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Remove clang unused argument warning
+# Remove clang/gcc unused argument warning
 cat $2 | sed '/^clang: warning: argument unused/d' | \
+sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
 sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture


### PR DESCRIPTION
We started throwing `-Wno-alloc-size-larger-than` for gcc 8+ in #15999.
Python interop testing was warning that this was unrecognized while
cythonizing things. This is because we're using gcc 8 for our compiles
so our makefiles add the option and pass it to cython, but cython then
goes and uses the system gcc 4 version, which doesn't support the flag.
Just filter the warning out like was being done for similar clang
warnings.