### PR TITLE
Update activate_chpl_test_venv to throw rather than exit

### DIFF
--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -10,8 +10,8 @@ import chpl_home_utils
 import chpl_make
 
 def error(message):
-    sys.stdout.write('[Error: {0}]\n'.format(message))
-    exit(1)
+    sys.stdout.write('[Warning: {0}]\n'.format(message))
+    raise ImportError(message)
 
 def log(message):
     sys.stdout.write('[{0}]\n'.format(message))


### PR DESCRIPTION
This PR is intended to fix problems with the nightly download-stats job.
It updates `activate_chpl_test_venv` to throw an error rather than exiting if the venv doesn't exist.

* checked that the error appears with start_test and paratest
  and that the solution is the last part of the error
* checked that genGraphs can now run without a test-venv

If the error message here proves confusing or problematic in practice, we
can update the call sites to `activate_chpl_test_venv` to catch this error
and/or add `try_activate_chpl_test_venv` and make `activate_chpl_test_venv`
exit.

Reviewed by @ronawho - thanks!