### PR TITLE
Fix disabling alloc-size warnings

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -186,10 +186,13 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
 endif
 
 #
-# Avoid false positives for allocation size and memcpy
+# Avoid false positives for allocation size and memcpy. Note that we use
+# -Walloc-size-larger-than=SIZE_MAX instead of `-Wno-alloc-size-larger-than`
+# since that did not exist in gcc 8.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 7; echo "$$?"),0)
-SQUASH_WARN_GEN_CFLAGS += -Wno-alloc-size-larger-than -Wno-restrict
+WARN_CXXFLAGS += -Walloc-size-larger-than=18446744073709551615
+SQUASH_WARN_GEN_CFLAGS += -Walloc-size-larger-than=18446744073709551615 -Wno-restrict
 endif
 
 #


### PR DESCRIPTION
In #15999 I tried using `-Wno-alloc-size-larger-than` to disable some
alloc-size warnings. However, I was testing with gcc 9, and it turns out
that flag doesn't exist in gcc 8. The only way to disable it is to set
alloc-size to SIZE_MAX (`-Walloc-size-larger-than=18446744073709551615`)
like #11710 was doing. I misread #11710, and was thinking that method was
no longer effective, but I missed that it was only using that for
CXXFLAGS and we want it for our generated C flags now.

Revert to the previous mechanism, but also apply to our GEN_CLAGS too.