### PR TITLE
Remove localAccess from some performance tests

### DIFF
--- a/test/npb/ft/npadmana/ft_transposed.chpl
+++ b/test/npb/ft/npadmana/ft_transposed.chpl
@@ -83,9 +83,9 @@ writef("MFLOPS : %10.4dr\n",mflops);
 
 proc evolve() {
   forall ijk in DomT {
-    const elt = V.localAccess[ijk]*Twiddle.localAccess[ijk];
-    V.localAccess[ijk] = elt;
-    Wt.localAccess[ijk] = elt;
+    const elt = V[ijk]*Twiddle[ijk];
+    V[ijk] = elt;
+    Wt[ijk] = elt;
   }
   doFFT_Transposed(FFTtype.DFT, Wt, W, FFTW_BACKWARD); // This is unnormalized
 
@@ -126,7 +126,7 @@ proc initialize_twiddle() {
       const x1 = if idx >= N/2 then idx-N else idx;
       e += x1**2;
     }
-    Twiddle.localAccess[xyz] = exp(-fac*e);
+    Twiddle[xyz] = exp(-fac*e);
   }
 }
 

--- a/test/studies/bale/indexgather/ig-variants.chpl
+++ b/test/studies/bale/indexgather/ig-variants.chpl
@@ -54,9 +54,9 @@ proc testit(mode: Mode, param explicit, printStats) {
     when Mode.directIndexLocal {
       forall i in D2 {
         if explicit then
-          unorderedCopy(tmp.localAccess[i], A[rindex.localAccess[i]]);
+          unorderedCopy(tmp[i], A[rindex[i]]);
         else
-          tmp.localAccess[i] = A[rindex.localAccess[i]];
+          tmp[i] = A[rindex[i]];
       }
     }
     when Mode.directIndex {

--- a/test/studies/bale/indexgather/ig.chpl
+++ b/test/studies/bale/indexgather/ig.chpl
@@ -44,10 +44,10 @@ proc main() {
   if useUnorderedCopy {
     use UnorderedCopy;
     forall i in D2 do
-      unorderedCopy(tmp.localAccess[i], A[rindex.localAccess[i]]);
+      unorderedCopy(tmp[i], A[rindex[i]]);
   } else {
     forall i in D2 do
-      tmp.localAccess[i] = A[rindex.localAccess[i]];
+      tmp[i] = A[rindex[i]];
   }
 
   t.stop();

--- a/test/studies/lulesh/bradc/lulesh-dense.chpl
+++ b/test/studies/lulesh/bradc/lulesh-dense.chpl
@@ -878,12 +878,12 @@ inline proc CalcTimeConstraintsForElems() {
 
 
 inline proc computeDTF(indx) {
-  const myvdov = vdov[indx];
+  const myvdov = vdov.localAccess[indx];
 
   if myvdov == 0.0 then
     return max(real);
 
-  const myarealg = arealg[indx];
+  const myarealg = arealg.localAccess[indx];
   var dtf = ss[indx]**2;
   if myvdov < 0.0 then
     dtf += qqc2 * myarealg**2 * myvdov**2;

--- a/test/studies/lulesh/bradc/lulesh-dense.chpl
+++ b/test/studies/lulesh/bradc/lulesh-dense.chpl
@@ -314,8 +314,8 @@ proc initMasses() {
     localizeNeighborNodes(eli, x, x_local, y, y_local, z, z_local);
 
     const volume = CalcElemVolume(x_local, y_local, z_local);
-    volo.localAccess[eli] = volume;
-    elemMass.localAccess[eli] = volume;
+    volo[eli] = volume;
+    elemMass[eli] = volume;
 
     for neighbor in elemToNodes[eli] do
       massAccum[neighbor].add(volume);
@@ -326,7 +326,7 @@ proc initMasses() {
   // procedure's return
 
   forall i in Nodes do
-    nodalMass.localAccess[i] = massAccum.localAccess[i].read() / 8.0;
+    nodalMass[i] = massAccum[i].read() / 8.0;
 
   if debug {
     writeln("ElemMass:");
@@ -353,16 +353,16 @@ proc initBoundaryConditions() {
   forall e in Elems do {
     var mask: int;
     for i in 0..#nodesPerElem do
-      mask += surfaceNode[elemToNode.localAccess[e][i]] << i;
+      mask += surfaceNode[elemToNode[e][i]] << i;
 
     // TODO: make an inlined function for this little idiom? (and below)
 
-    if ((mask & 0x0f) == 0x0f) then elemBC.localAccess[e] |= ZETA_M_SYMM;
-    if ((mask & 0xf0) == 0xf0) then elemBC.localAccess[e] |= ZETA_P_SYMM;
-    if ((mask & 0x33) == 0x33) then elemBC.localAccess[e] |= ETA_M_SYMM;
-    if ((mask & 0xcc) == 0xcc) then elemBC.localAccess[e] |= ETA_P_SYMM;
-    if ((mask & 0x99) == 0x99) then elemBC.localAccess[e] |= XI_M_SYMM;
-    if ((mask & 0x66) == 0x66) then elemBC.localAccess[e] |= XI_P_SYMM;
+    if ((mask & 0x0f) == 0x0f) then elemBC[e] |= ZETA_M_SYMM;
+    if ((mask & 0xf0) == 0xf0) then elemBC[e] |= ZETA_P_SYMM;
+    if ((mask & 0x33) == 0x33) then elemBC[e] |= ETA_M_SYMM;
+    if ((mask & 0xcc) == 0xcc) then elemBC[e] |= ETA_P_SYMM;
+    if ((mask & 0x99) == 0x99) then elemBC[e] |= XI_M_SYMM;
+    if ((mask & 0x66) == 0x66) then elemBC[e] |= XI_P_SYMM;
   }
 
 
@@ -405,12 +405,12 @@ proc initBoundaryConditions() {
     for i in 0..#nodesPerElem do
       mask += surfaceNode[elemToNode[e][i]] << i;
 
-    if ((mask & 0x0f) == 0x0f) then elemBC.localAccess[e] |= ZETA_M_FREE;
-    if ((mask & 0xf0) == 0xf0) then elemBC.localAccess[e] |= ZETA_P_FREE;
-    if ((mask & 0x33) == 0x33) then elemBC.localAccess[e] |= ETA_M_FREE;
-    if ((mask & 0xcc) == 0xcc) then elemBC.localAccess[e] |= ETA_P_FREE;
-    if ((mask & 0x99) == 0x99) then elemBC.localAccess[e] |= XI_M_FREE;
-    if ((mask & 0x66) == 0x66) then elemBC.localAccess[e] |= XI_P_FREE;
+    if ((mask & 0x0f) == 0x0f) then elemBC[e] |= ZETA_M_FREE;
+    if ((mask & 0xf0) == 0xf0) then elemBC[e] |= ZETA_P_FREE;
+    if ((mask & 0x33) == 0x33) then elemBC[e] |= ETA_M_FREE;
+    if ((mask & 0xcc) == 0xcc) then elemBC[e] |= ETA_P_FREE;
+    if ((mask & 0x99) == 0x99) then elemBC[e] |= XI_M_FREE;
+    if ((mask & 0x66) == 0x66) then elemBC[e] |= XI_P_FREE;
   }
 
   if debug {
@@ -430,7 +430,7 @@ inline proc localizeNeighborNodes(eli: index(Elems),
                                   z: [] real, ref z_local: 8*real) {
 
   for param i in 0..nodesPerElem-1 {
-    const noi = elemToNode.localAccess[eli][i];  // can this always be localAccess
+    const noi = elemToNode[eli][i];  // can this always be localAccess
     
     x_local[i] = x[noi];
     y_local[i] = y[noi];
@@ -507,9 +507,9 @@ proc CalcElemVolume(x, y, z) {
 
 proc InitStressTermsForElems(p, q, sigxx, sigyy, sigzz: [?D] real) {
   forall i in D {
-    sigxx.localAccess[i] = -p.localAccess[i] - q.localAccess[i];
-    sigyy.localAccess[i] = -p.localAccess[i] - q.localAccess[i];
-    sigzz.localAccess[i] = -p.localAccess[i] - q.localAccess[i];
+    sigxx[i] = -p[i] - q[i];
+    sigyy[i] = -p[i] - q[i];
+    sigzz[i] = -p[i] - q[i];
   }
 }
 
@@ -786,16 +786,16 @@ proc CalcPressureForElems(p_new: [?D] real, bvc, pbvc,
 
   forall i in D do local {
     const c1s = 2.0 / 3.0;
-    bvc.localAccess[i] = c1s * (compression.localAccess[i] + 1.0);
-    pbvc.localAccess[i] = c1s;
+    bvc[i] = c1s * (compression[i] + 1.0);
+    pbvc[i] = c1s;
   }
 
   forall i in D {
-    p_new.localAccess[i] = bvc.localAccess[i] * e_old.localAccess[i];
+    p_new[i] = bvc[i] * e_old[i];
 
-    if abs(p_new.localAccess[i]) < p_cut then p_new.localAccess[i] = 0.0;
-    if vnewc.localAccess[i] >= eosvmax then p_new.localAccess[i] = 0.0; //impossible?
-    if p_new.localAccess[i] < pmin then p_new.localAccess[i] = pmin;
+    if abs(p_new[i]) < p_cut then p_new[i] = 0.0;
+    if vnewc[i] >= eosvmax then p_new[i] = 0.0; //impossible?
+    if p_new[i] < pmin then p_new[i] = pmin;
   }
 }
 
@@ -878,13 +878,13 @@ inline proc CalcTimeConstraintsForElems() {
 
 
 inline proc computeDTF(indx) {
-  const myvdov = vdov.localAccess[indx];
+  const myvdov = vdov[indx];
 
   if myvdov == 0.0 then
     return max(real);
 
-  const myarealg = arealg.localAccess[indx];
-  var dtf = ss.localAccess[indx]**2;
+  const myarealg = arealg[indx];
+  var dtf = ss[indx]**2;
   if myvdov < 0.0 then
     dtf += qqc2 * myarealg**2 * myvdov**2;
   dtf = sqrt(dtf);
@@ -903,7 +903,7 @@ proc CalcCourantConstraintForElems() {
 
 
 inline proc calcDtHydroTmp(indx) {
-  const myvdov = vdov.localAccess[indx];
+  const myvdov = vdov[indx];
   if (myvdov == 0.0) then
     return max(real);
   else
@@ -969,11 +969,11 @@ proc IntegrateStressForElems(sigxx, sigyy, sigzz, determ) {
     local {
       /* Volume calculation involves extra work for numerical consistency. */
       CalcElemShapeFunctionDerivatives(x_local, y_local, z_local, 
-                                       b_x, b_y, b_z, determ.localAccess[k]);
+                                       b_x, b_y, b_z, determ[k]);
     
       CalcElemNodeNormals(b_x, b_y, b_z, x_local, y_local, z_local);
 
-      SumElemStressesToNodeForces(b_x, b_y, b_z, sigxx.localAccess[k], sigyy.localAccess[k], sigzz.localAccess[k], 
+      SumElemStressesToNodeForces(b_x, b_y, b_z, sigxx[k], sigyy[k], sigzz[k], 
                                   fx_local, fy_local, fz_local);
     }
 
@@ -1008,14 +1008,14 @@ proc CalcHourglassControlForElems(determ) {
 
     local {
       /* load into temporary storage for FB Hour Glass control */
-      (dvdx.localAccess[eli], dvdy.localAccess[eli], dvdz.localAccess[eli]) = CalcElemVolumeDerivative(x1, y1, z1);
+      (dvdx[eli], dvdy[eli], dvdz[eli]) = CalcElemVolumeDerivative(x1, y1, z1);
     }
 
-    x8n.localAccess[eli]  = x1;
-    y8n.localAccess[eli]  = y1;
-    z8n.localAccess[eli]  = z1;
+    x8n[eli]  = x1;
+    y8n[eli]  = y1;
+    z8n[eli]  = z1;
 
-    determ.localAccess[eli] = volo.localAccess[eli] * v.localAccess[eli];
+    determ[eli] = volo[eli] * v[eli];
   }
 
   /* Do a check for negative volumes */
@@ -1042,7 +1042,7 @@ proc CalcFBHourglassForceForElems(determ, x8n, y8n, z8n, dvdx, dvdy, dvdz) {
   /* compute the hourglass modes */
   forall eli in Elems {
     var hourgam: 8*(4*real);
-    const volinv = 1.0 / determ.localAccess[eli];
+    const volinv = 1.0 / determ[eli];
     var ss1, mass1, volume13: real;
     var hgfx, hgfy, hgfz: 8*real;
     var coefficient: real;
@@ -1066,31 +1066,31 @@ proc CalcFBHourglassForceForElems(determ, x8n, y8n, z8n, dvdx, dvdy, dvdz) {
         var hourmodx, hourmody, hourmodz: real;
         // reduction
         for param j in 0..7 {
-          hourmodx += x8n.localAccess[eli][j] * gammaCoef[i][j];
-          hourmody += y8n.localAccess[eli][j] * gammaCoef[i][j];
-          hourmodz += z8n.localAccess[eli][j] * gammaCoef[i][j];
+          hourmodx += x8n[eli][j] * gammaCoef[i][j];
+          hourmody += y8n[eli][j] * gammaCoef[i][j];
+          hourmodz += z8n[eli][j] * gammaCoef[i][j];
         }
 
         for param j in 0..7 {
           hourgam[j][i] = gammaCoef[i][j] - volinv * 
-            (dvdx.localAccess[eli][j] * hourmodx +
-             dvdy.localAccess[eli][j] * hourmody +
-             dvdz.localAccess[eli][j] * hourmodz);
+            (dvdx[eli][j] * hourmodx +
+             dvdy[eli][j] * hourmody +
+             dvdz[eli][j] * hourmodz);
         }
       }
 
       /* compute forces */
       /* store forces into h arrays (force arrays) */
-      ss1 = ss.localAccess[eli];
-      mass1 = elemMass.localAccess[eli];
-      volume13 = cbrt(determ.localAccess[eli]);
+      ss1 = ss[eli];
+      mass1 = elemMass[eli];
+      volume13 = cbrt(determ[eli]);
 
       coefficient = - hgcoef * 0.01 * ss1 * mass1 / volume13;
 
       CalcElemFBHourglassForce(xd1, yd1, zd1, hourgam, coefficient, hgfx, hgfy, hgfz);
     } // end local
 
-    const myElemToNode = elemToNode.localAccess[eli];
+    const myElemToNode = elemToNode[eli];
     for param i in 0..nodesPerElem-1 {
         const noi = myElemToNode[i];
       if useNetworkAtomics {
@@ -1114,9 +1114,9 @@ proc CalcFBHourglassForceForElems(determ, x8n, y8n, z8n, dvdx, dvdy, dvdz) {
 
 proc CalcAccelerationForNodes() {
   forall noi in Nodes do local {
-      xdd.localAccess[noi] = fx.localAccess[noi].peek() / nodalMass.localAccess[noi];
-      ydd.localAccess[noi] = fy.localAccess[noi].peek() / nodalMass.localAccess[noi];
-      zdd.localAccess[noi] = fz.localAccess[noi].peek() / nodalMass.localAccess[noi];
+      xdd[noi] = fx[noi].peek() / nodalMass[noi];
+      ydd[noi] = fy[noi].peek() / nodalMass[noi];
+      zdd[noi] = fz[noi].peek() / nodalMass[noi];
     }
 }
 
@@ -1136,24 +1136,24 @@ proc ApplyAccelerationBoundaryConditionsForNodes() {
 
 proc CalcVelocityForNodes(dt: real, u_cut: real) {
   forall i in Nodes do local {
-    var xdtmp = xd.localAccess[i] + xdd.localAccess[i] * dt,
-        ydtmp = yd.localAccess[i] + ydd.localAccess[i] * dt,
-        zdtmp = zd.localAccess[i] + zdd.localAccess[i] * dt;
+    var xdtmp = xd[i] + xdd[i] * dt,
+        ydtmp = yd[i] + ydd[i] * dt,
+        zdtmp = zd[i] + zdd[i] * dt;
     if abs(xdtmp) < u_cut then xdtmp = 0.0;
     if abs(ydtmp) < u_cut then ydtmp = 0.0;
     if abs(zdtmp) < u_cut then zdtmp = 0.0;
-    xd.localAccess[i] = xdtmp;
-    yd.localAccess[i] = ydtmp;
-    zd.localAccess[i] = zdtmp;
+    xd[i] = xdtmp;
+    yd[i] = ydtmp;
+    zd[i] = zdtmp;
   }
 }
 
 
 proc CalcPositionForNodes(dt: real) {
   forall ijk in Nodes {
-    x.localAccess[ijk] += xd.localAccess[ijk] * dt;
-    y.localAccess[ijk] += yd.localAccess[ijk] * dt;
-    z.localAccess[ijk] += zd.localAccess[ijk] * dt;
+    x[ijk] += xd[ijk] * dt;
+    y[ijk] += yd[ijk] * dt;
+    z[ijk] += zd[ijk] * dt;
   }
 }
 
@@ -1165,11 +1165,11 @@ proc CalcLagrangeElements() {
 
   // element loop to do some stuff not included in the elemlib function.
   forall k in Elems do local {
-    vdov.localAccess[k] = dxx.localAccess[k] + dyy.localAccess[k] + dzz.localAccess[k];
-    var vdovthird = vdov.localAccess[k] / 3.0;
-    dxx.localAccess[k] -= vdovthird;
-    dyy.localAccess[k] -= vdovthird;
-    dzz.localAccess[k] -= vdovthird;
+    vdov[k] = dxx[k] + dyy[k] + dzz[k];
+    var vdovthird = vdov[k] / 3.0;
+    dxx[k] -= vdovthird;
+    dyy[k] -= vdovthird;
+    dzz[k] -= vdovthird;
   }
 
   // See if any volumes are negative, and take appropriate action.
@@ -1199,12 +1199,12 @@ proc CalcKinematicsForElems(dxx, dyy, dzz, const dt: real) {
     local {
       //volume calculations
       const volume = CalcElemVolume(x_local, y_local, z_local);
-      const relativeVolume = volume / volo.localAccess[k];
-      vnew.localAccess[k] = relativeVolume;
-      delv.localAccess[k] = relativeVolume - v.localAccess[k];
+      const relativeVolume = volume / volo[k];
+      vnew[k] = relativeVolume;
+      delv[k] = relativeVolume - v[k];
 
       //set characteristic length
-      arealg.localAccess[k] = CalcElemCharacteristicLength(x_local, y_local, z_local,
+      arealg[k] = CalcElemCharacteristicLength(x_local, y_local, z_local,
                                                volume);
 
       for param i in 0..7 {
@@ -1222,9 +1222,9 @@ proc CalcKinematicsForElems(dxx, dyy, dzz, const dt: real) {
     }
 
     // put velocity gradient quantities into their global arrays.
-    dxx.localAccess[k] = d[0];
-    dyy.localAccess[k] = d[1];
-    dzz.localAccess[k] = d[2];
+    dxx[k] = d[0];
+    dyy[k] = d[1];
+    dzz[k] = d[2];
   }
 }
 
@@ -1261,7 +1261,7 @@ var vnewc: [MatElems] real;
 /* Expose all of the variables needed for material evaluation */
 proc ApplyMaterialPropertiesForElems() {
 
-  forall i in MatElems do vnewc.localAccess[i] = vnew.localAccess[i];
+  forall i in MatElems do vnewc[i] = vnew[i];
 
   if eosvmin != 0.0 then
     [c in vnewc] if c < eosvmin then c = eosvmin;
@@ -1274,7 +1274,7 @@ proc ApplyMaterialPropertiesForElems() {
   // currently, race-y
 
   forall matelm in MatElems {
-    var vc = v.localAccess[matelm];
+    var vc = v[matelm];
     if eosvmin != 0.0 && vc < eosvmin then vc = eosvmin;
     if eosvmax != 0.0 && vc > eosvmax then vc = eosvmax;
     if vc <= 0.0 {
@@ -1289,9 +1289,9 @@ proc ApplyMaterialPropertiesForElems() {
 
 proc UpdateVolumesForElems() {
   forall i in Elems do local {
-    var tmpV = vnew.localAccess[i];
+    var tmpV = vnew[i];
     if abs(tmpV-1.0) < v_cut then tmpV = 1.0;
-    v.localAccess[i] = tmpV;
+    v[i] = tmpV;
   }
 }
 
@@ -1306,7 +1306,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
     localizeNeighborNodes(eli, xd, xvl, yd, yvl, zd, zvl);
 
     local {
-      const vol = volo.localAccess[eli] * vnew.localAccess[eli],
+      const vol = volo[eli] * vnew[eli],
             norm = 1.0 / (vol + ptiny);
       var ax, ay, az, dxv, dyv, dzv: real;
 
@@ -1328,7 +1328,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
       ay = dzi*dxj - dxi*dzj;
       az = dxi*dyj - dyi*dxj;
 
-      delx_zeta.localAccess[eli] = vol / sqrt(ax*ax + ay*ay + az*az + ptiny);
+      delx_zeta[eli] = vol / sqrt(ax*ax + ay*ay + az*az + ptiny);
 
       ax *= norm;
       ay *= norm;
@@ -1338,7 +1338,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
       dyv = 0.25*((yvl[4]+yvl[5]+yvl[6]+yvl[7])-(yvl[0]+yvl[1]+yvl[2]+yvl[3]));
       dzv = 0.25*((zvl[4]+zvl[5]+zvl[6]+zvl[7])-(zvl[0]+zvl[1]+zvl[2]+zvl[3]));
 
-      delv_zeta.localAccess[eli] = ax*dxv + ay*dyv + az*dzv;
+      delv_zeta[eli] = ax*dxv + ay*dyv + az*dzv;
 
       /* find delxi and delvi ( j cross k ) */
 
@@ -1346,7 +1346,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
       ay = dzj*dxk - dxj*dzk;
       az = dxj*dyk - dyj*dxk;
 
-      delx_xi.localAccess[eli] = vol / sqrt(ax*ax + ay*ay + az*az + ptiny) ;
+      delx_xi[eli] = vol / sqrt(ax*ax + ay*ay + az*az + ptiny) ;
 
       ax *= norm;
       ay *= norm;
@@ -1356,7 +1356,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
       dyv = 0.25*((yvl[1]+yvl[2]+yvl[6]+yvl[5])-(yvl[0]+yvl[3]+yvl[7]+yvl[4]));
       dzv = 0.25*((zvl[1]+zvl[2]+zvl[6]+zvl[5])-(zvl[0]+zvl[3]+zvl[7]+zvl[4]));
 
-      delv_xi.localAccess[eli] = ax*dxv + ay*dyv + az*dzv ;
+      delv_xi[eli] = ax*dxv + ay*dyv + az*dzv ;
 
       /* find delxj and delvj ( k cross i ) */
 
@@ -1364,7 +1364,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
       ay = dzk*dxi - dxk*dzi;
       az = dxk*dyi - dyk*dxi;
 
-      delx_eta.localAccess[eli] = vol / sqrt(ax*ax + ay*ay + az*az + ptiny) ;
+      delx_eta[eli] = vol / sqrt(ax*ax + ay*ay + az*az + ptiny) ;
 
       ax *= norm;
       ay *= norm;
@@ -1374,7 +1374,7 @@ proc CalcMonotonicQGradientsForElems(delv_xi, delv_eta, delv_zeta,
       dyv= -0.25*((yvl[0]+yvl[1]+yvl[5]+yvl[4])-(yvl[3]+yvl[2]+yvl[6]+yvl[7]));
       dzv= -0.25*((zvl[0]+zvl[1]+zvl[5]+zvl[4])-(zvl[3]+zvl[2]+zvl[6]+zvl[7]));
 
-      delv_eta.localAccess[eli] = ax*dxv + ay*dyv + az*dzv ;
+      delv_eta[eli] = ax*dxv + ay*dyv + az*dzv ;
     } /* local */
   } /* forall eli */
 }
@@ -1386,20 +1386,20 @@ proc CalcMonotonicQForElems(delv_xi, delv_eta, delv_zeta,
 
   forall i in MatElems {
     const ptiny = 1.0e-36;
-    const bcMask = elemBC.localAccess[i];
+    const bcMask = elemBC[i];
     var norm, delvm, delvp: real;
 
     /* phixi */
-    norm = 1.0 / (delv_xi.localAccess[i] + ptiny);
+    norm = 1.0 / (delv_xi[i] + ptiny);
 
     select bcMask & XI_M {
-      when 0         do delvm = delv_xi[lxim.localAccess[i]];
-      when XI_M_SYMM do delvm = delv_xi.localAccess[i];
+      when 0         do delvm = delv_xi[lxim[i]];
+      when XI_M_SYMM do delvm = delv_xi[i];
       when XI_M_FREE do delvm = 0.0;
     }
     select bcMask & XI_P {
-      when 0         do delvp = delv_xi[lxip.localAccess[i]];
-      when XI_P_SYMM do delvp = delv_xi.localAccess[i];
+      when 0         do delvp = delv_xi[lxip[i]];
+      when XI_P_SYMM do delvp = delv_xi[i];
       when XI_P_FREE do delvp = 0.0;
     }
 
@@ -1417,16 +1417,16 @@ proc CalcMonotonicQForElems(delv_xi, delv_eta, delv_zeta,
     if phixi > monoq_max_slope then phixi = monoq_max_slope;
 
     /* phieta */
-    norm = 1.0 / (delv_eta.localAccess[i] + ptiny);
+    norm = 1.0 / (delv_eta[i] + ptiny);
 
     select bcMask & ETA_M {
-      when 0          do delvm = delv_eta[letam.localAccess[i]];
-      when ETA_M_SYMM do delvm = delv_eta.localAccess[i];      
+      when 0          do delvm = delv_eta[letam[i]];
+      when ETA_M_SYMM do delvm = delv_eta[i];      
       when ETA_M_FREE do delvm = 0.0;      
     }
     select bcMask & ETA_P {
-      when 0          do delvp = delv_eta[letap.localAccess[i]];
-      when ETA_P_SYMM do delvp = delv_eta.localAccess[i];      
+      when 0          do delvp = delv_eta[letap[i]];
+      when ETA_P_SYMM do delvp = delv_eta[i];      
       when ETA_P_FREE do delvp = 0.0;      
     }
 
@@ -1444,16 +1444,16 @@ proc CalcMonotonicQForElems(delv_xi, delv_eta, delv_zeta,
     if phieta > monoq_max_slope then phieta = monoq_max_slope;
 
     /*  phizeta     */
-    norm = 1.0 / (delv_zeta.localAccess[i] + ptiny);
+    norm = 1.0 / (delv_zeta[i] + ptiny);
 
     select bcMask & ZETA_M {
-      when 0           do delvm = delv_zeta[lzetam.localAccess[i]];
-      when ZETA_M_SYMM do delvm = delv_zeta.localAccess[i];       
+      when 0           do delvm = delv_zeta[lzetam[i]];
+      when ZETA_M_SYMM do delvm = delv_zeta[i];       
       when ZETA_M_FREE do delvm = 0.0;        
     }
     select bcMask & ZETA_P {
-      when 0           do delvp = delv_zeta[lzetap.localAccess[i]];
-      when ZETA_P_SYMM do delvp = delv_zeta.localAccess[i];       
+      when 0           do delvp = delv_zeta[lzetap[i]];
+      when ZETA_P_SYMM do delvp = delv_zeta[i];       
       when ZETA_P_FREE do delvp = 0.0;        
     }
 
@@ -1472,19 +1472,19 @@ proc CalcMonotonicQForElems(delv_xi, delv_eta, delv_zeta,
 
     /* Remove length scale */
     var qlin, qquad: real;
-    if vdov.localAccess[i] > 0.0 {
+    if vdov[i] > 0.0 {
       qlin  = 0.0;
       qquad = 0.0;
     } else {
-      var delvxxi   = delv_xi.localAccess[i]   * delx_xi.localAccess[i],
-          delvxeta  = delv_eta.localAccess[i]  * delx_eta.localAccess[i],
-          delvxzeta = delv_zeta.localAccess[i] * delx_zeta.localAccess[i];
+      var delvxxi   = delv_xi[i]   * delx_xi[i],
+          delvxeta  = delv_eta[i]  * delx_eta[i],
+          delvxzeta = delv_zeta[i] * delx_zeta[i];
 
       if delvxxi   > 0.0 then delvxxi   = 0.0;
       if delvxeta  > 0.0 then delvxeta  = 0.0;
       if delvxzeta > 0.0 then delvxzeta = 0.0;
 
-      const rho = elemMass.localAccess[i] / (volo.localAccess[i] * vnew.localAccess[i]);
+      const rho = elemMass[i] / (volo[i] * vnew[i]);
 
       qlin = -qlc_monoq * rho *
         ( delvxxi   * (1.0 - phixi) +
@@ -1496,8 +1496,8 @@ proc CalcMonotonicQForElems(delv_xi, delv_eta, delv_zeta,
           delvxeta**2  * (1.0 - phieta**2) +
           delvxzeta**2 * (1.0 - phizeta**2));
     }
-    qq.localAccess[i] = qquad;
-    ql.localAccess[i] = qlin;
+    qq[i] = qquad;
+    ql[i] = qlin;
 
   }
 }
@@ -1511,33 +1511,33 @@ proc EvalEOSForElems(vnewc) {
 
   /* compress data, minimal set */
   forall i in MatElems {
-    e_old.localAccess[i]  = e.localAccess[i];
-    delvc.localAccess[i]  = delv.localAccess[i];
-    p_old.localAccess[i]  = p.localAccess[i];
-    q_old.localAccess[i]  = q.localAccess[i];
-    qq_old.localAccess[i] = qq.localAccess[i];
-    ql_old.localAccess[i] = ql.localAccess[i];
+    e_old[i]  = e[i];
+    delvc[i]  = delv[i];
+    p_old[i]  = p[i];
+    q_old[i]  = q[i];
+    qq_old[i] = qq[i];
+    ql_old[i] = ql[i];
   }
 
   forall i in Elems do local {
-    compression.localAccess[i] = 1.0 / vnewc.localAccess[i] - 1.0;
-    const vchalf = vnewc.localAccess[i] - delvc.localAccess[i] * 0.5;
-    compHalfStep.localAccess[i] = 1.0 / vchalf - 1.0;
+    compression[i] = 1.0 / vnewc[i] - 1.0;
+    const vchalf = vnewc[i] - delvc[i] * 0.5;
+    compHalfStep[i] = 1.0 / vchalf - 1.0;
   }
 
   /* Check for v > eosvmax or v < eosvmin */
   // (note: I think this was already checked for in calling function!)
   if eosvmin != 0.0 {
     forall i in Elems {
-      if vnewc.localAccess[i] <= eosvmin then compHalfStep.localAccess[i] = compression.localAccess[i];
+      if vnewc[i] <= eosvmin then compHalfStep[i] = compression[i];
     }
   }
   if eosvmax != 0.0 {
     forall i in Elems {
-      if vnewc.localAccess[i] >= eosvmax {
-        p_old.localAccess[i] = 0.0;
-        compression.localAccess[i] = 0.0;
-        compHalfStep.localAccess[i] = 0.0;
+      if vnewc[i] >= eosvmax {
+        p_old[i] = 0.0;
+        compression[i] = 0.0;
+        compHalfStep[i] = 0.0;
       }
     }
   }
@@ -1547,9 +1547,9 @@ proc EvalEOSForElems(vnewc) {
                      vnewc, work, delvc, qq_old, ql_old);
 
   forall i in MatElems {
-    p.localAccess[i] = p_new.localAccess[i];
-    e.localAccess[i] = e_new.localAccess[i];
-    q.localAccess[i] = q_new.localAccess[i];
+    p[i] = p_new[i];
+    e[i] = e_new[i];
+    q[i] = q_new[i];
   }
 
   CalcSoundSpeedForElems(vnewc, rho0, e_new, p_new, pbvc, bvc);
@@ -1568,33 +1568,33 @@ proc CalcEnergyForElems(p_new, e_new, q_new, bvc, pbvc,
   const sixth = 1.0 / 6.0;
 
   forall i in Elems {
-    e_new.localAccess[i] = e_old.localAccess[i] - 0.5 * delvc.localAccess[i] * (p_old.localAccess[i] + q_old.localAccess[i]) 
-                        + 0.5 * work.localAccess[i];
-    if e_new.localAccess[i] < emin then e_new.localAccess[i] = emin;
+    e_new[i] = e_old[i] - 0.5 * delvc[i] * (p_old[i] + q_old[i]) 
+                        + 0.5 * work[i];
+    if e_new[i] < emin then e_new[i] = emin;
   }
 
   CalcPressureForElems(pHalfStep, bvc, pbvc, e_new, compHalfStep,
                        vnewc, pmin, p_cut, eosvmax);
 
   forall i in Elems {
-    const vhalf = 1.0 / (1.0 + compHalfStep.localAccess[i]);
+    const vhalf = 1.0 / (1.0 + compHalfStep[i]);
 
-    if delvc.localAccess[i] > 0.0 {
-      q_new.localAccess[i] = 0.0;
+    if delvc[i] > 0.0 {
+      q_new[i] = 0.0;
     } else {
-      var ssc = (pbvc.localAccess[i] * e_new.localAccess[i] + vhalf**2 * bvc.localAccess[i] * pHalfStep.localAccess[i]) / rho0;
+      var ssc = (pbvc[i] * e_new[i] + vhalf**2 * bvc[i] * pHalfStep[i]) / rho0;
       if ssc <= 0.0 then ssc = 0.333333e-36;
       else ssc = sqrt(ssc);
-      q_new.localAccess[i] = ssc * ql_old.localAccess[i] + qq_old.localAccess[i];
+      q_new[i] = ssc * ql_old[i] + qq_old[i];
     }
 
-    e_new.localAccess[i] += 0.5 * delvc.localAccess[i]
-      * (3.0*(p_old.localAccess[i] + q_old.localAccess[i]) - 4.0*(pHalfStep.localAccess[i] + q_new.localAccess[i]));
+    e_new[i] += 0.5 * delvc[i]
+      * (3.0*(p_old[i] + q_old[i]) - 4.0*(pHalfStep[i] + q_new[i]));
   }
   forall i in Elems {
-    e_new.localAccess[i] += 0.5 * work.localAccess[i];
-    if abs(e_new.localAccess[i] < e_cut) then e_new.localAccess[i] = 0.0;
-    if e_new.localAccess[i] < emin then e_new.localAccess[i] = emin;
+    e_new[i] += 0.5 * work[i];
+    if abs(e_new[i] < e_cut) then e_new[i] = 0.0;
+    if e_new[i] < emin then e_new[i] = emin;
   }
 
   CalcPressureForElems(p_new, bvc, pbvc, e_new, compression, vnewc, pmin,
@@ -1603,20 +1603,20 @@ proc CalcEnergyForElems(p_new, e_new, q_new, bvc, pbvc,
   forall i in Elems {
     var q_tilde:real;
 
-    if delvc.localAccess[i] > 0.0 {
+    if delvc[i] > 0.0 {
       q_tilde = 0.0;
     } else {
-      var ssc = (pbvc.localAccess[i] * e_new.localAccess[i] + vnewc.localAccess[i]**2 * bvc.localAccess[i] * p_new.localAccess[i] ) / rho0;
+      var ssc = (pbvc[i] * e_new[i] + vnewc[i]**2 * bvc[i] * p_new[i] ) / rho0;
       if ssc <= 0.0 then ssc = 0.333333e-36;
       else ssc = sqrt(ssc);
-      q_tilde = ssc * ql_old.localAccess[i] + qq_old.localAccess[i];
+      q_tilde = ssc * ql_old[i] + qq_old[i];
     }
 
-    e_new.localAccess[i] -= (7.0*(p_old.localAccess[i] + q_old.localAccess[i]) 
-                 - 8.0*(pHalfStep.localAccess[i] + q_new.localAccess[i]) 
-                 + (p_new.localAccess[i] + q_tilde)) * delvc.localAccess[i] * sixth;
-    if abs(e_new.localAccess[i]) < e_cut then e_new.localAccess[i] = 0.0;
-    if e_new.localAccess[i] < emin then e_new.localAccess[i] = emin;
+    e_new[i] -= (7.0*(p_old[i] + q_old[i]) 
+                 - 8.0*(pHalfStep[i] + q_new[i]) 
+                 + (p_new[i] + q_tilde)) * delvc[i] * sixth;
+    if abs(e_new[i]) < e_cut then e_new[i] = 0.0;
+    if e_new[i] < emin then e_new[i] = emin;
   }
 
   CalcPressureForElems(p_new, bvc, pbvc, e_new, compression, vnewc, pmin,
@@ -1624,12 +1624,12 @@ proc CalcEnergyForElems(p_new, e_new, q_new, bvc, pbvc,
 
 
   forall i in Elems do local {
-    if delvc.localAccess[i] <= 0.0 {
-      var ssc = (pbvc.localAccess[i] * e_new.localAccess[i] + vnewc.localAccess[i]**2 * bvc.localAccess[i] * p_new.localAccess[i] ) / rho0;
+    if delvc[i] <= 0.0 {
+      var ssc = (pbvc[i] * e_new[i] + vnewc[i]**2 * bvc[i] * p_new[i] ) / rho0;
       if ssc <= 0.0 then ssc = 0.333333e-36;
                     else ssc = sqrt(ssc);
-      q_new.localAccess[i] = ssc * ql_old.localAccess[i] + qq_old.localAccess[i];
-      if abs(q_new.localAccess[i]) < q_cut then q_new.localAccess[i] = 0.0;
+      q_new[i] = ssc * ql_old[i] + qq_old[i];
+      if abs(q_new[i]) < q_cut then q_new[i] = 0.0;
     }
   }
 }
@@ -1641,9 +1641,9 @@ proc CalcSoundSpeedForElems(vnewc, rho0:real, enewc, pnewc, pbvc, bvc) {
   // avoid losing updates?  (Jeff will go back and think on this)
   //
   forall i in MatElems {
-    var ssTmp = (pbvc.localAccess[i] * enewc.localAccess[i] + vnewc.localAccess[i]**2 * bvc.localAccess[i] * pnewc.localAccess[i]) / rho0;
+    var ssTmp = (pbvc[i] * enewc[i] + vnewc[i]**2 * bvc[i] * pnewc[i]) / rho0;
     if ssTmp <= 1.111111e-36 then ssTmp = 1.111111e-36;
-    ss.localAccess[i] = sqrt(ssTmp);
+    ss[i] = sqrt(ssTmp);
   }
 }
 

--- a/test/users/npadmana/npb-mg/mg.chpl
+++ b/test/users/npadmana/npb-mg/mg.chpl
@@ -170,7 +170,7 @@ proc restrict(coarse:[?coarseDom] real, fine : [?FineDom]real) {
                     fine.localAccess[i2+1, j2-1, k2+1] +
                     fine.localAccess[i2+1, j2+1, k2-1] +
                     fine.localAccess[i2+1, j2+1, k2+1]);
-    coarse.localAccess[i,j,k] = tmp;
+    coarse[i,j,k] = tmp;
   }
 }
 


### PR DESCRIPTION
This PR removes explicit `localAccess` calls from some multilocale performance
tests. After https://github.com/chapel-lang/chapel/pull/15713 these calls are
added by the compiler automatically.

I only confirmed the optimization in tests through generated compiler logs. For
LULESH, I did a perf test to confirm that there is no regression on 16-node XC.

Correctness testing:
- [x] standard
- [x] gasnet