### PR TITLE
mason build: skip registry update 

### DIFF
--- a/test/mason/chplVersion/tomls/fail/depWantsLaterUnbounded.good
+++ b/test/mason/chplVersion/tomls/fail/depWantsLaterUnbounded.good
@@ -1,2 +1,3 @@
+Skipping registry update since no dependency found in manifest file.
 The following package is incompatible with your version of Chapel (CHPL_CUR_FULL)
   twoZero-0.1.0 :  expecting 999.0.0 or later

--- a/test/mason/chplVersion/tomls/fail/failMultipleDeps.good
+++ b/test/mason/chplVersion/tomls/fail/failMultipleDeps.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 The following packages are incompatible with your version of Chapel (CHPL_CUR_FULL)
   simpleBadDepB-0.1.0 :  expecting 1.0.0
   simpleBadDepA-0.1.0 :  expecting 1.0.0

--- a/test/mason/chplVersion/tomls/fail/ivrsTwo.good
+++ b/test/mason/chplVersion/tomls/fail/ivrsTwo.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 Dependency resolution error: unable to find version of 'innerBadDep' compatible with your version of Chapel (CHPL_CUR_FULL):
   v0.2.0 expecting 1.1.0
   v0.1.0 expecting 1.0.0

--- a/test/mason/chplVersion/tomls/fail/rangeFailBug.good
+++ b/test/mason/chplVersion/tomls/fail/rangeFailBug.good
@@ -1,2 +1,3 @@
+Skipping registry update since no dependency found in manifest file.
 The following package is incompatible with your version of Chapel (CHPL_CUR_FULL)
   rangeFailBug-0.1.0 :  expecting 1.16.1

--- a/test/mason/chplVersion/tomls/fail/rangeFailMajor.good
+++ b/test/mason/chplVersion/tomls/fail/rangeFailMajor.good
@@ -1,2 +1,3 @@
+Skipping registry update since no dependency found in manifest file.
 The following package is incompatible with your version of Chapel (CHPL_CUR_FULL)
   rangeFailMajor-0.1.0 :  expecting 99.0.0

--- a/test/mason/chplVersion/tomls/fail/rangeFailMinor.good
+++ b/test/mason/chplVersion/tomls/fail/rangeFailMinor.good
@@ -1,2 +1,3 @@
+Skipping registry update since no dependency found in manifest file.
 The following package is incompatible with your version of Chapel (CHPL_CUR_FULL)
   rangeFailMinor-0.1.0 :  expecting 1.0.0..1.15.0

--- a/test/mason/chplVersion/tomls/format/badFormatNum.good
+++ b/test/mason/chplVersion/tomls/format/badFormatNum.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 Invalid chplVersion in package 'badFormatNum-0.1.0': 1.x.x
 Details: Invalid Chapel version format: 1.x.x
 

--- a/test/mason/chplVersion/tomls/format/badRangeFormat.good
+++ b/test/mason/chplVersion/tomls/format/badRangeFormat.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 Invalid chplVersion in package 'badRangeFormat-0.1.0': 1.1..1.2..1.3
 Details: Expecting 1 or 2 versions in chplVersion range.
 

--- a/test/mason/chplVersion/tomls/format/badRangeOrder.good
+++ b/test/mason/chplVersion/tomls/format/badRangeOrder.good
@@ -1,2 +1,3 @@
+Skipping registry update since no dependency found in manifest file.
 Invalid chplVersion in package 'badRangeOrder-0.1.0': 1.10..1.1
 Details: Lower bound of chplVersion must be <= upper bound: 1.10.0 > 1.1.0

--- a/test/mason/chplVersion/tomls/format/badVersion.good
+++ b/test/mason/chplVersion/tomls/format/badVersion.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 Invalid chplVersion in package 'badVersion-0.1.0': 1.2.3.4.5
 Details: Invalid Chapel version format: 1.2.3.4.5
 

--- a/test/mason/chplVersion/tomls/format/missingField.good
+++ b/test/mason/chplVersion/tomls/format/missingField.good
@@ -1,1 +1,2 @@
+Skipping registry update since no dependency found in manifest file.
 Brick 'missingField-0.1.0' missing required 'chplVersion' field

--- a/test/mason/chplVersion/tomls/format/noBug.good
+++ b/test/mason/chplVersion/tomls/format/noBug.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]

--- a/test/mason/chplVersion/tomls/format/unbounded.good
+++ b/test/mason/chplVersion/tomls/format/unbounded.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]

--- a/test/mason/chplVersion/tomls/format/unboundedLower.good
+++ b/test/mason/chplVersion/tomls/format/unboundedLower.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 Invalid chplVersion in package 'unboundedLower-0.1.0': ..1.99
 Details: Unbounded chplVersion ranges are not allowed.
 

--- a/test/mason/chplVersion/tomls/format/unboundedUpper.good
+++ b/test/mason/chplVersion/tomls/format/unboundedUpper.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 Invalid chplVersion in package 'unboundedUpper-0.1.0': 1.0..
 Details: Unbounded chplVersion ranges are not allowed.
 

--- a/test/mason/chplVersion/tomls/pass/ivrsChooses.good
+++ b/test/mason/chplVersion/tomls/pass/ivrsChooses.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]

--- a/test/mason/chplVersion/tomls/pass/simpleDep.good
+++ b/test/mason/chplVersion/tomls/pass/simpleDep.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]

--- a/test/mason/chplVersion/tomls/pass/simpleSolo.good
+++ b/test/mason/chplVersion/tomls/pass/simpleSolo.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]

--- a/test/mason/mason-example-with-opts/mason-example.good
+++ b/test/mason/mason-example-with-opts/mason-example.good
@@ -1,10 +1,12 @@
 Updating registry
+Skipping registry update since no dependency found in manifest file.
 Downloading dependency: _MasonTest1-0.2.0
 compiled depExample.chpl successfully
 compiled withOpts.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
 compiled example.chpl successfully
 Updating registry
+Skipping registry update since no dependency found in manifest file.
 Example with dependency Passed!
 Passed!
 Example within subdirectory Passed!

--- a/test/mason/mason-example/mason-example.good
+++ b/test/mason/mason-example/mason-example.good
@@ -1,10 +1,12 @@
 Updating registry
+Skipping registry update since no dependency found in manifest file.
 Downloading dependency: _MasonTest1-0.2.0
 compiled depExample.chpl successfully
 compiled example.chpl successfully
 compiled nomodule.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
 Updating registry
+Skipping registry update since no dependency found in manifest file.
 Example with dependency Passed!
 Example Passed!
 Example with dependency outside module Passed!

--- a/test/mason/mason-external/libtomlc99/mason-external.good
+++ b/test/mason/mason-external/libtomlc99/mason-external.good
@@ -1,6 +1,6 @@
   Fetch: <time>.  Build: <time>.  Total: <time>.
 Installing Spack backend ...
-Updating registry
+Skipping registry update since no dependency found in manifest file.
 Compiling [debug] target: CToml
 Build Successful
 

--- a/test/mason/mason-external/masonExternalRanges/.gitignore
+++ b/test/mason/mason-external/masonExternalRanges/.gitignore
@@ -1,0 +1,2 @@
+target/
+Mason.lock

--- a/test/mason/mason-external/masonExternalRanges/Mason.toml
+++ b/test/mason/mason-external/masonExternalRanges/Mason.toml
@@ -1,0 +1,13 @@
+
+[brick]
+name = "masonExternalRanges"
+version = "0.1.0"
+chplVersion = "1.23.0"
+license = "None"
+
+[dependencies]
+
+[external]
+libtomlc99 = "libtomlc99@0.2019.03.06:0.2019.06.24"
+
+

--- a/test/mason/mason-external/masonExternalRanges/src/masonExternalRanges.chpl
+++ b/test/mason/mason-external/masonExternalRanges/src/masonExternalRanges.chpl
@@ -1,0 +1,4 @@
+/* Documentation for masonExternalRanges */
+module masonExternalRanges {
+  writeln("New library: masonExternalRanges");
+}

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -1,4 +1,5 @@
 Updating registry
+Skipping registry update since no dependency found in manifest file.
 Downloading dependency: _MasonTest1-0.2.0
 
 ======================================================================

--- a/test/mason/masonTestSome/mason-test-some.good
+++ b/test/mason/masonTestSome/mason-test-some.good
@@ -1,4 +1,4 @@
-Updating registry
+Skipping registry update since no dependency found in manifest file.
 
 ======================================================================
 FAIL test1.chpl: test1

--- a/test/mason/masonTestSubString/mason-test-sub-string.good
+++ b/test/mason/masonTestSubString/mason-test-sub-string.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 
 ======================================================================
 FAIL test1.chpl: test1

--- a/test/mason/noDep.good
+++ b/test/mason/noDep.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 
 [root]
 name = "Tester"

--- a/test/mason/run/mason-run.good
+++ b/test/mason/run/mason-run.good
@@ -1,4 +1,4 @@
-Updating registry
+Skipping registry update since no dependency found in manifest file.
 Compiling [debug] target: FizzBuzz
 Build Successful
 

--- a/test/mason/simple.good
+++ b/test/mason/simple.good
@@ -1,3 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
 
 [root]
 name = "Tester"

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,4 +1,4 @@
-Updating registry
+Skipping registry update since no dependency found in manifest file.
 Compiling [debug] target: FizzBuzz
 Build Successful
 

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -103,6 +103,7 @@ proc masonBuild(args) throws {
     const tomlName = configNames[0];
     const lockName = configNames[1];
     buildProgram(release, show, force, compopts, tomlName, lockName);
+    
   }
 }
 

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -103,7 +103,6 @@ proc masonBuild(args) throws {
     const tomlName = configNames[0];
     const lockName = configNames[1];
     buildProgram(release, show, force, compopts, tomlName, lockName);
-    
   }
 }
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -84,7 +84,14 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock") {
     const projectHome = getProjectHome(cwd, tf);
     const tomlPath = projectHome + "/" + tf;
     const lockPath = projectHome + "/" + lf;
-    updateRegistry(skipUpdate);
+    
+    if isFile(lockPath) {
+      const openLock = openreader(lockPath);
+      const LockFile = parseToml(openLock);
+      if LockFile.pathExists('dependencies') then updateRegistry(skipUpdate);
+    }
+    else updateRegistry(skipUpdate);
+
     const openFile = openreader(tomlPath);
     const TomlFile = parseToml(openFile);
     if isDir(SPACK_ROOT) && TomlFile.pathExists('external') {

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -84,16 +84,12 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock") {
     const projectHome = getProjectHome(cwd, tf);
     const tomlPath = projectHome + "/" + tf;
     const lockPath = projectHome + "/" + lf;
-    
-    if isFile(lockPath) {
-      const openLock = openreader(lockPath);
-      const LockFile = parseToml(openLock);
-      if LockFile.pathExists('dependencies') then updateRegistry(skipUpdate);
-    }
-    else updateRegistry(skipUpdate);
-
     const openFile = openreader(tomlPath);
     const TomlFile = parseToml(openFile);
+    if isFile(tomlPath) {
+      if TomlFile['dependencies']!.A.size > 0 then updateRegistry(skipUpdate);
+      writeln("Skipping registry update since no dependency found in manifest file.");
+    }
     if isDir(SPACK_ROOT) && TomlFile.pathExists('external') {
       if getSpackVersion != spackVersion then
       throw new owned MasonError("Mason has been updated. " +


### PR DESCRIPTION
fixes #16115 

This PR adds a new feature to `mason build` where the update of mason-registry is skipped if there is no dependency found in the `Mason.lock` file inside of a mason project.