### PR TITLE
Fix method call not called on value

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -525,7 +525,7 @@ module Map {
      */
     proc addOrSet(in k: keyType, in v: valType) {
       _enter(); defer _leave();
-      var (found, slot) = findAvailableSlot(k);
+      var (found, slot) = table.findAvailableSlot(k);
       table.fillSlot(slot, k, v);
     }
 


### PR DESCRIPTION
A method call was missing the table value it was supposed to be called on.
Add the receiver argument.