### PR TITLE
Update version number to 1.24 pre-release

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -22,7 +22,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION 23
+#define MINOR_VERSION 24
 #define UPDATE_VERSION 0
 
 static const char* BUILD_VERSION =
@@ -32,6 +32,6 @@ static const char* BUILD_VERSION =
 // Flip this to 'true' when we're ready to roll out a release; then
 // back after branching
 //
-static bool officialRelease = true;
+static bool officialRelease = false;
 
 #endif

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.23.0
+:Version: 1.24.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.23.0
+:Version: 1.24.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.23.0
+ version 1.24.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -4,7 +4,8 @@ compiler=$3
 
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
-echo ""
+diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 
 if [ "$CHPL_LLVM" != "none" ]
 then

--- a/test/mason/init/masonInteractive.good
+++ b/test/mason/init/masonInteractive.good
@@ -4,7 +4,7 @@ create the project. Suggestions for defaults are also provided which will be
 considered if no input is given.
 
 Press ^C to quit interactive mode.
-Package name : Package version (0.1.0): Chapel version (1.23.0): License (None): 
+Package name : Package version (0.1.0): Chapel version (1.24.0): License (None): 
 [brick]
 name = "project"
 version = "1.2.3"

--- a/test/mason/new/masonInteractive.good
+++ b/test/mason/new/masonInteractive.good
@@ -4,7 +4,7 @@ create the project. Suggestions for defaults are also provided which will be
 considered if no input is given.
 
 Press ^C to quit interactive mode.
-Package name : Package version (0.1.0): Chapel version (1.23.0): License (None): 
+Package name : Package version (0.1.0): Chapel version (1.24.0): License (None): 
 [brick]
 name = "project"
 version = "1.2.3"


### PR DESCRIPTION
This puts us back into the "normal" mode of flagging version numbers as being pre-release.