### PR TITLE
Stop skipping setopts tests for arkouda CS release testing

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2013,6 +2013,8 @@ arkouda: &arkouda-base
   10/06/20:
     - text: Optimize aggregators by yielding more often (mhmerrill/arkouda/#509)
       config: 16-node-cs, 16-node-xc
+  10/21/20:
+    - Upgrade Arkouda release testing from 1.22 to 1.23 (#16599)
 
 
 arkouda-comp:

--- a/util/cron/test-perf.cray-cs.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.release.bash
@@ -19,7 +19,5 @@ export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
-# Skip setops for release testing (fragmentation causes timeout/oom)
-export CHPL_TEST_ARKOUDA_BENCHMARKS='stream argsort coargsort gather scatter reduce scan noop'
 test_release
 sync_graphs


### PR DESCRIPTION
Fragmentation issue that preventing us from running was fixed in 1.23.

Add perf annotation for upgrading to 1.23 while I'm at it.
