### PR TITLE
Initial GPU locale

### DIFF
--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 Advanced Micro Devices, Inc.
  * Copyright 2020 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
@@ -26,7 +25,7 @@ module LocaleModelHelpGPU {
   use SysCTypes;
 
   pragma "no doc"
-  config param debugAPULocale = false;
+  config param debugGPULocale = false;
 
   //////////////////////////////////////////
   //
@@ -90,7 +89,7 @@ module LocaleModelHelpGPU {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
     
-    if (debugAPULocale) {
+    if (debugGPULocale) {
       if (dsubloc == 0) {
           chpl_debug_writeln("** executing on CPU");
       }

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 Advanced Micro Devices, Inc.
+ * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module LocaleModelHelpGPU {
+
+  param localeModelHasSublocales = true;
+
+  public use LocaleModelHelpSetup;
+  public use LocaleModelHelpRuntime;
+  use SysCTypes;
+
+  pragma "no doc"
+  config param debugAPULocale = false;
+
+  //////////////////////////////////////////
+  //
+  // utilities
+  //
+  inline
+  proc chpl_getSubloc() {
+    extern proc chpl_task_getSubloc(): chpl_sublocID_t;
+    return chpl_task_getSubloc();
+  }
+
+  //////////////////////////////////////////
+  //
+  // support for "on" statements
+  //
+
+  //
+  // runtime interface
+  //
+  extern proc chpl_task_setSubloc(subloc: int(32));
+
+  //
+  // returns true if an executeOn can be handled directly
+  // by running the function in question.
+  // Applies to execute on and execute on fast.
+  // When performing a blocking on, the compiler will emit this sequence:
+  //
+  //  if (chpl_doDirectExecuteOn(targetLocale))
+  //         onStatementBodyFunction( args ... );
+  //  else
+  //         chpl_executeOn / chpl_executeOnFast
+  //
+  export
+  proc chpl_doDirectExecuteOn(in loc: chpl_localeID_t // target locale
+                             ):bool {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+
+    if (dnode != chpl_nodeID) {
+      return false; // need to move to different node
+    } else {
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        return true;
+      } else {
+        return false; // need to move to different sublocale
+      }
+    }
+  }
+
+  //
+  // regular "on"
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
+                      fn: int,              // on-body function idx
+                      args: chpl_comm_on_bundle_p,     // function args
+                      args_size: size_t     // args size
+                     ) {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    
+    if (debugAPULocale) {
+      if (dsubloc == 0) {
+          chpl_debug_writeln("** executing on CPU");
+      }
+      else if (dsubloc == 1) {
+          chpl_debug_writeln("** executing on GPU");
+      }
+    }
+
+   if dnode != chpl_nodeID {
+      var tls = chpl_task_getInfoChapel();
+      chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
+      chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+    } else {
+      // run directly on this node
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        chpl_ftable_call(fn, args);
+      } else {        
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        chpl_ftable_call(fn, args);
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+
+  //
+  // fast "on" (doesn't do anything that could deadlock a comm layer,
+  // in the Active Messages sense)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
+                          fn: int,              // on-body function idx
+                          args: chpl_comm_on_bundle_p,     // function args
+                          args_size: size_t     // args size
+                         ) {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if dnode != chpl_nodeID {
+      var tls = chpl_task_getInfoChapel();
+      chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
+      chpl_comm_execute_on_fast(dnode, dsubloc, fn, args, args_size);
+    } else {
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        chpl_ftable_call(fn, args);
+      } else {
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        chpl_ftable_call(fn, args);
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+
+  //
+  // nonblocking "on" (doesn't wait for completion)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
+                        fn: int,              // on-body function idx
+                        args: chpl_comm_on_bundle_p,     // function args
+                        args_size: size_t     // args size
+                       ) {
+    //
+    // If we're in serial mode, we should use blocking rather than
+    // non-blocking "on" in order to serialize the execute_ons.
+    //
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    var tls = chpl_task_getInfoChapel();
+    var isSerial = chpl_task_data_getSerial(tls);
+    if dnode == chpl_nodeID {
+      if isSerial {
+        chpl_ftable_call(fn, args);
+      } else {
+        chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
+        chpl_comm_taskCallFTable(fn, args, args_size, dsubloc);
+      }
+    } else {
+      chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
+      if isSerial {
+        chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+      } else {
+        chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
+      }
+    }
+  }
+}

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -93,12 +93,12 @@ module LocaleModelHelpGPU {
       if (dsubloc == 0) {
           chpl_debug_writeln("** executing on CPU");
       }
-      else if (dsubloc == 1) {
+      else if (dsubloc >= 1) {
           chpl_debug_writeln("** executing on GPU");
       }
     }
 
-   if dnode != chpl_nodeID {
+    if dnode != chpl_nodeID {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
       chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -36,6 +36,7 @@ module LocaleModelHelpSetup {
   use ChapelEnv;
   use Sys;
   use SysCTypes;
+  require "-lcudart";
 
   config param debugLocaleModel = false;
 
@@ -205,6 +206,31 @@ module LocaleModelHelpSetup {
     chpl_task_setSubloc(1:chpl_sublocID_t);
 
     dst.GPU = new unmanaged GPULocale(1:chpl_sublocID_t, dst);
+    chpl_task_setSubloc(origSubloc);
+  }
+
+  //helpSetupLocaleAPU(this, local_name, numSublocales, CPULocale, GPULocale);
+  proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string, out
+      numSublocales, type CPULocale, type GPULocale){
+
+    extern proc cudaGetDeviceCount(ref n: int);
+
+    var nDevices: int;
+    cudaGetDeviceCount(nDevices);
+
+    //1 cpu and number of GPU devices on a node
+    numSublocales = 1 + nDevices;
+
+    const origSubloc = chpl_task_getRequestedSubloc();
+
+    chpl_task_setSubloc(0:chpl_sublocID_t);
+    dst.CPU = new unmanaged CPULocale(0:chpl_sublocID_t, dst);
+
+    for i in 1..numSublocales {
+      chpl_task_setSubloc(1:chpl_sublocID_t);
+      dst.GPU = new unmanaged GPULocale(1:chpl_sublocID_t, dst);
+    }
+
     chpl_task_setSubloc(origSubloc);
   }
 }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -36,7 +36,6 @@ module LocaleModelHelpSetup {
   use ChapelEnv;
   use Sys;
   use SysCTypes;
-  require "-lcudart";
 
   config param debugLocaleModel = false;
 
@@ -103,6 +102,8 @@ module LocaleModelHelpSetup {
     root_accum.setRootLocaleValues(dst);
     here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
   }
+
+  //TODO: Create a helpSetupRootLocale function for GPUs
 
   // gasnet-smp and gasnet-udp w/ GASNET_SPAWNFN=L are local spawns
   private inline proc localSpawn() {
@@ -209,29 +210,12 @@ module LocaleModelHelpSetup {
     chpl_task_setSubloc(origSubloc);
   }
 
-  //helpSetupLocaleAPU(this, local_name, numSublocales, CPULocale, GPULocale);
-  //helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, numSublocales, type NumaDomain)
-  proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string, out
-      numSublocales, out childSpace, type CPULocale, type GPULocale){
+  proc helpSetupLocaleGPU(dst: borrowed LocaleModel, numSublocales: int,
+      out local_name:string, type CPULocale, type GPULocale){
 
-    extern proc cudaGetDeviceCount(ref n: int);
-
-    var nDevices: int;
-    cudaGetDeviceCount(nDevices);
-
-    //1 cpu and number of GPU devices on a node
-    numSublocales = 1 + nDevices;
-
-    //TODO: resize childSpace; childSpace = {0..#numSublocales};
-    childSpace = {0..#numSublocales};
+    var childSpace = {0..#numSublocales};
 
     const origSubloc = chpl_task_getRequestedSubloc();
-
-    //chpl_task_setSubloc(0:chpl_sublocID_t);
-
-    //TODO: if i == 0, then add cpu, otherwise GPU
-
-    //dst.CPU = new unmanaged CPULocale(0:chpl_sublocID_t, dst);
 
     for i in childSpace {
         chpl_task_setSubloc(i:chpl_sublocID_t);
@@ -240,12 +224,6 @@ module LocaleModelHelpSetup {
         else
           dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
     }
-/*
-    for i in 1..numSublocales {
-      chpl_task_setSubloc(i:chpl_sublocID_t);
-      dst.GPU = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
-    }
-*/
     chpl_task_setSubloc(origSubloc);
   }
 }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -210,8 +210,9 @@ module LocaleModelHelpSetup {
   }
 
   //helpSetupLocaleAPU(this, local_name, numSublocales, CPULocale, GPULocale);
+  //helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, numSublocales, type NumaDomain)
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string, out
-      numSublocales, type CPULocale, type GPULocale){
+      numSublocales, out childSpace, type CPULocale, type GPULocale){
 
     extern proc cudaGetDeviceCount(ref n: int);
 
@@ -221,16 +222,30 @@ module LocaleModelHelpSetup {
     //1 cpu and number of GPU devices on a node
     numSublocales = 1 + nDevices;
 
+    //TODO: resize childSpace; childSpace = {0..#numSublocales};
+    childSpace = {0..#numSublocales};
+
     const origSubloc = chpl_task_getRequestedSubloc();
 
-    chpl_task_setSubloc(0:chpl_sublocID_t);
-    dst.CPU = new unmanaged CPULocale(0:chpl_sublocID_t, dst);
+    //chpl_task_setSubloc(0:chpl_sublocID_t);
 
-    for i in 1..numSublocales {
-      chpl_task_setSubloc(1:chpl_sublocID_t);
-      dst.GPU = new unmanaged GPULocale(1:chpl_sublocID_t, dst);
+    //TODO: if i == 0, then add cpu, otherwise GPU
+
+    //dst.CPU = new unmanaged CPULocale(0:chpl_sublocID_t, dst);
+
+    for i in childSpace {
+        chpl_task_setSubloc(i:chpl_sublocID_t);
+        if i == 0 then
+          dst.childLocales[i] = new unmanaged CPULocale(i:chpl_sublocID_t, dst);
+        else
+          dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
     }
-
+/*
+    for i in 1..numSublocales {
+      chpl_task_setSubloc(i:chpl_sublocID_t);
+      dst.GPU = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
+    }
+*/
     chpl_task_setSubloc(origSubloc);
   }
 }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -103,7 +103,18 @@ module LocaleModelHelpSetup {
     here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
   }
 
-  //TODO: Create a helpSetupRootLocale function for GPUs
+  proc helpSetupRootLocaleGPU(dst:borrowed RootLocale) {
+    var root_accum:chpl_root_locale_accum;
+
+    forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
+      chpl_task_setSubloc(c_sublocid_any);
+      const node = new locale(new unmanaged LocaleModel(new locale (dst)));
+      dst.myLocales[locIdx] = node;
+      root_accum.accum(node);
+    }
+
+    root_accum.setRootLocaleValues(dst);
+  }
 
   // gasnet-smp and gasnet-udp w/ GASNET_SPAWNFN=L are local spawns
   private inline proc localSpawn() {

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -210,19 +210,19 @@ module LocaleModelHelpSetup {
     chpl_task_setSubloc(origSubloc);
   }
 
-  proc helpSetupLocaleGPU(dst: borrowed LocaleModel, numSublocales: int,
-      out local_name:string, type CPULocale, type GPULocale){
+  proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
+      numSublocales: int, type CPULocale, type GPULocale){
 
     var childSpace = {0..#numSublocales};
 
     const origSubloc = chpl_task_getRequestedSubloc();
 
     for i in childSpace {
-        chpl_task_setSubloc(i:chpl_sublocID_t);
-        if i == 0 then
-          dst.childLocales[i] = new unmanaged CPULocale(i:chpl_sublocID_t, dst);
-        else
-          dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
+      chpl_task_setSubloc(i:chpl_sublocID_t);
+      if i == 0 then
+        dst.childLocales[i] = new unmanaged CPULocale(i:chpl_sublocID_t, dst);
+      else
+        dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
     }
     chpl_task_setSubloc(origSubloc);
   }

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -326,20 +326,4 @@ module LocaleModel {
       }
     }
   }
-
-  //////////////////////////////////////////
-  //
-  // utilities
-  //
-  inline
-  proc chpl_getSubloc() {
-    halt("called chpl_getSubloc() in a locale model that lacks sublocales");
-    return c_sublocid_none;
-  }
-
-  proc deinit() {
-    for l in chpl_emptyLocales do {
-      delete l._instance;
-    }
-  }
 }

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -310,18 +310,18 @@ module LocaleModel {
     override proc getDefaultLocaleArray() const ref return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
-      // In the default architecture, there are only nodes and no sublocales.
-      // What is more, the nodeID portion of a wide pointer is the same as
-      // the index into myLocales that yields the locale representing that
-      // node.
-      return myLocales[chpl_rt_nodeFromLocaleID(id)];
+      const node = chpl_nodeFromLocaleID(id);
+      const subloc = chpl_sublocFromLocaleID(id);
+      if (subloc == c_sublocid_none) || (subloc == c_sublocid_any) then
+        return (myLocales[node:int]):locale;
+      else
+        return (myLocales[node:int].getChild(subloc:int)):locale;
     }
 
     proc deinit() {
       for loc in myLocales {
         on loc {
           rootLocaleInitialized = false;
-          delete loc._instance;
         }
       }
     }

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -241,7 +241,7 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      helpSetupLocaleGPU(this, numSublocales, local_name, CPULocale, GPULocale);
+      helpSetupLocaleGPU(this, local_name, numSublocales, CPULocale, GPULocale);
     }
     //------------------------------------------------------------------------}
   }

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -1,0 +1,107 @@
+module LocaleModel {
+
+  public use LocaleModelHelpFlat;
+  public use LocaleModelHelpMem;
+
+  use IO;
+
+  export
+  proc chpl_localeModel_sublocToExecutionSubloc(full_subloc:chpl_sublocID_t)
+  {
+    return full_subloc;  // execution sublocale is same as full sublocale
+  }
+
+  export
+  proc chpl_localeModel_sublocMerge(full_subloc:chpl_sublocID_t,
+                                    execution_subloc:chpl_sublocID_t)
+  {
+    return execution_subloc;  // no info needed from full sublocale
+  }
+  
+
+  //not in APU model but in flat model
+  //const chpl_emptyLocaleSpace: domain(1) = {1..0};
+  //pragma "unsafe"
+  //const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
+
+   //
+  // An instance of this class is the default contents 'rootLocale'.
+  //
+  // In the current implementation a platform-specific architectural description
+  // may overwrite this instance or any of its children to establish a more customized
+  // representation of the system resources.
+  //
+  class RootLocale : AbstractRootLocale {
+
+    const myLocaleSpace: domain(1) = {0..numLocales-1};
+    pragma "unsafe"
+    var myLocales: [myLocaleSpace] locale;
+
+    proc init() {
+      super.init(nilLocale);
+      nPUsPhysAcc = 0;
+      nPUsPhysAll = 0;
+      nPUsLogAcc = 0;
+      nPUsLogAll = 0;
+      maxTaskPar = 0;
+    }
+
+    // The setup() function must use chpl_initOnLocales() to iterate (in
+    // parallel) over the locales to set up the LocaleModel object.
+    // In addition, the initial 'here' must be set.
+    proc setup() {
+      helpSetupRootLocaleAPU(this);
+    }
+
+    // Has to be globally unique and not equal to a node ID.
+    // We return numLocales for now, since we expect nodes to be
+    // numbered less than this.
+    // -1 is used in the abstract locale class to specify an invalid node ID.
+    override proc chpl_id() return numLocales;
+    override proc chpl_localeid() {
+      return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
+    }
+    override proc chpl_name() return local_name();
+    proc local_name() return "rootLocale";
+
+    override proc writeThis(f) throws {
+      f <~> name;
+    }
+
+    override proc getChildCount() return this.myLocaleSpace.size;
+
+    proc getChildSpace() return this.myLocaleSpace;
+
+    iter getChildIndices() : int {
+      for idx in this.myLocaleSpace do
+        yield idx;
+    }
+
+    override proc getChild(idx:int) return this.myLocales[idx];
+
+    iter getChildren() : locale  {
+      for loc in this.myLocales do
+        yield loc;
+    }
+
+    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref return myLocales;
+
+    override proc localeIDtoLocale(id : chpl_localeID_t) {
+      const node = chpl_nodeFromLocaleID(id);
+      const subloc = chpl_sublocFromLocaleID(id);
+      if (subloc == c_sublocid_none) || (subloc == c_sublocid_any) then
+        return (myLocales[node:int]):locale;
+      else
+        return (myLocales[node:int].getChild(subloc:int)):locale;
+    }
+
+    proc deinit() {
+      for loc in myLocales {
+        on loc {
+          rootLocaleInitialized = false;
+        }
+      }
+    }
+  }
+}

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -272,7 +272,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc setup() {
-      helpSetupRootLocaleNUMA(this);
+      helpSetupRootLocaleGPU(this);
     }
 
     // Has to be globally unique and not equal to a node ID.

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -71,7 +71,8 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(new locale(_parent));
       sid = _sid;
-      name = _parent.chpl_name() + "-CPU" + sid:string;
+      //name = _parent.chpl_name() + "-CPU" + sid:string;
+      name = "node" + _parent._node_id:string + "-CPU" + sid:string;
     }
 
     override proc writeThis(f) throws {
@@ -168,7 +169,8 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(new locale(_parent));
       sid = _sid;
-      name = _parent.chpl_name() + "-GPU" + sid:string;
+      //name = _parent.chpl_name() + "-GPU" + sid:string;
+      name = "node"+ _parent._node_id:string + "-GPU" + sid:string;
     }
 
     override proc writeThis(f) throws {
@@ -365,16 +367,6 @@ module LocaleModel {
     proc setup() {
       //helpSetupLocaleAPU(this, local_name, numSublocales, CPULocale, GPULocale);
       helpSetupLocaleGPU(this, local_name, numSublocales, childSpace, CPULocale, GPULocale);
-      writeln(numSublocales);
-      //writeln(getChild(0).name);
-      //writeln(getChild(1).name);
-      //for child in this.getChildren() do {
-        //writeln(child.name);
-      //}
-      for idx in {0..#numSublocales} {
-        writeln(idx);
-        writeln(getChild(idx).name);
-      }
     }
     //------------------------------------------------------------------------}
   }
@@ -405,7 +397,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc setup() {
-      helpSetupRootLocaleFlat(this);
+      helpSetupRootLocaleNUMA(this);
     }
 
     // Has to be globally unique and not equal to a node ID.

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -1,10 +1,44 @@
-module LocaleModel {
+/*
+ * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// LocaleModel.chpl
+//
+// This provides a flat locale model architectural description.  The
+// locales contain memory and a multi-core processor with homogeneous
+// cores, and we ignore any affinity (NUMA effects) between the
+// processor cores and the memory.  This architectural description is
+// backward compatible with the architecture implicitly provided by
+// releases 1.6 and preceding.
+//
+module LocaleModel { 
 
   public use LocaleModelHelpFlat;
   public use LocaleModelHelpMem;
 
   use IO;
 
+  //
+  // The task layer calls these to convert between full sublocales and
+  // execution sublocales.  Full sublocales may contain more information
+  // in some locale models, but not in this one.
+  //
   export
   proc chpl_localeModel_sublocToExecutionSubloc(full_subloc:chpl_sublocID_t)
   {
@@ -17,14 +51,112 @@ module LocaleModel {
   {
     return execution_subloc;  // no info needed from full sublocale
   }
-  
 
-  //not in APU model but in flat model
-  //const chpl_emptyLocaleSpace: domain(1) = {1..0};
-  //pragma "unsafe"
-  //const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
+  const chpl_emptyLocaleSpace: domain(1) = {1..0};
+  pragma "unsafe"
+  const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
 
-   //
+  //
+  // A concrete class representing the nodes in this architecture.
+  //
+  class LocaleModel : AbstractLocaleModel {
+    const _node_id : int;
+    var local_name : string; // should never be modified after first assignment
+
+    // This constructor must be invoked "on" the node
+    // that it is intended to represent.  This trick is used
+    // to establish the equivalence the "locale" field of the locale object
+    // and the node ID portion of any wide pointer referring to it.
+    proc init() {
+      if rootLocaleInitialized {
+        halt("Cannot create additional LocaleModel instances");
+      }
+      _node_id = chpl_nodeID: int;
+
+      this.complete();
+
+      setup();
+    }
+
+    proc init(parent_loc : locale) {
+      if rootLocaleInitialized {
+        halt("Cannot create additional LocaleModel instances");
+      }
+
+      super.init(parent_loc);
+
+      _node_id = chpl_nodeID: int;
+
+      this.complete();
+
+      setup();
+    }
+
+    // top-level locale (node) number
+    override proc chpl_id() return _node_id;
+
+    override proc chpl_localeid() {
+      return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
+    }
+    override proc chpl_name() return local_name;
+
+    //
+    // Support for different types of memory:
+    // large, low latency, and high bandwidth
+    //
+    // The flat memory model assumes only one memory.
+    //
+    override proc defaultMemory() : locale {
+      return new locale(this);
+    }
+
+    override proc largeMemory() : locale {
+      return new locale(this);
+    }
+
+    override proc lowLatencyMemory() : locale {
+      return new locale(this);
+    }
+
+    override proc highBandwidthMemory() : locale {
+      return new locale(this);
+    }
+
+    proc getChildSpace() return chpl_emptyLocaleSpace;
+
+    override proc getChildCount() return 0;
+
+    iter getChildIndices() : int {
+      for idx in chpl_emptyLocaleSpace do
+        yield idx;
+    }
+
+    pragma "unsafe"
+    override proc getChild(idx:int) : locale {
+      halt("requesting a child from a flat LocaleModel locale");
+      var tmp:locale; // nil
+      return tmp;
+    }
+
+    iter getChildren() : locale  {
+      for loc in chpl_emptyLocales do
+        yield loc;
+    }
+
+    proc getChildArray() {
+      return chpl_emptyLocales;
+    }
+
+    //------------------------------------------------------------------------{
+    //- Implementation (private)
+    //-
+    proc setup() {
+      helpSetupLocaleFlat(this, local_name);
+    }
+    //------------------------------------------------------------------------}
+  }
+
+  //
   // An instance of this class is the default contents 'rootLocale'.
   //
   // In the current implementation a platform-specific architectural description
@@ -50,7 +182,7 @@ module LocaleModel {
     // parallel) over the locales to set up the LocaleModel object.
     // In addition, the initial 'here' must be set.
     proc setup() {
-      helpSetupRootLocaleAPU(this);
+      helpSetupRootLocaleFlat(this);
     }
 
     // Has to be globally unique and not equal to a node ID.
@@ -88,20 +220,36 @@ module LocaleModel {
     override proc getDefaultLocaleArray() const ref return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
-      const node = chpl_nodeFromLocaleID(id);
-      const subloc = chpl_sublocFromLocaleID(id);
-      if (subloc == c_sublocid_none) || (subloc == c_sublocid_any) then
-        return (myLocales[node:int]):locale;
-      else
-        return (myLocales[node:int].getChild(subloc:int)):locale;
+      // In the default architecture, there are only nodes and no sublocales.
+      // What is more, the nodeID portion of a wide pointer is the same as
+      // the index into myLocales that yields the locale representing that
+      // node.
+      return myLocales[chpl_rt_nodeFromLocaleID(id)];
     }
 
     proc deinit() {
       for loc in myLocales {
         on loc {
           rootLocaleInitialized = false;
+          delete loc._instance;
         }
       }
+    }
+  }
+
+  //////////////////////////////////////////
+  //
+  // utilities
+  //
+  inline
+  proc chpl_getSubloc() {
+    halt("called chpl_getSubloc() in a locale model that lacks sublocales");
+    return c_sublocid_none;
+  }
+
+  proc deinit() {
+    for l in chpl_emptyLocales do {
+      delete l._instance;
     }
   }
 }

--- a/runtime/include/localeModels/gpu/chpl-locale-model.h
+++ b/runtime/include/localeModels/gpu/chpl-locale-model.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_locale_model_h_
+#define _chpl_locale_model_h_
+
+#include "sys_basic.h"
+#include "chpltypes.h"
+
+//
+// This is the type of a global locale ID.
+//
+typedef struct {
+  int32_t node;
+} chpl_localeID_t;
+
+//
+// This is the initializer for a chpl_localeID_t.  This macro is
+// referenced explicitly in the compiler, in symbol.cpp.
+//
+#define CHPL_LOCALEID_T_INIT  {0}
+
+//
+// This is the external copy constructor for a chpl_localeID_t, specified
+// by the module code for a flat locale model.
+//
+static inline
+chpl_localeID_t chpl__initCopy_chpl_rt_localeID_t(chpl_localeID_t initial) {
+  return initial;
+}
+
+//
+// These functions are used by the module code to assemble and
+// disassemble global locale IDs.
+//
+static inline
+chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node, c_sublocid_t subloc) {
+  chpl_localeID_t loc = { node };
+  //assert(subloc == c_sublocid_any);
+  return loc;
+}
+
+static inline
+c_nodeid_t chpl_rt_nodeFromLocaleID(chpl_localeID_t loc) {
+  return loc.node;
+}
+
+static inline
+c_sublocid_t chpl_rt_sublocFromLocaleID(chpl_localeID_t loc) {
+  return c_sublocid_any;
+}
+
+//
+// These functions are exported from the locale model for use by
+// the tasking layer to convert between a full sublocale and an
+// execution sublocale.
+//
+extern
+c_sublocid_t chpl_localeModel_sublocToExecutionSubloc(
+                  c_sublocid_t full_subloc);
+
+extern
+c_sublocid_t chpl_localeModel_sublocMerge(c_sublocid_t full_subloc,
+                  c_sublocid_t execution_subloc);
+
+#endif // _chpl_locale_model_h_

--- a/runtime/include/localeModels/gpu/chpl-locale-model.h
+++ b/runtime/include/localeModels/gpu/chpl-locale-model.h
@@ -29,17 +29,18 @@
 //
 typedef struct {
   int32_t node;
+  int32_t subloc;
 } chpl_localeID_t;
 
 //
 // This is the initializer for a chpl_localeID_t.  This macro is
 // referenced explicitly in the compiler, in symbol.cpp.
 //
-#define CHPL_LOCALEID_T_INIT  {0}
+#define CHPL_LOCALEID_T_INIT  {0, 0}
 
 //
 // This is the external copy constructor for a chpl_localeID_t, specified
-// by the module code for a flat locale model.
+// by the module code for a numa locale model.
 //
 static inline
 chpl_localeID_t chpl__initCopy_chpl_rt_localeID_t(chpl_localeID_t initial) {
@@ -52,8 +53,7 @@ chpl_localeID_t chpl__initCopy_chpl_rt_localeID_t(chpl_localeID_t initial) {
 //
 static inline
 chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node, c_sublocid_t subloc) {
-  chpl_localeID_t loc = { node };
-  //assert(subloc == c_sublocid_any);
+  chpl_localeID_t loc = { node, subloc };
   return loc;
 }
 
@@ -64,7 +64,7 @@ c_nodeid_t chpl_rt_nodeFromLocaleID(chpl_localeID_t loc) {
 
 static inline
 c_sublocid_t chpl_rt_sublocFromLocaleID(chpl_localeID_t loc) {
-  return c_sublocid_any;
+  return loc.subloc;
 }
 
 //


### PR DESCRIPTION
This PR is an initial locale model for GPUs for one node (I haven't tried multiple nodes yet). For each locale, the first sublocale (sublocale 0) is a CPU and the N GPUs on the node are considered sublocale 1 to sublocale N. To get the number of GPUs, the function `cudaGetDeviceCount` is used, which is part of the CUDA runtime API.

This locale model is based on the APU locale model (for the implementation of the CPULocale and GPULocale class) and NUMA model (for implementation of the LocaleModel class).

The following code snippet iterates through and prints the names of the sublocales of a locale:
```chpl
var LM = here;
var n = LM.getChildCount();
for i in 0..n-1 do {
  writeln(LM.getChild(i).name);
}
```