### PR TITLE
Switch to a non-Cray version of the logo on the GitHub README page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,4 @@
-.. image:: https://chapel-lang.org/images/cray-chapel-logo-200.png
-    :align: center
+.. image:: https://chapel-lang.org/images/chapel-logo-200.png
 
 The Chapel Language
 ===================


### PR DESCRIPTION
With the acquisition by HPE, we're dropping "Cray" from the version of the Chapel logo that includes text.  This updates our GitHub README to use that updated version.

I made some attempts to also use a higher-res version of the logo and then shrinking it to get a crisper image on higher-res monitors like retina displays.  However, it seems that GitHub's rst doesn't support the height/width decorators on images (nor the center tag, which is why I removed it here).  See the commits on PR #16719 for my failed attempts including a link to an issue where many GitHub users have complained about this.