### PR TITLE
Track the emitted code size in arkouda perf testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -43,9 +43,21 @@ if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
   PERF_SUB_DIR="$CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION"
   mkdir -p "$PERF_SUB_DIR"
   export ARKOUDA_PRINT_PASSES_FILE="$PERF_SUB_DIR/comp-time"
-fi
-if ! make ; then
-  log_fatal_error "compiling arkouda"
+  export ARKOUDA_EMITTED_CODE_SIZE_FILE="$PERF_SUB_DIR/emitted-code-size"
+  export CHPL_DEBUG_FLAGS="${CHPL_DEBUG_FLAGS} --print-emitted-code-size"
+
+  make 2>&1 | tee $ARKOUDA_EMITTED_CODE_SIZE_FILE.tmp
+  if [ ${PIPESTATUS[0]} -ne "0" ] ; then
+    log_fatal_error "compiling arkouda"
+  fi
+  if grep -q "Statements emitted:" $ARKOUDA_EMITTED_CODE_SIZE_FILE.tmp ; then
+    grep "Statements emitted:" $ARKOUDA_EMITTED_CODE_SIZE_FILE.tmp > $ARKOUDA_EMITTED_CODE_SIZE_FILE
+    rm -f $ARKOUDA_EMITTED_CODE_SIZE_FILE.tmp
+  fi
+else
+  if ! make ; then
+    log_fatal_error "compiling arkouda"
+  fi
 fi
 
 # Install Arkouda and python dependencies to a python-deps subdir


### PR DESCRIPTION
Track how many statements are generated for Arkouda. Most of Arkouda
compilation time is spent in makeBinary, which tends to be correlated
with the amount of generated code. Start tracking how much we're
generating so that we can the difference across configurations and track
the improvements from some upcoming changes.

The actual implementation is a little ugly since we `tee` the make
output to a file and then grep it. This would be a lot cleaner if we had
support for a `--print-emitted-code-size-file` option (like we have for
`--print-passes-file`)