### PR TITLE
Remove a string workaround in needsAutoCopyAutoDestroyForArg

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -315,16 +315,12 @@ static bool needsAutoCopyAutoDestroyForArg(ArgSymbol* formal, Expr* arg,
   // coforall - since each task needs its own copy.
   // MPF - should this logic also apply to arguments to coforall fns
   // that had the 'in' task intent?
-  if (fn->hasFlag(FLAG_BEGIN) ||
-      isString(baseType))
+  if ((isRecord(baseType) && fn->hasFlag(FLAG_BEGIN)) ||
+      (isRecord(baseType) && var->hasFlag(FLAG_COFORALL_INDEX_VAR)))
   {
-    if ((isRecord(baseType) && fn->hasFlag(FLAG_BEGIN)) ||
-        (isRecord(baseType) && var->hasFlag(FLAG_COFORALL_INDEX_VAR)))
+    if (!formal->isRef())
     {
-      if (!formal->isRef())
-      {
-        return true;
-      }
+      return true;
     }
   }
 


### PR DESCRIPTION
Removes a workaround that is apparently no longer necessary.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing
- [x] full gasnet testing
- [x] release/examples/primers pass with valgrind and do not leak