### PR TITLE
Refactor mason update

### DIFF
--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -168,6 +168,17 @@ proc masonModifyHelp() {
   writeln("Package names and versions are not validated upon adding");
 }
 
+proc masonUpdateHelp() {
+  writeln("Updates/Generates Mason.lock file");
+  writeln("Usage:");
+  writeln("    mason update [options]");
+  writeln();
+  writeln("Options:");
+  writeln("    -h, --help                  Display this message");
+  writeln("    --update                    Explicitly set MASON_OFFLINE to true");
+  writeln("    --[no-]update               Overrides the default MASON_OFFLINE value");
+}
+
 proc masonEnvHelp() {
   writeln("Print environment variables recognized by mason");
   writeln();

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -27,6 +27,7 @@ use MasonUtils;
 use MasonEnv;
 use MasonSystem;
 use MasonExternal;
+use MasonHelp;
 
 
 /*
@@ -60,7 +61,10 @@ proc UpdateLock(args: [?d] string, tf="Mason.toml", lf="Mason.lock") {
 proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {
 
   try! {
-
+    if args.count('-h') == 1 || args.count('--help') == 1 {
+      masonUpdateHelp();
+      exit(0);
+    }
     const cwd = getEnv("PWD");
     const projectHome = getProjectHome(cwd, tf);
     const tomlPath = projectHome + "/" + tf;

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -84,7 +84,7 @@ proc main(args: [] string) throws {
       when 'add' do masonModify(args);
       when 'rm' do masonModify(args);
       when 'build' do masonBuild(args);
-      when 'update' do UpdateLock(args);
+      when 'update' do masonUpdate(args);
       when 'run' do masonRun(args);
       when 'search' do masonSearch(args);
       when 'system' do masonSystem(args);


### PR DESCRIPTION
fixes #13211 & #14990
- [x] Fix bug where `mason update --help` doesn't show help message and runs update instead.
- [x] Refactor mason update function.
- [x] Select style arg parsing

