### PR TITLE
Add test script for nightly gasnet ASAN testing

### DIFF
--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Test ASAN-compatible configuration with gasnet on full suite with
+# ASAN on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-gasnet.bash
+source $CWD/common-asan.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-asan"
+
+export GASNET_QUIET=Y
+
+# "Should be able to detect most memory errors, since remote r/w are
+# performed using active messages instead of RDMA".
+export CHPL_COMM_SUBSTRATE=udp
+export CHPL_GASNET_SEGMENT=everything
+
+echo $($CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 6) -multilocale)

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -17,4 +17,5 @@ export GASNET_QUIET=Y
 export CHPL_COMM_SUBSTRATE=udp
 export CHPL_GASNET_SEGMENT=everything
 
-echo $($CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 6) -multilocale)
+$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 6) -multilocale
+

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# Test ASAN-compatible configuration with gasnet on full suite with
-# ASAN on linux64.
+# Test ASAN-compatible configuration with gasnet & ASAN on linux64, running
+# multilocale tests only.
+#
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -18,5 +18,5 @@ export GASNET_QUIET=Y
 export CHPL_COMM_SUBSTRATE=udp
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 6) -multilocale
+$CWD/nightly -cron -multilocale ${nightly_args} $(get_nightly_paratest_args 6)
 

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -13,8 +13,10 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-asan"
 
 export GASNET_QUIET=Y
 
-# "Should be able to detect most memory errors, since remote r/w are
-# performed using active messages instead of RDMA".
+# The ASAN best practices doc recommends that SUBSTRATE be set to 'udp' and
+# SEGMENT be set to 'everything' in order to encourage active messages
+# instead of RDMA. This will let ASAN detect more memory errors.
+#
 export CHPL_COMM_SUBSTRATE=udp
 export CHPL_GASNET_SEGMENT=everything
 


### PR DESCRIPTION
Add a script to `util/cron` called `test-gasnet-asan.bash` that will run nightly AddressSanitizer testing for `COMM=gasnet`. Since single locale ASAN testing already takes 9+ hours, start by running `-multilocale` tests only.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>