### PR TITLE
Use python3 shebang generally

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -566,7 +566,7 @@ std::string runPrintChplEnv(std::map<std::string, const char*> varMap) {
 std::string getVenvDir() {
   // Runs `util/chplenv/chpl_home_utils.py --venv` and removes the newline
 
-  std::string command = "CHPL_HOME=" + std::string(CHPL_HOME) + " python ";
+  std::string command = "CHPL_HOME=" + std::string(CHPL_HOME) + " python3 ";
   command += std::string(CHPL_HOME) + "/util/chplenv/chpl_home_utils.py --venv 2> /dev/null";
 
   std::string venvDir = runCommand(command);

--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -318,7 +318,7 @@ For instance:
 
   .. code-block:: python
 
-     #!/usr/bin/env python
+     #!/usr/bin/env python3
 
      import os
      print(os.getenv('CHPL_TEST_PERF') == 'on' and

--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """chpl2rst converts a chapel program to an rst file, where all comments are

--- a/doc/util/extract-rst-tests.py
+++ b/doc/util/extract-rst-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """

--- a/test/analysis/alias/PREDIFF
+++ b/test/analysis/alias/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/compflags/bradc/mungeUserIdents/testmunge-export.prediff
+++ b/test/compflags/bradc/mungeUserIdents/testmunge-export.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # This test ensures that the generated code contains instances of foo,

--- a/test/compflags/bradc/mungeUserIdents/testmunge-extern.prediff
+++ b/test/compflags/bradc/mungeUserIdents/testmunge-extern.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # This test ensures that the generated code contains instances of certain

--- a/test/compflags/bradc/mungeUserIdents/testmunge.prediff
+++ b/test/compflags/bradc/mungeUserIdents/testmunge.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil
 

--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import subprocess
 import sys

--- a/test/compflags/link/sungeun/static_dynamic.prediff
+++ b/test/compflags/link/sungeun/static_dynamic.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, subprocess, string
 

--- a/test/compflags/sungeun/configs/basic/PREDIFF
+++ b/test/compflags/sungeun/configs/basic/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, string
 

--- a/test/compflags/sungeun/configs/type_variables/PREDIFF
+++ b/test/compflags/sungeun/configs/type_variables/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # WARNING: This script is pretty touchy wrt to its input
 #

--- a/test/distributions/robust/arithmetic/PREDIFF
+++ b/test/distributions/robust/arithmetic/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Figure out which of TESTNAME.*.good is applicable; copy it to TESTNAME.good.
 #

--- a/test/distributions/robust/arithmetic/basics/test_scan1.prediff
+++ b/test/distributions/robust/arithmetic/basics/test_scan1.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Figure out which of TESTNAME.*.good is applicable; copy it to TESTNAME.good.
 #

--- a/test/domains/sungeun/assoc/index_not_in_domain_1.prediff
+++ b/test/domains/sungeun/assoc/index_not_in_domain_1.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/domains/sungeun/assoc/index_not_in_domain_2.prediff
+++ b/test/domains/sungeun/assoc/index_not_in_domain_2.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/domains/sungeun/sparse/index_not_in_domain_1.prediff
+++ b/test/domains/sungeun/sparse/index_not_in_domain_1.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/domains/sungeun/sparse/index_not_in_domain_2.prediff
+++ b/test/domains/sungeun/sparse/index_not_in_domain_2.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/execflags/bradc/errors/PREDIFF
+++ b/test/execflags/bradc/errors/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, string
 

--- a/test/execflags/bradc/gdbddash/gdbSetConfig.skipif
+++ b/test/execflags/bradc/gdbddash/gdbSetConfig.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, os.path
 

--- a/test/execflags/dinan/PREDIFF
+++ b/test/execflags/dinan/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, string
 

--- a/test/execflags/ferguson/help2.prediff
+++ b/test/execflags/ferguson/help2.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/execflags/shannon/configs/configVarDashSVarEquals.prediff
+++ b/test/execflags/shannon/configs/configVarDashSVarEquals.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, string
 

--- a/test/execflags/shannon/configs/help/PREDIFF
+++ b/test/execflags/shannon/configs/help/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/execflags/shannon/help.prediff
+++ b/test/execflags/shannon/help.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, re
 

--- a/test/execflags/sungeun/about.prediff
+++ b/test/execflags/sungeun/about.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script fixes up the test output to remove the compiler version
 # number and then generates a .good file based on the output of

--- a/test/execflags/thomasvandoren/exceedMemInts.skipif
+++ b/test/execflags/thomasvandoren/exceedMemInts.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Only run this test on 32-bit platforms."""
 

--- a/test/functions/ferguson/main/sub_test
+++ b/test/functions/ferguson/main/sub_test
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import subprocess
 import sys

--- a/test/interop/C/multilocale.skipif
+++ b/test/interop/C/multilocale.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  Multilocale interoperability requires ZMQ

--- a/test/interop/python/errorMessages/abiIncompatible.skipif
+++ b/test/interop/python/errorMessages/abiIncompatible.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/interop/python/multilocale.skipif
+++ b/test/interop/python/multilocale.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  Multilocale interoperability requires ZMQ

--- a/test/io/ferguson/ctests/qio_bits_test.skipif
+++ b/test/io/ferguson/ctests/qio_bits_test.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """For valgrind, see qio_test.valgrind.test.c. Skip test when atomics are
 implemented with locks and tasking layer is not fifo.

--- a/test/io/ferguson/ctests/qio_test.compopts
+++ b/test/io/ferguson/ctests/qio_test.compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/io/ferguson/ctests/qio_test.skipif
+++ b/test/io/ferguson/ctests/qio_test.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Skip test when atomics are implemented with locks and tasking layer is not
 fifo.

--- a/test/io/ferguson/ctests/skip_non_fifo_atomic_locks.py
+++ b/test/io/ferguson/ctests/skip_non_fifo_atomic_locks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Skip test when atomics are implemented with locks and tasking layer is not fifo.
 

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.prediff
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This prediff exists to change an absolute
 # paths like /home/user/chapel/test/io/ferguson/test-dir

--- a/test/io/thomasvandoren/lustre/SKIPIF
+++ b/test/io/thomasvandoren/lustre/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Skip test if lustre is not set in CHPL_AUX_FILESYS."""
 

--- a/test/io/vass/time-write.skipif
+++ b/test/io/vass/time-write.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/library/draft/Vector/PREDIFF
+++ b/test/library/draft/Vector/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os.path
 

--- a/test/library/packages/Crypto/saru.skipif
+++ b/test/library/packages/Crypto/saru.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess
 from distutils.version import LooseVersion

--- a/test/library/packages/Crypto/saru/COMPOPTS
+++ b/test/library/packages/Crypto/saru/COMPOPTS
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess
 

--- a/test/library/packages/FFTW/SKIPIF
+++ b/test/library/packages/FFTW/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # skip this test when FFTW_DIR is not set or we're using pgi (JIRA 195).

--- a/test/library/packages/LAPACK.skipif
+++ b/test/library/packages/LAPACK.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Require BLAS and LAPACK modules

--- a/test/library/packages/LinearAlgebra/performance/csrmatmatMult-perf.py
+++ b/test/library/packages/LinearAlgebra/performance/csrmatmatMult-perf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """

--- a/test/library/packages/MPI/multilocale.skipif
+++ b/test/library/packages/MPI/multilocale.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import os

--- a/test/library/packages/MPI/spmd.skipif
+++ b/test/library/packages/MPI/spmd.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import os

--- a/test/library/packages/NetCDF.skipif
+++ b/test/library/packages/NetCDF.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The NetCDF package requires the netCDF library.
 #

--- a/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/ProtobufProtocolSupport/enumsRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/enumsRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/ProtobufProtocolSupport/mapsRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/mapsRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/ProtobufProtocolSupport/messagefieldRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/messagefieldRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/ProtobufProtocolSupport/oneofsRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/oneofsRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/ProtobufProtocolSupport/repeatedfieldRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/repeatedfieldRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/ProtobufProtocolSupport/typesRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/typesRunner.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 

--- a/test/library/packages/TOML/BurntSushi/compare.py
+++ b/test/library/packages/TOML/BurntSushi/compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 from __future__ import print_function

--- a/test/library/packages/TensorFlow.skipif
+++ b/test/library/packages/TensorFlow.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The TensorFlow package requires the tensorflow library.
 #

--- a/test/library/packages/UnitTest/Launcher_Test.prediff
+++ b/test/library/packages/UnitTest/Launcher_Test.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/library/packages/UnitTest/Launcher_Test.skipif
+++ b/test/library/packages/UnitTest/Launcher_Test.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/library/packages/ZMQ.skipif
+++ b/test/library/packages/ZMQ.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  The ZMQ package requires the zmq library.

--- a/test/library/packages/ZMQ/SKIPIF
+++ b/test/library/packages/ZMQ/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # These tests are disabled currently for multi-locale runs and with sanitizers
 

--- a/test/library/packages/ZMQ/multilocale/SKIPIF
+++ b/test/library/packages/ZMQ/multilocale/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from os import environ

--- a/test/library/standard/DataFrames/diten/readHDF5Df.skipif
+++ b/test/library/standard/DataFrames/diten/readHDF5Df.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The HDF5 package requires the hdf5 library.
 #

--- a/test/library/standard/FileSystem/chmod/chmod.prediff
+++ b/test/library/standard/FileSystem/chmod/chmod.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/test/library/standard/FileSystem/lydia/copy/copying.prediff
+++ b/test/library/standard/FileSystem/lydia/copy/copying.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/test/library/standard/FileSystem/lydia/copy/copying.preexec
+++ b/test/library/standard/FileSystem/lydia/copy/copying.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, stat
 

--- a/test/library/standard/FileSystem/lydia/copyFile/copyingContents.prediff
+++ b/test/library/standard/FileSystem/lydia/copyFile/copyingContents.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/test/library/standard/FileSystem/lydia/copyFile/copyingContents.preexec
+++ b/test/library/standard/FileSystem/lydia/copyFile/copyingContents.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, stat
 

--- a/test/library/standard/FileSystem/lydia/copyMode/copyingMode.prediff
+++ b/test/library/standard/FileSystem/lydia/copyMode/copyingMode.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/test/library/standard/FileSystem/lydia/copyMode/copyingMode.preexec
+++ b/test/library/standard/FileSystem/lydia/copyMode/copyingMode.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, stat, sys
 

--- a/test/library/standard/FileSystem/lydia/getIDs/getting.prediff
+++ b/test/library/standard/FileSystem/lydia/getIDs/getting.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/test/library/standard/FileSystem/lydia/getMode/basic.preexec
+++ b/test/library/standard/FileSystem/lydia/getMode/basic.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, stat
 

--- a/test/library/standard/FileSystem/lydia/isMount/checkMount.skipif
+++ b/test/library/standard/FileSystem/lydia/isMount/checkMount.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os.path
 

--- a/test/library/standard/FileSystem/lydia/isMount/checkRoot.skipif
+++ b/test/library/standard/FileSystem/lydia/isMount/checkRoot.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os.path
 

--- a/test/library/standard/FileSystem/lydia/isMount/symlinkToMount.skipif
+++ b/test/library/standard/FileSystem/lydia/isMount/symlinkToMount.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os.path
 

--- a/test/library/standard/FileSystem/lydia/mkdir/makeWithMode.prediff
+++ b/test/library/standard/FileSystem/lydia/mkdir/makeWithMode.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 

--- a/test/library/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.prediff
+++ b/test/library/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, os.path, sys
 import fileinput

--- a/test/library/standard/FileSystem/lydia/parallelDirState/chdirMultiTasks.prediff
+++ b/test/library/standard/FileSystem/lydia/parallelDirState/chdirMultiTasks.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, os.path, sys
 

--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os

--- a/test/library/standard/Math/promotion/generate_tests/make_promotion_tests.py
+++ b/test/library/standard/Math/promotion/generate_tests/make_promotion_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Create promotion tests
 import os
 

--- a/test/library/standard/Path/dlongnecke/absPath/absPath.preexec
+++ b/test/library/standard/Path/dlongnecke/absPath/absPath.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Produces the "absPath.good" file containing expected output for the Chapel
 # Path.absPath function. Nothing sophisticated yet, the calls in the Chapel

--- a/test/library/standard/Path/dlongnecke/absPath/fileAbsPath.preexec
+++ b/test/library/standard/Path/dlongnecke/absPath/fileAbsPath.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Produces the "fileAbsPath.good" file containing expected output for the
 # Chapel file.absPath function.

--- a/test/library/standard/Path/dlongnecke/normPath/normPath.preexec
+++ b/test/library/standard/Path/dlongnecke/normPath/normPath.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Python (2.7) code with proper output for os.path.normpath(). Use this to
 # generate the output for "testcases_normPath.good".

--- a/test/library/standard/Path/relPath/fileRelPath.preexec
+++ b/test/library/standard/Path/relPath/fileRelPath.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 # Produce the output file our test will compare itself against.

--- a/test/library/standard/Path/relPath/relPath.preexec
+++ b/test/library/standard/Path/relPath/relPath.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 # Produce the output file our test will compare itself against.

--- a/test/library/standard/Path/saru/getParentName/parentName.preexec
+++ b/test/library/standard/Path/saru/getParentName/parentName.preexec
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, stat
 

--- a/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.chpl
+++ b/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.chpl
@@ -20,7 +20,7 @@
    writeln(isAbsPath(getPythonsAbspath()));
 
    proc getPythonsAbspath() {
-     var command = "python -c 'import os; print(os.getcwd())'";
+     var command = "python3 -c 'import os; print(os.getcwd())'";
      var sub = spawnshell(command, stdout=PIPE);
 
      var absPath:string;

--- a/test/library/standard/machine/numPUs.prediff
+++ b/test/library/standard/machine/numPUs.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, multiprocessing
 

--- a/test/llvm/llvmDebug/llvmDebug_test.py
+++ b/test/llvm/llvmDebug/llvmDebug_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Python test script to verify the llvm debug info
 # is generated properly during Chapel compilation

--- a/test/localeModels/numa/basics/coforall_on.prediff
+++ b/test/localeModels/numa/basics/coforall_on.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys;
 

--- a/test/localeModels/numa/dataParallel/forall.prediff
+++ b/test/localeModels/numa/dataParallel/forall.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 logfile = sys.argv[2]

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Compare the help page and man page for chpl and chpldoc.
 

--- a/test/mason/SKIPIF
+++ b/test/mason/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/mason/filterDigits
+++ b/test/mason/filterDigits
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/mason/mason-example-with-opts/SKIPIF
+++ b/test/mason/mason-example-with-opts/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/mason/mason-example/SKIPIF
+++ b/test/mason/mason-example/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/mason/mason-external/SKIPIF
+++ b/test/mason/mason-external/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/mason/mason-external/libtomlc99/mason-external.prediff
+++ b/test/mason/mason-external/libtomlc99/mason-external.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/mason/mason-external/masonExternalRanges/mason-external.prediff
+++ b/test/mason/mason-external/masonExternalRanges/mason-external.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/mason/mason-help-scope/masonHelpScope.skipif
+++ b/test/mason/mason-help-scope/masonHelpScope.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason help tests require mason to be built

--- a/test/mason/mason-test/mason-test.prediff
+++ b/test/mason/mason-test/mason-test.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/mason/mason-update-toml-error/SKIPIF
+++ b/test/mason/mason-update-toml-error/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/mason/masonTestSome/mason-test-some.prediff
+++ b/test/mason/masonTestSome/mason-test-some.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/mason/masonTestSubString/mason-test-sub-string.prediff
+++ b/test/mason/masonTestSubString/mason-test-sub-string.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/mason/search/cacheTest/SKIPIF
+++ b/test/mason/search/cacheTest/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 mason requires CHPL_COMM=none (local)

--- a/test/mason/spec-parser/test-spec-parser.prediff
+++ b/test/mason/spec-parser/test-spec-parser.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil, os
 
 test_name = sys.argv[1]

--- a/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
+++ b/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/multilocale/local/diten/test_local2.prediff
+++ b/test/multilocale/local/diten/test_local2.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/multilocale/numLocales/bradc/printNumLocalesMissingArg.prediff
+++ b/test/multilocale/numLocales/bradc/printNumLocalesMissingArg.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, string
 

--- a/test/npb/ft/npadmana/ft_transposed.skipif
+++ b/test/npb/ft/npadmana/ft_transposed.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # skip this test when we don't have FFTW or we're doing gn+mpi perf testing
 

--- a/test/optimizations/bulkcomm/block/exchange.skipif
+++ b/test/optimizations/bulkcomm/block/exchange.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/optimizations/localon/wrong-local-on.skipif
+++ b/test/optimizations/localon/wrong-local-on.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/optimizations/sungeun/scalar-replace/PREDIFF
+++ b/test/optimizations/sungeun/scalar-replace/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Compare scalar replacement in the first run to the second
 #

--- a/test/parallel/cobegin/gbt/cobegin-stacksize.prediff
+++ b/test/parallel/cobegin/gbt/cobegin-stacksize.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # A prediff is needed because the failure mode for this test is slightly
 # different depending on the configuration. The signal is sometimes different,

--- a/test/parallel/coforall/gbt/time-sync-incs.prediff
+++ b/test/parallel/coforall/gbt/time-sync-incs.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.prediff
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Given that tasks #2 and #3 will run concurrently, collate their outputs
 # for deterministic matching against .good files.

--- a/test/performance/comm/barrier/empty-chpl-barrier.ml-compopts
+++ b/test/performance/comm/barrier/empty-chpl-barrier.ml-compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/performance/comm/low-level/arrayTransfer.execopts
+++ b/test/performance/comm/low-level/arrayTransfer.execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 # Valgrind causes a program to "use a lot more memory", so limit mem fraction,
 # and this test is slower under baseline

--- a/test/performance/compiler/elliot/passCheck.prediff
+++ b/test/performance/compiler/elliot/passCheck.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test serves as a sentinel for compiler performance testing so that when
 # a pass is moved, added, deleted, or renamed there is some test failure to

--- a/test/performance/ferguson/MYCOMPOPTS
+++ b/test/performance/ferguson/MYCOMPOPTS
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os

--- a/test/performance/vectorization/vectorPragmas/PREDIFF
+++ b/test/performance/vectorization/vectorPragmas/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/release/examples/benchmarks/hpcc/ra-atomics.ml-compopts
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.ml-compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run ra with n=33 and 10 million updates. ugni is much faster for ra-atomics,
 # so bump the number of updates to 1 billion to get stable timings. We get

--- a/test/release/examples/benchmarks/hpcc/ra-atomics.skipif
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test creates a large array of atomics designed to use ~1/4 of available
 # memory. However, that calculation is done based off the size of the raw type,

--- a/test/release/examples/benchmarks/hpcc/ra.ml-compopts
+++ b/test/release/examples/benchmarks/hpcc/ra.ml-compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run ra with n=33 and 10 million updates. ugni and gasnet-aries are much
 # faster for the rmo version, so bump the number of updates to 1 billion to get

--- a/test/release/examples/benchmarks/hpcc/variants/ra-unordered-atomics.ml-compopts
+++ b/test/release/examples/benchmarks/hpcc/variants/ra-unordered-atomics.ml-compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run ra with n=33 and 10 million updates. ugni is much faster for ra-atomics,
 # so bump the number of updates to 1 billion to get stable timings.

--- a/test/release/examples/benchmarks/hpcc/variants/ra-unordered-atomics.skipif
+++ b/test/release/examples/benchmarks/hpcc/variants/ra-unordered-atomics.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test creates a large array of atomics designed to use ~1/4 of available
 # memory. However, that calculation is done based off the size of the raw type,

--- a/test/release/examples/benchmarks/miniMD/miniMD.skipif
+++ b/test/release/examples/benchmarks/miniMD/miniMD.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Skip this test for gasnet+mpi performance testing. As of 08/08/15 it takes
 # ~30 minutes to complete

--- a/test/release/examples/benchmarks/shootout/mandelbrot.prediff
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Compare mandelbrot program output.
 

--- a/test/release/examples/benchmarks/shootout/threadring.suppressif
+++ b/test/release/examples/benchmarks/shootout/threadring.suppressif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.ml-execopts
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.prediff
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Validate debug output from SSCA2
 #

--- a/test/release/examples/primers/FFTWlib.skipif
+++ b/test/release/examples/primers/FFTWlib.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # skip this test when FFTW_DIR is not set

--- a/test/release/examples/primers/LAPACKlib.skipif
+++ b/test/release/examples/primers/LAPACKlib.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, os.path
 

--- a/test/release/examples/primers/learnChapelInYMinutes.prediff
+++ b/test/release/examples/primers/learnChapelInYMinutes.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, sys
 
 DEBUG_MODE = False

--- a/test/release/examples/primers/learnChapelInYMinutes.skipif
+++ b/test/release/examples/primers/learnChapelInYMinutes.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test writes to both stdout and stderr and expects a particular order.
 # Most launchers buffer stdout but not stderr which defeats the prediff processing.

--- a/test/release/examples/primers/taskParallel.prediff
+++ b/test/release/examples/primers/taskParallel.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # There are a number of things that matter in this test's output.
 #  We will check them here in this script and output SUCCESS if

--- a/test/runtime/configMatters/comm/atomics-api-on.compopts
+++ b/test/runtime/configMatters/comm/atomics-api-on.compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test with the default network atomics (and if it's not 'none' test 'none' as
 # well)

--- a/test/runtime/configMatters/comm/cache-remote/miniUnorderedCopyStress.execopts
+++ b/test/runtime/configMatters/comm/cache-remote/miniUnorderedCopyStress.execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/comm/oversubscribedArrayAlloc.execopts
+++ b/test/runtime/configMatters/comm/oversubscribedArrayAlloc.execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.skipif
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test only makes sense with hugepages, but not on ARM where it
 # runs for a really long time and nevertheless may not fail.

--- a/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.execenv
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.execenv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Use the largest hugepages we can get, so we can cover any compute node.
 print('HUGETLB_DEFAULT_PAGE_SIZE=512M')

--- a/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.skipif
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test only makes sense with mem=jemalloc, hugepages,
 # and dynamic heap extension, but not on ARM where it runs

--- a/test/runtime/configMatters/comm/ugni/overflow-mem-region-table.skipif
+++ b/test/runtime/configMatters/comm/ugni/overflow-mem-region-table.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This test only makes sense with mem=jemalloc, hugepages,
 # and dynamic heap extension.

--- a/test/runtime/configMatters/comm/unordered/oneLocaleParallelAtomicPerf.ml-execopts
+++ b/test/runtime/configMatters/comm/unordered/oneLocaleParallelAtomicPerf.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/comm/unordered/oneLocaleSerialAtomicPerf.ml-execopts
+++ b/test/runtime/configMatters/comm/unordered/oneLocaleSerialAtomicPerf.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/comm/unordered/unorderedAtomicsApiOn.compopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedAtomicsApiOn.compopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test with the default network atomics (and if it's not 'none' test 'none' as
 # well)

--- a/test/runtime/configMatters/comm/unordered/unorderedAtomicsStress.execopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedAtomicsStress.execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.execopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.ml-execopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/runtime/configMatters/mem/goodAllocSize.prediff
+++ b/test/runtime/configMatters/mem/goodAllocSize.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, os, shutil
 
 chplenv_dir = os.path.join(os.path.dirname(__file__), '../../../../util/chplenv')

--- a/test/runtime/sungeun/chpl-env-gen.precomp
+++ b/test/runtime/sungeun/chpl-env-gen.precomp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import shutil

--- a/test/setchplenv/verify_setchplenv_scripts.py
+++ b/test/setchplenv/verify_setchplenv_scripts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Verify the setchplenv.* script correctly set the environment for using chpl,
 et al.

--- a/test/sparse/CS/multiplication/performance.py
+++ b/test/sparse/CS/multiplication/performance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """Scipy.sparse CSR * CSC matrix-matrix multiplication"""

--- a/test/studies/bale/histogram/histo-atomics-forall-opt.ml-execopts
+++ b/test/studies/bale/histogram/histo-atomics-forall-opt.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run bale histo with 2 million updates per task. non-ugni configs have much
 # slower network atomics, so drop to 20,000 updates per task

--- a/test/studies/bale/histogram/histo-atomics.ml-execopts
+++ b/test/studies/bale/histogram/histo-atomics.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run bale histo with 2 million updates per task. non-ugni configs have much
 # slower network atomics, so drop to 20,000 updates per task

--- a/test/studies/bale/indexgather/ig-forall-opt.ml-execopts
+++ b/test/studies/bale/indexgather/ig-forall-opt.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run bale index gather with 1 million updates per task. ugni and gasnet-aries
 # are much faster so drop the number of updates for slower configs. 

--- a/test/studies/bale/indexgather/ig-variants.ml-execopts
+++ b/test/studies/bale/indexgather/ig-variants.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run bale index gather with 1 million updates per task. ugni and gasnet-aries
 # are much faster so drop the number of updates for slower configs. 

--- a/test/studies/bale/indexgather/ig.ml-execopts
+++ b/test/studies/bale/indexgather/ig.ml-execopts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Run bale index gather with 1 million updates per task. ugni and gasnet-aries
 # are much faster so drop the number of updates for slower configs. 

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, re
 

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Skip this test for gasnet+mpi and gasnet+ibv-large performance testing.
 # Also skip this test when using MPI-based launchers in other configs,

--- a/test/studies/comd/llnl/CoMD.prediff
+++ b/test/studies/comd/llnl/CoMD.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, re
 

--- a/test/studies/compOcean/compOcean.skipif
+++ b/test/studies/compOcean/compOcean.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The NetCDF package requires the netCDF library.
 #

--- a/test/studies/dedup/PREDIFF
+++ b/test/studies/dedup/PREDIFF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/studies/hpcc/CommDiags/PRECOMP
+++ b/test/studies/hpcc/CommDiags/PRECOMP
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Find the timed regions of the HPCC benchmarks and surround them with

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample5.prediff
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample5.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/studies/prk/DGEMM/SUMMA/dgemm.skipif
+++ b/test/studies/prk/DGEMM/SUMMA/dgemm.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Skip this test if
 # - running on cs 

--- a/test/studies/shootout/submitted/archive/threadring.suppressif
+++ b/test/studies/shootout/submitted/archive/threadring.suppressif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/studies/shootout/submitted/clbg-diff.py
+++ b/test/studies/shootout/submitted/clbg-diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """

--- a/test/studies/shootout/thread-ring/lydia/thread-ring-coforall-begin.suppressif
+++ b/test/studies/shootout/thread-ring/lydia/thread-ring-coforall-begin.suppressif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/studies/shootout/thread-ring/lydia/thread-ring-coforall.suppressif
+++ b/test/studies/shootout/thread-ring/lydia/thread-ring-coforall.suppressif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/studies/shootout/thread-ring/lydia/thread-ring-for-begin.suppressif
+++ b/test/studies/shootout/thread-ring/lydia/thread-ring-for-begin.suppressif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test/studies/twitter/strshuffle.prediff
+++ b/test/studies/twitter/strshuffle.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil, subprocess
 
 test_name = sys.argv[1]

--- a/test/studies/twitter/survey.prediff
+++ b/test/studies/twitter/survey.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, re, shutil
 
 test_name = sys.argv[1]

--- a/test/trivial/figueroa/UnmangledSymbols.skipif
+++ b/test/trivial/figueroa/UnmangledSymbols.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This test does not work with munging turned off.
 # It is confused by int32_t even though that symbol is in the reservedSymbolNames file.
 import os

--- a/test/types/cptr/func_ptr_as_c_fn_ptr.skipif
+++ b/test/types/cptr/func_ptr_as_c_fn_ptr.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from os import environ
 if '--baseline' in environ['COMPOPTS']:

--- a/test/types/cptr/func_ptr_as_void_ptr.skipif
+++ b/test/types/cptr/func_ptr_as_void_ptr.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from os import environ
 if '--baseline' in environ['COMPOPTS']:

--- a/test/types/range/elliot/anonymousRangeIter.prediff
+++ b/test/types/range/elliot/anonymousRangeIter.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, re
 

--- a/test/types/string/StringImpl/memLeaks/begin.prediff
+++ b/test/types/string/StringImpl/memLeaks/begin.prediff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This is not perfect, but there's no easy way to make sure all the
 # tasking data structures have been freed before we make the call to

--- a/test/users/npadmana/fftw/SKIPIF
+++ b/test/users/npadmana/fftw/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # skip this test when FFTW_DIR is not set

--- a/test/users/npadmana/gsl_demonstration/SKIPIF
+++ b/test/users/npadmana/gsl_demonstration/SKIPIF
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # This test requires:

--- a/test/users/npadmana/mpi/test_mpi.skipif
+++ b/test/users/npadmana/mpi/test_mpi.skipif
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import os

--- a/test/users/vass/isX/src/isX.byBlankArgs-compWarns.py
+++ b/test/users/vass/isX/src/isX.byBlankArgs-compWarns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, subprocess, string, signal
 import re

--- a/test/users/vass/isX/src/isX.module-writeln.py
+++ b/test/users/vass/isX/src/isX.module-writeln.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, subprocess, string, signal
 import re

--- a/third-party/chpl-venv/venv-use-sys-python.py
+++ b/third-party/chpl-venv/venv-use-sys-python.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright 2020 Hewlett Packard Enterprise Development LP

--- a/util/buildRelease/add_license_to_sources.py
+++ b/util/buildRelease/add_license_to_sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Add license and copyright text to source files."""
 

--- a/util/buildRelease/chpl-make-cpu_count
+++ b/util/buildRelease/chpl-make-cpu_count
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ prints Python cpu_count(), optionally capped by env var CHPL_MAKE_MAX_CPU_COUNT
 """
 import os

--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """CLI for building multiple Chapel configurations."""

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import sys
 

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import sys
 

--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 from glob import glob

--- a/util/chplenv/chpl_bin_subdir.py
+++ b/util/chplenv/chpl_bin_subdir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import optparse
 import sys

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_platform, overrides

--- a/util/chplenv/chpl_comm_debug.py
+++ b/util/chplenv/chpl_comm_debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import overrides

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_comm, chpl_comm_substrate, overrides

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_comm, chpl_platform, overrides

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import os
 import sys

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import collections
 import optparse
 import os

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_locale_model, chpl_tasks, overrides, third_party_utils

--- a/util/chplenv/chpl_jemalloc.py
+++ b/util/chplenv/chpl_jemalloc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from distutils.spawn import find_executable
 import sys
 

--- a/util/chplenv/chpl_lib_pic.py
+++ b/util/chplenv/chpl_lib_pic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import overrides

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import os
 import sys

--- a/util/chplenv/chpl_locale_model.py
+++ b/util/chplenv/chpl_locale_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import overrides

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from distutils.spawn import find_executable
 import sys
 

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import sys
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import os
 import platform

--- a/util/chplenv/chpl_python_version.py
+++ b/util/chplenv/chpl_python_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import sys
 

--- a/util/chplenv/chpl_regexp.py
+++ b/util/chplenv/chpl_regexp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/util/chplenv/chpl_sanitizers.py
+++ b/util/chplenv/chpl_sanitizers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import optparse
 import os
 import sys

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_compiler, chpl_platform, overrides

--- a/util/chplenv/chpl_timers.py
+++ b/util/chplenv/chpl_timers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import overrides

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 import chpl_platform, overrides, third_party_utils

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Provides simple 'get()' interface for accessing default value overrides
 Checks environment variables first, then chplconfig file for definitions

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Usage: printchplenv [options]
 

--- a/util/chplenv/third-party-pkgs
+++ b/util/chplenv/third-party-pkgs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
  Print the names of any third-party packages needed for the current

--- a/util/chpltags
+++ b/util/chpltags
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, sys, re, subprocess, optparse
 from distutils.spawn import find_executable
 

--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Removes path components that begin with $CHPL_HOME from the given path.
 

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Build SysCTypes.chpl module.
 

--- a/util/config/replace-paths.py
+++ b/util/config/replace-paths.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import optparse
 import os

--- a/util/config/update-if-different
+++ b/util/config/update-if-different
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import filecmp
 import optparse

--- a/util/cron/syncPerfGraphs.py
+++ b/util/cron/syncPerfGraphs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script is intended to sync the performance graphs to dreamhost. It is
 # essentially a large wrapper for rsync. The reason it is separated, rather

--- a/util/cron/verify_config_names.py
+++ b/util/cron/verify_config_names.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Ensure filenames for test-*.bash scripts match the config name registered

--- a/util/devel/check_paths
+++ b/util/devel/check_paths
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 Hewlett Packard Enterprise Development LP
 # Copyright 2004-2019 Cray Inc.

--- a/util/devel/check_scripts
+++ b/util/devel/check_scripts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Check that all script in dirs are invoked as follows:
 #

--- a/util/devel/gen-chpl-bash-completion.py
+++ b/util/devel/gen-chpl-bash-completion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import sys

--- a/util/devel/lookForBadRTCalls
+++ b/util/devel/lookForBadRTCalls
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Check Chapel runtime for 'inappropriate' function calls
 

--- a/util/devel/look_for_calls.py
+++ b/util/devel/look_for_calls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple script that effectively "greps" for function calls. By default it
 looks for calls to the system allocator. For projects that provide their own

--- a/util/devel/test/comment_perfdat
+++ b/util/devel/test/comment_perfdat
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # File: comment_perfdat
 #

--- a/util/devel/test/spliceDat
+++ b/util/devel/test/spliceDat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse, sys
 from datetime import date, datetime
 

--- a/util/devel/test/vagrant/re2-supported.py
+++ b/util/devel/test/vagrant/re2-supported.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/util/devel/updateDatFiles.py
+++ b/util/devel/updateDatFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import csv
 import re

--- a/util/start_test
+++ b/util/start_test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 #
 # CHAPEL TESTING

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Do basic validation and checks on the ANNOTATIONS.yaml file
 
 This is a kinda-ugly script that does basic validation of ANNOTATIONS.yaml

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Run Chapel test (execution only) inside pbs or slurm batch job.
 

--- a/util/test/combineCompPerfData
+++ b/util/test/combineCompPerfData
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script is used for compiler performance testing.
 # Each tests outputs its .dat files with the timing per pass and this script

--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # COMPUTE PERFORMANCE STATISTTICS
 # This is used by sub_test if start_test is called with the -performance flag.

--- a/util/test/convert_start_test_log_to_junit_xml.py
+++ b/util/test/convert_start_test_log_to_junit_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Convert start_test log to jUnit XML report."""

--- a/util/test/fileReadHelp.py
+++ b/util/test/fileReadHelp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Utility routines to help with reading files
 #

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, shutil, time, math, re, stat
 from optparse import OptionParser

--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Simple slurm-aware paratest wrapper for testing on the chapcs cluster. This

--- a/util/test/paratest.local
+++ b/util/test/paratest.local
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 local paratest wrapper - runs tests in parallel on a single machine.

--- a/util/test/prediff-for-incremental-warning
+++ b/util/test/prediff-for-incremental-warning
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This script is a system-wide prediff for use when incremental compilation is enabled.
 # If --incremental is used along with --fast it leads to a warning being generated, this

--- a/util/test/prediff-for-mpirun4ofi
+++ b/util/test/prediff-for-mpirun4ofi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This script is a system-wide prediff for use with the OpenMPI mpirun
 # launcher.  Depending on how OpenMPI is configured, when mpirun sees

--- a/util/test/prediff-for-slurm-srun
+++ b/util/test/prediff-for-slurm-srun
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This script is a system-wide prediff for use with the slurm-srun
 # launcher.

--- a/util/test/prediff-for-stacktrace
+++ b/util/test/prediff-for-stacktrace
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This script is a system-wide prediff for use when stack tracing is enabled.
 # If the test doesn't present a stack trace in the expected output, this script

--- a/util/test/re2_supports_valgrind.py
+++ b/util/test/re2_supports_valgrind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Portable email sender. Acts as replacement for mail, Mail, mailx,
 email (cygwin). Message body is taken from stdin.

--- a/util/test/sub_clean
+++ b/util/test/sub_clean
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Clean a directory or the files associated with a particular test
 #

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Rewrite of sub_test by Sung-Eun Choi (sungeun@cray.com)
 #  sub_test is used by start_test in the Chapel Testing system

--- a/util/test/timers/highPrecisionTimer
+++ b/util/test/timers/highPrecisionTimer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess, sys, timeit
 
 # high precision timer that uses the timeit module. Only reports real time, and


### PR DESCRIPTION
This PR updates most shebangs that run the python interpreter to run `python3` since that is the current recommended practice. #16560 updates core scripts to find `python3` or `python` or `python2`.

- [x] update https://github.com/chapel-lang/chapel/blob/master/compiler/util/files.cpp#L569
- [x] (with #16560) full local testing
- [ ] rebase after #16560