### PR TITLE
Always use amudprun launcher with gasnet-udp

### DIFF
--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -3,14 +3,24 @@ from distutils.spawn import find_executable
 import sys
 
 import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
-from utils import memoize
+from utils import error, memoize
 
 
 @memoize
 def get():
     launcher_val = overrides.get('CHPL_LAUNCHER')
+
+    comm_val = chpl_comm.get()
+    substrate_val = chpl_comm_substrate.get()
+    if comm_val == 'gasnet' and substrate_val == 'udp':
+        if not launcher_val:
+            launcher_val = 'amudprun'
+        elif launcher_val not in ('none', 'amudprun'):
+            error('CHPL_LAUNCHER={} is not supported for CHPL_COMM=gasnet '
+		  'CHPL_COMM_SUBSTRATE=udp, CHPL_LAUNCHER=amudprun is '
+                  'required'.format(launcher_val))
+
     if not launcher_val:
-        comm_val = chpl_comm.get()
         platform_val = chpl_platform.get('target')
 
         if platform_val.startswith('cray-') or platform_val.startswith('hpe-cray-'):
@@ -35,11 +45,8 @@ def get():
                     'Warning: Cannot detect launcher on this system. Please '
                     'set CHPL_LAUNCHER in the environment.\n')
         elif comm_val == 'gasnet':
-            substrate_val = chpl_comm_substrate.get()
             if substrate_val == 'smp':
                 launcher_val = 'smp'
-            elif substrate_val == 'udp':
-                launcher_val = 'amudprun'
             elif substrate_val == 'mpi':
                 launcher_val = 'gasnetrun_mpi'
             elif substrate_val == 'ibv':


### PR DESCRIPTION
gasnet-udp requires the amudprun launcher. Change our chplenv detection
so we always default to amudprun and error if a user tries to set it so
something else. Note that we also allow `CHPL_LAUNCHER=none` if they
want to manually launch.

Trying to use a different launcher with gasnet-udp would result in vague
errors like: `GASNet: Invalid number of nodes: -nl4` and this should
make the issue much more apparent.

Resolves https://github.com/chapel-lang/chapel/issues/16971