### PR TITLE
Add tests for changing param field in init=

### DIFF
--- a/test/classes/initializers/initequals/changing-param-field-error1.chpl
+++ b/test/classes/initializers/initequals/changing-param-field-error1.chpl
@@ -1,0 +1,36 @@
+record R {
+  param fixed; //never allowed to change
+  param p;
+  var x: int;
+}
+
+proc R.init=(rhs: R) {
+  // this one is not allowed to vary between lhs/rhs
+  if this.type.fixed != ? {
+    if this.type.fixed != rhs.fixed {
+      compilerError("cannot change fixed field in initialization");
+    }
+  }
+
+  this.fixed = rhs.fixed;
+
+  // this one is set to the rhs if not provided already in the lhs
+  this.p = if this.type.p != ? then this.type.p else rhs.p;
+
+  this.x = rhs.x;
+}
+
+proc =(ref lhs:R, const ref rhs:R) {
+  if lhs.fixed != rhs.fixed {
+    compilerError("cannot change fixed field in assignment");
+  }
+  lhs.x = rhs.x;
+}
+
+proc main() {
+  var start = new R(true, true, 1);
+  writeln(start.type:string, " ", start);
+
+  var b: R(false, false) = start; // init=
+  writeln(b.type:string, " ", b);
+}

--- a/test/classes/initializers/initequals/changing-param-field-error1.good
+++ b/test/classes/initializers/initequals/changing-param-field-error1.good
@@ -1,0 +1,2 @@
+changing-param-field-error1.chpl:30: In function 'main':
+changing-param-field-error1.chpl:34: error: cannot change fixed field in initialization

--- a/test/classes/initializers/initequals/changing-param-field-error2.chpl
+++ b/test/classes/initializers/initequals/changing-param-field-error2.chpl
@@ -1,0 +1,37 @@
+record R {
+  param fixed; //never allowed to change
+  param p;
+  var x: int;
+}
+
+proc R.init=(rhs: R) {
+  // this one is not allowed to vary between lhs/rhs
+  if this.type.fixed != ? {
+    if this.type.fixed != rhs.fixed {
+      compilerError("cannot change fixed field in initialization");
+    }
+  }
+
+  this.fixed = rhs.fixed;
+
+  // this one is set to the rhs if not provided already in the lhs
+  this.p = if this.type.p != ? then this.type.p else rhs.p;
+
+  this.x = rhs.x;
+}
+
+proc =(ref lhs:R, const ref rhs:R) {
+  if lhs.fixed != rhs.fixed {
+    compilerError("cannot change fixed field in assignment");
+  }
+  lhs.x = rhs.x;
+}
+
+proc main() {
+  var start = new R(true, true, 1);
+  writeln(start.type:string, " ", start);
+
+  var a: R(false, false); a; // no split-init
+  a = start; // assignment across types
+  writeln(a.type:string, " ", a);
+}

--- a/test/classes/initializers/initequals/changing-param-field-error2.good
+++ b/test/classes/initializers/initequals/changing-param-field-error2.good
@@ -1,0 +1,2 @@
+changing-param-field-error2.chpl:30: In function 'main':
+changing-param-field-error2.chpl:35: error: cannot change fixed field in assignment

--- a/test/classes/initializers/initequals/changing-param-field-error3.bad
+++ b/test/classes/initializers/initequals/changing-param-field-error3.bad
@@ -1,0 +1,2 @@
+R(true,true) (x = 1)
+R(false,false) (x = 1)

--- a/test/classes/initializers/initequals/changing-param-field-error3.chpl
+++ b/test/classes/initializers/initequals/changing-param-field-error3.chpl
@@ -1,0 +1,26 @@
+record R {
+  param fixed; //never allowed to change
+  param p;
+  var x: int;
+}
+
+proc R.init=(rhs: R) {
+  this.fixed = rhs.fixed;
+
+  // this one is set to the rhs if not provided already in the lhs
+  this.p = if this.type.p != ? then this.type.p else rhs.p;
+
+  this.x = rhs.x;
+}
+
+proc =(ref lhs:R, const ref rhs:R) {
+  lhs.x = rhs.x;
+}
+
+proc main() {
+  var start = new R(true, true, 1);
+  writeln(start.type:string, " ", start);
+
+  var b: R(false, false) = start; // init= -- expecting an error
+  writeln(b.type:string, " ", b);
+}

--- a/test/classes/initializers/initequals/changing-param-field-error3.future
+++ b/test/classes/initializers/initequals/changing-param-field-error3.future
@@ -1,0 +1,2 @@
+bug: missing expected error when attempting to change LHS type in init= 
+#16030

--- a/test/classes/initializers/initequals/changing-param-field-error3.good
+++ b/test/classes/initializers/initequals/changing-param-field-error3.good
@@ -1,0 +1,1 @@
+a compilation error

--- a/test/classes/initializers/initequals/changing-param-field.chpl
+++ b/test/classes/initializers/initequals/changing-param-field.chpl
@@ -1,0 +1,55 @@
+record R {
+  param fixed; //never allowed to change
+  param p;
+  var x: int;
+}
+
+proc R.init=(rhs: R) {
+  // this one is not allowed to vary between lhs/rhs
+  if this.type.fixed != ? {
+    if this.type.fixed != rhs.fixed {
+      compilerError("cannot change fixed field in initialization");
+    }
+  }
+
+  this.fixed = rhs.fixed;
+
+  // this one is set to the rhs if not provided already in the lhs
+  this.p = if this.type.p != ? then this.type.p else rhs.p;
+
+  this.x = rhs.x;
+}
+
+proc =(ref lhs:R, const ref rhs:R) {
+  if lhs.fixed != rhs.fixed {
+    compilerError("cannot change fixed field in assignment");
+  }
+  lhs.x = rhs.x;
+}
+
+proc main() {
+  var start = new R(true, true, 1);
+  writeln(start.type:string, " ", start);
+
+  writeln();
+
+  var a: R(true, false); a; // no split-init
+  a = start; // assignment across types
+  writeln(a.type:string, " ", a);
+
+  var b: R(true, false) = start; // init=
+  writeln(b.type:string, " ", b);
+  writeln();
+
+  var c = start; // inferred type
+  writeln(c.type:string, " ", c);
+  
+  var d:R = start; // specified generic type
+  writeln(d.type:string, " ", d);
+
+  var e:R(true) = start; // specified partial type
+  writeln(e.type:string, " ", e);
+  
+  var f:R(true, true) = start; // specified concrete type
+  writeln(f.type:string, " ", f);
+}

--- a/test/classes/initializers/initequals/changing-param-field.good
+++ b/test/classes/initializers/initequals/changing-param-field.good
@@ -1,0 +1,9 @@
+R(true,true) (x = 1)
+
+R(true,false) (x = 1)
+R(true,false) (x = 1)
+
+R(true,true) (x = 1)
+R(true,true) (x = 1)
+R(true,true) (x = 1)
+R(true,true) (x = 1)


### PR DESCRIPTION
I was thinking about adjusting `channel` to allow one to create a new
`channel` record that refers to the same pointer but has different
(compile-time) settings (for locking or binary mode). I looked around a
bit for tests using this pattern by combining features from partial
instantiation and init= but didn't see any.

This PR adds 4 tests for this pattern (using a record - no channels).
One of these is a future where an expected error is missing.

Test change only, not reviewed.