### PR TITLE
In the compiler, treat CHPL_LLVM=bundled like CHPL_LLVM=llvm.

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1952,7 +1952,8 @@ void runClang(const char* just_parse_filename) {
   if (0 == strcmp(CHPL_LLVM, "system")) {
     clangCC = get_clang_cc();
     clangCXX = get_clang_cxx();
-  } else if (0 == strcmp(CHPL_LLVM, "llvm")) {
+  } else if (0 == strcmp(CHPL_LLVM, "llvm") ||
+             0 == strcmp(CHPL_LLVM, "bundled")) {
     llvm_install += CHPL_THIRD_PARTY;
     llvm_install += "/llvm/install/";
     llvm_install += CHPL_LLVM_UNIQ_CFG_PATH;


### PR DESCRIPTION
This is more follow-up to the `CHPL_xyz=bundled` changes.  Here, teach the
compiler that `CHPL_LLVM=bundled` means what `CHPL_LLVM=llvm` has meant in
the past.