### PR TITLE
Add `use Sys;` to Spawn.chpl for ugni-specific behavior

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -461,7 +461,8 @@ module Spawn {
     // register with the NIC for numLocales == 1, and vfork is used instead of
     // fork when stdin, stdout, stderr=FORWARD so we won't run into this issue
     // under those circumstances. See issue #7550 for more details.
-    if CHPL_COMM == "ugni" then
+    if CHPL_COMM == "ugni" {
+      use Sys;
       if stdin != FORWARD || stdout != FORWARD || stderr != FORWARD then
         if numLocales > 1 {
           var env_c_str:c_string;
@@ -474,6 +475,7 @@ module Spawn {
                   "spawn with more than 1 locale for CHPL_COMM=ugni with hugepages currently requires stdin, stdout, stderr=FORWARD");
           }
         }
+    }
 
     if stdin == QIO_FD_PIPE || stdin == QIO_FD_BUFFERED_PIPE then
       stdin_pipe = true;


### PR DESCRIPTION
The Spawn module has a call to 'sys_getenv()' in a ugni-specific path
that I missed in my changes to make internal 'use' statements private
by default.  This PR adds a 'use Sys;' to make that call available
again to that code path.