### PR TITLE
Remove references to internal PyPI mirror

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -396,13 +396,6 @@ else
         ;;
     ( venv )
         load_prgenv_gnu
-
-        # If the installed libssl is too old to support TLS 1.1, some
-        # workarounds exist to enable building Chapel python-venv tools anyway.
-        # For example, the following gives a URL to a local PyPI mirror.
-
-        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
         ;;
     ( "" )
         : ok

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -330,11 +330,6 @@ else
         ;;
     ( venv )
         load_prgenv_gnu
-
-        # The following gives a URL to a local PyPI mirror that accepts http. It is optional for this build.
-
-        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
         ;;
     ( "" )
         : ok

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -386,13 +386,6 @@ else
         ;;
     ( venv )
         load_prgenv_gnu
-
-        # If the installed libssl is too old to support TLS 1.1, some
-        # workarounds exist to enable building Chapel python-venv tools anyway.
-        # For example, the following gives a URL to a local PyPI mirror.
-
-        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
         ;;
     ( "" )
         : ok


### PR DESCRIPTION
The internal PyPI mirror is not being maintained and as such does not have the
most up to date version of several Python packages.  Stop using it.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>