### PR TITLE
Revert "Remove generated man pages on clean/cleanall/clobber"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ third-party-fltk: FORCE
 
 clean: FORCE
 	cd compiler && $(MAKE) clean
-	if [ -e man/Makefile ]; then cd man && $(MAKE) clean; fi
 	cd modules && $(MAKE) clean
 	cd runtime && $(MAKE) clean
 	cd third-party && $(MAKE) clean
@@ -180,7 +179,6 @@ clean: FORCE
 
 cleanall: FORCE
 	cd compiler && $(MAKE) cleanall
-	if [ -e man/Makefile ]; then cd man && $(MAKE) cleanall; fi
 	cd modules && $(MAKE) cleanall
 	cd runtime && $(MAKE) cleanall
 	cd third-party && $(MAKE) cleanall
@@ -194,7 +192,6 @@ cleandeps: FORCE
 
 clobber: FORCE
 	cd compiler && $(MAKE) clobber
-	if [ -e man/Makefile ]; then cd man && $(MAKE) clobber; fi
 	cd modules && $(MAKE) clobber
 	cd runtime && $(MAKE) clobber
 	cd third-party && $(MAKE) clobber

--- a/man/Makefile
+++ b/man/Makefile
@@ -31,10 +31,6 @@ chpldoc: $(CHPLDOC_MANPAGE)
 clean:
 	rm -f $(TARGETS) $(CHPLDOC_MANPAGE)
 
-clobber: clean
-
-cleanall: clean
-
 man1/%.1: %.rst Makefile
 	mkdir -p $(shell dirname $@)
 	sed "/conf$</r conf$<" $< > $<.tmp


### PR DESCRIPTION
This reverts commit 0b4a2c622a76a093174ac3ad414bb5a69b112a14.

It turns out that our module build relies on `make clobber` explicitly leaving
the man pages behind.  We do think it's reasonable for `make clobber` to remove
these files and expect the right thing to do is probably to make a special
clean up command for the module build to call that removes most things except
the built man pages.  But we need to think about that a bit more, so just
revert this change for now.