### PR TITLE
Comm=ofi: Use the appropriate remote address for buffered transfers.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4396,7 +4396,7 @@ void do_remote_put_buff(void* addr, c_nodeid_t node, void* raddr,
   memcpy(&info->src_v[vi], addr, size);
   info->src_addr_v[vi] = &info->src_v[vi];
   info->locale_v[vi] = node;
-  info->tgt_addr_v[vi] = raddr;
+  info->tgt_addr_v[vi] = (void*) mrRaddr;
   info->size_v[vi] = size;
   info->remote_mr_v[vi] = mrKey;
   info->local_mr_v[vi] = mrDesc;
@@ -4666,7 +4666,7 @@ void do_remote_get_buff(void* addr, c_nodeid_t node, void* raddr,
   info->tgt_addr_v[vi] = addr;
   info->locale_v[vi] = node;
   info->remote_mr_v[vi] = mrKey;
-  info->src_addr_v[vi] = raddr;
+  info->src_addr_v[vi] = (void*) mrRaddr;
   info->size_v[vi] = size;
   info->local_mr_v[vi] = mrDesc;
   info->vi++;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4969,7 +4969,10 @@ size_t readCQ(struct fid_cq* cq, void* buf, size_t count) {
 
 static
 void reportCQError(struct fid_cq* cq) {
-  struct fi_cq_err_entry err = { 0 };
+  char err_data[ofi_info->domain_attr->max_err_data];
+  struct fi_cq_err_entry err = (struct fi_cq_err_entry)
+                               { .err_data = err_data,
+                                 .err_data_size = sizeof(err_data) };
   fi_cq_readerr(cq, &err, 0);
   if (err.err == FI_ETRUNC) {
     //

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -520,7 +520,7 @@ static chpl_bool provCtl_readAmoNeedsOpnd; // READ AMO needs operand (RxD)
 //
 
 typedef enum {
-  txnTrkNone,  // no tracking, ptr is ignored
+  txnTrkId,    // no tracking as such, context "ptr" is just an id value
   txnTrkDone,  // *ptr is atomic bool 'done' flag
   txnTrkTypeCount
 } txnTrkType_t;
@@ -541,6 +541,16 @@ void* txnTrkEncode(txnTrkType_t typ, void* p) {
   assert((((uint64_t) p) & ~TXNTRK_ADDR_MASK) == 0UL);
   return (void*) (  ((uint64_t) typ << TXNTRK_ADDR_BITS)
                   | ((uint64_t) p & TXNTRK_ADDR_MASK));
+}
+
+static inline
+void* txnTrkEncodeId(intptr_t id) {
+  return txnTrkEncode(txnTrkId, (void*) id);
+}
+
+static inline
+void* txnTrkEncodeDone(void* pDone) {
+  return txnTrkEncode(txnTrkDone, pDone);
 }
 
 static inline
@@ -2011,13 +2021,13 @@ void init_ofiForAms(void) {
                                       .desc = NULL,
                                       .iov_count = 1,
                                       .addr = FI_ADDR_UNSPEC,
-                                      .context = NULL,
+                                      .context = txnTrkEncodeId(__LINE__),
                                       .data = 0x0, };
   ofi_msg_reqs[1] = (struct fi_msg) { .msg_iov = &ofi_iov_reqs[1],
                                       .desc = NULL,
                                       .iov_count = 1,
                                       .addr = FI_ADDR_UNSPEC,
-                                      .context = NULL,
+                                      .context = txnTrkEncodeId(__LINE__),
                                       .data = 0x0, };
   ofi_msg_i = 0;
   OFI_CHK(fi_recvmsg(ofi_rxEp, &ofi_msg_reqs[ofi_msg_i], FI_MULTI_RECV));
@@ -2521,7 +2531,7 @@ void mcmReleaseOneNode(c_nodeid_t node, struct perTxCtxInfo_t* tcip,
   if (tcip->txCQ != NULL) {
     atomic_bool txnDone;
     atomic_init_bool(&txnDone, false);
-    void* ctx = txnTrkEncode(txnTrkDone, &txnDone);
+    void* ctx = txnTrkEncodeDone(&txnDone);
     ofi_get_ll(orderDummy, node, orderDummyMap[node], 1, ctx, tcip);
     waitForTxnComplete(tcip, ctx);
     atomic_destroy_bool(&txnDone);
@@ -3063,7 +3073,7 @@ void amRequestCommon(c_nodeid_t node,
   } else {
     atomic_bool txnDone;
     atomic_init_bool(&txnDone, false);
-    void* ctx = txnTrkEncode(txnTrkDone, &txnDone);
+    void* ctx = txnTrkEncodeDone(&txnDone);
 
     if (DBG_TEST_MASK(DBG_AM | DBG_AM_SEND)
         || (req->b.op == am_opAMO && DBG_TEST_MASK(DBG_AMO))) {
@@ -3613,7 +3623,7 @@ void amSendDone(c_nodeid_t node, amDone_t* pAmDone) {
   // now.
   //
   ofi_put_ll(amDone, node, pAmDone, sizeof(*pAmDone),
-             txnTrkEncode(txnTrkNone, NULL), amTcip, true /*useInject*/);
+             txnTrkEncodeId(__LINE__), amTcip, true /*useInject*/);
 }
 
 
@@ -4151,7 +4161,7 @@ chpl_comm_nb_handle_t ofi_put(const void* addr, c_nodeid_t node,
         || size > ofi_info->tx_attr->inject_size) {
       atomic_bool txnDone;
       atomic_init_bool(&txnDone, false);
-      void* ctx = txnTrkEncode(txnTrkDone, &txnDone);
+      void* ctx = txnTrkEncodeDone(&txnDone);
 
       DBG_PRINTF(DBG_RMA | DBG_RMA_WRITE,
                  "tx write: %d:%p <= %p, size %zd, key 0x%" PRIx64 ", ctx %p",
@@ -4310,7 +4320,7 @@ void ofi_put_V(int v_len, void** addr_v, void** local_mr_v,
                               .addr = rxRmaAddr(tcip, locale_v[vi]),
                               .rma_iov = &rma_iov,
                               .rma_iov_count = 1,
-                              .context = NULL,
+                              .context = txnTrkEncodeId(__LINE__),
                               .data = 0 };
     DBG_PRINTF(DBG_RMA | DBG_RMA_WRITE,
                "tx writemsg: %d:%p <= %p, size %zd, key 0x%" PRIx64,
@@ -4453,8 +4463,8 @@ chpl_comm_nb_handle_t ofi_get(void* addr, c_nodeid_t node,
     atomic_bool txnDone;
     atomic_init_bool(&txnDone, false);
     void* ctx = (tcip->txCQ == NULL)
-                ? NULL
-                : txnTrkEncode(txnTrkDone, &txnDone);
+                ? txnTrkEncodeId(__LINE__)
+                : txnTrkEncodeDone(&txnDone);
 
     DBG_PRINTF(DBG_RMA | DBG_RMA_READ,
                "tx read: %p <= %d:%p(0x%" PRIx64 "), size %zd, key 0x%" PRIx64
@@ -4587,7 +4597,7 @@ void ofi_get_V(int v_len, void** addr_v, void** local_mr_v,
                               .addr = rxRmaAddr(tcip, locale_v[vi]),
                               .rma_iov = &rma_iov,
                               .rma_iov_count = 1,
-                              .context = NULL,
+                              .context = txnTrkEncodeId(__LINE__),
                               .data = 0 };
     DBG_PRINTF(DBG_RMA | DBG_RMA_READ,
                "tx readmsg: %p <= %d:%p, size %zd, key 0x%" PRIx64,
@@ -4717,8 +4727,8 @@ chpl_comm_nb_handle_t ofi_amo(c_nodeid_t node, uint64_t object, uint64_t mrKey,
   atomic_bool txnDone;
   atomic_init_bool(&txnDone, false);
   void* ctx = (tcip->txCQ == NULL)
-              ? NULL
-              : txnTrkEncode(txnTrkDone, &txnDone);
+              ? txnTrkEncodeId(__LINE__)
+              : txnTrkEncodeDone(&txnDone);
 
   DBG_PRINTF((ofiOp == FI_ATOMIC_READ) ? DBG_AMO_READ : DBG_AMO,
              "tx AMO: obj %d:%" PRIx64 ", opnd1 <%s>, opnd2 <%s>, "
@@ -4838,7 +4848,7 @@ void ofi_amo_nf_V(int v_len, uint64_t* opnd1_v, void* local_mr,
                                  .rma_iov_count = 1,
                                  .datatype = type_v[vi],
                                  .op = cmd_v[vi],
-                                 .context = NULL,
+                                 .context = txnTrkEncodeId(__LINE__),
                                  .data = 0 };
     DBG_PRINTF(DBG_RMA | DBG_RMA_WRITE,
                "tx atomicmsg: obj %d:%p, opnd1 <%s>, op %s, typ %s, sz %zd, "
@@ -4928,16 +4938,14 @@ void checkTxCmplsCQ(struct perTxCtxInfo_t* tcip) {
   tcip->numTxnsOut -= numEvents;
   for (int i = 0; i < numEvents; i++) {
     struct fi_cq_msg_entry* cqe = &cqes[i];
-    DBG_PRINTF(DBG_ACK, "CQ ack tx, flags %#" PRIx64 ", ctx %p",
-               cqe->flags, cqe->op_context);
-    if (cqe->op_context != NULL) {
-      const txnTrkCtx_t trk = txnTrkDecode(cqe->op_context);
-      if (trk.typ == txnTrkDone) {
-        atomic_store_explicit_bool((atomic_bool*) trk.ptr, true,
-                                   memory_order_release);
-      } else {
-        INTERNAL_ERROR_V("unexpected trk.typ %d", trk.typ);
-      }
+    const txnTrkCtx_t trk = txnTrkDecode(cqe->op_context);
+    DBG_PRINTF(DBG_ACK, "CQ ack tx, flags %#" PRIx64 ", ctx %d:%p",
+               cqe->flags, trk.typ, trk.ptr);
+    if (trk.typ == txnTrkDone) {
+      atomic_store_explicit_bool((atomic_bool*) trk.ptr, true,
+                                 memory_order_release);
+    } else if (trk.typ != txnTrkId) {
+      INTERNAL_ERROR_V("unexpected trk.typ %d", trk.typ);
     }
   }
 }
@@ -4974,6 +4982,7 @@ void reportCQError(struct fid_cq* cq) {
                                { .err_data = err_data,
                                  .err_data_size = sizeof(err_data) };
   fi_cq_readerr(cq, &err, 0);
+  const txnTrkCtx_t trk = txnTrkDecode(err.op_context);
   if (err.err == FI_ETRUNC) {
     //
     // This only happens when reading from the CQ associated with the
@@ -4986,14 +4995,15 @@ void reportCQError(struct fid_cq* cq) {
     // aid failure analysis.
     //
     INTERNAL_ERROR_V("fi_cq_readerr(): AM recv buf FI_ETRUNC: "
-                     "flags %#" PRIx64 ", len %zd, olen %zd",
-                     err.flags, err.len, err.olen);
+                     "flags %#" PRIx64 ", len %zd, olen %zd, ctx %d:%p",
+                     err.flags, err.len, err.olen, trk.typ, trk.ptr);
   } else {
-    char bufProv[100];
-    (void) fi_cq_strerror(cq, err.prov_errno, err.err_data,
-                          bufProv, sizeof(bufProv));
-    INTERNAL_ERROR_V("fi_cq_read(): err %d, strerror %s",
-                     err.err, bufProv);
+    char buf[100];
+    const char* errStr = fi_cq_strerror(cq, err.prov_errno, err.err_data,
+                                        buf, sizeof(buf));
+    INTERNAL_ERROR_V("fi_cq_read(): err %d, prov_errno %d, errStr %s, "
+                     "ctx %d:%p",
+                     err.err, err.prov_errno, errStr, trk.typ, trk.ptr);
   }
 }
 
@@ -5001,8 +5011,8 @@ void reportCQError(struct fid_cq* cq) {
 static inline
 void waitForTxnComplete(struct perTxCtxInfo_t* tcip, void* ctx) {
   (*tcip->ensureProgressFn)(tcip);
-  if (ctx != NULL) {
-    const txnTrkCtx_t trk = txnTrkDecode(ctx);
+  const txnTrkCtx_t trk = txnTrkDecode(ctx);
+  if (trk.typ == txnTrkDone) {
     while (!atomic_load_explicit_bool((atomic_bool*) trk.ptr,
                                       memory_order_acquire)) {
       sched_yield();


### PR DESCRIPTION
(Duplicate PR #16909 from 1.23-for-EX to master.)

(Original PR reviewed by @ronawho.)

We were always using the virtual address as the remote address (source
for GETs, target for PUTs) in the buffered transfer support. But in
some circumstances, this remote address really needs to be the offset
into the memory registration that contains that virtual address. Make
that so.

While here, improve CQ error entry reporting and also make some changes
that ease associating CQ error entries with the operations that caused
them.