### PR TITLE
Update networkAtomics!=none comm counts for sliceBlockWithRanges.

### DIFF
--- a/test/arrays/slices/commCounts/sliceBlockWithRanges.good
+++ b/test/arrays/slices/commCounts/sliceBlockWithRanges.good
@@ -1,7 +1,7 @@
 
 Creating B (a normal slice)
 ---------------------------
-(execute_on = 4, execute_on_nb = 3) (get = 24, put = 1, execute_on = 2) (get = 24, put = 1) (get = 24, put = 1)
+(execute_on = 4, execute_on_nb = 3) (get = 23, put = 1, execute_on = 2) (get = 23, put = 1) (get = 23, put = 1)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0


### PR DESCRIPTION
Following the lead of #15239 (01fa4e7), update comm counts for comm
layers that support network atomics (ofi, ugni).