### PR TITLE
Refactor string iterators to reduce generated code size

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -576,34 +576,6 @@ module BytesStringCommon {
           yield chunk;
           splitCount += 1;
         }
-        
-        //var chunk: t;
-        //var end: _idxt = -1;
-
-        //if (maxsplit == 0) {
-          //chunk = localx;
-          //done = true;
-        //} else {
-          //if (splitAll || splitCount < maxsplit) then
-            //end = localx.find(localSep, start..);
-
-          //if(end == -1) {
-            //// Separator not found
-            //chunk = localx[start..];
-            //done = true;
-          //} else {
-            //chunk = localx[start..end-1];
-          //}
-        //}
-
-        //if !(ignoreEmpty && chunk.isEmpty()) {
-          //// Putting the yield inside the if prevents us from being inlined
-          //// in the zippered case, but I don't think there is any way to avoid
-          //// that easily
-          //yield chunk;
-          //splitCount += 1;
-        //}
-        //start = end+localSep.numBytes;
       }
     }
   }
@@ -691,76 +663,10 @@ module BytesStringCommon {
       const localx: t = x.localize();
       var i = 0;
       var splitCount: int = 0;
-      var _maxsplit = maxsplit;
 
       while i <= localx.numBytes-1 {
-        yield doSplitWSNoEncHelp(localx, _maxsplit, i, splitCount);
-        //_maxsplit -= 1;
+        yield doSplitWSNoEncHelp(localx, maxsplit, i, splitCount);
       }
-      //const localx: t = x.localize();
-      //var done : bool = false;
-      //var yieldChunk : bool = false;
-      //var chunk : t;
-
-      //const noSplits : bool = maxsplit == 0;
-      //const limitSplits : bool = maxsplit > 0;
-      //var splitCount: int = 0;
-      //const iEnd: idxType = localx.buffLen - 2;
-
-      //var inChunk : bool = false;
-      //var chunkStart : idxType;
-
-      //for (i,c) in zip(x.indices, localx.bytes()) {
-        //// emit whole string, unless all whitespace
-        //// TODO Engin: Why is x inside the loop?
-        //if noSplits {
-          //done = true;
-          //if !localx.isSpace() then {
-            //chunk = localx;
-            //yieldChunk = true;
-          //}
-        //} else {
-          //var cSpace = byte_isWhitespace(c);
-          //// first char of a chunk
-          //if !(inChunk || cSpace) {
-            //chunkStart = i;
-            //inChunk = true;
-            //if i > iEnd {
-              //chunk = localx[chunkStart..];
-              //yieldChunk = true;
-              //done = true;
-            //}
-          //} else if inChunk {
-            //// first char out of a chunk
-            //if cSpace {
-              //splitCount += 1;
-              //// last split under limit
-              //if limitSplits && splitCount > maxsplit {
-                //chunk = localx[chunkStart..];
-                //yieldChunk = true;
-                //done = true;
-              //// no limit
-              //} else {
-                //chunk = localx[chunkStart..i-1];
-                //yieldChunk = true;
-                //inChunk = false;
-              //}
-            //// out of chars
-            //} else if i > iEnd {
-              //chunk = localx[chunkStart..];
-              //yieldChunk = true;
-              //done = true;
-            //}
-          //}
-        //}
-
-        //if yieldChunk {
-          //yield chunk;
-          //yieldChunk = false;
-        //}
-        //if done then
-          //break;
-      //}
     }
   }
 

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -1190,6 +1190,20 @@ module BytesStringCommon {
     return (b & 0xc0) != 0x80;
   }
 
+  /* 
+   Returns the byte index of the beginning of the first codepoint starting from
+   (and including) i
+   */
+  proc _findStartOfNextCodepointFromByte(x: string, i: byteIndex) {
+    var ret = i:int;
+    if ret > 0 {
+      while ret < x.buffLen && !isInitialByte(x.buff[ret]) {
+        ret += 1;
+      }
+    }
+    return ret;
+  }
+
   // character-wise operation helpers
 
   require "ctype.h";

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -665,7 +665,10 @@ module BytesStringCommon {
       var splitCount: int = 0;
 
       while i <= localx.numBytes-1 {
-        yield doSplitWSNoEncHelp(localx, maxsplit, i, splitCount);
+        const chunk = doSplitWSNoEncHelp(localx, maxsplit, i, splitCount);
+        if !chunk.isEmpty() {
+          yield chunk;
+        }
       }
     }
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1300,21 +1300,10 @@ module String {
     Iterates over the string Unicode character by Unicode character.
   */
   iter string.codepoints(): int(32) {
-    var localThis: string = this.localize();
-
-    if this.isASCII() {
-      for b in this.chpl_bytes() do yield b;
-    }
-    else {
-      var i = 0;
-      while i < localThis.buffLen {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                   buffLen=localThis.buffLen,
-                                                   offset=i,
-                                                   allowEsc=true);
-        yield cp;
-        i += nBytes;
-      }
+    const localThis = this.localize();
+    var i = 0;
+    while i < localThis.buffLen {
+      yield _cpIndexLenHelpNoAdjustment(i)[0];  // this increments i
     }
   }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -900,35 +900,11 @@ module String {
       Assume we may accidentally start in the middle of a multibyte character,
       but the string is correctly encoded UTF-8.
     */
-    iter _cpIndexLen() {
-      const thisLen = this.buffLen;
-      var i = 0;
-      while i < thisLen {
+    iter _cpIndexLen(start = 0:byteIndex) {
+      const localThis = this.localize();
+      var i = _findStartOfNextCodepointFromByte(this, start);
+      while i < localThis.buffLen {
         yield _cpIndexLenHelpNoAdjustment(i);  // this increments i
-      }
-    }
-
-    iter _cpIndexLen(start: byteIndex) {
-      var localThis: string = this.localize();
-
-      if localThis.isASCII() {
-        for (i,b) in zip(this.byteIndices, this.chpl_bytes()) {
-          yield(b:int(32), i:byteIndex, 1:int);
-        }
-      }
-      else {
-        var i = start:int;
-        if i > 0 then
-          while i < localThis.buffLen && !isInitialByte(localThis.buff[i]) do
-            i += 1; // in case `start` is in the middle of a multibyte character
-        while i < localThis.buffLen {
-          const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                     buffLen=localThis.buffLen,
-                                                     offset=i,
-                                                     allowEsc=true);
-          yield (cp:int(32), i:byteIndex, nBytes:int);
-          i += nBytes;
-        }
       }
     }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1612,12 +1612,12 @@ module String {
                    indicate no limit.
    */
   iter string.split(maxsplit: int = -1) /* : string */ {
+    // TODO: specifying return type leads to un-inited string?
     if this.isASCII() {
       for s in doSplitWSNoEnc(this, maxsplit) do yield s;
     } else {
       // note: to improve performance, this code collapses several cases into a
       //       single yield statement, which makes it confusing to read
-      // TODO: specifying return type leads to un-inited string?
       if !this.isEmpty() {
         const localThis: string = this.localize();
         var done : bool = false;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1392,7 +1392,7 @@ module String {
   proc string.this(i: byteIndex) : string {
     var idx = i: int;
     if boundsChecking && (idx < 0 || idx >= this.buffLen)
-      then halt("index ", i, " out of bounds for string with ", this.buffLen, " bytes");
+      then halt("index ", i:int, " out of bounds for string with ", this.buffLen, " bytes");
 
     if this.isASCII() {
       var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=i:int,
@@ -1442,12 +1442,12 @@ module String {
    */
   proc string.item(i: codepointIndex) : string {
     if boundsChecking && i < 0 then
-      halt("index ", i, " out of bounds for string");
+      halt("index ", i:int, " out of bounds for string");
 
     if this.isEmpty() then return "";
     if this.isASCII() {
       if boundsChecking && i >= this.numBytes then
-        halt("index ", i, " out of bounds for string with length ", this.size);
+        halt("index ", i:int, " out of bounds for string with length ", this.size);
       var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=i:int,
                                             len=1, loc=this.locale_id);
       return chpl_createStringWithOwnedBufferNV(newBuff, 1, allocSize, 1);
@@ -1463,7 +1463,7 @@ module String {
         charCount += 1;
       }
       if boundsChecking then
-        halt("index ", i, " out of bounds for string with length ", this.size);
+        halt("index ", i:int, " out of bounds for string with length ", this.size);
       return "";
     }
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -952,8 +952,8 @@ module String {
     //TODO: this could be a much better string search
     //      (Boyer-Moore-Horspool|any thing other than brute force)
     //
-    inline proc doSearchUTF8(needle: string, region: range(?),
-                             param count: bool, param fromLeft: bool = true) {
+    proc doSearchUTF8(needle: string, region: range(?),
+                      param count: bool, param fromLeft: bool = true) {
       // needle.len is <= than this.buffLen, so go to the home locale
       var ret: int = -1;
       on __primitive("chpl_on_locale_num",

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1032,67 +1032,6 @@ module String {
         while i < localThis.buffLen {
           yield doSplitWSUTF8Help(localThis, maxsplit, i, splitCount);
         }
-        /*var done : bool = false;*/
-        //var yieldChunk : bool = false;
-        //var chunk : string;
-
-        //const noSplits : bool = maxsplit == 0;
-        //const limitSplits : bool = maxsplit > 0;
-        //const iEnd: byteIndex = localThis.buffLen - 2;
-
-        //var inChunk : bool = false;
-        //var chunkStart : byteIndex;
-
-        //for (c, i, nBytes) in localThis._cpIndexLen() {
-          //// emit whole string, unless all whitespace
-          //if noSplits {
-            //done = true;
-            //if !localThis.isSpace() then {
-              //chunk = localThis;
-              //yieldChunk = true;
-            //}
-          //} else {
-            //var cSpace = codepoint_isWhitespace(c);
-            //// first char of a chunk
-            //if !(inChunk || cSpace) {
-              //chunkStart = i;
-              //inChunk = true;
-              //if i - 1 + nBytes > iEnd {
-                //chunk = localThis[chunkStart..];
-                //yieldChunk = true;
-                //done = true;
-              //}
-            //} else if inChunk {
-              //// first char out of a chunk
-              //if cSpace {
-                //splitCount += 1;
-                //// last split under limit
-                //if limitSplits && splitCount > maxsplit {
-                  //chunk = localThis[chunkStart..];
-                  //yieldChunk = true;
-                  //done = true;
-                //// no limit
-                //} else {
-                  //chunk = localThis[chunkStart..i-1];
-                  //yieldChunk = true;
-                  //inChunk = false;
-                //}
-              //// out of chars
-              //} else if i - 1 + nBytes > iEnd {
-                //chunk = localThis[chunkStart..];
-                //yieldChunk = true;
-                //done = true;
-              //}
-            //}
-          //}
-
-          //if yieldChunk {
-            //yield chunk;
-            //yieldChunk = false;
-          //}
-          //if done then
-            //break;
-        //}
       }
     }
 


### PR DESCRIPTION
This PR refactors several string iterators to use a helper `proc`. This helps
reduce the code size of the iterators' bodies and thereby the overall generated
code size as we always inline iterators.

Iterators that are changed:

- `_cpIndexLen`
- `split`
- `codepoints`


The generated code size was initially increased by my #16092. The impact was
especially pronounced in Arkouda. Following are ARKOUDA_QUICK_COMPILE lines of
code with CHPL_COMM=none Chapel setup:

version                   | Total LOC | Compile Time (s)
--------------------------|-----------|-------------
Pre ASCII Opt             | 1533593   | 642
Post ASCII Opt (master)   | 1921869   | 786
Refactored String Iters   | 1366355   | 576

Test:
- [x] standard
- [x] gasnet
