### PR TITLE
Fix a bug with accidentally matching to symbols in scope for a module call

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -743,6 +743,20 @@ static astlocT* resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
   if (name == astrSdot || !usymExpr->inTree())
     return NULL;
 
+  if (CallExpr* parentCall = toCallExpr(usymExpr->parentExpr)) {
+    if (parentCall->baseExpr && parentCall->baseExpr == usymExpr &&
+        parentCall->numActuals() > 0) {
+      if (SymExpr* firstArg = toSymExpr(parentCall->get(1))) {
+        if (firstArg->symbol() == gModuleToken) {
+          // Don't resolve the name of transformed module calls - doing so will
+          // accidentally find closer symbols with the same name instead of
+          // going into the intended module.
+          return NULL;
+        }
+      }
+    }
+  }
+
   // Avoid duplicate work by not trying to resolve UnresolvedSymExprs that we've
   // already encountered an error when trying to resolve.
   for_vector(BaseAST, node, failedUSymExprs) {

--- a/test/visibility/import/edgeCases/qualInitsSameName.bad
+++ b/test/visibility/import/edgeCases/qualInitsSameName.bad
@@ -1,3 +1,0 @@
-qualInitsSameName.chpl:8: In function 'main':
-qualInitsSameName.chpl:10: error: 'y' used before defined
-qualInitsSameName.chpl:10: note: defined here

--- a/test/visibility/import/edgeCases/qualInitsSameName.future
+++ b/test/visibility/import/edgeCases/qualInitsSameName.future
@@ -1,4 +1,0 @@
-bug: qualified access to function matching variable name causes error
-
-I believe this should work.  Interestingly, if 'M.y' is a variable
-rather than a function, it does.

--- a/test/visibility/qualInitsSameName.bad
+++ b/test/visibility/qualInitsSameName.bad
@@ -1,3 +1,0 @@
-qualInitsSameName.chpl:8: In function 'main':
-qualInitsSameName.chpl:10: error: 'y' used before defined
-qualInitsSameName.chpl:10: note: defined here

--- a/test/visibility/qualInitsSameName.future
+++ b/test/visibility/qualInitsSameName.future
@@ -1,4 +1,0 @@
-bug: qualified access to function matching variable name causes error
-
-I believe this should work.  Interestingly, if 'M.y' is a variable
-rather than a function, it does.


### PR DESCRIPTION
While the transformation of explicit module calls during scope resolution was
appropriate, we didn't consider that it could have occurred at the time when we
resolve unresolved symbols - we didn't check to see if the symbol to be resolved
was used for a call, and as a result didn't think to check if such calls had a
module argument, so were treating them as unqualified calls and thus when a
non-function symbol was in scope and closer than the module's function, we would
match to that (and sometimes get a use-before-def error as a result).

This change adds the necessary check, which resolves the futures tracking the
failure.

Resolves #16023 

Remove the .bads and .futures for the motivating tests, as they now pass

Passed a full paratest with futures