### PR TITLE
Add back chpl2pdf and chapel_listing.tex

### DIFF
--- a/highlight/latex/README.md
+++ b/highlight/latex/README.md
@@ -1,6 +1,5 @@
 Chapel LaTeX support
 ====================
 
-See $CHPL_HOME/spec/chapel_listing.tex for a Chapel definition for the
-LaTeX [lst]listings package.  Eventually we should move that file
-here, but for now, using this placeholder instead.
+The file `chapel_listing.tex` is a Chapel syntaxt definiton for the LaTeX
+[lst]listings package.

--- a/highlight/latex/README.md
+++ b/highlight/latex/README.md
@@ -1,5 +1,5 @@
 Chapel LaTeX support
 ====================
 
-The file `chapel_listing.tex` is a Chapel syntaxt definiton for the LaTeX
-[lst]listings package.
+The file `chapel_listing.tex` is a Chapel syntax definiton for the LaTeX
+[lst] listings package.

--- a/highlight/latex/chapel_listing.tex
+++ b/highlight/latex/chapel_listing.tex
@@ -1,0 +1,74 @@
+\lstdefinelanguage{chapel}
+  {
+    morekeywords={
+      align, as, atomic,
+      begin, bool, borrowed, break, by, bytes
+      catch, class, cobegin, coforall, complex, config, const, continue,
+      defer, delete, dmapped, do, domain,
+      else, enum, except, export, extern,
+      false, for, forall, forwarding,
+      if, imag, in, index, inline, inout, int, iter,
+      label, lambda, let, lifetime, local, locale,
+      module,
+      new, nil, noinit,
+      on, only, opaque, otherwise, out, override, owned,
+      param, pragma, primitive, private, proc, prototype, public,
+      range, real, record, reduce, ref, require, return,
+      scan, select, serial, shared, single, sparse, string, subdomain, sync,
+      then, this, throw, throws, true, try, type,
+      uint, union, unmanaged, use,
+      var,
+      when, where, while, with,
+      yield,
+      zip
+    },
+    sensitive=false,
+    mathescape=true,
+    morecomment=[l]{//},
+    morecomment=[s]{/*}{*/},
+    morestring=[b]",
+}
+
+\lstset{
+    basicstyle=\footnotesize\ttfamily,
+    keywordstyle=\bfseries,
+    commentstyle=\em,
+    showstringspaces=false,
+    flexiblecolumns=false,
+    numbers=left,
+    numbersep=5pt,
+    numberstyle=\tiny,
+    numberblanklines=false,
+    stepnumber=0,
+    escapeinside={(*}{*)},
+    language=chapel,
+  }
+
+%\newcommand{\chpl}[1]{\lstinline[language=chapel,basicstyle=\ttfamily,keywordstyle=\bfseries]!#1!}
+\newcommand{\chpl}[1]{\lstinline[language=chapel,basicstyle=\small\ttfamily,keywordstyle=]!#1!}
+\newcommand{\varname}[1]{\emph{#1}}
+\newcommand{\typename}[1]{\emph{#1}}
+\newcommand{\fnname}[1]{\chpl{#1}}
+
+\lstnewenvironment{chapel}{\lstset{language=chapel,xleftmargin=2pc,stepnumber=0}}{}
+\lstnewenvironment{invisible}{\lstset{language=chapel,xleftmargin=2pc,stepnumber=0,keywordstyle=\bfseries\color{white},basicstyle=\small\ttfamily\color{white}}}{}
+\lstnewenvironment{chapel0}{\lstset{language=chapel,stepnumber=0}}{}
+
+\lstnewenvironment{numberedchapel}{\lstset{language=chapel,xleftmargin=15pt,stepnumber=1}}{}
+
+\lstnewenvironment{chapelcode}{\lstset{language=chapel,stepnumber=1}}{}
+
+% Uses the same listing style as the {chapel} environment, but keyword
+% formatting is turned off.  The argument is ignored in LaTeX
+% but used to name the .good file during test extraction.
+% The argument must be supplied but may be empty.
+% If empty it defaults to null, which signals the test extractor to 
+% autogenerate the .good file name as ``<test_name>.good''.
+\lstnewenvironment{chapelprintoutput}[1]
+  {\lstset{language=chapel,xleftmargin=2pc,stepnumber=0,keywordstyle=}}{}
+
+\lstnewenvironment{commandline}{\lstset{keywordstyle=,xleftmargin=2pc}}{}
+
+\lstnewenvironment{protohead}{\lstset{language=chapel,xleftmargin=0pc,belowskip=-10pt,stepnumber=0}}{}
+
+\newenvironment{protobody}{\begin{description}\item[\quad\quad] }{\end{description}}

--- a/util/misc/chpl2pdf
+++ b/util/misc/chpl2pdf
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import sys, os.path, tempfile, shutil
+
+if len(sys.argv) != 2: sys.exit('usage: '+sys.argv[0]+' filename.chpl')
+(s0, ext) = os.path.splitext(sys.argv[1]);
+if ext!='.chpl': sys.exit('usage: '+sys.argv[0]+' filename.chpl')
+
+cwd = os.getcwd()
+
+filename = os.path.basename(s0);
+tmpdir = tempfile.mkdtemp()
+latexfile = tmpdir+'/'+filename+'.tex'
+realfile = os.path.realpath(sys.argv[1])
+chpl_home = os.getenv('CHPL_HOME')
+if chpl_home==None:
+    sys.exit('Please set the CHPL_HOME environment variable.')
+chpl_listing = chpl_home+'/highlight/latex/chapel_listing.tex'
+
+print ('filename is : '+filename)
+print ('latexfile is: '+latexfile)
+print ('chpl_listing: '+chpl_listing)
+
+fh = open(latexfile, 'w')
+fh.write('\\documentclass[11pt]{article}\n')
+fh.write('\\usepackage{times}\n')
+fh.write('\\usepackage{fullpage}\n')
+fh.write('\\usepackage{listings}\n')
+fh.write('\\input{'+chpl_listing+'}\n')
+fh.write('\\lstset{stepnumber=1, mathescape=false}\n')
+fh.write('\\begin{document}\n')
+fh.write('\\lstinputlisting{'+realfile+'}')
+fh.write('\\end{document}\n')
+fh.close()
+
+os.chdir(tmpdir)
+os.system('pdflatex '+latexfile)
+os.system('cp '+filename+'.pdf '+cwd)
+os.chdir(cwd)
+
+shutil.rmtree(tmpdir)

--- a/util/misc/chpl2pdf
+++ b/util/misc/chpl2pdf
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
 
+"""
+This script creates a .pdf file presenting the code in a .chpl
+with highlighting.
+
+For example
+
+  ./util/misc/chpl2pdf examples/hello.chpl
+
+will produce hello.pdf.
+"""
+
 import sys, os.path, tempfile, shutil
 
 if len(sys.argv) != 2: sys.exit('usage: '+sys.argv[0]+' filename.chpl')


### PR DESCRIPTION
Follow-up to PR #16555.

PR #16555 removed util/misc/chpl2pdf but @bradcray indicated that script 
should continue to exist. This PR adds it back, gets it working with 
Python 3, and updates it to use `chapel_listing.tex` is in 
highlight/latex (which this PR also adds).

Reviewed by @vasslitvinov - thanks!
