### PR TITLE
Fix duplicate call to nested function in type alias

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2418,17 +2418,7 @@ static void normalizeTypeAlias(DefExpr* defExpr) {
 
   if ((init != NULL && !requestedSplitInit) || foundSplitInit == false) {
     // handle non-split initialization
-
-    // Replace the init with a temp to avoid duplicate call
-    VarSymbol* initTmp = newTemp("initTmp");
-    initTmp->addFlag(FLAG_TYPE_VARIABLE);
-    defExpr->insertBefore(new DefExpr(initTmp));
-    defExpr->insertBefore(new CallExpr(PRIM_MOVE, initTmp, init->copy()));
-    SymExpr* se = new SymExpr(initTmp);
-    init->replace(se);
-    init = se;
-
-    emitTypeAliasInit(defExpr, var, init);
+    emitTypeAliasInit(defExpr, var, init->remove());
   } else {
     // handle split initialization for type aliases
     var->addFlag(FLAG_SPLIT_INITED);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2418,6 +2418,16 @@ static void normalizeTypeAlias(DefExpr* defExpr) {
 
   if ((init != NULL && !requestedSplitInit) || foundSplitInit == false) {
     // handle non-split initialization
+
+    // Replace the init with a temp to avoid duplicate call
+    VarSymbol* initTmp = newTemp("initTmp");
+    initTmp->addFlag(FLAG_TYPE_VARIABLE);
+    defExpr->insertBefore(new DefExpr(initTmp));
+    defExpr->insertBefore(new CallExpr(PRIM_MOVE, initTmp, init->copy()));
+    SymExpr* se = new SymExpr(initTmp);
+    init->replace(se);
+    init = se;
+
     emitTypeAliasInit(defExpr, var, init);
   } else {
     // handle split initialization for type aliases

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8023,7 +8023,6 @@ static Type* resolveGenericActual(SymExpr* se, bool resolvePartials) {
       //   extern var x: c_ptr(c_int);
       if ((vs->hasFlag(FLAG_EXTERN) == true || isGlobal(vs)) &&
           vs->defPoint             != NULL &&
-          vs->defPoint->init       != NULL &&
           vs->getValType()         == dtUnknown ) {
         vs->type = resolveTypeAlias(se);
       }

--- a/test/types/type_variables/ferguson/issue-16316.chpl
+++ b/test/types/type_variables/ferguson/issue-16316.chpl
@@ -1,0 +1,56 @@
+config param compOption = true;
+config const option = true;
+
+proc returnsArrayType(arg) type {
+  return arg.type;
+}
+
+proc makeArray() {
+  writeln("in makeArray()");
+  var A:[1..10] int;
+  return A;
+}
+
+proc test1() {
+  writeln("test1");
+  type t = returnsArrayType(makeArray());
+}
+test1();
+
+proc test2() {
+  writeln("test2");
+  type t;
+  t = returnsArrayType(makeArray());
+}
+test2();
+
+proc test3() {
+  writeln("test3");
+  type t;
+  {
+    t = returnsArrayType(makeArray());
+  }
+}
+test3();
+
+proc test4() {
+  writeln("test4");
+  type t;
+  if compOption {
+    t = returnsArrayType(makeArray());
+  } else {
+    t = returnsArrayType(makeArray());
+  }
+}
+test4();
+
+proc test5() {
+  writeln("test5");
+  type t;
+  if option {
+    t = returnsArrayType(makeArray());
+  } else {
+    t = returnsArrayType(makeArray());
+  }
+}
+test5();

--- a/test/types/type_variables/ferguson/issue-16316.good
+++ b/test/types/type_variables/ferguson/issue-16316.good
@@ -1,0 +1,10 @@
+test1
+in makeArray()
+test2
+in makeArray()
+test3
+in makeArray()
+test4
+in makeArray()
+test5
+in makeArray()


### PR DESCRIPTION
Resolves #16316

The duplicate calls were coming from both the DefExpr's init field and a
`PRIM_MOVE` setting the type being present in the AST after normalize.

* Adjusts normalizeTypeAlias to remove the DefExpr's init field (this
  runs before adding call temps)
* Adjust resolveTypeAlias to consider `PRIM_MOVE` acceptable for setting
  the type in addition to having the DefExpr's init field set.
* Adjusted an early-resolution-of-extern-types workaround in
  resolveGenericActual to also accept the new pattern

Reviewed by @lydia-duncan - thanks!

- [x] full local futures testing