### PR TITLE
Print the original output when a prediff might hide compile errors

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1705,6 +1705,15 @@ for testname in testsrc:
             printTestVariation(compoptsnum, compoptslist);
             sys.stdout.write(']\n')
 
+            # If there was a prediff it may have hidden the compilation
+            # failure, so print out the full log. Note that we don't check
+            # systemPrediffs since they shouldn't be filtering all output
+            # anyways, and it could create noise for configs that use them.
+            if result != 0:
+                if prediff or globalPrediff:
+                    sys.stdout.write('[Compiler output before prediff was as follows:]\n')
+                    sys.stdout.write(origoutput)
+
             if (result != 0 and futuretest != ''):
                 badfile=test_filename+'.bad'
                 if os.access(badfile, os.R_OK):


### PR DESCRIPTION
Some of our prediffs grep for specific lines and discard everything
else. When compilation fails this results in hiding all the output,
so if compilation failed and there was a prediff print the original
output so it's easier to triage.