### PR TITLE
Add use CPtr to a valgrind test

### DIFF
--- a/test/memory/elliot/valgrind/I-fail-without-working-valgrind.chpl
+++ b/test/memory/elliot/valgrind/I-fail-without-working-valgrind.chpl
@@ -1,6 +1,8 @@
 // This test is intended to verify that valgrind is working by explicitly
 // accessing memory that hasn't been allocated
 
+use CPtr;
+
 proc main() {
   var c = c_malloc(int, 1);
   writeln(c[1]);            // invalid read


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/16451

The test was missed because it doesn't run in typical nightly setting.

The file compiles with this PR
