### PR TITLE
Include util/run-in-venv.bash in install/tarball

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -128,6 +128,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "util/buildRelease/install.sh",
        "util/chpl-completion.bash",
        "util/printchplenv",
+       "util/run-in-venv.bash",
        "util/setchplenv.bash",
        "util/setchplenv.csh",
        "util/setchplenv.fish",

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -260,6 +260,8 @@ myinstalldir  modules                 "$DEST_CHPL_HOME"/modules
 # copy util/printchplenv
 myinstallfile util/printchplenv       "$DEST_CHPL_HOME"/util/
 
+myinstallfile util/run-in-venv.bash   "$DEST_CHPL_HOME"/util/
+
 # copy util/chplenv
 myinstalldir  util/chplenv            "$DEST_CHPL_HOME"/util/chplenv/
 


### PR DESCRIPTION
Follow-up to PR #16644 and PR #16560.

To resolve smoke test failures.

Reviewed by @ronawho - thanks!

- [x] verified that `util/buildRelease/gen_release` and untarring that and running `make check-chpldoc` in it works