### PR TITLE
Update documentation for environment variable settings 'CHPL_*=bundled'

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -99,7 +99,7 @@ into the module::
   CHPL_ATOMICS: cstdlib
     CHPL_NETWORK_ATOMICS: none, ofi
   CHPL_GMP: none
-  CHPL_HWLOC: hwloc
+  CHPL_HWLOC: bundled
   CHPL_REGEXP: none
   CHPL_LLVM: none
   CHPL_AUX_FILESYS: none

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -733,7 +733,7 @@ Support for Extern Blocks
 
 [Note: The features in this section rely on Chapel to being built with
 llvm/clang enabled.  To do so, set environment variable CHPL_LLVM to
-'llvm' and rebuild your Chapel installation. See :ref:`readme-llvm`.].
+'bundled' and rebuild your Chapel installation. See :ref:`readme-llvm`.].
 
 C code and header files can be included directly within Chapel source
 code using an ``extern block`` as follows:

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -489,7 +489,8 @@ CHPL_GMP
        system   use a system install of GMP
                 (#include gmp.h, -lgmp)
        none     do not build GMP support into the Chapel runtime
-       gmp      use the GMP distribution bundled with Chapel in third-party
+       bundled  use the GMP distribution bundled with Chapel in third-party
+       gmp      deprecated - use bundled instead
        =======  ============================================================
 
    If unset, Chapel will attempt to build GMP using
@@ -500,7 +501,7 @@ CHPL_GMP
        ======= ====================================================
        Value   Description
        ======= ====================================================
-       gmp     if the build was successful
+       bundled if the build was successful
        system  if unsuccessful and :ref:`readme-chplenv.CHPL_TARGET_PLATFORM` is cray-x*
        none    otherwise
        ======= ====================================================
@@ -523,10 +524,11 @@ CHPL_HWLOC
        Value    Description
        ======== ==============================================================
        none     do not build hwloc support into the Chapel runtime
-       hwloc    use the hwloc distribution bundled with Chapel in third-party
+       bundled  use the hwloc distribution bundled with Chapel in third-party
+       hwloc    deprecated - use bundled instead
        ======== ==============================================================
 
-   If unset, ``CHPL_HWLOC`` defaults to ``hwloc`` if
+   If unset, ``CHPL_HWLOC`` defaults to ``bundled`` if
    :ref:`readme-chplenv.CHPL_TASKS` is ``qthreads``.  In all other cases
    it defaults to ``none``.  In the unlikely event the bundled hwloc
    distribution does not build successfully, it should still be possible
@@ -556,10 +558,11 @@ CHPL_HWLOC
           Value    Description
           ======== ==============================================================
           none     do not build or use jemalloc
-          jemalloc use the jemalloc distribution bundled with Chapel in third-party
+          bundled  use the jemalloc distribution bundled with Chapel in third-party
+          jemalloc deprecated - use bundled instead
           ======== ==============================================================
 
-      If unset, ``CHPL_JEMALLOC`` defaults to ``jemalloc`` if
+      If unset, ``CHPL_JEMALLOC`` defaults to ``bundled`` if
       :ref:`readme-chplenv.CHPL_MEM` is ``jemalloc``.  In all other cases it
       defaults to ``none``.
 
@@ -585,10 +588,11 @@ CHPL_HWLOC
           Value     Description
           ========= ==============================================================
           none      do not build or use libfabric
-          libfabric use the libfabric distribution bundled with Chapel in third-party
+          bundled   use the libfabric distribution bundled with Chapel in third-party
+          libfabric deprecated - use bundled instead
           ========= ==============================================================
 
-      If unset, ``CHPL_LIBFABRIC`` defaults to ``libfabric`` if
+      If unset, ``CHPL_LIBFABRIC`` defaults to ``bundled`` if
       :ref:`readme-chplenv.CHPL_COMM` is ``ofi``.  In all other cases it
       defaults to ``none``.
 
@@ -659,6 +663,7 @@ CHPL_LLVM
        Value          Description
        ============== ======================================================
        bundled        use the llvm/clang distribution in third-party
+       llvm           deprecated - use bundled instead
        system         find a compatible LLVM in system libraries;
                       note: the LLVM must be a version supported by Chapel
        none           do not support llvm/clang-related features
@@ -697,7 +702,8 @@ CHPL_UNWIND
        ========= =======================================================
        Value     Description
        ========= =======================================================
-       libunwind use the libunwind bundled with Chapel in third-party
+       bundled   use the libunwind bundled with Chapel in third-party
+       libunwind deprecated - use bundled instead
        system    assume libunwind is already installed on the system
        none      don't use an unwind library, disabling stack tracing
        ========= =======================================================

--- a/doc/rst/usingchapel/tasks.rst
+++ b/doc/rst/usingchapel/tasks.rst
@@ -181,7 +181,7 @@ execution time (see :ref:`oversubscribed-execution`).
 Hwloc
 =====
 
-When ``CHPL_TASKS=qthreads``, the default for ``CHPL_HWLOC`` becomes "hwloc",
+When ``CHPL_TASKS=qthreads``, the default for ``CHPL_HWLOC`` becomes "bundled",
 and the hwloc third-party package will be built.  Qthreads depends on
 this package to provide it with a description of the locale hardware, to
 support locality and affinity operations.


### PR DESCRIPTION
Update the documentation for environment variables that now should use bundled
as their value. For CHPL_XYZ=XYZ still mention the old value, but state that
it is deprecated and to use bundled instead.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>