### PR TITLE
Call setSubprogram on debug info for function when it is created

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -2367,6 +2367,7 @@ void FnSymbol::codegenDef() {
       llvm::DISubprogram* dbgScope = debug_info->get_function(this);
       info->irBuilder->SetCurrentDebugLocation(
         llvm::DebugLoc::get(linenum(),0,dbgScope));
+      func->setSubprogram(dbgScope);
     }
 
     // ABI support in this function is inspired by clang's


### PR DESCRIPTION
When doing codegen for a function with --lldb and -g, we were creating a
llvm::Subprogram unit for debug scope information, but never actually
assigning it to the function. Call setSubprogram with the debug scope
subprogram in order to pair it with the function.

Fixes execflags/bradc/gdbdash/declint and execflags/bradc/gdbdash/gdbSetConfig
with --llvm and --fast.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>