### PR TITLE
Do a dummy iteration to work around a resolution bug

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1372,6 +1372,10 @@ module ChapelBase {
     if t == string {
       return str;
     } else {
+      // we need to do an iteration over a range variable before casting a
+      // string to a type. Otherwise, we can't resolve chpl_debug_writeln in
+      // `range.these`
+      { var dummyRange = 1..0; for i in dummyRange {} }
       return str:t;
     }
   }


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/16278/commits/f657ab29615d4cafe1a5b547cfc2c27aaafce9a0
removed a function that called `string.find` which has a pattern that iterates
over a range variable. This was probably the first time that the compiler
encounters this pattern and resolved `range.these`.

After that function is removed we had issues with resolving
`chpl_debug_writeln`. So, this PR adds that pattern right before a string to int
cast to have the same behavior in terms of resolution order.

https://github.com/Cray/chapel-private/issues/1293 has some of the similar
issues to fix. This work around should be reverted once we have (maybe partly)
addressed the problem.

Test:
- [x] standard `release/examples`
