### PR TITLE
Don't try to default-load the PrgEnv-gnu module on EX systems.

### DIFF
--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -132,8 +132,13 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 }
 
 if { ! [ info exists env(PE_ENV) ] } {
-    module load PrgEnv-gnu
-    set compiler GNU
+    if { [string match hpe-cray-ex $CHPL_HOST_PLATFORM] } {
+        puts stderr "Error: The Chapel module requires a cpe-* module to be loaded."
+        exit 1
+    } else {
+        module load PrgEnv-gnu
+        set compiler GNU
+    }
 } else {
     set compiler $env(PE_ENV)
 }


### PR DESCRIPTION
The PrgEnv meta-modules do not exist on EX v1.3 and later.  So instead
of default-loading PrgEnv-gnu on EX, simply insist that the user have
some cpe module loaded.  (The cpe modules are what set `PE_ENV` in that
environment.)  It's not practical to load one ourselves because the cpe
modules are not meta-modules like the PrgEnv ones, and we'd have to load
all the individual things that go with it.