### PR TITLE
Fix python interop PREDIFF

### DIFF
--- a/test/interop/python/chapelBytes/PREDIFF
+++ b/test/interop/python/chapelBytes/PREDIFF
@@ -1,22 +1,24 @@
 #!/bin/bash
 
 # Remove clang/gcc unused argument warning
-sed '/^clang: warning: argument unused/d' $2 > $2.tmp
+cat $2 | sed '/^clang: warning: argument unused/d' | \
 sed '/warning: unrecognized command line option/d' | \
 # Remove warning about the object file being made for a different OSX version
-sed '/^ld: warning: object file/d' $2.tmp > $2
+sed '/^ld: warning: object file/d' | \
 # Remove warning about .a's being built for a different architecture
-sed '/ignoring file/d' $2 > $2.tmp
+sed '/ignoring file/d' | \
 # Remove numpy version deprecation warning (Cython is responsible for this)
-sed '/arrayobject.h:[0-9]*/d' $2.tmp > $2
-sed '/ndarraytypes.h:[0-9]*/d' $2 > $2.tmp
-sed '/Using deprecated NumPy API/d' $2.tmp > $2
-sed '/^ *\^/d' $2 > $2.tmp
-sed '/^1 warning generated./d' $2.tmp > $2
-sed '/^[ ]*$/d' $2 > $2.tmp
+sed '/arrayobject.h:[0-9]*/d' | \
+sed '/ndarraytypes.h:[0-9]*/d' | \
+sed '/Using deprecated NumPy API/d' | \
+sed '/^ *\^/d' | \
+sed '/^1 warning generated./d' | \
+sed '/^[ ]*$/d' | \
+sed '/^ *|/d' | \
 # avoid sporadic ld: warning errors (I'm sometimes seeing just that on a line,
 # or just multiple copies of it)
-sed '/^ld: warning/d' $2.tmp > $2
+sed '/^ld: warning/d' > $2.tmp
+cat $2.tmp > $2
 rm $2.tmp
-# Remove the __init__.py to prevent a warning.
+# Remove the __init__.py file to prevent a warning.
 rm lib/__init__.py


### PR DESCRIPTION
I used a sed command to modify the prediffs in #16008, but this one was
using file redirects instead of pipes. Just copy one of the other
prediffs to fix this. I wonder if these could just be symlinks to a
single prediff.