### PR TITLE
Update the skipif for mapOfArray test

### DIFF
--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -1,7 +1,3 @@
-#!/bin/bash
-
-if [[ "$CHPL_COMM" == "gasnet" ]]; then
-  echo True
-else
-  echo False
-fi
+# This .future is sometimes passing for multilocale/no-local
+CHPL_COMM!=none
+COMPOPTS <= --no-local


### PR DESCRIPTION
Update this test .skipif to skip it for CHPL_COMM!=none or
COMPOPTS<=--no-local. It's a .future, but can pass in those configurations.