### PR TITLE
fix man/Makefile

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -13,6 +13,10 @@ MANPAGE = man1/$(PROGRAM).1
 CHPLDOC_MANPAGE = man1/$(CHPLDOC).1
 TARGETS = $(MANPAGE) $(PROGRAM).pdf $(CHPLDOC).pdf
 
+VENV_DIR = $(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_home_utils.py --venv)
+
+RST2MAN = $(shell which rst2man.py || echo $(CHPL_MAKE_PYTHON) $(VENV_DIR)/bin/rst2man.py)
+
 STARS = \*\*\*\*\*
 
 default: echoman $(MANPAGE)
@@ -25,12 +29,13 @@ all: $(TARGETS)
 chpldoc: $(CHPLDOC_MANPAGE)
 
 clean:
-	rm -f $(TARGETS)
+	rm -f $(TARGETS) $(CHPLDOC_MANPAGE)
 
 man1/%.1: %.rst Makefile
 	mkdir -p $(shell dirname $@)
 	sed "/conf$</r conf$<" $< > $<.tmp
-	$(CHPL_MAKE_HOME)/util/run-in-venv.bash rst2man.py $<.tmp > $@
+	$(CHPL_MAKE_HOME)/util/run-in-venv.bash $(RST2MAN) $<.tmp > $<.tmp.out
+	mv $<.tmp.out $@
 	rm -f $<.tmp
 
 %.ps: man1/%.1

--- a/util/run-in-venv.bash
+++ b/util/run-in-venv.bash
@@ -3,7 +3,7 @@
 # usage: ./run-in-venv prog [args]
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set"
+  echo "Error: CHPL_HOME is not set" 1>&2
   exit 1
 fi
 
@@ -11,7 +11,7 @@ python=$($CHPL_HOME/util/config/find-python.sh)
 venv_path=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --venv)
 
 if [ ! -d "$venv_path" ]; then
-  echo "Error: virtualenv '$venv_path' does not exist"
+  echo "Error: virtualenv '$venv_path' does not exist" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
Follow-up to PR #16644 and #16560

* Adjust run-in-venv.bash to error messages to stderr
* Put back changes from PR #5579
* Invoke rst2man.py with the current python interpreter to avoid problems with the shebang being too long in some settings

Mostly trivial but by @ronawho - thanks!