### PR TITLE
Make caching of generic instantiations POI-aware 

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -55,6 +55,7 @@ FnSymbol::FnSymbol(const char* initName)
   retTag             = RET_VALUE;
   iteratorInfo       = NULL;
   iteratorGroup      = NULL;
+  cacheInfo          = NULL;
   _this              = NULL;
   instantiatedFrom   = NULL;
   _instantiationPoint = NULL;
@@ -82,14 +83,9 @@ FnSymbol::FnSymbol(const char* initName)
 FnSymbol::~FnSymbol() {
   cleanupIteratorInfo(this);
   cleanupIteratorGroup(this);
-
+  cleanupCacheInfo(this);
   BasicBlock::clear(this);
-  delete basicBlocks;
-
-  if (calledBy) {
-    delete calledBy;
-    calledBy = NULL;
-  }
+  delete calledBy;
 }
 
 void FnSymbol::verify() {

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -878,7 +878,10 @@ Expr* debugParentExpr(BaseAST* ast) {
   }
 }
 
-// print minimal information about each statement in the block
+//
+// blockSummary: print minimal information about each statement in the block
+//
+
 void blockSummary(int id) {
   if (BaseAST* ast = aid09(id))
     blockSummary(ast);
@@ -946,10 +949,10 @@ void blockSummary(BlockStmt* block, Symbol* sym) {
     summarySymbolPrint(sym, "in ", "\n");
 }
 
-
 //
 // map_view: print the contents of a SymbolMap
 //
+
 void map_view(SymbolMap* map) {
   map_view(*map);
 }
@@ -986,9 +989,8 @@ void map_view(SymbolMap& map) {
   log_need_space = temp_log_need_space;
 }
 
-
 //
-// vec_view: print the contents of a Vec.
+// vec_view: print the contents of a Vec or a std::vector
 //
 
 static void showFnSymbol(FnSymbol* fn) {
@@ -1136,11 +1138,26 @@ void vec_view(Vec<ResolutionCandidate*, VEC_INTEGRAL_SIZE>& v) {
   }
 }
 
+//
+// set_view: print the contents of a std::set
+//
 
+void set_view(std::set<BlockStmt*>* bss) {
+  set_view(*bss);
+}
+
+void set_view(std::set<BlockStmt*>& bss) {
+  printf("set<BlockStmt> %d elm(s)\n", (int)bss.size());
+  std::set<BlockStmt*>::iterator it = bss.begin();
+  while (it != bss.end()) {
+    debugSummary(*(it++));
+  }
+}
 
 //
 // fnsWithName: print all FnSymbols with the given name
 //
+
 void fnsWithName(const char* name) {
   fnsWithName(name, gFnSymbols);
 }
@@ -1163,6 +1180,7 @@ void fnsWithName(const char* name, Vec<FnSymbol*,VEC_INTEGRAL_SIZE>& fnVec) {
 //
 // whocalls: print all ways that the AST with the given 'id' is invoked
 //
+
 static void whocalls(int id, Symbol* sym);
 
 void whocalls(BaseAST* ast) {

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -24,7 +24,9 @@
 #include "library.h"
 #include "symbol.h"
 
-class IteratorGroup;
+class IteratorGroup;     // see iterator.h
+class GenericsCacheInfo; // see caches.h
+void cleanupCacheInfo(FnSymbol* fn);
 
 enum RetTag {
   RET_VALUE,
@@ -61,6 +63,8 @@ public:
   IteratorInfo*              iteratorInfo;
   // Pointers to other iterator variants - serial, standalone, etc.
   IteratorGroup*             iteratorGroup;
+  // Support for genericsCache.
+  GenericsCacheInfo*         cacheInfo;
 
   Symbol*                    _this;
   FnSymbol*                  instantiatedFrom;

--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -29,6 +29,7 @@
 
 class ArgSymbol;
 class CallInfo;
+class VisibilityInfo;
 class FnSymbol;
 class Symbol;
 
@@ -83,7 +84,8 @@ class ResolutionCandidate {
 public:
                           ResolutionCandidate(FnSymbol* fn);
 
-  bool                    isApplicable(CallInfo& info);
+  bool                    isApplicable(CallInfo& info,
+                                       VisibilityInfo* visInfo);
 
   FnSymbol*               fn;
   std::vector<Symbol*>    formalIdxToActual;
@@ -95,9 +97,11 @@ public:
 private:
                           ResolutionCandidate();
 
-  bool                    isApplicableConcrete(CallInfo& info);
+  bool                    isApplicableConcrete(CallInfo& info,
+                                               VisibilityInfo* visInfo);
 
-  bool                    isApplicableGeneric(CallInfo& info);
+  bool                    isApplicableGeneric(CallInfo& info,
+                                              VisibilityInfo* visInfo);
 
   bool                    computeAlignment(CallInfo& info);
 
@@ -114,7 +118,8 @@ private:
 
   void                    resolveTypedefedArgTypes();
 
-  bool                    checkResolveFormalsWhereClauses(CallInfo& info);
+  bool                    checkResolveFormalsWhereClauses(CallInfo& info,
+                                                    VisibilityInfo* visInfo);
 
   bool                    checkGenericFormals(Expr* ctx);
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 class CallInfo;
+class VisibilityInfo;
 class ResolutionCandidate;
 
 struct Serializers {
@@ -170,8 +171,9 @@ Expr* lowerPrimReduce(CallExpr* call);
 
 void buildFastFollowerChecksIfNeeded(CallExpr* checkCall);
 
-FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs);
-FnSymbol* instantiateSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call);
+FnSymbol* instantiateWithoutCall(FnSymbol* fn, SymbolMap& subs);
+FnSymbol* instantiateSignature(FnSymbol* fn, SymbolMap& subs,
+                               VisibilityInfo* info);
 void      instantiateBody(FnSymbol* fn);
 
 // generics support

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -78,6 +78,9 @@ void        viewFlags(int id);
 void        map_view(SymbolMap* map);
 void        map_view(SymbolMap& map);
 
+void        set_view(std::set<BlockStmt*>* bss);
+void        set_view(std::set<BlockStmt*>& bss);
+
 void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>* v);
 void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>& v);
 void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>* v);

--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -33,19 +33,41 @@ class FnSymbol;
 
 class VisibilityInfo {
 public:
+  // for proper scope traversal
   BlockStmt* currStart;
   BlockStmt* nextPOI;
-  VisibilityInfo() : currStart(NULL), nextPOI(NULL) {}
+
+  // for CalledFunInfo
+  std::vector<BlockStmt*> visitedScopes; // in visited order  
+  std::vector<BlockStmt*> instnPoints;   // one per POI depth
+  int poiDepth;
+  CallExpr* call;
+
+  VisibilityInfo(CallExpr* call_) :
+    currStart(NULL), nextPOI(NULL), poiDepth(-1), call(call_) { }
+
+  bool inPOI() { return poiDepth > 0; }
 };
 
-void       findVisibleFunctions(CallInfo&       info,
-                                Vec<FnSymbol*>& visibleFns);
+bool isTypeHelperName(const char* fnName);
+bool cachedInstantiationIsAlwaysApplicable(FnSymbol* fn);
+bool cachedInstantiationIsAlwaysApplicable(CallExpr* call);
+bool scopeMayDefineHazard(BlockStmt* scope, const char* fnName);
+
+void       findVisibleFunctionsAllPOIs(CallInfo&       info,
+                                       Vec<FnSymbol*>& visibleFns);
 
 void       findVisibleFunctions(CallInfo&             info,
                                 VisibilityInfo*       visInfo,
                                 std::set<BlockStmt*>* visited,
                                 int*                  numVisitedP,
                                 Vec<FnSymbol*>&       visibleFns);
+
+void       getVisibleFunctions(const char*                name,
+                                CallExpr*                call,
+                                VisibilityInfo*          visInfo,
+                                std::set<BlockStmt*>*    visited,
+                                Vec<FnSymbol*>&          visibleFns);
 
 void       getVisibleFunctions(const char*      name,
                                CallExpr*        call,

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -59,7 +59,8 @@ ResolutionCandidate::ResolutionCandidate(FnSymbol* function) {
 *                                                                             *
 ************************************** | *************************************/
 
-bool ResolutionCandidate::isApplicable(CallInfo& info) {
+bool ResolutionCandidate::isApplicable(CallInfo& info,
+                                       VisibilityInfo* visInfo) {
   bool retval = false;
 
   TagGenericResult tagResult = fn->tagIfGeneric(NULL, true);
@@ -67,9 +68,9 @@ bool ResolutionCandidate::isApplicable(CallInfo& info) {
     return false;
 
   if (! fn->isGeneric()) {
-    retval = isApplicableConcrete(info);
+    retval = isApplicableConcrete(info, visInfo);
   } else {
-    retval = isApplicableGeneric (info);
+    retval = isApplicableGeneric(info, visInfo);
   }
 
   // Note: for generic instantiations, this code will be executed twice.
@@ -84,7 +85,8 @@ bool ResolutionCandidate::isApplicable(CallInfo& info) {
   return retval;
 }
 
-bool ResolutionCandidate::isApplicableConcrete(CallInfo& info) {
+bool ResolutionCandidate::isApplicableConcrete(CallInfo& info,
+                                               VisibilityInfo* visInfo) {
 
   fn = expandIfVarArgs(fn, info);
   if (fn == NULL) {
@@ -97,10 +99,11 @@ bool ResolutionCandidate::isApplicableConcrete(CallInfo& info) {
   if (computeAlignment(info) == false)
     return false;
 
-  return checkResolveFormalsWhereClauses(info);
+  return checkResolveFormalsWhereClauses(info, visInfo);
 }
 
-bool ResolutionCandidate::isApplicableGeneric(CallInfo& info) {
+bool ResolutionCandidate::isApplicableGeneric(CallInfo& info,
+                                              VisibilityInfo* visInfo) {
 
   FnSymbol* oldFn = fn;
 
@@ -126,7 +129,7 @@ bool ResolutionCandidate::isApplicableGeneric(CallInfo& info) {
    * Instantiate enough of the generic to get through the rest of the
    * filtering and disambiguation processes.
    */
-  fn = instantiateSignature(fn, substitutions, info.call);
+  fn = instantiateSignature(fn, substitutions, visInfo);
 
   if (fn == NULL) {
     reason = RESOLUTION_CANDIDATE_OTHER;
@@ -138,7 +141,7 @@ bool ResolutionCandidate::isApplicableGeneric(CallInfo& info) {
   if (fn == oldFn)
     return true;
 
-  return isApplicable(info);
+  return isApplicable(info, visInfo);
 }
 
 /************************************* | **************************************
@@ -703,7 +706,8 @@ static bool looksLikeCopyInit(ResolutionCandidate* rc) {
 *                                                                             *
 ************************************** | *************************************/
 
-bool ResolutionCandidate::checkResolveFormalsWhereClauses(CallInfo& info) {
+bool ResolutionCandidate::checkResolveFormalsWhereClauses(CallInfo& info,
+                                                    VisibilityInfo* visInfo) {
   int coindex = -1;
 
   /*
@@ -912,7 +916,7 @@ classifyTypeMismatch(Type* actualType, Type* formalType) {
 void explainCandidateRejection(CallInfo& info, FnSymbol* fn) {
   ResolutionCandidate c(fn);
 
-  c.isApplicable(info);
+  c.isApplicable(info, NULL);
 
   USR_PRINT(fn, "this candidate did not match: %s", toString(fn));
 

--- a/compiler/resolution/caches.cpp
+++ b/compiler/resolution/caches.cpp
@@ -19,7 +19,13 @@
  */
 
 #include "caches.h"
+
+#include "callInfo.h"
+#include "ResolutionCandidate.h"
 #include "stmt.h"
+#include "stringutil.h"
+#include "visibleFunctions.h"
+#include "view.h"
 
 
 /************************************* | **************************************
@@ -28,7 +34,6 @@
 *                                                                             *
 ************************************** | *************************************/
 
-SymbolMapCache genericsCache;
 SymbolMapCache promotionsCache;
 
 static bool isCacheEntryMatch(SymbolMap* s1, SymbolMap* s2);
@@ -93,4 +98,423 @@ static bool isCacheEntryMatch(SymbolMap* s1, SymbolMap* s2) {
   }
 
   return true;
+}
+
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+//
+// CalledFunInfo: information about one best candidate during resolution.
+// CalledFunInfo entries are stored in FnSymbol->cacheInfo.
+//
+// Cf. a "VisibilityInfo" participates in gathering visible functions
+// when resolving a call within that FnSymbol, then feeds into a CalledFunInfo.
+//
+class CalledFunInfo {
+public:
+  const char* fnName;       // the name being called
+  BlockStmt* declScope;          // the scope where the candidate is declared
+  std::set<BlockStmt*> visitedScopes; // scopes visited in getVisibleFunctions
+
+  // Is this CFI's function defined in the 'scope'?
+  inline bool isDeclarationScope(BlockStmt* scope) {
+    return scope == declScope;
+  }
+
+  // Was the 'scope' visited while resolving the call to this CFI's function?
+  inline bool inVisitedScopes(BlockStmt* scope) {
+    return visitedScopes.find(scope) != visitedScopes.end();
+  }
+
+  // Does the 'scope' define a fn that might change resolution outcome?
+  bool mayDefineHazard(BlockStmt* scope) {
+    return scopeMayDefineHazard(scope, fnName);
+  }
+
+  CalledFunInfo(const char* funName, BlockStmt* dScope,
+                std::vector<BlockStmt*> vScopes):
+    fnName(funName),
+    declScope(dScope),
+    visitedScopes(vScopes.begin(), vScopes.end())
+  { }
+};
+
+
+//
+// Information about all best candidates while resolving this fn.
+//
+class GenericsCacheInfo {
+public:
+  std::vector<CalledFunInfo> infos;
+  int size() { return (int)(infos.size()); }
+};
+
+
+//
+// genericsCacheSummary(): summarize various GC-related things for debugging
+//
+
+void genericsCacheSummary(CalledFunInfo* fi) {
+  if (fi == NULL) printf("<NULL>\n");
+  else genericsCacheSummary(*fi);
+}
+
+void genericsCacheSummary(CalledFunInfo& fi) {
+  printf("CFI \"%s\"  declScope %d %s  visitedScopes %d:", fi.fnName,
+         fi.declScope->id, debugLoc(fi.declScope),
+         (int)fi.visitedScopes.size());
+  for_set(BlockStmt, block, fi.visitedScopes) printf(" %d", block->id);
+  printf("\n");
+}
+
+void genericsCacheSummary(GenericsCacheInfo* ci) {
+  if (ci == NULL) printf("<NULL>\n");
+  else genericsCacheSummary(*ci);
+}
+
+void genericsCacheSummary(GenericsCacheInfo& ci) {
+  printf("GenericsCacheInfo {\n");
+  for (std::vector<CalledFunInfo>::iterator it = ci.infos.begin();
+       it != ci.infos.end(); it++) {
+    printf("  ");
+    genericsCacheSummary(*it);
+  }
+  printf("GenericsCacheInfo }  %d infos\n\n", ci.size());
+}
+
+void genericsCacheSummary(VisibilityInfo* visInfo) {
+  if (visInfo == NULL) printf("<NULL>\n");
+  else genericsCacheSummary(*visInfo);
+}
+
+// todo also show visInfo.currStart, visInfo.nextPOI?
+void genericsCacheSummary(VisibilityInfo& visInfo) {
+  printf("{visitedScopes %d:", (int)visInfo.visitedScopes.size());
+  for_vector(BlockStmt, block, visInfo.visitedScopes)
+    printf(" %d", block->id);
+  printf("\n");
+
+  printf("instnPoints %d:\n", (int)visInfo.instnPoints.size());
+  for_vector(BlockStmt, block, visInfo.instnPoints)
+    printf("  %d %s\n", block->id, debugLoc(block));
+
+  printf("}  poiDepth %d   call %d %s\n", visInfo.poiDepth,
+         visInfo.call->id, debugLoc(visInfo.call));
+}
+
+void genericsCacheSummary(int id) {
+  if (BaseAST* ast = aid09(id)) genericsCacheSummary(ast);
+  else printf("genericsCacheSummary: id %d"
+              "does not correspond to an AST node\n", id);
+}
+
+void genericsCacheSummary(BaseAST* ast) {
+  if (FnSymbol* fn = toFnSymbol(ast)) {
+    if (GenericsCacheInfo* ci = fn->cacheInfo) genericsCacheSummary(ci);
+    else printf("fn %s[%d] has null cacheInfo\n", fn->name, fn->id);
+  } else if (DefExpr* def = toDefExpr(ast)) {
+    if (FnSymbol* fn = toFnSymbol(def->sym)) genericsCacheSummary(fn);
+    else printf("def %d  defines %s[%d] that is a %s, not a fn\n",
+            def->id, def->sym->name, def->sym->id, def->sym->astTagAsString());
+  } else {
+    printf("genericsCacheSummary: %d is a %s, not a fn or def\n",
+           ast->id, ast->astTagAsString());
+  }
+}
+
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+SymbolMapScopeCache genericsCache;
+
+SymbolMapScopeCacheEntry::SymbolMapScopeCacheEntry(FnSymbol* ifn, SymbolMap* imap) :
+  fn(ifn), map(*imap) { }
+
+void
+addCache(SymbolMapScopeCache& cache,
+         FnSymbol*       oldFn,
+         FnSymbol*       fn,
+         SymbolMap*      map) {
+  Vec<SymbolMapScopeCacheEntry*>* entries = cache.get(oldFn);
+  SymbolMapScopeCacheEntry*       entry = new SymbolMapScopeCacheEntry(fn, map);
+
+  if (entries) {
+    entries->add(entry);
+
+  } else {
+    entries = new Vec<SymbolMapScopeCacheEntry*>();
+    entries->add(entry);
+    cache.put(oldFn, entries);
+  }
+}
+
+
+static bool isApplicableInstantiation(VisibilityInfo& visInfo,
+                                      FnSymbol* cgi);
+
+FnSymbol*
+checkCache(SymbolMapScopeCache& cache, FnSymbol* oldFn,
+           VisibilityInfo* visInfo, SymbolMap* map)
+{
+  if (Vec<SymbolMapScopeCacheEntry*>* entries = cache.get(oldFn)) {
+    forv_Vec(SymbolMapScopeCacheEntry, entry, *entries) {
+      if (isCacheEntryMatch(map, &entry->map) &&
+          (visInfo == NULL || isApplicableInstantiation(*visInfo, entry->fn)) )
+        return entry->fn;
+    }
+  }
+
+  return NULL;
+}
+
+
+void
+freeCache(SymbolMapScopeCache& cache) {
+  form_Map(SymbolMapScopeCacheElem, elem, cache) {
+    forv_Vec(SymbolMapScopeCacheEntry, entry, *elem->value) {
+      delete entry;
+    }
+    delete elem->value;
+  }
+  cache.clear();
+}
+
+//
+// GenericsCacheInfo interface
+//
+
+void createCacheInfoIfNeeded(FnSymbol* fn) {
+  INT_ASSERT(fn->cacheInfo == NULL);
+  if (fn->instantiatedFrom == NULL ||  // a concrete function
+      cachedInstantiationIsAlwaysApplicable(fn)) {
+    // In these cases we will not be checking applicability
+    // of a cached instantiation. So, do not compute cacheInfo.
+    return;
+  }
+  fn->cacheInfo = new GenericsCacheInfo();
+}
+
+void clearCacheInfoIfEmpty(FnSymbol* fn) {
+  if (GenericsCacheInfo* cacheInfo = fn->cacheInfo) {
+    if (cacheInfo->infos.empty()) {
+      delete cacheInfo;
+      fn->cacheInfo = NULL; // Make future checks cheaper.
+    }
+  }
+}
+
+void cleanupCacheInfo(FnSymbol* fn) {
+  delete fn->cacheInfo;
+  fn->cacheInfo = NULL;
+}
+
+// Add to parentInfos the cacheInfo of the FnSymbol containing 'expr'.
+// If the FnSymbol does not have a cacheInfo, return false.
+static bool addOneParentInfo(std::vector<GenericsCacheInfo*>& parentInfos,
+                             Expr* expr) {
+  FnSymbol* parentFn = expr->getFunction();
+  if (parentFn->cacheInfo == NULL)
+    return false;
+
+  parentInfos.push_back(parentFn->cacheInfo);
+  return true;
+}
+
+// Generate a CalledFunInfo for 'candidFn' based on 'visInfo'
+// and add it to all cacheInfos in 'parentInfos'.
+static void updateOneCandidate(std::vector<GenericsCacheInfo*>& parentInfos,
+                               FnSymbol* candidFn, VisibilityInfo& visInfo) {
+  if (candidFn->hasFlag(FLAG_COBEGIN_OR_COFORALL) ||
+      candidFn->hasFlag(FLAG_BEGIN) ||
+      candidFn->hasFlag(FLAG_ON))
+    return; // do not record
+
+  CalledFunInfo cfi(candidFn->name, getVisibilityScope(candidFn->defPoint),
+                    visInfo.visitedScopes);
+
+  // Performance opt: skip this loop if the previous "best" candidate
+  // had the same name and scope. ("scope" means its defPoint->parentExpr.)
+
+  for_vector(GenericsCacheInfo, pInfo, parentInfos)
+    pInfo->infos.push_back(cfi);
+}
+
+//
+// The call 'visInfo.call' resolves to the candidate(s) visible through
+// (one of) its POIs. So, 'visInfo.call' must be in an instantiation
+// of a generic function; we have cached this instantiation in genericsCache.
+// For this cache entry to be applicable to another call in the future, those
+// candidates will need to be visible from that call or its POI(s).
+//
+// Record this requirement in the cacheInfos of the FnSymbols containing
+// visInfo.call and the POI(s). The requirement represented as a CalledFunInfo
+// within FnSymbol->cacheInfo. The CalledFunInfo is generated based on
+// 'visInfo' in updateOneCandidate().
+//
+void updateCacheInfosForACall(VisibilityInfo& visInfo,
+                              ResolutionCandidate* best1,
+                              ResolutionCandidate* best2,
+                              ResolutionCandidate* best3) {
+  INT_ASSERT(visInfo.poiDepth <= (int)visInfo.instnPoints.size());
+
+  //
+  // 'parentInfos' contains the cacheInfos to be updated.
+  // We precompute this set as an optimization, so that updateOneCandidate
+  // can compute the CalledFunInfo once and reuse it for all cacheInfos.
+  //
+  std::vector<GenericsCacheInfo*> parentInfos;
+  parentInfos.reserve(visInfo.poiDepth);
+
+  if (!addOneParentInfo(parentInfos, visInfo.call))
+    // We hit a method-like function. Currently these are always applicable.
+    // Do not impose CFI constraint on it or its callers.
+    return;
+
+  for (int depth = 0; depth < visInfo.poiDepth - 1; depth++)
+    if (!addOneParentInfo(parentInfos, visInfo.instnPoints[depth]))
+      break;
+
+  if (best1) updateOneCandidate(parentInfos, best1->fn, visInfo);
+  if (best2) updateOneCandidate(parentInfos, best2->fn, visInfo);
+  if (best3) updateOneCandidate(parentInfos, best3->fn, visInfo);
+}
+
+//
+// isApplicableInstantiation() and helpers
+//
+
+//
+// Check how visInfo.visitedScopes, starting from 'startVS', cover the CFIs
+// in 'toProcess'. Nullify the CFIs that have been satisfied and decrement
+// 'remainingCFIs' correspondingly. If we encounter a scope that might make
+// this cached instantiation not applicable, return false.
+//
+static bool reportVisitedScopes(std::vector<CalledFunInfo*>& toProcess,
+                                             VisibilityInfo& visInfo,
+                                                        int& remainingCFIs,
+                                                        int  startVS)
+{
+  int sizeCI = (int)toProcess.size(); // usu. at most a couple of elements
+  int sizeVS = (int)visInfo.visitedScopes.size();
+
+  // Visit the scopes in the order they would be visited from fn's POI #1.
+  // For each CFI, check whether the result of getVisibleFunctions()
+  // that was done to resolve that call remains unchanged for this callsite.
+  for (int iVS = startVS; iVS < sizeVS; iVS++) {
+    BlockStmt* scope = visInfo.visitedScopes[iVS];
+
+    // See how each CFI does w.r.t. this scope.
+    for (int iCFI = 0; iCFI < sizeCI; iCFI++) {
+      // Skip the CFIs that we have already checked off.
+      if (CalledFunInfo* cfi = toProcess[iCFI]) {
+
+        if (cfi->isDeclarationScope(scope)) {
+          // We reached the scope where 'cfi' is defined.
+          // No more checking for this 'cfi' is needed. Check it off.
+          toProcess[iCFI] = NULL;
+          remainingCFIs--;
+          continue;
+        }
+
+        if (cfi->inVisitedScopes(scope)) {
+          // 'fn' visited this scope during resolution. OK so far.
+
+        } else if (!cfi->mayDefineHazard(scope)) {
+          // This scope does not define a hazard. OK so far.
+
+        } else {
+          // This scope defines something that might change the outcome of
+          // resolving the call represented by 'cfi'. In which case reusing
+          // this cached instantiation would not be correct.
+          // Conservatively, report this cached instantiation not applicable.
+          return true;
+        }
+      }
+    } // done traversing 'toProcess'
+
+    if (remainingCFIs == 0) break; // approved all CFIs
+
+  } // done traversing visInfo.visitedScopes
+
+  return false; // no hazard scopes have been found
+}
+
+//
+// The generic instantiation, here represented by 'toProcess', looks promising
+// so far. Visit additional POI(s), looking for the scopes of remaining CFIs.
+// If we skip this step, the compiler gets into infinite recursion in
+//   test/functions/generic/poi/expBySquaring-repro.chpl
+//
+static void visitMorePOIs(std::vector<CalledFunInfo*>& toProcess,
+                          VisibilityInfo&              visInfoOrig,
+                          int&                         remainingCFIs)
+{
+// Implementation: we call getVisibleFunctions() to get the official order of
+// scope traversal, following the steps in findVisibleFunctionsAndCandidates().
+// All we need from getVisibleFunctions is a vector of scopes,
+// so use a dummy name to avoid useless picking up any visible functions.
+//
+// Also we do not want to modify the original 'visInfo' and 'visited', as they
+// may be needed for further *real* calls to findVisibleFunctions(), ex. if
+// the current candidate ends up not applicable. So, use temporary variables.
+
+  int numVisitedVis = 0;
+  const char* dummyName = astr("");
+  VisibilityInfo visInfo(visInfoOrig.call);
+  visInfo.currStart = visInfoOrig.nextPOI;
+  Vec<FnSymbol*> visibleFns;
+  std::set<BlockStmt*> visited(visInfoOrig.visitedScopes.begin(),
+                               visInfoOrig.visitedScopes.end());
+  do {
+    visInfo.poiDepth++;
+
+    getVisibleFunctions(dummyName, visInfoOrig.call,
+                        &visInfo, &visited, visibleFns);
+
+    if (reportVisitedScopes(toProcess, visInfo, remainingCFIs, numVisitedVis))
+      return;
+
+    numVisitedVis = (int)visInfo.visitedScopes.size();
+    advanceCurrStart(visInfo);
+  }
+  while
+    (remainingCFIs > 0 && visInfo.currStart != NULL);
+}
+
+//
+// Is the cached generic instantiation 'fn' applicable to the call
+// described by 'visInfo' ?
+//
+static bool isApplicableInstantiation(VisibilityInfo& visInfo, FnSymbol* fn)
+{
+  GenericsCacheInfo* cacheInfo = fn->cacheInfo;
+  if (cacheInfo == NULL) return true;
+  int sizeCI = cacheInfo->size();
+
+  if (cachedInstantiationIsAlwaysApplicable(visInfo.call)) {
+    // we are not checking these for now - see createCacheInfoIfNeeded()
+    INT_FATAL(visInfo.call, "unexpected");
+    return true;
+  }
+
+  int remainingCFIs = sizeCI;
+  std::vector<CalledFunInfo*> toProcess(sizeCI); // working copy
+  for (int i = 0; i < sizeCI; i++) toProcess[i] = &(cacheInfo->infos[i]);
+
+  if (reportVisitedScopes(toProcess, visInfo, remainingCFIs, 0))
+      return false;
+
+  if (remainingCFIs > 0 && visInfo.nextPOI != NULL)
+    visitMorePOIs(toProcess, visInfo, remainingCFIs);
+
+  // Return true if we have found the declaring scopes of all CFIs.
+  return remainingCFIs == 0;
 }

--- a/compiler/resolution/caches.cpp
+++ b/compiler/resolution/caches.cpp
@@ -397,10 +397,10 @@ void updateCacheInfosForACall(VisibilityInfo& visInfo,
 // 'remainingCFIs' correspondingly. If we encounter a scope that might make
 // this cached instantiation not applicable, return false.
 //
-static bool reportVisitedScopes(std::vector<CalledFunInfo*>& toProcess,
-                                             VisibilityInfo& visInfo,
-                                                        int& remainingCFIs,
-                                                        int  startVS)
+static bool analyzeVisitedScopes(std::vector<CalledFunInfo*>& toProcess,
+                                              VisibilityInfo& visInfo,
+                                                         int& remainingCFIs,
+                                                         int  startVS)
 {
   int sizeCI = (int)toProcess.size(); // usu. at most a couple of elements
   int sizeVS = (int)visInfo.visitedScopes.size();
@@ -479,7 +479,7 @@ static void visitMorePOIs(std::vector<CalledFunInfo*>& toProcess,
     getVisibleFunctions(dummyName, visInfoOrig.call,
                         &visInfo, &visited, visibleFns);
 
-    if (reportVisitedScopes(toProcess, visInfo, remainingCFIs, numVisitedVis))
+    if (analyzeVisitedScopes(toProcess, visInfo, remainingCFIs, numVisitedVis))
       return;
 
     numVisitedVis = (int)visInfo.visitedScopes.size();
@@ -509,7 +509,7 @@ static bool isApplicableInstantiation(VisibilityInfo& visInfo, FnSymbol* fn)
   std::vector<CalledFunInfo*> toProcess(sizeCI); // working copy
   for (int i = 0; i < sizeCI; i++) toProcess[i] = &(cacheInfo->infos[i]);
 
-  if (reportVisitedScopes(toProcess, visInfo, remainingCFIs, 0))
+  if (analyzeVisitedScopes(toProcess, visInfo, remainingCFIs, 0))
       return false;
 
   if (remainingCFIs > 0 && visInfo.nextPOI != NULL)

--- a/compiler/resolution/caches.h
+++ b/compiler/resolution/caches.h
@@ -23,6 +23,11 @@
 
 #include "baseAST.h"
 
+class CalledFunInfo;
+class VisibilityInfo;
+class GenericsCacheInfo;
+class ResolutionCandidate;
+
 //
 // SymbolMapCache: FnSymbol -> FnSymbol cache based on a SymbolMap
 //
@@ -69,7 +74,74 @@ void      freeCache(SymbolMapCache& cache);
 // wrappers for constructors.
 //
 
-extern SymbolMapCache genericsCache;
 extern SymbolMapCache promotionsCache;
+
+//
+// SymbolMapScopeCache: FnSymbol -> FnSymbol cache based on a SymbolMap+scope
+//
+//   addCache(cache, old_fn, new_fn, map): adds an entry to cache from
+//                                         old_fn to new_fn via map
+//
+//   checkCache(cache, fn, map): returns a function previously added
+//                               via addMapCache if fn matches old_fn
+//                               and the maps contain the same
+//                               key-value pairs (in any order)
+//
+//   freeCache(cache): frees memory associated with cache
+//
+class SymbolMapScopeCacheEntry {
+public:
+  SymbolMapScopeCacheEntry(FnSymbol* ifn, SymbolMap* imap);
+
+  FnSymbol* fn;
+  SymbolMap map;
+};
+
+typedef Map<FnSymbol*,     Vec<SymbolMapScopeCacheEntry*>*> SymbolMapScopeCache;
+typedef MapElem<FnSymbol*, Vec<SymbolMapScopeCacheEntry*>*> SymbolMapScopeCacheElem;
+
+void      addCache(SymbolMapScopeCache& cache,
+                   FnSymbol*       oldFn,
+                   FnSymbol*       newFn,
+                   SymbolMap*      map);
+
+FnSymbol* checkCache(SymbolMapScopeCache& cache,
+                     FnSymbol*            oldFn,
+                     VisibilityInfo*      visInfo,
+                     SymbolMap*           map);
+
+void      freeCache(SymbolMapScopeCache& cache);
+
+void      advanceCurrStart(VisibilityInfo& visInfo);
+
+//
+// Caches to avoid creating multiple identical wrappers and
+// instantiating the same functions in the same ways
+//
+// Note that these caches are necessary for correctness, not just
+// performance, because they can impact the types that are created
+// when instantiating constructors and building up the default
+// wrappers for constructors.
+//
+
+extern SymbolMapScopeCache genericsCache;
+
+// for debugging
+void genericsCacheSummary(CalledFunInfo* fi);
+void genericsCacheSummary(CalledFunInfo& fi);
+void genericsCacheSummary(GenericsCacheInfo* ci);
+void genericsCacheSummary(GenericsCacheInfo& ci);
+void genericsCacheSummary(VisibilityInfo* visInfo);
+void genericsCacheSummary(VisibilityInfo& visInfo);
+void genericsCacheSummary(int id);
+void genericsCacheSummary(BaseAST* ast);
+
+// GenericsCacheInfo interface
+void createCacheInfoIfNeeded(FnSymbol* fn);
+void clearCacheInfoIfEmpty(FnSymbol* fn);
+void updateCacheInfosForACall(VisibilityInfo& visInfo,
+                              ResolutionCandidate* best1,
+                              ResolutionCandidate* best2,
+                              ResolutionCandidate* best3);
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3031,6 +3031,7 @@ static FnSymbol* resolveNormalCall(CallExpr* call, check_state_t checkState);
 
 static void      findVisibleFunctionsAndCandidates(
                                      CallInfo&                  info,
+                                     VisibilityInfo&            visInfo,
                                      Vec<FnSymbol*>&            visibleFns,
                                      Vec<ResolutionCandidate*>& candidates);
 
@@ -3384,18 +3385,19 @@ static FnSymbol* resolveNormalCall(CallInfo& info, check_state_t checkState) {
   ResolutionCandidate*      bestCref   = NULL;
   ResolutionCandidate*      bestVal    = NULL;
 
+  VisibilityInfo            visInfo(info.call);
   int                       numMatches = 0;
 
   FnSymbol*                 retval     = NULL;
 
-  findVisibleFunctionsAndCandidates(info, mostApplicable, candidates);
+  findVisibleFunctionsAndCandidates(info, visInfo, mostApplicable, candidates);
 
-  numMatches = disambiguateByMatch(info,
-                                   candidates,
+  numMatches = disambiguateByMatch(info, candidates,
+                                   bestRef, bestCref, bestVal);
 
-                                   bestRef,
-                                   bestCref,
-                                   bestVal);
+  if (checkState == CHECK_NORMAL_CALL && visInfo.inPOI())
+    updateCacheInfosForACall(visInfo,
+                             bestRef, bestCref, bestVal);
 
   // If no candidates were found and it's a method, try forwarding
   if (candidates.n                  == 0 &&
@@ -4050,8 +4052,8 @@ struct ExampleCandidateComparator {
     ResolutionCandidate* a = new ResolutionCandidate(aFn);
     ResolutionCandidate* b = new ResolutionCandidate(bFn);
 
-    a->isApplicable(info);
-    b->isApplicable(info);
+    a->isApplicable(info, NULL);
+    b->isApplicable(info, NULL);
 
     if (failedCandidateIsBetterMatch(a, b))
       ret = true;
@@ -4299,11 +4301,15 @@ static void generateUnresolvedMsg(CallInfo& info, Vec<FnSymbol*>& visibleFns) {
 //
 typedef std::vector<FnSymbol*> LastResortCandidates;
 
-// add a null separator if needed
+// add a null separator
 static void markEndOfPOI(LastResortCandidates& lrc) {
-  if (int sz = (int) lrc.size())
-    if (lrc[sz-1] != NULL)
-      lrc.push_back(NULL);
+  lrc.push_back(NULL);
+}
+
+// do we have any LRCs to look at?
+static bool haveAnyLRCs(LastResortCandidates& lrc, int poiDepth) {
+  // discount (visInfo.poiDepth+1) nulls that are separators
+  return (int)lrc.size() > (poiDepth + 1);
 }
 
 // do we have more LRCs to look at?
@@ -4312,20 +4318,24 @@ static bool haveMoreLRCs(LastResortCandidates& lrc, int numVisited) {
 }
 
 static void filterCandidate (CallInfo&                  info,
+                             VisibilityInfo&            visInfo,
                              FnSymbol*                  fn,
                              Vec<ResolutionCandidate*>& candidates);
 
 static void gatherCandidates(CallInfo&                  info,
+                             VisibilityInfo&            visInfo,
                              FnSymbol*                  fn,
                              Vec<ResolutionCandidate*>& candidates);
 
-static void gatherCandidatesAndLastResort(CallInfo& info,
+static void gatherCandidatesAndLastResort(CallInfo&     info,
+                             VisibilityInfo&            visInfo,
                              Vec<FnSymbol*>&            visibleFns,
                              int&                       numVisited,
                              LastResortCandidates&      lrc,
                              Vec<ResolutionCandidate*>& candidates);
 
 static void gatherLastResortCandidates(CallInfo&                  info,
+                                       VisibilityInfo&            visInfo,
                                        LastResortCandidates&      lrc,
                                        int&                       numVisited,
                                        Vec<ResolutionCandidate*>& candidates);
@@ -4413,8 +4423,18 @@ void trimVisibleCandidates(CallInfo&       info,
   trimVisibleCandidates(info, mostApplicable, numVisitedVis, visibleFns);
 }
 
+void advanceCurrStart(VisibilityInfo& visInfo) {
+  INT_ASSERT((int)visInfo.instnPoints.size() == visInfo.poiDepth);
+  if (visInfo.nextPOI != NULL)
+    visInfo.instnPoints.push_back(visInfo.nextPOI);
+
+  visInfo.currStart = visInfo.nextPOI;
+  visInfo.nextPOI = NULL;
+}
+
 static void findVisibleFunctionsAndCandidates(
                                 CallInfo&                  info,
+                                VisibilityInfo&            visInfo,
                                 Vec<FnSymbol*>&            mostApplicable,
                                 Vec<ResolutionCandidate*>& candidates) {
   CallExpr* call = info.call;
@@ -4428,7 +4448,7 @@ static void findVisibleFunctionsAndCandidates(
     handleTaskIntentArgs(info, fn);
 
     // no need for trimVisibleCandidates() and findVisibleCandidates()
-    gatherCandidates(info, fn, candidates);
+    gatherCandidates(info, visInfo, fn, candidates);
 
     explainGatherCandidate(info, candidates);
 
@@ -4442,29 +4462,37 @@ static void findVisibleFunctionsAndCandidates(
   int numVisitedVis = 0, numVisitedMA = 0;
   LastResortCandidates lrc;
   std::set<BlockStmt*> visited;
-  VisibilityInfo visInfo;
   visInfo.currStart = getVisibilityScope(call);
+  INT_ASSERT(visInfo.poiDepth == -1); // we have not used it
 
   do {
+    visInfo.poiDepth++;
+
     findVisibleFunctions(info, &visInfo, &visited,
                          &numVisitedVis, visibleFns);
 
     trimVisibleCandidates(info, mostApplicable,
                           numVisitedVis, visibleFns);
 
-    gatherCandidatesAndLastResort(info, mostApplicable, numVisitedMA,
+    gatherCandidatesAndLastResort(info, visInfo, mostApplicable, numVisitedMA,
                                   lrc, candidates);
 
-    visInfo.currStart = visInfo.nextPOI;
-    visInfo.nextPOI = NULL;
+    advanceCurrStart(visInfo);
   }
   while
     (candidates.n == 0 && visInfo.currStart != NULL);
 
-  // If needed, look at "last resort" candidates.
-  int numVisitedLRC = 0;
-  while (candidates.n == 0 && haveMoreLRCs(lrc, numVisitedLRC)) {
-    gatherLastResortCandidates(info, lrc, numVisitedLRC, candidates);
+  // If we have not found any candidates after traversing all POIs,
+  // look at "last resort" candidates, if any.
+  if (candidates.n == 0 && haveAnyLRCs(lrc, visInfo.poiDepth)) {
+    visInfo.poiDepth = -1;
+    int numVisitedLRC = 0;
+    do {
+      visInfo.poiDepth++;
+      gatherLastResortCandidates(info, visInfo, lrc, numVisitedLRC, candidates);
+    }
+    while
+      (candidates.n == 0 && haveMoreLRCs(lrc, numVisitedLRC));
   }
 
   explainGatherCandidate(info, candidates);
@@ -4472,6 +4500,7 @@ static void findVisibleFunctionsAndCandidates(
 
 // run filterCandidate() on 'fn' if appropriate
 static void gatherCandidates(CallInfo&                  info,
+                             VisibilityInfo&            visInfo,
                              FnSymbol*                  fn,
                              Vec<ResolutionCandidate*>& candidates) {
       // Consider
@@ -4501,18 +4530,19 @@ static void gatherCandidates(CallInfo&                  info,
       //
 
       if (info.call->methodTag == false) {
-        filterCandidate(info, fn, candidates);
+        filterCandidate(info, visInfo, fn, candidates);
 
       } else {
         if (fn->hasFlag(FLAG_NO_PARENS) == true) {
-          filterCandidate(info, fn, candidates);
+          filterCandidate(info, visInfo, fn, candidates);
         }
       }
 }
 
 // filter non-last-resort fns into 'candidates',
 // store last-resort fns into 'lrc'
-static void gatherCandidatesAndLastResort(CallInfo& info,
+static void gatherCandidatesAndLastResort(CallInfo&     info,
+                             VisibilityInfo&            visInfo,
                              Vec<FnSymbol*>&            visibleFns,
                              int&                       numVisited,
                              LastResortCandidates&      lrc,
@@ -4522,7 +4552,7 @@ static void gatherCandidatesAndLastResort(CallInfo& info,
     if (fn->hasFlag(FLAG_LAST_RESORT))
       lrc.push_back(fn);
     else
-      gatherCandidates(info, fn, candidates);
+      gatherCandidates(info, visInfo, fn, candidates);
   }
   markEndOfPOI(lrc);
   numVisited = visibleFns.n;
@@ -4530,19 +4560,21 @@ static void gatherCandidatesAndLastResort(CallInfo& info,
 
 // run filterCandidate() on the next batch of last resort fns
 static void gatherLastResortCandidates(CallInfo&                  info,
+                                       VisibilityInfo&            visInfo,
                                        LastResortCandidates&      lrc,
                                        int&                       numVisited,
                                        Vec<ResolutionCandidate*>& candidates) {
   int idx = numVisited;
 
   for (FnSymbol* fn = lrc[idx]; fn != NULL; fn = lrc[++idx]) {
-    gatherCandidates(info, fn, candidates);
+    gatherCandidates(info, visInfo, fn, candidates);
   }
 
   numVisited = ++idx;
 }
     
 static void filterCandidate(CallInfo&                  info,
+                            VisibilityInfo&            visInfo,
                             FnSymbol*                  fn,
                             Vec<ResolutionCandidate*>& candidates) {
   ResolutionCandidate* candidate = new ResolutionCandidate(fn);
@@ -4557,7 +4589,7 @@ static void filterCandidate(CallInfo&                  info,
     }
   }
 
-  if (candidate->isApplicable(info) == true) {
+  if (candidate->isApplicable(info, &visInfo)) {
     candidates.add(candidate);
   } else {
     delete candidate;
@@ -8205,7 +8237,9 @@ Expr* resolveExpr(Expr* expr) {
     }
 
   } else if (CallExpr* call = toCallExpr(expr)) {
+    // Most calls to resolveCall() are from here.
     retval = resolveExprPhase2(expr, fn, preFold(call));
+
   } else if (CondStmt* stmt = toCondStmt(expr)) {
     BlockStmt* then = stmt->thenStmt;
     // TODO: Should we just store a boolean field in CondStmt instead?

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -313,7 +313,7 @@ void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var)
  * \param subs Type substitutions to be made during instantiation
  * \param call Call that is being resolved
  */
-FnSymbol* instantiate(FnSymbol* fn, SymbolMap& subs) {
+FnSymbol* instantiateWithoutCall(FnSymbol* fn, SymbolMap& subs) {
   FnSymbol* newFn = instantiateSignature(fn, subs, NULL);
 
   if (newFn != NULL) {
@@ -345,7 +345,9 @@ void instantiateBody(FnSymbol* fn) {
  */
 FnSymbol* instantiateSignature(FnSymbol*  fn,
                                SymbolMap& subs,
-                               CallExpr*  call) {
+                               VisibilityInfo* visInfo) {
+  CallExpr* call = visInfo ? visInfo->call : NULL;
+
   //
   // Handle tuples explicitly
   // (_build_tuple, tuple type constructor, tuple default constructor)
@@ -379,7 +381,7 @@ FnSymbol* instantiateSignature(FnSymbol*  fn,
     determineAllSubs(fn, root, subs, allSubs);
 
     // use cached instantiation if possible
-    if (FnSymbol* cached = checkCache(genericsCache, root, &allSubs)) {
+    if (FnSymbol* cached = checkCache(genericsCache, root, visInfo, &allSubs)) {
       if (cached != (FnSymbol*) gVoid) {
         checkInfiniteWhereInstantiation(cached);
 
@@ -407,7 +409,7 @@ FnSymbol* instantiateSignature(FnSymbol*  fn,
         // If we computed some substitutions based upon generic
         // arguments with defaults, also check the cache entry
         // with the complete list of substitutions.
-        if (FnSymbol* cached = checkCache(genericsCache, root, &allSubs)) {
+        if (FnSymbol* cached = checkCache(genericsCache, root, visInfo, &allSubs)) {
           if (cached != (FnSymbol*) gVoid) {
             checkInfiniteWhereInstantiation(cached);
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -490,7 +490,7 @@ static void resolveInitCall(CallExpr* call, AggregateType* newExprAlias, bool fo
     Vec<ResolutionCandidate*> candidates;
     ResolutionCandidate*      best        = NULL;
 
-    findVisibleFunctions(info, visibleFns);
+    findVisibleFunctionsAllPOIs(info, visibleFns);
 
     trimVisibleCandidates(info, mostApplicable, visibleFns);
 
@@ -631,20 +631,14 @@ static void doGatherInitCandidates(CallInfo&                  info,
 
 /** Tests to see if a function is a candidate for resolving a specific call.
  *  If it is a candidate, we add it to the candidate lists.
- *
- * This version of filterInitCandidate is called by code outside the
- * filterInitCandidate family of functions.
- *
- * \param candidates    The list to add possible candidates to.
- * \param currCandidate The current candidate to consider.
- * \param info          The CallInfo object for the call site.
  */
 static void filterInitCandidate(CallInfo&                  info,
                                 FnSymbol*                  fn,
                                 Vec<ResolutionCandidate*>& candidates) {
   ResolutionCandidate* candidate = new ResolutionCandidate(fn);
+  VisibilityInfo visInfo(info.call);
 
-  if (candidate->isApplicable(info) == true) {
+  if (candidate->isApplicable(info, &visInfo) == true) {
     candidates.add(candidate);
 
   } else {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -22,6 +22,7 @@
 
 #include "astutil.h"
 #include "AstVisitorTraverse.h"
+#include "caches.h"
 #include "CatchStmt.h"
 #include "CForLoop.h"
 #include "DecoratedClassType.h"
@@ -477,6 +478,8 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
 
     fn->tagIfGeneric();
 
+    createCacheInfoIfNeeded(fn);
+
     if (strcmp(fn->name, "init") == 0 && fn->isMethod()) {
       AggregateType* at = toAggregateType(fn->_this->getValType());
       if (at->symbol->hasFlag(FLAG_GENERIC) == false) {
@@ -526,6 +529,7 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
       markTypesWithDefaultInitEqOrAssign(fn);
     }
     popInstantiationLimit(fn);
+    clearCacheInfoIfEmpty(fn);
   }
 }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -219,7 +219,7 @@ static FnSymbol* getInstantiatedFunction(FnSymbol* pfn,
     return cfn;
 
   } else {
-    FnSymbol* fn = instantiate(cfn, subs);
+    FnSymbol* fn = instantiateWithoutCall(cfn, subs);
 
     //
     // BHARSH 2018-04-06:

--- a/test/functions/ferguson/hijacking/ApplicationB.bad
+++ b/test/functions/ferguson/hijacking/ApplicationB.bad
@@ -1,2 +1,0 @@
-In A.foo()
-In A.foo()

--- a/test/functions/ferguson/hijacking/ApplicationB.future
+++ b/test/functions/ferguson/hijacking/ApplicationB.future
@@ -1,2 +1,0 @@
-design: generic function cached despite scope differences
-#6252

--- a/test/functions/generic/poi/check-gc-reuse-warns.chpl
+++ b/test/functions/generic/poi/check-gc-reuse-warns.chpl
@@ -1,0 +1,107 @@
+// Ensure generic-instantiations cache entries for 'libfn'
+// are not reused when reuse would be incorrect.
+//
+// This version uses compilerWarnings.
+
+module Work {
+
+module Lib {
+  proc libfn(param p) {
+    worker();  // invoke through POI
+  }
+}
+
+module User {
+  use super.Lib;
+  proc worker() { compilerWarning("User.worker", 1); }
+
+  proc u1() {
+    libfn(0);  // create a cache entry
+  }
+
+  proc u2() {
+    {
+      libfn(0);  // reuse the cache entry
+    }
+  }
+
+  proc u3() {
+    proc worker() { compilerWarning("User.u3.worker", 1); }
+    libfn(0);   // cannot reuse the cache entry -> create a new one
+  }
+
+  proc main {
+    u1();
+    u2();
+    u3();
+    {
+      use super.More1;
+      m1con();
+      m1gen(0);
+    }
+    {
+      use super.More2;
+      m2con();
+      m2gen(0);
+    }
+    {
+      use super.Combo1;
+      combo1a();
+    }
+    {
+      use super.Combo2;
+      combo2b();
+    }
+    compilerError("done",0);
+  }
+}
+
+module More1 {
+  use super.Lib;
+  proc worker() { compilerWarning("More1.worker", 1); }
+
+  proc m1con() {
+    libfn(0);   // cannot reuse the cache entry -> create a new one
+  }
+  proc m1gen(param p) {
+    libfn(0);   // can reuse the cache entry created for m1con
+  }
+}
+
+module More2 {
+  use super.Lib;
+
+  proc m2con() {
+    // libfn(0);   // error: no visible worker()
+  }
+  proc m2gen(param p) {
+    libfn(0);   // can reuse the cache entry created for u1
+  }
+}
+
+module Combo1 {
+  use super.Lib;
+  proc worker() { compilerWarning("Combo1.worker", 1); }
+
+  proc combo1a() {
+    use super.Combo2;
+    combo2a(0);
+  }
+  proc combo1b(param p) {
+    libfn(0);   // can reuse the cache entry created for combo1a->combo2a
+  }
+}
+
+module Combo2 {
+  use super.Lib;
+
+  proc combo2a(param p) {
+    libfn(0); // create a fresh cache entry
+  }
+  proc combo2b() {
+    use super.Combo1;
+    combo1b(0);
+  }
+}
+
+} // module Work

--- a/test/functions/generic/poi/check-gc-reuse-warns.good
+++ b/test/functions/generic/poi/check-gc-reuse-warns.good
@@ -1,0 +1,14 @@
+check-gc-reuse-warns.chpl:9: In function 'libfn':
+check-gc-reuse-warns.chpl:10: warning: User.worker
+check-gc-reuse-warns.chpl:19: Function 'libfn' instantiated as: libfn(param p = 0)
+check-gc-reuse-warns.chpl:9: In function 'libfn':
+check-gc-reuse-warns.chpl:10: warning: User.u3.worker
+check-gc-reuse-warns.chpl:30: Function 'libfn' instantiated as: libfn(param p = 0)
+check-gc-reuse-warns.chpl:9: In function 'libfn':
+check-gc-reuse-warns.chpl:10: warning: More1.worker
+check-gc-reuse-warns.chpl:64: Function 'libfn' instantiated as: libfn(param p = 0)
+check-gc-reuse-warns.chpl:9: In function 'libfn':
+check-gc-reuse-warns.chpl:10: warning: Combo1.worker
+check-gc-reuse-warns.chpl:99: Function 'libfn' instantiated as: libfn(param p = 0)
+check-gc-reuse-warns.chpl:33: In function 'main':
+check-gc-reuse-warns.chpl:55: error: done

--- a/test/functions/generic/poi/check-gc-reuse-writes.chpl
+++ b/test/functions/generic/poi/check-gc-reuse-writes.chpl
@@ -1,0 +1,107 @@
+// Ensure generic-instantiations cache entries for 'libfn'
+// are not reused when reuse would be incorrect.
+//
+// This version uses writelns.
+
+module Work {
+
+module Lib {
+  proc libfn(param p) {
+    worker();  // invoke through POI
+  }
+}
+
+module User {
+  use super.Lib;
+  proc worker() { writeln("User.worker"); }
+
+  proc u1() {
+    libfn(0);  // create a cache entry
+  }
+
+  proc u2() {
+    {
+      libfn(0);  // reuse the cache entry
+    }
+  }
+
+  proc u3() {
+    proc worker() { writeln("User.u3.worker"); }
+    libfn(0);   // cannot reuse the cache entry -> create a new one
+  }
+
+  proc main {
+    u1();
+    u2();
+    u3();
+    {
+      use super.More1;
+      m1con();
+      m1gen(0);
+    }
+    {
+      use super.More2;
+      m2con();
+      m2gen(0);
+    }
+    {
+      use super.Combo1;
+      combo1a();
+    }
+    {
+      use super.Combo2;
+      combo2b();
+    }
+    //compilerError("done",0);
+  }
+}
+
+module More1 {
+  use super.Lib;
+  proc worker() { writeln("More1.worker"); }
+
+  proc m1con() {
+    libfn(0);   // cannot reuse the cache entry -> create a new one
+  }
+  proc m1gen(param p) {
+    libfn(0);   // can reuse the cache entry created for m1con
+  }
+}
+
+module More2 {
+  use super.Lib;
+
+  proc m2con() {
+    // libfn(0);   // error: no visible worker()
+  }
+  proc m2gen(param p) {
+    libfn(0);   // can reuse the cache entry created for u1
+  }
+}
+
+module Combo1 {
+  use super.Lib;
+  proc worker() { writeln("Combo1.worker"); }
+
+  proc combo1a() {
+    use super.Combo2;
+    combo2a(0); // will create a fresh cache entry
+  }
+  proc combo1b(param p) {
+    libfn(0);   // can reuse the cache entry created for combo1a
+  }
+}
+
+module Combo2 {
+  use super.Lib;
+
+  proc combo2a(param p) {
+    libfn(0);
+  }
+  proc combo2b() {
+    use super.Combo1;
+    combo1b(0);
+  }
+}
+
+} // module Work

--- a/test/functions/generic/poi/check-gc-reuse-writes.good
+++ b/test/functions/generic/poi/check-gc-reuse-writes.good
@@ -1,0 +1,8 @@
+User.worker
+User.worker
+User.u3.worker
+More1.worker
+More1.worker
+User.worker
+Combo1.worker
+Combo1.worker

--- a/test/functions/generic/poi/expBySquaring-repro.chpl
+++ b/test/functions/generic/poi/expBySquaring-repro.chpl
@@ -1,0 +1,68 @@
+// This code outlines the situation in:
+//   test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.chpl
+//
+// Resolution follows these steps:
+// * resolve the call to _expBySquaring() invoked from matPow()
+// * create an instantiation of the generic proc _expBySquaring
+//   call it GI ("generic instantiation")
+// * store GI in genericsCache
+// * start resolving the body of GI
+// * resolve (find the target of) the recursive call to _expBySquaring()
+// * the generic proc _expBySquaring is applicable,
+//   check genericsCache for its instantiations
+// * find GI, see if it is applicable
+//   which requires that procs eye() and dot() are visible
+// * yes, they are visible - from GI's POI#2 (proc main here),
+//   via 'use MyLinearAlgebra.Sparse'
+//
+// If the compiler did not recognize that eye() and dot() were visible,
+// it would get itself in trouble like so:
+// * conclude that GI is not applicable
+// * create a new instantiation of the generic _expBySquaring
+//   call it GI-2
+// * store GI-2 in genericsCache
+// * make GI-2 the target of the call to _expBySquaring in GI
+// * start resolving the body of GI-2
+// * resolve (find the target of) the call to _expBySquaring() in GI-2
+// * repeat the subsequent steps above for GI, this time for GI-2
+// * create GI-3, then GI-4, etc. -- infinite recursion
+
+module SuppressModuleWarning {
+
+module correctness {  // correctness.chpl
+
+  use super.MyLinearAlgebra;
+
+  proc main {
+    use MyLinearAlgebra.Sparse;
+    var A = CSRMatrix(real);
+    var B = matPow(A, 3);
+    compilerError("done",0);
+  }
+
+}
+
+module MyLinearAlgebra {
+
+  proc matPow(A: [], b) {
+    return _expBySquaring(A, b);
+  }
+
+  private proc _expBySquaring(x: ?t, n): t {
+    eye();
+    dot();
+    return _expBySquaring(x, n);
+  }
+
+  module Sparse {
+
+    proc CSRMatrix(type eltType) {
+      return [1,2];
+    }
+
+    proc eye() { }
+    proc dot() { }
+  }
+}
+
+}

--- a/test/functions/generic/poi/expBySquaring-repro.good
+++ b/test/functions/generic/poi/expBySquaring-repro.good
@@ -1,0 +1,2 @@
+expBySquaring-repro.chpl:36: In function 'main':
+expBySquaring-repro.chpl:40: error: done


### PR DESCRIPTION
This implements #15923 for non-method functions.
It resolves the .future test from #6252: `test/functions/ferguson/hijacking/ApplicationB.chpl`

The compiler now performs a test whether a cached generic instantiation created for one call is applicable for another call that resolves to the same generic function. Fundamentally, the guiding principle is that it should work the same as if no instantiations are cached, semantically.

### What is being tested - details

Let F be the generic function and FI be its instantiation at hand.

* While resolving FI body for the first call, we gather `GenericsCacheInfo` for FI.

* The applicability test for another call to F checks the scopes visible from that call and its POI(s) against that GenericsCacheInfo.

Intuitively, the test imitates resolution of FI body for the other call. If the test passes, the resolution outcomes for the other call would be the same as they were for the first call. Therefore reusing FI for the other call is appropriate.

Since #16158, the resolution outcomes will be the same when the target function is visible from the scope where F is defined. Therefore GenericsCacheInfo records information only for resolution targets visible from FI's point(s) of instantiation (POIs) and not from F's scope.

This test is performed only when the values of the generic arguments are the same for both calls. This precondition has already been in place and is unaffected by this PR.

#### Gathering GenericsCacheInfo

A GenericsCacheInfo is a set of `CalledFunInfo` entries.

Each call in FI body contributes a CalledFunInfo entry that describes its resolution target, provided the target is not visible from the call's lexical scope. The entry contains:

* the name of the target function
* the scope where it is declared
* the set of scopes visited when gathering visible functions for the call

GenericsCacheInfo for FI also includes CalledFunInfo entries for the functions called from FI body for which FI serves as POI. The entries where the target function is visible from the FI's definition scope are excluded.

#### Checking against GenericsCacheInfo

Upon another call to F, where FI is considered for reuse, we check each of its CalledFunInfo entries:

* Traverse the scopes visible from the call and its POI, in the order they are traversed while gathering visible candidates. For each scope:

  - If the scope matches the declaration scope from the CalledFunInfo, checking is complete, the test passes.

  - If the scope is not in CalledFunInfo's set of visited scopes, it means that it was not considered while resolving the corresponding call in FI. So we do not know if it contains function(s) that would be better candidate(s) and lead to a different resolution outcome. As a conservative approximation, check that scope for definitions of any functions with CalledFunInfo's name. If any are present, checking is complete, the test fails.

* If all scopes have been visited and CalledFunInfo's declaration scope has not been encountered, it means that the resolution target used in FI is not available this time. So the resolution outcome of the corresponding call in FI will be different this time. The test fails.

### Compilation time

On chapcs7, seconds:

| benchmark | before this PR | after this PR |
|---|---|---|
| hello | 5.16 | 5.18 |
| SSCA2 | 33.66 | 33.70 |
| arkouda (gasnet)  | | |
| * resolve | 148 | 152 |
| * make binary | 433 | 433 |
| * total | 685 | 690 |

#### While there

Rename an overload of findVisibleFunctions to findVisibleFunctionsAllPOIs and instantiate -> instantiateWithoutCall, for better grepping.

Remove parts of the comment for filterInitCandidate that are either incorrect or obvious.

Additional instrumentation was present earlier in e41d4a56d5..ff67f3a58d
The previous implementation of this strategy was in 6e813eac1b..dffe8da574

Testing: linux64; gasnet over multilocale tests.

