### PR TITLE
Version module simplification: one type rather than two

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -29,25 +29,22 @@ specifically.  In more detail, it features:
 * :var:`chplVersion`: the version number of the copy of ``chpl`` used
   to compile the program.
 
-* two types that can be used to represent version numbers:
-
-  * :type:`semanticVersion` which represents a semantic version value
-
-  * :type:`sourceVersion` which is a semantic version plus a commit value
+* :type:`sourceVersion`: a type that can be used to represent a semantic
+  version number plus an optional commit value.
 
 * :proc:`version`: a utility function for creating new version values
 
-Version types in this module are defined in terms of ``param`` values to
-support compile-time reasoning about versions and code specialization.
+Version numbers in this module are represented using ``param`` values
+to permit code specialization by being able to reason about versions
+at compile-time.
 
-The version types support:
+The :type:`sourceVersion` type supports:
 
 * being printed out or cast to a ``param`` string
 
-* compile-time comparisons between version values via ``==``, ``!=``,
-  ``<``, ``<=``, ``>``, and ``>``, including mixed version types.
-  Generally speaking, "less than" corresponds to "is an earlier
-  version than."  For example::
+* compile-time comparisons via ``==``, ``!=``, ``<``, ``<=``, ``>``,
+  and ``>``.  Generally speaking, "less than" corresponds to "is an
+  earlier version than."  For example::
 
     if chplVersion < version(1,23) then
       compilerWarning("This package doesn't support 'chpl' prior to 1.23.0");
@@ -64,12 +61,12 @@ module Version {
 
   /*
     The version of ``chpl`` used to compile this program.  For an
-    official Chapel release, this will have type
-    :type:`semanticVersion` while for a pre-release, it will have
-    type :type:`sourceVersion`.
+    official Chapel release, this will have an empty ``commit`` value,
+    while for a pre-release, it will indicate the Git SHA.
 
-    Note that Chapel ``1.x.y``/``2.x.y`` corresponds to version
-    ``0.x.y``/``1.x.y`` in traditional semantic versioning.
+    Note that, for historical reasons, Chapel ``1.x.y``/``2.x.y``
+    corresponds to version ``0.x.y``/``1.x.y`` in traditional semantic
+    versioning.
   */
 
   const chplVersion;
@@ -92,53 +89,12 @@ module Version {
     :arg commit: The optional commit ID (defaults to "")
     :type commit: `string`
 
-    :returns: A new version value.  If ``commit == ""``, this routine
-              returns a value of type :type:`semanticVersion`
-              otherwise it returns a value of type
-              :type:`sourceVersion`.
+    :returns: A new version value of type :type:`sourceVersion`.
   */
   proc version(param major: int, param minor: int,
-               param update: int = 0, param commit: string = "") {
-    if commit == "" then
-      return new semanticVersion(major, minor, update);
-    else
-      return new sourceVersion(major, minor, update, commit);
+               param update: int = 0, param commit: string = ""): sourceVersion(?) {
+    return new sourceVersion(major, minor, update, commit);
 
-  }
-
-
-  /*
-    This record represents a semantic version value.  It uses
-    ``param`` values to represent its components in order to support
-    compile-time comparison of version numbers which in turn permits
-    code to specialize to specific versions of Chapel.  When printed
-    or converted to a string, it is represented as ``version
-    major.minor.update``.
-  */
-  record semanticVersion {
-    /* The major version number.  For version ``2.0.1``, this would be
-       ``2``. */
-    param major: int;
-
-    /* The minor version number.  For version ``2.0.1``, this would be
-       ``0``. */
-    param minor: int;
-
-    /* The update version number.  For version ``2.0.1``, this would
-       be ``1``. */
-    param update: int;
-
-    pragma "no doc"
-    proc writeThis(s) throws {
-      s.write(this:string);
-    }
-  }
-
-  // cast from semanticVersion to string
-  pragma "no doc"
-  proc _cast(type t: string, x: semanticVersion(?)) param : string {
-    return "version " + x.major:string + "." + x.minor:string + "." +
-           x.update:string;
   }
 
 
@@ -151,31 +107,29 @@ module Version {
     major.minor.update (commit)``.
 
     Note that ordered comparisons between two :type:`sourceVersion`
-    values with identical semantic versions are not supported due to
-    the challenges involved in ordering commit values.  Moreover, when
-    a :type:`semanticVersion` is compared with a :type:`sourceVersion`
-    that has the identical semantic version, the :type:`sourceVersion`
-    value is considered to be less than the :type:`semanticVersion`
-    using the model that it represents a pre-release of the official
-    release represented by the semantic version.
-  */
-  record sourceVersion {
-    forwarding version only major, minor, update;
+    values that only differ in their ``commit`` values are not
+    supported due to the challenges involved in ordering commit
+    values.  However, when a value with an empty ``update`` value is
+    compared to one whose ``update`` is non-empty, the latter is
+    considered to be earlier than (less than) the former, due to the
+    interpretation that it represents a pre-release of the official
+    release.  */
 
-    /* The semantic version portion of the version number. */
-    const version: semanticVersion(?);
+    record sourceVersion {
+    /* The major version number.  For version ``2.0.1``, this would be
+       ``2``. */
+    param major: int;
 
-    /* The commit ID of the version (e.g., a git SHA) */
-    param commit: string;
+    /* The minor version number.  For version ``2.0.1``, this would be
+       ``0``. */
+    param minor: int;
 
-    pragma "no doc"
-    proc init(param major: int, param minor: int, param update: int,
-              param commit: string) {
-      this.version = new semanticVersion(major, minor, update);
-      this.commit = commit;
-      if commit == "" then
-        compilerError("sourceVersion values must have a commit value");
-    }
+    /* The update version number.  For version ``2.0.1``, this would
+       be ``1``. */
+    param update: int;
+
+    /* The commit ID of the version (e.g., a Git SHA) */
+    param commit: string = "";
 
     pragma "no doc"
     proc writeThis(s) throws {
@@ -186,7 +140,11 @@ module Version {
   // cast from sourceVersion to string
   pragma "no doc"
   proc _cast(type t: string, x: sourceVersion(?)) {
-    return x.version:string + " (" + x.commit + ")";
+    var str = "version " + x.major:string + "." + x.minor:string + "." +
+        x.update:string;
+    if (x.commit != "") then
+      str += " (" + x.commit + ")";
+    return str;
   }
 
 
@@ -201,61 +159,37 @@ module Version {
       return 1;
   }
 
-  private proc spaceship(v1: semanticVersion(?),
-                         v2: semanticVersion(?)) param : int {
+  private proc spaceship(v1: sourceVersion(?),
+                         v2: sourceVersion(?)) param : int {
     param majComp = spaceship(v1.major, v2.major);
-    if majComp != 0 then
+    if majComp != 0 {
       return majComp;
-    param minComp = spaceship(v1.minor, v2.minor);
-    if minComp != 0 then
-      return minComp;
-    return spaceship(v1.update, v2.update);
+    } else {
+      param minComp = spaceship(v1.minor, v2.minor);
+      if minComp != 0 {
+        return minComp;
+      } else {
+        param upComp = spaceship(v1.update, v2.update);
+        if upComp != 0 {
+          return upComp;
+        } else if v1.commit == v2.commit {
+          return 0;
+        } else if v1.commit == "" {
+          return 1;
+        } else if v2.commit == "" then {
+          return -1;
+        } else {
+          compilerError("can't compare sourceVersions that only differ by commit IDs", errorDepth=2);
+          return 0;
+        }
+      }
+    }
   }
-
-
-  // Comparisons between semanticVersions
-
-  proc ==(v1: semanticVersion(?), v2: semanticVersion(?)) param : bool {
-    return spaceship(v1,v2) == 0;
-  }
-
-  /*
-    Equality/inequality operators between two values of type
-    :type:`semanticVersion` check whether or not the two values
-    have identical major, minor, and update values.
-  */
-  proc !=(v1: semanticVersion(?), v2: semanticVersion(?)) param : bool {
-    return spaceship(v1,v2) != 0;
-  }
-
-  proc <(v1: semanticVersion(?), v2: semanticVersion(?)) param : bool {
-    return spaceship(v1,v2) < 0;
-  }
-
-  proc <=(v1: semanticVersion(?), v2: semanticVersion(?)) param : bool {
-    return spaceship(v1,v2) <= 0;
-  }
-
-  proc >(v1: semanticVersion(?), v2: semanticVersion(?)) param : bool {
-    return spaceship(v1,v2) > 0;
-  }
-
-  /*
-    Ordered comparisons between two values of type
-    :type:`semanticVersion` are based on the lexical ordering of each
-    value's ``major.minor.update`` value, reflecting an "was released
-    before/after" relationship.
-  */
-  proc >=(v1: semanticVersion(?), v2: semanticVersion(?)) param : bool {
-    return spaceship(v1,v2) >= 0;
-  }
-
 
   // Comparisons between sourceVersions
 
   proc ==(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    return (v1.version == v2.version &&
-            v1.commit == v2.commit);
+    return spaceship(v1, v2) == 0;
   }
 
   /*
@@ -264,129 +198,35 @@ module Version {
     have identical major, minor, update, and commit values.
   */
   proc !=(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    return (v1.version != v2.version ||
-            v1.commit != v2.commit);
+    return spaceship(v1, v2) != 0;
   }
 
   proc <(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    param versionComp = spaceship(v1.version, v2.version);
-    if versionComp != 0 {
-      return versionComp < 0;
-    } else if v1.commit == v2.commit {
-      return false;
-    } else {
-      compilerError("can't compare sourceVersions that only differ by commit IDs");
-      return false;
-    }
+    return spaceship(v1, v2) < 0;
   }
 
   proc <=(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    param versionComp = spaceship(v1.version, v2.version);
-    if versionComp != 0 {
-      return versionComp < 0;
-    } else if v1.commit == v2.commit {
-      return true;
-    } else {
-      compilerError("can't compare sourceVersions that only differ by commit IDs");
-      return false;
-    }
+    return spaceship(v1, v2) <= 0;
   }
 
   proc >(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    param versionComp = spaceship(v1.version, v2.version);
-    if versionComp != 0 {
-      return versionComp > 0;
-    } else if v1.commit == v2.commit {
-      return false;
-    } else {
-      compilerError("can't compare sourceVersions that only differ by commit IDs");
-      return false;
-    }
+    return spaceship(v1, v2) > 0;
   }
 
   /*
     Ordered comparisons between two values of type
     :type:`sourceVersion` are based on the ordering of the semantic
-    versions of the two values.  If the two values have identical
-    semantic versions, any cases that rely on an ordering of the
-    commits will generate a compile-time error due to the challenge of
-    ordering commits at compile-time.
+    versions of the two values, as defined by their ``major``,
+    ``minor``, and ``update`` components.  If the two values have
+    identical semantic versions, any cases that rely on an ordering of
+    the commits will generate a compile-time error if the values have
+    differing, non-empty ``commit`` values due to the challenge of
+    ordering commits at compile-time.  An empty ``commit`` value is
+    considered to come after (be greater than) a non-empty value, as
+    the former is considered an official release and the latter a
+    pre-release.
   */
   proc >=(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    param versionComp = spaceship(v1.version, v2.version);
-    if versionComp != 0 {
-      return versionComp > 0;
-    } else if v1.commit == v2.commit {
-      return true;
-    } else {
-      compilerError("can't compare sourceVersions that only differ by commit IDs");
-      return false;
-    }
-  }
-
-  // semanticVersion / sourceVersion == and != ops
-
-  proc ==(v1: semanticVersion(?), v2: sourceVersion(?)) param : bool {
-    return false;
-  }
-
-  proc !=(v1: semanticVersion(?), v2: sourceVersion(?)) param : bool {
-    return true;
-  }
-
-  proc ==(v1: sourceVersion(?), v2: semanticVersion(?)) param : bool {
-    return false;
-  }
-
-  /*
-    Equality/inequality comparisons between mixed values of type
-    :type:`semanticVersion` and :type:`sourceVersion` always return
-    ``false`` for ``==`` and ``true`` for ``!=``.
-  */
-  proc !=(v1: sourceVersion(?), v2: semanticVersion(?)) param : bool {
-    return true;
-  }
-
-
-  // ordered comparison operators for semanticVersion and sourceVersion
-
-  proc <(v1: semanticVersion(?), v2: sourceVersion(?)) param : bool {
-    return v1 < v2.version;
-  }
-
-  proc <=(v1: semanticVersion(?), v2: sourceVersion(?)) param : bool {
-    return v1 < v2.version;
-  }
-
-  proc >(v1: semanticVersion(?), v2: sourceVersion(?)) param : bool {
-    return v1 >= v2.version;
-  }
-
-  proc >=(v1: semanticVersion(?), v2: sourceVersion(?)) param : bool {
-    return v1 >= v2.version;
-  }
-
-  proc <(v1: sourceVersion(?), v2: semanticVersion(?)) param : bool {
-    return v2 >= v1;
-  }
-
-  proc <=(v1: sourceVersion(?), v2: semanticVersion(?)) param : bool {
-    return v2 > v1;
-  }
-
-  proc >(v1: sourceVersion(?), v2: semanticVersion(?)) param : bool {
-    return v2 <= v1;
-  }
-
-  /*
-    Ordered comparisons between mixed values of type
-    :type:`semanticVersion` and :type:`sourceVersion` are based on the
-    ordering of the semantic versions of the two values.  If the
-    two values have identical semantic versions, the
-    :type:`sourceVersion` value is considered less than the
-    :type:`semanticVersion` value.
-  */
-  proc >=(v1: sourceVersion(?), v2: semanticVersion(?)) param : bool {
-    return v2 < v1;
+    return spaceship(v1, v2) >= 0;
   }
 }

--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -179,8 +179,8 @@ module Version {
         } else if v2.commit == "" then {
           return -1;
         } else {
-          compilerError("can't compare sourceVersions that only differ by commit IDs", errorDepth=2);
-          return 0;
+          // sentinel for "not comparable"
+          return 2;
         }
       }
     }
@@ -202,15 +202,24 @@ module Version {
   }
 
   proc <(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    return spaceship(v1, v2) < 0;
+    param retval = spaceship(v1, v2);
+    if (retval == 2) then
+      compilerError("can't compare versions that only differ by commit IDs");
+    return retval < 0;
   }
 
   proc <=(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    return spaceship(v1, v2) <= 0;
+    param retval = spaceship(v1, v2);
+    if (retval == 2) then
+      compilerError("can't compare versions that only differ by commit IDs");
+    return retval <= 0;
   }
 
   proc >(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    return spaceship(v1, v2) > 0;
+    param retval = spaceship(v1, v2);
+    if (retval == 2) then
+      compilerError("can't compare versions that only differ by commit IDs");
+    return retval > 0 && retval != 2;
   }
 
   /*
@@ -227,6 +236,9 @@ module Version {
     pre-release.
   */
   proc >=(v1: sourceVersion(?), v2: sourceVersion(?)) param : bool {
-    return spaceship(v1, v2) >= 0;
+    param retval = spaceship(v1, v2);
+    if (retval == 2) then
+      compilerError("can't compare versions that only differ by commit IDs");
+    return retval >= 0 && retval != 2;
   }
 }

--- a/test/library/standard/Version/compareChplVersionErrors.good
+++ b/test/library/standard/Version/compareChplVersionErrors.good
@@ -1,17 +1,37 @@
 compareChplVersionErrors.chpl:25: In function 'compareVersions':
-compareChplVersionErrors.chpl:32: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:33: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:34: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:35: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:21: called as compareVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\"))
-compareChplVersionErrors.chpl:25: In function 'compareVersions':
-compareChplVersionErrors.chpl:32: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:33: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:34: error: can't compare sourceVersions that only differ by commit IDs
-compareChplVersionErrors.chpl:35: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(semanticVersion(2,1,0),\"bbb\"), v2: sourceVersion(semanticVersion(2,1,0),\"aaa\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(semanticVersion(2,1,0),\"aaa\"), v2: sourceVersion(semanticVersion(2,1,0),\"bbb\"))
+compareChplVersionErrors.chpl:30: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:21: called as compareVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
+$CHPL_HOME/modules/standard/Version.chpl:190: In function '==':
+$CHPL_HOME/modules/standard/Version.chpl:191: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:25: called as ==(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
+$CHPL_HOME/modules/standard/Version.chpl:199: In function '!=':
+$CHPL_HOME/modules/standard/Version.chpl:200: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:25: called as !=(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
+$CHPL_HOME/modules/standard/Version.chpl:203: In function '<':
+$CHPL_HOME/modules/standard/Version.chpl:204: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:25: called as <(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
+$CHPL_HOME/modules/standard/Version.chpl:207: In function '<=':
+$CHPL_HOME/modules/standard/Version.chpl:208: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:25: called as <=(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
+$CHPL_HOME/modules/standard/Version.chpl:211: In function '>':
+$CHPL_HOME/modules/standard/Version.chpl:212: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:25: called as >(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
+$CHPL_HOME/modules/standard/Version.chpl:223: In function '>=':
+$CHPL_HOME/modules/standard/Version.chpl:224: error: can't compare sourceVersions that only differ by commit IDs
+  compareChplVersionErrors.chpl:25: called as >=(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
+  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
 Comparing versions:
 version 2.1.0
 version 2.1.0 (aaa)
@@ -38,23 +58,23 @@ Comparing versions:
 version 2.1.0 (aaa)
 version 2.1.0 (bbb)
 ------------------
-== : false
-!= : true
+== : true
+!= : false
 <  : false
-<= : false
+<= : true
 >  : false
->= : false
+>= : true
 
 Comparing versions:
 version 2.1.0 (bbb)
 version 2.1.0 (aaa)
 ------------------
-== : false
-!= : true
+== : true
+!= : false
 <  : false
-<= : false
+<= : true
 >  : false
->= : false
+>= : true
 
 Comparing versions:
 version 2.0.0 (aaa)

--- a/test/library/standard/Version/compareChplVersionErrors.good
+++ b/test/library/standard/Version/compareChplVersionErrors.good
@@ -1,35 +1,15 @@
 compareChplVersionErrors.chpl:25: In function 'compareVersions':
-compareChplVersionErrors.chpl:30: error: can't compare sourceVersions that only differ by commit IDs
+compareChplVersionErrors.chpl:32: error: can't compare versions that only differ by commit IDs
+compareChplVersionErrors.chpl:33: error: can't compare versions that only differ by commit IDs
+compareChplVersionErrors.chpl:34: error: can't compare versions that only differ by commit IDs
+compareChplVersionErrors.chpl:35: error: can't compare versions that only differ by commit IDs
   compareChplVersionErrors.chpl:21: called as compareVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\")) from function 'compareBothVersions'
   compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
-$CHPL_HOME/modules/standard/Version.chpl:190: In function '==':
-$CHPL_HOME/modules/standard/Version.chpl:191: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:25: called as ==(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
-  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
-$CHPL_HOME/modules/standard/Version.chpl:199: In function '!=':
-$CHPL_HOME/modules/standard/Version.chpl:200: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:25: called as !=(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
-  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
-$CHPL_HOME/modules/standard/Version.chpl:203: In function '<':
-$CHPL_HOME/modules/standard/Version.chpl:204: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:25: called as <(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
-  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
-$CHPL_HOME/modules/standard/Version.chpl:207: In function '<=':
-$CHPL_HOME/modules/standard/Version.chpl:208: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:25: called as <=(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
-  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
-$CHPL_HOME/modules/standard/Version.chpl:211: In function '>':
-$CHPL_HOME/modules/standard/Version.chpl:212: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:25: called as >(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
-  compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
-  compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
-$CHPL_HOME/modules/standard/Version.chpl:223: In function '>=':
-$CHPL_HOME/modules/standard/Version.chpl:224: error: can't compare sourceVersions that only differ by commit IDs
-  compareChplVersionErrors.chpl:25: called as >=(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareVersions'
+compareChplVersionErrors.chpl:25: In function 'compareVersions':
+compareChplVersionErrors.chpl:32: error: can't compare versions that only differ by commit IDs
+compareChplVersionErrors.chpl:33: error: can't compare versions that only differ by commit IDs
+compareChplVersionErrors.chpl:34: error: can't compare versions that only differ by commit IDs
+compareChplVersionErrors.chpl:35: error: can't compare versions that only differ by commit IDs
   compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
   compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
 Comparing versions:
@@ -58,23 +38,23 @@ Comparing versions:
 version 2.1.0 (aaa)
 version 2.1.0 (bbb)
 ------------------
-== : true
-!= : false
+== : false
+!= : true
 <  : false
-<= : true
+<= : false
 >  : false
->= : true
+>= : false
 
 Comparing versions:
 version 2.1.0 (bbb)
 version 2.1.0 (aaa)
 ------------------
-== : true
-!= : false
+== : false
+!= : true
 <  : false
-<= : true
+<= : false
 >  : false
->= : true
+>= : false
 
 Comparing versions:
 version 2.0.0 (aaa)


### PR DESCRIPTION
This is an attempt to simplify the Version module by unifying down to a single type with empty or non-empty commit values rather than distinguishing these using two types (a semantic version vs. a source version) as we had before.

For the most part, this was a simple change, where the biggest effort was rewriting the docs.  I also reworded the error message slightly to reflect not having to distinguish between different representations of versions.
