### PR TITLE
Use only the innermost POI in getVisibleFunctions()

### DIFF
--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -35,16 +35,16 @@ class VisibilityInfo {
 public:
   BlockStmt* currStart;
   BlockStmt* nextPOI;
-  int        numVisited;
-  VisibilityInfo() : currStart(NULL), nextPOI(NULL), numVisited(0) {}
+  VisibilityInfo() : currStart(NULL), nextPOI(NULL) {}
 };
 
 void       findVisibleFunctions(CallInfo&       info,
                                 Vec<FnSymbol*>& visibleFns);
 
 void       findVisibleFunctions(CallInfo&             info,
-                                std::set<BlockStmt*>* visited,
                                 VisibilityInfo*       visInfo,
+                                std::set<BlockStmt*>* visited,
+                                int*                  numVisitedP,
                                 Vec<FnSymbol*>&       visibleFns);
 
 void       getVisibleFunctions(const char*      name,

--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -31,15 +31,21 @@ class CallInfo;
 class Expr;
 class FnSymbol;
 
+class VisibilityInfo {
+public:
+  BlockStmt* currStart;
+  BlockStmt* nextPOI;
+  int        numVisited;
+  VisibilityInfo() : currStart(NULL), nextPOI(NULL), numVisited(0) {}
+};
+
 void       findVisibleFunctions(CallInfo&       info,
                                 Vec<FnSymbol*>& visibleFns);
 
-void       findVisibleFunctions(CallInfo&       info,
-                                std::set<BlockStmt*>*    visited,
-                                std::vector<BlockStmt*>* currentScopes,
-                                std::vector<BlockStmt*>* nextScopes,
-                                int*            numVisitedP,
-                                Vec<FnSymbol*>& visibleFns);
+void       findVisibleFunctions(CallInfo&             info,
+                                std::set<BlockStmt*>* visited,
+                                VisibilityInfo*       visInfo,
+                                Vec<FnSymbol*>&       visibleFns);
 
 void       getVisibleFunctions(const char*      name,
                                CallExpr*        call,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4445,8 +4445,8 @@ static void findVisibleFunctionsAndCandidates(
   visInfo.currStart = getVisibilityScope(call);
 
   do {
-    findVisibleFunctions(info, &visited,
-                         &visInfo, visibleFns);
+    findVisibleFunctions(info, &visInfo, &visited,
+                         &numVisitedVis, visibleFns);
 
     trimVisibleCandidates(info, mostApplicable,
                           numVisitedVis, visibleFns);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4441,12 +4441,12 @@ static void findVisibleFunctionsAndCandidates(
   int numVisitedVis = 0, numVisitedMA = 0;
   LastResortCandidates lrc;
   std::set<BlockStmt*> visited;
-  std::vector<BlockStmt*> currentScopes, nextScopes;
-  currentScopes.push_back(getVisibilityScope(call));
+  VisibilityInfo visInfo;
+  visInfo.currStart = getVisibilityScope(call);
 
   do {
-    findVisibleFunctions(info, &visited, &currentScopes, &nextScopes,
-                         &numVisitedVis, visibleFns);
+    findVisibleFunctions(info, &visited,
+                         &visInfo, visibleFns);
 
     trimVisibleCandidates(info, mostApplicable,
                           numVisitedVis, visibleFns);
@@ -4454,11 +4454,11 @@ static void findVisibleFunctionsAndCandidates(
     gatherCandidatesAndLastResort(info, mostApplicable, numVisitedMA,
                                   lrc, candidates);
 
-    currentScopes.clear();
-    std::swap(currentScopes, nextScopes);
+    visInfo.currStart = visInfo.nextPOI;
+    visInfo.nextPOI = NULL;
   }
   while
-    (candidates.n == 0 && ! currentScopes.empty());
+    (candidates.n == 0 && visInfo.currStart != NULL);
 
   // If needed, look at "last resort" candidates.
   int numVisitedLRC = 0;

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -792,7 +792,8 @@ static void getVisibleFunctionsImpl(const char*       name,
       getVisibleFunctionsImpl(name, call, // visit all POIs right away
                   instantiationPt, NULL, visited, visibleFns, inUseChain);
     else
-      // Overwrites instantiationPt from an outer scope, if any
+      // Executes after recursing to outer/enclosing scopes above.
+      // Overwrites instantiationPt from an outer scope, if already in nextPOI.
       visInfo->nextPOI = instantiationPt; // come back to it later
   }
 }

--- a/test/functions/generic/poi/outer-inner.chpl
+++ b/test/functions/generic/poi/outer-inner.chpl
@@ -1,0 +1,19 @@
+// This example exposes POI-visibility of resolution candidates
+// in the case of nested generics.
+
+proc outer(param p) {
+  proc inner(param p) {
+    writeln("starting inner()");
+    xtra();     // which declarations of xtra() are visible here?
+  }
+  {
+    proc xtra() { writeln("xtra-1"); }
+    writeln("starting outer()");
+    inner(0);
+  }
+}
+{
+  proc xtra() { writeln("xtra-2"); }
+  writeln("starting main");
+  outer(0);
+}

--- a/test/functions/generic/poi/outer-inner.chpl
+++ b/test/functions/generic/poi/outer-inner.chpl
@@ -5,6 +5,7 @@ proc outer(param p) {
   proc inner(param p) {
     writeln("starting inner()");
     xtra();     // which declarations of xtra() are visible here?
+    onlyone();  // ensure that outer's POI is also visited
   }
   {
     proc xtra() { writeln("xtra-1"); }
@@ -14,6 +15,7 @@ proc outer(param p) {
 }
 {
   proc xtra() { writeln("xtra-2"); }
+  proc onlyone() { writeln("onlyone"); }
   writeln("starting main");
   outer(0);
 }

--- a/test/functions/generic/poi/outer-inner.good
+++ b/test/functions/generic/poi/outer-inner.good
@@ -2,3 +2,4 @@ starting main
 starting outer()
 starting inner()
 xtra-1
+onlyone

--- a/test/functions/generic/poi/outer-inner.good
+++ b/test/functions/generic/poi/outer-inner.good
@@ -1,0 +1,4 @@
+starting main
+starting outer()
+starting inner()
+xtra-1


### PR DESCRIPTION
getVisibleFunctionsImpl(), or getVisibleFunctions() prior to #16158,
considered POIs (Point of Instantiation) of both the inner and the outer
generic functions at once when a call was lexically nested in both.

With this change, only POI of the inner function is considered directly.
Also, if the innermost enclosing function is concrete and the concrete
function is nested in generic function(s), POI of the innermost of those
generic function(s) will be considered directly.

For example, POI of outer() is no longer considered after gathering visible
candidates in the scope of the call to callme() here:

```chpl
proc outer(type t) {
  proc inner(param p) {
    callme();  // this call
  }
  inner(1);
}
outer(int);
```

The former behavior does not match the POI rule ([see the spec](
https://chapel-lang.org/docs/language/spec/generics.html#function-visibility-in-generic-functions)
as modified in #15948 / #16158). This rule specifies that only a single POI
be followed per call or per scope.

Also, the former behavior does not reach any scopes/visible functions
that would not be reachable with the new behavior. For example, in the above
snippet POI of inner() - the call inner(1) - is itself inside outer().
So POI of outer() is consulted in due time after POI of inner().
The order of reaching these scopes may now be different, although we have not
observed this difference in practice.

#### Implementation details

This change is implemented by replacing the vectors `currentScopes` and
`nextScopes` with single pointers visInfo->currStart and visInfo->nextPOI.
If the scope visInfo->currStart is contained in one or more generic function,
POI of the innermost generic function will be queued in visInfo->nextPOI.

While there - I bundled several things passed around in findVisibleFunctions()
and getVisibleFunctions() into a class `VisibilityInfo`. It may be almost a wash
right now. However, I will be adding more things to pass around in my upcoming
#16261, so gathering them into one bundle will avoid further increase in
the number of arguments of these functions.

I also made minor aesthetic formatting tweaks.

Testing: linux64; multilocale tests under gasnet, both with futures.