### PR TITLE
Print all CHPL_XYZ=xyz is deprecated messages to stderr instead of stdout

### DIFF
--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -15,7 +15,7 @@ def get():
         else:
             hwloc_val = 'none'
     elif hwloc_val == 'hwloc':
-        sys.stdout.write("Warning: CHPL_HWLOC=hwloc is deprecated. "
+        sys.stderr.write("Warning: CHPL_HWLOC=hwloc is deprecated. "
                          "Use CHPL_HWLOC=bundled instead.\n");
         hwloc_val = 'bundled'
 

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -28,7 +28,7 @@ def get():
         libfabric_val = 'none'
 
     if libfabric_val == 'libfabric':
-        sys.stdout.write("Warning: CHPL_LIBFABRIC=libfabric is deprecated. "
+        sys.stderr.write("Warning: CHPL_LIBFABRIC=libfabric is deprecated. "
                          "Use CHPL_LIBFABRIC=bundled instead.\n")
         libfabric_val = 'bundled'
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -76,7 +76,7 @@ def get():
                 llvm_val = 'bundled'
 
     if llvm_val == 'llvm':
-        sys.stdout.write("Warning: CHPL_LLVM=llvm is deprecated. "
+        sys.stderr.write("Warning: CHPL_LLVM=llvm is deprecated. "
                          "Use CHPL_LLVM=bundled instead\n")
         llvm_val = 'bundled'
 


### PR DESCRIPTION
The messages about CHPL_XYZ=xyz is deprecated were sometimes going to stderr
and sometimes to stdout. Always print them to stderr.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>