### PR TITLE
mason bench & extend UnitTest for benchmarking

### DIFF
--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1440,11 +1440,19 @@ module UnitTest {
     }
    // returns total time
     proc totalTime() {
-      writeln("Total time elapsed(microseconds): ", t.elapsed(TimeUnits.microseconds));
+      return t.elapsed(TimeUnits.microseconds);
     }
    // returns average time
     proc avgTime() {
-      writeln("Average Time(ms/N): ", t.elapsed(TimeUnits.microseconds) / N);
+      return t.elapsed(TimeUnits.microseconds) / N;
     }
+   // log results
+   proc showData() {
+      const totalTimeElapsed = totalTime();
+      const averageTime = avgTime();
+      writeln("Iterations: ", N);
+      writeln("Total time elapsed(microseconds): ", totalTimeElapsed);
+      writeln("Average Time(ms/N): ", averageTime);
+   }
   }
 }

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1440,11 +1440,11 @@ module UnitTest {
     }
    // returns total time
     proc totalTime() {
-      writeln("Total time elapsed: ", t.elapsed(TimeUnits.microseconds));
+      writeln("Total time elapsed(microseconds): ", t.elapsed(TimeUnits.microseconds));
     }
    // returns average time
     proc avgTime() {
-      writeln("Average Time: ", t.elapsed(TimeUnits.microseconds) / N);
+      writeln("Average Time(ms/N): ", t.elapsed(TimeUnits.microseconds) / N);
     }
   }
 }

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1422,37 +1422,40 @@ module UnitTest {
 
   module Benchmark {
     use Time;
-    // N - default number of repititions
+    /* N - default number of repititions */
     var N: int = 10000;
-    // use hcf to match function signature
-    // to reset timer
+    // TODO: use hcf to match function signature
     var t: Timer;
+    var firstTest: bool = false;
+    /* Reset the timer */
     proc resetTimer() {
       t.clear();
     }
-    // start the timer
+    /* Start the timer */
     proc startTimer() {
       t.start();
+      resetTimer();
     }
-    // to stop timer and gather total time
+    /* Stop the timer */
     proc stopTimer() {
       t.stop();
     }
-   // returns total time
+    /* Returns total time elapsed */
     proc totalTime() {
       return t.elapsed(TimeUnits.microseconds);
     }
-   // returns average time
+    /* Returns average time (total time / number of iterations) */
     proc avgTime() {
       return t.elapsed(TimeUnits.microseconds) / N;
     }
-   // log results
-   proc showData() {
+    /* Output benchmark metrics */
+    proc log(functionName: string) {
       const totalTimeElapsed = totalTime();
       const averageTime = avgTime();
+      writeln("Function: ", functionName);
       writeln("Iterations: ", N);
-      writeln("Total time elapsed(microseconds): ", totalTimeElapsed);
-      writeln("Average Time(ms/N): ", averageTime);
-   }
+      writeln("Total Time Elapsed (ms): ", totalTimeElapsed);
+      writeln("Average Time (ms/N): ", averageTime);
+    }
   }
 }

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -113,18 +113,18 @@ conditionally with :proc:`~Test.skipIf`:
 
    use UnitTest;
 
-   /* calculates factorial */
+   // calculates factorial 
    proc factorial(x: int): int {
      return if x == 0 then 1 else x * factorial(x-1);
    }
 
-   /*Conditional skip*/
+   //Conditional skip
    proc test1(test: borrowed Test) throws {
      test.skipIf(factorial(0) != 1,"Base condition is wrong in factorial");
      test.assertTrue(factorial(5) == 120);
    }
 
-   /*Unconditional skip*/
+   //Unconditional skip
    proc test2(test: borrowed Test) throws {
      test.skip("Skipping the test directly");
    }
@@ -240,10 +240,12 @@ Output:
   OK
 
 */
+
 module UnitTest {
   use Reflection;
   use TestError;
   use List, Map;
+  public use Benchmark;
   private use IO;
 
   pragma "no doc"
@@ -1365,6 +1367,7 @@ module UnitTest {
       var details: string;
 
       proc init(details: string = "") {
+        writeln("Hi");
         this.details = details;
       }
 
@@ -1414,6 +1417,34 @@ module UnitTest {
       proc init(details: string = "") {
         super.init(details);
       }
+    }
+  }
+
+  module Benchmark {
+    use Time;
+    // N - default number of repititions
+    var N: int = 10000;
+    // use hcf to match function signature
+    // to reset timer
+    var t: Timer;
+    proc resetTimer() {
+      t.clear();
+    }
+    // start the timer
+    proc startTimer() {
+      t.start();
+    }
+    // to stop timer and gather total time
+    proc stopTimer() {
+      t.stop();
+    }
+   // returns total time
+    proc totalTime() {
+      writeln("Total time elapsed: ", t.elapsed(TimeUnits.microseconds));
+    }
+   // returns average time
+    proc avgTime() {
+      writeln("Average Time: ", t.elapsed(TimeUnits.microseconds) / N);
     }
   }
 }

--- a/tools/mason/MasonBench.chpl
+++ b/tools/mason/MasonBench.chpl
@@ -203,7 +203,7 @@ proc runBenchTestExecutables(benchTestNames: list(string), projectHome: string) 
       const benchTestName = basename(stripExt(benchTest, ".chpl"));
       const benchTestTomlPath = projectHome + "/benchmark/";
       // TODO: get bench execopts ?
-      runAndLogBenchmarks(projectHome, outputLoc, benchTestName, benchExecopts);
+      runAndLogBenchmarks(projectHome, outputLoc, benchTestName);
       writeln(separator);
     }
   }
@@ -213,7 +213,7 @@ proc runBenchTestExecutables(benchTestNames: list(string), projectHome: string) 
 }
 
 /* Execute benchmarks from target/ and log output */
-proc runAndLogBenchmarks(projectHome: string, outputLoc: string, benchTestName: string, benchExecopts: string) {
+proc runAndLogBenchmarks(projectHome: string, outputLoc: string, benchTestName: string) {
   var executable = outputLoc;
   var line: string;
   var exec = spawn([executable]);
@@ -233,6 +233,5 @@ proc getBenchMetadata(benchTomlPath: string, benchTestName: string, metadata: st
       opts = tomlFile[tableHeader]![metadata]!.s;
     }
   }
-  writeln(opts);
   return opts;
 }

--- a/tools/mason/MasonBench.chpl
+++ b/tools/mason/MasonBench.chpl
@@ -132,7 +132,7 @@ proc runBenchTests(show: bool, ref cmdLineCompopts: list(string)) throws {
       numBenchTests = files.size;
       customBenchTest = true;
     }
-    printMetadata(compopts, benchTestNames);
+    writeln("*********** Benchmark Results ****************");
     if numBenchTests > 0 {
       for benchTest in benchTestNames {
         var benchTestPath: string;
@@ -147,19 +147,28 @@ proc runBenchTests(show: bool, ref cmdLineCompopts: list(string)) throws {
         const outputLoc = projectHome + "/target/benchmark/" + stripExt(benchTestTemp, ".chpl");
         const moveTo = "-o " + outputLoc;
         const compCommand = " ".join("chpl", benchTestPath, projectPath, moveTo, allCompopts);
-        writeln(compCommand);
         const compilation = runWithStatus(compCommand, show);
         if compilation != 0 {
-          stderr.writeln("compilation failed for " + benchTest);
+          stderr.writeln("Compilation failed for " + benchTest);
           const errMsg = benchTest + " failed to compile";
           // TODO:  add to results from unit test 
         } else {
-          writeln("Compiled " + benchTest + "successfully");
+          writeln("Compiled " + benchTest + " successfully");
+          runAndLogBenchmarks(projectHome, outputLoc, benchTestName);
         }
+        writeln("**********************************************");
       }  
     }
   }
   catch e: MasonError {
     stderr.writeln(e.message());
   }
+}
+
+/* Execute benchmarks from target/ and log output */
+proc runAndLogBenchmarks(projectHome: string, outputLoc: string, benchTestName: string) {
+  var executable = outputLoc;
+  var line: string;
+  var exec = spawn([executable]);
+  exec.wait();
 }

--- a/tools/mason/MasonBench.chpl
+++ b/tools/mason/MasonBench.chpl
@@ -145,8 +145,9 @@ proc runBenchTests(show: bool, ref cmdLineCompopts: list(string)) throws {
         if cwd == projectHome && customTest then
           benchTestTemp = relPath(benchTestTemp, "benchmark/");
         const outputLoc = projectHome + "/target/benchmark/" + stripExt(benchTestTemp, ".chpl");
+        if !isDir(dirname(outputLoc)) then mkdir(dirname(outputLoc));
         const moveTo = "-o " + outputLoc;
-        const compCommand = " ".join("chpl", benchTestPath, projectPath, moveTo, allCompopts);
+        const compCommand = " ".join("chpl --fast", benchTestPath, projectPath, moveTo, allCompopts);
         const compilation = runWithStatus(compCommand, show);
         if compilation != 0 {
           stderr.writeln("Compilation failed for " + benchTest);

--- a/tools/mason/MasonBench.chpl
+++ b/tools/mason/MasonBench.chpl
@@ -1,0 +1,106 @@
+use TOML;
+use Path;
+use Spawn;
+use MasonEnv;
+use MasonNew;
+use MasonBuild;
+use MasonHelp;
+use MasonUtils;
+use MasonExample;
+use MasonModify;
+use FileSystem;
+use MasonTest;
+private use List;
+private use Map;
+
+var files : list(string);
+var dirs : list(string);
+
+proc masonBench(args) throws {
+  var show: bool = false;
+  var skipUpdate = MASON_OFFLINE;
+  var compopts: list(string);
+  var countArgs = args.indices.low+2;
+
+  for arg in args[args.indices.low+2..] {
+    countArgs += 1;
+    select(arg) {
+      when '-h' {
+        masonBenchHelp();
+        exit(0);
+      }
+      when '--help' {
+        masonBenchHelp();
+        exit(0);
+      }
+      when '--show' {
+        show = true;
+      }
+      otherwise {
+        try! {
+          // bench filenames, directories, compopts passed as args
+          if isFile(arg) && arg.endsWith(".chpl") then files.append(arg);
+          else if isDir(arg) then dirs.append(arg);
+          else {
+            if arg.startsWith('-') then compopts.append(arg);
+          } 
+        }
+      }
+    }
+  }
+  if show then printMetadata(compopts);
+  try! {
+    const cwd = getEnv("PWD"); 
+    const projectHome = getProjectHome(cwd);
+    var benchTestName: list(string);
+    var benchTestPath = joinPath(projectHome, "bench");
+    var benchTests = findfiles(startdir=benchTestPath, recursive=true, hidden=false);
+    for bench in benchTests {
+      if bench.endsWith(".chpl") {
+        benchTestName.append(getBenchTestPath(bench));
+      }
+    }
+    for bench in benchTestName do writeln(bench);
+    updateLock(skipUpdate);
+    runBenchTests(show, compopts);
+  }
+  catch e: MasonError {
+    writeln(e.message());
+    exit(1);
+  }
+}
+
+proc runBenchTests(show, compopts) {
+  for c in compopts do writeln(c); 
+}
+
+proc printMetadata(compopts: list(string)) {
+  writeln("Files : ");
+  for a in files do writeln(a);
+  writeln("Dirs : ");
+  for d in dirs do writeln(d);
+  writeln("Compopts : ");
+  for c in compopts do writeln(c);
+}
+
+// TODO: refactor getTestPath to accomodate bench tests and unit tests
+proc getBenchTestPath(fullPath: string, testPath = "") : string {
+  var split = splitPath(fullPath);
+	writeln(split);
+	return fullPath;
+/*
+  if split[1] == "bench" {
+    return testPath;
+  }
+  else {
+    if testPath == "" {
+      return getTestPath(split[0], split[1]);
+    }
+    else {
+      var appendedPath = joinPath(split[1], testPath);
+      return getTestPath(split[0], appendedPath);
+    }
+  }
+*/
+}
+

--- a/tools/mason/MasonBench.chpl
+++ b/tools/mason/MasonBench.chpl
@@ -56,6 +56,15 @@ proc masonBench(args) throws {
       when '--show' {
         show = true;
       }
+      when '--' {
+        throw new owned MasonError("Benchmarking doesn't support -- syntax");
+      }
+      when '--update' {
+        skipUpdate = false;
+      }
+      when '--no-update' {
+        skipUpdate = true;
+      }
       otherwise {
         try! {
           // bench filenames, directories, compopts passed as args
@@ -69,37 +78,10 @@ proc masonBench(args) throws {
     }
   }
   try! {
-    // get bench files from bench directory 
-    const cwd = getEnv("PWD"); 
-    const projectHome = getProjectHome(cwd);
-    var benchTestsFromDir: list(string);
-    var benchTestPath = joinPath(projectHome, "benchmark");
-    var benchTests = findfiles(startdir=benchTestPath, recursive=true, hidden=false);
-    for bench in benchTests {
-      if bench.endsWith(".chpl") {
-        benchTestsFromDir.append(bench);
-      }
-    }
-    // get bench files from Mason.toml or any toml files
-    var benchTestsFromToml: list(string);
-    const tomlFilePath = joinPath(projectHome, 'Mason.toml');
-    const toParse = open(tomlFilePath, iomode.r);
-    const tomlFile = owned.create(parseToml(toParse));
-    if isFile(tomlFilePath) {
-      if tomlFile.pathExists('brick.benchmarks') {
-        var benchTests = tomlFile['brick']!['benchmarks']!.toString(); 
-        var stripBenchTests = benchTests.split(',').strip('[]');
-        for test in stripBenchTests {
-          const benchTest = test.strip().strip('"');
-          benchTestsFromToml.append(benchTest);
-        }
-      }
-    }
-    if show {
-      printMetadata(compopts, benchTestsFromDir, benchTestsFromToml); 
-    }
+    getRuntimeComm();
     updateLock(skipUpdate);
-    runBenchTests(show, compopts, benchTestsFromDir, benchTestsFromToml);
+    compopts.append("".join('--comm=', comm));
+    runBenchTests(show, compopts);
   }
   catch e: MasonError {
     writeln(e.message());
@@ -108,61 +90,39 @@ proc masonBench(args) throws {
 }
 
 /* displays list of bench test files derived from bench/, Mason.toml file */
-proc printMetadata(compopts: list(string), benchTestsFromDir: list(string), benchTestsFromToml: list(string)) {
-  writeln("Bench Test files from bench directory ... ");
-  for benchTest in benchTestsFromDir do writeln(benchTest);
-  writeln("Bench Test files from Mason.toml...");
-  for benchTest in benchTestsFromToml do writeln(benchTest);
+proc printMetadata(compopts: list(string), benchTestsFromDir: list(string)) {
+  writeln("Benchmarking tests gathered from lockfile & benchmark directory...");
+  for test in benchTestsFromDir do writeln(test);
+  writeln("Compopts...");
+  for c in compopts do writeln(c);
 }
 
 /* run the bench tests gathered */
-proc runBenchTests(show:bool, ref cmdLineCompopts: list(string),
-    benchTestsFromDir: list(string), benchTestsFromToml: list(string)) throws {
-	try! {
-		if show then writeln("Running benchmarks ...");
-		const cwd = getEnv("PWD"); 
-		const projectHome = getProjectHome(cwd);
-		const toParse = open(projectHome + "/Mason.lock", iomode.r);
-		const lockFile = owned.create(parseToml(toParse));
-		const sourceList = genSourceList(lockFile);
-		getSrcCode(sourceList, show);
-		const project = lockFile["root"]!["name"]!.s;
-		const projectPath = "".join(projectHome, "/src/", project, ".chpl");
-		const compopts = getTomlCompopts(lockFile, cmdLineCompopts);
-		if isDir(joinPath(projectHome, "target/benchmark/")) {
-			rmTree(joinPath(projectHome, "target/benchmark/"));
-		}
-		// Make target files if they dont exist from a build
-		makeTargetFiles("debug", projectHome);
-		if show then writeln("Made target files...");
-		if(benchTestsFromToml.size > 0) {
-			// if benchTests found in Toml execute them only
-			// check if file actually exists in bench/ else show error that a file doesnt exist  
-			var invalidTests: list(string);
-			for bT in benchTestsFromToml {
-				var testPresentInDir: bool = false;
-				for benchT in benchTestsFromDir {
-					if(bT == basename(benchT)) then testPresentInDir = true;
-				}
-				if(testPresentInDir == false) then invalidTests.append(bT);
-			}
-			if invalidTests.size > 0 {
-				for test in invalidTests {
-					if invalidTests.size == 1 then write(test);
-					else write(test, ', ');
-				}
-				throw new owned MasonError("from Mason.toml could not be found in your benchmarks/ directory.");
-			} else {
-				// run benchmarks
-			}
-		} else {
-			// otherwise run other benchTests
-
-		}
-	}
-	catch e: MasonError {
-		writeln(e.message());
-		exit(1);
-	}
+proc runBenchTests(show: bool, ref cmdLineCompopts: list(string)) throws {
+  try! {
+    const cwd = getEnv("PWD");
+    const projectHome = getProjectHome(cwd);
+    const toParse = open(projectHome + "/Mason.lock" , iomode.r);
+    const lockFile = owned.create(parseToml(toParse));
+    const sourceList = genSourceList(lockFile);
+    getSrcCode(sourceList, show);
+    const project = lockFile["root"]!["name"]!.s;
+    const projectPath = "".join(projectHome, "/src/", project, ".chpl");
+    const compopts = getTomlCompopts(lockFile, cmdLineCompopts);
+    if isDir(joinPath(projectHome, "target/benchmark/")) {
+      rmTree(joinPath(projectHome, "target/benchmark/"));
+    }
+    makeTargetFiles("debug", projectHome);
+    var numBenchTests: int;
+    var benchTestNames: list(string);
+    var benchTestsCompiled: list(string);
+    if (files.size == 0 && dirs.size == 0) {
+      benchTestNames = getTests(lockFile.borrow(), projectHome, true);
+      numBenchTests = benchTestNames.size;
+    }
+    printMetadata(compopts, benchTestNames);
+  }
+  catch e: MasonError {
+    stderr.writeln(e.message());
+  }
 }
-

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -87,6 +87,7 @@ proc masonBenchHelp() {
   writeln('Options:');
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
+  writeln('        --[no]-update            [Do not] update the mason-registry before running benchmarks ');
   writeln();
 }
 

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -78,6 +78,18 @@ proc masonRunHelp() {
   writeln('   e.g. mason run --build - --runtimeArg=true');
 }
 
+proc masonBenchHelp() {
+  writeln('Run benchmarks using UnitTest Benchmarking framework.');
+  writeln();
+  writeln('Usage:');
+  writeln('    mason bench [options] <path>');
+  writeln();
+  writeln('Options:');
+  writeln('    -h, --help                   Display this message');
+  writeln('        --show                   Increase verbosity');
+  writeln();
+}
+
 proc masonBuildHelp() {
   writeln('Compile a local package and all of its dependencies');
   writeln();

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -276,6 +276,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         const outputLoc = projectHome + "/target/test/" + stripExt(testTemp, ".chpl");
         const moveTo = "-o " + outputLoc;
         const compCommand = " ".join("chpl",testPath, projectPath, moveTo, allCompOpts);
+        writeln(compCommand);
         const compilation = runWithStatus(compCommand, show);
         
         if compilation != 0 {

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -365,8 +365,8 @@ private proc printTestResults(ref result, timeElapsed) {
   }
 }
 
-
-private proc getMasonDependencies(sourceList: list(3*string),
+/* Get dependencies list from manifest */
+proc getMasonDependencies(sourceList: list(3*string),
                                  testName: string) {
 
   // Declare test to run as the main module

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -57,6 +57,7 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
   const target = joinPath(projectHome, 'target');
   const srcBin = joinPath(target, binLoc);
   const example = joinPath(target, 'example');
+  const benchmark = joinPath(target, 'benchmark');
 
   if !isDir(target) {
     mkdir(target);
@@ -66,6 +67,9 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
   }
   if !isDir(example) {
     mkdir(example);
+  }
+  if !isDir(benchmark) {
+    mkdir(benchmark);
   }
 
   const actualTest = joinPath(projectHome,'test');

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -37,6 +37,7 @@ use MasonSystem;
 use MasonExternal;
 use MasonPublish;
 use MasonInit;
+use MasonBench;
 
 /*
 
@@ -84,6 +85,7 @@ proc main(args: [] string) throws {
       when 'add' do masonModify(args);
       when 'rm' do masonModify(args);
       when 'build' do masonBuild(args);
+      when 'bench' do masonBench(args);
       when 'update' do masonUpdate(args);
       when 'run' do masonRun(args);
       when 'search' do masonSearch(args);


### PR DESCRIPTION
Aims to add a new `mason bench` command and extend the UnitTest module for running Benchmarks in Mason projects.

fixes #15680 