### PR TITLE
Fix use of python in shootout/Makefile

### DIFF
--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -23,8 +23,8 @@ TARGETS = \
 	spectralnorm \
 	threadring
 
-CHPL_MAKE_REGEXP=$(shell python $(CHPL_HOME)/util/chplenv/chpl_regexp.py)
-CHPL_MAKE_GMP=$(shell python $(CHPL_HOME)/util/chplenv/chpl_gmp.py)
+CHPL_MAKE_REGEXP=$(shell python3 $(CHPL_HOME)/util/chplenv/chpl_regexp.py)
+CHPL_MAKE_GMP=$(shell python3 $(CHPL_HOME)/util/chplenv/chpl_gmp.py)
 
 REALS = $(TARGETS:%=%_real)
 


### PR DESCRIPTION
Follow-up to PR #16560

To address a failure in the release-tarball-smoke-test.

Test change only - not reviewed.