### PR TITLE
Skip a bounds checking test with --fast

### DIFF
--- a/test/arrays/swap/sizeMismatchError.skipif
+++ b/test/arrays/swap/sizeMismatchError.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
This test was added in https://github.com/chapel-lang/chapel/pull/16620 and is
supposed the lock in the bounds checking behavior. So skip it with --fast.

Test is correctly skipped with this PR.
