### PR TITLE
Fix uses of C_HDF5 in HDF5 module

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3467,7 +3467,7 @@ module HDF5 {
     pragma "no doc"
     module HDF5_WAR {
       require "HDF5Helper/hdf5_helper.h";
-      use C_HDF5;
+      use HDF5.C_HDF5;
 
       extern proc H5LTget_dataset_info_WAR(loc_id: hid_t,
                                            dset_name: c_string,
@@ -3913,7 +3913,7 @@ module HDF5 {
        can use arrays distributed over different numbers of locales.
      */
     proc hdf5WriteDistributedArray(A: [], filename: string, dsetName: string) {
-      use MPI, C_HDF5, BlockDist;
+      use MPI, super.C_HDF5, BlockDist;
 
       // Declare some extern symbols this function uses
       extern type MPI_Info;
@@ -4047,7 +4047,7 @@ module HDF5 {
       // instead of:
       // A11, A12, B11, B12
       // A21, A22, B21, B22
-      use BlockDist, CyclicDist, C_HDF5;
+      use BlockDist, CyclicDist, super.C_HDF5;
       proc isBlock(D: Block) param return true;
       proc isBlock(D) param return false;
       proc isCyclic(D: Cyclic) param return true;


### PR DESCRIPTION
With the recent improvement to require use or import of parent
modules to reference their symbols, uses of sibling modules require
an explicit path to the module.  These uses needed to be updated
as a result.

Passed test/library/packages/HDF5 with HDF5 enabled