### PR TITLE
Add ability to use paratest.chapcs from nightly, use that for valgrind

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -24,6 +24,10 @@ $failuremail = "chapel+tests\@discoursemail.com";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net";
 $replymail = "";
 
+# these two are determined by the -chapcs flag
+$paratestscript = "";
+$paratestargs = "";
+
 $valgrind = 0;
 $interpret = 0;
 $printusage = 1;
@@ -64,6 +68,7 @@ $numtrials = "";
 $cronrecipient = "";
 $junit_xml = 0;
 $mason_build = 0;
+$chapcs = 0;
 
 while (@ARGV) {
     $flag = shift @ARGV;
@@ -152,6 +157,8 @@ while (@ARGV) {
         $asserts = 1;
     } elsif ($flag eq "-mason") {
         $mason_build = 1;
+    } elsif ($flag eq "-chapcs") {
+        $chapcs = 1;
     } else {
         $printusage = 1;
         last;
@@ -160,6 +167,18 @@ while (@ARGV) {
 
 
 print localtime() . "  host: " . hostname . "\n";
+
+# set the paratest script and args if needed
+if ($chapcs == 1) {
+  $paratestscript = "../util/test/paratest.chapcs";
+  $paratestargs = "-nightly";
+}
+else {
+  if ($parnodefile ne "") {
+    $paratestscript = "../util/test/paratest.server";
+    $paratestargs = "-nodefile $parnodefile";
+  }
+}
 
 # If this is running in jenkins, link to the job in the email.
 $crontab = "Unknown origin for this job...";
@@ -743,8 +762,8 @@ if ($runtests == 0) {
         $rawsummary = $permsum;
     } else {
         mysystem("cp $parnodefile $testdir/", "copying parallel node file", 1, 1);
-        print "about to execute: cd $testdir && ../util/test/paratest.server -nodefile $parnodefile $testflags\n";
-        $status = mysystem("cd $testdir && ../util/test/paratest.server -nodefile $parnodefile $testflags", "running parallel tests", 0, 0);
+        print "about to execute: cd $testdir && $paratestscript $paratestargs $testflags\n";
+        $status = mysystem("cd $testdir && $paratestscript $paratestargs $testflags", "running parallel tests", 0, 0);
     }
 
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -24,9 +24,10 @@ $failuremail = "chapel+tests\@discoursemail.com";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net";
 $replymail = "";
 
-# these two are determined by the -chapcs flag
-$paratestscript = "";
-$paratestargs = "";
+# these two are used to select one from start_test, paratest.server and
+# paratest.chapcs
+$script = "";
+$scriptflags = "";
 
 $valgrind = 0;
 $interpret = 0;
@@ -168,16 +169,16 @@ while (@ARGV) {
 
 print localtime() . "  host: " . hostname . "\n";
 
-# set the paratest script and args if needed
+# set the testing script and args
 if ($chapcs == 1) {
-  $paratestscript = "../util/test/paratest.chapcs";
-  $paratestargs = "-nightly";
-}
-else {
-  if ($parnodefile ne "") {
-    $paratestscript = "../util/test/paratest.server";
-    $paratestargs = "-nodefile $parnodefile";
-  }
+  $script = "../util/test/paratest.chapcs";
+  $scriptflags = "-nightly";
+} elsif ($parnodefile ne "") {
+  $script = "../util/test/paratest.server";
+  $scriptflags = "-nodefile $parnodefile";
+} else {
+  $script = "../util/start_test";
+  $scriptflags = "";
 }
 
 # If this is running in jenkins, link to the job in the email.
@@ -752,8 +753,8 @@ if ($runtests == 0) {
         mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
     }
 
+    $testcommand = "cd $testdir && $script $scriptflags $testflags";
     if ($parnodefile eq "") {
-        $testcommand = "cd $testdir && ../util/start_test $testflags";
         print "Executing $testcommand\n";
         $status = mysystem($testcommand, "running standard tests", 0, 0);
         print "Moving the log and summary files\n";
@@ -762,8 +763,8 @@ if ($runtests == 0) {
         $rawsummary = $permsum;
     } else {
         mysystem("cp $parnodefile $testdir/", "copying parallel node file", 1, 1);
-        print "about to execute: cd $testdir && $paratestscript $paratestargs $testflags\n";
-        $status = mysystem("cd $testdir && $paratestscript $paratestargs $testflags", "running parallel tests", 0, 0);
+        print "about to execute: $testcommand\n";
+        $status = mysystem($testcommand, "running parallel tests", 0, 0);
     }
 
 

--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -5,11 +5,10 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-valgrind.bash
-source $CWD/common-localnode-paratest.bash
 
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
-$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 20)
+$CWD/nightly -cron ${nightly_args} -chapcs

--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 import chpl_comm
 import utils
 
+debug = True
 
 def run_command_wrapper(command):
     """
@@ -133,17 +134,27 @@ def get_good_nodepara():
     return nodepara
 
 
-def run_paratest(args):
+def run_paratest(paratest_args, nightly=False):
     """
     Run paratest inside an salloc using all nodes that are not reserved
     exclusively on the chapel partition. Throw `--oversubscribe --nice` and
     turn off affinity and limit how many executables can run at once so we play
     nice with other testing going on.
     """
-    nodepara = get_good_nodepara()
-    num_free_nodes = get_num_non_exclusive_nodes()
-    para_env = ['-env', 'CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes', '-env',
-                'CHPL_RT_OVERSUBSCRIBED=yes']
+    if not debug:
+        nodepara = get_good_nodepara()
+        num_free_nodes = get_num_non_exclusive_nodes()
+    else:
+        print('Running in debug mode')
+        print('paratest_args: {}'.format(paratest_args))
+        print('nightly: {}'.format(nightly))
+        nodepara = 1
+        num_free_nodes = 1
+
+    para_env = ['-env', 'CHPL_RT_OVERSUBSCRIBED=yes']
+    # we run exclusively with nightly, so no need to limit
+    if not nightly:
+        para_env.extend(['-env', 'CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes'])
 
     salloc_cmd = ['salloc',
                   '--nodes={0}'.format(num_free_nodes),
@@ -152,21 +163,23 @@ def run_paratest(args):
                   '--oversubscribe',
                   '--nice']
 
-    exclude_set = get_exclusive_nodes()[1]
-    if exclude_set:
-        salloc_cmd.append('--exclude={0}'.format(','.join(exclude_set)))
+    if not debug:
+        exclude_set = get_exclusive_nodes()[1]
+        if exclude_set:
+            salloc_cmd.append('--exclude={0}'.format(','.join(exclude_set)))
 
     paratest_path = os.path.join(os.path.dirname(__file__), 'paratest.server')
 
     paratest_cmd = salloc_cmd + [paratest_path] + para_env
-    paratest_cmd += ['-nodepara', str(nodepara)] + args
+    paratest_cmd += ['-nodepara', str(nodepara)] + paratest_args
     print('running "{0}"'.format(' '.join(paratest_cmd)))
 
 
     start_time = timeit.default_timer()
-    for line in utils.run_live_command(paratest_cmd):
-        sys.stdout.write(line)
-        sys.stdout.flush()
+    if not debug:
+        for line in utils.run_live_command(paratest_cmd):
+            sys.stdout.write(line)
+            sys.stdout.flush()
     elapsed = int(timeit.default_timer() - start_time)
     minutes, seconds = divmod(elapsed, 60)
     print('paratest took {0} minutes and {1} seconds'.format(minutes, seconds))
@@ -184,13 +197,19 @@ def running_during_nightly():
     return nightly_start_exclusive <= now <= nightly_end_exclusive
 
 
-def main(paratest_args):
+def main(args):
     """ Just run paratest with the user's args """
-    if running_during_nightly():
-        print('Please avoid running when nightly has exclusive access')
-        exit(1)
 
-    run_paratest(paratest_args)
+    if '-nightly' in args:
+        args.remove('-nightly')
+        nightly = True
+    else:
+        if running_during_nightly():
+            print('Please avoid running when nightly has exclusive access')
+            exit(1)
+        nightly = False
+
+    run_paratest(paratest_args=args, nightly=nightly)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The main purpose of this PR is to use paratest.chapcs for valgrind testing so
that it runs quicker. In order to do that this PR:

- Adds a `-chapcs` flag to `nightly`

- Parametrizes the script that `nightly` uses so that we can choose between
  `start_test`, `paratest.server`, `paratest.chapcs` more easily

- Adds a `-nightly` flag to `paratest.chapcs`

- Adjusts `paratest.chapcs` to detect `-chapcs` argument anywhere in the command
  line and if it exists:

  - To stop checking for the exclusive nightly hours
  - To stop adding `CHPL_TEST_LIMIT_RUNNING_EXECUTABLES` (this'll require us to
    use exclusive allocations for correctness tests on chapcs)

- While there, adds a global `debug = False` that can be switched on to run the
  script locally without slurm to generate some debugging output.

- Drops localnode stuff from valgrind cron script, and throws in `-chapcs` while
  calling `nightly`

I have considered using `argparse` in `paratest.chapcs` but it may be an overkill.
Also, its prefix matching can only be disabled after Python 3.5 and I didn't want to
think whether that's an issue.
