### PR TITLE
Replace segfault when using qualified access to make a fcf with error message

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1275,12 +1275,21 @@ static void resolveModuleCall(CallExpr* call) {
                 call->replace(new CallExpr(fn));
 
               } else {
-                CallExpr* parent = toCallExpr(call->parentExpr);
+                if (CallExpr* parent = toCallExpr(call->parentExpr)) {
 
-                call->replace(new UnresolvedSymExpr(mbrName));
+                  call->replace(new UnresolvedSymExpr(mbrName));
 
-                parent->insertAtHead(mod);
-                parent->insertAtHead(gModuleToken);
+                  parent->insertAtHead(mod);
+                  parent->insertAtHead(gModuleToken);
+                } else {
+                  USR_FATAL_CONT(call, "This appears to be a first class "
+                                 "function reference created using qualified "
+                                 "access");
+                  USR_PRINT("First class functions created using "
+                            "qualified access are not supported");
+                  USR_PRINT("If this is not intended as a first class "
+                           "function, please report it to the Chapel team");
+                }
               }
 
             } else if (CallExpr* c = resolveModuleGetNewExpr(call, sym)) {

--- a/test/functions/resolution/parenless-call-segfault.bad
+++ b/test/functions/resolution/parenless-call-segfault.bad
@@ -1,8 +1,4 @@
-parenless-call-segfault.chpl:11: internal error: UTI-MIS-0691 chpl version 1.23.0 pre-release (c54a5da1fe)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+parenless-call-segfault.chpl:9: In function 'main':
+parenless-call-segfault.chpl:12: error: This appears to be a first class function reference created using qualified access
+note: First class functions created using qualified access are not supported
+note: If this is not intended as a first class function, please report it to the Chapel team

--- a/test/functions/resolution/parenless-call-segfault.chpl
+++ b/test/functions/resolution/parenless-call-segfault.chpl
@@ -1,5 +1,6 @@
 module M {
   proc y() {
+    writeln("Executing y");
     return 33;
   }
 }

--- a/test/functions/resolution/parenless-call-segfault.future
+++ b/test/functions/resolution/parenless-call-segfault.future
@@ -1,2 +1,2 @@
-bug: choice between qualified paren-ful and -less calls results in segfault
-
+unimplemented feature: creating a fcf using qualified access
+#16128

--- a/test/functions/resolution/parenless-call-segfault.good
+++ b/test/functions/resolution/parenless-call-segfault.good
@@ -1,1 +1,2 @@
+Executing y
 Success


### PR DESCRIPTION
The code was expecting a qualified access call to be within another CallExpr,
but this is not always the case for fcf accesses.  The initial transformation I
tried ended up causing the function to be executed instead of treated as a fcf,
so leave an error message for now instead of taking the more involved path to
fix what is very much a low priority issue.

Update the test for the new behavior:
Added a writeln that can be used for detecting the function is executing as
opposed to just becoming a fcf.  Updated the .bad file for the new error message
and the .good for the new writeln.  Updated the .future to point to the new
issue describing the problem.

Passed a full paratest with futures