### PR TITLE
Fix llvm vectorization tests from single task specialization removal

### DIFF
--- a/test/llvm/parallel_loop_access/simple_forall.chpl
+++ b/test/llvm/parallel_loop_access/simple_forall.chpl
@@ -9,13 +9,6 @@ proc loop(A) {
   forall i in 1..n {
     A[i] = 17.5 * i;
   }
-  // check the serial loop body
-  // CHECK: @loop
-  // CHECK: fmul
-  // CHECK: !llvm.access.group ![[GROUP1:[0-9]+]]
-  // CHECK: br i1
-  // CHECK-SAME: !llvm.loop ![[LOOP1:[0-9]+]]
-
   // check follower loop body in the coforall
   // CHECK: @coforall
   // CHECK: fmul
@@ -23,11 +16,6 @@ proc loop(A) {
   // CHECK: br i1
   // CHECK-SAME: !llvm.loop ![[LOOP2:[0-9]+]]
 }
-// CHECK: ![[LOOP1]] = distinct !{![[LOOP1]], ![[PA1:[0-9]+]]
-// CHECK: ![[PA1]] = !{!"llvm.loop.parallel_accesses",
-// CHECK-SAME: ![[GROUP1]]
-// CHECK-NOT: ![[GROUP2]]
-// CHECK-SAME: }
 
 // CHECK: ![[LOOP2]] = distinct !{![[LOOP2]], ![[PA2:[0-9]+]]
 // CHECK: ![[PA2]] = !{!"llvm.loop.parallel_accesses",

--- a/test/llvm/parallel_loop_access/zippered_forall.chpl
+++ b/test/llvm/parallel_loop_access/zippered_forall.chpl
@@ -9,13 +9,6 @@ proc loop(A) {
   forall (i,j) in zip(1..n, 2..) {
     A[i] = 17.5 * j;
   }
-  // check the serial loop body
-  // CHECK: @loop
-  // CHECK: fmul
-  // CHECK: !llvm.access.group ![[GROUP1:[0-9]+]]
-  // CHECK: br i1
-  // CHECK-SAME: !llvm.loop ![[LOOP1:[0-9]+]]
-
   // check follower loop body in the coforall
   // CHECK: @coforall
   // CHECK: fmul
@@ -23,12 +16,6 @@ proc loop(A) {
   // CHECK: br i1
   // CHECK-SAME: !llvm.loop ![[LOOP2:[0-9]+]]
 }
-
-// CHECK: ![[LOOP1]] = distinct !{![[LOOP1]], ![[PA1:[0-9]+]]
-// CHECK: ![[PA1]] = !{!"llvm.loop.parallel_accesses",
-// CHECK-SAME: ![[GROUP1]]
-// CHECK-NOT: ![[GROUP2]]
-// CHECK-SAME: }
 
 // CHECK: ![[LOOP2]] = distinct !{![[LOOP2]], ![[PA2:[0-9]+]]
 // CHECK: ![[PA2]] = !{!"llvm.loop.parallel_accesses",

--- a/test/llvm/vectorization/forall_loop.chpl
+++ b/test/llvm/vectorization/forall_loop.chpl
@@ -3,8 +3,6 @@ proc loop (A, B) {
   forall i in 0..511 {
       A[i] = B[i]*3;
   }
-  // CHECK: @loop
-  // CHECK: <4 x i32>
   // CHECK: @coforall
   // CHECK: <4 x i32>
 }


### PR DESCRIPTION
PR #16401 removed a bunch of internal for-loops in parallel iterators so
there's less loops to optimize now.