### PR TITLE
Minor cleanup in visibleFunctions et al.

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -29,6 +29,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 
+BlockStmt*                         rootBlock             = NULL;
 ModuleSymbol*                      rootModule            = NULL;
 ModuleSymbol*                      theProgram            = NULL;
 ModuleSymbol*                      baseModule            = NULL;
@@ -749,12 +750,11 @@ void ModuleSymbol::deadCodeModuleUseRemove(ModuleSymbol* mod) {
 }
 
 void initRootModule() {
-  rootModule           = new ModuleSymbol("_root",
-                                          MOD_INTERNAL,
-                                          new BlockStmt());
+  rootBlock  = new BlockStmt();
+  rootModule = new ModuleSymbol("_root", MOD_INTERNAL, rootBlock);
 
   rootModule->filename = astr("<internal>");
-  rootModule->block->parentSymbol = rootModule;
+  rootBlock->parentSymbol = rootModule;
 }
 
 void initStringLiteralModule() {

--- a/compiler/include/ModuleSymbol.h
+++ b/compiler/include/ModuleSymbol.h
@@ -117,6 +117,7 @@ private:
   bool                    hasTopLevelModule();
 };
 
+extern BlockStmt*         rootBlock;
 extern ModuleSymbol*      rootModule;
 extern ModuleSymbol*      theProgram;
 extern ModuleSymbol*      baseModule;


### PR DESCRIPTION
Reduces calls to getModule() and getFunction() and improves code clarity.

Removes or conditional-izes a couple of calls to getModule() and getFunction()
in visibleFunctions.cpp where that does not affect business logic.
This was triggered by an assertion failure on my w.i.p. CG branch.

Replaces some code in getVisibleMethodsImpl() with calls to
getVisibleFnsInstantiationPt() and getVisibleFnsShowBlock(),
sharing these with getVisibleFunctionsImpl().

Moves the check for rootModule->block to be the first thing in
getVisibleMethodsImpl() and getVisibleFunctionsImpl(), to
avoid unnecessary work.

Reworks some comments for clarity or conciseness.
The changes in createTaskFunctions.cpp were triggered
by the discovery that tiMarkHost was the only function
with a defPoint directly in rootModule.
