### PR TITLE
Skipif a new OOB test with --fast

### DIFF
--- a/test/sparse/domains/sparseDomAssignOOB.skipif
+++ b/test/sparse/domains/sparseDomAssignOOB.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/16530 has unfuturized a future. It is
now a test that checks for correct OOB message, and as such it should be skipped
with `--fast`
