### PR TITLE
Add module list commands to arkouda cray-cs and cray-xc jobs

### DIFF
--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -11,9 +11,14 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.arkouda"
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+module list
+
 # setup for CS perf (gasnet-large, gnu, 36-core Broadwell)
 source $CWD/common-cray-cs.bash
 source $CWD/common-perf-cray-cs.bash
+
+module list
+
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv

--- a/util/cron/test-perf.cray-cs.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.release.bash
@@ -11,9 +11,14 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.arkouda.release"
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+module list
+
 # setup for CS perf (gasnet-large, gnu, 36-core Broadwell)
 source $CWD/common-cray-cs.bash
 source $CWD/common-perf-cray-cs.bash
+
+module list
+
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -11,6 +11,8 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda"
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+module list
+
 # setup for XC perf (ugni, gnu, 28-core broadwell)
 module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
@@ -18,6 +20,8 @@ module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp
+
+module list
 
 export CHPL_LAUNCHER_CONSTRAINT=BW28
 export CHPL_LAUNCHER_CORES_PER_LOCALE=56

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -11,6 +11,8 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda.release"
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+module list
+
 # setup for XC perf (ugni, gnu, 28-core broadwell)
 module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
@@ -18,6 +20,8 @@ module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp
+
+module list
 
 export CHPL_LAUNCHER_CONSTRAINT=BW28
 export CHPL_LAUNCHER_CORES_PER_LOCALE=56


### PR DESCRIPTION
In debugging issues with the arkouda jobs as a result of our Python 3 changes,
I found myself wanting to know more about the environment in which these jobs
were run.  This change adds two `module list` commands to the jobs - one prior
to any modifications and one just after we expect the module list to be stable.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>