### PR TITLE
Change version cast-to-string to be param

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -141,12 +141,13 @@ module Version {
 
   // cast from sourceVersion to string
   pragma "no doc"
-  proc _cast(type t: string, x: sourceVersion(?)) {
-    var str = "version " + x.major:string + "." + x.minor:string + "." +
-        x.update:string;
-    if (x.commit != "") then
-      str += " (" + x.commit + ")";
-    return str;
+  proc _cast(type t: string, x: sourceVersion(?)) param {
+    if (x.commit == "") then
+      return ("version " + x.major:string + "." + x.minor:string + "." +
+              x.update:string);
+    else
+      return ("version " + x.major:string + "." + x.minor:string + "." +
+              x.update:string + " (" + x.commit + ")");
   }
 
 

--- a/test/library/standard/Version/versionCastIsParam.chpl
+++ b/test/library/standard/Version/versionCastIsParam.chpl
@@ -1,0 +1,11 @@
+use Version;
+
+var v = createVersion(1,23,0);
+param test = (v:string == "version 1.23.0");
+if test == false then
+  compilerError("Boo!");
+
+if test == true then
+  compilerError("Yay!");
+
+

--- a/test/library/standard/Version/versionCastIsParam.chpl
+++ b/test/library/standard/Version/versionCastIsParam.chpl
@@ -2,10 +2,12 @@ use Version;
 
 var v = createVersion(1,23,0);
 param test = (v:string == "version 1.23.0");
+
+var v2 = createVersion(1,23,0,"vass");
+compilerWarning(v2:string);
+
 if test == false then
   compilerError("Boo!");
 
 if test == true then
   compilerError("Yay!");
-
-

--- a/test/library/standard/Version/versionCastIsParam.good
+++ b/test/library/standard/Version/versionCastIsParam.good
@@ -1,1 +1,2 @@
-versionCastIsParam.chpl:9: error: Yay!
+versionCastIsParam.chpl:7: warning: version 1.23.0 (vass)
+versionCastIsParam.chpl:13: error: Yay!

--- a/test/library/standard/Version/versionCastIsParam.good
+++ b/test/library/standard/Version/versionCastIsParam.good
@@ -1,0 +1,1 @@
+versionCastIsParam.chpl:9: error: Yay!


### PR DESCRIPTION
It seems that the original version wasn't a param even though the
docs said it was (?!).  Thanks to @vasslitvinov for catching this.
