### PR TITLE
Bump nodepara to 6 for linux64 testing

### DIFF
--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
-$CWD/nightly -cron -mason -futures ${nightly_args} $(get_nightly_paratest_args)
+$CWD/nightly -cron -mason -futures ${nightly_args} $(get_nightly_paratest_args 6)


### PR DESCRIPTION
With linux64 testing moving to chapcs, we can increase `nodepara` to 6.
