### PR TITLE
Fix problem with sphinx-building having too-long shebang

### DIFF
--- a/doc/Makefile.sphinx
+++ b/doc/Makefile.sphinx
@@ -1,8 +1,15 @@
 # Makefile for Sphinx documentation
-#
+
+ifndef CHPL_MAKE_PYTHON
+export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
+endif
+
+VENV_DIR = $(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_home_utils.py --venv)
+
+
 # You can set these variables from the command line.
 SPHINXOPTS    = -W -n
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD = $(CHPL_MAKE_PYTHON) $(VENV_DIR)/bin/sphinx-build
 PAPER         =
 SOURCEDIR     = rst
 BUILDDIR      = ../build/doc
@@ -12,7 +19,6 @@ BUILDPATH     = $$CHPL_HOME/doc/$(BUILDDIR)
 export CHPLDOC_AUTHOR=Hewlett Packard Enterprise Development LP
 
 # User-friendly check for sphinx-build
-SPHINXTEST=$(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?)
 SPHINXERROR="Error - The '$(SPHINXBUILD)' command was not found. Make sure you \
 have Sphinx installed, then set the SPHINXBUILD environment variable to point \
 to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add \
@@ -64,7 +70,13 @@ help-sphinx:
 check-sphinxbuild:
 	@echo
 	@echo "Confirming that sphinx-build is available..."
-	@if [ $(SPHINXTEST) -eq 1 ]; then echo $(SPHINXERROR); fi
+	@if $(SPHINXBUILD) --version > /dev/null 2>&1 ; \
+	then \
+	  echo OK ; \
+	else \
+	  echo $(SPHINXERROR) ; \
+	  exit 1 ; \
+	fi
 
 html-release: check-sphinxbuild source clean-build
 	@echo


### PR DESCRIPTION
We were seeing test failures with `make docs` due to the `sphinx-build`
in the venv having a shebang that is too long.

So, run it with `python3 path/to/sphinx-build`. A reasonable alternative
would be to run `third-party/chpl-venv/venv-use-sys-python.py` all the
time instead of in certain configurations.

While there, this PR improves the checking for a `sphinx-build` to check
that `sphinx-build --version` works.