### PR TITLE
Increase the timeout for gasnet-ibv-fast performance testing

### DIFF
--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -14,6 +14,10 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.fast"
 source $CWD/common-cray-cs.bash y
 source $CWD/common-perf-cray-cs.bash
 
+# Keep long running tests as a performance issue instead of being reported as a
+# correctness timeout -- https://github.com/Cray/chapel-private/issues/443
+export CHPL_TEST_TIMEOUT=1800
+
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX=83G
 export CHPL_GASNET_MORE_CFG_OPTIONS=--disable-ibv-odp


### PR DESCRIPTION
When the machine we run on has been up long enough, tests that use a
large fraction of memory like ISx start taking longer and hitting our
timeout under gasnet-ibf-fast. This is a performance issue and not a
hang or correctness issue, so bump the timeout. We'll still track the
issue as a performance regression in our graphs, it just won't create
noise in nightly regression mails.

See https://github.com/Cray/chapel-private/issues/443 for more info