### PR TITLE
Remove an unneeded assignment from array view slice initializer

### DIFF
--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -75,8 +75,6 @@ module ArrayViewSlice {
       this._ArrInstance = _ArrInstance;
 
       this.indexCache = buildIndexCacheHelper(_ArrInstance, dom);
-
-      this.dom.definedConst = dom.definedConst;
     }
 
     forwarding arr except these,

--- a/test/optimizations/constDomain/arrView.chpl
+++ b/test/optimizations/constDomain/arrView.chpl
@@ -34,6 +34,18 @@
 }
 
 {
+  writeln("Slice with const domain");
+  var d = {1..10, 1..10};
+  var a: [d] int;
+
+  const sliceDom = {2..3, 2..3};
+  var arrView = a[sliceDom];
+
+  writeln(arrView.domain._value.definedConst);
+  writeln(arrView.domain.definedConst);
+}
+
+{
   writeln("Reindex with tuple of ranges");
   var d = {1..10, 1..10};
   var a: [d] int;

--- a/test/optimizations/constDomain/arrView.good
+++ b/test/optimizations/constDomain/arrView.good
@@ -8,6 +8,9 @@ true
 Slice with var domain
 false
 false
+Slice with const domain
+true
+true
 Reindex with tuple of ranges
 true
 true


### PR DESCRIPTION
This PR removes an assignment added in #16397.

I probably added it while testing alternatives and it was left there. This
caused some communication count increases:

https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2020/09/06&enddate=2020/09/25&suite=bulktransfer

Also adds a new case to an existing test.

Test:
- [x] gasnet `test/release/examples`
- [x] gasnet `test/optimizations/constDomain`
