### PR TITLE
Improve instantiation point error to print multiple instantiations

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -1086,9 +1086,17 @@ bool FnSymbol::retExprDefinesNonVoid() const {
   return retval;
 }
 
-const char* FnSymbol::argsToString(const char* sep) const {
+const char* FnSymbol::argsToString(const char* sep, bool forError) const {
   if (sep == NULL || sep[0] == '\0')
     sep = " ";
+
+  // Printing out generics substitutions as underlined
+  const char* startG = "";
+  const char* endG = "";
+  if (forError) {
+    startG = underlineErrorFormat();
+    endG = clearErrorFormat();
+  }
 
   const char* ret = astr("");
 
@@ -1105,6 +1113,8 @@ const char* FnSymbol::argsToString(const char* sep) const {
       // add a separator if this isn't the first one
       if (ret[0] != '\0')
         ret = astr(ret, sep);
+
+      bool isGeneric = sym != genericArg;
 
       // Get the concrete formal, too
       ArgSymbol* concreteArg = NULL;
@@ -1154,12 +1164,15 @@ const char* FnSymbol::argsToString(const char* sep) const {
           const size_t bufSize = 128;
           char buf[bufSize];
           snprint_imm(buf, bufSize, *imm);
-          ret = astr(ret, " = ", buf);
+          ret = astr(ret, " = ", startG, buf, endG);
         }
       } else if (isType) {
-        ret = astr(ret, "type ", name, " = ", toString(t));
+        ret = astr(ret, "type ", name, " = ", startG, toString(t), endG);
       } else {
-        ret = astr(ret, name, ": ", toString(t));
+        if (isGeneric)
+          ret = astr(ret, name, ": ", startG, toString(t), endG);
+        else
+          ret = astr(ret, name, ": ", toString(t));
       }
     }
   } else {

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -1086,7 +1086,7 @@ bool FnSymbol::retExprDefinesNonVoid() const {
   return retval;
 }
 
-const char* FnSymbol::substitutionsToString(const char* sep) const {
+const char* FnSymbol::argsToString(const char* sep) const {
   if (sep == NULL || sep[0] == '\0')
     sep = " ";
 
@@ -1097,69 +1097,81 @@ const char* FnSymbol::substitutionsToString(const char* sep) const {
   if (genericFn != NULL) {
     for_formals(genericArg, genericFn) {
       Symbol* sym = const_cast<FnSymbol*>(this)->substitutions.get(genericArg);
-      if (sym != NULL) {
-        Type* t = sym->getValType();
+      if (sym == NULL)
+        sym = genericArg;
 
-        // add a separator if this isn't the first one
-        if (ret[0] != '\0')
-          ret = astr(ret, sep);
+      Type* t = sym->getValType();
 
-        // Get the concrete formal, too
-        ArgSymbol* concreteArg = NULL;
-        for_formals(arg, this) {
-          if (arg->name == genericArg->name)
-            concreteArg = arg;
-        }
+      // add a separator if this isn't the first one
+      if (ret[0] != '\0')
+        ret = astr(ret, sep);
 
-        bool isParam = genericArg->intent == INTENT_PARAM ||
-                       genericArg->originalIntent == INTENT_PARAM;
-        bool isType = genericArg->intent == INTENT_TYPE ||
-                      genericArg->originalIntent == INTENT_TYPE ||
-                      genericArg->hasFlag(FLAG_TYPE_VARIABLE);
+      // Get the concrete formal, too
+      ArgSymbol* concreteArg = NULL;
+      for_formals(arg, this) {
+        if (arg->name == genericArg->name)
+          concreteArg = arg;
+      }
 
-        const char* name = genericArg->name;
-        if (genericArg->hasFlag(FLAG_EXPANDED_VARARGS) &&
-            name[0] == '_' && name[1] == 'e') {
-          // change _e##_name into name(##)
-          std::string num = name;
-          num.erase(0, 2); // remove _e
-          std::string n = num; // ##_name
-          num.resize(num.find('_')); // ##
-          n.erase(0, n.find('_')+1); // name
-          name = astr(n.c_str(), "(", num.c_str(), ")");
-        }
+      bool isParam = genericArg->intent == INTENT_PARAM ||
+                     genericArg->originalIntent == INTENT_PARAM;
+      bool isType = genericArg->intent == INTENT_TYPE ||
+                    genericArg->originalIntent == INTENT_TYPE ||
+                    genericArg->hasFlag(FLAG_TYPE_VARIABLE);
 
-        if (isParam) {
-          ret = astr(ret, "param ", name);
-          if (isNumericParamDefaultType(t) == false)
-            ret = astr(ret, ": ", toString(t));
-          Immediate* imm = getSymbolImmediate(sym);
-          if (imm == NULL && concreteArg != NULL) {
-            // Also look in the defaultExpr. See e.g. recursive-leader-errr.chpl
-            // and the iterKind enum.
-            // Not sure why this pattern doesn't set the immediate.
-            if (SymExpr* se = toSymExpr(concreteArg->defaultExpr->body.tail)) {
-              Symbol* sym = se->symbol();
-              imm = getSymbolImmediate(sym);
-              if (imm == NULL) {
-                if (isEnumSymbol(sym)) {
-                  ret = astr(ret, " = ", toString(t), ".", sym->name);
-                }
+      const char* name = genericArg->name;
+      if (genericArg->hasFlag(FLAG_EXPANDED_VARARGS) &&
+          name[0] == '_' && name[1] == 'e') {
+        // change _e##_name into name(##)
+        std::string num = name;
+        num.erase(0, 2); // remove _e
+        std::string n = num; // ##_name
+        num.resize(num.find('_')); // ##
+        n.erase(0, n.find('_')+1); // name
+        name = astr(n.c_str(), "(", num.c_str(), ")");
+      }
+
+      if (isParam) {
+        ret = astr(ret, "param ", name);
+        if (isNumericParamDefaultType(t) == false)
+          ret = astr(ret, ": ", toString(t));
+        Immediate* imm = getSymbolImmediate(sym);
+        if (imm == NULL && concreteArg != NULL) {
+          // Also look in the defaultExpr. See e.g. recursive-leader-errr.chpl
+          // and the iterKind enum.
+          // Not sure why this pattern doesn't set the immediate.
+          if (SymExpr* se = toSymExpr(concreteArg->defaultExpr->body.tail)) {
+            Symbol* sym = se->symbol();
+            imm = getSymbolImmediate(sym);
+            if (imm == NULL) {
+              if (isEnumSymbol(sym)) {
+                ret = astr(ret, " = ", toString(t), ".", sym->name);
               }
             }
           }
-          if (imm) {
-            const size_t bufSize = 128;
-            char buf[bufSize];
-            snprint_imm(buf, bufSize, *imm);
-            ret = astr(ret, " = ", buf);
-          }
-        } else if (isType) {
-          ret = astr(ret, "type ", name, " = ", toString(t));
-        } else {
-          ret = astr(ret, name, ": ", toString(t));
         }
+        if (imm) {
+          const size_t bufSize = 128;
+          char buf[bufSize];
+          snprint_imm(buf, bufSize, *imm);
+          ret = astr(ret, " = ", buf);
+        }
+      } else if (isType) {
+        ret = astr(ret, "type ", name, " = ", toString(t));
+      } else {
+        ret = astr(ret, name, ": ", toString(t));
       }
+    }
+  } else {
+    // get args for fully concrete functions
+    for_formals(arg, this) {
+      Type* t = arg->getValType();
+
+      // add a separator if this isn't the first one
+      if (ret[0] != '\0')
+        ret = astr(ret, sep);
+
+      ret = astr(ret, arg->name, ": ", toString(t));
     }
   }
 

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -63,6 +63,14 @@ void collectFnCalls(BaseAST* ast, std::vector<CallExpr*>& calls) {
       calls.push_back(call);
 }
 
+void collectVirtualAndFnCalls(BaseAST* ast, std::vector<CallExpr*>& calls) {
+  AST_CHILDREN_CALL(ast, collectFnCalls, calls);
+  if (CallExpr* call = toCallExpr(ast))
+    if (call->resolvedOrVirtualFunction() != NULL)
+      calls.push_back(call);
+}
+
+
 void collectExprs(BaseAST* ast, std::vector<Expr*>& exprs) {
   AST_CHILDREN_CALL(ast, collectExprs, exprs);
   if (Expr* expr = toExpr(ast))

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -211,7 +211,7 @@ public:
 
   bool                       retExprDefinesNonVoid()                     const;
 
-  const char*                substitutionsToString(const char* sep)      const;
+  const char*                argsToString(const char* sep)               const;
 
 private:
   virtual std::string        docsDirective();

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -211,7 +211,7 @@ public:
 
   bool                       retExprDefinesNonVoid()                     const;
 
-  const char*                argsToString(const char* sep)               const;
+  const char*                argsToString(const char* sep, bool forError) const;
 
 private:
   virtual std::string        docsDirective();

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -211,7 +211,9 @@ public:
 
   bool                       retExprDefinesNonVoid()                     const;
 
-  const char*                argsToString(const char* sep, bool forError) const;
+  std::string                nameAndArgsToString(const char* sep,
+                                                 bool forError,
+                                                 bool& printedUnderline) const;
 
 private:
   virtual std::string        docsDirective();

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -38,6 +38,8 @@ class Expr;
 
 // return vec of CallExprs of FnSymbols (no primitives)
 void collectFnCalls(BaseAST* ast, std::vector<CallExpr*>& calls);
+// same as above but also allows for virtual function calls
+void collectVirtualAndFnCalls(BaseAST* ast, std::vector<CallExpr*>& calls);
 // specialized helper for IBBs
 void collectTreeBoundGotosAndIteratorBreakBlocks(BaseAST* ast,
                                                  std::vector<GotoStmt*>& GOTOs,

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -145,6 +145,7 @@ extern bool fParseOnly;
 extern bool fPrintAllCandidates;
 extern bool fPrintCallGraph;
 extern bool fPrintCallStackOnError;
+extern bool fAutoPrintCallStackOnError;
 extern bool fPrintIDonError;
 extern bool fPrintModuleResolution;
 extern bool fPrintEmittedCodeSize;

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -153,6 +153,8 @@ extern bool fPrintDispatch;
 extern bool fPrintUnusedFns;
 extern bool fPrintUnusedInternalFns;
 extern bool fRegionVectorizer;
+extern bool fDetectColorTerminal;
+extern bool fUseColorTerminal;
 extern bool fGenIDS;
 extern bool fLocal;
 extern bool fIgnoreLocalClasses;

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -126,4 +126,11 @@ bool        printsUserLocation(const BaseAST* ast);
 // must be exported to avoid dead-code elimination by C++ compiler
 void        gdbShouldBreakHere();
 
+// Supporting bold / colorful output to terminals
+// These are "" if stderr is not a tty we think supports them
+// Otherwise they are format codes that can be print in error messages.
+const char* boldErrorFormat();
+const char* underlineErrorFormat();
+const char* clearErrorFormat();
+
 #endif

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -221,6 +221,7 @@ bool fExplainVerbose = false;
 bool fParseOnly = false;
 bool fPrintCallGraph = false;
 bool fPrintAllCandidates = false;
+bool fAutoPrintCallStackOnError = true;
 bool fPrintCallStackOnError = false;
 bool fPrintIDonError = false;
 bool fPrintModuleResolution = false;
@@ -824,6 +825,12 @@ static void setUseColorTerminalFlag(const ArgumentDescription* desc, const char*
   // fUseColorTerminal is set by the flag
 }
 
+static void setPrintCallstackOnErrorFlag(const ArgumentDescription* desc, const char* unused) {
+  // fPrintCallStackOnError is set by the flag
+  fAutoPrintCallStackOnError = false;
+}
+
+
 static void setHtmlUser(const ArgumentDescription* desc, const char* unused) {
   fdump_html = true;
   fdump_html_include_system_modules = false;
@@ -1012,7 +1019,7 @@ static ArgumentDescription arg_desc[] = {
  {"instantiate-max", ' ', "<max>", "Limit number of instantiations", "I", &instantiation_limit, "CHPL_INSTANTIATION_LIMIT", NULL},
  {"print-all-candidates", ' ', NULL, "[Don't] print all candidates for a resolution failure", "N", &fPrintAllCandidates, "CHPL_PRINT_ALL_CANDIDATES", NULL},
  {"print-callgraph", ' ', NULL, "[Don't] print a representation of the callgraph for the program", "N", &fPrintCallGraph, "CHPL_PRINT_CALLGRAPH", NULL},
- {"print-callstack-on-error", ' ', NULL, "[Don't] print the Chapel call stack leading to each error or warning", "N", &fPrintCallStackOnError, "CHPL_PRINT_CALLSTACK_ON_ERROR", NULL},
+ {"print-callstack-on-error", ' ', NULL, "[Don't] print the Chapel call stack leading to each error or warning", "N", &fPrintCallStackOnError, "CHPL_PRINT_CALLSTACK_ON_ERROR", setPrintCallstackOnErrorFlag},
  {"print-unused-functions", ' ', NULL, "[Don't] print the name and location of unused functions", "N", &fPrintUnusedFns, NULL, NULL},
  {"set", 's', "<name>[=<value>]", "Set config value", "S", NULL, NULL, readConfig},
  {"task-tracking", ' ', NULL, "Enable [disable] runtime task tracking", "N", &fEnableTaskTracking, "CHPL_TASK_TRACKING", NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -196,6 +196,8 @@ int scalar_replace_limit = 8;
 int inline_iter_yield_limit = 10;
 int tuple_copy_limit = scalar_replace_limit;
 bool fGenIDS = false;
+bool fDetectColorTerminal = true;
+bool fUseColorTerminal = false;
 int fLinkStyle = LS_DEFAULT; // use backend compiler's default
 bool fUserSetLocal = false;
 bool fLocal;   // initialized in postLocal()
@@ -817,6 +819,11 @@ static void setCacheEnable(const ArgumentDescription* desc, const char* unused) 
   parseCmdLineConfig("CHPL_CACHE_REMOTE", val);
 }
 
+static void setUseColorTerminalFlag(const ArgumentDescription* desc, const char* unused) {
+  fDetectColorTerminal = false;
+  // fUseColorTerminal is set by the flag
+}
+
 static void setHtmlUser(const ArgumentDescription* desc, const char* unused) {
   fdump_html = true;
   fdump_html_include_system_modules = false;
@@ -1044,6 +1051,7 @@ static ArgumentDescription arg_desc[] = {
  //       (so that they are available for user flags)
  {"", ' ', NULL, "Developer Flags -- Debug Output", NULL, NULL, NULL, NULL},
  {"cc-warnings", ' ', NULL, "[Don't] Give warnings for generated code", "N", &ccwarnings, "CHPL_CC_WARNINGS", NULL},
+ {"use-color-terminal", ' ', NULL, "[Don't] emit control codes for color and bold in error messages", "N", &fUseColorTerminal, "CHPL_USE_COLOR_TERMINAL", setUseColorTerminalFlag},
  {"gen-ids", ' ', NULL, "[Don't] pepper generated code with BaseAST::ids", "N", &fGenIDS, "CHPL_GEN_IDS", NULL},
  {"html", ' ', NULL, "Dump IR in HTML format (toggle)", "T", &fdump_html, "CHPL_HTML", NULL},
  {"html-user", ' ', NULL, "Dump IR in HTML for user module(s) only (toggle)", "T", &fdump_html, "CHPL_HTML_USER", setHtmlUser},

--- a/compiler/optimizations/noAliasSets.cpp
+++ b/compiler/optimizations/noAliasSets.cpp
@@ -728,7 +728,7 @@ void computeNoAliasSets() {
   forv_Vec(FnSymbol, p, gFnSymbols) {
     if (fnHasRefFormal(p)) {
       calls.clear();
-      collectFnCalls(p, calls);
+      collectVirtualAndFnCalls(p, calls);
 
       for_vector(CallExpr, call, calls) {
         FnSymbol* q = call->resolvedOrVirtualFunction();
@@ -926,7 +926,7 @@ void computeNoAliasSets() {
     INT_ASSERT(f1 != f2);
 
     calls.clear();
-    collectFnCalls(p, calls);
+    collectVirtualAndFnCalls(p, calls);
 
     for_vector(CallExpr, call, calls) {
       FnSymbol* q = call->resolvedOrVirtualFunction();

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -386,13 +386,19 @@ static void printInstantiationNote(FnSymbol* errFn, FnSymbol* prevFn,
 // Should be called at USR_STOP or just before the next
 // error changing err_fn is printed.
 static void printInstantiationNoteForLastError() {
-  if (err_fn_header_printed && err_fn &&
-      (err_fn->instantiatedFrom || fPrintCallStackOnError)) {
-    std::set<FnSymbol*> currentFns;
-    bool printedUnderline = false;
-    printInstantiationNote(err_fn, NULL, currentFns, printedUnderline);
-    if (printedUnderline) {
-      USR_PRINT("generic instantiations are underlined in the above callstack");
+  if (err_fn_header_printed && err_fn) {
+    bool printStack = false;
+    if (fAutoPrintCallStackOnError)
+      printStack = err_fn->instantiatedFrom != NULL;
+    else
+      printStack = fPrintCallStackOnError;
+
+    if (printStack) {
+      std::set<FnSymbol*> currentFns;
+      bool printedUnderline = false;
+      printInstantiationNote(err_fn, NULL, currentFns, printedUnderline);
+      if (printedUnderline)
+        USR_PRINT("generic instantiations are underlined in the above callstack");
     }
   }
 

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -292,12 +292,12 @@ static void printInstantiationNote(FnSymbol* errFn, FnSymbol* prevFn) {
     FnSymbol* inFn = bestPoint->getFunction();
 
     if (subsDesc == NULL || subsDesc[0] == '\0') {
-      print_error("%s:%d: %s called here",
+      print_error("%s:%d: %s called ",
                   cleanFilename(bestPoint),
                   bestPoint->linenum(),
                   fnKindAndName(errFn));
     } else {
-      print_error("%s:%d: %s called here as: %s(%s)",
+      print_error("%s:%d: %s called as %s(%s)",
                   cleanFilename(bestPoint),
                   bestPoint->linenum(),
                   fnKindAndName(errFn),

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -346,17 +346,17 @@ static void printInstantiationNote(FnSymbol* errFn, FnSymbol* prevFn,
   }
 
   if (bestPoint != NULL) {
-    const char* subsDesc = errFn->substitutionsToString(", ");
+    const char* subsDesc = errFn->argsToString(", ");
 
     FnSymbol* inFn = bestPoint->getFunction();
 
     if (subsDesc == NULL || subsDesc[0] == '\0') {
-      print_error("%s:%d: %s called ",
+      print_error("  %s:%d: %s called ",
                   cleanFilename(bestPoint),
                   bestPoint->linenum(),
                   fnKindAndName(errFn));
     } else {
-      print_error("%s:%d: %s called as %s(%s)",
+      print_error("  %s:%d: %s called as %s(%s)",
                   cleanFilename(bestPoint),
                   bestPoint->linenum(),
                   fnKindAndName(errFn),

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -356,17 +356,16 @@ static void printInstantiationNote(FnSymbol* errFn, FnSymbol* prevFn,
                   bestPoint->linenum(),
                   fnKindAndName(errFn));
     } else {
-      print_error("  %s:%d: %s called as %s(%s)",
+      print_error("  %s:%d: called as %s(%s)",
                   cleanFilename(bestPoint),
                   bestPoint->linenum(),
-                  fnKindAndName(errFn),
                   errFn->name,
                   subsDesc);
     }
 
     if (inFn->instantiatedFrom != NULL || fPrintCallStackOnError) {
       // finish the current line
-      print_error(" within %s\n", fnKindAndName(inFn));
+      print_error(" from %s\n", fnKindAndName(inFn));
       // continue to print call sites
       printInstantiationNote(inFn, errFn, currentFns);
     } else {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -797,37 +797,49 @@ static void setupErrorFormatEscapes() {
   if (gErrorFormatsSetup == false) {
     gErrorFormatsSetup = true;
 
-    // Check the TERM variable. This approach and these
-    // terminals are taken from googletest; see
-    // https://github.com/google/googletest/blob/master/googletest/src/gtest.cc#L3216
-    const char* term = getenv("TERM");
-    const char* colorTerms[] = {"xterm",
-                                "xterm-color",
-                                "xterm-256color",
-                                "screen",
-                                "screen-256color",
-                                "tmux",
-                                "tmux-256color",
-                                "rxvt-unicode",
-                                "rxvt-unicode-256color",
-                                "linux",
-                                "cygwin",
-                                NULL};
-    bool isColorTerm = false;
-    if (term == NULL) term = "";
-    for (int i = 0; colorTerms[i] != NULL; i++) {
-      if (0 == strcmp(term, colorTerms[i]))
-        isColorTerm = true;
+    // The normal configuration is
+    //   fUseColorTerminal=false
+    //   fDetectColorTerminal=true
+    // Other settings of these variables are for testing the formatting itself.
+    bool isColorTerm = fUseColorTerminal;
+    if (fDetectColorTerminal) {
+      // Check the TERM variable. This approach and these
+      // terminals are taken from googletest; see
+      // https://github.com/google/googletest/blob/master/googletest/src/gtest.cc#L3216
+      const char* term = getenv("TERM");
+      const char* colorTerms[] = {"xterm",
+                                  "xterm-color",
+                                  "xterm-256color",
+                                  "screen",
+                                  "screen-256color",
+                                  "tmux",
+                                  "tmux-256color",
+                                  "rxvt-unicode",
+                                  "rxvt-unicode-256color",
+                                  "linux",
+                                  "cygwin",
+                                  NULL};
+      if (term == NULL) term = "";
+      for (int i = 0; colorTerms[i] != NULL; i++) {
+        if (0 == strcmp(term, colorTerms[i]))
+          isColorTerm = true;
+      }
+
+      // Check if errors will be output to a tty. If not,
+      // the format codes will just store "" and have no effect.
+      if (isatty(fileno(stderr)) == 0) {
+        isColorTerm = false;
+      }
     }
 
     if (isColorTerm) {
-      // Check if errors will be output to a tty. If not,
-      // the format codes will just store "" and have no effect.
-      if (isatty(fileno(stderr))) {
-        gErrorFormatBold = "\x1B[1m";
-        gErrorFormatUnderline = "\x1B[4m";
-        gErrorFormatClearAll = "\x1B[0m";
-      }
+      gErrorFormatBold = "\x1B[1m";
+      gErrorFormatUnderline = "\x1B[4m";
+      gErrorFormatClearAll = "\x1B[0m";
+    } else {
+      gErrorFormatBold = "";
+      gErrorFormatUnderline = "";
+      gErrorFormatClearAll = "";
     }
   }
 }

--- a/test/analysis/flowanalysis/rec_fun-1.good
+++ b/test/analysis/flowanalysis/rec_fun-1.good
@@ -1,4 +1,4 @@
 rec_fun-1.chpl:2: error: unable to resolve return type of function 'f'
 rec_fun-1.chpl:2: In function 'f':
 rec_fun-1.chpl:5: error: called recursively at this point
-rec_fun-1.chpl:8: Function 'f' instantiated as: f(x: int(64))
+  rec_fun-1.chpl:8: called as f(x: int(64))

--- a/test/analysis/flowanalysis/rec_fun-2.good
+++ b/test/analysis/flowanalysis/rec_fun-2.good
@@ -1,4 +1,5 @@
 rec_fun-2.chpl:2: error: unable to resolve return type of function 'g'
 rec_fun-2.chpl:2: In function 'g':
 rec_fun-2.chpl:5: error: called recursively at this point
-rec_fun-2.chpl:9: Function 'g' instantiated as: g(x: int(64))
+  rec_fun-2.chpl:9: called as g(x: int(64)) from function 'f'
+  rec_fun-2.chpl:13: called as f(x: int(64))

--- a/test/analysis/flowanalysis/rec_fun-3.good
+++ b/test/analysis/flowanalysis/rec_fun-3.good
@@ -1,4 +1,5 @@
 rec_fun-3.chpl:2: error: unable to resolve return type of function 'g'
 rec_fun-3.chpl:2: In function 'g':
 rec_fun-3.chpl:5: error: called recursively at this point
-rec_fun-3.chpl:10: Function 'g' instantiated as: g(x: int(64))
+  rec_fun-3.chpl:10: called as g(x: int(64)) from function 'f'
+  rec_fun-3.chpl:15: called as f(x: int(64))

--- a/test/arrays/bradc/arrayOfArrayArg.bad
+++ b/test/arrays/bradc/arrayOfArrayArg.bad
@@ -1,6 +1,6 @@
 arrayOfArrayArg.chpl:5: In function 'bar':
 arrayOfArrayArg.chpl:5: error: unresolved call 'chpl__buildArrayRuntimeType(nil, type real(64))'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:433: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
+$CHPL_HOME/modules/internal/ChapelArray.chpl:453: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
 arrayOfArrayArg.chpl:5: note: because call actual argument #1 with type nil
-$CHPL_HOME/modules/internal/ChapelArray.chpl:433: note: is passed to formal 'dom: _domain'
-arrayOfArrayArg.chpl:1: Function 'bar' instantiated as: bar(X: [domain(1,int(64),false)] [domain(1,int(64),false)] real(64))
+$CHPL_HOME/modules/internal/ChapelArray.chpl:453: note: is passed to formal 'dom: _domain'
+  arrayOfArrayArg.chpl:1: called as bar(X: [domain(1,int(64),false)] [domain(1,int(64),false)] real(64))

--- a/test/arrays/errors/domainTypeAsDomainExpr.good
+++ b/test/arrays/errors/domainTypeAsDomainExpr.good
@@ -1,3 +1,3 @@
 domainTypeAsDomainExpr.chpl:6: In function 'fn':
 domainTypeAsDomainExpr.chpl:6: error: Domain expression was a type ('domain(1,int(64),false)') rather than a domain value or range list as expected
-domainTypeAsDomainExpr.chpl:12: Function 'fn' instantiated as: fn(vec: [domain(1,int(64),false)] owned Child)
+  domainTypeAsDomainExpr.chpl:12: called as fn(vec: [domain(1,int(64),false)] owned Child)

--- a/test/arrays/ferguson/return-array-as-int.good
+++ b/test/arrays/ferguson/return-array-as-int.good
@@ -1,3 +1,3 @@
-return-array-as-int.chpl:7: In function 'setRowNames':
+return-array-as-int.chpl:7: In method 'setRowNames':
 return-array-as-int.chpl:8: error: cannot return '[domain(1,int(64),false)] int(64)' when the declared return type is 'int(64)'
-return-array-as-int.chpl:12: Function 'setRowNames' instantiated as: setRowNames(rn: [domain(1,int(64),false)] string)
+  return-array-as-int.chpl:12: called as NamedMatrix.setRowNames(rn: [domain(1,int(64),false)] string)

--- a/test/arrays/ferguson/runtime-type-type.good
+++ b/test/arrays/ferguson/runtime-type-type.good
@@ -1,3 +1,3 @@
 runtime-type-type.chpl:3: In function 'tf':
 runtime-type-type.chpl:4: error: can't apply '.type' to a type ([domain(1,int(64),false)] int(64))
-runtime-type-type.chpl:7: Function 'tf' instantiated as: tf(type t = [domain(1,int(64),false)] int(64))
+  runtime-type-type.chpl:7: called as tf(type t = [domain(1,int(64),false)] int(64))

--- a/test/arrays/formals/queryArrOfArr2.bad
+++ b/test/arrays/formals/queryArrOfArr2.bad
@@ -1,3 +1,3 @@
 queryArrOfArr2.chpl:1: In function 'f':
 queryArrOfArr2.chpl:1: error: Query expressions are not currently supported in this context
-queryArrOfArr2.chpl:1: Function 'f' instantiated as: f(x: [domain(1,int(64),false)] real(64))
+  queryArrOfArr2.chpl:1: called as f(x: [domain(1,int(64),false)] real(64))

--- a/test/arrays/return/returnArbitraryBadEltType.good
+++ b/test/arrays/return/returnArbitraryBadEltType.good
@@ -1,3 +1,3 @@
 returnArbitraryBadEltType.chpl:1: In function 'inc':
 returnArbitraryBadEltType.chpl:2: error: array element type mismatch in return from real(64) to int(64)
-returnArbitraryBadEltType.chpl:7: Function 'inc' instantiated as: inc(X: [domain(1,int(64),false)] real(64))
+  returnArbitraryBadEltType.chpl:7: called as inc(X: [domain(1,int(64),false)] real(64))

--- a/test/arrays/return/returnArbitraryCoerced.bad
+++ b/test/arrays/return/returnArbitraryCoerced.bad
@@ -1,3 +1,3 @@
 returnArbitraryCoerced.chpl:1: In function 'inc':
 returnArbitraryCoerced.chpl:2: error: array element type mismatch in return from int(64) to real(64)
-returnArbitraryCoerced.chpl:7: Function 'inc' instantiated as: inc(X: [domain(1,int(64),false)] int(64))
+  returnArbitraryCoerced.chpl:7: called as inc(X: [domain(1,int(64),false)] int(64))

--- a/test/arrays/types-fixed-array/testTuple.bad
+++ b/test/arrays/types-fixed-array/testTuple.bad
@@ -9,4 +9,5 @@ note: element 0 of type shared T has no default value
 note: because it is a non-nilable class - consider the type shared T? instead
 note: element 1 of type shared T has no default value
 note: because it is a non-nilable class - consider the type shared T? instead
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: Function 'init_elts' instantiated as: init_elts(x: _ddata(2*shared T), s: int(64), type t = 2*shared T)
+  within internal functions (use --print-callstack-on-error to see)
+  testTuple.chpl:8: called as testArray(type t = 2*shared T)

--- a/test/arrays/types-resized-array/testTuple.bad
+++ b/test/arrays/types-resized-array/testTuple.bad
@@ -9,4 +9,5 @@ note: element 0 of type shared T has no default value
 note: because it is a non-nilable class - consider the type shared T? instead
 note: element 1 of type shared T has no default value
 note: because it is a non-nilable class - consider the type shared T? instead
-$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: Function 'init_elts' instantiated as: init_elts(x: _ddata(2*shared T), s: int(64), type t = 2*shared T)
+  within internal functions (use --print-callstack-on-error to see)
+  testTuple.chpl:8: called as testArray(type t = 2*shared T)

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,3 +1,3 @@
 ./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
 ./arrayAPItest.chpl:224: error: only sparse arrays have an IRV
-arrayOps2D.chpl:5: Function 'testArrayAPI2D' instantiated as: testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))
+  arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,3 +1,3 @@
 ./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
 ./arrayAPItest.chpl:220: error: reverse() is only supported on dense 1D arrays
-arrayOps2D.chpl:5: Function 'testArrayAPI2D' instantiated as: testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))
+  arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,3 +1,3 @@
 ./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
 ./arrayAPItest.chpl:229: error: sort() requires 1-D array
-arrayOps2D.chpl:5: Function 'testArrayAPI2D' instantiated as: testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))
+  arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/associative/types/testBorrowed.bad
+++ b/test/associative/types/testBorrowed.bad
@@ -1,3 +1,3 @@
 ./AssocTest.chpl:1: In function 'testAssoc':
 ./AssocTest.chpl:8: error: Cannot default initialize associative array because element type borrowed T is a non-nilable class
-testBorrowed.chpl:9: Function 'testAssoc' instantiated as: testAssoc(type t = borrowed T)
+  testBorrowed.chpl:9: called as testAssoc(type t = borrowed T)

--- a/test/associative/types/testOwned.bad
+++ b/test/associative/types/testOwned.bad
@@ -1,3 +1,3 @@
 ./AssocTest.chpl:1: In function 'testAssoc':
 ./AssocTest.chpl:8: error: Cannot default initialize associative array because element type owned T is a non-nilable class
-testOwned.chpl:8: Function 'testAssoc' instantiated as: testAssoc(type t = owned T)
+  testOwned.chpl:8: called as testAssoc(type t = owned T)

--- a/test/associative/types/testShared.bad
+++ b/test/associative/types/testShared.bad
@@ -1,3 +1,3 @@
 ./AssocTest.chpl:1: In function 'testAssoc':
 ./AssocTest.chpl:8: error: Cannot default initialize associative array because element type shared T is a non-nilable class
-testShared.chpl:8: Function 'testAssoc' instantiated as: testAssoc(type t = shared T)
+  testShared.chpl:8: called as testAssoc(type t = shared T)

--- a/test/associative/types/testTuple.bad
+++ b/test/associative/types/testTuple.bad
@@ -1,3 +1,3 @@
 ./AssocTest.chpl:1: In function 'testAssoc':
 ./AssocTest.chpl:8: error: Cannot default initialize associative array because element type 2*shared T cannot be default initialized
-testTuple.chpl:8: Function 'testAssoc' instantiated as: testAssoc(type t = 2*shared T)
+  testTuple.chpl:8: called as testAssoc(type t = 2*shared T)

--- a/test/associative/types/testUnmanaged.bad
+++ b/test/associative/types/testUnmanaged.bad
@@ -1,3 +1,3 @@
 ./AssocTest.chpl:1: In function 'testAssoc':
 ./AssocTest.chpl:8: error: Cannot default initialize associative array because element type unmanaged T is a non-nilable class
-testUnmanaged.chpl:9: Function 'testAssoc' instantiated as: testAssoc(type t = unmanaged T)
+  testUnmanaged.chpl:9: called as testAssoc(type t = unmanaged T)

--- a/test/classes/bradc/arrayInClass/arrayDomInClassRecord-illegal.good
+++ b/test/classes/bradc/arrayInClass/arrayDomInClassRecord-illegal.good
@@ -1,3 +1,3 @@
 arrayDomInClassRecord-illegal.chpl:30: In function 'baz':
 arrayDomInClassRecord-illegal.chpl:31: error: cannot assign to const variable
-arrayDomInClassRecord-illegal.chpl:16: Function 'baz' instantiated as: baz(x: R, y: int(64))
+  arrayDomInClassRecord-illegal.chpl:16: called as baz(x: R, y: int(64))

--- a/test/classes/bradc/compilerErrorInMethod/testClear.bad
+++ b/test/classes/bradc/compilerErrorInMethod/testClear.bad
@@ -1,2 +1,2 @@
-testClear.chpl:26: In function 'clear':
+testClear.chpl:26: In method 'clear':
 testClear.chpl:27: error: Can't clear a dense domain

--- a/test/classes/deinitializers/deinitExplicitCall.good
+++ b/test/classes/deinitializers/deinitExplicitCall.good
@@ -2,6 +2,6 @@ deinitExplicitCall.chpl:6: error: direct calls to deinit() are not allowed
 deinitExplicitCall.chpl:10: error: direct calls to deinit() are not allowed
 deinitExplicitCall.chpl:12: error: direct calls to deinit() are not allowed
 deinitExplicitCall.chpl:13: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:15: In function 'something':
+deinitExplicitCall.chpl:15: In method 'something':
 deinitExplicitCall.chpl:16: error: direct calls to deinit() are not allowed
 deinitExplicitCall.chpl:17: error: direct calls to deinit() are not allowed

--- a/test/classes/deitz/method/method_call2.good
+++ b/test/classes/deitz/method/method_call2.good
@@ -1,4 +1,4 @@
-method_call2.chpl:9: In function 'goo':
+method_call2.chpl:9: In method 'goo':
 method_call2.chpl:10: error: unresolved call 'bar.foo(2)'
 method_call2.chpl:1: note: this candidate did not match: foo(i: int)
 method_call2.chpl:10: note: because call is written as a method call

--- a/test/classes/delete-free/lifetimes/ref-escapes.good
+++ b/test/classes/delete-free/lifetimes/ref-escapes.good
@@ -25,9 +25,9 @@ ref-escapes.chpl:64: note: consider scope of y
 ref-escapes.chpl:68: In function 'badBar2':
 ref-escapes.chpl:70: error: Reference to scoped variable cannot be returned
 ref-escapes.chpl:69: note: consider scope of y
-ref-escapes.chpl:74: In function 'badBorrow1':
+ref-escapes.chpl:74: In method 'badBorrow1':
 ref-escapes.chpl:75: error: Reference to scoped variable other cannot be returned
 ref-escapes.chpl:74: note: consider scope of other
-ref-escapes.chpl:78: In function 'badBorrow2':
+ref-escapes.chpl:78: In method 'badBorrow2':
 ref-escapes.chpl:80: error: Reference to scoped variable tmp cannot be returned
 ref-escapes.chpl:78: note: consider scope of other

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.good
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.good
@@ -10,7 +10,7 @@ save-borrow-in-collection.chpl:25: note: consider scope of arg
 save-borrow-in-collection.chpl:36: In function 'error4':
 save-borrow-in-collection.chpl:37: error: Scoped variable would outlive the value it is set to
 save-borrow-in-collection.chpl:36: note: consider scope of arg
-save-borrow-in-collection.chpl:40: In function 'error5':
+save-borrow-in-collection.chpl:40: In method 'error5':
 save-borrow-in-collection.chpl:41: error: Scoped variable would outlive the value it is set to
 save-borrow-in-collection.chpl:40: note: consider scope of arg
 save-borrow-in-collection.chpl:50: In function 'error6':

--- a/test/classes/delete-free/lifetimes/specified-formal-order-primary-methods.good
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-primary-methods.good
@@ -1,4 +1,4 @@
-specified-formal-order-primary-methods.chpl:29: In function 'setCbad':
+specified-formal-order-primary-methods.chpl:29: In method 'setCbad':
 specified-formal-order-primary-methods.chpl:30: error: Scoped variable this would outlive the value it is set to
 specified-formal-order-primary-methods.chpl:29: note: consider scope of rhs
 specified-formal-order-primary-methods.chpl:34: In function 'badlt':

--- a/test/classes/delete-free/lifetimes/specified-formal-order-secondary-methods.good
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-secondary-methods.good
@@ -1,4 +1,4 @@
-specified-formal-order-secondary-methods.chpl:28: In function 'setCbad':
+specified-formal-order-secondary-methods.chpl:28: In method 'setCbad':
 specified-formal-order-secondary-methods.chpl:29: error: Scoped variable this would outlive the value it is set to
 specified-formal-order-secondary-methods.chpl:28: note: consider scope of rhs
 specified-formal-order-secondary-methods.chpl:32: In function 'badlt':

--- a/test/classes/delete-free/owned/owned-record-instantiation-types-user-init-borrows-error.good
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types-user-init-borrows-error.good
@@ -1,3 +1,3 @@
 owned-record-instantiation-types-user-init-borrows-error.chpl:11: In initializer:
 owned-record-instantiation-types-user-init-borrows-error.chpl:12: error: const actual is passed to a 'ref' formal of init=()
-owned-record-instantiation-types-user-init-borrows-error.chpl:18: Initializer instantiated as: init(field: owned MyClass)
+  owned-record-instantiation-types-user-init-borrows-error.chpl:18: called as GenericCollection.init(field: owned MyClass)

--- a/test/classes/delete-free/owned/owned-transfer-from-nonnil.good
+++ b/test/classes/delete-free/owned/owned-transfer-from-nonnil.good
@@ -36,7 +36,7 @@ owned-transfer-from-nonnil.chpl:201: error: mention of non-nilable variable afte
 owned-transfer-from-nonnil.chpl:200: note: ownership transfer occurred here
 owned-transfer-from-nonnil.chpl:207: In function 'test10':
 owned-transfer-from-nonnil.chpl:209: error: Cannot transfer ownership from this non-nilable reference variable
-owned-transfer-from-nonnil.chpl:220: In function 'init=':
+owned-transfer-from-nonnil.chpl:220: In method 'init=':
 owned-transfer-from-nonnil.chpl:221: error: Cannot transfer ownership from this non-nilable reference variable
 owned-transfer-from-nonnil.chpl:224: In function '=':
 owned-transfer-from-nonnil.chpl:225: error: Cannot transfer ownership from this non-nilable reference variable

--- a/test/classes/delete-free/type-casting.errors.good
+++ b/test/classes/delete-free/type-casting.errors.good
@@ -1,60 +1,60 @@
 type-casting.chpl:5: In function 'makeBorrowed1':
 type-casting.chpl:6: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:34: Function 'makeBorrowed1' instantiated as: makeBorrowed1(type t = borrowed MyClass)
+  type-casting.chpl:34: called as makeBorrowed1(type t = borrowed MyClass)
 type-casting.chpl:5: In function 'makeBorrowed1':
 type-casting.chpl:6: error: duplicate decorators - borrowed unmanaged MyClass
-type-casting.chpl:35: Function 'makeBorrowed1' instantiated as: makeBorrowed1(type t = unmanaged MyClass)
+  type-casting.chpl:35: called as makeBorrowed1(type t = unmanaged MyClass)
 type-casting.chpl:5: In function 'makeBorrowed1':
 type-casting.chpl:6: error: duplicate decorators - borrowed owned MyClass
-type-casting.chpl:36: Function 'makeBorrowed1' instantiated as: makeBorrowed1(type t = owned MyClass)
+  type-casting.chpl:36: called as makeBorrowed1(type t = owned MyClass)
 type-casting.chpl:5: In function 'makeBorrowed1':
 type-casting.chpl:6: error: duplicate decorators - borrowed borrowed MyClass?
-type-casting.chpl:40: Function 'makeBorrowed1' instantiated as: makeBorrowed1(type t = borrowed MyClass?)
+  type-casting.chpl:40: called as makeBorrowed1(type t = borrowed MyClass?)
 type-casting.chpl:5: In function 'makeBorrowed1':
 type-casting.chpl:6: error: duplicate decorators - borrowed unmanaged MyClass?
-type-casting.chpl:41: Function 'makeBorrowed1' instantiated as: makeBorrowed1(type t = unmanaged MyClass?)
+  type-casting.chpl:41: called as makeBorrowed1(type t = unmanaged MyClass?)
 type-casting.chpl:5: In function 'makeBorrowed1':
 type-casting.chpl:6: error: duplicate decorators - borrowed owned MyClass?
-type-casting.chpl:42: Function 'makeBorrowed1' instantiated as: makeBorrowed1(type t = owned MyClass?)
+  type-casting.chpl:42: called as makeBorrowed1(type t = owned MyClass?)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:55: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = MyClass)
+  type-casting.chpl:55: called as makeBorrowedBang1(type t = MyClass)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:56: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = borrowed MyClass)
+  type-casting.chpl:56: called as makeBorrowedBang1(type t = borrowed MyClass)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:57: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = unmanaged MyClass)
+  type-casting.chpl:57: called as makeBorrowedBang1(type t = unmanaged MyClass)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:58: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = owned MyClass)
+  type-casting.chpl:58: called as makeBorrowedBang1(type t = owned MyClass)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:61: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = MyClass?)
+  type-casting.chpl:61: called as makeBorrowedBang1(type t = MyClass?)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:62: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = borrowed MyClass?)
+  type-casting.chpl:62: called as makeBorrowedBang1(type t = borrowed MyClass?)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:63: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = unmanaged MyClass?)
+  type-casting.chpl:63: called as makeBorrowedBang1(type t = unmanaged MyClass?)
 type-casting.chpl:12: In function 'makeBorrowedBang1':
 type-casting.chpl:13: error: duplicate decorators - borrowed borrowed MyClass
-type-casting.chpl:64: Function 'makeBorrowedBang1' instantiated as: makeBorrowedBang1(type t = owned MyClass?)
+  type-casting.chpl:64: called as makeBorrowedBang1(type t = owned MyClass?)
 type-casting.chpl:19: In function 'makeBorrowedQ1':
 type-casting.chpl:20: error: duplicate decorators - borrowed borrowed MyClass?
-type-casting.chpl:78: Function 'makeBorrowedQ1' instantiated as: makeBorrowedQ1(type t = borrowed MyClass)
+  type-casting.chpl:78: called as makeBorrowedQ1(type t = borrowed MyClass)
 type-casting.chpl:19: In function 'makeBorrowedQ1':
 type-casting.chpl:20: error: duplicate decorators - borrowed unmanaged MyClass?
-type-casting.chpl:79: Function 'makeBorrowedQ1' instantiated as: makeBorrowedQ1(type t = unmanaged MyClass)
+  type-casting.chpl:79: called as makeBorrowedQ1(type t = unmanaged MyClass)
 type-casting.chpl:19: In function 'makeBorrowedQ1':
 type-casting.chpl:20: error: duplicate decorators - borrowed owned MyClass?
-type-casting.chpl:80: Function 'makeBorrowedQ1' instantiated as: makeBorrowedQ1(type t = owned MyClass)
+  type-casting.chpl:80: called as makeBorrowedQ1(type t = owned MyClass)
 type-casting.chpl:19: In function 'makeBorrowedQ1':
 type-casting.chpl:20: error: duplicate decorators - borrowed borrowed MyClass?
-type-casting.chpl:84: Function 'makeBorrowedQ1' instantiated as: makeBorrowedQ1(type t = borrowed MyClass?)
+  type-casting.chpl:84: called as makeBorrowedQ1(type t = borrowed MyClass?)
 type-casting.chpl:19: In function 'makeBorrowedQ1':
 type-casting.chpl:20: error: duplicate decorators - borrowed unmanaged MyClass?
-type-casting.chpl:85: Function 'makeBorrowedQ1' instantiated as: makeBorrowedQ1(type t = unmanaged MyClass?)
+  type-casting.chpl:85: called as makeBorrowedQ1(type t = unmanaged MyClass?)
 type-casting.chpl:19: In function 'makeBorrowedQ1':
 type-casting.chpl:20: error: duplicate decorators - borrowed owned MyClass?
-type-casting.chpl:86: Function 'makeBorrowedQ1' instantiated as: makeBorrowedQ1(type t = owned MyClass?)
+  type-casting.chpl:86: called as makeBorrowedQ1(type t = owned MyClass?)

--- a/test/classes/delete-free/undecorated-generic/duplicate-management-owned.bad
+++ b/test/classes/delete-free/undecorated-generic/duplicate-management-owned.bad
@@ -1,12 +1,12 @@
 duplicate-management-owned.chpl:3: In function 'to':
 duplicate-management-owned.chpl:3: error: duplicate decorators - owned owned MyClass
-duplicate-management-owned.chpl:7: Function 'to' instantiated as: to(type t = owned MyClass)
+  duplicate-management-owned.chpl:7: called as to(type t = owned MyClass)
 duplicate-management-owned.chpl:3: In function 'to':
 duplicate-management-owned.chpl:3: error: duplicate decorators - owned shared MyClass
-duplicate-management-owned.chpl:9: Function 'to' instantiated as: to(type t = shared MyClass)
+  duplicate-management-owned.chpl:9: called as to(type t = shared MyClass)
 duplicate-management-owned.chpl:19: In function 'ts':
 duplicate-management-owned.chpl:19: error: duplicate decorators - shared owned MyClass
-duplicate-management-owned.chpl:23: Function 'ts' instantiated as: ts(type t = owned MyClass)
+  duplicate-management-owned.chpl:23: called as ts(type t = owned MyClass)
 duplicate-management-owned.chpl:19: In function 'ts':
 duplicate-management-owned.chpl:19: error: duplicate decorators - shared shared MyClass
-duplicate-management-owned.chpl:25: Function 'ts' instantiated as: ts(type t = shared MyClass)
+  duplicate-management-owned.chpl:25: called as ts(type t = shared MyClass)

--- a/test/classes/delete-free/undecorated-generic/duplicate-management.good
+++ b/test/classes/delete-free/undecorated-generic/duplicate-management.good
@@ -1,42 +1,42 @@
 duplicate-management.chpl:3: In function 'factory':
 duplicate-management.chpl:4: error: duplicate decorators - owned owned MyClass
-duplicate-management.chpl:7: Function 'factory' instantiated as: factory(type t = owned MyClass)
+  duplicate-management.chpl:7: called as factory(type t = owned MyClass)
 duplicate-management.chpl:3: In function 'factory':
 duplicate-management.chpl:4: error: duplicate decorators - owned shared MyClass
-duplicate-management.chpl:9: Function 'factory' instantiated as: factory(type t = shared MyClass)
+  duplicate-management.chpl:9: called as factory(type t = shared MyClass)
 duplicate-management.chpl:3: In function 'factory':
 duplicate-management.chpl:4: error: duplicate decorators - owned unmanaged MyClass
-duplicate-management.chpl:11: Function 'factory' instantiated as: factory(type t = unmanaged MyClass)
+  duplicate-management.chpl:11: called as factory(type t = unmanaged MyClass)
 duplicate-management.chpl:3: In function 'factory':
 duplicate-management.chpl:4: error: duplicate decorators - owned borrowed MyClass
-duplicate-management.chpl:13: Function 'factory' instantiated as: factory(type t = borrowed MyClass)
+  duplicate-management.chpl:13: called as factory(type t = borrowed MyClass)
 duplicate-management.chpl:18: In function 'tu':
 duplicate-management.chpl:19: error: duplicate decorators - unmanaged owned MyClass
-duplicate-management.chpl:22: Function 'tu' instantiated as: tu(type t = owned MyClass)
+  duplicate-management.chpl:22: called as tu(type t = owned MyClass)
 duplicate-management.chpl:18: In function 'tu':
 duplicate-management.chpl:19: error: duplicate decorators - unmanaged shared MyClass
-duplicate-management.chpl:24: Function 'tu' instantiated as: tu(type t = shared MyClass)
+  duplicate-management.chpl:24: called as tu(type t = shared MyClass)
 duplicate-management.chpl:18: In function 'tu':
 duplicate-management.chpl:19: error: duplicate decorators - unmanaged unmanaged MyClass
-duplicate-management.chpl:26: Function 'tu' instantiated as: tu(type t = unmanaged MyClass)
+  duplicate-management.chpl:26: called as tu(type t = unmanaged MyClass)
 duplicate-management.chpl:18: In function 'tu':
 duplicate-management.chpl:19: error: duplicate decorators - unmanaged borrowed MyClass
-duplicate-management.chpl:28: Function 'tu' instantiated as: tu(type t = borrowed MyClass)
+  duplicate-management.chpl:28: called as tu(type t = borrowed MyClass)
 duplicate-management.chpl:34: In function 'tb':
 duplicate-management.chpl:35: error: duplicate decorators - borrowed owned MyClass
-duplicate-management.chpl:38: Function 'tb' instantiated as: tb(type t = owned MyClass)
+  duplicate-management.chpl:38: called as tb(type t = owned MyClass)
 duplicate-management.chpl:34: In function 'tb':
 duplicate-management.chpl:35: error: duplicate decorators - borrowed shared MyClass
-duplicate-management.chpl:40: Function 'tb' instantiated as: tb(type t = shared MyClass)
+  duplicate-management.chpl:40: called as tb(type t = shared MyClass)
 duplicate-management.chpl:34: In function 'tb':
 duplicate-management.chpl:35: error: duplicate decorators - borrowed unmanaged MyClass
-duplicate-management.chpl:42: Function 'tb' instantiated as: tb(type t = unmanaged MyClass)
+  duplicate-management.chpl:42: called as tb(type t = unmanaged MyClass)
 duplicate-management.chpl:34: In function 'tb':
 duplicate-management.chpl:35: error: duplicate decorators - borrowed borrowed MyClass
-duplicate-management.chpl:44: Function 'tb' instantiated as: tb(type t = borrowed MyClass)
+  duplicate-management.chpl:44: called as tb(type t = borrowed MyClass)
 duplicate-management.chpl:50: In function 'to':
 duplicate-management.chpl:50: error: duplicate decorators - owned owned MyClass
-duplicate-management.chpl:54: Function 'to' instantiated as: to(type t = owned MyClass)
+  duplicate-management.chpl:54: called as to(type t = owned MyClass)
 duplicate-management.chpl:50: In function 'to':
 duplicate-management.chpl:50: error: duplicate decorators - owned shared MyClass
-duplicate-management.chpl:56: Function 'to' instantiated as: to(type t = shared MyClass)
+  duplicate-management.chpl:56: called as to(type t = shared MyClass)

--- a/test/classes/diten/subclassMethodCall.bad
+++ b/test/classes/diten/subclassMethodCall.bad
@@ -1,6 +1,6 @@
-subclassMethodCall.chpl:17: In function 'method':
+subclassMethodCall.chpl:17: In method 'method':
 subclassMethodCall.chpl:18: error: unresolved call 'C2.foo()'
 subclassMethodCall.chpl:9: note: this candidate did not match: C1.foo()
 subclassMethodCall.chpl:18: note: because method call receiver with type C2
 subclassMethodCall.chpl:7: note: is passed to formal 'this: C1'
-subclassMethodCall.chpl:1: Function 'method' instantiated as: method(c: C2)
+  subclassMethodCall.chpl:1: called as borrowed Sub1.method(c: C2)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'borrowed MyClass?'
-init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-nil.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:10: error: Cannot assign to borrowed MyClass from nil
-init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)
+  init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:14: called as MyRecord.init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'owned MyClass?'
-init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)
+  init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'shared MyClass?'
-init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)
+  init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'unmanaged MyClass?'
-init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)
+  init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
-init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
-init-field-arg-nonnil-owned-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)
+  init-field-arg-nonnil-owned-from-nonnil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
-init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)
+  init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
-init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-nil.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-nil.chpl:10: error: Assigning non-nilable owned to nil
-init-field-arg-nonnil-owned-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)
+  init-field-arg-nonnil-owned-from-oknil-nil.chpl:14: called as MyRecord.init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-owned.chpl:10: error: cannot create a non-nilable owned variable from a nilable class instance
-init-field-arg-nonnil-owned-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)
+  init-field-arg-nonnil-owned-from-oknil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
-init-field-arg-nonnil-owned-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)
+  init-field-arg-nonnil-owned-from-oknil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
-init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)
+  init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
-init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
-init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)
+  init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
-init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-nil.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-nil.chpl:10: error: Assigning non-nilable shared to nil
-init-field-arg-nonnil-shared-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)
+  init-field-arg-nonnil-shared-from-oknil-nil.chpl:14: called as MyRecord.init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-owned.chpl:10: error: cannot create a non-nilable shared variable from a nilable class instance
-init-field-arg-nonnil-shared-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)
+  init-field-arg-nonnil-shared-from-oknil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-shared.chpl:10: error: cannot create a non-nilable shared variable from a nilable class instance
-init-field-arg-nonnil-shared-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)
+  init-field-arg-nonnil-shared-from-oknil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
-init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)
+  init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass' from a 'borrowed MyClass'
-init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass' from a 'owned MyClass'
-init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass)
+  init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass' from a 'shared MyClass'
-init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)
+  init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'borrowed MyClass?'
-init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-nil.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:10: error: Cannot assign to unmanaged MyClass from nil
-init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)
+  init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:14: called as MyRecord.init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'owned MyClass?'
-init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)
+  init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'shared MyClass?'
-init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)
+  init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'unmanaged MyClass?'
-init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)
+  init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
-init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)
+  init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-owned-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
-init-field-arg-oknil-owned-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)
+  init-field-arg-oknil-owned-from-nonnil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
-init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)
+  init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
-init-field-arg-oknil-owned-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-oknil-owned-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-owned-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
-init-field-arg-oknil-owned-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)
+  init-field-arg-oknil-owned-from-oknil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
-init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)
+  init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
-init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)
+  init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
-init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)
+  init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
-init-field-arg-oknil-shared-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-oknil-shared-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-unmanaged.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
-init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)
+  init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'borrowed MyClass'
-init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)
+  init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'owned MyClass'
-init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass)
+  init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'shared MyClass'
-init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)
+  init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-borrowed.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'borrowed MyClass?'
-init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)
+  init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-owned.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'owned MyClass?'
-init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)
+  init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:14: called as MyRecord.init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-shared.good
@@ -1,3 +1,3 @@
 init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'shared MyClass?'
-init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)
+  init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:14: called as MyRecord.init(rhs: shared MyClass?)

--- a/test/classes/ferguson/class-double-modifier.good
+++ b/test/classes/ferguson/class-double-modifier.good
@@ -1,36 +1,36 @@
 class-double-modifier.chpl:6: In function 'doit':
 class-double-modifier.chpl:8: error: duplicate decorators - unmanaged unmanaged A(int(64))
-class-double-modifier.chpl:41: Function 'doit' instantiated as: doit(type C = unmanaged A(int(64)))
+  class-double-modifier.chpl:41: called as doit(type C = unmanaged A(int(64)))
 class-double-modifier.chpl:6: In function 'doit':
 class-double-modifier.chpl:8: error: duplicate decorators - unmanaged owned A(int(64))
-class-double-modifier.chpl:42: Function 'doit' instantiated as: doit(type C = owned A(int(64)))
+  class-double-modifier.chpl:42: called as doit(type C = owned A(int(64)))
 class-double-modifier.chpl:6: In function 'doit':
 class-double-modifier.chpl:8: error: duplicate decorators - unmanaged shared A(int(64))
-class-double-modifier.chpl:43: Function 'doit' instantiated as: doit(type C = shared A(int(64)))
+  class-double-modifier.chpl:43: called as doit(type C = shared A(int(64)))
 class-double-modifier.chpl:6: In function 'doit':
 class-double-modifier.chpl:8: error: duplicate decorators - unmanaged borrowed A(int(64))
-class-double-modifier.chpl:44: Function 'doit' instantiated as: doit(type C = borrowed A(int(64)))
+  class-double-modifier.chpl:44: called as doit(type C = borrowed A(int(64)))
 class-double-modifier.chpl:15: In function 'doit2':
 class-double-modifier.chpl:17: error: duplicate decorators - owned unmanaged A(int(64))
-class-double-modifier.chpl:48: Function 'doit2' instantiated as: doit2(type C = unmanaged A(int(64)))
+  class-double-modifier.chpl:48: called as doit2(type C = unmanaged A(int(64)))
 class-double-modifier.chpl:15: In function 'doit2':
 class-double-modifier.chpl:17: error: duplicate decorators - owned owned A(int(64))
-class-double-modifier.chpl:49: Function 'doit2' instantiated as: doit2(type C = owned A(int(64)))
+  class-double-modifier.chpl:49: called as doit2(type C = owned A(int(64)))
 class-double-modifier.chpl:15: In function 'doit2':
 class-double-modifier.chpl:17: error: duplicate decorators - owned shared A(int(64))
-class-double-modifier.chpl:50: Function 'doit2' instantiated as: doit2(type C = shared A(int(64)))
+  class-double-modifier.chpl:50: called as doit2(type C = shared A(int(64)))
 class-double-modifier.chpl:15: In function 'doit2':
 class-double-modifier.chpl:17: error: duplicate decorators - owned borrowed A(int(64))
-class-double-modifier.chpl:51: Function 'doit2' instantiated as: doit2(type C = borrowed A(int(64)))
+  class-double-modifier.chpl:51: called as doit2(type C = borrowed A(int(64)))
 class-double-modifier.chpl:23: In function 'doit3':
 class-double-modifier.chpl:24: error: duplicate decorators - shared unmanaged A(int(64))
-class-double-modifier.chpl:55: Function 'doit3' instantiated as: doit3(type C = unmanaged A(int(64)))
+  class-double-modifier.chpl:55: called as doit3(type C = unmanaged A(int(64)))
 class-double-modifier.chpl:23: In function 'doit3':
 class-double-modifier.chpl:24: error: duplicate decorators - shared owned A(int(64))
-class-double-modifier.chpl:56: Function 'doit3' instantiated as: doit3(type C = owned A(int(64)))
+  class-double-modifier.chpl:56: called as doit3(type C = owned A(int(64)))
 class-double-modifier.chpl:23: In function 'doit3':
 class-double-modifier.chpl:24: error: duplicate decorators - shared shared A(int(64))
-class-double-modifier.chpl:57: Function 'doit3' instantiated as: doit3(type C = shared A(int(64)))
+  class-double-modifier.chpl:57: called as doit3(type C = shared A(int(64)))
 class-double-modifier.chpl:23: In function 'doit3':
 class-double-modifier.chpl:24: error: duplicate decorators - shared borrowed A(int(64))
-class-double-modifier.chpl:58: Function 'doit3' instantiated as: doit3(type C = borrowed A(int(64)))
+  class-double-modifier.chpl:58: called as doit3(type C = borrowed A(int(64)))

--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
@@ -1,4 +1,4 @@
-call-forwarded-omit-this.chpl:27: In function 'bad':
+call-forwarded-omit-this.chpl:27: In method 'bad':
 call-forwarded-omit-this.chpl:28: error: unresolved call 'area()'
 call-forwarded-omit-this.chpl:5: note: this candidate did not match: MyCircleImpl.area()
 call-forwarded-omit-this.chpl:28: note: because call is not written as a method call

--- a/test/classes/forwarding/forwardGenericVirtual.bad
+++ b/test/classes/forwarding/forwardGenericVirtual.bad
@@ -1,6 +1,6 @@
-forwardGenericVirtual.chpl:22: In function 'action':
+forwardGenericVirtual.chpl:22: In method 'action':
 forwardGenericVirtual.chpl:24: warning: Rank mismatch between borrowed Rect(3) and borrowed Rect(1)
 forwardGenericVirtual.chpl:26: error: unresolved call 'Rect(1).inner(borrowed Rect(3))'
 forwardGenericVirtual.chpl:18: note: this candidate did not match: Rect.inner(x)
 forwardGenericVirtual.chpl:18: note: because where clause evaluated to false
-forwardGenericVirtual.chpl:1: Function 'action' instantiated as: action(this: borrowed Rect(1), a: borrowed Rect(3))
+  forwardGenericVirtual.chpl:1: called as borrowed Rect(1).action(a: borrowed Rect(3))

--- a/test/classes/initializers/generics/phase1/nested-function-mods-field1.bad
+++ b/test/classes/initializers/generics/phase1/nested-function-mods-field1.bad
@@ -1,6 +1,6 @@
 nested-function-mods-field1.chpl:6: In initializer:
 nested-function-mods-field1.chpl:10: error: illegal lvalue in assignment
-nested-function-mods-field1.chpl:16: Initializer instantiated as: init(param val = 13)
+  nested-function-mods-field1.chpl:16: called as borrowed Foo.init(param val = 13)
 nested-function-mods-field1.chpl:6: In initializer:
 nested-function-mods-field1.chpl:10: error: parameter set multiple times
-nested-function-mods-field1.chpl:16: Initializer instantiated as: init(param val = 13)
+  nested-function-mods-field1.chpl:16: called as borrowed Foo.init(param val = 13)

--- a/test/classes/initializers/generics/phase1/nested-function-mods-field2.bad
+++ b/test/classes/initializers/generics/phase1/nested-function-mods-field2.bad
@@ -1,6 +1,6 @@
 nested-function-mods-field2.chpl:6: In initializer:
 nested-function-mods-field2.chpl:8: error: illegal lvalue in assignment
-nested-function-mods-field2.chpl:17: Initializer instantiated as: init(param val = 13)
+  nested-function-mods-field2.chpl:17: called as borrowed Foo.init(param val = 13)
 nested-function-mods-field2.chpl:6: In initializer:
 nested-function-mods-field2.chpl:8: error: parameter set multiple times
-nested-function-mods-field2.chpl:17: Initializer instantiated as: init(param val = 13)
+  nested-function-mods-field2.chpl:17: called as borrowed Foo.init(param val = 13)

--- a/test/classes/initializers/generics/phase1/nested-function-phase-2-mods-fields.bad
+++ b/test/classes/initializers/generics/phase1/nested-function-phase-2-mods-fields.bad
@@ -1,6 +1,6 @@
 nested-function-phase-2-mods-fields.chpl:7: In initializer:
 nested-function-phase-2-mods-fields.chpl:17: error: illegal lvalue in assignment
-nested-function-phase-2-mods-fields.chpl:23: Initializer instantiated as: init(param val = 13)
+  nested-function-phase-2-mods-fields.chpl:23: called as borrowed Foo.init(param val = 13)
 nested-function-phase-2-mods-fields.chpl:7: In initializer:
 nested-function-phase-2-mods-fields.chpl:17: error: parameter set multiple times
-nested-function-phase-2-mods-fields.chpl:23: Initializer instantiated as: init(param val = 13)
+  nested-function-phase-2-mods-fields.chpl:23: called as borrowed Foo.init(param val = 13)

--- a/test/classes/initializers/initequals/wrongType.bad
+++ b/test/classes/initializers/initequals/wrongType.bad
@@ -1,3 +1,3 @@
-wrongType.chpl:6: In function 'init=':
+wrongType.chpl:6: In method 'init=':
 wrongType.chpl:7: error: cannot assign expression of type 2*int(64) to field 'T' of type int(64)
-wrongType.chpl:13: Function 'init=' instantiated as: init=(this: R(int(64)))
+  wrongType.chpl:13: called as R(int(64)).init=(other: int(64))

--- a/test/classes/initializers/phase1/initFromThis.good
+++ b/test/classes/initializers/phase1/initFromThis.good
@@ -2,7 +2,7 @@ initFromThis.chpl:6: In initializer:
 initFromThis.chpl:7: error: cannot take a reference to "this" before this.complete()
 initFromThis.chpl:9: error: cannot take a reference to "this" before this.complete()
 initFromThis.chpl:11: error: cannot initialize a variable from "this" before this.complete()
-initFromThis.chpl:15: In function 'init=':
+initFromThis.chpl:15: In method 'init=':
 initFromThis.chpl:16: error: cannot take a reference to "this" before this.complete()
 initFromThis.chpl:18: error: cannot take a reference to "this" before this.complete()
 initFromThis.chpl:20: error: cannot initialize a variable from "this" before this.complete()

--- a/test/classes/initializers/postInit/invalidSuperPostinit.good
+++ b/test/classes/initializers/postInit/invalidSuperPostinit.good
@@ -1,16 +1,16 @@
-invalidSuperPostinit.chpl:11: In function 'postinit':
+invalidSuperPostinit.chpl:11: In method 'postinit':
 invalidSuperPostinit.chpl:12: error: "super.postinit()" may not be called in a if-statement without an else-branch
-invalidSuperPostinit.chpl:17: In function 'postinit':
+invalidSuperPostinit.chpl:17: In method 'postinit':
 invalidSuperPostinit.chpl:18: error: "super.postinit()" must be called in each branch of a conditional or not at all
-invalidSuperPostinit.chpl:24: In function 'postinit':
+invalidSuperPostinit.chpl:24: In method 'postinit':
 invalidSuperPostinit.chpl:26: error: Multiple calls to "super.postinit()"
-invalidSuperPostinit.chpl:31: In function 'postinit':
+invalidSuperPostinit.chpl:31: In method 'postinit':
 invalidSuperPostinit.chpl:32: error: "super.postinit()" is not allowed in loop statements
 invalidSuperPostinit.chpl:36: error: "super.postinit()" is not allowed in loop statements
 invalidSuperPostinit.chpl:42: error: "super.postinit()" is not allowed in loop statements
 invalidSuperPostinit.chpl:48: error: "super.postinit()" is not allowed in loop statements
 invalidSuperPostinit.chpl:50: error: "super.postinit()" is not allowed in loop statements
-invalidSuperPostinit.chpl:56: In function 'postinit':
+invalidSuperPostinit.chpl:56: In method 'postinit':
 invalidSuperPostinit.chpl:57: error: "super.postinit()" is not allowed in a coforall statement
 invalidSuperPostinit.chpl:59: error: "super.postinit()" is not allowed in a coforall statement
 invalidSuperPostinit.chpl:62: error: "super.postinit()" is not allowed in a begin statement

--- a/test/classes/nilability/error-with-bang-suggestion.good
+++ b/test/classes/nilability/error-with-bang-suggestion.good
@@ -14,4 +14,4 @@ error-with-bang-suggestion.chpl:30: note: this candidate did not match: myfun(ar
 error-with-bang-suggestion.chpl:38: note: because call actual argument #1 with type shared H5File?
 error-with-bang-suggestion.chpl:30: note: is passed to formal 'arg: H5File'
 error-with-bang-suggestion.chpl:38: note: try to apply the postfix ! operator to call actual argument #1
-error-with-bang-suggestion.chpl:11: Function 'writeScalarAttribute' instantiated as: writeScalarAttribute(loc: shared H5File?)
+  error-with-bang-suggestion.chpl:11: called as writeScalarAttribute(loc: shared H5File?)

--- a/test/compflags/ferguson/error-message-bolding.chpl
+++ b/test/compflags/ferguson/error-message-bolding.chpl
@@ -1,0 +1,29 @@
+proc h(arg) {
+  arg = 11;
+}
+
+proc g(arg, otherArg:int, param p, param pp, type t) {
+  h(arg);
+}
+
+record ConcreteRecord {
+  var concreteField: int;
+  proc methodA(arg) {
+    g(arg, 1, 2, 3:int(8), int);
+  }
+}
+
+record GenericRecord {
+  var genericField;
+  proc methodB(arg) {
+    var r = new ConcreteRecord(1);
+    r.methodA(arg);
+  }
+}
+
+proc f(arg) {
+  var r = new GenericRecord(1.0);
+  r.methodB(arg);
+}
+
+f("hi");

--- a/test/compflags/ferguson/error-message-bolding.colors.good
+++ b/test/compflags/ferguson/error-message-bolding.colors.good
@@ -1,0 +1,8 @@
+error-message-bolding.chpl:1: In function 'h':
+error-message-bolding.chpl:2: [1merror: [0mCannot assign to string from int(64)
+  error-message-bolding.chpl:6: called as h(arg: [4mstring[0m) from function 'g'
+  error-message-bolding.chpl:12: called as g(arg: [4mstring[0m, otherArg: int(64), param p = [4m2[0m, param pp = [4m3[0m: int(8), type t = [4mint(64)[0m) from method 'methodA'
+  error-message-bolding.chpl:20: called as ConcreteRecord.methodA(arg: [4mstring[0m) from method 'methodB'
+  error-message-bolding.chpl:26: called as [4mGenericRecord(real(64))[0m.methodB(arg: [4mstring[0m) from function 'f'
+  error-message-bolding.chpl:29: called as f(arg: [4mstring[0m)
+note: generic instantiations are underlined in the above callstack

--- a/test/compflags/ferguson/error-message-bolding.compopts
+++ b/test/compflags/ferguson/error-message-bolding.compopts
@@ -1,0 +1,2 @@
+--no-use-color-terminal # error-message-bolding.nocolors.good
+--use-color-terminal    # error-message-bolding.colors.good

--- a/test/compflags/ferguson/error-message-bolding.nocolors.good
+++ b/test/compflags/ferguson/error-message-bolding.nocolors.good
@@ -1,0 +1,7 @@
+error-message-bolding.chpl:1: In function 'h':
+error-message-bolding.chpl:2: error: Cannot assign to string from int(64)
+  error-message-bolding.chpl:6: called as h(arg: string) from function 'g'
+  error-message-bolding.chpl:12: called as g(arg: string, otherArg: int(64), param p = 2, param pp = 3: int(8), type t = int(64)) from method 'methodA'
+  error-message-bolding.chpl:20: called as ConcreteRecord.methodA(arg: string) from method 'methodB'
+  error-message-bolding.chpl:26: called as GenericRecord(real(64)).methodB(arg: string) from function 'f'
+  error-message-bolding.chpl:29: called as f(arg: string)

--- a/test/distributions/dm/s7.comm-none.good
+++ b/test/distributions/dm/s7.comm-none.good
@@ -1,9 +1,7 @@
 s7.chpl:104: In function 'copyToDF':
 s7.chpl:106: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s7.chpl:71: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockCyclicDim,ReplicatedDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),Replicated1dom(int(64),false))] int(64))
 s7.chpl:104: In function 'copyToDF':
 s7.chpl:106: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s7.chpl:72: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,ReplicatedDim,BlockCyclicDim,int(64),2),Replicated1dom(int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64))
 n 8  blkSize 2  locales 1*1
 
 11000101 12000102 11000103 12000104 11000105 12000106 11000107 12000108 0

--- a/test/distributions/dm/s7.compopts
+++ b/test/distributions/dm/s7.compopts
@@ -1,0 +1,1 @@
+--no-print-callstack-on-error

--- a/test/distributions/dm/s7.good
+++ b/test/distributions/dm/s7.good
@@ -1,9 +1,7 @@
 s7.chpl:104: In function 'copyToDF':
 s7.chpl:106: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s7.chpl:71: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockCyclicDim,ReplicatedDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),Replicated1dom(int(64),false))] int(64))
 s7.chpl:104: In function 'copyToDF':
 s7.chpl:106: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s7.chpl:72: Function 'copyToDF' instantiated as: copyToDF(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,ReplicatedDim,BlockCyclicDim,int(64),2),Replicated1dom(int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64))
 n 8  blkSize 2  locales 3*3
 
 11000101 12000102 1011000103 1012000104 2011000105 2012000106 11000107 12000108 0

--- a/test/distributions/dm/s8.comm-none.good
+++ b/test/distributions/dm/s8.comm-none.good
@@ -131,5 +131,3 @@ s8.chpl:38: In function 'test':
 s8.chpl:38: In function 'test':
 s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
 s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s8.chpl:72: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64), ix1: 2*int(64), ix2: 2*int(64))
-s8.chpl:73: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),true),BlockCyclic1dom(int(64),int(64),true))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/dm/s8.compopts
+++ b/test/distributions/dm/s8.compopts
@@ -1,0 +1,1 @@
+--no-print-callstack-on-error

--- a/test/distributions/dm/s8.good
+++ b/test/distributions/dm/s8.good
@@ -130,5 +130,3 @@ s8.chpl:38: In function 'test':
 s8.chpl:38: In function 'test':
 s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
 s8.chpl:61: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s8.chpl:72: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),false),BlockCyclic1dom(int(64),int(64),false))] int(64), ix1: 2*int(64), ix2: 2*int(64))
-s8.chpl:73: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockCyclicDim,BlockCyclicDim,int(64),2),BlockCyclic1dom(int(64),int(64),true),BlockCyclic1dom(int(64),int(64),true))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/dm/s9.comm-none.good
+++ b/test/distributions/dm/s9.comm-none.good
@@ -131,5 +131,3 @@ s9.chpl:42: In function 'test':
 s9.chpl:42: In function 'test':
 s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
 s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s9.chpl:76: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),false,BlockDim(int(64))),Block1dom(int(64),false,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))
-s9.chpl:77: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),true,BlockDim(int(64))),Block1dom(int(64),true,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/distributions/dm/s9.compopts
+++ b/test/distributions/dm/s9.compopts
@@ -1,0 +1,1 @@
+--no-print-callstack-on-error

--- a/test/distributions/dm/s9.good
+++ b/test/distributions/dm/s9.good
@@ -130,5 +130,3 @@ s9.chpl:42: In function 'test':
 s9.chpl:42: In function 'test':
 s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
 s9.chpl:65: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-s9.chpl:76: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),false,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),false,BlockDim(int(64))),Block1dom(int(64),false,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))
-s9.chpl:77: Function 'test' instantiated as: test(A: [DimensionalDom(2,int(64),true,unmanaged DimensionalDist2D([domain(2,int(64),false)] locale,BlockDim(int(64)),BlockDim(int(64)),int(64),2),Block1dom(int(64),true,BlockDim(int(64))),Block1dom(int(64),true,BlockDim(int(64))))] int(64), ix1: 2*int(64), ix2: 2*int(64))

--- a/test/domains/bradc/modDomQuery.good
+++ b/test/domains/bradc/modDomQuery.good
@@ -1,3 +1,3 @@
 modDomQuery.chpl:13: In function 'foo':
 modDomQuery.chpl:14: error: illegal lvalue in assignment
-modDomQuery.chpl:9: Function 'foo' instantiated as: foo(X: [domain(1,int(64),false)] real(64))
+  modDomQuery.chpl:9: called as foo(X: [domain(1,int(64),false)] real(64))

--- a/test/domains/compilerErrors/partialQueriedDomain-inIntent.good
+++ b/test/domains/compilerErrors/partialQueriedDomain-inIntent.good
@@ -1,4 +1,4 @@
-partialQueriedDomain-inIntent.chpl:21: In function 'c_l':
+partialQueriedDomain-inIntent.chpl:21: In method 'c_l':
 partialQueriedDomain-inIntent.chpl:21: error: cannot query part of a domain
 partialQueriedDomain-inIntent.chpl:21: error: 'chpl__buildArrayRuntimeType' undeclared (first use this function)
 partialQueriedDomain-inIntent.chpl:21: error: 'chpl__ensureDomainExpr' undeclared (first use this function)

--- a/test/domains/compilerErrors/partialQueriedDomain-multiple.good
+++ b/test/domains/compilerErrors/partialQueriedDomain-multiple.good
@@ -1,3 +1,3 @@
-partialQueriedDomain-multiple.chpl:21: In function 'c_l':
+partialQueriedDomain-multiple.chpl:21: In method 'c_l':
 partialQueriedDomain-multiple.chpl:21: error: cannot query part of a domain
 partialQueriedDomain-multiple.chpl:21: error: cannot query part of a domain

--- a/test/domains/compilerErrors/partialQueriedDomain.good
+++ b/test/domains/compilerErrors/partialQueriedDomain.good
@@ -1,2 +1,2 @@
-partialQueriedDomain.chpl:21: In function 'c_l':
+partialQueriedDomain.chpl:21: In method 'c_l':
 partialQueriedDomain.chpl:21: error: cannot query part of a domain

--- a/test/domains/marybeth/test_compare_range.good
+++ b/test/domains/marybeth/test_compare_range.good
@@ -1,3 +1,3 @@
 test_compare_range.chpl:14: In function 'initMatrix':
 test_compare_range.chpl:20: error: iterator or promoted expression iterator used in if or while condition
-test_compare_range.chpl:6: Function 'initMatrix' instantiated as: initMatrix(A: [domain(2,int(64),false)] real(64))
+  test_compare_range.chpl:6: called as initMatrix(A: [domain(2,int(64),false)] real(64))

--- a/test/domains/sungeun/assoc/expand.1.good
+++ b/test/domains/sungeun/assoc/expand.1.good
@@ -1,3 +1,4 @@
 expand.chpl:4: In function 'my_expand':
 expand.chpl:5: error: expand not supported on associative domains
-expand.chpl:11: Function 'my_expand' instantiated as: my_expand(D: DefaultAssociativeDom(int(64),true), off: int(64))
+  expand.chpl:11: called as my_expand(D: DefaultAssociativeDom(int(64),true), off: int(64)) from function 'dit'
+  expand.chpl:21: called as dit(D: DefaultAssociativeDom(int(64),true), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/expand.2.good
+++ b/test/domains/sungeun/assoc/expand.2.good
@@ -1,3 +1,4 @@
 expand.chpl:4: In function 'my_expand':
 expand.chpl:5: error: expand not supported on associative domains
-expand.chpl:11: Function 'my_expand' instantiated as: my_expand(D: DefaultAssociativeDom(int(64),false), off: int(64))
+  expand.chpl:11: called as my_expand(D: DefaultAssociativeDom(int(64),false), off: int(64)) from function 'dit'
+  expand.chpl:21: called as dit(D: DefaultAssociativeDom(int(64),false), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/exterior.1.good
+++ b/test/domains/sungeun/assoc/exterior.1.good
@@ -1,3 +1,4 @@
 exterior.chpl:4: In function 'my_exterior':
 exterior.chpl:5: error: exterior not supported on associative domains
-exterior.chpl:11: Function 'my_exterior' instantiated as: my_exterior(D: DefaultAssociativeDom(int(64),true), off: int(64))
+  exterior.chpl:11: called as my_exterior(D: DefaultAssociativeDom(int(64),true), off: int(64)) from function 'dit'
+  exterior.chpl:21: called as dit(D: DefaultAssociativeDom(int(64),true), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/exterior.2.good
+++ b/test/domains/sungeun/assoc/exterior.2.good
@@ -1,3 +1,4 @@
 exterior.chpl:4: In function 'my_exterior':
 exterior.chpl:5: error: exterior not supported on associative domains
-exterior.chpl:11: Function 'my_exterior' instantiated as: my_exterior(D: DefaultAssociativeDom(int(64),false), off: int(64))
+  exterior.chpl:11: called as my_exterior(D: DefaultAssociativeDom(int(64),false), off: int(64)) from function 'dit'
+  exterior.chpl:21: called as dit(D: DefaultAssociativeDom(int(64),false), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/interior.1.good
+++ b/test/domains/sungeun/assoc/interior.1.good
@@ -1,3 +1,4 @@
 interior.chpl:4: In function 'my_interior':
 interior.chpl:5: error: interior not supported on associative domains
-interior.chpl:11: Function 'my_interior' instantiated as: my_interior(D: DefaultAssociativeDom(int(64),true), off: int(64))
+  interior.chpl:11: called as my_interior(D: DefaultAssociativeDom(int(64),true), off: int(64)) from function 'dit'
+  interior.chpl:21: called as dit(D: DefaultAssociativeDom(int(64),true), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/interior.2.good
+++ b/test/domains/sungeun/assoc/interior.2.good
@@ -1,3 +1,4 @@
 interior.chpl:4: In function 'my_interior':
 interior.chpl:5: error: interior not supported on associative domains
-interior.chpl:11: Function 'my_interior' instantiated as: my_interior(D: DefaultAssociativeDom(int(64),false), off: int(64))
+  interior.chpl:11: called as my_interior(D: DefaultAssociativeDom(int(64),false), off: int(64)) from function 'dit'
+  interior.chpl:21: called as dit(D: DefaultAssociativeDom(int(64),false), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/translate.1.good
+++ b/test/domains/sungeun/assoc/translate.1.good
@@ -1,3 +1,4 @@
 translate.chpl:7: In function 'my_translate':
 translate.chpl:8: error: translate not supported on associative domains
-translate.chpl:14: Function 'my_translate' instantiated as: my_translate(D: DefaultAssociativeDom(int(64),true), off: int(64))
+  translate.chpl:14: called as my_translate(D: DefaultAssociativeDom(int(64),true), off: int(64)) from function 'dit'
+  translate.chpl:24: called as dit(D: DefaultAssociativeDom(int(64),true), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/assoc/translate.2.good
+++ b/test/domains/sungeun/assoc/translate.2.good
@@ -1,3 +1,4 @@
 translate.chpl:7: In function 'my_translate':
 translate.chpl:8: error: translate not supported on associative domains
-translate.chpl:14: Function 'my_translate' instantiated as: my_translate(D: DefaultAssociativeDom(int(64),false), off: int(64))
+  translate.chpl:14: called as my_translate(D: DefaultAssociativeDom(int(64),false), off: int(64)) from function 'dit'
+  translate.chpl:24: called as dit(D: DefaultAssociativeDom(int(64),false), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/sparse/expand.good
+++ b/test/domains/sungeun/sparse/expand.good
@@ -1,3 +1,4 @@
 expand.chpl:3: In function 'my_expand':
 expand.chpl:4: error: expand not supported on sparse domains
-expand.chpl:10: Function 'my_expand' instantiated as: my_expand(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))
+  expand.chpl:10: called as my_expand(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64)) from function 'dit'
+  expand.chpl:22: called as dit(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/sparse/exterior.good
+++ b/test/domains/sungeun/sparse/exterior.good
@@ -1,3 +1,4 @@
 exterior.chpl:3: In function 'my_exterior':
 exterior.chpl:4: error: exterior not supported on sparse domains
-exterior.chpl:10: Function 'my_exterior' instantiated as: my_exterior(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))
+  exterior.chpl:10: called as my_exterior(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64)) from function 'dit'
+  exterior.chpl:22: called as dit(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/sparse/interior.good
+++ b/test/domains/sungeun/sparse/interior.good
@@ -1,3 +1,4 @@
 interior.chpl:3: In function 'my_interior':
 interior.chpl:4: error: interior not supported on sparse domains
-interior.chpl:10: Function 'my_interior' instantiated as: my_interior(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))
+  interior.chpl:10: called as my_interior(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64)) from function 'dit'
+  interior.chpl:22: called as dit(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), lo: int(64), hi: int(64))

--- a/test/domains/sungeun/sparse/translate.good
+++ b/test/domains/sungeun/sparse/translate.good
@@ -1,3 +1,4 @@
 translate.chpl:6: In function 'my_translate':
 translate.chpl:7: error: translate not supported on sparse domains
-translate.chpl:13: Function 'my_translate' instantiated as: my_translate(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))
+  translate.chpl:13: called as my_translate(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64)) from function 'dit'
+  translate.chpl:25: called as dit(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), lo: int(64), hi: int(64))

--- a/test/errhandling/errorMessages/throwNew.good
+++ b/test/errhandling/errorMessages/throwNew.good
@@ -1,2 +1,2 @@
-throwNew.chpl:2: In function 'f':
+throwNew.chpl:2: In method 'f':
 throwNew.chpl:3: error: Cannot throw a type: 'Error'. Did you forget the keyword 'new'?

--- a/test/execflags/vass/print-callstack-on-error-1.good
+++ b/test/execflags/vass/print-callstack-on-error-1.good
@@ -1,8 +1,5 @@
 print-callstack-on-error-1.chpl:13: In function 'test3':
 print-callstack-on-error-1.chpl:14: error: error from test3, depth=0
-while processing the following Chapel call chain:
-  print-callstack-on-error-1.chpl:14: test3(z)
-  print-callstack-on-error-1.chpl:10: test2(y)
-  print-callstack-on-error-1.chpl:6: test1(x)
-  print-callstack-on-error-1.chpl:3: top-level module statements for print-callstack-on-error-1
-print-callstack-on-error-1.chpl:10: Function 'test3' instantiated as: test3(z: string)
+  print-callstack-on-error-1.chpl:10: called as test3(z: string) from function 'test2'
+  print-callstack-on-error-1.chpl:6: called as test2(y: string) from function 'test1'
+  print-callstack-on-error-1.chpl:3: called as test1(x: string) from module 'print-callstack-on-error-1'

--- a/test/execflags/vass/print-callstack-on-error-2.good
+++ b/test/execflags/vass/print-callstack-on-error-2.good
@@ -1,6 +1,4 @@
 print-callstack-on-error-2.chpl:4: In iterator 'these':
 print-callstack-on-error-2.chpl:5: error: error from myiter1.these(), depth=0
-while processing the following Chapel call chain:
-  print-callstack-on-error-2.chpl:5: myiter1.these()
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: _getIterator(x) [internal module]
-  print-callstack-on-error-2.chpl:11: top-level module statements for print-callstack-on-error-2
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: called as borrowed myiter.these() from function '_getIterator'
+  print-callstack-on-error-2.chpl:11: called as _getIterator(x: borrowed myiter1) from module 'print-callstack-on-error-2'

--- a/test/execflags/vass/print-callstack-on-warning-1.good
+++ b/test/execflags/vass/print-callstack-on-warning-1.good
@@ -1,53 +1,24 @@
 print-callstack-on-warning-1.chpl:15: In function 'test3':
 print-callstack-on-warning-1.chpl:16: warning: warning from test3, depth=0
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:16: test3(z)
-  print-callstack-on-warning-1.chpl:12: test2(y)
-  print-callstack-on-warning-1.chpl:8: test1(x)
-  print-callstack-on-warning-1.chpl:3: top-level module statements for print-callstack-on-warning-1
 print-callstack-on-warning-1.chpl:17: warning: warning from test3, default depth
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:17: test3(z)
-  print-callstack-on-warning-1.chpl:12: test2(y)
-  print-callstack-on-warning-1.chpl:8: test1(x)
-  print-callstack-on-warning-1.chpl:3: top-level module statements for print-callstack-on-warning-1
-print-callstack-on-warning-1.chpl:12: Function 'test3' instantiated as: test3(z: string)
+  print-callstack-on-warning-1.chpl:12: called as test3(z: string) from function 'test2'
+  print-callstack-on-warning-1.chpl:8: called as test2(y: string) from function 'test1'
+  print-callstack-on-warning-1.chpl:3: called as test1(x: string) from module 'print-callstack-on-warning-1'
 print-callstack-on-warning-1.chpl:33: In function 'ptest3':
 print-callstack-on-warning-1.chpl:34: warning: warning from ptest3, depth=0, z=6
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:34: ptest3(param z)
-  print-callstack-on-warning-1.chpl:30: ptest2(param y)
-  print-callstack-on-warning-1.chpl:26: ptest1(param x)
-  print-callstack-on-warning-1.chpl:21: top-level module statements for print-callstack-on-warning-1
 print-callstack-on-warning-1.chpl:35: warning: warning from ptest3, default depth, z=6
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:35: ptest3(param z)
-  print-callstack-on-warning-1.chpl:30: ptest2(param y)
-  print-callstack-on-warning-1.chpl:26: ptest1(param x)
-  print-callstack-on-warning-1.chpl:21: top-level module statements for print-callstack-on-warning-1
-print-callstack-on-warning-1.chpl:30: Function 'ptest3' instantiated as: ptest3(param z = 6)
+  print-callstack-on-warning-1.chpl:30: called as ptest3(param z = 6) from function 'ptest2'
+  print-callstack-on-warning-1.chpl:26: called as ptest2(param y = 3) from function 'ptest1'
+  print-callstack-on-warning-1.chpl:21: called as ptest1(param x = 1) from module 'print-callstack-on-warning-1'
 print-callstack-on-warning-1.chpl:33: In function 'ptest3':
 print-callstack-on-warning-1.chpl:34: warning: warning from ptest3, depth=0, z=13
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:34: ptest3(param z)
-  print-callstack-on-warning-1.chpl:30: ptest2(param y)
-  print-callstack-on-warning-1.chpl:22: top-level module statements for print-callstack-on-warning-1
 print-callstack-on-warning-1.chpl:35: warning: warning from ptest3, default depth, z=13
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:35: ptest3(param z)
-  print-callstack-on-warning-1.chpl:30: ptest2(param y)
-  print-callstack-on-warning-1.chpl:22: top-level module statements for print-callstack-on-warning-1
-print-callstack-on-warning-1.chpl:30: Function 'ptest3' instantiated as: ptest3(param z = 13)
+  print-callstack-on-warning-1.chpl:30: called as ptest3(param z = 13) from function 'ptest2'
+  print-callstack-on-warning-1.chpl:22: called as ptest2(param y = 10) from module 'print-callstack-on-warning-1'
 print-callstack-on-warning-1.chpl:33: In function 'ptest3':
 print-callstack-on-warning-1.chpl:34: warning: warning from ptest3, depth=0, z=100
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:34: ptest3(param z)
-  print-callstack-on-warning-1.chpl:23: top-level module statements for print-callstack-on-warning-1
 print-callstack-on-warning-1.chpl:35: warning: warning from ptest3, default depth, z=100
-while processing the following Chapel call chain:
-  print-callstack-on-warning-1.chpl:35: ptest3(param z)
-  print-callstack-on-warning-1.chpl:23: top-level module statements for print-callstack-on-warning-1
-print-callstack-on-warning-1.chpl:23: Function 'ptest3' instantiated as: ptest3(param z = 100)
+  print-callstack-on-warning-1.chpl:23: called as ptest3(param z = 100) from module 'print-callstack-on-warning-1'
 test3(z=test1)
 test3(z=test2)
 test3(z=test3)

--- a/test/execflags/vass/print-callstack-on-warning-2.good
+++ b/test/execflags/vass/print-callstack-on-warning-2.good
@@ -1,25 +1,13 @@
 print-callstack-on-warning-2.chpl:12: In iterator 'these':
 print-callstack-on-warning-2.chpl:13: warning: warning from myiter1.these(), depth=0
-while processing the following Chapel call chain:
-  print-callstack-on-warning-2.chpl:13: myiter1.these()
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: _getIterator(x) [internal module]
-  print-callstack-on-warning-2.chpl:5: top-level module statements for print-callstack-on-warning-2
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: called as borrowed myiter.these() from function '_getIterator'
+  print-callstack-on-warning-2.chpl:5: called as _getIterator(x: unmanaged myiter1) from module 'print-callstack-on-warning-2'
 print-callstack-on-warning-2.chpl:5: warning: warning from myiter1.these(), default depth
-while processing the following Chapel call chain:
-  print-callstack-on-warning-2.chpl:14: myiter1.these()
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: _getIterator(x) [internal module]
-  print-callstack-on-warning-2.chpl:5: top-level module statements for print-callstack-on-warning-2
 print-callstack-on-warning-2.chpl:34: In iterator 'these':
 print-callstack-on-warning-2.chpl:35: warning: warning from myiter2.these(), depth=0
-while processing the following Chapel call chain:
-  print-callstack-on-warning-2.chpl:35: myiter2.these()
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: _getIterator(x) [internal module]
-  print-callstack-on-warning-2.chpl:27: top-level module statements for print-callstack-on-warning-2
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: called as borrowed myiter.these() from function '_getIterator'
+  print-callstack-on-warning-2.chpl:27: called as _getIterator(x: unmanaged myiter2) from module 'print-callstack-on-warning-2'
 print-callstack-on-warning-2.chpl:27: warning: warning from myiter2.these(), default depth
-while processing the following Chapel call chain:
-  print-callstack-on-warning-2.chpl:36: myiter2.these()
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:: _getIterator(x) [internal module]
-  print-callstack-on-warning-2.chpl:27: top-level module statements for print-callstack-on-warning-2
 111
 111
 222

--- a/test/extern/fnPtrs/passBadFnsToCChapel-cPtrToChapel.good
+++ b/test/extern/fnPtrs/passBadFnsToCChapel-cPtrToChapel.good
@@ -1,3 +1,3 @@
 passBadFnsToCChapel.chpl:11: In function 'baz':
 passBadFnsToCChapel.chpl:12: error: Can't call a C function pointer within Chapel
-passBadFnsToCChapel.chpl:16: Function 'baz' instantiated as: baz(f: c_fn_ptr)
+  passBadFnsToCChapel.chpl:16: called as baz(f: c_fn_ptr)

--- a/test/functions/bradc/intents/intents-int.error1.good
+++ b/test/functions/bradc/intents/intents-int.error1.good
@@ -1,3 +1,3 @@
 intents-int.chpl:4: In function 'foo':
 intents-int.chpl:7: error: cannot assign to const variable
-intents-int.chpl:66: Function 'foo' instantiated as: foo(x: int(64))
+  intents-int.chpl:66: called as foo(x: int(64))

--- a/test/functions/bradc/intents/intents-int.error2.good
+++ b/test/functions/bradc/intents/intents-int.error2.good
@@ -1,3 +1,3 @@
 intents-int.chpl:12: In function 'bar':
 intents-int.chpl:15: error: cannot assign to const variable
-intents-int.chpl:68: Function 'bar' instantiated as: bar(x: int(64))
+  intents-int.chpl:68: called as bar(x: int(64))

--- a/test/functions/bradc/intents/intents-int.error3.good
+++ b/test/functions/bradc/intents/intents-int.error3.good
@@ -1,3 +1,3 @@
 intents-int.chpl:34: In function 'goo':
 intents-int.chpl:37: error: cannot assign to const variable
-intents-int.chpl:74: Function 'goo' instantiated as: goo(x: int(64))
+  intents-int.chpl:74: called as goo(x: int(64))

--- a/test/functions/bradc/intents/intents-int.error4.good
+++ b/test/functions/bradc/intents/intents-int.error4.good
@@ -1,3 +1,3 @@
 intents-int.chpl:42: In function 'hoo':
 intents-int.chpl:45: error: cannot assign to const variable
-intents-int.chpl:76: Function 'hoo' instantiated as: hoo(x: int(64))
+  intents-int.chpl:76: called as hoo(x: int(64))

--- a/test/functions/bradc/intents/intents-strings.error1.good
+++ b/test/functions/bradc/intents/intents-strings.error1.good
@@ -1,3 +1,3 @@
 intents-strings.chpl:4: In function 'foo':
 intents-strings.chpl:7: error: cannot assign to const variable
-intents-strings.chpl:66: Function 'foo' instantiated as: foo(x: string)
+  intents-strings.chpl:66: called as foo(x: string)

--- a/test/functions/bradc/intents/intents-strings.error2.good
+++ b/test/functions/bradc/intents/intents-strings.error2.good
@@ -1,3 +1,3 @@
 intents-strings.chpl:12: In function 'bar':
 intents-strings.chpl:15: error: cannot assign to const variable
-intents-strings.chpl:68: Function 'bar' instantiated as: bar(x: string)
+  intents-strings.chpl:68: called as bar(x: string)

--- a/test/functions/bradc/intents/intents-strings.error3.good
+++ b/test/functions/bradc/intents/intents-strings.error3.good
@@ -1,3 +1,3 @@
 intents-strings.chpl:34: In function 'goo':
 intents-strings.chpl:37: error: cannot assign to const variable
-intents-strings.chpl:74: Function 'goo' instantiated as: goo(x: string)
+  intents-strings.chpl:74: called as goo(x: string)

--- a/test/functions/bradc/intents/intents-strings.error4.good
+++ b/test/functions/bradc/intents/intents-strings.error4.good
@@ -1,3 +1,3 @@
 intents-strings.chpl:42: In function 'hoo':
 intents-strings.chpl:45: error: cannot assign to const variable
-intents-strings.chpl:76: Function 'hoo' instantiated as: hoo(x: string)
+  intents-strings.chpl:76: called as hoo(x: string)

--- a/test/functions/bradc/typeFns/myTypeFnConstKeyword.good
+++ b/test/functions/bradc/typeFns/myTypeFnConstKeyword.good
@@ -1,3 +1,3 @@
 myTypeFnConstKeyword.chpl:1: In function 'myint':
 myTypeFnConstKeyword.chpl:1: error: illegal return of type where value is expected
-myTypeFnConstKeyword.chpl:3: Function 'myint' instantiated as: myint(param x = 1)
+  myTypeFnConstKeyword.chpl:3: called as myint(param x = 1)

--- a/test/functions/bradc/typeFns/myTypeFnNoKeyword.good
+++ b/test/functions/bradc/typeFns/myTypeFnNoKeyword.good
@@ -1,3 +1,3 @@
 myTypeFnNoKeyword.chpl:1: In function 'myint':
 myTypeFnNoKeyword.chpl:1: error: illegal return of type where value is expected
-myTypeFnNoKeyword.chpl:3: Function 'myint' instantiated as: myint(param x = 1)
+  myTypeFnNoKeyword.chpl:3: called as myint(param x = 1)

--- a/test/functions/bradc/varFns/retLitFromVarFn.good
+++ b/test/functions/bradc/varFns/retLitFromVarFn.good
@@ -1,2 +1,2 @@
-retLitFromVarFn.chpl:4: In function 'this':
+retLitFromVarFn.chpl:4: In method 'this':
 retLitFromVarFn.chpl:6: error: function cannot return constant by ref

--- a/test/functions/bradc/varFns/retLocFromVarFn.good
+++ b/test/functions/bradc/varFns/retLocFromVarFn.good
@@ -1,2 +1,2 @@
-retLocFromVarFn.chpl:4: In function 'this':
+retLocFromVarFn.chpl:4: In method 'this':
 retLocFromVarFn.chpl:8: error: illegal expression to return by ref

--- a/test/functions/compilation-errors/error-stack-trace-recursive1.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-recursive1.chpl
@@ -1,0 +1,15 @@
+proc h(arg) {
+  h(arg);
+  arg = 11;
+  h(arg);
+}
+
+proc g(arg) {
+  h(arg);
+}
+
+proc f(arg:string) {
+  g(arg);
+}
+
+f("hi");

--- a/test/functions/compilation-errors/error-stack-trace-recursive1.good
+++ b/test/functions/compilation-errors/error-stack-trace-recursive1.good
@@ -1,4 +1,4 @@
 error-stack-trace-recursive1.chpl:1: In function 'h':
 error-stack-trace-recursive1.chpl:3: error: Cannot assign to string from int(64)
-error-stack-trace-recursive1.chpl:8: function 'h' called as h(arg: string) within function 'g'
-error-stack-trace-recursive1.chpl:12: function 'g' called as g(arg: string)
+  error-stack-trace-recursive1.chpl:8: function 'h' called as h(arg: string) within function 'g'
+  error-stack-trace-recursive1.chpl:12: function 'g' called as g(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-recursive1.good
+++ b/test/functions/compilation-errors/error-stack-trace-recursive1.good
@@ -1,0 +1,4 @@
+error-stack-trace-recursive1.chpl:1: In function 'h':
+error-stack-trace-recursive1.chpl:3: error: Cannot assign to string from int(64)
+error-stack-trace-recursive1.chpl:8: function 'h' called as h(arg: string) within function 'g'
+error-stack-trace-recursive1.chpl:12: function 'g' called as g(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-recursive1.good
+++ b/test/functions/compilation-errors/error-stack-trace-recursive1.good
@@ -1,4 +1,4 @@
 error-stack-trace-recursive1.chpl:1: In function 'h':
 error-stack-trace-recursive1.chpl:3: error: Cannot assign to string from int(64)
-  error-stack-trace-recursive1.chpl:8: function 'h' called as h(arg: string) within function 'g'
-  error-stack-trace-recursive1.chpl:12: function 'g' called as g(arg: string)
+  error-stack-trace-recursive1.chpl:8: called as h(arg: string) from function 'g'
+  error-stack-trace-recursive1.chpl:12: called as g(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-recursive2.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-recursive2.chpl
@@ -1,0 +1,33 @@
+proc f(arg) {
+  g(arg);
+}
+
+proc g(arg) {
+  h(arg);
+}
+
+proc h(arg) {
+  h(arg);
+  a(arg);
+  h(arg);
+}
+
+proc a(arg) {
+  b(arg);
+}
+
+proc b(arg) {
+  c(arg);
+}
+
+proc c(arg) {
+  a(arg);
+  badfn(arg);
+  a(arg);
+}
+
+proc badfn(arg) {
+  arg = 11;
+}
+
+f("hi");

--- a/test/functions/compilation-errors/error-stack-trace-recursive2.good
+++ b/test/functions/compilation-errors/error-stack-trace-recursive2.good
@@ -1,9 +1,9 @@
 error-stack-trace-recursive2.chpl:29: In function 'badfn':
 error-stack-trace-recursive2.chpl:30: error: Cannot assign to string from int(64)
-  error-stack-trace-recursive2.chpl:25: function 'badfn' called as badfn(arg: string) within function 'c'
-  error-stack-trace-recursive2.chpl:20: function 'c' called as c(arg: string) within function 'b'
-  error-stack-trace-recursive2.chpl:16: function 'b' called as b(arg: string) within function 'a'
-  error-stack-trace-recursive2.chpl:11: function 'a' called as a(arg: string) within function 'h'
-  error-stack-trace-recursive2.chpl:6: function 'h' called as h(arg: string) within function 'g'
-  error-stack-trace-recursive2.chpl:2: function 'g' called as g(arg: string) within function 'f'
-  error-stack-trace-recursive2.chpl:33: function 'f' called as f(arg: string)
+  error-stack-trace-recursive2.chpl:25: called as badfn(arg: string) from function 'c'
+  error-stack-trace-recursive2.chpl:20: called as c(arg: string) from function 'b'
+  error-stack-trace-recursive2.chpl:16: called as b(arg: string) from function 'a'
+  error-stack-trace-recursive2.chpl:11: called as a(arg: string) from function 'h'
+  error-stack-trace-recursive2.chpl:6: called as h(arg: string) from function 'g'
+  error-stack-trace-recursive2.chpl:2: called as g(arg: string) from function 'f'
+  error-stack-trace-recursive2.chpl:33: called as f(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-recursive2.good
+++ b/test/functions/compilation-errors/error-stack-trace-recursive2.good
@@ -1,0 +1,9 @@
+error-stack-trace-recursive2.chpl:29: In function 'badfn':
+error-stack-trace-recursive2.chpl:30: error: Cannot assign to string from int(64)
+error-stack-trace-recursive2.chpl:25: function 'badfn' called as badfn(arg: string) within function 'c'
+error-stack-trace-recursive2.chpl:20: function 'c' called as c(arg: string) within function 'b'
+error-stack-trace-recursive2.chpl:16: function 'b' called as b(arg: string) within function 'a'
+error-stack-trace-recursive2.chpl:11: function 'a' called as a(arg: string) within function 'h'
+error-stack-trace-recursive2.chpl:6: function 'h' called as h(arg: string) within function 'g'
+error-stack-trace-recursive2.chpl:2: function 'g' called as g(arg: string) within function 'f'
+error-stack-trace-recursive2.chpl:33: function 'f' called as f(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-recursive2.good
+++ b/test/functions/compilation-errors/error-stack-trace-recursive2.good
@@ -1,9 +1,9 @@
 error-stack-trace-recursive2.chpl:29: In function 'badfn':
 error-stack-trace-recursive2.chpl:30: error: Cannot assign to string from int(64)
-error-stack-trace-recursive2.chpl:25: function 'badfn' called as badfn(arg: string) within function 'c'
-error-stack-trace-recursive2.chpl:20: function 'c' called as c(arg: string) within function 'b'
-error-stack-trace-recursive2.chpl:16: function 'b' called as b(arg: string) within function 'a'
-error-stack-trace-recursive2.chpl:11: function 'a' called as a(arg: string) within function 'h'
-error-stack-trace-recursive2.chpl:6: function 'h' called as h(arg: string) within function 'g'
-error-stack-trace-recursive2.chpl:2: function 'g' called as g(arg: string) within function 'f'
-error-stack-trace-recursive2.chpl:33: function 'f' called as f(arg: string)
+  error-stack-trace-recursive2.chpl:25: function 'badfn' called as badfn(arg: string) within function 'c'
+  error-stack-trace-recursive2.chpl:20: function 'c' called as c(arg: string) within function 'b'
+  error-stack-trace-recursive2.chpl:16: function 'b' called as b(arg: string) within function 'a'
+  error-stack-trace-recursive2.chpl:11: function 'a' called as a(arg: string) within function 'h'
+  error-stack-trace-recursive2.chpl:6: function 'h' called as h(arg: string) within function 'g'
+  error-stack-trace-recursive2.chpl:2: function 'g' called as g(arg: string) within function 'f'
+  error-stack-trace-recursive2.chpl:33: function 'f' called as f(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace.chpl
+++ b/test/functions/compilation-errors/error-stack-trace.chpl
@@ -1,0 +1,13 @@
+proc h(arg) {
+  arg = 11;
+}
+
+proc g(arg) {
+  h(arg);
+}
+
+proc f(arg:string) {
+  g(arg);
+}
+
+f("hi");

--- a/test/functions/compilation-errors/error-stack-trace.chpl
+++ b/test/functions/compilation-errors/error-stack-trace.chpl
@@ -1,13 +1,13 @@
-proc h(arg) {
+proc h(arg, otherArg) {
   arg = 11;
 }
 
-proc g(arg) {
-  h(arg);
+proc g(arg, otherArg: int) {
+  h(arg, otherArg);
 }
 
-proc f(arg:string) {
-  g(arg);
+proc f(arg:string, otherArg:int) {
+  g(arg, otherArg);
 }
 
-f("hi");
+f("hi", 1);

--- a/test/functions/compilation-errors/error-stack-trace.good
+++ b/test/functions/compilation-errors/error-stack-trace.good
@@ -1,4 +1,4 @@
 error-stack-trace.chpl:1: In function 'h':
 error-stack-trace.chpl:2: error: Cannot assign to string from int(64)
-  error-stack-trace.chpl:6: function 'h' called as h(arg: string, otherArg: int(64)) within function 'g'
-  error-stack-trace.chpl:10: function 'g' called as g(arg: string, otherArg: int(64))
+  error-stack-trace.chpl:6: called as h(arg: string, otherArg: int(64)) from function 'g'
+  error-stack-trace.chpl:10: called as g(arg: string, otherArg: int(64))

--- a/test/functions/compilation-errors/error-stack-trace.good
+++ b/test/functions/compilation-errors/error-stack-trace.good
@@ -1,0 +1,4 @@
+error-stack-trace.chpl:1: In function 'h':
+error-stack-trace.chpl:2: error: Cannot assign to string from int(64)
+error-stack-trace.chpl:6: function 'h' called as h(arg: string) within function 'g'
+error-stack-trace.chpl:10: function 'g' called as g(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace.good
+++ b/test/functions/compilation-errors/error-stack-trace.good
@@ -1,4 +1,4 @@
 error-stack-trace.chpl:1: In function 'h':
 error-stack-trace.chpl:2: error: Cannot assign to string from int(64)
-error-stack-trace.chpl:6: function 'h' called as h(arg: string) within function 'g'
-error-stack-trace.chpl:10: function 'g' called as g(arg: string)
+  error-stack-trace.chpl:6: function 'h' called as h(arg: string, otherArg: int(64)) within function 'g'
+  error-stack-trace.chpl:10: function 'g' called as g(arg: string, otherArg: int(64))

--- a/test/functions/deitz/test_rec_infer.good
+++ b/test/functions/deitz/test_rec_infer.good
@@ -1,4 +1,4 @@
 test_rec_infer.chpl:1: error: unable to resolve return type of function 'foo'
 test_rec_infer.chpl:1: In function 'foo':
 test_rec_infer.chpl:2: error: called recursively at this point
-test_rec_infer.chpl:5: Function 'foo' instantiated as: foo(i: int(64))
+  test_rec_infer.chpl:5: called as foo(i: int(64))

--- a/test/functions/deitz/test_where_recursion.good
+++ b/test/functions/deitz/test_where_recursion.good
@@ -1,4 +1,4 @@
 test_where_recursion.chpl:1: In function 'foo':
 test_where_recursion.chpl:1: error: illegal where clause due to infinite instantiation
 test_where_recursion.chpl:1: note: evaluation of 'foo' where clause results in instantiation of 'foo'
-test_where_recursion.chpl:1: Function 'foo' instantiated as: foo(i: int(64))
+  test_where_recursion.chpl:1: called as foo(i: int(64))

--- a/test/functions/deitz/test_where_recursion2.good
+++ b/test/functions/deitz/test_where_recursion2.good
@@ -2,4 +2,4 @@ test_where_recursion2.chpl:1: In function 'foo':
 test_where_recursion2.chpl:1: error: illegal where clause due to infinite instantiation
 test_where_recursion2.chpl:1: note: evaluation of 'foo' where clause results in instantiation of 'bar'
 test_where_recursion2.chpl:1: note: evaluation of 'bar' where clause results in instantiation of 'foo'
-test_where_recursion2.chpl:1: Function 'foo' instantiated as: foo(i: int(64))
+  test_where_recursion2.chpl:1: called as foo(i: int(64))

--- a/test/functions/diten/badwhere.good
+++ b/test/functions/diten/badwhere.good
@@ -1,3 +1,3 @@
 badwhere.chpl:4: In function 'foo':
 badwhere.chpl:4: error: invalid where clause
-badwhere.chpl:1: Function 'foo' instantiated as: foo(x: string, y: string, z: bool)
+  badwhere.chpl:1: called as foo(x: string, y: string, z: bool)

--- a/test/functions/diten/compilerWarningDepth.good
+++ b/test/functions/diten/compilerWarningDepth.good
@@ -1,24 +1,41 @@
 compilerWarningDepth.chpl:13: In function 'f4':
 compilerWarningDepth.chpl:14: warning: warning from f4 with d = 0
-compilerWarningDepth.chpl:10: Function 'f4' instantiated as: f4(param d = 0)
+  compilerWarningDepth.chpl:10: called as f4(param d = 0) from function 'f3'
+  compilerWarningDepth.chpl:6: called as f3(param d = 0) from function 'f2'
+  compilerWarningDepth.chpl:2: called as f2(param d = 0) from function 'f1'
+  compilerWarningDepth.chpl:17: called as f1(param d = 0)
 compilerWarningDepth.chpl:9: In function 'f3':
 compilerWarningDepth.chpl:10: warning: warning from f4 with d = 1
-compilerWarningDepth.chpl:6: Function 'f3' instantiated as: f3(param d = 1)
+  compilerWarningDepth.chpl:6: called as f3(param d = 1) from function 'f2'
+  compilerWarningDepth.chpl:2: called as f2(param d = 1) from function 'f1'
+  compilerWarningDepth.chpl:18: called as f1(param d = 1)
 compilerWarningDepth.chpl:5: In function 'f2':
 compilerWarningDepth.chpl:6: warning: warning from f4 with d = 2
-compilerWarningDepth.chpl:2: Function 'f2' instantiated as: f2(param d = 2)
+  compilerWarningDepth.chpl:2: called as f2(param d = 2) from function 'f1'
+  compilerWarningDepth.chpl:19: called as f1(param d = 2)
 compilerWarningDepth.chpl:1: In function 'f1':
 compilerWarningDepth.chpl:2: warning: warning from f4 with d = 3
-compilerWarningDepth.chpl:20: Function 'f1' instantiated as: f1(param d = 3)
+  compilerWarningDepth.chpl:20: called as f1(param d = 3)
 compilerWarningDepth.chpl:21: warning: warning from f4 with d = 4
 $CHPL_HOME/modules/standard/Builtins.chpl:101: In function 'compilerWarning':
 $CHPL_HOME/modules/standard/Builtins.chpl:102: warning: compiler diagnostic depth value exceeds call stack depth
-compilerWarningDepth.chpl:14: Function 'compilerWarning' instantiated here
+  compilerWarningDepth.chpl:14: called as compilerWarning(param msg(0) = "warning from f4 with d = 5": string, param errorDepth = 5) from function 'f4'
+  compilerWarningDepth.chpl:10: called as f4(param d = 5) from function 'f3'
+  compilerWarningDepth.chpl:6: called as f3(param d = 5) from function 'f2'
+  compilerWarningDepth.chpl:2: called as f2(param d = 5) from function 'f1'
+  compilerWarningDepth.chpl:22: called as f1(param d = 5)
 compilerWarningDepth.chpl:22: warning: warning from f4 with d = 5
 $CHPL_HOME/modules/standard/Builtins.chpl:101: In function 'compilerWarning':
 $CHPL_HOME/modules/standard/Builtins.chpl:102: warning: compiler diagnostic depth value can not be negative
-compilerWarningDepth.chpl:14: Function 'compilerWarning' instantiated here
+  compilerWarningDepth.chpl:14: called as compilerWarning(param msg(0) = "warning from f4 with d = -1": string, param errorDepth = -1) from function 'f4'
+  compilerWarningDepth.chpl:10: called as f4(param d = -1) from function 'f3'
+  compilerWarningDepth.chpl:6: called as f3(param d = -1) from function 'f2'
+  compilerWarningDepth.chpl:2: called as f2(param d = -1) from function 'f1'
+  compilerWarningDepth.chpl:23: called as f1(param d = -1)
 compilerWarningDepth.chpl:13: In function 'f4':
 compilerWarningDepth.chpl:14: warning: warning from f4 with d = -1
-compilerWarningDepth.chpl:10: Function 'f4' instantiated as: f4(param d = -1)
+  compilerWarningDepth.chpl:10: called as f4(param d = -1) from function 'f3'
+  compilerWarningDepth.chpl:6: called as f3(param d = -1) from function 'f2'
+  compilerWarningDepth.chpl:2: called as f2(param d = -1) from function 'f1'
+  compilerWarningDepth.chpl:23: called as f1(param d = -1)
 compilerWarningDepth.chpl:25: warning: warning from f5 with default depth

--- a/test/functions/diten/formalArrayWithQueriedEltSize.bad
+++ b/test/functions/diten/formalArrayWithQueriedEltSize.bad
@@ -1,3 +1,3 @@
 formalArrayWithQueriedEltSize.chpl:1: In function 'f':
 formalArrayWithQueriedEltSize.chpl:1: error: Query expressions are not currently supported in this context
-formalArrayWithQueriedEltSize.chpl:1: Function 'f' instantiated as: f(x: [domain(1,int(64),false)] real(64))
+  formalArrayWithQueriedEltSize.chpl:1: called as f(x: [domain(1,int(64),false)] real(64))

--- a/test/functions/diten/test_redefine_greater_or_equal.good
+++ b/test/functions/diten/test_redefine_greater_or_equal.good
@@ -1,4 +1,5 @@
 test_redefine_greater_or_equal.chpl:1: In function '>=':
 test_redefine_greater_or_equal.chpl:1: error: illegal where clause due to infinite instantiation
 test_redefine_greater_or_equal.chpl:1: note: evaluation of '>=' where clause results in instantiation of '>='
-test_redefine_greater_or_equal.chpl:1: Function '>=' instantiated as: >=(param b = 0)
+  test_redefine_greater_or_equal.chpl:1: called as >=(a: uint(64), param b = 0) from function '>='
+  test_redefine_greater_or_equal.chpl:1: called as >=(a: uint(64), param b = 1)

--- a/test/functions/diten/tupleTypeInParamCondExpr.bad
+++ b/test/functions/diten/tupleTypeInParamCondExpr.bad
@@ -1,3 +1,3 @@
 tupleTypeInParamCondExpr.chpl:3: In function 'getType':
 tupleTypeInParamCondExpr.chpl:4: error: illegal return of value where type is expected
-tupleTypeInParamCondExpr.chpl:7: Function 'getType' instantiated as: getType(type t = 2*int(64))
+  tupleTypeInParamCondExpr.chpl:7: called as getType(type t = 2*int(64))

--- a/test/functions/ferguson/check-instantiations-with-defaults-simple.1.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults-simple.1.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults-simple.chpl:1: In function 'f':
 check-instantiations-with-defaults-simple.chpl:2: warning: int(64) int(64)
-check-instantiations-with-defaults-simple.chpl:9: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults-simple.chpl:9: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults-simple.2.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults-simple.2.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults-simple.chpl:1: In function 'f':
 check-instantiations-with-defaults-simple.chpl:2: warning: int(64) int(64)
-check-instantiations-with-defaults-simple.chpl:13: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults-simple.chpl:13: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults-simple.3.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults-simple.3.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults-simple.chpl:1: In function 'f':
 check-instantiations-with-defaults-simple.chpl:2: warning: int(64) int(64)
-check-instantiations-with-defaults-simple.chpl:17: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults-simple.chpl:17: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults-simple.4.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults-simple.4.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults-simple.chpl:1: In function 'f':
 check-instantiations-with-defaults-simple.chpl:2: warning: int(64) int(64)
-check-instantiations-with-defaults-simple.chpl:21: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults-simple.chpl:21: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults-simple.5.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults-simple.5.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults-simple.chpl:1: In function 'f':
 check-instantiations-with-defaults-simple.chpl:2: warning: int(64) int(64)
-check-instantiations-with-defaults-simple.chpl:25: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults-simple.chpl:25: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults-simple.6.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults-simple.6.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults-simple.chpl:1: In function 'f':
 check-instantiations-with-defaults-simple.chpl:2: warning: int(64) int(64)
-check-instantiations-with-defaults-simple.chpl:29: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults-simple.chpl:29: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults.1.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults.1.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults.chpl:9: In function 'f':
 check-instantiations-with-defaults.chpl:10: warning: int(64) int(64)
-check-instantiations-with-defaults.chpl:17: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults.chpl:17: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults.2.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults.2.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults.chpl:9: In function 'f':
 check-instantiations-with-defaults.chpl:10: warning: int(64) int(64)
-check-instantiations-with-defaults.chpl:21: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults.chpl:21: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults.3.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults.3.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults.chpl:9: In function 'f':
 check-instantiations-with-defaults.chpl:10: warning: int(64) int(64)
-check-instantiations-with-defaults.chpl:25: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults.chpl:25: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults.4.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults.4.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults.chpl:9: In function 'f':
 check-instantiations-with-defaults.chpl:10: warning: int(64) int(64)
-check-instantiations-with-defaults.chpl:29: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults.chpl:29: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults.5.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults.5.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults.chpl:9: In function 'f':
 check-instantiations-with-defaults.chpl:10: warning: int(64) int(64)
-check-instantiations-with-defaults.chpl:33: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults.chpl:33: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/check-instantiations-with-defaults.6.good
+++ b/test/functions/ferguson/check-instantiations-with-defaults.6.good
@@ -1,3 +1,3 @@
 check-instantiations-with-defaults.chpl:9: In function 'f':
 check-instantiations-with-defaults.chpl:10: warning: int(64) int(64)
-check-instantiations-with-defaults.chpl:37: Function 'f' instantiated as: f(arg: int(64))
+  check-instantiations-with-defaults.chpl:37: called as f(arg: int(64), b: _unknown)

--- a/test/functions/ferguson/generic-default-nil.good
+++ b/test/functions/ferguson/generic-default-nil.good
@@ -3,4 +3,4 @@ generic-default-nil.chpl:3: note: when calling foo with a default value for x
 generic-default-nil.chpl:3: In function 'foo':
 generic-default-nil.chpl:4: error: the type of the actual argument 'x' is generic
 note: generic actual arguments are not currently supported
-generic-default-nil.chpl:7: Function 'foo' instantiated here
+  generic-default-nil.chpl:7: called as foo(x: borrowed C)

--- a/test/functions/ferguson/generic-default-nil2.good
+++ b/test/functions/ferguson/generic-default-nil2.good
@@ -5,4 +5,4 @@ generic-default-nil2.chpl:4: error: the type of the actual argument 'x' is gener
 note: generic actual arguments are not currently supported
 generic-default-nil2.chpl:4: note: 'C' now means non-nilable class with any management
 generic-default-nil2.chpl:4: note: to migrate old code, change it to 'borrowed C'
-generic-default-nil2.chpl:7: Function 'foo' instantiated here
+  generic-default-nil2.chpl:7: called as foo(x: C)

--- a/test/functions/ferguson/generic-default-nil3.good
+++ b/test/functions/ferguson/generic-default-nil3.good
@@ -3,4 +3,4 @@ generic-default-nil3.chpl:4: error: the type of the actual argument 'x' is gener
 note: generic actual arguments are not currently supported
 generic-default-nil3.chpl:4: note: 'C?' now means nilable class with any management
 generic-default-nil3.chpl:4: note: to migrate old code, change it to 'borrowed C?'
-generic-default-nil3.chpl:7: Function 'foo' instantiated here
+  generic-default-nil3.chpl:7: called as foo(x: C?)

--- a/test/functions/ferguson/query/owned-inner2.bad
+++ b/test/functions/ferguson/query/owned-inner2.bad
@@ -1,3 +1,3 @@
 owned-inner2.chpl:1: In function 'f':
 owned-inner2.chpl:1: error: invalid query -- queried field must be a type or parameter
-owned-inner2.chpl:5: Function 'f' instantiated as: f(arg: owned MyClass)
+  owned-inner2.chpl:5: called as f(arg: owned MyClass)

--- a/test/functions/ferguson/query/unmanaged-inner2.bad
+++ b/test/functions/ferguson/query/unmanaged-inner2.bad
@@ -1,3 +1,3 @@
 unmanaged-inner2.chpl:1: In function 'f':
 unmanaged-inner2.chpl:1: error: invalid query -- queried field must be a type or parameter
-unmanaged-inner2.chpl:5: Function 'f' instantiated as: f(arg: unmanaged MyClass)
+  unmanaged-inner2.chpl:5: called as f(arg: unmanaged MyClass)

--- a/test/functions/ferguson/ref-pair/tuples/tuple-args2.good
+++ b/test/functions/ferguson/ref-pair/tuples/tuple-args2.good
@@ -1,9 +1,9 @@
 tuple-args2.chpl:20: In function 'writesComputed':
 tuple-args2.chpl:22: error: cannot assign to const variable
-tuple-args2.chpl:32: Function 'writesComputed' instantiated as: writesComputed(tup: 2*[domain(1,int(64),false)] int(64))
+  tuple-args2.chpl:32: called as writesComputed(tup: 2*[domain(1,int(64),false)] int(64))
 tuple-args2.chpl:15: In function 'writesAll':
 tuple-args2.chpl:17: error: cannot assign to const variable
-tuple-args2.chpl:34: Function 'writesAll' instantiated as: writesAll(tup: 2*[domain(1,int(64),false)] int(64))
+  tuple-args2.chpl:34: called as writesAll(tup: 2*[domain(1,int(64),false)] int(64))
 tuple-args2.chpl:25: In function 'writesComputedNested':
 tuple-args2.chpl:27: error: cannot assign to const variable
-tuple-args2.chpl:37: Function 'writesComputedNested' instantiated as: writesComputedNested(tup: 2*2*[domain(1,int(64),false)] int(64))
+  tuple-args2.chpl:37: called as writesComputedNested(tup: 2*2*[domain(1,int(64),false)] int(64))

--- a/test/functions/ferguson/set-const-ref-this.good
+++ b/test/functions/ferguson/set-const-ref-this.good
@@ -1,3 +1,3 @@
-set-const-ref-this.chpl:4: In function 'f':
+set-const-ref-this.chpl:4: In method 'f':
 set-const-ref-this.chpl:6: error: cannot assign to const variable
-set-const-ref-this.chpl:13: Function 'f' instantiated as: f(this: R(int(64)))
+  set-const-ref-this.chpl:13: called as R(int(64)).f()

--- a/test/functions/ferguson/set-const-this.good
+++ b/test/functions/ferguson/set-const-this.good
@@ -1,3 +1,3 @@
-set-const-this.chpl:4: In function 'f':
+set-const-this.chpl:4: In method 'f':
 set-const-this.chpl:6: error: cannot assign to const variable
-set-const-this.chpl:13: Function 'f' instantiated as: f(this: R(int(64)))
+  set-const-this.chpl:13: called as R(int(64)).f()

--- a/test/functions/ferguson/spec-insn-method-no-this.bad
+++ b/test/functions/ferguson/spec-insn-method-no-this.bad
@@ -1,3 +1,3 @@
-spec-insn-method-no-this.chpl:10: In function 'bar':
+spec-insn-method-no-this.chpl:10: In method 'bar':
 spec-insn-method-no-this.chpl:11: error: 'x' used before defined
 spec-insn-method-no-this.chpl:16: note: defined here

--- a/test/functions/generic/err-in-insn.good
+++ b/test/functions/generic/err-in-insn.good
@@ -3,4 +3,4 @@ err-in-insn.chpl:6: error: unresolved call 'myadd(MyRecord, OtherRecord)'
 err-in-insn.chpl:1: note: this candidate did not match: myadd(a: int, b: int)
 err-in-insn.chpl:6: note: because call actual argument #1 with type MyRecord
 err-in-insn.chpl:1: note: is passed to formal 'a: int(64)'
-err-in-insn.chpl:16: Function 'f' instantiated as: f(x: MyRecord, y: OtherRecord, param p = 1, type t = real(64))
+  err-in-insn.chpl:16: called as f(x: MyRecord, y: OtherRecord, param p = 1, type t = real(64))

--- a/test/functions/generic/poi/ApplicationB.methods.good
+++ b/test/functions/generic/poi/ApplicationB.methods.good
@@ -1,19 +1,19 @@
 ApplicationB.methods.chpl:13: In function 'callFoo1':
 ApplicationB.methods.chpl:14: warning: X.foo()
 ApplicationB.methods.chpl:15: warning: X.bar()
-ApplicationB.methods.chpl:27: Function 'callFoo1' instantiated as: callFoo1(arg: owned MyClass)
-ApplicationB.methods.chpl:17: In function 'callFoo2':
+  ApplicationB.methods.chpl:27: called as callFoo1(arg: owned MyClass)
+ApplicationB.methods.chpl:17: In method 'callFoo2':
 ApplicationB.methods.chpl:18: warning: X.foo()
 ApplicationB.methods.chpl:19: warning: X.bar()
-ApplicationB.methods.chpl:28: Function 'callFoo2' instantiated as: callFoo2(arg: owned MyClass)
+  ApplicationB.methods.chpl:28: called as borrowed MyClass.callFoo2(arg: owned MyClass)
 ApplicationB.methods.chpl:13: In function 'callFoo1':
 ApplicationB.methods.chpl:14: warning: Y.foo()
 ApplicationB.methods.chpl:15: warning: Y.bar()
-ApplicationB.methods.chpl:36: Function 'callFoo1' instantiated as: callFoo1(arg: owned MyClass)
-ApplicationB.methods.chpl:17: In function 'callFoo2':
+  ApplicationB.methods.chpl:36: called as callFoo1(arg: owned MyClass)
+ApplicationB.methods.chpl:17: In method 'callFoo2':
 ApplicationB.methods.chpl:18: warning: Y.foo()
 ApplicationB.methods.chpl:19: warning: Y.bar()
-ApplicationB.methods.chpl:37: Function 'callFoo2' instantiated as: callFoo2(arg: owned MyClass)
+  ApplicationB.methods.chpl:37: called as borrowed MyClass.callFoo2(arg: owned MyClass)
 X.foo()
 X.bar()
 X.foo()

--- a/test/functions/generic/poi/canresolve-in-sort.good
+++ b/test/functions/generic/poi/canresolve-in-sort.good
@@ -1,3 +1,5 @@
 canresolve-in-sort.chpl:46: In function 'canResolveMethod':
 canresolve-in-sort.chpl:47: error: success
-canresolve-in-sort.chpl:33: Function 'canResolveMethod' instantiated as: canResolveMethod(recv: DefaultComparator, name: string, a: int(64), b: int(64))
+  canresolve-in-sort.chpl:33: called as canResolveMethod(recv: DefaultComparator, name: string, a: int(64), b: int(64))
+  within internal functions (use --print-callstack-on-error to see)
+  canresolve-in-sort.chpl:19: called as BinarySearch(Data: int(64), val: int(64), comparator: DefaultComparator)

--- a/test/functions/generic/poi/check-gc-reuse.good
+++ b/test/functions/generic/poi/check-gc-reuse.good
@@ -3,11 +3,11 @@ check-gc-reuse.chpl:31: warning: User.u1
 check-gc-reuse.chpl:15: In function 'libFun':
 check-gc-reuse.chpl:16: warning: User.workFun
 check-gc-reuse.chpl:17: warning: User.workMet
-check-gc-reuse.chpl:32: Function 'libFun' instantiated as: libFun(myArg: owned MyClass)
-check-gc-reuse.chpl:19: In function 'libMet':
+  check-gc-reuse.chpl:32: called as libFun(myArg: owned MyClass)
+check-gc-reuse.chpl:19: In method 'libMet':
 check-gc-reuse.chpl:20: warning: User.workFun
 check-gc-reuse.chpl:21: warning: User.workMet
-check-gc-reuse.chpl:33: Function 'libMet' instantiated as: libMet(myArg: owned MyClass)
+  check-gc-reuse.chpl:33: called as borrowed MyClass.libMet(myArg: owned MyClass)
 check-gc-reuse.chpl:35: In function 'u2':
 check-gc-reuse.chpl:37: warning: User.u2
 check-gc-reuse.chpl:42: In function 'u3':
@@ -15,43 +15,45 @@ check-gc-reuse.chpl:45: warning: User.u3
 check-gc-reuse.chpl:15: In function 'libFun':
 check-gc-reuse.chpl:16: warning: User.u3.workFun
 check-gc-reuse.chpl:17: warning: User.u3.workMet
-check-gc-reuse.chpl:46: Function 'libFun' instantiated as: libFun(myArg: owned MyClass)
-check-gc-reuse.chpl:19: In function 'libMet':
+  check-gc-reuse.chpl:46: called as libFun(myArg: owned MyClass)
+check-gc-reuse.chpl:19: In method 'libMet':
 check-gc-reuse.chpl:20: warning: User.u3.workFun
 check-gc-reuse.chpl:21: warning: User.u3.workMet
-check-gc-reuse.chpl:47: Function 'libMet' instantiated as: libMet(myArg: owned MyClass)
+  check-gc-reuse.chpl:47: called as borrowed MyClass.libMet(myArg: owned MyClass)
 check-gc-reuse.chpl:80: In function 'm1con':
 check-gc-reuse.chpl:81: warning: More1.m1con
 check-gc-reuse.chpl:15: In function 'libFun':
 check-gc-reuse.chpl:16: warning: More1.workFun
 check-gc-reuse.chpl:17: warning: More1.workMet
-check-gc-reuse.chpl:82: Function 'libFun' instantiated as: libFun(myArg: owned MyClass)
-check-gc-reuse.chpl:19: In function 'libMet':
+  check-gc-reuse.chpl:82: called as libFun(myArg: owned MyClass)
+check-gc-reuse.chpl:19: In method 'libMet':
 check-gc-reuse.chpl:20: warning: More1.workFun
 check-gc-reuse.chpl:21: warning: More1.workMet
-check-gc-reuse.chpl:83: Function 'libMet' instantiated as: libMet(myArg: owned MyClass)
+  check-gc-reuse.chpl:83: called as borrowed MyClass.libMet(myArg: owned MyClass)
 check-gc-reuse.chpl:85: In function 'm1gen':
 check-gc-reuse.chpl:86: warning: More1.m1gen
-check-gc-reuse.chpl:57: Function 'm1gen' instantiated as: m1gen(param p = 0)
+  check-gc-reuse.chpl:57: called as m1gen(param p = 0)
 check-gc-reuse.chpl:95: In function 'm2con':
 check-gc-reuse.chpl:96: warning: More2.m2con
 check-gc-reuse.chpl:100: In function 'm2gen':
 check-gc-reuse.chpl:101: warning: More2.m2gen
-check-gc-reuse.chpl:62: Function 'm2gen' instantiated as: m2gen(param p = 0)
+  check-gc-reuse.chpl:62: called as m2gen(param p = 0)
 check-gc-reuse.chpl:126: In function 'combo2a':
 check-gc-reuse.chpl:127: warning: Combo2.combo2a
-check-gc-reuse.chpl:114: Function 'combo2a' instantiated as: combo2a(param p = 0)
+  check-gc-reuse.chpl:114: called as combo2a(param p = 0)
 check-gc-reuse.chpl:15: In function 'libFun':
 check-gc-reuse.chpl:16: warning: Combo1.workFun
 check-gc-reuse.chpl:17: warning: Combo1.workMet
-check-gc-reuse.chpl:128: Function 'libFun' instantiated as: libFun(myArg: owned MyClass)
-check-gc-reuse.chpl:19: In function 'libMet':
+  check-gc-reuse.chpl:128: called as libFun(myArg: owned MyClass) from function 'combo2a'
+  check-gc-reuse.chpl:114: called as combo2a(param p = 0)
+check-gc-reuse.chpl:19: In method 'libMet':
 check-gc-reuse.chpl:20: warning: Combo1.workFun
 check-gc-reuse.chpl:21: warning: Combo1.workMet
-check-gc-reuse.chpl:129: Function 'libMet' instantiated as: libMet(myArg: owned MyClass)
+  check-gc-reuse.chpl:129: called as borrowed MyClass.libMet(myArg: owned MyClass) from function 'combo2a'
+  check-gc-reuse.chpl:114: called as combo2a(param p = 0)
 check-gc-reuse.chpl:116: In function 'combo1b':
 check-gc-reuse.chpl:117: warning: Combo1.combo1b
-check-gc-reuse.chpl:133: Function 'combo1b' instantiated as: combo1b(param p = 0)
+  check-gc-reuse.chpl:133: called as combo1b(param p = 0)
 User.u1
 User.workFun
 User.workMet

--- a/test/functions/generic/poi/forwarding-wrapper.good
+++ b/test/functions/generic/poi/forwarding-wrapper.good
@@ -1,3 +1,3 @@
-forwarding-wrapper.chpl:24: In function 'fn':
+forwarding-wrapper.chpl:24: In method 'fn':
 forwarding-wrapper.chpl:25: error: success
-forwarding-wrapper.chpl:15: Function 'fn' instantiated as: fn(param arg1 = 1)
+  forwarding-wrapper.chpl:15: called as borrowed ForwardedClass.fn(param arg1 = 1)

--- a/test/functions/generic/poi/hashed-dist-with-mapper.good
+++ b/test/functions/generic/poi/hashed-dist-with-mapper.good
@@ -1,3 +1,5 @@
-hashed-dist-with-mapper.chpl:50: In function 'indexToLocaleIndex':
+hashed-dist-with-mapper.chpl:50: In method 'indexToLocaleIndex':
 hashed-dist-with-mapper.chpl:51: error: success
-hashed-dist-with-mapper.chpl:48: Function 'indexToLocaleIndex' instantiated as: indexToLocaleIndex(this: borrowed HashedDomain(MyMapper), elm: string)
+  hashed-dist-with-mapper.chpl:48: called as borrowed HashedDomain(MyMapper).indexToLocaleIndex(elm: string) from method 'dsiAdd'
+  hashed-dist-with-mapper.chpl:39: called as borrowed HashedDomain(MyMapper).dsiAdd(elm: string) from function 'add'
+  hashed-dist-with-mapper.chpl:32: called as add(D: owned HashedDomain(MyMapper), elm: string)

--- a/test/functions/generic/poi/init-in-private-array.good
+++ b/test/functions/generic/poi/init-in-private-array.good
@@ -1,3 +1,3 @@
 init-in-private-array.chpl:31: In initializer:
 init-in-private-array.chpl:32: error: success
-init-in-private-array.chpl:25: Initializer instantiated as: init(type eltType = R)
+  init-in-private-array.chpl:25: called as borrowed MyPrivateArray.init(type eltType = R)

--- a/test/functions/generic/poi/random-choice.good
+++ b/test/functions/generic/poi/random-choice.good
@@ -1,3 +1,3 @@
 random-choice.chpl:22: In function 'choice':
 random-choice.chpl:24: error: success
-random-choice.chpl:10: Function 'choice' instantiated as: choice(stream: int(64))
+  random-choice.chpl:10: called as choice(stream: int(64))

--- a/test/functions/generic/poi/shadowing-field.bad
+++ b/test/functions/generic/poi/shadowing-field.bad
@@ -1,6 +1,6 @@
-shadowing-field.chpl:18: In function 'genericMethod':
+shadowing-field.chpl:18: In method 'genericMethod':
 shadowing-field.chpl:19: warning: in Main.MyRecord.field
-shadowing-field.chpl:10: Function 'genericMethod' instantiated as: genericMethod(type t = int(64))
+  shadowing-field.chpl:10: called as MyRecord.genericMethod(type t = int(64))
 shadowing-field.chpl:9: In function 'main':
 shadowing-field.chpl:10: warning: in genericMethod()
 shadowing-field.chpl:9: warning: in Main.main

--- a/test/functions/generic/poi/shadowing-method.bad
+++ b/test/functions/generic/poi/shadowing-method.bad
@@ -1,4 +1,4 @@
-shadowing-method.chpl:21: In function 'genericMethod':
+shadowing-method.chpl:21: In method 'genericMethod':
 shadowing-method.chpl:22: warning: in Library.MyRecord.method
-shadowing-method.chpl:10: Function 'genericMethod' instantiated as: genericMethod(type t = int(64))
+  shadowing-method.chpl:10: called as MyRecord.genericMethod(type t = int(64))
 shadowing-method.chpl:9: error: in Main.main, done

--- a/test/functions/generic/poi/sort-check-comparator.good
+++ b/test/functions/generic/poi/sort-check-comparator.good
@@ -1,3 +1,4 @@
 sort-check-comparator.chpl:26: In function 'quickSort':
 sort-check-comparator.chpl:27: error: success
-sort-check-comparator.chpl:15: Function 'quickSort' instantiated as: quickSort(Data: int(64))
+  sort-check-comparator.chpl:15: called as quickSort(Data: int(64)) from function 'sort'
+  sort-check-comparator.chpl:9: called as sort(Data: int(64))

--- a/test/functions/generic/poi/writethis-user-record.good
+++ b/test/functions/generic/poi/writethis-user-record.good
@@ -1,3 +1,4 @@
 writethis-user-record.chpl:49: In function 'reproWriteln':
 writethis-user-record.chpl:52: error: success
-writethis-user-record.chpl:46: Function 'reproWriteln' instantiated as: reproWriteln(channel: owned object, arg: Color)
+  writethis-user-record.chpl:46: called as reproWriteln(channel: owned object, arg: Color) from function 'reproWriteln'
+  writethis-user-record.chpl:37: called as reproWriteln(arg: Color)

--- a/test/functions/generic/poi/zmq-initequals.good
+++ b/test/functions/generic/poi/zmq-initequals.good
@@ -1,3 +1,3 @@
 zmq-initequals.chpl:18: In function 'recv':
 zmq-initequals.chpl:20: error: success
-zmq-initequals.chpl:13: Function 'recv' instantiated as: recv(type T = Foo)
+  zmq-initequals.chpl:13: called as recv(type T = Foo)

--- a/test/functions/iterators/engin/paramFormalInForall.good
+++ b/test/functions/iterators/engin/paramFormalInForall.good
@@ -1,10 +1,11 @@
 paramFormalInForall.chpl:8: In function 'fun1':
 paramFormalInForall.chpl:10: warning: 5
 paramFormalInForall.chpl:11: warning: 5
-paramFormalInForall.chpl:16: Function 'fun1' instantiated as: fun1(param arg1 = 5)
+  paramFormalInForall.chpl:16: called as fun1(param arg1 = 5)
 paramFormalInForall.chpl:3: In function 'fun2':
 paramFormalInForall.chpl:4: warning: 5
-paramFormalInForall.chpl:11: Function 'fun2' instantiated as: fun2(param arg2 = 5)
+  paramFormalInForall.chpl:11: called as fun2(param arg2 = 5) from function 'fun1'
+  paramFormalInForall.chpl:16: called as fun1(param arg1 = 5)
 fun2 5
 fun2 5
 fun2 5

--- a/test/functions/iterators/recursive/recursive-leader-errr.good
+++ b/test/functions/iterators/recursive/recursive-leader-errr.good
@@ -2,4 +2,4 @@ recursive-leader-errr.chpl:14: In iterator 'asdf':
 recursive-leader-errr.chpl:18: error: the recursion pattern seen in the first iterable in this forall loop is not supported
 recursive-leader-errr.chpl:14: note: the corresponding iterator is here
 recursive-leader-errr.chpl:14: note: try declaring its return type
-recursive-leader-errr.chpl:6: Iterator 'asdf' instantiated as: asdf(param tag: iterKind = iterKind.leader)
+  recursive-leader-errr.chpl:6: called as asdf(param tag = iterKind.leader)

--- a/test/functions/iterators/vass/forall-over-iteratorRecord-arg.good
+++ b/test/functions/iterators/vass/forall-over-iteratorRecord-arg.good
@@ -1,4 +1,4 @@
 forall-over-iteratorRecord-arg.chpl:21: In function 'myTestProc':
 forall-over-iteratorRecord-arg.chpl:23: error: a forall loop over a formal argument corresponding to a for/forall/promoted expression or an iterator call is not implemented
 forall-over-iteratorRecord-arg.chpl:34: note: the actual argument is here
-forall-over-iteratorRecord-arg.chpl:34: Function 'myTestProc' instantiated as: myTestProc(IR: iterator)
+  forall-over-iteratorRecord-arg.chpl:34: called as myTestProc(IR: iterator)

--- a/test/functions/jplevyak/intent-5-error.good
+++ b/test/functions/jplevyak/intent-5-error.good
@@ -1,3 +1,3 @@
 intent-5-error.chpl:3: In function 'foo':
 intent-5-error.chpl:4: error: cannot assign to const variable
-intent-5-error.chpl:9: Function 'foo' instantiated as: foo(x: int(64))
+  intent-5-error.chpl:9: called as foo(x: int(64))

--- a/test/functions/lydia/method-iter-resolution-bug.bad
+++ b/test/functions/lydia/method-iter-resolution-bug.bad
@@ -1,4 +1,4 @@
-method-iter-resolution-bug.chpl:4: In function 'iTerate':
+method-iter-resolution-bug.chpl:4: In method 'iTerate':
 method-iter-resolution-bug.chpl:7: error: unresolved call 'C.iTerate(int(64), int(64))'
 method-iter-resolution-bug.chpl:4: note: this candidate did not match: C.iTerate(x: int)
 method-iter-resolution-bug.chpl:7: note: because call includes 2 arguments

--- a/test/functions/this/bradc/domainSliceConfusion.good
+++ b/test/functions/this/bradc/domainSliceConfusion.good
@@ -1,2 +1,2 @@
-domainSliceConfusion.chpl:8: In function 'this':
+domainSliceConfusion.chpl:8: In method 'this':
 domainSliceConfusion.chpl:9: error: unresolved access of '[domain(1,int(32),false)] real(64)' by '(int(64))'

--- a/test/functions/this/implicit-this.bad
+++ b/test/functions/this/implicit-this.bad
@@ -1,2 +1,2 @@
-implicit-this.chpl:9: In function 'z':
+implicit-this.chpl:9: In method 'z':
 implicit-this.chpl:10: error: 'x' undeclared (first use this function)

--- a/test/functions/vass/resolution/param-detuple.good
+++ b/test/functions/vass/resolution/param-detuple.good
@@ -1,10 +1,11 @@
 param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
-param-detuple.chpl:12: Function 'p2' instantiated here
+  param-detuple.chpl:12: called as p2(param args(0) = "a": _any)
 param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
-param-detuple.chpl:13: Function 'p2' instantiated as: p2(param args(0): string = "a", param args(1): string = "b")
+  param-detuple.chpl:13: called as p2(param args(0) = "a": string, param args(1) = "b": string)
 $CHPL_HOME/modules/standard/Builtins.chpl:83: In function 'compilerError':
 $CHPL_HOME/modules/standard/Builtins.chpl:84: warning: compiler diagnostic depth value exceeds call stack depth
-$CHPL_HOME/modules/standard/Builtins.chpl:145: Function 'compilerError' instantiated as: compilerError(param msg(0): string = "assert failed - ", param msg(1): string = "done", param errorDepth = 3)
+  $CHPL_HOME/modules/standard/Builtins.chpl:145: called as compilerError(param msg(0) = "assert failed - ": string, param msg(1) = "done": string, param errorDepth = 3) from function 'compilerAssert'
+  param-detuple.chpl:14: called as compilerAssert(param test = 0, param msg(0) = "done": string, param errorDepth = 2)
 param-detuple.chpl:14: error: assert failed - done

--- a/test/functions/vass/varargs-2.good
+++ b/test/functions/vass/varargs-2.good
@@ -1,30 +1,30 @@
 varargs-2.chpl:14: In function 'show_default':
 varargs-2.chpl:16: error: cannot assign to const variable
-varargs-2.chpl:64: Function 'show_default' instantiated as: show_default(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:64: called as show_default(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:20: In function 'show_const':
 varargs-2.chpl:21: error: cannot assign to const variable
 varargs-2.chpl:22: error: cannot assign to const variable
-varargs-2.chpl:65: Function 'show_const' instantiated as: show_const(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:65: called as show_const(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:26: In function 'show_const_in':
 varargs-2.chpl:27: error: cannot assign to const variable
 varargs-2.chpl:28: error: cannot assign to const variable
-varargs-2.chpl:66: Function 'show_const_in' instantiated as: show_const_in(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:66: called as show_const_in(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:32: In function 'show_const_ref':
 varargs-2.chpl:33: error: cannot assign to const variable
 varargs-2.chpl:34: error: cannot assign to const variable
-varargs-2.chpl:67: Function 'show_const_ref' instantiated as: show_const_ref(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:67: called as show_const_ref(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:41: In function 'test_default':
 varargs-2.chpl:43: error: cannot assign to const variable
-varargs-2.chpl:69: Function 'test_default' instantiated as: test_default(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:69: called as test_default(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:46: In function 'test_const':
 varargs-2.chpl:47: error: cannot assign to const variable
 varargs-2.chpl:48: error: cannot assign to const variable
-varargs-2.chpl:70: Function 'test_const' instantiated as: test_const(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:70: called as test_const(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:51: In function 'test_const_in':
 varargs-2.chpl:52: error: cannot assign to const variable
 varargs-2.chpl:53: error: cannot assign to const variable
-varargs-2.chpl:71: Function 'test_const_in' instantiated as: test_const_in(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:71: called as test_const_in(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
 varargs-2.chpl:56: In function 'test_const_ref':
 varargs-2.chpl:57: error: cannot assign to const variable
 varargs-2.chpl:58: error: cannot assign to const variable
-varargs-2.chpl:72: Function 'test_const_ref' instantiated as: test_const_ref(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))
+  varargs-2.chpl:72: called as test_const_ref(xxx(0): [domain(1,int(64),false)] int(64), xxx(1): int(64))

--- a/test/functions/whereClauses/whereClauseNoFn2.good
+++ b/test/functions/whereClauses/whereClauseNoFn2.good
@@ -1,4 +1,4 @@
 whereClauseNoFn2.chpl:1: In function 'foo':
 whereClauseNoFn2.chpl:1: error: unresolved call 'bar()'
 whereClauseNoFn2.chpl:1: note: because no functions named bar found in scope
-whereClauseNoFn2.chpl:1: Function 'foo' instantiated as: foo(x: int(64))
+  whereClauseNoFn2.chpl:1: called as foo(x: int(64))

--- a/test/functions/whereClauses/whereClauseNonParamGeneric.good
+++ b/test/functions/whereClauses/whereClauseNonParamGeneric.good
@@ -1,3 +1,3 @@
 whereClauseNonParamGeneric.chpl:1: In function 'foo':
 whereClauseNonParamGeneric.chpl:1: error: invalid where clause
-whereClauseNonParamGeneric.chpl:1: Function 'foo' instantiated as: foo(x: int(64))
+  whereClauseNonParamGeneric.chpl:1: called as foo(x: int(64), y: int(64))

--- a/test/library/draft/Vector/types/testBorrowed.good
+++ b/test/library/draft/Vector/types/testBorrowed.good
@@ -1,3 +1,4 @@
 Vector.chpl:xxx: In initializer:
 Vector.chpl:xxx: error: Vector does not support an eltType that can't be default initialized, here: borrowed T
-VectorTest.chpl:xxx: Initializer instantiated as: init(type eltType = borrowed T, param parSafe = 0)
+VectorTest.chpl:xxx: called as vector.init(type eltType = borrowed T, param parSafe = 0) from function 'testVector'
+  testBorrowed.chpl:xxx: called as testVector(type t = borrowed T)

--- a/test/library/draft/Vector/types/testOwned.good
+++ b/test/library/draft/Vector/types/testOwned.good
@@ -1,3 +1,4 @@
 Vector.chpl:xxx: In initializer:
 Vector.chpl:xxx: error: Vector does not support an eltType that can't be default initialized, here: owned T
-VectorTest.chpl:xxx: Initializer instantiated as: init(type eltType = owned T, param parSafe = 0)
+VectorTest.chpl:xxx: called as vector.init(type eltType = owned T, param parSafe = 0) from function 'testVector'
+  testOwned.chpl:xxx: called as testVector(type t = owned T)

--- a/test/library/draft/Vector/types/testShared.good
+++ b/test/library/draft/Vector/types/testShared.good
@@ -1,3 +1,4 @@
 Vector.chpl:xxx: In initializer:
 Vector.chpl:xxx: error: Vector does not support an eltType that can't be default initialized, here: shared T
-VectorTest.chpl:xxx: Initializer instantiated as: init(type eltType = shared T, param parSafe = 0)
+VectorTest.chpl:xxx: called as vector.init(type eltType = shared T, param parSafe = 0) from function 'testVector'
+  testShared.chpl:xxx: called as testVector(type t = shared T)

--- a/test/library/draft/Vector/types/testTuple.good
+++ b/test/library/draft/Vector/types/testTuple.good
@@ -1,3 +1,4 @@
 Vector.chpl:xxx: In initializer:
 Vector.chpl:xxx: error: Vector does not support an eltType that can't be default initialized, here: 2*shared T
-VectorTest.chpl:xxx: Initializer instantiated as: init(type eltType = 2*shared T, param parSafe = 0)
+VectorTest.chpl:xxx: called as vector.init(type eltType = 2*shared T, param parSafe = 0) from function 'testVector'
+  testTuple.chpl:xxx: called as testVector(type t = 2*shared T)

--- a/test/library/draft/Vector/types/testUnmanaged.good
+++ b/test/library/draft/Vector/types/testUnmanaged.good
@@ -1,3 +1,4 @@
 Vector.chpl:xxx: In initializer:
 Vector.chpl:xxx: error: Vector does not support an eltType that can't be default initialized, here: unmanaged T
-VectorTest.chpl:xxx: Initializer instantiated as: init(type eltType = unmanaged T, param parSafe = 0)
+VectorTest.chpl:xxx: called as vector.init(type eltType = unmanaged T, param parSafe = 0) from function 'testVector'
+  testUnmanaged.chpl:xxx: called as testVector(type t = unmanaged T)

--- a/test/library/standard/List/init/listInitGenericError.good
+++ b/test/library/standard/List/init/listInitGenericError.good
@@ -2,4 +2,4 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: creating a list with element type C
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: which now means class type with generic management
 $CHPL_HOME/modules/standard/List.chpl:nnnn: error: list element type cannot currently be generic
-listInitGenericError.chpl:nnnn: Initializer instantiated as: init(type eltType = C, param parSafe = 0)
+  listInitGenericError.chpl:nnnn: called as list.init(type eltType = C, param parSafe = 0)

--- a/test/library/standard/Version/compareChplVersionErrors.good
+++ b/test/library/standard/Version/compareChplVersionErrors.good
@@ -3,13 +3,15 @@ compareChplVersionErrors.chpl:32: error: can't compare sourceVersions that only 
 compareChplVersionErrors.chpl:33: error: can't compare sourceVersions that only differ by commit IDs
 compareChplVersionErrors.chpl:34: error: can't compare sourceVersions that only differ by commit IDs
 compareChplVersionErrors.chpl:35: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:21: Function 'compareVersions' instantiated as: compareVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\"))
+  compareChplVersionErrors.chpl:21: called as compareVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\"))
 compareChplVersionErrors.chpl:25: In function 'compareVersions':
 compareChplVersionErrors.chpl:32: error: can't compare sourceVersions that only differ by commit IDs
 compareChplVersionErrors.chpl:33: error: can't compare sourceVersions that only differ by commit IDs
 compareChplVersionErrors.chpl:34: error: can't compare sourceVersions that only differ by commit IDs
 compareChplVersionErrors.chpl:35: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:22: Function 'compareVersions' instantiated as: compareVersions(v1: sourceVersion(semanticVersion(2,1,0),\"bbb\"), v2: sourceVersion(semanticVersion(2,1,0),\"aaa\"))
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(semanticVersion(2,1,0),\"bbb\"), v2: sourceVersion(semanticVersion(2,1,0),\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\"))
 Comparing versions:
 version 2.1.0
 version 2.1.0 (aaa)

--- a/test/parallel/forall/vass/other/fields-of-this-3-const-fields.good
+++ b/test/parallel/forall/vass/other/fields-of-this-3-const-fields.good
@@ -1,4 +1,4 @@
-fields-of-this-3-const-fields.chpl:14: In function 'w1':
+fields-of-this-3-const-fields.chpl:14: In method 'w1':
 fields-of-this-3-const-fields.chpl:16: error: cannot assign to const variable
 fields-of-this-3-const-fields.chpl:17: error: illegal lvalue in assignment
 fields-of-this-3-const-fields.chpl:18: error: non-lvalue actual is passed to 'ref' formal 'arg' of modify()

--- a/test/parallel/taskPar/taskIntents/fields-of-this-3-const-fields.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-3-const-fields.good
@@ -1,4 +1,4 @@
-fields-of-this-3-const-fields.chpl:14: In function 'w1':
+fields-of-this-3-const-fields.chpl:14: In method 'w1':
 fields-of-this-3-const-fields.chpl:16: error: cannot assign to const variable
 fields-of-this-3-const-fields.chpl:17: error: illegal lvalue in assignment
 fields-of-this-3-const-fields.chpl:18: error: non-lvalue actual is passed to 'ref' formal 'arg' of modify()

--- a/test/parallel/taskPar/taskIntents/fields-of-this-4-begin-cobegin.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-4-begin-cobegin.good
@@ -1,10 +1,10 @@
-fields-of-this-4-begin-cobegin.chpl:13: In function 'bgn':
+fields-of-this-4-begin-cobegin.chpl:13: In method 'bgn':
 fields-of-this-4-begin-cobegin.chpl:15: error: cannot assign to const variable
-fields-of-this-4-begin-cobegin.chpl:24: In function 'cob':
+fields-of-this-4-begin-cobegin.chpl:24: In method 'cob':
 fields-of-this-4-begin-cobegin.chpl:26: error: cannot assign to const variable
 fields-of-this-4-begin-cobegin.chpl:27: error: cannot assign to const variable
-fields-of-this-4-begin-cobegin.chpl:42: In function 'bgn':
+fields-of-this-4-begin-cobegin.chpl:42: In method 'bgn':
 fields-of-this-4-begin-cobegin.chpl:44: error: cannot assign to const variable
-fields-of-this-4-begin-cobegin.chpl:53: In function 'cob':
+fields-of-this-4-begin-cobegin.chpl:53: In method 'cob':
 fields-of-this-4-begin-cobegin.chpl:55: error: cannot assign to const variable
 fields-of-this-4-begin-cobegin.chpl:56: error: cannot assign to const variable

--- a/test/parallel/taskPar/vass/const-in-intent-arrays-domains.good
+++ b/test/parallel/taskPar/vass/const-in-intent-arrays-domains.good
@@ -1,7 +1,7 @@
 const-in-intent-arrays-domains.chpl:6: In function 'testFormal':
 const-in-intent-arrays-domains.chpl:7: error: cannot assign to const variable
 const-in-intent-arrays-domains.chpl:8: error: cannot assign to const variable
-const-in-intent-arrays-domains.chpl:12: Function 'testFormal' instantiated as: testFormal(domArg: domain(1,int(64),false), arrArg: [domain(1,int(64),false)] int(64))
+  const-in-intent-arrays-domains.chpl:12: called as testFormal(domArg: domain(1,int(64),false), arrArg: [domain(1,int(64),false)] int(64))
 const-in-intent-arrays-domains.chpl:11: In function 'main':
 const-in-intent-arrays-domains.chpl:15: error: cannot assign to const variable
 const-in-intent-arrays-domains.chpl:14: note: The shadow variable 'DOM' is constant due to task intents in this begin statement

--- a/test/parallel/taskPar/vass/errorFieldMethodInWithClause.good
+++ b/test/parallel/taskPar/vass/errorFieldMethodInWithClause.good
@@ -1,5 +1,5 @@
 errorFieldMethodInWithClause.chpl:22: error: cannot reference a field or function 'myField' in a with-clause of this cobegin block
-errorFieldMethodInWithClause.chpl:16: In function 'test':
+errorFieldMethodInWithClause.chpl:16: In method 'test':
 errorFieldMethodInWithClause.chpl:26: error: cannot reference a field or function 'myProcc' in a with-clause of this cobegin block
 errorFieldMethodInWithClause.chpl:30: error: cannot reference a field or function 'ourProc' in a with-clause of this cobegin block
 errorFieldMethodInWithClause.chpl:30: error: cannot reference a field or function 'ourIter' in a with-clause of this cobegin block

--- a/test/param/diten/errorDepth.depth0.good
+++ b/test/param/diten/errorDepth.depth0.good
@@ -1,3 +1,5 @@
 errorDepth.chpl:1: In function 'foo':
 errorDepth.chpl:3: error: error 0
-errorDepth.chpl:10: Function 'foo' instantiated as: foo(param d = 0)
+  errorDepth.chpl:10: called as foo(param d = 0) from function 'bar'
+  errorDepth.chpl:11: called as bar(param d = 0) from function 'baz'
+  errorDepth.chpl:15: called as baz(param d = 0)

--- a/test/param/diten/errorDepth.depth1.good
+++ b/test/param/diten/errorDepth.depth1.good
@@ -1,3 +1,4 @@
 errorDepth.chpl:10: In function 'bar':
 errorDepth.chpl:10: error: error 1
-errorDepth.chpl:11: Function 'bar' instantiated as: bar(param d = 1)
+  errorDepth.chpl:11: called as bar(param d = 1) from function 'baz'
+  errorDepth.chpl:15: called as baz(param d = 1)

--- a/test/param/diten/errorDepth.depth2.good
+++ b/test/param/diten/errorDepth.depth2.good
@@ -1,3 +1,3 @@
 errorDepth.chpl:11: In function 'baz':
 errorDepth.chpl:11: error: error 2
-errorDepth.chpl:15: Function 'baz' instantiated as: baz(param d = 2)
+  errorDepth.chpl:15: called as baz(param d = 2)

--- a/test/param/ferguson/field-name-not-in-range.good
+++ b/test/param/ferguson/field-name-not-in-range.good
@@ -1,3 +1,3 @@
 $CHPL_HOME/modules/standard/Reflection.chpl:: In function 'getFieldName':
 $CHPL_HOME/modules/standard/Reflection.chpl:: error: '1' is not a valid field number for R
-field-name-not-in-range.chpl:: Function 'getFieldName' instantiated as: getFieldName(type t = R, param i = 1)
+  field-name-not-in-range.chpl:: called as getFieldName(type t = R, param i = 1)

--- a/test/param/ifExprCopyInitBug.bad
+++ b/test/param/ifExprCopyInitBug.bad
@@ -1,6 +1,6 @@
 ifExprCopyInitBug.chpl:3: In function 'test':
 ifExprCopyInitBug.chpl:5: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
-ifExprCopyInitBug.chpl:15: Function 'test' instantiated as: test(type T = owned C)
+  ifExprCopyInitBug.chpl:15: called as test(type T = owned C)
 ifExprCopyInitBug.chpl:3: In function 'test':
 ifExprCopyInitBug.chpl:5: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
-ifExprCopyInitBug.chpl:16: Function 'test' instantiated as: test(type T = owned C?)
+  ifExprCopyInitBug.chpl:16: called as test(type T = owned C?)

--- a/test/scan/scanViews.good
+++ b/test/scan/scanViews.good
@@ -1,15 +1,15 @@
 scanViews.chpl:3: In function 'scanArr':
 scanViews.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViews.chpl:10: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged domain(1,int(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(1,int(64),false),int(64),unmanaged domain(1,int(64),false)))] int(64))
+  scanViews.chpl:10: called as scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged domain(1,int(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(1,int(64),false),int(64),unmanaged domain(1,int(64),false)))] int(64))
 scanViews.chpl:3: In function 'scanArr':
 scanViews.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViews.chpl:11: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged domain(1,int(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(1,int(64),false),int(64),unmanaged domain(1,int(64),false)))] int(64))
+  scanViews.chpl:11: called as scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged domain(1,int(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(1,int(64),false),int(64),unmanaged domain(1,int(64),false)))] int(64))
 scanViews.chpl:3: In function 'scanArr':
 scanViews.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViews.chpl:12: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged domain(1,int(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(1,int(64),false),int(64),unmanaged domain(1,int(64),false)))] int(64))
+  scanViews.chpl:12: called as scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged domain(1,int(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(1,int(64),false),int(64),unmanaged domain(1,int(64),false)))] int(64))
 scanViews.chpl:3: In function 'scanArr':
 scanViews.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViews.chpl:16: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewRankChangeDom(1,int(64),false,2*bool,2*int(64),int(64),unmanaged ArrayViewRankChangeDist(unmanaged DefaultDist,2*bool,2*int(64)))] int(64))
+  scanViews.chpl:16: called as scanArr(X: [ArrayViewRankChangeDom(1,int(64),false,2*bool,2*int(64),int(64),unmanaged ArrayViewRankChangeDist(unmanaged DefaultDist,2*bool,2*int(64)))] int(64))
 1 3 6 10 15 21 28 36 45 55: [{1..10}]
 3 7 12: [{3..5}]
 1 3 6 10 15 21 28 36 45 55: [{0..9}]

--- a/test/scan/scanViewsBlock.good
+++ b/test/scan/scanViewsBlock.good
@@ -1,15 +1,15 @@
 scanViewsBlock.chpl:3: In function 'scanArr':
 scanViewsBlock.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViewsBlock.chpl:12: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist),int(64),unmanaged ArrayViewReindexDist(unmanaged Block(1,int(64),unmanaged DefaultDist),unmanaged domain(1,int(64),false),int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist)))] int(64))
+  scanViewsBlock.chpl:12: called as scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist),int(64),unmanaged ArrayViewReindexDist(unmanaged Block(1,int(64),unmanaged DefaultDist),unmanaged domain(1,int(64),false),int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist)))] int(64))
 scanViewsBlock.chpl:3: In function 'scanArr':
 scanViewsBlock.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViewsBlock.chpl:13: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist),int(64),unmanaged ArrayViewReindexDist(unmanaged Block(1,int(64),unmanaged DefaultDist),unmanaged domain(1,int(64),false),int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist)))] int(64))
+  scanViewsBlock.chpl:13: called as scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist),int(64),unmanaged ArrayViewReindexDist(unmanaged Block(1,int(64),unmanaged DefaultDist),unmanaged domain(1,int(64),false),int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist)))] int(64))
 scanViewsBlock.chpl:3: In function 'scanArr':
 scanViewsBlock.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViewsBlock.chpl:14: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist),int(64),unmanaged ArrayViewReindexDist(unmanaged Block(1,int(64),unmanaged DefaultDist),unmanaged domain(1,int(64),false),int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist)))] int(64))
+  scanViewsBlock.chpl:14: called as scanArr(X: [ArrayViewReindexDom(1,int(64),false,int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist),int(64),unmanaged ArrayViewReindexDist(unmanaged Block(1,int(64),unmanaged DefaultDist),unmanaged domain(1,int(64),false),int(64),unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist)))] int(64))
 scanViewsBlock.chpl:3: In function 'scanArr':
 scanViewsBlock.chpl:4: warning: scan has been serialized (see issue #12482)
-scanViewsBlock.chpl:18: Function 'scanArr' instantiated as: scanArr(X: [ArrayViewRankChangeDom(1,int(64),false,2*bool,2*int(64),int(64),unmanaged ArrayViewRankChangeDist(unmanaged DefaultDist,2*bool,2*int(64)))] int(64))
+  scanViewsBlock.chpl:18: called as scanArr(X: [ArrayViewRankChangeDom(1,int(64),false,2*bool,2*int(64),int(64),unmanaged ArrayViewRankChangeDist(unmanaged DefaultDist,2*bool,2*int(64)))] int(64))
 1 3 6 10 15 21 28 36 45 55: [{1..10}]
 3 7 12: [{3..5}]
 1 3 6 10 15 21 28 36 45 55: [{0..9}]

--- a/test/sparse/types/testBorrowed.good
+++ b/test/sparse/types/testBorrowed.good
@@ -1,3 +1,3 @@
 ./SparseTest.chpl:1: In function 'testSparse':
 ./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
-testBorrowed.chpl:9: Function 'testSparse' instantiated as: testSparse(type t = borrowed T)
+  testBorrowed.chpl:9: called as testSparse(type t = borrowed T)

--- a/test/sparse/types/testOwned.good
+++ b/test/sparse/types/testOwned.good
@@ -1,3 +1,3 @@
 ./SparseTest.chpl:1: In function 'testSparse':
 ./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
-testOwned.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = owned T)
+  testOwned.chpl:8: called as testSparse(type t = owned T)

--- a/test/sparse/types/testShared.good
+++ b/test/sparse/types/testShared.good
@@ -1,3 +1,3 @@
 ./SparseTest.chpl:1: In function 'testSparse':
 ./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
-testShared.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = shared T)
+  testShared.chpl:8: called as testSparse(type t = shared T)

--- a/test/sparse/types/testTuple.bad
+++ b/test/sparse/types/testTuple.bad
@@ -1,3 +1,3 @@
 ./SparseTest.chpl:1: In function 'testSparse':
 ./SparseTest.chpl:9: error: sparse arrays of non-default-initializable types are not currently supported
-testTuple.chpl:8: Function 'testSparse' instantiated as: testSparse(type t = 2*shared T)
+  testTuple.chpl:8: called as testSparse(type t = 2*shared T)

--- a/test/sparse/types/testUnmanaged.good
+++ b/test/sparse/types/testUnmanaged.good
@@ -1,3 +1,3 @@
 ./SparseTest.chpl:1: In function 'testSparse':
 ./SparseTest.chpl:9: error: sparse arrays of non-nilable classes are not currently supported
-testUnmanaged.chpl:9: Function 'testSparse' instantiated as: testSparse(type t = unmanaged T)
+  testUnmanaged.chpl:9: called as testSparse(type t = unmanaged T)

--- a/test/studies/beer/bradc/beer-promoted-infer.good
+++ b/test/studies/beer/bradc/beer-promoted-infer.good
@@ -1,3 +1,4 @@
 beer-promoted-infer.chpl:53: In function 'describeBottles':
 beer-promoted-infer.chpl:54: error: type '[domain(1,int(64),false)] int(64)' used in if or while condition
-beer-promoted-infer.chpl:46: Function 'describeBottles' instantiated as: describeBottles(bottleNum: [domain(1,int(64),false)] int(64))
+  beer-promoted-infer.chpl:46: called as describeBottles(bottleNum: [domain(1,int(64),false)] int(64), startOfVerse: _unknown) from function 'computeLyric'
+  beer-promoted-infer.chpl:32: called as computeLyric(verseNum: domain(1,int(64),false))

--- a/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.good
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.good
@@ -1,7 +1,8 @@
 hpl-blc-noreindex.chpl:176: In function 'schurComplement':
 hpl-blc-noreindex.chpl:188: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
 hpl-blc-noreindex.chpl:188: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
-hpl-blc-noreindex.chpl:143: Function 'schurComplement' instantiated as: schurComplement(Ab: [BlockCyclicDom(2,int(64),false)] real(64), AD: BlockCyclicDom(2,int(64),false), BD: BlockCyclicDom(2,int(64),false), Rest: BlockCyclicDom(2,int(64),false))
+  hpl-blc-noreindex.chpl:143: called as schurComplement(Ab: [BlockCyclicDom(2,int(64),false)] real(64), AD: BlockCyclicDom(2,int(64),false), BD: BlockCyclicDom(2,int(64),false), Rest: BlockCyclicDom(2,int(64),false)) from function 'LUFactorize'
+  hpl-blc-noreindex.chpl:80: called as LUFactorize(n: int(64), Ab: [BlockCyclicDom(2,int(64),false)] real(64), piv: [domain(1,int(64),false)] int(64))
 Problem size = 30 x 30
 Bytes per array = 7200
 Total memory required (GB) = 6.70552e-06

--- a/test/trivial/shannon/condReturn2.good
+++ b/test/trivial/shannon/condReturn2.good
@@ -1,2 +1,2 @@
-condReturn2.chpl:4: In function 'foo':
+condReturn2.chpl:4: In method 'foo':
 condReturn2.chpl:4: error: tuple size must be known at compile-time

--- a/test/types/bool/bradc/numBitsBytesDefault.good
+++ b/test/types/bool/bradc/numBitsBytesDefault.good
@@ -1,3 +1,3 @@
 numBitsBytesDefault.chpl:3: In function 'printSizes':
 numBitsBytesDefault.chpl:4: error: default-width 'bool' does not have a well-defined size
-numBitsBytesDefault.chpl:9: Function 'printSizes' instantiated as: printSizes(type t = bool)
+  numBitsBytesDefault.chpl:9: called as printSizes(type t = bool)

--- a/test/types/enum/paramEnumCast.good
+++ b/test/types/enum/paramEnumCast.good
@@ -1,11 +1,11 @@
 paramEnumCast.chpl:6: In function 'testEnum':
 paramEnumCast.chpl:19: error: Initializing parameter 'i' to value not known at compile time
-paramEnumCast.chpl:41: Function 'testEnum' instantiated as: testEnum(type t = gender, param e: gender = gender.decline, param expectStr: string = "decline", param expectVal = 0)
+  paramEnumCast.chpl:41: called as testEnum(type t = gender, param e = gender.decline, param expectStr = "decline": string, param expectVal = 0)
 paramEnumCast.chpl:41: warning: enum->int cast was a surprise for decline
 paramEnumCast.chpl:6: In function 'testEnum':
 paramEnumCast.chpl:23: error: Initializing parameter 'e3' to value not known at compile time
-paramEnumCast.chpl:41: Function 'testEnum' instantiated as: testEnum(type t = gender, param e: gender = gender.decline, param expectStr: string = "decline", param expectVal = 0)
+  paramEnumCast.chpl:41: called as testEnum(type t = gender, param e = gender.decline, param expectStr = "decline": string, param expectVal = 0)
 paramEnumCast.chpl:41: warning: int->enum cast was a surprise for decline
 paramEnumCast.chpl:6: In function 'testEnum':
 paramEnumCast.chpl:19: error: can't cast from an abstract enum ('color') to int(64)
-paramEnumCast.chpl:42: Function 'testEnum' instantiated as: testEnum(type t = color, param e: color = color.red, param expectStr: string = "red", param expectVal = 1)
+  paramEnumCast.chpl:42: called as testEnum(type t = color, param e = color.red, param expectStr = "red": string, param expectVal = 1)

--- a/test/types/errors/assignTypes.good
+++ b/test/types/errors/assignTypes.good
@@ -1,3 +1,3 @@
 assignTypes.chpl:17: In function '=':
 assignTypes.chpl:18: error: illegal assignment to type
-assignTypes.chpl:21: Function '=' instantiated as: =(lhs: R(int(64)))
+  assignTypes.chpl:21: called as =(lhs: R(int(64)), rhs: _unknown)

--- a/test/types/partial/match-param.bad
+++ b/test/types/partial/match-param.bad
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/String.chpl:420: note: is passed to formal 'x: byteI
 $CHPL_HOME/modules/internal/String.chpl:421: note: candidates are: ==(x: codepointIndex, y: codepointIndex)
 $CHPL_HOME/modules/internal/String.chpl:423: note:                 ==(x: byteIndex, y: int)
 note: and N other candidates, use --print-all-candidates to see them
-match-param.chpl:1: Function 'foo' instantiated as: foo(x: R(int(64),100))
+  match-param.chpl:1: called as foo(x: R(int(64),100))

--- a/test/types/range/open/openRanges-both.good
+++ b/test/types/range/open/openRanges-both.good
@@ -1,3 +1,3 @@
 openRanges-both.chpl:6: In function 'testRanges':
 openRanges-both.chpl:10: error: parallel iteration is not supported over unbounded ranges
-openRanges-both.chpl:1: Function 'testRanges' instantiated as: testRanges(type t = int(64))
+  openRanges-both.chpl:1: called as testRanges(type t = int(64))

--- a/test/types/range/open/openRanges-low.good
+++ b/test/types/range/open/openRanges-low.good
@@ -1,3 +1,3 @@
 openRanges-low.chpl:6: In function 'testRanges':
 openRanges-low.chpl:10: error: parallel iteration is not supported over unbounded ranges
-openRanges-low.chpl:1: Function 'testRanges' instantiated as: testRanges(type t = int(64))
+  openRanges-low.chpl:1: called as testRanges(type t = int(64))

--- a/test/types/range/userAPI/byteRangeTest.good
+++ b/test/types/range/userAPI/byteRangeTest.good
@@ -1,6 +1,6 @@
 ./rangeAPItest.chpl:3: In function 'testRangeAPI':
 ./rangeAPItest.chpl:43: warning: invoking 'offset' on an unstrided range has no effect.
-byteRangeTest.chpl:3: Function 'testRangeAPI' instantiated as: testRangeAPI(lbl: string, r: range(byteIndex,bounded,false), idx: byteIndex, subr: range(byteIndex,bounded,false))
+  byteRangeTest.chpl:3: called as testRangeAPI(lbl: string, r: range(byteIndex,bounded,false), idx: byteIndex, subr: range(byteIndex,bounded,false))
 byte index range
 ------------
 1..10

--- a/test/types/range/userAPI/codepointRangeTest.good
+++ b/test/types/range/userAPI/codepointRangeTest.good
@@ -1,6 +1,6 @@
 ./rangeAPItest.chpl:3: In function 'testRangeAPI':
 ./rangeAPItest.chpl:43: warning: invoking 'offset' on an unstrided range has no effect.
-codepointRangeTest.chpl:3: Function 'testRangeAPI' instantiated as: testRangeAPI(lbl: string, r: range(codepointIndex,bounded,false), idx: codepointIndex, subr: range(codepointIndex,bounded,false))
+  codepointRangeTest.chpl:3: called as testRangeAPI(lbl: string, r: range(codepointIndex,bounded,false), idx: codepointIndex, subr: range(codepointIndex,bounded,false))
 codepoint range
 ------------
 1..10

--- a/test/types/range/userAPI/simpleRangeTest.good
+++ b/test/types/range/userAPI/simpleRangeTest.good
@@ -1,6 +1,6 @@
 ./rangeAPItest.chpl:3: In function 'testRangeAPI':
 ./rangeAPItest.chpl:43: warning: invoking 'offset' on an unstrided range has no effect.
-simpleRangeTest.chpl:4: Function 'testRangeAPI' instantiated as: testRangeAPI(lbl: string, r: range(int(64),bounded,false), idx: int(64), subr: range(int(64),bounded,false))
+  simpleRangeTest.chpl:4: called as testRangeAPI(lbl: string, r: range(int(64),bounded,false), idx: int(64), subr: range(int(64),bounded,false))
 basic range
 ------------
 1..10

--- a/test/types/range/vass/offset-1.good
+++ b/test/types/range/vass/offset-1.good
@@ -1,6 +1,7 @@
 offset-1.chpl:10: In function 'test':
 offset-1.chpl:12: warning: invoking 'offset' on an unstrided range has no effect.
-offset-1.chpl:23: Function 'test' instantiated as: test(r: range(int(64),bounded,false))
+  offset-1.chpl:23: called as test(r: range(int(64),bounded,false), offs: _unknown) from function 'suite'
+  offset-1.chpl:28: called as suite(r: range(int(64),bounded,false))
 3..3  offs -4  3..3
 3..3  offs -2  3..3
 3..3  offs 0  3..3

--- a/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
+++ b/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelHashtable.chpl: In function 'clearSlot':
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl: In method 'clearSlot':
 $CHPL_HOME/modules/internal/ChapelHashtable.chpl: error: cannot assign to a record of the type Node using the default assignment operator because it has 'const' field(s)
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl: Function 'clearSlot' instantiated as: clearSlot(this: chpl__hashtable(Node,nothing))
+  within internal functions (use --print-callstack-on-error to see)
 scenario-3-assoc-dom-of-record-with-const-fld.chpl: error: cannot assign to a record of the type Coeff using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/generic/genericFieldDecl-used.bad
+++ b/test/types/records/generic/genericFieldDecl-used.bad
@@ -1,4 +1,9 @@
 $CHPL_HOME/modules/internal/ChapelIO.chpl:217: In function 'isIoField':
 $CHPL_HOME/modules/internal/ChapelIO.chpl:218: error: the type of the actual argument 'call_tmp' is generic
 note: generic actual arguments are not currently supported
-$CHPL_HOME/modules/internal/ChapelIO.chpl:273: Function 'isIoField' instantiated as: isIoField(x: One, param i = 1)
+  within internal functions (use --print-callstack-on-error to see)
+  $CHPL_HOME/modules/standard/IO.chpl:3086: called as _write_one_internal(_channel_internal: qio_channel_ptr_t, param kind = 0: iokind, x: One, loc: locale) from method '_writeOne'
+  $CHPL_HOME/modules/standard/IO.chpl:4034: called as channel(true,dynamic,true)._writeOne(param kind = 0: iokind, x: One, loc: locale) from method 'write'
+  $CHPL_HOME/modules/standard/IO.chpl:4083: called as channel(true,dynamic,true).write(args(0): One, args(1): ioNewline) from method 'writeln'
+  $CHPL_HOME/modules/internal/ChapelIO.chpl:841: called as channel.writeln(args(0): _any)
+  within internal functions (use --print-callstack-on-error to see)

--- a/test/types/sync/vass/generic-sync-1.good
+++ b/test/types/sync/vass/generic-sync-1.good
@@ -1,6 +1,6 @@
 generic-sync-1.chpl:7: In function 'test':
 generic-sync-1.chpl:8: warning: sync int(64)
-generic-sync-1.chpl:4: Function 'test' instantiated as: test(s: sync int(64))
+  generic-sync-1.chpl:4: called as test(s: sync int(64))
 generic-sync-1.chpl:5: warning: sync int(64)
 got lock
 isFull = true

--- a/test/types/sync/vass/ref-sync-1.good
+++ b/test/types/sync/vass/ref-sync-1.good
@@ -1,6 +1,6 @@
 ref-sync-1.chpl:8: In function 'MYPROC':
 ref-sync-1.chpl:9: warning: sync int(64)
-ref-sync-1.chpl:5: Function 'MYPROC' instantiated as: MYPROC(FORMAL: sync int(64))
+  ref-sync-1.chpl:5: called as MYPROC(FORMAL: sync int(64))
 started MYPROC
 read the FORMAL
 SVAR isFull: true

--- a/test/types/tuple/errors/returnWrongSize.good
+++ b/test/types/tuple/errors/returnWrongSize.good
@@ -1,3 +1,3 @@
 returnWrongSize.chpl:1: In function 'foo':
 returnWrongSize.chpl:3: error: cannot return '2*int(64)' when the declared return type is '3*int(64)'
-returnWrongSize.chpl:8: Function 'foo' instantiated as: foo(param small = 1)
+  returnWrongSize.chpl:8: called as foo(param small = 1)

--- a/test/types/tuple/errors/tuple-assignment-2.good
+++ b/test/types/tuple/errors/tuple-assignment-2.good
@@ -1,3 +1,3 @@
 tuple-assignment-2.chpl:3: In function 'modify':
 tuple-assignment-2.chpl:4: error: cannot assign to const variable
-tuple-assignment-2.chpl:9: Function 'modify' instantiated as: modify(A: [domain(1,int(64),false)] int(64))
+  tuple-assignment-2.chpl:9: called as modify(A: [domain(1,int(64),false)] int(64))

--- a/test/types/tuple/tupleTypeAccess.bad
+++ b/test/types/tuple/tupleTypeAccess.bad
@@ -1,4 +1,4 @@
-tupleTypeAccess.chpl:16: In function 'accept':
+tupleTypeAccess.chpl:16: In method 'accept':
 tupleTypeAccess.chpl:18: error: unresolved call '(GoodStudent,ExcellentStudent)(1)'
 tupleTypeAccess.chpl:18: note: because no functions named (GoodStudent,ExcellentStudent) found in scope
-tupleTypeAccess.chpl:25: Function 'accept' instantiated as: accept(this: borrowed AdvancedBasketWeaving((GoodStudent,ExcellentStudent)), student: owned Student)
+  tupleTypeAccess.chpl:25: called as borrowed AdvancedBasketWeaving((GoodStudent,ExcellentStudent)).accept(student: owned Student)

--- a/test/types/typeFunctions/illegalValueReturn.good
+++ b/test/types/typeFunctions/illegalValueReturn.good
@@ -1,3 +1,3 @@
 illegalValueReturn.chpl:2: In function 'helper':
 illegalValueReturn.chpl:8: error: illegal return of value where type is expected
-illegalValueReturn.chpl:11: Function 'helper' instantiated as: helper(param x = 42)
+  illegalValueReturn.chpl:11: called as helper(param x = 42)

--- a/test/types/type_variables/bharshbarg/illegalFieldQuery.good
+++ b/test/types/type_variables/bharshbarg/illegalFieldQuery.good
@@ -1,3 +1,3 @@
 illegalFieldQuery.chpl:8: In function 'foo':
 illegalFieldQuery.chpl:8: error: invalid query -- queried field must be a type or parameter
-illegalFieldQuery.chpl:13: Function 'foo' instantiated as: foo(x: borrowed Foo(true,5))
+  illegalFieldQuery.chpl:13: called as foo(x: borrowed Foo(true,5))

--- a/test/users/jglewis/array_reindexing/desirable_syntax.bad
+++ b/test/users/jglewis/array_reindexing/desirable_syntax.bad
@@ -1,3 +1,3 @@
 desirable_syntax.chpl:35: In function 'print_A_reindexed':
 desirable_syntax.chpl:35: error: one of domain's dimensions is not a bounded range
-desirable_syntax.chpl:25: Function 'print_A_reindexed' instantiated as: print_A_reindexed(A: [domain(2,int(64),false)] 2*int(64))
+  desirable_syntax.chpl:25: called as print_A_reindexed(A: [domain(2,int(64),false)] 2*int(64))

--- a/test/users/kreider/bug_array_of_arrays.bad
+++ b/test/users/kreider/bug_array_of_arrays.bad
@@ -1,6 +1,7 @@
-bug_array_of_arrays.chpl:24: In function 'pass_arrayofarrays':
+bug_array_of_arrays.chpl:24: In method 'pass_arrayofarrays':
 bug_array_of_arrays.chpl:24: error: unresolved call 'chpl__buildArrayRuntimeType(nil, type int(64))'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:433: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
+$CHPL_HOME/modules/internal/ChapelArray.chpl:453: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
 bug_array_of_arrays.chpl:24: note: because call actual argument #1 with type nil
-$CHPL_HOME/modules/internal/ChapelArray.chpl:433: note: is passed to formal 'dom: _domain'
-bug_array_of_arrays.chpl:14: Function 'pass_arrayofarrays' instantiated as: pass_arrayofarrays(this: borrowed tst(int(64),3), d: [domain(1,int(64),false)] [domain(1,int(64),false)] int(64))
+$CHPL_HOME/modules/internal/ChapelArray.chpl:453: note: is passed to formal 'dom: _domain'
+  bug_array_of_arrays.chpl:14: called as borrowed tst(int(64),3).pass_arrayofarrays(d: [domain(1,int(64),false)] [domain(1,int(64),false)] int(64)) from method 'run_test'
+  bug_array_of_arrays.chpl:31: called as borrowed tst(int(64),3).run_test()

--- a/test/users/lucashimizu/inferRecursive.bad
+++ b/test/users/lucashimizu/inferRecursive.bad
@@ -1,4 +1,4 @@
 inferRecursive.chpl:9: error: unable to resolve return type of function 'fibInfer'
 inferRecursive.chpl:9: In function 'fibInfer':
 inferRecursive.chpl:13: error: called recursively at this point
-inferRecursive.chpl:18: Function 'fibInfer' instantiated as: fibInfer(a: int(64))
+  inferRecursive.chpl:18: called as fibInfer(a: int(64))

--- a/test/users/vass/div-ceil-on-more-int-types.bad
+++ b/test/users/vass/div-ceil-on-more-int-types.bad
@@ -1,3 +1,4 @@
-$CHPL_HOME/modules/standard/Math.chpl:545: In function 'divceil':
-$CHPL_HOME/modules/standard/Math.chpl:547: error: illegal use of '+' on operands of type uint(64) and signed integer
-div-ceil-on-more-int-types.chpl:3: Function 'divceil' instantiated as: divceil(m: int(32), n: uint(64))
+$CHPL_HOME/modules/standard/Math.chpl:548: In function 'divceil':
+$CHPL_HOME/modules/standard/Math.chpl:550: error: illegal use of '+' on operands of type uint(64) and signed integer
+  div-ceil-on-more-int-types.chpl:3: called as divceil(m: int(32), n: uint(64)) from function 'launch'
+  div-ceil-on-more-int-types.chpl:8: called as launch(a: int(32), b: uint(64))

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.na-none.good
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.na-none.good
@@ -5,6 +5,7 @@ isBoolType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:191: called as test(arg: bool)
 
 bool(8)
 isBool
@@ -13,6 +14,7 @@ isBoolType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:192: called as test(arg: bool(8))
 
 bool(16)
 isBool
@@ -21,6 +23,7 @@ isBoolType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:193: called as test(arg: bool(16))
 
 bool(32)
 isBool
@@ -29,6 +32,7 @@ isBoolType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:194: called as test(arg: bool(32))
 
 bool(64)
 isBool
@@ -37,6 +41,7 @@ isBoolType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:195: called as test(arg: bool(64))
 
 int(8)
 isInt
@@ -51,6 +56,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:196: called as test(arg: int(8))
 
 int(16)
 isInt
@@ -65,6 +71,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:197: called as test(arg: int(16))
 
 int(32)
 isInt
@@ -79,6 +86,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:198: called as test(arg: int(32))
 
 int(64)
 isInt
@@ -93,6 +101,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:199: called as test(arg: int(64))
 
 uint(8)
 isUint
@@ -107,6 +116,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:200: called as test(arg: uint(8))
 
 uint(16)
 isUint
@@ -121,6 +131,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:201: called as test(arg: uint(16))
 
 uint(32)
 isUint
@@ -135,6 +146,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:202: called as test(arg: uint(32))
 
 uint(64)
 isUint
@@ -149,6 +161,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:203: called as test(arg: uint(64))
 
 real(32)
 isReal
@@ -163,6 +176,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:204: called as test(arg: real(32))
 
 real(64)
 isReal
@@ -177,6 +191,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:205: called as test(arg: real(64))
 
 imag(32)
 isImag
@@ -191,6 +206,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:206: called as test(arg: imag(32))
 
 imag(64)
 isImag
@@ -205,6 +221,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:207: called as test(arg: imag(64))
 
 complex(64)
 isComplex
@@ -216,6 +233,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:208: called as test(arg: complex(64))
 
 complex(128)
 isComplex
@@ -227,6 +245,7 @@ isNumericType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:209: called as test(arg: complex(128))
 
 string
 isString
@@ -235,11 +254,13 @@ isStringType
 isPrimitive
 isPrimitiveValue
 isPrimitiveType
+  isX.byBlankArgs-compWarns.chpl:210: called as test(arg: string)
 
 EnumType
 isEnum
 isEnumValue
 isEnumType
+  isX.byBlankArgs-compWarns.chpl:211: called as test(arg: EnumType)
 
 3*int(64)
 isTuple
@@ -248,90 +269,108 @@ isTupleType
 isHomogeneousTuple
 isHomogeneousTupleValue
 isHomogeneousTupleType
+  isX.byBlankArgs-compWarns.chpl:212: called as test(arg: 3*int(64))
 
 (int(64),real(64),string)
 isTuple
 isTupleValue
 isTupleType
+  isX.byBlankArgs-compWarns.chpl:213: called as test(arg: (int(64),real(64),string))
 
 borrowed ClassType
 isClass
 isClassValue
 isClassType
+  isX.byBlankArgs-compWarns.chpl:214: called as test(arg: borrowed ClassType)
 
 RecordSmall
 isRecord
 isRecordValue
 isRecordType
+  isX.byBlankArgs-compWarns.chpl:215: called as test(arg: RecordSmall)
 
 UnionType
 isUnion
 isUnionValue
 isUnionType
+  isX.byBlankArgs-compWarns.chpl:216: called as test(arg: UnionType)
 
 range(int(64),bounded,false)
 isRange
 isRangeValue
 isRangeType
+  isX.byBlankArgs-compWarns.chpl:217: called as test(arg: range(int(64),bounded,false))
 
 range(uint(8),boundedNone,true)
 isRange
 isRangeValue
 isRangeType
+  isX.byBlankArgs-compWarns.chpl:218: called as test(arg: range(uint(8),boundedNone,true))
 
 DefaultDist
 isDmap
 isDmapValue
 isDmapType
+  isX.byBlankArgs-compWarns.chpl:219: called as test(arg: DefaultDist)
 
 domain(1,int(64),false)
 isDomain
 isDomainValue
 isDomainType
+  isX.byBlankArgs-compWarns.chpl:220: called as test(arg: domain(1,int(64),false))
 
 domain(2,uint(32),true)
 isDomain
 isDomainValue
 isDomainType
+  isX.byBlankArgs-compWarns.chpl:221: called as test(arg: domain(2,uint(32),true))
 
 [domain(1,int(64),false)] int(64)
 isArray
 isArrayValue
 isArrayType
+  isX.byBlankArgs-compWarns.chpl:222: called as test(arg: [domain(1,int(64),false)] int(64))
 
 [domain(2,uint(32),true)] uint(16)
 isArray
 isArrayValue
 isArrayType
+  isX.byBlankArgs-compWarns.chpl:223: called as test(arg: [domain(2,uint(32),true)] uint(16))
 
 sync int(64)
 isSync
 isSyncValue
 isSyncType
+  isX.byBlankArgs-compWarns.chpl:224: called as test(arg: sync int(64))
 
 sync real(64)
 isSync
 isSyncValue
 isSyncType
+  isX.byBlankArgs-compWarns.chpl:225: called as test(arg: sync real(64))
 
 single int(64)
 isSingle
 isSingleValue
 isSingleType
+  isX.byBlankArgs-compWarns.chpl:226: called as test(arg: single int(64))
 
 single real(64)
 isSingle
 isSingleValue
 isSingleType
+  isX.byBlankArgs-compWarns.chpl:227: called as test(arg: single real(64))
 
 AtomicT(int(64))
 isAtomic
 isAtomicValue
 isAtomicType
+  isX.byBlankArgs-compWarns.chpl:228: called as test(arg: AtomicT(int(64)))
 
 AtomicT(real(64))
 isAtomic
 isAtomicValue
 isAtomicType
+  isX.byBlankArgs-compWarns.chpl:229: called as test(arg: AtomicT(real(64)))
 
 error: done

--- a/test/users/weili/raiseType-blc.good
+++ b/test/users/weili/raiseType-blc.good
@@ -1,3 +1,3 @@
 raiseType-blc.chpl:1: In function 'raiseType':
 raiseType-blc.chpl:3: error: illegal return of type where value is expected
-raiseType-blc.chpl:7: Function 'raiseType' instantiated as: raiseType(type x = bool)
+  raiseType-blc.chpl:7: called as raiseType(type x = bool)

--- a/test/visibility/private/uses/pointOfInstantiation/methodOnType2.good
+++ b/test/visibility/private/uses/pointOfInstantiation/methodOnType2.good
@@ -1,4 +1,4 @@
 methodOnType2.chpl:26: In function 'bar':
 methodOnType2.chpl:28: error: unresolved call 'C.goo()'
 methodOnType2.chpl:28: note: because no functions named goo found in scope
-methodOnType2.chpl:36: Function 'bar' instantiated as: bar(c: borrowed C)
+  methodOnType2.chpl:36: called as bar(c: borrowed C)

--- a/test/visibility/shadow-overload.good
+++ b/test/visibility/shadow-overload.good
@@ -1,4 +1,4 @@
-shadow-overload.chpl:11: In function 'shadow':
+shadow-overload.chpl:11: In method 'shadow':
 shadow-overload.chpl:14: error: unresolved call 'R.shadow(10)'
 shadow-overload.chpl:5: note: this candidate did not match: shadow(x)
 shadow-overload.chpl:14: note: because call is written as a method call

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -233,6 +233,7 @@ _chpl ()
 --no-stack-checks \
 --no-task-tracking \
 --no-tuple-copy-opt \
+--no-use-color-terminal \
 --no-vectorize \
 --no-verify \
 --no-warn-const-loops \
@@ -314,6 +315,7 @@ _chpl ()
 --timers \
 --tuple-copy-limit \
 --tuple-copy-opt \
+--use-color-terminal \
 --vectorize \
 --verify \
 --version \


### PR DESCRIPTION
We would like to print out more information for errors inside of generic
functions. We already print out details of the instantiation but a call
stack can be useful in such cases as well. Additionally, the
`--print-callstack-on-error` mechanism was previously available but not
on by default and did not work for errors that occur after the
functionResolution pass itself.

This PR addresses these problems by expanding upon the code that was
printing out instantiation details for functions to print call stacks.
This code does not use the call stack structure from function resolution
(rather it reconstructs the call stack by looking for call sites). This
allows it to function during or after functionResolution proper (as long
as which functions are called is established). This code is on by default
and does not need to be enabled with `--print-callstack-on-error`.

This PR keeps the flag`--print-callstack-on-error` and now it causes it
to also print traces for concrete functions and to include internal
functions. The `--no-print-callstack-on-error` will disable the stack
trace.

The PR also adds formatting (bold and underline) to error messages using
VT100 escape codes. This is by normally only enabled if a color terminal
is detected. Detecting a color terminal amounts to checking that `stderr`
is a tty and the `TERM` environment variable is a value expected to work.
The flag `--use-color-terminal` / `--no-use-color-terminal` is available
to override the detection. Note that when a test is run within
`start_test`, output is not a tty, and so .good files will not see this
formatting unless `--use-color-terminal` is provided.

For example, for this erroneous program in `bb.chpl`:

``` chapel
proc h(arg) {
  arg = 11;
}

proc g(arg) {
  h(arg);
}

proc f(arg) {
  g(arg);
}

f("hi");
```

the error now prints

```
bb.chpl:1: In function 'h':
bb.chpl:2: error: Cannot assign to string from int(64)
  bb.chpl:6: called as h(arg: string) from function 'g'
  bb.chpl:10: called as g(arg: string) from function 'f'
  bb.chpl:13: called as f(arg: string)
```

and on a terminal with formatting support it looks like this:

<img width="793" alt="image" src="https://user-images.githubusercontent.com/3653132/94038091-0e973880-fd94-11ea-9e62-9439c1f8928a.png">

where previously to this PR it would print
```
bb.chpl:1: In function 'h':
bb.chpl:2: error: Cannot assign to string from int(64)
bb.chpl:6: Function 'h' instantiated as: h(arg: string)
```

and previously to this PR with `--print-callstack-on-error` it would print
```
bb.chpl:1: In function 'h':
bb.chpl:2: error: Cannot assign to string from int(64)
while processing the following Chapel call chain:
  bb.chpl:2: h(arg)
  bb.chpl:6: g(arg)
  bb.chpl:10: f(arg)
  bb.chpl:13: top-level module statements for bb
bb.chpl:6: Function 'h' instantiated as: h(arg: string)
```

Reviewed by @e-kayrakli incorporating suggestions from @lydia-duncan and
@bradcray - thanks!

- [x] full local futures testing