### PR TITLE
Adjust remote cache to better handle task yields in comm events

### DIFF
--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -400,6 +400,133 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
   }
 }
 
+static inline
+void strd_common_call(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
+                      void* srcaddr_arg, size_t* srcstrides,
+                      size_t* count, int32_t stridelevels, size_t elemSize,
+                      void* ctx,
+                      void (callback)(/* addr */ void*,
+                                      /* node */ int32_t,
+                                      /* raddr */ void*,
+                                      /* size */ size_t,
+                                      /* ctx */ void*,
+                                      /* commID */ int32_t,
+                                      /* ln */ int, /* fn */ int32_t),
+                      int32_t commID, int ln, int32_t fn) {
+  const size_t strlvls=(size_t)stridelevels;
+  size_t i,j,k,t,total,off,x,carry;
+
+  int8_t* dstaddr,*dstaddr1;
+  int8_t* srcaddr,*srcaddr1;
+
+  int *srcdisp, *dstdisp;
+  size_t dststr[strlvls];
+  size_t srcstr[strlvls];
+  size_t cnt[strlvls+1];
+
+  //Only count[0] and strides are measured in number of bytes.
+  cnt[0]=count[0] * elemSize;
+  if(strlvls>0){
+    srcstr[0] = srcstrides[0] * elemSize;
+    dststr[0] = dststrides[0] * elemSize;
+    for (i=1;i<strlvls;i++)
+      {
+        srcstr[i] = srcstrides[i] * elemSize;
+        dststr[i] = dststrides[i] * elemSize;
+        cnt[i]=count[i];
+      }
+    cnt[strlvls]=count[strlvls];
+  }
+
+  switch(strlvls) {
+  case 0:
+    dstaddr=(int8_t*)dstaddr_arg;
+    srcaddr=(int8_t*)srcaddr_arg;
+
+    callback(dstaddr, srclocale, srcaddr, cnt[0], ctx, commID, ln, fn);
+    break;
+
+  case 1:
+    dstaddr=(int8_t*)dstaddr_arg;
+    srcaddr=(int8_t*)srcaddr_arg;
+    for(i=0; i<cnt[1]; i++) {
+      callback(dstaddr, srclocale, srcaddr, cnt[0], ctx, commID, ln, fn);
+      srcaddr+=srcstr[0];
+      dstaddr+=dststr[0];
+    }
+    break;
+
+  case 2:
+    for(i=0; i<cnt[2]; i++) {
+      srcaddr = (int8_t*)srcaddr_arg + srcstr[1]*i;
+      dstaddr = (int8_t*)dstaddr_arg + dststr[1]*i;
+      for(j=0; j<cnt[1]; j++) {
+        callback(dstaddr, srclocale, srcaddr, cnt[0], ctx, commID, ln, fn);
+        srcaddr+=srcstr[0];
+        dstaddr+=dststr[0];
+      }
+    }
+    break;
+
+  case 3:
+    for(i=0; i<cnt[3]; i++) {
+      srcaddr1 = (int8_t*)srcaddr_arg + srcstr[2]*i;
+      dstaddr1 = (int8_t*)dstaddr_arg + dststr[2]*i;
+      for(j=0; j<cnt[2]; j++) {
+        srcaddr = srcaddr1 + srcstr[1]*j;
+        dstaddr = dstaddr1 + dststr[1]*j;
+        for(k=0; k<cnt[1]; k++) {
+          callback(dstaddr, srclocale, srcaddr, cnt[0], ctx, commID, ln, fn);
+          srcaddr+=srcstr[0];
+          dstaddr+=dststr[0];
+        }
+      }
+    }
+    break;
+
+  default:
+    dstaddr=(int8_t*)dstaddr_arg;
+    srcaddr=(int8_t*)srcaddr_arg;
+
+    //Number of chpl_comm_get operations to do
+    total=1;
+    for (i=0; i<strlvls; i++)
+      total=total*cnt[i+1];
+
+    //displacement from the dstaddr and srcaddr start points
+    srcdisp=chpl_mem_allocMany(total,sizeof(int),CHPL_RT_MD_GETS_PUTS_STRIDES,0,0);
+    dstdisp=chpl_mem_allocMany(total,sizeof(int),CHPL_RT_MD_GETS_PUTS_STRIDES,0,0);
+
+    for (j=0; j<total; j++) {
+      carry=1;
+      for (t=1;t<=strlvls;t++) {
+        if (cnt[t]*carry>=j+1) {  //IF 1
+          x=j/carry;
+          off =j-(carry*x);
+
+          if (carry!=1) {  //IF 2
+            srcdisp[j]=srcstr[t-1]*x+srcdisp[off];
+            dstdisp[j]=dststr[t-1]*x+dstdisp[off];
+          } else {  //ELSE 2
+            srcdisp[j]=srcstr[t-1]*x;
+            dstdisp[j]=dststr[t-1]*x;
+          }
+          callback(dstaddr+dstdisp[j], srclocale, srcaddr+srcdisp[j], cnt[0],
+                   ctx, commID, ln, fn);
+          break;
+
+        } else {  //ELSE 1
+          carry=carry*cnt[t];
+        }
+      }
+    }
+    chpl_mem_free(srcdisp,0,0);
+    chpl_mem_free(dstdisp,0,0);
+    break;
+  }
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -140,6 +140,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 
 // Returns nonzero iff the handle has already been waited for and has
 // been cleared out in a call to chpl_comm_{wait,try}_some.
+// This function must not call chpl_task_yield.
 int chpl_comm_test_nb_complete(chpl_comm_nb_handle_t h);
 
 // Wait on handles created by chpl_comm_start_....  ignores completed handles.

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1951,17 +1951,16 @@ void do_wait_for(struct rdcache_s* cache, cache_seqn_t sn)
 }
 
 
-// "lock" the entry
-//  * if entry->entryReservedByTask is task_local, return - already locked
+// try to "lock" the entry
 //  * if entry->entryReservedByTask is NULL, set it to task_local
-//  * otherwise wait for entry->entryReservedByTask to become NULL
-//    by yielding, and then set it to task_local.
+//    and return 1 (indicating the lock was taken)
+//
+//  * otherwise, return 0
+//    (and assert that this task doesn't already have the lock).
+//    If 0 is returned, the caller should loop calling chpl_task_yield.
 //
 // This lock protects the entry from being evicted by another task
 // in the same pthread.
-//
-// returns 1 if the lock was taken (0 means someone else has it)
-// if 0 is returned, the calling loop should call chpl_task_yield.
 static
 int try_reserve_entry(struct rdcache_s* cache,
                       chpl_cache_taskPrvData_t* task_local,
@@ -1977,6 +1976,7 @@ int try_reserve_entry(struct rdcache_s* cache,
   }
 }
 
+// "unlock" the entry
 static
 void unreserve_entry(struct rdcache_s* cache,
                    chpl_cache_taskPrvData_t* task_local,

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2,15 +2,15 @@
  * Copyright 2020 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -294,7 +294,7 @@ use.
 // How many pending operations can we have at once?
 #define MAX_PENDING 32
 
-// CACHEPAGE_BITS 
+// CACHEPAGE_BITS
 // Controls the cache page size - the cache manages items of this many bytes
 // but also includes facilities for partial pages (valid and dirty bits).
 //
@@ -306,7 +306,7 @@ use.
 #define CACHEPAGE_SIZE (1 << CACHEPAGE_BITS)
 #define CACHEPAGE_MASK (CACHEPAGE_SIZE-1)
 
-// CACHELINE_BITS 
+// CACHELINE_BITS
 // Controls the cache line size - that is, the minimum number of bytes
 // that are fetched for any 'get' operation.
 //
@@ -317,7 +317,7 @@ use.
 #define CACHELINE_MASK (CACHELINE_SIZE-1)
 
 // What type can store the number of cache lines in a cache page?
-typedef int8_t line_per_page_t; 
+typedef int8_t line_per_page_t;
 // What type for a number of lines to read ahead?
 typedef int16_t readahead_distance_t;
 
@@ -331,7 +331,7 @@ typedef int16_t entry_id_t;
 #define MAX_PAGES_PER_PREFETCH 2
 
 // Should we enable sequential readahead?
-// For sequential access If we're reading  
+// For sequential access If we're reading
 #define ENABLE_READAHEAD 1
 #define ENABLE_READAHEAD_TRIGGER_WITHIN_PAGE 1
 #define ENABLE_READAHEAD_TRIGGER_SEQUENTIAL 0
@@ -386,7 +386,7 @@ static long time_duration(const struct timespec* t1, const struct timespec* t2)
 
 
 
-// ----------  SUPPORT FUNCTIONS 
+// ----------  SUPPORT FUNCTIONS
 #include "chpl-cache-support.c"
 
 
@@ -530,7 +530,7 @@ static int set_valid_lines(uint64_t* valid, uintptr_t skip, uintptr_t len)
 static void unset_valid_lines(uint64_t* valid, uintptr_t skip, uintptr_t len)
 {
   uint64_t myvalid[CACHE_LINES_PER_PAGE_BITMASK_WORDS];
-  unset_valids_for_skip_len(valid, myvalid, skip, len, CACHE_LINES_PER_PAGE_BITMASK_WORDS);  
+  unset_valids_for_skip_len(valid, myvalid, skip, len, CACHE_LINES_PER_PAGE_BITMASK_WORDS);
 }
 
 struct rdcache_s {
@@ -538,7 +538,7 @@ struct rdcache_s {
   // See "2Q: A Low Overhead High Performance Buffer Management
   //      Replacement Algorithm"
   //    by Theodore Johnson and Dennis Sasha, Proc 20th VLDB conference, 1994.
-  
+
   // The next request number -- there is currently no request or cache
   // element with this sequence number.
   cache_seqn_t next_request_number;
@@ -585,13 +585,13 @@ struct rdcache_s {
   //
   // Ain and Aout stores entries and pending operations and newly cached data
   // and looks like this:
-  //  <--                  <--                   <--                       <-- 
+  //  <--                  <--                   <--                       <--
   //  tail              complete                 start                     head
   //  "first entry"                                                "last entry"
   //  | completed requests | in-progress requests | write/prefetch requests |
   //                                                not yet started
   //
-  
+
   int max_pages;
   int max_entries;
 
@@ -703,7 +703,7 @@ struct rdcache_s* cache_create(void) {
 
   size_t total_size = 0;
   size_t allocated_size = 0;
-  unsigned int pending_len = MAX_PENDING; 
+  unsigned int pending_len = MAX_PENDING;
   unsigned char* buffer;
   unsigned char* pages;
 
@@ -721,7 +721,7 @@ struct rdcache_s* cache_create(void) {
   // How many pages can be dirty at once?
   dirty_pages = 16 + cache_pages / 64;
 
-  // How many cache entries do we need? 
+  // How many cache entries do we need?
   n_entries = cache_pages + aout_pages;
 
   // Lookup table size (note each slot is 4 entries, so this is 4x slots)
@@ -1354,7 +1354,7 @@ struct cache_entry_s* allocate_entry(struct rdcache_s* cache)
 {
   struct cache_entry_s* ret;
 
-  //printf("alloc entry ain %i aout %i am %i\n", 
+  //printf("alloc entry ain %i aout %i am %i\n",
   //       cache->ain_current, cache->aout_current, cache->am_current);
 
   // Make sure we have a free entry..
@@ -1365,7 +1365,7 @@ struct cache_entry_s* allocate_entry(struct rdcache_s* cache)
   // Remove it from the single-linked list.
   SINGLE_POP_HEAD(cache, free_entries);
 
-  return ret; 
+  return ret;
 }
 
 
@@ -1481,7 +1481,7 @@ cache_seqn_t pending_push(struct rdcache_s* cache, chpl_comm_nb_handle_t handle)
   index = cache->pending_last_entry;
   cache->pending[index] = handle;
   cache->pending_sequence_numbers[index] = sn;
- 
+
   DEBUG_PRINT(("in pending_push added pending[%i]=%p sn=%i\n",
                index, (void*) handle, (int) sn));
 
@@ -1651,9 +1651,9 @@ void validate_cache(struct rdcache_s* tree)
     assert(num_dirty == tree->num_dirty_pages);
     assert(with_entry_count == tree->num_dirty_pages);
   }
-  
+
   // 5: must not lose entries. Check that the entry free list
-  // contains the right number of entries. 
+  // contains the right number of entries.
   {
     struct cache_list_entry_s* cur;
     int num_free_entries = 0;
@@ -1749,7 +1749,7 @@ void flush_entry(struct rdcache_s* cache, struct cache_entry_s* entry, int op,
   uintptr_t num_lines, skip_lines;
   chpl_comm_nb_handle_t handle;
   uintptr_t got_skip, got_len;
-  
+
   DEBUG_PRINT(("flush_entry(%p, %i, %p, %i)\n",
                entry, op, (void*) raddr, (int) len));
 #ifdef DUMP
@@ -1875,7 +1875,7 @@ void use_entry(struct rdcache_s* cache,
   if( entry->queue == QUEUE_AM ) {
     DOUBLE_REMOVE(cache, entry, am_lru);
     DOUBLE_PUSH_HEAD(cache, entry, am_lru);
-  } 
+  }
   // Otherwise (it is in Ain) so leave it where it is.
 }
 
@@ -2012,11 +2012,11 @@ void cache_put(struct rdcache_s* cache,
 
   assert(chpl_nodeID != node); // should be handled in chpl_gen_comm_put
 
-  // And don't do anything if it's a zero-length 
+  // And don't do anything if it's a zero-length
   if( size == 0 ) {
     return;
   }
- 
+
   // first_page = raddr of start of first needed page
   ra_first_page = round_down_to_mask(raddr, CACHEPAGE_MASK);
   // last_page = raddr of start of last needed page
@@ -2051,7 +2051,7 @@ void cache_put(struct rdcache_s* cache,
       // Is this cache line available for use, based on when we
       // last ran an acquire fence?
       entry_after_acquire = ( entry->min_sequence_number >= last_acquire );
-   
+
       // If the cache line contains any overlapping writes or prefetches,
       // we must wait for them to complete before we store new data.
       // Nonblocking GETs and PUTs must not have their buffers changed
@@ -2197,7 +2197,7 @@ void cache_get_trigger_readahead(struct rdcache_s* cache,
     if( ! ok && request_raddr != 0 && request_size != 0 ) {
       // Adjust prefetch_start/prefetch_end so that it lies on the same
       // system page as the requested data.
-      
+
       page_size = sys_page_size();
 
       request_page = round_down_to_mask(request_raddr, page_size-1);
@@ -2356,7 +2356,7 @@ void cache_get_in_page(struct rdcache_s* cache,
     // Is this cache line available for use, based on when we
     // last ran an acquire fence?
     entry_after_acquire = ( entry->min_sequence_number >= last_acquire );
-   
+
     // Is the relevant data available in the cache line?
     has_data = check_valid_lines(entry->valid_lines,
                                  (ra_line - ra_page) >> CACHELINE_BITS,
@@ -2377,7 +2377,7 @@ void cache_get_in_page(struct rdcache_s* cache,
       sequential_readahead_length == 0 &&
       ! has_data &&
       ! (entry && entry->readahead_len) ) {
-    
+
     ra = 0;
 
     if( ENABLE_READAHEAD_TRIGGER_WITHIN_PAGE && entry ) {
@@ -2389,7 +2389,7 @@ void cache_get_in_page(struct rdcache_s* cache,
              (int) chpl_nodeID, ra, (void*) ra_line, (void*) ra_line_end, (void*) cache->last_cache_miss_read_addr));
       }
     }
-   
+
     if( ENABLE_READAHEAD_TRIGGER_SEQUENTIAL && ra == 0 &&
         cache->last_cache_miss_read_node == node ) {
       if(cache->last_cache_miss_read_addr < ra_line &&
@@ -2410,14 +2410,14 @@ void cache_get_in_page(struct rdcache_s* cache,
     if( ra == 1 ) {
       // Extend ra_line_end to the end of the current page.
       ra_line_end = ra_page + CACHEPAGE_SIZE;
-      
+
       readahead_skip = CACHEPAGE_SIZE;
       readahead_len = CACHEPAGE_SIZE;
     } else if(ra == -1) {
       // reverse prefetch
       // Extend ra_line to the start of the current page.
       ra_line = ra_page;
-      
+
       readahead_skip = -CACHEPAGE_SIZE;
       readahead_len = CACHEPAGE_SIZE;
     }
@@ -2455,15 +2455,15 @@ void cache_get_in_page(struct rdcache_s* cache,
       // If the cache line is in Am, move it to the front of Am.
       use_entry(cache, entry);
       if( ! isprefetch ) {
-    
-        //printf("cache hit on page %i:%p %p ra_len %i\n", 
+
+        //printf("cache hit on page %i:%p %p ra_len %i\n",
         //       node, (void*) ra_page, (void*) requested_start,
         //       (int) entry->readahead_len);
         // Copy the data out.
         chpl_memcpy(addr+(requested_start-raddr),
                     page+(requested_start-ra_page),
                     requested_size);
-  
+
         // If we are accessing a page that has a readahead condition,
         // trigger that readahead.
         if( ENABLE_READAHEAD && entry->readahead_len ) {
@@ -2486,7 +2486,7 @@ void cache_get_in_page(struct rdcache_s* cache,
 
       return; // Move on to the next page.
     }
- 
+
     // Get ready to start a get !
 
     // If there was an intervening acquire fence preventing
@@ -2523,7 +2523,7 @@ void cache_get_in_page(struct rdcache_s* cache,
   clock_gettime(CLOCK_REALTIME, &start_get1);
 #endif
   // Note: chpl_comm_get_nb could cause a different task body to run.
-  handle = 
+  handle =
     chpl_comm_get_nb(page+(ra_line-ra_page), /*local addr*/
                      node, (void*) ra_line,
                      ra_line_end - ra_line /*size*/,
@@ -2655,7 +2655,7 @@ void cache_get(struct rdcache_s* cache,
 
   assert(chpl_nodeID != node); // should be handled in chpl_gen_comm_prefetch.
 
-  // And don't do anything if it's a zero-length 
+  // And don't do anything if it's a zero-length
   if( size == 0 ) {
     return;
   }
@@ -2679,7 +2679,7 @@ void cache_get(struct rdcache_s* cache,
        ra_page <= ra_last_page;
        ra_page += CACHEPAGE_SIZE ) {
 
-   
+
     // We will need from ra_line to ra_line_end.
     ra_line_end = (ra_page==ra_last_page)?(ra_next_line):(ra_page+CACHEPAGE_SIZE);
     // Compute the portion of the page that was requested
@@ -2739,7 +2739,7 @@ int mock_get(struct rdcache_s* cache,
   if (chpl_nodeID == node)
     return 1;
 
-  // And don't do anything if it's a zero-length 
+  // And don't do anything if it's a zero-length
   if( size == 0 ) {
     return 1;
   }
@@ -2760,7 +2760,7 @@ int mock_get(struct rdcache_s* cache,
   for( ra_page = ra_first_page, ra_line = ra_first_line;
        ra_page <= ra_last_page;
        ra_page += CACHEPAGE_SIZE, ra_line = ra_page ) {
-    
+
     // We will need from ra_line to ra_line_end.
     ra_line_end = (ra_page==ra_last_page)?(ra_next_line):(ra_page+CACHEPAGE_SIZE);
     // Compute the portion of the page that was requested
@@ -2783,7 +2783,7 @@ int mock_get(struct rdcache_s* cache,
       // Is this cache line available for use, based on when we
       // last ran an acquire fence?
       entry_after_acquire = ( entry->min_sequence_number >= last_acquire );
-     
+
       // Is the relevant data available in the cache line?
       has_data = check_valid_lines(entry->valid_lines,
                                    (ra_line - ra_page) >> CACHELINE_BITS,
@@ -2829,7 +2829,7 @@ int mock_get(struct rdcache_s* cache,
         // Would copy the data out here, but not in mock get
         continue; // Move on to the next page.
       }
-   
+
       // Get ready to start a get !
 
       // If there was an intervening acquire fence preventing

--- a/test/optimizations/cache-remote/ferguson/reduces_comm/mycopy.chpl
+++ b/test/optimizations/cache-remote/ferguson/reduces_comm/mycopy.chpl
@@ -2,6 +2,8 @@ use CommDiagnostics;
 use Time;
 
 config const n = 10000;
+config const verbose = false;
+
 var A:[1..n] int;
 var B:[1..n] int;
 
@@ -40,13 +42,18 @@ stopCommDiagnostics();
 
 writeln(B[1]);
 writeln(B[n]);
-//writeln(t.elapsed(), " seconds");
+
+if verbose {
+  writeln(t.elapsed(), " seconds");
+}
 
 var d = getCommDiagnostics();
 var ngets = (d(1).get + d(1).get_nb):int;
-var nputs = (d(1).put + d(1).put):int;
-//writeln(ngets, " gets");
-//writeln(nputs, " puts");
+var nputs = (d(1).put + d(1).put_nb):int;
+if verbose {
+  writeln(ngets, " gets");
+  writeln(nputs, " puts");
+}
 
 assert(ngets < n);
 assert(nputs < n);

--- a/test/runtime/configMatters/comm/cache-remote/bulk-comm.chpl
+++ b/test/runtime/configMatters/comm/cache-remote/bulk-comm.chpl
@@ -1,4 +1,4 @@
-// Test that writes to array elemnets are fenced before a large transfer
+// Test that writes to array elements are fenced before a large transfer
 // containing those elements is issued.
 proc testArr(A) {
   on Locales[numLocales-1] {


### PR DESCRIPTION
Before this PR, the `--cache-remote` cache has used a "lock" to ensure
that only a single cache enters the cache API functions. This PR adjusts
it to instead "lock" at a cache entry level. (Here "lock" means to check
a variable indicating it is in use; to loop and yield until it is 0; and
then set it. This is similar to how a lock works but in this case it is
only managing access from other tasks as a result of `chpl_task_yield`).

Details:
* Added the `entryReservedByTask` to the cache entries. Adjusted
  `flush_entry`, `cache_get`, and `cache_put` to take this "lock".
* Passed `task_local` to many functions since it is used to know if the
  current task has the "lock" on an entry.  This allows the code to be
  able to know if the lock is already taken by the current task. This is
  primarily used in assertion checking right now.
* Factored per-page operations out of put/get/invalidate
* Added "lock" code around per-page operations -- put/get/invalidate as
  well as evictions take the lock and release it when completed
* Adjusted the code waiting for nonblocking comm operations
  (`do_wait_for`) to better tolerate task yields
* Took care with locking another entry while an entry is locked. This
  kind of thing can cause deadlock. The place it was present was in the
  `cache_get` code - it was making sure that there was a freed page while
  waiting for the nonblocking GET. Since this is a performance hint, I
  adjusted it to just give up if the page needing to be evicted is
  locked.
* Automatic readahead when doing GETs does not lock multiple entries
  because it only happens on a cache hit - so it unlocks the entry with
  the data before starting the prefetching (which will lock each page
  involved, one at a time).
* Added `EXTRA_YIELD` setting for debugging which does yielding around
  comms events. This allowed me to debug the issues with yielding using a
  local gasnet configuration.
* Added more debug printing/tracing that I used during debugging.

Additionally, I noticed that the strided get/put calls were invalidating
the entire cache but now we have functions to invalidate just a region.
At the same time, we have strided "common helper" functions that
enumerate the contiguous regions in
runtime/include/chpl-comm-strd-xfer.h. So, I updated the strided get/put
support in the cache to only invalidate the portions updated by the
operation, instead of the entire cache. To do so, I needed to add another
variant of the code in chpl-comm-strd-xfer.h since the other functions
there call `comm_get` / `comm_put` and this one needs to invalidate. We
can change the setting `STRIDED_INVALIDATE_ALL` to check the performance
of this change independently.

Related to PRs #15266, #16020 and issues
https://github.com/Cray/chapel-private/issues/585 and
https://github.com/Cray/chapel-private/issues/879. PR #12964 talks a bit
about why comm-compute overlap changes are important in comm performance.
This PR improves performance for several Arkouda operations when running
with `--cache-remote`. The reason it improves performance is that the
previous coarse-grained locking strategy adding yields without really
making progress on communication in oversubscribed settings. Tasks would
be created to try to do comms but not be able to make progress.

Reviewed by @gbtitus - thanks!

- [x] test/runtime/configMatters/comm/cache-remote and
  test/optimizations/cache-remote pass with `VERIFY` and `EXTRA_YIELDS`
  enabled (except for `ra_prefetch.chpl` which times out due to problem
  size too large for this configuration but functions with a smaller
  problem size)
- [x] full local gasnet testing
- [x] full local gasnet testing with `--cache-remote`