### PR TITLE
Use bundled libfabric for our nightly testing

### DIFF
--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -7,6 +7,7 @@ if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-* ]] ; then
 fi
 
 export CHPL_COMM=ofi
+export CHPL_LIBFABRIC=bundled
 
 # Select a launcher and out-of-band support.  If we're on a Cray XC
 # system this will just fall out automatically.  On a slurm-based system


### PR DESCRIPTION
Our new CS machine has a system libfab that is being detected, but it
doesn't work so use our bundled version instead.