### PR TITLE
Update datetime.now() to use 0-based tuple indexing

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -119,7 +119,7 @@ module DateTime {
 
     extern proc localtime_r(const ref t: time_t, ref resultp: tm): void;
 
-    const t1: time_t = __primitive("cast", time_t, t(1));
+    const t1: time_t = __primitive("cast", time_t, t(0));
     var breakDownTime: tm;
 
     localtime_r(t1, breakDownTime);

--- a/test/library/standard/DateTime/testNow.chpl
+++ b/test/library/standard/DateTime/testNow.chpl
@@ -1,0 +1,11 @@
+use DateTime;
+
+// Make sure datetime.now() is within a day of date.today(). They could be
+// different if the time passes midnight betwen the two calls.
+
+var now = datetime.now();
+//var today = date.today();
+var today = new date(2020, 9, 24);
+var diff = now - new datetime(today.year, today.month, today.day);
+
+assert(diff.days == 0 || diff.days == -1);

--- a/test/library/standard/DateTime/testNow.chpl
+++ b/test/library/standard/DateTime/testNow.chpl
@@ -4,8 +4,7 @@ use DateTime;
 // different if the time passes midnight betwen the two calls.
 
 var now = datetime.now();
-//var today = date.today();
-var today = new date(2020, 9, 24);
+var today = date.today();
 var diff = now - new datetime(today.year, today.month, today.day);
 
 assert(diff.days == 0 || diff.days == -1);


### PR DESCRIPTION
The function `datetime.now()` was calling a function that was using 1-based
tuple indexing, so the datetime was calculated with the milliseconds instead
of seconds. Fix it to be 0-based.

Add a test to make sure `datetime.now()` is reasonable.