### PR TITLE
Add a `bundled` target to the llvm Makefile

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -197,6 +197,8 @@ llvm-minimal: $(LLVM_CONFIGURED_HEADER_FILE) $(LLVM_HEADER_FILE) $(LLVM_SUPPORT_
 
 clang-included: llvm
 
+bundled: llvm
+
 system: $(LLVM_CLANG_CONFIG_FILE)
 
 system-minimal:


### PR DESCRIPTION
The llvm build expects to have a target matching what CHPL_LLVM is set to,
so add a `bundled` target that just requires the `llvm` target.