### PR TITLE
Quiet messages from lmod when submitting jobs in launchcmd

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -504,6 +504,11 @@ class AbstractJob(object):
         if self.submit_bin != 'qsub':
             raise RuntimeError('_launch_qsub called for non-pbs job type!')
 
+        # Quiet information from LMOD about module changes that would show up
+        # in our test output
+        logging.info('Setting LMOD_QUIET=1')
+        os.environ["LMOD_QUIET"] = "1"
+
         logging.info(
             'Starting {0} job "{1}" on {2} nodes with walltime {3} '
             'and output file: {4}'.format(


### PR DESCRIPTION
Lmod prints a lot of information about what modules are being changed or
reloaded, and we see these when doing a qsub. These messages will get
captured in our test output, which we don't want so quiet messages from
lmod to avoid that. Previously, we were setting this in a .bashrc file,
but here we're moving it to launchcmd so it doesn't have to be set
manually by developers.

Part of https://github.com/Cray/chapel-private/issues/1220