### PR TITLE
Use a newer gcc for CS testing

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -18,7 +18,7 @@ function loadCSModule()
 if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
   export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
-  loadCSModule gcc
+  loadCSModule gcc/8.1.0
   loadCSModule python/2.7.6
   loadCSModule cray-fftw
 else


### PR DESCRIPTION
The default gcc is 6.1, which is having problems with newer llvm
versions so bump to 8.1. I was thinking about only bumping llvm testing,
but 6.1 is getting old, so it's probably worth using a newer version
across the board.