### PR TITLE
Update a future that uses pragma init-copy-fn

### DIFF
--- a/test/errhandling/iterators/abort-loop-vs-init-pragma.bad
+++ b/test/errhandling/iterators/abort-loop-vs-init-pragma.bad
@@ -8,5 +8,5 @@ driver idx3 5
 driver idx3 6
 driver finish
 uncaught Error: 
-  abort-loop-vs-init-pragma.chpl:23: thrown here
-  abort-loop-vs-init-pragma.chpl:30: uncaught here
+  abort-loop-vs-init-pragma.chpl:24: thrown here
+  abort-loop-vs-init-pragma.chpl:31: uncaught here

--- a/test/errhandling/iterators/abort-loop-vs-init-pragma.chpl
+++ b/test/errhandling/iterators/abort-loop-vs-init-pragma.chpl
@@ -8,8 +8,9 @@ iter willthrow() throws {
 }
 
 // the behavior should not change when adding this pragma:
+// NOTE: we need the second argument to satisfy compiler assertions
 pragma "init copy fn"
-proc driver(ARG) {
+proc driver(ARG, definedConst: bool) {
   writeln("driver start");
 
   for idx1 in willthrow() do
@@ -29,6 +30,6 @@ proc driver(ARG) {
 
 proc main throws {
   writeln("main start");
-  var BBB = driver(willthrow());
+  var BBB = driver(willthrow(), definedConst=false);
   writeln("main finish");
 }


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/16218 changed some compiler
assertions to check any proc that has `pragma "init copy fn"` to have at least
two arguments instead of one. There's one future that test this pragma with
error handling. This PR updates that future by adding an argument to the proc.

`bad` file matches cleanly with this PR.
