### PR TITLE
Don't add pmi to CHPL_LD_FLAGS in ofi testing if pmi is a system library

### DIFF
--- a/util/cron/common-ofi.bash
+++ b/util/cron/common-ofi.bash
@@ -27,7 +27,10 @@ elif [[ "$($CHPL_HOME/util/chplenv/chpl_launcher.py)" == slurm-srun ]] ; then
     srunDir=$(which srun)
     sLibDir=${srunDir%/bin/srun}/lib64
     if [[ -d $sLibDir ]] ; then
-      export CHPL_LD_FLAGS="${CHPL_LD_FLAGS:+$CHPL_LD_FLAGS }-L$sLibDir -Wl,-rpath,$sLibDir"
+      # Set CHPL_LD_FLAGS to slurm pmi, if pmi isn't already in system lib dir
+      if ! ldconfig -p | grep -q libpmi2.so; then
+        export CHPL_LD_FLAGS="${CHPL_LD_FLAGS:+$CHPL_LD_FLAGS }-L$sLibDir -Wl,-rpath,$sLibDir"
+      fi
       export SLURM_MPI_TYPE=pmi2
       lchOK=y
     fi


### PR DESCRIPTION
On our new CS machine, slurm/pmi are system libraries and are found by
default by the linker. Previously, we were adding `-L /usr/lib64` to
`CHPL_LD_FLAGS`, which would result in the system libfabric being
brought in and its not compatible with the bundled version we're trying
to use since #16968.