### PR TITLE
Adjust use of CHPL_BIN_SUBDIR in the skipif and execenvs for this test dir

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/EXECENV
+++ b/test/library/packages/ProtobufProtocolSupport/EXECENV
@@ -1,1 +1,5 @@
-PATH=$CHPL_HOME/bin/$CHPL_BIN_SUBDIR:$PATH
+#!/usr/bin/env bash
+
+# ensure protoc-gen-chpl in PATH
+bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
+echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"

--- a/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
@@ -3,7 +3,6 @@
 from distutils.spawn import find_executable
 
 import os
-import os.path
 
 chplPath = os.path.join(os.environ['CHPL_HOME'], "bin", os.environ['CHPL_HOST_BIN_SUBDIR'])
 

--- a/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
@@ -4,7 +4,7 @@ from distutils.spawn import find_executable
 
 import os
 
-chplPath = os.environ['CHPL_HOME'] + "/bin/" + os.environ['CHPL_BIN_SUBDIR']
+chplPath = os.environ['CHPL_HOME'] + "/bin/" + os.environ['CHPL_HOST_BIN_SUBDIR']
 
 if find_executable("protoc") is not None and find_executable("protoc-gen-chpl", path=chplPath) is not None:
     print(False)

--- a/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
@@ -3,8 +3,9 @@
 from distutils.spawn import find_executable
 
 import os
+import os.path
 
-chplPath = os.environ['CHPL_HOME'] + "/bin/" + os.environ['CHPL_HOST_BIN_SUBDIR']
+chplPath = os.path.join(os.environ['CHPL_HOME'], "bin", os.environ['CHPL_HOST_BIN_SUBDIR'])
 
 if find_executable("protoc") is not None and find_executable("protoc-gen-chpl", path=chplPath) is not None:
     print(False)


### PR DESCRIPTION
CHPL_BIN_SUBDIR might not be set in the testing environment, but
CHPL_HOST_BIN_SUBDIR should be available for skipifs.

While here, also use os.path.join instead of concatenating the path
with "/" myself.

We couldn't use the same strategy for the EXECENV due to not injecting
environment variables when pulling in non-executable files.  Elliot has a
PR to fix that, but in the meanwhile mimic the behavior of the mason
testing EXECENVs and explicitly call the chplenv script

Suggested by Elliot

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>