### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -619,6 +619,8 @@ CoMD:
     - Update PR 5296 (#6722)
   06/25/19:
     - Simplify standalone iterator for DefaultRectangular domains/arrays (#13189)
+  08/05/20:
+    - Adjust target compiler versions for some Cray configs (#16196)
 
 CoMD-elegant-aos:
   06/12/18:
@@ -1717,6 +1719,8 @@ stencil:
     - machine related (no commits on the day before)
   03/24/15:
     - with CCE, bug fix to avoid vectorizing when not valid
+  08/13/20:
+    - Optimize array swap operator for basic cases (#16209)
 
 stream:
   05/13/16:


### PR DESCRIPTION
Adds two annotations:

- Parboil 3D Stencil improvement due to swap optimization

https://chapel-lang.org/perf/chapcs/?startdate=2020/04/17&enddate=2020/08/13&graphs=parboilstencil3dexecutiontime

https://github.com/chapel-lang/chapel/pull/16209

- CoMD regression due to backend compiler version change

https://chapel-lang.org/perf/16-node-xc/?startdate=2020/06/11&enddate=2020/08/12&graphs=llnlcomdtimesec

https://github.com/chapel-lang/chapel/pull/16196
