### PR TITLE
Adjust module commands so they work with both Tcl and Lmod.

### DIFF
--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -70,7 +70,7 @@ instead of RDMA.
 
 ``CHPL_COMM=ugni`` without hugepages can detect some, but not all invalid
 remote reads/writes, but comes with a large performance cost. Hugepages can be
-unloaded with ``module unload $(module list -t 2>&1 | grep craype-hugepages)``
+unloaded with ``module unload $(module -t list 2>&1 | grep craype-hugepages)``
 
 
 Configuration Limitations

--- a/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap
+++ b/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap
@@ -2,7 +2,7 @@
 
 # Pluck the execOptsNum out of the execution command line.
 case $(echo $1 | sed "s/^.*=\([0-9]\)/\1/") in
-1) module unload $(module list --terse 2>&1 | grep craype-hugepages);;
+1) module unload $(module -t list 2>&1 | grep craype-hugepages);;
 esac
 
 exec ./$(basename ${0})-2 $*

--- a/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.wrap
+++ b/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.wrap
@@ -6,7 +6,7 @@
 # heap size so that it's just big enough to cause the message
 # we're testing here.
 #
-hpm=$(module list --terse 2>&1 | grep craype-hugepages)
+hpm=$(module -t list 2>&1 | grep craype-hugepages)
 if [[ -n "$hpm" ]] ; then module unload $hpm ; fi
 
 export CHPL_RT_CALL_STACK_SIZE=128K

--- a/util/build_configs/module-functions.bash
+++ b/util/build_configs/module-functions.bash
@@ -10,8 +10,8 @@ function ck_module_list() {
 
     case "$1" in ( "" ) ;; ( * ) log_error "ck_module_list: too many args=$@"; exit 2;; esac
 
-    local output=$( set +x; module list -t 2>&1 ) || {
-        log_error "Failed: module list -t"
+    local output=$( set +x; module -t list 2>&1 ) || {
+        log_error "Failed: module -t list"
         exit 2
     }
     case "$output" in
@@ -32,7 +32,7 @@ function list_loaded_modules() {
 
     # Sorted module list (currently loaded modules) to stdout
 
-    module list -t 2>&1 | tail -n +2 | sort
+    module -t list 2>&1 | tail -n +2 | sort
 }
 
 function get_module_re() {
@@ -64,7 +64,7 @@ function get_module_re() {
     done
     case "$target" in ( "" ) log_error "get_module_re: missing args: one <target> is required"; exit 2;; esac
 
-    local found=$( set +x; module list -t 2>&1 | cut -d/ -f1 | grep -e "^$target" || : ok )
+    local found=$( set +x; module -t list 2>&1 | cut -d/ -f1 | grep -e "^$target" || : ok )
     if [ -n "$filter" ]; then
         found=$( grep -v -e "$filter" <<<"$found" || : ok )
     fi
@@ -84,7 +84,7 @@ function get_module_version() {
     case "$2" in ( "" ) ;; ( * ) log_error "get_module_version: too many args=$@"; exit 2;; esac
     local target=$1
 
-    local found=$( set +x; module list -t 2>&1 | grep -E -e "^$target(/|$)" || : ok )
+    local found=$( set +x; module -t list 2>&1 | grep -E -e "^$target(/|$)" || : ok )
     case "$found" in
     ( "" )  echo "";;
     ( *\ * )    log_error "Unrecognized module list=$found"; exit 2;;

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -29,7 +29,7 @@ if [[ $FAIL == 1 || -z $2 || -z $3 || -z $4 || -z $5 ]]; then
 fi
 
 # Ensure that PrgEnv-gnu is loaded
-existing_prgenv=$(module list --terse 2>&1 | grep PrgEnv-)
+existing_prgenv=$(module -t list 2>&1 | grep PrgEnv-)
 if [ -z "${existing_prgenv}" ]
 then
   # No PrgEnv loaded, load PrgEnv-gnu

--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -37,7 +37,7 @@ if [ -z "$lchOK" ] ; then
   module load gnu-openmpi
 
   set -x
-  module list -l 2>&1 | grep -E -q '\bgnu-openmpi\b' || return $?
+  module list 2>&1 | grep -E -q '\bgnu-openmpi\b' || return $?
 
   export MPI_DIR=$(which mpicc | sed 's,/bin/mpicc$,,')
 fi

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -110,7 +110,7 @@ case $COMPILER in
     cray|intel|gnu)
         # swap out network modules to get "host-only" environment
         log_info "Swap network module for host-only environment."
-        module unload $(module list -t 2>&1 | grep craype-network)
+        module unload $(module -t list 2>&1 | grep craype-network)
         module load craype-network-none
         ;;
     pgi)
@@ -160,7 +160,7 @@ fi
 
 # no cpu targeting module supports the esxbld CPUs, so force x86-64
 if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
-    module unload $(module list -t 2>&1| grep craype-| grep -v craype-network |grep -v craype-target)
+    module unload $(module -t list 2>&1| grep craype-| grep -v craype-network |grep -v craype-target)
     log_info "Setting CRAY_CPU_TARGET to x86-64 to stifle chpl_cpu.py warnings."
     export CRAY_CPU_TARGET=x86-64
 fi

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -12,9 +12,9 @@ source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
 # setup for XC perf (ugni, gnu, 28-core broadwell)
-module unload $(module list --terse 2>&1 | grep PrgEnv-)
+module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
-module unload $(module list --terse 2>&1 | grep craype-hugepages)
+module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp


### PR DESCRIPTION
Various build and test environments important to us are converting from
the old Tcl `module` command to the new Lmod-based one.  Unfortunately
the syntax is a bit different: the Lmod versions don't support the '-l'
(dash-ell) option for "long" output, and their '-t' option for terse
output must be applied the command itself rather than to the subcommand.
Here, adapt.  Get rid of the dash-ell options; we'll just live without
the timestamps they gave us.  And migrate the '-t' options from the
subcommand to the command, because as luck would have it, the Tcl-based
stuff supports that syntax also.