### PR TITLE
Codegen changes supporting GPU effort

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -926,7 +926,7 @@ visitVisibleFunctions(Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types)
 
   // Mark exported symbols and module init/deinit functions as visible.
   forv_Vec(FnSymbol, fn, gFnSymbols)
-    if (fn->hasFlag(FLAG_EXPORT))
+    if (fn->hasFlag(FLAG_EXPORT) || fn->hasFlag(FLAG_ALWAYS_RESOLVE))
       pruneVisit(fn, fns, types);
 
   // Mark well-known functions as visible

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -106,6 +106,8 @@ void checkAdjustedDataLayout();
 
 extern fileinfo gAllExternCode;
 
+void print_clang(clang::Decl* d);
+
 #endif // HAVE_LLVM
 
 #endif //CLANGUTIL_H

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -200,6 +200,10 @@ symbolFlag( FLAG_ITERATOR_CLASS , npr, "iterator class" , ncm )
 symbolFlag( FLAG_ITERATOR_FN , npr, "iterator fn" , ncm )
 symbolFlag( FLAG_ITERATOR_RECORD , npr, "iterator record" , ncm )
 symbolFlag( FLAG_ITERATOR_WITH_ON , npr, "iterator with on" , "iterator which contains an on block" )
+
+
+symbolFlag( FLAG_ALWAYS_RESOLVE , ypr, "always resolve function" , "keep this function even if it is not called so it can be called during codegen e.g." )
+
 // In resolution, functions marked as last-resort are considered only if
 // no functions without that flag are found. This usually is used to create
 // a pattern enabling user-supplied replacement of default behavior.

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -70,6 +70,7 @@ bool isTypeSizeSmallerThan(const llvm::DataLayout& layout, llvm::Type* ty, uint6
 
 void print_llvm(llvm::Type* t);
 void print_llvm(llvm::Value* v);
+void print_llvm(llvm::Module* m);
 
 #endif //HAVE_LLVM
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2480,6 +2480,13 @@ void LayeredValueTable::addGlobalType(StringRef name, llvm::Type *type) {
 }
 
 void LayeredValueTable::addGlobalCDecl(NamedDecl* cdecl) {
+  if (cdecl->getIdentifier() == nullptr) {
+    // Certain C++ things such as constructors can have
+    // special compound names. In this case getName() will
+    // fail.
+    return;
+  }
+
   addGlobalCDecl(cdecl->getName(), cdecl);
 
   // Also file structs under 'struct struct_name'

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3891,4 +3891,13 @@ static void moveGeneratedLibraryFile(const char* tmpbinname) {
   moveResultFromTmp(outputPath.c_str(), tmpbinname);
 }
 
+void print_clang(clang::Decl* d) {
+  if (d == NULL)
+    fprintf(stderr, "NULL");
+  else
+    d->print(llvm::dbgs());
+
+  fprintf(stderr, "\n");
+}
+
 #endif

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1237,15 +1237,20 @@ class CCodeGenConsumer : public ASTConsumer {
           // Handle forward declaration for structs
           info->lvt->addGlobalCDecl(rd);
         }
+      } else if (UsingDecl* ud = dyn_cast<UsingDecl>(d)) {
+        for (auto shadow : ud->shadows()) {
+          NamedDecl* nd = shadow->getTargetDecl();
+          doHandleDecl(nd);
+        }
       } else if (LinkageSpecDecl* ld = dyn_cast<LinkageSpecDecl>(d)) {
         // Handles extern "C" { }
-        for (auto &sub : ld->decls()) {
+        for (auto sub : ld->decls()) {
           doHandleDecl(sub);
         }
       } else if (ExternCContextDecl *ed = dyn_cast<ExternCContextDecl>(d)) {
         // TODO: is this an alternative extern "C"?
         // do we need to handle it?
-        for (auto &sub : ed->decls()) {
+        for (auto sub : ed->decls()) {
           doHandleDecl(sub);
         }
       }

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -563,6 +563,17 @@ void print_llvm(llvm::Value* v)
   fprintf(stderr, "\n");
 }
 
+void print_llvm(llvm::Module* m)
+{
+  if (m == NULL)
+    fprintf(stderr, "NULL");
+  else
+    m->print(llvm::dbgs(), NULL);
+
+  fprintf(stderr, "\n");
+}
+
+
 
 #endif
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9162,12 +9162,13 @@ static void resolveExports() {
       continue;
     }
 
-    if (fn->hasFlag(FLAG_EXPORT) == true) {
+    if (fn->hasFlag(FLAG_EXPORT) || fn->hasFlag(FLAG_ALWAYS_RESOLVE)) {
       SET_LINENO(fn);
 
       resolveSignatureAndFunction(fn);
 
-      exps.push_back(fn);
+      if (fn->hasFlag(FLAG_EXPORT))
+        exps.push_back(fn);
     }
   }
 

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -58,7 +58,7 @@ module LocaleModelHelpGPU {
   //  else
   //         chpl_executeOn / chpl_executeOnFast
   //
-  export
+  pragma "always resolve function"
   proc chpl_doDirectExecuteOn(in loc: chpl_localeID_t // target locale
                              ):bool {
     const dnode =  chpl_nodeFromLocaleID(loc);
@@ -80,7 +80,7 @@ module LocaleModelHelpGPU {
   // regular "on"
   //
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
                       fn: int,              // on-body function idx
                       args: chpl_comm_on_bundle_p,     // function args
@@ -121,7 +121,7 @@ module LocaleModelHelpGPU {
   // in the Active Messages sense)
   //
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
                           fn: int,              // on-body function idx
                           args: chpl_comm_on_bundle_p,     // function args
@@ -150,7 +150,7 @@ module LocaleModelHelpGPU {
   // nonblocking "on" (doesn't wait for completion)
   //
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
                         fn: int,              // on-body function idx
                         args: chpl_comm_on_bundle_p,     // function args

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -72,17 +72,17 @@ module LocaleModelHelpRuntime {
 
   // Compiler (and module code) interface for manipulating global locale IDs..
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_buildLocaleID(node: chpl_nodeID_t, subloc: chpl_sublocID_t)
     return chpl_rt_buildLocaleID(node, subloc);
 
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_nodeFromLocaleID(in loc: chpl_localeID_t)
     return chpl_rt_nodeFromLocaleID(loc);
 
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_sublocFromLocaleID(in loc: chpl_localeID_t)
     return chpl_rt_sublocFromLocaleID(loc);
 
@@ -131,7 +131,7 @@ module LocaleModelHelpRuntime {
   // add a task to a list of tasks being built for a begin statement
   //
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_taskListAddBegin(subloc_id: int,        // target sublocale
                              fn: int,               // task body function idx
                              args: chpl_task_bundle_p,      // function args
@@ -155,7 +155,7 @@ module LocaleModelHelpRuntime {
   // statement
   //
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_taskListAddCoStmt(subloc_id: int,        // target sublocale
                               fn: int,               // task body function idx
                               args: chpl_task_bundle_p,      // function args
@@ -182,7 +182,7 @@ module LocaleModelHelpRuntime {
   // make sure all tasks in a list have an opportunity to run
   //
   pragma "insert line file info"
-  export
+  pragma "always resolve function"
   proc chpl_taskListExecute(ref task_list: c_void_ptr) {
     // note: if we're serial, all of the tasks have already
     // been executed. Tasking layers should tolerate empty task


### PR DESCRIPTION
This PR includes some compiler changes motivated by the effort to get
native GPU code generation. Many of these changes improve support for
compiling the runtime includes with the embedded clang in C++ mode (which
we were trying to do in order to ask clang to treat it as CUDA code which
is a variant of C++). In that regard, this PR is a follow-up to PR
#16847.

This PR takes these steps:

* Ignore C++ constructors etc. in addGlobalCDecl 
* Handle extern "C" blocks in AST traversal 
* Add flag `FLAG_ALWAYS_RESOLVE`
* Add more debug print functions  to print out clang AST nodes
*  Handle C++ `using` statements to solve a problem with `atomic_bool`

Regarding `FLAG_ALWAYS_RESOLVE` - we have a number of locale model
routines today that are declared `export proc` but which do not have
declarations in the C runtime. Our current ABI strategy requires a C
declaration for these (and we could generate one but we don't yet --
see #12132).

This isn't presenting a problem for x86-64 but we observed problems with
it when generating PTX code. So, here we mark these functions instead
`FLAG_ALWAYS_RESOLVE` instead of `export` so that they are always
resolved (so calls can be added after resolution) but so that we don't
have to worry about C ABI compatability.

Reviewed by @e-kayrakli - thanks!

- [x] full local testing
- [x] full local --llvm testing
