### PR TITLE
Fix llvmDebug test for python3

### DIFF
--- a/test/llvm/llvmDebug/llvmDebug_test.py
+++ b/test/llvm/llvmDebug/llvmDebug_test.py
@@ -10,19 +10,27 @@ chpl_home = sys.argv[1]
 chplenv = subprocess.check_output([chpl_home + "/util/printchplenv",
                                    "--all", "--internal", "--simple"])
 
+CHPL_LLVM=None
 CHPL_HOST_BIN_SUBDIR=None
 CHPL_LLVM_UNIQ_CFG_PATH=None
 
 for line in chplenv.splitlines():
-  kv = line.split('=', 2)
+  line_str = str(line, encoding='utf-8', errors='surrogateescape')
+  kv = line_str.split('=', 2)
   key = kv[0]
   val = kv[1]
   if key == 'CHPL_HOST_BIN_SUBDIR':
     CHPL_HOST_BIN_SUBDIR= val
   if key == 'CHPL_LLVM_UNIQ_CFG_PATH':
     CHPL_LLVM_UNIQ_CFG_PATH= val
+  if key == 'CHPL_LLVM':
+    CHPL_LLVM= val
 
-llvm_tool_path = chpl_home + '/third-party/llvm/install/' + CHPL_LLVM_UNIQ_CFG_PATH + '/bin'
+llvm_tool_path = ""
+if CHPL_LLVM == "llvm":
+  llvm_tool_path = (chpl_home + '/third-party/llvm/install/' +
+                    CHPL_LLVM_UNIQ_CFG_PATH + '/bin/')
+
 build_options = '--baseline --llvm -g'
 source_path = os.getcwd() #same as target path
 source = source_path + os.sep + 'llvmDebug_test.chpl'
@@ -30,9 +38,9 @@ target = source_path + os.sep + 'llvmDebug_test'
 # Build Chapel Test Program
 Command_build = chpl_home + '/bin/' + CHPL_HOST_BIN_SUBDIR + '/chpl ' + build_options + ' ' + source + ' -o ' + target
 if os.system(Command_build) == 0:
-    print 'Build Succeeded'
+    print ('Build Succeeded')
 else:
-    print 'Build Failed'
+    print ('Build Failed')
     os._exit(1) #exit without raising an exception
 
 # Determine syntax from LLVM version
@@ -44,52 +52,53 @@ else:
     debug_option = ' -debug-str '
 
 # Check Debug Info Existence
-Command_check = llvm_tool_path + os.sep + 'llvm-dwarfdump' + debug_option + target
+Command_check = llvm_tool_path + 'llvm-dwarfdump' + debug_option + target
 
-output = subprocess.check_output(Command_check, shell=True)
+output_bytes = subprocess.check_output(Command_check, shell=True)
+output = str(output_bytes, encoding='utf-8', errors='surrogateescape')
 # Verify the module
 if 'My_foo' in output:
-    print 'checking module --PASS'
+    print ('checking module --PASS')
 else:
-    print 'checking module --FAIL'
+    print ('checking module --FAIL')
 
 # Verify the functions
 #if 'My_sayhello' in output:
 #    if 'My_factorial' in output:
 #        if 'main' in output:
-#            print 'checking functions --PASS'
+#            print ('checking functions --PASS')
 #else:
-#    print 'checking functions --FAIL'
+#    print ('checking functions --FAIL')
 
 # Verify the struct types
 if ('My_Actor' in output) and ('My_name' in output) and ('My_age' in output):
-    print 'checking types --PASS'
+    print ('checking types --PASS')
 else:
-    print 'checking types --FAIL'
+    print ('checking types --FAIL')
 
 # Verify the global variables
 #if 'My_message' in output:
 #    if 'My_gv_t' in output:
 #        if 'My_gv_b' in output:
 #            if 'My_globalActor' in output:
-#                print 'checking global variables --PASS'
+#                print ('checking global variables --PASS')
 #else:
-#    print 'checking global variables --FAIL'
+#    print ('checking global variables --FAIL')
 
 # Verify the local variables
 #if 'My_anything' in output:
 #    if 'My_localActor' in output:
 #        if 'My_Number' in output:
-#            print 'checking local variables --PASS'
+#            print ('checking local variables --PASS')
 #else:
-#    print 'checking local variables --FAIL'
+#    print ('checking local variables --FAIL')
 
 # Verify the formal arguments
 #if 'My_level' in output:
 #    if 'My_x' in output:
-#        print 'checking formal arguments --PASS'
+#        print ('checking formal arguments --PASS')
 #else:
-#    print 'checking formal arguments --FAIL'
+#    print ('checking formal arguments --FAIL')
 #
-print 'DONE with debug checking'
+print ('DONE with debug checking')
 

--- a/test/llvm/llvmDebug/sub_test
+++ b/test/llvm/llvmDebug/sub_test
@@ -8,8 +8,10 @@ COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
 
 # We test it only if we're on linux64 with LLVM
 if [ "$LLVM" != "llvm" ]; then
-echo "[Skipping test based on environment settings]";
-exit 0;
+  if [ "$LLVM" != "system" ]; then
+    echo "[Skipping test based on environment settings]";
+    exit 0;
+  fi
 fi
 
 if [ "$PLAT" != "linux64" ]; then
@@ -24,7 +26,7 @@ fi
 
 
 rm llvmDebug_test.out.tmp
-python llvmDebug_test.py "$CHPL_HOME" > llvmDebug_test.out.tmp 2>&1
+python3 llvmDebug_test.py "$CHPL_HOME" > llvmDebug_test.out.tmp 2>&1
 if ! diff llvmDebug_test.good llvmDebug_test.out.tmp; then
 echo "[Error matching debug info for llvmDebug_test]";
 else


### PR DESCRIPTION
Follow-up to PR #16560

Fix several problems with python script in test/llvm/llvmDebug.
While there, got the test working with CHPL_LLVM=system.

Test change only - not reviewed.

- [x] test/llvm/llvmDebug passes with CHPL_LLVM=system
- [x] test/llvm/llvmDebug passes with CHPL_LLVM=llvm