### PR TITLE
Make Random's use of PCGRandomLib private

### DIFF
--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -123,7 +123,7 @@ module FFTW {
   */
   config param isFFTW_MKL=false;
 
-  use SysCTypes;
+  use SysCTypes, SysBasic;
   require "fftw3.h"; // This is common
   if (isFFTW_MKL) {
     require "fftw3_mkl.h";

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -566,7 +566,7 @@ module MPI {
 
    */
    module C_MPI {
-     use SysCTypes;
+     use SysCTypes, SysBasic;
      use MPI;
 
   // Special case MPI_Init -- we will send these null pointers

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -92,10 +92,10 @@
  */
 module FileSystem {
 
-  use SysError;
-  private use Path;
-  private use HaltWrappers;
-  private use SysCTypes;
+  public use SysError;
+  use Path;
+  use HaltWrappers;
+  use SysCTypes;
   use IO;
 
 /* S_IRUSR and the following constants are values of the form

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -768,7 +768,7 @@ module Random {
 
     use super.RandomSupport;
     private use Random;
-    public use PCGRandomLib;
+    private use PCGRandomLib;
     private use ChapelLocks;
     private import HaltWrappers;
 

--- a/test/library/standard/GMP/studies/gmp-chudnovsky.chpl
+++ b/test/library/standard/GMP/studies/gmp-chudnovsky.chpl
@@ -27,7 +27,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-use GMP, Time, SysCTypes;
+use GMP, Time, SysCTypes, SysBasic;
 
 param A = 13591409,
       B = 545140134,

--- a/test/library/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-check.chpl
@@ -1,4 +1,4 @@
-use Random;
+use Random, PCGRandomLib;
 
 config const verbose = false;
 

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
@@ -1,4 +1,4 @@
-use Random;
+use Random, PCGRandomLib;
 
 config const verbose = false;
 

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
@@ -1,4 +1,4 @@
-use Random;
+use Random, PCGRandomLib;
 
 config const seed = 42;
 

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -5,7 +5,7 @@
 */
 
 require "random_draw.h", "random_draw.c";
-use Time;
+use Time, SysBasic;
 
 // use random_draw library from PRK repo
 extern proc LCG_init();


### PR DESCRIPTION
Michael pointed this out in #16119, though it's not unique to that PR
or related to its intent, so I saved it for a separate PR.