### PR TITLE
Fix make docs if CHPL_HOME is not set

### DIFF
--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -71,11 +71,16 @@ def gen_link(link, chapelfile):
     abspath = os.path.realpath(chapelfile)
     filename = os.path.split(chapelfile)[1]
 
-    chpl_home = os.path.realpath(os.getenv('CHPL_HOME'))
+    chpl_home = os.getenv('CHPL_MAKE_HOME')
+    if not chpl_home:
+        chpl_home = os.getenv('CHPL_HOME')
+
     if not chpl_home:
         print('Error: --link flag only works when $CHPL_HOME is defined')
         sys.exit(1)
-    elif not chpl_home in abspath:
+
+    chpl_home = os.path.realpath(chpl_home)
+    if not chpl_home in abspath:
         print('Error: --link flag only work for files within $CHPL_HOME')
         print('CHPL_HOME: {0}'.format(chpl_home))
         print('file path: {0}'.format(abspath))

--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -71,15 +71,15 @@ def gen_link(link, chapelfile):
     abspath = os.path.realpath(chapelfile)
     filename = os.path.split(chapelfile)[1]
 
-    chpl_home = os.getenv('CHPL_MAKE_HOME')
-    if not chpl_home:
-        chpl_home = os.getenv('CHPL_HOME')
+    chpl_home_env = os.getenv('CHPL_MAKE_HOME')
+    if not chpl_home_env:
+        chpl_home_env = os.getenv('CHPL_HOME')
 
-    if not chpl_home:
+    if not chpl_home_env:
         print('Error: --link flag only works when $CHPL_HOME is defined')
         sys.exit(1)
 
-    chpl_home = os.path.realpath(chpl_home)
+    chpl_home = os.path.realpath(chpl_home_env)
     if not chpl_home in abspath:
         print('Error: --link flag only work for files within $CHPL_HOME')
         print('CHPL_HOME: {0}'.format(chpl_home))


### PR DESCRIPTION
I noticed that `make docs` did not work if `CHPL_HOME` was not set.
This PR fixes the issue.

Reviewed by @ben-albrecht - thanks!

- [x] `make docs` succeeds without `CHPL_HOME` set
- [x] full local testing