### PR TITLE
Move ChapelIO to a standard module

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2797,6 +2797,7 @@ static bool symbolInBuiltinModule(Symbol* sym) {
   ModuleSymbol* mod = sym->getModule();
   if (mod->modTag == MOD_STANDARD &&
       (!strcmp(mod->name, "Builtins") ||
+       !strcmp(mod->name, "ChapelIO") ||
        !strcmp(mod->name, "VectorizingIterator") ||
        !strcmp(mod->name, "Types") ||
        !strcmp(mod->name, "Math"))) {

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -17,6 +17,7 @@ default:
    :maxdepth: 1
 
    Builtins <standard/Builtins>
+   IO Support <standard/ChapelIO>
    Math <standard/Math>
    Types <standard/Types>
    VectorizingIterator <standard/VectorizingIterator>

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -80,6 +80,7 @@ MODULES_TO_DOCUMENT = \
 	standard/Heap.chpl \
 	standard/Help.chpl \
 	standard/IO.chpl \
+	standard/ChapelIO.chpl \
 	standard/List.chpl \
 	standard/Map.chpl \
 	standard/Math.chpl \
@@ -158,7 +159,6 @@ INTERNAL_MODULES_TO_DOCUMENT =                \
 	internal/ChapelArray.chpl             \
 	internal/ChapelComplex_forDocs.chpl   \
 	internal/ChapelError.chpl             \
-	internal/ChapelIO.chpl                \
 	internal/ChapelLocale.chpl            \
 	internal/ChapelRange.chpl             \
 	internal/Bytes.chpl                   \

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -71,6 +71,7 @@ MODULES_TO_DOCUMENT = \
 	standard/BigInteger.chpl \
 	standard/BitOps.chpl \
 	standard/Builtins.chpl \
+	standard/ChapelIO.chpl \
 	standard/CommDiagnostics.chpl \
 	standard/CPtr.chpl \
 	standard/DateTime.chpl \
@@ -80,7 +81,6 @@ MODULES_TO_DOCUMENT = \
 	standard/Heap.chpl \
 	standard/Help.chpl \
 	standard/IO.chpl \
-	standard/ChapelIO.chpl \
 	standard/List.chpl \
 	standard/Map.chpl \
 	standard/Math.chpl \

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -122,13 +122,7 @@ removePattern "record:: _tuple" $file
 fixTitle "Tuples" $file
 removeUsage $file
 
-## ChapelIO ##
-
-file="./ChapelIO.rst"
-fixTitle "IO Support" $file
-removeUsage $file
-
-## End ChapelIO ##
+## End ChapelTuple ##
 
 
 ## ChapelLocale ##

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -22,6 +22,9 @@
 
 Basic types and utilities in support of I/O operation.
 
+.. note:: All Chapel programs automatically ``use`` this module by default.
+          An explicit ``use`` statement is not necessary.
+
 Most of Chapel's I/O support is within the :mod:`IO` module.  This section
 describes automatically included basic types and routines that support the
 :mod:`IO` module.

--- a/test/compflags/diten/printCallGraph.good
+++ b/test/compflags/diten/printCallGraph.good
@@ -2,12 +2,16 @@ e
   f
     e (Recursive)
     h
+      writeln
   g
     f
       e (Recursive)
       h
+        writeln
     h
+      writeln
   h
+    writeln
 main
 H
 H

--- a/test/functions/deitz/test_write_type_error.good
+++ b/test/functions/deitz/test_write_type_error.good
@@ -1,5 +1,5 @@
 test_write_type_error.chpl:2: error: unresolved call 'writeln(type int(64))'
-$CHPL_HOME/modules/internal/ChapelIO.chpl:: note: this candidate did not match: writeln(const args ...?n)
+$CHPL_HOME/modules/standard/ChapelIO.chpl:: note: this candidate did not match: writeln(const args ...?n)
 test_write_type_error.chpl:: note: because type call actual argument #1
-$CHPL_HOME/modules/internal/ChapelIO.chpl:: note: is passed to non-type formal 'const _e0_args'
-$CHPL_HOME/modules/internal/ChapelIO.chpl:: note: candidates are: writeln()
+$CHPL_HOME/modules/standard/ChapelIO.chpl:: note: is passed to non-type formal 'const _e0_args'
+$CHPL_HOME/modules/standard/ChapelIO.chpl:: note: candidates are: writeln()

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -24,6 +24,7 @@ end of module search dirs
   ./bah.chpl
   $CHPL_HOME/modules/standard/CPtr.chpl
   $CHPL_HOME/modules/standard/HaltWrappers.chpl
+  $CHPL_HOME/modules/standard/ChapelIO.chpl
   $CHPL_HOME/modules/standard/Builtins.chpl
   $CHPL_HOME/modules/standard/Types.chpl
   $CHPL_HOME/modules/standard/Math.chpl


### PR DESCRIPTION
This PR moves modules/internal/ChapelIO.chpl to 
modules/standard/ChapelIO.chpl and updates the documentation to list it
as one of the Automatic standard modules.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!