### PR TITLE
Remove 'enumerated', which was deprecated in 1.21

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1306,7 +1306,7 @@ static void buildEnumIntegerCastFunctions(EnumType* et) {
 //
 // Create a function that converts an enum symbol to an integer 0, 1, 2, ...:
 //
-//   'proc chpl_enumToOrder([param] e: enumerated) [param] : int'
+//   'proc chpl_enumToOrder([param] e: enum) [param] : int'
 //
 static void buildEnumToOrderFunction(EnumType* et, bool paramVersion) {
   FnSymbol* fn = new FnSymbol(astr("chpl__enumToOrder"));

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2395,9 +2395,4 @@ module ChapelBase {
   inline proc _removed_cast(in x) {
     return x;
   }
-
-  proc enumerated type {
-    compilerWarning("'enumerated' is deprecated - please use 'enum' instead");
-    return enum;
-  }
 }

--- a/test/deprecated/enumerated.chpl
+++ b/test/deprecated/enumerated.chpl
@@ -1,7 +1,0 @@
-enum color { red, green, blue };
-
-proc foo(e: enumerated) {
-  writeln("In foo: ", e);
-}
-
-foo(color.green);

--- a/test/deprecated/enumerated.good
+++ b/test/deprecated/enumerated.good
@@ -1,3 +1,0 @@
-enumerated.chpl:3: In function 'foo':
-enumerated.chpl:3: warning: 'enumerated' is deprecated - please use 'enum' instead
-In foo: green


### PR DESCRIPTION
PR #15150 deprecated `enumerated` in favor of `enum`.  This removes it.

---
Signed-off-by: Brad Chamberlain <bradcray@users.noreply.github.com>