### PR TITLE
Set: Fix deadlock in isDisjoint()

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -234,16 +234,27 @@ module Set {
 
       on this {
         _enter(); defer _leave();
-        var (hasFoundSlot, _) = _htb.findFullSlot(x);
-        result = hasFoundSlot;
+        result = _contains(x);
       }
 
       return result;
     }
 
     /*
+     As above, but parSafe lock must be held and must be called "on this".
+    */
+    proc const _contains(const ref x: eltType): bool {
+      var (hasFoundSlot, _) = _htb.findFullSlot(x);
+      return hasFoundSlot;
+    }
+
+    /*
       Returns `true` if this set shares no elements in common with the set
       `other`, and `false` otherwise.
+
+      .. warning::
+
+        `other` must not be modified during this call.
 
       :arg other: The set to compare against.
       :return: Whether or not this set and `other` are disjoint.
@@ -255,11 +266,10 @@ module Set {
       on this {
         _enter(); defer _leave();
 
-        if !(size == 0 || other.size == 0) {
-
+        if _size != 0 {
           // TODO: Take locks on other?
           for x in other do
-            if this.contains(x) {
+            if this._contains(x) {
               result = false;
               break;
             }
@@ -433,10 +443,19 @@ module Set {
 
       on this {
         _enter(); defer _leave();
-        result = _htb.tableNumFullSlots;
+        result = _size;
       }
 
       return result;
+    }
+
+    /*
+      As above, but the parSafe lock must be held, and must be called
+      "on this".
+    */
+    pragma "no doc"
+    inline proc const _size {
+      return _htb.tableNumFullSlots;
     }
 
     /*

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -243,6 +243,7 @@ module Set {
     /*
      As above, but parSafe lock must be held and must be called "on this".
     */
+    pragma "no doc"
     proc const _contains(const ref x: eltType): bool {
       var (hasFoundSlot, _) = _htb.findFullSlot(x);
       return hasFoundSlot;

--- a/test/library/standard/Set/isDisjoint/setIsDisjoint.chpl
+++ b/test/library/standard/Set/isDisjoint/setIsDisjoint.chpl
@@ -1,5 +1,6 @@
 use Set;
 
+config param parSafe = false;
 config const testIters = 8;
 
 record testRecord {
@@ -12,8 +13,8 @@ proc _cast(type t: testRecord, x: int) {
 }
 
 proc doTest(type eltType) {
-  var s1: set(eltType);
-  var s2: set(eltType);
+  var s1: set(eltType, parSafe);
+  var s2: set(eltType, parSafe);
 
   assert(s1.isDisjoint(s2));
   assert(s2.isDisjoint(s1));

--- a/test/library/standard/Set/isDisjoint/setIsDisjoint.compopts
+++ b/test/library/standard/Set/isDisjoint/setIsDisjoint.compopts
@@ -1,0 +1,2 @@
+-sparSafe=false
+-sparSafe=true


### PR DESCRIPTION
While holding the parSafe lock in isDisjoint(), don't call size or
contains(), which also take the lock.  Instead, call _size and
_contains(), added here, which rely on the caller having taken the
lock.

Remove the optimization on other.size.  We're about to iterate over
other, so if it's empty we won't be looping over anything.  And the
check introduces the potential for deadlock between a.isDisjoint(b)
and b.isDisjoint(a) if both are parSafe, without a way to establish a
lock ordering between them.

Modify the test/library/standard/Set/isDisjoint/setIsDisjoint test to
run with parSafe=true and with parSafe=false.

closes #16351