### PR TITLE
Use domain's array set only for resizing

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -195,8 +195,7 @@ module ChapelDistribution {
         // and mark this domain to free itself when that number reaches 0.
         local {
           _arrsLock.lock();
-          arr_count = _arrs.size;
-          arr_count += _arrs_containing_dom;
+          arr_count = _arrs_containing_dom;
           _free_when_no_arrs = true;
           _arrsLock.unlock();
         }
@@ -228,12 +227,10 @@ module ChapelDistribution {
         var cnt = -1;
         local {
           _arrsLock.lock();
+          _arrs_containing_dom -=1;
           if rmFromList && trackArrays() then
             _arrs.remove(x);
-          else
-            _arrs_containing_dom -=1;
-          cnt = _arrs.size;
-          cnt += _arrs_containing_dom;
+          cnt = _arrs_containing_dom;
           // add one for the main domain record
           if !_free_when_no_arrs then
             cnt += 1;
@@ -253,10 +250,9 @@ module ChapelDistribution {
       on this {
         if locking then
           _arrsLock.lock();
+        _arrs_containing_dom += 1;
         if addToList && trackArrays() then
           _arrs.add(x);
-        else
-          _arrs_containing_dom += 1;
         if locking then
           _arrsLock.unlock();
       }
@@ -269,8 +265,7 @@ module ChapelDistribution {
         var cnt = -1;
         _arrsLock.lock();
         _arrs_containing_dom -= 1;
-        cnt = _arrs.size;
-        cnt += _arrs_containing_dom;
+        cnt = _arrs_containing_dom;
         // add one for the main domain record
         if !_free_when_no_arrs then
           cnt += 1;


### PR DESCRIPTION
This PR changes how we track the references to a domain.

On master, the number of references to the domain is basically the sum of
the size of its hash table and `_arrs_containing_dom`. This PR changes the logic
there to always increment/decrement the latter and to avoid using the former for
freeing domains. Hashtable is only used while resizing a domain and when we need
to resize arrays defined using that domain.

This way, the constant domain optimization is more robust: if a domain's constness
changes over the course of its life (via being moved to a different domain) it doesn't
impact its deallocation.

Test:
- [x] valgrind examples
- [x] memleaks examples
- [x] gasnet+asan examples
- [x] standard
- [x] gasnet
