### PR TITLE
Adjust whitebox testing for esxbld to kay-elogin move

### DIFF
--- a/test/library/packages/NetCDF.skipif
+++ b/test/library/packages/NetCDF.skipif
@@ -17,6 +17,5 @@ from socket import gethostname
 
 foundLib = not (find_library('netcdf') is None)
 isXC = getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
-isWhitebox = gethostname().startswith("esxbld");
 
-print((not foundLib) or isXC or isWhitebox)
+print((not foundLib) or isXC)

--- a/test/release/examples/primers/LAPACKlib.skipif
+++ b/test/release/examples/primers/LAPACKlib.skipif
@@ -4,10 +4,9 @@ import os, os.path
 
 isXC = os.getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
 isGNU = 'gnu' in str(os.getenv('CHPL_TARGET_COMPILER'))
-isWB = not (os.path.exists('/etc/opt/cray/release/CLEinfo') or os.path.exists('/etc/opt/cray/release/cle-release'))
 isLLVM = '--llvm' in str(os.getenv('COMPOPTS'))
 
-if isXC and isGNU and not isWB and not isLLVM:
+if isXC and isGNU and not isLLVM:
   print(False) # Don't skip
 else:
   print(True) # Do skip

--- a/test/studies/compOcean/compOcean.skipif
+++ b/test/studies/compOcean/compOcean.skipif
@@ -17,6 +17,5 @@ from socket import gethostname
 
 foundLib = not (find_library('netcdf') is None)
 isXC = getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
-isWhitebox = gethostname().startswith("esxbld");
 
-print((not foundLib) or isXC or isWhitebox)
+print((not foundLib) or isXC)

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -97,11 +97,6 @@ if [ "${COMPILER}" != "gnu" ] ; then
     module load gcc/7.3.0
 fi
 
-# quiet libu warning about cpuid detection failure
-if [ "${COMPILER}" == "cray" ] ; then
-  export RFE_811452_DISABLE=true
-fi
-
 # Then load the selected compiler
 load_target_compiler ${COMPILER}
 
@@ -126,9 +121,6 @@ case $COMPILER in
         ;;
 esac
 
-log_info "Unloading cray-libsci module"
-module unload cray-libsci
-
 log_info "Unloading cray-mpich module"
 module unload cray-mpich
 
@@ -151,29 +143,15 @@ export CHPL_COMM=none
 export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
-# Ensure that one of the CPU modules is loaded.
-my_arch=$($CHPL_HOME/util/chplenv/chpl_cpu.py 2> /dev/null)
-if [ "${my_arch}" = "none" ] ; then
-    log_info "Loading craype-shanghai module to stifle chpl_cpu.py warnings."
-    module load craype-shanghai
-fi
+# Ensure compatible CPU targeting module is loaded. Unload any existing one
+# (craype- that's not network/ hugepages) and load sandybridge, the LCD for XC
+log_info "Loading craype-sandybridge."
+module unload $(module -t list 2>&1 | grep craype- | grep -v network  | grep -v hugepage)
+module load craype-sandybridge
 
-# no cpu targeting module supports the esxbld CPUs, so force x86-64
-if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
-    module unload $(module -t list 2>&1| grep craype-| grep -v craype-network |grep -v craype-target)
-    log_info "Setting CRAY_CPU_TARGET to x86-64 to stifle chpl_cpu.py warnings."
-    export CRAY_CPU_TARGET=x86-64
-fi
 
-if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then
-    # We want cray-fftw with PrgEnv compilers.  But that in turns loads
-    # cray-mpich and our PGI target compiler is so old that bringing in
-    # cray-mpich has become impossible, so skip cray-fftw with PGI.
-    if [ "${COMPILER}" != "pgi" ] ; then
-      log_info "Loading cray-fftw module."
-      module load cray-fftw
-    fi
-fi
+log_info "Loading cray-fftw module."
+module load cray-fftw
 
 log_info "Current loaded modules:"
 module list


### PR DESCRIPTION
We used to run on machines that emulated a Cray XC, but we now run on a
real elogin node. To that end we can use a real CPU targeting module and
remove some old workarounds.