### PR TITLE
Skip a new perf test on CS

### DIFF
--- a/test/studies/prk/DGEMM/SUMMA/dgemm.skipif
+++ b/test/studies/prk/DGEMM/SUMMA/dgemm.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM==cray-cs


### PR DESCRIPTION
We'll need to add some more flags and adjusts our config to
be able to run this test with BLAS on CS. We might also need to bump
the timeout for the native (and maybe BLAS?) versions. Until we get around
doing that, skip the performance test on CS for now.

Confirmed that the test is skipped on CS with this PR.