### PR TITLE
Allow indexing of string/bytes literals

### DIFF
--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -2226,13 +2226,13 @@ literal_expr:
     {
       $$ = new CallExpr("chpl__buildAssociativeArrayExpr", $2);
     }
-| str_bytes_literal TLSBR opt_actual_ls TRSBR
+| str_bytes_literal TLSBR actual_expr TRSBR
   {
-    $$ = buildSquareCallExpr($1, $3);
+    $$ = buildSquareCallExpr($1, new CallExpr(PRIM_ACTUALS_LIST, $3));
   }
-| str_bytes_literal TLP opt_actual_ls TRP
+| str_bytes_literal TLP actual_expr TRP
   {
-    $$ = new CallExpr($1, $3);
+    $$ = new CallExpr($1, new CallExpr(PRIM_ACTUALS_LIST, $3));
   }  
 
 ;

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -2203,8 +2203,7 @@ bool_literal:
 
 str_bytes_literal:
   STRINGLITERAL   { $$ = buildStringLiteral($1); }
-| BYTESLITERAL    { $$ = buildBytesLiteral($1); } 
-| CSTRINGLITERAL  { $$ = buildCStringLiteral($1); }
+| BYTESLITERAL    { $$ = buildBytesLiteral($1); }
 ;
 
 literal_expr:
@@ -2213,6 +2212,7 @@ literal_expr:
 | INTLITERAL            { $$ = buildIntLiteral($1, yyfilename, chplLineno);    }
 | REALLITERAL           { $$ = buildRealLiteral($1);   }
 | IMAGLITERAL           { $$ = buildImagLiteral($1);   }
+| CSTRINGLITERAL        { $$ = buildCStringLiteral($1); }
 | TNONE                 { $$ = new SymExpr(gNone); }
 | TLCBR expr_ls TRCBR   { $$ = new CallExpr("chpl__buildDomainExpr", $2); }
 | TLCBR expr_ls TCOMMA TRCBR   { $$ = new CallExpr("chpl__buildDomainExpr", $2); }

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -474,7 +474,7 @@
 %type <pexpr> lhs_expr
 %type <pexpr> unary_op_expr binary_op_expr
 %type <pexpr> parenthesized_expr expr actual_expr
-%type <pexpr> bool_literal literal_expr
+%type <pexpr> bool_literal str_bytes_literal literal_expr
 %type <pexpr> stmt_level_expr sub_type_level_expr type_level_expr scalar_type
 %type <pexpr> lifetime_components_expr
 %type <pexpr> lifetime_expr lifetime_ident
@@ -2201,14 +2201,18 @@ bool_literal:
 | TTRUE  { $$ = new SymExpr(gTrue); }
 ;
 
+str_bytes_literal:
+  STRINGLITERAL   { $$ = buildStringLiteral($1); }
+| BYTESLITERAL    { $$ = buildBytesLiteral($1); } 
+| CSTRINGLITERAL  { $$ = buildCStringLiteral($1); }
+;
+
 literal_expr:
   bool_literal
+| str_bytes_literal
 | INTLITERAL            { $$ = buildIntLiteral($1, yyfilename, chplLineno);    }
 | REALLITERAL           { $$ = buildRealLiteral($1);   }
 | IMAGLITERAL           { $$ = buildImagLiteral($1);   }
-| STRINGLITERAL         { $$ = buildStringLiteral($1); }
-| BYTESLITERAL          { $$ = buildBytesLiteral($1); }
-| CSTRINGLITERAL        { $$ = buildCStringLiteral($1); }
 | TNONE                 { $$ = new SymExpr(gNone); }
 | TLCBR expr_ls TRCBR   { $$ = new CallExpr("chpl__buildDomainExpr", $2); }
 | TLCBR expr_ls TCOMMA TRCBR   { $$ = new CallExpr("chpl__buildDomainExpr", $2); }
@@ -2222,6 +2226,14 @@ literal_expr:
     {
       $$ = new CallExpr("chpl__buildAssociativeArrayExpr", $2);
     }
+| str_bytes_literal TLSBR opt_actual_ls TRSBR
+  {
+    $$ = buildSquareCallExpr($1, $3);
+  }
+| str_bytes_literal TLP opt_actual_ls TRP
+  {
+    $$ = new CallExpr($1, $3);
+  }  
 
 ;
 

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndex.chpl
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndex.chpl
@@ -1,0 +1,13 @@
+// String
+writeln("Chapel"[1]);
+writeln("Chapel"[1..4]);
+writeln("Chapel"[1..]);
+writeln("Chapel"[..2]);
+writeln("Chapel"[1:byteIndex..2:byteIndex]);
+
+// Bytes
+writeln(b"Chapel"[1]);
+writeln(b"Chapel"[1..4]);
+writeln(b"Chapel"[1..]);
+writeln(b"Chapel"[..2]);
+writeln(b"Chapel"[1:byteIndex..2:byteIndex]);

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndex.good
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndex.good
@@ -1,0 +1,10 @@
+h
+hape
+hapel
+Cha
+ha
+104
+hape
+hapel
+Cha
+ha

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB1.chpl
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB1.chpl
@@ -1,0 +1,1 @@
+writeln("chapel"[6]);

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB1.good
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB1.good
@@ -1,0 +1,1 @@
+stringBytesLiteralIndexOOB1.chpl:1: error: halt reached - index 6 out of bounds for string with length 6

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB2.chpl
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB2.chpl
@@ -1,0 +1,1 @@
+writeln(b"Cha \xff pel"[10]);

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB2.good
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB2.good
@@ -1,0 +1,1 @@
+stringBytesLiteralIndexOOB2.chpl:1: error: halt reached - index 10 out of bounds for bytes with length 9


### PR DESCRIPTION
Fixes #16165

A simple fix by clubbing together `string`, `cstring`, and `bytes` literals.