### PR TITLE
Use the current perf graphs for Arkouda release testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -31,6 +31,7 @@ function test_release() {
   git checkout 1.22.1
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
+  git checkout $currentSha -- $CHPL_HOME/util/test/perf/
   $CWD/nightly -cron ${nightly_args}
 }
 


### PR DESCRIPTION
We made some graph changes that we want included in the release graphs