### PR TITLE
Consider cray-cs as cross-compiling

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -16,9 +16,6 @@ GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 GMP_CROSS_COMPILED=yes
-else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
-CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
-GMP_CROSS_COMPILED=yes
 endif
 
 # Disable use of alloca for pgi, it seems to cause stack overflows.
@@ -31,8 +28,6 @@ endif
 # On Macs, not building the shared libraries causes warnings.
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared
-else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_GMP_CFG_OPTIONS += --enable-static --disable-shared
 endif
 

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -10,11 +10,14 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CC)
 
 #
-# Cray X* builds are cross-compilations
+# Cray builds are cross-compilations
 #
 GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
+GMP_CROSS_COMPILED=yes
+else ifneq (, $(filter cray-cs,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-unknown-linux-gnu
 GMP_CROSS_COMPILED=yes
 endif
 

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -14,7 +14,7 @@ HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host ma
 #
 GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_GMP_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
+CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
 GMP_CROSS_COMPILED=yes
 endif
 

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -6,10 +6,12 @@ CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 #
-# Cray X* builds are cross-compilations.
+# Cray builds are cross-compilations.
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
+else ifneq (, $(filter cray-cs,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-unknown-linux-gnu
 endif
 
 #

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_HWLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
+CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
 endif
 
 #

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -10,8 +10,6 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_HWLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
-else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
-CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif
 
 #

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_JEMALLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
+CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
 endif
 
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -6,10 +6,12 @@ CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 #
-# Cray X* builds are cross-compilations.
+# Cray builds are cross-compilations.
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
+else ifneq (, $(filter cray-cs,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-unknown-linux-gnu
 endif
 
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -10,8 +10,6 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
-else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
-CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif
 
 CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -19,7 +19,7 @@ QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 # Cray X* builds are cross-compilations
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_QTHREAD_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
+CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
 endif
 
 ifneq ($(CHPL_MAKE_HWLOC),none)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -16,10 +16,12 @@ QTHREAD_BUILD_DIR = $(QTHREAD_ABS_DIR)/$(QTHREAD_BUILD_SUBDIR)
 QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 
 #
-# Cray X* builds are cross-compilations
+# Cray builds are cross-compilations
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-cle-linux-gnu
+else ifneq (, $(filter cray-cs,$(CHPL_MAKE_TARGET_PLATFORM)))
+CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_ARCH)-unknown-linux-gnu
 endif
 
 ifneq ($(CHPL_MAKE_HWLOC),none)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -20,8 +20,6 @@ QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 #
 ifneq (, $(filter cray-x% cray-shasta,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_QTHREAD_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
-else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
-CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif
 
 ifneq ($(CHPL_MAKE_HWLOC),none)

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -70,11 +70,6 @@ def get(flag='host', llvm_mode='default'):
             if subcompiler == 'none':
                 sys.stderr.write("Warning: Compiling on {0} without a PrgEnv loaded\n".format(platform_val))
             compiler_val = "cray-prgenv-{0}".format(subcompiler.lower())
-    elif chpl_platform.is_cross_compiling():
-        if flag == 'host':
-            compiler_val = 'gnu'
-        else:
-            compiler_val = platform_val + '-gnu'
     else:
         # Normal compilation (not "cross-compiling")
         # inherit the host compiler if the target compiler is not set and

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -13,14 +13,14 @@ def get():
         comm_val = chpl_comm.get()
         platform_val = chpl_platform.get('target')
 
-        if platform_val.startswith('cray-') or chpl_platform.is_cross_compiling():
+        if platform_val.startswith('cray-'):
             has_aprun = find_executable('aprun')
             has_slurm = find_executable('srun')
             if has_aprun and has_slurm:
                 launcher_val = 'none'
             elif has_aprun:
                 launcher_val = 'aprun'
-            elif has_slurm or platform_val == 'aarch64':
+            elif has_slurm:
                 launcher_val = 'slurm-srun'
             else:
                 # FIXME: Need to detect aprun/srun differently. On a cray

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -78,11 +78,6 @@ def get(flag='host'):
     return platform_val
 
 
-@memoize
-def is_cross_compiling():
-    return get('host') != get('target')
-
-
 def _main():
     parser = optparse.OptionParser(usage='usage: %prog [--host|target])')
     parser.add_option('--host', dest='flag', action='store_const',


### PR DESCRIPTION
(Duplicate PR #16335 from master to release/1.22.)

[original PR reviewed by @gbtitus]

Cray CS login and compute nodes can have different ISAs so consider
them as cross-compiling.

Resolves https://github.com/cray/chapel-private/issues/1262

This makes a few other improvements to our cross-compiling logic
while I was changing things.

It removes vestiges of target platform cross compilation support. We
used to experimentally support arm cross-compilation by specifying
`CHPL_TARGET_PLATFORM=aarch64`, but that was for a prototype system.
Most of that was removed in #11905, but this was left. I don't think
it has any purpose anymore, so remove it.

If we support a general cross compiling mechanism in the future I
suspect it will be with `CHPL_ARCH`, not `CHPL_PLATFORM` -- #11903

This also switches from using `uname -m` to `CHPL_TARGET_ARCH` for
specifying the third-party `./configure --host`

When we're cross-compiling for Cray's in our third-party scripts we
throw `--host` in order to tell configure what type of system the
code will be executing on (note that configure `--host` is backwards
from our notion of host vs. target.)

Previously, we were just using `uname -m`, which gives you the host
architecture and on crays the login and compute nodes have to be the
same architecture so this was safe. However, since that work was done
we added a `CHPL_{HOST,TARGET}_ARCH` variable so we can just use that
instead of computing uname. And here we're switching from using the
host arch to the target arch since it's what configure is looking
for. In the cray case they currently have to be the same, but that
might not be true in the future.