### PR TITLE
Specify dynamic linking for libfabric via pkg-config on Shasta.

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -62,7 +62,7 @@ def handle_la(la_path):
 # pkgconfig. The pkg can be a path to a .pc file or the name of a
 # system-installed package or the name of a third-party package.
 #
-# if system=True, searches for a system-instaled package.
+# if system=True, searches for a system-installed package.
 @memoize
 def pkgconfig_get_compile_args(pkg, ucp='', system=True):
   havePcFile = pkg.endswith('.pc')
@@ -93,10 +93,10 @@ def pkgconfig_get_compile_args(pkg, ucp='', system=True):
 # the name of a system-installed package or the name of
 # a third-party package.
 #
-# if system=True, searches for a system-instaled package.
+# if system=True, searches for a system-installed package.
 # if static=True, uses --static (suitable for static linking)
 @memoize
-def pkgconfig_get_link_args(pkg, ucp='', system=True, static=True):
+def pkgconfig_get_link_args(pkg, ucp='', system=True, static=(chpl_platform.get('target')!='cray-shasta')):
   havePcFile = pkg.endswith('.pc')
   pcArg = pkg
   if not havePcFile:


### PR DESCRIPTION
We link dynamically on Shasta, so indicate that when using pkg-config to
get linker options for libfabric on that target platform.

This resolves https://github.com/Cray/chapel-private/issues/1224.