### PR TITLE
Update spec links to modules/technotes/primers use chpl-domain references

### DIFF
--- a/doc/rst/language/spec/acknowledgements.rst
+++ b/doc/rst/language/spec/acknowledgements.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Acknowledgments:
 
 Acknowledgments

--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Arrays:
 
 Arrays

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -85,17 +85,15 @@ Each allocation of a class instance specifies a *memory management
 strategy*. Four memory management strategies are available: ``owned``,
 ``shared``, ``borrowed``, and ``unmanaged``.
 
-| ``owned`` and ``shared`` class instances always have their lifetime
-  managed by the compiler. In other words, the compiler automatically
-  calls ``delete`` on these instances to reclaim their memory. For these
-  instances, ``=`` and copy initialization can result in the transfer or
-  sharing of ownership. See
-| https://chapel-lang.org/docs/builtins/OwnedObject.html
-| and
-| https://chapel-lang.org/docs/builtins/SharedObject.html
-| When ``borrowed`` is used as a memory management strategy in a
-  ``new-expression``, it also creates an instance that has its lifetime
-  managed by the compiler (:ref:`Class_New`).
+``owned`` and ``shared`` class instances always have their lifetime
+managed by the compiler. In other words, the compiler automatically calls
+``delete`` on these instances to reclaim their memory. For these
+instances, ``=`` and copy initialization can result in the transfer or
+sharing of ownership. See the module documentation for :mod:`owned
+<OwnedObject>` and :mod:`shared <SharedObject>`.  When ``borrowed`` is
+used as a memory management strategy in a ``new-expression``, it also
+creates an instance that has its lifetime managed by the compiler
+(:ref:`Class_New`).
 
 Class instances that are ``unmanaged`` have their lifetime managed
 explicitly and ``delete`` must be used to reclaim their memory.
@@ -204,14 +202,14 @@ nilable (:ref:`Nilable_Classes`).
 
 The memory management strategies have the following meaning:
 
--  | ``owned`` the instance will be deleted automatically when the
-     ``owned`` variable goes out of scope, but only one ``owned``
-     variable can refer to the instance at a time. See
-   | https://chapel-lang.org/docs/builtins/OwnedObject.html
+-  ``owned`` the instance will be deleted automatically when the
+   ``owned`` variable goes out of scope, but only one ``owned`` variable
+   can refer to the instance at a time. See the module documentation for
+   :mod:`owned <OwnedObject>`.
 
--  | ``shared`` will be deleted when all of the ``shared`` variables
-     referring to the instance go out of scope. See
-   | https://chapel-lang.org/docs/builtins/SharedObject.html.
+-  ``shared`` will be deleted when all of the ``shared`` variables
+   referring to the instance go out of scope. See
+   the module documentation for :mod:`shared <SharedObject>`.
 
 -  ``borrowed`` refers to a class instance that has a lifetime managed
    by another variable.

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Classes:
 
 Classes

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Conversions:
 
 Conversions

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -93,12 +93,12 @@ In practice, the number of tasks that will be used to evaluate a
 *leading* the execution of the loop, as is the mapping of iterations to
 tasks.
 
-| This concept will be formalized in future drafts of the Chapel
-  specification. For now, the primer on parallel iterators in the online
-  documentation provides a brief introduction:
-| https://chapel-lang.org/docs/primers/parIters.html
-| Please also refer to *User-Defined Parallel Zippered Iterators in
-  Chapel*, published in the PGAS 2011 workshop.
+This concept will be formalized in future drafts of the Chapel
+specification. For now, the
+:ref:`primer on parallel iterators <primers-parIters>` in the online
+documentation provides a brief introduction.
+Please also refer to *User-Defined Parallel Zippered Iterators in
+Chapel*, published in the PGAS 2011 workshop.
 
 Control continues with the statement following the forall loop only
 after every iteration has been completely evaluated. At this point, all
@@ -319,17 +319,17 @@ creation time. Within the lexical scope of the forall construct, the
 variable name references the captured value instead of the original
 value.
 
-| A formal can be given another intent explicitly by listing it with
-  that intent in the optional ``task-intent-clause``. For example, for
-  variables of most types, the ``ref`` intent allows the body of the
-  forall loop to modify the corresponding original variable or to read
-  its updated value after concurrent modifications. The ``in`` intent is
-  an alternative way to obtain task-private variables
-  (:ref:`Task_Private_Variables`). A ``reduce`` intent can be used
-  to reduce values across iterations of a forall or coforall loop.
-  Reduce intents are described in the *Reduce Intents* technical note in
-  the online documentation:
-| https://chapel-lang.org/docs/technotes/reduceIntents.html
+A formal can be given another intent explicitly by listing it with
+that intent in the optional ``task-intent-clause``. For example, for
+variables of most types, the ``ref`` intent allows the body of the
+forall loop to modify the corresponding original variable or to read
+its updated value after concurrent modifications. The ``in`` intent is
+an alternative way to obtain task-private variables
+(:ref:`Task_Private_Variables`). A ``reduce`` intent can be used
+to reduce values across iterations of a forall or coforall loop.
+Reduce intents are described in the
+:ref:`Reduce Intents technical note <readme-reduceIntents>` in
+the online documentation.
 
    *Rationale*.
 

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Data_Parallelism:
 
 Data Parallelism

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -29,15 +29,15 @@ Domain maps are presented as follows:
 -  domain maps are not retained upon domain assignment
    :ref:`Domain_Maps_Not_Assigned`
 
--  | standard layouts and distributions, such as Block and Cyclic, are
-     documented under *Standard Layouts and Distributions* in Chapel's online
-     documentation here:
-   | https://chapel-lang.org/docs/modules/layoutdist.html
+-  standard layouts and distributions, such as Block and Cyclic, are
+   documented under
+   :ref:`Standard Layouts and Distributions <layouts_and_distributions>`
+   in Chapel's online documentation.
 
--  | specification of user-defined domain maps is forthcoming; please
-     refer to the *Domain Map Standard Interface* page under *Technical
-     Notes* in Chapel's online documentation here:
-   | https://chapel-lang.org/docs/technotes/dsi.html
+-  specification of user-defined domain maps is forthcoming; please
+   refer to the
+   :ref:`Domain Map Standard Interface technical note <readme-dsi>`
+   in Chapel's online documentation.
 
 .. _Domain_Maps_For_Types:
 

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -81,11 +81,10 @@ record with a single generic field, which holds the domain map instance.
       use BlockDist;
       var MyBlockDist: dmap(Block(rank=2));
 
-   | declares a variable capable of storing dmap values for a
-     two-dimensional Block distribution. The Block distribution is
-     described in more detail in the standard library documentation.
-     See:
-   | https://chapel-lang.org/docs/modules/dists/BlockDist.html
+   declares a variable capable of storing dmap values for a
+   two-dimensional Block distribution. The Block distribution is
+   described in more detail in the standard library documentation.
+   See the module documentation for :mod:`BlockDist`.
 
 ..
 

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Domain_Maps:
 
 Domain Maps

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Domains:
 
 Domains

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -12,10 +12,10 @@ a less-permissive mode intended for production code.
 
    *Implementation Notes*.
 
-   | Additional information about the current implementation of
-     error handling and the *strict* error handling mode, which is not
-     defined here, is available online in the technical note:
-   | https://chapel-lang.org/docs/technotes/errorHandling.html
+   Additional information about the current implementation of
+   error handling and the *strict* error handling mode, which is not
+   defined here, is available online in the errorHandling technical note
+   :ref:`readme-errorHandling`.
 
 .. _Throwing_Errors:
 
@@ -448,7 +448,7 @@ TaskErrors
 ``TaskErrors`` class helps coordinate errors among groups of tasks by
 collecting them for centralized handling. It can be iterated on and
 filtered for different kinds of errors. See also
-https://chapel-lang.org/docs/builtins/ChapelError.html#ChapelError.TaskErrors.
+the module documentation for :class:`TaskErrors <ChapelError.TaskErrors>`.
 
 Nested ``coforall`` statements do not produce nested ``TaskErrors``.
 Instead, the nested errors are flattened into the ``TaskErrors`` error
@@ -579,11 +579,11 @@ Creating New Error Types
 Errors in Chapel are implemented as classes, with a base class ``Error``
 defined in the standard modules. ``Error`` may be used directly, and new
 subclass hierarchies may be created from it. See also
-https://chapel-lang.org/docs/builtins/ChapelError.html.
+the module documentation for :mod:`ChapelError`.
 
 A hierarchy for system errors is included in the ``SysError`` module,
 accessed with a ``use`` statement. See also
-https://chapel-lang.org/docs/modules/standard/SysError.html
+the module documentation for :mod:`SysError`.
 
    *Example (defining-errors.chpl)*.
 

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Error_Handling:
 
 Error Handling

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Expressions:
 
 Expressions

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Generics:
 
 Generics

--- a/doc/rst/language/spec/input-and-output.rst
+++ b/doc/rst/language/spec/input-and-output.rst
@@ -8,8 +8,6 @@ Input and Output
 See Library Documentation
 -------------------------
 
-| Chapel includes an extensive library for input and output that is
-  documented in the standard library documentation. See
-| https://chapel-lang.org/docs/modules/standard/IO.html
-| and
-| https://chapel-lang.org/docs/builtins/ChapelIO.html.
+Chapel includes an extensive library for input and output that is
+documented in the standard library documentation. See
+the :mod:`IO` and :mod:`ChapelIO` module documentation.

--- a/doc/rst/language/spec/input-and-output.rst
+++ b/doc/rst/language/spec/input-and-output.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Input_and_Output:
 
 Input and Output

--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Interoperability:
 
 Interoperability

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Iterators:
 
 Iterators

--- a/doc/rst/language/spec/language-overview.rst
+++ b/doc/rst/language/spec/language-overview.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Language_Overview:
 
 Language Overview

--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Lexical_Structure:
 
 Lexical Structure

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Locales_Chapter:
 
 Locales

--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Memory_Consistency_Model:
 
 Memory Consistency Model

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Methods:
 
 Methods

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -1212,7 +1212,7 @@ deinitialization:
    function named ``deinit()``, it is executed first.
 
 -  If the module declares module-scope variables, they are deinitialized in
-   the reverse order of their declaration.
+   the reverse order of their initialization.
 
 Module deinitialization order is discussed
 in :ref:`Module_Deinitialization_Order`.

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Modules:
 
 Modules

--- a/doc/rst/language/spec/notation.rst
+++ b/doc/rst/language/spec/notation.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Notation:
 
 Notation

--- a/doc/rst/language/spec/organization.rst
+++ b/doc/rst/language/spec/organization.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Organization:
 
 Organization

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Procedures:
 
 Procedures

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Ranges:
 
 Ranges

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Records:
 
 Records

--- a/doc/rst/language/spec/scope.rst
+++ b/doc/rst/language/spec/scope.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Scope:
 
 Scope

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Statements:
 
 Statements

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -872,14 +872,14 @@ The syntax of the task intent clause is:
      formal-intent identifier
      task-private-var-decl
 
-| where the following intents can be used as a ``formal-intent``:
-  ``ref``, ``in``, ``const``, ``const in``, ``const ref``.
-  ``task-private-var-decl`` is defined in
-  :ref:`Task_Private_Variables`. In addition,
-  ``task-intent-item`` may define a ``reduce`` intent. Reduce intents
-  are described in the *Reduce Intents* technical note in the online
-  documentation:
-| https://chapel-lang.org/docs/technotes/reduceIntents.html
+where the following intents can be used as a ``formal-intent``:
+``ref``, ``in``, ``const``, ``const in``, ``const ref``.
+``task-private-var-decl`` is defined in
+:ref:`Task_Private_Variables`. In addition,
+``task-intent-item`` may define a ``reduce`` intent. Reduce intents
+are described in the
+:ref:`Reduce Intents technical note <readme-reduceIntents>` in
+the online documentation.
 
 The implicit treatment of outer scope variables as the task function’s
 formal arguments applies to both module level and local variables. It

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Task_Parallelism_and_Synchronization:
 
 Task Parallelism and Synchronization

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Tuples:
 
 Tuples

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -1,6 +1,6 @@
-.. _Chapter-Types:
-
 .. default-domain:: chpl
+
+.. _Chapter-Types:
 
 Types
 =====

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -220,10 +220,10 @@ The default complex type, ``complex``, is 128 bits; it consists of two
 machine-dependent, but usually include ``complex(64)`` and
 ``complex(128)``.
 
-| The real and imaginary components can be accessed via the methods
-  ``re`` and ``im``. The type of these components is real. The standard
-  ``Math`` module provides some functions on complex types. See
-| https://chapel-lang.org/docs/modules/standard/Math.html
+The real and imaginary components can be accessed via the methods ``re``
+and ``im``. The type of these components is real. The standard :mod:`Math`
+module provides some functions on complex types. See the :mod:`Math`
+module documentation.
 
    *Example*.
 

--- a/doc/rst/language/spec/unions.rst
+++ b/doc/rst/language/spec/unions.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Unions:
 
 Unions

--- a/doc/rst/language/spec/user-defined-reductions-and-scans.rst
+++ b/doc/rst/language/spec/user-defined-reductions-and-scans.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-User_Defined_Reductions_and_Scans:
 
 User-Defined Reductions and Scans

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -1,3 +1,5 @@
+.. default-domain:: chpl
+
 .. _Chapter-Variables:
 
 Variables


### PR DESCRIPTION
Using sphinx references for these links allows them to be checked during `make docs`.

Additionally it corrects the section on module-scope var deinitialization order as a follow-up to PR #16430.

Reviewed by @ben-albrecht - thanks!
