### PR TITLE
Add hdf5 tools to PATH for arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -35,6 +35,7 @@ else
   if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
     log_fatal_error "installing dependencies"
   fi
+  export "PATH=${ARKOUDA_HOME}/dep/hdf5-install/bin:$PATH"
 fi
 
 # Compile Arkouda


### PR DESCRIPTION
https://github.com/mhmerrill/arkouda/pull/411 started requiring h5ls for some I/O tests. Ensure it's available in the PATH when our start_test infrastructure is the thing installing the HDF5 dependency. Follow on to https://github.com/chapel-lang/chapel/pull/16066, which updated PATH for our nightly testing, which uses a prebuilt HDF5, but missed updating for users running themselves.