### PR TITLE
Add tests and futures looking at I/O on class hierarchies

### DIFF
--- a/test/classes/io/classIOinHierarchy-default.chpl
+++ b/test/classes/io/classIOinHierarchy-default.chpl
@@ -1,0 +1,38 @@
+class C {
+  var x: int;
+}
+
+class D : C {
+  var y: real;
+}
+
+class E : D {
+  var z: bool;
+}
+
+// static type C
+var c1: C = new C();
+var c2: C = new D();
+var c3: C = new E();
+
+// static type D
+var c4: D = new D();
+var c5: D = new E();
+
+// static type E
+var c6: E = new E();
+
+// inferred type
+var c7 = new C();
+var c8 = new D();
+var c9 = new E();
+
+writeln("c1 (static type: ", c1.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c1.borrow())):string, ") is: ", c1);
+writeln("c2 (static type: ", c2.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c2.borrow())):string, ") is: ", c2);
+writeln("c3 (static type: ", c3.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c3.borrow())):string, ") is: ", c3);
+writeln("c4 (static type: ", c4.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c4.borrow())):string, ") is: ", c4);
+writeln("c5 (static type: ", c5.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c5.borrow())):string, ") is: ", c5);
+writeln("c6 (static type: ", c6.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c6.borrow())):string, ") is: ", c6);
+writeln("c7 (static type: ", c7.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c7.borrow())):string, ") is: ", c7);
+writeln("c8 (static type: ", c8.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c8.borrow())):string, ") is: ", c8);
+writeln("c9 (static type: ", c9.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c9.borrow())):string, ") is: ", c9);

--- a/test/classes/io/classIOinHierarchy-default.good
+++ b/test/classes/io/classIOinHierarchy-default.good
@@ -1,0 +1,9 @@
+c1 (static type: owned C, dynamic type: C) is: {x = 0}
+c2 (static type: owned C, dynamic type: D) is: {x = 0, y = 0.0}
+c3 (static type: owned C, dynamic type: E) is: {x = 0, y = 0.0, z = false}
+c4 (static type: owned D, dynamic type: D) is: {x = 0, y = 0.0}
+c5 (static type: owned D, dynamic type: E) is: {x = 0, y = 0.0, z = false}
+c6 (static type: owned E, dynamic type: E) is: {x = 0, y = 0.0, z = false}
+c7 (static type: owned C, dynamic type: C) is: {x = 0}
+c8 (static type: owned D, dynamic type: D) is: {x = 0, y = 0.0}
+c9 (static type: owned E, dynamic type: E) is: {x = 0, y = 0.0, z = false}

--- a/test/classes/io/classIOinHierarchy-override.bad
+++ b/test/classes/io/classIOinHierarchy-override.bad
@@ -1,0 +1,9 @@
+c1 (static type: owned C, dynamic type: C) is: {x = 0}
+c2 (static type: owned C, dynamic type: D) is: {x = 0}
+c3 (static type: owned C, dynamic type: E) is: {x = 0, y = 0.0, z = false}
+c4 (static type: owned D, dynamic type: D) is: {x = 0}y is: 0.0
+c5 (static type: owned D, dynamic type: E) is: {x = 0}y is: 0.0
+c6 (static type: owned E, dynamic type: E) is: {x = 0}y is: 0.0
+c7 (static type: owned C, dynamic type: C) is: {x = 0}
+c8 (static type: owned D, dynamic type: D) is: {x = 0}y is: 0.0
+c9 (static type: owned E, dynamic type: E) is: {x = 0}y is: 0.0

--- a/test/classes/io/classIOinHierarchy-override.chpl
+++ b/test/classes/io/classIOinHierarchy-override.chpl
@@ -1,0 +1,42 @@
+class C {
+  var x: int;
+}
+
+class D : C {
+  var y: real;
+  proc writeThis(ch) throws {
+    super.writeThis(ch);
+    ch.write("y is: ", y);
+  }
+}
+
+class E : D {
+  var z: bool;
+}
+
+// static type C
+var c1: C = new C();
+var c2: C = new D();
+var c3: C = new E();
+
+// static type D
+var c4: D = new D();
+var c5: D = new E();
+
+// static type E
+var c6: E = new E();
+
+// inferred type
+var c7 = new C();
+var c8 = new D();
+var c9 = new E();
+
+writeln("c1 (static type: ", c1.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c1.borrow())):string, ") is: ", c1);
+writeln("c2 (static type: ", c2.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c2.borrow())):string, ") is: ", c2);
+writeln("c3 (static type: ", c3.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c3.borrow())):string, ") is: ", c3);
+writeln("c4 (static type: ", c4.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c4.borrow())):string, ") is: ", c4);
+writeln("c5 (static type: ", c5.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c5.borrow())):string, ") is: ", c5);
+writeln("c6 (static type: ", c6.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c6.borrow())):string, ") is: ", c6);
+writeln("c7 (static type: ", c7.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c7.borrow())):string, ") is: ", c7);
+writeln("c8 (static type: ", c8.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c8.borrow())):string, ") is: ", c8);
+writeln("c9 (static type: ", c9.type:string, ", dynamic type: ", __primitive("class name by id", __primitive("getcid", c9.borrow())):string, ") is: ", c9);

--- a/test/classes/io/classIOinHierarchy-override.future
+++ b/test/classes/io/classIOinHierarchy-override.future
@@ -1,0 +1,15 @@
+bug: I/O on class hierarchies seems broken when writeThis is overridden
+
+In this test, I would expect:
+
+* objects of dynamic type C to always use the compiler-generated writeThis()
+* objects of dynamic type D to always use the user-supplied override
+* objects of dynamic type E to always use D.writeThis() by virtue of the
+  user having overridden D.writeThis() yet not E.writeThis()
+
+However, what I'm finding is that when the static type is C:
+
+* when the dynamic type is D, it uses the compiler-generated C.writeThis()
+* when the dynamic type is E, it uses the compiler-generated E.writeThis()
+
+But I can't explain why.

--- a/test/classes/io/classIOinHierarchy-override.future
+++ b/test/classes/io/classIOinHierarchy-override.future
@@ -1,4 +1,4 @@
-bug: I/O on class hierarchies seems broken when writeThis is overridden
+bug: I/O on class hierarchies seems broken
 
 In this test, I would expect:
 

--- a/test/classes/io/classIOinHierarchy-override.future
+++ b/test/classes/io/classIOinHierarchy-override.future
@@ -1,5 +1,7 @@
 bug: I/O on class hierarchies seems broken
 
+#7118
+
 In this test, I would expect:
 
 * objects of dynamic type C to always use the compiler-generated writeThis()

--- a/test/classes/io/classIOinHierarchy-override.good
+++ b/test/classes/io/classIOinHierarchy-override.good
@@ -1,0 +1,9 @@
+c1 (static type: owned C, dynamic type: C) is: {x = 0}
+c2 (static type: owned C, dynamic type: D) is: {x = 0}y is: 0.0
+c3 (static type: owned C, dynamic type: E) is: {x = 0}y is: 0.0
+c4 (static type: owned D, dynamic type: D) is: {x = 0}y is: 0.0
+c5 (static type: owned D, dynamic type: E) is: {x = 0}y is: 0.0
+c6 (static type: owned E, dynamic type: E) is: {x = 0}y is: 0.0
+c7 (static type: owned C, dynamic type: C) is: {x = 0}
+c8 (static type: owned D, dynamic type: D) is: {x = 0}y is: 0.0
+c9 (static type: owned E, dynamic type: E) is: {x = 0}y is: 0.0

--- a/test/classes/io/classToString.chpl
+++ b/test/classes/io/classToString.chpl
@@ -1,0 +1,77 @@
+class C {
+  var x: int;
+}
+
+class D : C {
+  var y: real;
+  proc writeThis(ch) throws {
+    super.writeThis(ch);
+    ch.write("y is: ", y);
+  }
+}
+
+class E : D {
+  var z: bool;
+}
+
+// static type C
+var c1: C = new C();
+var c2: C = new D();
+var c3: C = new E();
+
+// static type D
+var c4: D = new D();
+var c5: D = new E();
+
+// static type E
+var c6: E = new E();
+
+// inferred type
+var c7 = new C();
+var c8 = new D();
+var c9 = new E();
+
+var c10: C = new shared E();
+var c11: C = new unmanaged E();
+var c12: C = c3.borrow();
+
+for mgmt in false..true {
+  writeln(dynamicTypeAsString(c1, mgmt));
+  writeln(dynamicTypeAsString(c2, mgmt));
+  writeln(dynamicTypeAsString(c3, mgmt));
+  writeln(dynamicTypeAsString(c4, mgmt));
+  writeln(dynamicTypeAsString(c5, mgmt));
+  writeln(dynamicTypeAsString(c6, mgmt));
+  writeln(dynamicTypeAsString(c7, mgmt));
+  writeln(dynamicTypeAsString(c8, mgmt));
+  writeln(dynamicTypeAsString(c9, mgmt));
+  writeln(dynamicTypeAsString(c10, mgmt));
+  writeln(dynamicTypeAsString(c11, mgmt));
+  writeln(dynamicTypeAsString(c12, mgmt));
+}
+
+proc dynamicTypeAsString(expr, printClassMgmt = true) {
+  var ret: string;
+  
+  if (isClass(expr)) {
+    if (printClassMgmt) {
+      if (isOwnedClass(expr)) {
+        ret = "owned ";
+      } else if (isBorrowedClass(expr)) {
+        ret = "borrowed ";
+      } else if (isSharedClass(expr)) {
+        ret = "shared ";
+      } else if (isUnmanagedClass(expr)) {
+        ret = "unmanaged ";
+      } else {
+        halt("Unanticipated class management type in dynamicTypeAsString()");
+      }
+    }
+    ret += __primitive("class name by id",
+                       __primitive("getcid", expr.borrow())
+                      ):string;
+    return ret;
+  } else {
+    compilerError("dynamicTypeAsString() isn't currently implemented for non-classes");
+  }
+}

--- a/test/classes/io/classToString.good
+++ b/test/classes/io/classToString.good
@@ -1,0 +1,24 @@
+C
+D
+E
+D
+E
+E
+C
+D
+E
+E
+E
+E
+owned C
+owned D
+owned E
+owned D
+owned E
+owned E
+owned C
+owned D
+owned E
+shared E
+unmanaged E
+borrowed E

--- a/test/classes/io/halt-in-parent-class-io.bad
+++ b/test/classes/io/halt-in-parent-class-io.bad
@@ -1,0 +1,2 @@
+{p = 0, c = 0}
+halt-in-parent-class-io.chpl:3: error: halt reached - halt

--- a/test/classes/io/halt-in-parent-class-io.chpl
+++ b/test/classes/io/halt-in-parent-class-io.chpl
@@ -1,0 +1,8 @@
+class parent {
+  var p: int;
+  override proc writeThis(f) throws { halt("halt"); }
+}
+class child: parent { var c: int; }
+writeln(new child());
+writeln(new parent());
+

--- a/test/classes/io/halt-in-parent-class-io.future
+++ b/test/classes/io/halt-in-parent-class-io.future
@@ -1,0 +1,14 @@
+bug: I/O on class hierarchies seems broken
+
+In this test, I would expect the 'child' class to inherit the 'parent'
+class's writeThis() routine, as with any other inherited method.  Or,
+if we decided that compiler-generated writeThis() routines should
+occur for child classes, that it would call into the parent class
+writeThis() as part of its definition.  In either case, I would expect
+the halt to be reached when printing out a child class, where it is
+not here.
+
+While I understand the current behavior, it seems inconsistent with
+the behavior in classIOinHierarchy-override.chpl for static type C,
+dynamic type E, in which D's writeThis() _is_ called.  I can't
+explain this.

--- a/test/classes/io/halt-in-parent-class-io.future
+++ b/test/classes/io/halt-in-parent-class-io.future
@@ -1,5 +1,7 @@
 bug: I/O on class hierarchies seems broken
 
+#7118
+
 In this test, I would expect the 'child' class to inherit the 'parent'
 class's writeThis() routine, as with any other inherited method.  Or,
 if we decided that compiler-generated writeThis() routines should

--- a/test/classes/io/halt-in-parent-class-io.good
+++ b/test/classes/io/halt-in-parent-class-io.good
@@ -1,0 +1,1 @@
+halt-in-parent-class-io.chpl:3: error: halt reached - halt


### PR DESCRIPTION
In the performance meeting yesterday, during some discussions about I/O and class hierarchies, we talked about some surprises which led me to write some tests, which led to some additional surprises.  The theme of the main tests here is "What kind of compiler-generated writeThis() routines are generated (or not) in a class hierarchy, particularly when some classes have supplied their own writeThis() overloads?"  The tests seem to indicate inconsistent behavior in which sometimes a completely distinct compiler-generated routine is called, and in some cases it seems not to be.

The tests are as follows:

* classIOinHierarchy-default.chpl: what happens when no user overrides are supplied?  (works as I'd currently expect)
* halt-in-parent-class-io.chpl: seems to indicate that the compiler generates a routine for the child class that has no bearing on the parent class; this surprises me, as I'd expect the child to just inherit the parent class method (or, if not, for the compiler-generated routine to call into the parent-class routine)
* classIOinHierarchy-override.chpl: what happens if we define a writeThis() on the middle class of a 3-class hierarchy?  this test's behavior is really puzzling to me, and seems inconsistent both with itself and the previous tests
* classToString.chpl: this is mostly unrelated to the above, but is a prototype of a library routine we could supply that generates a string representing a class expression's type.