### PR TITLE
Restrict 'sort()' to only support 1D rectangular arrays

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -470,8 +470,8 @@ proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
 pragma "no doc"
 /* Error message for multi-dimension arrays */
 proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
-  where Dom.rank != 1 {
-    compilerError("sort() requires 1-D array");
+  where Dom.rank != 1 || !isRectangularArr(Data) {
+    compilerError("sort() is currently only supported for 1D rectangular arrays");
 }
 
 

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,3 +1,3 @@
 ./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:229: error: sort() requires 1-D array
+./arrayAPItest.chpl:229: error: sort() is currently only supported for 1D rectangular arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/library/packages/Sort/errors/sortSparse.chpl
+++ b/test/library/packages/Sort/errors/sortSparse.chpl
@@ -1,0 +1,15 @@
+use Sort;
+
+proc main() {
+    var start : int(64) = 0;
+    var end : int(64) = 1 << 40;
+    var ALL : domain(1) = {start..end};
+    var D : sparse subdomain(ALL);
+    D.add(0);
+    D.add(10);
+    var values : [D] real;
+    values.IRV = 5.0;
+    values[0] = 0.0;
+    values[10] = 10.0;
+    sort(values);
+}

--- a/test/library/packages/Sort/errors/sortSparse.good
+++ b/test/library/packages/Sort/errors/sortSparse.good
@@ -1,0 +1,2 @@
+sortSparse.chpl:3: In function 'main':
+sortSparse.chpl:14: error: sort() is currently only supported for 1D rectangular arrays


### PR DESCRIPTION
In issue #16888 a user pointed out that our sort() routine currently
accepts sparse arrays, but then doesn't really do anything useful
with them (it was not intended to support them).  Previously, an
error message was generated for multidimensional arrays.  This
extends that error message to also support non-rectangular arrays
and updates the message slightly to reflect that.
