### PR TITLE
Fix unordered fence tests from single task specialization removal

### DIFF
--- a/test/runtime/configMatters/forall-unordered-opt/check-fence/check-fence-after-forall.good
+++ b/test/runtime/configMatters/forall-unordered-opt/check-fence/check-fence-after-forall.good
@@ -1,5 +1,4 @@
 ../needsFenceSerial.chpl:16: note: Optimized atomic call to be unordered
-../needsFenceSerial.chpl:16: note: Optimized atomic call to be unordered
 chpl_after_forall_fence();
 chpl_after_forall_fence();
 chpl_after_forall_fence();

--- a/test/runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence.good
+++ b/test/runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence.good
@@ -1,7 +1,3 @@
 ../needsFence.chpl:14: note: Optimized atomic call to be unordered
-../needsFence.chpl:14: note: Optimized atomic call to be unordered
-atomic_fence_chpl;
-chpl_comm_atomic_add_unordered_int64;
---
 atomic_fence_chpl;
 chpl_comm_atomic_add_unordered_int64;


### PR DESCRIPTION
PR #16401 removed a bunch of internal for-loops in parallel iterators so
there's less loops to optimize now.