### PR TITLE
Make our modulefile compatible with Lmod

### DIFF
--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -104,7 +104,11 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 
     # Load/unload cray-mpich if not previously loaded
 
-    set mpichLoaded [string match "*PE_MPICH*" $env(PE_PKGCONFIG_PRODUCTS)]
+    if { [ info exists env(PE_PKGCONFIG_PRODUCTS) ] } {
+        set mpichLoaded [string match "*PE_MPICH*" $env(PE_PKGCONFIG_PRODUCTS)]
+    } else {
+        set mpichLoaded 0
+    }
     # Logic for mpich is split into loading and unloading phases
     if { !([is-loaded chapel] == 1) }  {
         # Loading chapel
@@ -135,9 +139,11 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 
 if { ! [ info exists env(PE_ENV) ] } {
     module load PrgEnv-gnu
+    set compiler GNU
+} else {
+    set compiler $env(PE_ENV)
 }
 
-set compiler $env(PE_ENV)
 
 if { [string match cray-shasta $CHPL_HOST_PLATFORM] } {
     # Interim settings for Shasta systems.


### PR DESCRIPTION
This fixes our modulefile for when mpich and/or a PrgEnv aren't loaded
under Lmod. In the Lmod system you can't read an unset environment
variable so you have to ensure it's set before reading it.

Additionally, when TCL is converted to Lua the module commands are no
longer evaluated before set/test commands so you can't load a module and
then use an env var set by that module. Adapt to those limitations here.
See https://lmod.readthedocs.io/en/latest/095_tcl2lua.html for more
info.

Part of https://github.com/Cray/chapel-private/issues/1220