### PR TITLE
Try to ensure arkouda dependency versions match our test dependencies

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -62,7 +62,9 @@ fi
 
 # Install Arkouda and python dependencies to a python-deps subdir
 export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
-if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir -e .[dev] --user ; then
+# If Arkouda deps use any of our test deps, try to use the versions we want
+AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
+if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user ; then
   log_fatal_error "installing arkouda"
 fi
 


### PR DESCRIPTION
We pin to PyYaml 5.3.1 in test-requirements, but an Arkouda dependency
was pulling in 5.4.0 because we throw `--upgrade --no-cache-dir` since
#15654. There is some issue in PyYaml 5.4 that is breaking yaml imports
at the moment. To fix this and hopefully avoid similar issues in the
future list our test-requirements as a constraint for versioning. This
should make sure that Arkouda dependencies pull in the same versions we
want, assuming they don't hard code versions themselves.