### PR TITLE
Assert array type in mason entry point formals

### DIFF
--- a/test/library/packages/UnitTest/Launcher_Test.chpl
+++ b/test/library/packages/UnitTest/Launcher_Test.chpl
@@ -2,7 +2,6 @@ private use List;
 use MasonTest;
 
 proc main(args: [] string) {
-    var compopts: list(string) = ["mason", "--recursive"];
-    for arg in args[1..] do compopts.append(arg);
-    masonTest(compopts);
+  var masonArgs = ["mason", "--recursive", args[1]];
+  masonTest(masonArgs);
 }

--- a/test/mason/mason-external/masonExternalRanges/CLEANFILES
+++ b/test/mason/mason-external/masonExternalRanges/CLEANFILES
@@ -1,8 +1,5 @@
-Mason.toml
 example/
-src/
 test/
 .git/
-.gitignore
 mason_home/
 

--- a/test/mason/mason-external/masonExternalRanges/mason-external-range.chpl
+++ b/test/mason/mason-external/masonExternalRanges/mason-external-range.chpl
@@ -4,13 +4,6 @@ use MasonBuild;
 use MasonInit;
 
 proc main() {
-  // Initialise a library project
-  const initArgs = ['mason', 'init', '-d'];
-  masonInit(initArgs);
-  // Adds external library to Mason.toml
-  const args: [0..3] string;
-  args = ['mason','add','--external','libtomlc99@0.2019.03.06:0.2019.06.24'];
-  masonModify(args);
   // Sets up Spack
   const setupArgs = ['mason','external','--setup'];
   masonExternal(setupArgs);

--- a/test/mason/mason-external/masonExternalRanges/mason-external-range.good
+++ b/test/mason/mason-external/masonExternalRanges/mason-external-range.good
@@ -1,3 +1,1 @@
-Initialized new library project: masonExternalRanges
-Adding external dependency with spec libtomlc99@0.2019.03.06:0.2019.06.24
 Installing Spack backend ...

--- a/test/mason/mason-external/masonExternalRanges/src/CToml.chpl
+++ b/test/mason/mason-external/masonExternalRanges/src/CToml.chpl
@@ -1,0 +1,8 @@
+module CToml {
+  require "toml.h";
+
+  public use SysCTypes;
+
+  // TODO: This test would be better if it used the toml library
+
+}

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -33,7 +33,7 @@ use MasonSystem;
 use MasonExternal;
 use MasonExample;
 
-proc masonBuild(args) throws {
+proc masonBuild(args: [] string) throws {
   var show = false;
   var release = false;
   var force = false;
@@ -94,7 +94,7 @@ proc masonBuild(args) throws {
     if show then compopts.append("--show");
     if release then compopts.append("--release");
     if force then compopts.append("--force");
-    masonExample(compopts);
+    masonExample(compopts.toArray());
   }
   else {
     var argsList = new list(string);

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -24,7 +24,7 @@ private use MasonHelp;
 private use IO;
 private use MasonUtils;
 
-proc masonDoc(args) throws {
+proc masonDoc(args: [] string) throws {
   try! {
     if args.size > 2 {
       masonDocHelp();

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -32,7 +32,7 @@ use FileSystem;
 use MasonEnv;
 
 /* Runs the .chpl files found within the /example directory */
-proc masonExample(args) {
+proc masonExample(args: [] string) {
 
   var show = false;
   var run = true;

--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -36,7 +36,7 @@ Initialises a library project in a project directory
   mason init <dirName/path>
   or mason init (inside project directory)
 */
-proc masonInit(args) throws {
+proc masonInit(args: [] string) throws {
   try! {
     var dirName = '';
     var show = false;

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -24,7 +24,7 @@ use MasonUtils;
 private use Map;
 
 /* Modify manifest file */
-proc masonModify(args) throws {
+proc masonModify(args: [] string) throws {
   try! {
 
     // Check for help flags

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -33,7 +33,7 @@ use MasonEnv;
   Creates a new library project at a given directory
   mason new <projectName/directoryName>
 */
-proc masonNew(args) throws {
+proc masonNew(args: [] string) throws {
   var vcs = true;
   var show = false;
   var packageName = '';

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -26,7 +26,7 @@ use MasonExample;
 use FileSystem;
 use TOML;
 
-proc masonRun(args) throws {
+proc masonRun(args: [] string) throws {
 
   var show = false;
   var example = false;
@@ -199,7 +199,7 @@ private proc masonBuildRun(args: [?d] string) {
       if release then execopts.append("--release");
       if force then execopts.append("--force");
       if show then execopts.append("--show");
-      masonExample(execopts);
+      masonExample(execopts.toArray());
     }
     else {
       var buildArgs: list(string);
@@ -211,7 +211,7 @@ private proc masonBuildRun(args: [?d] string) {
       if force then buildArgs.append("--force");
       if show then buildArgs.append("--show");
 
-      masonBuild(buildArgs);
+      masonBuild(buildArgs.toArray());
       runProjectBinary(show, release, execopts);
     }
   }

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -27,7 +27,7 @@ use MasonHelp;
 use Regexp;
 
 /* Entry point for mason system commands */
-proc masonSystem(args) {
+proc masonSystem(args: [] string) {
   try! {
     if args.size < 3 {
       masonSystemHelp();

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -44,7 +44,7 @@ var files: list(string);
 /* Runs the .chpl files found within the /tests directory of Mason packages
    or files which in the path provided.
 */
-proc masonTest(args) throws {
+proc masonTest(args: [] string) throws {
 
   var show = false;
   var run = true;


### PR DESCRIPTION
Assert `args` type is an array of strings for all mason entry point function, e.g. `masonTest(..)`. 

Additionally:

- Update any cases that passed a list to an array.
- Address `mason-external-ranges.chpl` test leaving tracked files after testing

- [x] `start_test test/mason test/library/packages/UnitTest`