### PR TITLE
Fix an assertion error that comes up when cobegins contain syntax errors

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2371,7 +2371,13 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
 
   if (block->blockTag == BLOCK_SCOPELESS) {
     block = toBlockStmt(block->body.only());
-    INT_ASSERT(block);
+    if (block == NULL) {
+      // Though 'block' should be non-NULL in correct programs, in
+      // cobegins containing syntax errors, it may be NULL.  So we'll
+      // just return the original block statement to make progress
+      // until the compiler exits.
+      return outer;
+    }
     block->remove();
   }
 

--- a/test/parallel/cobegin/errors/cobeginSyntaxError.chpl
+++ b/test/parallel/cobegin/errors/cobeginSyntaxError.chpl
@@ -1,0 +1,6 @@
+var count$: sync int=0;
+cobegin{
+    count$+=1
+    count$+=1
+    count$+=1
+}

--- a/test/parallel/cobegin/errors/cobeginSyntaxError.good
+++ b/test/parallel/cobegin/errors/cobeginSyntaxError.good
@@ -1,0 +1,1 @@
+cobeginSyntaxError.chpl:4: syntax error: near 'count$'


### PR DESCRIPTION
This fixes an assertion error pointed out in an [SO issue](https://stackoverflow.com/questions/65137722/why-did-i-get-this-behaviour/65139736#65139736)
that occurs when the body of a 'cobegin' contains a syntax error.
Here, I'm working around it by replacing the assertion with a test and
returning early in such cases, believing the compiler will exit before
the lack of a built cobegin statement catches up with us.
