### PR TITLE
Add tests to track what happens when an operator on a type is private

### DIFF
--- a/test/visibility/private/functions/privateOperator.chpl
+++ b/test/visibility/private/functions/privateOperator.chpl
@@ -1,0 +1,27 @@
+module Library {
+  record Foo {
+    var x: int;
+  }
+
+  private inline proc +(a: Foo, b: Foo) {
+    writeln("In private +");
+    return new Foo(a.x + b.x);
+  }
+
+  proc addEm(a: Foo, b: Foo) {
+    return a + b;
+  }
+}
+
+module User {
+  use Library only Foo, addEm;
+
+  proc main() {
+    var first = new Foo(2);
+    var second = new Foo(3);
+    //var sum = first + second; // commented out because it fails
+    var sumCall = addEm(first, second);
+    //writeln(sum);
+    writeln(sumCall);
+  }
+}

--- a/test/visibility/private/functions/privateOperator.good
+++ b/test/visibility/private/functions/privateOperator.good
@@ -1,0 +1,2 @@
+In private +
+(x = 5)

--- a/test/visibility/private/functions/privateOperatorError.chpl
+++ b/test/visibility/private/functions/privateOperatorError.chpl
@@ -1,0 +1,27 @@
+module Library {
+  record Foo {
+    var x: int;
+  }
+
+  private inline proc +(a: Foo, b: Foo) {
+    writeln("In private +");
+    return new Foo(a.x + b.x);
+  }
+
+  proc addEm(a: Foo, b: Foo) {
+    return a + b;
+  }
+}
+
+module User {
+  use Library only Foo, addEm;
+
+  proc main() {
+    var first = new Foo(2);
+    var second = new Foo(3);
+    var sum = first + second; // expected to fail on this line, the + is private
+    var sumCall = addEm(first, second);
+    writeln(sum);
+    writeln(sumCall);
+  }
+}

--- a/test/visibility/private/functions/privateOperatorError.good
+++ b/test/visibility/private/functions/privateOperatorError.good
@@ -1,0 +1,8 @@
+privateOperatorError.chpl:19: In function 'main':
+privateOperatorError.chpl:22: error: unresolved call '+(Foo, Foo)'
+$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: this candidate did not match: +(s0: bytes, s1: bytes)
+privateOperatorError.chpl:22: note: because call actual argument #1 with type Foo
+$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: is passed to formal 's0: bytes'
+$CHPL_HOME/modules/internal/String.chpl:376: note: candidates are: +(x: byteIndex, y: int)
+$CHPL_HOME/modules/internal/String.chpl:377: note:                 +(x: codepointIndex, y: int)
+note: and 96 other candidates, use --print-all-candidates to see them

--- a/test/visibility/private/functions/privateOperatorError2.chpl
+++ b/test/visibility/private/functions/privateOperatorError2.chpl
@@ -1,0 +1,27 @@
+module Library {
+  record Foo {
+    var x: int;
+  }
+
+  private inline proc +(a: Foo, b: Foo) {
+    writeln("In private +");
+    return new Foo(a.x + b.x);
+  }
+
+  proc addEm(a: Foo, b: Foo) {
+    return a + b;
+  }
+}
+
+module User {
+  use Library;
+
+  proc main() {
+    var first = new Foo(2);
+    var second = new Foo(3);
+    var sum = first + second; // expected to fail on this line, the + is private
+    var sumCall = addEm(first, second);
+    writeln(sum);
+    writeln(sumCall);
+  }
+}

--- a/test/visibility/private/functions/privateOperatorError2.good
+++ b/test/visibility/private/functions/privateOperatorError2.good
@@ -1,0 +1,8 @@
+privateOperatorError2.chpl:19: In function 'main':
+privateOperatorError2.chpl:22: error: unresolved call '+(Foo, Foo)'
+$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: this candidate did not match: +(s0: bytes, s1: bytes)
+privateOperatorError2.chpl:22: note: because call actual argument #1 with type Foo
+$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: is passed to formal 's0: bytes'
+$CHPL_HOME/modules/internal/String.chpl:376: note: candidates are: +(x: byteIndex, y: int)
+$CHPL_HOME/modules/internal/String.chpl:377: note:                 +(x: codepointIndex, y: int)
+note: and 96 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
Checks that the operator is used in the scope in which it is defined, and can't
be found outside of it.

Passed a fresh checkout