### PR TITLE
Optimize serial default rectangular scans

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2256,8 +2256,11 @@ module DefaultRectangular {
     // Take first pass, computing per-task partial scans, stored in 'state'
     var (numTasks, rngs, state, _) = this.chpl__preScan(op, res, dom);
 
-    // Take second pass updating result based on the scanned 'state'
-    this.chpl__postScan(op, res, numTasks, rngs, state);
+    // Take second pass updating result based on the scanned 'state' if there
+    // are multiple tasks
+    if numTasks > 1 {
+      this.chpl__postScan(op, res, numTasks, rngs, state);
+    }
     if isPOD(resType) then res.dsiElementInitializationComplete();
 
     // Clean up and return


### PR DESCRIPTION
We use 2-pass scans. In the first pass each task scans the region of the
array that it owns in isolation. In the second pass each task will
adjust the region it owns to account for the preceding regions. When
only one task is scanning, there's no need to do the second pass because
there's no data from a previous region that needs to be incorporated.

This has minor performance benefits for serial reductions, which can
come about when comparing serial arkouda to numpy or more realistically
in cases where there's a scan in an already parallel region like we have
in ISx.

As a quick performance comparison on chapcs, this speeds up a serial
scan by 15% or so:

```
chpl test/scan/scanPerf.chpl --fast -o scanPerf-{Before,After}
export CHPL_RT_NUM_THREADS_PER_LOCALE=1

./scanPerf-Before --printTiming --printArray=false --n=100000000
Scan of 100000000 elements took 0.598985 seconds

./scanPerf-After --printTiming --printArray=false --n=100000000
Scan of 100000000 elements took 0.504926 seconds
```

Resolves https://github.com/Cray/chapel-private/issues/696