### PR TITLE
Discourage CHPL_LIBFABRIC!=system on Shasta systems.

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import sys
-from sys import stderr
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils
 from utils import error, memoize
@@ -20,8 +19,8 @@ def get():
         if libfabric_val == 'none':
             error("CHPL_LIBFABRIC must not be 'none' when CHPL_COMM is ofi")
         if platform_val == 'cray-shasta' and libfabric_val != 'system':
-            stderr.write('Warning: '
-                         'CHPL_LIBFABRIC!=system is discouraged on Shasta\n')
+            sys.stderr.write('Warning: CHPL_LIBFABRIC!=system is discouraged '
+                             'on Shasta\n')
     else:
         libfabric_val = 'none'
 

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import sys
+from sys import stderr
 
-import chpl_comm, chpl_comm_debug, chpl_launcher, overrides, third_party_utils
+import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils
 from utils import error, memoize
 
 
@@ -10,10 +11,17 @@ def get():
     comm_val = chpl_comm.get()
     if comm_val == 'ofi':
         libfabric_val = overrides.get('CHPL_LIBFABRIC')
+        platform_val = chpl_platform.get('target')
         if not libfabric_val:
-            libfabric_val = 'libfabric'
+            if platform_val == 'cray-shasta':
+                libfabric_val = 'system'
+            else:
+                libfabric_val = 'libfabric'
         if libfabric_val == 'none':
-          error("CHPL_LIBFABRIC must not be 'none' when CHPL_COMM is ofi")
+            error("CHPL_LIBFABRIC must not be 'none' when CHPL_COMM is ofi")
+        if platform_val == 'cray-shasta' and libfabric_val != 'system':
+            stderr.write('Warning: '
+                         'CHPL_LIBFABRIC!=system is discouraged on Shasta\n')
     else:
         libfabric_val = 'none'
 


### PR DESCRIPTION
Officially, using anything other than the system libfabric module is not
supported on Shasta systems.  Unofficially, we have (we think) observed
it to work, but it's possible we were fooling ourselves.  Here, add an
appropriate warning message.

This resolves Cray/chapel-private#1141.