### PR TITLE
Make ck_module_list compatible with Lmod

### DIFF
--- a/util/build_configs/module-functions.bash
+++ b/util/build_configs/module-functions.bash
@@ -19,7 +19,7 @@ function ck_module_list() {
         log_error "module list=<empty>"
         exit 2
         ;;
-    ( "Currently Loaded Modulefiles:"*[a-zA-Z0-9] )
+    ( *[a-zA-Z0-9] )
         ;;
     ( * )
         log_error "Unrecognized module list=$output"


### PR DESCRIPTION
The old function was expecting the first output in a `module list` to be
"Currently Loaded Modulefiles:", but that's not printed with Lmod so
just stop expecting that output.

Part of https://github.com/Cray/chapel-private/issues/1220