### PR TITLE
Update version to 1.23.1, preparing for HPE Cray EX v1.3 releases.

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -23,7 +23,7 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION 23
-#define UPDATE_VERSION 0
+#define UPDATE_VERSION 1
 
 static const char* BUILD_VERSION =
 #include "BUILD_VERSION"

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -78,7 +78,7 @@ html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
 # release = '1.23.0 (pre-release)'
-release = '1.23.0'
+release = '1.23.1'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.23.0.tar.gz
+         tar xzf chapel-1.23.1.tar.gz
 
    b. Make sure that your shell is in the directory containing
       QUICKSTART.rst, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.23.0
+         cd chapel-1.23.1
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -37,7 +37,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.23.0
+        export CHPL_HOME=~/chapel-1.23.1
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.23.0
+:Version: 1.23.1
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.23.0
+:Version: 1.23.1
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.23.0
+ version 1.23.1

--- a/test/mason/init/masonInteractive.good
+++ b/test/mason/init/masonInteractive.good
@@ -8,7 +8,7 @@ Package name : Package version (0.1.0): Chapel version (1.23.0): License (None):
 [brick]
 name = "project"
 version = "1.2.3"
-chplVersion = "1.21.0"
+chplVersion = "1.23.1"
 license = "MIT"
 
 [dependencies]

--- a/test/mason/new/masonInteractive.good
+++ b/test/mason/new/masonInteractive.good
@@ -8,7 +8,7 @@ Package name : Package version (0.1.0): Chapel version (1.23.0): License (None):
 [brick]
 name = "project"
 version = "1.2.3"
-chplVersion = "1.21.0"
+chplVersion = "1.23.1"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
EX v1.3 development and maintenance will be based on the 1.23 release
sources rather than the more volatile master branch. Here, prepare for
that by updating the version number.  This makes the same sort of
changes as were done in #16228 which prepared for EX 1.3 in the
release/1.22 branch by bumping to 1.22.2, and as were done in #16578
which recently updated to 1.24.  However, it skips the things the latter
did to put us back into "normal" (pre-release) mode, because for the
purposes of chasing the evolution of EX we're always in release mode.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>