### PR TITLE
Move min, max to Math module

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -795,52 +795,6 @@ module ChapelBase {
   inline proc _r2i(a: real(?w)) return __primitive("cast", imag(w), a);
 
   //
-  // min and max
-  //
-  inline proc min(x: int(?w), y: int(w)) return if x < y then x else y;
-  inline proc max(x: int(?w), y: int(w)) return if x > y then x else y;
-
-  inline proc min(x: uint(?w), y: uint(w)) return if x < y then x else y;
-  inline proc max(x: uint(?w), y: uint(w)) return if x > y then x else y;
-
-  inline proc min(x: real(?w), y: real(w)) return if (x < y) | isnan(x) then x else y;
-  inline proc max(x: real(?w), y: real(w)) return if (x > y) | isnan(x) then x else y;
-
-  inline proc min(x, y) return if x < y then x else y;
-  inline proc max(x, y) return if x > y then x else y;
-
-  inline proc min(x, y, z...?k) return min(min(x, y), (...z));
-  inline proc max(x, y, z...?k) return max(max(x, y), (...z));
-
-  inline proc min(param x: int(?w), param y: int(w)) param
-    return if x < y then x else y;
-  inline proc max(param x: int(?w), param y: int(w)) param
-    return if x > y then x else y;
-
-  inline proc min(param x: uint(?w), param y: uint(w)) param
-    return if x < y then x else y;
-  inline proc max(param x: uint(?w), param y: uint(w)) param
-    return if x > y then x else y;
-
-  inline proc min(param x: real(?w), param y: real(w)) param
-    return if x < y then x else y;
-  inline proc max(param x: real(?w), param y: real(w)) param
-    return if x > y then x else y;
-
-  inline proc min(param x: imag(?w), param y: imag(w)) param
-    return if x < y then x else y;
-  inline proc max(param x: imag(?w), param y: imag(w)) param
-    return if x > y then x else y;
-
-  inline proc min(x, y) where isAtomic(x) || isAtomic(y) {
-    compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
-  }
-
-  inline proc max(x, y) where isAtomic(x) || isAtomic(y) {
-    compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
-  }
-
-  //
   // More primitive funs
   //
   enum ArrayInit {heuristicInit, noInit, serialInit, parallelInit};

--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -46,16 +46,6 @@ Additional utilities
 
 module UtilMisc_forDocs {
 
-  /* Compute the minimum value of 2 or more arguments
-     using the ``<`` operator for comparison.
-     If one of the arguments is :proc:`Math.NAN`, the result is also NAN. */
-  inline proc min(x, y...) return min();  // dummy
-
-  /* Compute the maximum value of 2 or more arguments
-     using the ``>`` operator for comparison.
-     If one of the arguments is :proc:`Math.NAN`, the result is also NAN. */
-  inline proc max(x, y...) return max();  // dummy
-
   /* Returns `true` if the type `from` is coercible to the type `to`,
      or if ``isSubtype(from, to)`` would return `true`.
    */

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -892,24 +892,15 @@ module Math {
   // min and max
   //
 
-  /* Returns the maximum value of two integer arguments.
-
-     :rtype: The type of `x`.
-   */
+  pragma "no doc"
   inline proc max(x: int(?w), y: int(w)) return if x > y then x else y;
-  /* Returns the maximum value of two unsigned integer arguments.
-
-     :rtype: The type of `x`.
-   */
+  pragma "no doc"
   inline proc max(x: uint(?w), y: uint(w)) return if x > y then x else y;
-  /* Returns the maximum value of two ``real`` arguments.
-     If one of the arguments is :proc:`Math.NAN`, the result is also NAN.
-
-     :rtype: The type of `x`.
-   */
+  pragma "no doc"
   inline proc max(x: real(?w), y: real(w)) return if (x > y) | isnan(x) then x else y;
   /* Returns the maximum value of two arguments using the ``>`` operator
      for comparison.
+     If one of the arguments is :proc:`Math.NAN`, the result is also NAN.
 
      :rtype: The type of `x`.
    */
@@ -920,7 +911,7 @@ module Math {
 
     return if x > y then x else y;
   }
-  /* Returns the maximum value of 3 or more arguments using the above calls.
+  /* Returns the maximum value of 3 or more arguments using the above call.
    */
   inline proc max(x, y, z...?k) return max(max(x, y), (...z));
   /* Returns the maximum of 2 param ``int``, ``uint``, ``real``, or ``imag``
@@ -931,24 +922,16 @@ module Math {
     return if x > y then x else y;
   }
 
-  /* Returns the minimum value of two integer arguments.
-
-     :rtype: The type of `x`.
-   */
+  pragma "no doc"
   inline proc min(x: int(?w), y: int(w)) return if x < y then x else y;
-  /* Returns the minimum value of two unsigned integer arguments.
-
-     :rtype: The type of `x`.
-   */
+  pragma "no doc"
   inline proc min(x: uint(?w), y: uint(w)) return if x < y then x else y;
-  /* Returns the minimum value of two ``real`` arguments.
-     If one of the arguments is :proc:`Math.NAN`, the result is also NAN.
-
-     :rtype: The type of `x`.
-   */
+  pragma "no doc"
   inline proc min(x: real(?w), y: real(w)) return if (x < y) | isnan(x) then x else y;
   /* Returns the minimum value of two arguments using the ``<`` operator
      for comparison.
+
+     If one of the arguments is :proc:`Math.NAN`, the result is also NAN.
 
      :rtype: The type of `x`.
    */
@@ -959,7 +942,7 @@ module Math {
 
     return if x < y then x else y;
   }
-  /* Returns the minimum value of 3 or more arguments using the above calls.
+  /* Returns the minimum value of 3 or more arguments using the above call.
    */
   inline proc min(x, y, z...?k) return min(min(x, y), (...z));
   /* Returns the minimum of 2 param ``int``, ``uint``, ``real``, or ``imag``

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -888,6 +888,87 @@ module Math {
     return logBasePow2(val, 1);
   }
 
+  //
+  // min and max
+  //
+
+  /* Returns the maximum value of two integer arguments.
+
+     :rtype: The type of `x`.
+   */
+  inline proc max(x: int(?w), y: int(w)) return if x > y then x else y;
+  /* Returns the maximum value of two unsigned integer arguments.
+
+     :rtype: The type of `x`.
+   */
+  inline proc max(x: uint(?w), y: uint(w)) return if x > y then x else y;
+  /* Returns the maximum value of two ``real`` arguments.
+     If one of the arguments is :proc:`Math.NAN`, the result is also NAN.
+
+     :rtype: The type of `x`.
+   */
+  inline proc max(x: real(?w), y: real(w)) return if (x > y) | isnan(x) then x else y;
+  /* Returns the maximum value of two arguments using the ``>`` operator
+     for comparison.
+
+     :rtype: The type of `x`.
+   */
+  inline proc max(x, y) {
+    if isAtomic(x) || isAtomic(y) {
+      compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
+    }
+
+    return if x > y then x else y;
+  }
+  /* Returns the maximum value of 3 or more arguments using the above calls.
+   */
+  inline proc max(x, y, z...?k) return max(max(x, y), (...z));
+  /* Returns the maximum of 2 param ``int``, ``uint``, ``real``, or ``imag``
+     values as a param.
+   */
+  inline proc max(param x: numeric, param y: numeric) param
+    where !(isComplex(x) || isComplex(y)) {
+    return if x > y then x else y;
+  }
+
+  /* Returns the minimum value of two integer arguments.
+
+     :rtype: The type of `x`.
+   */
+  inline proc min(x: int(?w), y: int(w)) return if x < y then x else y;
+  /* Returns the minimum value of two unsigned integer arguments.
+
+     :rtype: The type of `x`.
+   */
+  inline proc min(x: uint(?w), y: uint(w)) return if x < y then x else y;
+  /* Returns the minimum value of two ``real`` arguments.
+     If one of the arguments is :proc:`Math.NAN`, the result is also NAN.
+
+     :rtype: The type of `x`.
+   */
+  inline proc min(x: real(?w), y: real(w)) return if (x < y) | isnan(x) then x else y;
+  /* Returns the minimum value of two arguments using the ``<`` operator
+     for comparison.
+
+     :rtype: The type of `x`.
+   */
+  inline proc min(x, y) {
+    if isAtomic(x) || isAtomic(y) {
+      compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
+    }
+
+    return if x < y then x else y;
+  }
+  /* Returns the minimum value of 3 or more arguments using the above calls.
+   */
+  inline proc min(x, y, z...?k) return min(min(x, y), (...z));
+  /* Returns the minimum of 2 param ``int``, ``uint``, ``real``, or ``imag``
+     values as a param.
+   */
+  inline proc min(param x: numeric, param y: numeric) param
+    where !(isComplex(x) || isComplex(y)) {
+    return if x < y then x else y;
+  }
 
   /* Computes the mod operator on the two arguments, defined as
      ``mod(m,n) = m - n * floor(m / n)``.
@@ -1182,7 +1263,7 @@ module Math {
     extern proc truncf(x: real(32)): real(32);
     return truncf(x);
   }
-  
+
   /* Returns the greatest common divisor of the integer argument `a` and
      `b`. */
   proc gcd(in a: int,in b: int): int {

--- a/test/domains/marybeth/test_compare_range.good
+++ b/test/domains/marybeth/test_compare_range.good
@@ -1,3 +1,1 @@
-test_compare_range.chpl:14: In function 'initMatrix':
-test_compare_range.chpl:20: error: iterator or promoted expression iterator used in if or while condition
-  test_compare_range.chpl:6: called as initMatrix(A: [domain(2,int(64),false)] real(64))
+$CHPL_HOME/modules/standard/Math.chpl:960: error: iterator or promoted expression iterator used in if or while condition


### PR DESCRIPTION
* Move min/max from ChapelBase to Math
* Remove documentation for them from UtilMisc_forDocs.
* Update the test domains/marybeth/test_compare_range according to the current output

Reviewed by @lydia-duncan - thanks!

Future work - improve domains/marybeth/test_compare_range test output to have a stacktrace.

- [x] full local testing