### PR TITLE
Fix some issues with constant domain optimization

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1594,7 +1594,7 @@ BlockStmt* buildVarDecls(BlockStmt* stmts, const char* docs,
           if (cnameExpr != NULL && !firstvar)
             USR_FATAL_CONT(var, "external symbol renaming can only be applied to one symbol at a time");
 
-          establishDefinedConstIfApplicable(defExpr, flags);
+          setDefinedConstForDefExprIfApplicable(defExpr, flags);
 
           for (std::set<Flag>::iterator it = flags->begin(); it != flags->end(); ++it) {
             var->addFlag(*it);

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -81,4 +81,6 @@ void computeNoAliasSets();
 
 void removeInitOrAutoCopyPostResolution(CallExpr *call);
 void establishDefinedConstIfApplicable(DefExpr* defExpr, std::set<Flag>* flags);
+void setDefinedConstField(CallExpr *call);
+void setConstnessOfDomainFieldsInInitializer(FnSymbol *fn);
 #endif

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -33,6 +33,9 @@
 #include "map.h"
 #include "vec.h"
 
+#include "flags.h"
+
+#include <set>
 #include <map>
 #include <vector>
 
@@ -40,6 +43,7 @@ class BaseAST;
 class BitVec;
 class BlockStmt;
 class CallExpr;
+class DefExpr;
 class FnSymbol;
 class ForallStmt;
 class Symbol;
@@ -76,5 +80,5 @@ void inferConstRefs();
 void computeNoAliasSets();
 
 void removeInitOrAutoCopyPostResolution(CallExpr *call);
-
+void establishDefinedConstIfApplicable(DefExpr* defExpr, std::set<Flag>* flags);
 #endif

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -80,8 +80,9 @@ void inferConstRefs();
 void computeNoAliasSets();
 
 void removeInitOrAutoCopyPostResolution(CallExpr *call);
-void establishDefinedConstIfApplicable(DefExpr* defExpr, std::set<Flag>* flags);
-void setDefinedConstForFieldIfApplicable(CallExpr *call);
+void setDefinedConstForDefExprIfApplicable(DefExpr* defExpr,
+                                           std::set<Flag>* flags);
+void setDefinedConstForPrimSetMemberIfApplicable(CallExpr *call);
 void setDefinedConstForFieldsInInitializer(FnSymbol *fn);
 
 #endif

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -81,6 +81,7 @@ void computeNoAliasSets();
 
 void removeInitOrAutoCopyPostResolution(CallExpr *call);
 void establishDefinedConstIfApplicable(DefExpr* defExpr, std::set<Flag>* flags);
-void setDefinedConstField(CallExpr *call);
-void setConstnessOfDomainFieldsInInitializer(FnSymbol *fn);
+void setDefinedConstForFieldIfApplicable(CallExpr *call);
+void setDefinedConstForFieldsInInitializer(FnSymbol *fn);
+
 #endif

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -39,6 +39,7 @@
 class BaseAST;
 class BitVec;
 class BlockStmt;
+class CallExpr;
 class FnSymbol;
 class ForallStmt;
 class Symbol;
@@ -73,5 +74,7 @@ void remoteValueForwarding();
 void inferConstRefs();
 
 void computeNoAliasSets();
+
+void removeInitOrAutoCopyPostResolution(CallExpr *call);
 
 #endif

--- a/compiler/optimizations/Makefile.share
+++ b/compiler/optimizations/Makefile.share
@@ -29,6 +29,7 @@ OPTIMIZATIONS_SRCS = \
         optimizeForallUnorderedOps.cpp \
 	optimizeOnClauses.cpp \
 	preNormalizeOptimizations.cpp \
+	propagateDomainConstness.cpp \
 	refPropagation.cpp \
 	remoteValueForwarding.cpp \
 	removeEmptyRecords.cpp \

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -191,7 +191,7 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   }
   INT_ASSERT(aggType);
 
-  Symbol *fieldSym = aggType->getField(fieldName);
+  Symbol *fieldSym = aggType->getValType()->getField(fieldName);
   Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
   VarSymbol *fieldRef = newTemp(fieldName, fieldType);
   insBefore->insertBefore(new DefExpr(fieldRef));

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "optimizations.h"
+
+#include "astutil.h"
+#include "CallExpr.h"
+#include "DecoratedClassType.h"
+#include "expr.h"
+
+void removeInitOrAutoCopyPostResolution(CallExpr *call) {
+  Expr *parentExpr = call->parentExpr;
+  Expr *nextExpr = parentExpr->next;
+  bool isDomain = false;
+
+  if (SymExpr *se = toSymExpr(call->get(1))) {
+    isDomain = se->symbol()->getValType()->symbol->hasFlag(FLAG_DOMAIN);
+  }
+
+  call->replace(call->get(1)->remove());
+
+  if (isDomain) {
+    Symbol *lhs = NULL;
+    if (CallExpr *parentCall = toCallExpr(parentExpr)) {
+      if (parentCall->isPrimitive(PRIM_MOVE)) {
+        if (SymExpr *lhsSE = toSymExpr(parentCall->get(1))) {
+          lhs = lhsSE->symbol();
+        }
+      }
+    }
+
+    INT_ASSERT(lhs);
+
+    // we removed the first argument already, so definedConst is the first
+    // argument now
+    Expr *secondArg = call->get(1)->remove();
+
+    if (SymExpr *se = toSymExpr(secondArg)) {
+      if (se->symbol()->type == dtBool) {  // must be definedConst
+        AggregateType *lhsAggType = toAggregateType(lhs->type);
+        Symbol *domInstanceField = lhsAggType->getField("_instance");
+        VarSymbol *domInstance = newTemp("dom_instance_tmp",
+                                         domInstanceField->type);
+        nextExpr->insertBefore(new DefExpr(domInstance));
+        CallExpr *getInstance = new CallExpr(PRIM_MOVE, domInstance,
+                                             new CallExpr(PRIM_GET_MEMBER,
+                                                          lhs,
+                                                          domInstanceField));
+
+        AggregateType *domInstAggType = toDecoratedClassType(domInstance->type)->getCanonicalClass();
+        
+        Symbol *definedConstField = domInstAggType->getField("definedConst");
+        VarSymbol *definedConstRef = newTemp("defined_const_tmp",
+                                             definedConstField->type->getRefType());
+        nextExpr->insertBefore(new DefExpr(definedConstRef));
+
+        CallExpr *getDefinedConstRef = new CallExpr(PRIM_MOVE, definedConstRef,
+                                                    new CallExpr(PRIM_GET_MEMBER,
+                                                                 domInstance,
+                                                                 definedConstField));
+        CallExpr *setDefinedConst = new CallExpr(PRIM_MOVE, 
+                                                 definedConstRef,
+                                                 secondArg);
+
+        nextExpr->insertAfter(getInstance);
+        getInstance->insertAfter(getDefinedConstRef);
+        getDefinedConstRef->insertAfter(setDefinedConst);
+      }
+    }
+  }
+}

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -197,8 +197,6 @@ static void setDefinedConstForDefExprWithIfExprs(Expr* e) {
   }
 }
 
-
-
 static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
                                  Expr *insBefore, Expr *&insAfter,
                                  bool asRef) {
@@ -213,28 +211,6 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   Symbol *fieldSym = aggType->getValType()->getField(fieldName);
   Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
   
-
-  //Symbol *fieldSym = NULL;
-  //if (aggType->symbol->hasFlag(FLAG_REF)) {
-    //fieldSym = aggType->getValType()->getField(fieldName);
-  //}
-  //else {
-    //fieldSym = aggType->getField(fieldName);
-  //}
-  //Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
-  //if (asRef) {
-    //fieldType = wideRefMap.get(fieldType);
-  //}
-  //Type *fieldType = fieldSym->type;
-  //if (asRef) {
-    //if (fieldType->symbol->hasFlag(FLAG_REF) ||
-        //fieldType->symbol->hasFlag(FLAG_WIDE_REF)) { 
-
-    //}
-    //else {
-      //fieldType = fieldType->getRefType();
-    //}
-  //}
   VarSymbol *fieldRef = newTemp(fieldName, fieldType);
   insBefore->insertBefore(new DefExpr(fieldRef));
 
@@ -248,24 +224,6 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   return fieldRef;
 }
 
-//static void addFieldSet(Symbol *receiver, const char *fieldName,
-                              //Expr *&insAfter, Symbol *setTo) {
-  //Type *receiverType = receiver->type;
-
-  //AggregateType *aggType = toAggregateType(receiverType);
-  //if (aggType == NULL) {
-    //aggType = toDecoratedClassType(receiverType)->getCanonicalClass();
-  //}
-  //INT_ASSERT(aggType);
-
-  //Symbol *fieldSym = aggType->getField(fieldName);
-  ////Type *fieldType = fieldSym->type;
-  //CallExpr *setField = new CallExpr(PRIM_SET_MEMBER, receiver, fieldSym, setTo);
-
-  //insAfter->insertAfter(setField);
-  //insAfter = setField;
-//}
-
 static void setDefinedConstForDomainSymbol(Symbol *domainSym, Expr *nextExpr,
                                            Expr *anchor, Symbol *isConst) {
   VarSymbol *domInstance = addFieldAccess(domainSym, "_instance",
@@ -274,8 +232,6 @@ static void setDefinedConstForDomainSymbol(Symbol *domainSym, Expr *nextExpr,
   VarSymbol *refToDefinedConst = addFieldAccess(domInstance, "definedConst",
                                                 nextExpr, anchor,
                                                 true);
-
-  //addFieldSet(domInstance, "definedConst", anchor, isConst);
 
   CallExpr *setDefinedConst = new CallExpr(PRIM_MOVE, refToDefinedConst,
                                            isConst);

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -214,12 +214,13 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   VarSymbol *fieldRef = newTemp(fieldName, fieldType);
   insBefore->insertBefore(new DefExpr(fieldRef));
 
-  CallExpr *getFieldRef = new CallExpr(PRIM_MOVE, fieldRef,
-                                       new CallExpr(PRIM_GET_MEMBER,
-                                                    receiver,
-                                                    fieldSym));
-  insAfter->insertAfter(getFieldRef);
-  insAfter = getFieldRef;
+  PrimitiveTag primTag = asRef ? PRIM_GET_MEMBER : PRIM_GET_MEMBER_VALUE;
+  CallExpr *getField= new CallExpr(PRIM_MOVE, fieldRef,
+                                   new CallExpr(primTag,
+                                                receiver,
+                                                fieldSym));
+  insAfter->insertAfter(getField);
+  insAfter = getField;
 
   return fieldRef;
 }

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -202,7 +202,7 @@ static void setDefinedConstForDefExprWithIfExprs(Expr* e) {
 static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
                                  Expr *insBefore, Expr *&insAfter,
                                  bool asRef) {
-  Type *receiverType = receiver->type;
+  Type *receiverType = receiver->getValType();
 
   AggregateType *aggType = toAggregateType(receiverType);
   if (aggType == NULL) {
@@ -210,8 +210,31 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   }
   INT_ASSERT(aggType);
 
-  Symbol *fieldSym = aggType->getValType()->getField(fieldName);
+  //Symbol *fieldSym = aggType->getValType()->getField(fieldName);
+  //Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
+  //
+
+  Symbol *fieldSym = NULL;
+  if (aggType->symbol->hasFlag(FLAG_REF)) {
+    fieldSym = aggType->getValType()->getField(fieldName);
+  }
+  else {
+    fieldSym = aggType->getField(fieldName);
+  }
   Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
+  //if (asRef) {
+    //fieldType = wideRefMap.get(fieldType);
+  //}
+  //Type *fieldType = fieldSym->type;
+  //if (asRef) {
+    //if (fieldType->symbol->hasFlag(FLAG_REF) ||
+        //fieldType->symbol->hasFlag(FLAG_WIDE_REF)) { 
+
+    //}
+    //else {
+      //fieldType = fieldType->getRefType();
+    //}
+  //}
   VarSymbol *fieldRef = newTemp(fieldName, fieldType);
   insBefore->insertBefore(new DefExpr(fieldRef));
 
@@ -225,14 +248,34 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   return fieldRef;
 }
 
+//static void addFieldSet(Symbol *receiver, const char *fieldName,
+                              //Expr *&insAfter, Symbol *setTo) {
+  //Type *receiverType = receiver->type;
+
+  //AggregateType *aggType = toAggregateType(receiverType);
+  //if (aggType == NULL) {
+    //aggType = toDecoratedClassType(receiverType)->getCanonicalClass();
+  //}
+  //INT_ASSERT(aggType);
+
+  //Symbol *fieldSym = aggType->getField(fieldName);
+  ////Type *fieldType = fieldSym->type;
+  //CallExpr *setField = new CallExpr(PRIM_SET_MEMBER, receiver, fieldSym, setTo);
+
+  //insAfter->insertAfter(setField);
+  //insAfter = setField;
+//}
+
 static void setDefinedConstForDomainSymbol(Symbol *domainSym, Expr *nextExpr,
                                            Expr *anchor, Symbol *isConst) {
   VarSymbol *domInstance = addFieldAccess(domainSym, "_instance",
-                                          nextExpr, anchor, /*asRef=*/ false);
+                                          nextExpr, anchor, /*asRef=*/ true);
 
   VarSymbol *refToDefinedConst = addFieldAccess(domInstance, "definedConst",
                                                 nextExpr, anchor,
-                                                /*asRef=*/ true);
+                                                true);
+
+  //addFieldSet(domInstance, "definedConst", anchor, isConst);
 
   CallExpr *setDefinedConst = new CallExpr(PRIM_MOVE, refToDefinedConst,
                                            isConst);

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -204,15 +204,11 @@ static void setDefinedConstForDefExprWithIfExprs(Expr* e) {
 static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
                                  Expr *insBefore, Expr *&insAfter,
                                  bool asRef) {
-  Type *receiverType = receiver->getValType();
 
-  AggregateType *aggType = toAggregateType(receiverType);
-  if (aggType == NULL) {
-    aggType = toDecoratedClassType(receiverType)->getCanonicalClass();
-  }
+  AggregateType *aggType = toAggregateType(canonicalClassType(receiver->getValType()));
   INT_ASSERT(aggType);
 
-  Symbol *fieldSym = aggType->getValType()->getField(fieldName);
+  Symbol *fieldSym = aggType->getField(fieldName);
   Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
   
   VarSymbol *fieldRef = newTemp(fieldName, fieldType);

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -46,31 +46,9 @@ static void setDefinedConstForDomainField(Symbol *thisSym, Symbol *fieldSym,
 // and changes pertinent arguments in the CallExprs as necessary
 void setDefinedConstForDefExprIfApplicable(DefExpr* defExpr,
                                            std::set<Flag>* flags) {
-
   if (defExpr->init != NULL) {
-    if (flags->size() == 1 && flags->count(FLAG_CONST)) {
+    if (flags->count(FLAG_CONST) == 0) {
       setDefinedConstForDefExprWithIfExprs(defExpr->init);
-    }
-  }
-
-  if (defExpr->exprType != NULL) {
-    if (CallExpr *initType = toCallExpr(defExpr->exprType)) {
-      if (initType->isNamed("chpl__distributed")) {
-        initType->get(3)->replace(new SymExpr(gTrue));
-        return;
-      }
-      else if (initType->isNamed("chpl__buildArrayRuntimeType")) {
-        if (CallExpr *typeCall = toCallExpr(initType->get(1))) {
-          if (typeCall->isNamed("chpl__ensureDomainExpr")) {
-            if (CallExpr *buildDomExpr = toCallExpr(typeCall->get(1))) {
-              if (buildDomExpr->isNamed("chpl__buildDomainExpr")) {
-                buildDomExpr->argList.last()->replace(new SymExpr(gTrue));
-                return;
-              }
-            }
-          }
-        }
-      }
     }
   }
 }
@@ -164,11 +142,11 @@ void removeInitOrAutoCopyPostResolution(CallExpr *call) {
 static void setDefinedConstForDefExprWithIfExprs(Expr* e) {
   if (CallExpr *initCall = toCallExpr(e)) {
     if (initCall->isNamed("chpl__buildDomainExpr")) {
-      initCall->argList.last()->replace(new SymExpr(gTrue));
+      initCall->argList.last()->replace(new SymExpr(gFalse));
       return;
     }
     else if (initCall->isNamed("chpl__distributed")) {
-      initCall->get(3)->replace(new SymExpr(gTrue));
+      initCall->get(3)->replace(new SymExpr(gFalse));
       return;
     }
   }
@@ -228,5 +206,4 @@ static void setDefinedConstForDomainField(Symbol *thisSym, Symbol *fieldSym,
                                        nextExpr, anchor, /*asRef=*/false);
     setDefinedConstForDomainSymbol(domSym, nextExpr, anchor, isConst);
 }
-
 

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -60,7 +60,7 @@ void setDefinedConstForPrimSetMemberIfApplicable(CallExpr *call) {
   INT_ASSERT(call->isPrimitive(PRIM_SET_MEMBER));
 
   bool createdNoop;
-  Expr *nextExpr = getNextExprOrCreateNoop(call->next, createdNoop);
+  Expr *nextExpr = getNextExprOrCreateNoop(call, createdNoop);
 
   // PRIM_SET_MEMBER args:
   // 1: this

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -37,8 +37,7 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
 static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
                                  Expr *insBefore, Expr *&insAfter,
                                  bool asRef);
-static Expr *getNextExprOrCreateNoop(Expr *baseExpr, Expr *nextExpr,
-                                     bool &createdNoop);
+static Expr *getNextExprOrCreateNoop(Expr *baseExpr, bool &createdNoop);
 static void setDefinedConstForDomainSymbol(Symbol *domainSym, Expr *nextExpr,
                                            Expr *anchor, Symbol *isConst);
 static void setDefinedConstForDomainField(Symbol *thisSym, Symbol *fieldSym,
@@ -61,7 +60,7 @@ void setDefinedConstForPrimSetMemberIfApplicable(CallExpr *call) {
   INT_ASSERT(call->isPrimitive(PRIM_SET_MEMBER));
 
   bool createdNoop;
-  Expr *nextExpr = getNextExprOrCreateNoop(call, call->next, createdNoop);
+  Expr *nextExpr = getNextExprOrCreateNoop(call->next, createdNoop);
 
   // PRIM_SET_MEMBER args:
   // 1: this
@@ -113,7 +112,7 @@ void removeInitOrAutoCopyPostResolution(CallExpr *call) {
   Expr *parentExpr = call->parentExpr;
 
   bool createdNoop;
-  Expr *nextExpr = getNextExprOrCreateNoop(call, parentExpr->next, createdNoop);
+  Expr *nextExpr = getNextExprOrCreateNoop(parentExpr, createdNoop);
 
   Symbol *argSym = NULL;
   Type *argType = NULL;
@@ -156,10 +155,9 @@ void removeInitOrAutoCopyPostResolution(CallExpr *call) {
   }
 }
 
-static Expr* getNextExprOrCreateNoop(Expr *baseExpr, Expr *nextExpr,
-                                     bool &createdNoop) {
+static Expr* getNextExprOrCreateNoop(Expr *baseExpr, bool &createdNoop) {
   createdNoop = false;
-  Expr *newNextExpr = nextExpr;
+  Expr *nextExpr = baseExpr->next;
 
   if (nextExpr == NULL) {
     createdNoop = true;
@@ -178,10 +176,10 @@ static Expr* getNextExprOrCreateNoop(Expr *baseExpr, Expr *nextExpr,
   if (createdNoop) {
     CallExpr *noop = new CallExpr(PRIM_NOOP);
     baseExpr->insertAfter(noop);
-    newNextExpr = noop;
+    return noop;
   }
 
-  return newNextExpr;
+  return nextExpr;
 }
                 
 static void setDefinedConstForDefExprWithIfExprs(Expr* e) {

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -211,6 +211,7 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
   
   VarSymbol *fieldRef = newTemp(fieldName, fieldType);
+  fieldRef->addFlag(FLAG_UNSAFE);  // this is a short-lived temp
   insBefore->insertBefore(new DefExpr(fieldRef));
 
   PrimitiveTag primTag = asRef ? PRIM_GET_MEMBER : PRIM_GET_MEMBER_VALUE;

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -205,7 +205,8 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
                                  Expr *insBefore, Expr *&insAfter,
                                  bool asRef) {
 
-  AggregateType *aggType = toAggregateType(canonicalClassType(receiver->getValType()));
+  AggregateType *aggType =
+      toAggregateType(canonicalClassType(receiver->getValType()));
   INT_ASSERT(aggType);
 
   Symbol *fieldSym = aggType->getField(fieldName);

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -210,18 +210,18 @@ static VarSymbol *addFieldAccess(Symbol *receiver, const char *fieldName,
   }
   INT_ASSERT(aggType);
 
-  //Symbol *fieldSym = aggType->getValType()->getField(fieldName);
-  //Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
-  //
-
-  Symbol *fieldSym = NULL;
-  if (aggType->symbol->hasFlag(FLAG_REF)) {
-    fieldSym = aggType->getValType()->getField(fieldName);
-  }
-  else {
-    fieldSym = aggType->getField(fieldName);
-  }
+  Symbol *fieldSym = aggType->getValType()->getField(fieldName);
   Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
+  
+
+  //Symbol *fieldSym = NULL;
+  //if (aggType->symbol->hasFlag(FLAG_REF)) {
+    //fieldSym = aggType->getValType()->getField(fieldName);
+  //}
+  //else {
+    //fieldSym = aggType->getField(fieldName);
+  //}
+  //Type *fieldType = asRef ? fieldSym->type->getRefType() : fieldSym->type;
   //if (asRef) {
     //fieldType = wideRefMap.get(fieldType);
   //}

--- a/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
+++ b/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
@@ -26,6 +26,7 @@
 #include "passes.h"
 #include "stlUtil.h"
 #include "stmt.h"
+#include "view.h"
 
 // We can remove the calls to chpl__initCopy (should actually be chpl__autoCopy)
 // and corresponding calls to chpl__autoDestroy for Plain-Old-Data (POD) types.
@@ -86,7 +87,14 @@ static void removePODinitDestroy()
           if (lhsType->getValType() != rhsType->getValType()) {
             INT_FATAL(actual, "Type mismatch in updateAutoCopy");
           } else {
-            call->replace(actual->remove());
+            //Expr *parentExpr = call->parentExpr;
+
+            //std::cout << "Before removal\n";
+            //nprint_view(parentExpr);
+            removeInitOrAutoCopyPostResolution(call);
+            //std::cout << "After removal\n";
+            //nprint_view(parentExpr);
+            //call->replace(actual->remove());
           }
         }
       }

--- a/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
+++ b/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
@@ -26,7 +26,6 @@
 #include "passes.h"
 #include "stlUtil.h"
 #include "stmt.h"
-#include "view.h"
 
 // We can remove the calls to chpl__initCopy (should actually be chpl__autoCopy)
 // and corresponding calls to chpl__autoDestroy for Plain-Old-Data (POD) types.
@@ -87,14 +86,7 @@ static void removePODinitDestroy()
           if (lhsType->getValType() != rhsType->getValType()) {
             INT_FATAL(actual, "Type mismatch in updateAutoCopy");
           } else {
-            //Expr *parentExpr = call->parentExpr;
-
-            //std::cout << "Before removal\n";
-            //nprint_view(parentExpr);
             removeInitOrAutoCopyPostResolution(call);
-            //std::cout << "After removal\n";
-            //nprint_view(parentExpr);
-            //call->replace(actual->remove());
           }
         }
       }

--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -9817,14 +9817,14 @@ yyreduce:
   case 593:
 #line 2215 "chapel.ypp" /* yacc.c:1663  */
     { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[-1].pcallexpr),
-                                            new SymExpr(gFalse)); }
+                                            new SymExpr(gTrue)); }
 #line 9822 "bison-chapel.cpp" /* yacc.c:1663  */
     break;
 
   case 594:
 #line 2217 "chapel.ypp" /* yacc.c:1663  */
     { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[-2].pcallexpr),
-                                                   new SymExpr(gFalse)); }
+                                                   new SymExpr(gTrue)); }
 #line 9829 "bison-chapel.cpp" /* yacc.c:1663  */
     break;
 
@@ -10003,7 +10003,7 @@ yyreduce:
   case 623:
 #line 2260 "chapel.ypp" /* yacc.c:1663  */
     { (yyval.pexpr) = new CallExpr("chpl__distributed", (yyvsp[0].pexpr), (yyvsp[-2].pexpr),
-                                               new SymExpr(gFalse)); }
+                                               new SymExpr(gTrue)); }
 #line 10008 "bison-chapel.cpp" /* yacc.c:1663  */
     break;
 

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -2213,9 +2213,9 @@ literal_expr:
 | CSTRINGLITERAL        { $$ = buildCStringLiteral($1); }
 | TNONE                 { $$ = new SymExpr(gNone); }
 | TLCBR expr_ls TRCBR   { $$ = new CallExpr("chpl__buildDomainExpr", $2,
-                                            new SymExpr(gFalse)); }
+                                            new SymExpr(gTrue)); }
 | TLCBR expr_ls TCOMMA TRCBR   { $$ = new CallExpr("chpl__buildDomainExpr", $2,
-                                                   new SymExpr(gFalse)); }
+                                                   new SymExpr(gTrue)); }
 | TLSBR expr_ls TRSBR   { $$ = new CallExpr("chpl__buildArrayExpr",  $2); }
 | TLSBR expr_ls TCOMMA TRSBR   { $$ = new CallExpr("chpl__buildArrayExpr",  $2); }
 | TLSBR assoc_expr_ls TRSBR
@@ -2258,7 +2258,7 @@ binary_op_expr:
 | expr TALIGN expr         { $$ = new CallExpr("chpl_align", $1, $3); }
 | expr THASH expr          { $$ = new CallExpr("#", $1, $3); }
 | expr TDMAPPED expr       { $$ = new CallExpr("chpl__distributed", $3, $1,
-                                               new SymExpr(gFalse)); }
+                                               new SymExpr(gTrue)); }
 ;
 
 unary_op_expr:

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -401,6 +401,7 @@ Expr* InitNormalize::genericFieldInitTypeWithInit(Expr*    insertBefore,
 Expr* InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
                                                    DefExpr* field,
                                                    Expr*    initExpr) const {
+  bool isConst   = field->sym->hasFlag(FLAG_CONST);
   bool isParam   = field->sym->hasFlag(FLAG_PARAM);
   bool isTypeVar = field->sym->hasFlag(FLAG_TYPE_VARIABLE);
 
@@ -427,7 +428,9 @@ Expr* InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
       Symbol*    name     = new_CStringSymbol(field->sym->name);
       CallExpr*  fieldSet = new CallExpr(PRIM_INIT_FIELD, _this, name, tmp);
 
-      if (isParam) {
+      if (isConst) {
+        tmp->addFlag(FLAG_CONST);
+      } else if (isParam) {
         tmp->addFlag(FLAG_PARAM);
       } else if (isTypeVar) {
         tmp->addFlag(FLAG_TYPE_VARIABLE);
@@ -469,7 +472,9 @@ Expr* InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
     Symbol*    name     = new_CStringSymbol(field->sym->name);
     CallExpr*  fieldSet = new CallExpr(PRIM_INIT_FIELD, _this, name, tmp);
 
-    if (isParam) {
+    if (isConst) {
+      tmp->addFlag(FLAG_CONST);
+    } else if (isParam) {
       tmp->addFlag(FLAG_PARAM);
     } else if (isTypeVar) {
       tmp->addFlag(FLAG_TYPE_VARIABLE);

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -36,7 +36,6 @@
 #include "resolveIntents.h"
 #include "stlUtil.h"
 #include "stringutil.h"
-#include "view.h"
 #include "virtualDispatch.h"
 
 #include <vector>
@@ -639,7 +638,6 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
   Symbol*   tmpVar    = newTemp("ret_tmp", useLhs->getValType());
 
   bool copiesToNoDestroy = false;
-  bool isDomain = false;
   bool isRhsInitOrAutoCopy = false;
 
   // Determine if
@@ -675,8 +673,6 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
               Type*      formalType = formalArg->type;
               Type*      actualType = copiedSe->symbol()->getValType();
               Type*      returnType = rhsFn->retType->getValType();
-
-              isDomain = actualType->symbol->hasFlag(FLAG_DOMAIN);
 
               // Skip this transformation if
               //  * the type differs

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -183,7 +183,11 @@ static void removeRandomPrimitive(CallExpr* call) {
       } else {
         // Confirm that this is already a correct field Symbol.
         sym = memberSE->symbol();
-        //INT_ASSERT(sym->defPoint->parentSymbol == baseType->symbol);
+        // This used to check for type equality, is this wrong?
+        INT_ASSERT(isSubtypeOrInstantiation(baseType, 
+                                            sym->defPoint->parentSymbol->type,
+                                            call));
+
       }
 
       if (sym->hasFlag(FLAG_TYPE_VARIABLE) ||

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -183,7 +183,7 @@ static void removeRandomPrimitive(CallExpr* call) {
       } else {
         // Confirm that this is already a correct field Symbol.
         sym = memberSE->symbol();
-        INT_ASSERT(sym->defPoint->parentSymbol == baseType->symbol);
+        //INT_ASSERT(sym->defPoint->parentSymbol == baseType->symbol);
       }
 
       if (sym->hasFlag(FLAG_TYPE_VARIABLE) ||

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6461,7 +6461,7 @@ static void resolveInitField(CallExpr* call) {
 
   call->primitive = primitives[PRIM_SET_MEMBER];
 
-  setDefinedConstField(call);
+  setDefinedConstForFieldIfApplicable(call);
 
   resolveSetMember(call); // Can we remove some of the above with this?
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6461,7 +6461,7 @@ static void resolveInitField(CallExpr* call) {
 
   call->primitive = primitives[PRIM_SET_MEMBER];
 
-  setDefinedConstForFieldIfApplicable(call);
+  setDefinedConstForPrimSetMemberIfApplicable(call);
 
   resolveSetMember(call); // Can we remove some of the above with this?
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -46,6 +46,7 @@
 #include "iterator.h"
 #include "lifetime.h"
 #include "ModuleSymbol.h"
+#include "optimizations.h"
 #include "ParamForLoop.h"
 #include "PartialCopyData.h"
 #include "passes.h"
@@ -6459,6 +6460,8 @@ static void resolveInitField(CallExpr* call) {
   }
 
   call->primitive = primitives[PRIM_SET_MEMBER];
+
+  setDefinedConstField(call);
 
   resolveSetMember(call); // Can we remove some of the above with this?
 }

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -689,7 +689,7 @@ static void resolveInitializerBody(FnSymbol* fn) {
 
   ensureInMethodList(fn);
 
-  setConstnessOfDomainFieldsInInitializer(fn);
+  setDefinedConstForFieldsInInitializer(fn);
 }
 
 /************************************* | **************************************

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -28,6 +28,7 @@
 #include "expandVarArgs.h"
 #include "expr.h"
 #include "initializerRules.h"
+#include "optimizations.h"
 #include "passes.h"
 #include "resolution.h"
 #include "ResolutionCandidate.h"
@@ -687,6 +688,8 @@ static void resolveInitializerBody(FnSymbol* fn) {
   fixPrimInitsAndAddCasts(fn);
 
   ensureInMethodList(fn);
+
+  setConstnessOfDomainFieldsInInitializer(fn);
 }
 
 /************************************* | **************************************

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -61,7 +61,6 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
-#include "view.h"
 #include "visibleFunctions.h"
 
 #include <map>

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -61,6 +61,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "view.h"
 #include "visibleFunctions.h"
 
 #include <map>
@@ -1369,7 +1370,11 @@ static void addArgCoercion(FnSymbol*  fn,
     if (typeNeedsCopyInitDeinit(at) && propagateNotPOD(at) &&
         !fn->hasFlag(FLAG_AUTO_COPY_FN) &&
         !fn->hasFlag(FLAG_INIT_COPY_FN)) {
-      Symbol *definedConst = formal->hasFlag(FLAG_CONST) ?  gTrue : gFalse;
+
+      bool isConstCopy = formal->intent == INTENT_CONST_IN ||
+                         formal->intent == INTENT_CONST_IN ||
+                         formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
+      Symbol *definedConst = isConstCopy ?  gTrue : gFalse;
       castCall = new CallExpr(astr_initCopy, prevActual, definedConst);
     } else {
       castCall   = new CallExpr(PRIM_DEREF, prevActual);
@@ -1673,9 +1678,13 @@ static void handleInIntent(FnSymbol* fn, CallExpr* call,
       if (formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT)) {
         tmp->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
       }
-
+      
       CallExpr* copy = NULL;
-      Symbol *definedConst = formal->hasFlag(FLAG_CONST) ?  gTrue : gFalse;
+
+      bool isConstCopy = formal->intent == INTENT_CONST_IN ||
+                         formal->originalIntent == INTENT_CONST_IN ||
+                         formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
+      Symbol *definedConst = isConstCopy ?  gTrue : gFalse;
       if (coerceRuntimeTypes)
         copy = new CallExpr(astr_coerceCopy, runtimeTypeTemp, actualSym,
                             definedConst);
@@ -1707,7 +1716,10 @@ static void handleInIntent(FnSymbol* fn, CallExpr* call,
           tmp->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
         }
 
-        Symbol *definedConst = formal->hasFlag(FLAG_CONST) ?  gTrue : gFalse;
+        bool isConstCopy = formal->intent == INTENT_CONST_IN ||
+                           formal->originalIntent == INTENT_CONST_IN ||
+                           formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
+        Symbol *definedConst = isConstCopy ?  gTrue : gFalse;
         CallExpr* copy = new CallExpr(astr_coerceMove,
                                       runtimeTypeTemp, actualSym, definedConst);
 

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -54,7 +54,7 @@ module ArrayViewSlice {
     // TODO: Can we privatize upon creation of the array-view slice and cache
     // the results?
     const _DomPid;
-    const dom; // Seems like the compiler requires a field called 'dom'...
+    var dom; // Seems like the compiler requires a field called 'dom'...
 
     // the representation of the sliced array
     const _ArrPid;
@@ -75,6 +75,8 @@ module ArrayViewSlice {
       this._ArrInstance = _ArrInstance;
 
       this.indexCache = buildIndexCacheHelper(_ArrInstance, dom);
+
+      this.dom.definedConst = true;
     }
 
     forwarding arr except these,

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -76,7 +76,7 @@ module ArrayViewSlice {
 
       this.indexCache = buildIndexCacheHelper(_ArrInstance, dom);
 
-      this.dom.definedConst = true;
+      this.dom.definedConst = dom.definedConst;
     }
 
     forwarding arr except these,

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2805,6 +2805,10 @@ module ChapelArray {
       pragma "no auto destroy" var d = _dom((...ranges));
       d._value._free_when_no_arrs = true;
 
+      // this domain is not exposed to the user in any way, so it is actually
+      // constant
+      d._value.definedConst = true;
+
       //
       // If this is already a slice array view, we can short-circuit
       // down to the underlying array.

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3088,7 +3088,11 @@ module ChapelArray {
       const redistRec = new _distribution(redist);
       // redist._free_when_no_doms = true;
 
-      pragma "no copy" pragma "no auto destroy" const newDom = new _domain(redistRec, rank, updom.idxType, updom.stridable, updom.dims());
+      pragma "no copy"
+      pragma "no auto destroy"
+      const newDom = new _domain(redistRec, rank, updom.idxType,
+                                 updom.stridable, updom.dims(),
+                                 definedConst=true);
       newDom._value._free_when_no_arrs = true;
 
       // TODO: With additional effort, we could collapse reindexings of

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2835,8 +2835,13 @@ module ChapelArray {
       if boundsChecking then
         checkRankChange(args);
 
+      // as we are making this a "no copy", we won't get chpl__initCopy, and
+      // thus no chance to adjust constness. So, define the variable var, but
+      // set its constness manually
       pragma "no copy"
-      const rcdom = this.domain[(...args)];
+      var rcdom = this.domain[(...args)];
+      rcdom.definedConst = true;
+
 
       // TODO: With additional effort, we could collapse rank changes of
       // rank-change array views to a single array view, similar to what

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -693,10 +693,15 @@ module ChapelDistribution {
       var dom = dsiGetBaseDom();
       // Remove the array from the domain
       // and find out if the domain should be removed.
+      extern proc printf(s...);
+      if dom == nil then printf("nil dom\n");
       rm_dom = dom.remove_arr(_to_unmanaged(this), rmFromList);
 
-      if rm_dom then
+
+      if rm_dom {
+        printf("setting ret_dom\n");
         ret_dom = dom;
+      }
 
       return (ret_arr, ret_dom);
     }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -693,10 +693,7 @@ module ChapelDistribution {
       var dom = dsiGetBaseDom();
       // Remove the array from the domain
       // and find out if the domain should be removed.
-      extern proc printf(s...);
-      if dom == nil then printf("nil dom\n");
       rm_dom = dom.remove_arr(_to_unmanaged(this), rmFromList);
-
 
       if rm_dom then
         ret_dom = dom;

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -698,10 +698,8 @@ module ChapelDistribution {
       rm_dom = dom.remove_arr(_to_unmanaged(this), rmFromList);
 
 
-      if rm_dom {
-        printf("setting ret_dom\n");
+      if rm_dom then
         ret_dom = dom;
-      }
 
       return (ret_arr, ret_dom);
     }

--- a/test/arrays/slices/commCounts/sliceBlockWithRanges.good
+++ b/test/arrays/slices/commCounts/sliceBlockWithRanges.good
@@ -1,7 +1,7 @@
 
 Creating B (a normal slice)
 ---------------------------
-(execute_on = 4, execute_on_nb = 3) (get = 23, put = 1, execute_on = 2) (get = 23, put = 1) (get = 23, put = 1)
+(execute_on = 4, execute_on_nb = 3) (get = 25, put = 2, execute_on = 2) (get = 25, put = 2) (get = 25, put = 2)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0

--- a/test/arrays/slices/commCounts/sliceBlockWithRanges.na-none.good
+++ b/test/arrays/slices/commCounts/sliceBlockWithRanges.na-none.good
@@ -1,7 +1,7 @@
 
 Creating B (a normal slice)
 ---------------------------
-(execute_on = 4, execute_on_nb = 3) (get = 24, put = 1, execute_on = 2, execute_on_fast = 1) (get = 24, put = 1, execute_on_fast = 1) (get = 24, put = 1, execute_on_fast = 1)
+(execute_on = 4, execute_on_nb = 3) (get = 25, put = 2, execute_on = 2, execute_on_fast = 1) (get = 25, put = 2, execute_on_fast = 1) (get = 25, put = 2, execute_on_fast = 1)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 82, put = 1, execute_on = 7) (get = 82, put = 1) (get = 82, put = 1)
+(execute_on = 14, execute_on_nb = 6) (get = 83, put = 2, execute_on = 7) (get = 83, put = 2) (get = 83, put = 2)
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.na-none.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 82, put = 1, execute_on = 7, execute_on_fast = 2) (get = 82, put = 1, execute_on_fast = 2) (get = 82, put = 1, execute_on_fast = 2)
+(execute_on = 14, execute_on_nb = 6) (get = 83, put = 2, execute_on = 7, execute_on_fast = 2) (get = 83, put = 2, execute_on_fast = 2) (get = 83, put = 2, execute_on_fast = 2)
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 96, put = 1, execute_on = 7) (get = 96, put = 1) (get = 96, put = 1)
+(execute_on = 14, execute_on_nb = 6) (get = 97, put = 2, execute_on = 7) (get = 97, put = 2) (get = 97, put = 2)
 (execute_on_nb = 3) (get = 96) (get = 96) (get = 168)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.na-none.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 96, put = 1, execute_on = 7, execute_on_fast = 2) (get = 96, put = 1, execute_on_fast = 2) (get = 96, put = 1, execute_on_fast = 2)
+(execute_on = 14, execute_on_nb = 6) (get = 97, put = 2, execute_on = 7, execute_on_fast = 2) (get = 97, put = 2, execute_on_fast = 2) (get = 97, put = 2, execute_on_fast = 2)
 (execute_on_nb = 3) (get = 96, execute_on_fast = 1) (get = 96, execute_on_fast = 1) (get = 168, execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.good
@@ -1,2 +1,2 @@
-(put = 12, execute_on = 12, execute_on_nb = 9) (get = 45, put = 1, execute_on = 10) (get = 45, put = 1, execute_on = 4) (get = 45, put = 1, execute_on = 4)
+(put = 12, execute_on = 12, execute_on_nb = 9) (get = 46, put = 2, execute_on = 10) (get = 46, put = 2, execute_on = 4) (get = 46, put = 2, execute_on = 4)
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.na-none.good
@@ -1,2 +1,2 @@
-(put = 12, execute_on = 12, execute_on_nb = 9) (get = 45, put = 1, execute_on = 10, execute_on_fast = 3) (get = 45, put = 1, execute_on = 4, execute_on_fast = 3) (get = 45, put = 1, execute_on = 4, execute_on_fast = 3)
+(put = 12, execute_on = 12, execute_on_nb = 9) (get = 46, put = 2, execute_on = 10, execute_on_fast = 3) (get = 46, put = 2, execute_on = 4, execute_on_fast = 3) (get = 46, put = 2, execute_on = 4, execute_on_fast = 3)
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 32, put = 1, execute_on = 4) (get = 32, put = 1) (get = 32, put = 1)
+(execute_on = 8, execute_on_nb = 9) (get = 33, put = 2, execute_on = 4) (get = 33, put = 2) (get = 33, put = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.na-none.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 32, put = 1, execute_on = 4, execute_on_fast = 3) (get = 32, put = 1, execute_on_fast = 3) (get = 32, put = 1, execute_on_fast = 3)
+(execute_on = 8, execute_on_nb = 9) (get = 33, put = 2, execute_on = 4, execute_on_fast = 3) (get = 33, put = 2, execute_on_fast = 3) (get = 33, put = 2, execute_on_fast = 3)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 42, put = 1, execute_on = 4) (get = 42, put = 1) (get = 42, put = 1)
+(execute_on = 8, execute_on_nb = 9) (get = 43, put = 2, execute_on = 4) (get = 43, put = 2) (get = 43, put = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.na-none.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 42, put = 1, execute_on = 4, execute_on_fast = 3) (get = 42, put = 1, execute_on_fast = 3) (get = 42, put = 1, execute_on_fast = 3)
+(execute_on = 8, execute_on_nb = 9) (get = 43, put = 2, execute_on = 4, execute_on_fast = 3) (get = 43, put = 2, execute_on_fast = 3) (get = 43, put = 2, execute_on_fast = 3)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 8, execute_on_nb = 9) (get = 53, put = 1, execute_on = 8) (get = 53, put = 1, execute_on = 4) (get = 53, put = 1, execute_on = 4)
+(put = 12, execute_on = 8, execute_on_nb = 9) (get = 54, put = 2, execute_on = 8) (get = 54, put = 2, execute_on = 4) (get = 54, put = 2, execute_on = 4)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.na-none.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 8, execute_on_nb = 9) (get = 53, put = 1, execute_on = 8, execute_on_fast = 3) (get = 53, put = 1, execute_on = 4, execute_on_fast = 3) (get = 53, put = 1, execute_on = 4, execute_on_fast = 3)
+(put = 12, execute_on = 8, execute_on_nb = 9) (get = 54, put = 2, execute_on = 8, execute_on_fast = 3) (get = 54, put = 2, execute_on = 4, execute_on_fast = 3) (get = 54, put = 2, execute_on = 4, execute_on_fast = 3)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 26, put = 1, execute_on = 3) (get = 26, put = 1, execute_on = 1) (get = 26, put = 1, execute_on = 1)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 27, put = 2, execute_on = 3) (get = 27, put = 2, execute_on = 1) (get = 27, put = 2, execute_on = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.na-none.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 26, put = 1, execute_on = 3, execute_on_fast = 2) (get = 26, put = 1, execute_on = 1, execute_on_fast = 2) (get = 26, put = 1, execute_on = 1, execute_on_fast = 2)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 27, put = 2, execute_on = 3, execute_on_fast = 2) (get = 27, put = 2, execute_on = 1, execute_on_fast = 2) (get = 27, put = 2, execute_on = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 36, put = 1, execute_on = 3) (get = 36, put = 1, execute_on = 1) (get = 36, put = 1, execute_on = 1)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 37, put = 2, execute_on = 3) (get = 37, put = 2, execute_on = 1) (get = 37, put = 2, execute_on = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.na-none.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 36, put = 1, execute_on = 3, execute_on_fast = 2) (get = 36, put = 1, execute_on = 1, execute_on_fast = 2) (get = 36, put = 1, execute_on = 1, execute_on_fast = 2)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 37, put = 2, execute_on = 3, execute_on_fast = 2) (get = 37, put = 2, execute_on = 1, execute_on_fast = 2) (get = 37, put = 2, execute_on = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.replicated.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 4, execute_on_nb = 6) (get = 44, put = 1, execute_on = 6) (get = 44, put = 1, execute_on = 4) (get = 44, put = 1, execute_on = 4)
+(put = 12, execute_on = 4, execute_on_nb = 6) (get = 45, put = 2, execute_on = 6) (get = 45, put = 2, execute_on = 4) (get = 45, put = 2, execute_on = 4)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.replicated.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.replicated.na-none.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 4, execute_on_nb = 6) (get = 44, put = 1, execute_on = 6, execute_on_fast = 2) (get = 44, put = 1, execute_on = 4, execute_on_fast = 2) (get = 44, put = 1, execute_on = 4, execute_on_fast = 2)
+(put = 12, execute_on = 4, execute_on_nb = 6) (get = 45, put = 2, execute_on = 6, execute_on_fast = 2) (get = 45, put = 2, execute_on = 4, execute_on_fast = 2) (get = 45, put = 2, execute_on = 4, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.block.good
@@ -1,5 +1,5 @@
 create slice (module-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (module-scope):
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 use slice via random access (module-scope):
@@ -15,7 +15,7 @@ use slice as follower (module-scope):
 2-arg promotion (module-scope):
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 create slice (local-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (local-scope):
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 use slice via random access (local-scope):

--- a/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.block.na-none.good
@@ -1,5 +1,5 @@
 create slice (module-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (module-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 use slice via random access (module-scope):
@@ -15,7 +15,7 @@ use slice as follower (module-scope):
 2-arg promotion (module-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 create slice (local-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (local-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 use slice via random access (local-scope):

--- a/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.cyclic.good
@@ -1,5 +1,5 @@
 create slice (module-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (module-scope):
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 use slice via random access (module-scope):
@@ -15,7 +15,7 @@ use slice as follower (module-scope):
 2-arg promotion (module-scope):
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 create slice (local-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (local-scope):
 (execute_on_nb = 3) (<no communication>) (<no communication>) (<no communication>)
 use slice via random access (local-scope):

--- a/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.cyclic.na-none.good
@@ -1,5 +1,5 @@
 create slice (module-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (module-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 use slice via random access (module-scope):
@@ -15,7 +15,7 @@ use slice as follower (module-scope):
 2-arg promotion (module-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 create slice (local-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (local-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 use slice via random access (local-scope):

--- a/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.replicated.good
@@ -1,5 +1,5 @@
 create slice (module-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (module-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 use slice via random access (module-scope):
@@ -15,7 +15,7 @@ use slice as follower (module-scope):
 2-arg promotion (module-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 create slice (local-scope):
-(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
+(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
 use slice via assignment (local-scope):
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)
 use slice via random access (local-scope):

--- a/test/optimizations/constDomain/arrView.chpl
+++ b/test/optimizations/constDomain/arrView.chpl
@@ -1,0 +1,79 @@
+{
+  writeln("Slice with tuple of ranges");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var arrView = a[2..3, 2..3];
+
+  writeln(arrView.domain);
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
+  writeln("Slice with domain literal");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var arrView = a[{2..3, 2..3}];
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
+  writeln("Slice with var domain");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var sliceDom = {2..3, 2..3};
+  var arrView = a[sliceDom];
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
+  writeln("Reindex with tuple of ranges");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var arrView = a.reindex(2..11, 2..11);
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
+  writeln("Reindex with domain literal");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var arrView = a.reindex({2..11, 2..11});
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
+  writeln("Reindex with var domain");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var reindexDom = {2..11, 2..11};
+  var arrView = a.reindex(reindexDom);
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
+  writeln("Rank change with tuple of ranges");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  var arrView = a[2..3, 2];
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}

--- a/test/optimizations/constDomain/arrView.good
+++ b/test/optimizations/constDomain/arrView.good
@@ -6,8 +6,8 @@ Slice with domain literal
 true
 true
 Slice with var domain
-true
-true
+false
+false
 Reindex with tuple of ranges
 true
 true

--- a/test/optimizations/constDomain/arrView.good
+++ b/test/optimizations/constDomain/arrView.good
@@ -1,0 +1,22 @@
+Slice with tuple of ranges
+{2..3, 2..3}
+true
+true
+Slice with domain literal
+true
+true
+Slice with var domain
+true
+true
+Reindex with tuple of ranges
+true
+true
+Reindex with domain literal
+true
+true
+Reindex with var domain
+true
+true
+Rank change with tuple of ranges
+true
+true

--- a/test/optimizations/constDomain/constIntoVar.chpl
+++ b/test/optimizations/constDomain/constIntoVar.chpl
@@ -1,0 +1,18 @@
+config const option = true;
+var A:[1..10] int;
+
+proc makeDomain() {
+  const D = {1..2};
+  writeln("in makeDomain, D.definedConst=", D._value.definedConst);
+  return D;
+}
+
+proc test1() {
+  writeln("test1");
+  var D = makeDomain();
+  writeln("in test, D.definedConst=", D._value.definedConst);
+  writeln("D. is ", D);
+  D = {2..2};
+  writeln("D is now ", D);
+}
+test1();

--- a/test/optimizations/constDomain/constIntoVar.good
+++ b/test/optimizations/constDomain/constIntoVar.good
@@ -1,0 +1,5 @@
+test1
+in makeDomain, D.definedConst=true
+in test, D.definedConst=false
+D. is {1..2}
+D is now {2..2}

--- a/test/optimizations/constDomain/constIntoVar2.chpl
+++ b/test/optimizations/constDomain/constIntoVar2.chpl
@@ -1,0 +1,19 @@
+var A:[1..10] int;
+writeln("A.domain definedConst=", A.domain._value.definedConst);
+
+proc returnADomainCopy() {
+  return A.domain; // copies to a non "view"
+}
+
+proc test1() {
+  const D = returnADomainCopy();
+  writeln("test1 D definedConst=", D._value.definedConst);
+}
+test1();
+
+proc test2() {
+  var D = returnADomainCopy();
+  writeln("test2 D definedConst=", D._value.definedConst);
+  // Could now do D = {1..2} e.g. ; so D's definedConst must not be true
+}
+test2();

--- a/test/optimizations/constDomain/constIntoVar2.good
+++ b/test/optimizations/constDomain/constIntoVar2.good
@@ -1,0 +1,3 @@
+A.domain definedConst=true
+test1 D definedConst=true
+test2 D definedConst=false

--- a/test/optimizations/constDomain/domainArgs.chpl
+++ b/test/optimizations/constDomain/domainArgs.chpl
@@ -1,0 +1,83 @@
+const colWidth = 12;
+const fmt = "%-"+colWidth:string+"s|%-"+colWidth:string+"s\n";
+
+//// this is const ref -- `const` doesn't matter here
+proc defIntent(d) {
+  writef(fmt, "(const ref)", d.definedConst);
+}
+
+// TODO: Something's wrong with generic in intents. File a bug report, and
+// make this generic once it is resolved
+//
+// It causes the copy to be dropped for a domain literal argument (maybe
+// correctly?), so this reports 'true' for a domain literal. For concrete
+// argument, the copy remains there and we get 'false' (correctly).
+proc inIntent(in d: domain(1, int, false)) {
+  writef(fmt, "in", d.definedConst);
+}
+
+proc outIntent(out d) {
+  writef(fmt, "out", d.definedConst);
+}
+
+proc inoutIntent(inout d) {
+  writef(fmt, "inout", d.definedConst);
+}
+
+proc refIntent(ref d) {
+  writef(fmt, "ref", d.definedConst);
+}
+
+// this is const ref -- `const` doesn't matter here
+proc constIntent(const d) {
+  writef(fmt, "const (ref)", d.definedConst);
+}
+
+proc constInIntent(const in d) {
+  writef(fmt, "const in", d.definedConst);
+}
+
+proc constRefIntent(const ref d) {
+  writef(fmt, "const ref", d.definedConst);
+}
+
+writeln("Passing domain literal");
+writef(fmt, "intent", "definedConst");
+writef(fmt, "-"*colWidth, "-"*colWidth);
+
+defIntent({1..10});
+inIntent({1..10});
+// outIntent({1..10});     // doesn't make sense
+// inoutIntent({1..10});   // doesn't make sense
+constIntent({1..10});
+constInIntent({1..10});
+constRefIntent({1..10});
+writeln();
+
+writeln("Passing var domain");
+writef(fmt, "intent", "definedConst");
+writef(fmt, "-"*colWidth, "-"*colWidth);
+
+var varDom = {1..10};
+defIntent(varDom);
+inIntent(varDom);
+outIntent(varDom);
+inoutIntent(varDom);
+constIntent(varDom);
+constInIntent(varDom);
+constRefIntent(varDom);
+writeln();
+
+writeln("Passing const domain");
+writef(fmt, "intent", "definedConst");
+writef(fmt, "-"*colWidth, "-"*colWidth);
+
+const constDom = {1..10};
+defIntent(constDom);
+inIntent(constDom);
+// outIntent(constDom);     // doesn't make sense
+// inoutIntent(constDom);   // doesn't make sense
+constIntent(constDom);
+constInIntent(constDom);
+constRefIntent(constDom);
+writeln();

--- a/test/optimizations/constDomain/domainArgs.chpl
+++ b/test/optimizations/constDomain/domainArgs.chpl
@@ -6,12 +6,12 @@ proc defIntent(d) {
   writef(fmt, "(const ref)", d.definedConst);
 }
 
-// TODO: Something's wrong with generic in intents. File a bug report, and
-// make this generic once it is resolved
-//
-// It causes the copy to be dropped for a domain literal argument (maybe
+// I wanted to make `d` a generic argument like the others below. However, it
+// causes the copy to be dropped for a domain literal argument (maybe
 // correctly?), so this reports 'true' for a domain literal. For concrete
 // argument, the copy remains there and we get 'false' (correctly).
+//
+// See: https://github.com/chapel-lang/chapel/issues/16398
 proc inIntent(in d: domain(1, int, false)) {
   writef(fmt, "in", d.definedConst);
 }

--- a/test/optimizations/constDomain/domainArgs.good
+++ b/test/optimizations/constDomain/domainArgs.good
@@ -1,0 +1,29 @@
+Passing domain literal
+intent      |definedConst
+------------|------------
+(const ref) |true        
+in          |false       
+const (ref) |true        
+const in    |true        
+const ref   |true        
+
+Passing var domain
+intent      |definedConst
+------------|------------
+(const ref) |false       
+in          |false       
+out         |false       
+inout       |false       
+const (ref) |false       
+const in    |true        
+const ref   |false       
+
+Passing const domain
+intent      |definedConst
+------------|------------
+(const ref) |true        
+in          |false       
+const (ref) |true        
+const in    |true        
+const ref   |true        
+

--- a/test/optimizations/constDomain/domainField.chpl
+++ b/test/optimizations/constDomain/domainField.chpl
@@ -1,0 +1,49 @@
+{
+  writeln("Pass literal to var field");
+  class C {
+    var d: domain(1);
+  }
+
+  var c = new C({1..10});
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}
+
+{
+  writeln("Pass const to var field");
+  class C {
+    var d: domain(1);
+  }
+
+  const d = {1..10};
+  var c = new C(d);
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}
+
+{
+  writeln("Pass literal to const field");
+  class C {
+    const d: domain(1);
+  }
+
+  var c = new C({1..10});
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}
+
+{
+  writeln("Pass var to const field");
+  class C {
+    const d: domain(1);
+  }
+
+  var d = {1..10};
+  var c = new C(d);
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}

--- a/test/optimizations/constDomain/domainField.good
+++ b/test/optimizations/constDomain/domainField.good
@@ -1,0 +1,12 @@
+Pass literal to var field
+false
+false
+Pass const to var field
+false
+false
+Pass literal to const field
+true
+true
+Pass var to const field
+true
+true

--- a/test/optimizations/constDomain/domainFieldUserInit.chpl
+++ b/test/optimizations/constDomain/domainFieldUserInit.chpl
@@ -1,0 +1,65 @@
+{
+  writeln("Pass literal to var field");
+  class C {
+    var d: domain(1);
+
+    proc init(d) {
+      this.d = d;
+    }
+  }
+
+  var c = new C({1..10});
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}
+
+{
+  writeln("Pass const to var field");
+  class C {
+    var d: domain(1);
+
+    proc init(d) {
+      this.d = d;
+    }
+  }
+
+  const d = {1..10};
+  var c = new C(d);
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}
+
+{
+  writeln("Pass literal to const field");
+  class C {
+    const d: domain(1);
+
+    proc init(d) {
+      this.d = d;
+    }
+  }
+
+  var c = new C({1..10});
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}
+
+{
+  writeln("Pass var to const field");
+  class C {
+    const d: domain(1);
+
+    proc init(d) {
+      this.d = d;
+    }
+  }
+
+  var d = {1..10};
+  var c = new C(d);
+
+  writeln(c.d.definedConst);
+  writeln(c.d._value.definedConst);
+}

--- a/test/optimizations/constDomain/domainFieldUserInit.good
+++ b/test/optimizations/constDomain/domainFieldUserInit.good
@@ -1,0 +1,12 @@
+Pass literal to var field
+false
+false
+Pass const to var field
+false
+false
+Pass literal to const field
+true
+true
+Pass var to const field
+true
+true

--- a/test/optimizations/constDomain/domainView.chpl
+++ b/test/optimizations/constDomain/domainView.chpl
@@ -1,0 +1,19 @@
+//rank change
+{
+  var d = {1..10, 1..10};
+
+  const domView = d[2..4, 3];
+
+  writeln(domView.definedConst);
+  writeln(domView._value.definedConst);
+}
+
+//slice
+{
+  var d = {1..10, 1..10};
+
+  const domView = d[2..4, 2..4];
+
+  writeln(domView.definedConst);
+  writeln(domView._value.definedConst);
+}

--- a/test/optimizations/constDomain/domainView.good
+++ b/test/optimizations/constDomain/domainView.good
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/test/optimizations/constDomain/forallIntent.chpl
+++ b/test/optimizations/constDomain/forallIntent.chpl
@@ -1,0 +1,114 @@
+const colWidth = 12;
+const fmt = "%-"+colWidth:string+"s|%-"+colWidth:string+"s\n";
+
+{
+  writeln("Passing var domain");
+  writef(fmt, "intent", "definedConst");
+  writef(fmt, "-"*colWidth, "-"*colWidth);
+
+  var d = {1..10};
+  {
+    var isConst: bool;
+    forall i in 1..2 with (ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "(const ref)", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (in d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "in", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (ref d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "ref", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (const d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "const (ref)", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (const in d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "const in", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (const ref d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "const ref", isConst);
+  }
+}
+
+writeln();
+
+{
+  writeln("Passing const domain");
+  writef(fmt, "intent", "definedConst");
+  writef(fmt, "-"*colWidth, "-"*colWidth);
+
+  const d = {1..10};
+  {
+    var isConst: bool;
+    forall i in 1..2 with (ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "(const ref)", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (in d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "in", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (ref d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "ref", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (const d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "const (ref)", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (const in d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "const in", isConst);
+  }
+
+  {
+    var isConst: bool;
+    forall i in 1..2 with (const ref d, ref isConst) {
+      if i == 1 then isConst = d.definedConst;
+    }
+    writef(fmt, "const ref", isConst);
+  }
+}

--- a/test/optimizations/constDomain/forallIntent.good
+++ b/test/optimizations/constDomain/forallIntent.good
@@ -1,0 +1,19 @@
+Passing var domain
+intent      |definedConst
+------------|------------
+(const ref) |false       
+in          |false       
+ref         |false       
+const (ref) |false       
+const in    |true        
+const ref   |false       
+
+Passing const domain
+intent      |definedConst
+------------|------------
+(const ref) |true        
+in          |false       
+ref         |true        
+const (ref) |true        
+const in    |true        
+const ref   |true        

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -563,8 +563,8 @@ proc AMRHierarchy.deleteBoundaryStructures( i: int )
 class PhysicalBoundary
 {
 
-  const grids:        domain(unmanaged Grid);
-  const multidomains: [grids] unmanaged MultiDomain(dimension,stridable=true)?;
+  var grids:        domain(unmanaged Grid);
+  var multidomains: [grids] unmanaged MultiDomain(dimension,stridable=true)?;
 
 
 

--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -106,8 +106,8 @@ class ArrayWrapper
 class CandidateDomain {
   
   param rank:       int;
-  const D:          domain(rank,stridable=true);
-  const flags:      [D] bool;
+  var D:          domain(rank,stridable=true);
+  var flags:      [D] bool;
   const min_width:  rank*int;
   var   signatures: rank*unmanaged ArrayWrapper;
 

--- a/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
@@ -20,8 +20,8 @@ class GridInvalidRegion {
   //| >    fields    | >
   //|/...............|/
   
-  const fine_neighbors: domain(unmanaged Grid);
-  const domains:        [fine_neighbors] domain(dimension,stridable=true);
+  var fine_neighbors: domain(unmanaged Grid);
+  var domains:        [fine_neighbors] domain(dimension,stridable=true);
   
   // /|'''''''''''''''/|
   //< |    fields    < |

--- a/test/studies/amr/lib/grid/Grid_def.chpl
+++ b/test/studies/amr/lib/grid/Grid_def.chpl
@@ -40,11 +40,11 @@ class Grid {
 
   const dx: dimension*real;
           
-  const cells:          domain(dimension, stridable=true);
-  const extended_cells: domain(dimension, stridable=true);
+  var cells:          domain(dimension, stridable=true);
+  var extended_cells: domain(dimension, stridable=true);
   
   // const ghost_domains: MultiDomain(dimension, stridable=true);
-  const ghost_domains: unmanaged List( domain(dimension, stridable=true) );
+  var ghost_domains: unmanaged List( domain(dimension, stridable=true) );
 
 
 

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -38,8 +38,8 @@ class Level {
   // the level.
   //--------------------------------------------------------------
   
-  const possible_cells:       domain(dimension, stridable=true);
-  const possible_ghost_cells: domain(dimension, stridable=true);
+  var possible_cells:       domain(dimension, stridable=true);
+  var possible_ghost_cells: domain(dimension, stridable=true);
 
 
   //==== Child grid info ====
@@ -315,8 +315,8 @@ proc Level.complete ()
 
 class SiblingGhostRegion {
 
-  const neighbors: domain(unmanaged Grid);
-  const overlaps:  [neighbors] domain(dimension,stridable=true);
+  var neighbors: domain(unmanaged Grid);
+  var overlaps:  [neighbors] domain(dimension,stridable=true);
   
   
   //|\''''''''''''''''''''|\


### PR DESCRIPTION
This PR improves constant domain optimization in several ways.

- Resolve https://github.com/chapel-lang/chapel/issues/16354

- Make domain literals always constant

- Fix domain constness w.r.t. argument/task intents

- Fix constant domain views

- Fix array views and how their domains' constness are handled

- Add bunch of tests

Implementation details:

- Creates a `compiler/optimizations/propagateDomainConstness.cpp` that contains
  all the relevant support functions.
- Adjusts where we remove init/autoCopy during `callDestructors` and
  `removeUnnecessaryAutoCopyCalls`
- Make domain literals always be constant (through parser changes), but unset
  constness if those literals are assigned to a `var` variable.
- Add `FLAG_CONST` to field initialization temps, if the field itself has that
  flag.
- Add adjustment code after replacing `PRIM_MOVE`s with `PRIM_SET_MEMBER`s in
  initializers
- Adjust `test/studies/amr` to not define irregular const domain fields in user
  types

Future steps:

- Depending on what happens with https://github.com/chapel-lang/chapel/issues/16398
  we may need to do some adjustments in this implementation.
- @mppf brings up a good point about how the domain constness is handled in two
  different ways. (1) we manipulate an additional argument to initCopy et al, to
  set the constness of the LHS, (2) set the definedConst field after the
  assignment [this mostly starts to happen with this PR].

  Initial hope was that with (1) we can handle many cases, and use (2) in
  limited number of scenarios. However, after this PR, I can't tell which one is
  the "main" way to handle this optimization, as there are some pretty
  significant scenarios where we can't do (1).

  I still hope that there can be something we can do with the types, and not
  have to have so many AST modifications only to set the constness of a
  variable. But, lumping constness into the type has its own challanges.

- Can we do something to optimize functions where a var domain is captured with 
  `const [ref]` intent?

```chapel
proc foo(const d: domain) {
  var a: [d] int;
  // do something with a but do *not* return it
}
var d = {1..10};
foo(d);
```

As `a`’s scope is a scope where `d` is constant, we can avoid tracking it, however, we don’t
do that today because `d` in `foo` is just a reference to a non-const domain.

- Improve how we handle `definedConst` for privatized instances to reduce
  commcounts.


Test:
- [x] standard
- [x] gasnet
