### PR TITLE
Update prereqs.rst for python 3

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,7 +48,7 @@ source: module-docs primers hellos symlinks
 module-docs: clean-module-docs
 	@echo
 	@echo "Generating module docs from "'$$CHPL_HOME'"/modules/ into $(SOURCEDIR)/modules"
-	(cd ../modules && make documentation)
+	(cd ../modules && $(MAKE) documentation)
 	cp -f $(SOURCEDIR)/meta/modules/* $(SOURCEDIR)/modules/
 	cp -f $(SOURCEDIR)/meta/builtins/* $(SOURCEDIR)/builtins/
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -18,16 +18,18 @@ about your environment for using Chapel:
   * You are using an environment that supports standard UNIX commands
     such as: ``cd, mkdir, rm, echo``
 
-  * You have the Bourne shell available at ``/bin/sh``, the C-shell
+  * You have a Bourne shell available at ``/bin/sh``, the C-shell
     available at ``/bin/csh``, 'env' available at ``/usr/bin/env``, and
-    that 'env' can locate Perl and Python on your system.
+    that 'env' can locate ``python3`` or ``python`` on your system.
+
+  * You have Python 2.7 or newer.
 
   * You have access to gmake or a GNU-compatible version of make.
 
   * You have access to standard C and C++ compilers. We test our code
     using a range of compilers on a nightly basis; these include
     relatively recent versions of gcc/g++, clang, and compilers from
-    Allinea, Cray, Intel, and PGI.
+    Cray and Intel.
 
     * Note that you will need a C++11 compiler to build LLVM or regular
       expression support (i.e.  CHPL_LLVM=llvm or CHPL_REGEXP=re2). If
@@ -35,12 +37,15 @@ about your environment for using Chapel:
 
   * Building GMP requires an M4 macro processor.
 
-  * Building LLVM requires cmake version 3.4.3 or later.
+  * Building LLVM requires cmake version 3.13.4 or later.
 
-  * If you wish to use chpldoc or Chapel's test system, ``curl`` and
-    python-devel (or equivalent packages for your platform) are required.
+  * If you wish to use chpldoc or Chapel's test system, Python 3.5 or
+    newer is required and the ``python3`` and ``pip3`` commands must be
+    available. Additionally, ``curl``, ``perl``, and ``python3-devel``
+    (or equivalent packages for your platform) are required.
 
-  * If you wish to use :ref:`readme-mason`, chapel's package manager,  ``git`` is required.
+  * If you wish to use :ref:`readme-mason`, chapel's package manager,
+    ``git`` is required.
 
     * The ``mason system`` subcommands additionally require ``pkg-config``.
 
@@ -51,22 +56,14 @@ Installation
 
 We have used the following commands to install the above prerequisites:
 
-  * CentOS::
+  * CentOS, Fedora::
 
-      sudo yum install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk git
-
-  * Fedora::
-
-      sudo dnf install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk git
-
-  * SLES, openSUSE::
-
-      sudo zypper install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk git
+      sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git
 
   * Debian, Ubuntu::
 
-      sudo apt-get install gcc g++ m4 perl python python-dev python-setuptools bash make mawk git pkg-config
+      sudo apt-get install gcc g++ m4 perl python3 python3-pip python3-dev bash make mawk git pkg-config
 
   * FreeBSD::
 
-     sudo pkg install gcc m4 perl5 python py27-setuptools bash gmake gawk git pkgconf
+     sudo pkg install gcc m4 perl5 python3 py37-pip bash gmake gawk git pkgconf

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -18,9 +18,9 @@ about your environment for using Chapel:
   * You are using an environment that supports standard UNIX commands
     such as: ``cd, mkdir, rm, echo``
 
-  * You have a Bourne shell available at ``/bin/sh``, the C-shell
-    available at ``/bin/csh``, 'env' available at ``/usr/bin/env``, and
-    that 'env' can locate ``python3`` or ``python`` on your system.
+  * You have a Bourne shell available at ``/bin/sh``, 'env' available at
+    ``/usr/bin/env``, and that 'env' can locate ``python3`` or ``python``
+    on your system.
 
   * You have Python 2.7 or newer.
 


### PR DESCRIPTION
Follow-up to PR #16560

* Update prereqs.rst to describe Python 3 requirements
* While there, I noticed a `make` that should be `$(MAKE)` in 
  `doc/Makefile`, so fix that too

I tested the updated suggested package-install commands (see PR #16619). 
I removed the OpenSUSE section because I was unable to test with a recent
OpenSUSE.

Reviewed by @lydia-duncan - thanks!