### PR TITLE
Fix compilation errors with rank change/reindex privatize

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -481,7 +481,7 @@ module ArrayViewRankChange {
     proc init(type eltType, const _DomPid, const dom,
               const _ArrPid, const _ArrInstance,
               const collapsedDim, const idx,
-              param ownsArrInstance : bool = false) {
+              param ownsArrInstance : bool) {
       super.init(eltType = eltType);
       this._DomPid         = _DomPid;
       this.dom             = dom;
@@ -704,7 +704,8 @@ module ArrayViewRankChange {
                                         _ArrPid=privatizeData(2),
                                         _ArrInstance=privatizeData(3),
                                         collapsedDim=privatizeData(4),
-                                        idx=privatizeData(5));
+                                        idx=privatizeData(5),
+                                        ownsArrInstance=this.ownsArrInstance);
     }
 
     //

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -386,7 +386,7 @@ module ArrayViewReindex {
 
     proc init(type eltType, const _DomPid, const dom,
               const _ArrPid, const _ArrInstance,
-              param ownsArrInstance : bool = false) {
+              param ownsArrInstance : bool) {
       super.init(eltType = eltType);
       this._DomPid         = _DomPid;
       this.dom             = dom;
@@ -598,7 +598,8 @@ module ArrayViewReindex {
                                      _DomPid=privatizeData(0),
                                      dom=privatizeData(1),
                                      _ArrPid=privatizeData(2),
-                                     _ArrInstance=privatizeData(3));
+                                     _ArrInstance=privatizeData(3),
+                                     ownsArrInstance=this.ownsArrInstance);
     }
 
     //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2851,7 +2851,8 @@ module ChapelArray {
                                          // TODO: Should the array really store
                                          // these redundantly?
                                          collapsedDim=rcdom._value.collapsedDim,
-                                         idx=rcdom._value.idx);
+                                         idx=rcdom._value.idx,
+                                         ownsArrInstance=false);
 
       // this doesn't need to lock since we just created the domain d
       rcdom._value.add_arr(a, locking=false);
@@ -3099,7 +3100,8 @@ module ChapelArray {
                                       _DomPid = newDom._pid,
                                       dom = newDom._instance,
                                       _ArrPid=arrpid,
-                                      _ArrInstance=arr);
+                                      _ArrInstance=arr,
+                                      ownsArrInstance=false);
       // this doesn't need to lock since we just created the domain d
       newDom._value.add_arr(x, locking=false);
       return _newArray(x);


### PR DESCRIPTION
Follow-up to PR #16180 to fix compilation errors related to assignment 
between rank change / reindex arrays that differ in ownsArrInstance.
These errors were coming about due to privatization support code.

Trivial and not reviewed.

- [x] full local testing
- [x] `--no-local` testing

