### PR TITLE
Remove lots of 'inline's in IO.chpl for non-trivial procedures

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
@@ -2212,7 +2212,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
 
    :throws SystemError: Thrown if the lock could not be acquired.
  */
- proc channel.lock() throws {
+proc channel.lock() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
@@ -2229,7 +2229,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
 /*
    Release a channel's lock.
  */
- proc channel.unlock() {
+proc channel.unlock() {
   if locking {
     on this.home {
       qio_channel_unlock(_channel_internal);
@@ -2329,7 +2329,7 @@ proc channel.advancePastByte(byte:uint(8)) throws {
   :returns: The offset that was marked
   :throws: SystemError: if marking the channel failed
  */
- proc channel.mark() throws where this.locking == false {
+proc channel.mark() throws where this.locking == false {
   const offset = this.offset();
   const err = qio_channel_mark(false, _channel_internal);
 
@@ -2401,7 +2401,7 @@ proc channel.seek(start:int, end:int = max(int)) throws {
    For a channel locked with :proc:`channel.lock`, return the offset
    of that channel.
  */
- proc channel._offset():int(64) {
+proc channel._offset():int(64) {
   var ret:int(64);
   on this.home {
     ret = qio_channel_offset_unlocked(_channel_internal);
@@ -2423,7 +2423,7 @@ proc channel.seek(start:int, end:int = max(int)) throws {
   :returns: The offset that was marked
   :throws: SystemError: if marking the channel failed
  */
- proc channel._mark() throws {
+proc channel._mark() throws {
   const offset = this.offset();
   const err = qio_channel_mark(false, _channel_internal);
 
@@ -2874,7 +2874,7 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t,
   return EINVAL;
 }
 
-private  proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, out x:?t):syserr where _isIoPrimitiveType(t) {
+private proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, out x:?t):syserr where _isIoPrimitiveType(t) {
   if isBoolType(t) {
     var got:int(32);
     got = qio_channel_read_byte(false, _channel_internal);
@@ -2970,7 +2970,7 @@ private  proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param b
   return EINVAL;
 }
 
-private  proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, x:?t):syserr where _isIoPrimitiveType(t) {
+private proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, x:?t):syserr where _isIoPrimitiveType(t) {
   if isBoolType(t) {
     var zero_one:uint(8) = if x then 1:uint(8) else 0:uint(8);
     return qio_channel_write_byte(false, _channel_internal, zero_one);
@@ -3088,7 +3088,7 @@ proc channel._writeOne(param kind: iokind, const x:?t, loc:locale) throws {
   }
 }
 
-private  proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
+private proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
                                        param kind:iokind,
                                        ref x:?t,
                                        loc:locale): syserr throws where _isIoPrimitiveTypeOrNewline(t) {
@@ -3122,7 +3122,7 @@ private  proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
   return e;
 }
 
-private  proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
+private proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
                                         param kind:iokind,
                                         const x:?t,
                                         loc:locale): syserr throws where _isIoPrimitiveTypeOrNewline(t) {
@@ -3154,7 +3154,7 @@ private  proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
   return e;
 }
 
-private  proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
+private proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
                                        param kind:iokind,
                                        ref x:?t,
                                        loc:locale): syserr throws {
@@ -3177,7 +3177,7 @@ private  proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
 }
 
 pragma "suppress lvalue error"
-private  proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
+private proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
                                         param kind:iokind,
                                         const x:?t,
                                         loc:locale): syserr throws {
@@ -3523,7 +3523,7 @@ private proc _args_to_proto(const args ...?k, preArg:string) {
 
 // better documented in the style= version
 /* returns true if read successfully, false if we encountered EOF */
- proc channel.read(ref args ...?k):bool throws {
+proc channel.read(ref args ...?k):bool throws {
   if writing then compilerError("read on write-only channel");
   const origLocale = this.getLocaleOfIoRequest();
 
@@ -3781,7 +3781,7 @@ private proc readBytesOrString(ch: channel, ref out_var: ?t,  len: int(64))
 
    :throws SystemError: Thrown if the bits could not be read from the channel.
  */
- proc channel.readbits(out v:integral, nbits:integral):bool throws {
+proc channel.readbits(out v:integral, nbits:integral):bool throws {
   if castChecking {
     // Error if reading more bits than fit into v
     if numBits(v.type) < nbits then
@@ -3944,7 +3944,7 @@ proc channel.read(type t ...?numTypes) throws where numTypes > 1 {
 
 // documented in style= error= version
 pragma "no doc"
- proc channel.write(const args ...?k):bool throws {
+proc channel.write(const args ...?k):bool throws {
   if !writing then compilerError("write on read-only channel");
 
   const origLocale = this.getLocaleOfIoRequest();
@@ -5166,7 +5166,7 @@ proc _toIntegral(x:?t) where isIntegralType(t)
 {
   return (x, true);
 }
-private 
+private
 proc _toIntegral(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
@@ -5208,7 +5208,7 @@ proc _toSigned(x:uint(64))
   return (x:int(64), true);
 }
 
-private 
+private
 proc _toSigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
@@ -5251,7 +5251,7 @@ proc _toUnsigned(x:int(64))
 }
 
 
-private 
+private
 proc _toUnsigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (uint, bool);
@@ -5273,7 +5273,7 @@ proc _toReal(x:?t) where isRealType(t)
 {
   return (x, true);
 }
-private 
+private
 proc _toReal(x:?t) throws where _isIoPrimitiveType(t) && !isRealType(t)
 {
   var ret: (real, bool);
@@ -5294,7 +5294,7 @@ proc _toImag(x:?t) where isImagType(t)
 {
   return (x, true);
 }
-private 
+private
 proc _toImag(x:?t) throws where _isIoPrimitiveType(t) && !isImagType(t)
 {
   var ret: (imag, bool);
@@ -5316,7 +5316,7 @@ proc _toComplex(x:?t) where isComplexType(t)
 {
   return (x, true);
 }
-private 
+private
 proc _toComplex(x:?t) throws where _isIoPrimitiveType(t) && !isComplexType(t)
 {
   var ret: (complex, bool);
@@ -5358,7 +5358,7 @@ proc _toNumeric(x:?t) where isNumericType(t)
 {
   return (x, true);
 }
-private 
+private
 proc _toNumeric(x:?t) throws where _isIoPrimitiveType(t) && !isNumericType(t)
 {
   // enums, bools get cast to int.
@@ -5421,7 +5421,7 @@ proc _toChar(x:?t) where isIntegralType(t)
 {
   return (x:int(32), true);
 }
-private 
+private
 proc _toChar(x:?t) where t == string
 {
   var chr:int(32);
@@ -5440,7 +5440,7 @@ proc _toChar(x:?t) where !(t==string || isIntegralType(t))
 // If we wanted to give ERANGE if (for example
 // var x:int(8); readf("%i", x);
 // was given the input 1000, this would be the place to do it.
-private 
+private
 proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t==bool&&_isIoPrimitiveType(t2)
 {
   var empty:t2;
@@ -5451,7 +5451,7 @@ proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t==bool&&_isIoP
   }
   return ENOERR;
 }
-private 
+private
 proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t!=bool&&_isIoPrimitiveType(t)
 {
   try {
@@ -6730,7 +6730,7 @@ proc bytes.format(args ...?k): bytes throws {
   return b"";
 }
 
-private  proc chpl_do_format(fmt:?t, args ...?k): t throws
+private proc chpl_do_format(fmt:?t, args ...?k): t throws
     where isStringType(t) || isBytesType(t) {
 
   // Open a memory buffer to store the result

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2212,7 +2212,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
 
    :throws SystemError: Thrown if the lock could not be acquired.
  */
-inline proc channel.lock() throws {
+ proc channel.lock() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
@@ -2229,7 +2229,7 @@ inline proc channel.lock() throws {
 /*
    Release a channel's lock.
  */
-inline proc channel.unlock() {
+ proc channel.unlock() {
   if locking {
     on this.home {
       qio_channel_unlock(_channel_internal);
@@ -2329,7 +2329,7 @@ proc channel.advancePastByte(byte:uint(8)) throws {
   :returns: The offset that was marked
   :throws: SystemError: if marking the channel failed
  */
-inline proc channel.mark() throws where this.locking == false {
+ proc channel.mark() throws where this.locking == false {
   const offset = this.offset();
   const err = qio_channel_mark(false, _channel_internal);
 
@@ -2401,7 +2401,7 @@ proc channel.seek(start:int, end:int = max(int)) throws {
    For a channel locked with :proc:`channel.lock`, return the offset
    of that channel.
  */
-inline proc channel._offset():int(64) {
+ proc channel._offset():int(64) {
   var ret:int(64);
   on this.home {
     ret = qio_channel_offset_unlocked(_channel_internal);
@@ -2423,7 +2423,7 @@ inline proc channel._offset():int(64) {
   :returns: The offset that was marked
   :throws: SystemError: if marking the channel failed
  */
-inline proc channel._mark() throws {
+ proc channel._mark() throws {
   const offset = this.offset();
   const err = qio_channel_mark(false, _channel_internal);
 
@@ -2874,7 +2874,7 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t,
   return EINVAL;
 }
 
-private inline proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, out x:?t):syserr where _isIoPrimitiveType(t) {
+private  proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, out x:?t):syserr where _isIoPrimitiveType(t) {
   if isBoolType(t) {
     var got:int(32);
     got = qio_channel_read_byte(false, _channel_internal);
@@ -2970,7 +2970,7 @@ private inline proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, p
   return EINVAL;
 }
 
-private inline proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, x:?t):syserr where _isIoPrimitiveType(t) {
+private  proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, x:?t):syserr where _isIoPrimitiveType(t) {
   if isBoolType(t) {
     var zero_one:uint(8) = if x then 1:uint(8) else 0:uint(8);
     return qio_channel_write_byte(false, _channel_internal, zero_one);
@@ -3088,7 +3088,7 @@ proc channel._writeOne(param kind: iokind, const x:?t, loc:locale) throws {
   }
 }
 
-private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
+private  proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
                                        param kind:iokind,
                                        ref x:?t,
                                        loc:locale): syserr throws where _isIoPrimitiveTypeOrNewline(t) {
@@ -3122,7 +3122,7 @@ private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
   return e;
 }
 
-private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
+private  proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
                                         param kind:iokind,
                                         const x:?t,
                                         loc:locale): syserr throws where _isIoPrimitiveTypeOrNewline(t) {
@@ -3154,7 +3154,7 @@ private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
   return e;
 }
 
-private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
+private  proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
                                        param kind:iokind,
                                        ref x:?t,
                                        loc:locale): syserr throws {
@@ -3177,7 +3177,7 @@ private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
 }
 
 pragma "suppress lvalue error"
-private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
+private  proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
                                         param kind:iokind,
                                         const x:?t,
                                         loc:locale): syserr throws {
@@ -3523,7 +3523,7 @@ private proc _args_to_proto(const args ...?k, preArg:string) {
 
 // better documented in the style= version
 /* returns true if read successfully, false if we encountered EOF */
-inline proc channel.read(ref args ...?k):bool throws {
+ proc channel.read(ref args ...?k):bool throws {
   if writing then compilerError("read on write-only channel");
   const origLocale = this.getLocaleOfIoRequest();
 
@@ -3781,7 +3781,7 @@ private proc readBytesOrString(ch: channel, ref out_var: ?t,  len: int(64))
 
    :throws SystemError: Thrown if the bits could not be read from the channel.
  */
-inline proc channel.readbits(out v:integral, nbits:integral):bool throws {
+ proc channel.readbits(out v:integral, nbits:integral):bool throws {
   if castChecking {
     // Error if reading more bits than fit into v
     if numBits(v.type) < nbits then
@@ -3944,7 +3944,7 @@ proc channel.read(type t ...?numTypes) throws where numTypes > 1 {
 
 // documented in style= error= version
 pragma "no doc"
-inline proc channel.write(const args ...?k):bool throws {
+ proc channel.write(const args ...?k):bool throws {
   if !writing then compilerError("write on read-only channel");
 
   const origLocale = this.getLocaleOfIoRequest();
@@ -5166,7 +5166,7 @@ proc _toIntegral(x:?t) where isIntegralType(t)
 {
   return (x, true);
 }
-private inline
+private 
 proc _toIntegral(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
@@ -5208,7 +5208,7 @@ proc _toSigned(x:uint(64))
   return (x:int(64), true);
 }
 
-private inline
+private 
 proc _toSigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
@@ -5251,7 +5251,7 @@ proc _toUnsigned(x:int(64))
 }
 
 
-private inline
+private 
 proc _toUnsigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (uint, bool);
@@ -5273,7 +5273,7 @@ proc _toReal(x:?t) where isRealType(t)
 {
   return (x, true);
 }
-private inline
+private 
 proc _toReal(x:?t) throws where _isIoPrimitiveType(t) && !isRealType(t)
 {
   var ret: (real, bool);
@@ -5294,7 +5294,7 @@ proc _toImag(x:?t) where isImagType(t)
 {
   return (x, true);
 }
-private inline
+private 
 proc _toImag(x:?t) throws where _isIoPrimitiveType(t) && !isImagType(t)
 {
   var ret: (imag, bool);
@@ -5316,7 +5316,7 @@ proc _toComplex(x:?t) where isComplexType(t)
 {
   return (x, true);
 }
-private inline
+private 
 proc _toComplex(x:?t) throws where _isIoPrimitiveType(t) && !isComplexType(t)
 {
   var ret: (complex, bool);
@@ -5358,7 +5358,7 @@ proc _toNumeric(x:?t) where isNumericType(t)
 {
   return (x, true);
 }
-private inline
+private 
 proc _toNumeric(x:?t) throws where _isIoPrimitiveType(t) && !isNumericType(t)
 {
   // enums, bools get cast to int.
@@ -5421,7 +5421,7 @@ proc _toChar(x:?t) where isIntegralType(t)
 {
   return (x:int(32), true);
 }
-private inline
+private 
 proc _toChar(x:?t) where t == string
 {
   var chr:int(32);
@@ -5440,7 +5440,7 @@ proc _toChar(x:?t) where !(t==string || isIntegralType(t))
 // If we wanted to give ERANGE if (for example
 // var x:int(8); readf("%i", x);
 // was given the input 1000, this would be the place to do it.
-private inline
+private 
 proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t==bool&&_isIoPrimitiveType(t2)
 {
   var empty:t2;
@@ -5451,7 +5451,7 @@ proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t==bool&&_isIoP
   }
   return ENOERR;
 }
-private inline
+private 
 proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t!=bool&&_isIoPrimitiveType(t)
 {
   try {
@@ -6730,7 +6730,7 @@ proc bytes.format(args ...?k): bytes throws {
   return b"";
 }
 
-private inline proc chpl_do_format(fmt:?t, args ...?k): t throws
+private  proc chpl_do_format(fmt:?t, args ...?k): t throws
     where isStringType(t) || isBytesType(t) {
 
   // Open a memory buffer to store the result


### PR DESCRIPTION
While looking through the IO module this week, I was surprised
at the number of its routines marked as `inline`, particularly given
that I/O isn't a particularly low-overhead operation (where I'm
skeptical that the inlining was likely to help that much).

As a quick experiment, I tried pulling the `inline` keywords off
of any routine that seemed nontrivial by some definition.  In my
first very non-scientific run, this seemed to have a significant
impact on Arkouda's compilation time, but upon re-running, the
margin closed.  Using a more deterministic metric, the generated
code size only changed by a bit:

master: 1007426 lines of `*.c/h` code produced by `--savec output`
branch: 1001703

So that's only a ~0.5% difference.

Some of these large routines may have folded away to something
short by virtue of having conditionals or selects that are folded at
compile-time... but it still wasn't clear to me that they were obvious
candidates for inlining.
