### PR TITLE
Deinit module-scope variables in reverse init order

### DIFF
--- a/test/types/records/split-init/split-init-globals-deinit-order.chpl
+++ b/test/types/records/split-init/split-init-globals-deinit-order.chpl
@@ -1,0 +1,33 @@
+record R {
+  var s:string;
+  proc deinit() {
+    writeln("deinit ", s);
+  }
+}
+
+config const option = true;
+
+var a;
+var b;
+
+b = new R("b");
+a = new R("a");
+
+var c;
+var d;
+
+{
+  d = new R("d");
+  c = new R("c");
+}
+
+var e;
+var f;
+
+if option {
+  f = new R("f");
+  e = new R("e");
+} else {
+  f = new R("f");
+  e = new R("e");
+}

--- a/test/types/records/split-init/split-init-globals-deinit-order.good
+++ b/test/types/records/split-init/split-init-globals-deinit-order.good
@@ -1,0 +1,6 @@
+deinit e
+deinit f
+deinit c
+deinit d
+deinit a
+deinit b

--- a/test/types/records/split-init/split-init-globals-reorder-cond-error.chpl
+++ b/test/types/records/split-init/split-init-globals-reorder-cond-error.chpl
@@ -1,0 +1,19 @@
+record R {
+  var s:string;
+  proc deinit() {
+    writeln("deinit ", s);
+  }
+}
+
+config const option = true;
+
+var a;
+var b;
+
+if option {
+  b = new R("b");
+  a = new R("a");
+} else {
+  a = new R("a");
+  b = new R("b");
+}

--- a/test/types/records/split-init/split-init-globals-reorder-cond-error.good
+++ b/test/types/records/split-init/split-init-globals-reorder-cond-error.good
@@ -1,0 +1,3 @@
+split-init-globals-reorder-cond-error.chpl:13: error: Initialization order in conditional does not match
+split-init-globals-reorder-cond-error.chpl:14: note: then initializes: b a
+split-init-globals-reorder-cond-error.chpl:17: note: else initializes: a b


### PR DESCRIPTION
Resolves #15570

This PR adjusts `insertGlobalAutoDestroyCalls` to consider the
initialization order of the module-scope variables being destroyed in the
module deinit function. It destroys these variables in reverse
initialization order rather than reverse declaration order.
(Initialization order will match declaration order unless split-init is
used).

Reviewed by @vasslitvinov - thanks!

- [x] primers pass with valgrind+verify and do not leak
- [x] full local futures testing
