### PR TITLE
Spec: fix broken references and display of literals

### DIFF
--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -761,8 +761,7 @@ The ``#`` operator can be applied to dense rectangular arrays with a
 tuple argument whose size matches the rank of the array (or optionally
 an integer in the case of a 1D array). The operator is equivalent to
 applying the ``#`` operator to the array’s domain and using the result
-to slice the array as described in
-Section \ `22.6.1 <#Rectangular_Array_Slicing>`__.
+to slice the array as described in :ref:`Rectangular_Array_Slicing`.
 
 .. _Array_Arguments_To_Functions:
 

--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -761,7 +761,7 @@ The ``#`` operator can be applied to dense rectangular arrays with a
 tuple argument whose size matches the rank of the array (or optionally
 an integer in the case of a 1D array). The operator is equivalent to
 applying the ``#`` operator to the array’s domain and using the result
-to slice the array as described in :ref:`Rectangular_Array_Slicing`.
+to slice the array as described in Section :ref:`Rectangular_Array_Slicing`.
 
 .. _Array_Arguments_To_Functions:
 

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -35,7 +35,7 @@ A class is defined with the following syntax:
 .. code-block:: syntax
 
    class-declaration-statement:
-     `class' identifier class-inherit[OPT] { class-statement-list[OPT] }
+     'class' identifier class-inherit[OPT] { class-statement-list[OPT] }
 
    class-inherit:
      : basic-class-type
@@ -171,16 +171,15 @@ memory management strategy.
 
    class-type:
      basic-class-type
-     `owned' basic-class-type
-     `shared' basic-class-type
-     `borrowed' basic-class-type
-     `unmanaged' basic-class-type
+     'owned' basic-class-type
+     'shared' basic-class-type
+     'borrowed' basic-class-type
+     'unmanaged' basic-class-type
 
 A basic class type is given simply by the class name for non-generic
 classes. Generic classes must be instantiated to serve as a
 fully-specified type, for example to declare a variable. This is done
-with type constructors, which are defined in
-Section \ `24.3.6 <#Type_Constructors>`__.
+with type constructors, which are defined in :ref:`Type_Constructors`.
 
 
 
@@ -446,15 +445,13 @@ Field access is described in :ref:`Class_Field_Accesses`.
 Class Methods
 ~~~~~~~~~~~~~
 
-Methods on classes are referred to as to as *class methods*. See the
-methods section :ref:`Chapter-Methods` for more information about
-methods.
+Methods on classes are referred to as *class methods*.
+See :ref:`Chapter-Methods` for more information about methods.
 
 Within a class method, the type of ``this`` is generally the non-nilable
 ``borrowed`` variant of the class type. It is different for type methods
 (see below) and it might be a different type if the class method is
-declared as a secondary method with a type expression
-(see `[Secondary_Methods_with_Type_Expressions] <#Secondary_Methods_with_Type_Expressions>`__).
+declared as a secondary method with a type expression.
 
 For example:
 
@@ -577,8 +574,8 @@ parent class.
 It is possible for a class to inherit from a generic class. Suppose for
 example that a class ``C`` inherits from class ``ParentC``. In this
 situation, ``C`` will have type constructor arguments based upon generic
-fields in the ``ParentC`` as described in
- `24.3.6 <#Type_Constructors>`__. Furthermore, a fully specified ``C``
+fields in the ``ParentC`` as described
+in :ref:`Type_Constructors`. Furthermore, a fully specified ``C``
 will be a subclass of a corresponding fully specified ``ParentC``.
 
 .. _The_object_Class:
@@ -700,7 +697,7 @@ The new expression can be defined by the following syntax:
 .. code-block:: syntax
 
    new-expression:
-     `new' type-expression ( argument-list )
+     'new' type-expression ( argument-list )
 
 An initializer for a given class is called by placing the ``new``
 operator in front of a type expression. Any initializer arguments follow
@@ -776,7 +773,7 @@ are initialized must be initialized in declaration order.
 Initializers for generic classes (:ref:`Generic_Types`) handle
 generic fields without default values differently and may need to
 satisfy additional requirements. See
-Section \ `24.3.9 <#Generic_User_Initializers>`__ for details.
+ref:`Generic_User_Initializers` for details.
 
    *Example (simpleInitializers.chpl)*.
 
@@ -2039,7 +2036,7 @@ with the ``delete`` statement:
 .. code-block:: syntax
 
    delete-statement:
-     `delete' expression-list ;
+     'delete' expression-list ;
 
 where the expression-list specifies the class objects whose memory will
 be reclaimed. Prior to releasing their memory, the deinitialization

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -179,7 +179,7 @@ memory management strategy.
 A basic class type is given simply by the class name for non-generic
 classes. Generic classes must be instantiated to serve as a
 fully-specified type, for example to declare a variable. This is done
-with type constructors, which are defined in :ref:`Type_Constructors`.
+with type constructors, which are defined in Section :ref:`Type_Constructors`.
 
 
 
@@ -773,7 +773,7 @@ are initialized must be initialized in declaration order.
 Initializers for generic classes (:ref:`Generic_Types`) handle
 generic fields without default values differently and may need to
 satisfy additional requirements. See
-ref:`Generic_User_Initializers` for details.
+Section :ref:`Generic_User_Initializers` for details.
 
    *Example (simpleInitializers.chpl)*.
 

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -12,6 +12,11 @@ expression can be a type expression. We refer to these two types the
 implicit (:ref:`Implicit_Conversions`) or
 explicit (:ref:`Explicit_Conversions`).
 
+   *Open issue*.
+
+   Should Chapel allow for user-defined conversions?
+   If so, how would the user define them?
+
 .. _Implicit_Conversions:
 
 Implicit Conversions

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -50,11 +50,11 @@ The syntax of the forall statement is given by
 .. code-block:: syntax
 
    forall-statement:
-     `forall' index-var-declaration `in' iteratable-expression task-intent-clause[OPT] `do' statement
-     `forall' index-var-declaration `in' iteratable-expression task-intent-clause[OPT] block-statement
-     `forall' iteratable-expression task-intent-clause[OPT] `do' statement
-     `forall' iteratable-expression task-intent-clause[OPT] block-statement
-     [ index-var-declaration `in' iteratable-expression task-intent-clause[OPT] ] statement
+     'forall' index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] 'do' statement
+     'forall' index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] block-statement
+     'forall' iteratable-expression task-intent-clause[OPT] 'do' statement
+     'forall' iteratable-expression task-intent-clause[OPT] block-statement
+     [ index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] ] statement
      [ iteratable-expression task-intent-clause[OPT] ] statement
 
 As with the for statement, the indices may be omitted if they are
@@ -80,7 +80,7 @@ yielded by the ``iteratable-expression``. Each instance of the forall
 loop’s body may be executed concurrently with the others, but this is
 not guaranteed. In particular, the loop must be serializable. Details
 regarding concurrency and iterator implementation are described
-in \ `23.4 <#Parallel_Iterators>`__.
+in :ref:`Parallel_Iterators`.
 
 This differs from the semantics of the ``coforall`` loop, discussed
 in :ref:`Coforall`, where each iteration is guaranteed to run
@@ -178,9 +178,9 @@ The syntax of a forall expression is given by
 .. code-block:: syntax
 
    forall-expression:
-     `forall' index-var-declaration `in' iteratable-expression task-intent-clause[OPT] `do' expression
-     `forall' iteratable-expression task-intent-clause[OPT] `do' expression
-     [ index-var-declaration `in' iteratable-expression task-intent-clause[OPT] ] expression
+     'forall' index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] 'do' expression
+     'forall' iteratable-expression task-intent-clause[OPT] 'do' expression
+     [ index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] ] expression
      [ iteratable-expression task-intent-clause[OPT] ] expression
 
 As with the for expression, the indices may be omitted if they are
@@ -235,7 +235,7 @@ the zipper case :ref:`Zipper_Promotion`.
    of the indices in the range ``1..10``.
 
 The forall expression follows the semantics of the forall statement as
-described in \ `27.1.2 <#forall_semantics>`__.
+in :ref:`forall_semantics`.
 
 Zipper Iteration
 ~~~~~~~~~~~~~~~~
@@ -371,9 +371,9 @@ statement’s with-clause is:
      task-private-var-kind identifier type-part[OPT] initialization-part[OPT]
 
    task-private-var-kind:
-     `const'
-     `var'
-     `ref'
+     'const'
+     'var'
+     'ref'
 
 The declaration of a ``const`` or ``var`` task-private variable must
 have at least one of ``type-part`` and ``initialization-part``. A
@@ -752,24 +752,29 @@ The syntax for a reduction expression is given by:
 .. code-block:: syntax
 
    reduce-expression:
-     reduce-scan-operator `reduce' iteratable-expression
-     class-type `reduce' iteratable-expression
+     reduce-scan-operator 'reduce' iteratable-expression
+     class-type 'reduce' iteratable-expression
 
    reduce-scan-operator: one of
-     + * && || & | ^ `min' `max' `minloc' `maxloc'
+     + * && || & | ^ 'min' 'max' 'minmax' 'minloc' 'maxloc'
 
 Chapel’s predefined reduction operators are defined by
 ``reduce-scan-operator`` above. In order, they are: sum, product,
 logical-and, logical-or, bitwise-and, bitwise-or, bitwise-exclusive-or,
-minimum, maximum, minimum-with-location, and maximum-with-location. The
+minimum, maximum, minimum-and-maximum,
+minimum-with-location, and maximum-with-location. The
 minimum reduction returns the minimum value as defined by the ``<``
 operator. The maximum reduction returns the maximum value as defined by
-the ``>`` operator. The minimum-with-location reduction returns the lowest
+the ``>`` operator. The minimum-and-maximum reduction returns a tuple
+with the first component being the result of the minimum reduction
+and the second component being the result of the maximum reduction.
+The minimum-with-location reduction returns the lowest
 index position with the minimum value (as defined by the ``<`` operator).
 The maximum-with-location reduction returns the lowest index position
 with the maximum value (as defined by the ``>`` operator). When a minimum,
-maximum, minimum-with-location, or maximum-with-location reduction
-encounters a NaN, the result is a NaN.
+maximum, minimum-and-maximum, minimum-with-location,
+or maximum-with-location reduction encounters a NaN, the result
+is or contains a NaN.
 
 The expression on the right-hand side of the ``reduce`` keyword can be
 of any type that can be iterated over, provided the reduction operator
@@ -844,8 +849,8 @@ The syntax for a scan expression is given by:
 .. code-block:: syntax
 
    scan-expression:
-     reduce-scan-operator `scan' iteratable-expression
-     class-type `scan' iteratable-expression
+     reduce-scan-operator 'scan' iteratable-expression
+     class-type 'scan' iteratable-expression
 
 The predefined scans are defined by ``reduce-scan-operator``. These are
 identical to the predefined reductions and are described
@@ -877,8 +882,8 @@ that can be iterated over and to which the operator can be applied.
       1 2 3
 
 User-defined scans are specified by preceding the keyword ``scan`` by
-the class type that implements the scan interface as described in
-Chapter \ `[User_Defined_Reductions_and_Scans] <#User_Defined_Reductions_and_Scans>`__.
+the class type that implements the scan interface as described
+in :ref:`Chapter-User_Defined_Reductions_and_Scans`.
 
 .. _data_parallel_knobs:
 

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -235,7 +235,7 @@ the zipper case :ref:`Zipper_Promotion`.
    of the indices in the range ``1..10``.
 
 The forall expression follows the semantics of the forall statement as
-in :ref:`forall_semantics`.
+described in :ref:`forall_semantics`.
 
 Zipper Iteration
 ~~~~~~~~~~~~~~~~

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -62,7 +62,7 @@ a ``dmapped`` clause:
 .. code-block:: syntax
 
    mapped-domain-type:
-     domain-type `dmapped' dmap-value
+     domain-type 'dmapped' dmap-value
 
    dmap-value:
      expression
@@ -167,7 +167,7 @@ clause, in the same way as a domain type’s map.
 .. code-block:: syntax
 
    mapped-domain-expression:
-     domain-expression `dmapped' dmap-value
+     domain-expression 'dmapped' dmap-value
 
 ..
 

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -137,7 +137,7 @@ The syntax of a rectangular domain type is summarized as follows:
 .. code-block:: syntax
 
    rectangular-domain-type:
-     `domain' ( named-expression-list )
+     'domain' ( named-expression-list )
 
 where ``named-expression-list`` permits the values of ``rank``,
 ``idxType``, and ``stridable`` to be specified using standard type
@@ -293,7 +293,7 @@ the indices that it stores. The syntax is as follows:
 .. code-block:: syntax
 
    associative-domain-type:
-     `domain' ( associative-index-type )
+     'domain' ( associative-index-type )
 
    associative-index-type:
      type-expression
@@ -431,7 +431,7 @@ A simple subdomain type is specified using the following syntax:
 .. code-block:: syntax
 
    simple-subdomain-type:
-     `subdomain' ( domain-expression )
+     'subdomain' ( domain-expression )
 
 This declares that ``domain-expression`` is the parent domain of this
 subdomain type. A simple subdomain specifies a subdomain with the same
@@ -470,7 +470,7 @@ Sparse Subdomain Types and Values
 .. code-block:: syntax
 
    sparse-subdomain-type:
-     `sparse' `subdomain'[OPT] ( domain-expression )
+     'sparse' 'subdomain'[OPT] ( domain-expression )
 
 This declaration creates a sparse subdomain. *Sparse subdomains* are
 irregular domains that describe an arbitrary subset of a domain, even if
@@ -530,7 +530,7 @@ set. Index types are described using the following syntax:
 .. code-block:: syntax
 
    index-type:
-     `index' ( domain-expression )
+     'index' ( domain-expression )
 
 A variable with a given index type is constrained to take on only values
 available within the domain on which it is defined. This restriction
@@ -710,7 +710,7 @@ integral tuple whose size matches the domain’s rank.
 .. code-block:: syntax
 
    domain-striding-expression:
-     domain-expression `by' expression
+     domain-expression 'by' expression
 
 The type of the resulting domain is the same as the original domain but
 with ``stridable`` set to true. In the case of an integer stride value,
@@ -735,7 +735,7 @@ value or an integral tuple whose size matches the domain’s rank.
 .. code-block:: syntax
 
    domain-alignment-expression:
-     domain-expression `align' expression
+     domain-expression 'align' expression
 
 The type of the resulting domain is the same as the original domain but
 with ``stridable`` set to true. In the case of an integer alignment
@@ -840,8 +840,7 @@ The ``#`` operator can be applied to dense rectangular domains with a
 tuple argument whose size matches the rank of the domain (or optionally
 an integer in the case of a 1D domain). The operator is equivalent to
 applying the ``#`` operator to the component ranges of the domain and
-then using them to slice the domain as in
-Section \ `21.8.4.2 <#Range_Based_Slicing>`__.
+then using them to slice the domain as in :ref:`Range_Based_Slicing`.
 
 .. _Adding_and_Removing_Domain_Indices:
 

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -840,7 +840,7 @@ The ``#`` operator can be applied to dense rectangular domains with a
 tuple argument whose size matches the rank of the domain (or optionally
 an integer in the case of a 1D domain). The operator is equivalent to
 applying the ``#`` operator to the component ranges of the domain and
-then using them to slice the domain as in :ref:`Range_Based_Slicing`.
+then using them to slice the domain as in Section :ref:`Range_Based_Slicing`.
 
 .. _Adding_and_Removing_Domain_Indices:
 

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -537,7 +537,7 @@ The syntax of a binary expression is given by:
      expression binary-operator expression
 
    binary-operator: one of
-     + - * / % ** & | ^ << >> && || == != <= >= < > `by' #
+     + - * / % ** & | ^ << >> && || == != <= >= < > 'by' #
 
 The operators are defined in subsequent sections.
 
@@ -1483,7 +1483,7 @@ by:
 .. code-block:: syntax
 
    let-expression:
-     `let' variable-declaration-list `in' expression
+     'let' variable-declaration-list 'in' expression
 
 The scope of the variables is the let-expression.
 
@@ -1530,8 +1530,8 @@ A conditional expression is given by the following syntax:
 .. code-block:: syntax
 
    if-expression:
-     `if' expression `then' expression `else' expression
-     `if' expression `then' expression
+     'if' expression 'then' expression 'else' expression
+     'if' expression 'then' expression
 
 The conditional expression is evaluated in two steps. First, the
 expression following the ``if`` keyword is evaluated. Then, if the
@@ -1581,8 +1581,8 @@ A for expression is given by the following syntax:
 .. code-block:: syntax
 
    for-expression:
-     `for' index-var-declaration `in' iteratable-expression `do' expression
-     `for' iteratable-expression `do' expression
+     'for' index-var-declaration 'in' iteratable-expression 'do' expression
+     'for' iteratable-expression 'do' expression
 
 A for expression is an iterator that executes a for loop
 (:ref:`The_For_Loop`), evaluates the body expression on each

--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -62,7 +62,7 @@ An external procedure declaration has the following syntax:
 .. code-block:: syntax
 
    external-procedure-declaration-statement:
-     `extern' external-name[OPT] `proc' function-name argument-list return-intent[OPT] return-type[OPT]
+     'extern' external-name[OPT] 'proc' function-name argument-list return-intent[OPT] return-type[OPT]
 
 Chapel code will call the external function using the parameter types
 supplied in the ``extern`` declaration. Therefore, in general, the type
@@ -140,7 +140,7 @@ An exported procedure declaration has the following syntax:
 .. code-block:: syntax
 
    exported-procedure-declaration-statement:
-     `export' external-name[OPT] `proc' function-name argument-list return-intent[OPT] return-type[OPT]
+     'export' external-name[OPT] 'proc' function-name argument-list return-intent[OPT] return-type[OPT]
        function-body
 
    external-name:
@@ -243,7 +243,7 @@ declaration with the following syntax.
 .. code-block:: syntax
 
    external-type-alias-declaration-statement:
-     `extern' `type' type-alias-declaration-list ;
+     'extern' 'type' type-alias-declaration-list ;
 
 In each ``type-alias-declaration``, if the ``type-expression`` part is
 supplied, then Chapel uses the supplied type specifier internally.
@@ -275,7 +275,7 @@ Chapel ``record`` definition with the ``extern`` keyword.
 .. code-block:: syntax
 
    external-record-declaration-statement:
-     `extern' external-name[OPT] simple-record-declaration-statement
+     'extern' external-name[OPT] simple-record-declaration-statement
 
 For example, consider an external C structure defined in ``foo.h``
 called ``fltdbl``. 

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -23,18 +23,18 @@ The syntax to declare an iterator is given by:
 .. code-block:: syntax
 
    iterator-declaration-statement:
-     privacy-specifier[OPT] `iter' iterator-name argument-list[OPT] yield-intent[OPT] yield-type[OPT] where-clause[OPT]
+     privacy-specifier[OPT] 'iter' iterator-name argument-list[OPT] yield-intent[OPT] yield-type[OPT] where-clause[OPT]
      iterator-body
 
    iterator-name:
      identifier
 
    yield-intent:
-     `const'
-     `const ref'
-     `ref'
-     `param'
-     `type'
+     'const'
+     'const ref'
+     'ref'
+     'param'
+     'type'
 
    yield-type:
      : type-expression
@@ -78,7 +78,7 @@ yield statement is given by
 .. code-block:: syntax
 
    yield-statement:
-     `yield' expression ;
+     'yield' expression ;
 
 When an iterator is executed and a ``yield`` is encountered, the value
 of the yield expression is returned to the iterator’s callsite. However,

--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -91,18 +91,18 @@ following syntax:
    legal-identifier-char:
      letter-or-underscore
      digit
-     `$'
+     '$'
 
    letter-or-underscore:
      letter
-     `_'
+     '_'
 
    letter: one of
-     `A' `B' `C' `D' `E' `F' `G' `H' `I' `J' `K' `L' `M' `N' `O' `P' `Q' `R' `S' `T' `U' `V' `W' `X' `Y' `Z'
-     `a' `b' `c' `d' `e' `f' `g' `h' `i' `j' `k' `l' `m' `n' `o' `p' `q' `r' `s' `t' `u' `v' `w' `x' `y' `z'
+     'A' 'B' 'C' 'D' 'E' 'F' 'G' 'H' 'I' 'J' 'K' 'L' 'M' 'N' 'O' 'P' 'Q' 'R' 'S' 'T' 'U' 'V' 'W' 'X' 'Y' 'Z'
+     'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 'u' 'v' 'w' 'x' 'y' 'z'
 
    digit: one of
-     `0' `1' `2' `3' `4' `5' `6' `7' `8' `9'
+     '0' '1' '2' '3' '4' '5' '6' '7' '8' '9'
 
 ..
 
@@ -245,7 +245,7 @@ Bool literals are designated by the following syntax:
 .. code-block:: syntax
 
    bool-literal: one of
-     `true' `false'
+     'true' 'false'
 
 Signed and unsigned integer literals are designated by the following
 syntax: 
@@ -254,12 +254,12 @@ syntax:
 
    integer-literal:
      digits
-     `0x' hexadecimal-digits
-     `0X' hexadecimal-digits
-     `0o' octal-digits
-     `0O' octal-digits
-     `0b' binary-digits
-     `0B' binary-digits
+     '0x' hexadecimal-digits
+     '0X' hexadecimal-digits
+     '0o' octal-digits
+     '0O' octal-digits
+     '0b' binary-digits
+     '0B' binary-digits
 
    digits:
      digit
@@ -267,9 +267,9 @@ syntax:
 
    separator-digits:
      digit
-     `_'
+     '_'
      digit separator-digits
-     `_' separator-digits
+     '_' separator-digits
 
    hexadecimal-digits:
      hexadecimal-digit
@@ -277,12 +277,12 @@ syntax:
 
    separator-hexadecimal-digits:
      hexadecimal-digit
-     `_'
+     '_'
      hexadecimal-digit separator-hexadecimal-digits
-     `_' separator-hexadecimal-digits
+     '_' separator-hexadecimal-digits
 
    hexadecimal-digit: one of
-     `0' `1' `2' `3' `4' `5' `6' `7' `8' `9' `A' `B' `C' `D' `E' `F' `a' `b' `c' `d' `e' `f'
+     '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' 'A' 'B' 'C' 'D' 'E' 'F' 'a' 'b' 'c' 'd' 'e' 'f'
 
    octal-digits:
      octal-digit
@@ -290,12 +290,12 @@ syntax:
 
    separator-octal-digits:
      octal-digit
-     `_'
+     '_'
      octal-digit separator-octal-digits
-     `_' separator-octal-digits
+     '_' separator-octal-digits
 
    octal-digit: one of
-     `0' `1' `2' `3' `4' `5' `6' `7'
+     '0' '1' '2' '3' '4' '5' '6' '7'
 
    binary-digits:
      binary-digit
@@ -303,12 +303,12 @@ syntax:
 
    separator-binary-digits:
      binary-digit
-     `_'
+     '_'
      binary-digit separator-binary-digits
-     `_' separator-binary-digits
+     '_' separator-binary-digits
 
    binary-digit: one of
-     `0' `1'
+     '0' '1'
 
 Integer literals in the range 0 to max(\ ``int``),
  :ref:`Signed_and_Unsigned_Integral_Types`, have type ``int`` and
@@ -339,18 +339,18 @@ Real literals are designated by the following syntax:
    real-literal:
      digits[OPT] . digits exponent-part[OPT]
      digits .[OPT] exponent-part
-     `0x' hexadecimal-digits[OPT] . hexadecimal-digits p-exponent-part[OPT]
-     `0X' hexadecimal-digits[OPT] . hexadecimal-digits p-exponent-part[OPT]
-     `0x' hexadecimal-digits .[OPT] p-exponent-part
-     `0X' hexadecimal-digits .[OPT] p-exponent-part
+     '0x' hexadecimal-digits[OPT] . hexadecimal-digits p-exponent-part[OPT]
+     '0X' hexadecimal-digits[OPT] . hexadecimal-digits p-exponent-part[OPT]
+     '0x' hexadecimal-digits .[OPT] p-exponent-part
+     '0X' hexadecimal-digits .[OPT] p-exponent-part
 
    exponent-part:
-     `e' sign[OPT] digits
-     `E' sign[OPT] digits
+     'e' sign[OPT] digits
+     'E' sign[OPT] digits
 
    p-exponent-part:
-     `p' sign[OPT] digits
-     `P' sign[OPT] digits
+     'p' sign[OPT] digits
+     'P' sign[OPT] digits
 
 
    sign: one of
@@ -381,8 +381,8 @@ Imaginary literals are designated by the following syntax:
 .. code-block:: syntax
 
    imaginary-literal:
-     real-literal `i'
-     integer-literal `i'
+     real-literal 'i'
+     integer-literal 'i'
 
 The type of an imaginary literal is ``imag``. Explicit conversions are
 necessary to change the size of the literal.
@@ -416,7 +416,7 @@ Interpreted string literals are designated by the following syntax:
      " single-quote-delimited-characters[OPT]
 
    string-character:
-     `any character except the double quote, single quote, or new line'
+     any character except the double quote, single quote, or new line
      simple-escape-character
      hexadecimal-escape-character
 
@@ -424,7 +424,7 @@ Interpreted string literals are designated by the following syntax:
      \' \" \? \\ \a \b \f \n \r \t \v
 
    hexadecimal-escape-character:
-     `\x' hexadecimal-digits
+     '\x' hexadecimal-digits
 
 Uninterpreted string literals are designated by the following syntax:
 
@@ -441,10 +441,10 @@ Uninterpreted string literals are designated by the following syntax:
      uninterpreted-single-quote-string-character uninterpreted-single-quote-delimited-characters[OPT]
 
    uninterpreted-double-quote-string-character:
-     `any character except three double quotes in a row'
+     any character except three double quotes in a row
 
    uninterpreted-single-quote-string-character:
-     `any character except three single quotes in a row'
+     any character except three single quotes in a row
 
 Uninterpreted string literals do not interpret their contents, so for
 example ``"""\n"""`` is not a newline, but rather two
@@ -520,7 +520,7 @@ language:
 ``,``                                                                                               expression separator
 ``.``                                                                                               member access
 ``?``                                                                                               type query
-``" '``                                                                                             string delimiters
+``"`` ``'``                                                                                         string delimiters
 =================================================================================================== =============================
 
 .. _Grouping_Tokens:

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -185,7 +185,7 @@ stored) is queried using the following syntax:
 .. code-block:: syntax
 
    locale-query-expression:
-     expression . `locale'
+     expression . 'locale'
 
 When the expression is a class, the access returns the locale on which
 the class object exists rather than the reference to the class. If the
@@ -266,8 +266,8 @@ given by
 .. code-block:: syntax
 
    on-statement:
-     `on' expression `do' statement
-     `on' expression block-statement
+     'on' expression 'do' statement
+     'on' expression block-statement
 
 The locale of the expression is automatically queried as described
 in :ref:`Querying_the_Locale_of_an_Expression`. Execution of the
@@ -293,4 +293,4 @@ keyword and braces. The syntax is given by:
 .. code-block:: syntax
 
    remote-variable-declaration-statement:
-     `on' expression variable-declaration-statement
+     'on' expression variable-declaration-statement

--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -71,7 +71,7 @@ parallelism dependencies between variable reads and writes. The *memory
 order* :math:`<_m` is a total order that describes the semantics of
 synchronizing memory operations (via ``atomic``, ``sync`` or ``single``
 variables) with sequential consistency. Non-SC atomic operations
-(described in Section \ `31.2 <#non_sc_atomics>`__) do not create this
+(described in :ref:`non_sc_atomics`) do not create this
 total order.
 
 Note that ``sync/single`` variables have memory consistency behavior
@@ -97,7 +97,7 @@ We will use the following notation:
 -  :math:`A_r(a,o)` indicates an *atomic operation* on a variable at
    address :math:`a` with ordering constraint :math:`o`, where :math:`o`
    can be one of *relaxed*, *acquire*, or *release* (see
-   Section \ `31.2 <#non_sc_atomics>`__). As with :math:`A_{sc}(a)`,
+   :ref:`non_sc_atomics`). As with :math:`A_{sc}(a)`,
    relaxed atomic operations must be completed as a single operation.
 
 -  :math:`L(a)`, :math:`S(a)`, :math:`A_{sc}(a)`, and :math:`A_r(a,o)`
@@ -145,7 +145,7 @@ of starting a task (``begin``) and waiting for some number of tasks
    :math:`i=1`..\ :math:`m`) and waits for them to complete
    (``waitFor(t_1..t_m)``). The number of tasks :math:`m` is defined
    by the implementation of the parallel iterator (See
-   Section \ `[Iterators] <#Iterators>`__ for details on iterators).
+   :ref:`Chapter-Iterators` for details on iterators).
 
 -  ``coforall`` creates one task per loop iteration
    (``t_i = begin{loop-body}`` for all loop iterations
@@ -270,7 +270,7 @@ to a data race that would prevent sequential consistency.
 
 When relaxed atomics are used only for atomicity and not as part of
 synchronizing tasks, their effect can be understood in the memory
-consistency model described in `31.1 <#SC_for_DRF>`__ by treating them
+consistency model described in :ref:`SC_for_DRF` by treating them
 as ordinary loads or stores with two exceptions:
 
 -  Atomic operations (including relaxed atomic operations) cannot create
@@ -322,8 +322,8 @@ section:
    memory.
 
 The *unordered* loads and stores :math:`UL(a)` and :math:`US(a)` respect
-fences but not program order. As in
-Section \ `31.1.2 <#memory_order>`__, unordered loads and stores are
+fences but not program order. As in :ref:`memory_order`,
+unordered loads and stores are
 ordered with SC atomics. That is, unordered loads and stores for a given
 task are in total order :math:`<_m` respecting the following rules which
 preserve the order of unordered loads and stores relative to SC atomic

--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -322,7 +322,7 @@ section:
    memory.
 
 The *unordered* loads and stores :math:`UL(a)` and :math:`US(a)` respect
-fences but not program order. As in :ref:`memory_order`,
+fences but not program order. As in Section :ref:`memory_order`,
 unordered loads and stores are
 ordered with SC atomics. That is, unordered loads and stores for a given
 task are in total order :math:`<_m` respecting the following rules which

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -17,19 +17,19 @@ Methods are declared with the following syntax:
        return-intent[OPT] return-type[OPT] where-clause[OPT] function-body
 
    proc-or-iter:
-     `proc'
-     `iter'
+     'proc'
+     'iter'
 
    this-intent:
-     `param'
-     `type'
-     `ref'
-     `const ref'
-     `const'
+     'param'
+     'type'
+     'ref'
+     'const ref'
+     'const'
 
    type-binding:
      identifier .
-     `(' expr `)' .
+     '(' expr ')' .
 
 Methods defined within the lexical scope of a class, record, or union
 are referred to as *primary methods*. For such methods, the
@@ -42,7 +42,9 @@ standalone functions rather than methods). Note that secondary methods
 can be defined not only for classes, records, and unions, but also for
 any other type (e.g., integers, reals, strings).
 
-[Secondary_Methods_with_Type_Expressions] Secondary methods can be
+.. _Secondary_Methods_with_Type_Expressions:
+
+Secondary methods can be
 declared with a type expression instead of a type identifier. In
 particular, if the ``type-binding`` is a parenthesized expression, the
 compiler will evaluate that expression to find the receiver type for the

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -28,14 +28,14 @@ A module is declared with the following syntax:
 .. code-block:: syntax
 
    module-declaration-statement:
-     privacy-specifier[OPT] prototype-specifier[OPT] `module' module-identifier block-statement
+     privacy-specifier[OPT] prototype-specifier[OPT] 'module' module-identifier block-statement
 
    privacy-specifier:
-     `private'
-     `public'
+     'private'
+     'public'
 
    prototype-specifier:
-     `prototype'
+     'prototype'
 
    module-identifier:
      identifier
@@ -422,7 +422,7 @@ The syntax of the use statement is given by:
 .. code-block:: syntax
 
    use-statement:
-     privacy-specifier[OPT] `use' module-or-enum-name-list ;
+     privacy-specifier[OPT] 'use' module-or-enum-name-list ;
 
    module-or-enum-name-list:
      module-or-enum-name limitation-clause[OPT]
@@ -433,8 +433,8 @@ The syntax of the use statement is given by:
      identifier . module-or-enum-name
 
    limitation-clause:
-     `except' exclude-list
-     `only' rename-list[OPT]
+     'except' exclude-list
+     'only' rename-list[OPT]
 
    exclude-list:
      identifier-list
@@ -445,8 +445,8 @@ The syntax of the use statement is given by:
      rename-base , rename-list
 
    rename-base:
-     identifier `as' identifier
-     identifier `as' _
+     identifier 'as' identifier
+     identifier 'as' _
      identifier
 
 For example, the program
@@ -665,7 +665,7 @@ The syntax of the import statement is given by:
 .. code-block:: syntax
 
    import-statement:
-     privacy-specifier[OPT] `import' import-expression-list ;
+     privacy-specifier[OPT] 'import' import-expression-list ;
 
    import-expression-list:
      import-expression

--- a/doc/rst/language/spec/notation.rst
+++ b/doc/rst/language/spec/notation.rst
@@ -38,11 +38,11 @@ alternative productions to define the non-terminal.
    .. code-block:: syntaxdonotcollect
 
       bool-literal:
-        `true'
-        `false'
+        'true'
+        'false'
 
-   defines ``bool-literal`` to be either the symbol :literal:`\`true'`
-   or :literal:`\`false'`.
+   defines ``bool-literal`` to be either the symbol ``true``
+   or ``false``.
 
 In the event that a single line of a definition needs to break across
 multiple lines of text, more indentation is used to indicate that it is

--- a/doc/rst/language/spec/organization.rst
+++ b/doc/rst/language/spec/organization.rst
@@ -7,109 +7,103 @@ Organization
 
 This specification is organized as follows:
 
--  Chapter \ `[Scope] <#Scope>`__, Scope, describes the scope of this
+-  Chapter :ref:`Chapter-Scope` describes the scope of this
    specification.
 
--  Chapter \ `[Notation] <#Notation>`__, Notation, introduces the
+-  Chapter :ref:`Chapter-Notation` introduces the
    notation that is used throughout this specification.
 
--  Chapter \ `[Organization] <#Organization>`__, Organization, describes
+-  This Chapter :ref:`Chapter-Organization` describes
    the contents of each of the chapters within this specification.
 
--  Chapter \ `[Acknowledgments] <#Acknowledgments>`__, Acknowledgements,
+-  Chapter :ref:`Chapter-Acknowledgments`
    offers a note of thanks to people and projects.
 
--  Chapter \ `[Language_Overview] <#Language_Overview>`__, Language
-   Overview, describes Chapel at a high level.
+-  Chapter :ref:`Chapter-Language_Overview` describes Chapel at a high level.
 
--  Chapter \ `[Lexical_Structure] <#Lexical_Structure>`__, Lexical
-   Structure, describes the lexical components of Chapel.
+-  Chapter :ref:`Chapter-Lexical_Structure` describes
+   the lexical components of Chapel.
 
--  Chapter \ `[Types] <#Types>`__, Types, describes the types in Chapel
+-  Chapter :ref:`Chapter-Types` describes the types in Chapel
    and defines the primitive and enumerated types.
 
--  Chapter \ `[Variables] <#Variables>`__, Variables, describes
+-  Chapter :ref:`Chapter-Variables` describes
    variables and constants in Chapel.
 
--  Chapter \ `[Conversions] <#Conversions>`__, Conversions, describes
+-  Chapter :ref:`Chapter-Conversions` describes
    the legal implicit and explicit conversions allowed between values of
-   different types. Chapel does not allow for user-defined conversions.
+   different types.
 
--  Chapter \ `[Expressions] <#Expressions>`__, Expressions, describes
+-  Chapter :ref:`Chapter-Expressions` describes
    the non-parallel expressions in Chapel.
 
--  Chapter \ `[Statements] <#Statements>`__, Statements, describes the
+-  Chapter :ref:`Chapter-Statements` describes the
    non-parallel statements in Chapel.
 
--  Chapter \ `[Modules] <#Modules>`__, Modules, describes modules in
-   Chapel., Chapel modules allow for namespace management.
+-  Chapter :ref:`Chapter-Modules` describes modules in
+   Chapel, which allow for namespace management.
 
--  Chapter \ `[Functions] <#Functions>`__, Functions, describes
+-  Chapter :ref:`Chapter-Procedures` describes
    functions and function resolution in Chapel.
+   It focuses on procedure functions.
 
--  Chapter \ `[Tuples] <#Tuples>`__, Tuples, describes tuples in Chapel.
+-  Chapter :ref:`Chapter-Tuples` describes tuples in Chapel.
 
--  Chapter \ `[Classes] <#Classes>`__, Classes, describes reference
-   classes in Chapel.
+-  Chapter :ref:`Chapter-Classes` describes classes in Chapel,
+   which offer reference semantics.
 
--  Chapter \ `[Records] <#Records>`__, Records, describes records or
-   value classes in Chapel.
+-  Chapter :ref:`Chapter-Records` describes records in Chapel,
+   which offer value semantics.
 
--  Chapter \ `[Unions] <#Unions>`__, Unions, describes unions in Chapel.
+-  Chapter :ref:`Chapter-Unions` describes unions in Chapel.
 
--  Chapter \ `[Ranges] <#Ranges>`__, Ranges, describes ranges in Chapel.
+-  Chapter :ref:`Chapter-Ranges` describes ranges in Chapel.
 
--  Chapter \ `[Domains] <#Domains>`__, Domains, describes domains in
+-  Chapter :ref:`Chapter-Domains` describes domains in
    Chapel. Chapel domains are first-class index sets that support the
    description of iteration spaces, array sizes and shapes, and sets of
    indices.
 
--  Chapter \ `[Arrays] <#Arrays>`__, Arrays, describes arrays in Chapel.
+-  Chapter :ref:`Chapter-Arrays` describes arrays in Chapel.
    Chapel arrays are more general than in most languages including
    support for multidimensional, sparse, associative, and unstructured
    arrays.
 
--  Chapter \ `[Iterators] <#Iterators>`__, Iterators, describes iterator
+-  Chapter :ref:`Chapter-Iterators` describes iterator
    functions.
 
--  Chapter \ `[Generics] <#Generics>`__, Generics, describes Chapel’s
+-  Chapter :ref:`Chapter-Generics` describes Chapel’s
    support for generic functions and types.
 
--  Chapter \ `[Input_and_Output] <#Input_and_Output>`__, Input and
-   Output, describes support for input and output in Chapel, including
-   file input and output..
+-  Chapter :ref:`Chapter-Input_and_Output` describes support for
+   input and output in Chapel, including file input and output.
 
--  Chapter \ `[Task_Parallelism_and_Synchronization] <#Task_Parallelism_and_Synchronization>`__,
-   Task Parallelism and Synchronization, describes task-parallel
-   expressions and statements in Chapel as well as synchronization
-   constructs, atomic variables, and the atomic statement.
+-  Chapter :ref:`Chapter-Task_Parallelism_and_Synchronization` describes
+   task-parallel expressions and statements in Chapel as well as
+   synchronization constructs, atomic variables, and the atomic statement.
 
--  Chapter \ `[Data_Parallelism] <#Data_Parallelism>`__, Data
-   Parallelism, describes data-parallel expressions and statements in
+-  Chapter :ref:`Chapter-Data_Parallelism` describes data-parallel expressions
+   and statements in
    Chapel including reductions and scans, whole array assignment, and
    promotion.
 
--  Chapter \ `[Locales_Chapter] <#Locales_Chapter>`__, Locales,
-   describes constructs for managing locality and executing Chapel
+-  Chapter :ref:`Chapter-Locales_Chapter` describes constructs for managing
+   locality and executing Chapel
    programs on distributed-memory systems.
 
--  Chapter \ `[Domain_Maps] <#Domain_Maps>`__, Domain Maps, describes
+-  Chapter :ref:`Chapter-Domain_Maps` describes
    Chapel’s *domain map* construct for defining the layout of domains
    and arrays within a single locale and/or the distribution of domains
    and arrays across multiple locales.
 
--  Chapter \ `[User_Defined_Reductions_and_Scans] <#User_Defined_Reductions_and_Scans>`__,
-   User-Defined Reductions and Scans, describes how Chapel programmers
+-  Chapter :ref:`Chapter-User_Defined_Reductions_and_Scans` describes
+   how Chapel programmers
    can define their own reduction and scan operators.
 
--  Chapter \ `[Memory_Consistency_Model] <#Memory_Consistency_Model>`__,
-   Memory Consistency Model, describes Chapel’s rules for ordering the
+-  Chapter :ref:`Chapter-Memory_Consistency_Model` describes Chapel’s rules
+   for ordering the
    reads and writes performed by a program’s tasks.
 
--  Chapter \ `[Interoperability] <#Interoperability>`__ describes
+-  Chapter :ref:`Chapter-Interoperability` describes
    Chapel’s interoperability features for combining Chapel programs with
    code written in different languages.
-
--  Appendix \ `[Syntax] <#Syntax>`__, Collected Lexical and Syntax
-   Productions, contains the syntax productions listed throughout this
-   specification in both alphabetical and depth-first order.

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -111,14 +111,14 @@ Procedures are defined with the following syntax:
 .. code-block:: syntax
 
    procedure-declaration-statement:
-     privacy-specifier[OPT] procedure-kind[OPT] `proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+     privacy-specifier[OPT] procedure-kind[OPT] 'proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
        function-body
 
    procedure-kind:
-     `inline'
-     `export'
-     `extern'
-     `override'
+     'inline'
+     'export'
+     'extern'
+     'override'
 
    function-name:
      identifier
@@ -154,28 +154,28 @@ Procedures are defined with the following syntax:
      ...
 
    formal-intent:
-     `const'
-     `const in'
-     `const ref'
-     `in'
-     `out'
-     `inout'
-     `ref'
-     `param'
-     `type'
+     'const'
+     'const in'
+     'const ref'
+     'in'
+     'out'
+     'inout'
+     'ref'
+     'param'
+     'type'
 
    return-intent:
-     `const'
-     `const ref'
-     `ref'
-     `param'
-     `type'
+     'const'
+     'const ref'
+     'ref'
+     'param'
+     'type'
 
    return-type:
      : type-expression
 
    where-clause:
-     `where' expression
+     'where' expression
 
    function-body:
      block-statement
@@ -602,8 +602,8 @@ The Default Intent
 
 When no intent is specified for a formal argument, the *default intent*
 is applied. It is designed to take the most natural/least surprising
-action for the argument, based on its type. The
-:ref:`Abstract_Intents_Table` earlier in this sub-section lists the
+action for the argument, based on its type.
+The :ref:`Abstract_Intents_Table` earlier in this sub-section lists the
 meaning of the default intent for each type.
 
 Default argument passing for tuples generally matches the default
@@ -621,7 +621,7 @@ type (see :ref:`Method_receiver_and_this`) is ``ref`` or
 the function, otherwise it is ``const ref``. Note that neither of these
 cause an array or record to be copied by default. The choice between
 ``ref`` and ``const ref`` is similar to and interacts with return intent
-overloads (see :ref:`Return_Intent_Overloads`).
+overloads (see :ref:`Return_Intent_Overloads`).
 
 .. _Default_Intent_for_owned_and_shared:
 
@@ -861,7 +861,7 @@ function to call when the candidate functions are otherwise ambiguous
 except for their return intent. This rule enables data structures such
 as sparse arrays.
 
-See `13.13.5 <#Choosing_Return_Intent_Overload>`__ for a detailed
+See :ref:`Choosing_Return_Intent_Overload` for a detailed
 description of how return intent overloads are chosen based upon calling
 context.
 
@@ -1026,7 +1026,7 @@ The syntax of the return statement is given by
 .. code-block:: syntax
 
    return-statement:
-     `return' expression[OPT] ;
+     'return' expression[OPT] ;
 
 ..
 
@@ -1556,7 +1556,7 @@ the following function(s) are selected as best functions:
 Choosing Return Intent Overloads Based on Calling Context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See also `13.7.3 <#Return_Intent_Overloads>`__.
+See also :ref:`Return_Intent_Overloads`.
 
 The compiler can choose between overloads differing in return intent
 when:

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -214,7 +214,7 @@ A range type has the following syntax:
 .. code-block:: syntax
 
    range-type:
-     `range' ( named-expression-list )
+     'range' ( named-expression-list )
 
 That is, a range type is obtained as if by invoking the range type
 constructor (:ref:`Type_Constructors`) that has the following
@@ -562,7 +562,7 @@ The syntax of the ``by`` operator is:
 .. code-block:: syntax
 
    strided-range-expression:
-     range-expression `by' step-expression
+     range-expression 'by' step-expression
 
    step-expression:
      expression
@@ -651,7 +651,7 @@ The syntax for the ``align`` operator is:
 .. code-block:: syntax
 
    aligned-range-expression:
-     range-expression `align' expression
+     range-expression 'align' expression
 
 The type of the resulting range expression is the same as that of the
 range appearing as the left operand, but with the ``stridable``

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -44,7 +44,7 @@ A record type is defined with the following syntax:
      external-record-declaration-statement
 
    simple-record-declaration-statement:
-     `record' identifier { record-statement-list }
+     'record' identifier { record-statement-list }
 
    record-statement-list:
      record-statement
@@ -102,8 +102,7 @@ permitted.
 For non-generic records, the record name by itself is sufficient to
 specify the type. Generic records must be instantiated to serve as a
 fully-specified type, for example to declare a variable. This is done
-with type constructors, which are defined in
-Section \ `24.3.6 <#Type_Constructors>`__.
+with type constructors, which are defined in :ref:`Type_Constructors`.
 
 .. _Record_Fields:
 
@@ -564,7 +563,7 @@ In it, the value of each field of the record on the right-hand side is
 assigned to the corresponding field of the record on the left-hand side.
 
 The compiler-provided assignment operator may be overridden as described
-in `11.3 <#Assignment_Statements>`__.
+in :ref:`Assignment_Statements`.
 
 The following example demonstrates record assignment.
 

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -102,7 +102,7 @@ permitted.
 For non-generic records, the record name by itself is sufficient to
 specify the type. Generic records must be instantiated to serve as a
 fully-specified type, for example to declare a variable. This is done
-with type constructors, which are defined in :ref:`Type_Constructors`.
+with type constructors, which are defined in Section :ref:`Type_Constructors`.
 
 .. _Record_Fields:
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -308,11 +308,11 @@ The syntax for a conditional statement is given by
 .. code-block:: syntax
 
    conditional-statement:
-     `if' expression `then' statement else-part[OPT]
-     `if' expression block-statement else-part[OPT]
+     'if' expression 'then' statement else-part[OPT]
+     'if' expression block-statement else-part[OPT]
 
    else-part:
-     `else' statement
+     'else' statement
 
 A conditional statement evaluates an expression of bool type. If the
 expression evaluates to true, the first statement in the conditional
@@ -385,17 +385,17 @@ statement. The syntax is given by:
 .. code-block:: syntax
 
    select-statement:
-     `select' expression { when-statements }
+     'select' expression { when-statements }
 
    when-statements:
      when-statement
      when-statement when-statements
 
    when-statement:
-     `when' expression-list `do' statement
-     `when' expression-list block-statement
-     `otherwise' statement
-     `otherwise' `do' statement
+     'when' expression-list 'do' statement
+     'when' expression-list block-statement
+     'otherwise' statement
+     'otherwise' 'do' statement
 
    expression-list:
      expression
@@ -429,15 +429,15 @@ while-do loop is given by:
 .. code-block:: syntax
 
    while-do-statement:
-     `while' expression `do' statement
-     `while' expression block-statement
+     'while' expression 'do' statement
+     'while' expression block-statement
 
 The syntax of the do-while loop is given by: 
 
 .. code-block:: syntax
 
    do-while-statement:
-     `do' statement `while' expression ;
+     'do' statement 'while' expression ;
 
 In both variants, the expression evaluates to a value of type ``bool``
 which determines when the loop terminates and control continues with the
@@ -544,10 +544,10 @@ loop is given by:
 .. code-block:: syntax
 
    for-statement:
-     `for' index-var-declaration `in' iteratable-expression `do' statement
-     `for' index-var-declaration `in' iteratable-expression block-statement
-     `for' iteratable-expression `do' statement
-     `for' iteratable-expression block-statement
+     'for' index-var-declaration 'in' iteratable-expression 'do' statement
+     'for' index-var-declaration 'in' iteratable-expression block-statement
+     'for' iteratable-expression 'do' statement
+     'for' iteratable-expression block-statement
 
    index-var-declaration:
      identifier
@@ -555,7 +555,7 @@ loop is given by:
 
    iteratable-expression:
      expression
-     `zip' ( expression-list )
+     'zip' ( expression-list )
 
 The ``index-var-declaration`` declares new variables for the scope of
 the loop. It may specify a new identifier or may specify multiple
@@ -616,12 +616,12 @@ parameter for loop statement is given by:
 .. code-block:: syntax
 
    param-for-statement:
-     `for' `param' identifier `in' param-iteratable-expression `do' statement
-     `for' `param' identifier `in' param-iteratable-expression block-statement
+     'for' 'param' identifier 'in' param-iteratable-expression 'do' statement
+     'for' 'param' identifier 'in' param-iteratable-expression block-statement
 
    param-iteratable-expression:
      range-literal
-     range-literal `by' integer-literal
+     range-literal 'by' integer-literal
 
 Parameter for loops are restricted to iteration over range literals with
 an optional by expression where the bounds and stride must be
@@ -655,13 +655,13 @@ The syntax for label, break, and continue statements is given by:
 .. code-block:: syntax
 
    break-statement:
-     `break' identifier[OPT] ;
+     'break' identifier[OPT] ;
 
    continue-statement:
-     `continue' identifier[OPT] ;
+     'continue' identifier[OPT] ;
 
    label-statement:
-     `label' identifier statement
+     'label' identifier statement
 
 A ``break`` statement cannot be used to exit a parallel loop
 :ref:`Forall`.
@@ -749,7 +749,7 @@ The syntax is:
 .. code-block:: syntax
 
    defer-statement:
-     `defer' statement
+     'defer' statement
 
 At each place where control flow exits a block, the compiler will add
 cleanup actions for the in-scope ``defer`` statements that have executed and

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -87,7 +87,7 @@ for the begin statement is given by
 .. code-block:: syntax
 
    begin-statement:
-     `begin' task-intent-clause[OPT] statement
+     'begin' task-intent-clause[OPT] statement
 
 Control continues concurrently with the statement following the begin
 statement.
@@ -186,10 +186,10 @@ by the following syntax:
 .. code-block:: syntax
 
    sync-type:
-     `sync' type-expression
+     'sync' type-expression
 
    single-type:
-     `single' type-expression
+     'single' type-expression
 
 A default-initialized synchronization variable will be empty. A
 synchronization variable initialized from another expression will be
@@ -530,7 +530,7 @@ following syntax:
 .. code-block:: syntax
 
    atomic-type:
-     `atomic' type-expression
+     'atomic' type-expression
 
 .. _Functions_on_Atomic_Variables:
 
@@ -695,7 +695,7 @@ The ``cobegin`` statement syntax is
 .. code-block:: syntax
 
    cobegin-statement:
-     `cobegin' task-intent-clause[OPT] block-statement
+     'cobegin' task-intent-clause[OPT] block-statement
 
 A new task and a corresponding task function are created for each
 statement in the ``block-statement``. Control continues when all of the
@@ -756,10 +756,10 @@ The syntax for the coforall loop is given by
 .. code-block:: syntax
 
    coforall-statement:
-     `coforall' index-var-declaration `in' iteratable-expression task-intent-clause[OPT] `do' statement
-     `coforall' index-var-declaration `in' iteratable-expression task-intent-clause[OPT] block-statement
-     `coforall' iteratable-expression task-intent-clause[OPT] `do' statement
-     `coforall' iteratable-expression task-intent-clause[OPT] block-statement
+     'coforall' index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] 'do' statement
+     'coforall' index-var-declaration 'in' iteratable-expression task-intent-clause[OPT] block-statement
+     'coforall' iteratable-expression task-intent-clause[OPT] 'do' statement
+     'coforall' iteratable-expression task-intent-clause[OPT] block-statement
 
 The ``coforall`` loop creates a separate task for each iteration of the
 loop. Control continues with the statement following the ``coforall``
@@ -862,7 +862,7 @@ The syntax of the task intent clause is:
 .. code-block:: syntax
 
    task-intent-clause:
-     `with' ( task-intent-list )
+     'with' ( task-intent-list )
 
    task-intent-list:
      task-intent-item
@@ -979,8 +979,8 @@ from within a statement. The syntax for the sync statement is given by
 .. code-block:: syntax
 
    sync-statement:
-     `sync' statement
-     `sync' block-statement
+     'sync' statement
+     'sync' block-statement
 
 Return statements are not allowed in sync statement blocks. Yield
 statement may only be lexically enclosed in sync statement blocks in
@@ -1066,8 +1066,8 @@ The syntax is:
 .. code-block:: syntax
 
    serial-statement:
-     `serial' expression[OPT] `do' statement
-     `serial' expression[OPT] block-statement
+     'serial' expression[OPT] 'do' statement
+     'serial' expression[OPT] block-statement
 
 where the optional ``expression`` evaluates to a boolean value. If the
 expression is omitted, it is as though ’true’ were specified. Whatever
@@ -1208,7 +1208,7 @@ The syntax for the atomic statement is given by:
 .. code-block:: syntax
 
    atomic-statement:
-     `atomic' statement
+     'atomic' statement
 
 ..
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -116,14 +116,14 @@ The syntax of a tuple expression is given by:
 
    tuple-component:
      expression
-     `_'
+     '_'
 
    tuple-component-list:
      tuple-component
      tuple-component , tuple-component-list
 
-An underscore can be used to omit components when splitting a tuple (see
-`16.6.1 <#Assignments_in_a_Tuple>`__).
+An underscore can be used to omit components when splitting a tuple
+(see :ref:`Assignments_in_a_Tuple`).
 
    *Example (values.chpl)*.
 

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -70,23 +70,23 @@ The primitive types are summarized by the following syntax:
 .. code-block:: syntax
 
    primitive-type:
-     `void'
-     `nothing'
-     `bool' primitive-type-parameter-part[OPT]
-     `int' primitive-type-parameter-part[OPT]
-     `uint' primitive-type-parameter-part[OPT]
-     `real' primitive-type-parameter-part[OPT]
-     `imag' primitive-type-parameter-part[OPT]
-     `complex' primitive-type-parameter-part[OPT]
-     `string'
-     `bytes'
-     `enum'
-     `record'
-     `class'
-     `owned'
-     `shared'
-     `unmanaged'
-     `borrowed'
+     'void'
+     'nothing'
+     'bool' primitive-type-parameter-part[OPT]
+     'int' primitive-type-parameter-part[OPT]
+     'uint' primitive-type-parameter-part[OPT]
+     'real' primitive-type-parameter-part[OPT]
+     'imag' primitive-type-parameter-part[OPT]
+     'complex' primitive-type-parameter-part[OPT]
+     'string'
+     'bytes'
+     'enum'
+     'record'
+     'class'
+     'owned'
+     'shared'
+     'unmanaged'
+     'borrowed'
 
    primitive-type-parameter-part:
      ( integer-parameter-expression )
@@ -269,7 +269,7 @@ Enumerated types are declared with the following syntax:
 .. code-block:: syntax
 
    enum-declaration-statement:
-     `enum' identifier { enum-constant-list }
+     'enum' identifier { enum-constant-list }
 
    enum-constant-list:
      enum-constant
@@ -527,7 +527,7 @@ Type aliases are declared with the following syntax:
 .. code-block:: syntax
 
    type-alias-declaration-statement:
-     privacy-specifier[OPT] `config'[OPT] `type' type-alias-declaration-list ;
+     privacy-specifier[OPT] 'config'[OPT] 'type' type-alias-declaration-list ;
      external-type-alias-declaration-statement
 
    type-alias-declaration-list:
@@ -598,7 +598,7 @@ Querying the Type of an Expression
 .. code-block:: syntax
 
    type-query-expression:
-     expression . `type'
+     expression . 'type'
 
 The type of a an expression can be queried with ``.type``. This
 functionality is particularly useful when doing generic programming

--- a/doc/rst/language/spec/unions.rst
+++ b/doc/rst/language/spec/unions.rst
@@ -37,7 +37,7 @@ A union is defined with the following syntax:
 .. code-block:: syntax
 
    union-declaration-statement:
-     `extern'[OPT] `union' identifier { union-statement-list }
+     'extern'[OPT] 'union' identifier { union-statement-list }
 
    union-statement-list:
      union-statement

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -23,14 +23,14 @@ Variables are declared with the following syntax:
      privacy-specifier[OPT] config-extern-or-export[OPT] variable-kind variable-declaration-list ;
 
    config-or-extern: one of
-     `config' `extern' `export'
+     'config' 'extern' 'export'
 
    variable-kind:
-     `param'
-     `const'
-     `var'
-     `ref'
-     `const ref'
+     'param'
+     'const'
+     'var'
+     'ref'
+     'const ref'
 
    variable-declaration-list:
      variable-declaration


### PR DESCRIPTION
* Fix cross-references that did not translate well from Latex. Many of them, if not all.
* Changed the display of syntax terminals to be symmetric: \`true' --> 'true'.

While there, some minor improvements and added `minmax` reduction.

Future work:
* [ ] Syntax appendix "Collected Lexical and Syntax Productions, contains the syntax productions listed throughout this specification in both alphabetical and depth-first order."
* [ ] Restore the link to Secondary_Methods_with_Type_Expressions under Class Methods, that my sphinx somehow rejected.