### PR TITLE
Fix prediff-for-incremental-warning for python 3

### DIFF
--- a/util/test/prediff-for-incremental-warning
+++ b/util/test/prediff-for-incremental-warning
@@ -33,7 +33,7 @@ try:
       if(line == "warning: Compiling with --incremental along with optimizations enabled may lead to a slower execution time compared to --fast or using -O optimizations directly.\n"):
         sys.exit(0)
 except IOError:
-    print "Can't find "+sys.argv[1]+".good"
+    print("Can't find "+sys.argv[1]+".good")
 
 # Matches the warning we are looking for
 pattern = re.compile("warning: Compiling with --incremental along with optimizations enabled may lead to a slower execution time compared to --fast or using -O optimizations directly.")


### PR DESCRIPTION
A print function call needed parens.

- [x] test/release/examples/benchmarks/hpcc/ra-atomics.chpl passes with `--incremental`

Reviewed by @lydia-duncan - thanks!