### PR TITLE
Improve error message for noinit without a type

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -348,7 +348,7 @@ Expr* InitNormalize::genericFieldInitTypeWoutInit(Expr*    insertBefore,
 
   Type* type = field->sym->type;
 
-  VarSymbol* tmp      = newTemp("tmp", type);
+  VarSymbol* tmp      = newTemp(field->sym->name, type);
   DefExpr*   tmpDefn  = new DefExpr(tmp);
   CallExpr*  tmpInit  = new CallExpr(PRIM_DEFAULT_INIT_VAR,
                                      tmp, field->exprType->copy());
@@ -419,7 +419,7 @@ Expr* InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
       insertBefore->insertBefore(fieldSet);
 
     } else {
-      VarSymbol* tmp      = newTemp("tmp");
+      VarSymbol* tmp      = newTemp(field->sym->name);
       DefExpr*   tmpDefn  = new DefExpr(tmp);
       PrimitiveTag tag    = isTypeVar ? PRIM_MOVE : PRIM_INIT_VAR;
       CallExpr*  tmpInit  = new CallExpr(tag, tmp, initExpr);
@@ -463,7 +463,7 @@ Expr* InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
       }
     }
 
-    VarSymbol* tmp      = newTemp("tmp");
+    VarSymbol* tmp      = newTemp(field->sym->name);
     DefExpr*   tmpDefn  = new DefExpr(tmp);
     PrimitiveTag tag    = isTypeVar ? PRIM_MOVE : PRIM_INIT_VAR;
     CallExpr*  tmpInit  = new CallExpr(tag, tmp, initExpr);
@@ -505,7 +505,7 @@ Expr* InitNormalize::fieldInitTypeWoutInit(Expr*    insertBefore,
 
   Type* type = field->sym->type;
 
-  VarSymbol* tmp      = newTemp("tmp", type);
+  VarSymbol* tmp      = newTemp(field->sym->name, type);
   DefExpr*   tmpDefn  = new DefExpr(tmp);
   CallExpr*  tmpInit  = new CallExpr(PRIM_DEFAULT_INIT_VAR,
                                      tmp, field->exprType->copy());
@@ -546,7 +546,7 @@ Expr* InitNormalize::fieldInitTypeWithInit(Expr*    insertBefore,
 
   } else {
     // Do not set type of 'tmp' so that resolution will infer it later
-    VarSymbol* tmp       = newTemp("tmp");
+    VarSymbol* tmp       = newTemp(field->sym->name);
     DefExpr*   tmpDefn   = new DefExpr(tmp);
     Expr*      checkType = NULL;
 
@@ -603,7 +603,7 @@ Expr* InitNormalize::fieldInitTypeInference(Expr*    insertBefore,
     insertBefore->insertBefore(fieldSet);
 
   } else {
-    VarSymbol* tmp      = newTemp("tmp");
+    VarSymbol* tmp      = newTemp(field->sym->name);
     DefExpr*   tmpDefn  = new DefExpr(tmp);
     CallExpr*  tmpInit  = new CallExpr(PRIM_INIT_VAR, tmp, initExpr);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6652,7 +6652,8 @@ void resolveInitVar(CallExpr* call) {
   if (srcExpr && srcExpr->symbol() == gNoInit) {
     if (call->numActuals() < 3) {
       // no init needs a type, cannot infer from gNoInit.
-      INT_FATAL(call, "bad no init call");
+      USR_FATAL(call, "cannot use noinit on the variable '%s' "
+                      "declared without a type", dst->name);
     }
 
     SymExpr* targetTypeExpr = toSymExpr(call->get(3)->remove());
@@ -6660,7 +6661,8 @@ void resolveInitVar(CallExpr* call) {
 
     if (targetType->symbol->hasFlag(FLAG_GENERIC)) {
       // no init needs a concrete type, cannot infer from gNoInit.
-      INT_FATAL(call, "bad no init call");
+      USR_FATAL(call, "cannot use noinit on the variable '%s' "
+                      "declared with generic type", dst->name);
     }
 
     // Since we are not initializing, just set the variable's type

--- a/test/expressions/noinit/generic-type-split.chpl
+++ b/test/expressions/noinit/generic-type-split.chpl
@@ -1,0 +1,2 @@
+var x: integral;
+x = noinit;

--- a/test/expressions/noinit/generic-type-split.good
+++ b/test/expressions/noinit/generic-type-split.good
@@ -1,0 +1,1 @@
+generic-type-split.chpl:2: error: cannot use noinit on the variable 'x' declared with generic type

--- a/test/expressions/noinit/no-type-split-class.chpl
+++ b/test/expressions/noinit/no-type-split-class.chpl
@@ -1,0 +1,8 @@
+class C {
+  var x;
+  proc init() {
+    x = noinit;
+  }
+}
+
+var myC = new C();

--- a/test/expressions/noinit/no-type-split-class.good
+++ b/test/expressions/noinit/no-type-split-class.good
@@ -1,0 +1,2 @@
+no-type-split-class.chpl:3: In initializer:
+no-type-split-class.chpl:4: error: cannot use noinit on the variable 'x' declared without a type

--- a/test/expressions/noinit/no-type-split.chpl
+++ b/test/expressions/noinit/no-type-split.chpl
@@ -1,0 +1,2 @@
+var x;
+x = noinit;

--- a/test/expressions/noinit/no-type-split.good
+++ b/test/expressions/noinit/no-type-split.good
@@ -1,0 +1,1 @@
+no-type-split.chpl:2: error: cannot use noinit on the variable 'x' declared without a type


### PR DESCRIPTION
Resolves #16794

When split-init is combined with noinit, it is possible to noinit
something without a type. This case was not caught by previous checking
and ran into an internal error. This PR improves that error to a better
user-facing one.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local futures testing