### PR TITLE
Quiet some tests under gasnet ASan

### DIFF
--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal.skipif
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal.skipif
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+import os
+
+print('memory' not in  os.getenv('CHPL_SANITIZE_EXE', ''))

--- a/test/optimizations/sungeun/optimized-on/loop.compopts
+++ b/test/optimizations/sungeun/optimized-on/loop.compopts
@@ -1,2 +1,9 @@
---no-cache-remote # loop.no-cache.good
---cache-remote    # loop.cache.good
+#!/usr/bin/env python3
+
+import os
+
+do_cache = os.getenv('CHPL_SANITIZE_EXE', '') == 'none'
+
+print(  '--no-cache-remote # loop.no-cache.good')
+if do_cache:
+  print('--cache-remote    # loop.cache.good')


### PR DESCRIPTION
Skip --cache-remote variant of optimizations/sungeun/optimized-on/loop when
ASan is on (cache-remote is not currently compatible with ASan)

Skip interop/C/multilocale/globals/use_reliesOnGlobal unless memory sanitizer
is on. This test relies on an uninitialized global having a defined value,
which is undefined behavior. The value is some sentinel under ASan, and happens
to be 0 on most systems we run on, but the behavior is truly undefined, so
don't run it unless memory sanitizer is on. We don't actually have memory
sanitizer testing yet, but when we do this test will run and should get a real
error message from MSan.

Resolves https://github.com/cray/chapel-private/issues/1488