### PR TITLE
Fix comment in arkouda 16-node-cs perf testing

### DIFF
--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -19,7 +19,7 @@ export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
-# Skip setops for master testing (fragmentation causes timeout/oom)
+# Skip setops for release testing (fragmentation causes timeout/oom)
 export CHPL_TEST_ARKOUDA_BENCHMARKS='stream argsort coargsort gather scatter reduce scan noop'
 test_release
 unset CHPL_TEST_ARKOUDA_BENCHMARKS


### PR DESCRIPTION
We're skipping setops for the release testing, not master. Code and PR
description in #16009 was right, just got the comment wrong.