### PR TITLE
Update chpldoc dependencies to later versions

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -312,16 +312,6 @@ texinfo_documents = [
 
 # -- Custom options -------------------------------------------------------
 
-## Patch to disable nonlocal image warning for Chapel logo in README.rst
-original_warn_mode = sphinx.environment.BuildEnvironment.warn_node
-
-def allow_nonlocal_image_warn_node(self, msg, node):
-    if not msg.startswith('nonlocal image URI found:'):
-        original_warn_mode(self, msg, node)
-
-sphinx.environment.BuildEnvironment.warn_node = allow_nonlocal_image_warn_node
-
-
 ### Custom lexers for syntax listings
 from pygments.lexer import RegexLexer
 from pygments import token

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -51,7 +51,7 @@ templates_path = ['meta/templates']
 
 # Setup CSS files
 def setup(app):
-    app.add_stylesheet('style.css')
+    app.add_css_file('style.css')
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,7 +1,7 @@
 # Many of these packages have newer versions that work on Python 3 only.
 Jinja2==2.10.1
 MarkupSafe==1.1.1
-Pygments==2.4.2
+Pygments==2.7.1
 Sphinx==1.8.5
 # Sphinx==2.0.1 # requires python 3
 # Sphinx==2.1.2 # requires python 3

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -3,7 +3,7 @@ Jinja2==2.11.2
 MarkupSafe==1.1.1
 Pygments==2.7.1
 Sphinx==3.2.1
-docutils==0.15.2
+docutils==0.16
 argparse==1.4.0
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-chapeldomain==0.0.17

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -7,4 +7,4 @@ docutils==0.16
 argparse==1.4.0
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-chapeldomain==0.0.17
-babel==2.7.0
+babel==2.8.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -4,6 +4,6 @@ MarkupSafe==1.1.1
 Pygments==2.7.1
 Sphinx==3.2.1
 docutils==0.16
-sphinx-rtd-theme==0.4.3
+sphinx-rtd-theme==0.5.0
 sphinxcontrib-chapeldomain==0.0.17
 babel==2.8.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -3,9 +3,6 @@ Jinja2==2.11.2
 MarkupSafe==1.1.1
 Pygments==2.7.1
 Sphinx==3.2.1
-# Sphinx==2.0.1 # requires python 3
-# Sphinx==2.1.2 # requires python 3
-# Sphinx==2.2.0 # requires python 3
 docutils==0.15.2
 argparse==1.4.0
 sphinx-rtd-theme==0.4.3

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -4,7 +4,6 @@ MarkupSafe==1.1.1
 Pygments==2.7.1
 Sphinx==3.2.1
 docutils==0.16
-argparse==1.4.0
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-chapeldomain==0.0.17
 babel==2.8.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,13 +1,13 @@
 # Many of these packages have newer versions that work on Python 3 only.
-Jinja2==2.10.1
+Jinja2==2.11.2
 MarkupSafe==1.1.1
 Pygments==2.7.1
-Sphinx==1.8.5
+Sphinx==3.2.1
 # Sphinx==2.0.1 # requires python 3
 # Sphinx==2.1.2 # requires python 3
 # Sphinx==2.2.0 # requires python 3
 docutils==0.15.2
 argparse==1.4.0
 sphinx-rtd-theme==0.4.3
-./sphinxcontrib-chapeldomain
+sphinxcontrib-chapeldomain==0.0.17
 babel==2.7.0


### PR DESCRIPTION
Due to trying to stay compliant with Python 2, chpldoc has had to rely on older versions of
its dependencies for a while now.  Now that we've switched to relying on Python 3, we can
finally update these packages to later versions.

This updates the version for every chpldoc dependency except MarkupSafe, which does not
have a new version.  This includes pinning to the latest version of our Chapel Sphinx domain
(which we had previously used a copy of due to imprecise version requirements that would
have broken chpldoc in previous releases.  Note that I have not removed this copy of the
repo yet, as I was trying to avoid merge conflicts - I will remove it in a separate PR).

As a result of this change, our script to build the online documentation (which relies on
chpldoc) needed a couple of updates for deprecated features.

Resolves Cray/chapel-private#905

Passed a full paratest with futures.  I also spot checked the built documentation with this
change and only observed positive changes (e.g. the update to Pygments means we now
highlight the import statement, etc.)