### PR TITLE
 Adjust env vars instead of using venv activate

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -70,6 +70,8 @@ $(CHPL_VENV_INSTALL_DIR):
 	mkdir -p $@
 
 # Create the virtualenv.
+# Replace the symlink to python3 with python3-wrapper
+#  (to allow for a different path to the system python3 in the future)
 $(CHPL_VENV_VIRTUALENV_DIR):
 	$(PYTHON) -m venv $@
 	export PYTHONPATH="$(PIPLIBS):$$PYTHONPATH" && \
@@ -77,8 +79,8 @@ $(CHPL_VENV_VIRTUALENV_DIR):
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	$(PIP) install \
 	--upgrade $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) wheel && \
-	rm  $(CHPL_VENV_VIRTUALENV_BIN)/python3
-	cp python3-wrapper $(CHPL_VENV_VIRTUALENV_BIN)/python3
+	rm -f $(CHPL_VENV_VIRTUALENV_BIN)/python3 && \
+	cp python3-wrapper $(CHPL_VENV_VIRTUALENV_BIN)/python3 && \
 	touch $(CHPL_VENV_VIRTUALENV_DIR)
 
 # Phony convenience target for creating virtualenv.

--- a/tools/c2chapel/c2chapel
+++ b/tools/c2chapel/c2chapel
@@ -25,15 +25,6 @@ if [ -z "$CHPL_HOME" ]; then
   exit 1
 fi
 
-python=$($CHPL_HOME/util/config/find-python.sh)
-venv_path=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --venv)
+exec $CHPL_HOME/util/config/run-in-venv.bash \
+     $CHPL_HOME/tools/c2chapel/c2chapel.py "$@"
 
-if [ ! -d "$venv_path" ]; then
-  echo "Error: virtualenv '$venv_path' does not exist"
-  exit 1
-fi
-
-. ${venv_path}/bin/activate
-
-PREFIX=$CHPL_HOME/tools/c2chapel
-exec ${PREFIX}/c2chapel.py "${@}"

--- a/util/config/run-in-venv.bash
+++ b/util/config/run-in-venv.bash
@@ -8,18 +8,21 @@ if [ -z "$CHPL_HOME" ]; then
 fi
 
 python=$($CHPL_HOME/util/config/find-python.sh)
-venv_path=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --venv)
+venv_dir=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --venv)
 
-if [ ! -d "$venv_path" ]; then
-  echo "Error: virtualenv '$venv_path' does not exist" 1>&2
+if [ ! -d "$venv_dir" ]; then
+  echo "Error: virtualenv '$venv_dir' does not exist" 1>&2
   exit 1
 fi
 
-if [ ! -f "$venv_path/bin/activate" ]; then
-  echo "Activation file $venv_path/bin/activate is missing" 1>&2
+if [ ! -f "$venv_dir/bin/python3" ]; then
+  echo "python3 wrapper file $venv_dir/bin/python3 is missing" 1>&2
   exit 1
 fi
 
-source "$venv_path/bin/activate"
+# these steps correspond to what a venv activate script contains
+export VIRTUAL_ENV="$venv_dir"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
+unset PYTHONHOME
 
 exec "$1" "${@:2}"

--- a/util/test/run-in-test-venv.bash
+++ b/util/test/run-in-test-venv.bash
@@ -31,14 +31,15 @@ else
 
   fi
 
-  if [ ! -f "$venv_dir/bin/activate" ]
-  then
-    echo "Activation file $venv_dir/bin/activate is missing" 1>&2
+  if [ ! -f "$venv_dir/bin/python3" ]; then
+    echo "python3 wrapper file $venv_dir/bin/python3 is missing" 1>&2
     exit 1
-
   fi
 
-  source "$venv_dir/bin/activate"
+  # these steps correspond to what a venv activate script contains
+  export VIRTUAL_ENV="$venv_dir"
+  export PATH="$VIRTUAL_ENV/bin:$PATH"
+  unset PYTHONHOME
 
 fi
 


### PR DESCRIPTION
Follow-up to PR #16644 and #16560

This PR (along with PR #16663) is intended to resolve warnings in nightly
testing like this

```
[Warning: could not import filelock]
```

The venv activate script stores the absolute path but that causes
problems in case it changes (e.g. if `CHPL_HOME` is renamed or in the
case of module builds).

So, this PR changes `run-in-venv.bash` and `run-in-test-venv.bash` to
adjust environment variables directly rather that using the activate
script. It also adjusts c2chapel to use `run-in-venv.bash` instead of the
activate script.

Reviewed by @lydia-duncan - thanks!

- [x] test/c2chapel and test/chpldoc pass after building chpldoc and c2chapel
- [x] full local testing
