### PR TITLE
Make man pages on 'make docs'

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -22,7 +22,7 @@ develall:
 	@$(MAKE) always-build-man
 	@$(MAKE) always-build-chplspell-venv
 
-docs: chpldoc
+docs: chpldoc man-chpldoc man-chapel
 	cd doc && $(MAKE) docs
 
 checkdocs: FORCE


### PR DESCRIPTION
I noticed that `make docs` does not cause the man page for `chpl` to be 
generated (although it does create the man page for `chpldoc`). This PR 
updates `make docs` to always create both man pages.

Reviewed by @ben-albrecht - thanks!