### PR TITLE
Improve MCM conformance in comm=ofi.

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1215,6 +1215,9 @@ module ChapelBase {
     delete _to_unmanaged(e);
   }
 
+  pragma "no doc"
+  extern proc chpl_comm_task_create();
+
   // This function is called by the initiating task once for each new
   // task *before* any of the tasks are started.  As above, no on
   // statement needed.
@@ -1237,6 +1240,9 @@ module ChapelBase {
     }
     if countRunningTasks {
       here.runningTaskCntAdd(1);  // decrement is in _waitEndCount()
+      chpl_comm_task_create();    // countRunningTasks is a proxy for "is local"
+                                  // here.  Comm layers are responsible for the
+                                  // remote case themselves.
     }
   }
 
@@ -1250,6 +1256,9 @@ module ChapelBase {
       if numTasks > 1 {
         here.runningTaskCntAdd(numTasks:int-1);  // decrement is in _waitEndCount()
       }
+      chpl_comm_task_create();    // countRunningTasks is a proxy for "is local"
+                                  // here.  Comm layers are responsible for the
+                                  // remote case themselves.
     } else {
       here.runningTaskCntSub(1);
     }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1215,9 +1215,6 @@ module ChapelBase {
     delete _to_unmanaged(e);
   }
 
-  pragma "no doc"
-  extern proc chpl_comm_task_create();
-
   // This function is called by the initiating task once for each new
   // task *before* any of the tasks are started.  As above, no on
   // statement needed.
@@ -1265,6 +1262,8 @@ module ChapelBase {
   }
 
   extern proc chpl_comm_unordered_task_fence(): void;
+
+  extern proc chpl_comm_task_create();
 
   pragma "task complete impl fn"
   extern proc chpl_comm_task_end(): void;

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -512,6 +512,17 @@ void chpl_comm_unordered_task_fence(void) {
 }
 
 
+// This is a hook that's called when a task is creating a child task.
+#ifndef CHPL_COMM_IMPL_TASK_CREATE
+#define CHPL_COMM_IMPL_TASK_CREATE() \
+        return
+#endif
+static inline
+void chpl_comm_task_create(void) {
+  CHPL_COMM_IMPL_TASK_CREATE();
+}
+
+
 // This is a hook that's called when a task is ending. It allows for things
 // like say flushing task private buffers.
 #ifndef CHPL_COMM_IMPL_TASK_END

--- a/runtime/include/comm/ofi/chpl-comm-impl.h
+++ b/runtime/include/comm/ofi/chpl-comm-impl.h
@@ -45,6 +45,10 @@ size_t chpl_comm_impl_regMemHeapPageSize(void);
         chpl_comm_impl_unordered_task_fence()
 void chpl_comm_impl_unordered_task_fence(void);
 
+#define CHPL_COMM_IMPL_TASK_CREATE() \
+        chpl_comm_impl_task_create()
+void chpl_comm_impl_task_create(void);
+
 #define CHPL_COMM_IMPL_TASK_END() \
         chpl_comm_impl_task_end()
 void chpl_comm_impl_task_end(void);

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -35,8 +35,6 @@
 
 typedef struct {
   chpl_cache_taskPrvData_t cache_data;
-  uint8_t nfaCount;     // nonfetching AMO AM count
-  void* nfaBitmap;      // nonfetching AMO AM target nodes
   void* amo_nf_buff;
   void* get_buff;
   void* put_buff;

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -34,9 +34,10 @@
 #define HAS_CHPL_CACHE_FNS
 
 typedef struct {
+  chpl_bool taskIsEnding;       // task is ending? (anticipate _downEndCount())
+  chpl_bool amDonePending;      // some delayed AM 'done' is expected?
+  uint8_t amDone;               // delayed 'done' indicator
   chpl_cache_taskPrvData_t cache_data;
-  void* pAmDone;
-  chpl_bool amDonePending;
   void* amo_nf_buff;
   void* get_buff;
   void* put_buff;

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -35,6 +35,8 @@
 
 typedef struct {
   chpl_cache_taskPrvData_t cache_data;
+  void* pAmDone;
+  chpl_bool amDonePending;
   void* amo_nf_buff;
   void* get_buff;
   void* put_buff;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1154,8 +1154,9 @@ void init_ofiFabricDomain(void) {
   //   - send-after-send ordering
   // - rx endpoints same as tx
   // - RDM endpoints
-  // - table-style address vectors
+  // - domain threading model, since we manage thread contention ourselves
   // - resource management, to improve the odds we hear about exhaustion
+  // - table-style address vectors
   // - in addition, include the memory registration modes we can support
   //
   const char* prov_name = getProviderName();
@@ -1175,8 +1176,9 @@ void init_ofiFabricDomain(void) {
   hints->tx_attr->msg_order = FI_ORDER_SAS;
   hints->rx_attr->msg_order = hints->tx_attr->msg_order;
   hints->ep_attr->type = FI_EP_RDM;
-  hints->domain_attr->av_type = FI_AV_TABLE;
+  hints->domain_attr->threading = FI_THREAD_DOMAIN;
   hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+  hints->domain_attr->av_type = FI_AV_TABLE;
 
   hints->domain_attr->mr_mode = (  FI_MR_LOCAL
                                  | FI_MR_VIRT_ADDR


### PR DESCRIPTION
This is a collection of changes that improve MCM conformance in the
libfabric-based comm layer.  The major changes are to favor delivery-
complete completion semantics as our solution for MCM conformance over
message ordering settings, and to improve how we ensure non-fetching
AMOs done by means of nonblocking AMs are complete as required by the
MCM.

The original "solution" to the problem of ensuring AMO completion was
added in PR #15712 and involved using non-blocking AMs, tracking the
number of such outstanding AMs and their target nodes, and following up
when needed with blocking no-op AMs to ensure the non-blocking ones were
done.  Unfortunately this was both heavyweight because it involved
allocating and maintaining a numNodes-sized bitmap, and broken because
it only forced order among AMOs targeting the same node, not all nodes
as the MCM requires.  So here, we remove this and instead solve the
problem by using blocking AMs so that we know when the target memory has
been updated, but not waiting for the 'done' indicators resulting from
those until we do the next thing with MCM implications.

Relatedly, this also adds `chpl_comm_task_create()` as a sibling of the
task fence function `chpl_comm_task_end()`, and calls this new function
from `_upEndCount()` before we create child tasks or groups of same.  We
only need the parent to call this because its purpose is to fence the
parent's "recent" remote operations (including non-fetching AMOs) so
that their results are definitely visible to children created later.
Because for now only comm=ofi needs this function, it's declared by
means of the usual mechanism for optional runtime functions and only ofi
defines it.

While here I also made some performance-related changes.  We now use the
"domain" threading model rather than the default "safe" one, which
reduces lock usage inside libfabric and its providers.  We also now
inject sending operations when possible instead of initiating them
normally, which speeds things up slightly.

This improves performance in some tests and reduces it in others, though
overall the effect seems positive.  (Some of the regressions seem to be
an unfortunate side effect of removing the bug related to non-fetching
AMO completion.)  The new create-task fence function may also allow us
to improve performance for regular PUTs in the future.

This resolves https://github.com/Cray/chapel-private/issues/1307.