### PR TITLE
Improve slurm for AWS auto-scaling

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -106,7 +106,7 @@ static int getCoresPerLocale(int nomultithread) {
   const int buflen = 1024;
   char buf[buflen];
   char partition_arg[128];
-  char* argv[8];
+  char* argv[7];
   char* numCoresString = getenv("CHPL_LAUNCHER_CORES_PER_LOCALE");
 
   if (numCoresString) {
@@ -121,13 +121,12 @@ static int getCoresPerLocale(int nomultithread) {
   argv[2] = (char *)  "--format=%c %Z"; // format for cpu/node and threads/cpu (%c %Z)
   argv[3] = (char *)  "--sort=+c";      // sort by num cpu (lower to higher)
   argv[4] = (char *)  "--noheader";     // don't show header (hide "CPU" header)
-  argv[5] = (char *)  "--responding";   // only care about online nodes
-  argv[6] = NULL;
+  argv[5] = NULL;
   // Set the partition if it was specified
   if (partition) {
     sprintf(partition_arg, "--partition=%s", partition);
-    argv[6] = partition_arg;
-    argv[7] = NULL;
+    argv[5] = partition_arg;
+    argv[6] = NULL;
   }
 
   memset(buf, 0, buflen);


### PR DESCRIPTION
Stop throwing `--responding` when trying to determine the number of
cores for slurm. With AWS auto-scaling nodes will go offline when they
haven't been used in a while so we want to consider non-responding nodes
too.

This was originally added in d5be4cccd8 but there wasn't any strong
reason for it, there just didn't seem to be a good reason to consider
offline nodes, but there is now.

Without this when using auto-scaling we'd see:
```
warning: Unable to run 'sinfo' (no bytes read)
error: Error trying to determine number of cores per node
```