### PR TITLE
Modified test to avoid split init following PR 16520

### DIFF
--- a/test/distributions/bharshbarg/promotedComms.chpl
+++ b/test/distributions/bharshbarg/promotedComms.chpl
@@ -4,7 +4,7 @@ use CommDiagnostics;
 proc main() {
   var Dom = {1..100};
   var Space = Dom dmapped Block(Dom);
-  var A, B, C : [Space] real;
+  var A, B, C : [Space] real = 0;
 
   startCommDiagnostics();
   A = B + C;


### PR DESCRIPTION
Follow-up to PR #16520

This PR removes split initialization from a test now that split initialization would apply if the test were left as is.

Test change only - not reviewed.