### PR TITLE
Add a skipif to this new test like for its sibling

### DIFF
--- a/test/performance/vectorization/vectorizeOnly/iterator-loop-vectorization.skipif
+++ b/test/performance/vectorization/vectorizeOnly/iterator-loop-vectorization.skipif
@@ -1,0 +1,3 @@
+# This test require that the --inline-iterators, --inline, --vectorize, and
+# --optimize-loop-iterators flags are thrown. (Might require a few other too.)
+COMPOPTS <= --baseline


### PR DESCRIPTION
Resolves a `--baseline` failure with
`performance/vectorization/vectorizeOnly/iterator-loop-vectorization`

Trivial and not reviewed.