### PR TITLE
Fix problems with mandelbrot tests in gasnet configs

### DIFF
--- a/test/release/examples/benchmarks/shootout/mandelbrot.prediff
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.prediff
@@ -38,8 +38,19 @@ else:
     if os.path.isfile(clbg_expect):
       expect = clbg_expect
 
-  if os.path.getsize(testout) != os.path.getsize(expect):
+  outsize = os.path.getsize(testout)
+  expectsize = os.path.getsize(expect)
+  if outsize != expectsize:
     error = "File lengths do not match"
+
+    # If there is extra stuff in the output, emit it
+    # (in case it is e.g. GASNet errors)
+    if outsize > expectsize:
+      with open(testout, "rb") as outF:
+        outF.seek(expectsize)
+        rest = outF.read()
+        rest = str(rest, encoding='utf-8', errors='backslashreplace')
+        error = error + "\n" + rest
 
   else:
 

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -539,7 +539,7 @@ def runSkipIf(skipifName):
     return stdout
 
 # Translate some known failures into more easily understood forms
-def translateOutput(output):
+def translateOutput(output_in):
     xlates = (('slurmstepd: Munge decode failed: Expired credential',
                'Jira 18 -- Expired slurm credential for'),
               ('output file from job .* does not exist',
@@ -563,6 +563,10 @@ def translateOutput(output):
 
     known_error = ''
     was_timeout = False
+
+    output = output_in
+    if isinstance(output, bytes):
+        output = str(output, encoding='utf-8', errors='surrogateescape')
 
     for x in xlates:
         if re.search(x[0], output, re.IGNORECASE) != None:
@@ -595,7 +599,7 @@ def filter_compiler_errors(compiler_output):
 
     return error_msg
 
-def filter_errors(output, pre_exec_output, execgoodfile, execlog):
+def filter_errors(output_in, pre_exec_output, execgoodfile, execlog):
     """Identify common errors that occur in runtime or compiler warnings.
     Return message to emit when error found."""
 
@@ -608,6 +612,11 @@ def filter_errors(output, pre_exec_output, execgoodfile, execlog):
                    'Slave got an xSocket: connection closed on recv',
                    'recursive failure in AMUDP_SPMDShutdown',
                    'AM_ERR_RESOURCE \(Problem with requested resource\)']
+
+    output = output_in
+    if isinstance(output, bytes):
+        output = str(output, encoding='utf-8', errors='surrogateescape')
+
     for s in err_strings:
         if re.search(s, output, re.IGNORECASE) != None:
             extra_msg = '(possible JIRA 154) '


### PR DESCRIPTION
Some GASNet configs can produce extra error output
at the end of the test. Adjust the mandelbrot.prediff
to show that (to make it easier to see the problem in
case it comes up again) and updated sub_test to
use surrogate-escape encoding when checking for known
failure patterns.

- [x] mandelbrot test passes on a Cray CS system
- [x] full local testing

Reviewed by @lydia-duncan - thanks!