### PR TITLE
Revert "Add --report-optimized-forall-unordered-ops to ra-atomics"

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ra-atomics.compopts
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.compopts
@@ -1,1 +1,1 @@
--O --report-optimized-forall-unordered-ops
+-O

--- a/test/release/examples/benchmarks/hpcc/ra-atomics.good
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.good
@@ -1,5 +1,3 @@
-ra-atomics.chpl:155: note: Optimized atomic call to be unordered
-ra-atomics.chpl:121: note: Optimized atomic call to be unordered
 Problem size = 1024 (2**10)
 Bytes per array = 8192
 Total memory required (GB) = 7.62939e-06


### PR DESCRIPTION
Follow-up to PR #16455.

This reverts commit d66c932ce3660f32f41bbe6356eb2432b76ad558.

The forall-unordered-opt can only optimize atomic operations in network
configurations that have network atomics (e.g.  CHPL_COMM=ugni). I didn't
want to deal with creating different .good files for this test for
local/ugni/other comms. So, just remove the flag.

Trivial and not reviewed.