### PR TITLE
Fix jenkins processing of Arkouda `make check` errors

### DIFF
--- a/test/studies/arkouda/functions.bash
+++ b/test/studies/arkouda/functions.bash
@@ -14,6 +14,18 @@ function subtest_end() {
   echo "[Finished subtest \"studies/arkouda\" - $elapsed seconds"
 }
 
+function test_start() {
+  subtest_test_name=$1
+  echo "[test: \"$subtest_test_name\"]"
+  SECONDS=0
+}
+
+function test_end() {
+  elapsed=$SECONDS
+  echo "[Elapsed time to compile and execute all versions of \"$subtest_test_name\" - $elapsed.000 seconds]"
+  unset subtest_test_name
+}
+
 function log_error() {
   local msg=$@
   echo "[Error ${msg}]"
@@ -22,6 +34,9 @@ function log_error() {
 function log_fatal_error() {
   local msg=$@
   echo "[Error ${msg}]"
+  if [[ -n $subtest_test_name ]]; then
+    test_end
+  fi
   subtest_end
   exit 0
 }
@@ -29,16 +44,4 @@ function log_fatal_error() {
 function log_success() {
   local msg=$@
   echo "[Success matching ${msg}]"
-}
-
-function test_start() {
-  local tname=$1
-  echo "[test: \"$tname\"]"
-  SECONDS=0
-}
-
-function test_end() {
-  local tname="$1"
-  elapsed=$SECONDS
-  echo "[Elapsed time to compile and execute all versions of \"$tname\" - $elapsed.000 seconds]"
 }

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -57,10 +57,9 @@ test_start "make check"
 if make check ; then
   log_success "make check output"
 else
-  test_end "make check"
   log_fatal_error "running make check"
 fi
-test_end "make check"
+test_end
 
 # Run Python unit tests
 test_start "make test-python"
@@ -69,7 +68,7 @@ if make test-python ; then
 else
   log_error "running make test-python"
 fi
-test_end "make test-python"
+test_end
 
 # Run benchmarks
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
@@ -101,7 +100,7 @@ if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
   else
     log_error "running benchmarks"
   fi
-  test_end "benchmarks"
+  test_end
 fi
 
 subtest_end


### PR DESCRIPTION
Previously, an error in Arkouda's `make check` wasn't getting detected
as an error in jenkins, though it did show up in our nightly emails.
This is because we were marking the test end before emitting the fatal
error, which messed up our junit processing. To fix this, print the
error before marking the test end. This is done by keeping track of the
current test and emitting the test_end in log_fatal_error before
exiting.