### PR TITLE
Make verbose flag tests pass in more HPE Cray EX environments.

### DIFF
--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
@@ -1,1 +1,7 @@
-EVARS=vals srun --job-name=CHPL-testVFlag --quiet --nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N --exclusive --mem=0 --kill-on-bad-exit --partition=P  ./testVFlag_real -v -nl 1 EXECOPTS
+#!/bin/sh
+echo "EVARS=vals" \
+     "srun --job-name=CHPL-testVFlag --quiet" \
+     "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
+     "--exclusive --mem=0" \
+     "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P} " \
+     "./testVFlag_real -v -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -39,11 +39,13 @@ fi
 # Address program output variations peculiar to the various configuation
 # settings.
 
-# On Cray CS and X* systems, compute node system names aren't meaningful.
+# On Cray CS, X*, and HPE Cray EX systems, compute node system names
+# aren't meaningful.
 case $target in
-  cray-cs|cray-x*) sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
-                       < $2 > $2.tmp &&
-                   mv $2.tmp $2;;
+  cray-cs|cray-x*|hpe-cray-ex)
+     sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
+         < $2 > $2.tmp &&
+     mv $2.tmp $2;;
 esac
 
 # With Qthreads, -v results in some lines of QTHREADS info we don't need.
@@ -75,7 +77,4 @@ case $launcher in
 esac
 
 sed -e "s;`pwd`;.;" $2 > $2.tmp
-cat $2.tmp
-echo ---
-cat $2
 mv $2.tmp $2

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
@@ -1,1 +1,7 @@
-EVARS=vals srun --job-name=CHPL-testVerbos --quiet --nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N --exclusive --mem=0 --kill-on-bad-exit --partition=P  ./testVerboseFlag_real --verbose -nl 1 EXECOPTS
+#!/bin/sh
+echo "EVARS=vals" \
+     "srun --job-name=CHPL-testVerbos --quiet" \
+     "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
+     "--exclusive --mem=0" \
+     "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P} " \
+     "./testVerboseFlag_real --verbose -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -39,11 +39,13 @@ fi
 # Address program output variations peculiar to the various configuation
 # settings.
 
-# On Cray CS and X* systems, compute node system names aren't meaningful.
+# On Cray CS, X*, and HPE Cray EX systems, compute node system names
+# aren't meaningful.
 case $target in
-  cray-cs|cray-x*) sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
-                       < $2 > $2.tmp &&
-                   mv $2.tmp $2;;
+  cray-cs|cray-x*|hpe-cray-ex)
+     sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
+         < $2 > $2.tmp &&
+     mv $2.tmp $2;;
 esac
 
 # With Qthreads, -v results in some lines of QTHREADS info we don't need.


### PR DESCRIPTION
Adjust so that testVFlag and testVerbose flag will pass with or without
an explicit Slurm partition specified when that launcher is used.  Add
HPE Cray EX systems to the list of those where the compute node names
should be ignored because they're not predictable.  We ran into both of
these while testing on a new-to-us in-house EX system.

This resolves https://github.com/Cray/chapel-private/issues/1528.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>