### PR TITLE
Improve PMI out-of-band selection on CS and similar systems.

### DIFF
--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -10,34 +10,44 @@ export CHPL_COMM=ofi
 
 # Select a launcher and out-of-band support.  If we're on a Cray XC
 # system this will just fall out automatically.  On a slurm-based system
-# where slurm was configured with the PMIx server-side plugin and we can
-# find a PMIx client-side library, then we can use slurm-srun directly,
-# along with the comm=ofi slurm-pmi2 out-of-band support.  This is seen
-# on Cray CS systems, for example.  Otherwise, our only option is the
-# stopgap mpirun4ofi launcher, in which case we also need MPI and the
-# MPI-based out-of-band support.
+# where slurm was configured with the PMI2 or PMIx server-side plugin
+# and we can find a matching client-side library, then we can use
+# slurm-srun directly, along with the comm=ofi slurm-pmi2 out-of-band
+# support.  This is seen on Cray CS systems, for example.  Otherwise,
+# our only option is the stopgap mpirun4ofi launcher, in which case we
+# also need MPI and the MPI-based out-of-band support.
 lchOK=
 if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) == cray-x* ]] ; then
   lchOK=y
-elif [[ "$($CHPL_HOME/util/chplenv/chpl_launcher.py)" == slurm-srun ]] && \
-     srun --mpi=list 2>&1 | grep -q pmix ; then
-  if module avail pmix 2>&1 | grep -q pmix ; then
-    module load pmix
-    lchOK=y
-  elif [ -d /opt/pmix/default/. ] ; then
-    # There's no module but we do have a pmix install.  Set up
-    # to use it manually.
-    export PATH=/opt/pmix/default/bin${PATH:+:$PATH}
-    export CPATH=/opt/pmix/default/include${CPATH:+:$CPATH}
-    export LD_LIBRARY_PATH=/opt/pmix/default/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-    export LIBRARY_PATH=/opt/pmix/default/lib${LIBRARY_PATH:+:$LIBRARY_PATH}
-    export MANPATH=/opt/pmix/default/share/man${MANPATH:+:$MANPATH}
-    lchOK=y
+elif [[ "$($CHPL_HOME/util/chplenv/chpl_launcher.py)" == slurm-srun ]] ; then
+  pmiTypes=$(srun --mpi=list 2>&1)
+  if [[ "$pmiTypes" == *pmi2* ]] ; then
+    # Try to use pmi2 support.
+    srunDir=$(which srun)
+    sLibDir=${srunDir%/bin/srun}/lib64
+    if [[ -d $sLibDir ]] ; then
+      export CHPL_LD_FLAGS="${CHPL_LD_FLAGS:+$CHPL_LD_FLAGS }-L$sLibDir -Wl,-rpath,$sLibDir"
+      export SLURM_MPI_TYPE=pmi2
+      lchOK=y
+    fi
+  fi
+  if [[ "$lchOK" != y && "$pmiTypes" == *pmix* ]] ; then
+    if module avail pmix 2>&1 | grep -q pmix ; then
+      module load pmix
+      export SLURM_MPI_TYPE=pmix
+      lchOK=y
+    elif [ -d /opt/pmix/default/. ] ; then
+      # There's no module but we can see a pmix install.  Set up
+      # to use it manually.
+      sLibDir=/opt/pmix/default/lib
+      export CHPL_LD_FLAGS="${CHPL_LD_FLAGS:+$CHPL_LD_FLAGS }-L$sLibDir -Wl,-rpath,$sLibDir"
+      export SLURM_MPI_TYPE=pmix
+      lchOK=y
+    fi
   fi
   if [ -n "$lchOK" ] ; then
     export CHPL_LAUNCHER=slurm-srun
     export CHPL_COMM_OFI_OOB=slurm-pmi2
-    export SLURM_MPI_TYPE=pmix
   fi
 fi
 

--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -20,13 +20,25 @@ lchOK=
 if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) == cray-x* ]] ; then
   lchOK=y
 elif [[ "$($CHPL_HOME/util/chplenv/chpl_launcher.py)" == slurm-srun ]] && \
-     srun --mpi=list 2>&1 | grep -q pmix && \
-     module avail pmix 2>&1 | grep -q pmix ; then
-  module load pmix
-  export CHPL_LAUNCHER=slurm-srun
-  export CHPL_COMM_OFI_OOB=slurm-pmi2
-  export SLURM_MPI_TYPE=pmix
-  lchOK=y
+     srun --mpi=list 2>&1 | grep -q pmix ; then
+  if module avail pmix 2>&1 | grep -q pmix ; then
+    module load pmix
+    lchOK=y
+  elif [ -d /opt/pmix/default/. ] ; then
+    # There's no module but we do have a pmix install.  Set up
+    # to use it manually.
+    export PATH=/opt/pmix/default/bin${PATH:+:$PATH}
+    export CPATH=/opt/pmix/default/include${CPATH:+:$CPATH}
+    export LD_LIBRARY_PATH=/opt/pmix/default/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    export LIBRARY_PATH=/opt/pmix/default/lib${LIBRARY_PATH:+:$LIBRARY_PATH}
+    export MANPATH=/opt/pmix/default/share/man${MANPATH:+:$MANPATH}
+    lchOK=y
+  fi
+  if [ -n "$lchOK" ] ; then
+    export CHPL_LAUNCHER=slurm-srun
+    export CHPL_COMM_OFI_OOB=slurm-pmi2
+    export SLURM_MPI_TYPE=pmix
+  fi
 fi
 
 if [ -z "$lchOK" ] ; then


### PR DESCRIPTION
On systems with a Slurm that supports the PMIx server side interface,
and a pmix module for the client-side library, we've been able to use
the PMI2-based comm=ofi out-of-band support with PMIx for quite a while.
But wider experience with the CS systems where we first encountered this
configuration indicates there may be other options: Slurm itself may
supply both the client- and server-side PMI2 support.  Or, there may be
a PMIx client-side library available even if there is no module for it.
Here, adjust the testing setup script for comm=ofi to take advantage of
both of those cases, and adjust the ordering so that we check for Slurm
supplying PMI2 first, then PMIx with or without a module.

This resolves https://github.com/Cray/chapel-private/issues/1521.