### PR TITLE
Don't copy metadata in FileSystem.copyTree

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -508,7 +508,8 @@ proc copyMode(out error: syserr, src: string, dest: string) {
 }
 
 /* Will recursively copy the tree which lives under `src` into `dst`,
-   including all contents, permissions, and metadata.  `dst` must not
+   including all contents and permissions. Metadata such as file creation and
+   modification times, uid, and gid will not be preserved.  `dst` must not
    previously exist, this function assumes it can create it and any missing
    parent directories. If `copySymbolically` is `true`, symlinks will be
    copied as symlinks, otherwise their contents and metadata will be copied

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -559,7 +559,7 @@ private proc copyTreeHelper(src: string, dest: string, copySymbolically: bool=fa
     } else {
       // Either we didn't find a link, or copy symbolically is false, which
       // means we want the contents of the linked file, not a link itself.
-      try copy(fileSrcName, fileDestName, metadata=true);
+      try copy(fileSrcName, fileDestName, metadata=false);
     }
   }
 

--- a/test/library/standard/FileSystem/copyTree/.gitignore
+++ b/test/library/standard/FileSystem/copyTree/.gitignore
@@ -1,0 +1,1 @@
+usercopy

--- a/test/library/standard/FileSystem/copyTree/copyRoot.chpl
+++ b/test/library/standard/FileSystem/copyTree/copyRoot.chpl
@@ -1,0 +1,9 @@
+use FileSystem;
+
+/* Test that copying a directory containing root-owned filed works */
+
+config const path = '/usr/include/curses';
+
+proc main() {
+  FileSystem.copyTree(path, './usercopy');
+}

--- a/test/library/standard/FileSystem/copyTree/copyRoot.cleanfiles
+++ b/test/library/standard/FileSystem/copyTree/copyRoot.cleanfiles
@@ -1,0 +1,1 @@
+usercopy

--- a/test/library/standard/FileSystem/copyTree/copyRoot.skipif
+++ b/test/library/standard/FileSystem/copyTree/copyRoot.skipif
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This test depends on a root-owned directory containing a file existing
+FILE='/usr/include/curses/curses.h'
+
+if [ -f "$FILE" ]; then
+    # don't skip
+    echo 0
+else
+    # skip
+    echo 1
+fi


### PR DESCRIPTION
Don't copy metadata (uid, gid, last modified time) for `FileSystem.copyTree`.

Copying files should change the uid and gid to the user who copied the data, rather than trying to `chown` the file back to the original uid/gid. This behavior is consistent with Python's `shutil.copytree()` and Unix's `cp -r` (among other copy interfaces), and Chapel's default `copy()` behavior.

This PR modifies `copyTree` to _not_ copy the metadata of files and adds an (admittedly unusual) test to lock in this behavior.

Resolves https://github.com/chapel-lang/chapel/issues/16741


- [x] `start_test test/library/standard/FileSystem`
- [x] Add a regression test