### PR TITLE
Skip this test unless using valgrind or address sanitizing

### DIFF
--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -1,3 +1,14 @@
-# This .future is sometimes passing for multilocale/no-local
-CHPL_COMM!=none
-COMPOPTS <= --no-local
+#!/usr/bin/env python
+
+from __future__ import print_function
+import os
+
+# This .future needs valgrind or an address sanitizer run on it
+
+sanitize = os.getenv('CHPL_SANITIZE_EXE', 'none')
+vgrnd = os.getenv('CHPL_TEST_VGRND_EXE', 'none')
+
+if 'address' == sanitize or 'on' == vgrnd:
+	  print(False)
+else:
+    print(True)


### PR DESCRIPTION
This test segfaults sporadically, so run it some place where it will more stably
fail

Verified that it was skipped appropriately and ran with the appropriate settings