### PR TITLE
Disable an assertion to turn an assertion error for incorrect user programs into a user-facing error

### DIFF
--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -198,7 +198,11 @@ bool LowerLoopExprVisitor::enterLoopExpr(LoopExpr* node) {
   if (node->getStmtExpr() == NULL) {
     // Don't touch LoopExprs in DefExprs, they should be copied later into
     // BlockStmts.
-    INT_ASSERT(isDefExpr(node->parentExpr));
+
+    // While this works for correct codes, it results in assertion errors
+    // for incorrect codes that don't generate errors until resolution:
+    //
+    //    INT_ASSERT(isDefExpr(node->parentExpr));
   } else {
     SET_LINENO(node);
 

--- a/test/classes/delete-free/borrowed/borrowed-array.chpl
+++ b/test/classes/delete-free/borrowed/borrowed-array.chpl
@@ -1,0 +1,14 @@
+record FScoreComparator {
+  var fScore :  borrowed [..] real;
+  proc init(fScore : borrowed [..] real) {
+    this.fScore = fScore;
+  }
+}
+
+proc FScoreComparator.key(i) {
+  var D = this.fScore.domain;
+  if D.contains(i) then
+    return this.fScore[i];
+  else
+    return max(real);
+}

--- a/test/classes/delete-free/borrowed/borrowed-array.good
+++ b/test/classes/delete-free/borrowed/borrowed-array.good
@@ -1,0 +1,2 @@
+borrowed-array.chpl:2: error: cannot make [domain(1,int(64),false)] real(64) into a borrowed class
+borrowed-array.chpl:2: error: cannot make [domain(1,int(64),false)] real(64) into a borrowed class


### PR DESCRIPTION
This addresses user issue #16860 in which an early assertion
in the compiler generated an internal error for unsupported
patterns in user code when the lack of the assertion results
in a user-facing error message later in compilation.  Specifically,
I removed the assertion and let the error case through.

Tested linux64 for everything and the new test with `--verify`,
ASAN, and valgrind.

Resolves #16860.