### PR TITLE
Require use of parent module when resolving uses and imports of sibling modules

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -674,8 +674,6 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
     ModuleSymbol* thisMod = enclosingModule();
     for (ptr = start; ptr != NULL && retval == NULL; ptr = ptr->mParent) {
       ModuleSymbol* ptrMod = ptr->enclosingModule();
-      if (thisMod != ptrMod && relativeScope == NULL && ptrMod != theProgram)
-        continue;
       // Check if the module is defined in this scope
       Symbol* sym = ptr->lookupNameLocallyForImport(name);
       if (ModuleSymbol* mod = toModuleSymbol(sym)) {
@@ -686,6 +684,9 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
           // if we're not in the root module scope or using relative import,
           // this is an improper match
           badCloserModule = mod;
+          if (thisMod != ptrMod) {
+            continue;
+          }
           if (isUse) { // TODO: remove this to disable relative use
             retval = sym;
             break;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -671,7 +671,11 @@ Symbol* ResolveScope::lookupForImport(Expr* expr, bool isUse) const {
     const ResolveScope* start = relativeScope!=NULL ? relativeScope : this;
     const ResolveScope* ptr = NULL;
     ModuleSymbol* badCloserModule = NULL;
+    ModuleSymbol* thisMod = enclosingModule();
     for (ptr = start; ptr != NULL && retval == NULL; ptr = ptr->mParent) {
+      ModuleSymbol* ptrMod = ptr->enclosingModule();
+      if (thisMod != ptrMod && relativeScope == NULL && ptrMod != theProgram)
+        continue;
       // Check if the module is defined in this scope
       Symbol* sym = ptr->lookupNameLocallyForImport(name);
       if (ModuleSymbol* mod = toModuleSymbol(sym)) {

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -28,7 +28,7 @@
 module CPtr {
   private use ChapelStandard;
   private use SysBasic, SysError, SysCTypes;
-  import HaltWrappers;
+  private import HaltWrappers;
 
   /* A Chapel version of a C NULL pointer. */
   inline proc c_nil:c_void_ptr {

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -69,7 +69,7 @@
 module ChapelLocale {
 
   use LocaleModel;
-  import HaltWrappers;
+  private import HaltWrappers;
   private use SysCTypes;
 
   //

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1926,7 +1926,7 @@ module SequentialInPlacePartitioning {
 pragma "no doc"
 module TwoArrayPartitioning {
   private use BlockDist;
-  private use MSBRadixSort;
+  private use super.MSBRadixSort;
   public use List only list;
   import Sort.{ShellSort, RadixSortHelp, SampleSortHelp, ShallowCopy};
 
@@ -2704,8 +2704,8 @@ module TwoArrayPartitioning {
 pragma "no doc"
 module TwoArrayRadixSort {
   import Sort.defaultComparator;
-  private use TwoArrayPartitioning;
-  private use RadixSortHelp;
+  private use super.TwoArrayPartitioning;
+  private use super.RadixSortHelp;
 
   proc twoArrayRadixSort(Data:[], comparator:?rec=defaultComparator) {
 
@@ -2752,9 +2752,9 @@ module TwoArrayRadixSort {
 pragma "no doc"
 module TwoArraySampleSort {
   import Sort.defaultComparator;
-  private use TwoArrayPartitioning;
-  private use SampleSortHelp;
-  private use RadixSortHelp;
+  private use super.TwoArrayPartitioning;
+  private use super.SampleSortHelp;
+  private use super.RadixSortHelp;
 
   proc twoArraySampleSort(Data:[], comparator:?rec=defaultComparator) {
 
@@ -2801,7 +2801,7 @@ module InPlacePartitioning {
 pragma "no doc"
 module MSBRadixSort {
   import Sort.{defaultComparator, ShellSort};
-  private use RadixSortHelp;
+  private use super.RadixSortHelp;
 
   // This structure tracks configuration for the radix sorter.
   record MSBRadixSortSettings {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -125,7 +125,7 @@ module TomlParser {
   use DateTime;
   use Map, List;
   import IO.channel;
-  import TOML.TomlReader.Source;
+  private use TOML.TomlReader;
   import TOML.TomlError;
 
   /* Prints a line by line output of parsing process */

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -867,6 +867,7 @@ proc getUID(out error: syserr, name: string): int {
 // of casting and error checking.
 //
 private module GlobWrappers {
+  private import HaltWrappers;
   extern type glob_t;
   use SysCTypes;
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -766,7 +766,7 @@ module Random {
   */
   module PCGRandom {
 
-    use RandomSupport;
+    use super.RandomSupport;
     private use Random;
     public use PCGRandomLib;
     private use ChapelLocks;
@@ -2449,7 +2449,7 @@ module Random {
   */
   module NPBRandom {
 
-    use RandomSupport;
+    use super.RandomSupport;
     private use ChapelLocks;
 
     /*

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -770,6 +770,7 @@ module Random {
     private use Random;
     public use PCGRandomLib;
     private use ChapelLocks;
+    private import HaltWrappers;
 
     // How many generators do we need for this type?
     private
@@ -2450,6 +2451,7 @@ module Random {
   module NPBRandom {
 
     use super.RandomSupport;
+    private import HaltWrappers;
     private use ChapelLocks;
 
     /*

--- a/test/functions/deitz/test_resolve_best_shadowed2.chpl
+++ b/test/functions/deitz/test_resolve_best_shadowed2.chpl
@@ -20,13 +20,13 @@ module OuterModule {
   }
 
   module M3 {
-    public use M5;
+    public use super.M5;
     proc h() { } // does not shadow other h based on call to h since
     // there is another path (through M4) to the other h
   }
 
   module M4 {
-    public use M5;
+    public use super.M5;
   }
 
   module M5 {

--- a/test/functions/jturner/fun_as_value_crossmodule.chpl
+++ b/test/functions/jturner/fun_as_value_crossmodule.chpl
@@ -8,7 +8,7 @@ module OuterModule {
   }
 
   module mod2 {
-    use mod1;
+    use super.mod1;
 
     proc main {
       proc add1(x: int) {

--- a/test/library/packages/TOML/test/checkParseLoop.chpl
+++ b/test/library/packages/TOML/test/checkParseLoop.chpl
@@ -1,0 +1,14 @@
+import TOML;
+use TOML.TomlParser;
+
+var tomlStr = "t = true\nf = false";
+var D: domain(string);
+var table: [D] unmanaged Toml?;
+var rootTable = new unmanaged Toml(table);
+const source = new unmanaged TOML.TomlReader.Source(tomlStr);
+const parser = new unmanaged Parser(source, rootTable);
+const tomlData = parser.parseLoop();
+writeln(tomlData);
+delete parser;
+delete source;
+delete tomlData;

--- a/test/library/packages/TOML/test/checkParseLoop.good
+++ b/test/library/packages/TOML/test/checkParseLoop.good
@@ -1,0 +1,4 @@
+t = true
+f = false
+
+

--- a/test/modules/deitz/test_module_access2.chpl
+++ b/test/modules/deitz/test_module_access2.chpl
@@ -4,7 +4,7 @@ module OuterModule {
   }
 
   module M {
-    use N;
+    use super.N;
     var y = 2;
   }
 

--- a/test/modules/vass/use-depth.chpl
+++ b/test/modules/vass/use-depth.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   // modules being used
 
   module M1 {
-    public use M11;
+    public use super.M11;
   }
 
   module M11 {
@@ -24,12 +24,12 @@ module OuterModule {
   }
 
   module M2 {
-    public use M22;
+    public use super.M22;
     var y: int;
   }
 
   module M22 {
-    public use M222;
+    public use super.M222;
     var z: int;
   }
 

--- a/test/types/records/bharshbarger/nestedRecordInClass1.chpl
+++ b/test/types/records/bharshbarger/nestedRecordInClass1.chpl
@@ -4,7 +4,7 @@ module OuterModule {
   }
 
   module MyModule {
-          use MyTypes;
+          use super.MyTypes;
           class Bar {
                   var thing : real;
                   record myR {

--- a/test/types/records/bharshbarger/nestedRecordInClass2.chpl
+++ b/test/types/records/bharshbarger/nestedRecordInClass2.chpl
@@ -4,7 +4,7 @@ module OuterModule {
   }
 
   module MyModule {
-          use MyTypes;
+          use super.MyTypes;
           class Bar {
                   var thing : Foo;
                   record myR {

--- a/test/visibility/empty/exceptEverything.chpl
+++ b/test/visibility/empty/exceptEverything.chpl
@@ -8,7 +8,7 @@ module OuterModule {
   module M2 {
     config param qualifiedAccess = false;
 
-    use M except *;  // require all symbols in M to be fully-qualified.
+    use super.M except *;  // require all symbols in M to be fully-qualified.
 
     proc main() {
       if qualifiedAccess then

--- a/test/visibility/empty/exceptEverythingField.chpl
+++ b/test/visibility/empty/exceptEverythingField.chpl
@@ -7,7 +7,7 @@ proc main() {
 }
 
 module bash {
-  public use Other;
+  public use super.Other;
 
   proc ls(args='') {
     var p = Other.makeFoo();

--- a/test/visibility/empty/onlyNothing.chpl
+++ b/test/visibility/empty/onlyNothing.chpl
@@ -8,7 +8,7 @@ module OuterModule {
   module M2 {
     config param qualifiedAccess = false;
 
-    use M only ;   // require all symbols in M to be fully-qualified
+    use super.M only ;   // require all symbols in M to be fully-qualified
 
     proc main() {
       if qualifiedAccess then

--- a/test/visibility/empty/onlyNothingField.chpl
+++ b/test/visibility/empty/onlyNothingField.chpl
@@ -7,7 +7,7 @@ proc main() {
 }
 
 module bash {
-  public use Other;
+  public use super.Other;
 
   proc ls(args='') {
     var p = Other.makeFoo();

--- a/test/visibility/empty/qualifiedTypeAccess-except.chpl
+++ b/test/visibility/empty/qualifiedTypeAccess-except.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   module M2 {
     config param accessPrimary = false;
 
-    use M except *; // require all symbols in M to be fully-qualified
+    use super.M except *; // require all symbols in M to be fully-qualified
 
     proc main() {
       var foo = new borrowed M.Foo();

--- a/test/visibility/empty/qualifiedTypeAccess.chpl
+++ b/test/visibility/empty/qualifiedTypeAccess.chpl
@@ -14,7 +14,7 @@ module OuterModule {
   module M2 {
     config param accessPrimary = false;
 
-    use M only; // require all symbols in M to be fully-qualified
+    use super.M only; // require all symbols in M to be fully-qualified
 
     proc main() {
       var foo = new borrowed M.Foo();

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew.chpl
@@ -12,7 +12,7 @@ module grandparent {
   }
 
   module sibling {
-    use parent;
+    use super.parent;
 
     proc main() {
       writeln(parent.child.secretFunction(11));

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew2.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew2.chpl
@@ -12,7 +12,7 @@ module grandparent {
   }
 
   module sibling {
-    use parent;
+    use super.parent;
 
     proc main() {
       writeln(child.secretFunction(11));

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew3.chpl
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew3.chpl
@@ -12,7 +12,7 @@ module grandparent {
   }
 
   module sibling {
-    use parent;
+    use super.parent;
 
     proc main() {
       writeln(secretFunction(11));

--- a/test/visibility/private/moduleSymbols/siblingSubmodule.chpl
+++ b/test/visibility/private/moduleSymbols/siblingSubmodule.chpl
@@ -6,7 +6,7 @@ module parent {
   }
 
   module sibling {
-    use child;
+    use super.child;
 
     proc main() {
       writeln(secretFunction(11));

--- a/test/visibility/private/uses/weirdEnumHiding.chpl
+++ b/test/visibility/private/uses/weirdEnumHiding.chpl
@@ -5,7 +5,7 @@ module weirdEnumHiding {
   }
 
   module B {
-    public use A;
+    public use super.A;
 
     proc checkFoo() {
       writeln(foo.b);
@@ -13,7 +13,7 @@ module weirdEnumHiding {
   }
 
   module C {
-    private use A;
+    private use super.A;
 
     proc checkFoo() {
       writeln(foo.b);
@@ -21,8 +21,8 @@ module weirdEnumHiding {
   }
 
   module D {
-    public use C;
-    public use B;
+    public use super.C;
+    public use super.B;
 
     proc checkFoo() {
       writeln(foo.b);


### PR DESCRIPTION
This is sorta a grab-bag PR, motivated by #15985

In that issue, I discovered that some modules were referencing symbols that did not
appear to be visible to them based on uses/imports in their scope but did appear to be
visible due to their parent scope.  I thought this was due to traversing uses and imports
from parent scopes even though a use or import of the parent module was not present -
it turns out that in two of the three cases I saw, it was actually due to internal module
imports of that module not being private; in the remaining case, we had no test of the
functions that would have been impacted by #15312, so I believe they were already failing
(rather than failing to fail, as I thought in #15985).

However, in trying to resolve the problem I thought was occurring with #15985, I did see
that we were allowing uses to go into the parent scope to look for sibling modules even
without a `super` prefix, and that should no longer be allowed.  This PR:
- resolves the issue of finding sibling modules for use statements without a `super` and fixes
17 tests that needed updates as a result
- makes the imports of HaltWrapper in the internal modules explicitly private and updates
the submodules of Random and FileSystem to explicitly import it as a result
- adds a test of the TOML submodule method that needed a more extensive use of a sibling
module and adds that needed use to the module.

Resolves #15985 
Resolves Cray/chapel-private#1167

Passed a full paratest with futures