### PR TITLE
Add overload of `update()` for backwards compatibility with 1.22

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -253,9 +253,8 @@ module Map {
     pragma "no doc"
     proc update(pragma "intent ref maybe const formal"
                 m: map(keyType, valType, parSafe)) {
-      compilerWarning('The `update()` method has new functionality in ' +
-                      'the 1.23 release - for forwards compatability ' +
-                      'call `extend()` instead');
+      compilerWarning('Adding to a map using `update()` is deprecated - ' +
+                      'use `extend()` instead');
       extend(m);
     }
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -250,6 +250,15 @@ module Map {
       }
     }
 
+    pragma "no doc"
+    proc update(pragma "intent ref maybe const formal"
+                m: map(keyType, valType, parSafe)) {
+      compilerWarning('The `update()` method has new functionality in ' +
+                      'the 1.23 release - for forwards compatability ' +
+                      'call `extend()` instead');
+      extend(m);
+    }
+
     /*
       Update a value in this map in a parallel safe manner via an updater
       object.

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -250,7 +250,18 @@ module Map {
       }
     }
 
-    pragma "no doc"
+    /*
+      Updates this map with the contents of the other, overwriting the values
+      for already-existing keys.
+
+      .. warning::
+
+        Adding to a map using :proc:`update` is deprecated. Please use
+        the :proc:`extend` method instead.
+
+      :arg m: The other map
+      :type m: map(keyType, valType)
+    */
     proc update(pragma "intent ref maybe const formal"
                 m: map(keyType, valType, parSafe)) {
       compilerWarning('Adding to a map using `update()` is deprecated - ' +

--- a/test/library/standard/Map/testOldUpdateWarning.chpl
+++ b/test/library/standard/Map/testOldUpdateWarning.chpl
@@ -1,0 +1,15 @@
+use Map;
+use utilFunctions;
+
+var m1 = new map(string, int, true);
+var m2 = new map(string, int, true);
+
+forall i in 1..20 with (ref m1) do
+  m1.add(intToEnglish(i), i);
+
+forall i in 19..40 with (ref m2) do
+  m2.add(intToEnglish(i), -i);
+
+m1.update(m2);
+var A = m1.values();
+writeln(A.sorted());

--- a/test/library/standard/Map/testOldUpdateWarning.good
+++ b/test/library/standard/Map/testOldUpdateWarning.good
@@ -1,0 +1,2 @@
+testOldUpdateWarning.chpl:13: warning: The `update()` method has new functionality in the 1.23 release - for forwards compatability call `extend()` instead
+-40 -39 -38 -37 -36 -35 -34 -33 -32 -31 -30 -29 -28 -27 -26 -25 -24 -23 -22 -21 -20 -19 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18

--- a/test/library/standard/Map/testOldUpdateWarning.good
+++ b/test/library/standard/Map/testOldUpdateWarning.good
@@ -1,2 +1,2 @@
-testOldUpdateWarning.chpl:13: warning: The `update()` method has new functionality in the 1.23 release - for forwards compatability call `extend()` instead
+testOldUpdateWarning.chpl:13: warning: Adding to a map using `update()` is deprecated - use `extend()` instead
 -40 -39 -38 -37 -36 -35 -34 -33 -32 -31 -30 -29 -28 -27 -26 -25 -24 -23 -22 -21 -20 -19 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18


### PR DESCRIPTION
Add an overload of `update()` that has the same type and behavior
as `extend()`. It includes a compiler warning that suggests users
call `extend()` in order to future-proof their code. The doc-string
for the 1.22 `update()` method is used, along with a deprecation
warning.

---

Testing:

- [x] `library/standard/Map` on `darwin` when `COMM=none`
- [x] `make` mason
- [x] `ALL` on `linux64` when `COMM=none`
- [x] Updated docs rendered locally