### PR TITLE
Make python2 available for arkouda release testing on cray-cs

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
@@ -18,6 +18,9 @@ source $CWD/common-cray-cs.bash
 export CHPL_LAUNCHER_PARTITION=rome64
 export CHPL_TARGET_CPU=none
 
+# python2 required for chapel 1.23, will not be required with 1.24+
+module load python/2.7.6
+
 module list
 
 export GASNET_PHYSMEM_MAX="9/10"

--- a/util/cron/test-perf.cray-cs.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.release.bash
@@ -17,6 +17,9 @@ module list
 source $CWD/common-cray-cs.bash
 source $CWD/common-perf-cray-cs.bash
 
+# python2 required for chapel 1.23, will not be required with 1.24+
+source ~/.setup_python2.bash
+
 module list
 
 export GASNET_PHYSMEM_MAX=83G


### PR DESCRIPTION
Arkouda release testing uses chapel 1.23, which requires python2 and for
python to be a python2. On CS systems we used to do this by loading a
python 2 module, but I thought that was no longer needed and removed it
in 16967. However, it is still needed for arkouda release testing. Use
that module for arkouda release testing on cray-cs-hdr, but use a
different trick (sourcing a PATH that has a python symlinked to
/usr/bin/python2) to bring in python2 for arkouda release testing on the
new cray-cs system that does not have the module available.