### PR TITLE
Fix a performance annotation

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1606,7 +1606,7 @@ regexdna-submitted:
 regexdnaredux-submitted:
   <<: *regexdna-base
 
-remote-gets.ml-perf:
+remote-puts.ml-perf:
   11/03/20:
     - Do fewer GETs to force PUTs into a visible state, and do them later (#16634)
 


### PR DESCRIPTION
I realized that I have put an annotation in the Remote GET performance plot,
though it was meant to be for Remote PUT one. This PR fixes that.


