### PR TITLE
Update non-'flat' locale models w.r.t. private use by default

### DIFF
--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -21,9 +21,9 @@ module LocaleModelHelpAPU {
 
   param localeModelHasSublocales = true;
 
-  use LocaleModelHelpSetup;
-  use LocaleModelHelpRuntime;
-  private use SysCTypes;
+  public use LocaleModelHelpSetup;
+  public use LocaleModelHelpRuntime;
+  use SysCTypes;
 
   pragma "no doc"
   config param debugAPULocale = false;

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -19,12 +19,12 @@
  */
 
 module LocaleModelHelpNUMA {
-  private use SysCTypes;
+  use SysCTypes;
 
   param localeModelHasSublocales = true;
 
-  use LocaleModelHelpSetup;
-  use LocaleModelHelpRuntime;
+  public use LocaleModelHelpSetup;
+  public use LocaleModelHelpRuntime;
 
   //////////////////////////////////////////
   //

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -28,10 +28,10 @@
 //
 module LocaleModel {
 
-  use LocaleModelHelpAPU;
-  use LocaleModelHelpMem;
+  public use LocaleModelHelpAPU;
+  public use LocaleModelHelpMem;
 
-  private use IO;
+  use IO;
 
   //
   // The task layer calls these to convert between full sublocales and

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -29,10 +29,10 @@
 //
 module LocaleModel {
 
-  use LocaleModelHelpNUMA;
-  use LocaleModelHelpMem;
+  public use LocaleModelHelpNUMA;
+  public use LocaleModelHelpMem;
 
-  private use IO;
+  use IO;
 
   //
   // The task layer calls these to convert between full sublocales and


### PR DESCRIPTION
This was a stupid oversight.  I'd updated the other locale models in my original attempt at this branch, but failed to notice that I hadn't done it in this second, and merged, attempt.  This just propagates the same public/private use changes from the `flat` locale model to our other locale models.
