### PR TITLE
Update language specification to discuss runtime types

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -402,12 +402,6 @@ formal/variable/field is non-nilable or generic, including generic
 memory management.
 
 
-
-.. code-block:: syntax
-
-   nil-expression:
-     `nil'
-
 .. _Class_Fields:
 
 Class Fields

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -13,7 +13,6 @@ Chapel provides the following expressions:
 
    expression:
      literal-expression
-     nil-expression
      variable-expression
      enum-constant-expression
      call-expression
@@ -36,7 +35,8 @@ Chapel provides the following expressions:
      module-access-expression
      tuple-expression
      tuple-expand-expression
-     locale-access-expression
+     locale-query-expression
+     type-query-expression
      mapped-domain-expression
 
 Individual expressions are defined in the remainder of this chapter and

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -49,13 +49,13 @@ additionally as follows:
 
 -  tuple and tuple expand :ref:`Chapter-Tuples`
 
--  locale access :ref:`Querying_the_Locale_of_a_Variable`
+-  locale query with ``.locale`` :ref:`Querying_the_Locale_of_an_Expression`
+
+-  type query with ``.type`` :ref:`Querying_the_Type_of_an_Expression`
 
 -  mapped domain :ref:`Chapter-Domain_Maps`
 
 -  initializer calls :ref:`Class_New`
-
--  ``nil`` :ref:`Class_nil_value`
 
 .. _Literal_Expressions:
 
@@ -511,12 +511,12 @@ precedence than those listed later.
    will learn of their error at compilation time because the resulting
    expression is not a scalar as expected.
 
+.. _Unary_Expressions:
 .. _Binary_Expressions:
 
 Operator Expressions
 --------------------
 
-[Unary_Expressions]
 
 The application of operators to expressions is itself an expression. The
 syntax of a unary expression is given by: 

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -900,7 +900,9 @@ User-Defined Initializers
 
 If a generic field of a class or record does not have a default value or
 type alias, each user-defined initializer for that class must explicitly
-initialize that field.
+initialize that field. In the event that the initializer is called using
+an already instantiated type, the initializer must initialize the generic
+fields to the same type.
 
    *Example (initializersForGenericFields.chpl)*.
 

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -901,8 +901,9 @@ User-Defined Initializers
 If a generic field of a class or record does not have a default value or
 type alias, each user-defined initializer for that class must explicitly
 initialize that field. In the event that the initializer is called using
-an already instantiated type, the initializer must initialize the generic
-fields to the same type.
+an already instantiated type as the receiver, the class or record
+instance created by the initializer must have that same instantiated
+type.
 
    *Example (initializersForGenericFields.chpl)*.
 

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -174,7 +174,7 @@ program. It refers to the locale that the current task is running on.
 
 The identifier ``here`` is not a keyword and can be overridden.
 
-.. _Querying_the_Locale_of_a_Variable:
+.. _Querying_the_Locale_of_an_Expression:
 
 Querying the Locale of an Expression
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -270,7 +270,7 @@ given by
      `on' expression block-statement
 
 The locale of the expression is automatically queried as described
-in :ref:`Querying_the_Locale_of_a_Variable`. Execution of the
+in :ref:`Querying_the_Locale_of_an_Expression`. Execution of the
 statement occurs on this specified locale and then continues after the
 ``on-statement``.
 

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -184,7 +184,7 @@ stored) is queried using the following syntax:
 
 .. code-block:: syntax
 
-   locale-access-expression:
+   locale-query-expression:
      expression . `locale'
 
 When the expression is a class, the access returns the locale on which

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -45,7 +45,7 @@ Functions are presented as follows:
    :ref:`Calling_External_Functions`
 
 -  calling Chapel functions from external
-   functions:ref:`Calling_Chapel_Functions`
+   functions :ref:`Calling_Chapel_Functions`
 
 -  determining the function to invoke for a given call site: function
    and operator overloading :ref:`Function_Overloading`,

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -335,16 +335,24 @@ assignment operator and a default expression to the declaration of the
 formal argument. If the actual argument is omitted from the function
 call, the default expression is evaluated when the function call is made
 and the evaluated result is passed to the formal argument as if it were
-passed from the call site. Default value
-expressions can refer to previous formal arguments or to variables that
-are visible to the scope of the function definition.
+passed from the call site. While the default expression is evaluated at
+the time of the function call, it is resolved in the scope of the
+definition of the called function, immediately before the called function
+is resolved. As a result, a default value expression can refer to
+previous formal arguments.
 
-When a default value is provided for an argument without a type, the
-argument type will be inferred to match the type of the default value.
-This inference is similar to the type inference for variable declarations
-(see :ref:`Local_Type_Inference`). However, there is one difference:
-the type inference for the argument does not include inferring
-the runtime component of the type (see
+When a default value is provided for an formal argument without a type,
+the argument type will be inferred to match the type of the default
+value.  This inference is similar to the type inference for variable
+declarations (see :ref:`Local_Type_Inference`). However, there is one
+difference: when the call provides a corresponding actual argument, and
+the actual argument is of a type that includes a runtime component (see
+:ref:`Types_with_Runtime_Components`), the runtime component of the
+formal argument's type will come from the actual argument, rather than
+from the default value expression.
+
+the type inference for the argument does not include
+inferring the runtime component of the type (see
 :ref:`Types_with_Runtime_Components`).
 
    *Example (default-values.chpl)*.
@@ -381,8 +389,8 @@ the runtime component of the type (see
 
    *Example (default-array-runtime-type.chpl)*.
 
-   This example shows that the runtime type of the default argument
-   does not impact the runtime type of the argument in the case
+   This example shows that the runtime type of the default expression
+   does not impact the runtime type of the formal argument in the case
    that an actual argument was provided.
 
    .. code-block:: chapel
@@ -399,14 +407,14 @@ the runtime component of the type (see
 
       bar(); // arg uses the default, so outputs {1..4}
 
-      var B:[0..3] int;
+      var B:[0..2] int;
       bar(B); // arg refers to B and so has the runtime type from B
-              // so outputs {0..3}
+              // so outputs {0..2}
 
    .. BLOCK-test-chapeloutput
 
       {1..4}
-      {0..3}
+      {0..2}
 
 
 .. _Argument_Intents:

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -341,7 +341,7 @@ definition of the called function, immediately before the called function
 is resolved. As a result, a default value expression can refer to
 previous formal arguments.
 
-When a default value is provided for an formal argument without a type,
+When a default value is provided for a formal argument without a type,
 the argument type will be inferred to match the type of the default
 value.  This inference is similar to the type inference for variable
 declarations (see :ref:`Local_Type_Inference`). However, there is one
@@ -350,10 +350,6 @@ the actual argument is of a type that includes a runtime component (see
 :ref:`Types_with_Runtime_Components`), the runtime component of the
 formal argument's type will come from the actual argument, rather than
 from the default value expression.
-
-the type inference for the argument does not include
-inferring the runtime component of the type (see
-:ref:`Types_with_Runtime_Components`).
 
    *Example (default-values.chpl)*.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -335,10 +335,17 @@ assignment operator and a default expression to the declaration of the
 formal argument. If the actual argument is omitted from the function
 call, the default expression is evaluated when the function call is made
 and the evaluated result is passed to the formal argument as if it were
-passed from the call site. Note though that the default value is
-evaluated in the same scope as the called function. Default value
+passed from the call site. Default value
 expressions can refer to previous formal arguments or to variables that
 are visible to the scope of the function definition.
+
+When a default value is provided for an argument without a type, the
+argument type will be inferred to match the type of the default value.
+This inference is similar to the type inference for variable declarations
+(see :ref:`Local_Type_Inference`). However, there is one difference:
+the type inference for the argument does not include inferring
+the runtime component of the type (see
+:ref:`Types_with_Runtime_Components`).
 
    *Example (default-values.chpl)*.
 
@@ -370,6 +377,37 @@ are visible to the scope of the function definition.
    to use a named argument for ``y`` in order to use the default value
    for ``x`` in the case when ``x`` appears earlier than ``y`` in the
    formal argument list.
+
+
+   *Example (default-array-runtime-type.chpl)*.
+
+   This example shows that the runtime type of the default argument
+   does not impact the runtime type of the argument in the case
+   that an actual argument was provided.
+
+   .. code-block:: chapel
+
+      var D = {1..4};
+      proc createArrayOverD() {
+        var A:[D] int;
+        return A;
+      }
+
+      proc bar(arg = createArrayOverD()) {
+        writeln(arg.domain);
+      }
+
+      bar(); // arg uses the default, so outputs {1..4}
+
+      var B:[0..3] int;
+      bar(B); // arg refers to B and so has the runtime type from B
+              // so outputs {0..3}
+
+   .. BLOCK-test-chapeloutput
+
+      {1..4}
+      {0..3}
+
 
 .. _Argument_Intents:
 

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -522,7 +522,7 @@ in :ref:`Atomic_Variables`.
 Type Aliases
 ------------
 
-Type aliases are declared with the following syntax: 
+Type aliases are declared with the following syntax:
 
 .. code-block:: syntax
 
@@ -595,6 +595,11 @@ generic (:ref:`Type_Aliases_in_Generic_Types`).
 Querying the Type of an Expression
 ----------------------------------
 
+.. code-block:: syntax
+
+   type-query-expression:
+     expression . `type'
+
 The type of a an expression can be queried with ``.type``. This
 functionality is particularly useful when doing generic programming
 (see :ref:`Chapter-Generics`).
@@ -619,25 +624,43 @@ functionality is particularly useful when doing generic programming
 
    *Open issue*.
 
-   For types that include a runtime component, it would be useful to be
-   able to query the static and runtime components separately.
+   Given a nested expression that has ``.type`` called on it,
+   for example ``f()`` in ``f().type``, in which circumstances should
+   ``f()`` be evaluated for side effects?
+
+   At first it might seem that ``f()`` should never be evaluated for side
+   effects. However, it must be evaluated for side effects if ``f()`` an
+   array or domain type, as these have a runtime component (see
+   :ref:`Types_with_Runtime_Components`). As a result, should ``f()`` in
+   such a setting always be evaluated for side effects?  The answer to
+   this question also also connected to the question of whether or not a
+   when a function returning a ``type`` is evaluated for side effects at
+   runtime.
+
+   One approach might be to introduce different means to query only the
+   compile-time component of the type or only the runtime component of
+   the time.
 
 
-.. _Operators_Available_on_Types:
+.. _Operations_Available_on_Types:
 
-Operators Available on Types
-----------------------------
+Operations Available on Types
+-----------------------------
 
-There are several operators that can operate on type aliases or type
-expressions (such as the ``.type`` queries described above).
+This section discusses how type expressions can be used. Type expressions
+include types, type aliases, ``.type`` queries, and calls to functions
+that use the ``type`` return intent.
 
-Types can also be passed to a ``type`` formal of a generic function (see
-:ref:`Formal_Type_Arguments`).
+A type expression can be used to indicate the type of a value, as with
+``var x: typeExpression;`` (see :ref:`Variable_Declarations`).
+
+A type expression can be passed to a ``type`` formal of a generic
+function (see :ref:`Formal_Type_Arguments`).
 
 See also the :mod:`Types` module documentation which provides many
-methods to query properties of types.
+functions to query properties of types.
 
-The language also provides :proc:`isCoercible <UtilMisc_forDocs.isCoercible>`,
+The language provides :proc:`isCoercible <UtilMisc_forDocs.isCoercible>`,
 :proc:`isSubtype <UtilMisc_forDocs.isSubtype>`, and
 :proc:`isProperSubtype <UtilMisc_forDocs.isProperSubtype>` for comparing types.
 The normal comparison operators are also available to compare types:
@@ -649,8 +672,8 @@ The normal comparison operators are also available to compare types:
  * ``<=`` and ``>=`` check if one type is a subtype of another (see
    :proc:`<= <UtilMisc_forDocs.<=>`)
 
-Additionally, it is possible to cast a type to a ``param`` string. This
-allows a type to be printed out.
+It is possible to cast a type to a ``param`` string. This allows a type
+to be printed out.
 
   *Example (type-to-string.chpl)*.
 
@@ -669,24 +692,32 @@ allows a type to be printed out.
 
       int(64)
 
+   *Open issue*.
+
+   If type comparison with ``==`` is called on two types with runtime
+   components (see :ref:`Types_with_Runtime_Components`), should the
+   runtime component be included in the comparison? Or, should ``==`` on
+   types only consider if the compile-time components match?
 
 .. _Types_with_Runtime_Components:
 
 Types with Runtime Components
 -----------------------------
 
-Domain and array types include a runtime component. (See
+Domain and array types include a *runtime component*. (See
 :ref:`Chapter-Domains` and :ref:`Chapter-Arrays` for more on arrays and
 domains).
 
 For a domain type, the runtime component of the type is the distribution over
 which the domain was declared.
 
-For an array type, the runtime component of the type is the domain over which
-the array was declared.
+For an array type, the runtime component of the type contains the domain
+over which the array was declared and the runtime component of the
+array's element type, if present.
 
-As a result, a type alias representing an array or domain type will exist
-at runtime.
+As a result, an array or domain type will be represented and manipulated
+at runtime. In particular, a function that returns a type with a runtime
+component will be executed at runtime.
 
 These features combine with the ``.type`` syntax to allow one to create
 an array that has the same element type, shape, and distribution as an
@@ -739,6 +770,21 @@ existing array.
 
    *Open issue*.
 
-   Currently, only array and domain types have a runtime component.
-   Other types that contain arrays or domains (such as a record
-   containing an array field) do not have a runtime component.
+   Should a record or class type also have a runtime component when it
+   contains array/domain field(s)? This runtime component is needed, for
+   example, to create a default-initialized instance of such a type in
+   the absence of user-defined default initializer.
+
+   *Open issue*.
+
+   Class types are not currently considered to have a runtime component.
+   Should class types be considered to have a runtime component, so that
+   querying an instance's type with ``myObject.type`` will produce the
+   type of the object known at runtime, rather than the type with which
+   ``myObject`` was declared?
+
+   *Open issue*.
+
+   Should functions returning a type always be evaluated for side
+   effects, or only evaluated for side effects when returning a type with
+   a runtime component?

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -615,7 +615,7 @@ functionality is particularly useful when doing generic programming
 
    .. BLOCK-test-chapeloutput
 
-      int
+      int(64)
 
    *Open issue*.
 
@@ -660,14 +660,14 @@ allows a type to be printed out.
    .. code-block:: chapel
 
       type myType = int;
-      param str = t:string;
+      param str = myType:string;
       writeln(str);
 
    It produces the output:
 
    .. code-block:: printoutput
 
-      int
+      int(64)
 
 
 .. _Types_with_Runtime_Components:

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -617,6 +617,12 @@ functionality is particularly useful when doing generic programming
 
       int
 
+   *Open issue*.
+
+   For types that include a runtime component, it would be useful to be
+   able to query the static and runtime components separately.
+
+
 .. _Operators_Available_on_Types:
 
 Operators Available on Types
@@ -643,4 +649,96 @@ The normal comparison operators are also available to compare types:
  * ``<=`` and ``>=`` check if one type is a subtype of another (see
    :proc:`<= <UtilMisc_forDocs.<=>`)
 
-Additionally, it is possible to cast a type to a string.
+Additionally, it is possible to cast a type to a ``param`` string. This
+allows a type to be printed out.
+
+  *Example (type-to-string.chpl)*.
+
+   For example, this code casts the type ``myType`` to a string in order
+   to print it out:
+
+   .. code-block:: chapel
+
+      type myType = int;
+      param str = t:string;
+      writeln(str);
+
+   It produces the output:
+
+   .. code-block:: printoutput
+
+      int
+
+
+.. _Types_with_Runtime_Components:
+
+Types with Runtime Components
+-----------------------------
+
+Domain and array types include a runtime component. (See
+:ref:`Chapter-Domains` and :ref:`Chapter-Arrays` for more on arrays and
+domains).
+
+For a domain type, the runtime component of the type is the distribution over
+which the domain was declared.
+
+For an array type, the runtime component of the type is the domain over which
+the array was declared.
+
+As a result, a type alias representing an array or domain type will exist
+at runtime.
+
+These features combine with the ``.type`` syntax to allow one to create
+an array that has the same element type, shape, and distribution as an
+existing array.
+
+  *Example (same-domain-array.chpl)*.
+
+   The example below shows a function that accepts an array and then
+   creates another array with the same element type, shape, and distribution:
+
+   .. code-block:: chapel
+
+      proc makeAnotherArray(arr: []) {
+        var newArray: arr.type;
+        return newArray;
+      }
+
+   The above program is equivalent to this program:
+
+   .. code-block:: chapel
+
+      proc equivalentAlternative(arr: []) {
+        var newArray:[arr.domain] arr.eltType;
+        return newArray;
+      }
+
+   Both create and return an array storing the same element type as the
+   passed array.
+
+    .. BLOCK-test-chapelpost
+
+      var A:[1..4] int = 1..4;
+      var B = makeAnotherArray(A);
+      var C = equivalentAlternative(A);
+      writeln("A.domain ", A.domain);
+      writeln("A ", A);
+      writeln("B.domain ", B.domain);
+      writeln("B ", B);
+      writeln("C.domain ", C.domain);
+      writeln("C ", C);
+
+   .. BLOCK-test-chapeloutput
+
+      A.domain {1..4}
+      A 1 2 3 4
+      B.domain {1..4}
+      B 0 0 0 0
+      C.domain {1..4}
+      C 0 0 0 0
+
+   *Open issue*.
+
+   Currently, only array and domain types have a runtime component.
+   Other types that contain arrays or domains (such as a record
+   containing an array field) do not have a runtime component.

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -589,3 +589,58 @@ generic (:ref:`Type_Aliases_in_Generic_Types`).
 
       2
 
+
+.. _Querying_the_Type_of_an_Expression:
+
+Querying the Type of an Expression
+----------------------------------
+
+The type of a an expression can be queried with ``.type``. This
+functionality is particularly useful when doing generic programming
+(see :ref:`Chapter-Generics`).
+
+   *Example (dot-type.chpl)*.
+
+   For example, this code uses ``.type`` to query the type of the
+   variable ``x`` and store that in the type alias ``t``:
+
+   .. code-block:: chapel
+
+      var x: int;
+      type t = x.type;
+
+   .. BLOCK-test-chapelpost
+
+      writeln(t:string);
+
+   .. BLOCK-test-chapeloutput
+
+      int
+
+.. _Operators_Available_on_Types:
+
+Operators Available on Types
+----------------------------
+
+There are several operators that can operate on type aliases or type
+expressions (such as the ``.type`` queries described above).
+
+Types can also be passed to a ``type`` formal of a generic function (see
+:ref:`Formal_Type_Arguments`).
+
+See also the :mod:`Types` module documentation which provides many
+methods to query properties of types.
+
+The language also provides :proc:`isCoercible <UtilMisc_forDocs.isCoercible>`,
+:proc:`isSubtype <UtilMisc_forDocs.isSubtype>`, and
+:proc:`isProperSubtype <UtilMisc_forDocs.isProperSubtype>` for comparing types.
+The normal comparison operators are also available to compare types:
+
+ * ``==`` checks if two types are equivalent
+ * ``!=`` checks if two types are different
+ * ``<`` and ``>`` check if one type is a proper subtype of another (see
+   :proc:`< <UtilMisc_forDocs.<>`)
+ * ``<=`` and ``>=`` check if one type is a subtype of another (see
+   :proc:`<= <UtilMisc_forDocs.<=>`)
+
+Additionally, it is possible to cast a type to a string.

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -657,8 +657,8 @@ A type expression can be used to indicate the type of a value, as with
 A type expression can be passed to a ``type`` formal of a generic
 function (see :ref:`Formal_Type_Arguments`).
 
-See also the :mod:`Types` module documentation which provides many
-functions to query properties of types.
+The :mod:`Types` module provides many functions to query properties of
+types.
 
 The language provides :proc:`isCoercible <UtilMisc_forDocs.isCoercible>`,
 :proc:`isSubtype <UtilMisc_forDocs.isSubtype>`, and


### PR DESCRIPTION
The spec did not describe runtime types and `.type` at all. This PR adds 
some description of these to the types chapter. Then, it updates the
discussion of argument defaults to indicate that the type inference from
those does not include the runtime type.

Follow-up to PR #16457.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing