### PR TITLE
Add .skipifs for tests that use --minimal-modules

### DIFF
--- a/test/trivial/diten/printVisibleConflict.skipif
+++ b/test/trivial/diten/printVisibleConflict.skipif
@@ -1,0 +1,1 @@
+../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/trivial/diten/printvisible.skipif
+++ b/test/trivial/diten/printvisible.skipif
@@ -1,0 +1,1 @@
+../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/trivial/diten/printvisibleOptFalse.skipif
+++ b/test/trivial/diten/printvisibleOptFalse.skipif
@@ -1,0 +1,1 @@
+../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/trivial/diten/printvisibleOptTrue.skipif
+++ b/test/trivial/diten/printvisibleOptTrue.skipif
@@ -1,0 +1,1 @@
+../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/visibility/private/variables/accessSiblingPrint.skipif
+++ b/test/visibility/private/variables/accessSiblingPrint.skipif
@@ -1,0 +1,1 @@
+../../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/visibility/private/variables/privateToParentPrint.skipif
+++ b/test/visibility/private/variables/privateToParentPrint.skipif
@@ -1,0 +1,1 @@
+../../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif


### PR DESCRIPTION
Add .skipif files that are symlinks to an existing .skipif for tests that
use --minimal-modules. The --minimal-modules option crashes the compiler
with CHPL_COMM!=none.