### PR TITLE
Adjust test for correctness runs

### DIFF
--- a/test/types/string/psahabu/perf/search-throughput.chpl
+++ b/test/types/string/psahabu/perf/search-throughput.chpl
@@ -60,7 +60,9 @@ for i in 1..n {
   totalNumBytes += word.numBytes;
 }
 
-writeln("Read ", totalNumBytes, " bytes");
+if timing {
+  writeln("Read ", totalNumBytes, " bytes");
+}
 
 // startsWith
 var tStartsWith: Timer;

--- a/test/types/string/psahabu/perf/search-throughput.execopts
+++ b/test/types/string/psahabu/perf/search-throughput.execopts
@@ -1,0 +1,1 @@
+--n=100 --timing=false # no-timing.good


### PR DESCRIPTION
I have added this performance test yesterday but overlooked the correctness
runs. This PR adds an execopts file and adjusts the test so that it passes
correctness.
