### PR TITLE
Correct codepoint indexing example in String documentation

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -186,8 +186,8 @@ byte of the argument:
 
    .. code-block:: chapel
 
-     proc getSecondByte(arg:string) : int {
-       var offsetInBytes = 2:byteIndex;
+     proc getSecondByte(arg:string) {
+       var offsetInBytes = 1:byteIndex;
        return arg[offsetInBytes];
      }
 
@@ -196,9 +196,9 @@ codepoint of the argument:
 
    .. code-block:: chapel
 
-     proc getSecondByte(arg:string) : int {
-       var offsetInBytes = 2:byteIndex;
-       return arg[offsetInBytes];
+     proc getSecondCodepoint(arg:string) {
+       var offsetInCodepoints = 1:codepointIndex;
+       return arg[offsetInCodepoints];
      }
 
 


### PR DESCRIPTION
The example that's described as returning the second codepoint was a
copy of the example returning the second byte.  Change its name and
indexing type to codepoint.

Also, use index 1 to return the second of each.

Also, each type of indexing returns a string, so the functions'
declaration as returning int failed to compile.  I opted to remove the
declared return type instead of specifying string.