### PR TITLE
Remove --legacy-classes

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -150,7 +150,6 @@ bool fNoDivZeroChecks = false;
 bool fNoFormalDomainChecks = false;
 bool fNoLocalChecks = false;
 bool fNoNilChecks = false;
-bool fLegacyClasses = false;
 bool fIgnoreNilabilityErrors = false;
 bool fOverloadSetsChecks = true;
 bool fNoStackChecks = false;
@@ -575,14 +574,6 @@ static void verifyStageAndSetStageNum(const ArgumentDescription* desc,
     USR_FATAL("Unknown llvm-print-ir-stage argument");
 
   llvmPrintIrStageNum = stageNum;
-}
-
-static void warnUponLegacyClasses(const ArgumentDescription* desc,
-                                  const char* arg)
-{
-  USR_WARN("'--legacy-classes' option has been deprecated"
-           " and will be removed in the next Chapel release;"
-           " it no longer affects compilation");
 }
 
 // In order to handle accumulating ccflags arguments, the argument
@@ -1111,7 +1102,6 @@ static ArgumentDescription arg_desc[] = {
  {"split-initialization", ' ', NULL, "Enable [disable] support for split initialization", "n", &fNoSplitInit, NULL, NULL},
  {"early-deinit", ' ', NULL, "Enable [disable] support for early deinit based upon expiring value analysis", "n", &fNoEarlyDeinit, NULL, NULL},
  {"copy-elision", ' ', NULL, "Enable [disable] copy elision based upon expiring value analysis", "n", &fNoCopyElision, NULL, NULL},
- {"legacy-classes", ' ', NULL, "Deprecated flag - does not affect compilation", "N", &fLegacyClasses, NULL, &warnUponLegacyClasses},
  {"ignore-nilability-errors", ' ', NULL, "Allow compilation to continue by coercing away nilability", "N", &fIgnoreNilabilityErrors, NULL, NULL},
  {"overload-sets-checks", ' ', NULL, "Report potentially hijacked calls", "N", &fOverloadSetsChecks, NULL, NULL},
  {"compile-time-nil-checking", ' ', NULL, "Enable [disable] compile-time nil checking", "N", &fCompileTimeNilChecking, "CHPL_NO_COMPILE_TIME_NIL_CHECKS", NULL},

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2204,12 +2204,6 @@ module ChapelBase {
   proc isBorrowedOrUnmanagedClassType(type t:borrowed) param return true;
   proc isBorrowedOrUnmanagedClassType(type t) param return false;
 
-  // Former support for --legacy-classes, to be removed after 1.21.
-  proc chpl_legacyClasses param {
-    compilerWarning("'chpl_legacyClasses' is deprecated and will be removed in the next release; it is now always false");
-    return false;
-  }
-
   proc isRecordType(type t) param {
     if __primitive("is record type", t) == false then
       return false;

--- a/test/deprecated/legacy-classes-opt.chpl
+++ b/test/deprecated/legacy-classes-opt.chpl
@@ -1,2 +1,0 @@
-// This test checks the compiler output for --legacy-classes.
-compilerError("done");

--- a/test/deprecated/legacy-classes-opt.compopts
+++ b/test/deprecated/legacy-classes-opt.compopts
@@ -1,2 +1,0 @@
---legacy-classes
---no-legacy-classes

--- a/test/deprecated/legacy-classes-opt.good
+++ b/test/deprecated/legacy-classes-opt.good
@@ -1,2 +1,0 @@
-warning: '--legacy-classes' option has been deprecated and will be removed in the next Chapel release; it no longer affects compilation
-legacy-classes-opt.chpl:2: error: done

--- a/test/deprecated/legacy-classes-param.chpl
+++ b/test/deprecated/legacy-classes-param.chpl
@@ -1,6 +1,0 @@
-
-if chpl_legacyClasses then
-  compilerError("yes");
-
-if !chpl_legacyClasses then
-  compilerError("no");

--- a/test/deprecated/legacy-classes-param.good
+++ b/test/deprecated/legacy-classes-param.good
@@ -1,3 +1,0 @@
-legacy-classes-param.chpl:2: warning: 'chpl_legacyClasses' is deprecated and will be removed in the next release; it is now always false
-legacy-classes-param.chpl:5: warning: 'chpl_legacyClasses' is deprecated and will be removed in the next release; it is now always false
-legacy-classes-param.chpl:6: error: no

--- a/test/studies/lulesh/release-valgrind/PREDIFF
+++ b/test/studies/lulesh/release-valgrind/PREDIFF
@@ -1,1 +1,0 @@
-orig-dir/PREDIFF

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -96,7 +96,6 @@ _chpl ()
 --interprocedural-alias-analysis \
 --launcher \
 --ldflags \
---legacy-classes \
 --lib-linkage \
 --lib-search-path \
 --library \
@@ -180,7 +179,6 @@ _chpl ()
 --no-inline \
 --no-inline-iterators \
 --no-interprocedural-alias-analysis \
---no-legacy-classes \
 --no-library-ml-debug \
 --no-lifetime-checking \
 --no-live-analysis \


### PR DESCRIPTION
The compiler flag `--legacy-classes` was deprecated in #14753
which left just enough of it to support deprecated warnings.

This PR removes these leftovers.

While there, remove test/studies/lulesh/release-valgrind/PREDIFF
which is a symlink whose target was removed in #15405
Greg OK-ed this removal.

Testing: standard paratest with futures.
