### PR TITLE
Add a use of the IO module to LinearAlgebra.leastSquares and a test file

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1538,6 +1538,7 @@ proc leastSquares(A: [] ?t, b: [] t, cond = -1.0) throws
   where usingLAPACK && isLAPACKType(t)
 {
   use SysCTypes;
+  use IO; // for string.format
   import LAPACK;
   require LAPACK.header;
 

--- a/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
@@ -276,6 +276,7 @@ proc testArray(truth : [?Dom] ?t, check : [Dom] t, src : string) {
 
 
 proc testEighHelper(mat0 : [?Dom]?t, true0, eig0) {
+  use IO; // for string.format
 
   param nBits = if isComplexType(t) then numBits(t)/2 else numBits(t);
   var one = eye(Dom, eltType=real(nBits));


### PR DESCRIPTION
Now that we have returned to respecting the privacy of use and import
statements when resolving methods, we need to add an explicit use of the IO
module in order to find string.format.

The tests that failed last night now pass with this change

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>