### PR TITLE
Fix copyrights that are failing the github check

### DIFF
--- a/modules/packages/OrderedSet.chpl
+++ b/modules/packages/OrderedSet.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/modules/packages/OrderedSet/Treap.chpl
+++ b/modules/packages/OrderedSet/Treap.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/util/buildRelease/license_text_for_comment.txt
+++ b/util/buildRelease/license_text_for_comment.txt
@@ -1,5 +1,4 @@
-Copyright 2020-2021 Hewlett Packard Enterprise Development LP
-Copyright 2004-2019 Cray Inc.
+Copyright 2021 Hewlett Packard Enterprise Development LP
 Other additional copyright holders may be indicated within.
 
 The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
These files were added last year and didn't follow the standard copyright header, so
got overlooked in PR #16886.  Here, rather than giving the files the normal copyright
block, I just put last year and this year since they had no history at Cray.  This is a bit
different from how we've done things traditionally, but seems more accurate and passes
our automated check (which surprised me, but pleasantly once I looked at the code).

As part of this, I've also updated the template that's suggested as a starting point to only
include the current year.

Going forward, this means that to update the copyrights, we'll need to change lines of
the form:

* `...20xy-2021 Hewlett...` to `...20xy-2022 Hewlett...`
* `...2021 Hewlett...` to `2021-2022 Hewlett...`

I've opened issue https://github.com/Cray/chapel-private/issues/1540 to capture this
notion.