### PR TITLE
Skip tests that check for local code in generated IR for --no-local

### DIFF
--- a/test/llvm/parallel_loop_access/parallel_loop_accesses3.skipif
+++ b/test/llvm/parallel_loop_access/parallel_loop_accesses3.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM!=none
+COMPOPTS <= --no-local

--- a/test/llvm/tbaa/tbaa_scalar.skipif
+++ b/test/llvm/tbaa/tbaa_scalar.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM!=none


### PR DESCRIPTION
For CHPL_COMM!=none or --no-local, skip tests that are expecting the IR
generated to be local and fail if it is not. They are testing for things
like stores in certain places in the IR where for --no-local they need to
be comm_put calls instead, etc.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>