### PR TITLE
Add an argument ignoreBuiltinModules to the 'get visible symbols' prim

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2785,7 +2785,7 @@ static bool readNamedArgument(CallExpr* call, const char* name,
       if (se && (se->symbol() == gTrue || se->symbol() == gFalse)) {
         ret = se->symbol() == gTrue;
       } else {
-        USR_FATAL(se, "the arguments to 'get visible symbols' must be literals 'true' or 'false'");
+        USR_FATAL(se, "the arguments to 'get visible symbols' must be either 'true' or 'false'");
       }
       break;
     }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2807,7 +2807,7 @@ static bool symbolInBuiltinModule(Symbol* sym) {
 
 static void errorForUnexpectedArgName(std::vector<std::string> argNames,
                                       CallExpr* call) {
-  if (call->numActuals() > argNames.size()) {
+  if (((unsigned)call->numActuals()) > argNames.size()) {
     USR_FATAL(call, "too many arguments to 'get visible symbols'");
   }
 
@@ -2819,7 +2819,7 @@ static void errorForUnexpectedArgName(std::vector<std::string> argNames,
     if (std::find(argNames.begin(), argNames.end(), (std::string)actual->name) == argNames.end()) {
       USR_FATAL_CONT(actual, "unrecognized argument to 'get visible symbols': %s", actual->name);
       USR_FATAL_CONT(call, "recognized names are:");
-      for (int i = 0; i < argNames.size(); i++) {
+      for (int i = 0; ((unsigned)i) < argNames.size(); i++) {
         USR_FATAL_CONT(call, "  %s", argNames[i].c_str());
       }
       USR_STOP();

--- a/test/trivial/diten/printVisibleConflict.chpl
+++ b/test/trivial/diten/printVisibleConflict.chpl
@@ -9,6 +9,6 @@ module MainMod {
   proc main {
     use M1, M2;
     var xyzSymbol = 1;
-    __primitive(c"get visible symbols");
+    __primitive(c"get visible symbols", ignoreBuiltinModules=true);
   }
 }

--- a/test/trivial/diten/printVisibleConflict.compopts
+++ b/test/trivial/diten/printVisibleConflict.compopts
@@ -1,1 +1,0 @@
---minimal-modules

--- a/test/trivial/diten/printVisibleConflict.skipif
+++ b/test/trivial/diten/printVisibleConflict.skipif
@@ -1,1 +1,0 @@
-../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/trivial/diten/printvisible.chpl
+++ b/test/trivial/diten/printvisible.chpl
@@ -1,2 +1,2 @@
 var xyzSymbol = 1;
-__primitive(c"get visible symbols");
+__primitive(c"get visible symbols", ignoreBuiltinModules=true);

--- a/test/trivial/diten/printvisible.compopts
+++ b/test/trivial/diten/printvisible.compopts
@@ -1,1 +1,0 @@
---minimal-modules

--- a/test/trivial/diten/printvisible.skipif
+++ b/test/trivial/diten/printvisible.skipif
@@ -1,1 +1,0 @@
-../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/trivial/diten/printvisibleExtraArg.chpl
+++ b/test/trivial/diten/printvisibleExtraArg.chpl
@@ -1,2 +1,2 @@
 var xyzSymbol = 1;
-__primitive(c"get visible symbols", true, false);
+__primitive(c"get visible symbols", true, false, false);

--- a/test/trivial/diten/printvisibleExtraArg.good
+++ b/test/trivial/diten/printvisibleExtraArg.good
@@ -1,1 +1,1 @@
-printvisibleExtraArg.chpl:2: error: get visible symbols may only have 0 or 1 arguments
+printvisibleExtraArg.chpl:2: error: too many arguments to 'get visible symbols'

--- a/test/trivial/diten/printvisibleOptTrue.chpl
+++ b/test/trivial/diten/printvisibleOptTrue.chpl
@@ -1,2 +1,2 @@
 var xyzSymbol = 1;
-__primitive(c"get visible symbols", ignoreInternalModules=true);
+__primitive(c"get visible symbols", ignoreInternalModules=true, ignoreBuiltinModules=true);

--- a/test/trivial/diten/printvisibleOptTrue.compopts
+++ b/test/trivial/diten/printvisibleOptTrue.compopts
@@ -1,1 +1,0 @@
---minimal-modules

--- a/test/trivial/diten/printvisibleOptTrue.skipif
+++ b/test/trivial/diten/printvisibleOptTrue.skipif
@@ -1,1 +1,0 @@
-../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/trivial/diten/printvisibleWrongName.good
+++ b/test/trivial/diten/printvisibleWrongName.good
@@ -1,1 +1,4 @@
-printvisibleWrongName.chpl:2: error: the argument to get visible symbols must be a named expression named ignoreInternalModules
+printvisibleWrongName.chpl:2: error: unrecognized argument to 'get visible symbols': ignore
+printvisibleWrongName.chpl:2: error: recognized names are:
+printvisibleWrongName.chpl:2: error:   ignoreInternalModules
+printvisibleWrongName.chpl:2: error:   ignoreBuiltinModules

--- a/test/trivial/diten/printvisibleWrongValue.good
+++ b/test/trivial/diten/printvisibleWrongValue.good
@@ -1,1 +1,1 @@
-printvisibleWrongValue.chpl:2: error: the argument to get visible symbols must be a literal 'true' or 'false'
+printvisibleWrongValue.chpl:2: error: the arguments to 'get visible symbols' must be literals 'true' or 'false'

--- a/test/trivial/diten/printvisibleWrongValue.good
+++ b/test/trivial/diten/printvisibleWrongValue.good
@@ -1,1 +1,1 @@
-printvisibleWrongValue.chpl:2: error: the arguments to 'get visible symbols' must be literals 'true' or 'false'
+printvisibleWrongValue.chpl:2: error: the arguments to 'get visible symbols' must be either 'true' or 'false'

--- a/test/visibility/private/variables/accessSiblingPrint.chpl
+++ b/test/visibility/private/variables/accessSiblingPrint.chpl
@@ -5,7 +5,7 @@ module M1 {
 module M2 {
   use M1;
   proc main() {
-    __primitive(c"get visible symbols");
+    __primitive(c"get visible symbols", ignoreBuiltinModules=true);
     // Ensures that the private module level variable foo is not visible
     // via explicit naming.
   }

--- a/test/visibility/private/variables/accessSiblingPrint.compopts
+++ b/test/visibility/private/variables/accessSiblingPrint.compopts
@@ -1,1 +1,0 @@
---minimal-modules

--- a/test/visibility/private/variables/accessSiblingPrint.skipif
+++ b/test/visibility/private/variables/accessSiblingPrint.skipif
@@ -1,1 +1,0 @@
-../../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif

--- a/test/visibility/private/variables/privateToParentPrint.chpl
+++ b/test/visibility/private/variables/privateToParentPrint.chpl
@@ -4,7 +4,7 @@ module M1 {
   module M2 {
     proc main() {
       use M1;
-      __primitive(c"get visible symbols");
+      __primitive(c"get visible symbols", ignoreBuiltinModules=true);
       // Should print foo, because we are under the
       // parent of the private variable.
     }

--- a/test/visibility/private/variables/privateToParentPrint.compopts
+++ b/test/visibility/private/variables/privateToParentPrint.compopts
@@ -1,1 +1,0 @@
---minimal-modules

--- a/test/visibility/private/variables/privateToParentPrint.skipif
+++ b/test/visibility/private/variables/privateToParentPrint.skipif
@@ -1,1 +1,0 @@
-../../../types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif


### PR DESCRIPTION
When true, it skips printing symbols in the Builtin, Types, and Math modules.

Updated some errors to allow for multiple arguments to this primitive.

Adjusted some tests to use the new argument and stop using --minimal-modules.