### PR TITLE
Disable cache remote for distributions comm count tests

### DIFF
--- a/test/arrays/slices/commCounts/COMPOPTS
+++ b/test/arrays/slices/commCounts/COMPOPTS
@@ -1,0 +1,1 @@
+--no-cache-remote

--- a/test/distributions/robust/arithmetic/performance/multilocale/COMPOPTS
+++ b/test/distributions/robust/arithmetic/performance/multilocale/COMPOPTS
@@ -1,1 +1,1 @@
--M../.. --fast
+-M../.. --fast --no-cache-remote

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/COMPOPTS
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/COMPOPTS
@@ -1,1 +1,1 @@
--M../../.. --fast -schpl_serializeSlices=true --main-module=testWrapper
+-M../../.. --fast -schpl_serializeSlices=true --main-module=testWrapper --no-cache-remote

--- a/test/types/bytes/dist-mem.compopts
+++ b/test/types/bytes/dist-mem.compopts
@@ -1,0 +1,1 @@
+--no-cache-remote


### PR DESCRIPTION
These tests are trying to see how much communication different
distribution implementations generate. They are mostly comparing across
implementations or are just trying to track the types of comm patterns
we generate. We don't necessarily care about the exact number of comms
going across the wire, we're just making sure that things look right in
general and we when we change the implementation we haven't added a
drastic amount of communication anywhere.