### PR TITLE
Change halt() for unexpected type in HDF5 to compilerError

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3655,7 +3655,7 @@ module HDF5 {
       }
 
       otherwise {
-        halt("Unhandled type in getHDF5Type: ", eltType:string);
+        compilerError("Unhandled type in getHDF5Type: " + eltType:string);
       }
     }
     return hdf5Type;

--- a/test/library/packages/canCompileNoLink/errors/getUnsupportedHDF5type.chpl
+++ b/test/library/packages/canCompileNoLink/errors/getUnsupportedHDF5type.chpl
@@ -1,0 +1,6 @@
+use HDF5;
+
+writeln(getHDF5Type(R));
+
+record R {
+}

--- a/test/library/packages/canCompileNoLink/errors/getUnsupportedHDF5type.good
+++ b/test/library/packages/canCompileNoLink/errors/getUnsupportedHDF5type.good
@@ -1,0 +1,1 @@
+getUnsupportedHDF5type.chpl:3: error: Unhandled type in getHDF5Type: R


### PR DESCRIPTION
This changes a type-logic halt() into a compilerError() for a better user experience, and a test to lock in the behavior.

Resolves #16587
