### PR TITLE
Don't consider loops as safe for the fast-on optimization

### DIFF
--- a/test/optimizations/sungeun/optimized-on/loop.chpl
+++ b/test/optimizations/sungeun/optimized-on/loop.chpl
@@ -1,0 +1,16 @@
+use BlockDist;
+
+var A = newBlockArr({1..numLocales}, int);
+
+on Locales[numLocales-1] {
+  A.localAccess[numLocales] = numLocales;
+}
+
+// Loops should inhibit fast-on since the trip count can be arbitrarily large
+on Locales[numLocales-1] {
+  for i in numLocales..numLocales {
+    A.localAccess[i] = i;
+  }
+}
+
+writeln(A);

--- a/test/optimizations/sungeun/optimized-on/loop.good
+++ b/test/optimizations/sungeun/optimized-on/loop.good
@@ -1,0 +1,2 @@
+Optimized on clause (wrapon_fn) in module loop (loop.chpl:5)
+0 0 0 4


### PR DESCRIPTION
Previously, loops would not inhibit fast-ons, but loops can have an
arbitrary trip count, so it's not something we really want to run in the
active-message handler. Technically there's nothing blocking about a
loop that makes it illegal for the AM handler it can just be slow, which
can have serious performance implications.

This was causing large regressions for some Arkouda aggregation work
that optimized some of the flushing such that there was nothing else but
a large loop in an on-stmt. Making that loop run directly in the AM
handler had a large performance hit.