### PR TITLE
Fix typos

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -157,7 +157,7 @@ void computeHasToplevelYields(BaseAST* ast, bool& result) {
   if (result)
     return;
   else if (CallExpr* call = toCallExpr(ast))
-    result = call->isPrimitive(PRIM_YIELD); // do not dig futher
+    result = call->isPrimitive(PRIM_YIELD); // do not dig further
   else if (isSymbol(ast) || isForallStmt(ast))
     ; // do not descend into these
   else

--- a/compiler/optimizations/preNormalizeOptimizations.cpp
+++ b/compiler/optimizations/preNormalizeOptimizations.cpp
@@ -138,7 +138,7 @@ Expr *preFoldMaybeLocalThis(CallExpr *call) {
 // 2: entering/exiting call
 // 3: information about call
 //
-// during resolution, the output is much more straighforward, and depth 0 is
+// during resolution, the output is much more straightforward, and depth 0 is
 // used always
 static void LOG(int depth, const char *msg, BaseAST *node) {
   if (fReportAutoLocalAccess) {

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -100,7 +100,7 @@ static void backPropagateInFunction(BlockStmt* block) {
   for_alist_backward(stmt, block->body) {
     if (DefExpr* def = toDefExpr(stmt)) {
 
-      //1. set local variableis -- analysis
+      //1. set local variables -- analysis
       if (def->init || def->exprType) {
 
         if(def->init != NULL) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1522,7 +1522,7 @@ static bool isFormalTempConst(FnSymbol *fn, ArgSymbol *formal) {
   // Today, if we generate a default initializer for a type with const fields,
   // the formals that correspond to those fields have `in` intents. However, we
   // still need to set those temporaries that will be passed to those formals to
-  // be constant before calling the initializer, in case the initializer have
+  // be constant before calling the initializer, in case the initializer has
   // another argument that will use that temporary.
   //
   // This comes up in:

--- a/doc/rst/developer/chips/1.rst
+++ b/doc/rst/developer/chips/1.rst
@@ -102,7 +102,7 @@ A CHIP can be Active or Inactive.
 
 
  * Inactive CHIPs are only of historical interest. If they were
-   implemented, the authoritative documention is elsewhere. The following
+   implemented, the authoritative documentation is elsewhere. The following
    keywords might also be useful in describing the status of an inactive
    CHIP:
     * Rejected - The proposal has been discussed and the Chapel project does

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -629,7 +629,7 @@ functionality is particularly useful when doing generic programming
    ``f()`` be evaluated for side effects?
 
    At first it might seem that ``f()`` should never be evaluated for side
-   effects. However, it must be evaluated for side effects if ``f()`` an
+   effects. However, it must be evaluated for side effects if ``f()`` returns an
    array or domain type, as these have a runtime component (see
    :ref:`Types_with_Runtime_Components`). As a result, should ``f()`` in
    such a setting always be evaluated for side effects?  The answer to

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -5,7 +5,7 @@ Technical Notes
 
 Technical Notes describe in-progress language features that are not
 yet stable enough to be in the language specification. Additionally, a
-Techinical Note can describe implementation details that can be ignored
+Technical Note can describe implementation details that can be ignored
 by most Chapel programmers.
 
 Base Language Features


### PR DESCRIPTION
Fix typos in spec/types.rst, chips/1.rst, technotes/index.rst
resolution/wrappers.cpp, astutil.cpp, cleanup.cpp, and
preNormalizeOptimizations.cpp.