### PR TITLE
Use python3 for finding numCores in common-gasnet

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -30,7 +30,7 @@ if [ "${tasks}" == "qthreads" ] ; then
     # running in a non-oversubscribed manner. Note that this is NOT
     # indicative of a real performance issue, and that when run on real
     # hardware we get the performance we expect
-    logicalCores=`python -c 'import multiprocessing ; print multiprocessing.cpu_count()'`
+    logicalCores=`python3 -c 'import multiprocessing ; print multiprocessing.cpu_count()'`
     if [ $logicalCores -le 8 ] ; then
         export CHPL_TEST_TIMEOUT=1800
     fi


### PR DESCRIPTION
Follow-up to PR #16560

Intended to resolve a smoke test failure.

Trivial and not reviewed.