### PR TITLE
Stop loading a gcc "gen" compiler for non gnu builds

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -86,17 +86,6 @@ esac
 # building with newer compilers.
 source $CHPL_INTERNAL_REPO/build/compiler_versions.bash
 
-# Always load the right version of GCC since we use it sometimes
-# to e.g. build the Chapel compiler with COMP_TYPE=TARGET
-if [ "${COMPILER}" != "gnu" ] ; then
-    ### TEMPORARY
-    # Restore the following line when we can.
-    # module load gcc/${CHPL_GCC_TARGET_VERSION}
-    # For now, we need to force it to gcc 7.3.0 so its libraries will
-    # link with earlier versions of the Intel compiler.
-    module load gcc/7.3.0
-fi
-
 # Then load the selected compiler
 load_target_compiler ${COMPILER}
 


### PR DESCRIPTION
We used to load a gcc gen compiler so that we'd have a newer gcc to
build the compiler with even when doing intel/cce runtime builds.
However, the Lmod module system does not allow intel and gcc to be
loaded at the same time so stop doing this. This was motivated by gcc
7.3.0 not being available on our target machine anymore, but even if we
used a newer version the `module load PrgEnv-intel` will just unload
gcc.
