### PR TITLE
Update start_test Python package dependencies

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,3 @@
-PyYAML==3.13
+PyYAML==5.3.1
 filelock==2.0.13
 argcomplete==1.9.4

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,3 @@
 PyYAML==5.3.1
 filelock==3.0.12
-argcomplete==1.9.4
+argcomplete==1.12.1

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,3 @@
 PyYAML==5.3.1
-filelock==2.0.13
+filelock==3.0.12
 argcomplete==1.9.4

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,3 @@
-argparse==1.3.0
 PyYAML==3.13
 filelock==2.0.13
 argcomplete==1.9.4


### PR DESCRIPTION
Due to trying to stay compliant with Python 2, start_test has had to rely on older versions of
its dependencies for a while now. Now that we've switched to relying on Python 3, we can
finally update these packages to later versions.

Removes the argparse requirement, as argparse is bundled into later versions of Python by
default.

Full paratest with futures passed.  Local spot test seemed to do fine.