### PR TITLE
Add a missing 'use' to the HDF5 public interface

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -75,7 +75,7 @@ module HDF5 {
      https://portal.hdfgroup.org/display/HDF5/HDF5
   */
   module C_HDF5 {
-    public use SysCTypes;
+    public use SysCTypes, SysBasic;
 
     // Header given to c2chapel:
     require "hdf5_hl.h";


### PR DESCRIPTION
revealed by Arkouda smoke testing as a result of PR #16146 