### PR TITLE
Fix broken hyperlinks in ContributorInfo.rst and git.rst

### DIFF
--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -242,7 +242,7 @@ As you work, you will want to periodically bring in changes from the main Chapel
 project to your feature branch (described in `Development commands`_), to avoid
 code drift.
 
-Development commands: git.rst#development-commands
+.. _Development commands: git.rst#development-commands
 
 .. _Add new tests:
 

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -317,6 +317,8 @@ Just do your local development and then update your feature branch as in
 
 Please follow the `Pull request guidance`_ and keep PRs reasonably sized.
 
+.. _How to open a PR: git.rst#how-to-open-a-pr
+
 .. _Find a reviewer:
 
 Find a reviewer

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -43,7 +43,6 @@ Overview:
 
 #. `Other useful information`_
 
-   #. `Chapel git workflow`_
    #. `Policy details`_
    #. `Chapel release process`_
 
@@ -221,8 +220,11 @@ Create new branch
 
 This should happen once for every new effort.
 
-Develop your feature, bug fix, etc on your fork.  To create a new branch, use
-the `New branch command`_.  Using a concisely named branch is encouraged.
+Develop your feature, bug fix, etc. on your fork.  To create a new
+branch, use ``git checkout -b <branch_name>``.  Using a concisely
+named branch is encouraged.
+
+
 
 .. _Develop and test contributions locally:
 
@@ -233,12 +235,14 @@ Your contribution will take the form of a series of commits.  While including
 sensible commit messages is a good idea, it is more important to have a good
 merge message once the pull request is going in. Likewise, it is OK to have many
 small commits that reflect the history of development rather than commits for
-the feature.  See `Development commands`_ for how to perform some common
+the feature.  Review git `Development commands`_ for how to perform some common
 operations during development.
 
 As you work, you will want to periodically bring in changes from the main Chapel
 project to your feature branch (described in `Development commands`_), to avoid
 code drift.
+
+Development commands: git.rst#development-commands
 
 .. _Add new tests:
 

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -275,6 +275,8 @@ work (see `How to push`_ for command details).  Note that if you have already
 created a pull request from a feature branch, pushing your work to that feature
 branch will update the pull request.
 
+.. _How to push: git.rst#how-to-push
+
 .. _Ask for feedback on your branch early (optional):
 
 Ask for feedback on your branch early (optional)
@@ -382,6 +384,9 @@ appropriate amount of testing before merging the final PR may be found at
 
 After the final version of the change has been agreed upon, the person making
 the merge should follow the steps for `How to merge a PR`_.
+
+.. _Developer Certificate of Origin: DCO.rst
+.. _How to merge a PR: git.rst#how-to-merge-a-pr
 
 
 .. _After merging:
@@ -681,8 +686,6 @@ Reviewer responsibilities
 .. _chapel-lang/chapel: https://github.com/chapel-lang/chapel
 .. _Set up a GitHub account: https://help.github.com/articles/signing-up-for-a-new-github-account
 .. _Fork the repo: https://guides.github.com/activities/forking/
-.. _Submit a pull request: https://help.github.com/articles/using-pull-requests
-.. _synced with the main repo: https://help.github.com/articles/syncing-a-fork
 
 What Copyright Should I Use?
 ++++++++++++++++++++++++++++

--- a/doc/rst/developer/bestPractices/git.rst
+++ b/doc/rst/developer/bestPractices/git.rst
@@ -353,8 +353,8 @@ details). When you click "Merge pull request", you will need to enter a commit
 message. See `Final merge message`_ for a reminder on what that commit message
 should entail (generally, this will closely resemble the PR message).
 
-..Who has or needs commit access to the main repository?: ContributorInfo.rst#who-has-or-needs-commit-access-to-the-main-repository
-..Final merge message: ContributorInfo.rst#final-merge-message
+.. _Who has or needs commit access to the main repository?: ContributorInfo.rst#who-has-or-needs-commit-access-to-the-main-repository
+.. _Final merge message: ContributorInfo.rst#final-merge-message
 
 More information on using git
 +++++++++++++++++++++++++++++

--- a/doc/rst/developer/bestPractices/git.rst
+++ b/doc/rst/developer/bestPractices/git.rst
@@ -326,6 +326,8 @@ How to open a PR:
 
   and you can discuss the patch with your reviewers there.
 
+.. _Submit a pull request: https://help.github.com/articles/using-pull-requests
+.. _synced with the main repo: https://help.github.com/articles/syncing-a-fork
 .. _Developer Certificate of Origin: https://github.com/chapel-lang/chapel/blob/master/.github/CONTRIBUTING.md
 
 .. _How to merge a PR:
@@ -350,6 +352,9 @@ merge the pull request from the command line also and the pull request page has
 details). When you click "Merge pull request", you will need to enter a commit
 message. See `Final merge message`_ for a reminder on what that commit message
 should entail (generally, this will closely resemble the PR message).
+
+..Who has or needs commit access to the main repository?: ContributorInfo.rst#who-has-or-needs-commit-access-to-the-main-repository
+..Final merge message: ContributorInfo.rst#final-merge-message
 
 More information on using git
 +++++++++++++++++++++++++++++


### PR DESCRIPTION
This fixes some broken hyperlinks that I'd overlooked in preparing PR #16788, pointed out by @mppf (thanks!).

Pro tip (that I'll likely forget before using it again):  When editing a .rst file, browse it in github, searching for the string:
```
`_
```

which is your indicator that you've broken a link.