### PR TITLE
Allow test name to be used as an explicit dat/perfkeys filename

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -2234,7 +2234,8 @@ for testname in testsrc:
                         keyfile = PerfTFile(test_filename,'keys') #e.g. .perfkeys
                     else:
                         perfexecname = re.sub(r'\{0}$'.format(PerfSfx('keys')), '', explicitexecgoodfile)
-                        if os.path.isfile(explicitexecgoodfile):
+                        if (os.path.isfile(explicitexecgoodfile) and
+                            test_filename != explicitexecgoodfile):
                             keyfile = explicitexecgoodfile
                         else:
                             keyfile = PerfTFile(test_filename,'keys')


### PR DESCRIPTION
This PR adjusts sub_test to ignore the actual test executable while trying
to create a base name for .dat and .perfkeys files for performance tests.

Resolves https://github.com/Cray/chapel-private/issues/1170
Solution proposed by @ronawho

While trying to expand a performance test, I wanted to:

- Add a `.perfcompopts` file
- Retain the existing test data. This data was stored in `foo.dat` for the test `foo.chpl`

So, while writing the perfcompopts, I did something like

```
-smode=0  # foo
-smode=1  # foo-mode1
-smode=2  # foo-mode2
```

However, this resulted in trying to read `foo` as the first compopt's key file, which is
actually the executable. 

Test:
- [x] full standard
- [x] `start_test -performance` in `test/performance`