### PR TITLE
Add 'use IO' to distributions

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -317,6 +317,7 @@ override proc BlockCyclic.dsiNewRectangularDom(param rank: int, type idxType,
 // output distribution
 //
 proc BlockCyclic.writeThis(x) throws {
+  use IO;
   x <~> "BlockCyclic\n";
   x <~> "-------\n";
   x <~> "distributes: " <~> lowIdx <~> "..." <~> "\n";
@@ -489,6 +490,7 @@ class LocBlockCyclic {
 
 
 proc LocBlockCyclic.writeThis(x) throws {
+  use IO;
   var localeid: int;
   on this {
     localeid = here.id;
@@ -597,6 +599,7 @@ iter BlockCyclicDom.these(param tag: iterKind, followThis) where tag == iterKind
 // output domain
 //
 proc BlockCyclicDom.dsiSerialWrite(x) {
+  use IO;
   x <~> whole;
 }
 
@@ -787,6 +790,7 @@ proc LocBlockCyclicDom.computeFlatInds() {
 // output local domain piece
 //
 proc LocBlockCyclicDom.writeThis(x) throws {
+  use IO;
   x <~> myStarts;
 }
 
@@ -1288,6 +1292,7 @@ proc LocBlockCyclicArr.this(i) ref {
 // output local array piece
 //
 proc LocBlockCyclicArr.writeThis(x) throws {
+  use IO;
   // note on this fails; see writeThisUsingOn.chpl
   x <~> myElems;
 }

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -613,6 +613,7 @@ override proc Block.dsiNewSparseDom(param rank: int, type idxType,
 // output distribution
 //
 proc Block.writeThis(x) throws {
+  use IO;
   x <~> "Block" <~> "\n";
   x <~> "-------" <~> "\n";
   x <~> "distributes: " <~> boundingBox <~> "\n";
@@ -868,6 +869,7 @@ iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follo
 // output domain
 //
 proc BlockDom.dsiSerialWrite(x) {
+  use IO;
   x <~> whole;
 }
 

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -395,6 +395,7 @@ proc _cyclic_matchArgsShape(type rangeType, type scalarType, args) type {
 }
 
 proc Cyclic.writeThis(x) throws {
+  use IO;
   x <~> this.type:string <~> "\n";
   x <~> "------\n";
   for locid in targetLocDom do
@@ -596,6 +597,7 @@ proc CyclicDom.dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
 }
 
 proc CyclicDom.dsiSerialWrite(x) {
+  use IO;
   if verboseCyclicDistWriters {
     x <~> this.type:string <~> "\n";
     x <~> "------\n";

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -769,6 +769,7 @@ proc DimensionalDom.dimSpecifier(param dim: int) {
 //== writing
 
 proc DimensionalDom.dsiSerialWrite(f): void {
+  use IO;
   f <~> whole;
 }
 

--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -234,6 +234,7 @@ class Hashed : BaseDist {
   // print out the distribution
   //
   proc writeThis(x) throws {
+    use IO;
     x <~> "Hashed\n";
     x <~> "-------\n";
     x <~> "distributed using: " <~> mapper <~> "\n";
@@ -458,6 +459,7 @@ class UserMapAssocDom: BaseAssociativeDom {
   // the print method for the domain
   //
   proc dsiSerialWrite(x) {
+    use IO;
     for locDom in locDoms do
       // TODO: This doesn't work -- accesses a bad file descriptor
       //      on locDom {

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -76,6 +76,7 @@ class Private: BaseDist {
   }
 
   proc writeThis(x) throws {
+    use IO;
     x <~> "Private Distribution\n";
   }
   // acts like a singleton
@@ -105,7 +106,7 @@ class PrivateDom: BaseRectangularDom {
       yield i;
   }
 
-  proc dsiSerialWrite(x) { x <~> "Private Domain"; }
+  proc dsiSerialWrite(x) { use IO; x <~> "Private Domain"; }
 
   proc dsiBuildArray(type eltType, param initElts:bool) {
     return new unmanaged PrivateArr(eltType=eltType, rank=rank, idxType=idxType, stridable=stridable, dom=_to_unmanaged(this), initElts=initElts);
@@ -286,6 +287,7 @@ iter PrivateArr.these(param tag: iterKind, followThis) ref where tag == iterKind
 }
 
 proc PrivateArr.dsiSerialWrite(x) {
+  use IO;
   var first: bool = true;
   for i in dom {
     if first then first = !first; else x <~> " ";

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -229,6 +229,7 @@ class SparseBlockDom: BaseSparseDomImpl {
   // output domain
   //
   proc dsiSerialWrite(f) {
+    use IO;
     if (rank == 1) {
       f <~> "{";
       for locdom in locDoms do {
@@ -367,6 +368,7 @@ class LocSparseBlockDom {
   }
 
   proc dsiSerialWrite(w) {
+    use IO;
     mySparseBlock._value.dsiSerialWrite(w, printBrackets=false);
     // w.write(mySparseBlock); // works, but gets brackets printed out redundantly
     //    w <~> mySparseBlock;
@@ -794,6 +796,7 @@ proc LocSparseBlockArr.this(i) ref {
 // output array
 //
 proc SparseBlockArr.dsiSerialWrite(f) {
+  use IO;
   if (rank == 1) {
     f <~> "[";
     for locarr in locArr do {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -579,6 +579,7 @@ override proc Stencil.dsiNewRectangularDom(param rank: int, type idxType,
 // output distribution
 //
 proc Stencil.writeThis(x) throws {
+  use IO;
   x <~> "Stencil\n";
   x <~> "-------\n";
   x <~> "distributes: " <~> boundingBox <~> "\n";
@@ -824,6 +825,7 @@ iter StencilDom.these(param tag: iterKind, followThis) where tag == iterKind.fol
 // output domain
 //
 proc StencilDom.dsiSerialWrite(x) {
+  use IO;
   x <~> whole;
 }
 
@@ -1372,6 +1374,7 @@ iter StencilArr.these(param tag: iterKind, followThis, param fast: bool = false)
 // output array
 //
 proc StencilArr.dsiSerialWrite(f) {
+  use IO;
   type strType = chpl__signedType(idxType);
   var binary = f.binary();
   if dom.dsiNumIndices == 0 then return;

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -615,6 +615,7 @@ class CSDom: BaseSparseDomImpl {
   }
 
   proc dsiSerialWrite(f) {
+    use IO;
     f <~> "{\n";
     if this.compressRows {
       for r in rowRange {
@@ -726,6 +727,7 @@ class CSArr: BaseSparseArrImpl {
   }
 
   proc dsiSerialWrite(f) {
+    use IO;
     if dom.compressRows {
       for r in dom.rowRange {
         const lo = dom.startIdx(r);


### PR DESCRIPTION
Adds `use IO` to distributions where previously compilation relied on accessing `<~>` through POI.

Inspired by #16838

Related: our internal modules rely heavily on POI lookup for resolving things in other internal modules.

For example, consider `module ChapelAutoLocalAccess` :
```chpl
  proc chpl__staticAutoLocalCheck(accessBase: [], loopDomain: domain) param {
    if chpl__isArrayView(accessBase) then return false;

    if accessBase.domain.type == loopDomain.type {
      return loopDomain.supportsAutoLocalAccess();
    }

    // support forall i in a.domain.localSubdomain() do .... a[i] ....           
    if loopDomain._value.type.isDefaultRectangular() {
      return accessBase.domain.supportsAutoLocalAccess();
    }

    return false;
  }
```
It needs:

* `ChapelArray` for chpl__isArrayView()
* `ChapelBase` for ==
* `ChapelDistribution` and `DefaultRectangular` for isDefaultRectangular()

Do we want to do anything about it? Would there be compilation time benefit to avoid these POI lookups?
