### PR TITLE
Add a use of the IO module to the Random modules to enable calls to <~>

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -65,7 +65,7 @@ module Random {
   public use NPBRandom;
   public use PCGRandom;
   import Set.set;
-
+  private use IO;
 
 
   /* Select between different supported RNG algorithms.
@@ -772,7 +772,7 @@ module Random {
   module PCGRandom {
 
     use super.RandomSupport;
-    private use Random;
+    private use Random, IO;
     private use PCGRandomLib;
     use ChapelLocks;
 
@@ -2474,6 +2474,7 @@ module Random {
 
     use super.RandomSupport;
     use ChapelLocks;
+    private use IO;
 
     /*
       Models a stream of pseudorandom numbers.  See the module-level

--- a/test/library/standard/Random/checkWriteThis.chpl
+++ b/test/library/standard/Random/checkWriteThis.chpl
@@ -1,0 +1,56 @@
+// This test locks in an odd bug with the point of instantiation, where calling
+// another generic function with a first class function caused us to notice a
+// missing use statement for PCGRandomStream's writeThis function, even though
+// the writeThis function should not have been considered when resolving the
+// other generic function.
+module Foo {
+  use Random;
+  use Random.PCGRandom only PCGRandomStream;
+
+  proc generateToken(len: int=32) : string {
+    var alphanum = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+                    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+                    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+                    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j","k", "l", "m",
+                    "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
+                    ];
+    var upper_bound = alphanum.size;
+    var indices : [0..upper_bound-1] int;
+    for i in 0..upper_bound-1 do
+      indices[i] = i;
+
+    var ret : [0..len-1] string;
+    var r = new owned PCGRandomStream(int);
+    var rindices = try! r.choice(indices, len);
+
+    for i in 1..len-1 do
+      ret[i] = alphanum[rindices[i]];
+    return ''.join(ret);
+  }
+}
+
+module Two {
+  use IO;
+  proc otherGenFunc(x) throws {
+    writeln("%s".format(x));
+  }
+}
+module Three {
+  use Two;
+
+  proc callGenFunc() {
+    try! otherGenFunc(otherFunc); // Note missing parentheses here
+  }
+
+  proc otherFunc() {
+    writeln("eh");
+  }
+}
+module User {
+  use Foo, Three;
+  proc main() {
+    callGenFunc();
+    var token = generateToken(32);
+    writeln(token);
+  }
+}

--- a/test/library/standard/Random/checkWriteThis.good
+++ b/test/library/standard/Random/checkWriteThis.good
@@ -1,0 +1,3 @@
+uncaught SystemError: Invalid argument: Argument type mismatch in argument 0 (in string.format)
+  checkWriteThis.chpl:35: thrown here
+  checkWriteThis.chpl:42: uncaught here


### PR DESCRIPTION
The writeThis methods in the Random module were getting away with calls to <~>,
probably due to uses of the IO module at the points where it is called.
Unfortunately, a user encountered a situation where such a use was not
available, causing the writeThis to fail to resolve. This adds a use of the IO
module at the scopes with the writeThis functions, to avoid this issue in the
future.

Passed a full std paratest with futures

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>