### PR TITLE
Update cache-remote to use attribute aligned instead of padding

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -634,16 +634,8 @@ struct rdcache_s {
   chpl_comm_nb_handle_t *pending;
   cache_seqn_t *pending_sequence_numbers;
 
-  // padding to get table 64-byte aligned
-  uint64_t pad0;
-  uint64_t pad1;
-  uint64_t pad2;
-  uint64_t pad3;
-  uint64_t pad4;
-  uint64_t pad5;
-  uint64_t pad6;
-
   // Lookup table
+  __attribute__ ((aligned (64)))
   struct cache_table_slot_s table[];
 };
 


### PR DESCRIPTION
Follow-up to PR #16379.

This PR updates the cache-remote implementation to use attribute aligned
instead of padding fields.  Note that either way the cache-remote
implementation includes an assertion checking for the alignment.

Reviewed by @gbtitus - thanks!

- [x] full local gasnet testing