### PR TITLE
Remove a local block from domain's array tracking code

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -237,20 +237,18 @@ module ChapelDistribution {
       var count = -1;
       on this {
         var cnt = -1;
-        local {
-          _arrsLock.lock();
-          _arrs_containing_dom -=1;
-          if rmFromList && trackArrays() {
-            if _arrs_head == x then _arrs_head = x.next;
-            if x.next != nil then x.next!.prev = x.prev;
-            if x.prev != nil then x.prev!.next = x.next;
-          }
-          cnt = _arrs_containing_dom;
-          // add one for the main domain record
-          if !_free_when_no_arrs then
-            cnt += 1;
-          _arrsLock.unlock();
+        _arrsLock.lock();
+        _arrs_containing_dom -=1;
+        if rmFromList && trackArrays() {
+          if _arrs_head == x then _arrs_head = x.next;
+          if x.next != nil then x.next!.prev = x.prev;
+          if x.prev != nil then x.prev!.next = x.next;
         }
+        cnt = _arrs_containing_dom;
+        // add one for the main domain record
+        if !_free_when_no_arrs then
+          cnt += 1;
+        _arrsLock.unlock();
         count = cnt;
       }
       return (count==0);

--- a/test/optimizations/remoteValueForwarding/serialization/domains.good
+++ b/test/optimizations/remoteValueForwarding/serialization/domains.good
@@ -1,6 +1,6 @@
 ===== on-stmt (variable domain) =====
 {1..10}
-LOCALE0: (<no communication>)
+LOCALE0: (get = 2)
 LOCALE1: (get = 9, put = 1, execute_on = 1)
 ===== on-stmt (const domain) =====
 LOCALE0: (<no communication>)

--- a/test/optimizations/remoteValueForwarding/serialization/domains.na-none.good
+++ b/test/optimizations/remoteValueForwarding/serialization/domains.na-none.good
@@ -1,6 +1,6 @@
 ===== on-stmt (variable domain) =====
 {1..10}
-LOCALE0: (<no communication>)
+LOCALE0: (get = 2)
 LOCALE1: (get = 9, put = 1, execute_on = 1)
 ===== on-stmt (const domain) =====
 LOCALE0: (<no communication>)


### PR DESCRIPTION
With #16740 we're now accessing remote data in what was a local block so
remove the local block. The alternative would be change to an external
list that localizes references, but that introduces allocations and
other overheads in the common case, whereas this introduces PUTs in a
relatively uncommon case of destroying an array on a different node than
the domain or other arrays declared over it.