### PR TITLE
Update signature of _toUnsigned function in the IO module

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5225,7 +5225,7 @@ proc _toSigned(x:?t) where !_isIoPrimitiveType(t)
 }
 
 private inline
-proc _toUnsigned(x:?t) where isUintType(t)
+proc _toUnsigned(x:uint(?w))
 {
   return (x, true);
 }


### PR DESCRIPTION
For a uint(8) argument, the `_toUnsigned(x: int(16))` overload was getting
called instead of the desired generic `_toUnsigned(x:?t) where isUintType(t)`.
Make this function less generic so it will be chosen instead by removing the
where clause and partially specifying the type of `x: uint(?w)`.

Fixes unsigned integer formatting errors for LLVM+GASNet.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>