### PR TITLE
Adjust map.items() to return by value rather than const ref

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -450,28 +450,23 @@ module Map {
     /*
       Iterates over the key-value pairs of this map.
 
-      :yields: A tuple of references to one of the key-value pairs contained in
-               this map.
+      :yields: A tuple containing a copy of one of the key-value pairs
+               contained in this map.
     */
     pragma "order independent yielding loops"
-    iter items() const ref {
+    iter items() {
+      if !isCopyableType(keyType) then
+        compilerError('in map.items(): map key type ' + keyType:string +
+                      ' is not copyable');
+
+      if !isCopyableType(valType) then
+        compilerError('in map.items(): map value type ' + valType:string +
+                      ' is not copyable');
+
       for slot in table.allSlots() {
         if table.isSlotFull(slot) {
           ref tabEntry = table.table[slot];
           yield (tabEntry.key, tabEntry.val);
-        }
-      }
-    }
-
-    pragma "no doc"
-    pragma "order independent yielding loops"
-    iter items() const ref where isNonNilableClass(valType) {
-      try! {
-        for slot in table.allSlots() {
-          if table.isSlotFull(slot) {
-            ref tabEntry = table.table[slot];
-            yield (tabEntry.key, tabEntry.val: valType);
-          }
         }
       }
     }

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -450,8 +450,8 @@ module Map {
     /*
       Iterates over the key-value pairs of this map.
 
-      :yields: A tuple containing a copy of one of the key-value pairs
-               contained in this map.
+      :yields: A tuple whose elements are a copy of one of the key-value
+               pairs contained in this map.
     */
     pragma "order independent yielding loops"
     iter items() {


### PR DESCRIPTION
The map.items() iterator currently returns a tuple by const ref. The
current rules for ref tuple returns mean that it is only possible
to return a tuple lvalue by ref, however the items() iterator
returns a tuple expression. This should be a bug (for now), so
adjust items to return by value instead.

Adjust the docs to mention that map.items() returns a copy.

Have items() emit a compiler error if either the keyType or valType
are not copyable.

Remove the overload of items() for non-nilable classes. It is
no longer needed now that Map is implemented using chpl__hashtable.

Resolves #16428.

---

Testing:

- [x] `library/standard/Map` locally with COMM=none
- [x] Updated docs rendered locally