### PR TITLE
Clean up how some of the Arkouda perf testing environment is set up

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -40,8 +40,9 @@ fi
 
 # Compile Arkouda
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-  export ARKOUDA_PRINT_PASSES_FILE="$CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION/comp-time"
-  mkdir -p $(dirname $ARKOUDA_PRINT_PASSES_FILE)
+  PERF_SUB_DIR="$CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION"
+  mkdir -p "$PERF_SUB_DIR"
+  export ARKOUDA_PRINT_PASSES_FILE="$PERF_SUB_DIR/comp-time"
 fi
 if ! make ; then
   log_fatal_error "compiling arkouda"

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -26,7 +26,7 @@ fi
 # test against Chapel release (checking our current test/cron directories)
 function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release
-  export CHPL_TEST_PERF_CONFIGS="release:v,master"
+  export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
   currentSha=`git rev-parse HEAD`
   git checkout 1.22.1
   git checkout $currentSha -- $CHPL_HOME/test/
@@ -34,10 +34,10 @@ function test_release() {
   $CWD/nightly -cron ${nightly_args}
 }
 
-# test against Chapel master
-function test_master() {
-  export CHPL_TEST_PERF_DESCRIPTION=master
-  export CHPL_TEST_PERF_CONFIGS="release:v,master"
+# test against Chapel nightly
+function test_nightly() {
+  export CHPL_TEST_PERF_DESCRIPTION=nightly
+  export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
   $CWD/nightly -cron ${nightly_args}
 }
 

--- a/util/cron/test-perf.chapcs.arkouda.bash
+++ b/util/cron/test-perf.chapcs.arkouda.bash
@@ -11,5 +11,5 @@ source $CWD/common-arkouda.bash
 # chapcs only has python 3.4, need newer one for arkouda
 source /cray/css/users/chapelu/setup_python36.bash
 
-test_master
+test_nightly
 sync_graphs

--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -19,5 +19,5 @@ export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
-test_master
+test_nightly
 sync_graphs

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -30,5 +30,5 @@ source /cray/css/users/chapelu/setup_python36.bash
 # Run on an elogin node, so we have to tunnel to the login
 export ARKOUDA_TUNNEL_SERVER=$EPROXY_LOGIN
 
-test_master
+test_nightly
 sync_graphs


### PR DESCRIPTION
Specify the performance subdirectory and create it instead of taking the
dirname of a file.