### PR TITLE
Make our modulefile more compatible with Lmod

### DIFF
--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -107,7 +107,7 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
         set mpichLoaded 0
     }
     # Logic for mpich is split into loading and unloading phases
-    if { !([is-loaded chapel] == 1) }  {
+    if { [ module-info mode load ] } {
         # Loading chapel
 
         if {$mpichLoaded} {
@@ -188,7 +188,7 @@ if { [info exists env(CHPL_COMM)] } {
 
 set hugepagesLoaded [string match "*HUGETLB*" $env(PE_PRODUCT_LIST)]
 # Logic for hugepages is split into loading and unloading phases
-if { !([is-loaded chapel] == 1) }  {
+if { [ module-info mode load ] } {
     # Loading chapel
 
     if {$hugepagesLoaded} {


### PR DESCRIPTION
The `is-loaded` command always returns false under Lmod, so switch to
using `module-info mode load` to determine if we're loading or unloading
the module. I think this is the preferred way to do this even under Tcl,
at least based on the few results I was able to find online and by
looking at other Cray modulefiles.

I couldn't find any info about is-loaded not working under Lmod, but I
had a hard time finding any relevant search results when I was trying to
look that up. No other Cray modulefiles use it, and I didn't find much
online.