### PR TITLE
Replace some where-clauses with formals types

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -71,10 +71,10 @@ module ChapelBase {
   inline proc =(ref a:opaque, b:opaque) {__primitive("=", a, b); }
   inline proc =(ref a:enum, b:enum) where (a.type == b.type) {__primitive("=", a, b); }
 
-  inline proc =(ref a, b: a.type) where isBorrowedOrUnmanagedClassType(a.type)
-  {
-    __primitive("=", a, b);
-  }
+  inline proc =(ref a: borrowed class, b: a.type) { __primitive("=", a, b); }
+  inline proc =(ref a: borrowed class?, b: a.type) { __primitive("=", a, b); }
+  inline proc =(ref a: unmanaged class, b: a.type) { __primitive("=", a, b); }
+  inline proc =(ref a: unmanaged class?, b: a.type) { __primitive("=", a, b); }
 
   pragma "compiler generated"
   pragma "last resort" // so user-supplied assignment will override this one.

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -71,20 +71,17 @@ module ChapelBase {
   inline proc =(ref a:opaque, b:opaque) {__primitive("=", a, b); }
   inline proc =(ref a:enum, b:enum) where (a.type == b.type) {__primitive("=", a, b); }
 
-  inline proc =(ref a: borrowed class, b: a.type) { __primitive("=", a, b); }
-  inline proc =(ref a: borrowed class?, b: a.type) { __primitive("=", a, b); }
-  inline proc =(ref a: unmanaged class, b: a.type) { __primitive("=", a, b); }
-  inline proc =(ref a: unmanaged class?, b: a.type) { __primitive("=", a, b); }
-
-  pragma "compiler generated"
-  pragma "last resort" // so user-supplied assignment will override this one.
-    // The CG pragma is needed because this function interferes with
-    // assignments defined for sync and single class types.
-  inline proc =(ref a, b:_nilType)
-  where isBorrowedOrUnmanagedClassType(a.type) &&
-        !isNonNilableClassType(a.type) {
-    __primitive("=", a, nil);
-  }
+  // Need pragma "last resort" to allow assignments to sync/single vars.
+  // a.type in a formal's type is computed before instantiation vs.
+  // a.type in the where clause is computed after instantiation.
+  pragma "last resort"
+  inline proc =(ref a: borrowed class,   b: a.type) where b.type <= a.type { __primitive("=", a, b); }
+  pragma "last resort"
+  inline proc =(ref a: borrowed class?,  b: a.type) where b.type <= a.type { __primitive("=", a, b); }
+  pragma "last resort"
+  inline proc =(ref a: unmanaged class,  b: a.type) where b.type <= a.type { __primitive("=", a, b); }
+  pragma "last resort"
+  inline proc =(ref a: unmanaged class?, b: a.type) where b.type <= a.type { __primitive("=", a, b); }
 
   inline proc =(ref a: nothing, b: ?t) where t != nothing {
     compilerError("a nothing variable cannot be assigned");

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -879,7 +879,7 @@ module ChapelRange {
    new type is not stridable, ensure at runtime that the old stride was 1.
  */
 pragma "no doc"
-proc range.safeCast(type t) where isRangeType(t) {
+proc range.safeCast(type t: range(?)) {
   var tmp: t;
 
   if tmp.boundedType != this.boundedType {
@@ -905,7 +905,7 @@ proc range.safeCast(type t) where isRangeType(t) {
    new type is not stridable, then force the new stride to be 1.
  */
 pragma "no doc"
-proc _cast(type t, r: range(?)) where isRangeType(t) {
+proc _cast(type t: range(?), r: range(?)) {
   var tmp: t;
 
   if tmp.boundedType != r.boundedType {
@@ -2411,7 +2411,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
   //# Utilities
   //#
 
-  proc _cast(type t, x: range(?)) where t == string {
+  proc _cast(type t: string, x: range(?)) {
     var ret: string;
 
     if x.hasLowBound() then

--- a/modules/internal/ChapelTaskID.chpl
+++ b/modules/internal/ChapelTaskID.chpl
@@ -30,8 +30,10 @@ module ChapelTaskID {
   inline proc ==(a: chpl_taskID_t, b: chpl_taskID_t)
     return __primitive("==", a, b);
 
-  inline proc _cast(type t, x: chpl_taskID_t) where t == int(64)
-                                                    || t == uint(64)
+  inline proc _cast(type t: int(64), x: chpl_taskID_t)
+    return __primitive("cast", t, x);
+
+  inline proc _cast(type t: uint(64), x: chpl_taskID_t)
     return __primitive("cast", t, x);
 
 }

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -313,12 +313,12 @@ module ChapelTuple {
   // Note: statically inlining the _chpl_complex runtime functions is necessary
   // for good performance
   //
-  inline proc _cast(type t, x: (?,?)) where t == complex(64) {
+  inline proc _cast(type t: complex(64), x: (?,?)) {
     extern proc _chpl_complex64(re:real(32),im:real(32)) : complex(64);
     return _chpl_complex64(x(0):real(32),x(1):real(32));
   }
 
-  inline proc _cast(type t, x: (?,?)) where t == complex(128) {
+  inline proc _cast(type t: complex(128), x: (?,?)) {
     extern proc _chpl_complex128(re:real(64),im:real(64)):complex(128);
     return _chpl_complex128(x(0):real(64),x(1):real(64));
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -360,139 +360,86 @@ module String {
   proc chpl__idxTypeToIntIdxType(type idxType: codepointIndex) type
     return int;
 
-  pragma "no doc"
-  inline proc >(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return x: int > y: int;
+  pragma "no doc" inline proc >(x: byteIndex, y: byteIndex)           return x: int > y: int;
+  pragma "no doc" inline proc >(x: codepointIndex, y: codepointIndex) return x: int > y: int;
 
-  pragma "no doc"
-  inline proc >(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return x: int > y;
+  pragma "no doc" inline proc >(x: byteIndex,      y: int) return x: int > y;
+  pragma "no doc" inline proc >(x: codepointIndex, y: int) return x: int > y;
 
-  pragma "no doc"
-  inline proc >(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return x > y: int;
+  pragma "no doc" inline proc >(x: int, y: byteIndex)      return x > y: int;
+  pragma "no doc" inline proc >(x: int, y: codepointIndex) return x > y: int;
   // End range helper support
 
   // Index arithmetic support
+
   // index + int or int + index --> index
-  pragma "no doc"
-  inline proc +(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return (x: int + y): t;
+  pragma "no doc" inline proc +(x: byteIndex,      y: int) return (x: int + y): byteIndex;
+  pragma "no doc" inline proc +(x: codepointIndex, y: int) return (x: int + y): codepointIndex;
 
-  pragma "no doc"
-  inline proc +(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return (x + y: int): t;
+  pragma "no doc" inline proc +(x: int, y: byteIndex)      return (x + y: int): byteIndex;
+  pragma "no doc" inline proc +(x: int, y: codepointIndex) return (x + y: int): codepointIndex;
 
-  pragma "no doc"
-  inline proc +(x: bufferType, y: byteIndex) {
-    return x+(y:int);
-  }
+  pragma "no doc" inline proc +(x: bufferType, y: byteIndex) return x+(y:int);
 
   // index - int --> index
-  pragma "no doc"
-  inline proc -(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return (x: int - y): t;
+  pragma "no doc" inline proc -(x: byteIndex,      y: int) return (x: int - y): byteIndex;
+  pragma "no doc" inline proc -(x: codepointIndex, y: int) return (x: int - y): codepointIndex;
 
   // index - index --> int
-  pragma "no doc"
-  inline proc -(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return x: int - y: int;
+  pragma "no doc" inline proc -(x: byteIndex, y: byteIndex)           return x: int - y: int;
+  pragma "no doc" inline proc -(x: codepointIndex, y: codepointIndex) return x: int - y: int;
 
   // other relationals
-  pragma "no doc"
-  inline proc <(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return x: int < y: int;
+  pragma "no doc" inline proc <(x: byteIndex, y: byteIndex)           return x: int < y: int;
+  pragma "no doc" inline proc <(x: codepointIndex, y: codepointIndex) return x: int < y: int;
 
-  pragma "no doc"
-  inline proc <(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return x: int < y;
+  pragma "no doc" inline proc <(x: byteIndex,      y: int) return x: int < y;
+  pragma "no doc" inline proc <(x: codepointIndex, y: int) return x: int < y;
 
-  pragma "no doc"
-  inline proc <(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return x < y: int;
+  pragma "no doc" inline proc <(x: int, y: byteIndex)      return x < y: int;
+  pragma "no doc" inline proc <(x: int, y: codepointIndex) return x < y: int;
 
-  pragma "no doc"
-  inline proc >=(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return x: int >= y: int;
+  pragma "no doc" inline proc >=(x: byteIndex, y: byteIndex)           return x: int >= y: int;
+  pragma "no doc" inline proc >=(x: codepointIndex, y: codepointIndex) return x: int >= y: int;
 
-  pragma "no doc"
-  inline proc >=(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return x: int >= y;
+  pragma "no doc" inline proc >=(x: byteIndex, y: int)      return x: int >= y;
+  pragma "no doc" inline proc >=(x: codepointIndex, y: int) return x: int >= y;
 
-  pragma "no doc"
-  inline proc >=(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return x >= y: int;
+  pragma "no doc" inline proc >=(x: int, y: byteIndex)      return x >= y: int;
+  pragma "no doc" inline proc >=(x: int, y: codepointIndex) return x >= y: int;
 
-  pragma "no doc"
-  inline proc <=(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return x: int <= y: int;
+  pragma "no doc" inline proc <=(x: byteIndex, y: byteIndex)           return x: int <= y: int;
+  pragma "no doc" inline proc <=(x: codepointIndex, y: codepointIndex) return x: int <= y: int;
 
-  pragma "no doc"
-  inline proc <=(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return x: int <= y;
+  pragma "no doc" inline proc <=(x: byteIndex, y: int)      return x: int <= y;
+  pragma "no doc" inline proc <=(x: codepointIndex, y: int) return x: int <= y;
 
-  pragma "no doc"
-  inline proc <=(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return x <= y: int;
+  pragma "no doc" inline proc <=(x: int, y: byteIndex)      return x <= y: int;
+  pragma "no doc" inline proc <=(x: int, y: codepointIndex) return x <= y: int;
 
-  pragma "no doc"
-  inline proc ==(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return (x:int) == (y:int);
+  pragma "no doc" inline proc ==(x: byteIndex, y: byteIndex)           return (x:int) == (y:int);
+  pragma "no doc" inline proc ==(x: codepointIndex, y: codepointIndex) return (x:int) == (y:int);
 
-  pragma "no doc"
-  inline proc ==(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return (x:int) == y;
+  pragma "no doc" inline proc ==(x: byteIndex,      y: int) return (x:int) == y;
+  pragma "no doc" inline proc ==(x: codepointIndex, y: int) return (x:int) == y;
 
-  pragma "no doc"
-  inline proc ==(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return x == (y:int);
+  pragma "no doc" inline proc ==(x: int, y: byteIndex)      return x == (y:int);
+  pragma "no doc" inline proc ==(x: int, y: codepointIndex) return x == (y:int);
 
-  pragma "no doc"
-  inline proc !=(x: ?t, y: t)
-    where t == byteIndex || t == codepointIndex
-    return (x:int) != (y:int);
+  pragma "no doc" inline proc !=(x: byteIndex, y: byteIndex)           return (x:int) != (y:int);
+  pragma "no doc" inline proc !=(x: codepointIndex, y: codepointIndex) return (x:int) != (y:int);
 
-  pragma "no doc"
-  inline proc !=(x: ?t, y: int)
-    where t == byteIndex || t == codepointIndex
-    return (x:int) != y;
+  pragma "no doc" inline proc !=(x: byteIndex, y: int)      return (x:int) != y;
+  pragma "no doc" inline proc !=(x: codepointIndex, y: int) return (x:int) != y;
 
-  pragma "no doc"
-  inline proc !=(x: int, y: ?t)
-    where t == byteIndex || t == codepointIndex
-    return x != (y:int);
+  pragma "no doc" inline proc !=(x: int, y: byteIndex)      return x != (y:int);
+  pragma "no doc" inline proc !=(x: int, y: codepointIndex) return x != (y:int);
 
-  pragma "no doc"
-  inline proc !(x: ?t)
-    where t == byteIndex || t == codepointIndex
-    return !(x:int);
+  pragma "no doc" inline proc !(x: byteIndex)      return !(x:int);
+  pragma "no doc" inline proc !(x: codepointIndex) return !(x:int);
 
-  pragma "no doc"
-  inline proc _cond_test(x: byteIndex)
-    return x != 0;
-
-  pragma "no doc"
-  inline proc _cond_test(x: codepointIndex)
-    return x != 0;
+  pragma "no doc" inline proc _cond_test(x: byteIndex)      return x != 0;
+  pragma "no doc" inline proc _cond_test(x: codepointIndex) return x != 0;
   // End index arithmetic support
 
   private proc validateEncoding(buf, len): int throws {
@@ -2378,13 +2325,13 @@ module String {
   //
 
   pragma "no doc"
-  inline proc _cast(type t, cs: c_string) where t == bufferType {
+  inline proc _cast(type t: bufferType, cs: c_string) {
     return __primitive("cast", t, cs);
   }
 
   // Cast from c_string to string
   pragma "no doc"
-  proc _cast(type t, cs: c_string) where t == string {
+  proc _cast(type t: string, cs: c_string) {
     try {
       return createStringWithNewBuffer(cs);
     }

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -141,17 +141,13 @@ inline proc !(a: syserr) return (qio_err_iserr(a) == 0:c_int);
 pragma "no doc"
 inline proc _cond_test(a: syserr) return (qio_err_iserr(a) != 0:c_int);
 pragma "no doc"
-inline proc _cast(type t, x: syserr) where t == int(32)
-  return qio_err_to_int(x);
+inline proc _cast(type t: int(32), x: syserr) return qio_err_to_int(x);
 pragma "no doc"
-inline proc _cast(type t, x: syserr) where t == int(64)
-  return qio_err_to_int(x):int(64);
+inline proc _cast(type t: int(64), x: syserr) return qio_err_to_int(x):int(64);
 pragma "no doc"
-inline proc _cast(type t, x: int(32)) where t == syserr
-  return qio_int_to_err(x);
+inline proc _cast(type t: syserr, x: int(32)) return qio_int_to_err(x);
 pragma "no doc"
-inline proc _cast(type t, x: int(64)) where t == syserr
-  return qio_int_to_err(x:int(32));
+inline proc _cast(type t: syserr, x: int(64)) return qio_int_to_err(x:int(32));
 pragma "no doc"
 inline proc =(ref ret:syserr, x:syserr) { __primitive("=", ret, x); }
 pragma "no doc"

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -799,8 +799,8 @@ This method performs the minimum number of runtime checks.
 For example, when casting from `uint(8)` to `uint(64)`,
 no checks at all will be done.
 */
-inline proc integral.safeCast(type T) : T where isUintType(T) {
-  if castChecking {
+inline proc integral.safeCast(type T: integral) : T {
+  if castChecking && isUintType(T) {
     if isIntType(this.type) {
       // int(?) -> uint(?)
       if this < 0 then // runtime check
@@ -815,12 +815,8 @@ inline proc integral.safeCast(type T) : T where isUintType(T) {
             " with a value greater than the maximum of "+ T:string+" to "+T:string);
     }
   }
-  return this:T;
-}
 
-pragma "no doc" // documented with the other safeCast above
-inline proc integral.safeCast(type T) : T where isIntType(T) {
-  if castChecking {
+  if castChecking && isIntType(T) {
     if max(this.type):uint > max(T):uint {
       // this isUintType check lets us avoid a runtime check for this < 0
       if isUintType(this.type) {

--- a/test/types/partial/match-param.bad
+++ b/test/types/partial/match-param.bad
@@ -1,8 +1,9 @@
 match-param.chpl:6: In function 'foo':
 match-param.chpl:6: error: unresolved call '==("hello", 100)'
-$CHPL_HOME/modules/internal/String.chpl:413: note: this candidate did not match: ==(x: ?t, y: int)
-$CHPL_HOME/modules/internal/String.chpl:413: note: because where clause evaluated to false
-match-param.chpl:1: note: candidates are: ==(_arg1: R, _arg2: R)
-$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:                 ==(a: _nilType, b: _nilType)
+match-param.chpl:1: note: this candidate did not match: ==(_arg1: R, _arg2: R)
+match-param.chpl:6: note: because call actual argument #1 with type string
+match-param.chpl:1: note: is passed to formal '_arg1: R'
+$CHPL_HOME/modules/internal/ChapelBase.chpl:100: note: candidates are: ==(a: _nilType, b: _nilType)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:101: note:                 ==(a: bool, b: bool)
 note: and N other candidates, use --print-all-candidates to see them
 match-param.chpl:1: Function 'foo' instantiated as: foo(x: R(int(64),100))

--- a/test/types/sync/vass/ref-sync-2.bad
+++ b/test/types/sync/vass/ref-sync-2.bad
@@ -1,0 +1,5 @@
+ref-sync-2.chpl:22: warning: fun1 sync
+ref-sync-2.chpl:23: warning: fun1 single
+ref-sync-2.chpl:24: error: ambiguous call 'fun2(sync int(64), int(64))'
+ref-sync-2.chpl:12: note: candidates are: fun2(ref x: int, y: int)
+ref-sync-2.chpl:13: note:                 fun2(x: _syncvar, y)

--- a/test/types/sync/vass/ref-sync-2.chpl
+++ b/test/types/sync/vass/ref-sync-2.chpl
@@ -1,7 +1,27 @@
 // Passing a sync variable to a non-sync 'ref' formal, same underlying type.
 
-var SVAR: sync int;
+/* See also:
+test/classes/delete-free/shared/shared-default-arg-nil-ref.chpl
+test/types/sync/ferguson/sync-coerce-to-ref.chpl
+*/
 
-MYPROC(SVAR);
+proc fun1(ref x: int,    y) { compilerWarning("fun1 int");    }
+proc fun1(ref x: sync,   y) { compilerWarning("fun1 sync");   }
+proc fun1(ref x: single, y) { compilerWarning("fun1 single"); }
 
-proc MYPROC(ref FORMAL: int) { }
+proc fun2(ref x: int,    y: int) { compilerWarning("fun2 int");    }
+proc fun2(ref x: sync,   y)      { compilerWarning("fun2 sync");   }
+
+proc fun3(ref x: int,    y: int) { compilerWarning("fun3 int");    }
+proc fun3(ref x: single, y)      { compilerWarning("fun3 single"); }
+
+var q: int;
+var sy: sync int;
+var si: single int;
+
+fun1(sy, q);
+fun1(si, q);
+fun2(sy, q);
+fun3(si, q);
+
+compilerError("done");

--- a/test/types/sync/vass/ref-sync-2.future
+++ b/test/types/sync/vass/ref-sync-2.future
@@ -1,0 +1,6 @@
+bug: 'ref x: int' formal is applicable to a 'sync int' actual
+#16137
+
+See also - to adjust .good:
+test/classes/delete-free/shared/shared-default-arg-nil-ref.chpl
+test/types/sync/ferguson/sync-coerce-to-ref.chpl

--- a/test/types/sync/vass/ref-sync-2.good
+++ b/test/types/sync/vass/ref-sync-2.good
@@ -1,2 +1,5 @@
-ref-sync-2.chpl:5: error: value from coercion passed to ref formal 'FORMAL'
-ref-sync-2.chpl:7: note: to function 'MYPROC' defined here
+ref-sync-2.chpl:22: warning: fun1 sync
+ref-sync-2.chpl:23: warning: fun1 single
+ref-sync-2.chpl:24: warning: fun2 sync
+ref-sync-2.chpl:25: warning: fun3 single
+ref-sync-2.chpl:27: error: done

--- a/test/types/unions/union-copy-init3.bad
+++ b/test/types/unions/union-copy-init3.bad
@@ -1,7 +1,8 @@
 union-copy-init3.chpl:5: In function 'init=':
 union-copy-init3.chpl:7: error: unresolved call '==(U, int(64))'
-$CHPL_HOME/modules/internal/String.chpl:465: note: this candidate did not match: ==(x: ?t, y: int)
-$CHPL_HOME/modules/internal/String.chpl:465: note: because where clause evaluated to false
-$CHPL_HOME/modules/internal/ChapelBase.chpl:99: note: candidates are: ==(a: _nilType, b: _nilType)
-$CHPL_HOME/modules/internal/ChapelBase.chpl:100: note:                 ==(a: bool, b: bool)
-note: and 122 other candidates, use --print-all-candidates to see them
+$CHPL_HOME/modules/internal/ChapelBase.chpl:100: note: this candidate did not match: ==(a: _nilType, b: _nilType)
+union-copy-init3.chpl:7: note: because call actual argument #1 with type U
+$CHPL_HOME/modules/internal/ChapelBase.chpl:100: note: is passed to formal 'a: nil'
+$CHPL_HOME/modules/internal/ChapelBase.chpl:101: note: candidates are: ==(a: bool, b: bool)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:107: note:                 ==(a: borrowed object?, b: borrowed object?)
+note: and 123 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
This PR restricts the types of previously-unrestricted generic formals of some overloads of commonly-invoked functions like `=`, `_cast`, `+`, etc.

For example:

```chpl
proc range.safeCast(type t) where isRangeType(t)   // before
proc range.safeCast(type t: range(?))              // after

// before: a generic overload
proc >(x: ?t, y: t)  where t == byteIndex || t == codepointIndex
// after: two concrete overloads
proc >(x: byteIndex, y: byteIndex)
proc >(x: codepointIndex, y: codepointIndex)
```

This reduces the number of times a generic function gets instantiated during resolution only to discover that its where-clause evaluates to false because the argument type is not as expected.

There are quite a few generic functions with where-clauses that already have type annotations on their formals, for example:

```chpl
inline proc ==(a: enum, b: enum) where (a.type != b.type)
proc =(ref a: [], b: _tuple) where isRectangularArr(a)
```

Even though they are generic, these type annotations are already effective to reduce the applicability of a generic resolution candidate.

I left without change several cases with unconstrained argument types where I did not see how to improve them, for example:

```chpl
// at least one formal has a type annotation
proc =(ref a: nothing, b: ?t) where t != nothing

// how to replace the constraint '! isPrimitiveType(x.type)' ?
proc _cast(type t, x) where t == string && ! isPrimitiveType(x.type)
```

Using `_anyManagementAnyNilable` and `chpl_anyPOD` might have helped simplify some cases. I was unaware of them when making these changes.

`match-param.bad` and `union-copy-init3.bad` needed adjustment because I removed a generic `==` function in String.chpl. They still illustrate the issues that they were created for.

While there, I repurposed `ref-sync-2.chpl` as a .future for #16137.
