### PR TITLE
Remove isAggregateTypeAndConstructor()

### DIFF
--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -125,9 +125,6 @@ private:
 
   void                  addBuiltIns();
 
-  bool                  isAggregateTypeAndConstructor(Symbol* sym0,
-                                                      Symbol* sym1);
-
   bool                  isSymbolAndMethod(Symbol* sym0,
                                           Symbol* sym1);
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -399,11 +399,6 @@ bool ResolveScope::extend(Symbol* newSym, bool isTopLevel) {
     if (oldFn != NULL && newFn != NULL) {
       retval = true;
 
-    // e.g. record String and proc String(...)
-    } else if (isAggregateTypeAndConstructor(oldSym, newSym) == true ||
-               isAggregateTypeAndConstructor(newSym, oldSym) == true) {
-      retval = true;
-
     // Methods currently leak their scope and can conflict with variables
     } else if (isSymbolAndMethod(oldSym, newSym)             == true ||
                isSymbolAndMethod(newSym, oldSym)             == true) {
@@ -440,21 +435,6 @@ bool ResolveScope::extend(VisibilityStmt* stmt) {
   }
 
   return true;
-}
-
-bool ResolveScope::isAggregateTypeAndConstructor(Symbol* sym0, Symbol* sym1) {
-  TypeSymbol* typeSym = toTypeSymbol(sym0);
-  FnSymbol*   funcSym = toFnSymbol(sym1);
-  bool        retval  = false;
-
-  if (typeSym != NULL && funcSym != NULL && funcSym->_this != NULL) {
-    AggregateType* type0 = toAggregateType(typeSym->type);
-    AggregateType* type1 = toAggregateType(funcSym->_this->type);
-
-    retval = (type0 == type1) ? true : false;
-  }
-
-  return retval;
 }
 
 bool ResolveScope::isSymbolAndMethod(Symbol* sym0, Symbol* sym1) {


### PR DESCRIPTION
Remove code that should no longer fire, since we do not have C++-constructor-style naming:

```chpl
// the now-removed code allowed 'R' mean both a type and a function
record R {...}
proc R(...){...} // used to be a constructor function
```

An error in the above code saying "this is a constructor, use an initializer instead" is issued elsewhere. It is not affected by this change.

Testing: standard with futures; gasnet over multilocale tests.