### PR TITLE
Stop inlining chpl__delete

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1752,7 +1752,7 @@ module ChapelBase {
 
   // implements 'delete' statement
   pragma "no borrow convert"
-  inline proc chpl__delete(arg) {
+  proc chpl__delete(arg) {
 
     if chpl_isDdata(arg.type) then
       compilerError("cannot delete data class");
@@ -1785,7 +1785,7 @@ module ChapelBase {
   }
 
   // delete two or more things
-  inline proc chpl__delete(arg, args...) {
+  proc chpl__delete(arg, args...) {
     chpl__delete(arg);
     for param i in 0..args.size-1 do
       chpl__delete(args(i));


### PR DESCRIPTION
`chpl__delete` is the module implementation of the `delete` statement. It
gets used a lot, which can create a lot of code bloat when inlined. It's
not a terribly performance sensitive operation so stop inlining it to
reduce the amount of code we generate.

This reduces the number of emitted statements for a comm=gasnet build of
Arkouda by ~160,000 (2,001,032 -> 1,838,056) and should result in a
non-trivial compilation time improvement.

Part of https://github.com/Cray/chapel-private/issues/1260