### PR TITLE
Remove the word "possible" from these filtered error messages

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -590,7 +590,7 @@ def filter_compiler_errors(compiler_output):
     err_strings = ['could not checkout FLEXlm license']
     for s in err_strings:
         if re.search(s, compiler_output, re.IGNORECASE) != None:
-            error_msg = '(possible private issue #398) '
+            error_msg = '(private issue #398) '
             break
 
     return error_msg
@@ -624,14 +624,14 @@ def filter_errors(output, pre_exec_output, execgoodfile, execlog):
     for s in err_strings:
         # NOTE: checking pre_exec (compiler) output
         if re.search(s, pre_exec_output, re.IGNORECASE) != None:
-            extra_msg = '(possible private issue #482) '
+            extra_msg = '(private issue #482) '
             break
 
     err_strings = ['could not checkout FLEXlm license']
     for s in err_strings:
         if (re.search(s, output, re.IGNORECASE) != None or
             re.search(s, pre_exec_output, re.IGNORECASE) != None):
-            extra_msg = '(possible private issue #398) '
+            extra_msg = '(private issue #398) '
             break
 
     err_strings = ['=* Memory Leaks =*']


### PR DESCRIPTION
We're pretty certain that's what's going on when these trigger, so no need to
hedge on them.