### PR TITLE
Add a test for automatic localAccess optimization

### DIFF
--- a/test/optimizations/autoLocalAccess/elemAsIndex.chpl
+++ b/test/optimizations/autoLocalAccess/elemAsIndex.chpl
@@ -1,0 +1,23 @@
+use BlockDist;
+
+// hijack these two methods to provide some output
+inline proc _array.this(i: int) ref {
+  writeln("Custom this was called");
+  return this._value.dsiAccess((i:int,));
+}
+
+inline proc _array.localAccess(i: int) ref {
+  writeln("Custom localAccess was called");
+  return this._value.dsiLocalAccess((i:int,));
+}
+
+
+var A = newBlockArr({1..10}, int);
+
+for (a,i) in zip(A, A.domain) do a=i;
+
+forall a in A {
+  A[a] = a*2;
+}
+
+writeln(A);

--- a/test/optimizations/autoLocalAccess/elemAsIndex.good
+++ b/test/optimizations/autoLocalAccess/elemAsIndex.good
@@ -1,0 +1,32 @@
+**** Start forall ****
+	elemAsIndex.chpl:19
+
+Iterated symbol
+	elemAsIndex.chpl:15
+
+Loop is suitable for further analysis
+	elemAsIndex.chpl:19
+
+Potential access
+	elemAsIndex.chpl:20
+
+Regular domain symbol was not found for array
+	elemAsIndex.chpl:15
+
+	Marking dynamic candidate
+	elemAsIndex.chpl:20
+
+**** End forall ****
+	elemAsIndex.chpl:19
+
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+2 4 6 8 10 12 14 16 18 20

--- a/test/optimizations/autoLocalAccess/zipper/elemAsIndex.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/elemAsIndex.chpl
@@ -1,0 +1,23 @@
+use BlockDist;
+
+// hijack these two methods to provide some output
+inline proc _array.this(i: int) ref {
+  writeln("Custom this was called");
+  return this._value.dsiAccess((i:int,));
+}
+
+inline proc _array.localAccess(i: int) ref {
+  writeln("Custom localAccess was called");
+  return this._value.dsiLocalAccess((i:int,));
+}
+
+
+var A = newBlockArr({1..10}, int);
+
+for (a,i) in zip(A, A.domain) do a=i;
+
+forall (a,i) in zip(A, 1..) {
+  A[a] = a*i;
+}
+
+writeln(A);

--- a/test/optimizations/autoLocalAccess/zipper/elemAsIndex.good
+++ b/test/optimizations/autoLocalAccess/zipper/elemAsIndex.good
@@ -1,0 +1,32 @@
+**** Start forall ****
+	elemAsIndex.chpl:19
+
+Iterated symbol
+	elemAsIndex.chpl:15
+
+Loop is suitable for further analysis
+	elemAsIndex.chpl:19
+
+Potential access
+	elemAsIndex.chpl:20
+
+Regular domain symbol was not found for array
+	elemAsIndex.chpl:15
+
+	Marking dynamic candidate
+	elemAsIndex.chpl:20
+
+**** End forall ****
+	elemAsIndex.chpl:19
+
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+Custom this was called
+1 4 9 16 25 36 49 64 81 100


### PR DESCRIPTION
This PR adds a test for a degenerate pattern that may trick the automatic
localAccess optimization.

I thought about this case while working on something else, and couldn't be sure
whether we would generate the correct code without trying. The pattern is:

```chapel
var A = newBlockArr({1..10}, int);

for (a,i) in zip(A, A.domain) do a=i;

forall a in A {
  A[a] = a*2;
}
```
Something like this is legal, though the motivation is questionable. We
currently do not optimize this case and that's the right thing to do. Added test
locks in that behavior.

Test:
- [x] standard
