### PR TITLE
Skip setops for 16-node-cs release arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -91,6 +91,9 @@ if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
   if [[ -n $CHPL_TEST_PERF_CONFIGS ]]; then
     benchmark_opts="${benchmark_opts} --configs $CHPL_TEST_PERF_CONFIGS"
   fi
+  if [[ -n $CHPL_TEST_ARKOUDA_BENCHMARKS ]]; then
+    benchmark_opts="${benchmark_opts} $CHPL_TEST_ARKOUDA_BENCHMARKS"
+  fi
 
   test_start "benchmarks"
   if ./benchmarks/run_benchmarks.py ${benchmark_opts} ; then

--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -19,6 +19,9 @@ export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
+# Skip setops for master testing (fragmentation causes timeout/oom)
+export CHPL_TEST_ARKOUDA_BENCHMARKS='stream argsort coargsort gather scatter reduce scan noop'
 test_release
+unset CHPL_TEST_ARKOUDA_BENCHMARKS
 test_master
 sync_graphs


### PR DESCRIPTION
We recently fixed a memory fragmentation issue for CS configurations
that was causing OOMs and timeouts for arkouda, especially with the new
setops benchmark. That issue still exists on the 1.22 release, so skip
setops to avoid the failure there.