### PR TITLE
Remove make spec rule

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -54,9 +54,6 @@ always-build-chplspell-venv: FORCE
 	$(MAKE) chplspell-venv; \
 	fi
 
-spec: FORCE
-	cd spec && $(MAKE)
-
 test: FORCE
 	cd test && start_test
 


### PR DESCRIPTION
It does not work since the spec now exists as .rst.
`make docs` will build the spec.

Reviewed by @vasslitvinov - thanks!