### PR TITLE
Change full '====' lines into ones that mix text

### DIFF
--- a/util/cron/lookForTabs.cron
+++ b/util/cron/lookForTabs.cron
@@ -56,7 +56,7 @@ sub mysystem {
             print MAIL "=== Summary ===================================================\n";
             print MAIL "ERROR $_[1]: $status\n";
             print MAIL "(workspace left at $tmpdir)\n";
-            print MAIL "===============================================================\n";
+            print MAIL "=== End Summary ===============================================\n";
             close(MAIL);
         } else {
             print "CHPL_TEST_NOMAIL: No $mailcommand\n";

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -121,7 +121,7 @@ sub startMailHeader {
 
 sub endMailHeader {
     my $mystr =
-        "===============================================================\n\n";
+        "=== End Summary ===============================================\n\n";
 
     $mystr;
 }
@@ -134,8 +134,7 @@ sub endMailChplenv {
     my $chplenv = `$ch/util/printchplenv --all --anonymize`;
 
     my $mystr =
-        "===============================================================\n" .
-        "Chapel Environment:\n" .
+        "=== Chapel Environment ========================================\n" .
         $chplenv . "\n";
 
     $mystr;

--- a/util/pastPerformance/getoldperf
+++ b/util/pastPerformance/getoldperf
@@ -144,7 +144,7 @@ sub mysystem {
             print MAIL "=== Summary ===================================================\n";
             print MAIL "ERROR $_[1]: $status\n";
             print MAIL "(workspace left at $tmpdir)\n";
-            print MAIL "===============================================================\n";
+            print MAIL "=== End Summary ===============================================\n";
             close(MAIL);
         } else {
             print "CHPL_TEST_NOMAIL: No $mailcommand\n";

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -314,7 +314,7 @@ sub mysystem {
             open(MAIL, $mailcommand);
             print MAIL "=== Summary ===================================================\n";
             print MAIL "ERROR $_[1]: $status\n";
-            print MAIL "===============================================================\n";
+            print MAIL "=== End Summary ===============================================\n";
             print MAIL "Build: ", $buildurl, "\n";
             close(MAIL);
         } else {


### PR DESCRIPTION
Discourse truncates messages when it finds lines that are full
of ASCII separator characters (most types of punctuation), but
preserves ones that mix text in, as demonstrated by this
auto-generated message:

https://chapel.discourse.group/t/cron-xc-ugni-qthreads-cray-aprun/89

and this one that I made by hand:

https://chapel.discourse.group/t/test-cron-xc-ugni-qthreads-cray-aprun-fwd/116

This PR changes any lines that are all '====' characters to
introduce text such that our script-generated messages won't
be truncated prematurely.