### PR TITLE
Improve atomics docs

### DIFF
--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -245,16 +245,23 @@ operations must be done with care and should generally not be used to
 synchronize tasks.
 
 Non-SC atomic operations are specified by providing a *memory order*
-argument to the atomic operations. See
-Section \ `26.4.1 <#Functions_on_Atomic_Variables>`__ for more
-information on the memory order types.
+argument to the atomic operations. See the
+:ref:`Functions_on_Atomic_Variables` section for more information on the
+memory order types.
+
+   *Open issue*.
+
+   This section describes ``memoryOrder.relaxed`` but does not yet
+   describe ``memoryOrder.acquire``, ``memoryOrder.release``, or
+   ``memoryOrder.acqRel`` orderings. The intention is that the behavior
+   of these orderings match the C and C++ definitions.
 
 .. _relaxed_atomics:
 
 Relaxed Atomic Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Although Chapel’s relaxed atomic operations (``memory_order_relaxed``)
+Although Chapel’s relaxed atomic operations (``memoryOrder.relaxed``)
 do not complete in a total order by themselves and might contribute to
 non-deterministic programs, relaxed atomic operations cannot contribute
 to a data race that would prevent sequential consistency.

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -554,6 +554,10 @@ values are:
 
 -  memoryOrder.seqCst
 
+See also :ref:`Chapter-Memory_Consistency_Model` and in particular
+:ref:`non_sc_atomics` for more information on the meaning of these memory
+orders.
+
 Unless specified, the default for the memoryOrder parameter is
 memoryOrder.seqCst.
 

--- a/test/release/examples/primers/atomics.chpl
+++ b/test/release/examples/primers/atomics.chpl
@@ -2,9 +2,9 @@
 
 /*
 
-  This primer illustrates Chapel's atomic variables.  For more information
-  on Chapel's atomics, see the :ref:`Chapel Language Specification
-  <chapel-spec>`.
+  This primer illustrates Chapel's atomic variables.  For more information on
+  Chapel's atomics, see the :ref:`Atomic_Variables` section of the language
+  specification.
 
 */
 


### PR DESCRIPTION
* Improve links between primer, functions on atomic vars section, and memory consistency model section
* use current spelling for orderings in memory consistency section
* add a note in memory consistency section about acquire/release not being described yet

Reviewed by @ronawho - thanks!