### PR TITLE
Fix fftw on the new CS system

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -20,6 +20,7 @@ if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
   loadCSModule gcc/8.1.0
   loadCSModule cray-fftw
+  export LD_LIBRARY_PATH="$FFTW_DIR:$LD_LIBRARY_PATH"
 else
   [ "$1" == y ] && log_info "Expected Cray CS, but does not seem to be one."
 fi


### PR DESCRIPTION
We're getting loader issues about not finding `libfftw3.so.mpi31.3` on
the new CS system. Add the FFTW lib dir to LD_LIBRARY_PATH to resolve
this.
