### PR TITLE
Fix one more test to use python3

### DIFF
--- a/test/studies/amr/advection/level/Level_AdvectionCTU_driver.prediff
+++ b/test/studies/amr/advection/level/Level_AdvectionCTU_driver.prediff
@@ -4,4 +4,4 @@
 mv "$2" "$2".save
 
 # the following overwrites "$2" with "ok" or error message(s)
-exec python ../../lib/python/regression_test.py "$2"
+exec python3 ../../lib/python/regression_test.py "$2"


### PR DESCRIPTION
Follow-up to PR #16560

Adjusts test/studies/amr/advection/level/Level_AdvectionCTU_driver.prediff
to use python3 rather than python. This one was missed in #16624.

Test change only - not reviewed.