### PR TITLE
Fix mason external install wrt spack master branch changes

### DIFF
--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -19,7 +19,7 @@
  */
 
 /* Version as of Chapel 1.22 - to be updated each release */
-const spackVersion = '0.14.2';
+const spackVersion = '0.15.0';
 const v = spackVersion.split('.');
 const major = v[0];
 const minor = v[1];


### PR DESCRIPTION
The working of `mason external` post 1.22 release & after merge of  #15641 :
- spack divided into "CLI" & "registry"
- for registry, we pull `master` branch, as prior to 1.22
- for CLI, we pull version tag `v0.14.2`
- `MASON_HOME/spack/etc/spack/defaults/repos.yaml` edited to link to `MASON_HOME/spack-registry`

After the latest removal of `master` in  https://github.com/spack/spack/pull/17377 by spack & merge of #16028 : 
- for registry, we pull `releases/latest` instead of `master`
- for CLI, we still pull version tag `v0.14.2`
A complication that arose is that, `libtomlc99` test failed, with the following error message: 
```
==> Error: name 'XorgPackage' is not defined
Package could not be installed
```
While debugging, running `spack list lib` inside `spack/` would show `libtomlc99` in the results. However, an install command for `libtomlc99` or any other package such as `zlib` would show the same error. 

Considering it as an internal spack error, in this PR we upgrade spack CLI version from `0.14.2` to `0.15.0`. Also, confirming both mason-external tests pass. 
```
[Test Summary - 200707.163903] 
[Summary: #Successes = 2 | #Failures = 0 | #Futures = 0 | #Warnings = 0 ] 
[Summary: #Passing Suppressions = 0 | #Passing Futures = 0 ]
[END]                                                                                                                          
```