### PR TITLE
Allow channel to be copied to one with different param settings

### DIFF
--- a/test/io/ferguson/channel-changing-type-error1.chpl
+++ b/test/io/ferguson/channel-changing-type-error1.chpl
@@ -1,0 +1,7 @@
+use IO;
+
+proc main() {
+  var f = opentmp();
+  var a = f.writer();
+  var b:channel(writing=false) = a;
+}

--- a/test/io/ferguson/channel-changing-type-error1.good
+++ b/test/io/ferguson/channel-changing-type-error1.good
@@ -1,0 +1,2 @@
+channel-changing-type-error1.chpl:3: In function 'main':
+channel-changing-type-error1.chpl:6: error: cannot init reading channel from writing channel

--- a/test/io/ferguson/channel-changing-type-error2.chpl
+++ b/test/io/ferguson/channel-changing-type-error2.chpl
@@ -1,0 +1,7 @@
+use IO;
+
+proc main() {
+  var f = opentmp();
+  var a = f.reader();
+  var b:channel(writing=true) = a;
+}

--- a/test/io/ferguson/channel-changing-type-error2.good
+++ b/test/io/ferguson/channel-changing-type-error2.good
@@ -1,0 +1,2 @@
+channel-changing-type-error2.chpl:3: In function 'main':
+channel-changing-type-error2.chpl:6: error: cannot init writing channel from reading channel

--- a/test/io/ferguson/channel-changing-type-error3.chpl
+++ b/test/io/ferguson/channel-changing-type-error3.chpl
@@ -1,0 +1,9 @@
+use IO;
+
+proc main() {
+  var f = opentmp();
+  var a = f.writer();
+  var b:channel(writing=false,kind=iokind.dynamic,locking=true);
+  b; // prevent split-init
+  b = a;
+}

--- a/test/io/ferguson/channel-changing-type-error3.good
+++ b/test/io/ferguson/channel-changing-type-error3.good
@@ -1,0 +1,2 @@
+channel-changing-type-error3.chpl:3: In function 'main':
+channel-changing-type-error3.chpl:8: error: cannot assign reading channel to writing channel

--- a/test/io/ferguson/channel-changing-type-error4.chpl
+++ b/test/io/ferguson/channel-changing-type-error4.chpl
@@ -1,0 +1,9 @@
+use IO;
+
+proc main() {
+  var f = opentmp();
+  var a = f.reader();
+  var b:channel(writing=true,kind=iokind.dynamic,locking=true);
+  b; // prevent split-init
+  b = a;
+}

--- a/test/io/ferguson/channel-changing-type-error4.good
+++ b/test/io/ferguson/channel-changing-type-error4.good
@@ -1,0 +1,2 @@
+channel-changing-type-error4.chpl:3: In function 'main':
+channel-changing-type-error4.chpl:8: error: cannot assign writing channel to reading channel

--- a/test/io/ferguson/channel-changing-type.chpl
+++ b/test/io/ferguson/channel-changing-type.chpl
@@ -1,0 +1,41 @@
+use IO;
+
+proc test1() {
+  var f = openmem();
+
+  {
+    var ch = f.writer(); // defaults to dynamic, text, locking
+    // make a binary, unlocked channel using same buffer as ch
+    var cha: channel(writing=true, kind=iokind.big, locking=false);
+    cha; // no split init
+    cha = ch;
+    cha.write(1);
+  }
+
+  // check the output
+  {
+    var i: int;
+    f.reader().readf("%>8i", i);
+    assert(i == 1);
+  }
+}
+test1();
+
+proc test2() {
+  var f = openmem();
+
+  {
+    var ch = f.writer(); // defaults to dynamic, text, locking
+    // make a binary, unlocked channel using same buffer as ch
+    var cha: channel(writing=true, kind=iokind.big, locking=false) = ch;
+    cha.write(1);
+  }
+
+  // check the output
+  {
+    var i: int;
+    f.reader().readf("%>8i", i);
+    assert(i == 1);
+  }
+}
+test2();


### PR DESCRIPTION
In support of work on protocol buffer support by @Aniket21mathur for
GSoC, this PR adds the ability to create or assign a channel from another
channel while changing the iokind and locking settings.

I think this was already possible with the assignment function but
certain errors were not being checked for and the behavior would change
if split-init caused apparent assignment to be initialization.

The expected use case that this PR enables looks like this, for example:

``` chapel
otherChannel.lock();
defer { otherChannel.unlock(); }
var myChannel: channel(writing=true, kind=iokind.big, locking=false) = otherChannel;
```

Here, myChannel and otherChannel actually refer to the same channel (they
share the buffer and the file etc). This kind of pattern can be useful
when implementing I/O code that needs to do lots of operations with a
particular mode (which comes up in protobuf support). Additionally, it
allows such I/O code to work with concrete channel types, since the param
information can be set to known values.

It might be interesting to one day have a different type for a locked
channel. This PR can be viewed as a starting point for that - as a
channel with `locking=false` is a channel that does not need locking.

While there, deprecates the (undocumented) pattern
`new channel(oldChannel)` since copy init / init= should be used instead.

PR #16031 was motivated by this effort and shows a similar pattern
outside of IO.

Reviewed by @lydia-duncan - thanks!

- [x] primers pass and do not leak
- [x] full local testing