### PR TITLE
Remove newline in mason pkg-config .good file

### DIFF
--- a/test/mason/pkgconfig-tests/zlib.good
+++ b/test/mason/pkgconfig-tests/zlib.good
@@ -14,4 +14,3 @@ libs = "zlibflags"
 include = "/usr/include"
 
 
-


### PR DESCRIPTION
Fix failure in pkg config test (follow-up to https://github.com/chapel-lang/chapel/pull/16214)