### PR TITLE
Upgrade arkouda release testing to 1.22.1

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -28,7 +28,7 @@ function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release
   export CHPL_TEST_PERF_CONFIGS="release:v,master"
   currentSha=`git rev-parse HEAD`
-  git checkout 1.22.0
+  git checkout 1.22.1
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
   $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
1.22.1 included some gcc 10 incompatibility fixes, and we're now running
on systems with gcc 10 so we need to upgrade.