### PR TITLE
Refactor the param loop in writef

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6122,6 +6122,117 @@ proc channel._read_complex(width:uint(32), out t:complex, i:int)
 }
 
 
+// This is called from within a param for loop in writef. It is important to
+// note here that the main benefit of this helper is that we don't pass all the
+// arguments from writef. This way, we can use the same code for an `arg` type
+// for which we have already created and instantiation of this.
+proc channel._writefOne(fmtStr, ref arg, i: int,
+                        ref cur: size_t, ref j: int,
+                        ref r: unmanaged _channel_regexp_info?, ref argType,
+                        ref conv: qio_conv_t, ref gotConv: bool,
+                        ref style: iostyle, ref err: syserr, origLocale: locale,
+                        len: size_t) throws {
+  //var conv:qio_conv_t;
+  //var style:iostyle;
+
+  gotConv = false;
+
+  if j <= i {
+    _format_reader(fmtStr, cur, len, err,
+                   conv, gotConv, style, r,
+                   false);
+  }
+
+  _conv_helper(err, conv, gotConv, j, argType);
+
+  var domore = _conv_sethandler(err, argType(i), style, i,arg,false);
+
+  if domore {
+    this._set_style(style);
+    // otherwise we will consume at least one argument.
+    select argType(i) {
+      when QIO_CONV_ARG_TYPE_SIGNED, QIO_CONV_ARG_TYPE_BINARY_SIGNED {
+        var (t,ok) = _toSigned(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else {
+          if argType(i) == QIO_CONV_ARG_TYPE_BINARY_SIGNED then
+            err = _write_signed(style.max_width_bytes, t, i);
+          else
+            try _writeOne(iokind.dynamic, t, origLocale);
+        }
+      } when QIO_CONV_ARG_TYPE_UNSIGNED, QIO_CONV_ARG_TYPE_BINARY_UNSIGNED {
+        var (t,ok) = _toUnsigned(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else {
+          if argType(i) == QIO_CONV_ARG_TYPE_BINARY_UNSIGNED then
+            err = _write_unsigned(style.max_width_bytes, t, i);
+          else
+            try _writeOne(iokind.dynamic, t, origLocale);
+        }
+      } when QIO_CONV_ARG_TYPE_REAL, QIO_CONV_ARG_TYPE_BINARY_REAL {
+        var (t,ok) = _toReal(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else {
+          if argType(i) == QIO_CONV_ARG_TYPE_BINARY_REAL then
+            err = _write_real(style.max_width_bytes, t, i);
+          else
+            try _writeOne(iokind.dynamic, t, origLocale);
+        }
+      } when QIO_CONV_ARG_TYPE_IMAG, QIO_CONV_ARG_TYPE_BINARY_IMAG {
+        var (t,ok) = _toImag(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else {
+          if argType(i) == QIO_CONV_ARG_TYPE_BINARY_IMAG then
+            err = _write_real(style.max_width_bytes, t:real, i);
+          else
+            try _writeOne(iokind.dynamic, t, origLocale);
+        }
+      } when QIO_CONV_ARG_TYPE_COMPLEX, QIO_CONV_ARG_TYPE_BINARY_COMPLEX {
+        var (t,ok) = _toComplex(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else {
+          if argType(i) == QIO_CONV_ARG_TYPE_BINARY_COMPLEX then
+            err = _write_complex(style.max_width_bytes, t, i);
+          else try _writeOne(iokind.dynamic, t, origLocale);
+        }
+      } when QIO_CONV_ARG_TYPE_NUMERIC {
+        var (t,ok) = _toNumeric(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else try _writeOne(iokind.dynamic, t, origLocale);
+      } when QIO_CONV_ARG_TYPE_CHAR {
+        var (t,ok) = _toChar(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else try _writeOne(iokind.dynamic, new ioChar(t), origLocale);
+      } when QIO_CONV_ARG_TYPE_BINARY_STRING {
+        var (t,ok) = _toBytes(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else try _writeOne(iokind.dynamic, t, origLocale);
+      } when QIO_CONV_ARG_TYPE_STRING { // can only happen with string
+        var (t,ok) = _toString(arg);
+        if ! ok {
+          err = qio_format_error_arg_mismatch(i);
+        } else try _writeOne(iokind.dynamic, t, origLocale);
+      } when QIO_CONV_ARG_TYPE_REGEXP { // It's not so clear what to do when printing
+        // a regexp. So we just don't handle it.
+        err = qio_format_error_write_regexp();
+      } when QIO_CONV_ARG_TYPE_REPR {
+        try _writeOne(iokind.dynamic, arg, origLocale);
+      } otherwise {
+        // Unhandled argument type!
+        throw new owned IllegalArgumentError("args(" + i:string + ")",
+                                       "writef internal error " + argType(i):string);
+      }
+    }
+  }
+}
 
 /*
 
@@ -6150,7 +6261,7 @@ proc channel.writef(fmtStr: ?t, const args ...?k): bool throws
     var conv:qio_conv_t;
     var gotConv:bool;
     var style:iostyle;
-    var end:size_t;
+    //var end:size_t;
     var argType:(k+5)*c_int;
 
     var r:unmanaged _channel_regexp_info?;
@@ -6165,107 +6276,8 @@ proc channel.writef(fmtStr: ?t, const args ...?k): bool throws
     var j = 0;
 
     for param i in 0..k-1 {
-      // The inside of this loop is a bit crazy because
-      // we're writing it all in a param for in order to
-      // get generic argument handling.
-
-      gotConv = false;
-
-      if j <= i {
-        _format_reader(fmtStr, cur, len, err,
-                       conv, gotConv, style, r,
-                       false);
-      }
-
-      _conv_helper(err, conv, gotConv, j, argType);
-
-      var domore = _conv_sethandler(err, argType(i), style, i,args(i),false);
-
-      if domore {
-        this._set_style(style);
-        // otherwise we will consume at least one argument.
-        select argType(i) {
-          when QIO_CONV_ARG_TYPE_SIGNED, QIO_CONV_ARG_TYPE_BINARY_SIGNED {
-            var (t,ok) = _toSigned(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else {
-              if argType(i) == QIO_CONV_ARG_TYPE_BINARY_SIGNED then
-                err = _write_signed(style.max_width_bytes, t, i);
-              else
-                try _writeOne(iokind.dynamic, t, origLocale);
-            }
-          } when QIO_CONV_ARG_TYPE_UNSIGNED, QIO_CONV_ARG_TYPE_BINARY_UNSIGNED {
-            var (t,ok) = _toUnsigned(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else {
-              if argType(i) == QIO_CONV_ARG_TYPE_BINARY_UNSIGNED then
-                err = _write_unsigned(style.max_width_bytes, t, i);
-              else
-                try _writeOne(iokind.dynamic, t, origLocale);
-            }
-          } when QIO_CONV_ARG_TYPE_REAL, QIO_CONV_ARG_TYPE_BINARY_REAL {
-            var (t,ok) = _toReal(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else {
-              if argType(i) == QIO_CONV_ARG_TYPE_BINARY_REAL then
-                err = _write_real(style.max_width_bytes, t, i);
-              else
-                try _writeOne(iokind.dynamic, t, origLocale);
-            }
-          } when QIO_CONV_ARG_TYPE_IMAG, QIO_CONV_ARG_TYPE_BINARY_IMAG {
-            var (t,ok) = _toImag(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else {
-              if argType(i) == QIO_CONV_ARG_TYPE_BINARY_IMAG then
-                err = _write_real(style.max_width_bytes, t:real, i);
-              else
-                try _writeOne(iokind.dynamic, t, origLocale);
-            }
-          } when QIO_CONV_ARG_TYPE_COMPLEX, QIO_CONV_ARG_TYPE_BINARY_COMPLEX {
-            var (t,ok) = _toComplex(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else {
-              if argType(i) == QIO_CONV_ARG_TYPE_BINARY_COMPLEX then
-                err = _write_complex(style.max_width_bytes, t, i);
-              else try _writeOne(iokind.dynamic, t, origLocale);
-            }
-          } when QIO_CONV_ARG_TYPE_NUMERIC {
-            var (t,ok) = _toNumeric(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else try _writeOne(iokind.dynamic, t, origLocale);
-          } when QIO_CONV_ARG_TYPE_CHAR {
-            var (t,ok) = _toChar(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else try _writeOne(iokind.dynamic, new ioChar(t), origLocale);
-          } when QIO_CONV_ARG_TYPE_BINARY_STRING {
-            var (t,ok) = _toBytes(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else try _writeOne(iokind.dynamic, t, origLocale);
-          } when QIO_CONV_ARG_TYPE_STRING { // can only happen with string
-            var (t,ok) = _toString(args(i));
-            if ! ok {
-              err = qio_format_error_arg_mismatch(i);
-            } else try _writeOne(iokind.dynamic, t, origLocale);
-          } when QIO_CONV_ARG_TYPE_REGEXP { // It's not so clear what to do when printing
-            // a regexp. So we just don't handle it.
-            err = qio_format_error_write_regexp();
-          } when QIO_CONV_ARG_TYPE_REPR {
-            try _writeOne(iokind.dynamic, args(i), origLocale);
-          } otherwise {
-            // Unhandled argument type!
-            throw new owned IllegalArgumentError("args(" + i:string + ")",
-                                           "writef internal error " + argType(i):string);
-          }
-        }
-      }
+      _writefOne(fmtStr, args(i), i, cur, j, r, argType, conv, gotConv, style,
+                 err, origLocale, len);
     }
 
     if ! err {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6132,9 +6132,6 @@ proc channel._writefOne(fmtStr, ref arg, i: int,
                         ref conv: qio_conv_t, ref gotConv: bool,
                         ref style: iostyle, ref err: syserr, origLocale: locale,
                         len: size_t) throws {
-  //var conv:qio_conv_t;
-  //var style:iostyle;
-
   gotConv = false;
 
   if j <= i {
@@ -6261,7 +6258,6 @@ proc channel.writef(fmtStr: ?t, const args ...?k): bool throws
     var conv:qio_conv_t;
     var gotConv:bool;
     var style:iostyle;
-    //var end:size_t;
     var argType:(k+5)*c_int;
 
     var r:unmanaged _channel_regexp_info?;


### PR DESCRIPTION
Move the code inside the arg-processing param loop in writef in a separate
helper.

Prior to this PR, we had a very large param loop inside writef. The main problem
with that is that writef is a vararg function, and for each call to writef with
different permutation of types, we create a separate instantiation and for all
of them we unroll a large param loop. This increases the generated code size
significantly if the application is using string/bytes formatting heavily.
Arkouda is one example application.

This PR changes the generated code size in Arkouda as follows (default Arkouda
compilation, gasnet-udp)

version   | lines of C code
----------|----------------
master    | 4718231
PR        | 3550247


On XC, with default settings, this shaves off more than 4 minutes in Arkouda
compilation:

version   | time (s) | time (m)
----------|----------|---------
master    | 1084.931 | 18.08
PR (initial)        | 824.845  | 13.75
PR (after @mppf's suggestion) | 763.251  | 12.72


https://github.com/Cray/chapel-private/issues/1260#issuecomment-678829764 is
where we realized this issue.


Test:
- [x] standard
- [x] gasnet

