### PR TITLE
Refactor Mac docs for clarity

### DIFF
--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -4,40 +4,54 @@
 Using Chapel on Mac OS X
 ========================
 
-By and large, Chapel can be used on a Macintosh running OS X just like
-any other platform -- refer to the :ref:`chapelhome-quickstart` for more
-information on building and using Chapel.
+There are two main approaches for using Chapel on Mac OS X:
+
+1) Install via Homebrew_.  For existing Homebrew users, this is the
+   quickest way to get up and running, but it results in a copy of
+   Chapel that only supports shared-memory (single-locale) executions.
+
+2) Install and build Chapel from source, as with any other UN*X
+   system.  This is slightly more involved, but supports Chapel's full
+   feature set.  Refer to the :ref:`chapelhome-quickstart` for more
+   information.
 
 --------
 Homebrew
 --------
 
 A minimal installation of Chapel can be obtained through Homebrew_ with the
-following command::
+following commands::
 
+    brew update
     brew install chapel
 
-The above command installs a release version of Chapel. It is also
-possible to use Homebrew_ to build and install a development version
-based on the master branch on GitHub::
-
-    brew install chapel --HEAD
-
-When using a Homebrew install of Chapel, the ``CHPL_HOME`` directory is
-here::
+These commands install the latest release of Chapel.  When using a
+Homebrew installation of Chapel, the ``CHPL_HOME`` directory is here::
 
     /usr/local/Cellar/chapel/<chapel-version>/libexec/
 
+Compile and run a test program::
+
+    chpl /usr/local/Cellar/chapel/<chapel-version>/libexec/hello.chpl
+    ./hello
+    
 .. note::
 
-   The Homebrew installation provides a minimal installation of Chapel for
-   users to explore and test the language.
-   Of the omitted features, :ref:`multilocale <readme-multilocale>` support
-   is most notable.
-   Users interested in utilizing all of the
-   language's rich features should clone the repository_ or
-   download a release_, and :ref:`build Chapel from source <readme-building>`.
+   The Homebrew installation provides a minimal installation of Chapel
+   for users to explore and test the language.  Of the omitted
+   features, :ref:`multilocale <readme-multilocale>` support is most
+   notable.  Users interested in utilizing Chapel's complete set of
+   features should build Chapel from source (option 1 above).
 
-.. _Homebrew: https://github.com/Homebrew/brew
+.. note::
+
+   It is also possible for developers to use Homebrew to build and
+   install a development version based on the master branch on
+   GitHub::
+
+    brew install chapel --HEAD
+
+
+.. _Homebrew: https://brew.sh/
 .. _repository: https://github.com/chapel-lang/chapel
 .. _release: https://github.com/chapel-lang/chapel/releases

--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -6,7 +6,7 @@ Using Chapel on Mac OS X
 
 There are two main approaches for using Chapel on Mac OS X:
 
-1) Install via Homebrew_.  For existing Homebrew users, this is the
+1) Install via Homebrew_.  For Homebrew users, this is the
    quickest way to get up and running, but it results in a copy of
    Chapel that only supports shared-memory (single-locale) executions.
 

--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -34,6 +34,10 @@ Compile and run a test program::
 
     chpl /usr/local/Cellar/chapel/<chapel-version>/libexec/hello.chpl
     ./hello
+
+If you're new to Chapel, refer to the `What's Next?
+<https://chapel-lang.org/docs/usingchapel/QUICKSTART.html#what-s-next>`_
+section of :ref:`chapelhome-quickstart` for next steps.
     
 .. note::
 
@@ -41,7 +45,7 @@ Compile and run a test program::
    for users to explore and test the language.  Of the omitted
    features, :ref:`multilocale <readme-multilocale>` support is most
    notable.  Users interested in utilizing Chapel's complete set of
-   features should build Chapel from source (option 1 above).
+   features should build Chapel from source (option 2 above).
 
 .. note::
 
@@ -53,5 +57,4 @@ Compile and run a test program::
 
 
 .. _Homebrew: https://brew.sh/
-.. _repository: https://github.com/chapel-lang/chapel
-.. _release: https://github.com/chapel-lang/chapel/releases
+.. _whatsnext: 


### PR DESCRIPTION
As a result in some confusion expressed in issue #16269, I've taken
a pass over the Mac documentation to try to clarify it.  I've also made
changes to the install-mac.html webpage in a separate effort to
avoid sending people to the Quickstart instructions prematurely,
which suggest they'll need to build from source.  Here's what the net
result looks like:

web page:

<img width="1059" alt="Screen Shot 2020-09-02 at 6 13 40 PM" src="https://user-images.githubusercontent.com/7536222/92060305-37558080-ed48-11ea-8cbb-6ff9000964a9.png">

docs page:

<img width="631" alt="Screen Shot 2020-09-02 at 6 12 38 PM" src="https://user-images.githubusercontent.com/7536222/92060430-91eedc80-ed48-11ea-9c8e-9689811379e9.png">
<img width="629" alt="Screen Shot 2020-09-02 at 6 12 47 PM" src="https://user-images.githubusercontent.com/7536222/92060439-96b39080-ed48-11ea-8918-2f752c8b87e1.png">

I spent some time thinking about what it would take to eliminate the arguable redundancy between these two pages, but ended up keeping it because I think the right way to get rid of the redundancy would be to eliminate the install-mac.html web page and have it point directly at the Mac-specific docs; but I think that this has the downside of not having a short-and-sweet version of the installation instructions for people who don't need much hand-holding (say, experienced Chapel + homebrew users trying it on a Mac for the first time).