### PR TITLE
Distinguish runtime comm consistency unordered-forall, task-end funcs.

### DIFF
--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -259,7 +259,7 @@ bool MarkOptimizableForallLastStmts::enterForallStmt(ForallStmt* forall) {
     markLoopsInForall(forall);
   }
 
-  // Either way, add chpl_comm_unordered_task_fence at the end of
+  // Either way, add chpl_comm_unordered_consist_fence at the end of
   // the forall.
   // TODO: move this to a better place in the compiler.
   SET_LINENO(forall);
@@ -358,7 +358,7 @@ void checkLifetimesForForallUnorderedOps(FnSymbol* fn,
 
   // This runs even for fNoOptimizeForallUnordered
   // because even if the optimization is disabled, we want
-  // to mark the ends of foralls with chpl_comm_unordered_task_fence.
+  // to mark the ends of foralls with chpl_comm_unordered_consist_fence.
 
   MarkOptimizableForallLastStmts mark;
   mark.lifetimeInfo = lifetimeInfo;

--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -259,7 +259,7 @@ bool MarkOptimizableForallLastStmts::enterForallStmt(ForallStmt* forall) {
     markLoopsInForall(forall);
   }
 
-  // Either way, add chpl_comm_unordered_consist_fence at the end of
+  // Either way, add chpl_after_forall_fence() at the end of
   // the forall.
   // TODO: move this to a better place in the compiler.
   SET_LINENO(forall);
@@ -358,7 +358,7 @@ void checkLifetimesForForallUnorderedOps(FnSymbol* fn,
 
   // This runs even for fNoOptimizeForallUnordered
   // because even if the optimization is disabled, we want
-  // to mark the ends of foralls with chpl_comm_unordered_consist_fence.
+  // to mark the ends of foralls with chpl_after_forall_fence().
 
   MarkOptimizableForallLastStmts mark;
   mark.lifetimeInfo = lifetimeInfo;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1266,6 +1266,9 @@ module ChapelBase {
 
   extern proc chpl_comm_unordered_consist_fence(): void;
 
+  pragma "task complete impl fn"
+  extern proc chpl_comm_task_end(): void;
+
   proc chpl_after_forall_fence() {
     chpl_comm_unordered_consist_fence();
   }
@@ -1273,9 +1276,6 @@ module ChapelBase {
   // This function is called once by each newly initiated task.  No on
   // statement is needed because the call to sub() will do a remote
   // fork (on) if needed.
-  pragma "task complete impl fn"
-  extern proc chpl_comm_task_end(): void;
-
   pragma "dont disable remote value forwarding"
   pragma "task complete impl fn"
   pragma "down end count fn"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1264,13 +1264,13 @@ module ChapelBase {
     }
   }
 
-  extern proc chpl_comm_unordered_consist_fence(): void;
+  extern proc chpl_comm_unordered_task_fence(): void;
 
   pragma "task complete impl fn"
   extern proc chpl_comm_task_end(): void;
 
   proc chpl_after_forall_fence() {
-    chpl_comm_unordered_consist_fence();
+    chpl_comm_unordered_task_fence();
   }
 
   // This function is called once by each newly initiated task.  No on

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1264,17 +1264,18 @@ module ChapelBase {
     }
   }
 
-  pragma "task complete impl fn"
-  extern proc chpl_comm_task_end(): void;
+  extern proc chpl_comm_unordered_consist_fence(): void;
 
-  pragma "task complete impl fn"
   proc chpl_after_forall_fence() {
-    chpl_comm_task_end(); // TODO: change to chpl_comm_unordered_task_fence()
+    chpl_comm_unordered_consist_fence();
   }
 
   // This function is called once by each newly initiated task.  No on
   // statement is needed because the call to sub() will do a remote
   // fork (on) if needed.
+  pragma "task complete impl fn"
+  extern proc chpl_comm_task_end(): void;
+
   pragma "dont disable remote value forwarding"
   pragma "task complete impl fn"
   pragma "down end count fn"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1264,12 +1264,12 @@ module ChapelBase {
     }
   }
 
-  pragma "compiler added remote fence"
   extern proc chpl_comm_unordered_task_fence(): void;
 
   pragma "task complete impl fn"
   extern proc chpl_comm_task_end(): void;
 
+  pragma "compiler added remote fence"
   proc chpl_after_forall_fence() {
     chpl_comm_unordered_task_fence();
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1264,6 +1264,7 @@ module ChapelBase {
     }
   }
 
+  pragma "compiler added remote fence"
   extern proc chpl_comm_unordered_task_fence(): void;
 
   pragma "task complete impl fn"

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -499,9 +499,30 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                                chpl_comm_on_bundle_t *arg, size_t arg_size,
                                int ln, int32_t fn);
 
+//
+// Hook to ensure remote memory consistency after unordered operations.
+//
+#ifndef CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE
+#define CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE() \
+        return
+#endif
+static inline
+void chpl_comm_unordered_consist_fence(void) {
+  CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE();
+}
+
+
 // This is a hook that's called when a task is ending. It allows for things
 // like say flushing task private buffers.
-void chpl_comm_task_end(void);
+#ifndef CHPL_COMM_IMPL_TASK_END
+#define CHPL_COMM_IMPL_TASK_END() \
+        return
+#endif
+static inline
+void chpl_comm_task_end(void) {
+  CHPL_COMM_IMPL_TASK_END();
+}
+
 
 void* chpl_get_global_serialize_table(int64_t idx);
 

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -502,13 +502,13 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
 //
 // Hook to ensure remote memory consistency after unordered operations.
 //
-#ifndef CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE
-#define CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE() \
+#ifndef CHPL_COMM_IMPL_UNORDERED_TASK_FENCE
+#define CHPL_COMM_IMPL_UNORDERED_TASK_FENCE() \
         return
 #endif
 static inline
-void chpl_comm_unordered_consist_fence(void) {
-  CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE();
+void chpl_comm_unordered_task_fence(void) {
+  CHPL_COMM_IMPL_UNORDERED_TASK_FENCE();
 }
 
 

--- a/runtime/include/comm/ofi/chpl-comm-impl.h
+++ b/runtime/include/comm/ofi/chpl-comm-impl.h
@@ -41,9 +41,9 @@ size_t chpl_comm_impl_regMemHeapPageSize(void);
 //
 // Remote memory consistency release/acquire hooks.
 //
-#define CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE() \
-        chpl_comm_impl_unordered_consist_fence()
-void chpl_comm_impl_unordered_consist_fence(void);
+#define CHPL_COMM_IMPL_UNORDERED_TASK_FENCE() \
+        chpl_comm_impl_unordered_task_fence()
+void chpl_comm_impl_unordered_task_fence(void);
 
 #define CHPL_COMM_IMPL_TASK_END() \
         chpl_comm_impl_task_end()

--- a/runtime/include/comm/ofi/chpl-comm-impl.h
+++ b/runtime/include/comm/ofi/chpl-comm-impl.h
@@ -38,4 +38,15 @@ size_t chpl_comm_impl_regMemHeapPageSize(void);
 //
 #include "chpl-comm-native-atomics.h"
 
+//
+// Remote memory consistency release/acquire hooks.
+//
+#define CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE() \
+        chpl_comm_impl_unordered_consist_fence()
+void chpl_comm_impl_unordered_consist_fence(void);
+
+#define CHPL_COMM_IMPL_TASK_END() \
+        chpl_comm_impl_task_end()
+void chpl_comm_impl_task_end(void);
+
 #endif // _chpl_comm_impl_h_

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -71,6 +71,17 @@ chpl_bool chpl_comm_impl_regMemFree(void* p, size_t size);
 #include "chpl-comm-native-atomics.h"
 
 //
+// Remote memory consistency release/acquire hooks.
+//
+#define CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE() \
+        chpl_comm_impl_unordered_consist_fence()
+void chpl_comm_impl_unordered_consist_fence(void);
+
+#define CHPL_COMM_IMPL_TASK_END() \
+        chpl_comm_impl_task_end()
+void chpl_comm_impl_task_end(void);
+
+//
 // Internal statistics gathering and reporting.
 //
 void chpl_comm_statsStartHere(void);

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -73,9 +73,9 @@ chpl_bool chpl_comm_impl_regMemFree(void* p, size_t size);
 //
 // Remote memory consistency release/acquire hooks.
 //
-#define CHPL_COMM_IMPL_UNORDERED_CONSIST_FENCE() \
-        chpl_comm_impl_unordered_consist_fence()
-void chpl_comm_impl_unordered_consist_fence(void);
+#define CHPL_COMM_IMPL_UNORDERED_TASK_FENCE() \
+        chpl_comm_impl_unordered_task_fence()
+void chpl_comm_impl_unordered_task_fence(void);
 
 #define CHPL_COMM_IMPL_TASK_END() \
         chpl_comm_impl_task_end()

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1601,5 +1601,3 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                       /*fast*/ true, /*blocking*/ true);
   }
 }
-
-void chpl_comm_task_end(void) { }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -259,5 +259,3 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
 
   chpl_ftable_call(fid, arg);
 }
-
-void chpl_comm_task_end(void) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2526,7 +2526,12 @@ void mcmReleaseAllNodes(struct bitmap_t* b, struct perTxCtxInfo_t* tcip,
 }
 
 
-void chpl_comm_task_end(void) {
+void chpl_comm_impl_unordered_consist_fence(void) {
+  task_local_buff_end(get_buff | put_buff | amo_nf_buff);
+}
+
+
+void chpl_comm_impl_task_end(void) {
   task_local_buff_end(get_buff | put_buff | amo_nf_buff);
 
   //

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2526,7 +2526,7 @@ void mcmReleaseAllNodes(struct bitmap_t* b, struct perTxCtxInfo_t* tcip,
 }
 
 
-void chpl_comm_impl_unordered_consist_fence(void) {
+void chpl_comm_impl_unordered_task_fence(void) {
   task_local_buff_end(get_buff | put_buff | amo_nf_buff);
 }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1932,7 +1932,7 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status)
   return 0;
 }
 
-void chpl_comm_impl_unordered_consist_fence(void) {
+void chpl_comm_impl_unordered_task_fence(void) {
   task_local_buff_end(get_buff | put_buff | amo_nf_buff);
 }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1932,7 +1932,11 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status)
   return 0;
 }
 
-void chpl_comm_task_end(void) {
+void chpl_comm_impl_unordered_consist_fence(void) {
+  task_local_buff_end(get_buff | put_buff | amo_nf_buff);
+}
+
+void chpl_comm_impl_task_end(void) {
   task_local_buff_end(get_buff | put_buff | amo_nf_buff);
 }
 


### PR DESCRIPTION
For some time we've had a comm layer function which ensures remote
memory consistency after a series of unordered comm operations, but
whose name (`chpl_comm_task_end()`) implies that it is related to task
termination.  There was even a TODO comment in `ChapelBase.chpl` saying
that at least one call to it should be changed to something implying a
relationship with unordered operations.  Here, do that.  Add a new
`chpl_comm_unordered_consist_fence()`.  Change `chpl_comm_task_end()` calls
following unordered foralls to go to `chpl_comm_unordered_consist_fence()`
instead.  Retain calls to `chpl_comm_task_end()` in `_downEndCount()`, thus
at task ending.  Implement `chpl_comm_unordered_consist_fence()` in the
two comm layers (ugni and ofi) that actually need it.

While here, also adjust the runtime declarations for these to use our
customary mechanism for optionally-implemented functions, and remove the
empty versions of `chpl_comm_task_end()` from comm=none and comm=gasnet,
since those don't actually need that function.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>