### PR TITLE
Prediff test output only in non-performance runs

### DIFF
--- a/test/optimizations/bulkcomm/block/exchange.prediff
+++ b/test/optimizations/bulkcomm/block/exchange.prediff
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-sed -n "s/.*\(Will do parallel transfer\).*/\1/p" <$2 >$2.tmp
-mv $2.tmp $2
+if [[ -z ${CHPL_TEST_PERF} ]]; then
+  sed -n "s/.*\(Will do parallel transfer\).*/\1/p" <$2 >$2.tmp
+  mv $2.tmp $2
+fi


### PR DESCRIPTION
I made this test a correctness test with a prediff yesterday. But that prediff
interfered with comm count testing. This PR adjusts the prediff file.
