### PR TITLE
Add a pragma for modules included by default

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -365,44 +365,57 @@ void ModuleSymbol::printDocs(std::ostream* file,
     *file << std::endl;
   }
 
-  if (fDocsTextOnly == false) {
-    *file << "**Usage**" << std::endl << std::endl;
-    *file << ".. code-block:: chapel" << std::endl << std::endl;
+  if (!this->hasFlag(FLAG_MODULE_INCLUDED_BY_DEFAULT)) {
 
+    if (fDocsTextOnly == false) {
+      *file << "**Usage**" << std::endl << std::endl;
+      *file << ".. code-block:: chapel" << std::endl << std::endl;
+
+    } else {
+      *file << std::endl;
+      *file << "Usage:" << std::endl;
+    }
+
+    this->printTabs(file, tabs + 1);
+
+    *file << "use ";
+
+    if (parentName != "") {
+      *file << parentName << ".";
+    }
+
+    *file << name << ";" << std::endl << std::endl;
+
+    if (!fDocsTextOnly) {
+      *file << std::endl;
+    }
+
+    *file  << "or" << std::endl << std::endl;
+
+    if (fDocsTextOnly == false) {
+      *file << ".. code-block:: chapel" << std::endl << std::endl;
+    }
+
+    this->printTabs(file, tabs + 1);
+
+    *file << "import ";
+
+    if (parentName != "") {
+      *file << parentName << ".";
+    }
+
+    *file << name << ";" << std::endl << std::endl;
   } else {
+    *file << ".. note::" << std::endl << std::endl;
+    this->printTabs(file, tabs + 1);
+    *file <<
+      "All Chapel programs automatically ``use`` this module by default.";
     *file << std::endl;
-    *file << "Usage:" << std::endl;
-  }
-
-  this->printTabs(file, tabs + 1);
-
-  *file << "use ";
-
-  if (parentName != "") {
-    *file << parentName << ".";
-  }
-
-  *file << name << ";" << std::endl << std::endl;
-
-  if (!fDocsTextOnly) {
+    this->printTabs(file, tabs + 1);
+    *file << "An explicit ``use`` statement is not necessary.";
+    *file << std::endl;
     *file << std::endl;
   }
-
-  *file  << "or" << std::endl << std::endl;
-   
-  if (fDocsTextOnly == false) {
-    *file << ".. code-block:: chapel" << std::endl << std::endl;
-  }
-
-  this->printTabs(file, tabs + 1);
-
-  *file << "import ";
-
-  if (parentName != "") {
-    *file << parentName << ".";
-  }
-
-  *file << name << ";" << std::endl << std::endl;
 
   // If we had submodules, be sure to link to them
   if (hasTopLevelModule() == true) {

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -258,6 +258,9 @@ symbolFlag( FLAG_METHOD_PRIMARY , npr, "primary method" , "function that is a me
 symbolFlag( FLAG_MODIFIES_CONST_FIELDS , npr, "modifies const fields" , "... of 'this' argument" )
 symbolFlag( FLAG_MODULE_FROM_COMMAND_LINE_FILE, npr, "module from command line file", "This is a module that came from a file named on the compiler command line")
 symbolFlag( FLAG_MODULE_INIT , npr, "module init" , "a module init function" )
+
+symbolFlag( FLAG_MODULE_INCLUDED_BY_DEFAULT , ypr, "module included by default" , "module is included by default" )
+
 // This flag marks the result of an autoCopy as necessary.
 // Necessary autoCopies are not removed by the removeUnnecessaryAutoCopyCalls optimization.
 symbolFlag( FLAG_NECESSARY_AUTO_COPY, npr, "necessary auto copy", "a variable containing a necessary autoCopy" )

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2795,16 +2795,8 @@ static bool readNamedArgument(CallExpr* call, const char* name,
 
 static bool symbolInBuiltinModule(Symbol* sym) {
   ModuleSymbol* mod = sym->getModule();
-  if (mod->modTag == MOD_STANDARD &&
-      (!strcmp(mod->name, "Builtins") ||
-       !strcmp(mod->name, "ChapelEnv") ||
-       !strcmp(mod->name, "ChapelIO") ||
-       !strcmp(mod->name, "VectorizingIterator") ||
-       !strcmp(mod->name, "Types") ||
-       !strcmp(mod->name, "Math"))) {
-    return true;
-  }
-  return false;
+  return (mod->modTag == MOD_STANDARD &&
+          mod->hasFlag(FLAG_MODULE_INCLUDED_BY_DEFAULT));
 }
 
 

--- a/modules/standard/Builtins.chpl
+++ b/modules/standard/Builtins.chpl
@@ -21,9 +21,8 @@
 /*
   This module contains built-in functions.
 
-  .. note:: All Chapel programs automatically ``use`` this module by default.
-            An explicit ``use`` statement is not necessary.
 */
+pragma "module included by default"
 module Builtins {
 
   /*

--- a/modules/standard/ChapelEnv.chpl
+++ b/modules/standard/ChapelEnv.chpl
@@ -26,15 +26,13 @@
 
 Access to Chapel Environment Variables
 
-.. note:: All Chapel programs automatically ``use`` this module by default.
-          An explicit ``use`` statement is not necessary.
-
 The values of Chapel's environment variables upon compile time are
 accessible through the built-in parameters shown below. This information
 can also be displayed from the command line by executing the compiled
 program with the ``--about`` flag.
 
  */
+pragma "module included by default"
 module ChapelEnv {
   private use String;
   private use ChapelStandard;

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -22,9 +22,6 @@
 
 Basic types and utilities in support of I/O operation.
 
-.. note:: All Chapel programs automatically ``use`` this module by default.
-          An explicit ``use`` statement is not necessary.
-
 Most of Chapel's I/O support is within the :mod:`IO` module.  This section
 describes automatically included basic types and routines that support the
 :mod:`IO` module.
@@ -200,6 +197,7 @@ appropriately before the elements can be read.
   data structures with these mechanisms.
 
  */
+pragma "module included by default"
 module ChapelIO {
   use ChapelBase; // for uint().
   use ChapelLocale;

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -21,9 +21,6 @@
 /*
 This module provides mathematical constants and functions.
 
-.. note:: All Chapel programs automatically ``use`` this module by default.
-          An explicit ``use`` statement is not necessary.
-
 It includes wrappers for many of the constants in functions in
 the C Math library, which is part of the C Language Standard (ISO/IEC 9899)
 as described in Section 7.12.  Please consult that standard for an
@@ -47,6 +44,7 @@ all math functions will return an implementation-defined value; no
 exception will be generated.
 
 */
+pragma "module included by default"
 module Math {
   import HaltWrappers;
   private use SysCTypes;

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -21,10 +21,8 @@
 /*
 Functions related to predefined types.
 
-.. note:: All Chapel programs automatically ``use`` this module by default.
-          An explicit ``use`` statement is not necessary.
-
 */
+pragma "module included by default"
 module Types {
   import HaltWrappers;
 

--- a/modules/standard/VectorizingIterator.chpl
+++ b/modules/standard/VectorizingIterator.chpl
@@ -22,9 +22,6 @@
 
   Iterators supporting vectorization without creating tasks.
 
-   .. note:: All Chapel programs automatically ``use`` this module by default.
-             An explicit ``use`` statement is not necessary.
-
   Data parallel constructs (such as ``forall`` loops) are implicitly
   vectorizable. If the ``--vectorize`` compiler flag is thrown the Chapel
   compiler will emit vectorization hints to the backend compiler, though the
@@ -42,6 +39,7 @@
  */
 pragma "error mode fatal"
 pragma "unsafe"
+pragma "module included by default"
 module VectorizingIterator {
   private use ChapelStandard;
 

--- a/test/functions/diten/compilerWarningDepth.good
+++ b/test/functions/diten/compilerWarningDepth.good
@@ -17,16 +17,16 @@ compilerWarningDepth.chpl:1: In function 'f1':
 compilerWarningDepth.chpl:2: warning: warning from f4 with d = 3
   compilerWarningDepth.chpl:20: called as f1(param d = 3)
 compilerWarningDepth.chpl:21: warning: warning from f4 with d = 4
-$CHPL_HOME/modules/standard/Builtins.chpl:101: In function 'compilerWarning':
-$CHPL_HOME/modules/standard/Builtins.chpl:102: warning: compiler diagnostic depth value exceeds call stack depth
+$CHPL_HOME/modules/standard/Builtins.chpl:nnn: In function 'compilerWarning':
+$CHPL_HOME/modules/standard/Builtins.chpl:nnn: warning: compiler diagnostic depth value exceeds call stack depth
   compilerWarningDepth.chpl:14: called as compilerWarning(param msg(0) = "warning from f4 with d = 5": string, param errorDepth = 5) from function 'f4'
   compilerWarningDepth.chpl:10: called as f4(param d = 5) from function 'f3'
   compilerWarningDepth.chpl:6: called as f3(param d = 5) from function 'f2'
   compilerWarningDepth.chpl:2: called as f2(param d = 5) from function 'f1'
   compilerWarningDepth.chpl:22: called as f1(param d = 5)
 compilerWarningDepth.chpl:22: warning: warning from f4 with d = 5
-$CHPL_HOME/modules/standard/Builtins.chpl:101: In function 'compilerWarning':
-$CHPL_HOME/modules/standard/Builtins.chpl:102: warning: compiler diagnostic depth value can not be negative
+$CHPL_HOME/modules/standard/Builtins.chpl:nnn: In function 'compilerWarning':
+$CHPL_HOME/modules/standard/Builtins.chpl:nnn: warning: compiler diagnostic depth value can not be negative
   compilerWarningDepth.chpl:14: called as compilerWarning(param msg(0) = "warning from f4 with d = -1": string, param errorDepth = -1) from function 'f4'
   compilerWarningDepth.chpl:10: called as f4(param d = -1) from function 'f3'
   compilerWarningDepth.chpl:6: called as f3(param d = -1) from function 'f2'

--- a/test/functions/diten/compilerWarningDepth.prediff
+++ b/test/functions/diten/compilerWarningDepth.prediff
@@ -2,5 +2,5 @@
 
 outfile=$2
 
-sed -e "/ChapelBase/ s/[0-9]*//g" $outfile > $outfile.tmp
+sed -e "/CHPL_HOME/ s/[0-9][0-9]*/nnn/g" $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/functions/vass/resolution/param-detuple.good
+++ b/test/functions/vass/resolution/param-detuple.good
@@ -4,8 +4,8 @@ param-detuple.chpl:9: warning: param proc
 param-detuple.chpl:8: In function 'p2':
 param-detuple.chpl:9: warning: param proc
   param-detuple.chpl:13: called as p2(param args(0) = "a": string, param args(1) = "b": string)
-$CHPL_HOME/modules/standard/Builtins.chpl:83: In function 'compilerError':
-$CHPL_HOME/modules/standard/Builtins.chpl:84: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/Builtins.chpl:145: called as compilerError(param msg(0) = "assert failed - ": string, param msg(1) = "done": string, param errorDepth = 3) from function 'compilerAssert'
+$CHPL_HOME/modules/standard/Builtins.chpl:nnn: In function 'compilerError':
+$CHPL_HOME/modules/standard/Builtins.chpl:nnn: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/Builtins.chpl:nnn: called as compilerError(param msg(0) = "assert failed - ": string, param msg(1) = "done": string, param errorDepth = 3) from function 'compilerAssert'
   param-detuple.chpl:14: called as compilerAssert(param test = 0, param msg(0) = "done": string, param errorDepth = 2)
 param-detuple.chpl:14: error: assert failed - done

--- a/test/functions/vass/resolution/param-detuple.prediff
+++ b/test/functions/vass/resolution/param-detuple.prediff
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cat $2 | sed s@ChapelBase.chpl:..:@ChapelBase.chpl:@ > $2.tmp
+cat $2 | sed -e "/CHPL_HOME/ s/:[0-9][0-9]*:/:nnn:/g" > $2.tmp
 mv $2.tmp $2

--- a/test/performance/vectorization/vectorizeOnly/nonIterableErrorMessage/vectorizeOnlyInvalidIterable.good
+++ b/test/performance/vectorization/vectorizeOnly/nonIterableErrorMessage/vectorizeOnlyInvalidIterable.good
@@ -1,3 +1,3 @@
-$CHPL_HOME/modules/standard/VectorizingIterator.chpl:130: In iterator 'vectorizeOnly':
-$CHPL_HOME/modules/standard/VectorizingIterator.chpl:130: error: cannot iterate over values of type int(64)
+$CHPL_HOME/modules/standard/VectorizingIterator.chpl:128: In iterator 'vectorizeOnly':
+$CHPL_HOME/modules/standard/VectorizingIterator.chpl:128: error: cannot iterate over values of type int(64)
   vectorizeOnlyInvalidIterable.chpl:4: called as vectorizeOnly(iterables(0): _any)


### PR DESCRIPTION
This is a follow-up to comments in PR #16848.

It adds a pragma to indicate a module is included by default. The pragma is used by a primitive listing symbols (to ignore default-included symbols). It is also used by chpldoc to generate a different header for the module. For example, look for the change in the Math module documentation.

Before this PR:


<img width="757" alt="image" src="https://user-images.githubusercontent.com/3653132/102115716-ed317000-3e09-11eb-8473-3c16c79bca09.png">

After this PR:

<img width="757" alt="image" src="https://user-images.githubusercontent.com/3653132/102115543-b52a2d00-3e09-11eb-9b61-27f49341bfb8.png">


Reviewed by @lydia-duncan - thanks!

- [x] full local testing