### PR TITLE
Make PCGRandomLib private by default

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -767,7 +767,7 @@ module Random {
 
     use super.RandomSupport;
     private use Random;
-    public use PCGRandomLib;
+    private use PCGRandomLib;
     use ChapelLocks;
 
     // How many generators do we need for this type?

--- a/test/classes/ferguson/forwarding/isx-bug.chpl
+++ b/test/classes/ferguson/forwarding/isx-bug.chpl
@@ -366,6 +366,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
 
 proc makeInput(taskID, myKeys) {
   use Random.PCGRandom;
+  use Random.PCGRandomLib;
 
   //
   // Seed RNG

--- a/test/library/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-check.chpl
@@ -1,4 +1,4 @@
-use Random;
+use Random, Random.PCGRandomLib;
 
 config const verbose = false;
 

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
@@ -1,4 +1,4 @@
-use Random;
+use Random, Random.PCGRandomLib;
 
 config const verbose = false;
 

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
@@ -1,4 +1,4 @@
-use Random;
+use Random, Random.PCGRandomLib;
 
 config const seed = 42;
 

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -340,6 +340,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
 
 proc makeInput(taskID, myKeys) {
   use Random.PCGRandom;
+  use Random.PCGRandomLib;
 
   //
   // Seed RNG

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -340,6 +340,7 @@ proc verifyResults(bucketID, myBucketSize, myLocalKeyCounts) {
 
 proc makeInput(bucketID) {
   use Random;
+  use Random.PCGRandomLib;
 
   var myKeys: [0..#keysPerBucket] keyType;
 

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -364,6 +364,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
 
 proc makeInput(taskID, myKeys) {
   use Random.PCGRandom;
+  use Random.PCGRandomLib;
 
   //
   // Seed RNG

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -332,6 +332,7 @@ proc verifyResults(bucketID, myBucketSize, myLocalKeyCounts) {
 
 proc makeInput(myKeys, bucketID) {
   use Random;
+  use Random.PCGRandomLib;
 
   //
   // Seed RNG

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -346,6 +346,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
 
 proc makeInput(taskID) {
   use Random;
+  use Random.PCGRandomLib;
 
   var myKeys: [0..#keysPerTask] keyType;
 


### PR DESCRIPTION
Michael pointed this out in #16119, though it was not unique to that PR
or related to its intent, so I saved it for a separate PR.

This required extending the current ISx benchmarks to make them
`use` it explicitly (is it appropriate that they do so?), and updating
some tests of the PCG stream's internals (which seems completely
appropriate).
