### PR TITLE
Don't change PATH when activating the test virtualenv

### DIFF
--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -43,10 +43,19 @@ def activate_venv():
         if not os.path.isfile(activation_file):
             error('Activation file {0} is missing'.format(activation_file))
 
+        old_path = os.environ.get('PATH', '')
+
         # actually activate
         with open(activation_file) as f:
             code = compile(f.read(), activation_file, 'exec')
             exec(code, dict(__file__=activation_file))
 
+        # put PATH back so that the system python may be used.
+        # python scripts using the virtualenv dependencies should use
+        #
+        #   from test import activate_chpl_test_venv
+        #
+        # near to the 'import' of a virtual dependency.
+        os.environ['PATH'] = old_path
 
 activate_venv()

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -2,6 +2,7 @@ import socket, time
 import json
 from collections import defaultdict
 
+import activate_chpl_test_venv
 import yaml
 try:
   # Use CLoader if available for the speed boost


### PR DESCRIPTION
Follow-up to PR #16560

The python interoperability tests rely on finding `cython` and `numpy`.
For these tests, we assume that these libraries are installed system-wide.
However, the Python test scripts have their own `virtualenv` which,
after PR #16560, includes a `python3` command for the virtualenv that
is first in `PATH`. The test system activates a virtualenv to have access
to packages that support testing (notably PyYAML for `import yaml` and
filelock for `import filelock`).

This PR adjusts the Python code that activates the test virtualenv to avoid
modifying `PATH`. That way, the Python modules are still available in the
test Python program itself. But, it does not interfere with which `python3`
is invoked in a subprocess. Python scripts that are created as subprocesses
during testing need to `import activate_chpl_test_venv` in order to have
access to any dependencies from the virtualenv.

- [x] full local testing
- [x] spot-checked a performance test
- [x] `CHPL_TEST_ARKOUDA=true ./util/start_test  test/studies/arkouda/` passes

Reviewed by @lydia-duncan - thanks!