### PR TITLE
Small adjustments for Path module doc

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -337,6 +337,8 @@ proc commonPath(paths: []): string {
       writeln(dirname("/foo/bar/baz")); // Prints "/foo/bar"
       writeln(dirname("/foo/bar/")); // Also prints "/foo/bar"
 
+   Note that this is different from the Unix ``dirname`` function.
+
    :arg name: A string file name.  Note that this string does not have to be
               a valid file name, as the file itself will not be affected.
    :type name: `string`

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -85,7 +85,7 @@ param parentDir;
 
 /* 
    Denotes the separator between a directory and its child.  On all the
-   platforms that Chapel supports this parameter is set to "/
+   platforms that Chapel supports this parameter is set to "/"
 */
 param pathSep;
 

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -70,14 +70,30 @@ use SysError, IO;
 use Sys, SysBasic;
 use CPtr;
 
-/* Represents generally the current directory. This starts as the directory
-   where the program is being executed from.
+/* 
+   Represents generally the current directory. This starts as the directory
+   where the program is being executed from. On all the platforms that Chapel
+   supports this parameter is set to ".".
 */
-param curDir = ".";
-/* Represents generally the parent directory. */
-param parentDir = "..";
-/* Denotes the separator between a directory and its child. */
-param pathSep = "/";
+param curDir;
+
+/* 
+   Represents generally the parent directory. On all the platforms that Chapel
+   supports this parameter is set to "..".
+*/
+param parentDir;
+
+/* 
+   Denotes the separator between a directory and its child.  On all the
+   platforms that Chapel supports this parameter is set to "/
+*/
+param pathSep;
+
+// these can be set within a param `if`, in case we start to support platforms
+// where these are not the right values (e.g. Windows)
+curDir = ".";
+parentDir = "..";
+pathSep = "/";
 
 /*
    Localizes and unescapes string to create a bytes to be used for obtaining a
@@ -148,14 +164,14 @@ proc file.absPath(): string throws {
   return try Path.absPath(this.path);
 }
 
-/* Returns the basename of the file name provided.  For instance:
+/* Returns the file name portion of the path provided.  For instance:
 
    .. code-block:: Chapel
 
       writeln(basename("/foo/bar/baz")); // Prints "baz"
       writeln(basename("/foo/bar/")); // Prints "", because of the empty string
 
-   Note that this is different from the Unix basename function.
+   Note that this is different from the Unix ``basename`` function.
 
    :arg name: A string file name.  Note that this string does not have to be
               a valid file name, as the file itself will not be affected.
@@ -314,7 +330,7 @@ proc commonPath(paths: []): string {
   return result;
 }
 
-/* Returns the parent directory of the file name provided.  For instance:
+/* Returns the parent directory portion of the path provided.  For instance:
 
    .. code-block:: Chapel
 

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -73,11 +73,11 @@ use CPtr;
 /* Represents generally the current directory. This starts as the directory
    where the program is being executed from.
 */
-const curDir = ".";
+param curDir = ".";
 /* Represents generally the parent directory. */
-const parentDir = "..";
+param parentDir = "..";
 /* Denotes the separator between a directory and its child. */
-const pathSep = "/";
+param pathSep = "/";
 
 /*
    Localizes and unescapes string to create a bytes to be used for obtaining a


### PR DESCRIPTION
This PR makes some minor adjustments in the Path module documentation.

- Makes module level `const`s `param`
- Split-inits them to "hide" the default values
  - However, adds the default value in documentation to be more expressive about
    them.
- Adjusts basename/dirname documentation to clarify what they do.

These items all came during the module interface review or followups.

Test:
- [x] make docs
- [x] quickstart in `test/library/standard/Path`
- [x] standard
- [x] gasnet
