### PR TITLE
Add some localAccesses back in lulesh-dense

### DIFF
--- a/test/studies/lulesh/bradc/lulesh-dense.chpl
+++ b/test/studies/lulesh/bradc/lulesh-dense.chpl
@@ -430,7 +430,7 @@ inline proc localizeNeighborNodes(eli: index(Elems),
                                   z: [] real, ref z_local: 8*real) {
 
   for param i in 0..nodesPerElem-1 {
-    const noi = elemToNode[eli][i];  // can this always be localAccess
+    const noi = elemToNode.localAccess[eli][i];  // can this always be localAccess
     
     x_local[i] = x[noi];
     y_local[i] = y[noi];
@@ -884,7 +884,7 @@ inline proc computeDTF(indx) {
     return max(real);
 
   const myarealg = arealg.localAccess[indx];
-  var dtf = ss[indx]**2;
+  var dtf = ss.localAccess[indx]**2;
   if myvdov < 0.0 then
     dtf += qqc2 * myarealg**2 * myvdov**2;
   dtf = sqrt(dtf);
@@ -903,7 +903,7 @@ proc CalcCourantConstraintForElems() {
 
 
 inline proc calcDtHydroTmp(indx) {
-  const myvdov = vdov[indx];
+  const myvdov = vdov.localAccess[indx];
   if (myvdov == 0.0) then
     return max(real);
   else


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/16071 removed a lot of
`localAccess`es from lulesh-dense. I used search and replace and mutlilocale
perf testing to confirm that we didn't slip the performance. However, there were
some regressions in single locale. This PR adds some of the needed explicit
`localAccess` calls back.

These ones cannot be automatically added by the compiler (yet?) because the
accesses are inside a function that's called from within a `forall`. Currently,
we only look at the body of the loop and don't go into the function calls where
the loop indices are passed as an argument.

Test:
- [x] improves performance locally
