### PR TITLE
Shift registry check to --dry-run

### DIFF
--- a/test/mason/publish-tests/PREDIFF
+++ b/test/mason/publish-tests/PREDIFF
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+outfile=$2
+temp=$outfile.temp
+
+cat $outfile | sed "s|${PWD}|\$PWD|" > $temp
+
+mv $temp $outfile

--- a/test/mason/publish-tests/dryTest.future
+++ b/test/mason/publish-tests/dryTest.future
@@ -1,0 +1,1 @@
+Future added since the program times out due to no input of username & password

--- a/test/mason/publish-tests/noFork.good
+++ b/test/mason/publish-tests/noFork.good
@@ -1,1 +1,9 @@
+Checking Registry with DummyPath path.
+------------------------------------------------------
+The current mason environment is:
+MASON_HOME: /home/anking/chapel/test/mason/publish-tests/mason_home *
+MASON_REGISTRY: registry|https://github.com/chapel-lang/mason-registry *
+MASON_OFFLINE: false *
+SPACK_ROOT: /home/anking/chapel/test/mason/publish-tests/mason_home/spack *
+   In order to use a local registry, ensure that MASON_REGISTRY points to the path.
 DummyPath is not a local git repository.

--- a/test/mason/publish-tests/noFork.good
+++ b/test/mason/publish-tests/noFork.good
@@ -5,5 +5,4 @@ MASON_HOME: $PWD/mason_home *
 MASON_REGISTRY: registry|https://github.com/chapel-lang/mason-registry *
 MASON_OFFLINE: false *
 SPACK_ROOT: $PWD/mason_home/spack *
-   In order to use a local registry, ensure that MASON_REGISTRY points to the path.
 DummyPath is not a local git repository.

--- a/test/mason/publish-tests/noFork.good
+++ b/test/mason/publish-tests/noFork.good
@@ -1,9 +1,9 @@
 Checking Registry with DummyPath path.
 ------------------------------------------------------
 The current mason environment is:
-MASON_HOME: /home/anking/chapel/test/mason/publish-tests/mason_home *
+MASON_HOME: $PWD/mason_home *
 MASON_REGISTRY: registry|https://github.com/chapel-lang/mason-registry *
 MASON_OFFLINE: false *
-SPACK_ROOT: /home/anking/chapel/test/mason/publish-tests/mason_home/spack *
+SPACK_ROOT: $PWD/mason_home/spack *
    In order to use a local registry, ensure that MASON_REGISTRY points to the path.
 DummyPath is not a local git repository.

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -21,6 +21,7 @@
 private use List;
 use MasonUtils;
 public use MasonHelp;
+const regUrl: string = "https://github.com/chapel-lang/mason-registry";
 
 proc MASON_HOME : string {
   const envHome = getEnv("MASON_HOME");
@@ -67,8 +68,7 @@ proc MASON_OFFLINE {
  */
 proc MASON_REGISTRY {
   const env = getEnv("MASON_REGISTRY");
-  const default = ("mason-registry",
-                   "https://github.com/chapel-lang/mason-registry");
+  const default = ("mason-registry",regUrl);
   var registries: list(2*string);
 
   if env == "" {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -273,16 +273,9 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
     writeln(spacer);
     writeln('The current mason environment is:');
     returnMasonEnv();
-    var regExists: bool = false;
-    const regUrl = "https://github.com/chapel-lang/mason-registry";
-    for regs in MASON_REGISTRY {
-      for reg in regs {
-        if reg == regUrl then regExists = true; 
-      }
-    }
-    if regExists {
-      writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
-    }
+    var reg = MASON_REGISTRY;
+    if reg.contains(('mason-registry', regUrl)) 
+      then writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
     if checkRegistryPath(registryPath, isLocal) {
       writeln('Package can be published to local registry');
       exit(0);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -274,8 +274,12 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
     writeln('The current mason environment is:');
     returnMasonEnv();
     var reg = MASON_REGISTRY;
-    if reg.contains(('mason-registry', regUrl)) 
-      then writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
+
+    if reg.size == 1 {
+      if reg[0] == ('mason-registry', regUrl) 
+        then writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
+    }
+
     if checkRegistryPath(registryPath, isLocal) {
       writeln('Package can be published to local registry');
       exit(0);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -104,7 +104,7 @@ proc masonPublish(ref args: list(string)) throws {
 
     if checkRegistryPath(registryPath, isLocal) {
       if dry {
-        dryRun(username, registryPath, isLocal);
+        dryRun(username, registryPath, true);
       }
       else {
         publishPackage(username, registryPath, isLocal);
@@ -267,6 +267,15 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
     }
   }
   else {
+    const spacer = '------------------------------------------------------';
+    writeln('Checking Registry with ' + registryPath + ' path.');
+    var registryTest = registryPathCheck(registryPath, username, false);
+    writeln(spacer);
+    writeln('The current mason environment is:');
+    returnMasonEnv();
+    if MASON_REGISTRY.size == 1 {
+      writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
+    }
     if checkRegistryPath(registryPath, isLocal) {
       writeln('Package can be published to local registry');
       exit(0);
@@ -549,14 +558,6 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     }
     writeln(spacer);
   }
-  writeln('Checking Registry with ' + path + ' path.');
-  var registryTest = registryPathCheck(path, username, trueIfLocal);
-  writeln(spacer);
-  writeln('The current mason environment is:');
-  returnMasonEnv();
-  if MASON_REGISTRY.size == 1 {
-    writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
-  }
   
   writeln(spacer);
   if package && !ci {
@@ -578,7 +579,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
   writeln('RESULTS');
   writeln(spacer);
 
-  if packageTest && remoteTest && moduleTest && registryTest && testTest 
+  if packageTest && remoteTest && moduleTest && testTest 
     && licenseTest && gitTagTest && masonFieldsTest {
     writeln('(PASSED) Your package is ready to publish');
   }
@@ -600,9 +601,6 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     }
     if !testTest {
       writeln('(FAILED) Your package does not have tests');
-    }
-    if !registryTest {
-      writeln('(FAILED) Your proposed registry is not a valid registry or path to a registry');
     }
     if !remoteTest {
       writeln('(FAILED) Your package has no remote origin and cannot be published');

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -273,7 +273,14 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
     writeln(spacer);
     writeln('The current mason environment is:');
     returnMasonEnv();
-    if MASON_REGISTRY.size == 1 {
+    var regExists: bool = false;
+    const regUrl = "https://github.com/chapel-lang/mason-registry";
+    for regs in MASON_REGISTRY {
+      for reg in regs {
+        if reg == regUrl then regExists = true; 
+      }
+    }
+    if regExists {
       writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
     }
     if checkRegistryPath(registryPath, isLocal) {


### PR DESCRIPTION
This PR aims to fix an error that shows up in the recent [Github Actions CI](https://github.com/chapel-lang/mason-registry/runs/907104647?check_suite_focus=true) on the registry. 
Therefore, shifting the check for fork of mason-registry from `mason publish --ci-check` to `mason publish --dry-run`.