### PR TITLE
Skip task functions in compiler error callstacks

### DIFF
--- a/test/functions/compilation-errors/error-stack-trace-task-fn1.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn1.chpl
@@ -1,0 +1,17 @@
+
+
+proc baz(arg) {
+  arg = 1;
+}
+
+proc bar(arg) {
+  on Locales[numLocales-1] {
+    baz(arg);
+  }
+}
+
+proc foo(arg) {
+  bar(arg);
+}
+
+foo("hi");

--- a/test/functions/compilation-errors/error-stack-trace-task-fn1.good
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn1.good
@@ -1,0 +1,5 @@
+error-stack-trace-task-fn1.chpl:3: In function 'baz':
+error-stack-trace-task-fn1.chpl:4: error: Cannot assign to string from int(64)
+  error-stack-trace-task-fn1.chpl:9: called as baz(arg: string) from function 'bar'
+  error-stack-trace-task-fn1.chpl:14: called as bar(arg: string) from function 'foo'
+  error-stack-trace-task-fn1.chpl:17: called as foo(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-task-fn2.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn2.chpl
@@ -1,0 +1,17 @@
+
+
+proc baz(arg) {
+  arg = 1;
+}
+
+proc bar(arg) {
+  begin {
+    baz(arg);
+  }
+}
+
+proc foo(arg) {
+  bar(arg);
+}
+
+foo("hi");

--- a/test/functions/compilation-errors/error-stack-trace-task-fn2.good
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn2.good
@@ -1,0 +1,5 @@
+error-stack-trace-task-fn2.chpl:3: In function 'baz':
+error-stack-trace-task-fn2.chpl:4: error: Cannot assign to string from int(64)
+  error-stack-trace-task-fn2.chpl:9: called as baz(arg: string) from function 'bar'
+  error-stack-trace-task-fn2.chpl:14: called as bar(arg: string) from function 'foo'
+  error-stack-trace-task-fn2.chpl:17: called as foo(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-task-fn3.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn3.chpl
@@ -1,0 +1,17 @@
+
+
+proc baz(arg) {
+  arg = 1;
+}
+
+proc bar(arg) {
+  begin on Locales[numLocales-1] {
+    baz(arg);
+  }
+}
+
+proc foo(arg) {
+  bar(arg);
+}
+
+foo("hi");

--- a/test/functions/compilation-errors/error-stack-trace-task-fn3.good
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn3.good
@@ -1,0 +1,5 @@
+error-stack-trace-task-fn3.chpl:3: In function 'baz':
+error-stack-trace-task-fn3.chpl:4: error: Cannot assign to string from int(64)
+  error-stack-trace-task-fn3.chpl:9: called as baz(arg: string) from function 'bar'
+  error-stack-trace-task-fn3.chpl:14: called as bar(arg: string) from function 'foo'
+  error-stack-trace-task-fn3.chpl:17: called as foo(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-task-fn4.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn4.chpl
@@ -1,0 +1,17 @@
+
+
+proc baz(arg) {
+  arg = 1;
+}
+
+proc bar(arg) {
+  cobegin {
+    {baz(arg);}
+    {}
+  }
+}
+proc foo(arg) {
+  bar(arg);
+}
+
+foo("hi");

--- a/test/functions/compilation-errors/error-stack-trace-task-fn4.good
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn4.good
@@ -1,0 +1,5 @@
+error-stack-trace-task-fn4.chpl:3: In function 'baz':
+error-stack-trace-task-fn4.chpl:4: error: Cannot assign to string from int(64)
+  error-stack-trace-task-fn4.chpl:9: called as baz(arg: string) from function 'bar'
+  error-stack-trace-task-fn4.chpl:14: called as bar(arg: string) from function 'foo'
+  error-stack-trace-task-fn4.chpl:17: called as foo(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-task-fn5.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn5.chpl
@@ -1,0 +1,17 @@
+
+
+proc baz(arg) {
+  arg = 1;
+}
+
+proc bar(arg) {
+  coforall i in 1..1 {
+    baz(arg);
+  }
+}
+
+proc foo(arg) {
+  bar(arg);
+}
+
+foo("hi");

--- a/test/functions/compilation-errors/error-stack-trace-task-fn5.good
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn5.good
@@ -1,0 +1,5 @@
+error-stack-trace-task-fn5.chpl:3: In function 'baz':
+error-stack-trace-task-fn5.chpl:4: error: Cannot assign to string from int(64)
+  error-stack-trace-task-fn5.chpl:9: called as baz(arg: string) from function 'bar'
+  error-stack-trace-task-fn5.chpl:14: called as bar(arg: string) from function 'foo'
+  error-stack-trace-task-fn5.chpl:17: called as foo(arg: string)

--- a/test/functions/compilation-errors/error-stack-trace-task-fn6.chpl
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn6.chpl
@@ -1,0 +1,17 @@
+
+
+proc baz(arg) {
+  arg = 1;
+}
+
+proc bar(arg) {
+  coforall i in 1..1 do on Locales[numLocales-1] {
+    baz(arg);
+  }
+}
+
+proc foo(arg) {
+  bar(arg);
+}
+
+foo("hi");

--- a/test/functions/compilation-errors/error-stack-trace-task-fn6.good
+++ b/test/functions/compilation-errors/error-stack-trace-task-fn6.good
@@ -1,0 +1,5 @@
+error-stack-trace-task-fn6.chpl:3: In function 'baz':
+error-stack-trace-task-fn6.chpl:4: error: Cannot assign to string from int(64)
+  error-stack-trace-task-fn6.chpl:9: called as baz(arg: string) from function 'bar'
+  error-stack-trace-task-fn6.chpl:14: called as bar(arg: string) from function 'foo'
+  error-stack-trace-task-fn6.chpl:17: called as foo(arg: string)


### PR DESCRIPTION
Follow-up to PR #16175. Resolves problems where stack traces were 
stopping at `on` statements in some configurations but not others. Fixes
problems where the callstack did not go through task functions.

Reviewed by @e-kayrakli - thanks!

- [x] full local futures testing