### PR TITLE
Updates to chplspell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Reporting bugs:        https://chapel-lang.org/bugs.html
 Chapel documentation:  https://chapel-lang.org/docs/
 GitHub:                https://github.com/chapel-lang/chapel
 Discussion forums:     https://chapel.discourse.group
-Gitter chatroom:       https://gitter.im/chapel-lang/chapel
+Gitter chat room:      https://gitter.im/chapel-lang/chapel
 Stack Overflow:        http://stackoverflow.com/questions/tagged/chapel
 Twitter:               https://twitter.com/ChapelLanguage
 Facebook:              https://www.facebook.com/ChapelLanguage

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -123,6 +123,7 @@ chown
 chplcast
 chplcgdecl
 chplcgfns
+chpldeps
 chpldev
 chpldirent
 chplenv
@@ -2705,6 +2706,7 @@ pnext
 rnext
 
 FILEID: 2d19bb3e-1d83-11e6-a3a6-10ddb1d4c3d5
+sysctypes
 urse
 wkfn
 yylloc
@@ -3243,6 +3245,7 @@ localt
 
 FILEID: 0ebaef5a-2409-11e6-a3a6-10ddb1d4c3d5
 kout
+subslots
 
 FILEID: 5dfff152-2952-11e6-a3a6-10ddb1d4c3d5
 ndex
@@ -3309,6 +3312,7 @@ postzero
 
 FILEID: dde58592-2ac6-11e6-a3a6-10ddb1d4c3d5
 newbehavior
+ärvi
 
 FILEID: e13e71b8-2ac6-11e6-a3a6-10ddb1d4c3d5
 conan
@@ -3770,6 +3774,8 @@ itid
 ncnt
 nucls
 probs
+аноним
+легионов
 
 FILEID: 24a5f32a-792f-11e6-807a-843835579daa
 eterm
@@ -3835,6 +3841,7 @@ FILEID: 7b9a1e46-8ab8-11e6-b915-843835579daa
 chplspell
 
 FILEID: c6d25ce8-a183-11e6-91b8-10ddb1d4c3d5
+atype
 bdce
 ccfbb
 urse
@@ -4742,6 +4749,7 @@ comparand
 configmore
 cqes
 cswap
+ctok
 ctxs
 dsrd
 dupinfo
@@ -4759,6 +4767,7 @@ mrdesc
 mrkey
 ofichkerr
 ofichkret
+ofidbg
 ofiwg
 olen
 opnd
@@ -4795,6 +4804,7 @@ ttcip
 txed
 txns
 txntrk
+underbars
 ungood
 waitset
 writemsg
@@ -5331,6 +5341,20 @@ logln
 FILEID: 22cf2998-09c4-11eb-b2e8-10ddb1d4c3d5
 globalvars
 
+FILEID: f50f46a0-2e9e-11eb-adc5-acbc32c4f96b
+gitconfig
+gitmessage
+
+FILEID: fdcdfd40-2e9e-11eb-adc5-acbc32c4f96b
+cyclicnuma
+ddatas
+
+FILEID: 1234061c-2e9f-11eb-adc5-acbc32c4f96b
+lcudart
+
+FILEID: fe77e30e-2e9f-11eb-adc5-acbc32c4f96b
+developercertificate
+
 NATURAL:
 aarch
 abcd
@@ -5352,6 +5376,7 @@ adjoint
 afaik
 afterwards
 aggregator
+aggregators
 akash
 akihiro
 akshansh
@@ -6268,6 +6293,7 @@ ghangas
 gilbert
 github
 gitignore
+gitter
 glagolitic
 glibc
 globalattr
@@ -7628,6 +7654,7 @@ sigkill
 sigmask
 signbit
 signedness
+signoff
 signum
 sigpipe
 sigplan
@@ -8210,4 +8237,8 @@ zlib
 zolotov
 zpos
 zypper
+álaga
+øbenhavns
+ławski
+śniak
 

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -4343,10 +4343,6 @@ thid
 tidx
 wyeoh
 
-FILEID: b000f2de-fd7e-11e6-980e-10ddb1d4c3d5
-cyclicnuma
-ddatas
-
 FILEID: cc606fa4-fd7e-11e6-980e-10ddb1d4c3d5
 taskfn
 

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -334,9 +334,6 @@
   "0cdb833a-fd7e-11e6-980e-10ddb1d4c3d5": [
     "doc/rst/developer/chips/17.rst"
   ],
-  "b000f2de-fd7e-11e6-980e-10ddb1d4c3d5": [
-    "doc/rst/developer/chips/18.rst"
-  ],
   "c16e02ce-36bc-11e7-96a7-10ddb1d4c3d5": [
     "doc/rst/developer/chips/19.rst"
   ],

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -1,4 +1,7 @@
 {
+  "fe77e30e-2e9f-11eb-adc5-acbc32c4f96b": [
+    ".github/CONTRIBUTING.md"
+  ],
   "20acc50e-2ad9-11e6-a3a6-10ddb1d4c3d5": [
     "ACKNOWLEDGEMENTS.md"
   ],
@@ -307,6 +310,9 @@
   "21b197c2-1e45-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/bestPractices/ContributorInfo.rst"
   ],
+  "f50f46a0-2e9e-11eb-adc5-acbc32c4f96b": [
+    "doc/rst/developer/bestPractices/DCO.rst"
+  ],
   "b1eb2c32-1e44-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/bestPractices/Potpourri.rst"
   ],
@@ -342,6 +348,9 @@
   ],
   "8ac11bda-2ac4-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/chips/inactive/11.rst"
+  ],
+  "fdcdfd40-2e9e-11eb-adc5-acbc32c4f96b": [
+    "doc/rst/developer/chips/inactive/18.rst"
   ],
   "45fe4b8e-62e1-11e7-88ba-10ddb1d4c3d5": [
     "doc/rst/developer/chips/inactive/21.rst"
@@ -561,6 +570,9 @@
   ],
   "e6ecf3ae-9c7b-11e8-b963-10ddb1d4c3d5": [
     "modules/internal/String.chpl"
+  ],
+  "1234061c-2e9f-11eb-adc5-acbc32c4f96b": [
+    "modules/internal/localeModels/gpu/LocaleModel.chpl"
   ],
   "d635d1bc-4aae-11e8-af7e-10ddb1d4c3d5": [
     "modules/internal/tasktable/on/ChapelTaskTable.chpl"


### PR DESCRIPTION
I didn't want the belated merging of Paul's PRs to have him be behind
again on day 1, so ran chplspell myself for once.  Turns out that due
to something (probably the Python 3 updates), we're now getting
mis-spellings on unicode characters.