### PR TITLE
We don't need a "system" libfabric for comm=ofi testing any more.

### DIFF
--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -42,9 +42,6 @@ if [ -z "$lchOK" ] ; then
   export MPI_DIR=$(which mpicc | sed 's,/bin/mpicc$,,')
 fi
 
-# Make sure we have a libfabric to use, with the required API version.
-source /cray/css/users/chapelu/setup_libfabric.bash || return 1
-
 if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-* ]] ; then
   # Bump the timeout slightly if we might be oversubscribed.
   export CHPL_TEST_TIMEOUT=500


### PR DESCRIPTION
Before we starting using bundled libfabric builds in PR #15729, we
pointed at a "system" libfabric in nightly testing.  We don't need that
any more now that we're using the bundled one, so remove where we set up
to be able to find it with pkg-config.