### PR TITLE
Disable cache remote from some network speed performance tests

### DIFF
--- a/test/performance/comm/low-level/ML-COMPOPTS
+++ b/test/performance/comm/low-level/ML-COMPOPTS
@@ -1,0 +1,1 @@
+--no-cache-remote

--- a/test/runtime/configMatters/comm/unordered/ML-COMPOPTS
+++ b/test/runtime/configMatters/comm/unordered/ML-COMPOPTS
@@ -1,0 +1,1 @@
+--no-cache-remote


### PR DESCRIPTION
Throw `--no-cache-remote` to some tests that are explicitly trying to
measure the network speed.