### PR TITLE
Fix a forwarding bug with out-intent arguments

### DIFF
--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -40,6 +40,7 @@ CallExpr::CallExpr(BaseAST* base,
   partialTag = false;
   methodTag  = false;
   square     = false;
+  forwarderCall = NULL;
   tryTag     = TRY_TAG_NONE;
 
   if (Symbol* b = toSymbol(base)) {
@@ -73,6 +74,7 @@ CallExpr::CallExpr(PrimitiveOp* prim,
   partialTag = false;
   methodTag  = false;
   square     = false;
+  forwarderCall = NULL;
   tryTag     = TRY_TAG_NONE;
 
   callExprHelper(this, arg1);
@@ -97,6 +99,7 @@ CallExpr::CallExpr(PrimitiveTag prim,
   partialTag = false;
   methodTag  = false;
   square     = false;
+  forwarderCall = NULL;
   tryTag     = TRY_TAG_NONE;
 
   callExprHelper(this, arg1);
@@ -121,6 +124,7 @@ CallExpr::CallExpr(const char* name,
   partialTag = false;
   methodTag  = false;
   square     = false;
+  forwarderCall = NULL;
   tryTag     = TRY_TAG_NONE;
 
   callExprHelper(this, arg1);

--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -35,13 +35,13 @@ CallExpr::CallExpr(BaseAST* base,
                    BaseAST* arg3,
                    BaseAST* arg4,
                    BaseAST* arg5) : Expr(E_CallExpr) {
-  primitive  = NULL;
-  baseExpr   = NULL;
-  partialTag = false;
-  methodTag  = false;
-  square     = false;
+  primitive     = NULL;
+  baseExpr      = NULL;
+  partialTag    = false;
+  methodTag     = false;
+  square        = false;
   forwarderCall = NULL;
-  tryTag     = TRY_TAG_NONE;
+  tryTag        = TRY_TAG_NONE;
 
   if (Symbol* b = toSymbol(base)) {
     baseExpr = new SymExpr(b);
@@ -69,13 +69,13 @@ CallExpr::CallExpr(PrimitiveOp* prim,
                    BaseAST*     arg3,
                    BaseAST*     arg4,
                    BaseAST*     arg5) : Expr(E_CallExpr) {
-  primitive  = prim;
-  baseExpr   = NULL;
-  partialTag = false;
-  methodTag  = false;
-  square     = false;
+  primitive     = prim;
+  baseExpr      = NULL;
+  partialTag    = false;
+  methodTag     = false;
+  square        = false;
   forwarderCall = NULL;
-  tryTag     = TRY_TAG_NONE;
+  tryTag        = TRY_TAG_NONE;
 
   callExprHelper(this, arg1);
   callExprHelper(this, arg2);
@@ -94,13 +94,13 @@ CallExpr::CallExpr(PrimitiveTag prim,
                    BaseAST*     arg3,
                    BaseAST*     arg4,
                    BaseAST*     arg5) : Expr(E_CallExpr) {
-  primitive  = primitives[prim];
-  baseExpr   = NULL;
-  partialTag = false;
-  methodTag  = false;
-  square     = false;
+  primitive     = primitives[prim];
+  baseExpr      = NULL;
+  partialTag    = false;
+  methodTag     = false;
+  square        = false;
   forwarderCall = NULL;
-  tryTag     = TRY_TAG_NONE;
+  tryTag        = TRY_TAG_NONE;
 
   callExprHelper(this, arg1);
   callExprHelper(this, arg2);
@@ -119,13 +119,13 @@ CallExpr::CallExpr(const char* name,
                    BaseAST*    arg3,
                    BaseAST*    arg4,
                    BaseAST*    arg5) : Expr(E_CallExpr) {
-  primitive  = NULL;
-  baseExpr   = new UnresolvedSymExpr(name);
-  partialTag = false;
-  methodTag  = false;
-  square     = false;
+  primitive     = NULL;
+  baseExpr      = new UnresolvedSymExpr(name);
+  partialTag    = false;
+  methodTag     = false;
+  square        = false;
   forwarderCall = NULL;
-  tryTag     = TRY_TAG_NONE;
+  tryTag        = TRY_TAG_NONE;
 
   callExprHelper(this, arg1);
   callExprHelper(this, arg2);

--- a/compiler/include/CallExpr.h
+++ b/compiler/include/CallExpr.h
@@ -116,6 +116,8 @@ public:
   Expr*           get(int index)                                         const;
   FnSymbol*       findFnSymbol();
 
+  CallExpr*       forwarderCall;
+
   void            convertToNoop();
 
   static void     registerPrimitivesForCodegen();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4449,9 +4449,6 @@ static const char* getForwardedMethodName(const char* calledName,
 
 static FnSymbol* adjustAndResolveForwardedCall(CallExpr* call, ForwardingStmt* delegate, const char* methodName) {
 
-      if (strcmp(call->fname(), "/Users/ekayraklio/code/chapel/versions/f01/chapel/rapizForwardingTest.chpl") == 0) {
-        gdbShouldBreakHere();
-      }
   FnSymbol* ret = NULL;
   const char* fnGetTgt   = delegate->fnReturningForwarding;
   Expr* receiver = call->get(2);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4449,6 +4449,9 @@ static const char* getForwardedMethodName(const char* calledName,
 
 static FnSymbol* adjustAndResolveForwardedCall(CallExpr* call, ForwardingStmt* delegate, const char* methodName) {
 
+      if (strcmp(call->fname(), "/Users/ekayraklio/code/chapel/versions/f01/chapel/rapizForwardingTest.chpl") == 0) {
+        gdbShouldBreakHere();
+      }
   FnSymbol* ret = NULL;
   const char* fnGetTgt   = delegate->fnReturningForwarding;
   Expr* receiver = call->get(2);
@@ -4587,6 +4590,7 @@ static FnSymbol* resolveForwardedCall(CallInfo& info, check_state_t checkState) 
     // Create a block to store temporaries etc.
     // Store it just before the call being resolved.
     CallExpr* forwardedCall = call->copy();
+    forwardedCall->forwarderCall = call;
     BlockStmt* block = new BlockStmt(forwardedCall, BLOCK_SCOPELESS);
     call->getStmtExpr()->insertBefore(block);
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -61,6 +61,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "view.h"
 #include "visibleFunctions.h"
 
 #include <map>
@@ -1771,6 +1772,11 @@ static void handleOutIntents(FnSymbol* fn, CallExpr* call) {
 
   Expr* anchor = call->getStmtExpr();
   Expr* anchorAfter = call->getStmtExpr();
+  if (CallExpr *anchorCE = toCallExpr(anchorAfter)) {
+    if (anchorCE->forwarderCall) {
+      anchorAfter = anchorCE->forwarderCall;
+    }
+  }
 
   Expr* currActual = call->get(1);
   Expr* nextActual = NULL;
@@ -1820,7 +1826,15 @@ static void handleOutIntents(FnSymbol* fn, CallExpr* call) {
 
       CallExpr* assign = new CallExpr("=", actualSym, tmp);
       anchorAfter->insertAfter(assign);
+      anchor->insertAfter(assign->copy());
+      if (strcmp(anchor->fname(), "/Users/ekayraklio/code/chapel/versions/f01/chapel/rapizForwardingTest.chpl") == 0) {
+        gdbShouldBreakHere();
+        nprint_view(assign);
+        std::cout << " was inserted after" << std::endl;
+        nprint_view(anchorAfter);
+      }
       anchorAfter = assign;
+      resolveCall(assign);
 
       currActual->replace(new SymExpr(tmp));
     }

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -61,7 +61,6 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
-#include "view.h"
 #include "visibleFunctions.h"
 
 #include <map>
@@ -1826,13 +1825,6 @@ static void handleOutIntents(FnSymbol* fn, CallExpr* call) {
 
       CallExpr* assign = new CallExpr("=", actualSym, tmp);
       anchorAfter->insertAfter(assign);
-      anchor->insertAfter(assign->copy());
-      if (strcmp(anchor->fname(), "/Users/ekayraklio/code/chapel/versions/f01/chapel/rapizForwardingTest.chpl") == 0) {
-        gdbShouldBreakHere();
-        nprint_view(assign);
-        std::cout << " was inserted after" << std::endl;
-        nprint_view(anchorAfter);
-      }
       anchorAfter = assign;
       resolveCall(assign);
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1826,7 +1826,6 @@ static void handleOutIntents(FnSymbol* fn, CallExpr* call) {
       CallExpr* assign = new CallExpr("=", actualSym, tmp);
       anchorAfter->insertAfter(assign);
       anchorAfter = assign;
-      resolveCall(assign);
 
       currActual->replace(new SymExpr(tmp));
     }


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/16045

The bug was rooted in how forwarding and out-intent handling added new AST
nodes.

```
(call foo (forwarder, outArg))
```

is first transformed into

```
(call forwardedCopy (forwardee, outArg))
(call foo (forwarder, outArg))
```

Then, the first call is resolved, and if the resolution was successful, the
second call's base and actuals are replaced with the ones in the first call.
And the first call is removed. However the first call is used as "anchor" when
adding new AST, which is the wrong thing to do w.r.t. out intent arguments. The
above AST is then transformed into:

```
(def formal_tmp)
(call forwardedCopy (forwardee, formal_tmp))
(= outArg formal_tmp)
(call foo (forwarder, outArg))
```

And then, the `forwardedCopy`s exprs are removed and put into `foo`:
```
(def formal_tmp)
(= outArg formal_tmp)
(call foo (forwardee, formal_tmp))
```

leaving the assignment to the actual in the wrong side of the call.

This PR adds a `forwarderCall` field to `CallExpr` and uses that as anchor while
adding the assignment to the out-intent argument. So we have something like:

```
(def formal_tmp)
(call forwardedCopy (forwardee, formal_tmp))
(call foo (forwarder, outArg))
(= outArg formal_tmp)
```

Before deleting the temp call for forwarding resolution.
