### PR TITLE
Fix a c_string to string assignment in the Spawn module

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -470,7 +470,7 @@ module Spawn {
           var env_c_str:c_string;
           var env_str:string;
           if sys_getenv(c"PE_PRODUCT_LIST", env_c_str)==1 {
-            env_str = env_c_str;
+            env_str = createStringWithNewBuffer(env_c_str);
             if env_str.count("HUGETLB") > 0 then
               throw SystemError.fromSyserr(
                   EINVAL,


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/16792 deprecated assigning from a
c_string to Chapel string. However, there's one usage of that left in the Spawn
module that's executed only on ugni. This PR changes that use to use
`createStringWithNewBuffer` instead.

Test:
- [x] `test/library/standard/Spawn/ugni` compiles without warning.

