### PR TITLE
Optimize ASCII strings

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -103,6 +103,7 @@ module ByteBufferHelpers {
   inline proc bufferCopyLocal(src_addr: bufferType, len: int) {
       const (dst, allocSize) = bufferAlloc(len+1);
       bufferMemcpyLocal(dst=dst, src=src_addr, len=len);
+      dst[len] = 0;
       return (dst, allocSize);
   }
 

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -675,7 +675,7 @@ module Bytes {
               :mod:`bytes <Bytes>`.
    */
   inline proc bytes.find(needle: bytes, region: range(?) = this.indices) : idxType {
-    return doSearch(this, needle, region, count=false): idxType;
+    return doSearchNoEnc(this, needle, region, count=false): idxType;
   }
 
   /*
@@ -692,7 +692,8 @@ module Bytes {
               :mod:`bytes <Bytes>`.
    */
   inline proc bytes.rfind(needle: bytes, region: range(?) = this.indices) : idxType {
-    return doSearch(this, needle, region, count=false, fromLeft=false): idxType;
+    return doSearchNoEnc(this, needle, region, count=false,
+                         fromLeft=false): idxType;
   }
 
   /*
@@ -707,7 +708,7 @@ module Bytes {
     :returns: the number of times `needle` occurs in the :mod:`bytes <Bytes>`
    */
   inline proc bytes.count(needle: bytes, region: range(?) = this.indices) : int {
-    return doSearch(this, needle, region, count=true);
+    return doSearchNoEnc(this, needle, region, count=true);
   }
 
   /*

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -814,46 +814,7 @@ module Bytes {
                 occurrences of characters in `chars` removed as appropriate.
     */
     proc bytes.strip(chars = b" \t\r\n", leading=true, trailing=true) : bytes {
-      if this.isEmpty() then return b"";
-      if chars.isEmpty() then return this;
-
-      const localThis: bytes = this.localize();
-      const localChars: bytes = chars.localize();
-
-      var start: idxType = 0;
-      var end: idxType = localThis.buffLen-1;
-
-      if leading {
-        label outer for (i, thisChar) in zip(this.indices, localThis.bytes()) {
-          for removeChar in localChars.bytes() {
-            if thisChar == removeChar {
-              start = i + 1;
-              continue outer;
-            }
-          }
-          break;
-        }
-      }
-
-      if trailing {
-        // Because we are working with codepoints whose starting byte index
-        // is not initially known, it is faster to work forward, assuming we
-        // are already past the end of the string, and then update the end
-        // point as we are proven wrong.
-        end = 0;
-        label outer for (i, thisChar) in zip(this.indices, localThis.bytes()) {
-          for removeChar in localChars.bytes() {
-            if thisChar == removeChar {
-              continue outer;
-            }
-          }
-          // This was not a character to be removed, so update tentative end.
-          end = i;
-        }
-      }
-
-      return localThis[start..end];
-
+      return doStripNoEnc(this, chars, leading, trailing);
     }
 
     /*

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -756,73 +756,7 @@ module Bytes {
     :yields: :mod:`bytes <Bytes>` 
    */
   iter bytes.split(maxsplit: int = -1) : bytes {
-    if !this.isEmpty() {
-      const localThis: bytes = this.localize();
-      var done : bool = false;
-      var yieldChunk : bool = false;
-      var chunk : bytes;
-
-      const noSplits : bool = maxsplit == 0;
-      const limitSplits : bool = maxsplit > 0;
-      var splitCount: int = 0;
-      const iEnd: idxType = localThis.buffLen - 2;
-
-      var inChunk : bool = false;
-      var chunkStart : idxType;
-
-      for (i,c) in zip(this.indices, localThis.bytes()) {
-        // emit whole string, unless all whitespace
-        // TODO Engin: Why is this inside the loop?
-        if noSplits {
-          done = true;
-          if !localThis.isSpace() then {
-            chunk = localThis;
-            yieldChunk = true;
-          }
-        } else {
-          var cSpace = byte_isWhitespace(c);
-          // first char of a chunk
-          if !(inChunk || cSpace) {
-            chunkStart = i;
-            inChunk = true;
-            if i > iEnd {
-              chunk = localThis[chunkStart..];
-              yieldChunk = true;
-              done = true;
-            }
-          } else if inChunk {
-            // first char out of a chunk
-            if cSpace {
-              splitCount += 1;
-              // last split under limit
-              if limitSplits && splitCount > maxsplit {
-                chunk = localThis[chunkStart..];
-                yieldChunk = true;
-                done = true;
-              // no limit
-              } else {
-                chunk = localThis[chunkStart..i-1];
-                yieldChunk = true;
-                inChunk = false;
-              }
-            // out of chars
-            } else if i > iEnd {
-              chunk = localThis[chunkStart..];
-              yieldChunk = true;
-              done = true;
-            }
-          }
-        }
-
-        if yieldChunk {
-          yield chunk;
-          yieldChunk = false;
-        }
-        if done then
-          break;
-      }
-    }
-
+    for s in doSplitWSNoEnc(this, maxsplit) do yield s;
   }
 
     /*
@@ -1368,70 +1302,6 @@ module Bytes {
   pragma "no doc"
   inline proc >(param a: bytes, param b: bytes) param {
     return (__primitive("string_compare", a, b) > 0);
-  }
-
-  // character-wise operation helpers
-
-  require "ctype.h";
-
-  private inline proc byte_isAscii(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isascii(c: c_int): c_int;
-    return isascii(c: c_int) != 0;
-  }
-
-  private inline proc byte_isWhitespace(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isspace(c: c_int): c_int;
-    return isspace(c: c_int) != 0;
-  }
-
-  private inline proc byte_isPrintable(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isprint(c: c_int): c_int;
-    return isprint(c: c_int) != 0;
-  }
-
-  private inline proc byte_isAlpha(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isalpha(c: c_int): c_int;
-    return isalpha(c: c_int) != 0;
-  }
-
-  private inline proc byte_isUpper(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isupper(c: c_int): c_int;
-    return isupper(c: c_int) != 0;
-  }
-
-  private inline proc byte_isLower(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc islower(c: c_int): c_int;
-    return islower(c: c_int) != 0;
-  }
-
-  private inline proc byte_isDigit(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isdigit(c: c_int): c_int;
-    return isdigit(c: c_int) != 0;
-  }
-
-  private inline proc byte_isAlnum(c: byteType): bool {
-    pragma "fn synchronization free"
-    extern proc isalnum(c: c_int): c_int;
-    return isalnum(c: c_int) != 0;
-  }
-
-  private inline proc byte_toUpper(c: byteType): byteType {
-    pragma "fn synchronization free"
-    extern proc toupper(c: c_int): c_int;
-    return toupper(c: c_int):byteType;
-  }
-
-  private inline proc byte_toLower(c: byteType): byteType {
-    pragma "fn synchronization free"
-    extern proc tolower(c: c_int): c_int;
-    return tolower(c: c_int):byteType;
   }
 
   //

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -680,15 +680,17 @@ module BytesStringCommon {
             then 0..#(numPossible)
             else 0..#(numPossible) by -1;
         for i in searchSpace {
-          const bufIdx = view.orderToIndex(i);
-          const found = bufferEqualsLocal(buf1=x.buff, off1=bufIdx,
-                                          buf2=localNeedle.buff, off2=0,
-                                          len=needleLen);
-          if found {
-            if count {
-              localRet += 1;
-            } else { // find
-              localRet = view.orderToIndex(i);
+          // j *is* the index into the localNeedle's buffer
+          for j in 0..#nLen {
+            const idx = view.orderToIndex(i+j); // 0s based idx
+            if x.buff[idx] != localNeedle.buff[j] then break;
+
+            if j == nLen-1 {
+              if count {
+                localRet += 1;
+              } else { // find
+                localRet = view.orderToIndex(i);
+              }
             }
           }
           if !count && localRet != -1 then break;

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -350,7 +350,7 @@ module BytesStringCommon {
       compilerError("codepointIndex ranges cannot be used with bytes in getView");
     }
 
-    if t == bytes || r.idxType == byteIndex {
+    proc simpleCaseHelper() {
       // cast the argument r to `int` to make sure that we are not dealing with
       // byteIndex
       const intR = r:range(int, r.boundedType, r.stridable);
@@ -361,6 +361,13 @@ module BytesStringCommon {
         }
       }
       return (intR[x.byteIndices], -1);  // -1; I can't know numCodepoints
+    }
+
+    if t == bytes || r.idxType == byteIndex {
+      return simpleCaseHelper();
+    }
+    else if t == string && x.isASCII() {
+      return simpleCaseHelper();
     }
     else {  // string with codepoint indexing
       if r.stridable {

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -553,8 +553,8 @@ module BytesStringCommon {
   // Helper function that uses a param bool to toggle between count and find
   //TODO: this could be a much better string search
   //      (Boyer-Moore-Horspool|any thing other than brute force)
-  proc doSearch(const ref x: ?t, needle: t, region: range(?),
-                param count: bool, param fromLeft: bool = true) {
+  proc doSearchNoEnc(const ref x: ?t, needle: t, region: range(?),
+                     param count: bool, param fromLeft: bool = true) {
     assertArgType(t, "doSearch");
 
     // needle.buffLen is <= than x.buffLen, so go to the home locale

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -360,7 +360,13 @@ module BytesStringCommon {
                x.numBytes);
         }
       }
-      return (intR[x.byteIndices], -1);  // -1; I can't know numCodepoints
+      if r.idxType == byteIndex {
+        return (intR[x.byteIndices], -1);  // -1; I can't know numCodepoints
+      }
+      else {
+        const retRange = intR[x.byteIndices];
+        return (retRange, retRange.size); // it maybe ascii string or bytes
+      }
     }
 
     if t == bytes || r.idxType == byteIndex {

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -356,8 +356,8 @@ module BytesStringCommon {
       const intR = r:range(int, r.boundedType, r.stridable);
       if boundsChecking {
         if !x.byteIndices.boundsCheck(intR) {
-          halt("range ", r, " out of bounds for " + t:string + " with ",
-               x.numBytes, " bytes");
+          halt("range ", r, " out of bounds for " + t:string + " with length ",
+               x.numBytes);
         }
       }
       return (intR[x.byteIndices], -1);  // -1; I can't know numCodepoints

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1221,7 +1221,7 @@ module String {
   proc string.encode(policy=encodePolicy.pass): bytes {
     var localThis: string = this.localize();
 
-    if policy == encodePolicy.pass {  // just copy
+    if policy == encodePolicy.pass || this.isASCII() {  // just copy
       return createBytesWithNewBuffer(localThis.buff, localThis.numBytes);
     }
     else {  // see if there is escaped data in the string

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2053,19 +2053,13 @@ module String {
       var result: string = this;
       if result.isEmpty() then return result;
 
-      var i = 0;
-      while i < result.buffLen {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=result.buff,
-                                                   buffLen=result.buffLen,
-                                                   offset=i,
-                                                   allowEsc=false);
+      for (cp, i, nBytes) in this._cpIndexLen() {
         var lowCodepoint = codepoint_toLower(cp);
         if lowCodepoint != cp && qio_nbytes_char(lowCodepoint) == nBytes {
           // Use the MacOS approach everywhere:  only change the case if
           // the result does not change the number of encoded bytes.
           qio_encode_char_buf(result.buff + i, lowCodepoint);
         }
-        i += nBytes;
       }
       return result;
     }
@@ -2083,19 +2077,13 @@ module String {
       var result: string = this;
       if result.isEmpty() then return result;
 
-      var i = 0;
-      while i < result.buffLen {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=result.buff,
-                                                   buffLen=result.buffLen,
-                                                   offset=i,
-                                                   allowEsc=false);
+      for (cp, i, nBytes) in this._cpIndexLen() {
         var upCodepoint = codepoint_toUpper(cp);
         if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
           // Use the MacOS approach everywhere:  only change the case if
           // the result does not change the number of encoded bytes.
           qio_encode_char_buf(result.buff + i, upCodepoint);
         }
-        i += nBytes;
       }
       return result;
     }
@@ -2116,12 +2104,7 @@ module String {
 
     param UN = 0, LETTER = 1;
     var last = UN;
-    var i = 0;
-    while i < result.buffLen {
-      const (decodeRet, cp, nBytes) = decodeHelp(buff=result.buff,
-                                                 buffLen=result.buffLen,
-                                                 offset=i,
-                                                 allowEsc=false);
+    for (cp, i, nBytes) in this._cpIndexLen() {
       if codepoint_isAlpha(cp) {
         if last == UN {
           last = LETTER;
@@ -2143,7 +2126,6 @@ module String {
         // Uncased elements
         last = UN;
       }
-      i += nBytes;
     }
     return result;
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1614,7 +1614,7 @@ module String {
                            region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
     if this.isASCII() then
       return doSearchNoEnc(this, needle, region,
-                      count=false, fromLeft=false): byteIndex;
+                           count=false, fromLeft=false): byteIndex;
     else
       return doSearchUTF8(needle, region,
                           count=false, fromLeft=false): byteIndex;
@@ -1677,8 +1677,7 @@ module String {
   iter string.split(maxsplit: int = -1) /* : string */ {
     if this.isASCII() {
       for s in doSplitWSNoEnc(this, maxsplit) do yield s;
-    }
-    else {
+    } else {
       // note: to improve performance, this code collapses several cases into a
       //       single yield statement, which makes it confusing to read
       // TODO: specifying return type leads to un-inited string?
@@ -1803,8 +1802,7 @@ module String {
     proc string.strip(chars: string = " \t\r\n", leading=true, trailing=true) : string {
       if this.isASCII() {
         return doStripNoEnc(this, chars, leading, trailing);
-      }
-      else {
+      } else {
         if this.isEmpty() then return "";
         if chars.isEmpty() then return this;
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1289,8 +1289,7 @@ module String {
 
     if localThis.isASCII() {
       for i in this.byteIndices {
-        var (newBuff, allocSize) = bufferCopyLocal(localThis.buff+i,
-                                                   len=1);
+        var (newBuff, allocSize) = bufferCopyLocal(localThis.buff+i, len=1);
         yield chpl_createStringWithOwnedBufferNV(newBuff, 1, allocSize, 1);
       }
     }
@@ -1303,8 +1302,6 @@ module String {
                                                    offset=i,
                                                    allowEsc=true);
         var (newBuf, newSize) = bufferCopyLocal(curPos, nBytes);
-        newBuf[nBytes] = 0;
-
         yield chpl_createStringWithOwnedBufferNV(newBuf, nBytes, newSize, 1);
 
         i += nBytes;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1395,6 +1395,7 @@ module String {
     // TODO: Engin: at least we can check whether the length is less than 4
     // bytes before localizing?
     var localThis: string = this.localize();
+
     if localThis.isEmpty() then
       halt("string.toCodepoint() only accepts single-codepoint strings");
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1289,9 +1289,9 @@ module String {
 
     if localThis.isASCII() {
       for i in this.byteIndices {
-      var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=i:int,
-                                            len=1, loc=this.locale_id);
-      yield chpl_createStringWithOwnedBufferNV(newBuff, 1, allocSize, 1);
+        var (newBuff, allocSize) = bufferCopyLocal(localThis.buff+i,
+                                                   len=1);
+        yield chpl_createStringWithOwnedBufferNV(newBuff, 1, allocSize, 1);
       }
     }
     else {
@@ -1299,9 +1299,9 @@ module String {
       while i < localThis.buffLen {
         const curPos = localThis.buff+i;
         const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                     buffLen=localThis.buffLen,
-                                                     offset=i,
-                                                     allowEsc=true);
+                                                   buffLen=localThis.buffLen,
+                                                   offset=i,
+                                                   allowEsc=true);
         var (newBuf, newSize) = bufferCopyLocal(curPos, nBytes);
         newBuf[nBytes] = 0;
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1529,7 +1529,10 @@ module String {
   inline proc string.find(needle: string,
                    region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
     // TODO: better name than region?
-    return _search_helper(needle, region, count=false): byteIndex;
+    if this.isASCII() then
+      return doSearch(this, needle, region, count=false): byteIndex;
+    else
+      return _search_helper(needle, region, count=false): byteIndex;
   }
 
   /*
@@ -1543,7 +1546,10 @@ module String {
    */
   inline proc string.rfind(needle: string,
                     region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
-    return _search_helper(needle, region, count=false, fromLeft=false): byteIndex;
+    if this.isASCII() then
+      return doSearch(this, needle, region, count=false, fromLeft=false): byteIndex;
+    else
+      return _search_helper(needle, region, count=false, fromLeft=false): byteIndex;
   }
 
   /*
@@ -1555,7 +1561,10 @@ module String {
     :returns: the number of times `needle` occurs in the string
    */
   inline proc string.count(needle: string, region: range(?) = this.indices) : int {
-    return _search_helper(needle, region, count=true);
+    if this.isASCII() then
+      return doSearch(this, needle, region, count=true);
+    else
+      return _search_helper(needle, region, count=true);
   }
 
   /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1530,7 +1530,7 @@ module String {
                           region: range(?) = this.byteIndices) : byteIndex {
     // TODO: better name than region?
     if this.isASCII() then
-      return doSearch(this, needle, region, count=false): byteIndex;
+      return doSearchNoEnc(this, needle, region, count=false): byteIndex;
     else
       return doSearchUTF8(needle, region, count=false): byteIndex;
   }
@@ -1547,7 +1547,7 @@ module String {
   inline proc string.rfind(needle: string,
                            region: range(?) = this.byteIndices) : byteIndex {
     if this.isASCII() then
-      return doSearch(this, needle, region,
+      return doSearchNoEnc(this, needle, region,
                       count=false, fromLeft=false): byteIndex;
     else
       return doSearchUTF8(needle, region,
@@ -1565,7 +1565,7 @@ module String {
   inline proc string.count(needle: string,
                            region: range(?) = this.indices) : int {
     if this.isASCII() then
-      return doSearch(this, needle, region, count=true);
+      return doSearchNoEnc(this, needle, region, count=true);
     else
       return doSearchUTF8(needle, region, count=true);
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -994,8 +994,8 @@ module String {
     //TODO: this could be a much better string search
     //      (Boyer-Moore-Horspool|any thing other than brute force)
     //
-    inline proc _search_helper(needle: string, region: range(?),
-                               param count: bool, param fromLeft: bool = true) {
+    inline proc doSearchUTF8(needle: string, region: range(?),
+                             param count: bool, param fromLeft: bool = true) {
       // needle.len is <= than this.buffLen, so go to the home locale
       var ret: int = -1;
       on __primitive("chpl_on_locale_num",
@@ -1532,7 +1532,7 @@ module String {
     if this.isASCII() then
       return doSearch(this, needle, region, count=false): byteIndex;
     else
-      return _search_helper(needle, region, count=false): byteIndex;
+      return doSearchUTF8(needle, region, count=false): byteIndex;
   }
 
   /*
@@ -1550,8 +1550,8 @@ module String {
       return doSearch(this, needle, region,
                       count=false, fromLeft=false): byteIndex;
     else
-      return _search_helper(needle, region,
-                            count=false, fromLeft=false): byteIndex;
+      return doSearchUTF8(needle, region,
+                          count=false, fromLeft=false): byteIndex;
   }
 
   /*
@@ -1567,7 +1567,7 @@ module String {
     if this.isASCII() then
       return doSearch(this, needle, region, count=true);
     else
-      return _search_helper(needle, region, count=true);
+      return doSearchUTF8(needle, region, count=true);
   }
 
   /*
@@ -1596,8 +1596,8 @@ module String {
                       * When `false` -- Empty strings will be yielded when
                                         `sep` occurs multiple times in a row.
    */
-    iter string.split(sep: string, maxsplit: int = -1,
-                      ignoreEmpty: bool = false) /* : string */ {
+  iter string.split(sep: string, maxsplit: int = -1,
+                    ignoreEmpty: bool = false) /* : string */ {
     // TODO: specifying return type leads to un-inited string?
     for s in doSplit(this, sep, maxsplit, ignoreEmpty) do yield s;
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1516,9 +1516,9 @@ module String {
     }
     else {
       var charCount = 0;
-      for (cp, i, nBytes) in _cpIndexLen() {
+      for (cp, byteIdx, nBytes) in _cpIndexLen() {
         if charCount == i {
-          var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=i:int,
+          var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=byteIdx:int,
                                                 len=nBytes, loc=this.locale_id);
           return chpl_createStringWithOwnedBufferNV(newBuff, nBytes, allocSize, 1);
         }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -936,17 +936,24 @@ module String {
     iter _cpIndexLen(start = 0:byteIndex) {
       var localThis: string = this.localize();
 
-      var i = start:int;
-      if i > 0 then
-        while i < localThis.buffLen && !isInitialByte(localThis.buff[i]) do
-          i += 1; // in case `start` is in the middle of a multibyte character
-      while i < localThis.buffLen {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                   buffLen=localThis.buffLen,
-                                                   offset=i,
-                                                   allowEsc=true);
-        yield (cp:int(32), i:byteIndex, nBytes:int);
-        i += nBytes;
+      if localThis.isASCII() {
+        for (i,b) in zip(this.byteIndices, this.chpl_bytes()) {
+          yield(b:int(32), i:byteIndex, 1:int);
+        }
+      }
+      else {
+        var i = start:int;
+        if i > 0 then
+          while i < localThis.buffLen && !isInitialByte(localThis.buff[i]) do
+            i += 1; // in case `start` is in the middle of a multibyte character
+        while i < localThis.buffLen {
+          const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
+                                                     buffLen=localThis.buffLen,
+                                                     offset=i,
+                                                     allowEsc=true);
+          yield (cp:int(32), i:byteIndex, nBytes:int);
+          i += nBytes;
+        }
       }
     }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1570,7 +1570,7 @@ module String {
               string, or -1 if the `needle` is not in the string.
    */
   inline proc string.find(needle: string,
-                          region: range(?) = this.byteIndices) : byteIndex {
+                          region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
     // TODO: better name than region?
     if this.isASCII() then
       return doSearchNoEnc(this, needle, region, count=false): byteIndex;
@@ -1588,7 +1588,7 @@ module String {
               within a string, or -1 if the `needle` is not in the string.
    */
   inline proc string.rfind(needle: string,
-                           region: range(?) = this.byteIndices) : byteIndex {
+                           region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
     if this.isASCII() then
       return doSearchNoEnc(this, needle, region,
                       count=false, fromLeft=false): byteIndex;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -916,6 +916,10 @@ module String {
       }
     }
 
+    inline proc isASCII() {
+      return this.numCodepoints==this.numBytes;
+    }
+
     inline proc byteIndices return 0..<this.numBytes;
 
     inline proc param c_str() param : c_string {

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1527,7 +1527,7 @@ module String {
               string, or -1 if the `needle` is not in the string.
    */
   inline proc string.find(needle: string,
-                   region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
+                          region: range(?) = this.byteIndices) : byteIndex {
     // TODO: better name than region?
     if this.isASCII() then
       return doSearch(this, needle, region, count=false): byteIndex;
@@ -1545,11 +1545,13 @@ module String {
               within a string, or -1 if the `needle` is not in the string.
    */
   inline proc string.rfind(needle: string,
-                    region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
+                           region: range(?) = this.byteIndices) : byteIndex {
     if this.isASCII() then
-      return doSearch(this, needle, region, count=false, fromLeft=false): byteIndex;
+      return doSearch(this, needle, region,
+                      count=false, fromLeft=false): byteIndex;
     else
-      return _search_helper(needle, region, count=false, fromLeft=false): byteIndex;
+      return _search_helper(needle, region,
+                            count=false, fromLeft=false): byteIndex;
   }
 
   /*
@@ -1560,7 +1562,8 @@ module String {
 
     :returns: the number of times `needle` occurs in the string
    */
-  inline proc string.count(needle: string, region: range(?) = this.indices) : int {
+  inline proc string.count(needle: string,
+                           region: range(?) = this.indices) : int {
     if this.isASCII() then
       return doSearch(this, needle, region, count=true);
     else
@@ -1576,7 +1579,8 @@ module String {
     :returns: a copy of the string where `replacement` replaces `needle` up
               to `count` times
    */
-  inline proc string.replace(needle: string, replacement: string, count: int = -1) : string {
+  inline proc string.replace(needle: string, replacement: string,
+                             count: int = -1) : string {
     return doReplace(this, needle, replacement, count);
   }
 
@@ -1592,7 +1596,8 @@ module String {
                       * When `false` -- Empty strings will be yielded when
                                         `sep` occurs multiple times in a row.
    */
-    iter string.split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) /* : string */ {
+    iter string.split(sep: string, maxsplit: int = -1,
+                      ignoreEmpty: bool = false) /* : string */ {
     // TODO: specifying return type leads to un-inited string?
     for s in doSplit(this, sep, maxsplit, ignoreEmpty) do yield s;
   }

--- a/test/types/string/engin/itemsNullTerm.chpl
+++ b/test/types/string/engin/itemsNullTerm.chpl
@@ -1,0 +1,6 @@
+var s = "asdf";
+
+for i in s.items() {
+  writeln(i.buffSize >= 2); // do we have the room for the null terminator?
+  writeln(i.buff[1] == 0);  // is it really null?
+}

--- a/test/types/string/engin/itemsNullTerm.good
+++ b/test/types/string/engin/itemsNullTerm.good
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/test/types/string/kbrady/strided-search-byteIndex.chpl
+++ b/test/types/string/kbrady/strided-search-byteIndex.chpl
@@ -1,8 +1,9 @@
-var x = "a1b2c3d4e5";
+config type dataType = string;
+var x = "a1b2c3d4e5":dataType;
 
-var y = "abcd abcd";
+var y = "abcd abcd":dataType;
 
-writeln(x.find("abcde", 0:byteIndex.. by 2));
-writeln(x.find("12345", 0:byteIndex.. by 2));
-writeln(x.find("12345", 1:byteIndex.. by 2));
-writeln(y.find("dcba", 0:byteIndex.. by -1));
+writeln(x.find("abcde":dataType, 0:byteIndex.. by 2));
+writeln(x.find("12345":dataType, 0:byteIndex.. by 2));
+writeln(x.find("12345":dataType, 1:byteIndex.. by 2));
+writeln(y.find("dcba":dataType, 0:byteIndex.. by -1));

--- a/test/types/string/kbrady/strided-search-byteIndex.compopts
+++ b/test/types/string/kbrady/strided-search-byteIndex.compopts
@@ -1,0 +1,2 @@
+-sdataType=string
+-sdataType=bytes

--- a/test/types/string/validation/asciiEscape.chpl
+++ b/test/types/string/validation/asciiEscape.chpl
@@ -1,0 +1,31 @@
+var myBytes = b"abc";
+
+writeln("Base bytes: ");
+for b in myBytes.bytes() {
+  writeln(b);
+}
+writeln();
+
+var myString = myBytes.decode(policy=decodePolicy.escape);
+writeln("Escaped string bytes: ");
+for b in myString.bytes() {
+  writef("Decimal: %u, Hexadecimal: %xu\n", b, b);
+}
+writeln();
+
+writeln("Direct copy string bytes: ");
+var directBytes = myString.encode(policy=encodePolicy.pass);
+for b in directBytes.bytes() {
+  writeln(b);
+}
+writeln();
+
+writeln("Unescaped string bytes: ");
+var unescapedBytes = myString.encode(policy=encodePolicy.unescape);
+for b in unescapedBytes.bytes() {
+  writeln(b);
+}
+writeln();
+
+writeln("Should be true: ", myBytes == directBytes);
+writeln("Should be true: ", myBytes == unescapedBytes);

--- a/test/types/string/validation/asciiEscape.good
+++ b/test/types/string/validation/asciiEscape.good
@@ -1,0 +1,22 @@
+Base bytes: 
+97
+98
+99
+
+Escaped string bytes: 
+Decimal: 97, Hexadecimal: 61
+Decimal: 98, Hexadecimal: 62
+Decimal: 99, Hexadecimal: 63
+
+Direct copy string bytes: 
+97
+98
+99
+
+Unescaped string bytes: 
+97
+98
+99
+
+Should be true: true
+Should be true: true

--- a/test/types/string/validation/isASCII.chpl
+++ b/test/types/string/validation/isASCII.chpl
@@ -1,0 +1,4 @@
+writeln("foo".isASCII());
+writeln("événement".isASCII());
+writeln("".isASCII());
+

--- a/test/types/string/validation/isASCII.good
+++ b/test/types/string/validation/isASCII.good
@@ -1,0 +1,3 @@
+true
+false
+true


### PR DESCRIPTION
This PR optimizes many string operations if the string contains only ASCII
characters.

#### Optimized operations

- search-based operations: `find`, `rfind`, `count`
- slicing
- unit access operations: `item(s)`, `codepoint(s)`, `toByte`, `this`
- `strip`
- `split`
- `encode`
  - Even if the user wanted to `unescape` while encoding, there is nothing to do
    if the string is ASCII only. (i.e. nothing was escaped while decoding)
- character-based operations: `toUpper`, `toLower` etc.
  - There can be some more optimization opportunities there. This PR only makes
    sure that we don't do a UTF8-based iteration over the string if it is ASCII.
    Even for ASCII strings, we still call the `wctype` library. I assume that
    the cost associated with that is much lower than the cost of decoding while
    iterating.

#### Implementation details
- Non-user facing (yet?) `proc string.isASCII()` is added.

- For methods where ASCII vs. UTF8 implementations differ, helpers like
  `doFooNoEnc` and `doFooUTF8` are added to `BytesStringCommon.chpl` and
  `String.chpl`

- byte-based checkers like `byte_isUpper` et al. are moved to
  `BytesStringCommon.chpl`

- The iterator `string._cpIndexLen` is optimized for ASCII strings, and used in
  several places.

- While there, optimize `item` for UTF8 strings, too.
  - We used to get the codepoint at the given index and than create a string
    from it using a validating factory function. Now, we just find the byteIndex
    of the codepoint and its length in bytes. Then create a small buffer for it
    and create a string with a non-validating function.

- While there, fix some bugs exposed by using bytes-only functions for strings
  after a long while. And adjusts/add tests to test fixed bugs.

- While there, make sure `bufferCopyLocal` adds a null byte at the end.


Test:
- [x] `types/string` and `types/bytes`
- [x] `types/string` and `types/bytes` valgrind
- [x] `types/string` and `types/bytes` memleaks
- [x] Some performance testing
- [x] standard
- [x] gasnet

