### PR TITLE
Add noinit technote

### DIFF
--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -15,6 +15,7 @@ Base Language Features
    :maxdepth: 1
 
    Associative Set Operations <sets>
+   Avoiding Array Element Initialization with noinit <noinit>
    Error Handling Modes and Prototype Modules <errorHandling>
    First-class Functions in Chapel <firstClassFns>
    Including Sub-Modules from Separate Files <module_include>

--- a/doc/rst/technotes/noinit.rst
+++ b/doc/rst/technotes/noinit.rst
@@ -1,0 +1,55 @@
+
+.. _readme-noinit:
+
+.. default-domain:: chpl
+
+=================================================
+Avoiding Array Element Initialization with noinit
+=================================================
+
+Overview
+--------
+
+Chapel 1.23 includes an early implementation of ``noinit`` for arrays.
+As of 1.23, ``noinit`` cannot be used with types other than arrays and it
+only works for types that are trivially copyable.
+
+Motivation
+----------
+
+In some cases, one would like to allocate memory for array elements
+without initializing the elements. This might aid in optimization. The
+elements might be initialized later and then the default initialization
+might be redundant. Additionally, the default initialization might impact
+the memory affinity of the array on a NUMA system.
+
+Example
+-------
+
+To use the ``noinit`` feature, declare an array and initialize it with
+the keyword ``noinit`` as this example shows:
+
+.. code-block:: chapel
+
+  config const n = 10;
+  var D = {1..n};
+  var A: [D] real = noinit;  // A's elements won't be initialized here
+
+  // Reading one of A's elements here is a memory error -
+  // it will read uninitialized memory.
+
+  // A's elements can be initialized using the assignment operator
+  forall a in A do
+    a = 0.0;
+
+Future Work
+-----------
+
+We are hoping to extend this feature to:
+
+ * provide a way to indicate when the array is fully initialized (to
+   support memory registration for communication, e.g.)
+ * provide an explicit way to move-initialize elements (so that the
+   feature can be extended to types that are not trivially copyable)
+ * adjust the implementation to avoid initializing new elements when a
+   ``noinit`` ed array is resized through its domain.


### PR DESCRIPTION
Follow-up to PR #16064.

The 1.23 release includes a very basic and restricted version of `noinit`
because we were able to agree on the behavior of that case.

The `noinit` feature is discussed in #15703 and #8792. The future work is
discussed in #16172, #16173.

Reviewed by @lydia-duncan - thanks!