### PR TITLE
Fix some ugni specific tests

### DIFF
--- a/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.chpl
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.chpl
@@ -1,3 +1,4 @@
+use Sys;
 //
 // This test checks the error message printed by the comm=ugni SIGBUS
 // handler when we run out of memory while trying to allocate an array

--- a/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.good
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.good
@@ -1,1 +1,1 @@
-SIGBUS-array-alloc.chpl:15: error: Out of memory allocating "array elements"
+SIGBUS-array-alloc.chpl:16: error: Out of memory allocating "array elements"

--- a/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.chpl
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.chpl
@@ -1,3 +1,4 @@
+use Sys;
 //
 // This test checks the error message printed by the comm=ugni SIGBUS
 // handler when we run out of memory trying to extend the heap, with

--- a/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap_real
+++ b/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap_real
@@ -2,6 +2,7 @@
 
 # Pluck the execOptsNum out of the execution command line.
 case $(echo $1 | sed "s/^.*=\([0-9]\)/\1/") in
+1) unset HUGETLB_DEFAULT_PAGE_SIZE;;
 2) unset HUGETLB_NO_RESERVE;;
 3) unset CHPL_JE_MALLOC_CONF;;
 esac


### PR DESCRIPTION
Our check to make sure we get a warning if hugepages aren't loaded is
currently failing on systems with Lmod. The problem is that we're
falling back to Tcl still, but we do that in our bashrc after Lmod is
loaded. When we do a qsub a new Lmod session starts, which ends up
reloading hugepages, so we weren't getting our warning. This shouldn't
be a problem once we're no longer failing back to Tcl, but until then
this should get testing working.

We also had some failures for the SIGBUS tests that I thought had the
same root cause, but it turns out they were just compilation failures
because sys_getenv is used, but the Sys module is no longer used by
default.