### PR TITLE
Work-around TOML bug in mason and add a future for bug

### DIFF
--- a/test/library/packages/TOML/test/commentOnly.chpl
+++ b/test/library/packages/TOML/test/commentOnly.chpl
@@ -1,0 +1,11 @@
+use TOML;
+
+config const str: string = """# Comment""";
+
+proc main() {
+  var TomlData = parseToml(str);
+  writeln(TomlData);
+  delete TomlData;
+}
+
+

--- a/test/library/packages/TOML/test/commentOnly.future
+++ b/test/library/packages/TOML/test/commentOnly.future
@@ -1,0 +1,2 @@
+bug: TOML containing only comments produces memory errors (caught in valgrind)
+

--- a/test/mason/search/badFileName/CLEANFILES
+++ b/test/mason/search/badFileName/CLEANFILES
@@ -1,0 +1,1 @@
+mason_home/mason-registry/Bricks/cache.toml

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -169,8 +169,7 @@ proc rankResults(results: list(string), query: string): [] string {
 /* Creates an empty cache file if its not found in registry */
 proc touch(pathToReg: string) {
   const fileWriter = open(pathToReg, iomode.cw).writer();
-  const contents = "# This cache file was created automatically by mason search";
-  fileWriter.write(contents);
+  fileWriter.write("");
   fileWriter.close();
 }
 


### PR DESCRIPTION
TOML module produces a seg fault when parsing a file containing only a comment on linux32 / valgrind configs.\

This was exposed when `mason search` started adding a cache file containing only a comment if a cache
file did not exist (#16223). 

In this PR, we work around this bug by creating an empty cache file instead.

Also:

- added the `cache.toml` to CLEANFILES to prevent previous runs from interfering with each other in local testing
- added a future for the TOML bug - to be debugged in the future.