### PR TITLE
Update masonModify tests to use standard mason skipif

### DIFF
--- a/test/mason/mason-modify/SKIPIF
+++ b/test/mason/mason-modify/SKIPIF
@@ -1,1 +1,1 @@
-../suseSkipif
+../SKIPIF


### PR DESCRIPTION
Use standard SKIPIF in mason-modify tests instead of the SSL-specific one. The mason modify tests check `mason {add,rm}` commands, and do not rely on an updated openssl, like some other tests that install spack packages.