### PR TITLE
Improve how CHPL_CACHE_REMOTE is set

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -69,6 +69,7 @@ VarSymbol *gCastChecking = NULL;
 VarSymbol *gNilChecking = NULL;
 VarSymbol *gOverloadSetsChecks = NULL;
 VarSymbol *gDivZeroChecking = NULL;
+VarSymbol* gCacheRemote = NULL;
 VarSymbol* gPrivatization = NULL;
 VarSymbol* gLocal = NULL;
 VarSymbol* gWarnUnstable = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -941,6 +941,10 @@ void initCompilerGlobals() {
   gDivZeroChecking->addFlag(FLAG_PARAM);
   setupBoolGlobal(gDivZeroChecking, !fNoDivZeroChecks);
 
+  gCacheRemote = new VarSymbol("CHPL_CACHE_REMOTE", dtBool);
+  gCacheRemote->addFlag(FLAG_PARAM);
+  setupBoolGlobal(gCacheRemote, fCacheRemote);
+
   gPrivatization = new VarSymbol("_privatization", dtBool);
   gPrivatization->addFlag(FLAG_PARAM);
   setupBoolGlobal(gPrivatization, !(fNoPrivatization || fLocal));

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -807,6 +807,7 @@ extern VarSymbol *gCastChecking;
 extern VarSymbol *gNilChecking;
 extern VarSymbol *gOverloadSetsChecks;
 extern VarSymbol *gDivZeroChecking;
+extern VarSymbol *gCacheRemote;
 extern VarSymbol *gPrivatization;
 extern VarSymbol *gLocal;
 extern VarSymbol *gWarnUnstable;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -806,11 +806,6 @@ static void setBaselineFlag(const ArgumentDescription* desc, const char* unused)
   fNoOptimizeForallUnordered = true;  // --no-optimize-forall-unordered-ops
 }
 
-static void setCacheEnable(const ArgumentDescription* desc, const char* unused) {
-  const char *val = fCacheRemote ? "true" : "false";
-  parseCmdLineConfig("CHPL_CACHE_REMOTE", val);
-}
-
 static void setUseColorTerminalFlag(const ArgumentDescription* desc, const char* unused) {
   fDetectColorTerminal = false;
   // fUseColorTerminal is set by the flag
@@ -931,7 +926,7 @@ static ArgumentDescription arg_desc[] = {
 
  {"", ' ', NULL, "Optimization Control Options", NULL, NULL, NULL, NULL},
  {"baseline", ' ', NULL, "Disable all Chapel optimizations", "F", &fBaseline, "CHPL_BASELINE", setBaselineFlag},
- {"cache-remote", ' ', NULL, "[Don't] enable cache for remote data", "N", &fCacheRemote, "CHPL_CACHE_REMOTE", setCacheEnable},
+ {"cache-remote", ' ', NULL, "[Don't] enable cache for remote data", "N", &fCacheRemote, "CHPL_CACHE_REMOTE", NULL},
  {"copy-propagation", ' ', NULL, "Enable [disable] copy propagation", "n", &fNoCopyPropagation, "CHPL_DISABLE_COPY_PROPAGATION", NULL},
  {"dead-code-elimination", ' ', NULL, "Enable [disable] dead code elimination", "n", &fNoDeadCodeElimination, "CHPL_DISABLE_DEAD_CODE_ELIMINATION", NULL},
  {"fast", ' ', NULL, "Disable checks; optimize/specialize code", "F", &fFastFlag, "CHPL_FAST", setFastFlag},

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -281,6 +281,7 @@ void ResolveScope::addBuiltIns() {
   extend(gNilChecking);
   extend(gOverloadSetsChecks);
   extend(gDivZeroChecking);
+  extend(gCacheRemote);
   extend(gPrivatization);
   extend(gLocal);
   extend(gWarnUnstable);

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -83,7 +83,7 @@
 pragma "atomic module"
 module Atomics {
 
-  use ChapelBase;             // to get CHPL_CACHE_REMOTE...
+  use ChapelBase;
   public use MemConsistency;  // OK: to get and propagate memoryOrder
 
   pragma "no doc"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -39,9 +39,6 @@ module ChapelBase {
   // the default low bound to use for arrays, tuples, etc.
   config param defaultLowBound = 0;
 
-  // Is the cache for remote data enabled at compile time?
-  config param CHPL_CACHE_REMOTE: bool = false;
-
   // minimum buffer size allocated for string/bytes
   config param chpl_stringMinAllocSize = 0;
 


### PR DESCRIPTION
This is a module param that's set by the compiler. Change it to be more
like other compiler set params such as `boundsChecking`. Previously the
value was only changed when `--[no-]cache-remote` was thrown on the
command line, but as we look enable the cache by default we want to
always set the value.

See https://github.com/Cray/chapel-private/issues/1602 for context