### PR TITLE
Fix checks that ensure single-locale, rectangular arrays

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -431,7 +431,7 @@ module CPtr {
     :returns: a pointer to the array's elements
   */
   inline proc c_ptrTo(arr: []) {
-    if (!chpl__isDROrDRView(arr)) then
+    if (!isRectangularArr(arr) || !arr.domain.dist._value.dsiIsLayout()) then
       compilerError("Only single-locale rectangular arrays support c_ptrTo() at present");
 
     if (arr._value.locale != here) then

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -5276,7 +5276,7 @@ module ChapelArray {
   // 'castToVoidStar' says whether we should cast the result to c_void_ptr
   pragma "no doc"
   proc chpl_arrayToPtr(arr: [], param castToVoidStar: bool = false) {
-    if (!chpl__isDROrDRView(arr)) then
+    if (!isRectangularArr(arr) || !arr.domain.dist._value.dsiIsLayout()) then
       compilerError("Only single-locale rectangular arrays can be passed to an external routine argument with array type", errorDepth=2);
 
     if (arr._value.locale != here) then


### PR DESCRIPTION
I'd previously used isDROrDRView to try and determine whether or not an array was a
single-locale rectangular array, but it turns out that the meaning of this routine has
changed such that for an array 'var B = A.reindex(...);' or 'var B = A[.., 1]', it no longer
returns `true` for 'B' since it isn't technically an array view, but rather an array that
has array view type.  So here, I'm switching to asking whether or not it's rectangular
and whether or not it's a layout instead.

This question — "is this array distributed or not?" (as best we can
tell from static information) — is something that's long overdue for
a proper user-facing interface.
