### PR TITLE
Small updates in support of the prebuilt module for EX systems.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -41,8 +41,8 @@
 //
 #ifdef CHPL_COMM_DEBUG
 
-uint64_t chpl_comm_ofi_dbg_level;
-FILE* chpl_comm_ofi_dbg_file;
+extern uint64_t chpl_comm_ofi_dbg_level;
+extern FILE* chpl_comm_ofi_dbg_file;
 
 #define DBG_STATS                      0x1UL
 #define DBG_STATSNODES                 0x2UL
@@ -118,7 +118,7 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 //
 // Simplify internal error checking
 //
-int chpl_comm_ofi_abort_on_error;
+extern int chpl_comm_ofi_abort_on_error;
 
 #define INTERNAL_ERROR_V(fmt, ...)                                      \
   do {                                                                  \

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -71,6 +71,22 @@
 
 ////////////////////////////////////////
 //
+// Data global to all comm-ofi*.c files
+//
+
+//
+// These are declared extern in comm-ofi-internal.h.
+//
+#ifdef CHPL_COMM_DEBUG
+uint64_t chpl_comm_ofi_dbg_level;
+FILE* chpl_comm_ofi_dbg_file;
+#endif
+
+int chpl_comm_ofi_abort_on_error;
+
+
+////////////////////////////////////////
+//
 // Libfabric API version
 //
 
@@ -84,7 +100,7 @@
 
 ////////////////////////////////////////
 //
-// Global types and data
+// Types and data global just within this file.
 //
 
 static struct fi_info* ofi_info;        // fabric interface info

--- a/runtime/src/launch/pals/pals-utils.c
+++ b/runtime/src/launch/pals/pals-utils.c
@@ -113,8 +113,7 @@ char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocales,
     APPEND_LARGV(nodeList);
   }
 
-  // craycli arg parser needs a marker at end of system launcher opts
-  APPEND_LARGV("--");
+  APPEND_LARGV("--abort-on-failure");  // kill job if any proc non-zero exits
 
   return chpl_bundle_exec_args(argc, argv, largc, (char* const *) largv);
 }

--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -132,8 +132,13 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 }
 
 if { ! [ info exists env(PE_ENV) ] } {
-    module load PrgEnv-gnu
-    set compiler GNU
+    if { [string match hpe-cray-ex $CHPL_HOST_PLATFORM] } {
+        puts stderr "Error: The Chapel module requires a cpe-* module to be loaded."
+        exit 1
+    } else {
+        module load PrgEnv-gnu
+        set compiler GNU
+    }
 } else {
     set compiler $env(PE_ENV)
 }

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -136,7 +136,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
         compilers=gnu,cray
         comms=none,ofi
-        launchers=pals,slurm-srun
+        launchers=none,pals,slurm-srun
         substrates=none
         locale_models=flat
         auxfs=none,lustre

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -341,7 +341,7 @@ else
         list_loaded_modules
     fi
 
-    gen_version_gcc=8.3.0
+    gen_version_gcc=10.1.0
     #[TODO] gen_version_intel=16.0.3.210
     gen_version_cce=10.0.2
 

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -89,9 +89,16 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_COMM_SUBSTRATE=none
     export CHPL_TASKS=qthreads
     export CHPL_LAUNCHER=none
-    export CHPL_LIBFABRIC=libfabric
+    export CHPL_LIBFABRIC=system
     export CHPL_LLVM=llvm       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
+
+    # We default to CHPL_LIBFABRIC=system for EX.  We need to point to
+    # a libfabric install for the builds.  On EX a module will supply
+    # this but on XC we have to reference our own.
+    if ! pkg-config --exists libfabric ; then
+      export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}/cray/css/users/chapelu/libfabric/install/cray-xc/lib/pkgconfig
+    fi
 
     # As a general rule, more CPUs --> faster make.
     # To use all available CPUs, export CHPL_MAKE_MAX_CPU_COUNT=0 before running this setenv.
@@ -338,11 +345,7 @@ else
     #[TODO] gen_version_intel=16.0.3.210
     gen_version_cce=10.0.2
 
-    if [ "$CRAYPE_NETWORK_TARGET" == slingshot* ]; then
-        target_cpu_module=craype-x86-rome
-    else
-        target_cpu_module=craype-sandybridge
-    fi
+    target_cpu_module=craype-x86-rome
 
     function load_prgenv_gnu() {
 


### PR DESCRIPTION
This is a collection of small changes in support of the EX module.

Use a 'system' libfabric and enable finding one with `pkg-config`.

Generate code for the Rome processor, which is our x86 least common
denominator CPU (for now) for EX systems.

Use gcc 10 for the gcc target compiler.  This is new enough to support
the Rome processor.  Relatedly, make some minor adjustments to how we
declare variables global to all the comm=ofi source files.

Update the command line we give to the PALS launcher, when that is in
use.

Add `CHPL_LAUNCHER=none` to the built configurations, which as a side
effect also enables PIC builds which are only used for on login nodes,
with launcher=none and comm=none.