### PR TITLE
Adjust spec for member -> contains deprecation

### DIFF
--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -974,7 +974,7 @@ The methods in this subsection can be applied to any domain.
 
 
 
-.. function:: proc domain.member(i)
+.. function:: proc domain.contains(i)
 
       Returns true if the given index ``i`` is a member of this domain’s index
       set, and false otherwise.

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -1153,15 +1153,15 @@ Other Queries
 
 
 
-.. function:: proc range.member(i: idxType): bool
+.. function:: proc range.contains(i: idxType): bool
 
    Returns ``true`` if the range’s represented sequence contains ``i``,
-   ``false`` otherwise. It is an error to invoke ``member`` if the
+   ``false`` otherwise. It is an error to invoke ``contains`` if the
    represented sequence is not defined.
 
 
 
-.. function:: proc range.member(other: range): bool
+.. function:: proc range.contains(other: range): bool
 
    Reports whether ``other`` is a subrange of the receiver. That is, if the
    represented sequences of the receiver and ``other`` are defined and the


### PR DESCRIPTION
`.member` has been deprecated for several releases now - this updates the spec to match.

Trivial and not reviewed.