### PR TITLE
Add --bounds-checks to OOB tests to ensure they pass under --fast

### DIFF
--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB1.compopts
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB1.compopts
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB2.compopts
+++ b/test/parsing/stringLiteralIndex/stringBytesLiteralIndexOOB2.compopts
@@ -1,0 +1,1 @@
+--bounds-checks


### PR DESCRIPTION
These new tests failed in today's `--fast` testing due to a common issue:  `--fast` turns off bounds checks, but they are designed to test bounds checks.  Since that's the point of the tests, I'm adding .compopts files to add `--bounds-checks` flags so that they'll pass tomorrow, as I believe we've done in other cases.