### PR TITLE
Update version to 1.22.2, preparing for Shasta v1.3 releases.

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -23,7 +23,7 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION "22"
-#define UPDATE_VERSION "1"
+#define UPDATE_VERSION "2"
 
 static const char* BUILD_VERSION =
 #include "BUILD_VERSION"

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -73,7 +73,7 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.22.1'
+release = '1.22.2'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.22.1.tar.gz
+         tar xzf chapel-1.22.2.tar.gz
 
    b. Make sure that your shell is in the directory containing
       QUICKSTART.rst, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.22.1
+         cd chapel-1.22.2
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -35,7 +35,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.22.1
+        export CHPL_HOME=~/chapel-1.22.2
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.22.1
+:Version: 1.22.2
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.22.1
+:Version: 1.22.2
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.22.1
+ version 1.22.2


### PR DESCRIPTION
Shasta v1.3 development and maintenance will be based on the 1.22
release sources rather than the more volatile master branch.  Here,
prepare the release/1.22 branch for that, by updating the version
number.