### PR TITLE
Optimize local single iteration coforalls

### DIFF
--- a/modules/internal/ChapelTaskData.chpl
+++ b/modules/internal/ChapelTaskData.chpl
@@ -27,9 +27,11 @@ module ChapelTaskData {
   // Chapel task-local data format:
   // up to 16 bytes of wide pointer for _remoteEndCountType
   // 1 byte for serial_state
+  // 1 byte for nextCoStmtSerial
   private const chpl_offset_endCount = 0:size_t;
   private const chpl_offset_serial = sizeof_endcount_ptr();
-  private const chpl_offset_end = chpl_offset_serial+1;
+  private const chpl_offset_nextCoStmtSerial = chpl_offset_serial+1;
+  private const chpl_offset_end = chpl_offset_nextCoStmtSerial+1;
 
   // What is the size of a wide _EndCount pointer?
   private
@@ -96,6 +98,26 @@ module ChapelTaskData {
     // check we got 1 or 0 if bounds checking is on
     // (to detect runtime implementation errors where this part of
     //  the argument bundle is stack trash)
+    if boundsChecking then
+      assert(v == 0 || v == 1);
+    return v == 1;
+  }
+
+  proc chpl_task_data_setNextCoStmtSerial(tls:c_ptr(chpl_task_infoChapel_t), makeSerial: bool) : void {
+    var prv = tls:c_ptr(c_uchar);
+    var i = chpl_offset_nextCoStmtSerial;
+    var v:uint(8) = 0;
+    if makeSerial then
+      v = 1;
+    c_memcpy(c_ptrTo(prv[i]), c_ptrTo(v), c_sizeof(uint(8)));
+  }
+
+  proc chpl_task_data_getNextCoStmtSerial(tls:c_ptr(chpl_task_infoChapel_t)) : bool {
+    var ret:bool = false;
+    var prv = tls:c_ptr(c_uchar);
+    var i = chpl_offset_nextCoStmtSerial;
+    var v:uint(8) = 0;
+    c_memcpy(c_ptrTo(v), c_ptrTo(prv[i]), c_sizeof(uint(8)));
     if boundsChecking then
       assert(v == 0 || v == 1);
     return v == 1;

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -165,6 +165,10 @@ module LocaleModelHelpRuntime {
                              ) {
     var tls = chpl_task_getInfoChapel();
     var isSerial = chpl_task_data_getSerial(tls);
+    if chpl_task_data_getNextCoStmtSerial(tls) {
+      isSerial = true;
+      chpl_task_data_setNextCoStmtSerial(tls, false);
+    }
     if isSerial {
       chpl_ftable_call(fn, args);
     } else {

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -22,6 +22,8 @@ ChapelEnv
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChapelEnv
 HaltWrappers
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.HaltWrappers
+ChapelTaskData
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChapelTaskData
 ChapelBase
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase
 Reflection
@@ -154,8 +156,6 @@ MemTracking
   from print-module-resolution.ChapelStandard.MemTracking
 ChapelUtil
   from print-module-resolution.ChapelStandard.ChapelUtil
-ChapelTaskData
-  from print-module-resolution.ChapelStandard.ChapelTaskData
 CPtr
   from print-module-resolution.ChapelStandard.ChapelSerializedBroadcast.CPtr
 ChapelSerializedBroadcast

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -45,7 +45,6 @@ Initializing Modules:
     MemTracking
     ChapelUtil
     ChapelError
-    ChapelTaskData
     Builtins
     AlignedTSupport
     CPtr

--- a/test/modules/sungeun/init/printModuleInitOrder.na-none.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.na-none.good
@@ -44,7 +44,6 @@ Initializing Modules:
     MemTracking
     ChapelUtil
     ChapelError
-    ChapelTaskData
     Builtins
     AlignedTSupport
     CPtr


### PR DESCRIPTION
Improve performance for single iteration coforalls like `coforall 1..1`.
You wouldn't write that code directly but it can come indirectly from
parallel iterators that are implemented with coforalls. Previously,
single iteration coforalls were pretty expensive so our internal
tuple/range/domain/array iterators all special case to avoid them.
This single task specialization improves execution performance, but
results in loop cloning which hurts compilation time. I'm hoping this PR
will allow us to remove that specialization. This results in a ~15x
speedup for serial single iteration coforalls and a ~90x speedup for
nested single iteration coforalls. There's still overhead for allocating
and manipulating the endcount, so it's not as cheap as the single task
specialization but the large sources of overhead are gone now.

This stops creating a task for single iteration coforalls, which gets
rid of task creation overhead and more importantly avoids spawning a new
task behind a task that's running on a different core and having to
wait. Without this optimization, removing the single task specialization
hurt ISx performance by 20% at 256 nodes. The implementation of this is
a little hacky because it's using task-local storage to store that the
next coforall task spawn should be serialized. We should probably do
this passing a flag but that required more compiler mods than I was
equipped to handle and I view this as a stopgop until we implement a
bulk/vector task spawn API (#9614).

This also avoids modifying the running task count for single task
coforalls where we'd end up adding/subtracting `0` anyways. The running
task counter is a shared atomic, so if you had an already parallel
section doing coforalls you'd have all tasks contending to add/sub `0`,
which hurt performance.

Here's a task creation microbenchmark run on chapcs (24-core server):

```chpl
use Time;

config const trials = 5_000_000;
var t: Timer; t.start();

for 1..trials do
  coforall 1..1 { }
writeln(t.elapsed()); t.clear();

coforall 1..here.maxTaskPar do
  for 1..trials do
    coforall 1..1 { }
writeln(t.elapsed()); t.clear();
```

| coforall type | before | now    |
| ------------- | ------ | ------ |
| serial        |  4.75s |  0.35s |
| nested        | 35.83s |  0.39s |

Closes https://github.com/Cray/chapel-private/issues/1306