### PR TITLE
Remove a chapelnoprint codeblock from the spec that was causing correctness issues

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1169,26 +1169,6 @@ concrete method to be selected when applicable. For example:
       var myIntNode = new MyNode(1);
       myIntNode.foo(); // outputs "in specific MyNode(int).foo()"
 
-   .. BLOCK-test-chapelnoprint
-
-      record MyNode {
-        var field;  // since no type is specified here, MyNode is a generic type
-      }
-
-      proc MyNode.foo() {
-        writeln("in generic MyNode.foo()");
-      }
-      proc (MyNode(int)).foo() {
-        writeln("in specific MyNode(int).foo()");
-      }
-
-      var myRealNode = new MyNode(1.0);
-      myRealNode.foo(); // outputs "in generic MyNode.foo()"
-      var myIntNode = new MyNode(1);
-      myIntNode.foo(); // outputs "in specific MyNode(int).foo()"
-
-
-
    .. BLOCK-test-chapeloutput
 
       in generic MyNode.foo()


### PR DESCRIPTION
Michael noted that https://github.com/chapel-lang/chapel/pull/16862 caused a
correctness issue in one of the tests.

One of the codeblocks that was fixed by that PR already had a
`BLOCK-test-chapelnoprint` twin. When that PR fixed the actual version of the
code, I failed to remove that twin. It caused the same code to be printed twice
in the generated test, causing issues.

This PR removes that block.

Test:
- [x] spec tests pass with quickstart
- [x] make docs generates correct docs with highlighting
