### PR TITLE
Add some missing 'use' clauses for NetCDF

### DIFF
--- a/modules/packages/NetCDF.chpl
+++ b/modules/packages/NetCDF.chpl
@@ -47,6 +47,7 @@ module NetCDF {
      https://www.unidata.ucar.edu/software/netcdf/docs
    */
   module C_NetCDF {
+    public use SysCTypes, SysBasic;
     // Generated with c2chapel version 0.1.0
 
     // Header given to c2chapel:

--- a/test/library/packages/canCompileNoLink/testNetCDF.chpl
+++ b/test/library/packages/canCompileNoLink/testNetCDF.chpl
@@ -1,0 +1,6 @@
+use NetCDF;
+use NetCDF.C_NetCDF;
+
+var f = ncopen("ppt2020_08_20.nc", NC_WRITE);
+var status: int = nc_close(f);
+


### PR DESCRIPTION
These omissions crept into the code base at some point when we were clamping
down on auto-available symbols that shouldn't be and weren't caught in
nightly testing, but were pointed out in a SO post:

https://stackoverflow.com/questions/63622128/sysctypes-errors-when-using-netcdf-chpl/63694151#63694151