### PR TITLE
Update tcl module builds.

### DIFF
--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -44,6 +44,8 @@ endif
 # If we're using the slurm PMI2 out-of-band support we have to
 # reference that library explicitly.
 #
-ifneq (, $(findstring slurm-pmi2, $(CHPL_COMM_OFI_OOB)))
+ifneq (, $(findstring hpe-cray-ex,$(CHPL_MAKE_TARGET_PLATFORM)))
+  LIBS += -lpmi2
+else ifneq (, $(findstring slurm-pmi2, $(CHPL_COMM_OFI_OOB)))
   LIBS += -lpmi2
 endif

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -33,6 +33,8 @@ ifneq (, $(findstring $(CHPL_COMM_OFI_OOB), mpi pmi sockets slurm-pmi2))
   COMM_SRCS += comm-ofi-oob-$(CHPL_COMM_OFI_OOB).c
 else ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
   COMM_SRCS += comm-ofi-oob-pmi.c
+else ifneq (, $(findstring hpe-cray-ex,$(CHPL_MAKE_TARGET_PLATFORM)))
+  COMM_SRCS += comm-ofi-oob-slurm-pmi2.c
 else ifneq (, $(filter cray-% hpe-cray-ex,$(CHPL_MAKE_TARGET_PLATFORM)))
   COMM_SRCS += comm-ofi-oob-mpi.c
 else ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))

--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -132,9 +132,8 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 }
 
 if { ! [ info exists env(PE_ENV) ] } {
-    puts stderr "Error: The Chapel module requires a PrgEnv environment"
-    puts stderr "to be loaded."
-    exit 1
+    module load PrgEnv-gnu
+    set compiler GNU
 } else {
     set compiler $env(PE_ENV)
 }

--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -68,7 +68,6 @@ proc ModulesHelp { } {
 }
 
 conflicts cray-mpich2 < 7.0.0
-conflicts xt-mpich2 < 6.0.0
 conflict chapel
 
 ##
@@ -76,9 +75,7 @@ conflict chapel
 ###
 #
 set network aries
-if { [ info exists env(XTPE_NETWORK_TARGET) ] } {
-    set network $env(XTPE_NETWORK_TARGET)
-} elseif { [ info exists env(CRAYPE_NETWORK_TARGET) ] } {
+if { [ info exists env(CRAYPE_NETWORK_TARGET) ] } {
     set network $env(CRAYPE_NETWORK_TARGET)
 }
 
@@ -135,8 +132,9 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 }
 
 if { ! [ info exists env(PE_ENV) ] } {
-    module load PrgEnv-gnu
-    set compiler GNU
+    puts stderr "Error: The Chapel module requires a PrgEnv environment"
+    puts stderr "to be loaded."
+    exit 1
 } else {
     set compiler $env(PE_ENV)
 }
@@ -144,15 +142,6 @@ if { ! [ info exists env(PE_ENV) ] } {
 
 if { [string match hpe-cray-ex $CHPL_HOST_PLATFORM] } {
     # Interim settings for HPE Cray EX systems.
-
-    # So far we only have gnu-based Chapel for EX.
-    if { [string equal -nocase cray $compiler] } {
-        module swap PrgEnv-cray PrgEnv-gnu
-    } elseif { [string equal -nocase intel $compiler] } {
-        module swap PrgEnv-intel PrgEnv-gnu
-    } elseif { [string equal -nocase pgi $compiler] } {
-        module swap PrgEnv-pgi PrgEnv-gnu
-    }
 
     # Some libraries are not available in static form.
     setenv CRAYPE_LINK_TYPE dynamic

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -128,9 +128,9 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         log_info "Building Chapel component: runtime"
 
         compilers=gnu,cray
-        comms=gasnet,none,ofi
+        comms=none,ofi
         launchers=pals,slurm-srun
-        substrates=mpi,none
+        substrates=none
         locale_models=flat
         auxfs=none,lustre
         libpics=none,pic

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -335,7 +335,7 @@ else
     fi
 
     gen_version_gcc=8.3.0
-    gen_version_intel=16.0.3.210
+    #[TODO] gen_version_intel=16.0.3.210
     gen_version_cce=10.0.2
 
     if [ "$CRAYPE_NETWORK_TARGET" == slingshot* ]; then

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -90,7 +90,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_TASKS=qthreads
     export CHPL_LAUNCHER=none
     export CHPL_LIBFABRIC=libfabric
-    export CHPL_LLVM=none       # llvm requires py27 and cmake
+    export CHPL_LLVM=llvm       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
 
     # As a general rule, more CPUs --> faster make.
@@ -127,28 +127,22 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 
-        compilers=gnu
-        comms=none,ofi
-        tasks=qthreads
-        launchers=slurm-srun
-        substrates=none
+        compilers=gnu,cray
+        comms=gasnet,none,ofi
+        launchers=pals,slurm-srun
+        substrates=mpi,none
         locale_models=flat
-        auxfs=none
-        regexp=re2
-        llvm=none
-        libpics=none
+        auxfs=none,lustre
+        libpics=none,pic
 
         log_info "Start build_configs $dry_run $verbose # no make target"
 
         $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.runtime.log" \
             --target-compiler=$compilers \
             --comm=$comms \
-            --tasks=$tasks \
             --launcher=$launchers \
             --substrate=$substrates \
             --locale-model=$locale_models \
-            --regexp=$regexp \
-            --llvm=$llvm \
             --auxfs=$auxfs \
             --lib-pic=$libpics \
             -- notcompiler
@@ -340,9 +334,9 @@ else
         list_loaded_modules
     fi
 
-    #[TODO] gen_version_gcc=
-    #[TODO] gen_version_intel=
-    #[TODO] gen_version_cce=
+    gen_version_gcc=8.3.0
+    gen_version_intel=16.0.3.210
+    gen_version_cce=10.0.2
 
     if [ "$CRAYPE_NETWORK_TARGET" == slingshot* ]; then
         target_cpu_module=craype-x86-rome
@@ -361,7 +355,7 @@ else
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        #[TODO] load_module_version $target_compiler $target_version 
+        load_module_version $target_compiler $target_version
     }
 
     function load_prgenv_intel() {
@@ -375,7 +369,7 @@ else
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        #[TODO] load_module_version $target_compiler $target_version
+        load_module_version $target_compiler $target_version
     }
 
     function load_prgenv_cray() {
@@ -389,7 +383,7 @@ else
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        #[TODO] load_module_version $target_compiler $target_version
+        load_module_version $target_compiler $target_version
     }
 
     function load_target_cpu() {

--- a/util/build_configs/package-functions.bash
+++ b/util/build_configs/package-functions.bash
@@ -22,7 +22,7 @@ function ck_chpl_home_bin()
     local chpl_home=$1
     local chpl_platform=$2
 
-    local bindir=`$chpl_home/util/chplenv/chpl_bin_subdir.py`
+    local bindir=`CHPL_HOST_PLATFORM=$chpl_platform $chpl_home/util/chplenv/chpl_bin_subdir.py`
 
     if [[ $bindir != "$chpl_platform"* ]]
     then

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -13,7 +13,7 @@ def get():
         comm_val = chpl_comm.get()
         platform_val = chpl_platform.get('target')
 
-        if platform_val.startswith('cray-'):
+        if platform_val.startswith('cray-') or platform_val.startswith('hpe-cray-'):
             has_aprun = find_executable('aprun')
             has_slurm = find_executable('srun')
             if has_aprun and has_slurm:


### PR DESCRIPTION
This is a collection of several improvements to the HPE Cray module
build process and the tcl-based modulefile itself.  We'll add direct
support for the Lmod module system in an upcoming PR; this PR mainly
tries to put the traditional tcl-based module system on XC systems in
good shape.

In the modulefile, remove references to the xt-mpich2 module and the
`XTPE_NETWORK_TARGET` environment variable, neither of which have been
used for a long time, I am told.

Increase the number of configurations built for the EX module, and at
the same time improve the Makefiles' and scripts' ability to make the
right choices automatically for EX configurations.  When we were only
building a very limited number of configurations we could afford to use
more manual settings, but that would be cumbersome going forward.  And
while doing this, make the EX module build setenv script more similar
to the XC one, to ease maintenance.