### PR TITLE
Improve the pygments lexer

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1114,7 +1114,7 @@ concrete method to be selected when applicable. For example:
 
    
 
-   ::
+   .. code-block:: chapel
 
       record MyNode {
         var field;  // since no type is specified here, MyNode is a generic type

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -356,9 +356,9 @@ The following methods are defined for variables of sync and single type.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).readFE(): t
+      proc (sync t).readFE(): t
 
 Returns the value of the sync variable. This method blocks until the
 sync variable is full. The state of the sync variable is set to empty
@@ -367,10 +367,10 @@ when this method completes. This method implements the normal read of a
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).readFF(): t
-   proc (single t).readFF(): t
+      proc (sync t).readFF(): t
+      proc (single t).readFF(): t
 
 Returns the value of the sync or single variable. This method blocks
 until the sync or single variable is full. The state of the sync or
@@ -379,10 +379,10 @@ implements the normal read of a ``single`` variable.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).readXX(): t
-   proc (single t).readXX(): t
+      proc (sync t).readXX(): t
+      proc (single t).readXX(): t
 
 Returns the value of the sync or single variable. This method is
 non-blocking and the state of the sync or single variable is unchanged
@@ -390,10 +390,10 @@ when this method completes.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).writeEF(v: t)
-   proc (single t).writeEF(v: t)
+      proc (sync t).writeEF(v: t)
+      proc (single t).writeEF(v: t)
 
 Assigns ``v`` to the value of the sync or single variable. This method
 blocks until the sync or single variable is empty. The state of the sync
@@ -402,9 +402,9 @@ method implements the normal write of a ``sync`` or ``single`` variable.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).writeFF(v: t)
+      proc (sync t).writeFF(v: t)
 
 Assigns ``v`` to the value of the sync variable. This method blocks
 until the sync variable is full. The state of the sync variable remains
@@ -412,9 +412,9 @@ full when this method completes.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).writeXF(v: t)
+      proc (sync t).writeXF(v: t)
 
 Assigns ``v`` to the value of the sync variable. This method is
 non-blocking and the state of the sync variable is set to full when this
@@ -422,9 +422,9 @@ method completes.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).reset()
+      proc (sync t).reset()
 
 Assigns the default value of type ``t`` to the value of the sync
 variable. This method is non-blocking and the state of the sync variable
@@ -432,10 +432,10 @@ is set to empty when this method completes.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (sync t).isFull: bool
-   proc (single t).isFull: bool
+      proc (sync t).isFull: bool
+      proc (single t).isFull: bool
 
 Returns ``true`` if the sync or single variable is full and ``false``
 otherwise. This method is non-blocking and the state of the sync or
@@ -571,35 +571,35 @@ memoryOrder.seqCst.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).read(param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).read(param order:memoryOrder = memoryOrder.seqCst): T
 
 Reads and returns the stored value. Defined for all atomic types.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).write(v: T, param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic T).write(v: T, param order:memoryOrder = memoryOrder.seqCst)
 
 Stores ``v`` as the new value. Defined for all atomic types.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).exchange(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).exchange(v: T, param order:memoryOrder = memoryOrder.seqCst): T
 
 Stores ``v`` as the new value and returns the original value. Defined
 for all atomic types.
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).compareExchange(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
-   proc (atomic T).compareExchange(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
-   proc (atomic T).compareExchangeWeak(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
-   proc (atomic T).compareExchangeWeak(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
+      proc (atomic T).compareExchange(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
+      proc (atomic T).compareExchange(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
+      proc (atomic T).compareExchangeWeak(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
+      proc (atomic T).compareExchangeWeak(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
 
 Stores ``v`` as the new value, if and only if the original value is
 equal to ``e``. Returns ``true`` if ``v`` was stored, otherwise
@@ -610,9 +610,9 @@ performance on some platforms. Defined for all atomic types.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).compareAndSwap(e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
+      proc (atomic T).compareAndSwap(e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
 
 Stores ``v`` as the new value, if and only if the original value is
 equal to ``e``. Returns ``true`` if ``v`` was stored, ``false``
@@ -620,13 +620,13 @@ otherwise. Defined for all atomic types.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).add(v: T, param order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).sub(v: T, param order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).or(v: T, param order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).and(v: T, param order:memoryOrder = memoryOrder.seqCst)
-   proc (atomic T).xor(v: T, param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic T).add(v: T, param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic T).sub(v: T, param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic T).or(v: T, param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic T).and(v: T, param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic T).xor(v: T, param order:memoryOrder = memoryOrder.seqCst)
 
 Applies the appropriate operator (``+``, ``-``, ``|``, ``&``, ``^``) to
 the original value and ``v`` and stores the result. All of the methods
@@ -643,13 +643,13 @@ for the ``bool`` atomic type.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).fetchAdd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchSub(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchOr(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchAnd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-   proc (atomic T).fetchXor(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).fetchAdd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).fetchSub(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).fetchOr(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).fetchAnd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
+      proc (atomic T).fetchXor(v: T, param order:memoryOrder = memoryOrder.seqCst): T
 
 Applies the appropriate operator (``+``, ``-``, ``|``, ``&``, ``^``) to
 the original value and ``v``, stores the result, and returns the original
@@ -659,27 +659,27 @@ methods are defined for the ``bool`` atomic type.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic bool).testAndSet(param order:memoryOrder = memoryOrder.seqCst): bool
+      proc (atomic bool).testAndSet(param order:memoryOrder = memoryOrder.seqCst): bool
 
 Stores ``true`` as the new value and returns the old value. Equivalent
 to ``exchange(true)``. Only defined for the ``bool`` atomic type.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic bool).clear(param order:memoryOrder = memoryOrder.seqCst)
+      proc (atomic bool).clear(param order:memoryOrder = memoryOrder.seqCst)
 
 Stores ``false`` as the new value. Equivalent to ``write(false)``. Only
 defined for the ``bool`` atomic type.
 
 
 
-::
+   .. code-block:: chapel
 
-   proc (atomic T).waitFor(v: T)
+      proc (atomic T).waitFor(v: T)
 
 Waits until the stored value is equal to ``v``. The implementation may
 yield the running task while waiting. Defined for all atomic types.

--- a/third-party/chpl-venv/sphinxcontrib-chapeldomain/sphinxcontrib/chapeldomain/__init__.py
+++ b/third-party/chpl-venv/sphinxcontrib-chapeldomain/sphinxcontrib/chapeldomain/__init__.py
@@ -29,6 +29,8 @@ from docutils.parsers.rst import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.nodes import make_refnode
 
+from chapel import ChapelLexer
+
 
 VERSION = '0.0.15'
 
@@ -1028,4 +1030,5 @@ class ChapelDomain(Domain):
 def setup(app):
     """Add Chapel domain to Sphinx app."""
     app.add_config_value('chapeldomain_modindex_common_prefix', [], 'html')
+    app.add_lexer('chapel', ChapelLexer())
     app.add_domain(ChapelDomain)

--- a/third-party/chpl-venv/sphinxcontrib-chapeldomain/sphinxcontrib/chapeldomain/chapel.py
+++ b/third-party/chpl-venv/sphinxcontrib-chapeldomain/sphinxcontrib/chapeldomain/chapel.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+    pygments.lexers.chapel
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the Chapel language.
+
+    :copyright: Copyright 2006-2020 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, bygroups, words
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation
+
+__all__ = ['ChapelLexer']
+
+
+class ChapelLexer(RegexLexer):
+    """
+    For `Chapel <https://chapel-lang.org/>`_ source.
+
+    .. versionadded:: 2.0
+    """
+    name = 'Chapel'
+    filenames = ['*.chpl']
+    aliases = ['chapel', 'chpl']
+    # mimetypes = ['text/x-chapel']
+
+    tokens = {
+        'root': [
+            (r'\n', Text),
+            (r'\s+', Text),
+            (r'\\\n', Text),
+
+            (r'//(.*?)\n', Comment.Single),
+            (r'/(\\\n)?[*](.|\n)*?[*](\\\n)?/', Comment.Multiline),
+
+            (r'(config|const|in|inout|out|param|ref|type|var)\b',
+             Keyword.Declaration),
+            (r'(false|nil|none|true)\b', Keyword.Constant),
+            (r'(bool|bytes|complex|imag|int|nothing|opaque|range|real|string|uint|void)\b',
+             Keyword.Type),
+            (words((
+                'align', 'as', 'atomic',
+                'begin', 'borrowed', 'break', 'by',
+                'catch', 'cobegin', 'coforall', 'continue',
+                'defer', 'delete', 'dmapped', 'do', 'domain',
+                'else', 'enum', 'except', 'export', 'extern',
+                'for', 'forall', 'forwarding',
+                'if', 'import', 'index', 'init', 'inline',
+                'label', 'lambda', 'let', 'lifetime', 'local', 'locale'
+                'new', 'noinit',
+                'on', 'only', 'otherwise', 'override', 'owned',
+                'pragma', 'private', 'prototype', 'public',
+                'reduce', 'require', 'return',
+                'scan', 'select', 'serial', 'shared', 'single', 'sparse', 'subdomain', 'sync',
+                'then', 'this', 'throw', 'throws', 'try',
+                'unmanaged', 'use',
+                'when', 'where', 'while', 'with',
+                'yield',
+                'zip'), suffix=r'\b'),
+             Keyword),
+            (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
+            (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
+            (r'(class|module|record|union)(\s+)', bygroups(Keyword, Text),
+             'classname'),
+
+            # imaginary integers
+            (r'\d+i', Number),
+            (r'\d+\.\d*([Ee][-+]\d+)?i', Number),
+            (r'\.\d+([Ee][-+]\d+)?i', Number),
+            (r'\d+[Ee][-+]\d+i', Number),
+
+            # reals cannot end with a period due to lexical ambiguity with
+            # .. operator. See reference for rationale.
+            (r'(\d*\.\d+)([eE][+-]?[0-9]+)?i?', Number.Float),
+            (r'\d+[eE][+-]?[0-9]+i?', Number.Float),
+
+            # integer literals
+            # -- binary
+            (r'0[bB][01]+', Number.Bin),
+            # -- hex
+            (r'0[xX][0-9a-fA-F]+', Number.Hex),
+            # -- octal
+            (r'0[oO][0-7]+', Number.Oct),
+            # -- decimal
+            (r'[0-9]+', Number.Integer),
+
+            # strings
+            (r'"(\\\\|\\"|[^"])*"', String),
+            (r"'(\\\\|\\'|[^'])*'", String),
+
+            # tokens
+            (r'(=|\+=|-=|\*=|/=|\*\*=|%=|&=|\|=|\^=|&&=|\|\|=|<<=|>>=|'
+             r'<=>|<~>|\.\.|by|#|\.\.\.|'
+             r'&&|\|\||!|&|\||\^|~|<<|>>|'
+             r'==|!=|<=|>=|<|>|'
+             r'[+\-*/%]|\*\*)', Operator),
+            (r'[:;,.?()\[\]{}]', Punctuation),
+
+            # identifiers
+            (r'[a-zA-Z_][\w$]*', Name.Other),
+        ],
+        'classname': [
+            (r'[a-zA-Z_][\w$]*', Name.Class, '#pop'),
+        ],
+        'procname': [
+            (r'([a-zA-Z_][.\w$]*|\~[a-zA-Z_][.\w$]*|[+*/!~%<>=&^|\-]{1,2})',
+             Name.Function, '#pop'),
+        ],
+    }

--- a/third-party/chpl-venv/sphinxcontrib-chapeldomain/sphinxcontrib/chapeldomain/chapel.py
+++ b/third-party/chpl-venv/sphinxcontrib-chapeldomain/sphinxcontrib/chapeldomain/chapel.py
@@ -27,6 +27,37 @@ class ChapelLexer(RegexLexer):
     aliases = ['chapel', 'chpl']
     # mimetypes = ['text/x-chapel']
 
+    known_types = ( 'bool', 'bytes', 'complex', 'locale', 'imag', 'int',
+                    'nothing', 'opaque', 'range', 'real', 'string', 'uint',
+                    'void' )
+
+    type_modifiers = ( 'atomic', 'single', 'sync',
+                       'borrowed', 'owned', 'shared', 'unmanaged' )
+
+    declarations = ( 'config', 'const', 'in', 'inout', 'out', 'param', 'ref',
+                     'type', 'var' )
+
+    constants = ( 'false', 'nil', 'none', 'true' )
+
+    other_keywords = ( 'align', 'as',
+                       'begin', 'break', 'by',
+                       'catch', 'cobegin', 'coforall', 'continue',
+                       'defer', 'delete', 'dmapped', 'do', 'domain',
+                       'else', 'enum', 'except', 'export', 'extern',
+                       'for', 'forall', 'forwarding',
+                       'if', 'import', 'index', 'init', 'inline',
+                       'label', 'lambda', 'let', 'lifetime', 'local',
+                       'new', 'noinit',
+                       'on', 'only', 'otherwise', 'override',
+                       'pragma', 'private', 'prototype', 'public',
+                       'reduce', 'require', 'return',
+                       'scan', 'select', 'serial', 'sparse', 'subdomain',
+                       'then', 'this', 'throw', 'throws', 'try',
+                       'use',
+                       'when', 'where', 'while', 'with',
+                       'yield',
+                       'zip' )
+
     tokens = {
         'root': [
             (r'\n', Text),
@@ -36,31 +67,11 @@ class ChapelLexer(RegexLexer):
             (r'//(.*?)\n', Comment.Single),
             (r'/(\\\n)?[*](.|\n)*?[*](\\\n)?/', Comment.Multiline),
 
-            (r'(config|const|in|inout|out|param|ref|type|var)\b',
-             Keyword.Declaration),
-            (r'(false|nil|none|true)\b', Keyword.Constant),
-            (r'(bool|bytes|complex|imag|int|nothing|opaque|range|real|string|uint|void)\b',
-             Keyword.Type),
-            (words((
-                'align', 'as', 'atomic',
-                'begin', 'borrowed', 'break', 'by',
-                'catch', 'cobegin', 'coforall', 'continue',
-                'defer', 'delete', 'dmapped', 'do', 'domain',
-                'else', 'enum', 'except', 'export', 'extern',
-                'for', 'forall', 'forwarding',
-                'if', 'import', 'index', 'init', 'inline',
-                'label', 'lambda', 'let', 'lifetime', 'local', 'locale'
-                'new', 'noinit',
-                'on', 'only', 'otherwise', 'override', 'owned',
-                'pragma', 'private', 'prototype', 'public',
-                'reduce', 'require', 'return',
-                'scan', 'select', 'serial', 'shared', 'single', 'sparse', 'subdomain', 'sync',
-                'then', 'this', 'throw', 'throws', 'try',
-                'unmanaged', 'use',
-                'when', 'where', 'while', 'with',
-                'yield',
-                'zip'), suffix=r'\b'),
-             Keyword),
+            (words(declarations, suffix=r'\b'), Keyword.Declaration),
+            (words(constants, suffix=r'\b'), Keyword.Constant),
+            (words(known_types, suffix=r'\b'), Keyword.Type),
+            (words((*type_modifiers, *other_keywords), suffix=r'\b'), Keyword),
+
             (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(class|module|record|union)(\s+)', bygroups(Keyword, Text),
@@ -106,7 +117,18 @@ class ChapelLexer(RegexLexer):
             (r'[a-zA-Z_][\w$]*', Name.Class, '#pop'),
         ],
         'procname': [
-            (r'([a-zA-Z_][.\w$]*|\~[a-zA-Z_][.\w$]*|[+*/!~%<>=&^|\-]{1,2})',
+            (r'([a-zA-Z_][.\w$]*|'    # regular function name, includin 2ndary
+             r'\~[a-zA-Z_][.\w$]*|'   # support for legacy destructors?
+             r'[+*/!~%<>=&^|\-]{1,2})',  # operators
              Name.Function, '#pop'),
+
+            # allow `proc (atomic T).foo`
+            (r'\(', Punctuation, "receivertype"),
+            (r'\)+\.', Punctuation),
+        ],
+        'receivertype': [
+            (words(type_modifiers, suffix=r'\b'), Keyword),
+            (words(known_types, suffix=r'\b'), Keyword.Type),
+            (r'[^()]*', Name.Other, '#pop'),
         ],
     }


### PR DESCRIPTION
This is a follow up to https://github.com/chapel-lang/chapel/pull/16557

Resolves the last two bullets in https://github.com/chapel-lang/chapel/issues/14623

- Improves the Pygments lexer to correctly tokenize complicated receivers for
  secondary methods like

```chapel
proc (atomic T).foo
proc (owned C?).foo
proc (GenericClass(int)).foo
```

  This is done by adding a new state `receivertype` that we enter if we see a `(`
  after a `(proc|iter)`

- Also refactors the lexer a bit to put the keywords in tuples for reuse.

I also realize that this causes the keyword `new` to be tokenized correctly,
however, I am not seeing anything wrong with that keyword today.
