### PR TITLE
Use surrogateescape in computePerfStats

### DIFF
--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -88,7 +88,7 @@ def log_timeouts(keys, time_out, date): # if we timed out
 def validate_output(verify_keys, output_file):
     # read output from file
     global test_output, test_output_raw
-    with open(output_file, "r") as file:
+    with open(output_file, "r", encoding="utf-8", errors="surrogateescape") as file:
         test_output_raw = file.read()
         test_output = test_output_raw.split("\n")
 


### PR DESCRIPTION
Follow-up to PR #16560

The `computePerfStats` program opens the output file looking for keys to find perf information (such as timing printouts). However, we have some programs (e.g. mandelbrot) that output binary data. That caused a problem after PR #16560 because the python3 default I/O is assuming UTF-8. This PR adjusts the file opened to read the perf information to tolerate UTF-8 encoding errors by using the `surrogateescape` error handling strategy. This allows the rest of the processing to assume UTF-8 and should have minimal impact since we expect the matched strings (e.g. `TIME=140.0`) will be UTF-8.

- [x] mandelbrot tests pass with `start_test -performance`

Reviewed by @ben-albrecht - thanks!