### PR TITLE
Require CPtr to get access to c_void_ptr

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -691,7 +691,7 @@ void initPrimitiveTypes() {
 
   // Could be == c_ptr(int(8)) e.g.
   // used in some runtime interfaces
-  dtCVoidPtr   = createPrimitiveType("c_void_ptr", "c_void_ptr" );
+  dtCVoidPtr   = createPrimitiveType("chpl__c_void_ptr", "c_void_ptr" );
   dtCVoidPtr->symbol->addFlag(FLAG_NO_CODEGEN);
   dtCVoidPtr->defaultValue = gNil;
 

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -203,6 +203,8 @@ const char* toString(Type* type, bool decorateAllClasses) {
           retval = useName;
         }
       }
+    } else if (vt == dtCVoidPtr) {  // de-sugar chpl__c_void_ptr
+      retval = "c_void_ptr";
     }
 
     if (retval == NULL)

--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -92,7 +92,7 @@ void expandExternArrayCalls() {
           SET_LINENO(formal);
           formal->typeExpr->replace(
               new BlockStmt(
-                new UnresolvedSymExpr("c_void_ptr")));
+                new UnresolvedSymExpr("chpl__c_void_ptr")));
         }
       }
       current_formal++;

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -92,7 +92,7 @@ static Expr* convertPointerToChplType(ModuleSymbol* module,
 
   // Pointers to void (aka void*) convert to c_void_ptr
   if (pointeeType.getTypePtr()->isVoidType()) {
-    return tryCResolveExpr(module, "c_void_ptr");
+    return tryCResolveExpr(module, "chpl__c_void_ptr");
   }
 
   Expr* pointee = convertToChplType(module, pointeeType.getTypePtr());

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -66,7 +66,7 @@ module ChapelDebugPrint {
   pragma "no doc"
   config param chpl__testParFlag = false;
   pragma "no doc"
-  config var chpl__testParOn = true;
+  var chpl__testParOn = false;
 
   pragma "no doc"
   proc chpl__testParStart() {

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -66,7 +66,7 @@ module ChapelDebugPrint {
   pragma "no doc"
   config param chpl__testParFlag = false;
   pragma "no doc"
-  var chpl__testParOn = false;
+  config var chpl__testParOn = true;
 
   pragma "no doc"
   proc chpl__testParStart() {

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -920,6 +920,7 @@ module ChapelSyncvar {
 private module SyncVarRuntimeSupport {
   use ChapelStandard, SysCTypes;
   use AlignedTSupport;
+  use CPtr;
 
   //
   // Sync var externs

--- a/modules/internal/LocaleModelHelpMem.chpl
+++ b/modules/internal/LocaleModelHelpMem.chpl
@@ -28,7 +28,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpMem {
-  private use ChapelStandard, SysCTypes;
+  private use ChapelStandard, SysCTypes, CPtr;
 
   //////////////////////////////////////////
   //

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -28,7 +28,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpRuntime {
-  private use ChapelStandard, SysCTypes;
+  private use ChapelStandard, SysCTypes, CPtr;
 
   // The chpl_localeID_t type is used internally.  It should not be exposed to
   // the user.  The runtime defines the actual type, as well as a functional

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -22,6 +22,7 @@ pragma "atomic module"
 module NetworkAtomics {
   private use ChapelStandard;
   private use MemConsistency;
+  private use CPtr;
 
   private proc externFunc(param s: string, type T) param {
     if isInt(T)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(T):string;

--- a/modules/minimal/internal/IO.chpl
+++ b/modules/minimal/internal/IO.chpl
@@ -22,10 +22,8 @@ module IO {
 
   extern type syserr;
   extern type qio_channel_ptr_t;
-
   private extern proc qio_int_to_err(a:int(32)):syserr;
-
-  type c_void_ptr = chpl__c_void_ptr;
+  extern type c_void_ptr = chpl__c_void_ptr;
 
   export proc chpl_qio_setup_plugin_channel(file:c_void_ptr, ref plugin_ch:c_void_ptr, start:int(64), end:int(64), qio_ch:qio_channel_ptr_t):syserr {
     return qio_int_to_err(0);

--- a/modules/minimal/internal/IO.chpl
+++ b/modules/minimal/internal/IO.chpl
@@ -25,6 +25,8 @@ module IO {
 
   private extern proc qio_int_to_err(a:int(32)):syserr;
 
+  type c_void_ptr = chpl__c_void_ptr;
+
   export proc chpl_qio_setup_plugin_channel(file:c_void_ptr, ref plugin_ch:c_void_ptr, start:int(64), end:int(64), qio_ch:qio_channel_ptr_t):syserr {
     return qio_int_to_err(0);
   } 

--- a/modules/packages/NetCDF.chpl
+++ b/modules/packages/NetCDF.chpl
@@ -47,7 +47,7 @@ module NetCDF {
      https://www.unidata.ucar.edu/software/netcdf/docs
    */
   module C_NetCDF {
-    public use SysCTypes, SysBasic;
+    public use SysCTypes, SysBasic, CPtr;
     // Generated with c2chapel version 0.1.0
 
     // Header given to c2chapel:

--- a/modules/packages/Prefetch.chpl
+++ b/modules/packages/Prefetch.chpl
@@ -35,5 +35,6 @@ module Prefetch {
 }
 
 module Prefetch_internal {
+  use CPtr;
   extern proc chpl_prefetch(addr: c_void_ptr);
 }

--- a/modules/standard/CPtr.chpl
+++ b/modules/standard/CPtr.chpl
@@ -32,7 +32,7 @@ module CPtr {
 
 
   /* A Chapel type alias for 'void*' in C. */
-  type c_void_ptr = chpl__c_void_ptr;
+  extern type c_void_ptr = chpl__c_void_ptr;
 
 
   /* A Chapel version of a C NULL pointer. */

--- a/modules/standard/CPtr.chpl
+++ b/modules/standard/CPtr.chpl
@@ -30,6 +30,11 @@ module CPtr {
   private use SysBasic, SysError, SysCTypes;
   private import HaltWrappers;
 
+
+  /* A Chapel type alias for 'void*' in C. */
+  type c_void_ptr = chpl__c_void_ptr;
+
+
   /* A Chapel version of a C NULL pointer. */
   inline proc c_nil:c_void_ptr {
     return __primitive("cast", c_void_ptr, nil);

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -340,7 +340,7 @@ Regular Expression Types and Methods
 
  */
 module Regexp {
-  private use SysBasic, SysError, SysCTypes;
+  private use SysBasic, SysError, SysCTypes, CPtr;
 
 pragma "no doc"
 extern type qio_regexp_t;

--- a/test/classes/delete-free/unmanaged/unmanaged-cast-void-ptr.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-cast-void-ptr.chpl
@@ -9,6 +9,7 @@ class MyClass : ParentClass {
 }
 
 proc test() {
+  use CPtr;
   var x = new unmanaged MyClass(1);
   var y = x:borrowed ParentClass;
   var z = x:c_void_ptr;

--- a/test/deprecated/c-void-ptr-non-nilable-casts.chpl
+++ b/test/deprecated/c-void-ptr-non-nilable-casts.chpl
@@ -1,5 +1,5 @@
 class MyClass { var x: int; }
-
+use CPtr;
 proc main() {
   var c = new MyClass();
   var ptr = c.borrow():c_void_ptr;

--- a/test/expressions/AtomicObject/voidPtrTest-unmanaged.chpl
+++ b/test/expressions/AtomicObject/voidPtrTest-unmanaged.chpl
@@ -1,5 +1,5 @@
 class Obj { var x : int; var y : int; var z : int;}
-
+use CPtr;
 proc fn(f : c_void_ptr) {
 	writeln(f : unmanaged Obj?);
 }

--- a/test/expressions/AtomicObject/voidPtrTest.chpl
+++ b/test/expressions/AtomicObject/voidPtrTest.chpl
@@ -1,5 +1,5 @@
 class Obj { var x : int; var y : int; var z : int;}
-
+use CPtr;
 proc fn(f : c_void_ptr) {
 	writeln(f : borrowed Obj?);
 }

--- a/test/extern/ferguson/c_void_pointer.chpl
+++ b/test/extern/ferguson/c_void_pointer.chpl
@@ -1,3 +1,5 @@
+use CPtr;
+
 extern proc mytest(x: c_void_ptr):c_void_ptr;
 
 proc mytest2(x: c_void_ptr):c_void_ptr

--- a/test/runtime/configMatters/mem/fragmentation.chpl
+++ b/test/runtime/configMatters/mem/fragmentation.chpl
@@ -27,7 +27,7 @@ assert(cnt == numTrials);
 // Estimate for how much memory we can allocate. Based on
 // chpl_comm_regMemHeapInfo if using a fixed heap, otherwise physical memory
 proc availMem() {
-  use SysCTypes;
+  use SysCTypes, CPtr;
   extern proc chpl_comm_regMemHeapInfo(ref start: c_void_ptr, ref size: size_t): void;
   var unused: c_void_ptr;
   var heap_size: size_t;

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -19,6 +19,7 @@ printvisibleOptFalse.chpl:2: Printing symbols visible from here:
   modules/minimal/internal/ChapelUtil.chpl:41: chpl_deinitModules
   modules/minimal/internal/IO.chpl:23: syserr
   modules/minimal/internal/IO.chpl:24: qio_channel_ptr_t
+  modules/minimal/internal/IO.chpl:26: c_void_ptr
   modules/minimal/internal/IO.chpl:28: chpl_qio_setup_plugin_channel
   modules/minimal/internal/IO.chpl:31: chpl_qio_read_atleast
   modules/minimal/internal/IO.chpl:34: chpl_qio_write

--- a/test/types/cptr/void_ptr_object.chpl
+++ b/test/types/cptr/void_ptr_object.chpl
@@ -5,7 +5,7 @@ class C {
 
 
 proc main() {
-
+  use CPtr;
   var c = new unmanaged C(1);
   // cast it to a c_void_ptr
   var ptr1 = c:c_void_ptr;

--- a/test/types/string/nspark/cast-cstring-to-cvoidptr.chpl
+++ b/test/types/string/nspark/cast-cstring-to-cvoidptr.chpl
@@ -1,6 +1,6 @@
 require 'cast-cstring-to-cvoidptr.h', 'cast-cstring-to-cvoidptr.c';
 
-use SysCTypes;
+use SysCTypes, CPtr;
 
 extern proc strlen(const s: c_string): size_t;
 extern proc strlen_voidptr(const s: c_void_ptr): size_t;


### PR DESCRIPTION
While working with Engin on making `CPtr` not be visible by default, I noticed that `c_void_ptr` is available by default due to the fact that the compiler introduces it.  This PR makes it only visible through CPtr by renaming the compiler-introduced variable to `chpl__c_void_ptr` and then introducing a type alias for it named `c_void_ptr` within CPtr.chpl.  As a nice side effect, this adds documentation for `c_void_ptr` to the `CPtr` module, where we didn't really have a good place for it before.  For the most part, this is fairly clean, though it does introduce the need to de-sugar the built-in type in type.cpp's `toString()` routine.

The changes are essentially:
* type.cpp: changed the compiler's type name and desugared it when converting to a string
* modules/standard/CPtr.chpl: added a user facing `c_void_ptr` type alias; made it extern to avoid codegen-ing
* modules/minimal/internal/IO.chpl: added a `c_void_ptr` alias for references to it in this file
* modules/*: added necessary `use CPtr;` statements where auto-availability of `c_void_ptr` had been assumed
* test/*.chpl: same as previous
* test/trivial/diten/printvisibleOptFalse.good: added a listing for `c_void_ptr` corresponding to bullet 3 above

Resolves #16671.