### PR TITLE
Fix List's listContains test's negative cases

### DIFF
--- a/test/library/standard/List/contains/listContains.chpl
+++ b/test/library/standard/List/contains/listContains.chpl
@@ -7,7 +7,7 @@ var lst: list(int) = 1..testIters;
 for i in 1..testIters do
   assert(lst.contains(i));
 
-for i in -1..-testIters do
+for i in -testIters..-1 do
   assert(!lst.contains(i));
 
 lst.clear();


### PR DESCRIPTION
The test was iterating over -1..-testIters, which is an empty range for
the positive value of testIters in use.  Change it to -testIters..-1.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>