### PR TITLE
Stop warning for memcmp overflows in GCC 9

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -226,7 +226,8 @@ endif
 #
 # Avoid false positives for memcmp size. This flag we are adding here is
 # available at least all the way back to gcc 7.3. However, we started seeing
-# errors when we switched to gcc 9.3. So, only throw this flag for version >9
+# errors when we switched to gcc 9.3. Moreover, we don't see it in version 10.
+# So, only throw this flag for major version 9
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 9; echo "$$?"),0)
 SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -224,6 +224,16 @@ WARN_CXXFLAGS += -Wno-error=init-list-lifetime
 endif
 
 #
+# Avoid false positives for memcmp size. This flag we are adding here is
+# available at least all the way back to gcc 7.3. However, we started seeing
+# errors when we switched to gcc 9.3. So, only throw this flag for version >9
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 9; echo "$$?"),0)
+SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
+endif
+
+
+#
 # 2016/03/28: Help to protect the Chapel compiler from a partially
 # characterized GCC optimizer regression when the compiler is being
 # compiled with gcc 5.X.


### PR DESCRIPTION
Adds `-Wno-stringop-overflow` flag to backend compilation. We started to see this warning when we switch to gcc version 9.3.0.

The warning/error said  
```
'__builtin_memcmp_eq' specified size between 9223372036854775808 and 18446744073709551615 exceeds maximum object size 9223372036854775807 
```
The numbers there doesn't make much sense, as those are not uint64_t limits. (Why's low bound not 0??). @bradcray notes that it is probably (poorly) point out the range that is not covered by int64_t.

This warning goes away with gcc >10, further making me believe that it was a bug that was fixed. So, the flag is currently added only for gcc major version 9.