### PR TITLE
Replace chplenv variables in ReadFileWithComments

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/EXECENV
+++ b/test/library/packages/ProtobufProtocolSupport/EXECENV
@@ -1,5 +1,1 @@
-#!/usr/bin/env bash
-
-# ensure protoc-gen-chpl in PATH
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH

--- a/test/library/packages/UnitTest/EXECENV
+++ b/test/library/packages/UnitTest/EXECENV
@@ -1,7 +1,4 @@
-#!/usr/bin/env bash
-
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
-echo "MASON_HOME=\$PWD/mason_home"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
+MASON_HOME=$PWD/mason_home
 # Note, this registry should only ever be used by mason update tests
-echo "MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry"
+MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry

--- a/test/mason/EXECENV
+++ b/test/mason/EXECENV
@@ -1,12 +1,9 @@
-#!/usr/bin/env bash
-
 # Ensure mason in PATH
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
 
 # Mason envs
-echo "MASON_HOME=\$PWD/mason_home"
+MASON_HOME=$PWD/mason_home
 # Note, this registry should only ever be used by mason update tests
-echo "MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry"
-echo "MASON_OFFLINE=false"
-echo "SPACK_ROOT=\$PWD/mason_home/spack"
+MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry
+MASON_OFFLINE=false
+SPACK_ROOT=$PWD/mason_home/spack

--- a/test/mason/mason-offline/EXECENV
+++ b/test/mason/mason-offline/EXECENV
@@ -1,5 +1,2 @@
-#!/usr/bin/env bash
-	
-	bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-	echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
-	echo "MASON_OFFLINE=true"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
+MASON_OFFLINE=true

--- a/test/mason/search/EXECENV
+++ b/test/mason/search/EXECENV
@@ -1,12 +1,9 @@
-#!/usr/bin/env bash
-
 # Ensure mason in PATH
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
 
 # Mason envs
-echo "MASON_HOME=\$PWD/mason_search_home"
+MASON_HOME=$PWD/mason_search_home
 # Note, this registry should only ever be used by mason update tests
-echo "MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry"
-echo "MASON_OFFLINE=false"
-echo "SPACK_ROOT=\$PWD/mason_home/spack"
+MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry
+MASON_OFFLINE=false
+SPACK_ROOT=$PWD/mason_home/spack

--- a/test/mason/search/badFileName/EXECENV
+++ b/test/mason/search/badFileName/EXECENV
@@ -1,5 +1,2 @@
-#!/usr/bin/env bash
-
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
-echo "MASON_HOME=\$PWD/mason_home"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
+MASON_HOME=$PWD/mason_home

--- a/test/mason/search/cacheTest/EXECENV
+++ b/test/mason/search/cacheTest/EXECENV
@@ -1,5 +1,2 @@
-#!/usr/bin/env bash
-
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
-echo "MASON_HOME=\$PWD/mason_home"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
+MASON_HOME=$PWD/mason_home

--- a/test/patterns/cltools/fileCompile/chplCompile.execenv
+++ b/test/patterns/cltools/fileCompile/chplCompile.execenv
@@ -1,4 +1,1 @@
-#!/usr/bin/env bash
-
-bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
-echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"
+PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -267,14 +267,11 @@ def get_chplenv():
     chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
     return chpl_env
 
-# os.path.expandvars but stuff chplenv into it too
+# Similar to os.path.expandvars but stuff chplenv into it too
 def expandvars_chpl(path):
-    orig_env = os.environ.copy()
-    os.environ.update(get_chplenv())
-    new_path = os.path.expandvars(path)
-    os.environ.clear()
-    os.environ.update(orig_env)
-    return new_path
+    expand_env = os.environ.copy()
+    expand_env.update(get_chplenv())
+    return string.Template(path).safe_substitute(expand_env)
 
 # Read a file or if the file is executable read its output. If the file is
 # executable, the current chplenv is copied into the env before executing.

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -261,10 +261,25 @@ def PerfDirFile(s):
 def PerfTFile(test_filename, sfx):
     return test_filename + '.' + perflabel + sfx
 
+def get_chplenv():
+    env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
+    chpl_env = py3_compat.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
+    chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
+    return chpl_env
+
+# os.path.expandvars but stuff chplenv into it too
+def expandvars_chpl(path):
+    orig_env = os.environ.copy()
+    os.environ.update(get_chplenv())
+    new_path = os.path.expandvars(path)
+    os.environ.clear()
+    os.environ.update(orig_env)
+    return new_path
+
 # Read a file or if the file is executable read its output. If the file is
 # executable, the current chplenv is copied into the env before executing.
-# Expands shell variables and strip out comments/whitespace. Returns a list of
-# string, one per line in the file.
+# Expands shell and chplenv variables and strip out comments/whitespace.
+# Returns a list of string, one per line in the file.
 def ReadFileWithComments(f, ignoreLeadingSpace=True):
     mylines = ""
     # if the file is executable, run it and grab the output. If we get an
@@ -272,9 +287,7 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
     if os.access(f, os.X_OK):
         try:
             # grab the chplenv so it can be stuffed into the subprocess env
-            env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
-            chpl_env = py3_compat.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
-            chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
+            chpl_env = get_chplenv()
             file_env = os.environ.copy()
             file_env.update(chpl_env)
 
@@ -303,7 +316,7 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
         else:
             if line[0] == '#': continue
         # expand shell variables
-        line = os.path.expandvars(line)
+        line = expandvars_chpl(line)
         mylist.append(line)
     return mylist
 


### PR DESCRIPTION
`ReadFileWithComments` and `runSkipIf` are responsible for reading most
testing infrastructure files in sub_test. Both can either just read in a
non-executable file or run an executable file and read in the output.
`runSkipIf` will inject the chplenv for executable and non-executable
files, but `ReadFileWithComments` was only doing so for executable
files.

For non-executable files `ReadFileWithComments` was only injecting
env vars. Update it to inject chplenv vars as well.

Related prior work:
 - https://github.com/chapel-lang/chapel/commit/407f09565165d0181ce95473416f4a74ee1e2da4
 - https://github.com/chapel-lang/chapel/commit/fe51b2f45e047ce7cbc2e586caf5548ba7616b19
 - https://github.com/chapel-lang/chapel/commit/4b1eeb4a3d05b58335af0a943cd20a7fa33484c2

See https://github.com/chapel-lang/chapel/pull/16805 for motivation