### PR TITLE
Fix get_link_args() for libfabric

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -77,7 +77,7 @@ def get_compile_args(libfabric=get()):
 @memoize
 def get_link_args(libfabric=get()):
     libs = []
-    if libfabric == 'libfabric':
+    if libfabric == 'bundled':
         return third_party_utils.default_get_link_args('libfabric',
                                                        ucp=get_uniq_cfg_path(),
                                                        libs=['libfabric.la'],


### PR DESCRIPTION
Compare against 'bundled' for a variable setting instead of against
'libfabric'. This fixes the libfabric link issues introduced with the
bundled change.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>