### PR TITLE
Improve tracking of unsigned types in llvm codegen

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1339,6 +1339,7 @@ GenRet createTempVar(const char* ctype)
     llvm::Type* llTy = info->lvt->getType(ctype);
     INT_ASSERT(llTy);
     ret.val = createVarLLVM(llTy, name);
+    ret.isUnsigned = info->lvt->getIsUnsigned(ctype);
 #endif
   }
   return ret;
@@ -1368,6 +1369,7 @@ GenRet createTempVar(Type* t)
 #endif
   }
   ret.chplType = t;
+  ret.isUnsigned = !is_signed(t);
   return ret;
 }
 

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -1336,10 +1336,11 @@ GenRet createTempVar(const char* ctype)
     ret.c = std::string("&") + name;
   } else {
 #ifdef HAVE_LLVM
-    llvm::Type* llTy = info->lvt->getType(ctype);
+    bool isUnsigned;
+    llvm::Type* llTy = info->lvt->getType(ctype, &isUnsigned);
     INT_ASSERT(llTy);
     ret.val = createVarLLVM(llTy, name);
-    ret.isUnsigned = info->lvt->getIsUnsigned(ctype);
+    ret.isUnsigned = isUnsigned;
 #endif
   }
   return ret;

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -93,7 +93,7 @@ void EnumType::codegenDef() {
 
     if(!(type = info->lvt->getType(symbol->cname))) {
       type = ty->codegen().type;
-      info->lvt->addGlobalType(symbol->cname, type);
+      info->lvt->addGlobalType(symbol->cname, type, !is_signed(ty));
 
       // Convert enums to constants with the user-specified immediate,
       // sized appropriately, when it exists.  When it doesn't, give
@@ -436,7 +436,7 @@ void AggregateType::codegenDef() {
   if( !outfile ) {
 #ifdef HAVE_LLVM
     if( ! this->symbol->llvmType ) {
-      info->lvt->addGlobalType(this->symbol->cname, type);
+      info->lvt->addGlobalType(this->symbol->cname, type, false);
       this->symbol->llvmType = type;
     }
 #endif
@@ -459,10 +459,10 @@ void AggregateType::codegenPrototype() {
 
       llvm::StructType* st;
       st = llvm::StructType::create(info->module->getContext(), struct_name);
-      info->lvt->addGlobalType(struct_name, st);
+      info->lvt->addGlobalType(struct_name, st, false);
 
       llvm::PointerType* pt = llvm::PointerType::getUnqual(st);
-      info->lvt->addGlobalType(symbol->cname, pt);
+      info->lvt->addGlobalType(symbol->cname, pt, false);
       symbol->llvmType = pt;
 #endif
     }

--- a/compiler/include/LayeredValueTable.h
+++ b/compiler/include/LayeredValueTable.h
@@ -122,7 +122,7 @@ class LayeredValueTable
     void addValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned);
     void addGlobalValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned); //, Type* type=NULL);
     void addGlobalValue(llvm::StringRef name, GenRet gend);
-    void addGlobalType(llvm::StringRef name, llvm::Type *type);
+    void addGlobalType(llvm::StringRef name, llvm::Type *type, bool isUnsigned);
     void addGlobalCDecl(clang::NamedDecl* cdecl);
     void addGlobalCDecl(llvm::StringRef name, clang::NamedDecl* cdecl, const char* castToType=NULL);
     void addGlobalVarSymbol(llvm::StringRef name, VarSymbol* var, const char* castToType=NULL);
@@ -130,6 +130,7 @@ class LayeredValueTable
     GenRet getValue(llvm::StringRef name);
     llvm::BasicBlock *getBlock(llvm::StringRef name);
     llvm::Type *getType(llvm::StringRef name);
+    bool getIsUnsigned(llvm::StringRef name);
     void getCDecl(llvm::StringRef name, clang::TypeDecl** cTypeOut,
         clang::ValueDecl** cValueOut, const char** cCastedToTypeOut=NULL,
         astlocT *astlocOut=NULL);

--- a/compiler/include/LayeredValueTable.h
+++ b/compiler/include/LayeredValueTable.h
@@ -129,8 +129,7 @@ class LayeredValueTable
     void addBlock(llvm::StringRef name, llvm::BasicBlock *block);
     GenRet getValue(llvm::StringRef name);
     llvm::BasicBlock *getBlock(llvm::StringRef name);
-    llvm::Type *getType(llvm::StringRef name);
-    bool getIsUnsigned(llvm::StringRef name);
+    llvm::Type *getType(llvm::StringRef name, bool* isUnsigned=NULL);
     void getCDecl(llvm::StringRef name, clang::TypeDecl** cTypeOut,
         clang::ValueDecl** cValueOut, const char** cCastedToTypeOut=NULL,
         astlocT *astlocOut=NULL);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2630,7 +2630,9 @@ llvm::Type *LayeredValueTable::getType(StringRef name) {
       // Convert it to an LLVM type.
       store->u.type = codegenCType(store->u.cTypeDecl);
       const clang::Type *type = store->u.cTypeDecl->getTypeForDecl();
-      store->isUnsigned = type->isUnsignedIntegerOrEnumerationType();
+      if (type != NULL) {
+        store->isUnsigned = type->isUnsignedIntegerOrEnumerationType();
+      }
       return store->u.type;
     }
   }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2616,8 +2616,12 @@ llvm::BasicBlock *LayeredValueTable::getBlock(StringRef name) {
   return NULL;
 }
 
-llvm::Type *LayeredValueTable::getType(StringRef name) {
+llvm::Type *LayeredValueTable::getType(StringRef name, bool *isUnsigned) {
   if(Storage *store = get(name)) {
+    if (isUnsigned != NULL) {
+      *isUnsigned = store->isUnsigned;
+    }
+
     if( store->u.type ) {
       INT_ASSERT(isa<llvm::Type>(store->u.type));
       return store->u.type;
@@ -2637,13 +2641,6 @@ llvm::Type *LayeredValueTable::getType(StringRef name) {
     }
   }
   return NULL;
-}
-
-bool LayeredValueTable::getIsUnsigned(StringRef name) {
-  if (Storage *store = get(name)) {
-    return store->isUnsigned;
-  }
-  return false;
 }
 
 // Returns a type or a name decl for a given name

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2489,9 +2489,10 @@ void LayeredValueTable::addGlobalValue(StringRef name, GenRet gend) {
   addGlobalValue(name, gend.val, gend.isLVPtr, gend.isUnsigned);
 }
 
-void LayeredValueTable::addGlobalType(StringRef name, llvm::Type *type) {
+void LayeredValueTable::addGlobalType(StringRef name, llvm::Type *type, bool isUnsigned) {
   Storage store;
   store.u.type = type;
+  store.isUnsigned = isUnsigned;
   /*fprintf(stderr, "Adding global type %s ", name.str().c_str());
   type->dump();
   fprintf(stderr, "\n");
@@ -2628,10 +2629,19 @@ llvm::Type *LayeredValueTable::getType(StringRef name) {
 
       // Convert it to an LLVM type.
       store->u.type = codegenCType(store->u.cTypeDecl);
+      const clang::Type *type = store->u.cTypeDecl->getTypeForDecl();
+      store->isUnsigned = type->isUnsignedIntegerOrEnumerationType();
       return store->u.type;
     }
   }
   return NULL;
+}
+
+bool LayeredValueTable::getIsUnsigned(StringRef name) {
+  if (Storage *store = get(name)) {
+    return store->isUnsigned;
+  }
+  return false;
 }
 
 // Returns a type or a name decl for a given name


### PR DESCRIPTION
In some cases we were losing track of types or symbols being unsigned. Update
LayeredValueTable to keep better track of this, and update codegen functions
to set the GenRet::isUnsigned flag appropriately.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>