### PR TITLE
Improve CHPL_LIBFABRIC handling.

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from distutils.spawn import find_executable
 import sys
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -3,7 +3,7 @@ from distutils.spawn import find_executable
 import sys
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils
-from utils import error, memoize, run_command_deluxe
+from utils import error, memoize, try_run_command
 
 
 @memoize
@@ -13,10 +13,9 @@ def get():
         libfabric_val = overrides.get('CHPL_LIBFABRIC')
         platform_val = chpl_platform.get('target')
         if not libfabric_val:
-            exists, returncode = run_command_deluxe(['pkg-config',
-                                                    '--exists',
-                                                    'libfabric'])[0:2]
-
+            exists, returncode = try_run_command(['pkg-config',
+                                                  '--exists',
+                                                  'libfabric'])[0:2]
             if exists and returncode == 0:
                 libfabric_val = 'system'
             else:

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
+from distutils.spawn import find_executable
 import sys
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils
-from utils import error, memoize
+from utils import error, memoize, run_command_deluxe
 
 
 @memoize
@@ -12,7 +13,11 @@ def get():
         libfabric_val = overrides.get('CHPL_LIBFABRIC')
         platform_val = chpl_platform.get('target')
         if not libfabric_val:
-            if platform_val == 'hpe-cray-ex':
+            exists, returncode = run_command_deluxe(['pkg-config',
+                                                    '--exists',
+                                                    'libfabric'])[0:2]
+
+            if exists and returncode == 0:
                 libfabric_val = 'system'
             else:
                 libfabric_val = 'libfabric'

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -23,6 +23,7 @@ chplvars = [
              'CHPL_COMM',
              'CHPL_COMM_SUBSTRATE',
              'CHPL_GASNET_SEGMENT',
+             'CHPL_LIBFABRIC',
              'CHPL_TASKS',
              'CHPL_LAUNCHER',
              'CHPL_TIMERS',

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -33,8 +33,9 @@ class CommandError(Exception):
     pass
 
 
-def run_command_deluxe(command, stdout=True, stderr=False, cmd_input=None):
-    """Command subprocess wrapper.
+def try_run_command(command, stdout=True, stderr=False, cmd_input=None):
+    """Command subprocess wrapper tolerating failure to find or run the cmd.
+       For normal usage the vanilla run_command() may be simpler to use.
        This should be the only invocation of subprocess in all chplenv scripts.
        This could be replaced by subprocess.check_output, but that
        is only available after Python 2.7, and we still support 2.6 :("""
@@ -59,8 +60,10 @@ def run_command_deluxe(command, stdout=True, stderr=False, cmd_input=None):
 
 
 def run_command(command, stdout=True, stderr=False, cmd_input=None):
-    exists, returncode, output = run_command_deluxe(command, stdout, stderr,
-                                                    cmd_input)
+    """Command subprocess wrapper.
+       This is the usual way to run a command and collect its output."""
+    exists, returncode, output = try_run_command(command, stdout, stderr,
+                                                 cmd_input)
     if not exists:
         error("command not found: {0}".format(command[0]), OSError)
     if returncode != 0:

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -33,7 +33,7 @@ class CommandError(Exception):
     pass
 
 
-def run_command(command, stdout=True, stderr=False, cmd_input=None):
+def run_command_deluxe(command, stdout=True, stderr=False, cmd_input=None):
     """Command subprocess wrapper.
        This should be the only invocation of subprocess in all chplenv scripts.
        This could be replaced by subprocess.check_output, but that
@@ -44,23 +44,30 @@ def run_command(command, stdout=True, stderr=False, cmd_input=None):
                                    stderr=subprocess.PIPE,
                                    stdin=subprocess.PIPE)
     except OSError:
-        error("command not found: {0}".format(command[0]), OSError)
-
+        return False, 0, ''
     byte_cmd_input = str.encode(cmd_input, "utf-8") if cmd_input else None
     output = process.communicate(input=byte_cmd_input)
-    if process.returncode != 0:
+    output = (output[0].decode("utf-8"), output[1].decode("utf-8"))
+    if stdout and stderr:
+        return True, process.returncode, output
+    elif stdout:
+        return True, process.returncode, output[0]
+    elif stderr:
+        return True, process.returncode, output[1]
+    else:
+        return True, process.returncode, ''
+
+
+def run_command(command, stdout=True, stderr=False, cmd_input=None):
+    exists, returncode, output = run_command_deluxe(command, stdout, stderr,
+                                                    cmd_input)
+    if not exists:
+        error("command not found: {0}".format(command[0]), OSError)
+    if returncode != 0:
         error("command failed: {0}\noutput was:\n{1}".format(
             command, output[1]), CommandError)
-    else:
-        output = (output[0].decode("utf-8"), output[1].decode("utf-8"))
-        if stdout and stderr:
-            return output
-        elif stdout:
-            return output[0]
-        elif stderr:
-            return output[1]
-        else:
-            return ''
+    return output
+
 
 def run_live_command(command):
     """Run a command, yielding the merged output (stdout/stderr) as the process


### PR DESCRIPTION
(Duplicate PR #16605 from master to 1.23-for-EX.)

Make a couple of adjustments to the CHPL_LIBFABRIC handling. The main
change is to default to CHPL_LIBFABRIC=system whenever pkg-config exists
and can find a libfabric, on the assumption that a system one is more
likely to match up with the system's characteristics than our bundled
one is. While here, also add CHPL_LIBFABRIC to the list of config vars
that can override our defaults, getting rid of an incorrect and annoying
but nevertheless harmless message during compilation.