### PR TITLE
Update chpl2rst.py to explicitly use UTF-8 encoding

### DIFF
--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -95,7 +95,7 @@ def titlecomment(line):
 
 def gen_title(chapelfile):
     """Generate file title, based on if title comment exists"""
-    with open(chapelfile, 'r') as handle:
+    with open(chapelfile, 'r', encoding='utf-8') as handle:
         line1 = handle.readline()
         if titlecomment(line1):
             title = line1.lstrip('//').strip()
@@ -268,7 +268,7 @@ def write(rstoutput, output):
         sys.stdout.write(rstoutput)
         return
 
-    with open(output, 'w') as handle:
+    with open(output, 'w', encoding='utf-8') as handle:
         handle.write(rstoutput)
 
 
@@ -287,7 +287,7 @@ def main(**kwargs):
 
         preamble = gen_preamble(chapelfile, link=link)
 
-        with open(chapelfile, 'r') as handle:
+        with open(chapelfile, 'r', encoding='utf-8') as handle:
             if codeblock:
                 rstoutput = gen_codeblock(handle)
             else:


### PR DESCRIPTION
Follow-up to PR #16560 and #16608

This PR updates chpl2rst.py to open input and output files with UTF-8 encoding.

Some testing configurations are running `make docs` with settings
that lead Python 3 to use the ascii encoding by default.

The problem is reproducible with
```
LC_ALL=C PYTHONUTF8=0 make docs
```

and that command works after this PR.

Reviewed by @lydia-duncan - thanks!