### PR TITLE
First attempt at sorting the standard modules by category

### DIFF
--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -13,10 +13,6 @@ Automatic Modules
 All Chapel programs automatically ``use`` the modules :chpl:mod:`Builtins` ,
 :chpl:mod:`Math` , and :chpl:mod:`Types` by default.
 
-
-.. toctree::
-   :hidden:
-
 .. toctree::
    :maxdepth: 1
 

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -32,7 +32,7 @@ Data Structures
    Map <standard/Map>
    Set <standard/Set>
 
-   
+
 Diagnostics
 -----------
 
@@ -41,9 +41,8 @@ Diagnostics
 
    CommDiagnostics <standard/CommDiagnostics>
    Memory <standard/Memory>
-   Time <standard/Time>
 
-   
+
 Files/IO
 --------
 .. toctree::
@@ -52,34 +51,18 @@ Files/IO
    FileSystem <standard/FileSystem>
    IO <standard/IO>
    Path <standard/Path>
-   Regexp <standard/Regexp>
 
 
-System/Interoperability
------------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   CPtr <standard/CPtr>
-   DateTime <standard/DateTime>
-   Spawn <standard/Spawn>
-   Sys <standard/Sys>
-   SysBasic <standard/SysBasic>
-   SysCTypes <standard/SysCTypes>
-   SysError <standard/SysError>
-
-Language
---------
+Language Support
+----------------
 
 .. toctree::
    :maxdepth: 1
 
-   Help <standard/Help>
    Reflection <standard/Reflection>
    Types <standard/Types>
-   Version <standard/Version>
-   
+
+
 Math/Numerical
 --------------
 
@@ -92,7 +75,7 @@ Math/Numerical
    Math <standard/Math>
    Random <standard/Random>
 
-   
+
 Parallelism/Distributed Computing
 ---------------------------------
 
@@ -101,6 +84,32 @@ Parallelism/Distributed Computing
 
    Barriers <standard/Barriers>
    DynamicIters <standard/DynamicIters>
+
+System/Interoperability
+-----------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   CPtr <standard/CPtr>
+   Spawn <standard/Spawn>
+   Sys <standard/Sys>
+   SysBasic <standard/SysBasic>
+   SysCTypes <standard/SysCTypes>
+   SysError <standard/SysError>
+
+Utilities
+---------
+
+.. toctree::
+   :maxdepth: 1
+
+   DateTime <standard/DateTime>
+   Help <standard/Help>
+   Regexp <standard/Regexp>
+   Time <standard/Time>
+   Version <standard/Version>
+
 
 Deprecated Modules
 ------------------

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -6,6 +6,10 @@ Standard Modules
 Standard modules are those which describe features that are considered
 part of the Chapel Standard Library.
 
+
+Automatic Modules
+-----------------
+
 All Chapel programs automatically ``use`` the modules :chpl:mod:`Builtins` ,
 :chpl:mod:`Math` , and :chpl:mod:`Types` by default.
 
@@ -15,10 +19,102 @@ All Chapel programs automatically ``use`` the modules :chpl:mod:`Builtins` ,
 
 .. toctree::
    :maxdepth: 1
-   :glob:
+
+   Builtins <standard/Builtins>
+   Math <standard/Math>
+   Types <standard/Types>
 
 
-   standard/*
+Data Structures
+---------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Heap <standard/Heap>
+   List <standard/List>
+   Map <standard/Map>
+   Set <standard/Set>
+
+   
+Diagnostics
+-----------
+
+.. toctree::
+   :maxdepth: 1
+
+   CommDiagnostics <standard/CommDiagnostics>
+   Memory <standard/Memory>
+   Time <standard/Time>
+
+   
+Files/IO
+--------
+.. toctree::
+   :maxdepth: 1
+
+   FileSystem <standard/FileSystem>
+   IO <standard/IO>
+   Path <standard/Path>
+   Regexp <standard/Regexp>
+
+
+System/Interoperability
+-----------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   CPtr <standard/CPtr>
+   DateTime <standard/DateTime>
+   Spawn <standard/Spawn>
+   Sys <standard/Sys>
+   SysBasic <standard/SysBasic>
+   SysCTypes <standard/SysCTypes>
+   SysError <standard/SysError>
+
+Language
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   Help <standard/Help>
+   Reflection <standard/Reflection>
+   Types <standard/Types>
+   Version <standard/Version>
+   
+Math/Numerical
+--------------
+
+.. toctree::
+   :maxdepth: 1
+
+   BigInteger <standard/BigInteger>
+   BitOps <standard/BitOps>
+   GMP <standard/GMP>
+   Math <standard/Math>
+   Random <standard/Random>
+
+   
+Parallelism/Distributed Computing
+---------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Barriers <standard/Barriers>
+   DynamicIters <standard/DynamicIters>
+
+Deprecated Modules
+------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   Assert <standard/Assert>
+
+
 
 
 Index

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -10,8 +10,8 @@ part of the Chapel Standard Library.
 Automatic Modules
 -----------------
 
-All Chapel programs automatically ``use`` the modules :chpl:mod:`Builtins` ,
-:chpl:mod:`Math` , and :chpl:mod:`Types` by default.
+All Chapel programs automatically ``use`` the following modules by
+default:
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This is a concept that came up while reviewing the standard modules to stabilize their interfaces: having the documentation sort the long laundry list of standard modules into categories to make it easier to browse.
