### PR TITLE
Disable remote cache if address sanitizer is enabled

### DIFF
--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -24,7 +24,9 @@
 #include "chpltypes.h"
 #include "chpl-atomics.h"
 #include "chpl-comm.h" // to get HAS_CHPL_CACHE_FNS via chpl-comm-task-decls.h
+#include "chpl-env.h"
 #include "chpl-tasks.h"
+#include "error.h"
 
 #ifdef HAS_CHPL_CACHE_FNS
 // This is a cache for remote data.
@@ -33,25 +35,47 @@
 extern "C" {
 #endif
 
-// Is the cache enabled? (set at compile time)
+// Is the cache supposed to be enabled? (set at compile time)
 extern const int CHPL_CACHE_REMOTE;
+
+#if defined(__SANITIZE_ADDRESS__)
+#define CHPL_ASAN 1
+#endif
+
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define CHPL_ASAN 1
+#endif
+#endif
+
+#if !defined(CHPL_ASAN)
+#define CHPL_ASAN 0
+#endif
+
+static
+void chpl_cache_warn_if_disabled(void)
+{
+  if (CHPL_CACHE_REMOTE && chpl_nodeID == 0 &&
+      !chpl_env_rt_get_bool("CACHE_QUIET", false)) {
+    if (CHPL_ASAN) {
+      chpl_warning("Disabling --cache-remote due to incompatibility with "
+                   "AddressSanitizer (quiet with CHPL_RT_CACHE_QUIET=true)", 0, 0);
+    } else if (chpl_task_canMigrateThreads()) {
+      chpl_warning("Disabling --cache-remote because tasks can migrate "
+                   "threads (quiet with CHPL_RT_CACHE_QUIET=true)", 0, 0);
+    }
+  }
+}
 
 static inline
 int chpl_cache_enabled(void)
 {
-  // The cache is not compatible with address sanitizer
-#if defined(__SANITIZE_ADDRESS__)
-  return 0;
-#endif
-#if defined(__has_feature)
-# if __has_feature(address_sanitizer)
-  return 0;
-# endif
-#endif
-  // The remote cache uses thread local storage, so if tasks can migrate
-  // between threads we lose out ability to correctly fence.
-  return CHPL_CACHE_REMOTE && !chpl_task_canMigrateThreads();
+  // The remote cache is not compatible with ASan, and it uses thread local
+  // storage, so if tasks can migrate between threads we lose our ability to
+  // correctly fence.
+  return CHPL_CACHE_REMOTE && !CHPL_ASAN && !chpl_task_canMigrateThreads();
 }
+#undef CHPL_ASAN
 
 
 // Initialize the remote data cache layer. 

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -39,6 +39,15 @@ extern const int CHPL_CACHE_REMOTE;
 static inline
 int chpl_cache_enabled(void)
 {
+  // The cache is not compatible with address sanitizer
+#if defined(__SANITIZE_ADDRESS__)
+  return 0;
+#endif
+#if defined(__has_feature)
+# if __has_feature(address_sanitizer)
+  return 0;
+# endif
+#endif
   // The remote cache uses thread local storage, so if tasks can migrate
   // between threads we lose out ability to correctly fence.
   return CHPL_CACHE_REMOTE && !chpl_task_canMigrateThreads();

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -3613,6 +3613,8 @@ void chpl_cache_do_init(void)
 
 void chpl_cache_init(void) {
 
+  chpl_cache_warn_if_disabled();
+
   if( ! chpl_cache_enabled() ) {
     return;
   }

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -13,6 +13,9 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-asan"
 
 export GASNET_QUIET=Y
 
+# Cache does not work with ASan, quiet warnings about it for testing
+export CHPL_RT_CACHE_QUIET=true
+
 # The ASAN best practices doc recommends that SUBSTRATE be set to 'udp' and
 # SEGMENT be set to 'everything' in order to encourage active messages
 # instead of RDMA. This will let ASAN detect more memory errors.

--- a/util/cron/test-gasnet.numa.bash
+++ b/util/cron/test-gasnet.numa.bash
@@ -17,7 +17,9 @@ export CHPL_NIGHTLY_TEST_DIRS="release/examples/hello*.chpl localeModels"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.numa"
 
-# TODO: Do we need/want this? (thomasvandoren, 2014-07-01)
 export GASNET_QUIET=Y
+
+# Cache does not work with migratable, quiet warnings about it for testing
+export CHPL_RT_CACHE_QUIET=true
 
 $CWD/nightly -cron -multilocale


### PR DESCRIPTION
The cache reads whole cache lines at a time, even if only part of the
line is allocated. This is an intentional design choice, but it is
technically reading unallocated memory, which is one of the things ASan
catches. For now just disable the cache if asan is enabled. See
https://github.com/Cray/chapel-private/issues/933 for more info.

This also adds warnings if the cache was requested but can't be used.
This includes warning for Asan and if tasks can migrate threads, which
isn't support because the cache relies on thread local storage.

These warnings can be quieted by compiling with `--no-cache-remote`,
executing with `--quiet` (which is a big hammer), or by setting
`CHPL_RT_CACHE_QUIET=true`. Use `CHPL_RT_CACHE_QUIET=true` in our gasnet
ASan and numa configurations in prep for cache remote being enabled by
default