### PR TITLE
Update HDF5 tests to take a path prefix from an environment variable

### DIFF
--- a/test/library/packages/HDF5/Hdf5PathHelp.chpl
+++ b/test/library/packages/HDF5/Hdf5PathHelp.chpl
@@ -1,0 +1,13 @@
+const pathPrefixEnvName = c"CHPL_HDF5_FILE_PREFIX";
+
+// The prefix read from the environment variable will be added
+// to the path for HDF5 files. Make sure to include the trailing slash!
+proc readPrefixEnv() {
+  use Sys;
+  var prefix: c_string;
+  if sys_getenv(pathPrefixEnvName, prefix) {
+    return createStringWithNewBuffer(prefix);
+  } else {
+    return "";
+  }
+}

--- a/test/library/packages/HDF5/ex_lite1.chpl
+++ b/test/library/packages/HDF5/ex_lite1.chpl
@@ -2,6 +2,7 @@
 // https://bitbucket.hdfgroup.org/projects/HDFFV/repos/hdf5/browse/examples/h5_crtdat.c
 
 use HDF5.C_HDF5;
+use Hdf5PathHelp;
 
 param RANK = 2:c_int;
 
@@ -13,7 +14,7 @@ proc main {
                              4:c_int, 5:c_int, 6:c_int];
 
   /* create HDF5 file */
-  file_id = H5Fcreate(c"ex_lite1.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  file_id = H5Fcreate((readPrefixEnv() + "ex_lite1.h5").c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
   /* create and write an integer type dataset named "dset" */
   H5LTmake_dataset_WAR(file_id, c"dset", RANK,

--- a/test/library/packages/HDF5/ex_lite2.chpl
+++ b/test/library/packages/HDF5/ex_lite2.chpl
@@ -3,13 +3,23 @@
 
 proc main {
   use HDF5.C_HDF5;
+  use Hdf5PathHelp;
+
   var file_id: hid_t,
       data: [0..#6] c_int,
       dims: [0..#2] hsize_t,
       i, j, nrow, n_values: size_t;
 
+  const filename = "ex_lite2_input.h5";
+  var pathPrefix = readPrefixEnv();
+
+  if pathPrefix != "" {
+    use FileSystem;
+    copyFile(filename, pathPrefix + filename);
+  }
+
   /* open file from ex_lite1.chpl */
-  file_id = H5Fopen(c"ex_lite2_input.h5", H5F_ACC_RDONLY, H5P_DEFAULT);
+  file_id = H5Fopen((pathPrefix + filename).c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
   /* read the dataset */
   H5LTread_dataset_int(file_id, c"/dset", data[0]);

--- a/test/library/packages/HDF5/ex_lite3.chpl
+++ b/test/library/packages/HDF5/ex_lite3.chpl
@@ -5,13 +5,16 @@ param ATTR_SIZE = 5;
 
 proc main {
   use HDF5.C_HDF5;
+  use Hdf5PathHelp;
 
   var file_id, dset_id, space_id: hid_t;
   var dims: [0..0] hsize_t = ATTR_SIZE;
   var data: [0..#ATTR_SIZE] c_int = [1:c_int, 2:c_int, 3:c_int, 4:c_int, 5:c_int];
+  const filename = "ex_lite3.h5";
+  const pathPrefix = readPrefixEnv();
 
   /* Create a file */
-  file_id = H5Fcreate("ex_lite3.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  file_id = H5Fcreate((pathPrefix+filename).c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
   /* Create a data space */
   space_id = H5Screate_simple(1, c_ptrTo(dims), nil);

--- a/test/library/packages/HDF5/parallelHdf5WriteSingleFile.chpl
+++ b/test/library/packages/HDF5/parallelHdf5WriteSingleFile.chpl
@@ -3,7 +3,9 @@ config const fileName = "mydata.h5",
 
 proc main {
   use BlockDist, HDF5, HDF5.IOusingMPI, SysCTypes;
+  use Hdf5PathHelp;
 
+  const pathPrefix = readPrefixEnv();
   var A = newBlockArr({1..100, 1..100}, c_int);
 
   for (i,j) in A.domain {
@@ -11,12 +13,12 @@ proc main {
   }
 
   writeln("Writing array");
-  hdf5WriteDistributedArray(A, fileName, dsetName);
+  hdf5WriteDistributedArray(A, pathPrefix + fileName, dsetName);
   writeln("Wrote array");
 
   var B = newBlockArr({1..100, 1..100}, c_int);
   writeln("Reading array");
-  hdf5ReadDistributedArray(B, fileName, dsetName);
+  hdf5ReadDistributedArray(B, pathPrefix + fileName, dsetName);
   writeln("Read array");
   for (i,j) in B.domain {
     if B[i,j] != (i*1000+j): c_int {

--- a/test/library/packages/HDF5/parallelReadInto1DArray.chpl
+++ b/test/library/packages/HDF5/parallelReadInto1DArray.chpl
@@ -1,16 +1,31 @@
 use HDF5;
+use Hdf5PathHelp;
 
 config const inputDir = "EXAMPLE_HDF5";
 config const dsetName = "/gisette";
 
+
+
 proc main {
   var filenameDom = {1..8, 1..1};
   var filenames: [filenameDom] string;
+  const prefixPath = readPrefixEnv();
+  if prefixPath != "" {
+    use FileSystem;
+    copyTree(inputDir, prefixPath + inputDir);
+  }
+
   for (i,j) in filenameDom {
-    filenames[i,j] = inputDir + "/datafile_" + i:string + "_" + j:string + ".h5";
+    filenames[i,j] = prefixPath + inputDir + "/datafile_" + i:string + "_" + j:string + ".h5";
   }
 
   var A = readNamedHDF5FilesInto1DArrayInt(filenames[.., 1], 8, 1, dsetName);
 
   writeln(A[5999*5000 + 50]);
+
+  if prefixPath != "" {
+    use FileSystem;
+    rmTree(prefixPath + inputDir);
+  }
+
 }

--- a/test/library/packages/HDF5/parallelReadInto1DArrayPreprocess.chpl
+++ b/test/library/packages/HDF5/parallelReadInto1DArrayPreprocess.chpl
@@ -1,4 +1,5 @@
 use HDF5, HDF5Preprocessors;
+use Hdf5PathHelp;
 
 config const inputDir = "EXAMPLE_HDF5";
 config const dsetName = "/gisette";
@@ -6,11 +7,22 @@ config const dsetName = "/gisette";
 proc main {
   var filenameDom = {1..8, 1..1};
   var filenames: [filenameDom] string;
+  const prefixPath = readPrefixEnv();
+
+  if prefixPath != "" {
+    use FileSystem;
+    copyTree(inputDir, prefixPath + inputDir);
+  }
+
   for (i,j) in filenameDom {
-    filenames[i,j] = inputDir + "/datafile_" + i:string + "_" + j:string + ".h5";
+    filenames[i,j] = prefixPath + inputDir + "/datafile_" + i:string + "_" + j:string + ".h5";
   }
   var p = new owned AddNPreprocessor(2);
   var A = readNamedHDF5FilesInto1DArrayInt(filenames[.., 1], 8, 1, dsetName, preprocessor=p);
 
   writeln(A[5999*5000 + 50]);
+  if prefixPath != "" {
+    use FileSystem;
+    rmTree(prefixPath + inputDir);
+  }
 }

--- a/test/library/packages/HDF5/parallelReadMultitype.chpl
+++ b/test/library/packages/HDF5/parallelReadMultitype.chpl
@@ -1,4 +1,5 @@
 use FileSystem, HDF5;
+use Hdf5PathHelp;
 
 type inputTypes = (int, real, c_string);
 
@@ -10,13 +11,19 @@ config const printTiming = false;
 proc main {
   use HDF5, Time;
 
+  const pathPrefix = readPrefixEnv();
+  if pathPrefix != "" {
+    use FileSystem;
+    copyTree(inputDir, pathPrefix + inputDir);
+  }
+
   var t = new Timer();
 
   for param i in 0..<inputTypes.size {
     type inType = inputTypes(i);
     param typeName = inType:string;
     t.start();
-    var files = readAllHDF5Files(Locales, inputDir, "/dset",
+    var files = readAllHDF5Files(Locales, pathPrefix+inputDir, "/dset",
                                  inType:string, inType, rank=2);
     t.stop();
 
@@ -35,5 +42,9 @@ proc main {
       writeln("read type ", typeName);
     }
     t.clear();
+  }
+  if pathPrefix != "" {
+    use FileSystem;
+    rmTree(pathPrefix + inputDir);
   }
 }

--- a/test/library/packages/HDF5/parallelReadMultitypePreprocess.chpl
+++ b/test/library/packages/HDF5/parallelReadMultitypePreprocess.chpl
@@ -1,4 +1,5 @@
 use FileSystem, HDF5, HDF5Preprocessors;
+use Hdf5PathHelp;
 
 type inputTypes = (int, real);
 
@@ -10,6 +11,13 @@ config const printTiming = false;
 proc main {
   use Time;
 
+  const pathPrefix = readPrefixEnv();
+  if pathPrefix != "" {
+    use FileSystem;
+    copyTree(inputDir, pathPrefix + inputDir);
+  }
+
+
   var t = new Timer();
   var preprocess = new owned AddNPreprocessor(1);
 
@@ -17,7 +25,7 @@ proc main {
     type inType = inputTypes(i);
     param typeName = inType:string;
     t.start();
-    var files = readAllHDF5Files(Locales, inputDir, "/dset",
+    var files = readAllHDF5Files(Locales, pathPrefix+inputDir, "/dset",
                                  inType:string, inType, rank=2,
                                  preprocessor=preprocess);
     t.stop();
@@ -38,4 +46,9 @@ proc main {
     }
     t.clear();
   }
+  if pathPrefix != "" {
+    use FileSystem;
+    rmTree(pathPrefix + inputDir);
+  }
+
 }

--- a/test/library/packages/HDF5/parallelWriteMultitype.chpl
+++ b/test/library/packages/HDF5/parallelWriteMultitype.chpl
@@ -1,4 +1,4 @@
-use BlockDist, HDF5, FileSystem;
+use BlockDist, HDF5, FileSystem, Hdf5PathHelp;
 
 record MyRec {
   var D: domain(1);
@@ -22,12 +22,15 @@ config const cleanupFiles = true;
 
 // This directory will be created and removed. Since it will be removed
 // don't allow setting it via 'config'.
-const hdf5Dir = "hdf5_dir";
+var hdf5Dir = "hdf5_dir";
 
 proc main {
   var Space = {1..nFiles};
   var BlockSpace = Space dmapped Block(Space, Locales, dataParTasksPerLocale=1);
   var data: [BlockSpace] MyRec;
+  const pathPrefix = readPrefixEnv();
+
+  hdf5Dir = pathPrefix + hdf5Dir;
 
   // create the directory hdf5Dir
   if !exists(hdf5Dir) then

--- a/test/library/packages/HDF5/readChunks1D.chpl
+++ b/test/library/packages/HDF5/readChunks1D.chpl
@@ -1,9 +1,15 @@
-use HDF5;
+use HDF5, Hdf5PathHelp;
 
 config const infileName = "readChunks1DInput.h5";
 config const dsetName = "Ai";
 
-for A in hdf5ReadChunks(infileName, dsetName,
+const pathPrefix = readPrefixEnv();
+if pathPrefix != "" {
+  use FileSystem;
+  copyFile(infileName, pathPrefix + infileName);
+}
+
+for A in hdf5ReadChunks(pathPrefix + infileName, dsetName,
                         chunkShape={1..8}, eltType=int) {
   writeln(A);
 }

--- a/test/library/packages/HDF5/readChunks1DPreprocess.chpl
+++ b/test/library/packages/HDF5/readChunks1DPreprocess.chpl
@@ -1,7 +1,13 @@
-use HDF5, HDF5Preprocessors;
+use HDF5, HDF5Preprocessors, Hdf5PathHelp;
 
 config const infileName = "readChunks1DInput.h5";
 config const dsetName = "Ai";
+
+const pathPrefix = readPrefixEnv();
+if pathPrefix != "" {
+  use FileSystem;
+  copyFile(infileName, pathPrefix + infileName);
+}
 
 const script = """
 #!/usr/bin/env bash
@@ -17,7 +23,7 @@ done < /dev/stdin
 
 var myScript = new owned ScriptPreprocessor(script);
 
-for A in hdf5ReadChunks(infileName, dsetName,
+for A in hdf5ReadChunks(pathPrefix+infileName, dsetName,
                         chunkShape={1..8}, eltType=int, preprocessor=myScript) {
   writeln(A);
 }

--- a/test/library/packages/HDF5/readChunks2D.chpl
+++ b/test/library/packages/HDF5/readChunks2D.chpl
@@ -1,9 +1,15 @@
-use HDF5;
+use HDF5, Hdf5PathHelp;
 
 config const infileName = "readChunks2DInput.h5";
 config const dsetName = "/dset";
 
-for A in hdf5ReadChunks(infileName, dsetName,
+const pathPrefix = readPrefixEnv();
+if pathPrefix != "" {
+  use FileSystem;
+  copy(infileName, pathPrefix + infileName);
+}
+
+for A in hdf5ReadChunks(pathPrefix+infileName, dsetName,
                         chunkShape={1..5, 1..5}, eltType=int) {
   writeln(A);
   writeln();

--- a/test/library/packages/HDF5/readChunks2DPreprocess.chpl
+++ b/test/library/packages/HDF5/readChunks2DPreprocess.chpl
@@ -1,11 +1,18 @@
-use HDF5, HDF5Preprocessors;
+use HDF5, HDF5Preprocessors, Hdf5PathHelp;
 
 config const infileName = "readChunks2DInput.h5";
 config const dsetName = "/dset";
 
+const pathPrefix = readPrefixEnv();
+if pathPrefix != "" {
+  use FileSystem;
+  copy(infileName, pathPrefix + infileName);
+}
+
+
 var addOne = new owned AddNPreprocessor(1);
 
-for A in hdf5ReadChunks(infileName, dsetName,
+for A in hdf5ReadChunks(pathPrefix+infileName, dsetName,
                         chunkShape={1..5, 1..5}, eltType=int, addOne) {
   writeln(A);
   writeln();

--- a/test/library/packages/HDF5/readDistrib1D.chpl
+++ b/test/library/packages/HDF5/readDistrib1D.chpl
@@ -6,7 +6,13 @@ config param testBlock       = true,
              testBlockCyclic = false;
 
 proc main {
-  use HDF5, HDF5.IOusingMPI;
+  use HDF5, HDF5.IOusingMPI, Hdf5PathHelp;
+
+  const pathPrefix = readPrefixEnv();
+  if pathPrefix != "" {
+    use FileSystem;
+    copy(fileName, pathPrefix + fileName);
+  }
 
   var Space = {1..100};
 
@@ -17,7 +23,7 @@ proc main {
     var BlockSpace = Space dmapped Block(boundingBox=Space);
     var A: [BlockSpace] int;
 
-    hdf5ReadDistributedArray(A, fileName, dsetName);
+    hdf5ReadDistributedArray(A, pathPrefix+fileName, dsetName);
     writeln(A);
   }
 
@@ -26,7 +32,7 @@ proc main {
     writeln("CyclicDist:");
     var CyclicSpace = Space dmapped Cyclic(startIdx=Space.low);
     var A: [CyclicSpace] int;
-    hdf5ReadDistributedArray(A, fileName, dsetName);
+    hdf5ReadDistributedArray(A, pathPrefix+fileName, dsetName);
     writeln(A);
   }
 
@@ -36,7 +42,7 @@ proc main {
     var BlockCyclicSpace = Space dmapped BlockCyclic(startIdx=Space.low,
                                                      blocksize=10);
     var A: [BlockCyclicSpace] int;
-    hdf5ReadDistributedArray(A, fileName, dsetName);
+    hdf5ReadDistributedArray(A, pathPrefix+fileName, dsetName);
     writeln(A);
   }
 }

--- a/test/library/packages/HDF5/readDistrib2D.chpl
+++ b/test/library/packages/HDF5/readDistrib2D.chpl
@@ -6,7 +6,13 @@ config param testBlock       = true,
              testBlockCyclic = false;
 
 proc main {
-  use HDF5, HDF5.IOusingMPI;
+  use HDF5, HDF5.IOusingMPI, Hdf5PathHelp;
+
+  const pathPrefix = readPrefixEnv();
+  if pathPrefix != "" {
+    use FileSystem;
+    copy(fileName, pathPrefix + fileName);
+  }
 
   var Space = {1..10, 1..10};
 
@@ -17,7 +23,7 @@ proc main {
     var BlockSpace = Space dmapped Block(boundingBox=Space);
     var A: [BlockSpace] int;
 
-    hdf5ReadDistributedArray(A, fileName, dsetName);
+    hdf5ReadDistributedArray(A, pathPrefix+fileName, dsetName);
     writeln(A);
   }
 
@@ -26,7 +32,7 @@ proc main {
     writeln("CyclicDist:");
     var CyclicSpace = Space dmapped Cyclic(startIdx=Space.low);
     var A: [CyclicSpace] int;
-    hdf5ReadDistributedArray(A, fileName, dsetName);
+    hdf5ReadDistributedArray(A, pathPrefix+fileName, dsetName);
     writeln(A);
   }
 
@@ -36,7 +42,7 @@ proc main {
     var BlockCyclicSpace = Space dmapped BlockCyclic(startIdx=Space.low,
                                                      blocksize=(3,3));
     var A: [BlockCyclicSpace] int;
-    hdf5ReadDistributedArray(A, fileName, dsetName);
+    hdf5ReadDistributedArray(A, pathPrefix+fileName, dsetName);
     writeln(A);
   }
 }


### PR DESCRIPTION
Update the HDF5 tests to read a path prefix from the environment variable
CHPL_HDF5_FILE_PREFIX. The path must include a trailing slash. They copy
any input files or directories to that path, then read/write there.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>