### PR TITLE
Move ChapelEnv to a standard module

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2797,6 +2797,7 @@ static bool symbolInBuiltinModule(Symbol* sym) {
   ModuleSymbol* mod = sym->getModule();
   if (mod->modTag == MOD_STANDARD &&
       (!strcmp(mod->name, "Builtins") ||
+       !strcmp(mod->name, "ChapelEnv") ||
        !strcmp(mod->name, "ChapelIO") ||
        !strcmp(mod->name, "VectorizingIterator") ||
        !strcmp(mod->name, "Types") ||

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -17,6 +17,7 @@ default:
    :maxdepth: 1
 
    Builtins <standard/Builtins>
+   Chapel Environment Variables <standard/ChapelEnv>
    IO Support <standard/ChapelIO>
    Math <standard/Math>
    Types <standard/Types>

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -71,6 +71,7 @@ MODULES_TO_DOCUMENT = \
 	standard/BigInteger.chpl \
 	standard/BitOps.chpl \
 	standard/Builtins.chpl \
+	standard/ChapelEnv.chpl \
 	standard/ChapelIO.chpl \
 	standard/CommDiagnostics.chpl \
 	standard/CPtr.chpl \
@@ -165,7 +166,6 @@ INTERNAL_MODULES_TO_DOCUMENT =                \
 	internal/String.chpl                  \
 	internal/ChapelSyncvar.chpl           \
 	internal/ChapelTuple.chpl             \
-	internal/ChapelEnv.chpl               \
 	internal/OwnedObject.chpl             \
 	internal/SharedObject.chpl
 

--- a/modules/internal/ChapelEnv.chpl
+++ b/modules/internal/ChapelEnv.chpl
@@ -24,10 +24,15 @@
 
 /*
 
-    The values of Chapel's environment variables upon compile time are
-    accessible through the built-in parameters shown below. This information
-    can also be displayed from the command line by executing the compiled
-    program with the ``--about`` flag.
+Chapel Environment Variables
+
+.. note:: All Chapel programs automatically ``use`` this module by default.
+          An explicit ``use`` statement is not necessary.
+
+The values of Chapel's environment variables upon compile time are
+accessible through the built-in parameters shown below. This information
+can also be displayed from the command line by executing the compiled
+program with the ``--about`` flag.
 
  */
 module ChapelEnv {
@@ -35,85 +40,112 @@ module ChapelEnv {
   private use ChapelStandard;
 
   /* See :ref:`readme-chplenv.CHPL_HOME` for more information. */
-  param CHPL_HOME:string            = __primitive("get compiler variable", "CHPL_HOME");
+  param CHPL_HOME:string;
+  CHPL_HOME = __primitive("get compiler variable", "CHPL_HOME");
 
   /* Deprecated */
-  param CHPL_AUX_FILESYS:string     = __primitive("get compiler variable", "CHPL_AUX_FILESYS");
+  param CHPL_AUX_FILESYS:string;
+  CHPL_AUX_FILESYS = __primitive("get compiler variable", "CHPL_AUX_FILESYS");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_PLATFORM` for more information. */
-  param CHPL_TARGET_PLATFORM:string = __primitive("get compiler variable", "CHPL_TARGET_PLATFORM");
+  param CHPL_TARGET_PLATFORM:string;
+  CHPL_TARGET_PLATFORM = __primitive("get compiler variable", "CHPL_TARGET_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_PLATFORM` for more information. */
-  param CHPL_HOST_PLATFORM:string   = __primitive("get compiler variable", "CHPL_HOST_PLATFORM");
+  param CHPL_HOST_PLATFORM:string;
+  CHPL_HOST_PLATFORM = __primitive("get compiler variable", "CHPL_HOST_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_ARCH` for more information. */
-  param CHPL_HOST_ARCH:string   = __primitive("get compiler variable", "CHPL_HOST_ARCH");
+  param CHPL_HOST_ARCH:string;
+  CHPL_HOST_ARCH = __primitive("get compiler variable", "CHPL_HOST_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
-  param CHPL_HOST_COMPILER:string   = __primitive("get compiler variable", "CHPL_HOST_COMPILER");
+  param CHPL_HOST_COMPILER:string;
+  CHPL_HOST_COMPILER = __primitive("get compiler variable", "CHPL_HOST_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
-  param CHPL_TARGET_COMPILER:string = __primitive("get compiler variable", "CHPL_TARGET_COMPILER");
+  param CHPL_TARGET_COMPILER:string;
+  CHPL_TARGET_COMPILER = __primitive("get compiler variable", "CHPL_TARGET_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_ARCH` for more information. */
-  param CHPL_TARGET_ARCH:string     = __primitive("get compiler variable", "CHPL_TARGET_ARCH");
+  param CHPL_TARGET_ARCH:string;
+  CHPL_TARGET_ARCH = __primitive("get compiler variable", "CHPL_TARGET_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_CPU` for more information. */
-  param CHPL_TARGET_CPU:string     = __primitive("get compiler variable", "CHPL_TARGET_CPU");
+  param CHPL_TARGET_CPU:string;
+  CHPL_TARGET_CPU = __primitive("get compiler variable", "CHPL_TARGET_CPU");
 
   /* See :ref:`readme-chplenv.CHPL_LOCALE_MODEL` for more information. */
-  param CHPL_LOCALE_MODEL:string    = __primitive("get compiler variable", "CHPL_LOCALE_MODEL");
+  param CHPL_LOCALE_MODEL:string;
+  CHPL_LOCALE_MODEL = __primitive("get compiler variable", "CHPL_LOCALE_MODEL");
 
   /* See :ref:`readme-chplenv.CHPL_COMM` for more information. */
-  param CHPL_COMM:string            = __primitive("get compiler variable", "CHPL_COMM");
+  param CHPL_COMM:string;
+  CHPL_COMM = __primitive("get compiler variable", "CHPL_COMM");
 
   /* See :ref:`readme-launcher` for more information. */
-  param CHPL_COMM_SUBSTRATE:string  = __primitive("get compiler variable", "CHPL_COMM_SUBSTRATE");
+  param CHPL_COMM_SUBSTRATE:string;
+  CHPL_COMM_SUBSTRATE = __primitive("get compiler variable", "CHPL_COMM_SUBSTRATE");
 
   /* See :ref:`readme-multilocale` for more information. */
-  param CHPL_GASNET_SEGMENT:string  = __primitive("get compiler variable", "CHPL_GASNET_SEGMENT");
+  param CHPL_GASNET_SEGMENT:string;
+  CHPL_GASNET_SEGMENT = __primitive("get compiler variable", "CHPL_GASNET_SEGMENT");
 
   pragma "no doc"
   /* See :ref:`readme-chplenv.CHPL_LIBFABRIC` for more information. */
-  param CHPL_LIBFABRIC:string       = __primitive("get compiler variable", "CHPL_LIBFABRIC");
+  param CHPL_LIBFABRIC:string;
+  CHPL_LIBFABRIC = __primitive("get compiler variable", "CHPL_LIBFABRIC");
 
   /* See :ref:`readme-chplenv.CHPL_TASKS` for more information. */
-  param CHPL_TASKS:string           = __primitive("get compiler variable", "CHPL_TASKS");
+  param CHPL_TASKS:string;
+  CHPL_TASKS = __primitive("get compiler variable", "CHPL_TASKS");
 
   /* See :ref:`readme-chplenv.CHPL_LAUNCHER` for more information. */
-  param CHPL_LAUNCHER:string        = __primitive("get compiler variable", "CHPL_LAUNCHER");
+  param CHPL_LAUNCHER:string;
+  CHPL_LAUNCHER = __primitive("get compiler variable", "CHPL_LAUNCHER");
 
   /* See :ref:`readme-chplenv.CHPL_TIMERS` for more information. */
-  param CHPL_TIMERS:string          = __primitive("get compiler variable", "CHPL_TIMERS");
+  param CHPL_TIMERS:string;
+  CHPL_TIMERS = __primitive("get compiler variable", "CHPL_TIMERS");
 
   /* See :ref:`readme-chplenv.CHPL_UNWIND` for more information. */
-  param CHPL_UNWIND:string          = __primitive("get compiler variable", "CHPL_UNWIND");
+  param CHPL_UNWIND:string;
+  CHPL_UNWIND = __primitive("get compiler variable", "CHPL_UNWIND");
 
   /* See :ref:`readme-chplenv.CHPL_MEM` for more information. */
-  param CHPL_MEM:string             = __primitive("get compiler variable", "CHPL_MEM");
+  param CHPL_MEM:string;
+  CHPL_MEM = __primitive("get compiler variable", "CHPL_MEM");
 
   /* See :ref:`readme-chplenv.CHPL_MAKE` for more information. */
-  param CHPL_MAKE:string            = __primitive("get compiler variable", "CHPL_MAKE");
+  param CHPL_MAKE:string;
+  CHPL_MAKE = __primitive("get compiler variable", "CHPL_MAKE");
 
   /* See :ref:`readme-chplenv.CHPL_ATOMICS` for more information. */
-  param CHPL_ATOMICS:string         = __primitive("get compiler variable", "CHPL_ATOMICS");
+  param CHPL_ATOMICS:string;
+  CHPL_ATOMICS = __primitive("get compiler variable", "CHPL_ATOMICS");
 
   /* See :ref:`readme-atomics` for more information. */
-  param CHPL_NETWORK_ATOMICS:string = __primitive("get compiler variable", "CHPL_NETWORK_ATOMICS");
+  param CHPL_NETWORK_ATOMICS:string;
+  CHPL_NETWORK_ATOMICS = __primitive("get compiler variable", "CHPL_NETWORK_ATOMICS");
 
   /* See :ref:`readme-chplenv.CHPL_GMP` for more information. */
-  param CHPL_GMP:string             = __primitive("get compiler variable", "CHPL_GMP");
+  param CHPL_GMP:string;
+  CHPL_GMP = __primitive("get compiler variable", "CHPL_GMP");
 
   /* See :ref:`readme-chplenv.CHPL_HWLOC` for more information. */
-  param CHPL_HWLOC:string           = __primitive("get compiler variable", "CHPL_HWLOC");
+  param CHPL_HWLOC:string;
+  CHPL_HWLOC = __primitive("get compiler variable", "CHPL_HWLOC");
 
   pragma "no doc"
   /* See :ref:`readme-chplenv.CHPL_JEMALLOC` for more information. */
-  param CHPL_JEMALLOC:string           = __primitive("get compiler variable", "CHPL_JEMALLOC");
+  param CHPL_JEMALLOC:string;
+  CHPL_JEMALLOC = __primitive("get compiler variable", "CHPL_JEMALLOC");
 
   /* See :ref:`readme-chplenv.CHPL_REGEXP` for more information. */
-  param CHPL_REGEXP:string          = __primitive("get compiler variable", "CHPL_REGEXP");
+  param CHPL_REGEXP:string;
+  CHPL_REGEXP = __primitive("get compiler variable", "CHPL_REGEXP");
 
   /* See :ref:`readme-chplenv.CHPL_LLVM` for more information. */
-  param CHPL_LLVM:string            = __primitive("get compiler variable", "CHPL_LLVM");
+  param CHPL_LLVM:string;
+  CHPL_LLVM = __primitive("get compiler variable", "CHPL_LLVM");
 }

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -217,15 +217,6 @@ replace "chpl_bytes" "bytes" $file
 
 ## End of Bytes ##
 
-## ChapelEnv ##
-
-file="./ChapelEnv.rst"
-fixTitle "Chapel Environment Variables" $file
-replace " = AppendExpr.Call09" "" $file
-removeUsage $file
-
-## End of ChapelEnv ##
-
 ## ChapelError ##
 
 file=ChapelError.rst

--- a/modules/standard/ChapelEnv.chpl
+++ b/modules/standard/ChapelEnv.chpl
@@ -24,7 +24,7 @@
 
 /*
 
-Chapel Environment Variables
+Access to Chapel Environment Variables
 
 .. note:: All Chapel programs automatically ``use`` this module by default.
           An explicit ``use`` statement is not necessary.

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -22,6 +22,7 @@ end of module search dirs
   subdir2/bap.chpl
   subdir4/subdir/bax.chpl
   ./bah.chpl
+  $CHPL_HOME/modules/standard/ChapelEnv.chpl
   $CHPL_HOME/modules/standard/CPtr.chpl
   $CHPL_HOME/modules/standard/HaltWrappers.chpl
   $CHPL_HOME/modules/standard/ChapelIO.chpl


### PR DESCRIPTION
This PR moves modules/internal/ChapelEnv.chpl to 
modules/standard/ChapelEnv.chpl and lists it in the Automatic standard
modules in the docs.

Reviewed by @lydia-duncan - thanks!

- [x] full local testing