### PR TITLE
Make nightly compiler and runtime build failures fatal

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -503,16 +503,7 @@ if ($hostcompiler eq "cray-prgenv-cray") {
 
 
 print "Making $make_vars_opt compiler\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", 0, 1);
-if ($makestat != 0) {
-    print "Making $make_vars_no_opt compiler\n";
-    # Since the rest of the compiler is being built unoptimized, disable
-    # compiler performance testing so we don't get unexplained hiccups in
-    # the perf graphs.
-    print "compiler performance testing will be disabled\n";
-    $compperformance = 0;
-    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_no_opt compiler", "making chapel compiler", 1, 1);
-}
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", 1, 1);
 
 # Speculatively build a couple third-party libraries. This command should not
 # fail, even if it fails to build the libraries.
@@ -550,15 +541,8 @@ if ($buildruntime == 0) {
     exit 0;
 }
 
-# if this is a performance test run then failing to build the runtime with
-# optimizations is a fatal error.  Otherwise we could get hiccups in the
-# performance graphs that are difficult to track.
-print "Making $make_vars_opt $qthreadopts runtime\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt $qthreadopts runtime", "making chapel runtime", $performance, 1);
-if ($makestat != 0) {
-    print "Making $make_vars_no_opt $qthreadopts runtime\n";
-    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_no_opt $qthreadopts runtime", "making chapel runtime", 1, 1);
-}
+print "Making $make_vars_opt runtime\n";
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt runtime", "making chapel runtime", 1, 1);
 
 print "Making modules\n";
 $makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", 1, 1);


### PR DESCRIPTION
Previously, if the compiler or runtime build failed we would retry
without optimizations. This was added a long time ago (726865ee4b)
when the build was less stable and we didn't have smoke testing like
we do today. The original intention was to allow us to get some
nightly results even if the optimized build failed, but I can't
remember this happening in many years. The retry build has confused
us recently for transient build issues, so just make build issues
always a fatal error to avoid confusion. We may lose a night of
testing for these configurations with transient errors, but I don't
think that's a huge deal and we should work to address those issues
instead of relying on the retry mechanism.