### PR TITLE
Change mason to store binary in bin dir rather than symlink

### DIFF
--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -32,10 +32,13 @@ linkFile=$(bdir)/mason
 
 MASON_SOURCES=*.chpl
 
-all: mason
+all: $(bdir)/mason
 
+mason: $(bdir)/mason
 
-mason: $(MASON_SOURCES)
+install: $(bdir)/mason
+
+$(bdir)/mason: $(MASON_SOURCES)
 	@if [ $(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_regexp.py) != re2 ]; then \
         echo "CHPL_REGEXP=re2 is required to build mason"; \
         exit 1;\
@@ -43,28 +46,8 @@ mason: $(MASON_SOURCES)
 	@echo "Building Mason..."
 	@chplBinDir=$(bdir) ./buildMason
 
-install: mason
-ifneq ($(wildcard $(linkFile)),)
-	@echo "Removing old symbolic link..."
-	rm -f $(linkFile)
-	@echo
-endif
-	@echo "Installing symbolic link..."
-	@mkdir -p $(bdir)
-	cd $(CHPL_BIN_DIR) && ln -s $(link) mason
-
-update:
-	@echo "Re-building Mason..."
-	@chplBinDir=$(bdir) ./buildMason
-
 clean:
 	@echo "Removing Mason..."
-	rm -f $(shell pwd)/mason
-ifneq ($(wildcard $(linkFile)),)
-	@echo "Removing old symbolic link..."
-	@rm -f $(linkFile)
-	@echo
-endif
-
+	rm -f $(bdir)/mason
 
 clobber: clean

--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -32,11 +32,11 @@ linkFile=$(bdir)/mason
 
 MASON_SOURCES=*.chpl
 
-all: $(bdir)/mason
+all: $(bdir)/mason FORCE
 
-mason: $(bdir)/mason
+mason: $(bdir)/mason FORCE
 
-install: $(bdir)/mason
+install: $(bdir)/mason FORCE
 
 $(bdir)/mason: $(MASON_SOURCES)
 	@if [ $(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_regexp.py) != re2 ]; then \
@@ -46,8 +46,10 @@ $(bdir)/mason: $(MASON_SOURCES)
 	@echo "Building Mason..."
 	@chplBinDir=$(bdir) ./buildMason
 
-clean:
+clean: FORCE
 	@echo "Removing Mason..."
 	rm -f $(bdir)/mason
 
-clobber: clean
+clobber: clean FORCE
+
+FORCE:

--- a/tools/mason/buildMason
+++ b/tools/mason/buildMason
@@ -16,7 +16,7 @@ if command -v module > /dev/null 2>&1 ; then
   fi
 fi
 
-$chplBinDir/chpl mason.chpl
+$chplBinDir/chpl mason.chpl -o $chplBinDir/mason
 EXIT_STATUS=$?
 
 if [ ${EXIT_STATUS} != 0 ] ; then


### PR DESCRIPTION
We would like the mason binary to be in the bin directory so that builds 
with different platforms will work and to keep the built binary files
separate from the sources.

This PR changes the mason Makefile to store the binary in the bin dir and 
not create a symbolic link. It leaves `mason` and `install` targets for
compatibility but removes the `update` target.

Reviewed by @ben-albrecht - thanks!

- [x] full local testing