### PR TITLE
Fix c2chapel and its tests

### DIFF
--- a/test/c2chapel/testStructs.chpl
+++ b/test/c2chapel/testStructs.chpl
@@ -1,5 +1,6 @@
 
 use structGen;
+use CPtr;
 
 proc foo(x : int) {
   writeln("In foo function, given: ", x);

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -577,6 +577,10 @@ def preamble(args, fakes):
         genComment("Note: Generated with fake std headers")
         print()
 
+    # Arguably we can tighten the use of this module based on what we actually
+    # generate, but for now this is good enough
+    print("use CPtr;")
+
 # TODO: accept file from stdin?
 if __name__=="__main__":
     (args, unknowns)  = getArgs()


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/16451

Adds `use CPtr;` in all the files auto-generated by c2chapel.

Also, fixes a c2chapel test.

Two tests that failed due to these pass.
