### PR TITLE
Improve find-python.sh to check python --version

### DIFF
--- a/util/config/find-python.sh
+++ b/util/config/find-python.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
 for cmd in python3 python python2; do
-  command -v > /dev/null $cmd && echo $cmd && exit 0
+  if command -v $cmd > /dev/null 2>&1
+  then
+    if $cmd --version > /dev/null 2>&1
+    then
+      echo $cmd
+      exit 0
+    fi
+  fi
 done
 
 echo "python3 not found - please install python3 and add it to PATH" 1>&2


### PR DESCRIPTION
Follow-up to PR #16560

Does not check the output of python --version. It just
tries to run that and checks for return code 0.

This addresses problems with pyenv when python3 is installed
but not selected as the current python and when the system
does not include a python3 installation.

Helps with https://github.com/Cray/chapel-private/issues/1407

Reviewed by @lydia-duncan - thanks!

- [x] full local testing