### PR TITLE
Skipif knucleotide-strings with baseline and valgrind

### DIFF
--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.skipif
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.skipif
@@ -1,0 +1,3 @@
+COMPOPTS <= --baseline
+CHPL_TEST_VGRND_EXE == on
+


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/16266 slowed down some string
operations that have especially big impact without --fast. That causes this test
to timeout in slower configs such as valgrindexe and baseline. So skip it in
those settings.
