### PR TITLE
Avoid a comm_get on a remote += operation for LLVM

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3470,7 +3470,7 @@ void codegenOpAssign(GenRet a, GenRet b, const char* op,
     info->cStatements.push_back(stmt);
   } else {
     // LLVM version of a += b is just a = a + b.
-    codegenAssign(aLocal, codegenOp(codegenValue(ap), bv));
+    codegenAssign(aLocal, codegenOp(codegenValue(aLocal), bv));
   }
 
   if( aIsRemote ) {


### PR DESCRIPTION
Paired with @mppf

When 'a' is a wide reference,
a += 0.1

Was code being generated for LLVM as:
aLoc = get(a)
aLoc = +(get(a), 0.1)
put(a, aLoc)

Instead, reuse the local copy:
aLoc = get(a)
aLoc = +(aLoc, 0.1)
put(a, aLoc)

This fixes arrays/slices/commCounts/sliceLocDist.chpl for
`CHPL_COMM=gasnet` with `--llvm`.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>