### PR TITLE
Filter line nums from privateOperatorError tests

### DIFF
--- a/test/visibility/private/functions/privateOperatorError.good
+++ b/test/visibility/private/functions/privateOperatorError.good
@@ -1,8 +1,8 @@
 privateOperatorError.chpl:19: In function 'main':
 privateOperatorError.chpl:22: error: unresolved call '+(Foo, Foo)'
-$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: this candidate did not match: +(s0: bytes, s1: bytes)
+$CHPL_HOME/modules/internal/Bytes.chpl:nnnn: note: this candidate did not match: +(s0: bytes, s1: bytes)
 privateOperatorError.chpl:22: note: because call actual argument #1 with type Foo
-$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: is passed to formal 's0: bytes'
-$CHPL_HOME/modules/internal/String.chpl:376: note: candidates are: +(x: byteIndex, y: int)
-$CHPL_HOME/modules/internal/String.chpl:377: note:                 +(x: codepointIndex, y: int)
+$CHPL_HOME/modules/internal/Bytes.chpl:nnnn: note: is passed to formal 's0: bytes'
+$CHPL_HOME/modules/internal/String.chpl:nnnn: note: candidates are: +(x: byteIndex, y: int)
+$CHPL_HOME/modules/internal/String.chpl:nnnn: note:                 +(x: codepointIndex, y: int)
 note: and 96 other candidates, use --print-all-candidates to see them

--- a/test/visibility/private/functions/privateOperatorError.prediff
+++ b/test/visibility/private/functions/privateOperatorError.prediff
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Ignores line numbers printed upon compilerError in Sort.chpl
+# Note: This is a work around for a bug. The line numbers should not be printed
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+mv $tmptmp $tmpfile

--- a/test/visibility/private/functions/privateOperatorError2.good
+++ b/test/visibility/private/functions/privateOperatorError2.good
@@ -1,8 +1,8 @@
 privateOperatorError2.chpl:19: In function 'main':
 privateOperatorError2.chpl:22: error: unresolved call '+(Foo, Foo)'
-$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: this candidate did not match: +(s0: bytes, s1: bytes)
+$CHPL_HOME/modules/internal/Bytes.chpl:nnnn: note: this candidate did not match: +(s0: bytes, s1: bytes)
 privateOperatorError2.chpl:22: note: because call actual argument #1 with type Foo
-$CHPL_HOME/modules/internal/Bytes.chpl:1165: note: is passed to formal 's0: bytes'
-$CHPL_HOME/modules/internal/String.chpl:376: note: candidates are: +(x: byteIndex, y: int)
-$CHPL_HOME/modules/internal/String.chpl:377: note:                 +(x: codepointIndex, y: int)
+$CHPL_HOME/modules/internal/Bytes.chpl:nnnn: note: is passed to formal 's0: bytes'
+$CHPL_HOME/modules/internal/String.chpl:nnnn: note: candidates are: +(x: byteIndex, y: int)
+$CHPL_HOME/modules/internal/String.chpl:nnnn: note:                 +(x: codepointIndex, y: int)
 note: and 96 other candidates, use --print-all-candidates to see them

--- a/test/visibility/private/functions/privateOperatorError2.prediff
+++ b/test/visibility/private/functions/privateOperatorError2.prediff
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Ignores line numbers printed upon compilerError in Sort.chpl
+# Note: This is a work around for a bug. The line numbers should not be printed
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+mv $tmptmp $tmpfile


### PR DESCRIPTION
These tests started failing after #15664. This PR removes the standard module line numbers from the error messages to make them more stable.