### PR TITLE
Stop tunneling Arkouda Cray-XC testing through the login node

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -27,8 +27,5 @@ nightly_args="${nightly_args} -no-buildcheck"
 # XC has new enough python, but missing pip
 source /cray/css/users/chapelu/setup_python36.bash
 
-# Run on an elogin node, so we have to tunnel to the login
-export ARKOUDA_TUNNEL_SERVER=$EPROXY_LOGIN
-
 test_nightly
 sync_graphs

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -27,8 +27,5 @@ nightly_args="${nightly_args} -no-buildcheck"
 # XC has new enough python, but missing pip
 source /cray/css/users/chapelu/setup_python36.bash
 
-# Run on an elogin node, so we have to tunnel to the login
-export ARKOUDA_TUNNEL_SERVER=$EPROXY_LOGIN
-
 test_release
 sync_graphs


### PR DESCRIPTION
The job has been moved back to a proper login node instead of an elogin.