### PR TITLE
Stop targeting ...cronmail...@cray.com mailing addresses

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -8,8 +8,8 @@ $chplhomedir = abs_path("$cwd/../..");
 
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com chapel+tests\@discoursemail.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
+$failuremail = "chapel+tests\@discoursemail.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net";
 $replymail = "";
 
 $printusage = 1;

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -20,8 +20,8 @@ use lib "$FindBin::Bin";
 use nightlysubs;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com chapel+tests\@discoursemail.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
+$failuremail = "chapel+tests\@discoursemail.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net";
 $replymail = "";
 
 $valgrind = 0;

--- a/util/cron/start_opt_test
+++ b/util/cron/start_opt_test
@@ -20,8 +20,8 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com chapel+tests\@discoursemail.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
+$failuremail = "chapel+tests\@discoursemail.com";
+$allmail = "chapel-test-results-all\@lists.sourceforge.net";
 
 while (@ARGV) {
   $flag = shift @ARGV;

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -4,7 +4,7 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com chapel+tests\@discoursemail.com";
+$failuremail = "chapel+tests\@discoursemail.com";
 $replymail = "";
 
 $tokctdir = abs_path(dirname(__FILE__));


### PR DESCRIPTION
This, along with a pair of PRs on our internal repo, changes our test
structure to stop mailing the ...cronmail...@cray.com addresses.  The most
important / failure mails are sent to our emerging Discourse site.
The "all" results are still sent to the SourceForge list (because it
seemed easier at this point than refactoring that logic to not send
anywhere at all).