### PR TITLE
Add better checking in find-llvm-config.sh

### DIFF
--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -6,6 +6,9 @@ endif
 
 ifndef LLVM_CONFIG
   export LLVM_CONFIG:=$(shell $(THIRD_PARTY_DIR)/llvm/find-llvm-config.sh $(PREFERRED_LLVM_VERS))
+  ifeq ($(LLVM_CONFIG), missing-llvm-config)
+    $(error Could not find compatible LLVM version for CHPL_LLVM=system)
+  endif
 endif
 
 ifndef LLVM_CONFIG_INCLUDE_DIR

--- a/third-party/llvm/find-llvm-config.sh
+++ b/third-party/llvm/find-llvm-config.sh
@@ -1,33 +1,82 @@
-#!/bin/sh
+#!/bin/bash
 
-# takes in a single argument: the preferred version, e.g. 3.7
-PREFERRED_VERSION=$1
-PREFERRED_VERSION_MAJOR=`echo $1 | cut -d. -f1`
+# Arguments are versions that are allowed, e.g. 10.0 11.0
+# Looks for an installed LLVM with the same major version.
 
 command_exists()
 {
   command -v "$1" >/dev/null 2>&1
 }
 
-if command_exists llvm-config-$PREFERRED_VERSION
+ARGS="$*"
+BAD=""
+BAD_VERSION=""
+FOUND=""
+ALLOW_VERS=""
+
+# Compute a human-readable set of versions separated by " or "
+for v in $ARGS
+do
+  ALLOW_VERS="$ALLOW_VERS or $v"
+done
+ALLOW_VERS=${ALLOW_VERS## or }
+
+# Print usage and stop if no version argument was provided
+if [ "$ALLOW_VERS" = "" ]
 then
-  command -v llvm-config-$PREFERRED_VERSION
-elif command_exists llvm-config-$PREFERRED_VERSION_MAJOR
+  echo "Usage: $0 <versions>"
+  exit 1
+fi
+
+for arg in $ARGS
+do
+  PREFERRED_VERSION=$arg
+  PREFERRED_VERSION_MAJOR=`echo $arg | cut -d. -f1`
+
+  # Check a bunch of paths and names for llvm-config
+  # The /usr/local/opt ones are indended to support Homebrew
+  for t in "llvm-config-$PREFERRED_VERSION" \
+           "llvm-config-$PREFERRED_VERSION_MAJOR" \
+           "llvm-config" \
+           "/usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config" \
+           "/usr/local/opt/llvm@$PREFERRED_VERSION_MAJOR/bin/llvm-config" \
+           "/usr/local/opt/llvm/bin/llvm-config"
+  do
+    if command_exists "$t"
+    then
+      FOUND=`command -v "$t"`
+      # Check that the version found is compatible
+      FOUND_VERSION=`$FOUND --version`
+      FOUND_VERSION_MAJOR=`echo $FOUND_VERSION | cut -d. -f1`
+      if [ "$PREFERRED_VERSION_MAJOR" = "$FOUND_VERSION_MAJOR" ]
+      then
+        break
+      else
+        # version check failed, so don't consider this one
+        # we can use BAD when reporting an error.
+        BAD_VERSION="$FOUND_VERSION"
+        BAD="$FOUND"
+        FOUND=""
+      fi
+    fi
+  done
+
+  if [ "$FOUND" != "" ]
+  then
+    break
+  fi
+done
+
+if [ "$FOUND" != "" ]
 then
-  command -v llvm-config-$PREFERRED_VERSION_MAJOR
-elif command_exists llvm-config
-then
-  command -v llvm-config
-# If llvm-config is not found by now, search the Mac Homebrew directories.
-elif command_exists /usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config
-then
-  command -v /usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config
-elif command_exists /usr/local/opt/llvm@$PREFERRED_VERSION_MAJOR/bin/llvm-config
-then
-  command -v /usr/local/opt/llvm@$PREFERRED_VERSION_MAJOR/bin/llvm-config
-elif command_exists /usr/local/opt/llvm/bin/llvm-config
-then
-  command -v /usr/local/opt/llvm/bin/llvm-config
+  echo "$FOUND"
 else
+  echo "Could not find an installed LLVM with version $ALLOW_VERS" 1>&2
+  if [ "$BAD" != "" ]
+  then
+    echo "Found version $BAD_VERSION at path $BAD" 1>&2
+    echo "Please install an LLVM with version $ALLOW_VERS" 1>&2
+    echo "or set CHPL_LLVM=llvm to use the included LLVM" 1>&2
+  fi
   echo missing-llvm-config
 fi


### PR DESCRIPTION
Resolves #16325

Updates find-llvm-config.sh to check that the found `llvm-config`
has a compatible version.

And, while there, update find-llvm-config.sh to
handle checking for multiple compatible LLVM versions
(there is currently just 1 version allowed but we expect
to change that).

Reviewed by @ronawho - thanks!

- [x] `make` and `make check` and hellos work with CHPL_LLVM=system
- [x] manual testing of find-llvm-config.sh for multiple versions that are missing
- [x] reasonable error on `make` when I change the LLVM_VERSION file to something not installed