### PR TITLE
Fix typos

### DIFF
--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -47,7 +47,7 @@ static llvm::MDNode* generateLoopMetadata(bool thisLoopParallelAccess,
   auto &ctx = info->module->getContext();
 
   std::vector<llvm::Metadata*> args;
-  // Reselve operand 0 for the loop id self reference
+  // Resolve operand 0 for the loop id self reference
   auto tmpNode        = llvm::MDNode::getTemporary(ctx, llvm::None);
   args.push_back(tmpNode.get());
 

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -370,7 +370,7 @@ symbolFlag( FLAG_POD , ypr, "plain old data" , "data can be bit copied")
 // These will be allocated outside of the loop in the IR (with an alloca
 // instruction). So, it should mark all variables other than those that
 // are loop-local stack variables inside of an order-independent loop.
-symbolFlag( FLAG_POINTS_OUTSIDE_ORDER_INDEPENDENT_LOOP , npr, "points outside order independent loop" , "points to memory other than local variables inside order indpendent loop")
+symbolFlag( FLAG_POINTS_OUTSIDE_ORDER_INDEPENDENT_LOOP , npr, "points outside order independent loop" , "points to memory other than local variables inside order independent loop")
 
 symbolFlag( FLAG_PRIMITIVE_TYPE , ypr, "primitive type" , "attached to primitive types to keep them from being deleted" )
 symbolFlag( FLAG_PRINT_MODULE_INIT_FN , ypr, "print module init fn" , ncm )

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -127,7 +127,7 @@ public:
   // Loads/stores to/from loop local stack variables should not be considered
   // for this, so this variable tracks if a pointer must point to something
   // other than a local variable (e.g. an array element, a class field);
-  // or if it points to a value from outside any order indpendent loop.
+  // or if it points to a value from outside any order independent loop.
   bool mustPointOutsideOrderIndependentLoop;
 
   // always set if available

--- a/doc/rst/technotes/protoGenCodeGuide.rst
+++ b/doc/rst/technotes/protoGenCodeGuide.rst
@@ -187,7 +187,7 @@ A scalar message field can have one of the following types, the table shows the
 type specified in the ``.proto`` file, and the corresponding generated Chapel type:
 
 ..
-  This table is intended to match the order given by the proto3 languge documentation.
+  This table is intended to match the order given by the proto3 language documentation.
 
 .. list-table::
    :widths: 50 50
@@ -327,7 +327,7 @@ fields along with explicit ``get/set`` type methods:
     ...
   }
 
-The explicit methods are declared to allow the user toset at most one of the
+The explicit methods are declared to allow the user to set at most one of the
 fields in a oneof at a time. For example:
 
 .. code-block:: chpl

--- a/doc/rst/tools/protoc-gen-chpl/protoc-gen-chpl.rst
+++ b/doc/rst/tools/protoc-gen-chpl/protoc-gen-chpl.rst
@@ -33,7 +33,7 @@ It builds the ``protoc-gen-chpl`` binary so that the command line interface can 
 This installs ``protoc-gen-chpl`` in the same place as the chapel compiler (``chpl``) so that
 it can be used anywhere in the user's file system.
 
-To remove protobuf suppot, change directory to ``$CHPL_HOME/tools/protoc-gen-chpl`` and run:
+To remove protobuf support, change directory to ``$CHPL_HOME/tools/protoc-gen-chpl`` and run:
 
 .. code-block:: sh
 
@@ -47,7 +47,7 @@ a ``.proto`` file. The definitions in a ``.proto`` file contain a message for ea
 data structure you want to serialize, then specify a name and a type for each 
 field in the message.
 
-Below is an example of an ``addressbook`` for a person. This section descibes a
+Below is an example of an ``addressbook`` for a person. This section describes a
 simple ``.proto`` file and the corresponding generated chapel code. For complete
 details on ``.proto`` files see the links at the end of this document.
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1512,7 +1512,7 @@ proc solve (A: [?Adom] ?eltType, b: [?bdom] eltType) {
    Compute a vector ``x`` such that the 2-norm ``|b - A x|`` is minimized.
 
    ``cond`` is the cut-off threshold such that singular values will be
-   considered 0.0. If ``cond < 0.0`` (defaults to ``-1.0``), the treshold will
+   considered 0.0. If ``cond < 0.0`` (defaults to ``-1.0``), the threshold will
    be set to ``max((...A.shape)) * epsilon``, where ``epsilon`` is the machine
    precision for ``A.eltType``.
 

--- a/modules/packages/ProtobufProtocolSupport.chpl
+++ b/modules/packages/ProtobufProtocolSupport.chpl
@@ -24,7 +24,7 @@
 
     This module provides a Chapel implementation for protocol buffers binary
     `wire format <https://developers.google.com/protocol-buffers/docs/encoding/>`_
-    enoding algorithms. It has functions to support serialization and deserialization
+    encoding algorithms. It has functions to support serialization and deserialization
     of protocol buffer messages.
  */
 module ProtobufProtocolSupport {

--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -97,7 +97,7 @@ static int chpl_unwind_getLineNum(void *addr){
     // Try using the file path from the current executable
     path_len = readlink("/proc/self/exe", &buf[i], sizeof(buf)-i);
     if (path_len >= sizeof(buf)-i)
-      return 0; // truncation occured - give up.
+      return 0; // truncation occurred - give up.
     if (path_len == -1)
       return 0; // readlink returned error - give up.
   }


### PR DESCRIPTION
Fix typos in

CForLoop.cpp, flags_list.h, genret.h, runtime/src/error.c,
protoGenCodeGuide.rst, protoc-gen-chpl.rst,
LinearAlgebra.chpl, ProtobufProtocolSupport.chpl
