### PR TITLE
Skip --cache-remote tests when ASAN is enabled

### DIFF
--- a/test/optimizations/cache-remote/ferguson/reduces_comm/SKIPIF
+++ b/test/optimizations/cache-remote/ferguson/reduces_comm/SKIPIF
@@ -1,3 +1,2 @@
-# currently --cache-remote only supported for gasnet,fifo
-CHPL_COMM!=gasnet
-CHPL_TASKS!=fifo
+CHPL_COMM == none
+CHPL_SANITIZE_EXE != none

--- a/test/performance/ferguson/MYCOMPOPTS
+++ b/test/performance/ferguson/MYCOMPOPTS
@@ -12,9 +12,8 @@ perftest = ''
 if suffix != "compopts":
   perftest = base
 
-do_llvm = True
-if os.getenv('CHPL_LLVM', 'none') == 'none':
-    do_llvm = False
+do_llvm = os.getenv('CHPL_LLVM', 'none') != 'none'
+do_cache = os.getenv('CHPL_SANITIZE_EXE') == 'none'
 
 basecompopts='--fast '
 
@@ -33,7 +32,8 @@ checkMaxAttained=' -scheckMaxAttained=true'
 f('--no-llvm --no-cache-remote ' + checkMaxAttained, 'c')
 
 # C backend, cache remote
-f('--no-llvm --cache-remote', 'c-cache')
+if do_cache:
+  f('--no-llvm --cache-remote', 'c-cache')
 
 if do_llvm:
   # LLVM backend, no cache remote
@@ -43,4 +43,5 @@ if do_llvm:
   # LLVM backend, llvm wide opts, no cache remote
   f('--llvm --llvm-wide-opt --no-cache-remote', 'llvm-wide-opt')
   # LLVM backend, llvm wide opts, cache remote
-  f('--llvm --llvm-wide-opt --cache-remote', 'llvm-wide-opt-cache')
+  if do_cache:
+    f('--llvm --llvm-wide-opt --cache-remote', 'llvm-wide-opt-cache')

--- a/test/runtime/configMatters/comm/cache-remote/SKIPIF
+++ b/test/runtime/configMatters/comm/cache-remote/SKIPIF
@@ -1,1 +1,2 @@
-CHPL_COMM==none
+CHPL_COMM == none
+CHPL_SANITIZE_EXE != none


### PR DESCRIPTION
`--cache-remote` reads entire cache lines when doing GETs, which is
currently incompatible with ASAN. ASAN reports that these GETs are heap
overflows, which is true since we're reading past our allocations, but
that's intentional and harmless (the cache may read parts of a cache
line that haven't been allocated, but unless there's other invalid
memory accesses that later read from the cache that's ok.)

For now just skip these tests until we come up with a better solution.

See https://github.com/cray/chapel-private/issues/933 for more info