### PR TITLE
Add flags to control parallel comm in array assignment

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -44,8 +44,8 @@ module DefaultRectangular {
   config param reportInPlaceRealloc = false;
 
   config param parallelAssignThreshold = 2*1024*1024;
-  config const enableParallelGetsInAssignment = false;
-  config const enableParallelPutsInAssignment = false;
+  config param enableParallelGetsInAssignment = false;
+  config param enableParallelPutsInAssignment = false;
 
   config param defaultDoRADOpt = true;
   config param defaultDisableLazyRADOpt = false;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1959,7 +1959,7 @@ module DefaultRectangular {
     const isFullyLocal = Alocid == Blocid;
     var doParallelAssign = isSizeAboveThreshold && isFullyLocal;
 
-    if enableParallelPutsInAssignment || enableParallelPutsInAssignment {
+    if enableParallelGetsInAssignment || enableParallelPutsInAssignment {
       if isSizeAboveThreshold && !isFullyLocal {
         if enableParallelPutsInAssignment && Blocid == here.id {
           doParallelAssign = true;

--- a/test/optimizations/bulkcomm/block/exchange-BothLocal.good
+++ b/test/optimizations/bulkcomm/block/exchange-BothLocal.good
@@ -1,4 +1,2 @@
 Will do parallel transfer
 Will do parallel transfer
-Will do parallel transfer
-Will do parallel transfer

--- a/test/optimizations/bulkcomm/block/exchange-DestLocal.good
+++ b/test/optimizations/bulkcomm/block/exchange-DestLocal.good
@@ -1,2 +1,0 @@
-Will do parallel transfer
-Will do parallel transfer


### PR DESCRIPTION
This PR adds

```chapel
config param enableParallelGetsInAssignment = false;
config param enableParallelPutsInAssignment = false;
```

to enable parallel communication for DefaultRectangular array assignments.

We have seen that parallel assignment makes local transfers reliably faster,
however, when the transfer is remote we see different behaviors on different
systems while using different communication layer setups.

With these we are not doing any parallel communication for DefaultRectangular
assignments to avoid regressions, but they can be enabled selectively in some
setups to increase comm bandwidth.

Test:
- [x] standard
- [x] gasnet
