### PR TITLE
mason bash completion script

### DIFF
--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -85,7 +85,15 @@ _complete_mason_search(){
 }
 
 _complete_mason_update(){
-  _options update
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in
+    -*) 
+      _options update
+      ;;
+     *)
+      ;;
+  esac
 }
 
 _complete_mason_run(){

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -89,11 +89,20 @@ _complete_mason_update(){
 }
 
 _complete_mason_run(){
+  local optional
+  local optional_abbr
+  optional=$(mason run --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+            sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
+             sed -e 's/.*=//g' |\
+             xargs echo)
+  optional_abbr=$(mason run --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+          sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
+          xargs echo)
   local cur
   cur=${COMP_WORDS[COMP_CWORD]}
   case "$cur" in
     -*)
-      _options run 
+      COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "${COMP_WORDS[COMP_CWORD]}" ))
       ;;
     *)
       COMPREPLY=($(compgen -d -S / -- "$cur"))
@@ -102,7 +111,25 @@ _complete_mason_run(){
 }
 
 _complete_mason_build(){
-  _options build
+  local optional
+  local optional_abbr
+  optional=$(mason build --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+            sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
+             sed -e 's/.*=//g' | sed -e 's/[][]//g'|  \
+             xargs echo)
+  optional_abbr=$(mason build --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+          sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
+          xargs echo)
+  local cur
+  local update_tag="--update"
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in 
+    -*) 
+      COMPREPLY=($(compgen -W "$optional $optional_abbr $update_tag" -- "${COMP_WORDS[COMP_CWORD]}" ))
+      ;;
+     *)
+      ;;
+  esac
 }
 
 _complete_mason_add(){

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -1,31 +1,63 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
+
+_complete_mason_init(){
+  local optional 
+  local optional_abbr
+  local arg
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
+  arg=$(mason init --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     cut -d" " -f1 | xargs echo)
+  optional=$(mason init --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+            sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
+            xargs echo)
+  optional_abbr=$(mason init --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+          sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
+          xargs echo)
+  case "$cur" in
+    -*)
+      COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "$1"))
+      ;;
+    *)
+      COMPREPLY=($(compgen -d -S / -- "$cur"))
+      ;;
+  esac
+}
 
 _complete_mason_new(){
-  local optional=`mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+  local optional
+  local optional_abbr
+  optional=$(mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
             sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
-                      xargs echo`
-  local optional_abbr=`mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+            xargs echo)
+  optional_abbr=$(mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
           sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
-                  xargs echo`
+          xargs echo)
   COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "$1"))
 
 }
 _complete_mason_option(){
-  local optional=`mason --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+  local optional
+  local optional_abbr
+  optional=$(mason --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
             sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
-                      xargs echo`
-  local optional_abbr=`mason --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+            xargs echo)
+  optional_abbr=$(mason --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
           sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
-                  xargs echo`
-  COMPREPLY=($(compgen -W "$optional $optional_abbr" -- $1 ))
+          xargs echo)
+  COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "$1" ))
 }
 
 _complete_mason_command(){
-  local cur=${COMP_WORDS[COMP_CWORD]}
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-  local arg=`mason --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+  local cur
+  local prev
+  local arg
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  arg=$(mason --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
      grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
-     cut -d" " -f1 | xargs echo`
+     cut -d" " -f1 | xargs echo)
     COMPREPLY=($(compgen -W "$arg" "${COMP_WORDS[1]}"))
 }
 
@@ -37,20 +69,41 @@ _mason(){
   then
     case "$cur" in
       -*)
-        _complete_mason_option $cur 
+        _complete_mason_option "$cur"
         ;;
       *)
-        _complete_mason_command $cur
+        _complete_mason_command "$cur"
     esac
   fi
   if [[ ${COMP_CWORD} -ge 2 ]]
   then
     local cur=${COMP_WORDS[COMP_CWORD]}
     local prev=${COMP_WORDS[COMP_CWORD-1]}
-    case $prev in 
+    local alt_prev=${COMP_WORDS[COMP_CWORD-2]}
+    local subcmd
+    local arg
+    arg=$(mason --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+       grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+       cut -d" " -f1 | xargs echo)
+
+    for i in $arg
+    do
+      if [[ $prev == "$i" ]]
+      then
+        subcmd=$prev
+        break;
+      elif [[ $alt_prev == "$i" ]]
+      then
+        subcmd=$alt_prev
+        break;
+      fi
+    done
+    case "$subcmd" in 
       'new')
-        _complete_mason_new $cur
+        _complete_mason_new "$cur"
         ;;
+      'init')
+        _complete_mason_init "$cur"
     esac
   fi
 }

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -1,0 +1,62 @@
+#/usr/bin/env bash
+
+_complete_mason_new(){
+  local optional=`mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+            sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
+                      xargs echo`
+  local optional_abbr=`mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+          sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
+                  xargs echo`
+  COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "$1"))
+
+}
+_complete_mason_option(){
+  local optional=`mason --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+            sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
+                      xargs echo`
+  local optional_abbr=`mason --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+          sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
+                  xargs echo`
+  COMPREPLY=($(compgen -W "$optional $optional_abbr" -- $1 ))
+}
+
+_complete_mason_command(){
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+  local arg=`mason --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     cut -d" " -f1 | xargs echo`
+    COMPREPLY=($(compgen -W "$arg" "${COMP_WORDS[1]}"))
+}
+
+_mason(){
+  local cur
+  COMPREPLY=()
+  cur=${COMP_WORDS[COMP_CWORD]}
+  if [[ ${COMP_CWORD} -lt 2 ]]
+  then
+    case "$cur" in
+      -*)
+        _complete_mason_option $cur 
+        ;;
+      *)
+        _complete_mason_command $cur
+    esac
+  fi
+  if [[ ${COMP_CWORD} -ge 2 ]]
+  then
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local prev=${COMP_WORDS[COMP_CWORD-1]}
+    echo ""
+    echo $cur "curr" 
+    echo $prev "prev"
+    case $prev in 
+      'new')
+        _complete_mason_new $cur
+        ;;
+    esac
+  fi
+}
+
+# run _mason on hitting tab with mason
+complete -F _mason mason

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -47,9 +47,6 @@ _mason(){
   then
     local cur=${COMP_WORDS[COMP_CWORD]}
     local prev=${COMP_WORDS[COMP_CWORD-1]}
-    echo ""
-    echo $cur "curr" 
-    echo $prev "prev"
     case $prev in 
       'new')
         _complete_mason_new $cur

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -17,14 +17,27 @@ _complete_mason_system(){
      grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
      cut -d" " -f1 | xargs echo)
   cur=${COMP_WORDS[COMP_CWORD]}
-  case "$cur" in 
-    -*)
-      _options system
-      ;;
-     *)
-      COMPREPLY=($(compgen -W "$arg" "$cur"))
-      ;;
-  esac
+  if [[ ${COMP_CWORD} -le 2 ]]
+  then
+    case "$cur" in 
+      -*)
+        _options system 
+        ;;
+       *)
+        COMPREPLY=($(compgen -W "$arg" "$cur"))
+        ;;
+    esac
+  fi
+  if [[ ${COMP_CWORD} -gt 2 ]]
+  then
+    case "$cur" in
+      -*)
+        _options system
+        ;;
+       *)
+        ;;
+    esac
+  fi
 }
 
 _complete_mason_publish(){

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -14,7 +14,7 @@ _options(){
 
 _complete_mason_system(){
   arg=$(mason system --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
-     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
      cut -d" " -f1 | xargs echo)
   cur=${COMP_WORDS[COMP_CWORD]}
   case "$cur" in 
@@ -29,7 +29,7 @@ _complete_mason_system(){
 
 _complete_mason_external(){
   arg=$(mason external --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
-     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
      cut -d" " -f1 | xargs echo)
   cur=${COMP_WORDS[COMP_CWORD]}
   case "$cur" in 
@@ -179,7 +179,7 @@ _complete_mason_command(){
   cur=${COMP_WORDS[COMP_CWORD]}
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   arg=$(mason --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
-     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
      cut -d" " -f1 | xargs echo)
     COMPREPLY=($(compgen -W "$arg" "${COMP_WORDS[1]}"))
 }
@@ -206,7 +206,7 @@ _mason(){
     local subcmd
     local arg
     arg=$(mason --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
-       grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+       grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
        cut -d" " -f1 | xargs echo)
 
     for i in $arg

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -1,23 +1,90 @@
 #!/usr/bin/env bash
 
-_complete_mason_init(){
-  local optional 
+_options(){
+  local optional
   local optional_abbr
-  local arg
-  local cur
-  cur=${COMP_WORDS[COMP_CWORD]}
-  arg=$(mason init --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
-     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
-     cut -d" " -f1 | xargs echo)
-  optional=$(mason init --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
+  optional=$(mason "$1" --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
             sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
             xargs echo)
-  optional_abbr=$(mason init --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
+  optional_abbr=$(mason "$1" --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
           sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
           xargs echo)
+  COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "${COMP_WORDS[COMP_CWORD]}" ))
+}
+
+_complete_mason_publish(){
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
   case "$cur" in
     -*)
-      COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "$1"))
+      _options publish
+      ;;
+    *)
+      COMPREPLY=($(compgen -d -S / -- "$cur"))
+      ;;
+  esac
+}
+
+_complete_mason_test(){
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in
+    -*)
+      _options test 
+      ;;
+    *)
+      COMPREPLY=($(compgen -d -S / -- "$cur"))
+      ;;
+  esac
+}
+
+_complete_mason_doc(){
+  COMPREPLY=($(compgen -W "--help -h" -- "$1" ))
+}
+
+_complete_mason_clean(){
+  COMPREPLY=($(compgen -W "--help -h" -- "$1" ))
+}
+
+_complete_mason_env(){
+  COMPREPLY=($(compgen -W "--help -h" -- "$1" ))
+}
+
+_complete_mason_search(){
+  _options search
+}
+
+_complete_mason_update(){
+  _options update
+}
+
+_complete_mason_run(){
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in
+    -*)
+      _options run 
+      ;;
+    *)
+      COMPREPLY=($(compgen -d -S / -- "$cur"))
+      ;;
+  esac
+}
+
+_complete_mason_build(){
+  _options build
+}
+
+_complete_mason_add(){
+  _options add
+}
+
+_complete_mason_init(){
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in
+    -*)
+      _options init 
       ;;
     *)
       COMPREPLY=($(compgen -d -S / -- "$cur"))
@@ -26,16 +93,7 @@ _complete_mason_init(){
 }
 
 _complete_mason_new(){
-  local optional
-  local optional_abbr
-  optional=$(mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |      \
-            sed -e 's;^\(.*--[^ ]*\).*$;\1;' | sed -e 's;-[A-Za-z],;   ;' | \
-            xargs echo)
-  optional_abbr=$(mason new --help | grep -v '^[A-Za-z]' | grep '^.*--' |        \
-          sed -e 's;^\(.*--[^ ]*\).*$;\1;' | grep ',' | sed -e 's;,.*$;;' | \
-          xargs echo)
-  COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "$1"))
-
+  _options new
 }
 _complete_mason_option(){
   local optional
@@ -104,6 +162,46 @@ _mason(){
         ;;
       'init')
         _complete_mason_init "$cur"
+        ;;
+      'add')
+        _complete_mason_add "$cur"
+        ;;
+      'rm')
+        _complete_mason_add "$cur"
+        ;;
+      'run')
+        _complete_mason_run "$cur"
+        ;;
+      'build')
+        _complete_mason_build "$cur"
+        ;;
+      'update')
+        _complete_mason_update "$cur"
+        ;;
+      'search')
+        _complete_mason_search "$cur"
+        ;;
+      'env')
+        _complete_mason_env "$cur"
+        ;;
+      'clean')
+        _complete_mason_clean "$cur"
+        ;;
+      'doc')
+        _complete_mason_doc "$cur"
+        ;;
+      'test')
+        _complete_mason_test "$cur"
+        ;;
+      'publish')
+        _complete_mason_publish "$cur"
+        ;;
+      'external')
+
+        ;;
+      'system')
+
+        ;;
     esac
   fi
 }

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -12,6 +12,36 @@ _options(){
   COMPREPLY=($(compgen -W "$optional $optional_abbr" -- "${COMP_WORDS[COMP_CWORD]}" ))
 }
 
+_complete_mason_system(){
+  arg=$(mason system --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     cut -d" " -f1 | xargs echo)
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in 
+    -*)
+      _options system
+      ;;
+     *)
+      COMPREPLY=($(compgen -W "$arg" "$cur"))
+      ;;
+  esac
+}
+
+_complete_mason_external(){
+  arg=$(mason external --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed 's/^[ \t]*//' | \
+     cut -d" " -f1 | xargs echo)
+  cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in 
+    -*)
+      _options external
+      ;;
+     *)
+      COMPREPLY=($(compgen -W "$arg" "$cur"))
+      ;;
+  esac
+}
+
 _complete_mason_publish(){
   local cur
   cur=${COMP_WORDS[COMP_CWORD]}
@@ -197,10 +227,10 @@ _mason(){
         _complete_mason_publish "$cur"
         ;;
       'external')
-
+        _complete_mason_external "$cur"
         ;;
       'system')
-
+        _complete_mason_system "$cur"
         ;;
     esac
   fi

--- a/util/devel/mason-completion.bash
+++ b/util/devel/mason-completion.bash
@@ -27,21 +27,6 @@ _complete_mason_system(){
   esac
 }
 
-_complete_mason_external(){
-  arg=$(mason external --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
-     grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
-     cut -d" " -f1 | xargs echo)
-  cur=${COMP_WORDS[COMP_CWORD]}
-  case "$cur" in 
-    -*)
-      _options external
-      ;;
-     *)
-      COMPREPLY=($(compgen -W "$arg" "$cur"))
-      ;;
-  esac
-}
-
 _complete_mason_publish(){
   local cur
   cur=${COMP_WORDS[COMP_CWORD]}
@@ -157,9 +142,38 @@ _complete_mason_init(){
   esac
 }
 
+_complete_mason_external(){
+  arg=$(mason external --help | grep -v '^[A-Za-z]' | grep -v '^.*--'  | \
+     grep -v '<command>' | grep -v '\[options\]'  | sed $'s/^[ \t]*//' | \
+     cut -d" " -f1 | xargs echo)
+  cur=${COMP_WORDS[COMP_CWORD]}
+  if [[ ${COMP_CWORD} -le 2 ]]
+  then
+    case "$cur" in 
+      -*)
+        _options external
+        ;;
+       *)
+        COMPREPLY=($(compgen -W "$arg" "$cur"))
+        ;;
+    esac
+  fi
+  if [[ ${COMP_CWORD} -gt 2 ]]
+  then
+    case "$cur" in
+      -*)
+        _options external
+        ;;
+       *)
+        ;;
+    esac
+  fi
+}
+
 _complete_mason_new(){
   _options new
 }
+
 _complete_mason_option(){
   local optional
   local optional_abbr


### PR DESCRIPTION
fixes #16014 

This PR aims to introduce a bash completion script for mason, which when loaded to shell using `source` can provide command completion for mason commands.
Commands included: 
- [x] mason new
- [x] mason init
- [x] mason add
- [x] mason rm
- [x] mason run
- [x] mason build
- [x] mason update
- [x] mason search
- [x] mason env
- [x] mason clean
- [x] mason doc
- [x] mason test
- [x] mason publish
- [x] mason external 
- [x] mason system