### PR TITLE
Fix an issue with generic in formals taking domain arguments

### DIFF
--- a/test/optimizations/constDomain/domainArgs.chpl
+++ b/test/optimizations/constDomain/domainArgs.chpl
@@ -1,18 +1,13 @@
 const colWidth = 12;
 const fmt = "%-"+colWidth:string+"s|%-"+colWidth:string+"s\n";
 
-//// this is const ref -- `const` doesn't matter here
+// this is const ref -- note that if you pass a var domain, we don't set it
+//                      const
 proc defIntent(d) {
   writef(fmt, "(const ref)", d.definedConst);
 }
 
-// I wanted to make `d` a generic argument like the others below. However, it
-// causes the copy to be dropped for a domain literal argument (maybe
-// correctly?), so this reports 'true' for a domain literal. For concrete
-// argument, the copy remains there and we get 'false' (correctly).
-//
-// See: https://github.com/chapel-lang/chapel/issues/16398
-proc inIntent(in d: domain(1, int, false)) {
+proc inIntent(in d) {
   writef(fmt, "in", d.definedConst);
 }
 
@@ -28,7 +23,8 @@ proc refIntent(ref d) {
   writef(fmt, "ref", d.definedConst);
 }
 
-// this is const ref -- `const` doesn't matter here
+// this is const ref -- note that if you pass a var domain, we don't set it
+//                      const
 proc constIntent(const d) {
   writef(fmt, "const (ref)", d.definedConst);
 }

--- a/test/optimizations/constDomain/domainArgsConcrete.chpl
+++ b/test/optimizations/constDomain/domainArgsConcrete.chpl
@@ -1,0 +1,79 @@
+const colWidth = 12;
+const fmt = "%-"+colWidth:string+"s|%-"+colWidth:string+"s\n";
+
+// this is const ref -- note that if you pass a var domain, we don't set it
+//                      const
+proc defIntent(d: domain(1, int, false)) {
+  writef(fmt, "(const ref)", d.definedConst);
+}
+
+proc inIntent(in d: domain(1, int, false)) {
+  writef(fmt, "in", d.definedConst);
+}
+
+proc outIntent(out d: domain(1, int, false)) {
+  writef(fmt, "out", d.definedConst);
+}
+
+proc inoutIntent(inout d: domain(1, int, false)) {
+  writef(fmt, "inout", d.definedConst);
+}
+
+proc refIntent(ref d: domain(1, int, false)) {
+  writef(fmt, "ref", d.definedConst);
+}
+
+// this is const ref -- note that if you pass a var domain, we don't set it
+//                      const
+proc constIntent(const d: domain(1, int, false)) {
+  writef(fmt, "const (ref)", d.definedConst);
+}
+
+proc constInIntent(const in d: domain(1, int, false)) {
+  writef(fmt, "const in", d.definedConst);
+}
+
+proc constRefIntent(const ref d: domain(1, int, false)) {
+  writef(fmt, "const ref", d.definedConst);
+}
+
+writeln("Passing domain literal");
+writef(fmt, "intent", "definedConst");
+writef(fmt, "-"*colWidth, "-"*colWidth);
+
+defIntent({1..10});
+inIntent({1..10});
+// outIntent({1..10});     // doesn't make sense
+// inoutIntent({1..10});   // doesn't make sense
+constIntent({1..10});
+constInIntent({1..10});
+constRefIntent({1..10});
+writeln();
+
+writeln("Passing var domain");
+writef(fmt, "intent", "definedConst");
+writef(fmt, "-"*colWidth, "-"*colWidth);
+
+var varDom = {1..10};
+defIntent(varDom);
+inIntent(varDom);
+outIntent(varDom);
+inoutIntent(varDom);
+constIntent(varDom);
+constInIntent(varDom);
+constRefIntent(varDom);
+writeln();
+
+writeln("Passing const domain");
+writef(fmt, "intent", "definedConst");
+writef(fmt, "-"*colWidth, "-"*colWidth);
+
+const constDom = {1..10};
+defIntent(constDom);
+inIntent(constDom);
+// outIntent(constDom);     // doesn't make sense
+// inoutIntent(constDom);   // doesn't make sense
+constIntent(constDom);
+constInIntent(constDom);
+constRefIntent(constDom);
+writeln();

--- a/test/optimizations/constDomain/domainArgsConcrete.good
+++ b/test/optimizations/constDomain/domainArgsConcrete.good
@@ -1,0 +1,29 @@
+Passing domain literal
+intent      |definedConst
+------------|------------
+(const ref) |true        
+in          |false       
+const (ref) |true        
+const in    |true        
+const ref   |true        
+
+Passing var domain
+intent      |definedConst
+------------|------------
+(const ref) |false       
+in          |false       
+out         |false       
+inout       |false       
+const (ref) |false       
+const in    |true        
+const ref   |false       
+
+Passing const domain
+intent      |definedConst
+------------|------------
+(const ref) |true        
+in          |false       
+const (ref) |true        
+const in    |true        
+const ref   |true        
+


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/16398
Resolves two leaks

While passing a domain literal to an `in` formal, we adjust the related initCopy
to take care of the `definedConst` field of the domain. However, we don't have
that initCopy for fully generic formals. This causes two issues:

- We don't set the constness correctly for `in` formals (#16398)
- Consider:

```chapel
record R {
  var d;
  var a: [d] int;
}

var r = new R({1..3});
```

we move the literal to `d` in the default initializer and adjust its constness
in the initializer body, however, we create the default array argument at the
call site where the domain still has `definedConst=true`.

With this PR, when we move variables, we check whether it was a domain literal
and take the necessary action to make sure we set its `definedConst=false`, even
though it is a literal.

Test:
- [x] standard
- [x] gasnet


