### PR TITLE
Disable cache remote for tests that check specific optimizations

### DIFF
--- a/test/library/standard/CommDiagnostics/commDiagsTable.compopts
+++ b/test/library/standard/CommDiagnostics/commDiagsTable.compopts
@@ -1,1 +1,1 @@
--scommDiagsPrintUnstable=false
+-scommDiagsPrintUnstable=false --no-cache-remote

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/COMPOPTS
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/COMPOPTS
@@ -1,0 +1,1 @@
+--no-cache-remote

--- a/test/optimizations/remoteValueForwarding/serialization/COMPOPTS
+++ b/test/optimizations/remoteValueForwarding/serialization/COMPOPTS
@@ -1,0 +1,1 @@
+--no-cache-remote

--- a/test/optimizations/sungeun/RADOpt/COMPOPTS
+++ b/test/optimizations/sungeun/RADOpt/COMPOPTS
@@ -1,1 +1,1 @@
---fast --main-module access
+--fast --main-module access --no-cache-remote


### PR DESCRIPTION
Throw `--no-cache-remote` for some tests that are using comm counts as a
proxy to see that other optimizations are working. i.e. tests that use
comm counts to check that things like RVF or the RAD-opt are working. In
this case we want to verify the optimizations themselves are firing and
we don't want --cache-remote to hide comms if they aren't.