### PR TITLE
Skip a test if we are not using jemalloc

### DIFF
--- a/test/runtime/configMatters/mem/fragmentation.skipif
+++ b/test/runtime/configMatters/mem/fragmentation.skipif
@@ -1,0 +1,1 @@
+CHPL_MEM != jemalloc


### PR DESCRIPTION
This test run OOM in valgrind testing. It's supposed to allocate large amounts
of memory, but the tested behavior seems to be only applicable to jemalloc. So,
this PR skips the test if we are using `CHPL_MEM=jemalloc`

Test:
- [x] test is skipped with quickstart
