### PR TITLE
Improve error messages for modules used as variables or functions

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2616,6 +2616,18 @@ static void removeUnusedModules() {
     if (usedModules.count(mod) == 0) {
       INT_ASSERT(mod->defPoint); // we should not be removing e.g. _root
       mod->defPoint->remove();
+
+      // Check that any mentions of the dead module are in
+      // dead modules
+      if (fVerify) {
+        for_SymbolSymExprs(se, mod) {
+          if (ModuleSymbol* inMod = se->getModule()) {
+            if (usedModules.count(inMod) != 0) {
+              INT_FATAL(se, "Invalid reference to unused module");
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -689,6 +689,8 @@ static bool isMethodNameLocal(const char* name, Type* type);
 static void checkIdInsideWithClause(Expr*              exprInAst,
                                     UnresolvedSymExpr* origUSE);
 
+static void checkModuleSymExpr(SymExpr* se);
+
 static void resolveUnresolvedSymExprs() {
   //
   // Translate M.x where M is a ModuleSymbol into just x where x is
@@ -802,6 +804,11 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
     usymExpr->replace(symExpr);
 
     updateMethod(usymExpr, sym, symExpr);
+
+    // Check for invalid uses of module symbols
+    if (isModuleSymbol(sym)) {
+      checkModuleSymExpr(symExpr);
+    }
 
   // sjd: stopgap to avoid shadowing variables or functions by methods
   } else if (fn->isMethod() == true) {
@@ -1094,6 +1101,47 @@ static void checkIdInsideWithClause(Expr*              exprInAst,
         errorDotInsideWithClause(origUSE, blockInfo->primitive->name);
       }
     }
+  }
+}
+
+// se refers to a ModuleSymbol. Check it is a valid mention of a module.
+static void checkModuleSymExpr(SymExpr* se) {
+  bool validModuleMention = false;
+
+  ModuleSymbol* mod = toModuleSymbol(se->symbol());
+  INT_ASSERT(mod != NULL); // caller should ensure this
+
+  CallExpr* call = toCallExpr(se->parentExpr);
+  if (call != NULL) {
+    // check for (Call gModuleToken, ModuleName, Args)
+    if (SymExpr* prevSe = toSymExpr(se->prev))
+      if (prevSe->symbol() == gModuleToken)
+        validModuleMention = true;
+    // check for (Call (Call . ModuleName FnName) Args)
+    if (call->isNamedAstr(astrSdot))
+      validModuleMention = true;
+    // check for PRIM_REFERENCED_MODULES_LIST
+    if (call->isPrimitive(PRIM_REFERENCED_MODULES_LIST))
+      validModuleMention = true;
+  }
+  if (Expr* stmt = se->getStmtExpr())
+    if (isUseStmt(stmt) || isImportStmt(stmt))
+      validModuleMention = true;
+
+  if (validModuleMention == false) {
+    bool callOfModule = false;
+    if (call != NULL)
+      if (SymExpr* baseSe = toSymExpr(call->baseExpr))
+        if (baseSe->symbol() == mod)
+          callOfModule = true;
+
+    const char* reason = NULL;
+    if (callOfModule)
+      reason = "cannot be called like procedures";
+    else
+      reason = "cannot be mentioned like variables";
+
+    USR_FATAL_CONT(se, "modules (like '%s' here) %s", mod->name, reason);
   }
 }
 

--- a/test/modules/errors/assign-param-from-module.chpl
+++ b/test/modules/errors/assign-param-from-module.chpl
@@ -1,0 +1,5 @@
+module Program {
+  module M { }
+
+  param m = M;
+}

--- a/test/modules/errors/assign-param-from-module.good
+++ b/test/modules/errors/assign-param-from-module.good
@@ -1,0 +1,1 @@
+assign-param-from-module.chpl:4: error: modules (like 'M' here) cannot be mentioned like variables

--- a/test/modules/errors/assign-var-from-imported-module.chpl
+++ b/test/modules/errors/assign-var-from-imported-module.chpl
@@ -1,0 +1,5 @@
+module Program {
+  module M { }
+  import Program.M;
+  var m = M;
+}

--- a/test/modules/errors/assign-var-from-imported-module.good
+++ b/test/modules/errors/assign-var-from-imported-module.good
@@ -1,0 +1,1 @@
+assign-var-from-imported-module.chpl:4: error: modules (like 'M' here) cannot be mentioned like variables

--- a/test/modules/errors/assign-var-from-module.chpl
+++ b/test/modules/errors/assign-var-from-module.chpl
@@ -1,0 +1,5 @@
+module Program {
+  module M { }
+
+  var m = M;
+}

--- a/test/modules/errors/assign-var-from-module.good
+++ b/test/modules/errors/assign-var-from-module.good
@@ -1,0 +1,1 @@
+assign-var-from-module.chpl:4: error: modules (like 'M' here) cannot be mentioned like variables

--- a/test/modules/errors/call-imported-module.chpl
+++ b/test/modules/errors/call-imported-module.chpl
@@ -1,0 +1,5 @@
+module Program {
+  module M { }
+  import Program.M;
+  M(20);
+}

--- a/test/modules/errors/call-imported-module.good
+++ b/test/modules/errors/call-imported-module.good
@@ -1,0 +1,1 @@
+call-imported-module.chpl:4: error: modules (like 'M' here) cannot be called like procedures

--- a/test/modules/errors/call-module.chpl
+++ b/test/modules/errors/call-module.chpl
@@ -1,0 +1,4 @@
+module Program {
+  module M { }
+  M(20);
+}

--- a/test/modules/errors/call-module.good
+++ b/test/modules/errors/call-module.good
@@ -1,0 +1,1 @@
+call-module.chpl:3: error: modules (like 'M' here) cannot be called like procedures

--- a/test/modules/errors/issue-14537.chpl
+++ b/test/modules/errors/issue-14537.chpl
@@ -1,0 +1,15 @@
+module Main {
+  module bar {
+    writeln("module bar");
+  }
+  
+  module fabs {
+    private proc bar() { writeln("proc bar"); }
+  }
+
+  module fibs {
+    use Main;
+    bar();
+    proc main() { writeln("main"); }
+  }
+}

--- a/test/modules/errors/issue-14537.good
+++ b/test/modules/errors/issue-14537.good
@@ -1,0 +1,1 @@
+issue-14537.chpl:12: error: modules (like 'bar' here) cannot be called like procedures


### PR DESCRIPTION
Resolves #13907
Resolves #14537

This PR improves error checking for invalid mentions of modules.  First, 
it addresses the memory corruption issue observed in those issues by
adding an internal error under `--verify` for uses of removed modules.
(It is an internal error under --verify because this code is not expected
to be encountered after the following steps).  Then, it adds
checkModuleSymExpr, called from resolveUnresolvedSymExpr in scopeResolve,
to check for invalid mentions of a module and to report a user-facing
error in that case.  Finally, it adds tests from issues #13907 and #14537
along with several variations.

Reviewed by @lydia-duncan - thanks!

- [x] full local --verify testing