### PR TITLE
Specialize type->value resolution error for varargs & clean up

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -1162,14 +1162,9 @@ static std::string argToString(FnSymbol* concreteFn,
 
   std::string ret = "";
   std::string name = concreteArg->name;
-  if (genericArg && genericArg->hasFlag(FLAG_EXPANDED_VARARGS) &&
-      name[0] == '_' && name[1] == 'e') {
-    // change _e##_name into name(##)
-    std::string num = name;
-    num.erase(0, 2); // remove _e
-    std::string n = num; // ##_name
-    num.resize(num.find('_')); // ##
-    n.erase(0, n.find('_')+1); // name
+  if (genericArg && genericArg->hasFlag(FLAG_EXPANDED_VARARGS)) {
+    std::string num;
+    std::string n = genericArg->demungeVarArgName(&num);
     name = n + "(" + num + ")";
   }
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -961,6 +961,22 @@ void ArgSymbol::accept(AstVisitor* visitor) {
   }
 }
 
+std::string ArgSymbol::demungeVarArgName(std::string* num) {
+  std::string name = this->name;
+  if (!this->hasFlag(FLAG_EXPANDED_VARARGS)) {
+    INT_FATAL(this, "demungeVarArgName() called on non-vararg ArgSymbol");
+  }
+  std::string mynum = name;
+  mynum.erase(0, 2); // remove _e
+  std::string n = mynum; // ##_name
+  mynum.resize(mynum.find('_')); // ##
+  n.erase(0, n.find('_')+1); // name
+  if (num != NULL) {
+    *num = mynum;
+  }
+  return n;
+}
+
 /******************************** | *********************************
 *                                                                   *
 *                                                                   *

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -395,6 +395,8 @@ public:
   std::string     getPythonDefaultValue();
   std::string     getPythonArgTranslation();
 
+  std::string     demungeVarArgName(std::string* num=NULL);
+
   IntentTag       intent;
   IntentTag       originalIntent; // stores orig intent after resolve intents
   BlockStmt*      typeExpr;    // Type expr for arg type, or NULL.

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -1075,11 +1075,12 @@ void explainCandidateRejection(CallInfo& info, FnSymbol* fn) {
         USR_PRINT(failingFormal, "is passed to formal '%s'",
                                  toString(failingFormal));
       } else {
-        USR_PRINT(call, "because type %s", failingActualDesc);
+        USR_PRINT(call, "because %s is a type", failingActualDesc);
         if (failingFormal->hasFlag(FLAG_EXPANDED_VARARGS)) {
-          USR_PRINT(fn, "cannot be passed to a varargs routine");
+          USR_PRINT(fn, "but is passed to non-type varargs formal '%s'",
+                    failingFormal->demungeVarArgName().c_str());
         } else {
-          USR_PRINT(fn, "is passed to non-type formal '%s'",
+          USR_PRINT(fn, "but is passed to non-type formal '%s'",
                     toString(failingFormal));
         }
       }

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -1076,8 +1076,12 @@ void explainCandidateRejection(CallInfo& info, FnSymbol* fn) {
                                  toString(failingFormal));
       } else {
         USR_PRINT(call, "because type %s", failingActualDesc);
-        USR_PRINT(fn, "is passed to non-type formal '%s'",
-                      toString(failingFormal));
+        if (failingFormal->hasFlag(FLAG_EXPANDED_VARARGS)) {
+          USR_PRINT(fn, "cannot be passed to a varargs routine");
+        } else {
+          USR_PRINT(fn, "is passed to non-type formal '%s'",
+                    toString(failingFormal));
+        }
       }
       break;
     case RESOLUTION_CANDIDATE_TOO_MANY_ARGUMENTS:

--- a/test/classes/bradc/callMethodOnClass.good
+++ b/test/classes/bradc/callMethodOnClass.good
@@ -1,5 +1,5 @@
 callMethodOnClass.chpl:23: In function 'main':
 callMethodOnClass.chpl:25: error: unresolved call 'type D.start'
 callMethodOnClass.chpl:14: note: this candidate did not match: D.start
-callMethodOnClass.chpl:25: note: because type method call receiver
-callMethodOnClass.chpl:14: note: is passed to non-type formal 'this: borrowed D'
+callMethodOnClass.chpl:25: note: because method call receiver is a type
+callMethodOnClass.chpl:14: note: but is passed to non-type formal 'this: borrowed D'

--- a/test/classes/generic/typeOfGenericField-fromTypeVariable.bad
+++ b/test/classes/generic/typeOfGenericField-fromTypeVariable.bad
@@ -1,7 +1,7 @@
 typeOfGenericField-fromTypeVariable.chpl:12: error: unresolved call 'type [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64)._instance'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:992: note: this candidate did not match: _distribution._instance
-typeOfGenericField-fromTypeVariable.chpl:12: note: because type method call receiver
-$CHPL_HOME/modules/internal/ChapelArray.chpl:992: note: is passed to non-type formal 'ref this: _distribution'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1126: note: candidates are: _domain._instance
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2417: note:                 []._instance
+$CHPL_HOME/modules/internal/ChapelArray.chpl:1048: note: this candidate did not match: _distribution._instance
+typeOfGenericField-fromTypeVariable.chpl:12: note: because method call receiver is a type
+$CHPL_HOME/modules/internal/ChapelArray.chpl:1048: note: but is passed to non-type formal 'ref this: _distribution'
+$CHPL_HOME/modules/internal/ChapelArray.chpl:1187: note: candidates are: _domain._instance
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2465: note:                 []._instance
 note: and 2 other candidates, use --print-all-candidates to see them

--- a/test/functions/deitz/test_write_type_error.good
+++ b/test/functions/deitz/test_write_type_error.good
@@ -1,5 +1,5 @@
 test_write_type_error.chpl:2: error: unresolved call 'writeln(type int(64))'
 $CHPL_HOME/modules/standard/ChapelIO.chpl:: note: this candidate did not match: writeln(const args ...?n)
-test_write_type_error.chpl:: note: because type call actual argument #1
-$CHPL_HOME/modules/standard/ChapelIO.chpl:: note: is passed to non-type formal 'const _e0_args'
+test_write_type_error.chpl:: note: because call actual argument #1 is a type
+$CHPL_HOME/modules/standard/ChapelIO.chpl:: note: but is passed to non-type varargs formal 'args'
 $CHPL_HOME/modules/standard/ChapelIO.chpl:: note: candidates are: writeln()

--- a/test/functions/lydia/variadic-mix-type-var.bad
+++ b/test/functions/lydia/variadic-mix-type-var.bad
@@ -1,4 +1,4 @@
 variadic-mix-type-var.chpl:4: error: unresolved call 'foo(type int(64), "blah")'
 variadic-mix-type-var.chpl:1: note: this candidate did not match: foo(args ...)
-variadic-mix-type-var.chpl:4: note: because type call actual argument #1
-variadic-mix-type-var.chpl:1: note: is passed to non-type formal '_e0_args'
+variadic-mix-type-var.chpl:4: note: because call actual argument #1 is a type
+variadic-mix-type-var.chpl:1: note: but is passed to non-type varargs formal 'args'

--- a/test/functions/varargs/typeToVarArgs.chpl
+++ b/test/functions/varargs/typeToVarArgs.chpl
@@ -1,0 +1,4 @@
+var x: int;
+
+writeln("x's type is: ", x.type);
+

--- a/test/functions/varargs/typeToVarArgs.good
+++ b/test/functions/varargs/typeToVarArgs.good
@@ -1,0 +1,5 @@
+typeToVarArgs.chpl:3: error: unresolved call 'writeln("x's type is: ", type int(64))'
+$CHPL_HOME/modules/standard/ChapelIO.chpl:841: note: this candidate did not match: writeln(const args ...?n)
+typeToVarArgs.chpl:3: note: because type call actual argument #2
+$CHPL_HOME/modules/standard/ChapelIO.chpl:841: note: cannot be passed to a varargs routine
+$CHPL_HOME/modules/standard/ChapelIO.chpl:847: note: candidates are: writeln()

--- a/test/functions/varargs/typeToVarArgs.good
+++ b/test/functions/varargs/typeToVarArgs.good
@@ -1,5 +1,5 @@
 typeToVarArgs.chpl:3: error: unresolved call 'writeln("x's type is: ", type int(64))'
 $CHPL_HOME/modules/standard/ChapelIO.chpl:841: note: this candidate did not match: writeln(const args ...?n)
-typeToVarArgs.chpl:3: note: because type call actual argument #2
-$CHPL_HOME/modules/standard/ChapelIO.chpl:841: note: cannot be passed to a varargs routine
+typeToVarArgs.chpl:3: note: because call actual argument #2 is a type
+$CHPL_HOME/modules/standard/ChapelIO.chpl:841: note: but is passed to non-type varargs formal 'args'
 $CHPL_HOME/modules/standard/ChapelIO.chpl:847: note: candidates are: writeln()

--- a/test/functions/varargs/typeToVarArgs2.chpl
+++ b/test/functions/varargs/typeToVarArgs2.chpl
@@ -1,0 +1,8 @@
+proc foo(x...) {
+}
+
+proc bar(type x...) {
+}
+
+bar(int, real);
+foo("int", real);

--- a/test/functions/varargs/typeToVarArgs2.good
+++ b/test/functions/varargs/typeToVarArgs2.good
@@ -1,0 +1,4 @@
+typeToVarArgs2.chpl:8: error: unresolved call 'foo("int", type real(64))'
+typeToVarArgs2.chpl:1: note: this candidate did not match: foo(x ...)
+typeToVarArgs2.chpl:8: note: because call actual argument #2 is a type
+typeToVarArgs2.chpl:1: note: but is passed to non-type varargs formal 'x'

--- a/test/library/standard/Reflection/mix-type-val-args.bad
+++ b/test/library/standard/Reflection/mix-type-val-args.bad
@@ -1,5 +1,5 @@
 mix-type-val-args.chpl:6: error: unresolved call 'Reflection.canResolve("foo", type int(64), 3)'
-$CHPL_HOME/modules/standard/Reflection.chpl:201: note: this candidate did not match: canResolve(param fname: string, args ...)
-mix-type-val-args.chpl:6: note: because type call actual argument #2
-$CHPL_HOME/modules/standard/Reflection.chpl:201: note: is passed to non-type formal '_e0_args'
-$CHPL_HOME/modules/standard/Reflection.chpl:195: note: candidates are: canResolve(param fname: string)
+$CHPL_HOME/modules/standard/Reflection.chpl:276: note: this candidate did not match: canResolve(param fname: string, args ...)
+mix-type-val-args.chpl:6: note: because call actual argument #2 is a type
+$CHPL_HOME/modules/standard/Reflection.chpl:276: note: but is passed to non-type varargs formal 'args'
+$CHPL_HOME/modules/standard/Reflection.chpl:270: note: candidates are: canResolve(param fname: string)


### PR DESCRIPTION
In issue #16917, it was noted that our error messages are not particularly clear when passing type expressions to value varargs functions.  This PR improves that situation and also makes other modest tweaks to the "type->value" resolution error messages.  Specifically, where before, the error was:

```
foo.chpl:8: error: unresolved call 'foo("int", type real(64))'
foo.chpl:1: note: this candidate did not match: foo(x ...)
foo.chpl:8: note: because type call actual argument #2
foo.chpl:1: note: is passed to non-type formal '_e1_x'
```

Now it is:

```
foo.chpl:8: error: unresolved call 'foo("int", type real(64))'
foo.chpl:1: note: this candidate did not match: foo(x ...)
foo.chpl:8: note: because call actual argument #2 is a type
foo.chpl:1: note: but is passed to non-type varargs formal 'x'
```

[as a follow-up, I plan to replace the phrase "call actual argument" with simply "actual argument" for brevity / simplicity, but that affected more tests than I wanted to get into here, and in more superficial ways]

I made this change by specializing our "you can't pass this type to this value" error message for the case when the formal was flagged as being an expanded varargs argument and refactoring some existing code that de-munged an expanded varargs identifier into a new helper method on ArgumentSymbol for re-use.

Because of shared code, this change also rephrases more general errors around passing types to values from things like:

```
bar.chpl:25: note: because type method call receiver
bar.chpl:14: note: is passed to non-type formal 'this: borrowed D'
```

to:

```
bar.chpl:25: note: because method call receiver is a type
bar.chpl:14: note: but is passed to non-type formal 'this: borrowed D'
```

Resolves #16932.