### PR TITLE
Fix isOuterVar

### DIFF
--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -535,14 +535,15 @@ static bool isGlobalVar(Symbol* sym) {
 //
 // Is this symbol defined outside 'enclosingExpr'?
 //
-static bool isOuterVar(Symbol* sym, Expr* enclosingExpr) {
+bool isOuterVarLoop(Symbol* sym, Expr* enclosingExpr) {
   Symbol* enclosingSym = enclosingExpr->parentSymbol;
   Expr* curr = sym->defPoint;
   Symbol* currParentSym = curr->parentSymbol;
 
   // See if we are even in the same function.
   while (currParentSym != enclosingSym) {
-    if (currParentSym == NULL || currParentSym == rootModule)
+    if (isModuleSymbol(currParentSym))
+      // we made it all the way to the top without crossing enclosingSym, so
       return true; // 'sym' is defined outside 'enclosingSym', so it is outer
 
     curr = currParentSym->defPoint;
@@ -554,6 +555,8 @@ static bool isOuterVar(Symbol* sym, Expr* enclosingExpr) {
     if (curr == NULL) {
       // 'sym' better not be defined under a Symbol
       // that is adjacent to 'enclosingExpr'.
+      // 2020-11 the assert below means we do not enter the above while-loop,
+      // meaning that we do not encounter symbols with nested symbols.
       INT_ASSERT(currParentSym == sym->defPoint->parentSymbol);
       return true;
     }
@@ -562,9 +565,6 @@ static bool isOuterVar(Symbol* sym, Expr* enclosingExpr) {
 
     curr = curr->parentExpr;
   }
-
-  INT_ASSERT(false); // should not get here
-  return false;
 }
 
 static bool considerForOuter(Symbol* sym) {
@@ -599,7 +599,7 @@ static void findOuterVars(LoopExpr* loopExpr, std::set<Symbol*>& outerVars) {
 
   for_vector(SymExpr, se, uses) {
     Symbol* sym = se->symbol();
-    if (considerForOuter(sym) && isOuterVar(sym, loopExpr))
+    if (considerForOuter(sym) && isOuterVarLoop(sym, loopExpr))
         outerVars.insert(sym);
   }
 }

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -772,9 +772,11 @@ void ArgSymbol::verify() {
     INT_FATAL(this, "Bad ArgSymbol::variableExpr::parentSymbol");
   // ArgSymbols appear only in formal parameter lists.
   if (defPoint) {
-    FnSymbol* pfs = toFnSymbol(defPoint->parentSymbol);
-    INT_ASSERT(pfs);
-    INT_ASSERT(defPoint->list == &(pfs->formals));
+    if (FnSymbol* pfs = toFnSymbol(defPoint->parentSymbol)) {
+      INT_ASSERT(defPoint->list == &(pfs->formals));
+    } else {
+      INT_ASSERT(isTiMark(this));
+    }
   }
   if (intentsResolved) {
     if (intent == INTENT_BLANK || intent == INTENT_CONST) {

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -98,6 +98,11 @@ void buildEnumFunctions(EnumType* et);
 FnSymbol* build_accessor(AggregateType* ct, Symbol* field,
                          bool setter, bool typeMethod);
 
+// createTaskFunctions.cpp
+void initForTaskIntents();
+void removeTiMarks();
+bool isTiMark(Symbol* sym);
+
 // deadCodeElimination.cpp
 void deadBlockElimination();
 
@@ -116,6 +121,9 @@ CallExpr* setIteratorRecordShape(Expr* ref, Symbol* ir, Symbol* shapeSpec,
                                  bool fromForExpr);
 void setIteratorRecordShape(CallExpr* call);
 bool checkIteratorFromForExpr(Expr* ref, Symbol* shape);
+
+// LoopExpr.cpp
+bool isOuterVarLoop(Symbol* sym, Expr* enclosingExpr);
 
 // lowerIterators.cpp, lowerForalls.cpp
 void lowerForallStmtsInline();
@@ -138,8 +146,5 @@ CallExpr* findDownEndCount(FnSymbol* fn);
 // resolution
 Expr*     resolveExpr(Expr* expr);
 void      resolveBlockStmt(BlockStmt* blockStmt);
-
-// type.cpp
-void initForTaskIntents();
 
 #endif

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -57,59 +57,50 @@ Symbol*           markUnspecified = NULL;
 
 static ArgSymbol* tiMarkBlank     = NULL;
 static ArgSymbol* tiMarkIn        = NULL;
-static ArgSymbol* tiMarkConstDflt = NULL;
+static ArgSymbol* tiMarkConstDft  = NULL;
 static ArgSymbol* tiMarkConstIn   = NULL;
 static ArgSymbol* tiMarkConstRef  = NULL;
 static ArgSymbol* tiMarkRef       = NULL;
 
 void initForTaskIntents() {
-  //
-  // The function 'tiMarkHost' exists solely to host the ArgSymbols
-  // created below. Otherwise they would be purged by cleanAST().
-  //
-  // As of this writing, it is the only function with defPoint in rootModule.
-  // It is there to avoid cluttering the scope for the module "theProgram".
-  // It is never resolved, never invoked, and purged at the end of resolve().
-  //
-  FnSymbol* tiMarkHost = new FnSymbol("tiMarkHost");
-
   markPruned      = gVoid;
   markUnspecified = gNil;
 
-  tiMarkBlank     = new ArgSymbol(INTENT_BLANK,
-                                  "tiMarkBlank",
-                                  dtNothing);
+  tiMarkBlank    = new ArgSymbol(INTENT_BLANK,    "tiMarkBlank",   dtNothing);
+  tiMarkIn       = new ArgSymbol(INTENT_IN,       "tiMarkIn",      dtNothing);
+  tiMarkConstDft = new ArgSymbol(INTENT_CONST,    "tiMarkConstDft",dtNothing);
+  tiMarkConstIn  = new ArgSymbol(INTENT_CONST_IN, "tiMarkConstIn", dtNothing);
+  tiMarkConstRef = new ArgSymbol(INTENT_CONST_REF,"tiMarkConstRef",dtNothing);
+  tiMarkRef      = new ArgSymbol(INTENT_REF,      "tiMarkRef",     dtNothing);
 
-  tiMarkIn        = new ArgSymbol(INTENT_IN,
-                                  "tiMarkIn",
-                                  dtNothing);
+  // An ArgSymbol is expected to have its defPoint under an FnSymbol.
+  // Somehow we get away with placing these ones directly in rootBlock,
+  // which eliminates the need to have a dummy FnSymbol to host them.
+  // Ideally, replace these with dedicated representation.
+  rootBlock->insertAtTail(new DefExpr(tiMarkBlank));
+  rootBlock->insertAtTail(new DefExpr(tiMarkIn));
+  rootBlock->insertAtTail(new DefExpr(tiMarkConstDft));
+  rootBlock->insertAtTail(new DefExpr(tiMarkConstIn));
+  rootBlock->insertAtTail(new DefExpr(tiMarkConstRef));
+  rootBlock->insertAtTail(new DefExpr(tiMarkRef));
+}
 
-  tiMarkConstDflt = new ArgSymbol(INTENT_CONST,
-                                  "tiMarkConstDflt",
-                                  dtNothing);
+bool isTiMark(Symbol* sym) {
+  return sym == tiMarkBlank    ||
+         sym == tiMarkIn       ||
+         sym == tiMarkConstDft ||
+         sym == tiMarkConstIn  ||
+         sym == tiMarkConstRef ||
+         sym == tiMarkRef;
+}
 
-  tiMarkConstIn   = new ArgSymbol(INTENT_CONST_IN,
-                                  "tiMarkConstIn",
-                                  dtNothing);
-
-  tiMarkConstRef  = new ArgSymbol(INTENT_CONST_REF,
-                                  "tiMarkConstRef",
-                                  dtNothing);
-
-  tiMarkRef       = new ArgSymbol(INTENT_REF,
-                                  "tiMarkRef",
-                                  dtNothing);
-
-  tiMarkHost->insertFormalAtTail(tiMarkBlank);
-  tiMarkHost->insertFormalAtTail(tiMarkIn);
-  tiMarkHost->insertFormalAtTail(tiMarkConstDflt);
-  tiMarkHost->insertFormalAtTail(tiMarkConstIn);
-  tiMarkHost->insertFormalAtTail(tiMarkConstRef);
-  tiMarkHost->insertFormalAtTail(tiMarkRef);
-
-  tiMarkHost->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
-
-  rootBlock->insertAtTail(new DefExpr(tiMarkHost));
+void removeTiMarks() {
+  tiMarkBlank->defPoint->remove();
+  tiMarkIn->defPoint->remove();
+  tiMarkConstDft->defPoint->remove();
+  tiMarkConstIn->defPoint->remove();
+  tiMarkConstRef->defPoint->remove();
+  tiMarkRef->defPoint->remove();
 }
 
 // Return the tiMark symbol for the given ForallIntentTag.
@@ -117,7 +108,7 @@ void initForTaskIntents() {
 ArgSymbol* tiMarkForForallIntent(ShadowVarSymbol* svar) {
   switch (svar->intent) {
     case TFI_DEFAULT:     return tiMarkBlank;
-    case TFI_CONST:       return tiMarkConstDflt;
+    case TFI_CONST:       return tiMarkConstDft;
     case TFI_IN:          return tiMarkIn;
     case TFI_CONST_IN:    return tiMarkConstIn;
     case TFI_REF:         return tiMarkRef;
@@ -417,10 +408,11 @@ static bool isCorrespCoforallIndex(FnSymbol* fn, Symbol* sym)
 //
 static bool considerAsOuterVar(Symbol* sym, FnSymbol* fn) {
   if (sym->defPoint->parentSymbol == fn         || // defined in 'fn'
+      sym->defPoint->parentSymbol == rootModule || // a system symbol
       sym->isParameter()                        || // includes isImmediate()
       sym->hasFlag(FLAG_INSTANTIATED_PARAM)     || // a param, too (during resolution)
-      sym->defPoint->parentSymbol == rootModule || // a system symbol
       sym->hasFlag(FLAG_TEMP)                   || // a temp
+      sym->hasFlag(FLAG_LOCALE_PRIVATE)         || // special handling
 
       // NB 'type' formals do not have INTENT_TYPE
       sym->hasFlag(FLAG_TYPE_VARIABLE)     // 'type' aliases or formals
@@ -439,28 +431,27 @@ static bool considerAsOuterVar(Symbol* sym, FnSymbol* fn) {
 
 
 // Is 'sym' a non-const variable (including formals) defined outside of 'fn'?
-// This is a modification of isOuterVar() from flattenFunctions.cpp.
-//
-static bool
-isOuterVar(Symbol* sym, FnSymbol* fn) {
+static bool isOuterVarTaskFn(Symbol* sym, FnSymbol* fn) {
+  INT_ASSERT(! isModuleSymbol(sym));
+
+  // hit some common cases up front
   Symbol* symParent = sym->defPoint->parentSymbol;
-  Symbol* parent = fn->defPoint->parentSymbol;
+  if (symParent == fn)  // sym is declared within fn
+    return false;
+  if (isModuleSymbol(symParent)             ||   // sym is a global
+      symParent == fn->defPoint->parentSymbol)   // sym is adjacent to fn
+    return true;
 
+  // General case: for 'sym' to be non-outer,
+  // its chain of parentSymbol links must cross 'fn'.
+  Symbol* symGrandParent = symParent;
   while (true) {
-    if (!isFnSymbol(parent) && !isModuleSymbol(parent))
-      return false;
-    if (symParent == parent)
-      return true;
-    if (!parent->defPoint)
-      // Only happens when parent==rootModule (right?). This means symParent
-      // is not in any of the lexically-enclosing functions/modules, so
-      // it's gotta be within 'fn'.
-      return false;
+    symGrandParent = symGrandParent->defPoint->parentSymbol;
 
-    // continue to the enclosing scope
-    INT_ASSERT(parent->defPoint->parentSymbol &&
-               parent->defPoint->parentSymbol != parent); // ensure termination
-    parent = parent->defPoint->parentSymbol;
+    if (symGrandParent == fn)
+      return false;
+    if (isModuleSymbol(symGrandParent))
+      return true; // terminate search, as modules are not nested in functions
   }
 }
 
@@ -472,7 +463,7 @@ findOuterVars(FnSymbol* fn, SymbolMap& uses) {
   for_vector(SymExpr, symExpr, SEs) {
       Symbol* sym = symExpr->symbol();
 
-      if (considerAsOuterVar(sym, fn) && isOuterVar(sym, fn))
+      if (considerAsOuterVar(sym, fn) && isOuterVarTaskFn(sym, fn))
           uses.put(sym, markUnspecified);
   }
 }

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -889,6 +889,8 @@ static void cleanupVoidVarsAndFields() {
 void pruneResolvedTree() {
   removeUnusedFunctions();
 
+  removeTiMarks();
+
   if (fRemoveUnreachableBlocks) {
     deadBlockElimination();
   }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -31,31 +31,6 @@
 // needsShadowVar() and helpers
 //
 
-// Is 'sym' defined outside 'block'?
-static bool isOuterVarNew(Symbol* sym, BlockStmt* block) {
-  DefExpr*  defPt = sym->defPoint;
-  Expr* parentExp = defPt->parentExpr;
-
-  while (true) {
-    if (!parentExp) {
-      Symbol* parentSym = defPt->parentSymbol;
-      if (isModuleSymbol(parentSym))
-        // We reached the outermost level and did not come across 'block'.
-        return true;
-
-      defPt     = parentSym->defPoint;
-      parentExp = defPt->parentExpr;
-      continue;
-    }
-    if (parentExp == block)
-      return false;
-
-    parentExp = parentExp->parentExpr;
-  }
-  INT_ASSERT(false);
-  return false; // dummy
-}
-
 // Is 'sym' an index variable of 'fs' ?
 static bool isFsIndexVar(ForallStmt* fs, Symbol* sym)
 {
@@ -84,7 +59,7 @@ static bool needsShadowVar(ForallStmt* fs, BlockStmt* block, Symbol* sym) {
     !sym->hasFlag(FLAG_TEMP)     && // not a temp
     !isFsIndexVar(fs, sym)       && // not fs's index var
     !isFsShadowVar(fs, sym)      && // not fs's shadow var
-    isOuterVarNew(sym, block);      // it must be an outer variable
+    isOuterVarLoop(sym, block);     // it must be an outer variable
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -236,6 +236,10 @@ static void buildVisibleFunctionMap() {
         block = theProgram->block;
       } else {
         block = getVisibilityScope(fn->defPoint);
+        // As of PR #16695, getVisibleFunctions() et al do not check rootModule
+        // for visible functions. (Although they could, if desired.)
+        // So, ensure we do not add anything there.
+        INT_ASSERT(block != rootBlock);
       }
       VisibleFunctionBlock* vfb = visibleFunctionMap.get(block);
       if (!vfb) {

--- a/test/modules/diten/moduleNotInitialized.chpl
+++ b/test/modules/diten/moduleNotInitialized.chpl
@@ -9,7 +9,7 @@ module OuterModule {
     }
     var a: unmanaged C?;
     var raninit = false;
-    proc init() {
+    proc M1init() {
       if (!raninit) {
         raninit = true;
         lock1 = false;
@@ -23,14 +23,14 @@ module OuterModule {
     use OuterModule;
     proc main {
       var b, c: sync borrowed object?;
-      begin {
+      begin with (ref a) {
         use M1;
-        M1.init();
+        M1init();
         b = a;
       }
       lock1;
       use M1;
-      M1.init();
+      M1init();
       c = a;
       lock2 = false;
 

--- a/test/modules/diten/moduleNotInitialized2.chpl
+++ b/test/modules/diten/moduleNotInitialized2.chpl
@@ -6,7 +6,7 @@ module OuterModule {
     use OuterModule;
     var a: int;
     var raninit = false;
-    proc init() {
+    proc M1init() {
       if (!raninit) {
         raninit = true;
         lock1 = false;
@@ -20,14 +20,14 @@ module OuterModule {
     use OuterModule;
     proc main {
       var b, c: sync int;
-      begin {
+      begin with (ref a) {
         use M1;
-        M1.init();
+        M1init();
         b = a;
       }
       lock1;
       use M1;
-      M1.init();
+      M1init();
       c = a;
       lock2 = false;
       writeln(b.readFF());

--- a/test/parallel/taskPar/taskIntents/module-outer-var.chpl
+++ b/test/parallel/taskPar/taskIntents/module-outer-var.chpl
@@ -1,0 +1,22 @@
+module Lib {
+  var globalLib = 10;
+  proc updateLib() { globalLib += 1; }
+}
+
+module Main {
+  use Lib;
+  var s$: sync int;
+  var globalMain = 20;
+  proc updateMain() { globalMain += 1; }
+
+  proc main {
+    coforall 1..2 {
+      s$ = 1; // grab the lock
+      writeln("globaLib   = ", globalLib);
+      writeln("globalMain = ", globalMain);
+      updateLib();
+      updateMain();
+      s$;
+    }
+  }
+}

--- a/test/parallel/taskPar/taskIntents/module-outer-var.good
+++ b/test/parallel/taskPar/taskIntents/module-outer-var.good
@@ -1,0 +1,4 @@
+globaLib   = 10
+globalMain = 20
+globaLib   = 10
+globalMain = 20


### PR DESCRIPTION
Resolves #16743.

Enforces special-case handling of variables with pragma "locale private"
aka FLAG_LOCALE_PRIVATE: even if such a variable is outer w.r.t. a task
construct, it is always referenced directly, a shadow variable is never
created for it.
Cf. forall loops / forall intents are not affected by this change.

Reviews several implementations of `isOuterVar()`:
* Fix the one in createTaskFunctions.cpp to iterate up from the symbol's def
  rather than from the task function's def. This is slightly more efficient
  than the one in LoopExpr because it can look at parentSymbols directly
  without worrying about parentExprs.
* Slightly tidy up the one in LoopExpr.cpp, now `isOuterVarLoop()`.
* Remove the one in implementForallIntents.cpp, instead use isOuterVarLoop().
* The one in flattenFunctions.cpp is left alone. It is a project on its own,
  as it incorporates concerns about RVF.


Fixing `isOuterVar()` in createTaskFunctions.cpp, now `isOuterVarTaskFn()`,
is the change responsible for resolving #16743.

While there:

* Eliminates the function `tiMarkHost`. Now that no visible functions are
  added to rootModule directly, adds an assert about that.
  This was triggered by the tiMark* ArgSymbols throwing off the new
  implementation of isOuterVarTaskFn(), which would have required
  a special case without this change.

* Shortens initForTaskIntents for readability. Renames tiMarkConstDflt
  to fit the code comfortably in eighty columns.

* As I had to add `with (ref a)` to the following two tests,
  I renamed their module-level function from init() to M1init(),
  expecting resolution of #16760:
```
test/modules/diten/moduleNotInitialized.chpl
test/modules/diten/moduleNotInitialized2.chpl
```

Testing:
* [x] standard paratest with futures
* [x] gasnet over multilocale tests