### PR TITLE
Fall back on pip3 if CHPL_PIP doesn't match major Python vers

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -134,7 +134,7 @@ rm-chplspell-reqs: FORCE
 # Python installation (ie, the Python used was not installed under "/usr/...").
 # Only applicable when building a Cray Chapel module under certain conditions.
 use-system-python: FORCE
-	@./venv-use-sys-python.py $(CHPL_VENV_INSTALL_DIR)
+	@$(PYTHON) ./venv-use-sys-python.py $(CHPL_VENV_INSTALL_DIR)
 
 FORCE:
 

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -49,15 +49,19 @@ PIPLIBS=$(PIPLIB_VER):$(PIPLIB):$(PIPLIB64_VER):$(PIPLIB64)
 
 
 GET_PIP_COMMAND=export PYTHONUSERBASE=$(CHPL_VENV_INSTALL_DIR) && $(PYTHON) get-pip.py --user --no-warn-conflicts
+
 # If CHPL_PIP env var is set, then don't install custom pip
+PIP:=0
 ifdef CHPL_PIP
-  PIP = $(CHPL_PIP)
+  # Use a script to check that this PIP matches the PYTHON version
+  # and to use pip3 if not.
+  PIP:=$(shell $(PYTHON) $(CHPL_VENV_DIR)/find-pip.py $(CHPL_PIP))
 else
   ifdef VIRTUAL_ENV
-    PIP=$(VIRTUAL_ENV)/bin/pip
+    PIP:=$(VIRTUAL_ENV)/bin/pip
     GET_PIP_COMMAND=$(PYTHON) get-pip.py --no-warn-conflicts
   else
-    PIP=-S $(CHPL_VENV_INSTALL_DIR)/bin/pip
+    PIP:=-S $(CHPL_VENV_INSTALL_DIR)/bin/pip
     # This must be separate from global CHPL_PIP_INSTALL_PARAMS
     LOCAL_PIP_FLAGS=--no-warn-conflicts --no-warn-script-location
   endif

--- a/third-party/chpl-venv/find-pip.py
+++ b/third-party/chpl-venv/find-pip.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Checks pip major version against the Python version.
+   If there is a mismatch, returns 'pip3'.
+
+    ./find-pip.py pip-path
+"""
+
+import optparse
+import os
+import sys
+import subprocess
+import shutil
+
+def main():
+    parser = optparse.OptionParser(usage=__doc__)
+
+    (options, args) = parser.parse_args()
+
+    if len(args) != 1:
+        sys.stderr.write('Error: path-value must be supplied\n\n')
+        parser.print_help()
+        sys.exit(1)
+
+    pip = args[0]
+
+    p = subprocess.Popen([pip, '--version'], stdout=subprocess.PIPE)
+    pip_python_major = 0
+    for line_bytes in p.stdout.readlines():
+        # look for (python 3 or (python 2
+        line = str(line_bytes, encoding='utf-8', errors='surrogateescape')
+        needle = '(python '
+        at = line.find(needle)
+        if at >= 0:
+            after = line[at+len(needle):]
+            vers = after.split('.')
+            pip_python_major = int(vers[0])
+
+    python_vers = sys.version_info
+    python_major = python_vers[0]
+
+    pip3_path = pip
+
+    if pip_python_major != 0:
+        if python_major != pip_python_major:
+            sys.stderr.write('{0} uses python version {1} but have python {2}\n'
+                             .format(pip, pip_python_major, python_major))
+            pip3_path = shutil.which('pip3')
+
+            sys.stderr.write('falling back on pip3 {0}\n'.format(pip3_path))
+
+    sys.stdout.write('{0}\n'.format(pip3_path))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
We are having problems in certain testing configurations that set
`CHPL_PIP` to a Python 2 version of pip. We plan to adjust these testing
configurations to not do that but that is taking some time. In the
meantime, this PR adjusts the Makefile logic setting the `PIP` variable
from `CHPL_PIP` to run a Python script to check the provided value of
`CHPL_PIP`. If the provided `CHPL_PIP` is for a different major version
of Python, fall back on `pip3`.

- [x] `python3 third-party/chpl-venv/find-pip.py  pip3` behaves as
  expected (returns pip3)
- [x] `python3 third-party/chpl-venv/find-pip.py  pip2` behaves as
  expected (returns pip3)
- [x] `make docs` works in a weird `CHPL_PIP` setup
- [x] `make docs` works on a linux system

Reviewed by @lydia-duncan - thanks!