### PR TITLE
Trivial heap doc fixes

### DIFF
--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -28,9 +28,10 @@
   * Querying the top element is O(1).
   * Initialization from an array is O(N).
 
-  The heap accepts a comparator to determine how elements are compared. The default 
-  comparator is `defaultComparator` and makes a max-heap. In this case, ``top`` 
-  will return the greatest element in the heap.
+  The heap accepts a :ref:`comparator <comparators>` to determine how
+  elements are compared. The default comparator is `defaultComparator` and makes
+  a max-heap. In this case, ``top`` will return the greatest element in the
+  heap.
 
   If a ``reverseComparator`` is passed to ``init``, 
   ``top`` will return the minimal element.
@@ -336,7 +337,7 @@ module Heap {
     }
 
     /*
-      Iterate over the elements of this heap in in arbitrary order.
+      Iterate over the elements of this heap in an arbitrary order.
     */
     iter these() ref {
       for e in _data {


### PR DESCRIPTION
Fixes a typo and adds a link to Comparators in the new Heap module's docs.

`make docs` runs successfully.
