### PR TITLE
Stop loading python 2.7 in Cray-CS testing

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -19,7 +19,6 @@ if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
   export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
   loadCSModule gcc/8.1.0
-  loadCSModule python/2.7.6
   loadCSModule cray-fftw
 else
   [ "$1" == y ] && log_info "Expected Cray CS, but does not seem to be one."


### PR DESCRIPTION
This was a workaround added in #14219, but we're no longer reliant on
python2, so we don't need it anymore. It's also not available on the new
CS machine we're running on.