### PR TITLE
Rename `version()` to `createVersion()`

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -32,7 +32,7 @@ specifically.  In more detail, it features:
 * :type:`sourceVersion`: a type that can be used to represent a semantic
   version number plus an optional commit value.
 
-* :proc:`version`: a utility function for creating new version values
+* :proc:`createVersion`: a utility function for creating new version values
 
 Version numbers in this module are represented using ``param`` values
 to permit code specialization by being able to reason about versions
@@ -46,7 +46,7 @@ The :type:`sourceVersion` type supports:
   and ``>``.  Generally speaking, "less than" corresponds to "is an
   earlier version than."  For example::
 
-    if chplVersion < version(1,23) then
+    if chplVersion < createVersion(1,23) then
       compilerWarning("This package doesn't support 'chpl' prior to 1.23.0");
 
 */
@@ -70,7 +70,7 @@ module Version {
   */
 
   const chplVersion;
-  chplVersion = version(chplMajor, chplMinor, chplUpdate, chplSHA);
+  chplVersion = createVersion(chplMajor, chplMinor, chplUpdate, chplSHA);
 
 
   /*
@@ -91,8 +91,10 @@ module Version {
 
     :returns: A new version value of type :type:`sourceVersion`.
   */
-  proc version(param major: int, param minor: int,
-               param update: int = 0, param commit: string = ""): sourceVersion(?) {
+  proc createVersion(param major: int,
+                     param minor: int,
+                     param update: int = 0,
+                     param commit: string = ""): sourceVersion(?) {
     return new sourceVersion(major, minor, update, commit);
 
   }

--- a/test/library/standard/Version/compareChplVersion.chpl
+++ b/test/library/standard/Version/compareChplVersion.chpl
@@ -1,18 +1,18 @@
 use Version;
 
-const v2_1_0 = version(2,1);
-const v2_1_1 = version(2,1,1);
-const v2_2_0 = version(2,2,0);
-const v2_2_1 = version(2,2,1);
-const v3_1_0 = version(3,1);
-const v3_1_1 = version(3,1,1);
+const v2_1_0 = createVersion(2,1);
+const v2_1_1 = createVersion(2,1,1);
+const v2_2_0 = createVersion(2,2,0);
+const v2_2_1 = createVersion(2,2,1);
+const v3_1_0 = createVersion(3,1);
+const v3_1_1 = createVersion(3,1,1);
 
-const v2_1_0_p = version(2,1,0,"aaa");
-const v2_1_1_p = version(2,1,1,"bbb");
-const v2_2_0_p = version(2,2,commit="ccc");
-const v2_2_1_p = version(2,2,1,"ddd");
-const v3_1_0_p = version(3,1,0,"eee");
-const v3_1_1_p = version(3,1,1,"fff");
+const v2_1_0_p = createVersion(2,1,0,"aaa");
+const v2_1_1_p = createVersion(2,1,1,"bbb");
+const v2_2_0_p = createVersion(2,2,commit="ccc");
+const v2_2_1_p = createVersion(2,2,1,"ddd");
+const v3_1_0_p = createVersion(3,1,0,"eee");
+const v3_1_1_p = createVersion(3,1,1,"fff");
 
 compareVersions(v2_1_0, v2_1_0);
 compareVersions(v2_1_0_p, v2_1_0_p);

--- a/test/library/standard/Version/compareChplVersionErrors.chpl
+++ b/test/library/standard/Version/compareChplVersionErrors.chpl
@@ -1,9 +1,9 @@
 use Version;
 
-const v2_1_0 = version(2,1);
-const v2_1_0_a = version(2,1,0,"aaa");
-const v2_1_0_b = version(2,1,commit="bbb");
-const v2_0_0_a = version(2,0,0,"aaa");
+const v2_1_0 = createVersion(2,1);
+const v2_1_0_a = createVersion(2,1,0,"aaa");
+const v2_1_0_b = createVersion(2,1,commit="bbb");
+const v2_0_0_a = createVersion(2,0,0,"aaa");
 
 compareBothVersions(v2_1_0, v2_1_0_a);
 compareBothVersions(v2_1_0_a, v2_1_0_b);


### PR DESCRIPTION
Based on polling the team, this renames the helper function `version()` to `createVersion()`.  Some reasons for this include (a) it's what we're doing for factory functions more now, (b) it removes a potential for conflict or confusion for library modules that want to store a member variable `version`, (c) we anticipate that the more common case for end-users might be to compare against floating point values (where `version()` was originally designed to make such cases easy to read).