### PR TITLE
Avoid attempting to build a launcher for with LLVM in --library mode

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3632,7 +3632,7 @@ void makeBinaryLLVM(void) {
   }
 
   // If we're not using a launcher, copy the program here
-  if (0 == strcmp(CHPL_LAUNCHER, "none")) {
+  if (fLibraryCompile || (0 == strcmp(CHPL_LAUNCHER, "none"))) {
 
     if (fLibraryCompile) {
       moveGeneratedLibraryFile(tmpbinname);


### PR DESCRIPTION
Building a launcher was failing for --library with LLVM+GASNet, but it really
shouldn't be built anyway. Turn off the attempt to build it and move some
files manually.

This gets `interop/C/errorMessage/debugFlag/debugFlag.chpl` passing for LLVM+GASNet.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>