### PR TITLE
Skip this test on cygwin

### DIFF
--- a/test/library/packages/Sort/correctness/two-array-radix-sort-bug.skipif
+++ b/test/library/packages/Sort/correctness/two-array-radix-sort-bug.skipif
@@ -3,3 +3,9 @@
 # since valgrind will test smaller problems
 # elsewhere.
 CHPL_TEST_VGRND_EXE == on
+#
+# Once the single-task specialization was removed (PR #16401), it also
+# runs too long on cygwin64, presumably due to higher overheads in
+# allocating the task end-count, so skip it there.
+#
+CHPL_TARGET_PLATFORM == cygwin64


### PR DESCRIPTION
With the removal of the single-task optimization in PR #16401 (which
this test relied on heavily), the running time for this test tipped
over the 5-minute mark, presumably due to the higher overhead for
allocating endcounts on Cygwin.  This isn't a particularly important
test to do for cygwin, so skip it.

---
Signed-off-by: Brad Chamberlain <bradcray@users.noreply.github.com>