### PR TITLE
Fix memory leak for global array type expressions

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1030,10 +1030,11 @@ static void collectGlobals(ModuleSymbol* mod,
 
         // Recurse into calls to compiler generated functions that
         // return array types (forall expression functions).
-        // (Seach for globalTemps in normalize.cpp to see related code).
+        // (Search for globalTemps in normalize.cpp to see related code).
         if (FnSymbol* calledFn = fCall->resolvedFunction())
           if (calledFn->hasFlag(FLAG_MAYBE_ARRAY_TYPE))
-            collectGlobals(mod, calledFn->body, inited, initedSet);
+            if (calledFn->hasFlag(FLAG_COMPILER_GENERATED))
+              collectGlobals(mod, calledFn->body, inited, initedSet);
       }
 
     // Recurse in to a BlockStmt (or sub-classes of BlockStmt e.g. a loop)

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1027,6 +1027,13 @@ static void collectGlobals(ModuleSymbol* mod,
           if (VarSymbol* v = initsVariableOut(formal, actual))
             noteGlobalInitialization(mod, v, inited, initedSet);
         }
+
+        // Recurse into calls to compiler generated functions that
+        // return array types (forall expression functions).
+        // (Seach for globalTemps in normalize.cpp to see related code).
+        if (FnSymbol* calledFn = fCall->resolvedFunction())
+          if (calledFn->hasFlag(FLAG_MAYBE_ARRAY_TYPE))
+            collectGlobals(mod, calledFn->body, inited, initedSet);
       }
 
     // Recurse in to a BlockStmt (or sub-classes of BlockStmt e.g. a loop)


### PR DESCRIPTION
This PR fixes a leak apparent with code like this:

``` chapel
  type arrOfArr = [1..2][100..200] int;
  writeln(arrOfArr:string);
```

This is visible in the existing test
```
  types/typedefs/bradc/arrayTypedef.chpl
```

The problem here is that evaluateAutoDestroy in normalize.cpp hoists some
temporaries out of forall-expr functions representing types into module
scope. Meanwhile, the change to callDestructors in PR #16430 caused it to
no longer deinitialize such globals (because it never found the
initialization because it is within another function).  This commit
adjusts collectGlobals in callDestructors to delve into functions that
might return array types.

- [x] full local testing
- [x] types/typedefs/bradc/arrayTypedef.chpl no longer leaks
- [x] primers pass with verify+valgrind and do not leak

Reviewed by @e-kayrakli - thanks!

Future Work
 * can we manage memory for runtime types in a more principled manner,
   perhaps following along with domains (where some functions return
   unowned and some return owned)?
