### PR TITLE
Change CHPL_LLVM=llvm to CHPL_LLVM=bundled everywhere.

### DIFF
--- a/doc/rst/technotes/llvm.rst
+++ b/doc/rst/technotes/llvm.rst
@@ -29,7 +29,7 @@ generation, and support for ``--llvm-wide-opt``:
 .. code-block:: sh
 
   source ./util/setchplenv.bash
-  export CHPL_LLVM=llvm
+  export CHPL_LLVM=bundled
   # or, if you have already installed compatible LLVM libraries
   # export CHPL_LLVM=system
 
@@ -38,7 +38,7 @@ generation, and support for ``--llvm-wide-opt``:
 Note:
 
 * If you have a built llvm in ``third-party/llvm/install``, even if you forget
-  to ``export CHPL_LLVM=llvm``, the default will be to use the built llvm.  You
+  to ``export CHPL_LLVM=bundled``, the default will be to use the built llvm.  You
   can override this default by setting ``CHPL_LLVM=none``.
 
 * the Makefile in third-party/llvm will unpack LLVM and Clang source releases

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -212,7 +212,7 @@ CHPL_*_COMPILER
    ``CHPL_TARGET_COMPILER`` will default to the same value as ``CHPL_HOST_COMPILER``.
 
    .. note::
-     Note that builds with :ref:`readme-llvm` (i.e. when ``CHPL_LLVM=llvm``)
+     Note that builds with :ref:`readme-llvm` (i.e. when ``CHPL_LLVM=bundled``)
      will build the runtime twice: once with the compiler as described above and
      once with clang-included. We do this in order to avoid issues in linking
      objects built by different compilers.
@@ -658,17 +658,17 @@ CHPL_LLVM
        ============== ======================================================
        Value          Description
        ============== ======================================================
-       llvm           use the llvm/clang distribution in third-party
+       bundled        use the llvm/clang distribution in third-party
        system         find a compatible LLVM in system libraries;
                       note: the LLVM must be a version supported by Chapel
-       none           do not support llvm-/clang-related features
+       none           do not support llvm/clang-related features
        ============== ======================================================
 
    .. (comment) -minimal can be used but is only interesting for developers
        llvm-minimal   as above, but only build and link LLVM ADTs
        system-minimal as above, but only link LLVM ADTs
 
-   If unset, ``CHPL_LLVM`` defaults to ``llvm`` if you've already installed
+   If unset, ``CHPL_LLVM`` defaults to ``bundled`` if you've already installed
    llvm in third-party and ``none`` otherwise.
 
    Chapel currently supports LLVM 10.0.

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -32,7 +32,7 @@ about your environment for using Chapel:
     Cray and Intel.
 
     * Note that you will need a C++11 compiler to build LLVM or regular
-      expression support (i.e.  CHPL_LLVM=llvm or CHPL_REGEXP=re2). If
+      expression support (i.e.  CHPL_LLVM=bundled or CHPL_REGEXP=re2). If
       GCC is used, we recommend GCC version 5 or newer for this purpose.
 
   * Building GMP requires an M4 macro processor.

--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -22,7 +22,7 @@
   .. note:: 
 
     This package relies on Chapel ``extern`` code blocks and so requires that
-    ``CHPL_LLVM=llvm`` or ``CHPL_LLVM=system`` and that the Chapel compiler is
+    ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` and that the Chapel compiler is
     built with LLVM enabled. As well, currently only ``CHPL_TARGET_ARCH=x86_64``
     is supported as we make use of the x86-64 instruction: CMPXCHG16B_.
 

--- a/test/llvm/llvmDebug/llvmDebug_test.py
+++ b/test/llvm/llvmDebug/llvmDebug_test.py
@@ -49,7 +49,7 @@ else:
     debug_option = ' -debug-str '
 
 llvm_dwarfdump = None
-if CHPL_LLVM == "llvm":
+if CHPL_LLVM == "bundled":
     llvm_dwarfdump = (chpl_home + '/third-party/llvm/install/' +
                       CHPL_LLVM_UNIQ_CFG_PATH + '/bin/llvm-dwarfdump')
 else:

--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -17,7 +17,7 @@ to the Chapel team at https://chapel-lang.org/bugs.html.
 Using LLVM with Chapel
 ======================
 
-Chapel can be built (by setting CHPL_LLVM=llvm) to include LLVM
+Chapel can be built (by setting CHPL_LLVM=bundled) to include LLVM
 in order to enable extern block support and LLVM code generation.
 
 For more information on the current support for LLVM within Chapel,

--- a/third-party/llvm/find-llvm-config.sh
+++ b/third-party/llvm/find-llvm-config.sh
@@ -76,7 +76,7 @@ else
   then
     echo "Found version $BAD_VERSION at path $BAD" 1>&2
     echo "Please install an LLVM with version $ALLOW_VERS" 1>&2
-    echo "or set CHPL_LLVM=llvm to use the included LLVM" 1>&2
+    echo "or set CHPL_LLVM=bundled to use the included LLVM" 1>&2
   fi
   echo missing-llvm-config
 fi

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -90,7 +90,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_TASKS=qthreads
     export CHPL_LAUNCHER=none
     export CHPL_LIBFABRIC=system
-    export CHPL_LLVM=llvm       # llvm requires py27 and cmake
+    export CHPL_LLVM=bundled       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
 
     # We default to CHPL_LIBFABRIC=system for EX.  We need to point to

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -89,7 +89,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_COMM_SUBSTRATE=none
     export CHPL_TASKS=qthreads
     export CHPL_LAUNCHER=none
-    export CHPL_LLVM=llvm       # llvm requires cmake
+    export CHPL_LLVM=bundled       # llvm requires cmake
     export CHPL_AUX_FILESYS=none
 
     # As a general rule, more CPUs --> faster make.

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -89,7 +89,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_COMM_SUBSTRATE=none
     export CHPL_TASKS=qthreads
     export CHPL_LAUNCHER=none
-    export CHPL_LLVM=llvm       # llvm requires py27 and cmake
+    export CHPL_LLVM=bundled       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
 
     # As a general rule, more CPUs --> faster make.

--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -4,26 +4,26 @@
 #
 # We examine the first commandline parameter,
 #   $ source $CWD/common-llvm.bash system # $1 is "system", for example
-# if $1 is "llvm" or "system", we set CHPL_LLVM = $1
-# all other cases, we set CHPL_LLVM = "llvm" for backward-compatibility
+# if $1 is "bundled" or "system", we set CHPL_LLVM = $1
+# all other cases, we set CHPL_LLVM = "bundled" for backward-compatibility
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-# set CHPL_LLVM = "llvm" or "system", based on $1 if any
-# (default CHPL_LLVM = "llvm", and CHPL_LLVM = "none" is not allowed)
+# set CHPL_LLVM = "bundled" or "system", based on $1 if any
+# (default CHPL_LLVM = "bundled", and CHPL_LLVM = "none" is not allowed)
 
 case "$1" in
-( llvm | system )
+( bundled | system )
     export CHPL_LLVM=$1
     ;;
 ( * )
-    export CHPL_LLVM=llvm
+    export CHPL_LLVM=bundled
     ;;
 esac
 
-# setup environment based on CHPL_LLVM = "llvm" or "system"
+# setup environment based on CHPL_LLVM = "bundled" or "system"
 
-if test "$CHPL_LLVM" = llvm; then
+if test "$CHPL_LLVM" = bundled; then
 
     # Ensure that python 2.7 is at front of PATH. This is only done for
     # llvm configuration because the test systems are _very_ finicky about

--- a/util/cron/test-gasnet.llvm.bash
+++ b/util/cron/test-gasnet.llvm.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test gasnet configuration with CHPL_LLVM=llvm and pass --llvm flag to
+# Test gasnet configuration with CHPL_LLVM=bundled and pass --llvm flag to
 # compiler on linux64.
 
 CWD=$(cd $(dirname $0) ; pwd)

--- a/util/cron/test-llvm.bash
+++ b/util/cron/test-llvm.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Full test suite with CHPL_LLVM=llvm and pass --llvm flag to
+# Full test suite with CHPL_LLVM=bundled and pass --llvm flag to
 # compiler on linux64. Now uses paratest.server.
 
 # Needs /data/cf/chapel/setup_python27.bash (common-llvm)

--- a/util/cron/test-slurm-gasnet-ibv.llvm.bash
+++ b/util/cron/test-slurm-gasnet-ibv.llvm.bash
@@ -2,7 +2,7 @@
 #
 # Multi-node, multi-locale testing on a cray-cs with slurm-gasnetrun_ibv
 # launcher:
-# test gasnet configuration with CHPL_LLVM=llvm and pass --llvm flag to compiler.
+# test gasnet configuration with CHPL_LLVM=bundled and pass --llvm flag to compiler.
 # test against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)


### PR DESCRIPTION
This follows up https://github.com/chapel-lang/chapel/pull/16540.  It
converts all `CHPL_LLVM=llvm` settings to `CHPL_LLVM=bundled`.  We had
thought we didn't need to do that because the original PR caused
'llvm' to be treated as 'bundled' implicitly, but it also caused a
warning to be printed and that warning led to some unexpected
problems.  So here, just convert all the settings.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>