### PR TITLE
Add common and base test scripts for nightly AddressSanitizer testing

### DIFF
--- a/util/cron/common-asan.bash
+++ b/util/cron/common-asan.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Configure environment for testing AddressSanitizer.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
+export CHPL_MEM=cstdlib
+export CHPL_TASKS=fifo
+export CHPL_SANITIZE_EXE=address
+export ASAN_OPTIONS=detect_leaks=0

--- a/util/cron/common-asan.bash
+++ b/util/cron/common-asan.bash
@@ -6,5 +6,5 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 export CHPL_MEM=cstdlib
 export CHPL_TASKS=fifo
-export CHPL_SANITIZE_EXE=address
+export CHPL_SANITIZE=address
 export ASAN_OPTIONS=detect_leaks=0

--- a/util/cron/test-asan.bash
+++ b/util/cron/test-asan.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test ASAN-compatible configuration on full suite with ASAN on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+source $CWD/common-asan.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="asan"
+
+$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 6)


### PR DESCRIPTION
The common file is very simple and sets the environment as described in
https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/Sanitizers.rst

The actual test script starts with standard config by sourcing `common.bash`
and fires off nightly with 6 tasks per node as we do in other chapcs
correctness tests.