### PR TITLE
Remove numIndices/numElements queries

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1762,12 +1762,6 @@ module ChapelArray {
 
     /* Return the number of indices in this domain */
     proc size return _value.dsiNumIndices;
-    /* Deprecated - please use :proc:`size`. */
-    proc numIndices {
-      compilerWarning("'domain.numIndices' is deprecated - " +
-                      "please use 'domain.size' instead");
-      return size;
-    }
     /* Return the lowest index in this domain */
     proc low return _value.dsiLow;
     /* Return the highest index in this domain */
@@ -2962,12 +2956,6 @@ module ChapelArray {
       }
     }
 
-    /* Deprecated - please use :proc:`size`. */
-    proc numElements {
-      compilerWarning("'array.numElements' is deprecated - " +
-                      "please use 'array.size' instead");
-      return size;
-    }
     /* Return the number of elements in the array */
     proc size return _value.dom.dsiNumIndices;
 

--- a/test/deprecated/numIndicesElements.chpl
+++ b/test/deprecated/numIndicesElements.chpl
@@ -1,5 +1,0 @@
-const D = {1..10};
-var A: [D] real;
-
-writeln(D.numIndices);
-writeln(A.numElements);

--- a/test/deprecated/numIndicesElements.good
+++ b/test/deprecated/numIndicesElements.good
@@ -1,4 +1,0 @@
-numIndicesElements.chpl:4: warning: 'domain.numIndices' is deprecated - please use 'domain.size' instead
-numIndicesElements.chpl:5: warning: 'array.numElements' is deprecated - please use 'array.size' instead
-10
-10


### PR DESCRIPTION
The `.numIndices` and `.numElements` queries on domains and arrays were deprecated in PR #16442 for Chapel 1.21.  This removes them.