### PR TITLE
Move setting memleaks to after setting dirname in paratest.client

### DIFF
--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -67,10 +67,6 @@ sub main {
     $valgrind = "-valgrind" if ($ARGV[5] == 1);
     $valgrind = "-valgrindexe" if ($ARGV[5] == 2);
 
-    $memleaks = "";
-    $memleaks = "-memleaks" if ($ARGV[6] == 1);
-    $memleaks = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[6] == 2);
-
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
     if ($#ARGV>=7) {
         $compopts = "-compopts \"" . $ARGV[7] . "\"";
@@ -102,6 +98,10 @@ sub main {
     $dirfname =~ s/\//-/g;
     $logfile = "$logdir/$dirfname.$node.log";
     unlink $logfile if (-e $logfile);
+
+    $memleaks = "";
+    $memleaks = "-memleaks" if ($ARGV[6] == 1);
+    $memleaks = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[6] == 2);
 
     $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks";
     $testarg = "$testarg $testdir -norecurse";


### PR DESCRIPTION
While changing the memleaks infrastructure I moved some lines in paratest.client
up, causing some variables to be read before being written. Perl, being a very
powerful language, allowed me to do that, and we got bogus memleaks testing last
few nights.

This PR moves setting the memory leak path after the per-node directory is set.
