### PR TITLE
Stop running this future with asan

### DIFF
--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -3,9 +3,8 @@
 from __future__ import print_function
 import os
 
-# This .future needs valgrind or potentially something ASAN provides other
-# than address sanitization (it passes at least somewhat with address
-# sanitization)
+# This .future has uninitialized reads, which are not caught by asan so only
+# test under valgrind
 
 vgrnd = os.getenv('CHPL_TEST_VGRND_EXE', 'none')
 

--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -3,12 +3,13 @@
 from __future__ import print_function
 import os
 
-# This .future needs valgrind or an address sanitizer run on it
+# This .future needs valgrind or potentially something ASAN provides other
+# than address sanitization (it passes at least somewhat with address
+# sanitization)
 
-sanitize = os.getenv('CHPL_SANITIZE_EXE', 'none')
 vgrnd = os.getenv('CHPL_TEST_VGRND_EXE', 'none')
 
-if 'address' in sanitize or 'on' == vgrnd:
-	  print(False)
+if 'on' == vgrnd:
+    print(False)
 else:
     print(True)


### PR DESCRIPTION
This future has uninitialized reads, which are not caught by asan so only test under valgrind