### PR TITLE
Explicitly use UTF-8 encoding in 'make spectests'

### DIFF
--- a/doc/util/extract-rst-tests.py
+++ b/doc/util/extract-rst-tests.py
@@ -56,7 +56,7 @@ def save_to(outdir, chapter, name, data, isexe=False):
         os.makedirs(os.path.dirname(path))
 
     #print('Writing to: ', path)
-    with open(path, 'w') as handle:
+    with open(path, 'w', encoding='utf-8') as handle:
         handle.write(data)
 
     if isexe:
@@ -110,7 +110,7 @@ def extract_tests(rstfile, outdir):
     print("Processing .rst file: ", rstfile)
 
     lines = ( )
-    with open(rstfile, 'r') as handle:
+    with open(rstfile, 'r', encoding='utf-8') as handle:
         lines = handle.readlines()
 
     chapter = ""


### PR DESCRIPTION
To avoid errors in some testing configurations that seem to use ASCII by default.

Allows this command to run:
```
LC_ALL=C PYTHONUTF8=0 doc/util/extract-rst-tests.py  doc/rst/language/spec/ --output ./test/release/examples/spec
```

I am not sure what the testing configurations are doing to end up with an ASCII by default Python, but the code can be adjusted here in any case.

Reviewed by @ben-albrecht - thanks!