### PR TITLE
 Fix chpl_home_utils.py --test-venv calls take 2

### DIFF
--- a/third-party/chpl-venv/chpldeps-main.py
+++ b/third-party/chpl-venv/chpldeps-main.py
@@ -1,5 +1,7 @@
+# This script ends up in chpldeps/__main__.py
+
 """
-chpldeps/__main__.py
+chpldeps
 ======
 
 This Python module contains the dependencies used by the Chapel project.
@@ -7,6 +9,7 @@ Dependencies can be invoked as subcommands in the following ways:
 
   python3 path/to/chpldeps sphinx-build <sphinx options>
   python3 path/to/chpldeps rst2man <rst2man options>
+  python3 path/to/chpldeps register-python-argcomplete
   python3 path/to/chpldeps path/to/something.py <something.py options>
 
 For the last case, this program assumes that something.py has a
@@ -20,14 +23,25 @@ import re
 import sys
 import importlib.util
 
+def missing_subcommand():
+    print("chpldeps requires a subcommand", file=sys.stderr)
+    print(__doc__, file=sys.stderr)
+    sys.exit(-1)
+
 if __name__ == '__main__':
 
     # leave out a python3 call if present
     starti = 1
+    if starti >= len(sys.argv):
+        missing_subcommand()
+
     if (sys.argv[1] == 'python3' or sys.argv[1] == 'python' or
         sys.argv[1].endswith('/python3') or sys.argv[1].endswith('/python')):
 
         starti = 2
+
+    if starti >= len(sys.argv):
+        missing_subcommand()
 
     # compute the subcommand we are running
     subcommand = sys.argv[starti]
@@ -58,6 +72,16 @@ if __name__ == '__main__':
 
         publish_cmdline(writer=manpage.Writer(), description=description)
 
+    elif subcommand == 'register-python-argcomplete':
+
+        # Run the argument as a program within bin/
+        # just by exec'ing it
+        # (can't import something with dashes)
+        my_bin_dir = os.path.join(os.path.dirname(__file__), 'bin')
+        subcommand_path = os.path.join(my_bin_dir, subcommand)
+
+        exec(open(subcommand_path).read())
+
     elif os.path.isfile(subcommand):
         # Run the argument as a python script with the dependencies.
         # Assumes that the script uses the convention of having a
@@ -73,4 +97,5 @@ if __name__ == '__main__':
     else:
         print("Unknown chpldeps subcommand {0}".format(subcommand),
               file=sys.stderr)
+        print(__doc__, file=sys.stderr)
         sys.exit(-1)

--- a/util/devel/chpl-scripts-completion.bash
+++ b/util/devel/chpl-scripts-completion.bash
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 
-CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-venv_path=$(python "$CWD/../chplenv/chpl_home_utils.py" --test-venv)
+# get the chpl home directory
+FIND_CHPL_HOME=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; cd ..; pwd)
 
-register_argcomplete="register-python-argcomplete"
-if [[ "$venv_path" != "none" && -d "$venv_path" ]]; then
-  register_argcomplete="$venv_path/bin/$register_argcomplete"
+CHPL_PYTHON=$($FIND_CHPL_HOME/util/config/find-python.sh)
+CHPLDEPS=$($CHPL_PYTHON "$FIND_CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
+
+register_argcomplete="none"
+if [[ "$CHPLDEPS" != "none" && -d "$CHPLDEPS" ]]; then
+  register_argcomplete="$CHPL_PYTHON $CHPLDEPS register-python-argcomplete"
+else
+  if [ -x "$(command -v register-python-argcomplete)" ]; then
+    register_argcomplete="register-python-argcomplete"
+  fi
 fi
 
 # Register any python scripts that use argparse/argcomplete
-if [ -x "$(command -v $register_argcomplete)" ]; then
+if [ "$register_argcomplete" != "none" ]; then
   eval "$($register_argcomplete start_test)"
 fi

--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -55,7 +55,8 @@ export CHPL_HOME_ORIG=$CHPL_HOME
 export CHPL_TEST_UTIL_DIR=$CHPL_HOME_ORIG/util
 
 if [[ -z $CHPL_TEST_VENV_DIR ]]; then
-    export CHPL_TEST_VENV_DIR=`python $CHPL_TEST_UTIL_DIR/chplenv/chpl_home_utils.py --test-venv`
+    echo "ERROR: script needs updating to work without CHPL_TEST_VENV_DIR set"
+    exit 1
 fi
 if [[ ! -d $CHPL_TEST_VENV_DIR ]]; then
     echo "ERROR: incorrect or missing CHPL_TEST_VENV_DIR='$CHPL_TEST_VENV_DIR'"


### PR DESCRIPTION
Follow-up to PR #16694 and #16560

Replaces #16722.

The --test-venv option was removed in #16694, so adjust scripts that were
using it.  To support chpl-scripts-completion.bash, added
`register-python-argcomplete` as a subcommand for the chpldeps
application. While there, improved the usage checking for chpldeps.

Reviewed by @ronawho - thanks!
