### PR TITLE
Update c2chapel tests to work if c2chapel not in path

### DIFF
--- a/test/c2chapel/SKIPIF
+++ b/test/c2chapel/SKIPIF
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
-command -v c2chapel > /dev/null 2>&1 || { echo "True"; exit 0; }
-echo "False"
+BINDIR="$CHPL_HOME"/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
+C2CHAPEL="$BINDIR/c2chapel"
+if [[ -f "$C2CHAPEL"  && -x "$C2CHAPEL" ]]
+then
+  echo False
+else
+  echo True
+fi

--- a/test/c2chapel/printfWrapper.precomp
+++ b/test/c2chapel/printfWrapper.precomp
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-c2chapel printfWrapper.h > printfGen.chpl
+BINDIR="$CHPL_HOME"/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
+
+"$BINDIR"/c2chapel printfWrapper.h > printfGen.chpl

--- a/test/c2chapel/testFunctions.precomp
+++ b/test/c2chapel/testFunctions.precomp
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-c2chapel testFunctions.h > functionGen.chpl
+BINDIR="$CHPL_HOME"/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
+
+"$BINDIR"/c2chapel testFunctions.h > functionGen.chpl

--- a/test/c2chapel/testStructs.precomp
+++ b/test/c2chapel/testStructs.precomp
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-c2chapel testStructs.h > structGen.chpl
+BINDIR="$CHPL_HOME"/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
+
+"$BINDIR"/c2chapel testStructs.h > structGen.chpl

--- a/tools/c2chapel/test/tester.sh
+++ b/tools/c2chapel/test/tester.sh
@@ -2,6 +2,7 @@
 
 # This script must be run within c2chapel/test
 
+
 # Only use colors for stdout with a color-supporting terminal
 if test -t 1; then
   nc=$(tput colors)
@@ -13,9 +14,16 @@ if test -t 1; then
   fi
 fi
 
+C2CHAPEL=c2chapel
 if ! type "c2chapel" > /dev/null 2>&1; then
-  printf "${RED}Failure: c2chapel command not found${NORMAL}\n"
-  exit 1;
+  BINDIR="$CHPL_HOME"/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
+  C2CHAPEL="$BINDIR/c2chapel"
+  if [[ -f "$C2CHAPEL"  && -x "$C2CHAPEL" ]]; then
+    :
+  else
+    printf "${RED}Failure: c2chapel command not found${NORMAL}\n"
+    exit 1;
+  fi
 fi
 
 numFailures=0
@@ -36,7 +44,7 @@ function helper() {
   fi
 
   printf "%s: " "$msg"
-  c2chapel $args > $outFile 2>&1
+  "$C2CHAPEL" $args > $outFile 2>&1
   if diff $outFile $good > $diffFile 2>&1; then
     printf "${GREEN}OK${NORMAL}\n"
   elif diff $outFile $good2 > $diffFile 2>&1; then


### PR DESCRIPTION
Follow-up to PR #16644 and #16560.

PR #16644 stopped leaving anything in `CHPL_HOME` in `PATH` when running 
tests (because PATH was updated inconsistently in the past and because we
need to remove the venv path).

However that caused problems for test/c2chapel because it assumed 
c2chapel was in the PATH. This PR fixes those tests to find c2chapel in
the bin directory.

Reviewed by @ben-albrecht - thanks!

- [x] full local testing