### PR TITLE
Fix a memleak related flag in nightly

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -680,7 +680,7 @@ if ($memleak == 1) {
     $testflags = "$testflags -memleaks";
 }
 if (!($memleakslog eq "")) {
-    $testflags = "$testflags -memleakslog $basetmpdir/$memleaks";
+    $testflags = "$testflags -memleakslog $basetmpdir/$memleakslog";
 }
 if ($nolocal == 1) {
     $testflags = "$testflags -compopts --no-local";


### PR DESCRIPTION
This PR changes one of the memleaks-related flags in the nightly script.

I forgot this one in https://github.com/chapel-lang/chapel/pull/15961 and then
we didn't get a clean run because of system issues on memleaks testing before
the weekend, so this error lingered on for a while.
