### PR TITLE
Improve string to numerical casts' compilation and execution performance

### DIFF
--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -191,7 +191,6 @@ module StringCasts {
 
   proc _cleanupStringForNumericCast(ref s: string) {
     param underscore = "_".toByte();
-    var len = s.size;
 
     var hasUnderscores = false;
     for bIdx in 1..<s.numBytes {
@@ -205,6 +204,7 @@ module StringCasts {
       s = s.strip();
       // don't remove anything and let it fail later on
       if _isSingleWord(s) {
+        var len = s.size;
         if len >= 2 {
           // Don't remove a leading underscore in the string number,
           // but remove the rest.

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -82,29 +82,6 @@ module StringCasts {
                                               numCodepoints=len);
   }
 
-  private proc removeUnderscores(type t: integral, x: string) throws {
-    var localX = x.localize();
-    const hasUnderscores = localX.find("_") != -1;
-
-    if hasUnderscores {
-      localX = localX.strip();
-      // make sure the string only has one word
-      var numElements: int;
-      for localX.split() {
-        numElements += 1;
-        if numElements > 1 then break;
-      }
-      if numElements > 1 then
-        throw new owned IllegalArgumentError("bad cast from string '" + x + "' to " + t:string);
-
-      // remove underscores everywhere but the first position
-      if localX.size >= 2 then
-        localX = localX[0] + localX[1..].replace("_", "");
-    }
-
-    return localX;
-  }
-
   inline proc _cast(type t:integral, x: string) throws {
     //TODO: switch to using qio's readf somehow
     pragma "fn synchronization free"
@@ -135,7 +112,8 @@ module StringCasts {
     var retVal: t;
     var isErr: bool;
     // localize the string and remove leading and trailing whitespace
-    const localX = removeUnderscores(t, x);
+    var localX = x.localize();
+    _cleanupStringForNumericCast(localX, t:string);
 
     if localX.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to " + t:string);
@@ -195,11 +173,12 @@ module StringCasts {
     return _real_cast_helper(r, true);
   }
 
-  inline proc _cleanupStringForRealCast(type t, ref s: string) throws {
+  proc _cleanupStringForNumericCast(ref s: string, typeName: string) throws {
     var len = s.size;
 
     if s.isEmpty() then
-      throw new owned IllegalArgumentError("bad cast from empty string to " + t: string);
+      throw new owned IllegalArgumentError("bad cast from empty string to " +
+                                           typeName);
 
     if len >= 2 && s[1..].find("_") != -1 {
       // Don't remove a leading underscore in the string number,
@@ -224,7 +203,7 @@ module StringCasts {
     var isErr: bool;
     var localX = x.localize();
 
-    _cleanupStringForRealCast(t, localX);
+    _cleanupStringForNumericCast(t, localX);
 
     select numBits(t) {
       when 32 do retVal = c_string_to_real32(localX.c_str(), isErr);
@@ -250,7 +229,7 @@ module StringCasts {
     var isErr: bool;
     var localX = x.localize();
 
-    _cleanupStringForRealCast(t, localX);
+    _cleanupStringForNumericCast(t, localX);
 
     select numBits(t) {
       when 32 do retVal = c_string_to_imag32(localX.c_str(), isErr);

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -190,15 +190,22 @@ module StringCasts {
   }
 
   proc _cleanupStringForNumericCast(ref s: string) {
+    param underscore = "_".toByte();
     var len = s.size;
 
-    const hasUnderscores = s[1..].find("_") != -1;
+    var hasUnderscores = false;
+    for bIdx in 1..<s.numBytes {
+      if s.byte[bIdx] == underscore then {
+        hasUnderscores = true;
+        break;
+      }
+    }
 
     if hasUnderscores {
       s = s.strip();
       // don't remove anything and let it fail later on
       if _isSingleWord(s) {
-        if len >= 2 && s[1..].find("_") != -1 {
+        if len >= 2 {
           // Don't remove a leading underscore in the string number,
           // but remove the rest.
           if len > 2 && s[0] == "_" {

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -102,10 +102,7 @@ static int illegalFirstUnsChar(char c) {
       *invalidCh = *str;                                                \
       return -1;                                                        \
     }                                                                   \
-    if (uns)                                                            \
-      val = (_type(base, width))strtoull(str, &endPtr, numberBase);  \
-    else                                                                \
-      val = (_type(base, width))strtoll(str, &endPtr, numberBase);   \
+    val = (_type(base, width))strtoull(str, &endPtr, numberBase);  \
     if (negative) {                                                     \
       val = -1*val;                                                     \
     }                                                                   \

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -66,7 +66,6 @@ static int illegalFirstUnsChar(char c) {
                                                           int* invalid,    \
                                                           char* invalidCh) { \
     char* endPtr;                                                       \
-    char* newStr = NULL;                                                \
     int numberBase = 10;                                                \
     int negative = 0;                                                   \
     _type(base, width) val;                                             \
@@ -91,35 +90,34 @@ static int illegalFirstUnsChar(char c) {
         str += 2;                                                       \
       }                                                                 \
     }                                                                   \
+    if (negative) {                                                     \
+      if (uns) {                                                        \
+        *invalid = 1;                                                   \
+        *invalidCh = *str;                                              \
+        return -1;                                                      \
+      }                                                                 \
+    }                                                                   \
     if (str[0] == '-' || str[0] == '+') {                               \
       *invalid = 1;                                                     \
       *invalidCh = *str;                                                \
       return -1;                                                        \
     }                                                                   \
-    if (negative) {                                                     \
-      newStr = chpl_mem_alloc(strlen(str) + 2,                          \
-                              CHPL_RT_MD_STR_COPY_DATA, 0, 0);          \
-      newStr[0] = '-';                                                  \
-      strcpy(&newStr[1], str);                                          \
-    } else {                                                            \
-      newStr = chpl_mem_alloc(strlen(str) + 1,                          \
-                              CHPL_RT_MD_STR_COPY_DATA, 0, 0);          \
-      strcpy(newStr, str);                                              \
-    }                                                                   \
     if (uns)                                                            \
-      val = (_type(base, width))strtoull(newStr, &endPtr, numberBase);  \
+      val = (_type(base, width))strtoull(str, &endPtr, numberBase);  \
     else                                                                \
-      val = (_type(base, width))strtoll(newStr, &endPtr, numberBase);   \
+      val = (_type(base, width))strtoll(str, &endPtr, numberBase);   \
+    if (negative) {                                                     \
+      val = -1*val;                                                     \
+    }                                                                   \
     while (*endPtr && isspace(*endPtr))                                 \
       endPtr++;                                                         \
-    *invalid = (*newStr == '\0' || *endPtr != '\0');                    \
+    *invalid = (*str == '\0' || *endPtr != '\0');                    \
     *invalidCh = *endPtr;                                               \
     /* for negatives, strtol works, but we wouldn't want chapel to */   \
-    if (*invalid == 0 && uns && illegalFirstUnsChar(*newStr)) {         \
+    if (*invalid == 0 && uns && illegalFirstUnsChar(*str)) {         \
       *invalid = 1;                                                     \
       *invalidCh = *str;                                                \
     }                                                                   \
-    chpl_mem_free(newStr, 0, 0);                                        \
     return val;                                                         \
   }
 

--- a/test/types/string/cast/intLimits.chpl
+++ b/test/types/string/cast/intLimits.chpl
@@ -1,0 +1,29 @@
+proc testType(type t) {
+  writeln("Testing ", t:string);
+
+  var upper = max(t);
+  var lower = min(t);
+
+  var upperAsString = upper:string;
+  var lowerAsString = lower:string;
+
+  writeln("Upper limit: ", upperAsString, " (must be ", upper, ")");
+  writeln("Lower limit: ", lowerAsString, " (must be ", lower, ")");
+
+
+  writeln("Can cast upper limit back?: ", upperAsString:t==upper);
+  writeln("Can cast lower limit back?: ", lowerAsString:t==lower);
+
+  writeln();
+}
+
+
+testType(int(8));
+testType(int(16));
+testType(int(32));
+testType(int(64));
+
+testType(uint(8));
+testType(uint(16));
+testType(uint(32));
+testType(uint(64));

--- a/test/types/string/cast/intLimits.good
+++ b/test/types/string/cast/intLimits.good
@@ -1,0 +1,48 @@
+Testing int(8)
+Upper limit: 127 (must be 127)
+Lower limit: -128 (must be -128)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing int(16)
+Upper limit: 32767 (must be 32767)
+Lower limit: -32768 (must be -32768)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing int(32)
+Upper limit: 2147483647 (must be 2147483647)
+Lower limit: -2147483648 (must be -2147483648)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing int(64)
+Upper limit: 9223372036854775807 (must be 9223372036854775807)
+Lower limit: -9223372036854775808 (must be -9223372036854775808)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing uint(8)
+Upper limit: 255 (must be 255)
+Lower limit: 0 (must be 0)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing uint(16)
+Upper limit: 65535 (must be 65535)
+Lower limit: 0 (must be 0)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing uint(32)
+Upper limit: 4294967295 (must be 4294967295)
+Lower limit: 0 (must be 0)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+
+Testing uint(64)
+Upper limit: 18446744073709551615 (must be 18446744073709551615)
+Lower limit: 0 (must be 0)
+Can cast upper limit back?: true
+Can cast lower limit back?: true
+

--- a/test/types/string/diten/stringToRealError.chpl
+++ b/test/types/string/diten/stringToRealError.chpl
@@ -1,0 +1,6 @@
+var s1 = "1234  ": real,
+    s2 = "  1234": real,
+    s3 = "  1234  ": real,
+    s4 = "  1234  _": real;
+
+writeln((s1, s2, s3, s4));

--- a/test/types/string/diten/stringToRealError.good
+++ b/test/types/string/diten/stringToRealError.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: bad cast from string '  1234  _' to real(64)
+  stringToRealError.chpl:4: thrown here
+  stringToRealError.chpl:4: uncaught here


### PR DESCRIPTION
This PR contains several improvements to string to numerical type casts mainly
motivated by reducing the generated code size.

Follow on to https://github.com/chapel-lang/chapel/pull/16266

- Change `_cleanupStringForRealCast` to `_cleanupStringForNumericCast` and use
  it for casts to both integers and reals.

  This reduces the amount of code in the integer casts by a significant amount.
  For Arkouda (quickstart local Chapel, ARKOUDA_QUICK_COMPILE=1), we have the
  following generated code sizes:

version                   | Total LOC 
--------------------------|-----------
master                    | 1366355   
This PR                   | 1217989

  This is because the inlined string->int cast has a logic with several
  high-level string functions and iterators that are also inlined. This causes
  serious code bloat and compiler performance degradation. These calls are now
  in a non-inlined `_cleanupStringForNumericCast`

- While making that change, use a simpler approach to make some checks to get
  some performance. `real` and `imag` casts are about 2.3-2.6 sec range today,
  and with this change it is about 2.0-2.3 sec.

- While making that change, fix a bug where we erroneously allowed
  `" 12 _":real`. This cast was correctly not allowed if the type is `int`.
  Also, add a test to lock that behavior.

- This change adds a function call overhead in integer casts. Currently, we get
  about 0.6 sec in the relevant benchmark, where the function call brought us to
  about 1.0 sec. So, I removed an extra memory allocation in the runtime
  implementation of the integer casts. We still pay for the function call, but
  this brings us to about 0.4 sec for integer casts.

  See: https://github.com/chapel-lang/chapel/pull/12097/files#r249146382

I also wanted to take a step to fix
https://github.com/Cray/chapel-private/issues/654, but I think that should be
handled under the umbrella of "how to pass strings to externs" and should take a
more serious effort. So, this PR doesn't do that.

Test:
- [x] standard in types/string
- [x] linux32 in types/string
- [x] standard
- [x] gasnet
