### PR TITLE
Fix protobuf tests failing over gasnet

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
@@ -19,11 +19,11 @@ proc endToEndTest(package: string) {
   if debug then writeln("Writing and reading from Chapel");
   shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl");
   shell2.wait();
-  shell2 = spawnshell(packageDir+"/./write");
+  shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
   shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
   shell2.wait();
-  shell2 = spawnshell(packageDir+"/./read", stdout=PIPE);
+  shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=PIPE);
   while shell2.stdout.readline(line1) {
     if(line1.strip() != "true") then writeln("Chapel to Chapel failed");
   }
@@ -32,7 +32,7 @@ proc endToEndTest(package: string) {
   if debug then writeln("Writing from Chapel and reading from Python");
   shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl");
   shell2.wait();
-  shell2 = spawnshell(packageDir+"/./write");
+  shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
   shell2 = spawnshell("python3 "+packageDir+"/read.py", stdout=PIPE);
   while shell2.stdout.readline(line1) {
@@ -45,7 +45,7 @@ proc endToEndTest(package: string) {
   shell2.wait();
   shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
   shell2.wait();
-  shell2 = spawnshell(packageDir+"/./read", stdout=PIPE);
+  shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=PIPE);
   while shell2.stdout.readline(line1) {
     if(line1.strip() != "true") then writeln("Python to Chapel failed");
   }


### PR DESCRIPTION
Specify the number of locales while running compiled chapel binaries in protobuf end to end tests to avoid failing over gasnet.

Fixes https://github.com/chapel-lang/chapel/issues/16908