### PR TITLE
Adjust chpl_launchcmd.py and mandelbrot.prediff

### DIFF
--- a/test/release/examples/benchmarks/shootout/mandelbrot.prediff
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.prediff
@@ -8,6 +8,7 @@
 
 import os
 import os.path
+import shutil
 import socket
 import sys
 
@@ -74,6 +75,16 @@ else:
            str(diffs) + " bit differences]")
     if diffs > diffs_to_allow:
       error = "There were " + str(diffs) + " bit differences"
+
+# Save a copy of the failed output but only if there was an error
+savefile=testout + ".save"
+if error != "":
+  shutil.copyfile(testout, testout + ".save");
+else:
+  try:
+    os.remove(savefile)
+  except:
+    pass
 
 # Now output error to testout
 with open(testout, "w") as outF:

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -57,8 +57,8 @@ def main():
     """Run the program!"""
     job = AbstractJob.init_from_environment()
     (stdout, stderr) = job.run()
-    sys.stdout.write(stdout)
-    sys.stderr.write(stderr)
+    sys.stdout.buffer.write(stdout)
+    sys.stderr.buffer.write(stderr)
 
 
 class AbstractJob(object):
@@ -288,8 +288,8 @@ class AbstractJob(object):
 
 
     def run(self):
-        """Run batch job in subprocess and wait for job to complete. When finished,
-        returns output as string.
+        """Run batch job in subprocess and wait for job to complete.
+        When finished, returns output as bytes.
 
         :rtype: str
         :returns: stdout/stderr from job
@@ -388,15 +388,15 @@ class AbstractJob(object):
                 pass
 
             logging.debug('Reading output file.')
-            with open(output_file, 'r') as fp:
+            with open(output_file, 'rb') as fp:
                 output = fp.read()
 
             logging.debug('Reading error file.')
-            with open(error_file, 'r') as fp:
+            with open(error_file, 'rb') as fp:
                 error = fp.read()
 
             try:
-                with open('{0}.more'.format(error_file), 'r') as fp:
+                with open('{0}.more'.format(error_file), 'rb') as fp:
                     error += fp.read()
             except:
                 pass


### PR DESCRIPTION
* adjusted chpl_launchcmd to read into bytes (rather than UTF-8)
  to avoid an error with the mandelbrot test's binary output
* adjusted mandelbrot.prediff to save the failed output
  to make these problems easier to find in the future

Resolves a failure with
 release/examples/benchmarks/shootout/mandelbrot.chpl

on XC when chpl_launchmd.py is used.

Reviewed by @lydia-duncan - thanks!