### PR TITLE
Use iteratorGroup in resolveForallHeader()

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -158,7 +158,6 @@ void ForallStmt::verify() {
   INT_ASSERT(fLoopBody->blockTag == BLOCK_NORMAL);
   INT_ASSERT(!fLoopBody->blockInfoGet());
   INT_ASSERT(!fLoopBody->isLoopStmt());
-  INT_ASSERT(!fLoopBody->useList);
   INT_ASSERT(!fLoopBody->userLabel);
   INT_ASSERT(!fLoopBody->byrefVars);
 

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -485,6 +485,8 @@ static ParIterFlavor findParIter(ForallStmt* pfs, CallExpr* iterCall,
                                  SymExpr* origSE, FnSymbol* origTarget)
 {
   ParIterFlavor retval = PIF_NONE;
+  IteratorGroup* igroup = origTarget ? origTarget->iteratorGroup : NULL;
+  FnSymbol* noniterFn = NULL;
 
   checkForExplicitTagArgs(iterCall);
 
@@ -495,14 +497,28 @@ static ParIterFlavor findParIter(ForallStmt* pfs, CallExpr* iterCall,
 
   // try standalone
   if (!pfs->zippered()) {
-    bool gotSA = tryResolveCall(iterCall);
+    bool gotSA = false;
+    if (igroup) {
+      gotSA = igroup->standalone != NULL;
+      if (gotSA) iterCall->baseExpr->replace(new SymExpr(igroup->standalone));
+      else noniterFn = igroup->noniterSA;
+    } else {
+      gotSA = tryResolveCall(iterCall);
+    }
     if (gotSA) retval = PIF_STANDALONE;
   }
 
   // try leader
   if (retval == PIF_NONE) {
     tag->actual->replace(new SymExpr(gLeaderTag));
-    bool gotLeader = tryResolveCall(iterCall);
+    bool gotLeader = false;
+    if (igroup) {
+      gotLeader = igroup->leader != NULL;
+      if (gotLeader) iterCall->baseExpr->replace(new SymExpr(igroup->leader));
+      else if (!noniterFn) noniterFn = igroup->noniterL;
+    } else {
+      gotLeader = tryResolveCall(iterCall);
+    }
     if (gotLeader) retval = PIF_LEADER;
   }
 
@@ -521,13 +537,16 @@ static ParIterFlavor findParIter(ForallStmt* pfs, CallExpr* iterCall,
   }
 
   if (retval == PIF_NONE) {
-    // Cannot USR_FATAL_CONT in general: e.g. if these() is not found,
-    // we do not know the type of the index variable.
-    // Without which we cannot typecheck the loop body.
+   if (noniterFn != NULL) {
+    USR_FATAL_CONT(iterCall, "The iterable-expression resolves to a non-iterator function '%s' when looking for a parallel iterator", noniterFn->name);
+    USR_PRINT(noniterFn, "The function '%s' is declared here", noniterFn->name);
+    USR_STOP();
+   } else {
     if (iterCall->isNamed("these") && isTypeExpr(iterCall->get(2)))
       USR_FATAL(iterCall, "unable to iterate over type '%s'", toString(iterCall->get(2)->getValType()));
     else
       USR_FATAL(iterCall, "A%s leader iterator is not found for the iterable expression in this forall loop", pfs->zippered() ? "" : " standalone or");
+   }
   }
 
   return retval;
@@ -808,19 +827,6 @@ static void addParIdxVarsAndRestruct(ForallStmt* fs, VarSymbol* parIdx) {
   INT_ASSERT(fs->numInductionVars() == 1);
 }
 
-static void checkForNonIterator(IteratorGroup* igroup, ParIterFlavor flavor,
-                                CallExpr* parCall)
-{
-  if ((flavor == PIF_STANDALONE && igroup->noniterSA) ||
-      (flavor == PIF_LEADER     && igroup->noniterL)   )
-  {
-    FnSymbol* dest = parCall->resolvedFunction();
-    USR_FATAL_CONT(parCall, "The iterable-expression resolves to a non-iterator function '%s' when looking for a parallel iterator", dest->name);
-    USR_PRINT(dest, "The function '%s' is declared here", dest->name);
-    USR_STOP();
-  }
-}
-
 static RetTag iteratorTag(FnSymbol* iterFn) {
   IteratorInfo* ii = iterFn->iteratorInfo;
   if (ii == NULL) {
@@ -1016,7 +1022,7 @@ CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
 
   checkWhenOverTupleExpand(pfs);
 
-  FnSymbol* origTarget = NULL; //for assertions
+  FnSymbol* origTarget = NULL;
   CallExpr* iterCall = buildForallParIterCall(pfs, origSE, origTarget);
 
   // So we know where iterCall is.
@@ -1033,21 +1039,6 @@ CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
   CallExpr* firstIterCall = iterCall;
   FnSymbol* origIterFn = iterCall->resolvedFunction();
   bool gotSA = (flavor != PIF_LEADER); // "got Single iterAtor"
-
-  if (origTarget) {
-    IteratorGroup* igroup = origTarget->iteratorGroup;
-    checkForNonIterator(igroup, flavor, iterCall);
-
-    if (origTarget == origIterFn) {
-      INT_ASSERT(flavor == PIF_SERIAL);
-      INT_ASSERT(pfs->allowSerialIterator());
-      INT_ASSERT(origIterFn == igroup->serial);
-    } else if (gotSA) {
-      INT_ASSERT(origIterFn == igroup->standalone);
-    } else {
-      INT_ASSERT(origIterFn == igroup->leader);
-    }
-  }
 
   if (flavor == PIF_SERIAL && pfs->numIteratedExprs() > 1) {
     // numIteratedExprs() is a good number to check, right?

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -165,7 +165,7 @@ LOGISTICS
 
 IteratorGroup::IteratorGroup() :
   serial(NULL), standalone(NULL), leader(NULL), follower(NULL),
-  noniterSA(false), noniterL(false)
+  noniterSA(NULL), noniterL(NULL)
 {}
 
 static bool isIteratorOrForwarder(FnSymbol* it) {
@@ -182,7 +182,7 @@ static bool isIteratorOrForwarder(FnSymbol* it) {
 // Look for the iterator for 'iterKindTag' and update the iterator group.
 static void checkParallelIterator(FnSymbol* serial, Expr* call,
                                   Symbol* iterKindTag, IteratorGroup* igroup,
-                                  FnSymbol*& outParIter, bool& noniterFlag)
+                                  FnSymbol*& outParIter, FnSymbol*& noniterFn)
 {
   // Build a "representative call".
   CallExpr* repCall = new CallExpr(new UnresolvedSymExpr(serial->name));
@@ -210,7 +210,7 @@ static void checkParallelIterator(FnSymbol* serial, Expr* call,
     } else {
       // If this is not an iterator, do not record it.
       // We may need to raise an error later.
-      noniterFlag = true;
+      noniterFn = parIter;
     }
   }
 

--- a/compiler/include/iterator.h
+++ b/compiler/include/iterator.h
@@ -60,7 +60,7 @@ public:
   FnSymbol* follower;
 
   // Search for a standalone/leader gave a non-iterator/forwarder.
-  bool noniterSA, noniterL;
+  FnSymbol *noniterSA, *noniterL;
 
   IteratorGroup();
 };


### PR DESCRIPTION
resolveForallHeader() used to resolve a parallel iterator call
to find the standalone or leader iterator. If a relevant iteratorGroup
were available, resolveForallHeader() used to assert that the iterator
produced by call resolution matched the one stored in the iteratorGroup.

I wrote the code this way to ensure that iteratorGroup worked properly.
Now that the assertions have been holding for many months, I am ready
to use the iterator from the iteratorGroup instead of call resolution,
when the iteratorGroup is available.

I am keeping the code path that uses call resolution because an iteratorGroup
may not be available, ex. when the iterable expression is a variable.

While there: remove an inappropriate assertion in ForallStmt::verify(),
which ensured that the forall body does not have a 'use' statement.
Now we can compile arkouda with --verify.

Testing: linux64 with futures, multilocale tests with futures.