### PR TITLE
Add a flag to enable/disable tracking arrays for constant domains

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -187,6 +187,9 @@ module ChapelArray {
   pragma "no doc"
   config param useBulkPtrTransfer = useBulkTransfer;
 
+  pragma "no doc"
+  config param trackArraysForConstDomains = false;
+
   // Return POD values from arrays as values instead of const ref?
   pragma "no doc"
   config param PODValAccess = true;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -188,7 +188,7 @@ module ChapelArray {
   config param useBulkPtrTransfer = useBulkTransfer;
 
   pragma "no doc"
-  config param trackArraysForConstDomains = false;
+  config param disableConstDomainOpt = false;
 
   // Return POD values from arrays as values instead of const ref?
   pragma "no doc"

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -171,8 +171,8 @@ module ChapelDistribution {
       return ret;
     }
 
-    proc trackArrays() {
-      return trackArraysForConstDomains || !this.definedConst;
+    inline proc trackArrays() {
+      return disableConstDomainOpt || !this.definedConst;
     }
 
     // Returns (dom, dist).

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -171,6 +171,10 @@ module ChapelDistribution {
       return ret;
     }
 
+    proc trackArrays() {
+      return trackArraysForConstDomains || !this.definedConst;
+    }
+
     // Returns (dom, dist).
     // if this domain should be deleted, dom=this; otherwise it is nil.
     // dist is nil or a distribution that should be removed.
@@ -224,7 +228,7 @@ module ChapelDistribution {
         var cnt = -1;
         local {
           _arrsLock.lock();
-          if rmFromList && !this.definedConst then
+          if rmFromList && trackArrays() then
             _arrs.remove(x);
           else
             _arrs_containing_dom -=1;
@@ -249,7 +253,7 @@ module ChapelDistribution {
       on this {
         if locking then
           _arrsLock.lock();
-        if addToList && !this.definedConst then
+        if addToList && trackArrays() then
           _arrs.add(x);
         else
           _arrs_containing_dom += 1;

--- a/test/optimizations/constDomain/trackArraysFlag-false.good
+++ b/test/optimizations/constDomain/trackArraysFlag-false.good
@@ -1,0 +1,1 @@
+The domain is tracking 0 arrays

--- a/test/optimizations/constDomain/trackArraysFlag-true.good
+++ b/test/optimizations/constDomain/trackArraysFlag-true.good
@@ -1,0 +1,1 @@
+The domain is tracking 1 arrays

--- a/test/optimizations/constDomain/trackArraysFlag.chpl
+++ b/test/optimizations/constDomain/trackArraysFlag.chpl
@@ -1,0 +1,5 @@
+const d = {1..3};
+
+var a: [d] int;
+
+writeln("The domain is tracking ", d._value._arrs.size, " arrays");

--- a/test/optimizations/constDomain/trackArraysFlag.compopts
+++ b/test/optimizations/constDomain/trackArraysFlag.compopts
@@ -1,2 +1,2 @@
--strackArraysForConstDomains=false   #trackArraysFlag-false
--strackArraysForConstDomains=true   #trackArraysFlag-true
+-sdisableConstDomainOpt=false   #trackArraysFlag-false
+-sdisableConstDomainOpt=true   #trackArraysFlag-true

--- a/test/optimizations/constDomain/trackArraysFlag.compopts
+++ b/test/optimizations/constDomain/trackArraysFlag.compopts
@@ -1,0 +1,2 @@
+-strackArraysForConstDomains=false   #trackArraysFlag-false
+-strackArraysForConstDomains=true   #trackArraysFlag-true


### PR DESCRIPTION
This PR adds `config param trackArraysForConstDomains = false`, which can be
set to `true` at compile time to track arrays even if we know that the domain is
constant. This is added as a stopgap measure in case there is a bug in
determining whether a domain is constant or not.

Also adds a test for the flag's behavior.

Test:
- [x] gasnet `test/release/examples`
- [x] gasnet `test/optimizations/constDomain`
