### PR TITLE
Only reference count a distribution's domains

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3697,7 +3697,7 @@ module ChapelArray {
   proc =(ref a: _distribution, b: _distribution) {
     if a._value == nil {
       __primitive("move", a, chpl__autoCopy(b.clone(), definedConst=false));
-    } else if a._value._doms.size == 0 {
+    } else if a._value._doms_containing_dist == 0 {
       if a._value.type != b._value.type then
         compilerError("type mismatch in distribution assignment");
       if a._value == b._value {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -29,7 +29,7 @@ module ChapelDistribution {
   //
   pragma "base dist"
   class BaseDist {
-    var _doms: chpl__simpleSet(unmanaged BaseDom); // domains declared over this distribution
+    var _doms_containing_dist: int; // number of domains using this distribution
     var _domsLock: chpl_LocalSpinlock; // lock for concurrent access
     var _free_when_no_doms: bool; // true when original _distribution is destroyed
     var pid:int = nullPid; // privatized ID, if privatization is supported
@@ -49,7 +49,7 @@ module ChapelDistribution {
             // Set a flag to indicate it should be freed when _doms
             // becomes empty
             _free_when_no_doms = true;
-            dom_count = _doms.size;
+            dom_count = _doms_containing_dist;
             _domsLock.unlock();
           }
           if dom_count == 0 then
@@ -73,8 +73,8 @@ module ChapelDistribution {
         var cnt = -1;
         local {
           _domsLock.lock();
-          _doms.remove(x);
-          cnt = _doms.size;
+          _doms_containing_dist -= 1;
+          cnt = _doms_containing_dist;
 
           // add one for the main distribution instance
           if !_free_when_no_doms then
@@ -102,7 +102,7 @@ module ChapelDistribution {
     inline proc add_dom(x:unmanaged BaseDom) {
       on this {
         _domsLock.lock();
-        _doms.add(x);
+        _doms_containing_dist += 1 ;
         _domsLock.unlock();
       }
     }

--- a/test/distributions/vass/changeBoundingBox.chpl
+++ b/test/distributions/vass/changeBoundingBox.chpl
@@ -74,7 +74,7 @@ domains/arrays.
 proc Block.changeBoundingBox(newBB) {
   // Comment out this check if desired. NB Block-distributed domains created
   // using 'this' will not be re-distributed upon changeBoundingBox().
-  if _doms.size != 0 then
+  if _doms_containing_dist != 0 then
     halt("changeBoundingBox: the distribution already has declared domain(s)");
 
   // From Block.dsiAssign, with mods.


### PR DESCRIPTION
Previously, a distribution would keep track of all the domains declared
over it. When only a single domain is declared over the distribution,
the tracking got more expensive when we switched from using a list of
domains to a set of domains in #15895. This hurt the performance of
creating rank-change/reindex array views, which create a single-use
distribution and domain.

It turns out that nothing actually uses the distributions list/set of
domains, only the count of how many we have. Given that, switch to just
tracking the count, which is much cheaper.

There is a potential desire to be able to change domains declared over a
distribution when the distribution changes in the future (like how we
resize arrays declared over a domain if the domain changes), but today
that's an unimplemented feature that will halt. If we decide to support
that in the future, we can always revert this change, but for now we
don't need to pay the performance penalty.

At this point we're just using a lock to bump a counter, so we could
switch to an atomic, but I didn't want to make more drastic changes this
close to the release. Cleaning this up in the future is captured in
https://github.com/Cray/chapel-private/issues/1378

Resolves https://github.com/Cray/chapel-private/issues/1096