### PR TITLE
Add hdf5 tools to PATH for arkouda testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -20,6 +20,7 @@ ARKOUDA_DEP_DIR=/cray/css/users/chapelu/arkouda-deps
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}
   export ARKOUDA_HDF5_PATH=${ARKOUDA_HDF5_PATH:-$ARKOUDA_DEP_DIR/hdf5-install}
+  export PATH="$ARKOUDA_HDF5_PATH/bin:$PATH"
 fi
 
 currentSha=`git rev-parse HEAD`


### PR DESCRIPTION
https://github.com/mhmerrill/arkouda/pull/411 started requiring h5ls for
some I/O tests. Ensure it's available in the PATH.