### PR TITLE
Add skipifs for Vector's OOB tests

### DIFF
--- a/test/library/draft/Vector/first/vectorFirstHalt.skipif
+++ b/test/library/draft/Vector/first/vectorFirstHalt.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/library/draft/Vector/indexOf/vectorIndexOfHaltEnd.skipif
+++ b/test/library/draft/Vector/indexOf/vectorIndexOfHaltEnd.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/library/draft/Vector/indexOf/vectorIndexOfHaltStart.skipif
+++ b/test/library/draft/Vector/indexOf/vectorIndexOfHaltStart.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/library/draft/Vector/last/vectorLastHalt.skipif
+++ b/test/library/draft/Vector/last/vectorLastHalt.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
These tests are testing OOB-like errors which don't fire with --fast.

This PR adds skipifs for those tests.

Test:
- [x] `library/draft/Vector` with --fast