### PR TITLE
added skipif for create registry test

### DIFF
--- a/test/mason/publish/create-registry/SKIPIF
+++ b/test/mason/publish/create-registry/SKIPIF
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+"""
+mason requires CHPL_COMM=none (local)
+"""
+
+from __future__ import print_function
+from os import environ
+
+print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2' or environ['CHPL_LAUNCHER'] != 'none')

--- a/test/mason/publish/create-registry/SKIPIF
+++ b/test/mason/publish/create-registry/SKIPIF
@@ -1,10 +1,1 @@
-#!/usr/bin/env python
-
-"""
-mason requires CHPL_COMM=none (local)
-"""
-
-from __future__ import print_function
-from os import environ
-
-print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2' or environ['CHPL_LAUNCHER'] != 'none')
+../SKIPIF


### PR DESCRIPTION
Added a SKIPIF to `mason publish --create-registry`  test, which failed in nightly test. 