### PR TITLE
Adjust futures following split-init for multi-var decls

### DIFF
--- a/test/types/records/const-checking/todo-duplicate-cannotassign-error.bad
+++ b/test/types/records/const-checking/todo-duplicate-cannotassign-error.bad
@@ -1,3 +1,3 @@
-todo-duplicate-cannotassign-error.chpl:8: error: cannot assign to a record of the type REC using the default assignment operator because it has 'const' field(s)
-todo-duplicate-cannotassign-error.chpl:8: error: cannot assign to a record of the type REC using the default assignment operator because it has 'const' field(s)
-todo-duplicate-cannotassign-error.chpl:8: error: cannot assign to a record of the type REC using the default assignment operator because it has 'const' field(s)
+todo-duplicate-cannotassign-error.chpl:9: error: cannot assign to a record of the type REC using the default assignment operator because it has 'const' field(s)
+todo-duplicate-cannotassign-error.chpl:9: error: cannot assign to a record of the type REC using the default assignment operator because it has 'const' field(s)
+todo-duplicate-cannotassign-error.chpl:9: error: cannot assign to a record of the type REC using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/todo-duplicate-cannotassign-error.chpl
+++ b/test/types/records/const-checking/todo-duplicate-cannotassign-error.chpl
@@ -4,5 +4,6 @@ record REC {
   const F1, F2, F3: int;
 }
 
-var RR, QQ: REC;
+var RR = new REC();
+var QQ = new REC();
 RR = QQ;

--- a/test/types/records/const-checking/todo-multiple-asgn-errors.bad
+++ b/test/types/records/const-checking/todo-multiple-asgn-errors.bad
@@ -1,2 +1,2 @@
-todo-multiple-asgn-errors.chpl:9: error: cannot assign to a record of the type RECTYPE using the default assignment operator because it has 'const' field(s)
-todo-multiple-asgn-errors.chpl:25: error: cannot assign to a record of the type OUTERREC using the default assignment operator because it has 'const' field(s)
+todo-multiple-asgn-errors.chpl:10: error: cannot assign to a record of the type RECTYPE using the default assignment operator because it has 'const' field(s)
+todo-multiple-asgn-errors.chpl:27: error: cannot assign to a record of the type OUTERREC using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/todo-multiple-asgn-errors.chpl
+++ b/test/types/records/const-checking/todo-multiple-asgn-errors.chpl
@@ -5,7 +5,8 @@ record RECTYPE {
   const CONSTFIELD: int;
 }
 
-var r1, r2: RECTYPE;
+var r1 = new RECTYPE();
+var r2 = new RECTYPE();
 r1 = r2;  // error
 r2 = r1;  // also error
 
@@ -21,7 +22,8 @@ record OUTERREC {
   const outerconst: RECTYPE;
 }
 
-var r6, r7: OUTERREC;
+var r6 = new OUTERREC();
+var r7 = new OUTERREC();
 r6 = r7;  // error
 r7 = r6;  // also error
 

--- a/test/types/tuple/split-init/noTypeIndividual.bad
+++ b/test/types/tuple/split-init/noTypeIndividual.bad
@@ -1,1 +1,1 @@
-noTypeIndividual.chpl:1: error: 'tmp' undeclared (first use this function)
+noTypeIndividual.chpl:1: error: use of 'tmp' before encountering its definition, type unknown

--- a/test/types/tuple/split-init/sameType.bad
+++ b/test/types/tuple/split-init/sameType.bad
@@ -1,1 +1,1 @@
-sameType.chpl:1: error: 'tmp' undeclared (first use this function)
+sameType.chpl:1: error: use of 'tmp' before encountering its definition, type unknown

--- a/test/types/tuple/split-init/tupleDestructure.bad
+++ b/test/types/tuple/split-init/tupleDestructure.bad
@@ -1,1 +1,1 @@
-tupleDestructure.chpl:1: error: 'tmp' undeclared (first use this function)
+tupleDestructure.chpl:1: error: use of 'tmp' before encountering its definition, type unknown


### PR DESCRIPTION
Follow-up to PR #16520

This PR adjusts a few future .bad files and adjusts a few futures checking assign behavior to avoid split-init.

Test change only - not reviewed.