### PR TITLE
Revamp comm=ofi libfabric provider selection.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -50,7 +50,8 @@ FILE* chpl_comm_ofi_dbg_file;
 #define DBG_STATSPROGRESS              0x8UL
 #define DBG_CFG                       0x10UL
 #define DBG_CFGFAB                   0x100UL
-#define DBG_CFGFABSALL               0x200UL
+#define DBG_CFGFABHINTS              0x200UL
+#define DBG_CFGFABSALL               0x400UL
 #define DBG_CFGAV                   0x1000UL
 #define DBG_THREADS                0x10000UL
 #define DBG_THREADDETAILS          0x20000UL

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -44,37 +44,37 @@
 uint64_t chpl_comm_ofi_dbg_level;
 FILE* chpl_comm_ofi_dbg_file;
 
-#define DBG_STATS                   0x1UL
-#define DBG_STATSNODES              0x2UL
-#define DBG_STATSTHREADS            0x4UL
-#define DBG_STATSPROGRESS           0x8UL
-#define DBG_CFG                    0x10UL
-#define DBG_CFGFAB                 0x20UL
-#define DBG_CFGFABSALL             0x40UL
-#define DBG_CFGAV                  0x80UL
-#define DBG_THREADS               0x100UL
-#define DBG_THREADDETAILS         0x200UL
-#define DBG_TCIPS                 0x800UL
-#define DBG_INTERFACE            0x1000UL
-#define DBG_AM                  0x10000UL
-#define DBG_AMSEND              0x20000UL
-#define DBG_AMRECV              0x40000UL
-#define DBG_AMBUFFERS           0x80000UL
-#define DBG_RMA                0x100000UL
-#define DBG_RMAWRITE           0x200000UL
-#define DBG_RMAREAD            0x400000UL
-#define DBG_RMAUNORD           0x800000UL
-#define DBG_AMO               0x1000000UL
-#define DBG_AMOREAD           0x2000000UL
-#define DBG_ACK               0x4000000UL
-#define DBG_ORDER             0x8000000UL
-#define DBG_MR               0x10000000UL
-#define DBG_MRDESC           0x20000000UL
-#define DBG_MRKEY            0x40000000UL
-#define DBG_HUGEPAGES        0x80000000UL
-#define DBG_BARRIER         0x100000000UL
-#define DBG_OOB            0x1000000000UL
-#define DBG_TSTAMP        0x10000000000UL
+#define DBG_STATS                      0x1UL
+#define DBG_STATSNODES                 0x2UL
+#define DBG_STATSTHREADS               0x4UL
+#define DBG_STATSPROGRESS              0x8UL
+#define DBG_CFG                       0x10UL
+#define DBG_CFGFAB                   0x100UL
+#define DBG_CFGFABSALL               0x200UL
+#define DBG_CFGAV                   0x1000UL
+#define DBG_THREADS                0x10000UL
+#define DBG_THREADDETAILS          0x20000UL
+#define DBG_TCIPS                  0x80000UL
+#define DBG_INTERFACE             0x100000UL
+#define DBG_AM                   0x1000000UL
+#define DBG_AMSEND               0x2000000UL
+#define DBG_AMRECV               0x4000000UL
+#define DBG_AMBUFFERS            0x8000000UL
+#define DBG_RMA                 0x10000000UL
+#define DBG_RMAWRITE            0x20000000UL
+#define DBG_RMAREAD             0x40000000UL
+#define DBG_RMAUNORD            0x80000000UL
+#define DBG_AMO                0x100000000UL
+#define DBG_AMOREAD            0x200000000UL
+#define DBG_ACK               0x1000000000UL
+#define DBG_ORDER             0x2000000000UL
+#define DBG_MR               0x10000000000UL
+#define DBG_MRDESC           0x20000000000UL
+#define DBG_MRKEY            0x40000000000UL
+#define DBG_HUGEPAGES        0x80000000000UL
+#define DBG_BARRIER         0x100000000000UL
+#define DBG_OOB            0x1000000000000UL
+#define DBG_TSTAMP        0x10000000000000UL
 
 void chpl_comm_ofi_dbg_init(void);
 char* chpl_comm_ofi_dbg_prefix(void);

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -104,14 +104,6 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 #include <libiberty.h>
 #endif
 
-struct cfgHint {
-  const char* str;
-  unsigned long int val;
-};
-
-#define CFG_HINT(s)    { #s, (uint64_t) (s) }
-#define CFG_HINT_NULL  { NULL, 0ULL }
-
 #else // CHPL_COMM_DEBUG
 
 #define DBG_INIT()

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -104,6 +104,14 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 #include <libiberty.h>
 #endif
 
+struct cfgHint {
+  const char* str;
+  unsigned long int val;
+};
+
+#define CFG_HINT(s)    { #s, (uint64_t) (s) }
+#define CFG_HINT_NULL  { NULL, 0ULL }
+
 #else // CHPL_COMM_DEBUG
 
 #define DBG_INIT()

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1129,9 +1129,8 @@ void init_ofiFabricDomain(void) {
   struct fi_info* hints;
   CHK_TRUE((hints = fi_allocinfo()) != NULL);
 
-  hints->caps = FI_MSG | FI_SEND | FI_RECV | FI_MULTI_RECV
-                | FI_RMA | FI_READ | FI_WRITE
-                | FI_REMOTE_READ | FI_REMOTE_WRITE;
+  hints->caps = (FI_MSG | FI_MULTI_RECV
+                 | FI_RMA | FI_LOCAL_COMM | FI_REMOTE_COMM);
   if (providerAvail(provType_gni)) {
     hints->caps |= FI_ATOMICS; // we don't get this without asking
   }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -494,7 +494,11 @@ void init_providerInUse(void) {
 
 static
 chpl_bool providerInUse(provider_t p) {
-  PTHREAD_CHK(pthread_once(&providerInUseOnce, init_providerInUse));
+  if (ofi_info != NULL) {
+    // Early exit hedge: don't init "in use" info until we have one.
+    PTHREAD_CHK(pthread_once(&providerInUseOnce, init_providerInUse));
+  }
+
   return providerSetTest(&providerInUseSet, p);
 }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1400,7 +1400,7 @@ void init_ofiEp(void) {
   const enum fi_wait_obj waitObj = (ofi_amhWaitSet == NULL)
                                    ? FI_WAIT_NONE
                                    : FI_WAIT_SET;
-  if (ofi_info->domain_attr->cntr_cnt == 0) {
+  if (true /*ofi_info->domain_attr->cntr_cnt == 0*/) { // disable tx counters
     cqAttr = (struct fi_cq_attr)
              { .format = FI_CQ_FORMAT_MSG,
                .size = 100,
@@ -1445,7 +1445,7 @@ void init_ofiEp(void) {
 
   OFI_CHK(fi_endpoint(ofi_domain, ofi_info, &ofi_rxEpRma, NULL));
   OFI_CHK(fi_ep_bind(ofi_rxEpRma, &ofi_av->fid, 0));
-  if (ofi_info->domain_attr->cntr_cnt == 0) {
+  if (true /*ofi_info->domain_attr->cntr_cnt == 0*/) { // disable tx counters
     OFI_CHK(fi_cq_open(ofi_domain, &cqAttr, &ofi_rxCQRma,
                        &checkRxRmaCmplsFn));
     ofi_rxCmplFidRma = &ofi_rxCQRma->fid;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1305,12 +1305,19 @@ void init_ofiEp(void) {
   // is needed.  It uses poll and wait sets to manage this, if it can.
   // Note: we'll either have both a poll and a wait set, or neither.
   //
+  // We don't use poll and waits sets with the efa provider because that
+  // doesn't support wait objects.  I tried just setting the cq_attr
+  // wait object to FI_WAIT_UNSPEC for all providers, since we don't
+  // reference the wait object explicitly anyway, but then saw hangs
+  // with (at least) the tcp;ofi_rxm provider.
+  //
   // We don't use poll and wait sets with the gni provider because (1)
   // it returns -ENOSYS for fi_poll_open() and (2) although a wait set
   // seems to work properly during execution, we haven't found a way to
   // avoid getting -FI_EBUSY when we try to close it.
   //
-  if (!providerInUse(provType_gni)) {
+  if (!providerInUse(provType_efa)
+      && !providerInUse(provType_gni)) {
     int ret;
     struct fi_poll_attr pollSetAttr = (struct fi_poll_attr)
                                       { .flags = 0, };

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1149,7 +1149,6 @@ void init_ofiFabricDomain(void) {
   }
   hints->tx_attr->op_flags = FI_COMPLETION;
   hints->tx_attr->msg_order = FI_ORDER_SAS;
-  hints->rx_attr->op_flags = hints->tx_attr->op_flags;
   hints->rx_attr->msg_order = hints->tx_attr->msg_order;
   hints->ep_attr->type = FI_EP_RDM;
   hints->domain_attr->av_type = FI_AV_TABLE;
@@ -1169,8 +1168,7 @@ void init_ofiFabricDomain(void) {
   debugOverrideHints(hints);
   ord_cmplt_forced =
     hints->tx_attr->op_flags != hintsOrig->tx_attr->op_flags
-    || hints->tx_attr->msg_order != hintsOrig->tx_attr->msg_order
-    || hints->rx_attr->op_flags != hintsOrig->rx_attr->op_flags;
+    || hints->tx_attr->msg_order != hintsOrig->tx_attr->msg_order;
   fi_freeinfo(hintsOrig);
 #endif
 
@@ -1278,7 +1276,6 @@ void init_ofiFabricDomain(void) {
   // doesn't actually do it.
   //
   hints->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
-  hints->rx_attr->op_flags = hints->tx_attr->op_flags;
 
   struct fi_info* infoCmplt = NULL;
   OFI_CHK_2(fi_getinfo(COMM_OFI_FI_VERSION, NULL, NULL, 0, hints, &infoCmplt),
@@ -1311,7 +1308,7 @@ void init_ofiFabricDomain(void) {
   hints->tx_attr->op_flags = FI_COMPLETION;
 
   //
-  // We couldn't get FI_DELIVERY_COMPLETE  in a desirable provider
+  // We couldn't get FI_DELIVERY_COMPLETE in a desirable provider
   // either.  Just use anything that matched.
   //
   if (infoTxOrd != NULL) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1081,7 +1081,13 @@ void debugOverrideHints(struct fi_info* hints) {
 #endif
 
 
-static
+static inline
+chpl_bool isInProvider(const char* s, struct fi_info* info) {
+  return isInProvName(s, info->fabric_attr->prov_name);
+}
+
+
+static inline
 chpl_bool isGoodCoreProvider(struct fi_info* info) {
   if (!isInProvName("sockets", info->fabric_attr->prov_name)
       && !isInProvName("tcp", info->fabric_attr->prov_name)) {
@@ -1137,6 +1143,8 @@ void init_ofiFabricDomain(void) {
   // - in addition, include the memory registration modes we can support
   //
   const char* prov_name = getProviderName();
+  const chpl_bool mandatory_RxD = isInProvName("ofi_rxd", prov_name);
+  const chpl_bool mandatory_RxM = isInProvName("ofi_rxm", prov_name);
 
   struct fi_info* hints;
   CHK_TRUE((hints = fi_allocinfo()) != NULL);
@@ -1252,13 +1260,19 @@ void init_ofiFabricDomain(void) {
   struct fi_info* infoTxOrd = NULL;
   OFI_CHK_2(fi_getinfo(COMM_OFI_FI_VERSION, NULL, NULL, 0, hints, &infoTxOrd),
             ret, -FI_ENODATA);
-  if (ret == FI_SUCCESS
-      && (isGoodCoreProvider(infoTxOrd) || prov_name != NULL)) {
-    DBG_PRINTF_NODE0(DBG_CFGFAB,
-                     "====================\n"
-                     "with transaction orderings, found desirable provider");
-    ofi_info = infoTxOrd;
-    goto haveProvider;
+
+  if (ret == FI_SUCCESS) {
+    for (struct fi_info* info = infoTxOrd; info != NULL; info = info->next) {
+      if ((prov_name != NULL || isGoodCoreProvider(info))
+          && (mandatory_RxD || !isInProvider("ofi_rxd", info))) {
+        DBG_PRINTF_NODE0(DBG_CFGFAB,
+                         "====================\n"
+                         "found desirable provider with transaction orderings");
+        ofi_info = fi_dupinfo(info);
+        fi_freeinfo(infoTxOrd);
+        goto haveProvider;
+      }
+    }
   }
 
   DBG_PRINTF_NODE0(DBG_CFGFAB,
@@ -1281,29 +1295,23 @@ void init_ofiFabricDomain(void) {
   OFI_CHK_2(fi_getinfo(COMM_OFI_FI_VERSION, NULL, NULL, 0, hints, &infoCmplt),
             ret, -FI_ENODATA);
   if (ret == FI_SUCCESS) {
-    struct fi_info* info = infoCmplt;
-    if (!isInProvName("ofi_rxm", prov_name)) { // find non-RxM, unless forced
-      for ( ; info != NULL; info = info->next) {
-        if ((isGoodCoreProvider(info) || prov_name != NULL)
-            && !isInProvName("ofi_rxm", info->fabric_attr->prov_name)) {
-          break;
-        }
+    for (struct fi_info* info = infoCmplt; info != NULL; info = info->next) {
+      if ((prov_name != NULL || isGoodCoreProvider(info))
+          && (mandatory_RxD || !isInProvider("ofi_rxd", info))
+          && (mandatory_RxM || !isInProvider("ofi_rxm", info))) {
+        DBG_PRINTF_NODE0(DBG_CFGFAB,
+                         "====================\n"
+                         "found desirable provider with delivery-complete");
+        ofi_info = fi_dupinfo(info);
+        fi_freeinfo(infoCmplt);
+        goto haveProvider;
       }
-    }
-
-    if (info != NULL) {
-      DBG_PRINTF_NODE0(DBG_CFGFAB,
-                       "====================\n"
-                       "with delivery-complete, found desirable provider");
-      ofi_info = fi_dupinfo(info);
-      fi_freeinfo(infoCmplt);
-      goto haveProvider;
     }
   }
 
   DBG_PRINTF_NODE0(DBG_CFGFAB,
                    "====================\n"
-                   "with delivery-complete, no desirable provider");
+                   "no desirable provider with delivery-complete");
 
   hints->tx_attr->op_flags = FI_COMPLETION;
 
@@ -1314,8 +1322,8 @@ void init_ofiFabricDomain(void) {
   if (infoTxOrd != NULL) {
     DBG_PRINTF_NODE0(DBG_CFGFAB,
                      "====================\n"
-                     "with transaction orderings, "
-                     "found a less desirable provider");
+                     "found less-desirable provider with transaction "
+                     "orderings");
     ofi_info = infoTxOrd;
     if (infoCmplt != NULL) {
       fi_freeinfo(infoCmplt);
@@ -1326,8 +1334,7 @@ void init_ofiFabricDomain(void) {
   if (infoCmplt != NULL) {
     DBG_PRINTF_NODE0(DBG_CFGFAB,
                      "====================\n"
-                     "with delivery-complete, "
-                     "found a less desirable provider");
+                     "found less-desirable provider with delivery-complete");
     ofi_info = infoCmplt;
     goto haveProvider;
   }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -389,6 +389,7 @@ chpl_bool isInThisProviderName(const char* s, const char* prov_name) {
 // provider type
 //
 typedef enum {
+  provType_efa,
   provType_gni,
   provType_verbs,
   provType_rxd,
@@ -442,7 +443,9 @@ void init_providerAvail(void) {
       DBG_PRINTF(DBG_CFGFABSALL, "----------");
     }
     const char* pn = info->fabric_attr->prov_name;
-    if (isInThisProviderName("gni", pn)) {
+    if (isInThisProviderName("efa", pn)) {
+      providerSetSet(&providerAvailSet, provType_efa);
+    } else if (isInThisProviderName("gni", pn)) {
       providerSetSet(&providerAvailSet, provType_gni);
     } else if (isInThisProviderName("verbs", pn)) {
       providerSetSet(&providerAvailSet, provType_verbs);
@@ -476,7 +479,9 @@ void init_providerInUse(void) {
   // We can be using only one primary provider.
   //
   const char* pn = ofi_info->fabric_attr->prov_name;
-  if (isInThisProviderName("gni", pn)) {
+  if (isInThisProviderName("efa", pn)) {
+    providerSetSet(&providerInUseSet, provType_efa);
+  } else if (isInThisProviderName("gni", pn)) {
     providerSetSet(&providerInUseSet, provType_gni);
   } else if (isInThisProviderName("verbs", pn)) {
     providerSetSet(&providerInUseSet, provType_verbs);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1071,7 +1071,11 @@ void debugOverrideHints(struct fi_info* hints) {
                                   CFG_HINT(FI_PROGRESS_AUTO),
                                   CFG_HINT(FI_PROGRESS_MANUAL),
                                   CFG_HINT_NULL, };
-    if (getCfgHint("COMM_OFI_HINTS_PROGRESS",
+    if (getCfgHint("COMM_OFI_HINTS_CONTROL_PROGRESS",
+                   hintVals, true /*justOne*/, &val)) {
+      hints->domain_attr->control_progress = (enum fi_progress) val;
+    }
+    if (getCfgHint("COMM_OFI_HINTS_DATA_PROGRESS",
                    hintVals, true /*justOne*/, &val)) {
       hints->domain_attr->data_progress = (enum fi_progress) val;
     }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -960,6 +960,12 @@ void init_ofi(void) {
 
 
 #ifdef CHPL_COMM_DEBUG
+struct cfgHint {
+  const char* str;
+  unsigned long int val;
+};
+
+
 static
 chpl_bool getCfgHint(const char* evName, struct cfgHint hintVals[],
                      chpl_bool justOne, uint64_t* pVal) {
@@ -994,92 +1000,96 @@ chpl_bool getCfgHint(const char* evName, struct cfgHint hintVals[],
 
   return true;
 }
-#endif
 
 
 static
 void debugOverrideHints(struct fi_info* hints) {
-  if (DBG_TEST_MASK(DBG_CFGFAB)) {
-    uint64_t val;
+  #define CFG_HINT(s)    { #s, (uint64_t) (s) }
+  #define CFG_HINT_NULL  { NULL, 0ULL }
 
-    {
-      struct cfgHint hintVals[] = { CFG_HINT(FI_COMMIT_COMPLETE),
-                                    CFG_HINT(FI_COMPLETION),
-                                    CFG_HINT(FI_DELIVERY_COMPLETE),
-                                    CFG_HINT(FI_INJECT),
-                                    CFG_HINT(FI_INJECT_COMPLETE),
-                                    CFG_HINT(FI_TRANSMIT_COMPLETE),
-                                    CFG_HINT_NULL, };
-      if (getCfgHint("COMM_OFI_HINTS_TX_OP_FLAGS",
-                     hintVals, false /*justOne*/, &val)) {
-        hints->tx_attr->op_flags = val;
-      }
-    }
+  uint64_t val;
 
-    {
-      struct cfgHint hintVals[] = { CFG_HINT(FI_ORDER_ATOMIC_RAR),
-                                    CFG_HINT(FI_ORDER_ATOMIC_RAW),
-                                    CFG_HINT(FI_ORDER_ATOMIC_WAR),
-                                    CFG_HINT(FI_ORDER_ATOMIC_WAW),
-                                    CFG_HINT(FI_ORDER_NONE),
-                                    CFG_HINT(FI_ORDER_RAR),
-                                    CFG_HINT(FI_ORDER_RAS),
-                                    CFG_HINT(FI_ORDER_RAW),
-                                    CFG_HINT(FI_ORDER_RMA_RAR),
-                                    CFG_HINT(FI_ORDER_RMA_RAW),
-                                    CFG_HINT(FI_ORDER_RMA_WAR),
-                                    CFG_HINT(FI_ORDER_RMA_WAW),
-                                    CFG_HINT(FI_ORDER_SAR),
-                                    CFG_HINT(FI_ORDER_SAS),
-                                    CFG_HINT(FI_ORDER_SAW),
-                                    CFG_HINT(FI_ORDER_WAR),
-                                    CFG_HINT(FI_ORDER_WAS),
-                                    CFG_HINT(FI_ORDER_WAW),
-                                    CFG_HINT_NULL, };
-      if (getCfgHint("COMM_OFI_HINTS_MSG_ORDER",
-                     hintVals, false /*justOne*/, &val)) {
-        hints->tx_attr->msg_order = hints->rx_attr->msg_order = val;
-      }
-    }
-
-    {
-      struct cfgHint hintVals[] = { CFG_HINT(FI_COMMIT_COMPLETE),
-                                    CFG_HINT(FI_COMPLETION),
-                                    CFG_HINT(FI_DELIVERY_COMPLETE),
-                                    CFG_HINT(FI_MULTI_RECV),
-                                    CFG_HINT_NULL, };
-      if (getCfgHint("COMM_OFI_HINTS_RX_OP_FLAGS",
-                     hintVals, false /*justOne*/, &val)) {
-        hints->rx_attr->op_flags = val;
-      }
-    }
-
-    {
-      struct cfgHint hintVals[] = { CFG_HINT(FI_PROGRESS_UNSPEC),
-                                    CFG_HINT(FI_PROGRESS_AUTO),
-                                    CFG_HINT(FI_PROGRESS_MANUAL),
-                                    CFG_HINT_NULL, };
-      if (getCfgHint("COMM_OFI_HINTS_PROGRESS",
-                     hintVals, true /*justOne*/, &val)) {
-        hints->domain_attr->data_progress = (enum fi_progress) val;
-      }
-    }
-
-    {
-      struct cfgHint hintVals[] = { CFG_HINT(FI_THREAD_UNSPEC),
-                                    CFG_HINT(FI_THREAD_SAFE),
-                                    CFG_HINT(FI_THREAD_FID),
-                                    CFG_HINT(FI_THREAD_DOMAIN),
-                                    CFG_HINT(FI_THREAD_COMPLETION),
-                                    CFG_HINT(FI_THREAD_ENDPOINT),
-                                    CFG_HINT_NULL, };
-      if (getCfgHint("COMM_OFI_HINTS_THREADING",
-                     hintVals, true /*justOne*/, &val)) {
-        hints->domain_attr->threading = (enum fi_threading) val;
-      }
+  {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_COMMIT_COMPLETE),
+                                  CFG_HINT(FI_COMPLETION),
+                                  CFG_HINT(FI_DELIVERY_COMPLETE),
+                                  CFG_HINT(FI_INJECT),
+                                  CFG_HINT(FI_INJECT_COMPLETE),
+                                  CFG_HINT(FI_TRANSMIT_COMPLETE),
+                                  CFG_HINT_NULL, };
+    if (getCfgHint("COMM_OFI_HINTS_TX_OP_FLAGS",
+                   hintVals, false /*justOne*/, &val)) {
+      hints->tx_attr->op_flags = val;
     }
   }
+
+  {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_ORDER_ATOMIC_RAR),
+                                  CFG_HINT(FI_ORDER_ATOMIC_RAW),
+                                  CFG_HINT(FI_ORDER_ATOMIC_WAR),
+                                  CFG_HINT(FI_ORDER_ATOMIC_WAW),
+                                  CFG_HINT(FI_ORDER_NONE),
+                                  CFG_HINT(FI_ORDER_RAR),
+                                  CFG_HINT(FI_ORDER_RAS),
+                                  CFG_HINT(FI_ORDER_RAW),
+                                  CFG_HINT(FI_ORDER_RMA_RAR),
+                                  CFG_HINT(FI_ORDER_RMA_RAW),
+                                  CFG_HINT(FI_ORDER_RMA_WAR),
+                                  CFG_HINT(FI_ORDER_RMA_WAW),
+                                  CFG_HINT(FI_ORDER_SAR),
+                                  CFG_HINT(FI_ORDER_SAS),
+                                  CFG_HINT(FI_ORDER_SAW),
+                                  CFG_HINT(FI_ORDER_WAR),
+                                  CFG_HINT(FI_ORDER_WAS),
+                                  CFG_HINT(FI_ORDER_WAW),
+                                  CFG_HINT_NULL, };
+    if (getCfgHint("COMM_OFI_HINTS_MSG_ORDER",
+                   hintVals, false /*justOne*/, &val)) {
+      hints->tx_attr->msg_order = hints->rx_attr->msg_order = val;
+    }
+  }
+
+  {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_COMMIT_COMPLETE),
+                                  CFG_HINT(FI_COMPLETION),
+                                  CFG_HINT(FI_DELIVERY_COMPLETE),
+                                  CFG_HINT(FI_MULTI_RECV),
+                                  CFG_HINT_NULL, };
+    if (getCfgHint("COMM_OFI_HINTS_RX_OP_FLAGS",
+                   hintVals, false /*justOne*/, &val)) {
+      hints->rx_attr->op_flags = val;
+    }
+  }
+
+  {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_PROGRESS_UNSPEC),
+                                  CFG_HINT(FI_PROGRESS_AUTO),
+                                  CFG_HINT(FI_PROGRESS_MANUAL),
+                                  CFG_HINT_NULL, };
+    if (getCfgHint("COMM_OFI_HINTS_PROGRESS",
+                   hintVals, true /*justOne*/, &val)) {
+      hints->domain_attr->data_progress = (enum fi_progress) val;
+    }
+  }
+
+  {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_THREAD_UNSPEC),
+                                  CFG_HINT(FI_THREAD_SAFE),
+                                  CFG_HINT(FI_THREAD_FID),
+                                  CFG_HINT(FI_THREAD_DOMAIN),
+                                  CFG_HINT(FI_THREAD_COMPLETION),
+                                  CFG_HINT(FI_THREAD_ENDPOINT),
+                                  CFG_HINT_NULL, };
+    if (getCfgHint("COMM_OFI_HINTS_THREADING",
+                   hintVals, true /*justOne*/, &val)) {
+      hints->domain_attr->threading = (enum fi_threading) val;
+    }
+  }
+
+  #undef CFG_HINT
+  #undef CFG_HINT_NULL
 }
+#endif
 
 
 static
@@ -1178,7 +1188,9 @@ void init_ofiFabricDomain(void) {
 
   hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 
+#ifdef CHPL_COMM_DEBUG
   debugOverrideHints(hints);
+#endif
 
   //
   // Try to find a provider that can do what we want.  If more than one

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1091,6 +1091,26 @@ void debugOverrideHints(struct fi_info* hints) {
     }
   }
 
+  {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_MR_UNSPEC),
+                                  CFG_HINT(FI_MR_BASIC),
+                                  CFG_HINT(FI_MR_SCALABLE),
+                                  CFG_HINT(FI_MR_LOCAL),
+                                  CFG_HINT(FI_MR_RAW),
+                                  CFG_HINT(FI_MR_VIRT_ADDR),
+                                  CFG_HINT(FI_MR_ALLOCATED),
+                                  CFG_HINT(FI_MR_PROV_KEY),
+                                  CFG_HINT(FI_MR_MMU_NOTIFY),
+                                  CFG_HINT(FI_MR_RMA_EVENT),
+                                  CFG_HINT(FI_MR_ENDPOINT),
+                                  CFG_HINT(FI_MR_HMEM),
+                                  CFG_HINT_NULL, };
+    if (getCfgHint("COMM_OFI_HINTS_MR_MODE",
+                   hintVals, false /*justOne*/, &val)) {
+      hints->domain_attr->mr_mode = (int) val;
+    }
+  }
+
   #undef CFG_HINT
   #undef CFG_HINT_NULL
 }
@@ -1179,17 +1199,13 @@ void init_ofiFabricDomain(void) {
   // PROV_KEY is marked TODO only because if the provider doesn't assert
   // that mode we may be able to avoid broadcasting keys around the job.
   //
-  int mr_mode;
-  if ((mr_mode = chpl_env_rt_get_int("COMM_MR_MODE", -1)) == -1) {
-    mr_mode = FI_MR_LOCAL
-              | FI_MR_VIRT_ADDR
-              | FI_MR_PROV_KEY /*TODO*/
-              | FI_MR_ENDPOINT;
-    if (chpl_numNodes > 1 && chpl_comm_getenvMaxHeapSize() > 0) {
-      mr_mode |= FI_MR_ALLOCATED;
-    }
+  hints->domain_attr->mr_mode = (  FI_MR_LOCAL
+                                 | FI_MR_VIRT_ADDR
+                                 | FI_MR_PROV_KEY /*TODO*/
+                                 | FI_MR_ENDPOINT);
+  if (chpl_numNodes > 1 && chpl_comm_getenvMaxHeapSize() > 0) {
+    hints->domain_attr->mr_mode |= FI_MR_ALLOCATED;
   }
-  hints->domain_attr->mr_mode = mr_mode;
 
   hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 


### PR DESCRIPTION
We have been just setting hints and then getting whatever provider
`fi_getinfo()` returned.  Here, do something more like a negotiated
agreement.  Set fundamental hints for the things we can't do without,
like messaging and RMA over RDM endpoints.  Then, try two different
things (transaction orderings and completion types) that, if successful,
will give us a "good" provider that has the functionality we need to
achieve the Chapel MCM.  "Good" here means it's neither the tcp nor the
sockets core provider, doesn't use the RxM utility provider if we've
asked for delivery-complete (since RxM can't do that correctly), and
also doesn't use the RxD utility provider since that hangs for us and is
pre-mainstream based on the libfabric Makefiles not building its man
page.

While doing the above, allow for the user having specified the provider
through the usual libfabric `FI_PROVIDER` environment variable mechanism,
and also allow for adjusting the hints manually if the comm layer was
built with debug.

Add the efa core provider, for the high-performance Elastic Fabric
Adaptor network on AWS.  This is now automatically selected, if it's
available and we're using a fixed heap.  (The fixed-heap requirement is
due to the need to register memory, similar to ofi-verbs.)

Don't use poll and wait sets with the efa provider.  It doesn't support
wait objects, and with `FI_WAIT_SET` in the CQ attributes wait_obj member
we get `ENOSYS` on fi_cq_open().  (Before doing what's here I tried simply
putting `FI_WAIT_UNSPEC` in the CQ attributes wait_obj member, but then
even simple tests with tcp;ofi_rxm hung.  I wasn't sure doing that was
legal anyway, and figuring out why the hang occurred seemed like it
might take a while, so I gave up at that point.)

Don't specify completion-related op_flags for the receive endpoint
attributes, because they don't actually apply there.

Fix a bug and clean up in CQ/counter binding.  The AM handler's tx
context CQ/counter wasn't bound for SENDs (oops!) or READs (simplifies
the code and doesn't hurt anything).

Disable completion counters for now.  We're having trouble with
completion counters with some providers, most notably that there seems
to be some variation in the requirement that tx endpoints must have CQs
so that they can gather errors related to transmits.  So until we can
rework the counter logic to allow for both CQs and counters on an
endpoint, and maybe until we see some evidence that counters make much
performance difference, disable support for them in the comm layer.
(The logic for counters is still there.  We just won't ever choose to
use them, even if the provider supports them.)

Get rid of the "available providers" support, because one use of it
disappeared in the provider selection rewrite the and other could be
replaced with an equally specific target platform check.

Fix a bug in the logic flow related to unilateral exit, which allowed
referencing the fabric info before it had been set by selecting a
provider.

Reconfigure the debug flags again, because they had gotten messy.

This resolves Cray/chapel-private#1086.