### PR TITLE
Add a Lua/Lmod modulefile for Chapel on EX systems.

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -59,16 +59,33 @@ module.
 To use Chapel with the default settings and confirm it is correctly
 installed, do the following:
 
-1) Load the Chapel module::
+1) Load the Chapel module:
 
-     module load chapel
+   If you are using the Tcl module system, first load these required
+   modules:
 
-   Note that a side effect of loading the chapel module is that these
-   other modules will either be loaded or swapped to, as needed::
+   .. code-block:: sh
 
-     PrgEnv-gnu
-     cray-mpich
-     libfabric
+      PrgEnv-cray or PrgEnv-gnu
+      cray-mpich
+
+   Alternatively, if you are using the Lmod module system and the HPE
+   Cray Programming Environment Lmod Hierarchy, first load these
+   required modules:
+
+   .. code-block:: sh
+
+      craype
+      both cpe-cray and cce, or both cpe-gnu and gcc
+      craype-network-ofi
+      craype-x86-rome
+      cray-mpich
+
+   Then, with either module system, load the Chapel module:
+
+   .. code-block:: sh
+
+      module load chapel
 
 
 2) Compile an example program like this::
@@ -82,27 +99,28 @@ installed, do the following:
 
 
 Currently the number of Chapel configurations available on
-HPE Cray EX systems is quite limited.  Only the following have been built
+HPE Cray EX systems is somewhat limited.  Only the following have been built
 into the module::
 
   CHPL_TARGET_PLATFORM: hpe-cray-ex
-  CHPL_TARGET_COMPILER: cray-prgenv-gnu
+  CHPL_TARGET_COMPILER: cray-prgenv-cray, cray-prgenv-gnu
   CHPL_TARGET_ARCH: x86_64
-  CHPL_TARGET_CPU: sandybridge
+  CHPL_TARGET_CPU: x86-rome
   CHPL_LOCALE_MODEL: flat
   CHPL_COMM: none, ofi
   CHPL_TASKS: qthreads
-  CHPL_LAUNCHER: none
+  CHPL_LAUNCHER: none, pals, slurm-srun
   CHPL_TIMERS: generic
   CHPL_UNWIND: none
   CHPL_MEM: jemalloc
   CHPL_ATOMICS: cstdlib
     CHPL_NETWORK_ATOMICS: none, ofi
-  CHPL_GMP: none
+  CHPL_GMP: gmp
   CHPL_HWLOC: hwloc
-  CHPL_REGEXP: none
-  CHPL_LLVM: none
-  CHPL_AUX_FILESYS: none
+  CHPL_REGEXP: re2
+  CHPL_LLVM: llvm
+  CHPL_AUX_FILESYS: none, lustre
+  CHPL_LIB_PIC: none, pic
 
 You may be able to build Chapel from source on an EX system if you do
 not have a module already.  Generally you should be able to follow the

--- a/util/build_configs/cray-internal/README.md
+++ b/util/build_configs/cray-internal/README.md
@@ -43,10 +43,15 @@ new subdir.
     or for development purposes. Does NOT produce the release_info used in official releases.
   - generate-modulefile.bash: The Cray modulefile, installed by the Chapel RPM.
     Supports "module load chapel" on Cray computers.
-  - generate-rpmspec.bash: The RPM "spec" file read by the rpmbuild tool.
   - generate-set_default.bash: The Cray set_default file, installed by the Chapel RPM.
     A Cray system management tool, this script sets the default Chapel version obtained
     when a user runs `module load chapel` without specifying a specific version.
+
+* template files:
+  - chapel.spec.template: A template for the RPM spec file read by the
+    rpmbuild tool.
+  - process-template.py: This performs textual substitutions on template
+    files to produce what goes into the module.
 
 * setenv-\*-\*.bash:
   Setenv scripts for Chapel Cray RPMs of various types. These setenv scripts are based on

--- a/util/build_configs/cray-internal/chapel.modulefile.lua.template
+++ b/util/build_configs/cray-internal/chapel.modulefile.lua.template
@@ -1,0 +1,174 @@
+--[[
+
+    file chapel module
+
+    (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+
+]]--
+
+
+-- reasons to keep module from continuing --
+
+
+-- no need to conflict with chapel Lmod has a one name rule
+conflict("cray-mpich2", "xt-mpich2")
+prereq("craype")
+
+--[[ a hugepages module is required for XC, not required for shasta at present 09/30/2020
+prereq_any(
+            "craype-hugepages2M",
+            "craype-hugepages4M",
+            "craype-hugepages8M",
+            "craype-hugepages16M",
+            "craype-hugepages32M",
+            "craype-hugepages64M",
+            "craype-hugepages128M",
+            "craype-hugepages256M",
+            "craype-hugepages512M",
+            "craype-hugepages1G",
+            "craype-hugepages2G"
+)
+--]]
+
+
+-- local vars: define & assign --
+
+
+-- template variables ----------------------------------------------------------
+local MOD_LEVEL           = "@@{pkg_version}"       -- 1.23.0, e.g.
+local INSTALL_ROOT        = "@@{platform_prefix}"   -- former BASE_INSTALL_DIR
+--------------------------------------------------------------------------------
+
+-- set comm layer
+local CHPL_COMM = os.getenv("CHPL_COMM") or ""
+
+-- set host arch
+local CHPL_HOST_ARCH = os.getenv("CPU") or ""
+if CHPL_HOST_ARCH ~= "aarch64" and CHPL_HOST_ARCH ~= "x86_64" then
+    -- host arch is neither ARM-based CPU nor Cray-XC/HPE Cray EX
+    -- LmodError() will cause this module to exit
+    LmodError("Cannot determine vaild host CPU. CPU found was " .. tostring(CHPL_HOST_ARCH))
+end
+
+-- set host network platform
+local CHPL_HOST_PLATFORM = ""
+local this_module_path = myFileName()
+if string.find(this_module_path, "aries") then
+    CHPL_HOST_PLATFORM = "cray-xc"
+elseif string.find(this_module_path, "ofi") then
+    CHPL_HOST_PLATFORM = "hpe-cray-ex"
+elseif string.find(this_module_path, "slingshot") then
+    CHPL_HOST_PLATFORM = "hpe-cray-ex"
+else
+    -- LmodError() will cause this module to exit
+    LmodError("Cannot determine host network platform. Network found was " .. tostring(CHPL_HOST_PLATFORM))
+end
+
+-- set chapel install location
+local CHPL_LOC = INSTALL_ROOT .. myModuleName() .. "/" .. MOD_LEVEL .. "/" ..CHPL_HOST_PLATFORM
+
+-- information variables
+local REL_FILE           = CHPL_LOC .. "/release_info"
+local rel_info           = ""
+if (isFile(REL_FILE)) then
+    local f = io.open(REL_FILE, "r")
+    local data = f:read("*all")
+    f:close()
+    if data ~= nil then rel_info = data end
+end
+
+
+-- standered Lmod functions --
+
+
+help(rel_info .. [[
+
+===================================================================
+To re-display ]] .. myModuleName() .. "/" .. MOD_LEVEL .. [[ release information,
+type:    less ]] .. CHPL_LOC .. [[/release_info
+===================================================================
+
+]])
+
+whatis("This modulefile defines the system paths and environment variables " ..
+       "needed to use the Chapel compiler on Cray systems. This module requires " ..
+       "a PrgEnv environment to be loaded."
+)
+
+
+-- local functions --
+
+
+--[[
+
+    control_family_load
+    Special handling for the loading/unloading of modules in a family that maybe
+    have a family member loaded prior to this module. Function keeps any modules
+    loaded that were loaded prior to this module via a "control" environment variable.
+    Note: the return value of the function myModuleName() is appended to the
+    "control" environment variable. This ensures other modules using this funtion
+    will not mistake thire own "control" environment variable for anothers.
+
+    param   modName
+            string, the name of the module whose load/unload is being controlled.
+            This module will be loaded if they is not already a module loaded
+            within its family.
+
+    param   modFamily
+            string, the name of the module family load/unload is being controlled
+
+    return  lua code chunk, the chunk may be either a function or
+            table of functions.
+
+]]--
+function control_family_load(modName, modFamily)
+    local isFamilyModLoadedEnvVar = modFamily .. "_already_loaded"
+    -- lmod modules can be in a lmod family. by checking the env var Lmod creates
+    -- for a family, this code can determine if a module from a specific family
+    -- is loaded and if one is loaded which one.
+    local familyModLoaded =  os.getenv("LMOD_FAMILY_".. modFamily) or ""
+    if ( mode() == "load") then
+        if (isloaded(familyModLoaded)) then
+            -- track that this mod was loaded before calling module
+            setenv(  isFamilyModLoadedEnvVar,  "1"  )
+        else
+            -- normal load/unload
+            load(modName)
+        end
+    else
+        if (os.getenv(isFamilyModLoadedEnvVar) == "1") then
+            -- keeps module loaded in unload mode
+            always_load(familyModLoaded)
+            -- unset the env var in unload mode
+            setenv(  isFamilyModLoadedEnvVar,  "1"  )
+        else
+            -- normal load/unload (unloads module in unload mode
+            load(modName)
+        end
+    end
+end
+
+
+-- environment modifications --
+
+
+-- MPICH_GNI_DYNAMIC_CONN: mpich will always be loaded but, variable still needed on XC 09/30/2020
+-- setenv       (    "MPICH_GNI_DYNAMIC_CONN",    "disabled"    )
+
+setenv       (    "CHPL_HOME",                 CHPL_LOC      )
+setenv       (    "CHPL_MODULE_HOME",          CHPL_LOC      )
+
+prepend_path (    "PATH",                      CHPL_LOC .. "/bin/" .. CHPL_HOST_PLATFORM .. "-" .. CHPL_HOST_ARCH    )
+prepend_path (    "MANPATH",                   CHPL_LOC .. "/man"                                                    )
+append_path  (    "PE_PRODUCT_LIST",           string.upper(myModuleName())                                          )
+
+-- set hugepages if nessasary. EX systems only 09/30/2020
+-- the default comm layer on cray-x* is ugni, which requires a craype-hugepages
+-- module for performance.  If CHPL_COMM is not set in the environment or is set
+-- to ugni, make sure there is a craype-hugepages module loaded. Use
+-- craype-hugepages16M if a craype-hugepages module is not already loaded.
+if CHPL_COMM == "ugni" or CHPL_HOST_PLATFORM == "cray-xc" then
+    -- hugepages module is required
+    -- load hugepages module if there is not another hugepages module already loaded
+    control_family_load("craype-hugepages16M", "CRAYPE_HUGEPAGES")
+end

--- a/util/build_configs/cray-internal/chapel.modulefile.lua.template
+++ b/util/build_configs/cray-internal/chapel.modulefile.lua.template
@@ -65,7 +65,7 @@ else
 end
 
 -- set chapel install location
-local CHPL_LOC = INSTALL_ROOT .. myModuleName() .. "/" .. MOD_LEVEL .. "/" ..CHPL_HOST_PLATFORM
+local CHPL_LOC = INSTALL_ROOT .. "/" .. myModuleName() .. "/" .. MOD_LEVEL .. "/" ..CHPL_HOST_PLATFORM
 
 -- information variables
 local REL_FILE           = CHPL_LOC .. "/release_info"

--- a/util/build_configs/cray-internal/chapel.spec.template
+++ b/util/build_configs/cray-internal/chapel.spec.template
@@ -1,62 +1,13 @@
-#!/bin/bash
-
-# Generate an RPM spec file for Chapel Cray Module
-# Writes to stdout
-
-set -e
-
-cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
-source $cwd/../functions.bash
-
-# Accept command line parameters of the form NAME=Value. Or use environment variables.
-
-while test $# -gt 0; do
-    case $1 in ( *=* ) export "$1" ;; esac
-    shift
-done
-
-# Cray-internal-specific shell variables
-
-source $cwd/common.bash
-
-# Generate the first part of the spec file with shell expansion
-
-if [ "$chpl_platform" = hpe-cray-ex ]; then
-    # HPE Cray EX rpm may be relocatable, since all %files start with %prefix.
-    platform_prefix=/opt/cray
-    set_def_subdir=admin-pe/set_default_files
-else
-    # Before HPE Cray EX, rpm is not relocatable.
-    platform_prefix=/opt
-    set_def_subdir=cray/admin-pe/set_default_files
-fi
-
-cat <<PART_1
-%define name chapel-$pkg_version
+%define name chapel-@@{pkg_version}
 %define real_name chapel
-%define version $rpm_version
-%define pkg_version $pkg_version
-%define chpl_home_basename $( basename "$CHPL_HOME" )
-%define pkg_release $rpm_release
-%define build_type $chpl_platform
-%define platform_prefix $platform_prefix
-%define set_def_subdir $set_def_subdir
+%define version @@{rpm_version}
+%define pkg_version @@{pkg_version}
+%define chpl_home_basename @@{basename_of_CHPL_HOME}
+%define pkg_release @@{rpm_release}
+%define build_type @@{chpl_platform}
+%define platform_prefix @@{platform_prefix}
+%define set_def_subdir @@{set_def_subdir}
 %define _binary_payload w9.gzdio
-PART_1
-
-# Notes:
-#
-#   "Source: %{chpl_home_basename}.tar.gz" (below) is bogus.
-#   There is no such file. We do not use the usual RPM %setup macro.
-#   Instead, we provide a _builddir (RPM_BUILD_DIR) already
-#   pre-populated, to save the time of tarring/un-tarring the big
-#   compressed tar file.
-#   Rpmbuild uses the given "Source:" filename only to infer the
-#   "basename" of RPM_BUILD_DIR (e.g. chapel-1.17.1).
-
-# Generate the rest of the spec file, without shell expansion
-
-cat <<\PART_2
 Summary: Chapel language compiler and libraries
 Name:    %{name}
 Version: %{version}
@@ -156,4 +107,3 @@ fi
 %{prefix}/%{real_name}/%{pkg_version}
 %{prefix}/modulefiles/%{real_name}/%{pkg_version}
 %{prefix}/%{set_def_subdir}/set_default_%{real_name}_%{pkg_version}
-PART_2

--- a/util/build_configs/cray-internal/chapel.spec.template
+++ b/util/build_configs/cray-internal/chapel.spec.template
@@ -7,6 +7,9 @@
 %define build_type @@{chpl_platform}
 %define platform_prefix @@{platform_prefix}
 %define set_def_subdir @@{set_def_subdir}
+%define lmod_prefix @@{lmod_prefix}
+%define lmod_suffix @@{lmod_suffix}
+%define lmod_tgt_compilers @@{lmod_tgt_compilers}
 %define _binary_payload w9.gzdio
 Summary: Chapel language compiler and libraries
 Name:    %{name}
@@ -44,6 +47,7 @@ chmod -Rf a+rX,u+w,g-w,o-w .
 
 %install
 
+# Tcl modulefiles, and module itself
 cd          %{_topdir}
 mkdir -p                                                $RPM_BUILD_ROOT/%{prefix}/%{set_def_subdir}
 cp -p       set_default_%{real_name}_%{pkg_version}     $RPM_BUILD_ROOT/%{prefix}/%{set_def_subdir}/
@@ -56,6 +60,15 @@ cd          $RPM_BUILD_DIR/%{chpl_home_basename}
 find . -mindepth 1 -maxdepth 1 -exec mv -f {}           $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/%{build_type} \;
 cd          %{_topdir}
 cp -p       release_info                                $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/%{build_type}
+
+# Lua modulefiles
+for lmod_compiler in %{lmod_tgt_compilers} ; do
+  module_dir=%{lmod_prefix}/$lmod_compiler/%{lmod_suffix}/%{real_name}
+  mkdir -p $RPM_BUILD_ROOT/$module_dir
+  cp -p modulefile-lua-%{pkg_version} \
+        $RPM_BUILD_ROOT/$module_dir/%{pkg_version}.lua
+done
+
 # Clean up *.o files
 #rm -rf     $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/*/*/gen
 rm -rf      $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/%{build_type}/*/compiler/*/gen
@@ -84,7 +97,6 @@ fi
 chmod 755 $RPM_INSTALL_PREFIX/%{set_def_subdir}/set_default_%{real_name}_%{pkg_version}
 
 sed --in-place "s:\[BASE_INSTALL_DIR\]:$RPM_INSTALL_PREFIX:g" $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/%{pkg_version}
-
 %postun
 if [ $1 == 1 ]
 then
@@ -107,3 +119,4 @@ fi
 %{prefix}/%{real_name}/%{pkg_version}
 %{prefix}/modulefiles/%{real_name}/%{pkg_version}
 %{prefix}/%{set_def_subdir}/set_default_%{real_name}_%{pkg_version}
+%{lmod_prefix}/*/*/%{lmod_suffix}/%{real_name}/%{pkg_version}.lua

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -204,8 +204,8 @@ log_debug "Generate Lua modulefile ..."
     $cwd/process-template.py pkg_version="$pkg_version" \
                              platform_prefix="$platform_prefix" \
         --template $cwd/chapel.modulefile.lua.template \
-        --output $rpmbuild_dir/chapel.$pkg_version.lua
-    chmod 644 $rpmbuild_dir/chapel.$pkg_version.lua
+        --output $rpmbuild_dir/modulefile-lua-$pkg_version
+    chmod 644 $rpmbuild_dir/modulefile-lua-$pkg_version
 )
 
 # Generate set_default script, w versions
@@ -214,22 +214,26 @@ log_debug "Generate set_default_chapel_$pkg_version ..."
 $cwd/generate-set_default.bash > "$rpmbuild_dir/set_default_chapel_$pkg_version"
 chmod 755 "$rpmbuild_dir/set_default_chapel_$pkg_version"
 
-# Generate chapel.spec, w versions
+# Generate RPM spec file.
 
 log_debug "Generate chapel.spec ..."
 
 (
     if [ "$chpl_platform" = hpe-cray-ex ]; then
-        # HPE Cray EX rpm may be relocatable; all %files start with %prefix.
+        lmod_network=ofi
         platform_prefix=/opt/cray
         set_def_subdir=admin-pe/set_default_files
     else
-        # Before HPE Cray EX, rpm is not relocatable.
         platform_prefix=/opt
         set_def_subdir=cray/admin-pe/set_default_files
     fi
+    lmod_prefix=/opt/cray/pe/lmod/modulefiles/mpi
+    lmod_suffix=${lmod_network}/1.0/cray-mpich/8.0
     $cwd/process-template.py basename_of_CHPL_HOME="${CHPL_HOME##*/}" \
                              chpl_platform="$chpl_platform" \
+                             lmod_prefix="$lmod_prefix" \
+                             lmod_suffix="$lmod_suffix" \
+                             lmod_tgt_compilers="crayclang/10.0 gnu/8.0" \
                              pkg_version="$pkg_version" \
                              platform_prefix="$platform_prefix" \
                              rpm_release="$rpm_release" \

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -191,6 +191,23 @@ log_debug "Generate modulefile-$pkg_version ..."
 $cwd/generate-modulefile.bash > "$rpmbuild_dir/modulefile-$pkg_version"
 chmod 644 "$rpmbuild_dir/modulefile-$pkg_version"
 
+# Generate Lua modulefile for PE Lmod Hierarchy.
+
+log_debug "Generate Lua modulefile ..."
+
+(
+    if [ "$chpl_platform" = hpe-cray-ex ]; then
+        platform_prefix=/opt/cray
+    else
+        platform_prefix=/opt
+    fi
+    $cwd/process-template.py pkg_version="$pkg_version" \
+                             platform_prefix="$platform_prefix" \
+        --template $cwd/chapel.modulefile.lua.template \
+        --output $rpmbuild_dir/chapel.$pkg_version.lua
+    chmod 644 $rpmbuild_dir/chapel.$pkg_version.lua
+)
+
 # Generate set_default script, w versions
 
 log_debug "Generate set_default_chapel_$pkg_version ..."

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -200,7 +200,27 @@ chmod 755 "$rpmbuild_dir/set_default_chapel_$pkg_version"
 # Generate chapel.spec, w versions
 
 log_debug "Generate chapel.spec ..."
-$cwd/generate-rpmspec.bash > "$rpmbuild_dir/chapel.spec"
+
+(
+    if [ "$chpl_platform" = hpe-cray-ex ]; then
+        # HPE Cray EX rpm may be relocatable; all %files start with %prefix.
+        platform_prefix=/opt/cray
+        set_def_subdir=admin-pe/set_default_files
+    else
+        # Before HPE Cray EX, rpm is not relocatable.
+        platform_prefix=/opt
+        set_def_subdir=cray/admin-pe/set_default_files
+    fi
+    $cwd/process-template.py basename_of_CHPL_HOME="${CHPL_HOME##*/}" \
+                             chpl_platform="$chpl_platform" \
+                             pkg_version="$pkg_version" \
+                             platform_prefix="$platform_prefix" \
+                             rpm_release="$rpm_release" \
+                             rpm_version="$rpm_version" \
+                             set_def_subdir="$set_def_subdir" \
+        --template $cwd/chapel.spec.template \
+        --output $rpmbuild_dir/chapel.spec
+)
 
 # Prepare the rpmbuild_dir subdirectory structure, with hardlinked files from CHPL_HOME/...
 

--- a/util/build_configs/cray-internal/process-template.py
+++ b/util/build_configs/cray-internal/process-template.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Replace substitutable strings starting with // in templates.
+Replace substitutable strings starting with @@ in templates.
 """
 
 import argparse, sys
@@ -24,15 +24,16 @@ def cli_to_dict(keys):
         substitutions[words[0]] = words[1]
     return substitutions
 
-# Use // as the delimiter
-class SlashTemplate(Template):
+# Change the delimiter from the default '$', since that might occur in
+# places we don't want to change in the files we're dealing with.
+class MyTemplate(Template):
     delimiter = '@@'
 
 def _main():
     args, keys = create_parser().parse_known_args()
 
     substitutions = cli_to_dict(keys)
-    src = SlashTemplate(args.template.read())
+    src = MyTemplate(args.template.read())
     result = src.substitute(substitutions)
     args.output.write(result)
 

--- a/util/build_configs/cray-internal/process-template.py
+++ b/util/build_configs/cray-internal/process-template.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+"""
+Replace substitutable strings starting with // in templates.
+"""
+
+import argparse, sys
+from string import Template
+
+def create_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--template', type=argparse.FileType('r'),
+                        help='The input template',
+                        default=sys.stdin)
+    parser.add_argument('--output', type=argparse.FileType('w'),
+                        help='The output file with substitutions made',
+                        default=sys.stdout)
+    return parser
+
+def cli_to_dict(keys):
+    substitutions = {}
+    for arg in keys:
+        words = arg.split('=', 1)
+        substitutions[words[0]] = words[1]
+    return substitutions
+
+# Use // as the delimiter
+class SlashTemplate(Template):
+    delimiter = '@@'
+
+def _main():
+    args, keys = create_parser().parse_known_args()
+
+    substitutions = cli_to_dict(keys)
+    src = SlashTemplate(args.template.read())
+    result = src.substitute(substitutions)
+    args.output.write(result)
+
+if __name__ == '__main__':
+    _main()

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -12,10 +12,10 @@ def get():
     gmp_val = overrides.get('CHPL_GMP')
     if not gmp_val:
         target_compiler = chpl_compiler.get('target')
-        if target_compiler == 'cray-prgenv-cray':
+        target_platform = chpl_platform.get('target')
+        if target_compiler == 'cray-prgenv-cray' and target_platform.startswith('cray-x'):
             gmp_val = 'system'
         else:
-            target_platform = chpl_platform.get('target')
 
             # Detect if gmp has been built for this configuration.
             third_party = get_chpl_third_party()

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -46,9 +46,14 @@ if module avail PrgEnv- 2>&1 | grep --quiet PrgEnv- ; then
     module unload "${existing_prgenv}" 2>/dev/null
     module load PrgEnv-gnu 2>/dev/null
   fi
-else if module savelist 2>&1 | grep --quiet PrgEnv-gnu ; then
+elif module savelist 2>&1 | grep --quiet PrgEnv-gnu ; then
   # We have a PrgEnv-gnu collection.
-  module restore PrgEnv-gnu 2> /dev/null
+  #
+  # The 'restore' will unload our Chapel module, so we have to preserve
+  # CHPL_HOME, which we'll need below.
+  save_CHPL_HOME=$CHPL_HOME
+  module restore PrgEnv-gnu &> /dev/null
+  export CHPL_HOME=$save_CHPL_HOME
 else
   # No PrgEnv-* meta-modules are available.  We can't tell the compiler
   # what to link.

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -28,17 +28,31 @@ if [[ $FAIL == 1 || -z $2 || -z $3 || -z $4 || -z $5 ]]; then
     exit 1
 fi
 
-# Ensure that PrgEnv-gnu is loaded
-existing_prgenv=$(module -t list 2>&1 | grep PrgEnv-)
-if [ -z "${existing_prgenv}" ]
-then
-  # No PrgEnv loaded, load PrgEnv-gnu
-  module load PrgEnv-gnu 2>/dev/null
-elif [[ "${existing_prgenv}" != PrgEnv-gnu* ]]
-then
-  # Replace current PrgEnv with PrgEnv-gnu
-  module unload "${existing_prgenv}" 2>/dev/null
-  module load PrgEnv-gnu 2>/dev/null
+#
+# We need to ensure that the Programming Environment is set up to use
+# the Gnu compiler.  This is complicated by the fact that PrgEnv-gnu
+# could be either a meta-module or a collection.
+#
+if module avail PrgEnv- 2>&1 | grep --quiet PrgEnv- ; then
+  # We have PrgEnv-* meta-modules.
+  existing_prgenv=$(module -t list 2>&1 | grep PrgEnv-)
+  if [ -z "${existing_prgenv}" ]
+  then
+    # No PrgEnv loaded, load PrgEnv-gnu
+    module load PrgEnv-gnu 2>/dev/null
+  elif [[ "${existing_prgenv}" != PrgEnv-gnu* ]]
+  then
+    # Replace current PrgEnv with PrgEnv-gnu
+    module unload "${existing_prgenv}" 2>/dev/null
+    module load PrgEnv-gnu 2>/dev/null
+  fi
+else if module savelist 2>&1 | grep --quiet PrgEnv-gnu ; then
+  # We have a PrgEnv-gnu collection.
+  module restore PrgEnv-gnu 2> /dev/null
+else
+  # No PrgEnv-* meta-modules are available.  We can't tell the compiler
+  # what to link.
+  exit 0
 fi
 
 # Set up the environment to make the proper libraries and include

--- a/util/config/gather-pe-chapel-pkgconfig-libs.bash
+++ b/util/config/gather-pe-chapel-pkgconfig-libs.bash
@@ -27,6 +27,10 @@ if [[ "$chpl_comm" != none ]]; then
       pe_chapel_pkgconfig_libs="cray-udreg:$pe_chapel_pkgconfig_libs"
     fi
   fi
+
+  if [[ "$chpl_comm" == ofi && $($CHPL_HOME/util/chplenv/chpl_libfabric.py) == system ]]; then
+    pe_chapel_pkgconfig_libs="libfabric:$pe_chapel_pkgconfig_libs"
+  fi
 fi
 
 


### PR DESCRIPTION
The Programming Environment on HPE Cray EX and XC systems has added a
Lua/Lmod hierarchical module system to the existing flat Tcl-based one.
Here, add a Lua modulefile for Chapel to work with that on EX systems.
We're only targeting EX systems for now because we need to match up with
their system feature-complete schedules.  This work will be adapted
later for XC systems.

A related change is that instead of using shell syntax to parameterize
here-documents to produce the modulefiles, this starts with standalone
template files and parameterizes those using a general-purpose python
script.  This seems a much cleaner and more readable technique.

This resolves https://github.com/Cray/chapel-private/issues/1416.
It also addresses https://github.com/Cray/chapel-private/issues/1390, but
doesn't fully resolve that one because we're still missing some files that
would be supplied by the PrgEnv command line driver that we don't use in
the situation described by that Issue.
It also addresses https://github.com/Cray/chapel-private/issues/1253, but
doesn't fully resolve that one because we need to deal with XC target
platforms also.