### PR TITLE
Fix formatting near inout intent and add discussion of iterators passing to in

### DIFF
--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -108,7 +108,7 @@ Iterators are invoked using regular call expressions:
 All details of iterator calls, including argument passing, function
 resolution, the use of parentheses versus brackets to delimit the
 parameter list, and so on, are identical to procedure calls as described
-in Chapter \ `[Functions] <#Functions>`__.
+in :ref:`Chapter-Procedures`.
 
 However, the result of an iterator call depends upon its context, as
 described below.
@@ -127,10 +127,12 @@ iteration, the iterator yields a value and the body is executed.
 Iterators as Arrays
 ~~~~~~~~~~~~~~~~~~~
 
-If an iterator function is captured into a new variable declaration or
-assigned to an array, the iterator is iterated over in total and the
-expression evaluates to a one-dimensional arithmetic array that contains
-the values returned by the iterator on each iteration.
+If an iterator function is captured into a new variable declaration,
+passed to an `in` intent argument, or assigned to an array, the iterator
+is iterated over in total and the expression evaluates to a rectangular
+array that contains the values returned by the iterator on each
+iteration. Iterators can pass to `in` intent arguments declared with a
+compatible array type expression.
 
    *Example (as-arrays.chpl)*.
 

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -127,12 +127,21 @@ iteration, the iterator yields a value and the body is executed.
 Iterators as Arrays
 ~~~~~~~~~~~~~~~~~~~
 
-If an iterator function is captured into a new variable declaration,
-passed to an `in` intent argument, or assigned to an array, the iterator
-is iterated over in total and the expression evaluates to a rectangular
-array that contains the values returned by the iterator on each
-iteration. Iterators can pass to `in` intent arguments declared with a
-compatible array type expression.
+*Capturing an iterator* into a new variable creates a new rectangular
+array storing the same elements that the iterator yielded.
+
+An iterator can be captured by:
+
+ * storing it into a new ``var`` or ``const`` variable declaration
+ * passing it to function formal argument accepting it with ``in`` intent
+
+In other words, an iterator can be implicitly converted into an array
+with matching shape and element type (see also :ref:`Implicit_Conversions`).
+
+When an iterator is assigned to an existing array, the array and the
+iterator will be iterated over with zippered iteration
+(:ref:`Zipper_Iteration`) and the array elements assigned to the yielded
+value.
 
    *Example (as-arrays.chpl)*.
 

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -108,7 +108,7 @@ Iterators are invoked using regular call expressions:
 All details of iterator calls, including argument passing, function
 resolution, the use of parentheses versus brackets to delimit the
 parameter list, and so on, are identical to procedure calls as described
-in :ref:`Chapter-Procedures`.
+in the :ref:`Procedures Chapter <Chapter-Procedures>`.
 
 However, the result of an iterator call depends upon its context, as
 described below.

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -135,6 +135,9 @@ An iterator can be captured by:
  * storing it into a new ``var`` or ``const`` variable declaration
  * passing it to function formal argument accepting it with ``in`` intent
 
+In both cases, the variable or formal argument needs to be untyped or
+have a compatible rectangular array type.
+
 In other words, an iterator can be implicitly converted into an array
 with matching shape and element type (see also :ref:`Implicit_Conversions`).
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -469,7 +469,7 @@ The assignment implementing the ``out`` intent is a candidate for
 :ref:`Split_Initialization`. As a result, an actual argument might be
 initialized by a call passing the actual by ``out`` intent.
 
-_The_Inout_Intent:
+.. _The_Inout_Intent:
 
 The Inout Intent
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Follow-up to PR #16180.

* fixes a few formatting errors
* adds discussion of passing an iterator to an `in` intent argument

Reviewed by @vasslitvinov - thanks!