### PR TITLE
Make empty sparse domain optimization more strict

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -596,6 +596,18 @@ module ChapelDistribution {
               " (expected to be within ", parentDom, ")");
     }
 
+    proc canDoDirectAssignment(rhs: domain) {
+      if isRectangularDom(this.parentDom) &&
+         isRectangularDom(rhs.parentDom) {
+        if this.dsiNumIndices == 0 {
+          if rhs.parentDom.isSubset(this.parentDom) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
     //basic DSI functions
     proc dsiDim(d: int) { return parentDom.dim(d); }
     proc dsiDims() { return parentDom.dims(); }

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -363,7 +363,8 @@ module DefaultSparse {
     }
 
     proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
-      if _to_borrowed(rhs._instance.type) == this.type && this.dsiNumIndices == 0 {
+      if _to_borrowed(rhs._instance.type) == this.type && 
+         canDoDirectAssignment(rhs) {
 
         // ENGIN: We cannot use bulkGrow here, because rhs might be grown using
         // grow, which has a different heuristic to grow the internal arrays.

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -153,7 +153,8 @@ class CSDom: BaseSparseDomImpl {
   override proc dsiMyDist() return dist;
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
-    if _to_borrowed(rhs._instance.type) == this.type && this.dsiNumIndices == 0 {
+    if _to_borrowed(rhs._instance.type) == this.type && 
+       canDoDirectAssignment(rhs) {
       // Optimized CSC->CSC / CSR->CSR
 
       // ENGIN: We cannot use bulkGrow here, because rhs might be grown using

--- a/test/sparse/domains/sparseDomAssignOOB.bad
+++ b/test/sparse/domains/sparseDomAssignOOB.bad
@@ -1,3 +1,0 @@
-{2 3 4}
-{2 3 4}
-sparseDomAssignOOB.chpl:19: error: halt reached - array index out of bounds: (2)

--- a/test/sparse/domains/sparseDomAssignOOB.future
+++ b/test/sparse/domains/sparseDomAssignOOB.future
@@ -1,6 +1,0 @@
-bug: should bounds-check sparse domain assignments
-
-The current sparse domain assignment code seems to assume that all
-indices in the RHS domain will be in the LHS domain's parent domain,
-but of course this isn't necessarily the case as this test
-demonstrates.

--- a/test/sparse/domains/sparseDomAssignOOB.good
+++ b/test/sparse/domains/sparseDomAssignOOB.good
@@ -1,1 +1,1 @@
-sparseDomAssignOOB.chpl:12: error: halt reached - sparse domain index '2' out of bounds for parent domain '{1..0}'
+sparseDomAssignOOB.chpl:12: error: halt reached - Sparse domain/array index out of bounds: 2 (expected to be within {1..0})


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/16385

https://github.com/chapel-lang/chapel/pull/14112 added an optimization for
assigning to empty sparse domains. However, this optimization didn't properly do
a bounds checking causing errors to be caught much later in the usage of the
sparse domain.

This PR adds a more strict check for that optimization and unfuturizes a related
test.

Test:
- [x] standard
- [x] gasnet