### PR TITLE
Add Mason Packages placeholder to documentation

### DIFF
--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -26,6 +26,7 @@ Chapel Documentation
    modules/standard
    modules/packages
    modules/layoutdist
+   mason-packages
    users-guide/index
 
 .. toctree::

--- a/doc/rst/mason-packages.rst
+++ b/doc/rst/mason-packages.rst
@@ -4,7 +4,7 @@ Mason Packages
 ==============
 
 Community-developed modules are available as Mason packages on the
-`Mason registry <https://github.com/chapel-lang/mason-registry/>`_.
+`Mason registry repository <https://github.com/chapel-lang/mason-registry/>`_.
 These packages can be downloaded and used through :ref:`Mason <readme-mason>`,
 Chapel's package manager.
 
@@ -17,6 +17,7 @@ documentation on :ref:`submitting a package <submit-a-package>`.
 
 .. note::
 
-    This document and processes for submitting a mason package are still
-    under development and are subject to change in the future.
+    The process of publishing mason packages is still under development. As a
+    result, the current process still has some rough edges, but is expected to
+    improve over time.
 

--- a/doc/rst/mason-packages.rst
+++ b/doc/rst/mason-packages.rst
@@ -1,0 +1,22 @@
+.. _mason-packages:
+
+Mason Packages
+==============
+
+Community-developed modules are available as Mason packages on the
+`Mason registry <https://github.com/chapel-lang/mason-registry/>`_.
+These packages can be downloaded and used through :ref:`Mason <readme-mason>`,
+Chapel's package manager.
+
+Browsing available packages is best done through the ``mason`` command line
+tool, via ``mason search``. They can also be found by browsing the mason
+registry repository.
+
+For details on contributing a package to the mason registry, see the
+documentation on :ref:`submitting a package <submit-a-package>`.
+
+.. note::
+
+    This document and processes for submitting a mason package are still
+    under development and are subject to change in the future.
+

--- a/doc/rst/mason-packages.rst
+++ b/doc/rst/mason-packages.rst
@@ -3,9 +3,9 @@
 Mason Packages
 ==============
 
-Community-developed modules are available as Mason packages on the
-`Mason registry repository <https://github.com/chapel-lang/mason-registry/>`_.
-These packages can be downloaded and used through :ref:`Mason <readme-mason>`,
+Community-developed modules are available as mason packages on the
+`mason registry repository <https://github.com/chapel-lang/mason-registry/>`_.
+These packages can be downloaded and used through :ref:`mason <readme-mason>`,
 Chapel's package manager.
 
 Browsing available packages is best done through the ``mason`` command line

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -846,6 +846,8 @@ recent.
     Packages will be listed regardless of their ``chplVersion`` compatibility.
 
 
+.. _submit-a-package:
+
 Submit a Package
 ================
 


### PR DESCRIPTION
This PR adds a short top-level documentation page under the module docs in "Writing Chapel Programs" for advertising and explaining the processes around mason packages.

Resolves https://github.com/chapel-lang/chapel/issues/16913