### PR TITLE
Fix issues with python27 testing

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -737,6 +737,8 @@ if ($runtests == 0) {
 
   # test system depends on python3, so with python2 we cannot do much other than
   # `make check`
+  $ENV{'CHPL_HOME'} = $chplhomedir;
+
   $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 make check";
   mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
 

--- a/util/cron/test-linux64-python27.bash
+++ b/util/cron/test-linux64-python27.bash
@@ -9,4 +9,18 @@ source $CWD/common.bash
 export CHPL_NIGHTLY_MAKE=gmake
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python27"
 
-$CWD/nightly -cron -python2 -examples ${nightly_args}
+# we need to override pythons that were setup by `source .bashrc` in
+# common.bash before running nightly. Also see the llvm config for a similar
+# trick
+py27_setup=/data/cf/chapel/setup_python27.bash
+if [ -f "${py27_setup}" ] ; then
+  source ${py27_setup}
+else
+  echo "[Warning: cannot find the python configuration script: ${py27_setup}]"
+fi
+
+export PATH=/cray/css/users/chapelu/no-python:$PATH
+export PATH=/cray/css/users/chapelu/no-python3:$PATH
+
+
+$CWD/nightly -cron -python2 ${nightly_args}


### PR DESCRIPTION
Fixes issues with python 2.7 testing:

- We were passing `-examples` to nightly, which would rely on python3
  dependence, so stop doing that.

- Even though we're setting some paths on the jenkins side to avoid using
  python3, `common.bash` runs a `source ~/.bashrc` which overrides python back
  to 3. So, modify the python27 test script to reset to python2.7.

- The part of `nightly` that runs was leaving `CHPL_HOME` unset but was using it,
   fix that.


