### PR TITLE
Add future requesting split initialization via tuple assignment

### DIFF
--- a/test/types/tuple/split-init/splitInitRecordViaTuple.bad
+++ b/test/types/tuple/split-init/splitInitRecordViaTuple.bad
@@ -1,0 +1,2 @@
+In default initializer
+(x = 78)

--- a/test/types/tuple/split-init/splitInitRecordViaTuple.chpl
+++ b/test/types/tuple/split-init/splitInitRecordViaTuple.chpl
@@ -1,0 +1,27 @@
+record R {
+  var x: int;
+
+  proc init() {
+    writeln("In default initializer");
+    this.x = 33;
+  }
+
+  proc init=(x: int) {
+    writeln("In copy initializer");
+    this.x = x;
+  }
+}
+
+proc =(ref lhs: R, rhs: int) {
+  lhs.x = rhs;
+}
+
+proc bar() {
+  return (78, 45);
+}
+
+var myR: R;
+
+(myR, _) = bar();
+
+writeln(myR);

--- a/test/types/tuple/split-init/splitInitRecordViaTuple.future
+++ b/test/types/tuple/split-init/splitInitRecordViaTuple.future
@@ -1,0 +1,6 @@
+feature request: support split initialization via tuple destructuring
+
+#16937
+
+In this test, it seems as though the tuple assignment should cause
+split initialization to fire, yet it doesn't.

--- a/test/types/tuple/split-init/splitInitRecordViaTuple.good
+++ b/test/types/tuple/split-init/splitInitRecordViaTuple.good
@@ -1,0 +1,2 @@
+In copy initializer
+(x = 78)


### PR DESCRIPTION
This PR adds a future in support of issue #16937, requesting that assignments of the form:

```
(r, ...) = tupleExpr
```

be considered as split-initialization candidates for `r`.
