### PR TITLE
Update block na-none comm counts

### DIFF
--- a/test/arrays/slices/commCounts/sliceBlockWithRanges.na-none.good
+++ b/test/arrays/slices/commCounts/sliceBlockWithRanges.na-none.good
@@ -1,7 +1,7 @@
 
 Creating B (a normal slice)
 ---------------------------
-(execute_on = 4, execute_on_nb = 3) (get = 25, put = 2, execute_on = 2, execute_on_fast = 1) (get = 25, put = 2, execute_on_fast = 1) (get = 25, put = 2, execute_on_fast = 1)
+(execute_on = 4, execute_on_nb = 3) (get = 24, put = 1, execute_on = 2, execute_on_fast = 1) (get = 24, put = 1, execute_on_fast = 1) (get = 24, put = 1, execute_on_fast = 1)
 
 A is:
 0.0 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0 1.0

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.na-none.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 83, put = 2, execute_on = 7, execute_on_fast = 2) (get = 83, put = 2, execute_on_fast = 2) (get = 83, put = 2, execute_on_fast = 2)
+(execute_on = 14, execute_on_nb = 6) (get = 82, put = 1, execute_on = 7, execute_on_fast = 2) (get = 82, put = 1, execute_on_fast = 2) (get = 82, put = 1, execute_on_fast = 2)
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.block.na-none.good
@@ -1,1 +1,1 @@
-(execute_on = 8, execute_on_nb = 9) (get = 33, put = 2, execute_on = 4, execute_on_fast = 3) (get = 33, put = 2, execute_on_fast = 3) (get = 33, put = 2, execute_on_fast = 3)
+(execute_on = 8, execute_on_nb = 9) (get = 32, put = 1, execute_on = 4, execute_on_fast = 3) (get = 32, put = 1, execute_on_fast = 3) (get = 32, put = 1, execute_on_fast = 3)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.block.na-none.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 27, put = 2, execute_on = 3, execute_on_fast = 2) (get = 27, put = 2, execute_on = 1, execute_on_fast = 2) (get = 27, put = 2, execute_on = 1, execute_on_fast = 2)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 26, put = 1, execute_on = 3, execute_on_fast = 2) (get = 26, put = 1, execute_on = 1, execute_on_fast = 2) (get = 26, put = 1, execute_on = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/sliceOps.block.na-none.good
@@ -1,5 +1,5 @@
 create slice (module-scope):
-(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
+(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
 use slice via assignment (module-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 use slice via random access (module-scope):
@@ -15,7 +15,7 @@ use slice as follower (module-scope):
 2-arg promotion (module-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 create slice (local-scope):
-(execute_on = 2) (get = 1, put = 1, execute_on = 1) (get = 1, put = 1) (get = 1, put = 1)
+(execute_on = 2) (execute_on = 1) (<no communication>) (<no communication>)
 use slice via assignment (local-scope):
 (execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)
 use slice via random access (local-scope):


### PR DESCRIPTION
While doing a sanity check on master against all my PRs tonight,
I found that PR #16477 improved comm counts for a handful of
tests.  I had the energy to update the block na-none cases, but
not the others, hoping that this would save us at least a few
emails tonight.
