### PR TITLE
Add a skipif for mapOfArray test

### DIFF
--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ "$CHPL_COMM" == "gasnet" ]]; then
+  echo True
+else
+  echo False
+fi


### PR DESCRIPTION
The mapOfArray .future test hangs with CHPL_COMM=gasnet on my OSX computer,
and passes on linux64 with gasnet. Skip it if CHPL_COMM=gasnet.