### PR TITLE
Do not check for order independence in forall-unordered opt

### DIFF
--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -978,7 +978,7 @@ void optimizeForallUnorderedOps() {
     if (block->isLoopStmt()) {
       LoopStmt* loop = toLoopStmt(block);
 
-      if (loop->isOrderIndependent()) {
+      {
         std::vector<Expr*> lastStmts;
         getLastStmts(loop, lastStmts);
         for_vector(Expr, lastStmt, lastStmts) {

--- a/test/optimizations/forall-unordered-opt/compilation-tests/opt-expected.chpl
+++ b/test/optimizations/forall-unordered-opt/compilation-tests/opt-expected.chpl
@@ -142,3 +142,35 @@ proc mini_ra_recursive() {
   }
 }
 mini_ra_recursive();
+
+config const multiplier = 1234567;
+config const increment = 98765;
+
+// An iterator representing a not-order-independent loop
+// similar to RAStream
+iter rng_iter() {
+  var cursor = multiplier + increment;
+  for i in 1..M {
+    cursor = cursor * multiplier + increment;
+    yield cursor;
+  }
+}
+iter rng_iter(param tag: iterKind, followThis) where tag == iterKind.follower {
+  const (followInds,) = followThis;
+  const start = followInds.low;
+  var cursor = multiplier * start + increment;
+  for i in 1..M {
+    cursor = cursor * multiplier + increment;
+    yield cursor;
+  }
+}
+
+proc mini_ra_lf() {
+  var T: [0..1023] atomic int;
+  var indexMask = 1023;
+  var Updates: [0..#M] int;
+
+  forall (_, r) in zip(Updates, rng_iter()) do
+    T(r & indexMask).xor(r);
+}
+mini_ra_lf();

--- a/test/optimizations/forall-unordered-opt/compilation-tests/opt-expected.good
+++ b/test/optimizations/forall-unordered-opt/compilation-tests/opt-expected.good
@@ -2,6 +2,7 @@ opt-expected.chpl:109: note: Optimized atomic call to be unordered
 opt-expected.chpl:123: note: Optimized atomic call to be unordered
 opt-expected.chpl:141: note: Optimized atomic call to be unordered
 opt-expected.chpl:14: note: Optimized assign to be unordered
+opt-expected.chpl:174: note: Optimized atomic call to be unordered
 opt-expected.chpl:24: note: Optimized atomic call to be unordered
 opt-expected.chpl:35: note: Optimized atomic call to be unordered
 opt-expected.chpl:47: note: Optimized atomic call to be unordered

--- a/test/release/examples/benchmarks/hpcc/ra-atomics.compopts
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.compopts
@@ -1,1 +1,1 @@
--O
+-O --report-optimized-forall-unordered-ops

--- a/test/release/examples/benchmarks/hpcc/ra-atomics.good
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.good
@@ -1,3 +1,5 @@
+ra-atomics.chpl:155: note: Optimized atomic call to be unordered
+ra-atomics.chpl:121: note: Optimized atomic call to be unordered
 Problem size = 1024 (2**10)
 Bytes per array = 8192
 Total memory required (GB) = 7.62939e-06


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/1317
See #12150 for previous discussion of the forall-unordered-opt and its legality.

The forall-unordered opt already only applies to forall loops. This PR
removes an additional check that the loop being optimized (after lowering
iterators) was order independent.

The  forall-unordered opt already only applies to forall loops because
the optimization legality checks before iterator lowering (where
lifetimes are checked) only add the OptInfo to forall loops. The later
part of the pass which runs after iterator inlining will only optimize
last statements that are followed by an OptInfo.

As a result, it does not need to check that the forall loop only
contained order-independent code. If the last statement came from a
follower loop, that last statement won't be marked with OptInfo (because
it wasn't present in the forall loop before iterator inlining) and the
optimization will fail. If the last statement came from the original
forall loop then the order-independent-ness of the iterator follower
loops is irrelevant - since the author of the original forall loop
indicated it was order independent and the code being delayed is from
that loop.

Adds some tests of patterns along these lines to verify that they are
optimized (or not) as expected.

Reviewed by @ronawho - thanks!

- [x] full futures local testing
