### PR TITLE
Fix problem where 'make docs' would run sphinx twice

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -22,7 +22,7 @@ develall:
 	@$(MAKE) always-build-man
 	@$(MAKE) always-build-chplspell-venv
 
-docs: chpldoc man-chpldoc man-chapel
+docs: chpldoc man-chpl man-chpldoc
 	cd doc && $(MAKE) docs
 
 checkdocs: FORCE
@@ -31,10 +31,14 @@ checkdocs: FORCE
 man: third-party-chpldoc-venv FORCE
 	cd man && $(MAKE)
 
-man-chpldoc: FORCE
+man-chpldoc: third-party-chpldoc-venv FORCE
 	cd man && $(MAKE) chpldoc
 
-man-chapel: FORCE
+man-chpl: third-party-chpldoc-venv FORCE
+	cd man && $(MAKE)
+
+# this target generates all of the API documentation into a single man page
+man-chapel: third-party-chpldoc-venv FORCE
 	cd doc && $(MAKE) man-chapel
 	mkdir -p man/man3
 	cp build/doc/man/chapel.3 man/man3/chapel.3


### PR DESCRIPTION
Follow-up to PR #16864.

PR #16864 added an invocation of the Makefile target `man-chapel` but 
that was wrong. `make man-chapel` creates a single man page with all the
API docs (in man/man3/chapel.1). I meant to make man/man1/chpl.1. This PR
fixes it by adding `man-chpl` to be symmetrical with `man-chpldoc` which
just creates the man page for the command and then updates `make docs` to
run that. While there, it makes sure that these targets have the chpldoc
dependencies.

Reviewed by @ben-albrecht - thanks!