### PR TITLE
Make some helpers common to string and bytes casts

### DIFF
--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -198,7 +198,7 @@ module BytesCasts {
     var isErr: bool;
     var localX = x.localize();
 
-    _cleanupForNumericCast(t, localX);
+    _cleanupForNumericCast(localX);
 
     select numBits(t) {
       when 32 do retVal = c_string_to_real32(localX.c_str(), isErr);
@@ -227,7 +227,7 @@ module BytesCasts {
     var isErr: bool;
     var localX = x.localize();
 
-    _cleanupForNumericCast(t, localX);
+    _cleanupForNumericCast(localX);
 
     select numBits(t) {
       when 32 do retVal = c_string_to_imag32(localX.c_str(), isErr);

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -28,7 +28,7 @@ module BytesCasts {
   //
   // Bool
   //
-  inline proc _cast(type t:bytes, x: bool) {
+  proc _cast(type t:bytes, x: bool) {
     if (x) {
       return b"true";
     } else {
@@ -84,7 +84,7 @@ module BytesCasts {
     return ret;
   }
 
-  inline proc _cast(type t:integral, x: bytes) throws {
+  proc _cast(type t:integral, x: bytes) throws {
     //TODO: switch to using qio's readf somehow
     pragma "fn synchronization free"
     pragma "insert line file info"
@@ -157,7 +157,7 @@ module BytesCasts {
   //
   // real & imag
   //
-  inline proc _real_cast_helper(x: real(64), param isImag: bool) : bytes {
+  proc _real_cast_helper(x: real(64), param isImag: bool) : bytes {
     pragma "fn synchronization free"
     extern proc real_to_c_string(x:real(64), isImag: bool) : c_string;
     pragma "fn synchronization free"
@@ -173,7 +173,7 @@ module BytesCasts {
     return ret;
   }
 
-  proc _cast(type t:bytes, x:chpl_anyreal) {
+  inline proc _cast(type t:bytes, x:chpl_anyreal) {
     //TODO: switch to using qio's writef somehow
     return _real_cast_helper(x:real(64), false);
   }
@@ -186,7 +186,7 @@ module BytesCasts {
     return _real_cast_helper(r, true);
   }
 
-  inline proc _cast(type t:chpl_anyreal, x: bytes) throws {
+  proc _cast(type t:chpl_anyreal, x: bytes) throws {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc c_string_to_real32(x: c_string, ref err: bool) : real(32);
@@ -215,7 +215,7 @@ module BytesCasts {
     return retVal;
   }
 
-  inline proc _cast(type t:chpl_anyimag, x: bytes) throws {
+  proc _cast(type t:chpl_anyimag, x: bytes) throws {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc c_string_to_imag32(x: c_string, ref err: bool) : imag(32);
@@ -270,7 +270,7 @@ module BytesCasts {
   }
 
 
-  inline proc _cast(type t:chpl_anycomplex, x: bytes) throws {
+  proc _cast(type t:chpl_anycomplex, x: bytes) throws {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc c_string_to_complex64(x:c_string, ref err: bool) : complex(64);

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -1345,6 +1345,48 @@ module BytesStringCommon {
     return ret;
   }
 
+  // cast helpers
+  proc _cleanupForNumericCast(ref x: ?t) {
+    assertArgType(t, "_cleanupForNumericCast");
+
+    param underscore = "_".toByte();
+
+    var hasUnderscores = false;
+    for bIdx in 1..<x.numBytes {
+      if x.byte[bIdx] == underscore then {
+        hasUnderscores = true;
+        break;
+      }
+    }
+
+    if hasUnderscores {
+      x = x.strip();
+      // don't remove anything and let it fail later on
+      if _isSingleWord(x) {
+        var len = x.size;
+        if len >= 2 {
+          // Don't remove a leading underscore in the string number,
+          // but remove the rest.
+          if len > 2 && x.byte(0) == underscore {
+            x = x[0] + x[1..].replace("_":t, "":t);
+          } else {
+            x = x.replace("_":t, "":t);
+          }
+        }
+      }
+    }
+  }
+
+  private proc _isSingleWord(const ref x: ?t) {
+    assertArgType(t, "_isSingleWord");
+    // here we assume that the string is all ASCII, if not, we'll get an error
+    // from the actual conversion function, anyways
+    for b in x.bytes() {
+      if byte_isWhitespace(b) then return false;
+    }
+    return true;
+  }
+
   // character-wise operation helpers
 
   require "ctype.h";

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -1368,7 +1368,7 @@ module BytesStringCommon {
           // Don't remove a leading underscore in the string number,
           // but remove the rest.
           if len > 2 && x.byte(0) == underscore {
-            x = x[0] + x[1..].replace("_":t, "":t);
+            x = x.item(0) + x[1..].replace("_":t, "":t);
           } else {
             x = x.replace("_":t, "":t);
           }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -123,7 +123,7 @@ module StringCasts {
     _cleanupForNumericCast(localX);
 
     if localX.isEmpty() then
-      throw new owned IllegalArgumentError("bad cast from empty string to " + t:string);
+      throw new owned IllegalArgumentError("bad cast from string '"+ x + "' to " + t:string);
 
     if isIntType(t) {
       select numBits(t) {


### PR DESCRIPTION
String casts have gone through some improvements recently:

https://github.com/chapel-lang/chapel/pull/16278
https://github.com/chapel-lang/chapel/pull/16355

However, we haven't made the symmetric changes for BytesCasts. This PR makes
such changes. Namely:

- Moves string cleanup routines to `BytesStringCommon` and uses them from
  `BytesCasts`

- Removes `inline` from many functions in `BytesCasts`

https://github.com/chapel-lang/chapel/pull/15870 also made some changes in how
we create new strings in `StringCasts`, however, we don't have symmetric changes
in `BytesCasts`, yet. In the near future, I hope to be able reduce this
redundancy by putting many cast implementations to `BytesStringCommon`.

Test:
- [x] standard
- [x] gasnet
