### PR TITLE
Fix some LLVM-only tests w.r.t CPtr

### DIFF
--- a/test/extern/jjueckstock/ptr.chpl
+++ b/test/extern/jjueckstock/ptr.chpl
@@ -41,6 +41,7 @@ module OuterModule {
   } }
 
   use C;
+  use CPtr;
 
   var a: C.st;
   a.c = "a string".c_str();

--- a/test/interop/C/llvm/exportArray/exportFuncWithPtr.chpl
+++ b/test/interop/C/llvm/exportArray/exportFuncWithPtr.chpl
@@ -1,3 +1,4 @@
+use CPtr;
 export proc foo(ref x: [] int, otherVal: c_ptr(int)) {
   writeln(x); // Note: this assumes x will have initial contents
   for i in x.domain {

--- a/test/llvm/macros/complex-macro-type.chpl
+++ b/test/llvm/macros/complex-macro-type.chpl
@@ -1,5 +1,7 @@
 extern type ComplexType;
 
+use CPtr;
+
 proc main() {
   var a: ComplexType;
   writeln(c_ptrTo(a):c_void_ptr);


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/16451

These tests run only with CHPL_LLVM, so I've missed them
