### PR TITLE
Source to setup correct cmake version for LLVM on CS

### DIFF
--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -47,7 +47,13 @@ if test "$CHPL_LLVM" = llvm; then
     if [ -f "${cmake_setup}" ] ; then
         source ${cmake_setup}
     else
-        echo "[Warning: llvm may not build correctly with cmake: $(which cmake)]"
+        # This is the path to look for on CS systems we have
+        cmake_setup=/cray/css/users/chapelu/setup_cmake39.bash
+        if [ -f "${cmake_setup}" ] ; then
+            source ${cmake_setup}
+        else
+            echo "[Warning: llvm may not build correctly with cmake: $(which cmake)]"
+        fi
     fi
 fi
 


### PR DESCRIPTION
The version of cmake we have on the CS system that we recently
 started using for correctness test is lower than what LLVM needs.
The typical path we have for higher cmake version is no
 accessible on that system. This PR adds the new path.

[Reviewed by @ronawho]