### PR TITLE
Make --report-auto-local-access output more readable

### DIFF
--- a/compiler/optimizations/preNormalizeOptimizations.cpp
+++ b/compiler/optimizations/preNormalizeOptimizations.cpp
@@ -42,7 +42,7 @@
 //     localAccess during resolution
 
 
-static void LOG(const char *msg, BaseAST *node);
+static void LOG(int depth, const char *msg, BaseAST *node);
 static bool callHasSymArguments(CallExpr *ce, const std::vector<Symbol *> &syms);
 static Symbol *getDotDomBaseSym(Expr *expr);
 static Expr *getDomExprFromTypeExprOrQuery(Expr *e);
@@ -57,7 +57,7 @@ static std::vector<Symbol *> getLoopIndexSymbols(ForallStmt *forall,
                                                  Symbol *baseSym);
 static void gatherForallInfo(ForallStmt *forall);
 static bool loopHasValidInductionVariables(ForallStmt *forall);
-static bool canDetermineLoopDomainStatically(ForallStmt *forall);
+static Symbol *canDetermineLoopDomainStatically(ForallStmt *forall);
 static Symbol *getCallBaseSymIfSuitable(CallExpr *call, ForallStmt *forall);
 static Symbol *getCallBase(CallExpr *call);
 static void generateDynamicCheckForAccess(CallExpr *access,
@@ -130,22 +130,29 @@ Expr *preFoldMaybeLocalThis(CallExpr *call) {
 
 
 // logging support for --report-auto-local-access
-static void LOG(const char *msg, BaseAST *node) {
+static void LOG(int depth, const char *msg, BaseAST *node) {
   if (fReportAutoLocalAccess) {
-    const bool verbose = (node->getModule()->modTag != MOD_INTERNAL &&
-                          node->getModule()->modTag != MOD_STANDARD);
+    bool verbose = false;
+    if (node == NULL) {
+      verbose = true;
+    }
+    else {
+      verbose = (node->getModule()->modTag != MOD_INTERNAL &&
+                 node->getModule()->modTag != MOD_STANDARD);
+    }
 
     const bool veryVerbose = false;
     if (verbose) {
-      std::cout << msg << std::endl;
+      for (int i = 0 ; i < depth; i++) {
+        std::cout << " ";
+      }
+      std::cout << msg;
       if (node != NULL) {
-        std::cout << "\t" << node->stringLoc() << std::endl;
+        std::cout << " (" << node->stringLoc() << ")";
         if (veryVerbose) {
           nprint_view(node);
         }
-        else {
-          std::cout << std::endl;
-        }
+        std::cout << std::endl;
       }
     }
   }
@@ -362,7 +369,7 @@ static std::vector<Symbol *> getLoopIndexSymbols(ForallStmt *forall,
   // pattern.
   if (indexVarCount == -1 ||
       ((std::size_t)indexVarCount) != indexSymbols.size()) {
-    LOG("Can't recognize loop's index symbols", baseSym);
+    LOG(0, "Can't recognize loop's index symbols", baseSym);
     indexSymbols.clear();
   }
 
@@ -380,7 +387,7 @@ static void gatherForallInfo(ForallStmt *forall) {
     if (SymExpr *iterSE = toSymExpr(iterExprs.head)) {
       forall->optInfo.iterSym = iterSE->symbol();
 
-      LOG("Iterated symbol", forall->optInfo.iterSym);
+      LOG(0, "Iterated symbol", forall->optInfo.iterSym);
     }
   }
   // it might be in the form `A.domain` where A is used in the loop body
@@ -389,12 +396,12 @@ static void gatherForallInfo(ForallStmt *forall) {
     forall->optInfo.dotDomIterSym = dotDomBaseSym;
     forall->optInfo.dotDomIterSymDom = getDomSym(forall->optInfo.dotDomIterSym);
 
-    LOG("Iterated over the domain of", forall->optInfo.dotDomIterSym);
+    LOG(0, "Iterated over the domain of", forall->optInfo.dotDomIterSym);
     if (forall->optInfo.dotDomIterSymDom != NULL) {
-      LOG(", which is", forall->optInfo.dotDomIterSymDom);
+      LOG(0, ", which is", forall->optInfo.dotDomIterSymDom);
     }
     else {
-      LOG(", whose domain cannot be determined statically",
+      LOG(0, ", whose domain cannot be determined statically",
                     forall->optInfo.dotDomIterSym);
     }
   }
@@ -404,10 +411,10 @@ static void gatherForallInfo(ForallStmt *forall) {
       if(Symbol *iterCallTmp = earlyNormalizeForallIterand(iterCall, forall)) {
         forall->optInfo.iterCall = iterCall;
         forall->optInfo.iterCallTmp = iterCallTmp;
-        LOG("Loop iterand is a call. Will attempt dynamic optimization.", iterCall);
+        LOG(0, "Loop iterand is a call. Will attempt dynamic optimization.", iterCall);
       }
       else {
-        LOG("Loop iterand is a call. But it cannot be normalized early.", iterCall);
+        LOG(0, "Loop iterand is a call. But it cannot be normalized early.", iterCall);
       }
     }
   }
@@ -442,11 +449,16 @@ static bool loopHasValidInductionVariables(ForallStmt *forall) {
   return forall->optInfo.multiDIndices.size() > 0;
 }
 
-static bool canDetermineLoopDomainStatically(ForallStmt *forall) {
+static Symbol *canDetermineLoopDomainStatically(ForallStmt *forall) {
   // a forall is suitable for static optimization only if it iterates over a
   // symbol (with the hopes that that symbol is a domain), or a foo.domain
-  return (forall->optInfo.iterSym != NULL ||
-          forall->optInfo.dotDomIterSym != NULL);
+  if (forall->optInfo.iterSym != NULL ){
+    return forall->optInfo.iterSym;
+  }
+  else if (forall->optInfo.dotDomIterSym != NULL) {
+    return forall->optInfo.dotDomIterSym;
+  }
+  return NULL;
 }
 
 // Bunch of checks to see if `call` is a candidate for optimization within
@@ -638,17 +650,12 @@ static void optimizeLoop(ForallStmt *forall,
     Symbol *checkSym = generateStaticCheckForAccess(candidate,
                                                     forall,
                                                     staticCond);
-    if (doStatic) {
-      LOG("\tMarking static candidate", candidate);
-    }
-    else {
+    if (!doStatic) {
       forall->optInfo.staticCheckSymsForDynamicCandidates.push_back(checkSym);
 
       generateDynamicCheckForAccess(candidate,
                                     forall,
                                     dynamicCond);
-
-      LOG("\tMarking dynamic candidate", candidate);
     }
 
     replaceCandidate(candidate, checkSym, doStatic);
@@ -808,20 +815,23 @@ static void autoLocalAccess(ForallStmt *forall) {
   }
   forall->optInfo.autoLocalAccessChecked = true;
 
-  LOG("**** Start forall ****", forall);
+  LOG(0, "Start analyzing forall", forall);
 
   gatherForallInfo(forall);
 
   if (!loopHasValidInductionVariables(forall)) {
+    LOG(1, "Can't optimize this forall: invalid induction variables", forall);
     return;
   }
 
-  bool staticLoopDomain = canDetermineLoopDomainStatically(forall);
+  Symbol *loopDomain = canDetermineLoopDomainStatically(forall);
+  bool staticLoopDomain = loopDomain != NULL;
   if (staticLoopDomain) {
-    LOG("Loop is suitable for static and dynamic analysis", forall);
+    LOG(1, "Found loop domain", loopDomain);
+    LOG(1, "Will attempt static and dynamic optimizations", forall);
   }
   else {
-    LOG("Loop is suitable for dynamic analysis only", forall);
+    LOG(1, "Couldn't determine loop domain: will attempt dynamic optimizations only", forall);
   }
 
   std::vector<CallExpr *> allCallExprs;
@@ -834,7 +844,7 @@ static void autoLocalAccess(ForallStmt *forall) {
       continue;
     }
 
-    LOG("Potential access", call);
+    LOG(2, "Start analyzing call", call);
 
     bool canOptimizeStatically = false;
 
@@ -844,34 +854,35 @@ static void autoLocalAccess(ForallStmt *forall) {
       if (forall->optInfo.dotDomIterSym == accBaseSym) {
         canOptimizeStatically = true;
 
-        LOG("\tCan optimize: Access base is the iterator's base", call);
+        LOG(3, "Can optimize: Access base is the iterator's base", call);
       }
       else {
         Symbol *domSym = getDomSym(accBaseSym);
 
         if (domSym != NULL) {  //  I can find the domain of the array
-          LOG("\twith domain defined at", domSym);
+          LOG(3, "Found the domain of the access base", domSym);
           
           // forall i in A.domain do ... B[i] ... where B and A share domain
           if (forall->optInfo.dotDomIterSymDom == domSym) {
             canOptimizeStatically = true;
 
-            LOG("\tCan optimize: Access base has the same domain as iterator's base", call);
+            LOG(3, "Can optimize: Access base has the same domain as iterator's base", call);
           }
          
           // forall i in D do ... A[i] ... where D is A's domain
           else if (forall->optInfo.iterSym == domSym) {
             canOptimizeStatically = true;
 
-            LOG("\tCan optimize: Access base's domain is the iterator", call);
+            LOG(3, "Can optimize: Access base's domain is the iterator", call);
           }
         }
         else {
-          LOG("\tregular domain symbol was not found for array", accBaseSym);
+          LOG(3, "Can't determine the domain of access base", accBaseSym);
         }
       }
 
       if (canOptimizeStatically) {
+        LOG(3, "This call is a static optimization candidate", call);
         forall->optInfo.staticCandidates.push_back(call);
       }
     }
@@ -887,13 +898,15 @@ static void autoLocalAccess(ForallStmt *forall) {
       // determine the symbol of the loop domain. But this call that I am
       // looking at still has potential because it is `A(i)` where `i` is
       // the loop index. So, add this call to dynamic candidates
+      LOG(3, "This call is a dynamic optimization candidate", call);
       forall->optInfo.dynamicCandidates.push_back(call);
     }
   }
 
   generateOptimizedLoops(forall);
 
-  LOG("**** End forall ****", forall);
+  LOG(0, "End analyzing forall", forall);
+  //LOG(0, "\n", NULL);
 }
 
 
@@ -902,7 +915,7 @@ static void autoLocalAccess(ForallStmt *forall) {
 // Resolution support for auto-local-access
 //
 static CallExpr *revertAccess(CallExpr *call) {
-  LOG("Static check failed. Reverting optimization", call);
+  LOG(0, "Static check failed. Reverting optimization", call);
 
   CallExpr *repl = new CallExpr(new UnresolvedSymExpr("this"),
                                 gMethodToken);
@@ -919,10 +932,10 @@ static CallExpr *revertAccess(CallExpr *call) {
 
 static CallExpr *confirmAccess(CallExpr *call) {
   if (toSymExpr(call->get(call->argList.length))->symbol() == gTrue) {
-    LOG("Static check successful. Using localAccess", call);
+    LOG(0, "Static check successful. Using localAccess", call);
   }
   else {
-    LOG("Static check successful. Using localAccess with dynamic check", call);
+    LOG(0, "Static check successful. Using localAccess with dynamic check", call);
   }
 
   CallExpr *repl = new CallExpr(new UnresolvedSymExpr("localAccess"),

--- a/test/optimizations/autoLocalAccess/allDynamicsFailStatic.good
+++ b/test/optimizations/autoLocalAccess/allDynamicsFailStatic.good
@@ -1,36 +1,17 @@
-**** Start forall ****
-	allDynamicsFailStatic.chpl:17
 
-Iterated symbol
-	allDynamicsFailStatic.chpl:4
+Start analyzing forall (allDynamicsFailStatic.chpl:17)
+| Found loop domain (allDynamicsFailStatic.chpl:4)
+| Will attempt static and dynamic optimizations (allDynamicsFailStatic.chpl:17)
+|
+|  Start analyzing call (allDynamicsFailStatic.chpl:18)
+|   Found the domain of the access base (allDynamicsFailStatic.chpl:4)
+|   Can optimize: Access base's domain is the iterator (allDynamicsFailStatic.chpl:18)
+|  This call is a static optimization candidate (allDynamicsFailStatic.chpl:18)
+|
+|  Start analyzing call (allDynamicsFailStatic.chpl:19)
+|   Can't determine the domain of access base (allDynamicsFailStatic.chpl:8)
+|  This call is a dynamic optimization candidate (allDynamicsFailStatic.chpl:19)
+|
+End analyzing forall (allDynamicsFailStatic.chpl:17)
 
-Loop is suitable for static and dynamic analysis
-	allDynamicsFailStatic.chpl:17
-
-Potential access
-	allDynamicsFailStatic.chpl:18
-
-	with domain defined at
-	allDynamicsFailStatic.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	allDynamicsFailStatic.chpl:18
-
-Potential access
-	allDynamicsFailStatic.chpl:19
-
-	regular domain symbol was not found for array
-	allDynamicsFailStatic.chpl:8
-
-	Marking static candidate
-	allDynamicsFailStatic.chpl:18
-
-	Marking dynamic candidate
-	allDynamicsFailStatic.chpl:19
-
-**** End forall ****
-	allDynamicsFailStatic.chpl:17
-
-Static check successful. Using localAccess
-	allDynamicsFailStatic.chpl:18
-
+Static check successful. Using localAccess (allDynamicsFailStatic.chpl:18)

--- a/test/optimizations/autoLocalAccess/commaDecl.good
+++ b/test/optimizations/autoLocalAccess/commaDecl.good
@@ -1,43 +1,20 @@
-**** Start forall ****
-	commaDecl.chpl:9
 
-Iterated symbol
-	commaDecl.chpl:3
+Start analyzing forall (commaDecl.chpl:9)
+| Found loop domain (commaDecl.chpl:3)
+| Will attempt static and dynamic optimizations (commaDecl.chpl:9)
+|
+|  Start analyzing call (commaDecl.chpl:10)
+|   Found the domain of the access base (commaDecl.chpl:3)
+|   Can optimize: Access base's domain is the iterator (commaDecl.chpl:10)
+|  This call is a static optimization candidate (commaDecl.chpl:10)
+|
+|  Start analyzing call (commaDecl.chpl:10)
+|   Found the domain of the access base (commaDecl.chpl:3)
+|   Can optimize: Access base's domain is the iterator (commaDecl.chpl:10)
+|  This call is a static optimization candidate (commaDecl.chpl:10)
+|
+End analyzing forall (commaDecl.chpl:9)
 
-Loop is suitable for static and dynamic analysis
-	commaDecl.chpl:9
-
-Potential access
-	commaDecl.chpl:10
-
-	with domain defined at
-	commaDecl.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	commaDecl.chpl:10
-
-Potential access
-	commaDecl.chpl:10
-
-	with domain defined at
-	commaDecl.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	commaDecl.chpl:10
-
-	Marking static candidate
-	commaDecl.chpl:10
-
-	Marking static candidate
-	commaDecl.chpl:10
-
-**** End forall ****
-	commaDecl.chpl:9
-
-Static check successful. Using localAccess
-	commaDecl.chpl:10
-
-Static check successful. Using localAccess
-	commaDecl.chpl:10
-
+Static check successful. Using localAccess (commaDecl.chpl:10)
+Static check successful. Using localAccess (commaDecl.chpl:10)
 10 10 10 10 10 10 10 10 10 10

--- a/test/optimizations/autoLocalAccess/copyInitDeclaration.good
+++ b/test/optimizations/autoLocalAccess/copyInitDeclaration.good
@@ -1,61 +1,27 @@
-**** Start forall ****
-	copyInitDeclaration.chpl:14
 
-Iterated symbol
-	copyInitDeclaration.chpl:4
+Start analyzing forall (copyInitDeclaration.chpl:14)
+| Found loop domain (copyInitDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (copyInitDeclaration.chpl:14)
+|
+|  Start analyzing call (copyInitDeclaration.chpl:15)
+|   Found the domain of the access base (copyInitDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (copyInitDeclaration.chpl:15)
+|  This call is a static optimization candidate (copyInitDeclaration.chpl:15)
+|
+|  Start analyzing call (copyInitDeclaration.chpl:15)
+|   Found the domain of the access base (copyInitDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (copyInitDeclaration.chpl:15)
+|  This call is a static optimization candidate (copyInitDeclaration.chpl:15)
+|
+|  Start analyzing call (copyInitDeclaration.chpl:15)
+|   Can't determine the domain of access base (copyInitDeclaration.chpl:8)
+|  This call is a dynamic optimization candidate (copyInitDeclaration.chpl:15)
+|
+End analyzing forall (copyInitDeclaration.chpl:14)
 
-Loop is suitable for static and dynamic analysis
-	copyInitDeclaration.chpl:14
-
-Potential access
-	copyInitDeclaration.chpl:15
-
-	with domain defined at
-	copyInitDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	copyInitDeclaration.chpl:15
-
-Potential access
-	copyInitDeclaration.chpl:15
-
-	with domain defined at
-	copyInitDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	copyInitDeclaration.chpl:15
-
-Potential access
-	copyInitDeclaration.chpl:15
-
-	regular domain symbol was not found for array
-	copyInitDeclaration.chpl:8
-
-	Marking static candidate
-	copyInitDeclaration.chpl:15
-
-	Marking static candidate
-	copyInitDeclaration.chpl:15
-
-	Marking dynamic candidate
-	copyInitDeclaration.chpl:15
-
-**** End forall ****
-	copyInitDeclaration.chpl:14
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess with dynamic check
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess with dynamic check (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0

--- a/test/optimizations/autoLocalAccess/differentButAlignedDoms.good
+++ b/test/optimizations/autoLocalAccess/differentButAlignedDoms.good
@@ -1,222 +1,112 @@
-**** Start forall ****
-	differentButAlignedDoms.chpl:21
 
-Iterated symbol
-	differentButAlignedDoms.chpl:20
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:21
-
-Potential access
-	differentButAlignedDoms.chpl:22
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:22
-
-**** End forall ****
-	differentButAlignedDoms.chpl:21
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:31
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:31
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:31
-
-Potential access
-	differentButAlignedDoms.chpl:32
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:32
-
-**** End forall ****
-	differentButAlignedDoms.chpl:31
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:44
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:44
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:44
-
-Potential access
-	differentButAlignedDoms.chpl:45
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:45
-
-**** End forall ****
-	differentButAlignedDoms.chpl:44
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:50
-
-Iterated symbol
-	differentButAlignedDoms.chpl:48
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:50
-
-Potential access
-	differentButAlignedDoms.chpl:51
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:51
-
-**** End forall ****
-	differentButAlignedDoms.chpl:50
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:55
-
-Iterated symbol
-	differentButAlignedDoms.chpl:54
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:55
-
-Potential access
-	differentButAlignedDoms.chpl:56
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:56
-
-**** End forall ****
-	differentButAlignedDoms.chpl:55
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:44
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:44
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:44
-
-Potential access
-	differentButAlignedDoms.chpl:45
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:45
-
-**** End forall ****
-	differentButAlignedDoms.chpl:44
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:50
-
-Iterated symbol
-	differentButAlignedDoms.chpl:48
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:50
-
-Potential access
-	differentButAlignedDoms.chpl:51
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:51
-
-**** End forall ****
-	differentButAlignedDoms.chpl:50
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:55
-
-Iterated symbol
-	differentButAlignedDoms.chpl:54
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:55
-
-Potential access
-	differentButAlignedDoms.chpl:56
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:56
-
-**** End forall ****
-	differentButAlignedDoms.chpl:55
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:67
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:67
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:67
-
-Potential access
-	differentButAlignedDoms.chpl:68
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:68
-
-**** End forall ****
-	differentButAlignedDoms.chpl:67
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:73
-
-Iterated symbol
-	differentButAlignedDoms.chpl:71
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:73
-
-Potential access
-	differentButAlignedDoms.chpl:74
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:74
-
-**** End forall ****
-	differentButAlignedDoms.chpl:73
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:22
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:32
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:45
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:51
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:56
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:68
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:74
-
+Start analyzing forall (differentButAlignedDoms.chpl:21)
+| Found loop domain (differentButAlignedDoms.chpl:20)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:21)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:22)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:22)
+|
+End analyzing forall (differentButAlignedDoms.chpl:21)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:31)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:31)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:32)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:32)
+|
+End analyzing forall (differentButAlignedDoms.chpl:31)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:44)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:44)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:45)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:45)
+|
+End analyzing forall (differentButAlignedDoms.chpl:44)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:50)
+| Found loop domain (differentButAlignedDoms.chpl:48)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:50)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:51)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:51)
+|
+End analyzing forall (differentButAlignedDoms.chpl:50)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:55)
+| Found loop domain (differentButAlignedDoms.chpl:54)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:55)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:56)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:56)
+|
+End analyzing forall (differentButAlignedDoms.chpl:55)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:44)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:44)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:45)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:45)
+|
+End analyzing forall (differentButAlignedDoms.chpl:44)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:50)
+| Found loop domain (differentButAlignedDoms.chpl:48)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:50)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:51)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:51)
+|
+End analyzing forall (differentButAlignedDoms.chpl:50)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:55)
+| Found loop domain (differentButAlignedDoms.chpl:54)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:55)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:56)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:56)
+|
+End analyzing forall (differentButAlignedDoms.chpl:55)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:67)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:67)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:68)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:68)
+|
+End analyzing forall (differentButAlignedDoms.chpl:67)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:73)
+| Found loop domain (differentButAlignedDoms.chpl:71)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:73)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:74)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:74)
+|
+End analyzing forall (differentButAlignedDoms.chpl:73)
+
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:22)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:32)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:45)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:51)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:56)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:68)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:74)
 Iterand is a different symbol
 Custom localAccess was called
 Custom localAccess was called

--- a/test/optimizations/autoLocalAccess/dotDomDeclaration.good
+++ b/test/optimizations/autoLocalAccess/dotDomDeclaration.good
@@ -1,231 +1,100 @@
-**** Start forall ****
-	dotDomDeclaration.chpl:14
 
-Iterated symbol
-	dotDomDeclaration.chpl:4
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:14
-
-Potential access
-	dotDomDeclaration.chpl:15
-
-	with domain defined at
-	dotDomDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	dotDomDeclaration.chpl:15
-
-Potential access
-	dotDomDeclaration.chpl:15
-
-	with domain defined at
-	dotDomDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	dotDomDeclaration.chpl:15
-
-Potential access
-	dotDomDeclaration.chpl:15
-
-	with domain defined at
-	dotDomDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	dotDomDeclaration.chpl:15
-
-	Marking static candidate
-	dotDomDeclaration.chpl:15
-
-	Marking static candidate
-	dotDomDeclaration.chpl:15
-
-	Marking static candidate
-	dotDomDeclaration.chpl:15
-
-**** End forall ****
-	dotDomDeclaration.chpl:14
-
-**** Start forall ****
-	dotDomDeclaration.chpl:31
-
-Iterated over the domain of
-	dotDomDeclaration.chpl:23
-
-, which is
-	dotDomDeclaration.chpl:21
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:31
-
-Potential access
-	dotDomDeclaration.chpl:32
-
-	Can optimize: Access base is the iterator's base
-	dotDomDeclaration.chpl:32
-
-Potential access
-	dotDomDeclaration.chpl:32
-
-	with domain defined at
-	dotDomDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:32
-
-Potential access
-	dotDomDeclaration.chpl:32
-
-	with domain defined at
-	dotDomDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:32
-
-	Marking static candidate
-	dotDomDeclaration.chpl:32
-
-	Marking static candidate
-	dotDomDeclaration.chpl:32
-
-	Marking static candidate
-	dotDomDeclaration.chpl:32
-
-**** End forall ****
-	dotDomDeclaration.chpl:31
-
-**** Start forall ****
-	dotDomDeclaration.chpl:48
-
-Iterated over the domain of
-	dotDomDeclaration.chpl:41
-
-, which is
-	dotDomDeclaration.chpl:38
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:48
-
-Potential access
-	dotDomDeclaration.chpl:49
-
-	with domain defined at
-	dotDomDeclaration.chpl:38
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:49
-
-Potential access
-	dotDomDeclaration.chpl:49
-
-	Can optimize: Access base is the iterator's base
-	dotDomDeclaration.chpl:49
-
-Potential access
-	dotDomDeclaration.chpl:49
-
-	with domain defined at
-	dotDomDeclaration.chpl:38
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:49
-
-	Marking static candidate
-	dotDomDeclaration.chpl:49
-
-	Marking static candidate
-	dotDomDeclaration.chpl:49
-
-	Marking static candidate
-	dotDomDeclaration.chpl:49
-
-**** End forall ****
-	dotDomDeclaration.chpl:48
-
-**** Start forall ****
-	dotDomDeclaration.chpl:65
-
-Iterated over the domain of
-	dotDomDeclaration.chpl:59
-
-, which is
-	dotDomDeclaration.chpl:55
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:65
-
-Potential access
-	dotDomDeclaration.chpl:66
-
-	with domain defined at
-	dotDomDeclaration.chpl:55
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:66
-
-Potential access
-	dotDomDeclaration.chpl:66
-
-	with domain defined at
-	dotDomDeclaration.chpl:55
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:66
-
-Potential access
-	dotDomDeclaration.chpl:66
-
-	Can optimize: Access base is the iterator's base
-	dotDomDeclaration.chpl:66
-
-	Marking static candidate
-	dotDomDeclaration.chpl:66
-
-	Marking static candidate
-	dotDomDeclaration.chpl:66
-
-	Marking static candidate
-	dotDomDeclaration.chpl:66
-
-**** End forall ****
-	dotDomDeclaration.chpl:65
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:49
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:49
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:49
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:66
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:66
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:66
-
+Start analyzing forall (dotDomDeclaration.chpl:14)
+| Found loop domain (dotDomDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:14)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:15)
+|   Found the domain of the access base (dotDomDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (dotDomDeclaration.chpl:15)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:15)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:15)
+|   Found the domain of the access base (dotDomDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (dotDomDeclaration.chpl:15)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:15)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:15)
+|   Found the domain of the access base (dotDomDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (dotDomDeclaration.chpl:15)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:15)
+|
+End analyzing forall (dotDomDeclaration.chpl:14)
+
+
+Start analyzing forall (dotDomDeclaration.chpl:31)
+| Found loop domain (dotDomDeclaration.chpl:23)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:31)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:32)
+|   Can optimize: Access base is the iterator's base (dotDomDeclaration.chpl:32)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:32)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:32)
+|   Found the domain of the access base (dotDomDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:32)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:32)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:32)
+|   Found the domain of the access base (dotDomDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:32)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:32)
+|
+End analyzing forall (dotDomDeclaration.chpl:31)
+
+
+Start analyzing forall (dotDomDeclaration.chpl:48)
+| Found loop domain (dotDomDeclaration.chpl:41)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:48)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:49)
+|   Found the domain of the access base (dotDomDeclaration.chpl:38)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:49)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:49)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:49)
+|   Can optimize: Access base is the iterator's base (dotDomDeclaration.chpl:49)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:49)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:49)
+|   Found the domain of the access base (dotDomDeclaration.chpl:38)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:49)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:49)
+|
+End analyzing forall (dotDomDeclaration.chpl:48)
+
+
+Start analyzing forall (dotDomDeclaration.chpl:65)
+| Found loop domain (dotDomDeclaration.chpl:59)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:65)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:66)
+|   Found the domain of the access base (dotDomDeclaration.chpl:55)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:66)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:66)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:66)
+|   Found the domain of the access base (dotDomDeclaration.chpl:55)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:66)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:66)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:66)
+|   Can optimize: Access base is the iterator's base (dotDomDeclaration.chpl:66)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:66)
+|
+End analyzing forall (dotDomDeclaration.chpl:65)
+
+Static check successful. Using localAccess (dotDomDeclaration.chpl:15)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:15)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:15)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:32)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:32)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:32)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:49)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:49)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:49)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:66)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:66)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:66)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0

--- a/test/optimizations/autoLocalAccess/dynamicCheckInGenericFunction.good
+++ b/test/optimizations/autoLocalAccess/dynamicCheckInGenericFunction.good
@@ -1,36 +1,16 @@
-**** Start forall ****
-	dynamicCheckInGenericFunction.chpl:16
 
-Iterated over the domain of
-	dynamicCheckInGenericFunction.chpl:13
+Start analyzing forall (dynamicCheckInGenericFunction.chpl:16)
+| Found loop domain (dynamicCheckInGenericFunction.chpl:13)
+| Will attempt static and dynamic optimizations (dynamicCheckInGenericFunction.chpl:16)
+|
+|  Start analyzing call (dynamicCheckInGenericFunction.chpl:17)
+|   Can optimize: Access base is the iterator's base (dynamicCheckInGenericFunction.chpl:17)
+|  This call is a static optimization candidate (dynamicCheckInGenericFunction.chpl:17)
+|
+|  Start analyzing call (dynamicCheckInGenericFunction.chpl:17)
+|   Can't determine the domain of access base (dynamicCheckInGenericFunction.chpl:13)
+|  This call is a dynamic optimization candidate (dynamicCheckInGenericFunction.chpl:17)
+|
+End analyzing forall (dynamicCheckInGenericFunction.chpl:16)
 
-, whose domain cannot be determined statically
-	dynamicCheckInGenericFunction.chpl:13
-
-Loop is suitable for static and dynamic analysis
-	dynamicCheckInGenericFunction.chpl:16
-
-Potential access
-	dynamicCheckInGenericFunction.chpl:17
-
-	Can optimize: Access base is the iterator's base
-	dynamicCheckInGenericFunction.chpl:17
-
-Potential access
-	dynamicCheckInGenericFunction.chpl:17
-
-	regular domain symbol was not found for array
-	dynamicCheckInGenericFunction.chpl:13
-
-	Marking static candidate
-	dynamicCheckInGenericFunction.chpl:17
-
-	Marking dynamic candidate
-	dynamicCheckInGenericFunction.chpl:17
-
-**** End forall ****
-	dynamicCheckInGenericFunction.chpl:16
-
-Static check successful. Using localAccess
-	dynamicCheckInGenericFunction.chpl:17
-
+Static check successful. Using localAccess (dynamicCheckInGenericFunction.chpl:17)

--- a/test/optimizations/autoLocalAccess/dynamicChecks.good
+++ b/test/optimizations/autoLocalAccess/dynamicChecks.good
@@ -1,85 +1,37 @@
-**** Start forall ****
-	dynamicChecks.chpl:28
 
-Iterated symbol
-	dynamicChecks.chpl:16
+Start analyzing forall (dynamicChecks.chpl:28)
+| Found loop domain (dynamicChecks.chpl:16)
+| Will attempt static and dynamic optimizations (dynamicChecks.chpl:28)
+|
+|  Start analyzing call (dynamicChecks.chpl:29)
+|   Found the domain of the access base (dynamicChecks.chpl:16)
+|   Can optimize: Access base's domain is the iterator (dynamicChecks.chpl:29)
+|  This call is a static optimization candidate (dynamicChecks.chpl:29)
+|
+|  Start analyzing call (dynamicChecks.chpl:29)
+|   Found the domain of the access base (dynamicChecks.chpl:16)
+|   Can optimize: Access base's domain is the iterator (dynamicChecks.chpl:29)
+|  This call is a static optimization candidate (dynamicChecks.chpl:29)
+|
+|  Start analyzing call (dynamicChecks.chpl:30)
+|   Can't determine the domain of access base (dynamicChecks.chpl:20)
+|  This call is a dynamic optimization candidate (dynamicChecks.chpl:30)
+|
+|  Start analyzing call (dynamicChecks.chpl:31)
+|   Found the domain of the access base (dynamicChecks.chpl:15)
+|  This call is a dynamic optimization candidate (dynamicChecks.chpl:31)
+|
+|  Start analyzing call (dynamicChecks.chpl:32)
+|   Can't determine the domain of access base (dynamicChecks.chpl:22)
+|  This call is a dynamic optimization candidate (dynamicChecks.chpl:32)
+|
+End analyzing forall (dynamicChecks.chpl:28)
 
-Loop is suitable for static and dynamic analysis
-	dynamicChecks.chpl:28
-
-Potential access
-	dynamicChecks.chpl:29
-
-	with domain defined at
-	dynamicChecks.chpl:16
-
-	Can optimize: Access base's domain is the iterator
-	dynamicChecks.chpl:29
-
-Potential access
-	dynamicChecks.chpl:29
-
-	with domain defined at
-	dynamicChecks.chpl:16
-
-	Can optimize: Access base's domain is the iterator
-	dynamicChecks.chpl:29
-
-Potential access
-	dynamicChecks.chpl:30
-
-	regular domain symbol was not found for array
-	dynamicChecks.chpl:20
-
-Potential access
-	dynamicChecks.chpl:31
-
-	with domain defined at
-	dynamicChecks.chpl:15
-
-Potential access
-	dynamicChecks.chpl:32
-
-	regular domain symbol was not found for array
-	dynamicChecks.chpl:22
-
-	Marking static candidate
-	dynamicChecks.chpl:29
-
-	Marking static candidate
-	dynamicChecks.chpl:29
-
-	Marking dynamic candidate
-	dynamicChecks.chpl:30
-
-	Marking dynamic candidate
-	dynamicChecks.chpl:31
-
-	Marking dynamic candidate
-	dynamicChecks.chpl:32
-
-**** End forall ****
-	dynamicChecks.chpl:28
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
-Static check successful. Using localAccess with dynamic check
-	dynamicChecks.chpl:30
-
-Static check failed. Reverting optimization
-	dynamicChecks.chpl:31
-
-Static check failed. Reverting optimization
-	dynamicChecks.chpl:32
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
+Static check successful. Using localAccess with dynamic check (dynamicChecks.chpl:30)
+Static check failed. Reverting optimization (dynamicChecks.chpl:31)
+Static check failed. Reverting optimization (dynamicChecks.chpl:32)
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0 30.0 33.0

--- a/test/optimizations/autoLocalAccess/elemAsIndex.good
+++ b/test/optimizations/autoLocalAccess/elemAsIndex.good
@@ -1,23 +1,13 @@
-**** Start forall ****
-	elemAsIndex.chpl:19
 
-Iterated symbol
-	elemAsIndex.chpl:15
-
-Loop is suitable for static and dynamic analysis
-	elemAsIndex.chpl:19
-
-Potential access
-	elemAsIndex.chpl:20
-
-	regular domain symbol was not found for array
-	elemAsIndex.chpl:15
-
-	Marking dynamic candidate
-	elemAsIndex.chpl:20
-
-**** End forall ****
-	elemAsIndex.chpl:19
+Start analyzing forall (elemAsIndex.chpl:19)
+| Found loop domain (elemAsIndex.chpl:15)
+| Will attempt static and dynamic optimizations (elemAsIndex.chpl:19)
+|
+|  Start analyzing call (elemAsIndex.chpl:20)
+|   Can't determine the domain of access base (elemAsIndex.chpl:15)
+|  This call is a dynamic optimization candidate (elemAsIndex.chpl:20)
+|
+End analyzing forall (elemAsIndex.chpl:19)
 
 Custom this was called
 Custom this was called

--- a/test/optimizations/autoLocalAccess/functionArgs.good
+++ b/test/optimizations/autoLocalAccess/functionArgs.good
@@ -1,393 +1,172 @@
-**** Start forall ****
-	functionArgs.chpl:11
 
-Iterated over the domain of
-	functionArgs.chpl:10
-
-, which is
-	functionArgs.chpl:10
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:11
-
-Potential access
-	functionArgs.chpl:12
-
-	Can optimize: Access base is the iterator's base
-	functionArgs.chpl:12
-
-Potential access
-	functionArgs.chpl:13
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:13
-
-	Marking static candidate
-	functionArgs.chpl:12
-
-	Marking static candidate
-	functionArgs.chpl:13
-
-**** End forall ****
-	functionArgs.chpl:11
-
-**** Start forall ****
-	functionArgs.chpl:17
-
-Iterated over the domain of
-	functionArgs.chpl:10
-
-, which is
-	functionArgs.chpl:10
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:17
-
-Potential access
-	functionArgs.chpl:18
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:18
-
-Potential access
-	functionArgs.chpl:19
-
-	Can optimize: Access base is the iterator's base
-	functionArgs.chpl:19
-
-	Marking static candidate
-	functionArgs.chpl:18
-
-	Marking static candidate
-	functionArgs.chpl:19
-
-**** End forall ****
-	functionArgs.chpl:17
-
-**** Start forall ****
-	functionArgs.chpl:23
-
-Iterated symbol
-	functionArgs.chpl:10
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:23
-
-Potential access
-	functionArgs.chpl:24
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:24
-
-Potential access
-	functionArgs.chpl:25
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:25
-
-	Marking static candidate
-	functionArgs.chpl:24
-
-	Marking static candidate
-	functionArgs.chpl:25
-
-**** End forall ****
-	functionArgs.chpl:23
-
-**** Start forall ****
-	functionArgs.chpl:31
-
-Iterated over the domain of
-	functionArgs.chpl:5
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:31
-
-Potential access
-	functionArgs.chpl:32
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:32
-
-Potential access
-	functionArgs.chpl:33
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:33
-
-	Marking static candidate
-	functionArgs.chpl:32
-
-	Marking static candidate
-	functionArgs.chpl:33
-
-**** End forall ****
-	functionArgs.chpl:31
-
-**** Start forall ****
-	functionArgs.chpl:37
-
-Iterated over the domain of
-	functionArgs.chpl:6
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:37
-
-Potential access
-	functionArgs.chpl:38
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:38
-
-Potential access
-	functionArgs.chpl:39
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:39
-
-	Marking static candidate
-	functionArgs.chpl:38
-
-	Marking static candidate
-	functionArgs.chpl:39
-
-**** End forall ****
-	functionArgs.chpl:37
-
-**** Start forall ****
-	functionArgs.chpl:43
-
-Iterated symbol
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:43
-
-Potential access
-	functionArgs.chpl:44
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:44
-
-Potential access
-	functionArgs.chpl:45
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:45
-
-	Marking static candidate
-	functionArgs.chpl:44
-
-	Marking static candidate
-	functionArgs.chpl:45
-
-**** End forall ****
-	functionArgs.chpl:43
-
-**** Start forall ****
-	functionArgs.chpl:51
-
-Iterated over the domain of
-	functionArgs.chpl:5
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:51
-
-Potential access
-	functionArgs.chpl:52
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:52
-
-Potential access
-	functionArgs.chpl:53
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:53
-
-	Marking static candidate
-	functionArgs.chpl:52
-
-	Marking static candidate
-	functionArgs.chpl:53
-
-**** End forall ****
-	functionArgs.chpl:51
-
-**** Start forall ****
-	functionArgs.chpl:57
-
-Iterated over the domain of
-	functionArgs.chpl:6
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:57
-
-Potential access
-	functionArgs.chpl:58
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:58
-
-Potential access
-	functionArgs.chpl:59
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:59
-
-	Marking static candidate
-	functionArgs.chpl:58
-
-	Marking static candidate
-	functionArgs.chpl:59
-
-**** End forall ****
-	functionArgs.chpl:57
-
-**** Start forall ****
-	functionArgs.chpl:63
-
-Iterated symbol
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:63
-
-Potential access
-	functionArgs.chpl:64
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:64
-
-Potential access
-	functionArgs.chpl:65
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:65
-
-	Marking static candidate
-	functionArgs.chpl:64
-
-	Marking static candidate
-	functionArgs.chpl:65
-
-**** End forall ****
-	functionArgs.chpl:63
-
-Static check successful. Using localAccess
-	functionArgs.chpl:12
-
-Static check successful. Using localAccess
-	functionArgs.chpl:13
-
-Static check successful. Using localAccess
-	functionArgs.chpl:18
-
-Static check successful. Using localAccess
-	functionArgs.chpl:19
-
-Static check successful. Using localAccess
-	functionArgs.chpl:24
-
-Static check successful. Using localAccess
-	functionArgs.chpl:25
-
-Static check successful. Using localAccess
-	functionArgs.chpl:32
-
-Static check successful. Using localAccess
-	functionArgs.chpl:33
-
-Static check successful. Using localAccess
-	functionArgs.chpl:38
-
-Static check successful. Using localAccess
-	functionArgs.chpl:39
-
-Static check successful. Using localAccess
-	functionArgs.chpl:44
-
-Static check successful. Using localAccess
-	functionArgs.chpl:45
-
-Static check successful. Using localAccess
-	functionArgs.chpl:52
-
-Static check successful. Using localAccess
-	functionArgs.chpl:53
-
-Static check successful. Using localAccess
-	functionArgs.chpl:58
-
-Static check successful. Using localAccess
-	functionArgs.chpl:59
-
-Static check successful. Using localAccess
-	functionArgs.chpl:64
-
-Static check successful. Using localAccess
-	functionArgs.chpl:65
-
+Start analyzing forall (functionArgs.chpl:11)
+| Found loop domain (functionArgs.chpl:10)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:11)
+|
+|  Start analyzing call (functionArgs.chpl:12)
+|   Can optimize: Access base is the iterator's base (functionArgs.chpl:12)
+|  This call is a static optimization candidate (functionArgs.chpl:12)
+|
+|  Start analyzing call (functionArgs.chpl:13)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:13)
+|  This call is a static optimization candidate (functionArgs.chpl:13)
+|
+End analyzing forall (functionArgs.chpl:11)
+
+
+Start analyzing forall (functionArgs.chpl:17)
+| Found loop domain (functionArgs.chpl:10)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:17)
+|
+|  Start analyzing call (functionArgs.chpl:18)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:18)
+|  This call is a static optimization candidate (functionArgs.chpl:18)
+|
+|  Start analyzing call (functionArgs.chpl:19)
+|   Can optimize: Access base is the iterator's base (functionArgs.chpl:19)
+|  This call is a static optimization candidate (functionArgs.chpl:19)
+|
+End analyzing forall (functionArgs.chpl:17)
+
+
+Start analyzing forall (functionArgs.chpl:23)
+| Found loop domain (functionArgs.chpl:10)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:23)
+|
+|  Start analyzing call (functionArgs.chpl:24)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:24)
+|  This call is a static optimization candidate (functionArgs.chpl:24)
+|
+|  Start analyzing call (functionArgs.chpl:25)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:25)
+|  This call is a static optimization candidate (functionArgs.chpl:25)
+|
+End analyzing forall (functionArgs.chpl:23)
+
+
+Start analyzing forall (functionArgs.chpl:31)
+| Found loop domain (functionArgs.chpl:5)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:31)
+|
+|  Start analyzing call (functionArgs.chpl:32)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:32)
+|  This call is a static optimization candidate (functionArgs.chpl:32)
+|
+|  Start analyzing call (functionArgs.chpl:33)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:33)
+|  This call is a static optimization candidate (functionArgs.chpl:33)
+|
+End analyzing forall (functionArgs.chpl:31)
+
+
+Start analyzing forall (functionArgs.chpl:37)
+| Found loop domain (functionArgs.chpl:6)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:37)
+|
+|  Start analyzing call (functionArgs.chpl:38)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:38)
+|  This call is a static optimization candidate (functionArgs.chpl:38)
+|
+|  Start analyzing call (functionArgs.chpl:39)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:39)
+|  This call is a static optimization candidate (functionArgs.chpl:39)
+|
+End analyzing forall (functionArgs.chpl:37)
+
+
+Start analyzing forall (functionArgs.chpl:43)
+| Found loop domain (functionArgs.chpl:3)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:43)
+|
+|  Start analyzing call (functionArgs.chpl:44)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:44)
+|  This call is a static optimization candidate (functionArgs.chpl:44)
+|
+|  Start analyzing call (functionArgs.chpl:45)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:45)
+|  This call is a static optimization candidate (functionArgs.chpl:45)
+|
+End analyzing forall (functionArgs.chpl:43)
+
+
+Start analyzing forall (functionArgs.chpl:51)
+| Found loop domain (functionArgs.chpl:5)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:51)
+|
+|  Start analyzing call (functionArgs.chpl:52)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:52)
+|  This call is a static optimization candidate (functionArgs.chpl:52)
+|
+|  Start analyzing call (functionArgs.chpl:53)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:53)
+|  This call is a static optimization candidate (functionArgs.chpl:53)
+|
+End analyzing forall (functionArgs.chpl:51)
+
+
+Start analyzing forall (functionArgs.chpl:57)
+| Found loop domain (functionArgs.chpl:6)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:57)
+|
+|  Start analyzing call (functionArgs.chpl:58)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:58)
+|  This call is a static optimization candidate (functionArgs.chpl:58)
+|
+|  Start analyzing call (functionArgs.chpl:59)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:59)
+|  This call is a static optimization candidate (functionArgs.chpl:59)
+|
+End analyzing forall (functionArgs.chpl:57)
+
+
+Start analyzing forall (functionArgs.chpl:63)
+| Found loop domain (functionArgs.chpl:3)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:63)
+|
+|  Start analyzing call (functionArgs.chpl:64)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:64)
+|  This call is a static optimization candidate (functionArgs.chpl:64)
+|
+|  Start analyzing call (functionArgs.chpl:65)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:65)
+|  This call is a static optimization candidate (functionArgs.chpl:65)
+|
+End analyzing forall (functionArgs.chpl:63)
+
+Static check successful. Using localAccess (functionArgs.chpl:12)
+Static check successful. Using localAccess (functionArgs.chpl:13)
+Static check successful. Using localAccess (functionArgs.chpl:18)
+Static check successful. Using localAccess (functionArgs.chpl:19)
+Static check successful. Using localAccess (functionArgs.chpl:24)
+Static check successful. Using localAccess (functionArgs.chpl:25)
+Static check successful. Using localAccess (functionArgs.chpl:32)
+Static check successful. Using localAccess (functionArgs.chpl:33)
+Static check successful. Using localAccess (functionArgs.chpl:38)
+Static check successful. Using localAccess (functionArgs.chpl:39)
+Static check successful. Using localAccess (functionArgs.chpl:44)
+Static check successful. Using localAccess (functionArgs.chpl:45)
+Static check successful. Using localAccess (functionArgs.chpl:52)
+Static check successful. Using localAccess (functionArgs.chpl:53)
+Static check successful. Using localAccess (functionArgs.chpl:58)
+Static check successful. Using localAccess (functionArgs.chpl:59)
+Static check successful. Using localAccess (functionArgs.chpl:64)
+Static check successful. Using localAccess (functionArgs.chpl:65)
 10 10 10 10 10 10 10 10 10 10
 20 20 20 20 20 20 20 20 20 20
 30 30 30 30 30 30 30 30 30 30

--- a/test/optimizations/autoLocalAccess/interveningForallOrOn.good
+++ b/test/optimizations/autoLocalAccess/interveningForallOrOn.good
@@ -1,42 +1,23 @@
-**** Start forall ****
-	interveningForallOrOn.chpl:12
 
-Loop iterand is a call. Will attempt dynamic optimization.
-	interveningForallOrOn.chpl:12
+Start analyzing forall (interveningForallOrOn.chpl:12)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (interveningForallOrOn.chpl:12)
+|
+|  Start analyzing call (interveningForallOrOn.chpl:13)
+|  This call is a dynamic optimization candidate (interveningForallOrOn.chpl:13)
+|
+End analyzing forall (interveningForallOrOn.chpl:12)
 
-Loop is suitable for dynamic analysis only
-	interveningForallOrOn.chpl:12
 
-Potential access
-	interveningForallOrOn.chpl:13
+Start analyzing forall (interveningForallOrOn.chpl:11)
+| Found loop domain (interveningForallOrOn.chpl:5)
+| Will attempt static and dynamic optimizations (interveningForallOrOn.chpl:11)
+|
+End analyzing forall (interveningForallOrOn.chpl:11)
 
-	Marking dynamic candidate
-	interveningForallOrOn.chpl:13
 
-**** End forall ****
-	interveningForallOrOn.chpl:12
-
-**** Start forall ****
-	interveningForallOrOn.chpl:11
-
-Iterated symbol
-	interveningForallOrOn.chpl:5
-
-Loop is suitable for static and dynamic analysis
-	interveningForallOrOn.chpl:11
-
-**** End forall ****
-	interveningForallOrOn.chpl:11
-
-**** Start forall ****
-	interveningForallOrOn.chpl:25
-
-Iterated symbol
-	interveningForallOrOn.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	interveningForallOrOn.chpl:25
-
-**** End forall ****
-	interveningForallOrOn.chpl:25
+Start analyzing forall (interveningForallOrOn.chpl:25)
+| Found loop domain (interveningForallOrOn.chpl:19)
+| Will attempt static and dynamic optimizations (interveningForallOrOn.chpl:25)
+|
+End analyzing forall (interveningForallOrOn.chpl:25)
 

--- a/test/optimizations/autoLocalAccess/multipleAccessDynamic.good
+++ b/test/optimizations/autoLocalAccess/multipleAccessDynamic.good
@@ -1,54 +1,23 @@
-**** Start forall ****
-	multipleAccessDynamic.chpl:7
 
-Iterated over the domain of
-	multipleAccessDynamic.chpl:3
+Start analyzing forall (multipleAccessDynamic.chpl:7)
+| Found loop domain (multipleAccessDynamic.chpl:3)
+| Will attempt static and dynamic optimizations (multipleAccessDynamic.chpl:7)
+|
+|  Start analyzing call (multipleAccessDynamic.chpl:9)
+|   Can optimize: Access base is the iterator's base (multipleAccessDynamic.chpl:9)
+|  This call is a static optimization candidate (multipleAccessDynamic.chpl:9)
+|
+|  Start analyzing call (multipleAccessDynamic.chpl:9)
+|   Can't determine the domain of access base (multipleAccessDynamic.chpl:4)
+|  This call is a dynamic optimization candidate (multipleAccessDynamic.chpl:9)
+|
+|  Start analyzing call (multipleAccessDynamic.chpl:9)
+|   Can't determine the domain of access base (multipleAccessDynamic.chpl:4)
+|  This call is a dynamic optimization candidate (multipleAccessDynamic.chpl:9)
+|
+End analyzing forall (multipleAccessDynamic.chpl:7)
 
-, whose domain cannot be determined statically
-	multipleAccessDynamic.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	multipleAccessDynamic.chpl:7
-
-Potential access
-	multipleAccessDynamic.chpl:9
-
-	Can optimize: Access base is the iterator's base
-	multipleAccessDynamic.chpl:9
-
-Potential access
-	multipleAccessDynamic.chpl:9
-
-	regular domain symbol was not found for array
-	multipleAccessDynamic.chpl:4
-
-Potential access
-	multipleAccessDynamic.chpl:9
-
-	regular domain symbol was not found for array
-	multipleAccessDynamic.chpl:4
-
-	Marking static candidate
-	multipleAccessDynamic.chpl:9
-
-	Marking dynamic candidate
-	multipleAccessDynamic.chpl:9
-
-	Marking dynamic candidate
-	multipleAccessDynamic.chpl:9
-
-**** End forall ****
-	multipleAccessDynamic.chpl:7
-
-Static check successful. Using localAccess
-	multipleAccessDynamic.chpl:9
-
-Static check successful. Using localAccess with dynamic check
-	multipleAccessDynamic.chpl:9
-
-Static check successful. Using localAccess with dynamic check
-	multipleAccessDynamic.chpl:9
-
-Static check successful. Using localAccess
-	multipleAccessDynamic.chpl:9
-
+Static check successful. Using localAccess (multipleAccessDynamic.chpl:9)
+Static check successful. Using localAccess with dynamic check (multipleAccessDynamic.chpl:9)
+Static check successful. Using localAccess with dynamic check (multipleAccessDynamic.chpl:9)
+Static check successful. Using localAccess (multipleAccessDynamic.chpl:9)

--- a/test/optimizations/autoLocalAccess/multipleAccessStatic.good
+++ b/test/optimizations/autoLocalAccess/multipleAccessStatic.good
@@ -1,42 +1,19 @@
-**** Start forall ****
-	multipleAccessStatic.chpl:8
 
-Iterated symbol
-	multipleAccessStatic.chpl:3
+Start analyzing forall (multipleAccessStatic.chpl:8)
+| Found loop domain (multipleAccessStatic.chpl:3)
+| Will attempt static and dynamic optimizations (multipleAccessStatic.chpl:8)
+|
+|  Start analyzing call (multipleAccessStatic.chpl:10)
+|   Found the domain of the access base (multipleAccessStatic.chpl:3)
+|   Can optimize: Access base's domain is the iterator (multipleAccessStatic.chpl:10)
+|  This call is a static optimization candidate (multipleAccessStatic.chpl:10)
+|
+|  Start analyzing call (multipleAccessStatic.chpl:10)
+|   Found the domain of the access base (multipleAccessStatic.chpl:3)
+|   Can optimize: Access base's domain is the iterator (multipleAccessStatic.chpl:10)
+|  This call is a static optimization candidate (multipleAccessStatic.chpl:10)
+|
+End analyzing forall (multipleAccessStatic.chpl:8)
 
-Loop is suitable for static and dynamic analysis
-	multipleAccessStatic.chpl:8
-
-Potential access
-	multipleAccessStatic.chpl:10
-
-	with domain defined at
-	multipleAccessStatic.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	multipleAccessStatic.chpl:10
-
-Potential access
-	multipleAccessStatic.chpl:10
-
-	with domain defined at
-	multipleAccessStatic.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	multipleAccessStatic.chpl:10
-
-	Marking static candidate
-	multipleAccessStatic.chpl:10
-
-	Marking static candidate
-	multipleAccessStatic.chpl:10
-
-**** End forall ****
-	multipleAccessStatic.chpl:8
-
-Static check successful. Using localAccess
-	multipleAccessStatic.chpl:10
-
-Static check successful. Using localAccess
-	multipleAccessStatic.chpl:10
-
+Static check successful. Using localAccess (multipleAccessStatic.chpl:10)
+Static check successful. Using localAccess (multipleAccessStatic.chpl:10)

--- a/test/optimizations/autoLocalAccess/nonDomainIter.good
+++ b/test/optimizations/autoLocalAccess/nonDomainIter.good
@@ -1,30 +1,15 @@
-**** Start forall ****
-	nonDomainIter.chpl:19
 
-Iterated symbol
-	nonDomainIter.chpl:17
-
-Loop is suitable for static and dynamic analysis
-	nonDomainIter.chpl:19
-
-Potential access
-	nonDomainIter.chpl:20
-
-	regular domain symbol was not found for array
-	nonDomainIter.chpl:14
-
-Potential access
-	nonDomainIter.chpl:20
-
-	regular domain symbol was not found for array
-	nonDomainIter.chpl:15
-
-	Marking dynamic candidate
-	nonDomainIter.chpl:20
-
-	Marking dynamic candidate
-	nonDomainIter.chpl:20
-
-**** End forall ****
-	nonDomainIter.chpl:19
+Start analyzing forall (nonDomainIter.chpl:19)
+| Found loop domain (nonDomainIter.chpl:17)
+| Will attempt static and dynamic optimizations (nonDomainIter.chpl:19)
+|
+|  Start analyzing call (nonDomainIter.chpl:20)
+|   Can't determine the domain of access base (nonDomainIter.chpl:14)
+|  This call is a dynamic optimization candidate (nonDomainIter.chpl:20)
+|
+|  Start analyzing call (nonDomainIter.chpl:20)
+|   Can't determine the domain of access base (nonDomainIter.chpl:15)
+|  This call is a dynamic optimization candidate (nonDomainIter.chpl:20)
+|
+End analyzing forall (nonDomainIter.chpl:19)
 

--- a/test/optimizations/autoLocalAccess/oneStaticFailOtherDynamicSuccess.good
+++ b/test/optimizations/autoLocalAccess/oneStaticFailOtherDynamicSuccess.good
@@ -1,39 +1,20 @@
-**** Start forall ****
-	oneStaticFailOtherDynamicSuccess.chpl:23
 
-Iterated symbol
-	oneStaticFailOtherDynamicSuccess.chpl:16
+Start analyzing forall (oneStaticFailOtherDynamicSuccess.chpl:23)
+| Found loop domain (oneStaticFailOtherDynamicSuccess.chpl:16)
+| Will attempt static and dynamic optimizations (oneStaticFailOtherDynamicSuccess.chpl:23)
+|
+|  Start analyzing call (oneStaticFailOtherDynamicSuccess.chpl:24)
+|   Can't determine the domain of access base (oneStaticFailOtherDynamicSuccess.chpl:18)
+|  This call is a dynamic optimization candidate (oneStaticFailOtherDynamicSuccess.chpl:24)
+|
+|  Start analyzing call (oneStaticFailOtherDynamicSuccess.chpl:24)
+|   Can't determine the domain of access base (oneStaticFailOtherDynamicSuccess.chpl:19)
+|  This call is a dynamic optimization candidate (oneStaticFailOtherDynamicSuccess.chpl:24)
+|
+End analyzing forall (oneStaticFailOtherDynamicSuccess.chpl:23)
 
-Loop is suitable for static and dynamic analysis
-	oneStaticFailOtherDynamicSuccess.chpl:23
-
-Potential access
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-	regular domain symbol was not found for array
-	oneStaticFailOtherDynamicSuccess.chpl:18
-
-Potential access
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-	regular domain symbol was not found for array
-	oneStaticFailOtherDynamicSuccess.chpl:19
-
-	Marking dynamic candidate
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-	Marking dynamic candidate
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-**** End forall ****
-	oneStaticFailOtherDynamicSuccess.chpl:23
-
-Static check successful. Using localAccess with dynamic check
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-Static check failed. Reverting optimization
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
+Static check successful. Using localAccess with dynamic check (oneStaticFailOtherDynamicSuccess.chpl:24)
+Static check failed. Reverting optimization (oneStaticFailOtherDynamicSuccess.chpl:24)
 Custom localAccess was called
 Custom localAccess was called
 Custom localAccess was called

--- a/test/optimizations/autoLocalAccess/preventMultiCall.good
+++ b/test/optimizations/autoLocalAccess/preventMultiCall.good
@@ -1,42 +1,21 @@
-**** Start forall ****
-	preventMultiCall.chpl:29
 
-Loop iterand is a call. Will attempt dynamic optimization.
-	preventMultiCall.chpl:29
+Start analyzing forall (preventMultiCall.chpl:29)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (preventMultiCall.chpl:29)
+|
+|  Start analyzing call (preventMultiCall.chpl:30)
+|  This call is a dynamic optimization candidate (preventMultiCall.chpl:30)
+|
+|  Start analyzing call (preventMultiCall.chpl:31)
+|  This call is a dynamic optimization candidate (preventMultiCall.chpl:31)
+|
+|  Start analyzing call (preventMultiCall.chpl:32)
+|  This call is a dynamic optimization candidate (preventMultiCall.chpl:32)
+|
+End analyzing forall (preventMultiCall.chpl:29)
 
-Loop is suitable for dynamic analysis only
-	preventMultiCall.chpl:29
-
-Potential access
-	preventMultiCall.chpl:30
-
-Potential access
-	preventMultiCall.chpl:31
-
-Potential access
-	preventMultiCall.chpl:32
-
-	Marking dynamic candidate
-	preventMultiCall.chpl:30
-
-	Marking dynamic candidate
-	preventMultiCall.chpl:31
-
-	Marking dynamic candidate
-	preventMultiCall.chpl:32
-
-**** End forall ****
-	preventMultiCall.chpl:29
-
-Static check successful. Using localAccess with dynamic check
-	preventMultiCall.chpl:30
-
-Static check successful. Using localAccess with dynamic check
-	preventMultiCall.chpl:31
-
-Static check successful. Using localAccess with dynamic check
-	preventMultiCall.chpl:32
-
+Static check successful. Using localAccess with dynamic check (preventMultiCall.chpl:30)
+Static check successful. Using localAccess with dynamic check (preventMultiCall.chpl:31)
+Static check successful. Using localAccess with dynamic check (preventMultiCall.chpl:32)
 returnDom is called
 Custom localAccess was called
 Custom localAccess was called

--- a/test/optimizations/autoLocalAccess/preventMultiCallIter.good
+++ b/test/optimizations/autoLocalAccess/preventMultiCallIter.good
@@ -1,32 +1,17 @@
-**** Start forall ****
-	preventMultiCallIter.chpl:46
 
-Loop iterand is a call. Will attempt dynamic optimization.
-	preventMultiCallIter.chpl:46
-
-Loop is suitable for dynamic analysis only
-	preventMultiCallIter.chpl:46
-
-Potential access
-	preventMultiCallIter.chpl:47
-
-Potential access
-	preventMultiCallIter.chpl:48
-
-Potential access
-	preventMultiCallIter.chpl:49
-
-	Marking dynamic candidate
-	preventMultiCallIter.chpl:47
-
-	Marking dynamic candidate
-	preventMultiCallIter.chpl:48
-
-	Marking dynamic candidate
-	preventMultiCallIter.chpl:49
-
-**** End forall ****
-	preventMultiCallIter.chpl:46
+Start analyzing forall (preventMultiCallIter.chpl:46)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (preventMultiCallIter.chpl:46)
+|
+|  Start analyzing call (preventMultiCallIter.chpl:47)
+|  This call is a dynamic optimization candidate (preventMultiCallIter.chpl:47)
+|
+|  Start analyzing call (preventMultiCallIter.chpl:48)
+|  This call is a dynamic optimization candidate (preventMultiCallIter.chpl:48)
+|
+|  Start analyzing call (preventMultiCallIter.chpl:49)
+|  This call is a dynamic optimization candidate (preventMultiCallIter.chpl:49)
+|
+End analyzing forall (preventMultiCallIter.chpl:46)
 
 standalone iterator invoked
 Custom this was called

--- a/test/optimizations/autoLocalAccess/regularCommaDeclaration.good
+++ b/test/optimizations/autoLocalAccess/regularCommaDeclaration.good
@@ -1,116 +1,51 @@
-**** Start forall ****
-	regularCommaDeclaration.chpl:12
 
-Iterated symbol
-	regularCommaDeclaration.chpl:4
+Start analyzing forall (regularCommaDeclaration.chpl:12)
+| Found loop domain (regularCommaDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (regularCommaDeclaration.chpl:12)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:13)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularCommaDeclaration.chpl:13)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:13)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:13)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularCommaDeclaration.chpl:13)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:13)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:13)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularCommaDeclaration.chpl:13)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:13)
+|
+End analyzing forall (regularCommaDeclaration.chpl:12)
 
-Loop is suitable for static and dynamic analysis
-	regularCommaDeclaration.chpl:12
 
-Potential access
-	regularCommaDeclaration.chpl:13
+Start analyzing forall (regularCommaDeclaration.chpl:27)
+| Found loop domain (regularCommaDeclaration.chpl:21)
+| Will attempt static and dynamic optimizations (regularCommaDeclaration.chpl:27)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:28)
+|   Can optimize: Access base is the iterator's base (regularCommaDeclaration.chpl:28)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:28)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:28)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:19)
+|   Can optimize: Access base has the same domain as iterator's base (regularCommaDeclaration.chpl:28)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:28)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:28)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:19)
+|   Can optimize: Access base has the same domain as iterator's base (regularCommaDeclaration.chpl:28)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:28)
+|
+End analyzing forall (regularCommaDeclaration.chpl:27)
 
-	with domain defined at
-	regularCommaDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularCommaDeclaration.chpl:13
-
-Potential access
-	regularCommaDeclaration.chpl:13
-
-	with domain defined at
-	regularCommaDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularCommaDeclaration.chpl:13
-
-Potential access
-	regularCommaDeclaration.chpl:13
-
-	with domain defined at
-	regularCommaDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularCommaDeclaration.chpl:13
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:13
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:13
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:13
-
-**** End forall ****
-	regularCommaDeclaration.chpl:12
-
-**** Start forall ****
-	regularCommaDeclaration.chpl:27
-
-Iterated over the domain of
-	regularCommaDeclaration.chpl:21
-
-, which is
-	regularCommaDeclaration.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	regularCommaDeclaration.chpl:27
-
-Potential access
-	regularCommaDeclaration.chpl:28
-
-	Can optimize: Access base is the iterator's base
-	regularCommaDeclaration.chpl:28
-
-Potential access
-	regularCommaDeclaration.chpl:28
-
-	with domain defined at
-	regularCommaDeclaration.chpl:19
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularCommaDeclaration.chpl:28
-
-Potential access
-	regularCommaDeclaration.chpl:28
-
-	with domain defined at
-	regularCommaDeclaration.chpl:19
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularCommaDeclaration.chpl:28
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:28
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:28
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:28
-
-**** End forall ****
-	regularCommaDeclaration.chpl:27
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:13
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:13
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:13
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:28
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:28
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:28
-
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:13)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:13)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:13)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:28)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:28)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:28)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0

--- a/test/optimizations/autoLocalAccess/regularDeclaration.good
+++ b/test/optimizations/autoLocalAccess/regularDeclaration.good
@@ -1,116 +1,51 @@
-**** Start forall ****
-	regularDeclaration.chpl:14
 
-Iterated symbol
-	regularDeclaration.chpl:4
+Start analyzing forall (regularDeclaration.chpl:14)
+| Found loop domain (regularDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (regularDeclaration.chpl:14)
+|
+|  Start analyzing call (regularDeclaration.chpl:15)
+|   Found the domain of the access base (regularDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration.chpl:15)
+|
+|  Start analyzing call (regularDeclaration.chpl:15)
+|   Found the domain of the access base (regularDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration.chpl:15)
+|
+|  Start analyzing call (regularDeclaration.chpl:15)
+|   Found the domain of the access base (regularDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration.chpl:15)
+|
+End analyzing forall (regularDeclaration.chpl:14)
 
-Loop is suitable for static and dynamic analysis
-	regularDeclaration.chpl:14
 
-Potential access
-	regularDeclaration.chpl:15
+Start analyzing forall (regularDeclaration.chpl:31)
+| Found loop domain (regularDeclaration.chpl:23)
+| Will attempt static and dynamic optimizations (regularDeclaration.chpl:31)
+|
+|  Start analyzing call (regularDeclaration.chpl:32)
+|   Can optimize: Access base is the iterator's base (regularDeclaration.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration.chpl:32)
+|
+|  Start analyzing call (regularDeclaration.chpl:32)
+|   Found the domain of the access base (regularDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (regularDeclaration.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration.chpl:32)
+|
+|  Start analyzing call (regularDeclaration.chpl:32)
+|   Found the domain of the access base (regularDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (regularDeclaration.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration.chpl:32)
+|
+End analyzing forall (regularDeclaration.chpl:31)
 
-	with domain defined at
-	regularDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration.chpl:15
-
-Potential access
-	regularDeclaration.chpl:15
-
-	with domain defined at
-	regularDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration.chpl:15
-
-Potential access
-	regularDeclaration.chpl:15
-
-	with domain defined at
-	regularDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration.chpl:15
-
-	Marking static candidate
-	regularDeclaration.chpl:15
-
-	Marking static candidate
-	regularDeclaration.chpl:15
-
-	Marking static candidate
-	regularDeclaration.chpl:15
-
-**** End forall ****
-	regularDeclaration.chpl:14
-
-**** Start forall ****
-	regularDeclaration.chpl:31
-
-Iterated over the domain of
-	regularDeclaration.chpl:23
-
-, which is
-	regularDeclaration.chpl:21
-
-Loop is suitable for static and dynamic analysis
-	regularDeclaration.chpl:31
-
-Potential access
-	regularDeclaration.chpl:32
-
-	Can optimize: Access base is the iterator's base
-	regularDeclaration.chpl:32
-
-Potential access
-	regularDeclaration.chpl:32
-
-	with domain defined at
-	regularDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularDeclaration.chpl:32
-
-Potential access
-	regularDeclaration.chpl:32
-
-	with domain defined at
-	regularDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularDeclaration.chpl:32
-
-	Marking static candidate
-	regularDeclaration.chpl:32
-
-	Marking static candidate
-	regularDeclaration.chpl:32
-
-	Marking static candidate
-	regularDeclaration.chpl:32
-
-**** End forall ****
-	regularDeclaration.chpl:31
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:32
-
+Static check successful. Using localAccess (regularDeclaration.chpl:15)
+Static check successful. Using localAccess (regularDeclaration.chpl:15)
+Static check successful. Using localAccess (regularDeclaration.chpl:15)
+Static check successful. Using localAccess (regularDeclaration.chpl:32)
+Static check successful. Using localAccess (regularDeclaration.chpl:32)
+Static check successful. Using localAccess (regularDeclaration.chpl:32)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0

--- a/test/optimizations/autoLocalAccess/regularDeclaration2D.good
+++ b/test/optimizations/autoLocalAccess/regularDeclaration2D.good
@@ -1,117 +1,53 @@
-**** Start forall ****
-	regularDeclaration2D.chpl:14
 
-Iterated symbol
-	regularDeclaration2D.chpl:4
+Start analyzing forall (regularDeclaration2D.chpl:14)
+| Found loop domain (regularDeclaration2D.chpl:4)
+| Will attempt static and dynamic optimizations (regularDeclaration2D.chpl:14)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:15)
+|   Found the domain of the access base (regularDeclaration2D.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:15)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:15)
+|   Found the domain of the access base (regularDeclaration2D.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:15)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:15)
+|   Found the domain of the access base (regularDeclaration2D.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:15)
+|
+End analyzing forall (regularDeclaration2D.chpl:14)
 
-Loop is suitable for static and dynamic analysis
-	regularDeclaration2D.chpl:14
 
-Potential access
-	regularDeclaration2D.chpl:15
+Start analyzing forall (regularDeclaration2D.chpl:31)
+| Found loop domain (regularDeclaration2D.chpl:21)
+| Will attempt static and dynamic optimizations (regularDeclaration2D.chpl:31)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:32)
+|   Found the domain of the access base (regularDeclaration2D.chpl:21)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:32)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:32)
+|   Found the domain of the access base (regularDeclaration2D.chpl:21)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:32)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:32)
+|   Found the domain of the access base (regularDeclaration2D.chpl:21)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:32)
+|
+End analyzing forall (regularDeclaration2D.chpl:31)
 
-	with domain defined at
-	regularDeclaration2D.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:15
-
-Potential access
-	regularDeclaration2D.chpl:15
-
-	with domain defined at
-	regularDeclaration2D.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:15
-
-Potential access
-	regularDeclaration2D.chpl:15
-
-	with domain defined at
-	regularDeclaration2D.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:15
-
-	Marking static candidate
-	regularDeclaration2D.chpl:15
-
-	Marking static candidate
-	regularDeclaration2D.chpl:15
-
-	Marking static candidate
-	regularDeclaration2D.chpl:15
-
-**** End forall ****
-	regularDeclaration2D.chpl:14
-
-**** Start forall ****
-	regularDeclaration2D.chpl:31
-
-Iterated symbol
-	regularDeclaration2D.chpl:21
-
-Loop is suitable for static and dynamic analysis
-	regularDeclaration2D.chpl:31
-
-Potential access
-	regularDeclaration2D.chpl:32
-
-	with domain defined at
-	regularDeclaration2D.chpl:21
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:32
-
-Potential access
-	regularDeclaration2D.chpl:32
-
-	with domain defined at
-	regularDeclaration2D.chpl:21
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:32
-
-Potential access
-	regularDeclaration2D.chpl:32
-
-	with domain defined at
-	regularDeclaration2D.chpl:21
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:32
-
-	Marking static candidate
-	regularDeclaration2D.chpl:32
-
-	Marking static candidate
-	regularDeclaration2D.chpl:32
-
-	Marking static candidate
-	regularDeclaration2D.chpl:32
-
-**** End forall ****
-	regularDeclaration2D.chpl:31
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:32
-
+Static check successful. Using localAccess (regularDeclaration2D.chpl:15)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:15)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:15)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:32)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:32)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:32)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0

--- a/test/optimizations/autoLocalAccess/staticSuccessDynamicFail.good
+++ b/test/optimizations/autoLocalAccess/staticSuccessDynamicFail.good
@@ -1,43 +1,19 @@
-**** Start forall ****
-	staticSuccessDynamicFail.chpl:6
 
-Iterated over the domain of
-	staticSuccessDynamicFail.chpl:4
+Start analyzing forall (staticSuccessDynamicFail.chpl:6)
+| Found loop domain (staticSuccessDynamicFail.chpl:4)
+| Will attempt static and dynamic optimizations (staticSuccessDynamicFail.chpl:6)
+|
+|  Start analyzing call (staticSuccessDynamicFail.chpl:7)
+|   Can optimize: Access base is the iterator's base (staticSuccessDynamicFail.chpl:7)
+|  This call is a static optimization candidate (staticSuccessDynamicFail.chpl:7)
+|
+|  Start analyzing call (staticSuccessDynamicFail.chpl:7)
+|   Can't determine the domain of access base (staticSuccessDynamicFail.chpl:3)
+|  This call is a dynamic optimization candidate (staticSuccessDynamicFail.chpl:7)
+|
+End analyzing forall (staticSuccessDynamicFail.chpl:6)
 
-, whose domain cannot be determined statically
-	staticSuccessDynamicFail.chpl:4
-
-Loop is suitable for static and dynamic analysis
-	staticSuccessDynamicFail.chpl:6
-
-Potential access
-	staticSuccessDynamicFail.chpl:7
-
-	Can optimize: Access base is the iterator's base
-	staticSuccessDynamicFail.chpl:7
-
-Potential access
-	staticSuccessDynamicFail.chpl:7
-
-	regular domain symbol was not found for array
-	staticSuccessDynamicFail.chpl:3
-
-	Marking static candidate
-	staticSuccessDynamicFail.chpl:7
-
-	Marking dynamic candidate
-	staticSuccessDynamicFail.chpl:7
-
-**** End forall ****
-	staticSuccessDynamicFail.chpl:6
-
-Static check successful. Using localAccess
-	staticSuccessDynamicFail.chpl:7
-
-Static check successful. Using localAccess with dynamic check
-	staticSuccessDynamicFail.chpl:7
-
-Static check successful. Using localAccess
-	staticSuccessDynamicFail.chpl:7
-
+Static check successful. Using localAccess (staticSuccessDynamicFail.chpl:7)
+Static check successful. Using localAccess with dynamic check (staticSuccessDynamicFail.chpl:7)
+Static check successful. Using localAccess (staticSuccessDynamicFail.chpl:7)
 0 0 0 0 0 0 0 0 0

--- a/test/optimizations/autoLocalAccess/unalignedSameDist.good
+++ b/test/optimizations/autoLocalAccess/unalignedSameDist.good
@@ -1,43 +1,19 @@
-**** Start forall ****
-	unalignedSameDist.chpl:24
 
-Iterated over the domain of
-	unalignedSameDist.chpl:19
+Start analyzing forall (unalignedSameDist.chpl:24)
+| Found loop domain (unalignedSameDist.chpl:19)
+| Will attempt static and dynamic optimizations (unalignedSameDist.chpl:24)
+|
+|  Start analyzing call (unalignedSameDist.chpl:25)
+|   Can't determine the domain of access base (unalignedSameDist.chpl:18)
+|  This call is a dynamic optimization candidate (unalignedSameDist.chpl:25)
+|
+|  Start analyzing call (unalignedSameDist.chpl:26)
+|   Can optimize: Access base is the iterator's base (unalignedSameDist.chpl:26)
+|  This call is a static optimization candidate (unalignedSameDist.chpl:26)
+|
+End analyzing forall (unalignedSameDist.chpl:24)
 
-, whose domain cannot be determined statically
-	unalignedSameDist.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	unalignedSameDist.chpl:24
-
-Potential access
-	unalignedSameDist.chpl:25
-
-	regular domain symbol was not found for array
-	unalignedSameDist.chpl:18
-
-Potential access
-	unalignedSameDist.chpl:26
-
-	Can optimize: Access base is the iterator's base
-	unalignedSameDist.chpl:26
-
-	Marking static candidate
-	unalignedSameDist.chpl:26
-
-	Marking dynamic candidate
-	unalignedSameDist.chpl:25
-
-**** End forall ****
-	unalignedSameDist.chpl:24
-
-Static check successful. Using localAccess with dynamic check
-	unalignedSameDist.chpl:25
-
-Static check successful. Using localAccess
-	unalignedSameDist.chpl:26
-
-Static check successful. Using localAccess
-	unalignedSameDist.chpl:26
-
+Static check successful. Using localAccess with dynamic check (unalignedSameDist.chpl:25)
+Static check successful. Using localAccess (unalignedSameDist.chpl:26)
+Static check successful. Using localAccess (unalignedSameDist.chpl:26)
 2 2 2 2 2 2 2 2 2 2

--- a/test/optimizations/autoLocalAccess/withInitializerCall.good
+++ b/test/optimizations/autoLocalAccess/withInitializerCall.good
@@ -1,108 +1,48 @@
-**** Start forall ****
-	withInitializerCall.chpl:13
 
-Iterated over the domain of
-	withInitializerCall.chpl:12
+Start analyzing forall (withInitializerCall.chpl:13)
+| Found loop domain (withInitializerCall.chpl:12)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:13)
+|
+|  Start analyzing call (withInitializerCall.chpl:14)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:14)
+|  This call is a static optimization candidate (withInitializerCall.chpl:14)
+|
+End analyzing forall (withInitializerCall.chpl:13)
 
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:12
 
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:13
+Start analyzing forall (withInitializerCall.chpl:20)
+| Found loop domain (withInitializerCall.chpl:19)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:20)
+|
+|  Start analyzing call (withInitializerCall.chpl:21)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:21)
+|  This call is a static optimization candidate (withInitializerCall.chpl:21)
+|
+End analyzing forall (withInitializerCall.chpl:20)
 
-Potential access
-	withInitializerCall.chpl:14
 
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:14
+Start analyzing forall (withInitializerCall.chpl:29)
+| Found loop domain (withInitializerCall.chpl:28)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:29)
+|
+|  Start analyzing call (withInitializerCall.chpl:30)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:30)
+|  This call is a static optimization candidate (withInitializerCall.chpl:30)
+|
+End analyzing forall (withInitializerCall.chpl:29)
 
-	Marking static candidate
-	withInitializerCall.chpl:14
 
-**** End forall ****
-	withInitializerCall.chpl:13
+Start analyzing forall (withInitializerCall.chpl:36)
+| Found loop domain (withInitializerCall.chpl:35)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:36)
+|
+|  Start analyzing call (withInitializerCall.chpl:37)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:37)
+|  This call is a static optimization candidate (withInitializerCall.chpl:37)
+|
+End analyzing forall (withInitializerCall.chpl:36)
 
-**** Start forall ****
-	withInitializerCall.chpl:20
-
-Iterated over the domain of
-	withInitializerCall.chpl:19
-
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:20
-
-Potential access
-	withInitializerCall.chpl:21
-
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:21
-
-	Marking static candidate
-	withInitializerCall.chpl:21
-
-**** End forall ****
-	withInitializerCall.chpl:20
-
-**** Start forall ****
-	withInitializerCall.chpl:29
-
-Iterated over the domain of
-	withInitializerCall.chpl:28
-
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:28
-
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:29
-
-Potential access
-	withInitializerCall.chpl:30
-
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:30
-
-	Marking static candidate
-	withInitializerCall.chpl:30
-
-**** End forall ****
-	withInitializerCall.chpl:29
-
-**** Start forall ****
-	withInitializerCall.chpl:36
-
-Iterated over the domain of
-	withInitializerCall.chpl:35
-
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:35
-
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:36
-
-Potential access
-	withInitializerCall.chpl:37
-
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:37
-
-	Marking static candidate
-	withInitializerCall.chpl:37
-
-**** End forall ****
-	withInitializerCall.chpl:36
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:14
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:21
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:30
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:37
-
+Static check successful. Using localAccess (withInitializerCall.chpl:14)
+Static check successful. Using localAccess (withInitializerCall.chpl:21)
+Static check successful. Using localAccess (withInitializerCall.chpl:30)
+Static check successful. Using localAccess (withInitializerCall.chpl:37)

--- a/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.good
+++ b/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.good
@@ -1,36 +1,17 @@
-**** Start forall ****
-	allDynamicsFailStatic.chpl:17
 
-Iterated symbol
-	allDynamicsFailStatic.chpl:4
+Start analyzing forall (allDynamicsFailStatic.chpl:17)
+| Found loop domain (allDynamicsFailStatic.chpl:4)
+| Will attempt static and dynamic optimizations (allDynamicsFailStatic.chpl:17)
+|
+|  Start analyzing call (allDynamicsFailStatic.chpl:18)
+|   Found the domain of the access base (allDynamicsFailStatic.chpl:4)
+|   Can optimize: Access base's domain is the iterator (allDynamicsFailStatic.chpl:18)
+|  This call is a static optimization candidate (allDynamicsFailStatic.chpl:18)
+|
+|  Start analyzing call (allDynamicsFailStatic.chpl:19)
+|   Can't determine the domain of access base (allDynamicsFailStatic.chpl:8)
+|  This call is a dynamic optimization candidate (allDynamicsFailStatic.chpl:19)
+|
+End analyzing forall (allDynamicsFailStatic.chpl:17)
 
-Loop is suitable for static and dynamic analysis
-	allDynamicsFailStatic.chpl:17
-
-Potential access
-	allDynamicsFailStatic.chpl:18
-
-	with domain defined at
-	allDynamicsFailStatic.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	allDynamicsFailStatic.chpl:18
-
-Potential access
-	allDynamicsFailStatic.chpl:19
-
-	regular domain symbol was not found for array
-	allDynamicsFailStatic.chpl:8
-
-	Marking static candidate
-	allDynamicsFailStatic.chpl:18
-
-	Marking dynamic candidate
-	allDynamicsFailStatic.chpl:19
-
-**** End forall ****
-	allDynamicsFailStatic.chpl:17
-
-Static check successful. Using localAccess
-	allDynamicsFailStatic.chpl:18
-
+Static check successful. Using localAccess (allDynamicsFailStatic.chpl:18)

--- a/test/optimizations/autoLocalAccess/zipper/commaDecl.good
+++ b/test/optimizations/autoLocalAccess/zipper/commaDecl.good
@@ -1,43 +1,20 @@
-**** Start forall ****
-	commaDecl.chpl:9
 
-Iterated symbol
-	commaDecl.chpl:3
+Start analyzing forall (commaDecl.chpl:9)
+| Found loop domain (commaDecl.chpl:3)
+| Will attempt static and dynamic optimizations (commaDecl.chpl:9)
+|
+|  Start analyzing call (commaDecl.chpl:10)
+|   Found the domain of the access base (commaDecl.chpl:3)
+|   Can optimize: Access base's domain is the iterator (commaDecl.chpl:10)
+|  This call is a static optimization candidate (commaDecl.chpl:10)
+|
+|  Start analyzing call (commaDecl.chpl:10)
+|   Found the domain of the access base (commaDecl.chpl:3)
+|   Can optimize: Access base's domain is the iterator (commaDecl.chpl:10)
+|  This call is a static optimization candidate (commaDecl.chpl:10)
+|
+End analyzing forall (commaDecl.chpl:9)
 
-Loop is suitable for static and dynamic analysis
-	commaDecl.chpl:9
-
-Potential access
-	commaDecl.chpl:10
-
-	with domain defined at
-	commaDecl.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	commaDecl.chpl:10
-
-Potential access
-	commaDecl.chpl:10
-
-	with domain defined at
-	commaDecl.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	commaDecl.chpl:10
-
-	Marking static candidate
-	commaDecl.chpl:10
-
-	Marking static candidate
-	commaDecl.chpl:10
-
-**** End forall ****
-	commaDecl.chpl:9
-
-Static check successful. Using localAccess
-	commaDecl.chpl:10
-
-Static check successful. Using localAccess
-	commaDecl.chpl:10
-
+Static check successful. Using localAccess (commaDecl.chpl:10)
+Static check successful. Using localAccess (commaDecl.chpl:10)
 10 20 30 40 50 60 70 80 90 100

--- a/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/copyInitDeclaration.good
@@ -1,61 +1,27 @@
-**** Start forall ****
-	copyInitDeclaration.chpl:14
 
-Iterated symbol
-	copyInitDeclaration.chpl:4
+Start analyzing forall (copyInitDeclaration.chpl:14)
+| Found loop domain (copyInitDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (copyInitDeclaration.chpl:14)
+|
+|  Start analyzing call (copyInitDeclaration.chpl:15)
+|   Found the domain of the access base (copyInitDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (copyInitDeclaration.chpl:15)
+|  This call is a static optimization candidate (copyInitDeclaration.chpl:15)
+|
+|  Start analyzing call (copyInitDeclaration.chpl:15)
+|   Found the domain of the access base (copyInitDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (copyInitDeclaration.chpl:15)
+|  This call is a static optimization candidate (copyInitDeclaration.chpl:15)
+|
+|  Start analyzing call (copyInitDeclaration.chpl:15)
+|   Can't determine the domain of access base (copyInitDeclaration.chpl:8)
+|  This call is a dynamic optimization candidate (copyInitDeclaration.chpl:15)
+|
+End analyzing forall (copyInitDeclaration.chpl:14)
 
-Loop is suitable for static and dynamic analysis
-	copyInitDeclaration.chpl:14
-
-Potential access
-	copyInitDeclaration.chpl:15
-
-	with domain defined at
-	copyInitDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	copyInitDeclaration.chpl:15
-
-Potential access
-	copyInitDeclaration.chpl:15
-
-	with domain defined at
-	copyInitDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	copyInitDeclaration.chpl:15
-
-Potential access
-	copyInitDeclaration.chpl:15
-
-	regular domain symbol was not found for array
-	copyInitDeclaration.chpl:8
-
-	Marking static candidate
-	copyInitDeclaration.chpl:15
-
-	Marking static candidate
-	copyInitDeclaration.chpl:15
-
-	Marking dynamic candidate
-	copyInitDeclaration.chpl:15
-
-**** End forall ****
-	copyInitDeclaration.chpl:14
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess with dynamic check
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	copyInitDeclaration.chpl:15
-
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess with dynamic check (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
+Static check successful. Using localAccess (copyInitDeclaration.chpl:15)
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/differentButAlignedDoms.good
+++ b/test/optimizations/autoLocalAccess/zipper/differentButAlignedDoms.good
@@ -1,222 +1,112 @@
-**** Start forall ****
-	differentButAlignedDoms.chpl:21
 
-Iterated symbol
-	differentButAlignedDoms.chpl:20
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:21
-
-Potential access
-	differentButAlignedDoms.chpl:22
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:22
-
-**** End forall ****
-	differentButAlignedDoms.chpl:21
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:31
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:31
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:31
-
-Potential access
-	differentButAlignedDoms.chpl:32
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:32
-
-**** End forall ****
-	differentButAlignedDoms.chpl:31
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:44
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:44
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:44
-
-Potential access
-	differentButAlignedDoms.chpl:45
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:45
-
-**** End forall ****
-	differentButAlignedDoms.chpl:44
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:50
-
-Iterated symbol
-	differentButAlignedDoms.chpl:48
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:50
-
-Potential access
-	differentButAlignedDoms.chpl:51
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:51
-
-**** End forall ****
-	differentButAlignedDoms.chpl:50
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:55
-
-Iterated symbol
-	differentButAlignedDoms.chpl:54
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:55
-
-Potential access
-	differentButAlignedDoms.chpl:56
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:56
-
-**** End forall ****
-	differentButAlignedDoms.chpl:55
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:44
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:44
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:44
-
-Potential access
-	differentButAlignedDoms.chpl:45
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:45
-
-**** End forall ****
-	differentButAlignedDoms.chpl:44
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:50
-
-Iterated symbol
-	differentButAlignedDoms.chpl:48
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:50
-
-Potential access
-	differentButAlignedDoms.chpl:51
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:51
-
-**** End forall ****
-	differentButAlignedDoms.chpl:50
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:55
-
-Iterated symbol
-	differentButAlignedDoms.chpl:54
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:55
-
-Potential access
-	differentButAlignedDoms.chpl:56
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:56
-
-**** End forall ****
-	differentButAlignedDoms.chpl:55
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:67
-
-Loop iterand is a call. Will attempt dynamic optimization.
-	differentButAlignedDoms.chpl:67
-
-Loop is suitable for dynamic analysis only
-	differentButAlignedDoms.chpl:67
-
-Potential access
-	differentButAlignedDoms.chpl:68
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:68
-
-**** End forall ****
-	differentButAlignedDoms.chpl:67
-
-**** Start forall ****
-	differentButAlignedDoms.chpl:73
-
-Iterated symbol
-	differentButAlignedDoms.chpl:71
-
-Loop is suitable for static and dynamic analysis
-	differentButAlignedDoms.chpl:73
-
-Potential access
-	differentButAlignedDoms.chpl:74
-
-	with domain defined at
-	differentButAlignedDoms.chpl:3
-
-	Marking dynamic candidate
-	differentButAlignedDoms.chpl:74
-
-**** End forall ****
-	differentButAlignedDoms.chpl:73
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:22
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:32
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:45
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:51
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:56
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:68
-
-Static check successful. Using localAccess with dynamic check
-	differentButAlignedDoms.chpl:74
-
+Start analyzing forall (differentButAlignedDoms.chpl:21)
+| Found loop domain (differentButAlignedDoms.chpl:20)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:21)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:22)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:22)
+|
+End analyzing forall (differentButAlignedDoms.chpl:21)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:31)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:31)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:32)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:32)
+|
+End analyzing forall (differentButAlignedDoms.chpl:31)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:44)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:44)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:45)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:45)
+|
+End analyzing forall (differentButAlignedDoms.chpl:44)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:50)
+| Found loop domain (differentButAlignedDoms.chpl:48)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:50)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:51)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:51)
+|
+End analyzing forall (differentButAlignedDoms.chpl:50)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:55)
+| Found loop domain (differentButAlignedDoms.chpl:54)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:55)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:56)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:56)
+|
+End analyzing forall (differentButAlignedDoms.chpl:55)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:44)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:44)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:45)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:45)
+|
+End analyzing forall (differentButAlignedDoms.chpl:44)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:50)
+| Found loop domain (differentButAlignedDoms.chpl:48)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:50)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:51)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:51)
+|
+End analyzing forall (differentButAlignedDoms.chpl:50)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:55)
+| Found loop domain (differentButAlignedDoms.chpl:54)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:55)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:56)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:56)
+|
+End analyzing forall (differentButAlignedDoms.chpl:55)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:67)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (differentButAlignedDoms.chpl:67)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:68)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:68)
+|
+End analyzing forall (differentButAlignedDoms.chpl:67)
+
+
+Start analyzing forall (differentButAlignedDoms.chpl:73)
+| Found loop domain (differentButAlignedDoms.chpl:71)
+| Will attempt static and dynamic optimizations (differentButAlignedDoms.chpl:73)
+|
+|  Start analyzing call (differentButAlignedDoms.chpl:74)
+|   Found the domain of the access base (differentButAlignedDoms.chpl:3)
+|  This call is a dynamic optimization candidate (differentButAlignedDoms.chpl:74)
+|
+End analyzing forall (differentButAlignedDoms.chpl:73)
+
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:22)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:32)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:45)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:51)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:56)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:68)
+Static check successful. Using localAccess with dynamic check (differentButAlignedDoms.chpl:74)
 Iterand is a different symbol
 Custom localAccess was called
 Custom localAccess was called

--- a/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/dotDomDeclaration.good
@@ -1,231 +1,100 @@
-**** Start forall ****
-	dotDomDeclaration.chpl:14
 
-Iterated symbol
-	dotDomDeclaration.chpl:4
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:14
-
-Potential access
-	dotDomDeclaration.chpl:15
-
-	with domain defined at
-	dotDomDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	dotDomDeclaration.chpl:15
-
-Potential access
-	dotDomDeclaration.chpl:15
-
-	with domain defined at
-	dotDomDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	dotDomDeclaration.chpl:15
-
-Potential access
-	dotDomDeclaration.chpl:15
-
-	with domain defined at
-	dotDomDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	dotDomDeclaration.chpl:15
-
-	Marking static candidate
-	dotDomDeclaration.chpl:15
-
-	Marking static candidate
-	dotDomDeclaration.chpl:15
-
-	Marking static candidate
-	dotDomDeclaration.chpl:15
-
-**** End forall ****
-	dotDomDeclaration.chpl:14
-
-**** Start forall ****
-	dotDomDeclaration.chpl:31
-
-Iterated over the domain of
-	dotDomDeclaration.chpl:23
-
-, which is
-	dotDomDeclaration.chpl:21
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:31
-
-Potential access
-	dotDomDeclaration.chpl:32
-
-	Can optimize: Access base is the iterator's base
-	dotDomDeclaration.chpl:32
-
-Potential access
-	dotDomDeclaration.chpl:32
-
-	with domain defined at
-	dotDomDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:32
-
-Potential access
-	dotDomDeclaration.chpl:32
-
-	with domain defined at
-	dotDomDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:32
-
-	Marking static candidate
-	dotDomDeclaration.chpl:32
-
-	Marking static candidate
-	dotDomDeclaration.chpl:32
-
-	Marking static candidate
-	dotDomDeclaration.chpl:32
-
-**** End forall ****
-	dotDomDeclaration.chpl:31
-
-**** Start forall ****
-	dotDomDeclaration.chpl:48
-
-Iterated over the domain of
-	dotDomDeclaration.chpl:41
-
-, which is
-	dotDomDeclaration.chpl:38
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:48
-
-Potential access
-	dotDomDeclaration.chpl:49
-
-	with domain defined at
-	dotDomDeclaration.chpl:38
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:49
-
-Potential access
-	dotDomDeclaration.chpl:49
-
-	Can optimize: Access base is the iterator's base
-	dotDomDeclaration.chpl:49
-
-Potential access
-	dotDomDeclaration.chpl:49
-
-	with domain defined at
-	dotDomDeclaration.chpl:38
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:49
-
-	Marking static candidate
-	dotDomDeclaration.chpl:49
-
-	Marking static candidate
-	dotDomDeclaration.chpl:49
-
-	Marking static candidate
-	dotDomDeclaration.chpl:49
-
-**** End forall ****
-	dotDomDeclaration.chpl:48
-
-**** Start forall ****
-	dotDomDeclaration.chpl:65
-
-Iterated over the domain of
-	dotDomDeclaration.chpl:59
-
-, which is
-	dotDomDeclaration.chpl:55
-
-Loop is suitable for static and dynamic analysis
-	dotDomDeclaration.chpl:65
-
-Potential access
-	dotDomDeclaration.chpl:66
-
-	with domain defined at
-	dotDomDeclaration.chpl:55
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:66
-
-Potential access
-	dotDomDeclaration.chpl:66
-
-	with domain defined at
-	dotDomDeclaration.chpl:55
-
-	Can optimize: Access base has the same domain as iterator's base
-	dotDomDeclaration.chpl:66
-
-Potential access
-	dotDomDeclaration.chpl:66
-
-	Can optimize: Access base is the iterator's base
-	dotDomDeclaration.chpl:66
-
-	Marking static candidate
-	dotDomDeclaration.chpl:66
-
-	Marking static candidate
-	dotDomDeclaration.chpl:66
-
-	Marking static candidate
-	dotDomDeclaration.chpl:66
-
-**** End forall ****
-	dotDomDeclaration.chpl:65
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:49
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:49
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:49
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:66
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:66
-
-Static check successful. Using localAccess
-	dotDomDeclaration.chpl:66
-
+Start analyzing forall (dotDomDeclaration.chpl:14)
+| Found loop domain (dotDomDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:14)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:15)
+|   Found the domain of the access base (dotDomDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (dotDomDeclaration.chpl:15)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:15)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:15)
+|   Found the domain of the access base (dotDomDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (dotDomDeclaration.chpl:15)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:15)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:15)
+|   Found the domain of the access base (dotDomDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (dotDomDeclaration.chpl:15)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:15)
+|
+End analyzing forall (dotDomDeclaration.chpl:14)
+
+
+Start analyzing forall (dotDomDeclaration.chpl:31)
+| Found loop domain (dotDomDeclaration.chpl:23)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:31)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:32)
+|   Can optimize: Access base is the iterator's base (dotDomDeclaration.chpl:32)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:32)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:32)
+|   Found the domain of the access base (dotDomDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:32)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:32)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:32)
+|   Found the domain of the access base (dotDomDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:32)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:32)
+|
+End analyzing forall (dotDomDeclaration.chpl:31)
+
+
+Start analyzing forall (dotDomDeclaration.chpl:48)
+| Found loop domain (dotDomDeclaration.chpl:41)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:48)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:49)
+|   Found the domain of the access base (dotDomDeclaration.chpl:38)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:49)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:49)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:49)
+|   Can optimize: Access base is the iterator's base (dotDomDeclaration.chpl:49)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:49)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:49)
+|   Found the domain of the access base (dotDomDeclaration.chpl:38)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:49)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:49)
+|
+End analyzing forall (dotDomDeclaration.chpl:48)
+
+
+Start analyzing forall (dotDomDeclaration.chpl:65)
+| Found loop domain (dotDomDeclaration.chpl:59)
+| Will attempt static and dynamic optimizations (dotDomDeclaration.chpl:65)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:66)
+|   Found the domain of the access base (dotDomDeclaration.chpl:55)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:66)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:66)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:66)
+|   Found the domain of the access base (dotDomDeclaration.chpl:55)
+|   Can optimize: Access base has the same domain as iterator's base (dotDomDeclaration.chpl:66)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:66)
+|
+|  Start analyzing call (dotDomDeclaration.chpl:66)
+|   Can optimize: Access base is the iterator's base (dotDomDeclaration.chpl:66)
+|  This call is a static optimization candidate (dotDomDeclaration.chpl:66)
+|
+End analyzing forall (dotDomDeclaration.chpl:65)
+
+Static check successful. Using localAccess (dotDomDeclaration.chpl:15)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:15)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:15)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:32)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:32)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:32)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:49)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:49)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:49)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:66)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:66)
+Static check successful. Using localAccess (dotDomDeclaration.chpl:66)
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.good
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicCheckInGenericFunction.good
@@ -1,36 +1,16 @@
-**** Start forall ****
-	dynamicCheckInGenericFunction.chpl:16
 
-Iterated over the domain of
-	dynamicCheckInGenericFunction.chpl:13
+Start analyzing forall (dynamicCheckInGenericFunction.chpl:16)
+| Found loop domain (dynamicCheckInGenericFunction.chpl:13)
+| Will attempt static and dynamic optimizations (dynamicCheckInGenericFunction.chpl:16)
+|
+|  Start analyzing call (dynamicCheckInGenericFunction.chpl:17)
+|   Can optimize: Access base is the iterator's base (dynamicCheckInGenericFunction.chpl:17)
+|  This call is a static optimization candidate (dynamicCheckInGenericFunction.chpl:17)
+|
+|  Start analyzing call (dynamicCheckInGenericFunction.chpl:17)
+|   Can't determine the domain of access base (dynamicCheckInGenericFunction.chpl:13)
+|  This call is a dynamic optimization candidate (dynamicCheckInGenericFunction.chpl:17)
+|
+End analyzing forall (dynamicCheckInGenericFunction.chpl:16)
 
-, whose domain cannot be determined statically
-	dynamicCheckInGenericFunction.chpl:13
-
-Loop is suitable for static and dynamic analysis
-	dynamicCheckInGenericFunction.chpl:16
-
-Potential access
-	dynamicCheckInGenericFunction.chpl:17
-
-	Can optimize: Access base is the iterator's base
-	dynamicCheckInGenericFunction.chpl:17
-
-Potential access
-	dynamicCheckInGenericFunction.chpl:17
-
-	regular domain symbol was not found for array
-	dynamicCheckInGenericFunction.chpl:13
-
-	Marking static candidate
-	dynamicCheckInGenericFunction.chpl:17
-
-	Marking dynamic candidate
-	dynamicCheckInGenericFunction.chpl:17
-
-**** End forall ****
-	dynamicCheckInGenericFunction.chpl:16
-
-Static check successful. Using localAccess
-	dynamicCheckInGenericFunction.chpl:17
-
+Static check successful. Using localAccess (dynamicCheckInGenericFunction.chpl:17)

--- a/test/optimizations/autoLocalAccess/zipper/dynamicChecks.good
+++ b/test/optimizations/autoLocalAccess/zipper/dynamicChecks.good
@@ -1,85 +1,37 @@
-**** Start forall ****
-	dynamicChecks.chpl:28
 
-Iterated symbol
-	dynamicChecks.chpl:16
+Start analyzing forall (dynamicChecks.chpl:28)
+| Found loop domain (dynamicChecks.chpl:16)
+| Will attempt static and dynamic optimizations (dynamicChecks.chpl:28)
+|
+|  Start analyzing call (dynamicChecks.chpl:29)
+|   Found the domain of the access base (dynamicChecks.chpl:16)
+|   Can optimize: Access base's domain is the iterator (dynamicChecks.chpl:29)
+|  This call is a static optimization candidate (dynamicChecks.chpl:29)
+|
+|  Start analyzing call (dynamicChecks.chpl:29)
+|   Found the domain of the access base (dynamicChecks.chpl:16)
+|   Can optimize: Access base's domain is the iterator (dynamicChecks.chpl:29)
+|  This call is a static optimization candidate (dynamicChecks.chpl:29)
+|
+|  Start analyzing call (dynamicChecks.chpl:30)
+|   Can't determine the domain of access base (dynamicChecks.chpl:20)
+|  This call is a dynamic optimization candidate (dynamicChecks.chpl:30)
+|
+|  Start analyzing call (dynamicChecks.chpl:31)
+|   Found the domain of the access base (dynamicChecks.chpl:15)
+|  This call is a dynamic optimization candidate (dynamicChecks.chpl:31)
+|
+|  Start analyzing call (dynamicChecks.chpl:32)
+|   Can't determine the domain of access base (dynamicChecks.chpl:22)
+|  This call is a dynamic optimization candidate (dynamicChecks.chpl:32)
+|
+End analyzing forall (dynamicChecks.chpl:28)
 
-Loop is suitable for static and dynamic analysis
-	dynamicChecks.chpl:28
-
-Potential access
-	dynamicChecks.chpl:29
-
-	with domain defined at
-	dynamicChecks.chpl:16
-
-	Can optimize: Access base's domain is the iterator
-	dynamicChecks.chpl:29
-
-Potential access
-	dynamicChecks.chpl:29
-
-	with domain defined at
-	dynamicChecks.chpl:16
-
-	Can optimize: Access base's domain is the iterator
-	dynamicChecks.chpl:29
-
-Potential access
-	dynamicChecks.chpl:30
-
-	regular domain symbol was not found for array
-	dynamicChecks.chpl:20
-
-Potential access
-	dynamicChecks.chpl:31
-
-	with domain defined at
-	dynamicChecks.chpl:15
-
-Potential access
-	dynamicChecks.chpl:32
-
-	regular domain symbol was not found for array
-	dynamicChecks.chpl:22
-
-	Marking static candidate
-	dynamicChecks.chpl:29
-
-	Marking static candidate
-	dynamicChecks.chpl:29
-
-	Marking dynamic candidate
-	dynamicChecks.chpl:30
-
-	Marking dynamic candidate
-	dynamicChecks.chpl:31
-
-	Marking dynamic candidate
-	dynamicChecks.chpl:32
-
-**** End forall ****
-	dynamicChecks.chpl:28
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
-Static check successful. Using localAccess with dynamic check
-	dynamicChecks.chpl:30
-
-Static check failed. Reverting optimization
-	dynamicChecks.chpl:31
-
-Static check failed. Reverting optimization
-	dynamicChecks.chpl:32
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
-Static check successful. Using localAccess
-	dynamicChecks.chpl:29
-
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
+Static check successful. Using localAccess with dynamic check (dynamicChecks.chpl:30)
+Static check failed. Reverting optimization (dynamicChecks.chpl:31)
+Static check failed. Reverting optimization (dynamicChecks.chpl:32)
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
+Static check successful. Using localAccess (dynamicChecks.chpl:29)
 6.0 13.0 24.0 39.0 58.0 81.0 108.0 139.0 174.0 213.0

--- a/test/optimizations/autoLocalAccess/zipper/elemAsIndex.good
+++ b/test/optimizations/autoLocalAccess/zipper/elemAsIndex.good
@@ -1,23 +1,13 @@
-**** Start forall ****
-	elemAsIndex.chpl:19
 
-Iterated symbol
-	elemAsIndex.chpl:15
-
-Loop is suitable for static and dynamic analysis
-	elemAsIndex.chpl:19
-
-Potential access
-	elemAsIndex.chpl:20
-
-	regular domain symbol was not found for array
-	elemAsIndex.chpl:15
-
-	Marking dynamic candidate
-	elemAsIndex.chpl:20
-
-**** End forall ****
-	elemAsIndex.chpl:19
+Start analyzing forall (elemAsIndex.chpl:19)
+| Found loop domain (elemAsIndex.chpl:15)
+| Will attempt static and dynamic optimizations (elemAsIndex.chpl:19)
+|
+|  Start analyzing call (elemAsIndex.chpl:20)
+|   Can't determine the domain of access base (elemAsIndex.chpl:15)
+|  This call is a dynamic optimization candidate (elemAsIndex.chpl:20)
+|
+End analyzing forall (elemAsIndex.chpl:19)
 
 Custom this was called
 Custom this was called

--- a/test/optimizations/autoLocalAccess/zipper/functionArgs.good
+++ b/test/optimizations/autoLocalAccess/zipper/functionArgs.good
@@ -1,393 +1,172 @@
-**** Start forall ****
-	functionArgs.chpl:11
 
-Iterated over the domain of
-	functionArgs.chpl:10
-
-, which is
-	functionArgs.chpl:10
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:11
-
-Potential access
-	functionArgs.chpl:12
-
-	Can optimize: Access base is the iterator's base
-	functionArgs.chpl:12
-
-Potential access
-	functionArgs.chpl:13
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:13
-
-	Marking static candidate
-	functionArgs.chpl:12
-
-	Marking static candidate
-	functionArgs.chpl:13
-
-**** End forall ****
-	functionArgs.chpl:11
-
-**** Start forall ****
-	functionArgs.chpl:17
-
-Iterated over the domain of
-	functionArgs.chpl:10
-
-, which is
-	functionArgs.chpl:10
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:17
-
-Potential access
-	functionArgs.chpl:18
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:18
-
-Potential access
-	functionArgs.chpl:19
-
-	Can optimize: Access base is the iterator's base
-	functionArgs.chpl:19
-
-	Marking static candidate
-	functionArgs.chpl:18
-
-	Marking static candidate
-	functionArgs.chpl:19
-
-**** End forall ****
-	functionArgs.chpl:17
-
-**** Start forall ****
-	functionArgs.chpl:23
-
-Iterated symbol
-	functionArgs.chpl:10
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:23
-
-Potential access
-	functionArgs.chpl:24
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:24
-
-Potential access
-	functionArgs.chpl:25
-
-	with domain defined at
-	functionArgs.chpl:10
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:25
-
-	Marking static candidate
-	functionArgs.chpl:24
-
-	Marking static candidate
-	functionArgs.chpl:25
-
-**** End forall ****
-	functionArgs.chpl:23
-
-**** Start forall ****
-	functionArgs.chpl:31
-
-Iterated over the domain of
-	functionArgs.chpl:5
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:31
-
-Potential access
-	functionArgs.chpl:32
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:32
-
-Potential access
-	functionArgs.chpl:33
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:33
-
-	Marking static candidate
-	functionArgs.chpl:32
-
-	Marking static candidate
-	functionArgs.chpl:33
-
-**** End forall ****
-	functionArgs.chpl:31
-
-**** Start forall ****
-	functionArgs.chpl:37
-
-Iterated over the domain of
-	functionArgs.chpl:6
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:37
-
-Potential access
-	functionArgs.chpl:38
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:38
-
-Potential access
-	functionArgs.chpl:39
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:39
-
-	Marking static candidate
-	functionArgs.chpl:38
-
-	Marking static candidate
-	functionArgs.chpl:39
-
-**** End forall ****
-	functionArgs.chpl:37
-
-**** Start forall ****
-	functionArgs.chpl:43
-
-Iterated symbol
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:43
-
-Potential access
-	functionArgs.chpl:44
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:44
-
-Potential access
-	functionArgs.chpl:45
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:45
-
-	Marking static candidate
-	functionArgs.chpl:44
-
-	Marking static candidate
-	functionArgs.chpl:45
-
-**** End forall ****
-	functionArgs.chpl:43
-
-**** Start forall ****
-	functionArgs.chpl:51
-
-Iterated over the domain of
-	functionArgs.chpl:5
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:51
-
-Potential access
-	functionArgs.chpl:52
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:52
-
-Potential access
-	functionArgs.chpl:53
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:53
-
-	Marking static candidate
-	functionArgs.chpl:52
-
-	Marking static candidate
-	functionArgs.chpl:53
-
-**** End forall ****
-	functionArgs.chpl:51
-
-**** Start forall ****
-	functionArgs.chpl:57
-
-Iterated over the domain of
-	functionArgs.chpl:6
-
-, which is
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:57
-
-Potential access
-	functionArgs.chpl:58
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:58
-
-Potential access
-	functionArgs.chpl:59
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base has the same domain as iterator's base
-	functionArgs.chpl:59
-
-	Marking static candidate
-	functionArgs.chpl:58
-
-	Marking static candidate
-	functionArgs.chpl:59
-
-**** End forall ****
-	functionArgs.chpl:57
-
-**** Start forall ****
-	functionArgs.chpl:63
-
-Iterated symbol
-	functionArgs.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	functionArgs.chpl:63
-
-Potential access
-	functionArgs.chpl:64
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:64
-
-Potential access
-	functionArgs.chpl:65
-
-	with domain defined at
-	functionArgs.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	functionArgs.chpl:65
-
-	Marking static candidate
-	functionArgs.chpl:64
-
-	Marking static candidate
-	functionArgs.chpl:65
-
-**** End forall ****
-	functionArgs.chpl:63
-
-Static check successful. Using localAccess
-	functionArgs.chpl:12
-
-Static check successful. Using localAccess
-	functionArgs.chpl:13
-
-Static check successful. Using localAccess
-	functionArgs.chpl:18
-
-Static check successful. Using localAccess
-	functionArgs.chpl:19
-
-Static check successful. Using localAccess
-	functionArgs.chpl:24
-
-Static check successful. Using localAccess
-	functionArgs.chpl:25
-
-Static check successful. Using localAccess
-	functionArgs.chpl:32
-
-Static check successful. Using localAccess
-	functionArgs.chpl:33
-
-Static check successful. Using localAccess
-	functionArgs.chpl:38
-
-Static check successful. Using localAccess
-	functionArgs.chpl:39
-
-Static check successful. Using localAccess
-	functionArgs.chpl:44
-
-Static check successful. Using localAccess
-	functionArgs.chpl:45
-
-Static check successful. Using localAccess
-	functionArgs.chpl:52
-
-Static check successful. Using localAccess
-	functionArgs.chpl:53
-
-Static check successful. Using localAccess
-	functionArgs.chpl:58
-
-Static check successful. Using localAccess
-	functionArgs.chpl:59
-
-Static check successful. Using localAccess
-	functionArgs.chpl:64
-
-Static check successful. Using localAccess
-	functionArgs.chpl:65
-
+Start analyzing forall (functionArgs.chpl:11)
+| Found loop domain (functionArgs.chpl:10)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:11)
+|
+|  Start analyzing call (functionArgs.chpl:12)
+|   Can optimize: Access base is the iterator's base (functionArgs.chpl:12)
+|  This call is a static optimization candidate (functionArgs.chpl:12)
+|
+|  Start analyzing call (functionArgs.chpl:13)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:13)
+|  This call is a static optimization candidate (functionArgs.chpl:13)
+|
+End analyzing forall (functionArgs.chpl:11)
+
+
+Start analyzing forall (functionArgs.chpl:17)
+| Found loop domain (functionArgs.chpl:10)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:17)
+|
+|  Start analyzing call (functionArgs.chpl:18)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:18)
+|  This call is a static optimization candidate (functionArgs.chpl:18)
+|
+|  Start analyzing call (functionArgs.chpl:19)
+|   Can optimize: Access base is the iterator's base (functionArgs.chpl:19)
+|  This call is a static optimization candidate (functionArgs.chpl:19)
+|
+End analyzing forall (functionArgs.chpl:17)
+
+
+Start analyzing forall (functionArgs.chpl:23)
+| Found loop domain (functionArgs.chpl:10)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:23)
+|
+|  Start analyzing call (functionArgs.chpl:24)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:24)
+|  This call is a static optimization candidate (functionArgs.chpl:24)
+|
+|  Start analyzing call (functionArgs.chpl:25)
+|   Found the domain of the access base (functionArgs.chpl:10)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:25)
+|  This call is a static optimization candidate (functionArgs.chpl:25)
+|
+End analyzing forall (functionArgs.chpl:23)
+
+
+Start analyzing forall (functionArgs.chpl:31)
+| Found loop domain (functionArgs.chpl:5)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:31)
+|
+|  Start analyzing call (functionArgs.chpl:32)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:32)
+|  This call is a static optimization candidate (functionArgs.chpl:32)
+|
+|  Start analyzing call (functionArgs.chpl:33)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:33)
+|  This call is a static optimization candidate (functionArgs.chpl:33)
+|
+End analyzing forall (functionArgs.chpl:31)
+
+
+Start analyzing forall (functionArgs.chpl:37)
+| Found loop domain (functionArgs.chpl:6)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:37)
+|
+|  Start analyzing call (functionArgs.chpl:38)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:38)
+|  This call is a static optimization candidate (functionArgs.chpl:38)
+|
+|  Start analyzing call (functionArgs.chpl:39)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:39)
+|  This call is a static optimization candidate (functionArgs.chpl:39)
+|
+End analyzing forall (functionArgs.chpl:37)
+
+
+Start analyzing forall (functionArgs.chpl:43)
+| Found loop domain (functionArgs.chpl:3)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:43)
+|
+|  Start analyzing call (functionArgs.chpl:44)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:44)
+|  This call is a static optimization candidate (functionArgs.chpl:44)
+|
+|  Start analyzing call (functionArgs.chpl:45)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:45)
+|  This call is a static optimization candidate (functionArgs.chpl:45)
+|
+End analyzing forall (functionArgs.chpl:43)
+
+
+Start analyzing forall (functionArgs.chpl:51)
+| Found loop domain (functionArgs.chpl:5)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:51)
+|
+|  Start analyzing call (functionArgs.chpl:52)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:52)
+|  This call is a static optimization candidate (functionArgs.chpl:52)
+|
+|  Start analyzing call (functionArgs.chpl:53)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:53)
+|  This call is a static optimization candidate (functionArgs.chpl:53)
+|
+End analyzing forall (functionArgs.chpl:51)
+
+
+Start analyzing forall (functionArgs.chpl:57)
+| Found loop domain (functionArgs.chpl:6)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:57)
+|
+|  Start analyzing call (functionArgs.chpl:58)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:58)
+|  This call is a static optimization candidate (functionArgs.chpl:58)
+|
+|  Start analyzing call (functionArgs.chpl:59)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base has the same domain as iterator's base (functionArgs.chpl:59)
+|  This call is a static optimization candidate (functionArgs.chpl:59)
+|
+End analyzing forall (functionArgs.chpl:57)
+
+
+Start analyzing forall (functionArgs.chpl:63)
+| Found loop domain (functionArgs.chpl:3)
+| Will attempt static and dynamic optimizations (functionArgs.chpl:63)
+|
+|  Start analyzing call (functionArgs.chpl:64)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:64)
+|  This call is a static optimization candidate (functionArgs.chpl:64)
+|
+|  Start analyzing call (functionArgs.chpl:65)
+|   Found the domain of the access base (functionArgs.chpl:3)
+|   Can optimize: Access base's domain is the iterator (functionArgs.chpl:65)
+|  This call is a static optimization candidate (functionArgs.chpl:65)
+|
+End analyzing forall (functionArgs.chpl:63)
+
+Static check successful. Using localAccess (functionArgs.chpl:12)
+Static check successful. Using localAccess (functionArgs.chpl:13)
+Static check successful. Using localAccess (functionArgs.chpl:18)
+Static check successful. Using localAccess (functionArgs.chpl:19)
+Static check successful. Using localAccess (functionArgs.chpl:24)
+Static check successful. Using localAccess (functionArgs.chpl:25)
+Static check successful. Using localAccess (functionArgs.chpl:32)
+Static check successful. Using localAccess (functionArgs.chpl:33)
+Static check successful. Using localAccess (functionArgs.chpl:38)
+Static check successful. Using localAccess (functionArgs.chpl:39)
+Static check successful. Using localAccess (functionArgs.chpl:44)
+Static check successful. Using localAccess (functionArgs.chpl:45)
+Static check successful. Using localAccess (functionArgs.chpl:52)
+Static check successful. Using localAccess (functionArgs.chpl:53)
+Static check successful. Using localAccess (functionArgs.chpl:58)
+Static check successful. Using localAccess (functionArgs.chpl:59)
+Static check successful. Using localAccess (functionArgs.chpl:64)
+Static check successful. Using localAccess (functionArgs.chpl:65)
 10 20 30 40 50 60 70 80 90 100
 20 40 60 80 100 120 140 160 180 200
 30 60 90 120 150 180 210 240 270 300

--- a/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.good
+++ b/test/optimizations/autoLocalAccess/zipper/interveningForallOrOn.good
@@ -1,42 +1,23 @@
-**** Start forall ****
-	interveningForallOrOn.chpl:12
 
-Loop iterand is a call. Will attempt dynamic optimization.
-	interveningForallOrOn.chpl:12
+Start analyzing forall (interveningForallOrOn.chpl:12)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (interveningForallOrOn.chpl:12)
+|
+|  Start analyzing call (interveningForallOrOn.chpl:13)
+|  This call is a dynamic optimization candidate (interveningForallOrOn.chpl:13)
+|
+End analyzing forall (interveningForallOrOn.chpl:12)
 
-Loop is suitable for dynamic analysis only
-	interveningForallOrOn.chpl:12
 
-Potential access
-	interveningForallOrOn.chpl:13
+Start analyzing forall (interveningForallOrOn.chpl:11)
+| Found loop domain (interveningForallOrOn.chpl:5)
+| Will attempt static and dynamic optimizations (interveningForallOrOn.chpl:11)
+|
+End analyzing forall (interveningForallOrOn.chpl:11)
 
-	Marking dynamic candidate
-	interveningForallOrOn.chpl:13
 
-**** End forall ****
-	interveningForallOrOn.chpl:12
-
-**** Start forall ****
-	interveningForallOrOn.chpl:11
-
-Iterated symbol
-	interveningForallOrOn.chpl:5
-
-Loop is suitable for static and dynamic analysis
-	interveningForallOrOn.chpl:11
-
-**** End forall ****
-	interveningForallOrOn.chpl:11
-
-**** Start forall ****
-	interveningForallOrOn.chpl:25
-
-Iterated symbol
-	interveningForallOrOn.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	interveningForallOrOn.chpl:25
-
-**** End forall ****
-	interveningForallOrOn.chpl:25
+Start analyzing forall (interveningForallOrOn.chpl:25)
+| Found loop domain (interveningForallOrOn.chpl:19)
+| Will attempt static and dynamic optimizations (interveningForallOrOn.chpl:25)
+|
+End analyzing forall (interveningForallOrOn.chpl:25)
 

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.good
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessDynamic.good
@@ -1,54 +1,23 @@
-**** Start forall ****
-	multipleAccessDynamic.chpl:7
 
-Iterated over the domain of
-	multipleAccessDynamic.chpl:3
+Start analyzing forall (multipleAccessDynamic.chpl:7)
+| Found loop domain (multipleAccessDynamic.chpl:3)
+| Will attempt static and dynamic optimizations (multipleAccessDynamic.chpl:7)
+|
+|  Start analyzing call (multipleAccessDynamic.chpl:9)
+|   Can optimize: Access base is the iterator's base (multipleAccessDynamic.chpl:9)
+|  This call is a static optimization candidate (multipleAccessDynamic.chpl:9)
+|
+|  Start analyzing call (multipleAccessDynamic.chpl:9)
+|   Can't determine the domain of access base (multipleAccessDynamic.chpl:4)
+|  This call is a dynamic optimization candidate (multipleAccessDynamic.chpl:9)
+|
+|  Start analyzing call (multipleAccessDynamic.chpl:9)
+|   Can't determine the domain of access base (multipleAccessDynamic.chpl:4)
+|  This call is a dynamic optimization candidate (multipleAccessDynamic.chpl:9)
+|
+End analyzing forall (multipleAccessDynamic.chpl:7)
 
-, whose domain cannot be determined statically
-	multipleAccessDynamic.chpl:3
-
-Loop is suitable for static and dynamic analysis
-	multipleAccessDynamic.chpl:7
-
-Potential access
-	multipleAccessDynamic.chpl:9
-
-	Can optimize: Access base is the iterator's base
-	multipleAccessDynamic.chpl:9
-
-Potential access
-	multipleAccessDynamic.chpl:9
-
-	regular domain symbol was not found for array
-	multipleAccessDynamic.chpl:4
-
-Potential access
-	multipleAccessDynamic.chpl:9
-
-	regular domain symbol was not found for array
-	multipleAccessDynamic.chpl:4
-
-	Marking static candidate
-	multipleAccessDynamic.chpl:9
-
-	Marking dynamic candidate
-	multipleAccessDynamic.chpl:9
-
-	Marking dynamic candidate
-	multipleAccessDynamic.chpl:9
-
-**** End forall ****
-	multipleAccessDynamic.chpl:7
-
-Static check successful. Using localAccess
-	multipleAccessDynamic.chpl:9
-
-Static check successful. Using localAccess with dynamic check
-	multipleAccessDynamic.chpl:9
-
-Static check successful. Using localAccess with dynamic check
-	multipleAccessDynamic.chpl:9
-
-Static check successful. Using localAccess
-	multipleAccessDynamic.chpl:9
-
+Static check successful. Using localAccess (multipleAccessDynamic.chpl:9)
+Static check successful. Using localAccess with dynamic check (multipleAccessDynamic.chpl:9)
+Static check successful. Using localAccess with dynamic check (multipleAccessDynamic.chpl:9)
+Static check successful. Using localAccess (multipleAccessDynamic.chpl:9)

--- a/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.good
+++ b/test/optimizations/autoLocalAccess/zipper/multipleAccessStatic.good
@@ -1,42 +1,19 @@
-**** Start forall ****
-	multipleAccessStatic.chpl:8
 
-Iterated symbol
-	multipleAccessStatic.chpl:3
+Start analyzing forall (multipleAccessStatic.chpl:8)
+| Found loop domain (multipleAccessStatic.chpl:3)
+| Will attempt static and dynamic optimizations (multipleAccessStatic.chpl:8)
+|
+|  Start analyzing call (multipleAccessStatic.chpl:10)
+|   Found the domain of the access base (multipleAccessStatic.chpl:3)
+|   Can optimize: Access base's domain is the iterator (multipleAccessStatic.chpl:10)
+|  This call is a static optimization candidate (multipleAccessStatic.chpl:10)
+|
+|  Start analyzing call (multipleAccessStatic.chpl:10)
+|   Found the domain of the access base (multipleAccessStatic.chpl:3)
+|   Can optimize: Access base's domain is the iterator (multipleAccessStatic.chpl:10)
+|  This call is a static optimization candidate (multipleAccessStatic.chpl:10)
+|
+End analyzing forall (multipleAccessStatic.chpl:8)
 
-Loop is suitable for static and dynamic analysis
-	multipleAccessStatic.chpl:8
-
-Potential access
-	multipleAccessStatic.chpl:10
-
-	with domain defined at
-	multipleAccessStatic.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	multipleAccessStatic.chpl:10
-
-Potential access
-	multipleAccessStatic.chpl:10
-
-	with domain defined at
-	multipleAccessStatic.chpl:3
-
-	Can optimize: Access base's domain is the iterator
-	multipleAccessStatic.chpl:10
-
-	Marking static candidate
-	multipleAccessStatic.chpl:10
-
-	Marking static candidate
-	multipleAccessStatic.chpl:10
-
-**** End forall ****
-	multipleAccessStatic.chpl:8
-
-Static check successful. Using localAccess
-	multipleAccessStatic.chpl:10
-
-Static check successful. Using localAccess
-	multipleAccessStatic.chpl:10
-
+Static check successful. Using localAccess (multipleAccessStatic.chpl:10)
+Static check successful. Using localAccess (multipleAccessStatic.chpl:10)

--- a/test/optimizations/autoLocalAccess/zipper/nonDomainIter.good
+++ b/test/optimizations/autoLocalAccess/zipper/nonDomainIter.good
@@ -1,30 +1,15 @@
-**** Start forall ****
-	nonDomainIter.chpl:27
 
-Iterated symbol
-	nonDomainIter.chpl:25
-
-Loop is suitable for static and dynamic analysis
-	nonDomainIter.chpl:27
-
-Potential access
-	nonDomainIter.chpl:28
-
-	regular domain symbol was not found for array
-	nonDomainIter.chpl:22
-
-Potential access
-	nonDomainIter.chpl:28
-
-	regular domain symbol was not found for array
-	nonDomainIter.chpl:23
-
-	Marking dynamic candidate
-	nonDomainIter.chpl:28
-
-	Marking dynamic candidate
-	nonDomainIter.chpl:28
-
-**** End forall ****
-	nonDomainIter.chpl:27
+Start analyzing forall (nonDomainIter.chpl:27)
+| Found loop domain (nonDomainIter.chpl:25)
+| Will attempt static and dynamic optimizations (nonDomainIter.chpl:27)
+|
+|  Start analyzing call (nonDomainIter.chpl:28)
+|   Can't determine the domain of access base (nonDomainIter.chpl:22)
+|  This call is a dynamic optimization candidate (nonDomainIter.chpl:28)
+|
+|  Start analyzing call (nonDomainIter.chpl:28)
+|   Can't determine the domain of access base (nonDomainIter.chpl:23)
+|  This call is a dynamic optimization candidate (nonDomainIter.chpl:28)
+|
+End analyzing forall (nonDomainIter.chpl:27)
 

--- a/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.good
+++ b/test/optimizations/autoLocalAccess/zipper/oneStaticFailOtherDynamicSuccess.good
@@ -1,39 +1,20 @@
-**** Start forall ****
-	oneStaticFailOtherDynamicSuccess.chpl:23
 
-Iterated symbol
-	oneStaticFailOtherDynamicSuccess.chpl:16
+Start analyzing forall (oneStaticFailOtherDynamicSuccess.chpl:23)
+| Found loop domain (oneStaticFailOtherDynamicSuccess.chpl:16)
+| Will attempt static and dynamic optimizations (oneStaticFailOtherDynamicSuccess.chpl:23)
+|
+|  Start analyzing call (oneStaticFailOtherDynamicSuccess.chpl:24)
+|   Can't determine the domain of access base (oneStaticFailOtherDynamicSuccess.chpl:18)
+|  This call is a dynamic optimization candidate (oneStaticFailOtherDynamicSuccess.chpl:24)
+|
+|  Start analyzing call (oneStaticFailOtherDynamicSuccess.chpl:24)
+|   Can't determine the domain of access base (oneStaticFailOtherDynamicSuccess.chpl:19)
+|  This call is a dynamic optimization candidate (oneStaticFailOtherDynamicSuccess.chpl:24)
+|
+End analyzing forall (oneStaticFailOtherDynamicSuccess.chpl:23)
 
-Loop is suitable for static and dynamic analysis
-	oneStaticFailOtherDynamicSuccess.chpl:23
-
-Potential access
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-	regular domain symbol was not found for array
-	oneStaticFailOtherDynamicSuccess.chpl:18
-
-Potential access
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-	regular domain symbol was not found for array
-	oneStaticFailOtherDynamicSuccess.chpl:19
-
-	Marking dynamic candidate
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-	Marking dynamic candidate
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-**** End forall ****
-	oneStaticFailOtherDynamicSuccess.chpl:23
-
-Static check successful. Using localAccess with dynamic check
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
-Static check failed. Reverting optimization
-	oneStaticFailOtherDynamicSuccess.chpl:24
-
+Static check successful. Using localAccess with dynamic check (oneStaticFailOtherDynamicSuccess.chpl:24)
+Static check failed. Reverting optimization (oneStaticFailOtherDynamicSuccess.chpl:24)
 Custom localAccess was called
 Custom localAccess was called
 Custom localAccess was called

--- a/test/optimizations/autoLocalAccess/zipper/preventMultiCall.good
+++ b/test/optimizations/autoLocalAccess/zipper/preventMultiCall.good
@@ -1,42 +1,21 @@
-**** Start forall ****
-	preventMultiCall.chpl:29
 
-Loop iterand is a call. Will attempt dynamic optimization.
-	preventMultiCall.chpl:29
+Start analyzing forall (preventMultiCall.chpl:29)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (preventMultiCall.chpl:29)
+|
+|  Start analyzing call (preventMultiCall.chpl:30)
+|  This call is a dynamic optimization candidate (preventMultiCall.chpl:30)
+|
+|  Start analyzing call (preventMultiCall.chpl:31)
+|  This call is a dynamic optimization candidate (preventMultiCall.chpl:31)
+|
+|  Start analyzing call (preventMultiCall.chpl:32)
+|  This call is a dynamic optimization candidate (preventMultiCall.chpl:32)
+|
+End analyzing forall (preventMultiCall.chpl:29)
 
-Loop is suitable for dynamic analysis only
-	preventMultiCall.chpl:29
-
-Potential access
-	preventMultiCall.chpl:30
-
-Potential access
-	preventMultiCall.chpl:31
-
-Potential access
-	preventMultiCall.chpl:32
-
-	Marking dynamic candidate
-	preventMultiCall.chpl:30
-
-	Marking dynamic candidate
-	preventMultiCall.chpl:31
-
-	Marking dynamic candidate
-	preventMultiCall.chpl:32
-
-**** End forall ****
-	preventMultiCall.chpl:29
-
-Static check successful. Using localAccess with dynamic check
-	preventMultiCall.chpl:30
-
-Static check successful. Using localAccess with dynamic check
-	preventMultiCall.chpl:31
-
-Static check successful. Using localAccess with dynamic check
-	preventMultiCall.chpl:32
-
+Static check successful. Using localAccess with dynamic check (preventMultiCall.chpl:30)
+Static check successful. Using localAccess with dynamic check (preventMultiCall.chpl:31)
+Static check successful. Using localAccess with dynamic check (preventMultiCall.chpl:32)
 returnDom is called
 Custom localAccess was called
 Custom localAccess was called

--- a/test/optimizations/autoLocalAccess/zipper/preventMultiCallIter.good
+++ b/test/optimizations/autoLocalAccess/zipper/preventMultiCallIter.good
@@ -1,32 +1,17 @@
-**** Start forall ****
-	preventMultiCallIter.chpl:47
 
-Loop iterand is a call. Will attempt dynamic optimization.
-	preventMultiCallIter.chpl:47
-
-Loop is suitable for dynamic analysis only
-	preventMultiCallIter.chpl:47
-
-Potential access
-	preventMultiCallIter.chpl:48
-
-Potential access
-	preventMultiCallIter.chpl:49
-
-Potential access
-	preventMultiCallIter.chpl:50
-
-	Marking dynamic candidate
-	preventMultiCallIter.chpl:48
-
-	Marking dynamic candidate
-	preventMultiCallIter.chpl:49
-
-	Marking dynamic candidate
-	preventMultiCallIter.chpl:50
-
-**** End forall ****
-	preventMultiCallIter.chpl:47
+Start analyzing forall (preventMultiCallIter.chpl:47)
+| Couldn't determine loop domain: will attempt dynamic optimizations only (preventMultiCallIter.chpl:47)
+|
+|  Start analyzing call (preventMultiCallIter.chpl:48)
+|  This call is a dynamic optimization candidate (preventMultiCallIter.chpl:48)
+|
+|  Start analyzing call (preventMultiCallIter.chpl:49)
+|  This call is a dynamic optimization candidate (preventMultiCallIter.chpl:49)
+|
+|  Start analyzing call (preventMultiCallIter.chpl:50)
+|  This call is a dynamic optimization candidate (preventMultiCallIter.chpl:50)
+|
+End analyzing forall (preventMultiCallIter.chpl:47)
 
 leader iterator invoked
 follower iterator invoked

--- a/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/regularCommaDeclaration.good
@@ -1,116 +1,51 @@
-**** Start forall ****
-	regularCommaDeclaration.chpl:12
 
-Iterated symbol
-	regularCommaDeclaration.chpl:4
+Start analyzing forall (regularCommaDeclaration.chpl:12)
+| Found loop domain (regularCommaDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (regularCommaDeclaration.chpl:12)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:13)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularCommaDeclaration.chpl:13)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:13)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:13)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularCommaDeclaration.chpl:13)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:13)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:13)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularCommaDeclaration.chpl:13)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:13)
+|
+End analyzing forall (regularCommaDeclaration.chpl:12)
 
-Loop is suitable for static and dynamic analysis
-	regularCommaDeclaration.chpl:12
 
-Potential access
-	regularCommaDeclaration.chpl:13
+Start analyzing forall (regularCommaDeclaration.chpl:27)
+| Found loop domain (regularCommaDeclaration.chpl:21)
+| Will attempt static and dynamic optimizations (regularCommaDeclaration.chpl:27)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:28)
+|   Can optimize: Access base is the iterator's base (regularCommaDeclaration.chpl:28)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:28)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:28)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:19)
+|   Can optimize: Access base has the same domain as iterator's base (regularCommaDeclaration.chpl:28)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:28)
+|
+|  Start analyzing call (regularCommaDeclaration.chpl:28)
+|   Found the domain of the access base (regularCommaDeclaration.chpl:19)
+|   Can optimize: Access base has the same domain as iterator's base (regularCommaDeclaration.chpl:28)
+|  This call is a static optimization candidate (regularCommaDeclaration.chpl:28)
+|
+End analyzing forall (regularCommaDeclaration.chpl:27)
 
-	with domain defined at
-	regularCommaDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularCommaDeclaration.chpl:13
-
-Potential access
-	regularCommaDeclaration.chpl:13
-
-	with domain defined at
-	regularCommaDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularCommaDeclaration.chpl:13
-
-Potential access
-	regularCommaDeclaration.chpl:13
-
-	with domain defined at
-	regularCommaDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularCommaDeclaration.chpl:13
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:13
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:13
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:13
-
-**** End forall ****
-	regularCommaDeclaration.chpl:12
-
-**** Start forall ****
-	regularCommaDeclaration.chpl:27
-
-Iterated over the domain of
-	regularCommaDeclaration.chpl:21
-
-, which is
-	regularCommaDeclaration.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	regularCommaDeclaration.chpl:27
-
-Potential access
-	regularCommaDeclaration.chpl:28
-
-	Can optimize: Access base is the iterator's base
-	regularCommaDeclaration.chpl:28
-
-Potential access
-	regularCommaDeclaration.chpl:28
-
-	with domain defined at
-	regularCommaDeclaration.chpl:19
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularCommaDeclaration.chpl:28
-
-Potential access
-	regularCommaDeclaration.chpl:28
-
-	with domain defined at
-	regularCommaDeclaration.chpl:19
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularCommaDeclaration.chpl:28
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:28
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:28
-
-	Marking static candidate
-	regularCommaDeclaration.chpl:28
-
-**** End forall ****
-	regularCommaDeclaration.chpl:27
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:13
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:13
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:13
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:28
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:28
-
-Static check successful. Using localAccess
-	regularCommaDeclaration.chpl:28
-
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:13)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:13)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:13)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:28)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:28)
+Static check successful. Using localAccess (regularCommaDeclaration.chpl:28)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration.good
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration.good
@@ -1,116 +1,51 @@
-**** Start forall ****
-	regularDeclaration.chpl:14
 
-Iterated symbol
-	regularDeclaration.chpl:4
+Start analyzing forall (regularDeclaration.chpl:14)
+| Found loop domain (regularDeclaration.chpl:4)
+| Will attempt static and dynamic optimizations (regularDeclaration.chpl:14)
+|
+|  Start analyzing call (regularDeclaration.chpl:15)
+|   Found the domain of the access base (regularDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration.chpl:15)
+|
+|  Start analyzing call (regularDeclaration.chpl:15)
+|   Found the domain of the access base (regularDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration.chpl:15)
+|
+|  Start analyzing call (regularDeclaration.chpl:15)
+|   Found the domain of the access base (regularDeclaration.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration.chpl:15)
+|
+End analyzing forall (regularDeclaration.chpl:14)
 
-Loop is suitable for static and dynamic analysis
-	regularDeclaration.chpl:14
 
-Potential access
-	regularDeclaration.chpl:15
+Start analyzing forall (regularDeclaration.chpl:31)
+| Found loop domain (regularDeclaration.chpl:23)
+| Will attempt static and dynamic optimizations (regularDeclaration.chpl:31)
+|
+|  Start analyzing call (regularDeclaration.chpl:32)
+|   Can optimize: Access base is the iterator's base (regularDeclaration.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration.chpl:32)
+|
+|  Start analyzing call (regularDeclaration.chpl:32)
+|   Found the domain of the access base (regularDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (regularDeclaration.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration.chpl:32)
+|
+|  Start analyzing call (regularDeclaration.chpl:32)
+|   Found the domain of the access base (regularDeclaration.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (regularDeclaration.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration.chpl:32)
+|
+End analyzing forall (regularDeclaration.chpl:31)
 
-	with domain defined at
-	regularDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration.chpl:15
-
-Potential access
-	regularDeclaration.chpl:15
-
-	with domain defined at
-	regularDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration.chpl:15
-
-Potential access
-	regularDeclaration.chpl:15
-
-	with domain defined at
-	regularDeclaration.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration.chpl:15
-
-	Marking static candidate
-	regularDeclaration.chpl:15
-
-	Marking static candidate
-	regularDeclaration.chpl:15
-
-	Marking static candidate
-	regularDeclaration.chpl:15
-
-**** End forall ****
-	regularDeclaration.chpl:14
-
-**** Start forall ****
-	regularDeclaration.chpl:31
-
-Iterated over the domain of
-	regularDeclaration.chpl:23
-
-, which is
-	regularDeclaration.chpl:21
-
-Loop is suitable for static and dynamic analysis
-	regularDeclaration.chpl:31
-
-Potential access
-	regularDeclaration.chpl:32
-
-	Can optimize: Access base is the iterator's base
-	regularDeclaration.chpl:32
-
-Potential access
-	regularDeclaration.chpl:32
-
-	with domain defined at
-	regularDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularDeclaration.chpl:32
-
-Potential access
-	regularDeclaration.chpl:32
-
-	with domain defined at
-	regularDeclaration.chpl:21
-
-	Can optimize: Access base has the same domain as iterator's base
-	regularDeclaration.chpl:32
-
-	Marking static candidate
-	regularDeclaration.chpl:32
-
-	Marking static candidate
-	regularDeclaration.chpl:32
-
-	Marking static candidate
-	regularDeclaration.chpl:32
-
-**** End forall ****
-	regularDeclaration.chpl:31
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration.chpl:32
-
+Static check successful. Using localAccess (regularDeclaration.chpl:15)
+Static check successful. Using localAccess (regularDeclaration.chpl:15)
+Static check successful. Using localAccess (regularDeclaration.chpl:15)
+Static check successful. Using localAccess (regularDeclaration.chpl:32)
+Static check successful. Using localAccess (regularDeclaration.chpl:32)
+Static check successful. Using localAccess (regularDeclaration.chpl:32)
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0
 10.0 17.0 24.0 31.0 38.0 45.0 52.0 59.0 66.0 73.0

--- a/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.good
+++ b/test/optimizations/autoLocalAccess/zipper/regularDeclaration2D.good
@@ -1,117 +1,53 @@
-**** Start forall ****
-	regularDeclaration2D.chpl:14
 
-Iterated symbol
-	regularDeclaration2D.chpl:4
+Start analyzing forall (regularDeclaration2D.chpl:14)
+| Found loop domain (regularDeclaration2D.chpl:4)
+| Will attempt static and dynamic optimizations (regularDeclaration2D.chpl:14)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:15)
+|   Found the domain of the access base (regularDeclaration2D.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:15)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:15)
+|   Found the domain of the access base (regularDeclaration2D.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:15)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:15)
+|   Found the domain of the access base (regularDeclaration2D.chpl:4)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:15)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:15)
+|
+End analyzing forall (regularDeclaration2D.chpl:14)
 
-Loop is suitable for static and dynamic analysis
-	regularDeclaration2D.chpl:14
 
-Potential access
-	regularDeclaration2D.chpl:15
+Start analyzing forall (regularDeclaration2D.chpl:31)
+| Found loop domain (regularDeclaration2D.chpl:21)
+| Will attempt static and dynamic optimizations (regularDeclaration2D.chpl:31)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:32)
+|   Found the domain of the access base (regularDeclaration2D.chpl:21)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:32)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:32)
+|   Found the domain of the access base (regularDeclaration2D.chpl:21)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:32)
+|
+|  Start analyzing call (regularDeclaration2D.chpl:32)
+|   Found the domain of the access base (regularDeclaration2D.chpl:21)
+|   Can optimize: Access base's domain is the iterator (regularDeclaration2D.chpl:32)
+|  This call is a static optimization candidate (regularDeclaration2D.chpl:32)
+|
+End analyzing forall (regularDeclaration2D.chpl:31)
 
-	with domain defined at
-	regularDeclaration2D.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:15
-
-Potential access
-	regularDeclaration2D.chpl:15
-
-	with domain defined at
-	regularDeclaration2D.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:15
-
-Potential access
-	regularDeclaration2D.chpl:15
-
-	with domain defined at
-	regularDeclaration2D.chpl:4
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:15
-
-	Marking static candidate
-	regularDeclaration2D.chpl:15
-
-	Marking static candidate
-	regularDeclaration2D.chpl:15
-
-	Marking static candidate
-	regularDeclaration2D.chpl:15
-
-**** End forall ****
-	regularDeclaration2D.chpl:14
-
-**** Start forall ****
-	regularDeclaration2D.chpl:31
-
-Iterated symbol
-	regularDeclaration2D.chpl:21
-
-Loop is suitable for static and dynamic analysis
-	regularDeclaration2D.chpl:31
-
-Potential access
-	regularDeclaration2D.chpl:32
-
-	with domain defined at
-	regularDeclaration2D.chpl:21
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:32
-
-Potential access
-	regularDeclaration2D.chpl:32
-
-	with domain defined at
-	regularDeclaration2D.chpl:21
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:32
-
-Potential access
-	regularDeclaration2D.chpl:32
-
-	with domain defined at
-	regularDeclaration2D.chpl:21
-
-	Can optimize: Access base's domain is the iterator
-	regularDeclaration2D.chpl:32
-
-	Marking static candidate
-	regularDeclaration2D.chpl:32
-
-	Marking static candidate
-	regularDeclaration2D.chpl:32
-
-	Marking static candidate
-	regularDeclaration2D.chpl:32
-
-**** End forall ****
-	regularDeclaration2D.chpl:31
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:15
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:32
-
-Static check successful. Using localAccess
-	regularDeclaration2D.chpl:32
-
+Static check successful. Using localAccess (regularDeclaration2D.chpl:15)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:15)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:15)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:32)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:32)
+Static check successful. Using localAccess (regularDeclaration2D.chpl:32)
 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0 17.0
 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0 24.0

--- a/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.good
+++ b/test/optimizations/autoLocalAccess/zipper/staticSuccessDynamicFail.good
@@ -1,43 +1,19 @@
-**** Start forall ****
-	staticSuccessDynamicFail.chpl:6
 
-Iterated over the domain of
-	staticSuccessDynamicFail.chpl:4
+Start analyzing forall (staticSuccessDynamicFail.chpl:6)
+| Found loop domain (staticSuccessDynamicFail.chpl:4)
+| Will attempt static and dynamic optimizations (staticSuccessDynamicFail.chpl:6)
+|
+|  Start analyzing call (staticSuccessDynamicFail.chpl:7)
+|   Can optimize: Access base is the iterator's base (staticSuccessDynamicFail.chpl:7)
+|  This call is a static optimization candidate (staticSuccessDynamicFail.chpl:7)
+|
+|  Start analyzing call (staticSuccessDynamicFail.chpl:7)
+|   Can't determine the domain of access base (staticSuccessDynamicFail.chpl:3)
+|  This call is a dynamic optimization candidate (staticSuccessDynamicFail.chpl:7)
+|
+End analyzing forall (staticSuccessDynamicFail.chpl:6)
 
-, whose domain cannot be determined statically
-	staticSuccessDynamicFail.chpl:4
-
-Loop is suitable for static and dynamic analysis
-	staticSuccessDynamicFail.chpl:6
-
-Potential access
-	staticSuccessDynamicFail.chpl:7
-
-	Can optimize: Access base is the iterator's base
-	staticSuccessDynamicFail.chpl:7
-
-Potential access
-	staticSuccessDynamicFail.chpl:7
-
-	regular domain symbol was not found for array
-	staticSuccessDynamicFail.chpl:3
-
-	Marking static candidate
-	staticSuccessDynamicFail.chpl:7
-
-	Marking dynamic candidate
-	staticSuccessDynamicFail.chpl:7
-
-**** End forall ****
-	staticSuccessDynamicFail.chpl:6
-
-Static check successful. Using localAccess
-	staticSuccessDynamicFail.chpl:7
-
-Static check successful. Using localAccess with dynamic check
-	staticSuccessDynamicFail.chpl:7
-
-Static check successful. Using localAccess
-	staticSuccessDynamicFail.chpl:7
-
+Static check successful. Using localAccess (staticSuccessDynamicFail.chpl:7)
+Static check successful. Using localAccess with dynamic check (staticSuccessDynamicFail.chpl:7)
+Static check successful. Using localAccess (staticSuccessDynamicFail.chpl:7)
 0 0 0 0 0 0 0 0 0

--- a/test/optimizations/autoLocalAccess/zipper/withInitializerCall.good
+++ b/test/optimizations/autoLocalAccess/zipper/withInitializerCall.good
@@ -1,108 +1,48 @@
-**** Start forall ****
-	withInitializerCall.chpl:13
 
-Iterated over the domain of
-	withInitializerCall.chpl:12
+Start analyzing forall (withInitializerCall.chpl:13)
+| Found loop domain (withInitializerCall.chpl:12)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:13)
+|
+|  Start analyzing call (withInitializerCall.chpl:14)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:14)
+|  This call is a static optimization candidate (withInitializerCall.chpl:14)
+|
+End analyzing forall (withInitializerCall.chpl:13)
 
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:12
 
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:13
+Start analyzing forall (withInitializerCall.chpl:20)
+| Found loop domain (withInitializerCall.chpl:19)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:20)
+|
+|  Start analyzing call (withInitializerCall.chpl:21)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:21)
+|  This call is a static optimization candidate (withInitializerCall.chpl:21)
+|
+End analyzing forall (withInitializerCall.chpl:20)
 
-Potential access
-	withInitializerCall.chpl:14
 
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:14
+Start analyzing forall (withInitializerCall.chpl:29)
+| Found loop domain (withInitializerCall.chpl:28)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:29)
+|
+|  Start analyzing call (withInitializerCall.chpl:30)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:30)
+|  This call is a static optimization candidate (withInitializerCall.chpl:30)
+|
+End analyzing forall (withInitializerCall.chpl:29)
 
-	Marking static candidate
-	withInitializerCall.chpl:14
 
-**** End forall ****
-	withInitializerCall.chpl:13
+Start analyzing forall (withInitializerCall.chpl:36)
+| Found loop domain (withInitializerCall.chpl:35)
+| Will attempt static and dynamic optimizations (withInitializerCall.chpl:36)
+|
+|  Start analyzing call (withInitializerCall.chpl:37)
+|   Can optimize: Access base is the iterator's base (withInitializerCall.chpl:37)
+|  This call is a static optimization candidate (withInitializerCall.chpl:37)
+|
+End analyzing forall (withInitializerCall.chpl:36)
 
-**** Start forall ****
-	withInitializerCall.chpl:20
-
-Iterated over the domain of
-	withInitializerCall.chpl:19
-
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:19
-
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:20
-
-Potential access
-	withInitializerCall.chpl:21
-
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:21
-
-	Marking static candidate
-	withInitializerCall.chpl:21
-
-**** End forall ****
-	withInitializerCall.chpl:20
-
-**** Start forall ****
-	withInitializerCall.chpl:29
-
-Iterated over the domain of
-	withInitializerCall.chpl:28
-
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:28
-
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:29
-
-Potential access
-	withInitializerCall.chpl:30
-
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:30
-
-	Marking static candidate
-	withInitializerCall.chpl:30
-
-**** End forall ****
-	withInitializerCall.chpl:29
-
-**** Start forall ****
-	withInitializerCall.chpl:36
-
-Iterated over the domain of
-	withInitializerCall.chpl:35
-
-, whose domain cannot be determined statically
-	withInitializerCall.chpl:35
-
-Loop is suitable for static and dynamic analysis
-	withInitializerCall.chpl:36
-
-Potential access
-	withInitializerCall.chpl:37
-
-	Can optimize: Access base is the iterator's base
-	withInitializerCall.chpl:37
-
-	Marking static candidate
-	withInitializerCall.chpl:37
-
-**** End forall ****
-	withInitializerCall.chpl:36
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:14
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:21
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:30
-
-Static check successful. Using localAccess
-	withInitializerCall.chpl:37
-
+Static check successful. Using localAccess (withInitializerCall.chpl:14)
+Static check successful. Using localAccess (withInitializerCall.chpl:21)
+Static check successful. Using localAccess (withInitializerCall.chpl:30)
+Static check successful. Using localAccess (withInitializerCall.chpl:37)


### PR DESCRIPTION
This PR improves the logging support for the automatic localAccess optimization.

The generated output looks like the following:

```

Start analyzing forall (dynamicCheckInGenericFunction.chpl:16)
| Found loop domain (dynamicCheckInGenericFunction.chpl:13)
| Will attempt static and dynamic optimizations (dynamicCheckInGenericFunction.chpl:16)
|
|  Start analyzing call (dynamicCheckInGenericFunction.chpl:17)
|   Can optimize: Access base is the iterator's base (dynamicCheckInGenericFunction.chpl:17)
|  This call is a static optimization candidate (dynamicCheckInGenericFunction.chpl:17)
|
|  Start analyzing call (dynamicCheckInGenericFunction.chpl:17)
|   Can't determine the domain of access base (dynamicCheckInGenericFunction.chpl:13)
|  This call is a dynamic optimization candidate (dynamicCheckInGenericFunction.chpl:17)
|
End analyzing forall (dynamicCheckInGenericFunction.chpl:16)

Static check successful. Using localAccess (dynamicCheckInGenericFunction.chpl:17)
```

where the first phase of the optimization concerns foralls and those are all grouped within `|`s. And the second phase concerns individual accesses and they are standalone one-liners.

Test:
- [x] standard
- [x] gasnet