### PR TITLE
Add 'use CPtr;' to the expected output of the c2chapel tests

### DIFF
--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -5,6 +5,7 @@ require "arrayDecl.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern var intArr : c_ptr(c_int);
 
 extern var stringList : c_ptr(c_string);

--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -5,6 +5,7 @@ require "chapelKeywords.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc foo(out_arg : c_int, ref_arg : c_char) : c_int;
 
 // Unable to generate function 'coforall' because its name is a Chapel keyword

--- a/tools/c2chapel/test/chapelVarargs.chpl
+++ b/tools/c2chapel/test/chapelVarargs.chpl
@@ -5,6 +5,7 @@ require "chapelVarargs.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc printf_wrapper(format : c_string, c__varargs ...) : void;
 
 // Overload for empty varargs

--- a/tools/c2chapel/test/cstrvoid.chpl
+++ b/tools/c2chapel/test/cstrvoid.chpl
@@ -5,6 +5,7 @@ require "cstrvoid.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc arg_c_string(str : c_string, n : c_int) : void;
 
 extern proc arg_c_void_ptr(ptr : c_void_ptr) : void;

--- a/tools/c2chapel/test/dashEye.chpl
+++ b/tools/c2chapel/test/dashEye.chpl
@@ -5,6 +5,7 @@ require "dashEye.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc otherFunction(ref arr : c_int) : void;
 
 extern proc otherFunction(arr : c_ptr(c_int)) : void;

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -5,6 +5,7 @@ require "enum.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 // Enum: anonymous
 extern const TEST_STATUS_PASSED :c_int;
 extern const TEST_STATUS_FAILED :c_int;

--- a/tools/c2chapel/test/enumVar.chpl
+++ b/tools/c2chapel/test/enumVar.chpl
@@ -5,6 +5,7 @@ require "enumVar.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 // Enum: E
 extern const UP :c_int;
 extern const DOWN :c_int;

--- a/tools/c2chapel/test/fileGlobals.chpl
+++ b/tools/c2chapel/test/fileGlobals.chpl
@@ -5,6 +5,7 @@ require "fileGlobals.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern var globalInt : c_int;
 
 extern var globalChar : c_char;

--- a/tools/c2chapel/test/fnPointers.chpl
+++ b/tools/c2chapel/test/fnPointers.chpl
@@ -5,6 +5,7 @@ require "fnPointers.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc fnPointerArgs(callback : c_fn_ptr, msg : c_string) : c_int;
 
 extern proc foo(a : myFunctionPointer, b : c_int) : c_int;

--- a/tools/c2chapel/test/fnints.chpl
+++ b/tools/c2chapel/test/fnints.chpl
@@ -5,6 +5,7 @@ require "fnints.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc firstFunc(a : c_int, b : c_int, c : c_int) : void;
 
 extern proc secondFunc(a : c_int, ref b : c_int, ref c : c_ptr(c_int)) : void;

--- a/tools/c2chapel/test/intDefines.chpl
+++ b/tools/c2chapel/test/intDefines.chpl
@@ -5,6 +5,7 @@ require "intDefines.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 // #define'd integer literals:
 // Note: some of these may have been defined with an ifdef
 extern const FOO_OK : int;

--- a/tools/c2chapel/test/justC.chpl
+++ b/tools/c2chapel/test/justC.chpl
@@ -2,6 +2,7 @@
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc foobar(x : c_int) : c_int;
 
 extern proc main() : c_int;

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -5,6 +5,7 @@ require "miscTypedef.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern record simpleStruct {
   var a : c_int;
   var b : c_char;

--- a/tools/c2chapel/test/nestedStruct.chpl
+++ b/tools/c2chapel/test/nestedStruct.chpl
@@ -5,6 +5,7 @@ require "nestedStruct.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern record first {
   var a : c_int;
   var b : c_string;

--- a/tools/c2chapel/test/opaqueStruct.chpl
+++ b/tools/c2chapel/test/opaqueStruct.chpl
@@ -5,6 +5,7 @@ require "opaqueStruct.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern record foobar {
   var a : c_int;
   var b : c_int;

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -5,6 +5,7 @@ require "simpleRecords.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern record allInts {
   var a : c_int;
   var b : c_uint;

--- a/tools/c2chapel/test/sysCTypes.chpl
+++ b/tools/c2chapel/test/sysCTypes.chpl
@@ -5,6 +5,7 @@ require "sysCTypes.h";
 
 // Note: Generated with fake std headers
 
+use CPtr;
 extern proc test_int(a : c_int, ref b : c_int) : c_int;
 
 extern proc test_int(a : c_int, b : c_ptr(c_int)) : c_int;


### PR DESCRIPTION
This PR is straightforward, but it raises for me the question:  I'd expected c2chapel to put other `use`s into the generated code like `use SysCTypes;`  How does it get away with not doing so?  Is it expected that the user will add it manually?