### PR TITLE
Update Arkouda setup.py extras_require key 'test' -> 'dev'

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -48,7 +48,7 @@ fi
 
 # Install Arkouda and python dependencies to a python-deps subdir
 export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
-if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir -e .[test] --user ; then
+if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir -e .[dev] --user ; then
   log_fatal_error "installing arkouda"
 fi
 


### PR DESCRIPTION
https://github.com/mhmerrill/arkouda/pull/426 changed the `extras_require` key name from `test` to `dev`. This PR updates our key to `dev` in nightly testing.