### PR TITLE
Handle bool tests in the compiler

### DIFF
--- a/compiler/AST/WhileStmt.cpp
+++ b/compiler/AST/WhileStmt.cpp
@@ -168,27 +168,16 @@ void WhileStmt::checkConstLoops()
         {
           if (outerCall->isPrimitive(PRIM_MOVE))
           {
-            // Expect the update to be the result of a call to _cond_test.
-            if (CallExpr* innerCall = toCallExpr(outerCall->get(2)))
-            {
-              FnSymbol* fn = innerCall->resolvedFunction();
+            Expr* condSrc = skip_cond_test(outerCall->get(2));
 
-              if (innerCall->numActuals()        == 1 &&
-                  strcmp(fn->name, "_cond_test") == 0)
-              {
-                checkWhileLoopCondition(innerCall->get(1));
-              }
-              else
-              {
-                INT_FATAL(innerCall,
-                          "Expected the update of a loop conditional "
-                          "to be piped through _cond_test().");
-              }
+            // The RHS of the move can be a call.
+            if (CallExpr* condCall = toCallExpr(condSrc)) {
+              checkWhileLoopCondition(condCall);
             }
 
             // The RHS of the move can also be a SymExpr as the result of param
             // folding ...
-            else if (SymExpr* moveSrc = toSymExpr(outerCall->get(2)))
+            else if (SymExpr* moveSrc = toSymExpr(condSrc))
             {
               // ... in which case, the literal should be 'true' or 'false'.
               if (moveSrc->symbol() == gTrue)
@@ -206,9 +195,8 @@ void WhileStmt::checkConstLoops()
 
               else
               {
-                INT_FATAL(moveSrc,
-                          "Expected const loop condition variable to be "
-                          "true or false.");
+                // ... or without param folding
+                checkWhileLoopCondition(moveSrc);
               }
             }
 

--- a/compiler/AST/WhileStmt.cpp
+++ b/compiler/AST/WhileStmt.cpp
@@ -195,7 +195,7 @@ void WhileStmt::checkConstLoops()
 
               else
               {
-                // ... or without param folding
+                // Check more if the RHS of the move is not a param.
                 checkWhileLoopCondition(moveSrc);
               }
             }

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -1016,6 +1016,16 @@ CondStmt* isConditionalInCondStmt(Expr* expr) {
   return NULL;
 }
 
+// If 'expr' is the result of a call to '_cond_stmt', return the call's
+// actual argument. Otherwise return 'expr'.
+Expr* skip_cond_test(Expr* expr) {
+  if (CallExpr* call = toCallExpr(expr))
+    if (call->numActuals() == 1    &&
+        call->isNamed("_cond_test")  )
+      return call->get(1);
+  return expr;
+}
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -350,6 +350,7 @@ extern Map<GotoStmt*, GotoStmt*> copiedIterResumeGotos;
 
 const char*  gotoTagToString(GotoTag gotoTag);
 CondStmt*    isConditionalInCondStmt(Expr* expr);
+Expr*        skip_cond_test(Expr* expr);
 
 // Probably belongs in Expr; doesn't really mean Stmt, but rather
 // statement-level expression.

--- a/compiler/resolution/nilChecking.cpp
+++ b/compiler/resolution/nilChecking.cpp
@@ -1011,9 +1011,8 @@ static bool adjustWhenNilCmp(Expr* arg1, Expr* arg2,
 static bool doAdjustForConditional(CondStmt* cond, bool inThenBranch,
                                    AliasMap& OUT) {
 
-  if (CallExpr* CE = toCallExpr(getSingleDefExpr(cond->condExpr)))
-   if (CE->isNamed("_cond_test") && CE->numActuals() == 1)
-    if (SymExpr* testArg = toSymExpr(CE->get(1)))
+  Expr* theCond = skip_cond_test(getSingleDefExpr(cond->condExpr));
+  if (SymExpr* testArg = toSymExpr(theCond))
     {
      if (isClassIshType(testArg->symbol()))
       // in Chapel: if obj then ...

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -715,8 +715,7 @@ module ChapelBase {
   inline proc chpl_statementLevelSymbol(a) { }
   inline proc chpl_statementLevelSymbol(a: sync)  { a.readFE(); }
   inline proc chpl_statementLevelSymbol(a: single) { a.readFF(); }
-  inline proc chpl_statementLevelSymbol(param a) param { return a; }
-  inline proc chpl_statementLevelSymbol(type a) type { return a; }
+  // param and type args are handled in the compiler
 
   //
   // If an iterator is called without capturing the result, iterate over it
@@ -742,22 +741,23 @@ module ChapelBase {
 
   inline proc _cond_test(x: borrowed object?) return x != nil;
   inline proc _cond_test(x: bool) return x;
-  inline proc _cond_test(x: integral) return x != 0:x.type;
+  inline proc _cond_test(x: int) return x != 0;
+  inline proc _cond_test(x: uint) return x != 0;
 
   inline proc _cond_test(param x: bool) param return x;
   inline proc _cond_test(param x: integral) param return x != 0:x.type;
 
   inline proc _cond_test(x) {
+   if !( x.type <= _iteratorRecord ) then
     compilerError("type '", x.type:string, "' used in if or while condition");
-  }
-
-  inline proc _cond_test(x: _iteratorRecord) {
+   else
     compilerError("iterator or promoted expression ", x.type:string, " used in if or while condition");
   }
 
-  proc _cond_invalid(x: borrowed object) param return false;
+  proc _cond_invalid(x: borrowed object?) param return false;
   proc _cond_invalid(x: bool) param return false;
-  proc _cond_invalid(x: integral) param return false;
+  proc _cond_invalid(x: int) param return false;
+  proc _cond_invalid(x: uint) param return false;
   proc _cond_invalid(x) param return true;
 
   //


### PR DESCRIPTION
The compiler does a lot of instantiating `_cond_test`, `_cond_invalid`
and `isTrue`. The common case is to call those on a boolean, when
the behavior of these functions is trivial.

This change handles these common cases in the compiler / preFoldNamed,
yielding minor compilation-time speedup.  I added `skip_cond_test` helper
in the compiler to handle both the case where `_cond_test` was eliminated
and the case where it was not.

WHAT ELSE I CONSIDERED

I tried to avoid inserting `_cond_test` altogether, so that the compiler
implements its functionality directly instead. However, there are too
many cases where _cond_test is used, so that would be too much work
to implement this idea. Also we may want to keep `_cond_test` so that
the user can define it on their data types, see #15904.

I tried to adding `pragma "last resort"` on the generic overloads
of these functions. This does not work when it is invoked, for example,
on a range, because then the compiler promotes the `int` overload,
which is non-last-resort, and we do not want promotion here.

I tried removing the `bool` overloads to reduce the number of candidates
that the compiler considers. Alas this broke the cases that use bools of
non-default sizes. Then, I tried to recognize all bool sizes in the
compiler instead of just the default size. However, in some cases the compiler
expects default-sized booleans downstream. To make those work, we can
have the compiler convert any boolean to the default size. I left that
for another day, as it was not obvious that reducing the number of candidates
was worth it w.r.t. compilation speedup.

Another promising idea is to have preFold handle assignments (`=`)
on POD types by replacing them with PRIM_ASSIGN.
However, post-resolution passes rely heavily on assignments
being calls to "=", so it will take an effort.
Replacing the multitude of individual `proc =` with a single
`proc =(lhs: chpl_anyPOD, ...)` is less promising w.r.t.
compilation time improvement.

GENERIC / NON-GENERIC OVERLOADS

I replaced the generic overloads on `integral` with two concrete overloads
on `int` and `uint`, to reduce the number of generic instantiations.

I collapsed the two generic overloads of `_cond_test` into one,
for the same reason.

Testing: linux64; gasnet over multilocale tests