### PR TITLE
Fix chpl_home_utils.py --test-venv calls

### DIFF
--- a/util/devel/chpl-scripts-completion.bash
+++ b/util/devel/chpl-scripts-completion.bash
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-venv_path=$(python "$CWD/../chplenv/chpl_home_utils.py" --test-venv)
+venv_path=$(python "$CWD/../chplenv/chpl_home_utils.py" --chpldeps)
 
 register_argcomplete="register-python-argcomplete"
 if [[ "$venv_path" != "none" && -d "$venv_path" ]]; then
+  export PYTHONPATH="$venv_path":$PYTHONPATH
   register_argcomplete="$venv_path/bin/$register_argcomplete"
 fi
 

--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -55,7 +55,7 @@ export CHPL_HOME_ORIG=$CHPL_HOME
 export CHPL_TEST_UTIL_DIR=$CHPL_HOME_ORIG/util
 
 if [[ -z $CHPL_TEST_VENV_DIR ]]; then
-    export CHPL_TEST_VENV_DIR=`python $CHPL_TEST_UTIL_DIR/chplenv/chpl_home_utils.py --test-venv`
+    export CHPL_TEST_VENV_DIR=`python $CHPL_TEST_UTIL_DIR/chplenv/chpl_home_utils.py --chpldeps`
 fi
 if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then
     echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR='$CHPL_TEST_VENV_DIR'"


### PR DESCRIPTION
The `--test-venv` option was replaced with `--chpldeps` in #16694, so adjust
script that were using it.