### PR TITLE
Use CPtr in some python tests

### DIFF
--- a/test/interop/python/otherPointer.chpl
+++ b/test/interop/python/otherPointer.chpl
@@ -1,3 +1,4 @@
+use CPtr;
 export proc gimmePointer(x: c_ptr(real)) {
   var y = 4.0;
   c_memcpy(x, c_ptrTo(y), c_sizeof(y.type));

--- a/test/interop/python/otherPointer_int.chpl
+++ b/test/interop/python/otherPointer_int.chpl
@@ -1,3 +1,4 @@
+use CPtr;
 export proc gimmePointer(x: c_ptr(int(64))) {
   var y = 4;
   c_memcpy(x, c_ptrTo(y), c_sizeof(y.type));

--- a/test/interop/python/otherPointer_int32.chpl
+++ b/test/interop/python/otherPointer_int32.chpl
@@ -1,3 +1,4 @@
+use CPtr;
 export proc gimmePointer(x: c_ptr(int(32))) {
   var y: int(32) = 4;
   c_memcpy(x, c_ptrTo(y), c_sizeof(y.type));

--- a/test/interop/python/stringAllocated.chpl
+++ b/test/interop/python/stringAllocated.chpl
@@ -1,3 +1,4 @@
+use CPtr;
 export proc g(size: int, ptr: c_ptr(uint(8))): int {
   var s = 'foo';
   if s.numBytes >= size {


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/16451.

These tests do not run in a typical paratest config, so, I have missed.

The files compile with `--library` after this PR.
