### PR TITLE
Don't set LIBFABRIC_DIR in the Shasta module.

### DIFF
--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -153,21 +153,12 @@ if { [string match cray-shasta $CHPL_HOST_PLATFORM] } {
         module swap PrgEnv-pgi PrgEnv-gnu
     }
 
-    # Some libraries are not yet available in static form.
+    # Some libraries are not available in static form.
     setenv CRAYPE_LINK_TYPE dynamic
 
-    # Work around libfabric module not setting everything we need yet:
-    # set LIBFABRIC_DIR to the parent of libfabric's PATH entry.
     if { ! [info exists env(LOADEDMODULES)] ||
          ! [string match *libfabric* $env(LOADEDMODULES)] } {
         module load libfabric
-    }
-    if { [info exists env(PATH)] &&
-         [regsub {^(.*:)?([^:]*libfabric[^:]*)/bin.*} $env(PATH) {\2} lfp] == 1
-       } {
-        setenv LIBFABRIC_DIR $lfp
-    } else {
-        puts stderr "Error: Cannot find libfabric path"
     }
 }
 


### PR DESCRIPTION
(Duplicate PR #16210 from master to release/1.22.)

The system libfabric module for Shasta appears to have matured to the
point that we can depend on it to set `PKG_CONFIG_PATH` so that we can
always find libfabric. Therefore, stop setting `LIBFABRIC_DIR`, which we
were using to compensate for not having `PKG_CONFIG_PATH`.

As a side effect, this also solves a problem on some Shasta systems
where `libfabric.so` is in a `.../lib64` directory but our `util/chplenv`
scripts were searching `$LIBFABRIC_DIR/lib`.