### PR TITLE
Use the defaultTimer for multi-locale no-op perf test

### DIFF
--- a/test/performance/elliot/no-op.ml-timeexec
+++ b/test/performance/elliot/no-op.ml-timeexec
@@ -1,1 +1,1 @@
-highPrecisionTimer
+defaultTimer


### PR DESCRIPTION
We have a multi-locale performance test that just measures startup time.
Historically, we used the highPrecision timer which is implemented in
python for this test, but that seems to be causing issues with ofi
testing since we switched to Slurm's PMI2. Using the defaultTimer, which
is implemented as a bash wrapper, seems to work fine and we don't need
that high of precision for multi-locale startup since it's relatively
slow (at least compared to single locale startup where precision was
important.)

Resolves https://github.com/Cray/chapel-private/issues/1531
