### PR TITLE
Improvements to runtime type support to prepare for array noinit

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -34,6 +34,7 @@
 #include "LoopExpr.h"
 #include "passes.h"
 #include "ParamForLoop.h"
+#include "resolution.h"
 #include "stlUtil.h"
 #include "stmt.h"
 #include "symbol.h"
@@ -791,10 +792,9 @@ bool isTypeExpr(Expr* expr) {
       }
 
     } else if (call->isPrimitive(PRIM_GET_RUNTIME_TYPE_FIELD)) {
-      // optional 4th argument in PRIM_GET_RUNTIME_TYPE_FIELD
-      // indicates it is returning a type.
-      if (call->numActuals() == 4)
-        retval = true;
+      bool isType = false;
+      getPrimGetRuntimeTypeFieldReturnType(call, isType);
+      retval = isType;
 
     } else if (call->numActuals() == 1 &&
                call->baseExpr &&

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -563,7 +563,9 @@ returnInfoToNonNilable(CallExpr* call) {
 
 static QualifiedType
 returnInfoRuntimeTypeField(CallExpr* call) {
-  return call->get(1)->qualType();
+  bool isType = false;
+  Type* t = getPrimGetRuntimeTypeFieldReturnType(call, isType);
+  return QualifiedType(t, QUAL_VAL);
 }
 
 
@@ -1096,11 +1098,9 @@ initPrimitive() {
 
   prim_def(PRIM_AUTO_DESTROY_RUNTIME_TYPE, "auto destroy runtime type", returnInfoVoid, false, false);
 
-  // Accepts 3 arguments:
-  // 1) type variable representing static type of field in _RuntimeTypeInfo
-  // 2) type variable that will become the _RuntimeTypeInfo
-  // 3) param-string name of the field in the _RuntimeTypeInfo
-  // existence of an optional 4th argument indicates the result is a type
+  // Accepts 2 arguments:
+  // 1) type variable that will become the _RuntimeTypeInfo
+  // 2) field symbol or param-string name of the field in the _RuntimeTypeInfo
   prim_def(PRIM_GET_RUNTIME_TYPE_FIELD, "get runtime type field", returnInfoRuntimeTypeField, false, false);
 
   // Corresponds to LLVM's invariant start

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1584,7 +1584,14 @@ VarSymbol *new_BytesSymbol(const char *str) {
   // DefExpr(s) always goes into the module scope to make it a global
   stringLiteralModule->block->insertAtTail(bytesLitDef);
 
-  CallExpr *initCall = new CallExpr(astr("createBytesWithBorrowedBuffer"),
+  Expr* initFn = NULL;
+  if (gChplCreateBytesWithLiteral != NULL)
+    initFn = new SymExpr(gChplCreateBytesWithLiteral);
+  else
+    initFn = new UnresolvedSymExpr("chpl_createBytesWithLiteral");
+
+
+  CallExpr *initCall = new CallExpr(initFn,
                                     bytesTemp,
                                     new_IntSymbol(bytesLength));
 

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -62,6 +62,7 @@ FnSymbol *gChplForallError;
 FnSymbol *gAtomicFenceFn;
 FnSymbol *gChplAfterForallFence;
 FnSymbol *gChplCreateStringWithLiteral;
+FnSymbol *gChplCreateBytesWithLiteral;
 FnSymbol *gChplBuildLocaleId;
 
 /************************************* | **************************************
@@ -351,6 +352,12 @@ static WellKnownFn sWellKnownFns[] = {
   {
     "chpl_createStringWithLiteral",
     &gChplCreateStringWithLiteral,
+    FLAG_UNKNOWN
+  },
+
+  {
+    "chpl_createBytesWithLiteral",
+    &gChplCreateBytesWithLiteral,
     FLAG_UNKNOWN
   },
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -263,6 +263,7 @@ bool isCoercibleOrInstantiation(Type* sub, Type* super, Expr* ctx);
 void printTaskOrForallConstErrorNote(Symbol* aVar);
 
 void adjustRuntimeTypeInitFn(FnSymbol* fn);
+Symbol* getPrimGetRuntimeTypeField_Field(CallExpr* call);
 Type* getPrimGetRuntimeTypeFieldReturnType(CallExpr* call, bool& isType);
 
 // tuples

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -262,6 +262,8 @@ bool isCoercibleOrInstantiation(Type* sub, Type* super, Expr* ctx);
 
 void printTaskOrForallConstErrorNote(Symbol* aVar);
 
+void adjustRuntimeTypeInitFn(FnSymbol* fn);
+
 // tuples
 FnSymbol* createTupleSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -263,6 +263,7 @@ bool isCoercibleOrInstantiation(Type* sub, Type* super, Expr* ctx);
 void printTaskOrForallConstErrorNote(Symbol* aVar);
 
 void adjustRuntimeTypeInitFn(FnSymbol* fn);
+Type* getPrimGetRuntimeTypeFieldReturnType(CallExpr* call, bool& isType);
 
 // tuples
 FnSymbol* createTupleSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call);

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -74,6 +74,7 @@ extern FnSymbol *gChplForallError;
 extern FnSymbol *gAtomicFenceFn;
 extern FnSymbol *gChplAfterForallFence;
 extern FnSymbol *gChplCreateStringWithLiteral;
+extern FnSymbol *gChplCreateBytesWithLiteral;
 extern FnSymbol *gChplBuildLocaleId;
 
 #endif

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3298,6 +3298,13 @@ static void fixupExportedArrayFormals(FnSymbol* fn) {
                   " must specify its type", formal->name, fn->name);
         continue;
       }
+      if (formal->intent == INTENT_OUT) {
+        USR_FATAL(formal, "array argument '%s' in exported function '%s'"
+                  " uses out intent - out intent not yet supported"
+                  " for arrays in export procs",
+                  formal->name, fn->name);
+        continue;
+      }
 
       // Save the element type we shuffle away, so that it can be referenced at
       // codegen.  We may want to move these operations after type resolution to

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -112,8 +112,24 @@ static void removeUnusedFunctions() {
   }
 }
 
+static CallExpr* replaceRuntimeTypeGetField(CallExpr* call) {
+  SymExpr* rt = toSymExpr(call->get(1));
+
+  INT_ASSERT(rt->typeInfo()->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE));
+
+  Symbol* field = getPrimGetRuntimeTypeField_Field(call);
+  INT_ASSERT(field);
+  SET_LINENO(call);
+  CallExpr* ret = new CallExpr(PRIM_GET_MEMBER_VALUE, rt->remove(), field);
+  call->replace(ret);
+  return ret;
+}
 
 static void removeRandomPrimitive(CallExpr* call) {
+
+  if (call->isPrimitive(PRIM_GET_RUNTIME_TYPE_FIELD))
+    call = replaceRuntimeTypeGetField(call);
+
   switch (call->primitive->tag)
   {
     default: /* do nothing */ break;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -189,7 +189,7 @@ static void populateRuntimeTypeMap();
 static void resolveAutoCopies();
 static void resolveSerializers();
 static void resolveDestructors();
-static Type* buildRuntimeTypeInfo(FnSymbol* fn);
+static AggregateType* buildRuntimeTypeInfo(FnSymbol* fn);
 static void insertReturnTemps();
 static void initializeClass(Expr* stmt, Symbol* sym);
 static void ensureAndResolveInitStringLiterals();
@@ -9346,8 +9346,7 @@ static void handleStatementLevelIteratorCall(DefExpr* def, VarSymbol* tmp)
 }
 
 
-static Type*
-buildRuntimeTypeInfo(FnSymbol* fn) {
+static AggregateType* buildRuntimeTypeInfo(FnSymbol* fn) {
   SET_LINENO(fn);
   AggregateType* ct = new AggregateType(AGGREGATE_RECORD);
   TypeSymbol* ts = new TypeSymbol(astr("_RuntimeTypeInfo"), ct);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -196,8 +196,8 @@ static void ensureAndResolveInitStringLiterals();
 static void handleRuntimeTypes();
 static void buildRuntimeTypeInitFns();
 static void buildRuntimeTypeInitFn(FnSymbol* fn, Type* runtimeType);
-static void replaceValuesWithRuntimeTypes();
-static void replaceReturnedValuesWithRuntimeTypes();
+static void replaceTypeFormalsWithRuntimeTypes();
+static void replaceReturnedTypesWithRuntimeTypes();
 static void replaceRuntimeTypeVariableTypes();
 static void replaceRuntimeTypePrims();
 static FnSymbol* findGenMainFn();
@@ -9511,8 +9511,8 @@ static void handleRuntimeTypes()
   // record R { var A: [1..1][1..1] real; }
   populateRuntimeTypeMap();
   buildRuntimeTypeInitFns();
-  replaceValuesWithRuntimeTypes();
-  replaceReturnedValuesWithRuntimeTypes();
+  replaceTypeFormalsWithRuntimeTypes();
+  replaceReturnedTypesWithRuntimeTypes();
   replaceRuntimeTypeVariableTypes();
   replaceRuntimeTypePrims();
 }
@@ -9829,7 +9829,7 @@ static void buildRuntimeTypeInitFn(FnSymbol* fn, Type* runtimeType)
   fn->replaceBodyStmtsWithStmts(block);
 }
 
-static void replaceValuesWithRuntimeTypes()
+static void replaceTypeFormalsWithRuntimeTypes()
 {
   for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
       for_formals(formal, fn) {
@@ -9847,7 +9847,7 @@ static void replaceValuesWithRuntimeTypes()
   }
 }
 
-static void replaceReturnedValuesWithRuntimeTypes()
+static void replaceReturnedTypesWithRuntimeTypes()
 {
   for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
       if (fn->retTag == RET_TYPE) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -515,6 +515,9 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
         resolveAlsoParallelIterators(fn, forCall);
       }
 
+      if (fn->hasFlag(FLAG_RUNTIME_TYPE_INIT_FN))
+        adjustRuntimeTypeInitFn(fn);
+
       markTypesWithDefaultInitEqOrAssign(fn);
     }
     popInstantiationLimit(fn);

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -152,13 +152,17 @@ module Bytes {
 
     :returns: A new :mod:`bytes <Bytes>`
   */
-  proc createBytesWithBorrowedBuffer(x: c_string, length=x.size) {
-    //NOTE: This function is heavily used by the compiler to create bytes
-    //literals. So, inlining this causes some bloat in the AST that increases
-    //the compilation time slightly. Therefore, currently we are keeping this
-    //one non-inlined.
+  inline proc createBytesWithBorrowedBuffer(x: c_string, length=x.size) {
     return createBytesWithBorrowedBuffer(x:c_ptr(uint(8)), length=length,
                                                            size=length+1);
+  }
+
+  pragma "no doc"
+  proc chpl_createBytesWithLiteral(x: c_string, length: int) {
+    // NOTE: This is a "wellknown" function used by the compiler to create
+    // string literals. Inlining this creates some bloat in the AST, slowing the
+    // compilation.
+    return createBytesWithBorrowedBuffer(x, length);
   }
 
   pragma "last resort"

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -370,41 +370,71 @@ module ChapelArray {
   //
   // NOTE: the bodies of functions marked with runtime type init fn such as
   // chpl__buildDomainRuntimeType and chpl__buildArrayRuntimeType are replaced
-  // by the compiler to just create a record storing the arguments. The body
-  // is moved by the compiler to chpl__convertRuntimeTypeToValue.
+  // by the compiler to just create a record storing the arguments.
   // The return type of chpl__build...RuntimeType is what tells the
   // compiler which runtime type it is creating.
+  // These functions are considered type functions early in compilation.
 
   //
   // Support for domain types
   //
   pragma "runtime type init fn"
   proc chpl__buildDomainRuntimeType(d: _distribution, param rank: int,
-                                   type idxType = int,
-                                   param stridable: bool = false)
+                                    type idxType = int,
+                                    param stridable: bool = false) {
     return new _domain(d, rank, idxType, stridable);
+  }
 
   pragma "runtime type init fn"
   proc chpl__buildDomainRuntimeType(d: _distribution, type idxType,
-                                    param parSafe: bool = true)
+                                    param parSafe: bool = true) {
     return new _domain(d, idxType, parSafe);
+  }
 
   pragma "runtime type init fn"
-  proc chpl__buildSparseDomainRuntimeType(d: _distribution, dom: domain)
+  proc chpl__buildSparseDomainRuntimeType(d: _distribution, dom: domain) {
     return new _domain(d, dom);
+  }
+
+  proc chpl__domInstType(type rtt: domain) {
+    return __primitive("static field type", rtt, "_instance");
+  }
+
+  proc chpl__convertRuntimeTypeToValue(d: _distribution, param rank: int,
+                                       type idxType = int,
+                                       param stridable: bool) {
+    return new _domain(d, rank, idxType, stridable);
+  }
+
+  proc chpl__convertRuntimeTypeToValue(d: _distribution, type idxType,
+                                       param parSafe: bool) {
+    return new _domain(d, idxType, parSafe);
+  }
+
+  proc chpl__convertRuntimeTypeToValue(d: _distribution, dom: domain) {
+    return new _domain(d, dom);
+  }
+
+  proc chpl__convertRuntimeTypeToValue(type t: domain) {
+    compilerError("the global domain class of each domain map implementation must be a subclass of BaseRectangularDom, BaseAssociativeDom, or BaseSparseDom", 0);
+    return 0; // dummy
+  }
 
   proc chpl__convertValueToRuntimeType(dom: domain) type
-   where isSubtype(dom._value.type, BaseRectangularDom)
+   where isSubtype(dom._value.type, BaseRectangularDom) {
     return chpl__buildDomainRuntimeType(dom.dist, dom._value.rank,
                               dom._value.idxType, dom._value.stridable);
+  }
 
   proc chpl__convertValueToRuntimeType(dom: domain) type
-   where isSubtype(dom._value.type, BaseAssociativeDom)
+   where isSubtype(dom._value.type, BaseAssociativeDom) {
     return chpl__buildDomainRuntimeType(dom.dist, dom._value.idxType, dom._value.parSafe);
+  }
 
   proc chpl__convertValueToRuntimeType(dom: domain) type
-   where isSubtype(_to_borrowed(dom._value.type), BaseSparseDom)
+   where isSubtype(dom._value.type, BaseSparseDom) {
     return chpl__buildSparseDomainRuntimeType(dom.dist, dom._value.parentDom);
+  }
 
   proc chpl__convertValueToRuntimeType(dom: domain) type {
     compilerError("the global domain class of each domain map implementation must be a subclass of BaseRectangularDom, BaseAssociativeDom, or BaseSparseDom", 0);
@@ -415,8 +445,19 @@ module ChapelArray {
   // Support for array types
   //
   pragma "runtime type init fn"
-  proc chpl__buildArrayRuntimeType(dom: domain, type eltType)
+  proc chpl__buildArrayRuntimeType(dom: domain, type eltType) {
     return dom.buildArray(eltType, true);
+  }
+
+  proc chpl__convertRuntimeTypeToValue(dom: domain, type eltType) {
+    // TODO: add initElts argument
+    return dom.buildArray(eltType, true);
+  }
+
+  proc chpl__convertValueToRuntimeType(arr: []) type {
+    return chpl__buildArrayRuntimeType(arr.domain, arr.eltType);
+  }
+
 
   proc _getLiteralType(type t) type {
     if t != c_string then return t;
@@ -507,10 +548,6 @@ module ChapelArray {
 
     return A;
   }
-
-
-  proc chpl__convertValueToRuntimeType(arr: []) type
-    return chpl__buildArrayRuntimeType(arr.domain, arr.eltType);
 
   //
   // These routines increment and decrement the reference count
@@ -752,6 +789,22 @@ module ChapelArray {
     return isSparseDom(dom);
   }
 
+  proc chpl__parentDomainFromDomainRuntimeType(type domainType) {
+    pragma "ignore runtime type"
+    proc getParentDomType() type {
+      var dom : domainType;
+      return __primitive("static typeof", dom._value.parentDom.type);
+    }
+
+    pragma "no copy"
+    pragma "no auto destroy"
+    var parentDom = __primitive("get runtime type field", getParentDomType(),
+                                                          domainType,
+                                                          "dom");
+
+    return _getDomain(parentDom._value);
+  }
+
   proc chpl__distributed(d: _distribution, type domainType) type {
     if !isDomainType(domainType) then
       compilerError("cannot apply 'dmapped' to the non-domain type ",
@@ -761,17 +814,7 @@ module ChapelArray {
       return chpl__buildDomainRuntimeType(d, dom._value.rank, dom._value.idxType,
                                           dom._value.stridable);
     } else if chpl__isSparseDomType(domainType) {
-      proc getParentDomType() type {
-        var dom : domainType;
-        return __primitive("static typeof", dom._value.parentDom.type);
-      }
-
-      pragma "no copy"
-      pragma "no auto destroy"
-      var parentDom = __primitive("get runtime type field", getParentDomType(),
-                                                            domainType,
-                                                            "dom");
-
+      const ref parentDom = chpl__parentDomainFromDomainRuntimeType(domainType);
       return chpl__buildSparseDomainRuntimeType(d, parentDom);
     } else {
       var dom: domainType;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -790,18 +790,12 @@ module ChapelArray {
     return isSparseDom(dom);
   }
 
+  pragma "return not owned"
   proc chpl__parentDomainFromDomainRuntimeType(type domainType) {
-    pragma "ignore runtime type"
-    proc getParentDomType() type {
-      var dom : domainType;
-      return __primitive("static typeof", dom._value.parentDom.type);
-    }
-
     pragma "no copy"
     pragma "no auto destroy"
-    var parentDom = __primitive("get runtime type field", /*getParentDomType(),*/
-                                                          domainType,
-                                                          "parentDom");
+    var parentDom = __primitive("get runtime type field",
+                                domainType, "parentDom");
 
     return _getDomain(parentDom._value);
   }
@@ -825,60 +819,28 @@ module ChapelArray {
 
   pragma "return not owned"
   proc chpl__distributionFromDomainRuntimeType(type rtt) {
-    pragma "ignore runtime type"
-    proc getDomDistType() type {
-      pragma "unsafe"
-      var arr : rtt;
-      return __primitive("static typeof", arr.dist);
-    }
-
     pragma "no copy"
     pragma "no auto destroy"
-    var dist = __primitive("get runtime type field",
-                           /*getDomDistType(),*/ rtt, "dist");
+    var dist = __primitive("get runtime type field", rtt, "dist");
 
     return _getDistribution(dist._value);
   }
 
   pragma "return not owned"
   proc chpl__domainFromArrayRuntimeType(type rtt) {
-    pragma "ignore runtime type"
-    proc getArrDomType() type {
-      pragma "unsafe"
-      var arr : rtt;
-      return __primitive("static typeof", arr.domain);
-    }
-
     pragma "no copy"
     pragma "no auto destroy"
-    var dom = __primitive("get runtime type field",
-                          /*getArrDomType(),*/ rtt, "dom");
+    var dom = __primitive("get runtime type field", rtt, "dom");
 
     return _getDomain(dom._value);
   }
 
   proc chpl__eltTypeFromArrayRuntimeType(type rtt) type {
-    pragma "ignore runtime type"
-    proc getArrEltType() type {
-      pragma "unsafe"
-      var arr : rtt;
-      return __primitive("static typeof", arr.eltType);
-    }
+    pragma "no copy"
+    pragma "no auto destroy"
+    type eltType = __primitive("get runtime type field", rtt, "eltType");
 
-    // does the element type have a runtime component?
-    if isSubtype(getArrEltType(), _array) ||
-       isSubtype(getArrEltType(), _domain) {
-
-      pragma "no copy"
-      pragma "no auto destroy"
-      type eltType = __primitive("get runtime type field",
-                                 /*getArrEltType(),*/ rtt, "eltType"/*, true*/);
-
-      return eltType;
-
-    } else {
-      return getArrEltType();
-    }
+    return eltType;
   }
 
   pragma "ignore runtime type"

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -397,10 +397,6 @@ module ChapelArray {
     return new _domain(dist, parentDom);
   }
 
-  proc chpl__domInstType(type rtt: domain) {
-    return __primitive("static field type", rtt, "_instance");
-  }
-
   proc chpl__convertRuntimeTypeToValue(dist: _distribution, param rank: int,
                                        type idxType = int,
                                        param stridable: bool) {
@@ -848,9 +844,7 @@ module ChapelArray {
     // this function is compile-time only and should not be run
     __primitive("chpl_warning",
                 "chpl__instanceTypeFromArrayRuntimeType should not be run");
-    pragma "unsafe"
-    var arr: rtt;
-    return __primitive("static typeof", arr._instance);
+    return __primitive("static field type", rtt, "_instance");
   }
 
   //
@@ -4233,9 +4227,8 @@ module ChapelArray {
   }
 
   private proc desyncEltType(type t:_array) type {
-    pragma "unsafe"
-    var tmp: t;
-    return _desync(tmp.eltType);
+    type eltType = chpl__eltTypeFromArrayRuntimeType(t);
+    return _desync(eltType);
   }
 
   proc =(ref a: [], b: _desync(a.eltType)) {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -798,7 +798,7 @@ module ChapelArray {
 
     pragma "no copy"
     pragma "no auto destroy"
-    var parentDom = __primitive("get runtime type field", getParentDomType(),
+    var parentDom = __primitive("get runtime type field", /*getParentDomType(),*/
                                                           domainType,
                                                           "dom");
 
@@ -834,7 +834,7 @@ module ChapelArray {
     pragma "no copy"
     pragma "no auto destroy"
     var dist = __primitive("get runtime type field",
-                           getDomDistType(), rtt, "d");
+                           /*getDomDistType(),*/ rtt, "d");
 
     return _getDistribution(dist._value);
   }
@@ -851,7 +851,7 @@ module ChapelArray {
     pragma "no copy"
     pragma "no auto destroy"
     var dom = __primitive("get runtime type field",
-                          getArrDomType(), rtt, "dom");
+                          /*getArrDomType(),*/ rtt, "dom");
 
     return _getDomain(dom._value);
   }
@@ -871,7 +871,7 @@ module ChapelArray {
       pragma "no copy"
       pragma "no auto destroy"
       type eltType = __primitive("get runtime type field",
-                                 getArrEltType(), rtt, "eltType", true);
+                                 /*getArrEltType(),*/ rtt, "eltType"/*, true*/);
 
       return eltType;
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -392,8 +392,8 @@ module ChapelArray {
   }
 
   pragma "runtime type init fn"
-  proc chpl__buildSparseDomainRuntimeType(d: _distribution, dom: domain) {
-    return new _domain(d, dom);
+  proc chpl__buildSparseDomainRuntimeType(d: _distribution, parentDom: domain) {
+    return new _domain(d, parentDom);
   }
 
   proc chpl__domInstType(type rtt: domain) {
@@ -411,8 +411,8 @@ module ChapelArray {
     return new _domain(d, idxType, parSafe);
   }
 
-  proc chpl__convertRuntimeTypeToValue(d: _distribution, dom: domain) {
-    return new _domain(d, dom);
+  proc chpl__convertRuntimeTypeToValue(d: _distribution, parentDom: domain) {
+    return new _domain(d, parentDom);
   }
 
   proc chpl__convertRuntimeTypeToValue(type t: domain) {
@@ -800,7 +800,7 @@ module ChapelArray {
     pragma "no auto destroy"
     var parentDom = __primitive("get runtime type field", /*getParentDomType(),*/
                                                           domainType,
-                                                          "dom");
+                                                          "parentDom");
 
     return _getDomain(parentDom._value);
   }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -379,40 +379,41 @@ module ChapelArray {
   // Support for domain types
   //
   pragma "runtime type init fn"
-  proc chpl__buildDomainRuntimeType(d: _distribution, param rank: int,
+  proc chpl__buildDomainRuntimeType(dist: _distribution, param rank: int,
                                     type idxType = int,
                                     param stridable: bool = false) {
-    return new _domain(d, rank, idxType, stridable);
+    return new _domain(dist, rank, idxType, stridable);
   }
 
   pragma "runtime type init fn"
-  proc chpl__buildDomainRuntimeType(d: _distribution, type idxType,
+  proc chpl__buildDomainRuntimeType(dist: _distribution, type idxType,
                                     param parSafe: bool = true) {
-    return new _domain(d, idxType, parSafe);
+    return new _domain(dist, idxType, parSafe);
   }
 
   pragma "runtime type init fn"
-  proc chpl__buildSparseDomainRuntimeType(d: _distribution, parentDom: domain) {
-    return new _domain(d, parentDom);
+  proc chpl__buildSparseDomainRuntimeType(dist: _distribution,
+                                          parentDom: domain) {
+    return new _domain(dist, parentDom);
   }
 
   proc chpl__domInstType(type rtt: domain) {
     return __primitive("static field type", rtt, "_instance");
   }
 
-  proc chpl__convertRuntimeTypeToValue(d: _distribution, param rank: int,
+  proc chpl__convertRuntimeTypeToValue(dist: _distribution, param rank: int,
                                        type idxType = int,
                                        param stridable: bool) {
-    return new _domain(d, rank, idxType, stridable);
+    return new _domain(dist, rank, idxType, stridable);
   }
 
-  proc chpl__convertRuntimeTypeToValue(d: _distribution, type idxType,
+  proc chpl__convertRuntimeTypeToValue(dist: _distribution, type idxType,
                                        param parSafe: bool) {
-    return new _domain(d, idxType, parSafe);
+    return new _domain(dist, idxType, parSafe);
   }
 
-  proc chpl__convertRuntimeTypeToValue(d: _distribution, parentDom: domain) {
-    return new _domain(d, parentDom);
+  proc chpl__convertRuntimeTypeToValue(dist: _distribution, parentDom: domain) {
+    return new _domain(dist, parentDom);
   }
 
   proc chpl__convertRuntimeTypeToValue(type t: domain) {
@@ -834,7 +835,7 @@ module ChapelArray {
     pragma "no copy"
     pragma "no auto destroy"
     var dist = __primitive("get runtime type field",
-                           /*getDomDistType(),*/ rtt, "d");
+                           /*getDomDistType(),*/ rtt, "dist");
 
     return _getDistribution(dist._value);
   }

--- a/test/arrays/ferguson/array-of-owned/array-of-owned-error4.good
+++ b/test/arrays/ferguson/array-of-owned/array-of-owned-error4.good
@@ -1,2 +1,1 @@
-array-of-owned-error4.chpl:3: In function 'main':
 array-of-owned-error4.chpl:6: error: cannot default-initialize the array b because it has a non-nilable element type 'owned C'

--- a/test/classes/ferguson/forwarding/array-member-nil-error.chpl
+++ b/test/classes/ferguson/forwarding/array-member-nil-error.chpl
@@ -2,7 +2,7 @@
 record Wrapper {
   type t;
   var Array:[1..1] t;
-  forwarding Array[1]!;
+  forwarding Array[1];
   proc foo() { writeln("in Wrapper.foo()"); }
 }
 
@@ -13,8 +13,8 @@ class C {
   proc baz() { field = 1; }
 }
 
-var r:Wrapper(unmanaged C?);
-r.Array[1] = new unmanaged C?();
+var r:Wrapper(unmanaged C);
+r.Array[1] = new unmanaged C();
 r.foo(); // prints "in Wrapper.foo()"
 r.bar(); // same as r.instance.bar(), prints "in C.foo()"
 

--- a/test/classes/ferguson/forwarding/array-member-nil-error.good
+++ b/test/classes/ferguson/forwarding/array-member-nil-error.good
@@ -1,0 +1,1 @@
+array-member-nil-error.chpl:4: error: cannot default-initialize the array Array because it has a non-nilable element type 'unmanaged C'

--- a/test/classes/nilability/array-with-nonnilable-elttype.good
+++ b/test/classes/nilability/array-with-nonnilable-elttype.good
@@ -1,8 +1,8 @@
+array-with-nonnilable-elttype.chpl:12: error: cannot default-initialize the array A1 because it has a non-nilable element type 'borrowed object'
 array-with-nonnilable-elttype.chpl:15: error: cannot default-initialize the array field A1 because it has a non-nilable element type 'borrowed object'
-array-with-nonnilable-elttype.chpl:20: In initializer:
 array-with-nonnilable-elttype.chpl:22: error: cannot default-initialize the array field A2 because it has a non-nilable element type 'borrowed object'
+array-with-nonnilable-elttype.chpl:38: error: cannot default-initialize the array B1 because it has a non-nilable element type 'borrowed object'
 array-with-nonnilable-elttype.chpl:41: error: cannot default-initialize the array field B1 because it has a non-nilable element type 'borrowed object'
-array-with-nonnilable-elttype.chpl:46: In initializer:
 array-with-nonnilable-elttype.chpl:48: error: cannot default-initialize the array field B2 because it has a non-nilable element type 'borrowed object'
 array-with-nonnilable-elttype.chpl:5: error: cannot default-initialize the array x1 because it has a non-nilable element type 'owned object'
 array-with-nonnilable-elttype.chpl:6: error: cannot default-initialize the array x2 because it has a non-nilable element type 'shared object'

--- a/test/functions/export/export-array-out.chpl
+++ b/test/functions/export/export-array-out.chpl
@@ -1,0 +1,4 @@
+
+
+export proc badFormalIntentOut(out s: [] int) {}
+

--- a/test/functions/export/export-array-out.good
+++ b/test/functions/export/export-array-out.good
@@ -1,0 +1,1 @@
+export-array-out.chpl:3: error: array argument 's' in exported function 'badFormalIntentOut' uses out intent - out intent not yet supported for arrays in export procs

--- a/test/interop/python/errorMessages/badFormalIntent-array.chpl
+++ b/test/interop/python/errorMessages/badFormalIntent-array.chpl
@@ -1,14 +1,9 @@
-
-
 export proc badFormalIntentNone(s: [] int) {}
 
 export proc badFormalIntentConst(const s: [] int) {}
-
-export proc badFormalIntentOut(out s: [] int) {}
 
 export proc badFormalIntentInOut(inout s: [] int) {}
 
 export proc badFormalIntentRef(ref s: [] int) {}
 
 export proc badFormalIntentConstRef(const ref s: [] int) {}
-

--- a/test/interop/python/errorMessages/badFormalIntent-array.good
+++ b/test/interop/python/errorMessages/badFormalIntent-array.good
@@ -1,5 +1,4 @@
-badFormalIntent-array.chpl:3: error: Formal 's' of type 'array' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
-badFormalIntent-array.chpl:5: error: Formal 's' of type 'array' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
-badFormalIntent-array.chpl:7: error: Formal 's' of type 'array' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
-badFormalIntent-array.chpl:9: error: Formal 's' of type 'array' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
-badFormalIntent-array.chpl:11: error: Formal 's' of type 'array' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent-array.chpl:1: error: Formal 's' of type 'array' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent-array.chpl:3: error: Formal 's' of type 'array' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent-array.chpl:5: error: Formal 's' of type 'array' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent-array.chpl:7: error: Formal 's' of type 'array' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries

--- a/test/types/type_variables/ferguson/tuple-of-array-type-default-init.chpl
+++ b/test/types/type_variables/ferguson/tuple-of-array-type-default-init.chpl
@@ -1,0 +1,11 @@
+proc makeit(type t) {
+  var x: t;
+  return x;
+}
+
+proc main() {
+  var A:[1..3] int;
+  var x = makeit( (A.type, A.type) );
+  writeln(x(0));
+  writeln(x(1));
+}

--- a/test/types/type_variables/ferguson/tuple-of-array-type-default-init.good
+++ b/test/types/type_variables/ferguson/tuple-of-array-type-default-init.good
@@ -1,0 +1,1 @@
+tuple-of-array-type-default-init.chpl:2: error: default initialization of tuple containing array or domain type not yet implemented


### PR DESCRIPTION
This PR makes improvements to runtime type support to prepare for
implementing `noinit` support for arrays in support of issue #15673.

When implementing `noinit` on an array type, it is important that the
compiler be able to create a different initialization pattern for an
array that is no-inited. However the way that arrays are
default-initialized is tied to the runtime type support in the compiler
in a way that makes that difficult. The following comment describes the
previous situation:

```
  // NOTE: the bodies of functions marked with runtime type init fn such as
  // chpl__buildDomainRuntimeType and chpl__buildArrayRuntimeType are replaced
  // by the compiler to just create a record storing the arguments. The body
  // is moved by the compiler to chpl__convertRuntimeTypeToValue.
  // The return type of chpl__build...RuntimeType is what tells the
  // compiler which runtime type it is creating.
```

To implement noinit support for arrays, we would like to add a `param
initElts` argument to the function that default-initializes an array
(`chpl__convertRuntimeTypeToValue`). However, because
`chpl__buildArrayRuntimeType` both constructs the runtime type (when
called `chpl__buildArrayRuntimeType`) and implements default
initialization (when called `chpl__convertRuntimeTypeToValue`), this was
not possible in a straightforward manner. In particular, the new `param
initElts` argument should not apply to constructing the runtime type;
only to creating a value of that type.

In order to overcome that obstacle, this PR changes the strategy taken by
the compiler to handle these runtime type support functions. Now
`chpl__convertRuntimeTypeToValue` functions are implemented directly in
module code (instead of being constructed by the compiler by cloning
`chpl__buildArrayRuntimeType` etc). This required some adjustment to
several functions handling runtime types in functionResolution.cpp. 

This PR adjusts function resolution to populate the fields of the runtime
type right away once the relevant array type is created by
`chpl__buildArrayRuntimeType` etc. It does this by calling a new
function, `adjustRuntimeTypeInitFn`, once a function marked with `pragma
"runtime type init fn"` is resolved. This new function generates the
runtime type record and adds it to the runtime types map. Additionally,
it populates the runtime type record with type and param fields that were
previously skipped in order to keep these details preserved. (They will
be removed in late resolution just like with any other record). As a
result, the primitive `PRIM_GET_RUNTIME_TYPE_FIELD` no longer needs an
argument indicating the field type. The argument indicating the field
type was problematic because it was most naturally computed by default
initialization (in several functions added in #11140 and #15239) but that
could have performance impact (see #15767). Now that
`PRIM_GET_RUNTIME_TYPE_FIELD` no longer needs the field type (since the
compiler knows it during resolution), there is no need for the
problematic code.

Since the runtime type record is created earlier, in
`adjustRuntimeTypeInitFn`, now `buildRuntimeTypeInitFns` just adjusts the
runtime type init functions to return the runtime type. It no longer
generates `chpl__convertRuntimeTypeToValue` by cloning e.g.
`chpl__buildArrayRuntimeType` as `chpl__convertRuntimeTypeToValue` is now
written in module code.

In order to get arrays-of-arrays to work correctly with these changes, it
was also necessary to change how default initialization for variables
with runtime types was handled. Now, default initialization for these
types is handled in `lowerPrimInit` which calls `lowerRuntimeTypeInit`.
At that time, the runtime type records exist but are not yet used. So,
the lowering makes use of `PRIM_GET_RUNTIME_TYPE_FIELD` to gather the
arguments to pass to `chpl__convertRuntimeTypeToValue`. (That, in turn,
relies upon the changes to the creation of runtime type records described
above; including in particular having the runtime type record exist and
have `param` fields at this point).

`insertRuntimeTypeTemps` is renamed to `populateRuntimeTypeMap` to better
reflect what it does. In addition, it now includes a check to skip work
in the event the relevant map entry is already present.

`replaceValuesWithRuntimeTypes` is renamed to
`replaceTypeFormalsWithRuntimeTypes` to better reflect what it does. So
too is `replaceReturnedValuesWithRuntimeTypes` renamed to
`replaceReturnedTypesWithRuntimeTypes`

`replaceRuntimeTypePrims`, now limited to just handling
`PRIM_GET_RUNTIME_TYPE_FIELD`, is moved to `removeRandomPrimitive` in
order to prevent an additional traversal over all calls in the AST.

To reduce the potential for confusion, this PR also renames the fields in
the runtime type records. For the runtime type record for a domain, this
PR renames the distribution field from`d` to `dist`. For the runtime type
record for a sparse domain, this PR renames the parent domain field from
`dom` to `parentDom`.

In order to resolve a problem encountered during development, this PR
adds `chpl_createBytesWithLiteral`, makes it a well-known function, and
calls it in `new_BytesSymbol`.

Here is a summary of the way runtime types are handled in the compiler
after this PR:
* `adjustRuntimeTypeInitFn` is called in `resolveFunction` for `pragma
  "runtime type init fn"` functions such as
  `chpl__buildArrayRuntimeType`. It generates the runtime type record,
  complete with param and type fields, and stores a link to that record
  in `runtimeTypeMap`.
* `lowerPrimInit` calls `lowerRuntimeTypeInit` to change default
  initialization of variables with runtime type into calls to
  `chpl__convertRuntimeTypeToValue`
* `populateRuntimeTypeMap` populates a map from types with runtime type
  to `chpl__convertValueToRuntimeType` functions. These functions are
  implemented in ChapelArray.
* `handleRuntimeTypes` runs late in resolution and takes these steps:
   * run `populateRuntimeTypeMap` a second time
   * `buildRuntimeTypeInitFns` converts `chpl__buildArrayRuntimeType`
     etc. into functions returning a runtime type record
   * `replaceTypeFormalsWithRuntimeTypes` changes `type` formals with
     runtime type into runtime type records
   * `replaceReturnedValuesWithRuntimeTypes` changes returned `type`
     values into runtime type records
   * `replaceRuntimeTypeVariableTypes` changes `type` variables into
     runtime type records
* `removeRandomPrimitive` (called in `pruneResolvedTree`) lowers
  `PRIM_GET_RUNTIME_TYPE_FIELD`.
 
Reviewed by @vasslitvinov - thanks!

- [x] primers pass with valgrind/verify and do not leak
- [x] full local testing
