### PR TITLE
Fix ofi perf testing

### DIFF
--- a/util/cron/test-perf.cray-cs.ofi.bash
+++ b/util/cron/test-perf.cray-cs.ofi.bash
@@ -21,7 +21,7 @@ export CHPL_TEST_TIMEOUT=1800
 
 if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-cs ]] || \
    [[ "$CHPL_COMM_OFI_OOB" != slurm-pmi2 ]] || \
-   [[ "$SLURM_MPI_TYPE" != pmix ]] ; then
+   [[ "$SLURM_MPI_TYPE" != pmi2 ]] ; then
   log_error "Unexpected environment for Cray CS comm=ofi testing.  Exiting."
   exit 1
 fi


### PR DESCRIPTION
Assert `SLURM_MPI_TYPE=pmi2` instead of `pmix` for ofi-perf testing. We
changed what pmi we're using in #16839.
