### PR TITLE
Deallocate the RTT memory returned from empty for expressions

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -5256,6 +5256,9 @@ module ChapelArray {
       pragma "no copy"
       var A = D.buildArrayWith(elemType, data, size:int);
 
+      // in lieu of automatic memory management for runtime types
+      __primitive("auto destroy runtime type", elemType);
+
       return A;
     }
   }


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/15609

This PR adds a `PRIM_AUTO_DESTROY_RUNTIME_TYPE` for the `chpl__initCopy`
overload that takes an iterator argument. The new primitive is added to the
code path where we don't allocate any data to be copied.

This comes up in the following case:

```chapel
var AAA = for i in 1..0 do [1,2,3];
```

which leaks without this PR. The leak is coming from the domain of `[1,2,3]` not
being freed because of the missing `PRIM_AUTO_DESTROY_RUNTIME_TYPE` added by
this PR.

This closes leaks in:

```
arrays/ferguson/from/iterator/for-yields-no-arrays.chpl
arrays/shapes/skyline.when-empty.chpl
```

Test:
- [x] asan
- [x] standard
- [x] gasnet
