### PR TITLE
Drop valgrindexe nodepara to 6

### DIFF
--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -12,4 +12,4 @@ unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrindexe"
 
-$CWD/nightly -cron -valgrindexe ${nightly_args} $(get_nightly_paratest_args 20)
+$CWD/nightly -cron -valgrindexe ${nightly_args} $(get_nightly_paratest_args 6)


### PR DESCRIPTION
`valgrindexe` testing is taking 2-3 hours. This PR drops its nodepara from 20 to
6.
