### PR TITLE
Make it a fatal error if the llvm runtime is needed and fails to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ parser: FORCE
 modules: FORCE
 	@echo "Making the modules..."
 	@cd modules && CHPL_LLVM_CODEGEN=0 $(MAKE)
-	-@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
+	@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
 	echo "Making the modules for LLVM..."; \
 	cd modules && CHPL_LLVM_CODEGEN=1 $(MAKE) ; \
 	fi
@@ -91,7 +91,7 @@ modules: FORCE
 runtime: FORCE
 	@echo "Making the runtime..."
 	@cd runtime && CHPL_LLVM_CODEGEN=0 $(MAKE)
-	-@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
+	@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
 	echo "Making the runtime for LLVM..."; \
 	cd runtime && CHPL_LLVM_CODEGEN=1 $(MAKE) ; \
 	fi


### PR DESCRIPTION
Making llvm build failures non-fatal was done in 9e813328f0 so that:

"""
If you try to chpl --llvm and the runtime with clang-included is not
built, you do get a decent error from the compiler. But some
LLVM-based features will still work (extern blocks) if the
clang-included runtime does not build.
"""

However, that was 5+ years ago before we were considering making llvm
the default. Nowadays I think we want to get these failures as early
as we can and limit confusion at `chpl` invocation time.