### PR TITLE
Disable restrict warnings for gcc

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -186,10 +186,10 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
 endif
 
 #
-# Avoid false positives for allocation size
+# Avoid false positives for allocation size and memcpy
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 7; echo "$$?"),0)
-SQUASH_WARN_GEN_CFLAGS += -Wno-alloc-size-larger-than
+SQUASH_WARN_GEN_CFLAGS += -Wno-alloc-size-larger-than -Wno-restrict
 endif
 
 #


### PR DESCRIPTION
We're getting some bogus Wrestrict warnings from gcc for memcpy calls in
the string module. We quieted some of these warnings before in #15791,
but now we're seeing them more often. These are false positives and
they're getting noisier so disable the warnings. In general recent
versions of gcc seem to have a much higher rate of false-positives for
new warnings, so I have been more on board with just quieting ones that
don't seem that valuable anyways.