### PR TITLE
Update Arkouda testing to use python 3.7

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -16,11 +16,18 @@ export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 export CHPL_TEST_ARKOUDA_PERF=true
 
-ARKOUDA_DEP_DIR=/cray/css/users/chapelu/arkouda-deps
+CSS_DIR=/cray/css/users/chapelu
+ARKOUDA_DEP_DIR=$CSS_DIR/arkouda-deps
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}
   export ARKOUDA_HDF5_PATH=${ARKOUDA_HDF5_PATH:-$ARKOUDA_DEP_DIR/hdf5-install}
   export PATH="$ARKOUDA_HDF5_PATH/bin:$PATH"
+fi
+
+# Arkouda requires Python >= 3.7
+SETUP_PYTON=$CSS_DIR/setup_python37.bash
+if [ -d $SETUP_PYTON ]; then
+  source $SETUP_PYTON
 fi
 
 # test against Chapel release (checking our current test/cron directories)

--- a/util/cron/test-perf.chapcs.arkouda.bash
+++ b/util/cron/test-perf.chapcs.arkouda.bash
@@ -8,8 +8,5 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.arkouda"
 source $CWD/common-arkouda.bash
 
-# chapcs only has python 3.4, need newer one for arkouda
-source /cray/css/users/chapelu/setup_python36.bash
-
 test_nightly
 sync_graphs

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -8,8 +8,5 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.arkouda.release"
 source $CWD/common-arkouda.bash
 
-# chapcs only has python 3.4, need newer one for arkouda
-source /cray/css/users/chapelu/setup_python36.bash
-
 test_release
 sync_graphs

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -24,8 +24,5 @@ export CHPL_LAUNCHER_CORES_PER_LOCALE=56
 export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"
 
-# XC has new enough python, but missing pip
-source /cray/css/users/chapelu/setup_python36.bash
-
 test_nightly
 sync_graphs

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -24,8 +24,5 @@ export CHPL_LAUNCHER_CORES_PER_LOCALE=56
 export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"
 
-# XC has new enough python, but missing pip
-source /cray/css/users/chapelu/setup_python36.bash
-
 test_release
 sync_graphs


### PR DESCRIPTION
Arkouda now requires python 3.7 so update our testing to bring in a new
enough python.

See https://github.com/mhmerrill/arkouda/issues/552 for more info.
