### PR TITLE
Increase the problem size for the multi-locale scan performance test

### DIFF
--- a/test/scan/scanPerf.ml-execopts
+++ b/test/scan/scanPerf.ml-execopts
@@ -1,1 +1,1 @@
---printTiming --printArray=false --n=1000000
+--printTiming --printArray=false --memFraction=4


### PR DESCRIPTION
The old problem size was set when distributed scan was serial and slow,
but it was significantly optimized a while back in #12481. The current
problem size finishes in ~0.01 seconds, which isn't that telling.
Increase the problem size to 1/4 of memory, which is what we use for the
single locale problem size.