### PR TITLE
Fix Crypto module under --llvm

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -688,7 +688,7 @@ GenRet VarSymbol::codegenVarSymbol(bool lhsInSetReference) {
 #endif
   }
 
-  USR_FATAL("Could not find C type %s - "
+  USR_FATAL(this->defPoint, "Could not find C type %s - "
             "perhaps it is a complex macro?", cname);
   return ret;
 }
@@ -2539,7 +2539,8 @@ GenRet FnSymbol::codegen() {
           if( isBuiltinExternCFunction(cname) ) {
             // it's OK.
           } else {
-            USR_FATAL("Could not find C function for %s; "
+            USR_FATAL(this->defPoint,
+                      "Could not find C function for %s; "
                       " perhaps it is missing or is a macro?", cname);
           }
         } else {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -596,9 +596,20 @@ static void handleMacroTokens(const MacroInfo* inMacro,
   if (_unsigned == 0 && _signed == 0 &&
       _long == 0 && _short == 0 &&
       _int == 0 && _char == 0 && _float == 0 && _double == 0) {
+
     Token tok = *start; // the main token
+    ++start;
+
+    // Give up if there are any tokens beyond the main token
+    if (start != end)
+      return;
+
     handleMacroToken(inMacro, negate, tok, varRet, cTypeRet, cValueRet);
   } else {
+    // Give up if we didn't handle all the tokens in the above loop
+    if (start != end)
+      return;
+
     const char* nType = NULL;
     if (_double > 0) nType = "c_double";
     else if (_float > 0) nType = "c_float";

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -368,7 +368,7 @@ module Crypto {
   pragma "no doc"
   proc digestPrimitives(digestName: string, hashLen: int, inputBuffer: CryptoBuffer) {
 
-    OpenSSL_add_all_digests();
+    CHPL_OpenSSL_add_all_digests();
 
     var ctx = CHPL_EVP_MD_CTX_new();
 
@@ -919,7 +919,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
   pragma "no doc"
   proc PBKDF2(userKey: string, saltBuff: CryptoBuffer, byteLen: int, iterCount: int, digestName: string) {
 
-    OpenSSL_add_all_digests();
+    CHPL_OpenSSL_add_all_digests();
 
     var key: [0..#byteLen] uint(8);
     var salt = saltBuff.getBuffData();
@@ -1208,6 +1208,15 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     extern type CONST_EVP_MD_PTR;
     extern type CONST_EVP_CIPHER_PTR;
 
+    extern type EVP_MD;
+    extern type EVP_MD_CTX;
+    extern type CHPL_EVP_MD_CTX;
+    extern type ENGINE;
+
+    type EVP_MD_PTR = c_ptr(EVP_MD);
+    type EVP_MD_CTX_PTR = c_ptr(EVP_MD_CTX);
+    type ENGINE_PTR = c_ptr(ENGINE);
+
     extern proc EVP_CIPHER_iv_length(e: CONST_EVP_CIPHER_PTR): c_int;
     extern proc EVP_PKEY_size(pkey: EVP_PKEY_PTR): c_int;
     extern proc EVP_PKEY_CTX_new_id(id: c_int, e: ENGINE_PTR): EVP_PKEY_CTX_PTR;
@@ -1229,16 +1238,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
                                outl: c_ptr(c_int), inp: c_ptr(c_uchar), inl: c_int): c_int;
     extern proc EVP_OpenFinal(ref ctx: EVP_CIPHER_CTX, outm: c_ptr(c_uchar), outl: c_ptr(c_int)): c_int;
 
-    extern type EVP_MD;
-    extern type EVP_MD_CTX;
-    extern type CHPL_EVP_MD_CTX;
-    extern type ENGINE;
-
-    extern type EVP_MD_PTR = c_ptr(EVP_MD);
-    extern type EVP_MD_CTX_PTR = c_ptr(EVP_MD_CTX);
-    extern type ENGINE_PTR = c_ptr(ENGINE);
-
-    extern proc OpenSSL_add_all_digests();
+    extern proc CHPL_OpenSSL_add_all_digests();
     extern proc EVP_get_digestbyname(name: c_string): CONST_EVP_MD_PTR;
 
     extern proc CHPL_EVP_MD_CTX_new(): CHPL_EVP_MD_CTX;

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -1217,6 +1217,13 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     type EVP_MD_CTX_PTR = c_ptr(EVP_MD_CTX);
     type ENGINE_PTR = c_ptr(ENGINE);
 
+    extern type EVP_CIPHER;
+    extern type EVP_CIPHER_CTX;
+    extern type CHPL_EVP_CIPHER_CTX;
+
+    type EVP_CIPHER_PTR = c_ptr(EVP_CIPHER);
+    type EVP_CIPHER_CTX_PTR = c_ptr(EVP_CIPHER_CTX);
+
     extern proc EVP_CIPHER_iv_length(e: CONST_EVP_CIPHER_PTR): c_int;
     extern proc EVP_PKEY_size(pkey: EVP_PKEY_PTR): c_int;
     extern proc EVP_PKEY_CTX_new_id(id: c_int, e: ENGINE_PTR): EVP_PKEY_CTX_PTR;
@@ -1247,13 +1254,6 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     extern proc EVP_DigestInit_ex(ctx: EVP_MD_CTX_PTR, types: CONST_EVP_MD_PTR, impl: ENGINE_PTR): c_int;
     extern proc EVP_DigestUpdate(ctx: EVP_MD_CTX_PTR, const d: c_void_ptr, cnt: size_t): c_int;
     extern proc EVP_DigestFinal_ex(ctx: EVP_MD_CTX_PTR, md: c_ptr(c_uchar), ref s: c_uint): c_int;
-
-    extern type EVP_CIPHER;
-    extern type EVP_CIPHER_CTX;
-    extern type CHPL_EVP_CIPHER_CTX;
-
-    extern type EVP_CIPHER_PTR = c_ptr(EVP_CIPHER);
-    extern type EVP_CIPHER_CTX_PTR = c_ptr(EVP_CIPHER_CTX);
 
     extern proc RAND_bytes(buf: c_ptr(c_uchar), num: c_int) : c_int;
 

--- a/modules/packages/CryptoHandlers/openssl_c_support.h
+++ b/modules/packages/CryptoHandlers/openssl_c_support.h
@@ -22,6 +22,7 @@
 //  * work around issues with openssl defining I in conflict with C std
 //  * insulate the Chapel code from fiddly differences between 1.0.2 and 1.1
 //  * work around issues with constant pointers in generated C code
+//  * work around problems with macro-functions for the LLVM backend
 
 #undef I
 #include <openssl/rsa.h>
@@ -91,3 +92,7 @@ static inline EVP_CIPHER_CTX* CHPL_EVP_CIPHER_CTX_ptr(CHPL_EVP_CIPHER_CTX* arg) 
 
 #endif
 
+static inline void CHPL_OpenSSL_add_all_digests(void) {
+  // OpenSSL_add_all_digests is a complex macro in some implementations
+  OpenSSL_add_all_digests();
+}

--- a/test/llvm/macros/COMPOPTS
+++ b/test/llvm/macros/COMPOPTS
@@ -1,0 +1,1 @@
+--llvm complex-macros.h

--- a/test/llvm/macros/SKIPIF
+++ b/test/llvm/macros/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_LLVM==none

--- a/test/llvm/macros/complex-macro1.chpl
+++ b/test/llvm/macros/complex-macro1.chpl
@@ -1,0 +1,5 @@
+extern proc ComplexFnLike();
+
+proc main() {
+  ComplexFnLike();
+}

--- a/test/llvm/macros/complex-macro1.good
+++ b/test/llvm/macros/complex-macro1.good
@@ -1,0 +1,1 @@
+complex-macro1.chpl:1: error: Could not find C function for ComplexFnLike;  perhaps it is missing or is a macro?

--- a/test/llvm/macros/complex-macro2.chpl
+++ b/test/llvm/macros/complex-macro2.chpl
@@ -1,0 +1,6 @@
+extern type ComplexType;
+
+proc main() {
+  var a: ComplexType;
+  writeln(c_ptrTo(a):c_void_ptr);
+}

--- a/test/llvm/macros/complex-macro2.good
+++ b/test/llvm/macros/complex-macro2.good
@@ -1,0 +1,1 @@
+complex-macro2.chpl:1: error: Could not find C type for ComplexType

--- a/test/llvm/macros/complex-macro3.chpl
+++ b/test/llvm/macros/complex-macro3.chpl
@@ -1,3 +1,4 @@
+use SysCTypes;
 extern var ComplexVar:c_int;
 
 proc main() {

--- a/test/llvm/macros/complex-macro3.chpl
+++ b/test/llvm/macros/complex-macro3.chpl
@@ -1,0 +1,6 @@
+extern var ComplexVar:c_int;
+
+proc main() {
+  var i = ComplexVar;
+  writeln(i);
+}

--- a/test/llvm/macros/complex-macro3.good
+++ b/test/llvm/macros/complex-macro3.good
@@ -1,1 +1,1 @@
-complex-macro3.chpl:1: error: 'c_int' undeclared (first use this function)
+complex-macro3.chpl:2: error: Could not find C type ComplexVar - perhaps it is a complex macro?

--- a/test/llvm/macros/complex-macro3.good
+++ b/test/llvm/macros/complex-macro3.good
@@ -1,0 +1,1 @@
+complex-macro3.chpl:1: error: 'c_int' undeclared (first use this function)

--- a/test/llvm/macros/complex-macro4.chpl
+++ b/test/llvm/macros/complex-macro4.chpl
@@ -1,0 +1,5 @@
+extern proc ComplexFnLikeArgs(arg);
+
+proc main() {
+  ComplexFnLikeArgs(1);
+}

--- a/test/llvm/macros/complex-macro4.good
+++ b/test/llvm/macros/complex-macro4.good
@@ -1,0 +1,1 @@
+complex-macro4.chpl:1: error: Could not find C function for ComplexFnLikeArgs;  perhaps it is missing or is a macro?

--- a/test/llvm/macros/complex-macros.h
+++ b/test/llvm/macros/complex-macros.h
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+#define ComplexFnLike() \
+  printf("hi\n")
+
+#define ComplexFnLikeArgs(arg) \
+  printf("hi %i\n", arg)
+
+#define MAKE_UNSIGNED(a) \
+  unsigned a
+
+#define ComplexType \
+  MAKE_UNSIGNED(int)
+
+#define ComplexVar \
+  getchar()


### PR DESCRIPTION
This PR takes two steps motivated by the Crypto module under --llvm.

First, it adds better checking for unsupported macros used in --llvm

When calling a macro like the below with --llvm, the compiler should emit
an error, but instead it was trying to call `OPENSSL_init_crypto()`.

```
 #define OpenSSL_add_all_digests() \
   OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_DIGESTS, NULL)
```

Add tests to check that these cases behave reasonably.

Second, it updates the Crypto module to avoid 2 problems with --llvm

First, on some versions of libssl, `OpenSSL_add_all_digests` is a macro.
So call it from a `static inline` function that is defined in
`CryptoHandlers/openssl_c_support.h`.

Second, after PR #16057, the compiler began (correctly) showing errors
for the declarations like

```
 extern type EVP_MD_PTR = c_ptr(EVP_MD);
```

In fact `EVP_MD_PTR` is not a type defined in C at all (at least
with the version of libssl I have been using). So change these
to

```
 type EVP_MD_PTR = c_ptr(EVP_MD);
```

and move these and related types to before they are used in the extern
proc declarations.

Reviewed by @e-kayrakli - thanks!

- [x] test/library/packages/Crypto/saru passes on an Ubuntu 20.04 system
- [x] full local testing with CHPL_LLVM=system
- [x] full local testing with --llvm