### PR TITLE
File future against OOB sparse domain assignments

### DIFF
--- a/test/sparse/domains/sparseDomAssignOOB.bad
+++ b/test/sparse/domains/sparseDomAssignOOB.bad
@@ -1,0 +1,3 @@
+{2 3 4}
+{2 3 4}
+sparseDomAssignOOB.chpl:19: error: halt reached - array index out of bounds: (2)

--- a/test/sparse/domains/sparseDomAssignOOB.chpl
+++ b/test/sparse/domains/sparseDomAssignOOB.chpl
@@ -1,0 +1,21 @@
+const D1: domain(1) = {1..10};
+var SD1: sparse subdomain(D1);
+
+var inds = [2, 3, 4];
+
+SD1 += inds;
+
+const D2: domain(1);
+var SD2: sparse subdomain(D2);
+var SA2: [SD2] real;
+
+SD2 = SD1;  // This result in an execution-time error: since D2 is
+            // empty, there are no legal indices that can be put into
+            // SD2.
+
+writeln(SD1);
+writeln(SD2);
+
+SA2[2] = 1.2;  // Unfortunately, the OOB error doesn't show up until here
+
+

--- a/test/sparse/domains/sparseDomAssignOOB.future
+++ b/test/sparse/domains/sparseDomAssignOOB.future
@@ -1,0 +1,6 @@
+bug: should bounds-check sparse domain assignments
+
+The current sparse domain assignment code seems to assume that all
+indices in the RHS domain will be in the LHS domain's parent domain,
+but of course this isn't necessarily the case as this test
+demonstrates.

--- a/test/sparse/domains/sparseDomAssignOOB.good
+++ b/test/sparse/domains/sparseDomAssignOOB.good
@@ -1,0 +1,1 @@
+sparseDomAssignOOB.chpl:12: error: halt reached - sparse domain index '2' out of bounds for parent domain '{1..0}'


### PR DESCRIPTION
The current sparse domain assignment code seems to assume that all
indices in the RHS domain will be in the LHS domain's parent domain,
but of course this isn't necessarily the case as this test
demonstrates.  Such cases should generate OOB errors at the time
of domain assignment.
