### PR TITLE
Fixup CG .good files

### DIFF
--- a/test/constrained-generics/basic/error-call-ug.good
+++ b/test/constrained-generics/basic/error-call-ug.good
@@ -1,6 +1,6 @@
 error-call-ug.chpl:16: In function 'cgFun':
 error-call-ug.chpl:18: error: unresolved call 'ugFun(Q)'
 error-call-ug.chpl:21: note: this candidate did not match: ugFun(arg)
-error-call-ug.chpl:18: note: because call actual argument #1 of an interface type Q
+error-call-ug.chpl:18: note: because actual argument #1 of an interface type Q
 error-call-ug.chpl:21: note: is passed to a generic formal
 error-call-ug.chpl:21: note: passing a constrained-generic formal to a non-constrained-generic function is not allowed

--- a/test/constrained-generics/basic/error-cg-arg.good
+++ b/test/constrained-generics/basic/error-cg-arg.good
@@ -1,5 +1,5 @@
 error-cg-arg.chpl:15: In function 'cgFun':
 error-cg-arg.chpl:17: error: unresolved call 'reqFun(5, int(64))'
 error-cg-arg.chpl:9: note: this candidate did not match: reqFun(cgFormal: Q, formal2: int(64))
-error-cg-arg.chpl:17: note: because call actual argument #1 with type int(64)
+error-cg-arg.chpl:17: note: because actual argument #1 with type 'int(64)'
 error-cg-arg.chpl:9: note: is passed to formal 'cgFormal: Q'

--- a/test/constrained-generics/basic/error-concrete-arg.good
+++ b/test/constrained-generics/basic/error-concrete-arg.good
@@ -1,6 +1,6 @@
 error-concrete-arg.chpl:14: In function 'cgFun':
 error-concrete-arg.chpl:16: error: unresolved call 'reqFun(Q, 1.5)'
 error-concrete-arg.chpl:8: note: this candidate did not match: reqFun(cgFormal: Q, formal2: int(64))
-error-concrete-arg.chpl:16: note: because call actual argument #2 with type real(64)
+error-concrete-arg.chpl:16: note: because actual argument #2 with type 'real(64)'
 error-concrete-arg.chpl:8: note: is passed to formal 'formal2: int(64)'
 error-concrete-arg.chpl:20: note: candidates are: reqFun(arg1: real, arg2: int)

--- a/test/constrained-generics/basic/self-call-ug.good
+++ b/test/constrained-generics/basic/self-call-ug.good
@@ -2,6 +2,6 @@ self-call-ug.chpl:11: In function 'dfltImpl':
 self-call-ug.chpl:12: warning: string
 self-call-ug.chpl:13: error: unresolved call 'ugFun(type Self)'
 self-call-ug.chpl:24: note: this candidate did not match: ugFun(type arg)
-self-call-ug.chpl:13: note: because call actual argument #1 of an interface type Self
+self-call-ug.chpl:13: note: because actual argument #1 of an interface type Self
 self-call-ug.chpl:24: note: is passed to a generic formal
 self-call-ug.chpl:24: note: passing a constrained-generic formal to a non-constrained-generic function is not allowed


### PR DESCRIPTION
This adjusts .good files introduced in #16942
for a change in error message text that happened
while PR was in development.

Trivial, not reviewed.
