### PR TITLE
Add skipif for empty-omp-taskspawn and comment within it

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.chpl
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.chpl
@@ -1,3 +1,26 @@
+/*
+   This program measures OpenMP task spawn performance in a combined
+   executable. It is run with QT_AFFINITY=no to avoid runtime contention
+   but it might be reasonable to have a test that runs a standalone
+   OpenMP C program to avoid the possibility of runtime contention.
+
+   A Chapel program that calls OpenMP is a reasonable thing to do;
+   it just might not be the best way to compare task startup times.
+
+   However testing a standalone C program isn't currently easy to do.
+   Some challenges are:
+     * we don't currently have perf testing for .test.c tests
+     * we don't currently have a way to launch C programs in the test infra
+     * possibility for contention exists if the Chapel program is running
+       at all (so e.g. Spawn wouldn't help)
+     * OpenMP implementations don't tend to infer the number of threads,
+       so we'd have to get something equivalent to here.maxTaskPar
+
+   It might be possible to replace the _real program with a C program
+   compiled in a .preexec (in launcher configurations) but that doesn't
+   solve the last issue.
+ */
+
 use Time;
 
 config const numTrials = 100;

--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
@@ -1,0 +1,5 @@
+# mppf: For some reason I havn't been able to understand yet,
+# nightly testing configurations that build LLVM have trouble
+# finding omp.h. I haven't been able to reproduce this myself.
+# Skip this test under LLVM configurations as a workaround.
+CHPL_LLVM!=none


### PR DESCRIPTION
Follow-up to PR #16187. After that PR, some nightly testing
configurations had failures for the test

```
  test/parallel/taskCompare/elliot/empty-omp-taskspawn.chpl
```

due to a failure to find the OpenMP header `omp.h` in C code.

I haven't been able to reproduce this issue myself yet and it doesn't
seem particularly high priority so this PR skips that test under LLVM
configurations. (It doesn't just check for `--llvm` compopts because that
won't work anymore as we move to llvm-by-default.  It could, however,
pass `--no-llvm` if we like).

Because I spent a lot of time learning about why empty-omp-taskspawn.chpl
is written the way it is, this PR also adds a comment about some of the
challenges of doing that test it in a standalone C program.

Reviewed by @ronawho - thanks!

- [x] empty-omp-taskspawn.chpl passes on Mac OS X
- [x] empty-omp-taskspawn.chpl is skipped in with `CHPL_LLVM=llvm`
- [x] empty-omp-taskspawn.chpl runs with `CHPL_LLVM=none`

