### PR TITLE
Set the encoding when calling check_output in the build_configs script

### DIFF
--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -563,7 +563,8 @@ def check_output(command, chpl_home, env, stdin=None, file=None):
         stdout=stdout,
         stderr=stderr,
         cwd=chpl_home,
-        env=env
+        env=env,
+        encoding='utf-8'
     )
     out, err = p.communicate(input=stdin)
     retcode = p.returncode


### PR DESCRIPTION
Without this change, the returned output was bytes rather than str, which lead
to issues with concatenating a str to it later in the file.

./util/buildRelease/test_rpm_module.bash builds a module that can be loaded
and used to build hello.chpl (which runs appropriately) with this change.