### PR TITLE
Fix memory leak for classes/io/classToString

### DIFF
--- a/test/classes/io/classToString.chpl
+++ b/test/classes/io/classToString.chpl
@@ -50,6 +50,8 @@ for mgmt in false..true {
   writeln(dynamicTypeAsString(c12, mgmt));
 }
 
+delete c11;
+
 proc dynamicTypeAsString(expr, printClassMgmt = true) {
   var ret: string;
   

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1317,7 +1317,7 @@ def parser_setup():
     parser.add_argument("-logfile", "--logfile", action="store",
             dest="log_file", help="set alternate log file")
     # mem leaks
-    parser.add_argument("-memleaks", "-memleaks", "-memLeaks", "--memLeaks",
+    parser.add_argument("-memleaks", "--memleaks", "-memLeaks", "--memLeaks",
             action="store_true", dest="mem_leaks", help="run with --memLeaks")
     # mem leaks log
     parser.add_argument("-memleakslog", "--memleakslog", "-memLeaksLog",


### PR DESCRIPTION
Fix a user memory leak for an unmanaged class in a new test. Also fix
`--memleaks` support for start_test while here (I tried to use it while
testing, and found the flag was wrong.)