### PR TITLE
Make FFTWlib primer's compopts conditional

### DIFF
--- a/test/release/examples/primers/FFTWlib.compopts
+++ b/test/release/examples/primers/FFTWlib.compopts
@@ -1,1 +1,9 @@
--I$FFTW_DIR/include -L$FFTW_DIR/lib -sautoInitFFTW_MT=false  -lfftw3
+#!/usr/bin/env bash
+system=$($CHPL_HOME/util/printchplenv | grep 'CHPL_TARGET_PLATFORM' | cut -d\  -f2)
+
+if [ "$system" = "cray-xc" ] || [ "$system" = "cray-cs" ]
+then 
+    echo "-I$FFTW_INC -L$FFTW_DIR -sautoInitFFTW_MT=false  -lfftw3"
+else
+    echo "-I$FFTW_DIR/include -L$FFTW_DIR/lib -sautoInitFFTW_MT=false  -lfftw3"
+fi


### PR DESCRIPTION
With some tests moved to a CS system, we need to adjust this test's compopts
to adapt for the FFTW module's setup on CS systems. This PR sets include and lib
paths based on `CHPL_TARGET_PLATFORM`.

Confirmed on CS that the test is not skipped and runs successfully.