### PR TITLE
Put technotes into sections

### DIFF
--- a/doc/rst/technotes/allocators.rst
+++ b/doc/rst/technotes/allocators.rst
@@ -1,8 +1,8 @@
 .. _readme-allocators:
 
-==========================
-Chapel's Use of Allocators
-==========================
+=================================
+Using the Chapel Allocator from C
+=================================
 
 The Chapel runtime will select an allocator according to the ``CHPL_MEM``
 environment variable. See :ref:`readme-chplenv` for details on how that

--- a/doc/rst/technotes/errorHandling.rst
+++ b/doc/rst/technotes/errorHandling.rst
@@ -1,8 +1,8 @@
 .. _readme-errorHandling:
 
-==============
-Error Handling
-==============
+==========================================
+Error Handling Modes and Prototype Modules
+==========================================
 
 Overview
 --------

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -7,7 +7,7 @@ C Interoperability
 ==================
 
 This README describes support in the Chapel compiler for referring to C
-code within Chapel using a keyword named 'extern'. These features are
+code within Chapel using a keyword named `extern`. These features are
 still in the process of being improved.
 
 External C functions, variables, and types can be referred to within a

--- a/doc/rst/technotes/globalvars.rst
+++ b/doc/rst/technotes/globalvars.rst
@@ -1,8 +1,8 @@
 .. _readme-globalvars:
 
-==================================
-Global Variables
-==================================
+=============================================
+Variables to Detect Compilation Configuration
+=============================================
 
 .. warning:: The variables defined here are not part of the Chapel Standard and 
              they can be changed, renamed, or removed at any point in the future.

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -8,28 +8,6 @@ yet stable enough to be in the language specification. Additionally, a
 Techinical Note can describe implementation details that can be ignored
 by most Chapel programmers.
 
-Interoperability
-----------------
-
-.. toctree::
-   :maxdepth: 1
-
-   C Interoperability <extern>
-   Calling Chapel Code from Other Languages <libraries>
-   Fortran Interoperability <fortranInterop>
-   Using the Chapel Allocator from C <allocators>
-
-Initializers and Generic Programming
-------------------------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   Forwarding Methods Calls <forwarding>
-   The ‘init=’ Method <initequals>
-   Invoking Initializers with a Generic Instantiation <initTypeAlias>
-   Partial Instantiations <partialInstantiations>
-
 Base Language Features
 ----------------------
 
@@ -42,6 +20,18 @@ Base Language Features
    Including Sub-Modules from Separate Files <module_include>
    main() Functions <main>
    Module Search Paths <module_search>
+
+
+Initializers and Generic Programming
+------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Forwarding Methods Calls <forwarding>
+   The ‘init=’ Method <initequals>
+   Invoking Initializers with a Generic Instantiation <initTypeAlias>
+   Partial Instantiations <partialInstantiations>
 
 Parallel Language Features
 --------------------------
@@ -56,6 +46,17 @@ Parallel Language Features
    Reduce Intents <reduceIntents>
    Runtime Support for Atomics <atomics>
 
+Interoperability
+----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   C Interoperability <extern>
+   Calling Chapel Code from Other Languages <libraries>
+   Fortran Interoperability <fortranInterop>
+   Using the Chapel Allocator from C <allocators>
+
 Compiler Features
 -----------------
 
@@ -68,8 +69,8 @@ Compiler Features
    LLVM Support <llvm>
    Variables to Detect Compilation Configuration <globalvars>
 
-Tool Implementation Details
----------------------------
+Tool Details
+------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -3,13 +3,75 @@
 Technical Notes
 ===============
 
-Contents:
+Technical Notes describe in-progress language features that are not
+yet stable enough to be in the language specification. Additionally, a
+Techinical Note can describe implementation details that can be ignored
+by most Chapel programmers.
 
-.. toctree::
-   :hidden:
+Interoperability
+----------------
 
 .. toctree::
    :maxdepth: 1
-   :glob:
 
-   **
+   C Interoperability <extern>
+   Calling Chapel Code from Other Languages <libraries>
+   Fortran Interoperability <fortranInterop>
+   Using the Chapel Allocator from C <allocators>
+
+Initializers and Generic Programming
+------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Forwarding Methods Calls <forwarding>
+   The ‘init=’ Method <initequals>
+   Invoking Initializers with a Generic Instantiation <initTypeAlias>
+   Partial Instantiations <partialInstantiations>
+
+Base Language Features
+----------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Associative Set Operations <sets>
+   Error Handling Modes and Prototype Modules <errorHandling>
+   First-class Functions in Chapel <firstClassFns>
+   Including Sub-Modules from Separate Files <module_include>
+   main() Functions <main>
+   Module Search Paths <module_search>
+
+Parallel Language Features
+--------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Domain Map Standard Interface <dsi>
+   The ‘local’ keyword <local>
+   Locale Models <localeModels>
+   Querying a Local Subdomain <subquery>
+   Reduce Intents <reduceIntents>
+   Runtime Support for Atomics <atomics>
+
+Compiler Features
+-----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Checking for Nil Dereferences <nilChecking>
+   Checking Overload Sets <overloadSets>
+   Checking Variable Lifetimes <lifetimeChecking>
+   LLVM Support <llvm>
+   Variables to Detect Compilation Configuration <globalvars>
+
+Tool Implementation Details
+---------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Protocol Buffers Support - Generated Chapel Code <protoGenCodeGuide>

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -1,8 +1,8 @@
 .. _readme-libraries:
 
-=============================
-Exporting Chapel as a Library
-=============================
+========================================
+Calling Chapel Code from Other Languages
+========================================
 
 .. note::
 

--- a/doc/rst/technotes/lifetimeChecking.rst
+++ b/doc/rst/technotes/lifetimeChecking.rst
@@ -1,8 +1,8 @@
 .. _readme-lifetime-checking:
 
-=================
-Lifetime Checking
-=================
+===========================
+Checking Variable Lifetimes
+===========================
 
 As of Chapel 1.18, Chapel includes a compiler component called the
 lifetime checker. The lifetime checker produces errors at compile time to

--- a/doc/rst/technotes/main.rst
+++ b/doc/rst/technotes/main.rst
@@ -1,8 +1,8 @@
 .. _readme-main:
 
-============================
-Support for main() Functions
-============================
+================
+main() Functions
+================
 
 After running module initialization code (top-level statements in
 modules), a Chapel program will start executing from the entry point,

--- a/doc/rst/technotes/protoGenCodeGuide.rst
+++ b/doc/rst/technotes/protoGenCodeGuide.rst
@@ -1,12 +1,14 @@
 .. _readme-protoGenCodeGuide:
 
-=====================
-Chapel Generated Code
-=====================
+================================================
+Protocol Buffers Support - Generated Chapel Code
+================================================
 
 This page describes exactly what Chapel code the protocol buffer compiler
-generates for protocol definitions using ``proto3`` syntax. You should read
-the `proto3 language guide`_ before reading this document.
+generates for protocol definitions using ``proto3`` syntax. Please see
+:ref:`readme-protobuf` for information about how to use the protocol
+buffer support. Additionally, this document assumes familiarity with the
+`proto3 language guide`_.
 
 .. note::
 

--- a/doc/rst/tools/protoc-gen-chpl/protoc-gen-chpl.rst
+++ b/doc/rst/tools/protoc-gen-chpl/protoc-gen-chpl.rst
@@ -1,8 +1,10 @@
-===============
-Chapel Protobuf
-===============
+.. _readme-protobuf:
 
-Chapel Protobuf is a Google Protocol Buffers implementation for Chapel.
+==================================
+Protocol Buffers Support in Chapel
+==================================
+
+This document describes a Google Protocol Buffers implementation for Chapel.
 `Protocol Buffers`_ is a language-neutral, platform-neutral, extensible mechanism
 for serializing structured data. The protocol buffer language is a language for 
 specifying the schema for structured data. This schema is compiled into language


### PR DESCRIPTION
I find the technotes section of the online docs an overwhelming jumble - 
it has a lot of things in it and they aren't ordered in any reasonable
way (not even alphabetical!).

This PR attempts to improve upon that situation by creating sections in 
the technote outline. Within each section, it lists the technotes in
alphabetical order. New technotes will need to be added to
technotes/index.rst in a reasonable section.

Also change several technote titles to better fit into the outline and to
make them more findable. Added a link from the protoc generated code
guide to the tool docs.

Reviewed by @lydia-duncan and discussed with others - thanks!
