### PR TITLE
Refactor docs related to DCOs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,15 +1,22 @@
-# How to Contribute
+# Contributing to Chapel
 
-As an open-source project, Chapel welcomes source contributions from 
-the community.  Chapel enforces the Developer Certificate of Origin (DCO) 
-on Pull Requests. It requires all commit messages to contain the 
-Signed-off-by line with an email address that matches the commit 
-author and the name on your GitHub account.
+As an open-source project, Chapel welcomes contributions from the
+community.  This document describes the high-level requirements for
+contributing source to Chapel, while other documents linked at the
+bottom of this one provide additional detail about the process of
+contributing to Chapel.
 
-The Developer Certificate of Origin (DCO) is a lightweight way for 
-contributors to certify that they wrote or otherwise have the right 
-to submit the code they are contributing to the project. Here is the 
-full [text of the DCO][0], reformatted for readability:
+
+# Chapel and the Developer Certificate of Origin (DCO)
+
+Chapel enforces the Developer Certificate of Origin (DCO) on Pull
+Requests (PRs). This means that all commit messages must contain a
+signature line to indicate that the developer accepts the DCO.
+
+The DCO is a lightweight way for contributors to certify that they
+wrote (or otherwise have the right to submit) the code and changes
+they are contributing to the project. Here is the full [text of the
+DCO][0], reformatted for readability:
 
     By making a contribution to this project, I certify that:
 
@@ -28,45 +35,33 @@ full [text of the DCO][0], reformatted for readability:
           (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may 
           be redistributed consistent with this project or the open source license(s) involved.
 
-Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
+
+Contributors indicate that they adhere to these requirements by adding
+a `Signed-off-by` line to their commit messages.  For example:
 
     This is my commit message
 
     Signed-off-by: Random J Developer <random@developer.example.org>
 
-Git has a `-s | --signoff` command line option to append this automatically to your commit message:
+The name and email address in this line must match those of the
+committing author's GitHub account.
 
-    git commit -s -m "This is my commit message"
-
-If you have authored a commit that is missing the signed-off-by line, you can amend your commits and push them to GitHub.
-
-    git commit --amend --signoff
-
-If you've pushed your changes to GitHub already you'll need to force push your branch after this with `git push -f`.
-
-## Fixing DCO
-
-If your Pull Request fails the DCO check, it's necessary to fix the entire commit history in the PR. Best practice is to 
-squash the commit history to a single commit, append the DCO sign-off as described above, and force push. For example, 
-if you have 2 commits in your history (Note the ~2):
-
-    git rebase -i HEAD~2
-    (interactive squash + DCO append)
-    git push origin -f
-
-Note, that in general rewriting history in this way may introduce issues to the review process and this should only be done to 
-correct a DCO mistake.
+For additional details about Chapel's use of DCOs and signing commits,
+please refer to [Chapel's use of the Developer Certificate of Origin
+(DCO)][1].
 
 
-## Resources for contributing to Chapel
+## Further resources about contributing to Chapel
 
-[Contributing Page][2] : A task-oriented guide on how to get started contributing to Chapel.
+For further information about contributing effectively to the Chapel
+project, please refer to:
 
-[ContributorInfo.rst][1] : A description of the mechanisms and policies for contributing to Chapel
+[Contributing Page][1] : A high-level description about how to get started with contributing to Chapel.
+
+[ContributorInfo.rst][2] : A more detailed description of how to contribute to Chapel's code base.
 
 ---
 
 [0]: https://developercertificate.org/
-[1]: https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/bestPractices/ContributorInfo.rst
-[2]: https://chapel-lang.org/contributing.html
-
+[1]: https://chapel-lang.org/contributing.html
+[2]: https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/bestPractices/ContributorInfo.rst

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,12 +56,13 @@ please refer to [Chapel's use of the Developer Certificate of Origin
 For further information about contributing effectively to the Chapel
 project, please refer to:
 
-[Contributing Page][1] : A high-level description about how to get started with contributing to Chapel.
+[Contributing Page][2] : A high-level description about how to get started with contributing to Chapel.
 
-[ContributorInfo.rst][2] : A more detailed description of how to contribute to Chapel's code base.
+[ContributorInfo.rst][3] : A more detailed description of how to contribute to Chapel's code base.
 
 ---
 
 [0]: https://developercertificate.org/
-[1]: https://chapel-lang.org/contributing.html
-[2]: https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/bestPractices/ContributorInfo.rst
+[1]: https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/bestPractices/DCO.rst
+[2]: https://chapel-lang.org/contributing.html
+[3]: https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/bestPractices/ContributorInfo.rst

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 As an open-source project, Chapel welcomes contributions from the
 community.  This document describes the high-level requirements for
-contributing source to Chapel, while other documents linked at the
-bottom of this one provide additional detail about the process of
-contributing to Chapel.
+contributing changes via pull request to Chapel's git repository,
+while other documents linked at the bottom of this one provide
+additional detail about the process of contributing to Chapel.
 
 
 # Chapel and the Developer Certificate of Origin (DCO)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ DCO][0], reformatted for readability:
       (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source 
           license indicated in the file; or
 
-      (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an > 
+      (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an
           appropriate open source license and I have the right under that license to submit that work with modifications, 
           whether created in whole or in part by me, under the same open source license (unless I am permitted to submit 
           under a different license), as indicated in the file; or

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -18,17 +18,17 @@ Overview:
 
 #. `Design`_
 
-    #. `When design discussion is needed`_
-    #. `Creating a design issue`_
-    #. `Leading a design discussion`_
+   #. `When design discussion is needed`_
+   #. `Creating a design issue`_
+   #. `Leading a design discussion`_
 
 #. `Development`_
 
-    #. `Get set up`_
-    #. `Create new branch`_
-    #. `Develop and test contributions locally`_
+   #. `Get set up`_
+   #. `Create new branch`_
+   #. `Develop and test contributions locally`_
 
-       #. `Add new tests`_
+      #. `Add new tests`_
 
 
 #. `Contributing changes`_
@@ -344,9 +344,9 @@ Before merging
 Before the change can be merged, go through this checklist to ensure:
 
 - all design changes have been discussed
+- all commits contain the required "Signed-off-by:" line to indicate
+  compliance with the `Developer Certificate of Origin`_ (DCO)
 - the PR has been reviewed
-- the "signed-off-by" comments have been added in all commits to accept
-  `Developer Certificate of Origin`_ (DCO)
 - the `Git history is clear`_ of anything that should not be in the repo
 - relevant configurations pass testing
 
@@ -456,26 +456,17 @@ Configure your local git
 
 .. _Commit messages setup
 
-Set up commit messages with a .gitmessage Template
-++++++++++++++++++++++++++++++++++++++++++++++++++
+Make sure you understand how to create signed commits
++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Chapel enforces the Developer Certificate of Origin (DCO) on pull requests.
-It requires all commit message to contain the Signed-off-by line with an email
-address that matches the commit author and the name on your GitHub account.
+Chapel enforces the Developer Certificate of Origin (DCO) on all pull requests.
+This requires all commits you make to be signed to indicate that they adhere
+to the DCO policy.  If you're not already familiar with DCOs, read `Getting
+started with Chapel and the Developer Certificate of Origin`_ to learn more
+about them and how to sign your commits.
 
-To tell Git to use the default message with the ``Signed-off-by`` line that appears in your 
-editor when you run ``git commit``, set the commit.template configuration value:
+.. _Getting started with Chapel and the Developer Certificate of Origin: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/DCO.rst
 
-.. code-block:: bash
-
-     git config --global commit.template ~/.gitmessage
-
-Then create ~/.gitmessage template with the ``Signed-off-by`` line:
-
-.. code-block:: bash
-
-     ---
-     Signed-off-by: Random J Developer <random@developer.example.org>
 
 
 .. _New branch command:

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -10,7 +10,7 @@ Chapel workflow recommendations.
 Below are instructions for setting up a GitHub account, developing a
 feature, and submitting pull requests.
 
-.. note:: A `contributor license agreement`_ must be signed before any contributing pull requests can be merged.
+.. note:: All commits must be signed according to the DCO (see below) in order to be merged.
 
 Overview:
 
@@ -187,15 +187,24 @@ grow).
    also `Fork the repo`_).  Then `configure your local git`_ and check out your
    fork
 
+#. Make sure you understand how to sign your commits with respect to the DCO.
+
+   Chapel enforces the Developer Certificate of Origin (DCO) on all
+   pull requests.  This requires all commits you make to be signed to
+   indicate that they adhere to the DCO policy.  If you're not already
+   familiar with DCOs, read `Getting started with Chapel and the
+   Developer Certificate of Origin`_ to learn more about them and how
+   to sign your commits.
+
+.. _Getting started with Chapel and the Developer Certificate of Origin: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/DCO.rst
+
+   
 #. If you're working on a long-term effort, announce it on the
    chapel-developers_ mailing list to make sure toes are not being stepped on,
    work is not being pursued redundantly, etc.  Similarly, fundamental changes
    to the language or architecture should be circulated to the
    chapel-developers_ and/or chapel-users_ lists to make sure effort is not
    wasted.
-
-#. Sign a Chapel `contributor license agreement`_ and mail it, with your GitHub
-   ID.
 
 * You do not need commit/push access to the main repo in order to
   contribute code.  See
@@ -453,20 +462,6 @@ Configure your local git
     git remote set-url --push upstream no_push
     # Optionally add remotes for commonly viewed branches
     git remote add <branch_owner_username> https://github.com/<branch_owner_username>/chapel.git
-
-.. _Commit messages setup
-
-Make sure you understand how to create signed commits
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-Chapel enforces the Developer Certificate of Origin (DCO) on all pull requests.
-This requires all commits you make to be signed to indicate that they adhere
-to the DCO policy.  If you're not already familiar with DCOs, read `Getting
-started with Chapel and the Developer Certificate of Origin`_ to learn more
-about them and how to sign your commits.
-
-.. _Getting started with Chapel and the Developer Certificate of Origin: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/DCO.rst
-
 
 
 .. _New branch command:
@@ -1111,10 +1106,15 @@ Reviewer responsibilities
 +++++++++++++++++++++++++
 
 * If you're reviewing a commit from a developer outside the Chapel core
-  team, be sure they have signed the `contributor license agreement`_ (see the
-  `Developer Workflow`_ instructions for this).  If the developer cannot
-  or will not sign the agreement, bring the situation to the attention
-  of the Chapel project leadership.
+  team, be sure their commits are signed via the DCO bot (one of several
+  github action checks that will run on each PR).  If they're not, help
+  the developer understand the requirement.
+
+  Note that using GitHub's "squash and merge" feature will effectively
+  drop all DCO signature lines from the pull request, and so should
+  not be used on external commits (or potentially even for commits
+  from the core team?) in order to preserve the signed nature of the
+  commits.
 
   Care may need to be taken when committing third-party code that
   originates from a different git[hub] repository.  As an example, in
@@ -1151,7 +1151,7 @@ Reviewer responsibilities
 What Copyright Should I Use?
 ++++++++++++++++++++++++++++
 
-By signing a Contributor Agreement, you have agreed that code you contribute
+By opening a PR with signed commits, you are agreeing that code you contribute
 will be governed by the license and copyright of the project as a whole.  A
 standard block of license text is required at the top of every compiler,
 runtime, and module code file.  Browse other files of the same type to see the

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -196,9 +196,6 @@ grow).
    Developer Certificate of Origin`_ to learn more about them and how
    to sign your commits.
 
-.. _Getting started with Chapel and the Developer Certificate of Origin: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/DCO.rst
-
-   
 #. If you're working on a long-term effort, announce it on the
    chapel-developers_ mailing list to make sure toes are not being stepped on,
    work is not being pursued redundantly, etc.  Similarly, fundamental changes
@@ -213,6 +210,9 @@ grow).
 * Third-party code requires additional approvals, see the policy details on
   `Third-party code`_.
 
+.. _Getting started with Chapel and the Developer Certificate of Origin: DCO.rst
+
+   
 .. _Create new branch:
 
 Create new branch

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -729,7 +729,7 @@ How to open a PR:
 
   and you can discuss the patch with your reviewers there.
 
-.. _Developer Certificate of Origin: https://github.com/chapel-lang/chapel/tree/master/doc/rst/developer/contributorAgreements/
+.. _Developer Certificate of Origin: https://github.com/chapel-lang/chapel/blob/master/.github/CONTRIBUTING.md
 
 .. _How to merge a PR:
 

--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -99,7 +99,7 @@ visible to you / easier to forget about.
 
 To take this approach, copy the script from
 `$CHPL_HOME/util/misc/pre-commit-msg-hook` to
-`$CHPL_HOME/.git/hooks/commit-hook`.
+`$CHPL_HOME/.git/hooks/commit-msg`.
 
 You can also use variations on this script to exit with an error if
 the signature line is missing rather than adding it automatically.

--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -28,84 +28,87 @@ Ways to Sign Commits
 
 #. Signing each commit manually
 
-Of course, when you are making a commit and editing the commit
-message, you can sign it manually, by typing the line above but with
-your GitHub account's name and email address.  However, this has the
-obvious downsides of being tedious and error-prone.
+   Of course, when you are making a commit and editing the commit
+   message, you can sign it manually, by typing the line above but
+   with your GitHub account's name and email address.  However, this
+   has the obvious downsides of being tedious and error-prone.
 
 
 #. Using `git -s`
 
-Git has a `-s | --signoff` command-line flag that will automatically
-add your 'Signed-off-by' line to your commit message.  For an
-interactive commit like the following:
+   Git has a `-s | --signoff` command-line flag that will
+   automatically add your 'Signed-off-by' line to your commit message.
+   For an interactive commit like the following:
 
-    git commit -s
+   .. code-block:: bash
+        git commit -s
 
-you should see the 'Signed-off-by' line in your editor when it brings
-up the buffer representing the commit message.  If you supply the
-commit message on the command-line, the 'Signed-off-by' line will be
-automatically added for you.
+   you should see the 'Signed-off-by' line in your editor when it
+   brings up the buffer representing the commit message.  If you
+   supply the commit message on the command-line, the 'Signed-off-by'
+   line will be automatically added for you.
 
-    git commit -s -m "This is my commit message"
+   .. code-block:: bash
+        git commit -s -m "This is my commit message"
 
-This approach has the advantage of being fairly straightforward and
-requiring no configuration, but the downside that you need to remember
-to use the flag with each commit.
+   This approach has the advantage of being fairly straightforward and
+   requiring no configuration, but the downside that you need to
+   remember to use the flag with each commit.
 
 
 #. Using a git commit template
 
-This approach uses a template file that contains your signature for
-interactive commit messages.  It has the advantage of being fairly
-straightforward and making your signature visible to you when you
-commit.  However, a downside is that it doesn't apply your signature
-to git commits that skip the interactive editing of commit messages,
-like `git revert` or `git commit -m ...`.
+   This approach uses a template file that contains your signature for
+   interactive commit messages.  It has the advantage of being fairly
+   straightforward and making your signature visible to you when you
+   commit.  However, a downside is that it doesn't apply your
+   signature to git commits that skip the interactive editing of
+   commit messages, like `git revert` or `git commit -m ...`.
 
-To take this approach, create a file (say, `~/.gitmessage`) that will
-form the basis for any interactive commit messages, containing your
-signature line:
+   To take this approach, create a file (say, `~/.gitmessage`) that
+   will form the basis for any interactive commit messages, containing
+   your signature line:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-     ---
-     Signed-off-by: Random J Developer <random@developer.example.org>
+        ---
+        Signed-off-by: Random J Developer <random@developer.example.org>
 
-Then, tell your git configuration to open this file for any new
-interactive commit messages using one of the following forms.  To set
-this up for the current repository only:
+   Then, tell your git configuration to open this file for any new
+   interactive commit messages using one of the following forms.  To
+   set this up for the current repository only:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-     git config commit.template ~/.gitmessage
+        git config commit.template ~/.gitmessage
 
-To set it up across repositories via your `~/.gitconfig` file:
+   To set it up across repositories via your `~/.gitconfig` file:
      
-.. code-block:: bash
+   .. code-block:: bash
 
-     git config --global commit.template ~/.gitmessage
+        git config --global commit.template ~/.gitmessage
      
 
 #. Using a git commit hook
 
-This approach uses a script to automatically add your signature line
-to new commits within a given repository if it isn't found in the
-commit message.  Relative to the previous approach, it has the
-advantage of being used more consistently across different styles of
-committing, but the slight downside of making the fact that you're
-signing your commits less visible to you / easier to forget about.
+   This approach uses a script to automatically add your signature
+   line to new commits within a given repository if it isn't found in
+   the commit message.  Relative to the previous approach, it has the
+   advantage of being used more consistently across different styles
+   of committing, but the slight downside of making the fact that
+   you're signing your commits less visible to you / easier to forget
+   about.
 
-To take this approach, copy the script from
-`$CHPL_HOME/util/misc/pre-commit-msg-hook` to
-`$CHPL_HOME/.git/hooks/commit-msg`:
+   To take this approach, copy the script from
+   `$CHPL_HOME/util/misc/pre-commit-msg-hook` to
+   `$CHPL_HOME/.git/hooks/commit-msg`:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-     cp $CHPL_HOME/util/misc/pre-commit-msg-hook $CHPL_HOME/.git/hooks/commit-msg
+        cp $CHPL_HOME/util/misc/pre-commit-msg-hook $CHPL_HOME/.git/hooks/commit-msg
 
-You can also use variations on this script to exit with an error if
-the signature line is missing rather than adding it automatically.
+   You can also use variations on this script to exit with an error if
+   the signature line is missing rather than adding it automatically.
    
 
 Troubleshooting DCOs
@@ -114,7 +117,9 @@ Troubleshooting DCOs
 If you have authored a commit that is missing its 'Signed-off-by'
 line, you can amend your commits and push them to GitHub.
 
-    git commit --amend --signoff
+   .. code-block:: bash
+
+        git commit --amend --signoff
 
 If you've pushed your changes to GitHub already you'll need to force
 push your branch after this with `git push -f`.
@@ -125,9 +130,11 @@ commit history to a single commit, append the DCO sign-off as
 described above, and force push. For example, if you have 2 commits in
 your history (Note the ~2):
 
-    git rebase -i HEAD~2
-    (interactive squash + DCO append)
-    git push origin -f
+   .. code-block:: bash
+
+        git rebase -i HEAD~2
+        (interactive squash + DCO append)
+        git push origin -f
 
 Note that, in general, rewriting history in this way may introduce
 issues to the review process and this should only be done to correct a

--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -92,14 +92,17 @@ To set it up across repositories via your `~/.gitconfig` file:
 This approach uses a script to automatically add your signature line
 to new commits within a given repository if it isn't found in the
 commit message.  Relative to the previous approach, it has the
-advantage of being used more consistently for different styles of
-committing, but the slight downsides of needing to be set up for each
-repository and making the fact that you're signing your commits less
-visible to you / easier to forget about.
+advantage of being used more consistently across different styles of
+committing, but the slight downside of making the fact that you're
+signing your commits less visible to you / easier to forget about.
 
 To take this approach, copy the script from
 `$CHPL_HOME/util/misc/pre-commit-msg-hook` to
-`$CHPL_HOME/.git/hooks/commit-msg`.
+`$CHPL_HOME/.git/hooks/commit-msg`:
+
+.. code-block:: bash
+
+     cp $CHPL_HOME/util/misc/pre-commit-msg-hook $CHPL_HOME/.git/hooks/commit-msg
 
 You can also use variations on this script to exit with an error if
 the signature line is missing rather than adding it automatically.

--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -1,0 +1,131 @@
+Getting started with Chapel and the Developer Certificate of Origin (DCO)
+=========================================================================
+
+In order to merge a pull request (PR) to the Chapel repository, all
+git commits must be signed by their developers to certify that they
+wrote, or otherwise have the right to submit, the changes to the
+project.  The full text of the DCO is available in Chapel's
+`CONTRIBUTING.md`_ file.
+
+This means that the message for each commit you submit must contain a
+line that reads:
+
+    Signed-off-by: Random J Developer <random@developer.example.org>
+
+where the name and email address must match those of your GitHub
+account as indicated by `git config user.name` and `git config
+user.email`.  The presence of this line signifies that you're making
+the commit in accordance with the DCO.
+
+The rest of this document describes some tips and tricks for signing
+commits proactively or retroactively.
+
+.. _CONTRIBUTING.md: https://github.com/chapel-lang/chapel/blob/master/.github/CONTRIBUTING.md
+
+
+Ways to Sign Commits
+--------------------
+
+#. Signing each commit manually
+
+Of course, when you are making a commit and editing the commit
+message, you can sign it manually, by typing the line above but with
+your GitHub account's name and email address.  However, this has the
+obvious downsides of being tedious and error-prone.
+
+
+#. Using `git -s`
+
+Git has a `-s | --signoff` command-line flag that will automatically
+add your 'Signed-off-by' line to your commit message.  For an
+interactive commit like the following:
+
+    git commit -s
+
+you should see the 'Signed-off-by' line in your editor when it brings
+up the buffer representing the commit message.  If you supply the
+commit message on the command-line, the 'Signed-off-by' line will be
+automatically added for you.
+
+    git commit -s -m "This is my commit message"
+
+This approach has the advantage of being fairly straightforward and
+requiring no configuration, but the downside that you need to remember
+to use the flag with each commit.
+
+
+#. Using a git commit template
+
+This approach uses a template file that contains your signature for
+interactive commit messages.  It has the advantage of being fairly
+straightforward and making your signature visible to you when you
+commit.  However, a downside is that it doesn't apply your signature
+to git commits that skip the interactive editing of commit messages,
+like `git revert` or `git commit -m ...`.
+
+To take this approach, create a file (say, `~/.gitmessage`) that will
+form the basis for any interactive commit messages, containing your
+signature line:
+
+.. code-block:: bash
+
+     ---
+     Signed-off-by: Random J Developer <random@developer.example.org>
+
+Then, tell your git configuration to open this file for any new
+interactive commit messages using one of the following forms.  To set
+this up for the current repository only:
+
+.. code-block:: bash
+
+     git config commit.template ~/.gitmessage
+
+To set it up across repositories via your `~/.gitconfig` file:
+     
+.. code-block:: bash
+
+     git config --global commit.template ~/.gitmessage
+     
+
+#. Using a git commit hook
+
+This approach uses a script to automatically add your signature line
+to new commits within a given repository if it isn't found in the
+commit message.  Relative to the previous approach, it has the
+advantage of being used more consistently for different styles of
+committing, but the slight downsides of needing to be set up for each
+repository and making the fact that you're signing your commits less
+visible to you / easier to forget about.
+
+To take this approach, copy the script from
+`$CHPL_HOME/util/misc/pre-commit-msg-hook` to
+`$CHPL_HOME/.git/hooks/commit-hook`.
+
+You can also use variations on this script to exit with an error if
+the signature line is missing rather than adding it automatically.
+   
+
+Troubleshooting DCOs
+--------------------
+    
+If you have authored a commit that is missing its 'Signed-off-by'
+line, you can amend your commits and push them to GitHub.
+
+    git commit --amend --signoff
+
+If you've pushed your changes to GitHub already you'll need to force
+push your branch after this with `git push -f`.
+
+If your Pull Request fails the DCO check, it will be necessary to fix
+the entire commit history for the PR. Best practice is to squash the
+commit history to a single commit, append the DCO sign-off as
+described above, and force push. For example, if you have 2 commits in
+your history (Note the ~2):
+
+    git rebase -i HEAD~2
+    (interactive squash + DCO append)
+    git push origin -f
+
+Note that, in general, rewriting history in this way may introduce
+issues to the review process and this should only be done to correct a
+DCO mistake.

--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -11,11 +11,12 @@ This means that the message for each commit you submit must contain a
 line that reads:
 
 .. code-block:: bash
+
      Signed-off-by: Random J Developer <random@developer.example.org>
 
 where the name and email address must match those of your GitHub
-account as indicated by `git config user.name` and `git config
-user.email`.  The presence of this line signifies that you're making
+account as indicated by ``git config user.name`` and ``git config
+user.email``.  The presence of this line signifies that you're making
 the commit in accordance with the DCO.
 
 The rest of this document describes some tips and tricks for signing
@@ -35,9 +36,9 @@ Ways to Sign Commits
    has the obvious downsides of being tedious and error-prone.
 
 
-#. Using `git -s`
+#. Using ``git -s``
 
-   Git has a `-s | --signoff` command-line flag that will
+   Git has a ``-s | --signoff`` command-line flag that will
    automatically add your 'Signed-off-by' line to your commit message.
    For an interactive commit like the following:
 
@@ -64,9 +65,9 @@ Ways to Sign Commits
    straightforward and making your signature visible to you when you
    commit.  However, a downside is that it doesn't apply your
    signature to git commits that skip the interactive editing of
-   commit messages, like `git revert` or `git commit -m ...`.
+   commit messages, like ``git revert`` or ``git commit -m ...``.
 
-   To take this approach, create a file (say, `~/.gitmessage`) that
+   To take this approach, create a file (say, ``~/.gitmessage``) that
    will form the basis for any interactive commit messages, containing
    your signature line:
 
@@ -83,7 +84,7 @@ Ways to Sign Commits
 
         git config commit.template ~/.gitmessage
 
-   To set it up across repositories via your `~/.gitconfig` file:
+   To set it up across repositories via your ``~/.gitconfig`` file:
      
    .. code-block:: bash
 
@@ -101,8 +102,8 @@ Ways to Sign Commits
    about.
 
    To take this approach, copy the script from
-   `$CHPL_HOME/util/misc/pre-commit-msg-hook` to
-   `$CHPL_HOME/.git/hooks/commit-msg`:
+   ``$CHPL_HOME/util/misc/pre-commit-msg-hook`` to
+   ``$CHPL_HOME/.git/hooks/commit-msg``:
 
    .. code-block:: bash
 
@@ -123,7 +124,7 @@ line, you can amend your commits and push them to GitHub.
      git commit --amend --signoff
 
 If you've pushed your changes to GitHub already you'll need to force
-push your branch after this with `git push -f`.
+push your branch after this with ``git push -f``.
 
 If your Pull Request fails the DCO check, it will be necessary to fix
 the entire commit history for the PR. Best practice is to squash the

--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -10,7 +10,8 @@ project.  The full text of the DCO is available in Chapel's
 This means that the message for each commit you submit must contain a
 line that reads:
 
-    Signed-off-by: Random J Developer <random@developer.example.org>
+.. code-block:: bash
+     Signed-off-by: Random J Developer <random@developer.example.org>
 
 where the name and email address must match those of your GitHub
 account as indicated by `git config user.name` and `git config
@@ -117,9 +118,9 @@ Troubleshooting DCOs
 If you have authored a commit that is missing its 'Signed-off-by'
 line, you can amend your commits and push them to GitHub.
 
-   .. code-block:: bash
+.. code-block:: bash
 
-        git commit --amend --signoff
+     git commit --amend --signoff
 
 If you've pushed your changes to GitHub already you'll need to force
 push your branch after this with `git push -f`.
@@ -130,11 +131,11 @@ commit history to a single commit, append the DCO sign-off as
 described above, and force push. For example, if you have 2 commits in
 your history (Note the ~2):
 
-   .. code-block:: bash
+.. code-block:: bash
 
-        git rebase -i HEAD~2
-        (interactive squash + DCO append)
-        git push origin -f
+     git rebase -i HEAD~2
+     (interactive squash + DCO append)
+     git push origin -f
 
 Note that, in general, rewriting history in this way may introduce
 issues to the review process and this should only be done to correct a

--- a/doc/rst/developer/contributorAgreements/README.md
+++ b/doc/rst/developer/contributorAgreements/README.md
@@ -1,48 +1,13 @@
 Chapel Contributor Agreements
 =============================
 
-Chapel enforces the Developer Certificate of Origin (DCO) 
-on Pull Requests. It requires all commit messages to contain the 
-Signed-off-by line with an email address that matches the commit 
-author and the name on your GitHub account.
+In November 2020, Chapel switched from requiring Apache Contributor
+Licensing Agreements (CLAs) from each contributor to using commits
+signed in acceptance of the Developer Certificate of Origin (DCO).
+For more information including the text of the DCO, please refer to
+[CONTRIBUTING.md][0].  For tips on getting set up with signed commits,
+please refer to [Chapel's use of the Developer Certificate of Origin
+(DCO)][1].
 
-The Developer Certificate of Origin (DCO) is a lightweight way for 
-contributors to certify that they wrote or otherwise have the right 
-to submit the code they are contributing to the project. Here is the 
-full [text of the DCO][0], reformatted for readability:
-
-    By making a contribution to this project, I certify that:
-
-      (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source 
-          license indicated in the file; or
-
-      (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an > 
-          appropriate open source license and I have the right under that license to submit that work with modifications, 
-          whether created in whole or in part by me, under the same open source license (unless I am permitted to submit 
-          under a different license), as indicated in the file; or
-
-      (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not 
-          modified it.
-
-      (d) I understand and agree that this project and the contribution are public and that a record of the contribution 
-          (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may 
-          be redistributed consistent with this project or the open source license(s) involved.
-
-Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
-
-    This is my commit message
-
-    Signed-off-by: Random J Developer <random@developer.example.org>
-
-Git has a `-s | --signoff` command line option to append this automatically to your commit message:
-
-    git commit -s -m "This is my commit message"
-
-If you have authored a commit that is missing the signed-off-by line, you can amend your commits and push them to GitHub.
-
-    git commit --amend --signoff
-
-If you've pushed your changes to GitHub already you'll need to force push your branch after this with `git push -f`.
-
-
-[0]: https://developercertificate.org/
+[0]: https://github.com/chapel-lang/chapel/blob/master/.github/CONTRIBUTING.md
+[1]: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/DCO.rst

--- a/doc/rst/developer/contributorAgreements/README.md
+++ b/doc/rst/developer/contributorAgreements/README.md
@@ -10,4 +10,4 @@ please refer to [Chapel's use of the Developer Certificate of Origin
 (DCO)][1].
 
 [0]: https://github.com/chapel-lang/chapel/blob/master/.github/CONTRIBUTING.md
-[1]: https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/DCO.rst
+[1]: ../bestPractices/DCO.rst


### PR DESCRIPTION
This refactors our docs related to DCOs in the following ways:

* moves most of the details relating to DCOs into a new file, DCO.rst,
  in order to simplify CONTRIBUTING.md, ContributorInfo.rst, and
  contributorAgreements/README.md.

* introduces additional ways of signing commits for completeness and
  because the file template approach wasn't as bulletproof as hoped.
  Pluses and minuses are given for each.

* refactors CONTRIBUTING.md to make its role relative to
  ContributorInfo.rst clearer

* makes contributorAgreements/README.md more of a historical
  placeholder and less of a restatement of the DCO.

