### PR TITLE
mason : consistent kwarg parsing 

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -356,7 +356,7 @@ Tests can be listed in the ``Mason.toml`` as a TOML array of strings for the
             "test2.chpl",
             "test3.chpl"]
 
-
+An user may also set the ``CHPL_COMM`` value for running the tests, e.g. ``none``, ``gasnet``, ``ugni`` using ``mason test --setComm``.
 
 Creating and Running Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -68,6 +68,10 @@ proc masonBuild(args) throws {
       else if arg == '--show' {
         show = true;
       }
+      else if arg.startsWith('--example=') {
+        example = true;
+        compopts.append(arg);
+      }
       else if arg == '--example' {
         example = true;
       }

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -64,6 +64,11 @@ proc masonExample(args) {
     else if arg == '--update' {
       update = true;
     }
+    else if arg.startsWith('--example=') {
+      var exampleProgram = arg.split("=");
+      examples.append(exampleProgram[1]);
+      continue;
+    }
     else if arg == '--example' {
       continue;
     }

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -59,6 +59,10 @@ proc masonRun(args) throws {
       else if arg == '--release' {
         release=true;
       }
+      else if arg.startsWith('--example=') {
+        masonBuildRun(args);
+        exit(0);
+      }
       else if arg == '--example' {        
         if args.size > 3 {
           masonBuildRun(args);
@@ -150,6 +154,7 @@ private proc masonBuildRun(args: [?d] string) {
     var buildExample = false;
     var updateRegistry = true;
     var execopts: list(string);
+    var exampleProgram='';
     for arg in args[2..] {
       if exec == true {
         execopts.append(arg);
@@ -158,6 +163,10 @@ private proc masonBuildRun(args: [?d] string) {
         if example then
           throw new owned MasonError("Examples do not support `--` syntax");
         exec = true;
+      }
+      else if arg.startsWith("--example=") {
+        execopts.append(arg);
+        example = true;
       }
       else if arg == "--example" {
         example = true;

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -86,6 +86,9 @@ proc masonTest(args) throws {
       when '--update' {
         update = true;
       }
+      when '--no-update' {
+        update = false;
+      }
       when '--setComm' {
         setComm = args[countArgs];
       }

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -53,42 +53,46 @@ proc masonTest(args) throws {
   if MASON_OFFLINE then update = false;
   var compopts: list(string);
   var searchSubStrings: list(string);
-  var countArgs = 0;
-  for arg in args {
+  var countArgs = args.domain.low+2;
+  for arg in args[args.domain.low+2..] {
     countArgs += 1;
-    if countArgs > 2 {
-      if arg == '-h' || arg == '--help' {
+    select (arg) {
+      when '-h'{
         masonTestHelp();
         exit(0);
       }
-      else if arg == '--show' {
+      when '--help'{
+        masonTestHelp();
+        exit(0);
+      }
+      when '--show'{
         show = true;
       }
-      else if arg == '--no-run' {
+      when '--no-run'{
         run = false;
       }
-      else if arg == '--parallel' {
+      when '--parallel' {
         parallel = true;
       }
-      else if arg == '--' {
+      when '--' {
         throw new owned MasonError("Testing does not support -- syntax");
       }
-      else if arg == '--no-update' {
-        update = false;
-      }
-      else if arg == '--keep-binary' {
+      when '--keep-binary' {
         keepExec = true;
       }
-      else if arg == '--recursive' {
+      when '--recursive' {
         subdir = true;
       }
-      else if arg == '--update' {
+      when '--update' {
         update = true;
       }
-      else if arg.startsWith('--setComm=') {
-        setComm = arg['--setComm='.size+1..];
+      when '--setComm' {
+        setComm = args[countArgs];
       }
-      else {
+      otherwise {
+        if arg.startsWith('--setComm='){
+          setComm = arg['--setComm='.size..];
+        }
         try! {
           if isFile(arg) && arg.endsWith(".chpl") {
             files.append(arg);


### PR DESCRIPTION
Support `--flag=value` & `--flag value` for mason flags that accept a value.
- [x] `mason build --example <example>`
- [x] `mason run --example <example>`
- [x] `mason test --setComm <comm>`
- [x] Updated mason docs to include usage of `--setComm` 

Additionally, rewrite arg parsing to select style.