### PR TITLE
Add a prediff for test_compare_range

### DIFF
--- a/test/domains/marybeth/test_compare_range.good
+++ b/test/domains/marybeth/test_compare_range.good
@@ -1,1 +1,1 @@
-$CHPL_HOME/modules/standard/Math.chpl:960: error: iterator or promoted expression iterator used in if or while condition
+$CHPL_HOME/modules/standard/Math.chpl:nnn: error: iterator or promoted expression iterator used in if or while condition

--- a/test/domains/marybeth/test_compare_range.prediff
+++ b/test/domains/marybeth/test_compare_range.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+testname=$1
+outfile=$2
+sed -e 's/[0-9][0-9]*/nnn/' $outfile > $outfile.tmp
+mv $outfile.tmp $outfile


### PR DESCRIPTION
Follow-up to PR #16823

To avoid having a Math.chpl line number in the .good file,
add a prediff and update the .good.

Test change only - not reviewed.