### PR TITLE
Updated Dockerfile and README to reflect the latest release of 1.23.0

### DIFF
--- a/util/dockerfiles/Dockerfile
+++ b/util/dockerfiles/Dockerfile
@@ -21,12 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHPL_VERSION master
+ENV CHPL_VERSION 1.23.0
 ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
 ENV CHPL_GMP     system
 
 RUN mkdir -p /opt/chapel \
-    && wget -q -O - https://github.com/chapel-lang/chapel/archive/$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall

--- a/util/dockerfiles/README.md
+++ b/util/dockerfiles/README.md
@@ -11,15 +11,15 @@
 
 ## `chapel/chapel:<version>`
 Supported Chapel versions:
-* [`1.20.0`, `latest` (_1.20.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.20/util/dockerfiles/Dockerfile/)
-* [`1.19.0` (_1.19.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.19/util/dockerfiles/1.19.0/Dockerfile/)
+* [`1.23.0`, `latest` (_1.23.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.23/util/dockerfiles/Dockerfile/)
+* [`1.22.0` (_1.22.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.22/util/dockerfiles/Dockerfile/)
 
 This is the core image for Chapel. It provides the complete Chapel compiler and runtime.  It can be used to compile and run Chapel programs inside the Docker container. On 64-bit Linux hosts, the compiled Chapel program binary can sometimes be executed outside the container (your mileage may vary). Other Chapel-based Docker images can be created from this image.
 
 ## [`chapel/chapel-gasnet:<version>`](https://hub.docker.com/r/chapel/chapel-gasnet/)
 
-* [`1.20.0`, `latest` (_1.20.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.20/util/dockerfiles/gasnet/Dockerfile/)
-* [`1.19.0` (_1.19.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.19/util/dockerfiles/1.19.0/gasnet/Dockerfile/)
+* [`1.23.0`, `latest` (_1.23.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.23/util/dockerfiles/gasnet/Dockerfile/)
+* [`1.22.0` (_1.22.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.22/util/dockerfiles/gasnet/Dockerfile/)
 
 The Chapel core image (above), rebuilt with `CHPL_COMM=gasnet` and `GASNET_SPAWNFN=L`. Simulates a multilocale Chapel platform within the Docker container.
 
@@ -66,7 +66,7 @@ Hello, world!
 # Documentation
 
 Chapel's documentation is [available online](https://chapel-lang.org/docs/).
-Documentation for a specific release is also available: [1.19](https://chapel-lang.org/docs/1.19/).
+Documentation for a specific release is also available: [1.22](https://chapel-lang.org/docs/1.22/).
 
 # License
 


### PR DESCRIPTION
Updated the version to 1.23.0 and kept the reference to current and 1 previous release.
This is for the release branch 1.23.0 update only.

Here is the link to the previous release update:
https://github.com/chapel-lang/chapel/pull/15513

---
Signed-off-by: Soohoon Choi <soohoon.choi@hpe.com>