### PR TITLE
Use python3 in a few test scripts rather than python

### DIFF
--- a/test/library/standard/FileSystem/fsouza/chown/chown_nothing.prediff
+++ b/test/library/standard/FileSystem/fsouza/chown/chown_nothing.prediff
@@ -7,8 +7,8 @@
 
 set -e
 
-file_user=$(python -c 'import os ; print(os.stat("file.txt").st_uid)')
-file_group=$(python -c 'import os ; print(os.stat("file.txt").st_gid)')
+file_user=$(python3 -c 'import os ; print(os.stat("file.txt").st_uid)')
+file_group=$(python3 -c 'import os ; print(os.stat("file.txt").st_gid)')
 
 expected_file_group=$(cat file.gid)
 expected_file_user=$(cat file.uid)

--- a/test/library/standard/FileSystem/fsouza/chown/chown_nothing.preexec
+++ b/test/library/standard/FileSystem/fsouza/chown/chown_nothing.preexec
@@ -2,5 +2,5 @@
 
 touch file.txt
 
-python -c 'import os ; print(os.stat("file.txt").st_uid)' > file.uid
-python -c 'import os ; print(os.stat("file.txt").st_gid)' > file.gid
+python3 -c 'import os ; print(os.stat("file.txt").st_uid)' > file.uid
+python3 -c 'import os ; print(os.stat("file.txt").st_gid)' > file.gid

--- a/test/performance/compiler/elliot/updateDatFiles.chpl
+++ b/test/performance/compiler/elliot/updateDatFiles.chpl
@@ -10,7 +10,7 @@ const tempDat = "compilerPerformance.tmp";
 const testDatFile = "\"%s/%s\"".format(here.cwd(), tempDat);
 
 copy(origDat, tempDat);
-var command = "cd %s && python -c 'import updateDatFiles; updateDatFiles.test(%s)'".format(develPath, testDatFile);
+var command = "cd %s && python3 -c 'import updateDatFiles; updateDatFiles.test(%s)'".format(develPath, testDatFile);
 spawnshell(command).wait();
 spawnshell("cat %s".format(tempDat)).wait();
 remove(tempDat);

--- a/test/setchplenv/sub_test
+++ b/test/setchplenv/sub_test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-python verify_setchplenv_scripts.py --verbose && \
+python3 verify_setchplenv_scripts.py --verbose && \
     echo '[Success matching setchplenv.* scripts check.]' || \
         echo '[Error found checking setchplenv.* scripts.]'

--- a/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.prediff
+++ b/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.prediff
@@ -7,5 +7,5 @@ then
   mv "$2" "$2".save
 
   # the following overwrites "$2" with "ok" or error message(s)
-  exec python ../../lib/python/regression_test.py "$2"
+  exec python3 ../../lib/python/regression_test.py "$2"
 fi

--- a/test/studies/amr/advection/grid/Grid_AdvectionCTU_driver.prediff
+++ b/test/studies/amr/advection/grid/Grid_AdvectionCTU_driver.prediff
@@ -4,4 +4,4 @@
 mv "$2" "$2".save
 
 # the following overwrites "$2" with "ok" or error message(s)
-exec python ../../lib/python/regression_test.py "$2"
+exec python3 ../../lib/python/regression_test.py "$2"

--- a/test/studies/amr/diffusion/grid/Grid_DiffusionBE_driver.prediff
+++ b/test/studies/amr/diffusion/grid/Grid_DiffusionBE_driver.prediff
@@ -4,4 +4,4 @@
 mv "$2" "$2".save
 
 # the following overwrites "$2" with "ok" or error message(s)
-exec python ../../lib/python/regression_test.py "$2"
+exec python3 ../../lib/python/regression_test.py "$2"

--- a/test/studies/amr/diffusion/level/Level_DiffusionBE_driver.prediff
+++ b/test/studies/amr/diffusion/level/Level_DiffusionBE_driver.prediff
@@ -4,4 +4,4 @@
 mv "$2" "$2".save
 
 # the following overwrites "$2" with "ok" or error message(s)
-exec python ../../lib/python/regression_test.py "$2"
+exec python3 ../../lib/python/regression_test.py "$2"


### PR DESCRIPTION
Follow-up to PR #16560 

Since `python` is not available on many current linux distributions
and since `python3` is the current testing dependency.

Test change only - not reviewed.