### PR TITLE
Reduce loop cloning in fast followers

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -2640,7 +2640,14 @@ static void fixUnresolvedSymExprsForPromotionWrapper(FnSymbol* wrapper,
 // exist yet), we use a primitive as a placeholder. When the record is filled
 // in during iterator lowering, we replace the primitive with the actual field.
 //
-static void buildFastFollowerCheck(bool                  isStatic,
+
+enum FastFollowerCheckType {
+  CAN_HAVE_FF,
+  STATIC_FF_CHECK,
+  DYNAMIC_FF_CHECK
+};
+
+static void buildFastFollowerCheck(FastFollowerCheckType checkType,
                                    bool                  addLead,
                                    FnSymbol*             wrapper,
                                    Type*                 IRtype,
@@ -2659,13 +2666,17 @@ static void buildFastFollowerCheck(bool                  isStatic,
   returnTmp->addFlag(FLAG_EXPR_TEMP);
   returnTmp->addFlag(FLAG_MAYBE_PARAM);
 
-  if (isStatic == true) {
+  if (checkType == CAN_HAVE_FF) {
+    fnName          = "chpl__canHaveFastFollowers";
+
+    checkFn         = new FnSymbol(fnName);
+    checkFn->retTag = RET_PARAM;
+  } else if (checkType == STATIC_FF_CHECK) {
     fnName          = "chpl__staticFastFollowCheck";
 
     checkFn         = new FnSymbol(fnName);
     checkFn->retTag = RET_PARAM;
-
-  } else {
+  } else if (checkType == DYNAMIC_FF_CHECK) {
     fnName          = "chpl__dynamicFastFollowCheck";
 
     checkFn         = new FnSymbol(fnName);
@@ -2736,13 +2747,19 @@ void buildFastFollowerChecksIfNeeded(CallExpr* checkCall) {
   std::set<ArgSymbol*>& requiresPromotion = promotionFormalsMap[wrapFn];
   SET_LINENO(wrapFn);
 
+  // Build "canHaveFastFollowers" check functions -- these doesn't call DSI
+  // functions. They are called before calling DSI functions and return true for
+  // arrays, false otherwise. 
+  buildFastFollowerCheck(CAN_HAVE_FF,  false, wrapFn, ir, requiresPromotion);
+  buildFastFollowerCheck(CAN_HAVE_FF,  true,  wrapFn, ir, requiresPromotion);
+
   // Build static (param) fast follower check functions
-  buildFastFollowerCheck(true,  false, wrapFn, ir, requiresPromotion);
-  buildFastFollowerCheck(true,  true,  wrapFn, ir, requiresPromotion);
+  buildFastFollowerCheck(STATIC_FF_CHECK,  false, wrapFn, ir, requiresPromotion);
+  buildFastFollowerCheck(STATIC_FF_CHECK,  true,  wrapFn, ir, requiresPromotion);
 
   // Build dynamic fast follower check functions
-  buildFastFollowerCheck(false, false, wrapFn, ir, requiresPromotion);
-  buildFastFollowerCheck(false, true,  wrapFn, ir, requiresPromotion);
+  buildFastFollowerCheck(DYNAMIC_FF_CHECK, false, wrapFn, ir, requiresPromotion);
+  buildFastFollowerCheck(DYNAMIC_FF_CHECK, true,  wrapFn, ir, requiresPromotion);
 
   // Done with this wrapFn.
   promotionFormalsMap.erase(wrapFn);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -2666,21 +2666,25 @@ static void buildFastFollowerCheck(FastFollowerCheckType checkType,
   returnTmp->addFlag(FLAG_EXPR_TEMP);
   returnTmp->addFlag(FLAG_MAYBE_PARAM);
 
-  if (checkType == CAN_HAVE_FF) {
-    fnName          = "chpl__canHaveFastFollowers";
-
-    checkFn         = new FnSymbol(fnName);
-    checkFn->retTag = RET_PARAM;
-  } else if (checkType == STATIC_FF_CHECK) {
-    fnName          = "chpl__staticFastFollowCheck";
-
-    checkFn         = new FnSymbol(fnName);
-    checkFn->retTag = RET_PARAM;
-  } else if (checkType == DYNAMIC_FF_CHECK) {
-    fnName          = "chpl__dynamicFastFollowCheck";
-
-    checkFn         = new FnSymbol(fnName);
-    checkFn->retTag = RET_VALUE;
+  switch (checkType) {
+    case CAN_HAVE_FF:
+      fnName          = "chpl__canHaveFastFollowers";
+      checkFn         = new FnSymbol(fnName);
+      checkFn->retTag = RET_PARAM;
+      break;
+    case STATIC_FF_CHECK:
+      fnName          = "chpl__staticFastFollowCheck";
+      checkFn         = new FnSymbol(fnName);
+      checkFn->retTag = RET_PARAM;
+      break;
+    case DYNAMIC_FF_CHECK:
+      fnName          = "chpl__dynamicFastFollowCheck";
+      checkFn         = new FnSymbol(fnName);
+      checkFn->retTag = RET_VALUE;
+      break;
+    default:
+      INT_FATAL("Unknown FastFollowerCheckType");
+      break;
   }
 
   checkFn->addFlag(FLAG_COMPILER_GENERATED);
@@ -2747,7 +2751,7 @@ void buildFastFollowerChecksIfNeeded(CallExpr* checkCall) {
   std::set<ArgSymbol*>& requiresPromotion = promotionFormalsMap[wrapFn];
   SET_LINENO(wrapFn);
 
-  // Build "canHaveFastFollowers" check functions -- these doesn't call DSI
+  // Build "canHaveFastFollowers" check functions -- these don't call DSI
   // functions. They are called before calling DSI functions and return true for
   // arrays, false otherwise. 
   buildFastFollowerCheck(CAN_HAVE_FF,  false, wrapFn, ir, requiresPromotion);

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -509,7 +509,7 @@ module ChapelIteratorSupport {
     if x.size-1 == dim then
       return chpl__staticFastFollowCheckZip(x(dim), lead);
     else
-      return chpl__staticFastFollowCheckZip(x(dim), lead) || chpl__staticFastFollowCheckZip(x, lead, dim+1);
+      return chpl__staticFastFollowCheckZip(x(dim), lead) && chpl__staticFastFollowCheckZip(x, lead, dim+1);
   }
 
   //

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -42,8 +42,6 @@ module ChapelIteratorSupport {
   private use ChapelStandard;
   private use Reflection;
 
-  extern proc printf(s...);
-
   //
   // module support for iterators
   //

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -473,19 +473,66 @@ module ChapelIteratorSupport {
     return _toStandalone(x.these(), (...args));
   }
 
+  // arrays: can lead fast followers, can produce fast followers
+  // domains: can lead fast followers, doesn't produce fast followers
+  // other iterators: cannot lead fast followers, doesn't produce fast followers
+
+  // There are three types of iterands w.r.t. fast followers:
+  // 1. Those that can have fast followers:
+  //    
+  //    We can generate fast followers for these types, and they are the only
+  //    category of types that can result in fast followers in a
+  //    non-zippered forall.
+  //    
+  //    Arrays are in this category
+  //
+  // 2. Those that can lead fast followers:
+  // 
+  //    We can generate fast followers in zippered foralls where the first
+  //    iterand is one of these types. Note that, being able to lead fast
+  //    followers doesn't mean being able to generate fast followers.
+  //
+  //    Domains and arrays are in this category
+  //    
+  // 3. Those that can appear in a fast copy of a forall as followers
+  //
+  //    Basically reverse of 1. These iterands do not break static or dynamic
+  //    check. When `toFastFollower` is called with them, we just call
+  //    `toFollow`
+  //
+  //    Domains and other iterators are in this category
+  proc chpl__canHaveFastFollowers(x) param {
+    return isArray(x);
+  }
+
+  proc chpl__canLeadFastFollowers(x) param {
+    if isDomain(x) || isArray(x) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+
+  proc chpl__hasInertFastFollowers(x) param { 
+    return !isArray(x);
+  }
 
   //
   // return true if any iterator supports fast followers
   //
   proc chpl__staticFastFollowCheck(x) param {
     pragma "no copy" const lead = x;
-    if isDomain(lead) || isArray(lead) then
+    if chpl__canHaveFastFollowers(lead) then
       return chpl__staticFastFollowCheck(x, lead);
-    else
+    else {
       return false;
+    }
   }
 
   proc chpl__staticFastFollowCheck(x, lead) param {
+    compilerWarning("Static fast follow check called with unexpected types ",
+                    x.type:string, " and ", lead.type:string);
     return false;
   }
 
@@ -495,21 +542,23 @@ module ChapelIteratorSupport {
 
   proc chpl__staticFastFollowCheckZip(x: _tuple) param {
     pragma "no copy" const lead = x(0);
-    if isDomain(lead) || isArray(lead) then
+    if chpl__canLeadFastFollowers(lead) then
       return chpl__staticFastFollowCheckZip(x, lead);
     else
       return false;
   }
 
   proc chpl__staticFastFollowCheckZip(x, lead) param {
-    return chpl__staticFastFollowCheck(x, lead);
+    return chpl__hasInertFastFollowers(x) ||
+           chpl__staticFastFollowCheck(x, lead);
   }
 
   proc chpl__staticFastFollowCheckZip(x: _tuple, lead, param dim = 0) param {
     if x.size-1 == dim then
       return chpl__staticFastFollowCheckZip(x(dim), lead);
     else
-      return chpl__staticFastFollowCheckZip(x(dim), lead) && chpl__staticFastFollowCheckZip(x, lead, dim+1);
+      return chpl__staticFastFollowCheckZip(x(dim), lead) &&
+             chpl__staticFastFollowCheckZip(x, lead, dim+1);
   }
 
   //
@@ -517,11 +566,18 @@ module ChapelIteratorSupport {
   // their fast followers
   //
   proc chpl__dynamicFastFollowCheck(x) {
-    return chpl__dynamicFastFollowCheck(x, x);
+    if chpl__canHaveFastFollowers(x) {
+      return chpl__dynamicFastFollowCheck(x, x);
+    }
+    else {
+      return false;
+    }
   }
 
   proc chpl__dynamicFastFollowCheck(x, lead) {
-    return true;
+    compilerWarning("Dynamic fast follow check called with unexpected types ",
+                    x.type:string, " and ", lead.type:string);
+    return false;
   }
 
   proc chpl__dynamicFastFollowCheck(x: [], lead) {
@@ -532,11 +588,16 @@ module ChapelIteratorSupport {
   }
 
   proc chpl__dynamicFastFollowCheckZip(x: _tuple) {
-    return chpl__dynamicFastFollowCheckZip(x, x(0));
+    if chpl__canLeadFastFollowers(x(0)) {
+      return chpl__dynamicFastFollowCheckZip(x, x(0));
+    }
+    else {
+      return false;
+    }
   }
 
   proc chpl__dynamicFastFollowCheckZip(x, lead) {
-    return chpl__dynamicFastFollowCheck(x, lead);
+    return chpl__hasInertFastFollowers(x) || chpl__dynamicFastFollowCheck(x, lead);
   }
 
   proc chpl__dynamicFastFollowCheckZip(x: _tuple, lead, param dim = 0) {
@@ -600,7 +661,7 @@ module ChapelIteratorSupport {
 
   pragma "fn returns iterator"
   inline proc _toFastFollower(x, leaderIndex) {
-    if chpl__staticFastFollowCheck(x) then
+    if chpl__canHaveFastFollowers(x) then
       return _toFastFollower(_getIterator(x), leaderIndex, fast=true);
     else
       return _toFollower(_getIterator(x), leaderIndex);
@@ -625,6 +686,7 @@ module ChapelIteratorSupport {
       return (_toFastFollowerZip(x(dim), leaderIndex),
               (..._toFastFollowerZip(x, leaderIndex, dim+1)));
   }
+
 
 
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -687,10 +687,7 @@ module ChapelIteratorSupport {
 
   pragma "fn returns iterator"
   inline proc _toFastFollower(x, leaderIndex) {
-    // ENGIN: want to call chpl__canHaveFastFollowers, but we need the promotion
-    // wrapper written by the compiler.
-    if chpl__staticFastFollowCheck(x) then
-    //if chpl__canHaveFastFollowers(x) then
+    if chpl__canHaveFastFollowers(x) then
       return _toFastFollower(_getIterator(x), leaderIndex, fast=true);
     else
       return _toFollower(_getIterator(x), leaderIndex);

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -518,6 +518,15 @@ module ChapelIteratorSupport {
     return !isArray(x);
   }
 
+  proc chpl__hasAnIterandWithFastFollowers(x: _tuple, param dim=0) param {
+    if x.size-1 == dim then
+      return chpl__canHaveFastFollowers(x(dim));
+    else
+      return chpl__canHaveFastFollowers(x(dim)) ||
+             chpl__hasAnIterandWithFastFollowers(x, dim+1);
+
+  }
+
   //
   // return true if any iterator supports fast followers
   //
@@ -541,11 +550,16 @@ module ChapelIteratorSupport {
   }
 
   proc chpl__staticFastFollowCheckZip(x: _tuple) param {
-    pragma "no copy" const lead = x(0);
-    if chpl__canLeadFastFollowers(lead) then
-      return chpl__staticFastFollowCheckZip(x, lead);
-    else
+    if !chpl__hasAnIterandWithFastFollowers(x) {
       return false;
+    }
+    else {
+      pragma "no copy" const lead = x(0);
+      if chpl__canLeadFastFollowers(lead) then
+        return chpl__staticFastFollowCheckZip(x, lead);
+      else
+        return false;
+    }
   }
 
   proc chpl__staticFastFollowCheckZip(x, lead) param {

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -675,7 +675,8 @@ module ChapelIteratorSupport {
 
   pragma "fn returns iterator"
   inline proc _toFastFollower(x, leaderIndex) {
-    if chpl__canHaveFastFollowers(x) then
+    // ENGIN: want to call chpl__canHaveFastFollowers, but can't get it to work
+    if chpl__staticFastFollowCheck(x) then
       return _toFastFollower(_getIterator(x), leaderIndex, fast=true);
     else
       return _toFollower(_getIterator(x), leaderIndex);

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -504,7 +504,24 @@ module ChapelIteratorSupport {
   //
   //    Domains and other iterators are in this category
   proc chpl__canHaveFastFollowers(x) param {
-    return isArray(x);
+    return false;
+  }
+
+  proc chpl__canHaveFastFollowers(x: []) param {
+    return true;
+  }
+
+  proc chpl__canHaveFastFollowers(x: _tuple) param {
+    return chpl__canHaveFastFollowers(x, 0);
+  }
+
+  proc chpl__canHaveFastFollowers(x: _tuple, param dim) param {
+    if x.size-1 == dim then
+      return chpl__canHaveFastFollowers(x(dim));
+    else
+      return chpl__canHaveFastFollowers(x(dim)) ||
+             chpl__canHaveFastFollowers(x, dim+1);
+
   }
 
   proc chpl__canLeadFastFollowers(x) param {
@@ -539,15 +556,6 @@ module ChapelIteratorSupport {
     }
   }
 
-  proc chpl__hasAnIterandWithFastFollowers(x: _tuple, param dim=0) param {
-    if x.size-1 == dim then
-      return chpl__canHaveFastFollowers(x(dim));
-    else
-      return chpl__canHaveFastFollowers(x(dim)) ||
-             chpl__hasAnIterandWithFastFollowers(x, dim+1);
-
-  }
-
   //
   // return true if any iterator supports fast followers
   //
@@ -571,7 +579,7 @@ module ChapelIteratorSupport {
   }
 
   proc chpl__staticFastFollowCheckZip(x: _tuple) param {
-    if !chpl__hasAnIterandWithFastFollowers(x) {
+    if !chpl__canHaveFastFollowers(x) {
       return false;
     }
     else {

--- a/test/distributions/bharshbarg/fastFollowerEquality.chpl
+++ b/test/distributions/bharshbarg/fastFollowerEquality.chpl
@@ -3,6 +3,8 @@ use BlockDist;
 use StencilDist;
 use CyclicDist;
 
+config param zipRange = true;
+
 proc test(Orig : domain) {
   var Copy = Orig;
   test(Orig, Copy);
@@ -31,14 +33,25 @@ proc test(A : [?DA], B : [?DB]) {
   DB.dist.displayRepresentation();
   writeln();
 
-  forall (a,b) in zip(A,B) do
-    a += b;
+  if !zipRange {
+    forall (a,b) in zip(A,B) do
+      a += b;
+  }
+  else {
+    forall (a,b,i) in zip(A,B, 0..) do
+      a += b+i;
+  }
   writeln("----------");
   writeln();
 
   var cur = 0;
   for i in DA {
-    assert(A[i] == cur * 2);
+    if !zipRange {
+      assert(A[i] == cur * 2);
+    }
+    else {
+      assert(A[i] == cur * 3);
+    }
     cur += 1;
   }
 }

--- a/test/distributions/bharshbarg/fastFollowerEquality.compopts
+++ b/test/distributions/bharshbarg/fastFollowerEquality.compopts
@@ -1,1 +1,2 @@
--sCyclicDist.testFastFollowerOptimization -sBlockDist.testFastFollowerOptimization -sdataParTasksPerLocale=2
+-sCyclicDist.testFastFollowerOptimization -sBlockDist.testFastFollowerOptimization -sdataParTasksPerLocale=2 -szipRange=false
+-sCyclicDist.testFastFollowerOptimization -sBlockDist.testFastFollowerOptimization -sdataParTasksPerLocale=2 -szipRange=true


### PR DESCRIPTION
This PR adjusts the module support for fast followers to reduce the amount of
loop cloning we do.

Initially attempted at https://github.com/chapel-lang/chapel/pull/16001
Also see https://github.com/chapel-lang/chapel/pull/16053, which has done
similar reductions in loop cloning that happens with fast followers

Motivation
----------

The static check that we do today is way too lax. Because for a leader that
supports fast followers, we always have a fast loop. However that loop is unused
if any of the followers don't support fast followers and/or not of same type as
the leader.

This decision seems to be made in 2010 when fast followers were first
implemented. I assume that compiler wasn't this powerful and slow and/or there
wasn't param unfolding etc. 

The commit where this was added is 0dd8331b8903cb1e280ee69af37187997c6d77e7.

Citing part of it that alludes to this decision:

>   This optimization works as follows: When 'parsing' a forall loop, we
>   generate code that generates two loops in a conditional, a fast
>   follower loop and a normal follower loop.  The conditional is guarded
>   by or'ing the result of calling the static checks on all of the
>   followers, and then and'ing the result of calling the dynamic checks
>   on all of the followers.  That is, if any follower has a fast version
>   that may be called, let's generate the code, but we're only going to
>   run the fast loop (all fast followers) if every follower that may be
>   called should be called.

Where there is no strong argument for having this behavior.

I believe these type of false optimizations are the main reason for the
performance overhead of fast followers.

Approach
--------

The fast follower implementation in general is too complicated. I think the
reason for that was we were overloading the meaning of static and dynamic checks
probably to reduce the amount of code. These checks return a bool and thus can
be used for binary choices. However, we have a more complicated taxonomy of
types w.r.t fast followers:

- Arrays
  - Array types that supports fast followers: can lead and generate fast
    followers
  - Array types that don't support fast followers: cannot lead or generate fast
    followers

- Domains: Can lead fast followers. Can take place among other fast followers in
  a zippered loop.

- Other iterators: Cannot lead or generate fast followers. However, can take
  place among other fast followers in a zippered loop

This PR adds three helpers (and their overloads) to distinguish these:
- `chpl__canHaveFastFollowers`: Returns true for an array, or a zip tuple that
  has at least one array. (This check doesn't involve the specific type of the
  array, it is still handled by `chpl__staticFastFollowCheck`

- `chpl__canLeadFastFollowers`: Returns true for arrays and domains.

- `chpl__hasInertFastFollowers`: Returns false for arrays. For a zip tuple, it
  returns false if there is one array.

These helpers are used in the other existing checks to limit loop cleaning and
improve readability.

Performance
-----------

For benchmarks where fast followers are used heavily (stream, prk-stencil) there
isn't any change in compiler or application performance. We see small
improvements in benchmarks where we create fast followers unnecessarily
(cross-type array assignments/zippering are examples where this may happen).

On miniMD: I see 3 seconds faster --fast compilation on XC and locally
On SSCA2: I see 6 seconds faster --fast compilation locally, but not so much of
an improvement on XC.

The reduction in the code size is there but its impact on performance is a bit
of a hit-and-miss and depends on where you compile.


Readability Advantages
----------------------

- Static and dynamic checks are more symmetrical
- Static check is and'ed instead of or'ed. i.e. we only have a clone if it makes
  sense
- Dynamic check no longer returns `true` for generic argument.

Test:
- [x] standard
- [x] gasnet
