### PR TITLE
Make a few fixes to HDF5 w.r.t. CPtr

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -55,7 +55,7 @@ The native HDF5 functions can be called directly by calling into the
 :mod:`C_HDF5` submodule.
 */
 module HDF5 {
-  use SysCTypes, BlockDist;
+  use SysCTypes, BlockDist, CPtr;
 
   // This interface was generated with HDF5 1.10.1. Due to a change of the
   // `hid_t` type from 32-bit to 64-bit in this version, versions prior
@@ -4119,7 +4119,7 @@ module HDF5 {
                                      c_ptrTo(memOffsetArr),
                                      c_ptrTo(memStrideArr),
                                      c_ptrTo(memCountArr), nil);
-          ref AA = A[dom];
+          ref AA = A.localSlice[dom];
           C_HDF5.H5Dread(dataset, getHDF5Type(A.eltType), memspace, dataspace,
                          C_HDF5.H5P_DEFAULT, c_ptrTo(AA));
 


### PR DESCRIPTION
* add a `use CPtr` to the top-level module
* change call to c_ptrTo() to apply to a local rather than distributed array

---
Signed-off-by: Brad Chamberlain <bradcray@users.noreply.github.com>