### PR TITLE
Fix make && make man when CHPL_HOME is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ third-party-fltk: FORCE
 
 clean: FORCE
 	cd compiler && $(MAKE) clean
+	if [ -e man/Makefile ]; then cd man && $(MAKE) clean; fi
 	cd modules && $(MAKE) clean
 	cd runtime && $(MAKE) clean
 	cd third-party && $(MAKE) clean
@@ -179,6 +180,7 @@ clean: FORCE
 
 cleanall: FORCE
 	cd compiler && $(MAKE) cleanall
+	if [ -e man/Makefile ]; then cd man && $(MAKE) cleanall; fi
 	cd modules && $(MAKE) cleanall
 	cd runtime && $(MAKE) cleanall
 	cd third-party && $(MAKE) cleanall
@@ -192,6 +194,7 @@ cleandeps: FORCE
 
 clobber: FORCE
 	cd compiler && $(MAKE) clobber
+	if [ -e man/Makefile ]; then cd man && $(MAKE) clobber; fi
 	cd modules && $(MAKE) clobber
 	cd runtime && $(MAKE) clobber
 	cd third-party && $(MAKE) clobber

--- a/man/Makefile
+++ b/man/Makefile
@@ -31,6 +31,10 @@ chpldoc: $(CHPLDOC_MANPAGE)
 clean:
 	rm -f $(TARGETS) $(CHPLDOC_MANPAGE)
 
+clobber: clean
+
+cleanall: clean
+
 man1/%.1: %.rst Makefile
 	mkdir -p $(shell dirname $@)
 	sed "/conf$</r conf$<" $< > $<.tmp

--- a/util/config/run-in-venv.bash
+++ b/util/config/run-in-venv.bash
@@ -3,8 +3,8 @@
 # usage: ./run-in-venv prog [args]
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set" 1>&2
-  exit 1
+  # compute the chpl home directory
+  export CHPL_HOME=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
 fi
 
 python=$($CHPL_HOME/util/config/find-python.sh)


### PR DESCRIPTION
Follow-up to PR #16644 and #16560

Some nightly testing configurations run `make` and then `make man`
without having `CHPL_HOME` set. However, `make man` was recently
changed to use `run-in-venv.bash` but this script required `CHPL_HOME`
be set.

This PR adjusts `run-in-venv.bash` to determine `CHPL_HOME` if it is
not set and in that event to set `CHPL_HOME` for the subcommand. This
allows `make && make man` as well as `make && make docs`
to function when `CHPL_HOME` is not set.

While testing this PR, I noticed additionally that `make clobber` does
not remove the generated files in `man/man1`, so this PR adjusts
`Makefile` and `man1/Makefile` to do so.

Reviewed by @ronawho - thanks!

- [x] make && make man && make docs works
- [x] test/chpldoc/ passes