### PR TITLE
Fix module build for python3

### DIFF
--- a/third-party/chpl-venv/venv-use-sys-python.py
+++ b/third-party/chpl-venv/venv-use-sys-python.py
@@ -37,7 +37,11 @@ def rm_python_bins(bindir):
         for f in os.listdir(bindir):
             abs_f = os.path.join(bindir, f)
             # abs_f is the abs path to some file system object under bindir
-            if f in [ 'python', 'python2', 'python2.6', 'python2.7' ]:
+            if f in [ 'python', 'python3', 'python2',
+                      'python2.6', 'python2.7',
+                      'python3.0', 'python3.1', 'python3.2', 'python3.3',
+                      'python3.4', 'python3.5', 'python3.6', 'python3.7',
+                      'python3.8' ]:
                 print('Removing {0}'.format(abs_f))
                 os.remove(abs_f)
     else:

--- a/third-party/chpl-venv/venv-use-sys-python.py
+++ b/third-party/chpl-venv/venv-use-sys-python.py
@@ -64,6 +64,11 @@ def rw_shebangs(root):
 
             abs_f = os.path.join(root, f)
             # abs_f is the abs path to some file system object under root
+
+            # look into the bin directory
+            if os.path.isdir(abs_f) and f == "bin":
+                rw_shebangs(abs_f)
+
             if os.path.isfile(abs_f) and not os.path.islink(abs_f):
                 # abs_f is a file
                 with open(abs_f) as fin:

--- a/third-party/chpl-venv/venv-use-sys-python.py
+++ b/third-party/chpl-venv/venv-use-sys-python.py
@@ -41,7 +41,7 @@ def rm_python_bins(bindir):
                       'python2.6', 'python2.7',
                       'python3.0', 'python3.1', 'python3.2', 'python3.3',
                       'python3.4', 'python3.5', 'python3.6', 'python3.7',
-                      'python3.8' ]:
+                      'python3.8', 'python3.9' ]:
                 print('Removing {0}'.format(abs_f))
                 os.remove(abs_f)
     else:

--- a/third-party/chpl-venv/venv-use-sys-python.py
+++ b/third-party/chpl-venv/venv-use-sys-python.py
@@ -36,12 +36,12 @@ def rm_python_bins(bindir):
     if os.path.isdir(bindir) and not os.path.islink(bindir):
         for f in os.listdir(bindir):
             abs_f = os.path.join(bindir, f)
+            ver = sys.version_info
+            p0 = 'python'
+            p1 = 'python{0}'.format(ver[0]) # e.g. python3
+            p2 = 'python{0}.{1}'.format(ver[0], ver[1]) # e.g. python3.8
             # abs_f is the abs path to some file system object under bindir
-            if f in [ 'python', 'python3', 'python2',
-                      'python2.6', 'python2.7',
-                      'python3.0', 'python3.1', 'python3.2', 'python3.3',
-                      'python3.4', 'python3.5', 'python3.6', 'python3.7',
-                      'python3.8', 'python3.9' ]:
+            if f in [ p0, p1, p2 ]:
                 print('Removing {0}'.format(abs_f))
                 os.remove(abs_f)
     else:

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -172,60 +172,33 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
         log_debug "Checking the system-installed Python"
 
-        pyLT27=$( /usr/bin/python -c "import sys; print(sys.version_info[0:2] < (2, 7))" || : ok )
-        whichPy=$( which python || : ok )
-        case "$pyLT27" in
-        ( False | True )
-            case "$whichPy" in
-            ( /usr/bin/python )
-                ;;
-            ( * )
-                log_error "Found unexpected path to default python executable: '$whichPy'"
-                log_error "The expected path was '/usr/bin/python'"
-                exit 2
-                ;;
-            esac
-            ;;
-        ( * )
-            log_error "/usr/bin/python broken or not found"
-            echo >&2 "stdout:'$pyLT27'"
-            ls -ldL >&2 /usr/bin/python || : ok
-            exit 2
-            ;;
-        esac
-
-            # Chapel python-venv tools requires a working internet connection and either:
-            # - modern version of libssl that supports TLS 1.1
-            # - local workarounds such as the variables shown in the "venv" callback, below.
+        # Chapel python-venv tools requires a working internet connection and either:
+        # - modern version of libssl that supports TLS 1.1
+        # - local workarounds such as the variables shown in the "venv" callback, below.
 
         log_info "Start build_configs $dry_run $verbose -- $venv_targets"
 
         $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv.log" \
             --target-compiler=venv -- $venv_targets
 
-        if [ "$pyLT27" = "True" ]; then
-
-            # If the system-installed Python was 2.6, Build a second copy of Chapel
-            # python-venv tools using the alternate Python 2.7 installation,
-            # which must be implemented by the "venv_py27" callback, below.
-
-            log_info "Building Chapel component: venv ($venv_targets with venv_py27 callback)"
-
-            log_info "Start build_configs $dry_run $verbose -- $venv_targets"
-
-            $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27.log" \
-                --target-compiler=venv_py27 -- $venv_targets
-
-            # Custom Chapel make target to rm files or links named "python" from the installed py27
-            # bin dir, forcing users of the installed Chapel RPM to get "python" from the system.
-
+        # If we are not using the system-installed python, update
+        # the scripts in chpl-venv to use the system-installed python.
+        findPy=$($CHPL_HOME/util/config/find-python.sh)
+        whichPy=$( which $findPy || : ok )
+        case "$whichPy" in
+        ( /usr/bin/python* )
+            log_info "Found system python $whichPy"
+            ;;
+        ( * )
+            log_info "Found non-system python $whichPy - adjusting paths"
+            # Custom Chapel make target to rm files or links named "python3"
+            # from the installed bin dir, forcing users of the installed
+            # Chapel RPM to get "python3" from the system.
             use_system_python="-C third-party/chpl-venv use-system-python"
-
-            log_info "Start build_configs $dry_run $verbose -- $use_system_python"
-
             $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27-use_system_python.log" \
-                --target-compiler=venv_py27 -- $use_system_python
-        fi
+                --target-compiler=venv -- $use_system_python
+            ;;
+        esac
         ;;
     ( * )
         log_info "NO building Chapel component: venv"
@@ -403,17 +376,6 @@ else
         load_module $target
     }
 
-    function use_python27() {
-        if \! $(python --version 2>&1 | grep -q ' 2\.7\>') ; then
-            log_info "Using Python 2.7 from /cray/css/users/chapelu/setup_python27.bash"
-            if [ ! -f /cray/css/users/chapelu/setup_python27.bash ] ; then
-                log_error "Python 2.7 setup script is not accessible at /cray/css/users/chapelu/setup_python27.bash"
-                exit 1
-            fi
-            source /cray/css/users/chapelu/setup_python27.bash
-        fi
-    }
-
     # ---
 
     # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
@@ -447,17 +409,6 @@ else
         else
           export CHPL_PIP=/usr/bin/pip
         fi
-        ;;
-    ( venv_py27 )
-        load_prgenv_gnu
-
-        # Alternate python version
-        use_python27
-
-        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
-        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
-        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
         ;;
     ( "" )
         : ok

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -397,18 +397,12 @@ else
     ( venv )
         load_prgenv_gnu
 
-        # If the installed libssl is too old to support TLS 1.1, some workarounds exist to
-        # enable building Chapel python-venv tools anyway.
-        # For example, the following gives a URL to a local PyPI mirror that accepts http,
-        # and the location of a pre-installed "pip" on the host machine.
-        if [[ -f /cray/css/users/chapelu/opt/lib/pip/__main__.py ]] ; then
-          export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-          export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
-          export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
-          export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
-        else
-          export CHPL_PIP=/usr/bin/pip
-        fi
+        # If the installed libssl is too old to support TLS 1.1, some
+        # workarounds exist to enable building Chapel python-venv tools anyway.
+        # For example, the following gives a URL to a local PyPI mirror.
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
         ;;
     ( "" )
         : ok

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -387,10 +387,9 @@ else
     ( venv )
         load_prgenv_gnu
 
-        # If the installed libssl is too old to support TLS 1.1, some workarounds exist to
-        # enable building Chapel python-venv tools anyway.
-        # For example, the following gives a URL to a local PyPI mirror that accepts http,
-        # and the location of a pre-installed "pip" on the host machine.
+        # If the installed libssl is too old to support TLS 1.1, some
+        # workarounds exist to enable building Chapel python-venv tools anyway.
+        # For example, the following gives a URL to a local PyPI mirror.
 
         export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
         export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -158,66 +158,37 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     case ",$components," in
     ( *,venv,* )
 
-        # Build Chapel python-venv tools with the system-installed Python, no matter which version
-
         log_info "Building Chapel component: venv ($venv_targets)"
 
         log_debug "Checking the system-installed Python"
 
-        pyLT27=$( /usr/bin/python -c "import sys; print(sys.version_info[0:2] < (2, 7))" || : ok )
-        whichPy=$( which python || : ok )
-        case "$pyLT27" in
-        ( False | True )
-            case "$whichPy" in
-            ( /usr/bin/python )
-                ;;
-            ( * )
-                log_error "Found unexpected path to default python executable: '$whichPy'"
-                log_error "The expected path was '/usr/bin/python'"
-                exit 2
-                ;;
-            esac
-            ;;
-        ( * )
-            log_error "/usr/bin/python broken or not found"
-            echo >&2 "stdout:'$pyLT27'"
-            ls -ldL >&2 /usr/bin/python || : ok
-            exit 2
-            ;;
-        esac
-
-            # Chapel python-venv tools requires a working internet connection and either:
-            # - modern version of libssl that supports TLS 1.1
-            # - local workarounds such as the variables shown in the "venv" callback, below.
+        # Chapel python-venv tools requires a working internet connection and either:
+        # - modern version of libssl that supports TLS 1.1
+        # - local workarounds such as the variables shown in the "venv" callback, below.
 
         log_info "Start build_configs $dry_run $verbose -- $venv_targets"
 
         $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv.log" \
             --target-compiler=venv -- $venv_targets
 
-        if [ "$pyLT27" = "True" ]; then
-
-            # If the system-installed Python was 2.6, Build a second copy of Chapel
-            # python-venv tools using the alternate Python 2.7 installation,
-            # which must be implemented by the "venv_py27" callback, below.
-
-            log_info "Building Chapel component: venv ($venv_targets with venv_py27 callback)"
-
-            log_info "Start build_configs $dry_run $verbose -- $venv_targets"
-
-            $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27.log" \
-                --target-compiler=venv_py27 -- $venv_targets
-
-            # Custom Chapel make target to rm files or links named "python" from the installed py27
-            # bin dir, forcing users of the installed Chapel RPM to get "python" from the system.
-
+        # If we are not using the system-installed python, update
+        # the scripts in chpl-venv to use the system-installed python.
+        findPy=$($CHPL_HOME/util/config/find-python.sh)
+        whichPy=$( which $findPy || : ok )
+        case "$whichPy" in
+        ( /usr/bin/python* )
+            log_info "Found system python $whichPy"
+            ;;
+        ( * )
+            log_info "Found non-system python $whichPy - adjusting paths"
+            # Custom Chapel make target to rm files or links named "python3"
+            # from the installed bin dir, forcing users of the installed
+            # Chapel RPM to get "python3" from the system.
             use_system_python="-C third-party/chpl-venv use-system-python"
-
-            log_info "Start build_configs $dry_run $verbose -- $use_system_python"
-
             $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27-use_system_python.log" \
-                --target-compiler=venv_py27 -- $use_system_python
-        fi
+                --target-compiler=venv -- $use_system_python
+            ;;
+        esac
         ;;
     ( * )
         log_info "NO building Chapel component: venv"
@@ -395,15 +366,6 @@ else
         load_module $target
     }
 
-    function use_python27() {
-        log_info "Using Python 2.7 from /cray/css/users/chapelu/setup_python27.bash"
-        if [ ! -f /cray/css/users/chapelu/setup_python27.bash ] ; then
-            log_error "Python 2.7 setup script is not accessible at /cray/css/users/chapelu/setup_python27.bash"
-            exit 1
-        fi
-        source /cray/css/users/chapelu/setup_python27.bash
-    }
-
     # ---
 
     # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
@@ -432,19 +394,6 @@ else
 
         export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
         export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
-        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
-        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
-        ;;
-    ( venv_py27 )
-        load_prgenv_gnu
-
-        # Alternate python version
-        use_python27
-
-        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
-        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
-        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
         ;;
     ( "" )
         : ok

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -169,6 +169,61 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         ;;
     esac
 
+    venv_targets="test-venv chpldoc"
+    case ",$components," in
+    ( *,venv,* )
+
+        log_info "Building Chapel component: venv ($venv_targets)"
+
+        log_debug "Checking the system-installed Python"
+
+        # Chapel python-venv tools requires a working internet connection and either:
+        # - modern version of libssl that supports TLS 1.1
+        # - local workarounds such as the variables shown in the "venv" callback, below.
+
+        log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+        $cwd/build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv.log" \
+            --target-compiler=venv -- $venv_targets
+
+        # If we are not using the system-installed python, update
+        # the scripts in chpl-venv to use the system-installed python.
+        findPy=$($CHPL_HOME/util/config/find-python.sh)
+        whichPy=$( which $findPy || : ok )
+        case "$whichPy" in
+        ( /usr/bin/python* )
+            log_info "Found system python $whichPy"
+            ;;
+        ( * )
+            log_info "Found non-system python $whichPy - adjusting paths"
+            # Custom Chapel make target to rm files or links named "python3"
+            # from the installed bin dir, forcing users of the installed
+            # Chapel RPM to get "python3" from the system.
+            use_system_python="-C third-party/chpl-venv use-system-python"
+            $cwd/build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27-use_system_python.log" \
+                --target-compiler=venv -- $use_system_python
+            ;;
+        esac
+        ;;
+    ( * )
+        log_info "NO building Chapel component: venv"
+        ;;
+    esac
+
+    case "$components" in
+    ( *mason* )
+        log_info "Building Chapel component: mason"
+
+        log_info "Start build_configs $dry_run $verbose -- mason"
+
+        $cwd/build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.mason.log" \
+            --target-compiler=gnu -- mason
+        ;;
+    ( * )
+        log_info "NO building Chapel component: mason"
+        ;;
+    esac
+
     tools_targets="test-venv chpldoc mason"
     case "$components" in
     ( *tools* )
@@ -312,6 +367,9 @@ else
     ##  export CHPL_PIP_INSTALL_PARAMS="-i http://mirror-pypi.example.com/pypi/simple --trusted-host mirror-pypi.example.com"
     ##  export CHPL_PIP=/data/example/opt/lib/pip/__main__.py
     ##  export CHPL_PYTHONPATH=/data/example/opt/lib
+        ;;
+    ( venv )
+        load_prgenv_gnu
         ;;
     ( gnu )
         load_prgenv_gnu

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -24,8 +24,8 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     # current list of selected components initially empty
     components=
-    valid_components="compiler,runtime,tools,clean"
-    default_components="compiler,runtime"
+    valid_components="compiler,runtime,venv,mason,clean"
+    default_components="compiler,runtime,venv,mason"
         ## clean is not default; more developer-friendly
         ## tools could be default, except that would makes this example script less portable
 


### PR DESCRIPTION
Follow-up to PR #16560.

* updates venv-use-sys-python to consider python3 filenames and rewrite 
  shebangs in bin/ (see also PR #3571)
* updates `setenv-hpe-cray-ex-x86_64.bash` and `setenv-xc-x86_64.bash` to use
  whichever python `find-python.sh` gives us but to run
  venv-use-sys-python if it is not the system python
* updates `util/build_configs/setenv-example-3.bash` to be more similar to
  the others with a venv target so that it can test the venv build and
  venv-use-sys-python part

- [x] `test_rpm_module.bash` succeeds and uses system python for things 
  in venv's bin

Reviewed by @lydia-duncan - thanks!