### PR TITLE
Un-future a bunch of function pointer futures that behave OK now

### DIFF
--- a/test/io/sungeun/funcPtr1.future
+++ b/test/io/sungeun/funcPtr1.future
@@ -1,5 +1,0 @@
-bug: writeln() called with a function argument leads to unexpected output.
-
-This test currently prints {}.  It should probably be illegal and
-result in a compile-time error.
-

--- a/test/io/sungeun/funcPtr1.good
+++ b/test/io/sungeun/funcPtr1.good
@@ -1,1 +1,1 @@
-funcPtr1.chpl:5: error: FIX ME!
+foo()

--- a/test/io/sungeun/funcPtr2.future
+++ b/test/io/sungeun/funcPtr2.future
@@ -1,4 +1,0 @@
-bug: writeln() called with an extern function argument leads to unexpected output.
-
-This test currently prints {}.  It should probably be illegal and
-result in a compile-time error.

--- a/test/io/sungeun/funcPtr2.good
+++ b/test/io/sungeun/funcPtr2.good
@@ -1,1 +1,1 @@
-funcPtr2.chpl:3: error: FIX ME!
+blah()

--- a/test/io/sungeun/funcPtr3.future
+++ b/test/io/sungeun/funcPtr3.future
@@ -1,8 +1,0 @@
-bug: writeln() called with a writeln as an argument leads to unexpected output.
-
-This test currently fails compilation with the following message:
-
-   funcPtr3.chpl:1: error: 'writeln' undeclared (first use this function)
-
-It should probably be illegal and give the same compile-time error as
-the other funcPtr*.chpl programs.

--- a/test/io/sungeun/funcPtr3.good
+++ b/test/io/sungeun/funcPtr3.good
@@ -1,1 +1,1 @@
-funcPtr3.chpl:1: error: FIX ME!
+funcPtr3.chpl:1: error: writeln: can not capture overloaded functions as values

--- a/test/io/sungeun/funcPtr4.chpl
+++ b/test/io/sungeun/funcPtr4.chpl
@@ -1,1 +1,2 @@
+use CommDiagnostics;
 writeln(getCommDiagnostics); // missing parens

--- a/test/io/sungeun/funcPtr4.future
+++ b/test/io/sungeun/funcPtr4.future
@@ -1,6 +1,0 @@
-bug: writeln() called with a getCommDiagnostics as an argument leads to unexpected output.
-
-This test currently fails during the C compilation step.
-
-It should probably be illegal and give the same compile-time error as
-the other funcPtr*.chpl programs.

--- a/test/io/sungeun/funcPtr4.good
+++ b/test/io/sungeun/funcPtr4.good
@@ -1,1 +1,1 @@
-funcPtr4.chpl:1: error: FIX ME!
+getCommDiagnostics()

--- a/test/io/sungeun/funcPtr5.future
+++ b/test/io/sungeun/funcPtr5.future
@@ -1,9 +1,0 @@
-bug: writeln() called with an iterator as an argument leads to unexpected output.
-
-This test currently fails compilation with the following message:
-
-   funcPtr5.chpl:1: In iterator 'blah':
-   funcPtr5.chpl:2: error: Iterators not allowed in first class functions
-
-It should probably be illegal and give the same compile-time error as
-the other funcPtr*.chpl programs.

--- a/test/io/sungeun/funcPtr5.good
+++ b/test/io/sungeun/funcPtr5.good
@@ -1,1 +1,2 @@
-funcPtr5.chpl:5: error: FIX ME!
+funcPtr5.chpl:1: In iterator 'blah':
+funcPtr5.chpl:2: error: Iterators not allowed in first class functions

--- a/test/io/sungeun/funcPtr6.future
+++ b/test/io/sungeun/funcPtr6.future
@@ -1,5 +1,0 @@
-bug: writeln() called with a generic function as an argument leads to unexpected output.
-
-This test currently fails with an internal error in callInfo.cpp
-(during function resolution).  It should probably be illegal and give
-the same compile-time error as the other funcPtr*.chpl programs.

--- a/test/io/sungeun/funcPtr6.good
+++ b/test/io/sungeun/funcPtr6.good
@@ -1,1 +1,1 @@
-funcPtr6.chpl:5: error: FIX ME!
+funcPtr6.chpl:5: error: 'foo' cannot be captured as a value because it is a generic function


### PR DESCRIPTION
I noticed these futures were out of date when making PR #15686.
They seem to have relatively reasonable behavior/error messages now
and the original failure modes are no longer present.

Trivial and not reviewed.

- [x] test/io/sungeun/ passes