### PR TITLE
Declare a constructor for ForallOptimizationInfo for GCC 4

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -25,6 +25,18 @@
 #include "passes.h"
 #include "stringutil.h"
 
+ForallOptimizationInfo::ForallOptimizationInfo():
+  iterSym(NULL),
+  dotDomIterExpr(NULL),
+  dotDomIterSym(NULL),
+  dotDomIterSymDom(NULL),
+  iterCall(NULL),
+  iterCallTmp(NULL),
+  autoLocalAccessChecked(false),
+  confirmedFastFollower(false)
+{
+}
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // ForallStmt represents a forall loop statement

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -25,13 +25,13 @@
 
 class ForallOptimizationInfo {
   public:
-    Symbol *iterSym = NULL;
-    Expr *dotDomIterExpr = NULL;
-    Symbol *dotDomIterSym = NULL;
-    Symbol *dotDomIterSymDom = NULL;
+    Symbol *iterSym;
+    Expr *dotDomIterExpr;
+    Symbol *dotDomIterSym;
+    Symbol *dotDomIterSymDom;
 
-    CallExpr *iterCall = NULL;  // refers to the original CallExpr
-    Symbol *iterCallTmp = NULL; // this is the symbol to use for checks
+    CallExpr *iterCall;  // refers to the original CallExpr
+    Symbol *iterCallTmp; // this is the symbol to use for checks
 
     // even if there are multiple indices we store them in a vector
     std::vector<Symbol *> multiDIndices;
@@ -52,6 +52,8 @@ class ForallOptimizationInfo {
 
 
     bool confirmedFastFollower;
+
+    ForallOptimizationInfo();
 };
 
 ///////////////////////////////////


### PR DESCRIPTION
ForallOptimizationInfo included some code that does not compile with GCC 4.4.
Replace it with a more typical C++ pattern that does compile.

I think the problematic pattern originated in PR #15713.

Reviewed by @e-kayrakli - thanks!
