### PR TITLE
Add a future for #16290, notest a relevant test

### DIFF
--- a/test/classes/initializers/compilerGenerated/copyDomainFormal.bad
+++ b/test/classes/initializers/compilerGenerated/copyDomainFormal.bad
@@ -1,0 +1,6 @@
+These should be different:
+{1..5}
+{1..5}
+These should be different:
+{1..5}
+{1..5}

--- a/test/classes/initializers/compilerGenerated/copyDomainFormal.chpl
+++ b/test/classes/initializers/compilerGenerated/copyDomainFormal.chpl
@@ -1,0 +1,43 @@
+{
+  class MyClass {
+    var D;
+    var A: [D] int;
+
+    /*
+    // uncomment this to get the desired behavior
+    proc init(d) {
+      this.D = d;
+    }
+    */
+  }
+
+  var arr = [1,2,3];
+  var c = new MyClass(arr.domain);
+  c.D = {1..5};
+
+  writeln("These should be different:");
+  writeln(c.A.domain);
+  writeln(arr.domain);
+}
+
+{
+  record MyRecord {
+    var D;
+    var A: [D] int;
+
+    /*
+    // uncomment this to get the desired behavior
+    proc init(d) {
+      this.D = d;
+    }
+    */
+  }
+
+  var arr = [1,2,3];
+  var c = new MyRecord(arr.domain);
+  c.D = {1..5};
+
+  writeln("These should be different:");
+  writeln(c.A.domain);
+  writeln(arr.domain);
+}

--- a/test/classes/initializers/compilerGenerated/copyDomainFormal.future
+++ b/test/classes/initializers/compilerGenerated/copyDomainFormal.future
@@ -1,0 +1,9 @@
+Compiler-generated init doesn't copy domain formals
+#16290
+
+With this future, we are notest'ing
+
+  test/classes/initializers/compilerGenerated/modifyDomain-array-created-by-init
+
+because it causes invalid writes. Once this bug is fixed, that notest should be
+removed

--- a/test/classes/initializers/compilerGenerated/copyDomainFormal.good
+++ b/test/classes/initializers/compilerGenerated/copyDomainFormal.good
@@ -1,0 +1,6 @@
+These should be different:
+{1..5}
+{0..2}
+These should be different:
+{1..5}
+{0..2}


### PR DESCRIPTION
Add a `.notest` for

  `classes/initializers/compilerGenerated/modifyDomain-array-created-by-init`

because https://github.com/chapel-lang/chapel/pull/16218 exposed a bug that
causes this test to fail under valgrind. This is captured in
https://github.com/chapel-lang/chapel/issues/16290.

Note that we already have 

  `classes/initializers/phase1/modifyDom-init-noType2`

which is a very similar test that contains the workaround for the bug already.

Also add a future for that issue.
