### PR TITLE
Parallelize large DefaultRectangular assignments

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -42,9 +42,7 @@ module DefaultRectangular {
   config param debugDataParNuma = false;
   config param disableArrRealloc = false;
   config param reportInPlaceRealloc = false;
-
-  //TODO make this a param,  it is const only for testing
-  config const parallelAssignThreshold = 2*1024*1024;
+  config param parallelAssignThreshold = 2*1024*1024;
 
   config param defaultDoRADOpt = true;
   config param defaultDisableLazyRADOpt = false;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -43,6 +43,9 @@ module DefaultRectangular {
   config param disableArrRealloc = false;
   config param reportInPlaceRealloc = false;
 
+  //TODO make this a param,  it is const only for testing
+  config const parallelAssignThreshold = 2*1024*1024;
+
   config param defaultDoRADOpt = true;
   config param defaultDisableLazyRADOpt = false;
   config param earlyShiftData = true;
@@ -1968,10 +1971,41 @@ module DefaultRectangular {
     const Adata = _ddata_shift(A.eltType, A.theData, Aidx);
     const Bidx = B.getDataIndex(Blo);
     const Bdata = _ddata_shift(B.eltType, B.theData, Bidx);
-    _simpleTransferHelper(A, B, Adata, Bdata, len);
+
+    type t = A.eltType;
+    const elemsizeInBytes = if isNumericType(t) then numBytes(t)
+                            else c_sizeof(t).safeCast(int);
+    const doParallelAssign = len:int*elemsizeInBytes >= parallelAssignThreshold;
+
+    if doParallelAssign {
+      _simpleParallelTransferHelper(A, B, Adata, Bdata, len);
+    }
+    else{
+      _simpleTransferHelper(A, B, Adata, Bdata, len);
+    }
   }
 
-  private proc _simpleTransferHelper(A, B, Adata, Bdata, len) {
+  private proc _simpleParallelTransferHelper(A, B, Adata, Bdata, len) {
+    const numTasks = if __primitive("task_get_serial") then
+                      1 else _computeNumChunks(len);
+    const lenPerTask = len:int/numTasks;
+
+    if debugDefaultDistBulkTransfer && numTasks > 1 then
+      chpl_debug_writeln("\tWill do parallel transfer with ", numTasks, " tasks");
+
+    coforall tid in 0..#numTasks {
+      const myOffset = tid*lenPerTask;
+
+      if tid == numTasks-1 {
+        _simpleTransferHelper(A, B, Adata, Bdata, len:int-myOffset, offset=myOffset);
+      }
+      else {
+        _simpleTransferHelper(A, B, Adata, Bdata, lenPerTask, offset=myOffset);
+      }
+    }
+  }
+
+  private proc _simpleTransferHelper(A, B, Adata, Bdata, len, offset=0) {
     if Adata == Bdata then return;
 
     // NOTE: This does not work with --heterogeneous, but heterogeneous
@@ -1980,15 +2014,18 @@ module DefaultRectangular {
     if Adata.locale.id==here.id {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tlocal get() from ", B.locale.id);
-      __primitive("chpl_comm_array_get", Adata[0], Bdata.locale.id, Bdata[0], len);
+      __primitive("chpl_comm_array_get", Adata[offset], Bdata.locale.id,
+                  Bdata[offset], len);
     } else if Bdata.locale.id==here.id {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tlocal put() to ", A.locale.id);
-      __primitive("chpl_comm_array_put", Bdata[0], Adata.locale.id, Adata[0], len);
+      __primitive("chpl_comm_array_put", Bdata[offset], Adata.locale.id,
+                  Adata[0], len);
     } else on Adata.locale {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tremote get() on ", here.id, " from ", B.locale.id);
-      __primitive("chpl_comm_array_get", Adata[0], Bdata.locale.id, Bdata[0], len);
+      __primitive("chpl_comm_array_get", Adata[offset], Bdata.locale.id,
+                  Bdata[0], len);
     }
   }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2014,12 +2014,12 @@ module DefaultRectangular {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tlocal put() to ", A.locale.id);
       __primitive("chpl_comm_array_put", Bdata[offset], Adata.locale.id,
-                  Adata[0], len);
+                  Adata[offset], len);
     } else on Adata.locale {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tremote get() on ", here.id, " from ", B.locale.id);
       __primitive("chpl_comm_array_get", Adata[offset], Bdata.locale.id,
-                  Bdata[0], len);
+                  Bdata[offset], len);
     }
   }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1984,8 +1984,8 @@ module DefaultRectangular {
   }
 
   private proc _simpleParallelTransferHelper(A, B, Adata, Bdata, len) {
-    const numTasks = if __primitive("task_get_serial") then
-                      1 else _computeNumChunks(len);
+    const numTasks = if __primitive("task_get_serial") then 1
+                        else _computeNumChunks(len);
     const lenPerTask = len:int/numTasks;
 
     if debugDefaultDistBulkTransfer && numTasks > 1 then
@@ -1993,13 +1993,9 @@ module DefaultRectangular {
 
     coforall tid in 0..#numTasks {
       const myOffset = tid*lenPerTask;
+      const myLen = if tid == numTasks-1 then len:int-myOffset else lenPerTask;
 
-      if tid == numTasks-1 {
-        _simpleTransferHelper(A, B, Adata, Bdata, len:int-myOffset, offset=myOffset);
-      }
-      else {
-        _simpleTransferHelper(A, B, Adata, Bdata, lenPerTask, offset=myOffset);
-      }
+      _simpleTransferHelper(A, B, Adata, Bdata, myLen, myOffset);
     }
   }
 

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -279,7 +279,13 @@ prototype module DistributedFFT {
       // Use temp work array to avoid overwriting the Src array
       var myplane : [{0..0, ySrc, zSrc}] T;
 
-      myplane = Src[{xSrc.first..xSrc.first, ySrc, zSrc}];
+      if usePrimitiveComm {
+        forall iy in ySrc {
+          copy(myplane[0, iy, zSrc.first], Src[xSrc.first, iy, zSrc.first], myLineSize);
+        }
+      } else {
+        myplane = Src[{xSrc.first..xSrc.first, ySrc, zSrc}];
+      }
 
       for ix in xSrc {
         // Y-transform

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -279,13 +279,7 @@ prototype module DistributedFFT {
       // Use temp work array to avoid overwriting the Src array
       var myplane : [{0..0, ySrc, zSrc}] T;
 
-      if usePrimitiveComm {
-        forall iy in ySrc {
-          copy(myplane[0, iy, zSrc.first], Src[xSrc.first, iy, zSrc.first], myLineSize);
-        }
-      } else {
-        myplane = Src[{xSrc.first..xSrc.first, ySrc, zSrc}];
-      }
+      myplane = Src[{xSrc.first..xSrc.first, ySrc, zSrc}];
 
       for ix in xSrc {
         // Y-transform

--- a/test/optimizations/parallelAssign/basicDR.chpl
+++ b/test/optimizations/parallelAssign/basicDR.chpl
@@ -53,5 +53,5 @@ t.stop();
 
 
 if !correctness {
-  writef("Throughput (MB/s): %.5dr\n", n*eltSize/MB/nIter/t.elapsed());
+  writef("Throughput (MB/s): %.5dr\n", n*eltSize*nIter/MB/t.elapsed());
 }

--- a/test/optimizations/parallelAssign/basicDR.chpl
+++ b/test/optimizations/parallelAssign/basicDR.chpl
@@ -1,0 +1,57 @@
+use Time;
+use RangeChunk;
+
+type eltType = int;
+param eltSize = numBytes(eltType);
+const GB = 2**30:real;
+const MB = 2**20:real;
+
+config const correctness = false;
+config const n = 1_000_000_000;
+config const nIter = 10;
+
+enum testMode {assign, serCopy, parCopy};
+
+config const mode = testMode.assign;
+
+
+var A, B: [1..n] eltType;
+
+proc timerWrite(name, ref t) {
+  if !correctness {
+    writef("%10s: %.5dr\n", name, t.elapsed()); t.clear();
+  }
+}
+
+// Warmup (and correctness)
+A = B;
+var t: Timer;
+
+t.start();
+select mode {
+  when testMode.assign {
+    for i in 0..#nIter {
+      A = B;
+    }
+  }
+  when testMode.serCopy {
+    for i in 0..#nIter {
+      c_memcpy(c_ptrTo(B[1]), c_ptrTo(A[1]), n*numBytes(int));
+    }
+  }
+  when testMode.parCopy {
+    for i in 0..#nIter {
+      const numTasks = here.maxTaskPar;
+      coforall tid in 0..#numTasks {
+        var c = chunk(1..n, numTasks, tid);
+        c_memcpy(c_ptrTo(B[c.first]), c_ptrTo(A[c.first]), c.size*numBytes(int));
+      }
+    }
+  }
+}
+t.stop();
+
+
+if !correctness {
+  writef("Throughput (MB/s): %.5dr\n", n*eltSize/MB/nIter/t.elapsed());
+}

--- a/test/optimizations/parallelAssign/basicDR.compopts
+++ b/test/optimizations/parallelAssign/basicDR.compopts
@@ -1,0 +1,1 @@
+-sdebugDefaultDistBulkTransfer=true 

--- a/test/optimizations/parallelAssign/basicDR.execopts
+++ b/test/optimizations/parallelAssign/basicDR.execopts
@@ -1,0 +1,1 @@
+--correctness --n=1_000_000 --nIter=0

--- a/test/optimizations/parallelAssign/basicDR.good
+++ b/test/optimizations/parallelAssign/basicDR.good
@@ -1,10 +1,1 @@
-isDataContiguous(): off=(1) blk=(1)
-	YES!
-isDataContiguous(): off=(1) blk=(1)
-	YES!
-Performing simple DefaultRectangular transfer
-	Will do parallel transfer with 4 tasks
-	local get() from 0
-	local get() from 0
-	local get() from 0
-	local get() from 0
+Will do parallel transfer

--- a/test/optimizations/parallelAssign/basicDR.good
+++ b/test/optimizations/parallelAssign/basicDR.good
@@ -1,0 +1,10 @@
+isDataContiguous(): off=(1) blk=(1)
+	YES!
+isDataContiguous(): off=(1) blk=(1)
+	YES!
+Performing simple DefaultRectangular transfer
+	Will do parallel transfer with 4 tasks
+	local get() from 0
+	local get() from 0
+	local get() from 0
+	local get() from 0

--- a/test/optimizations/parallelAssign/basicDR.prediff
+++ b/test/optimizations/parallelAssign/basicDR.prediff
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -n "s/.*\(Will do parallel transfer\).*/\1/p" <$2 >$2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
This PR parallelize assignments between two DefaultRectangular arrays if the
transfer size is larger than 2MBs. This size is the same as parallel
initialization threshold and is controlled by `parallelAssignThreshold`.

Resolves https://github.com/chapel-lang/chapel/issues/14478

Also removes a part of optimization in @npadmana's distributed FFT.

Test:
- [x] standard
- [x] gasnet
