### PR TITLE
Improve the isDistributed check in LinearAlgebra

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -664,6 +664,7 @@ private proc isDistributed(a) param {
   }
   else if isSparseDom(a.domain) {
     // TODO: is there a better way to check for distributed sparse domains?
+    use BlockDist;
     return isSubtype(a.domain.dist.type, Block);
   }
   else {

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -657,7 +657,18 @@ private proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
 pragma "no doc"
 /* Returns ``true`` if the domain is distributed */
 private proc isDistributed(a) param {
-  return !isSubtype(a.domain.dist.type, DefaultDist);
+  if chpl__isArrayView(a) {
+    // NOTE that this'll return true even if `a` is a slice of a distributed
+    // array that falls entirely in a single locale
+    return !chpl__getActualArray(a).isDefaultRectangular();
+  }
+  else if isSparseDom(a.domain) {
+    // TODO: is there a better way to check for distributed sparse domains?
+    return isSubtype(a.domain.dist.type, Block);
+  }
+  else {
+    return !isSubtype(a.domain.dist.type, DefaultDist);
+  }
 }
 
 /* Inner product of 2 vectors. */

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -655,8 +655,12 @@ private proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
 }
 
 pragma "no doc"
-/* Returns ``true`` if the domain is distributed */
-private proc isDistributed(a) param {
+/* 
+   Returns ``true`` if the domain is distributed 
+
+   This is currently public only for unit testing purposes.
+*/
+proc isDistributed(a) param {
   if chpl__isArrayView(a) {
     // NOTE that this'll return true even if `a` is a slice of a distributed
     // array that falls entirely in a single locale

--- a/test/library/packages/LinearAlgebra/correctness/testIsDistributed.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testIsDistributed.chpl
@@ -1,0 +1,30 @@
+use LinearAlgebra;
+
+use BlockDist;
+use LayoutCS;
+
+
+var distArr = newBlockArr({1..10}, int);
+var sliceOfDist = distArr[1..8];
+var locArr: [1..8] int;
+
+var locSparseDom: sparse subdomain(locArr.domain);
+var locSparseArr: [locSparseDom] int;
+
+var space2D = {1..10, 1..10};
+var locSparseDomCSR: sparse subdomain(space2D) dmapped CS();
+var locSparseArrCSR: [locSparseDomCSR] int;
+
+var distSparseDom: sparse subdomain(distArr.domain);
+var distSparseArr: [distSparseDom] int;
+
+var distCSRBlock = {1..10, 1..10} dmapped Block({1..10, 1..10}, sparseLayoutType=CS);
+var distSparseArrCSR: [distCSRBlock] int;
+
+assert(isDistributed(distArr) == true);
+assert(isDistributed(sliceOfDist) == true);
+assert(isDistributed(locArr) == false);
+assert(isDistributed(locSparseArr) == false);
+assert(isDistributed(locSparseArrCSR) == false);
+assert(isDistributed(distSparseArr) == true);
+assert(isDistributed(distSparseArrCSR) == true);


### PR DESCRIPTION
This PR patches `LinearAlgebra.isDistributed` to check for couple of other
cases.

This is necessary for https://github.com/chapel-lang/chapel/pull/16106

Note that we can probably improve the ways in which we check for distributed
arrays. When we do that such checks should be moved to Types.chpl or somewhere
where it is also user-facing. Currently this is a private helper for the
LinearAlgebra module and the change is necessary for other LinearAlgebra work to
proceed.

Another note is that the check for array views come from some other effort, but
can't remember what that was offhand.

To test `isDistributed`, this PR also makes it public (but still `no doc`) and adds
a test.

Test:
- [x] `library/packages/LinearAlgebra` on XC
