### PR TITLE
Quiet some warnings about string truncation

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -193,12 +193,13 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
 endif
 
 #
-# Avoid false positives for allocation size and memcpy. Note that we use
-# -Walloc-size-larger-than=SIZE_MAX instead of `-Wno-alloc-size-larger-than`
-# since that did not exist in gcc 8.
+# Avoid false positives for allocation size, memcpy, and string truncation.
+# Note that we use -Walloc-size-larger-than=SIZE_MAX instead of
+# `-Wno-alloc-size-larger-than` since that did not exist in gcc 8.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 7; echo "$$?"),0)
 WARN_CXXFLAGS += -Walloc-size-larger-than=18446744073709551615
+WARN_CXXFLAGS += -Wno-stringop-truncation
 SQUASH_WARN_GEN_CFLAGS += -Walloc-size-larger-than=18446744073709551615 -Wno-restrict
 endif
 


### PR DESCRIPTION
We're only seeing these with gcc 8+ when AddressSanitizer is enabled. The
warnings are harmless, so quiet them.