### PR TITLE
More debugging functionality in view.cpp

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -82,6 +82,8 @@ list_sym(const Symbol* sym, bool type = true) {
     printf("arg intent-%s ", arg->intentDescrString());
   } else if (isTypeSymbol(sym)) {
     printf("type ");
+  } else if (isInterfaceSymbol(sym)) {
+    printf("interface ");
   }
   printf("%s", sym->name);
   printf("[%d]", sym->id);
@@ -142,6 +144,12 @@ static void forallPreamble(const Expr* expr, const BaseAST* parentAst,
   } else if (const ShadowVarSymbol* svar = toConstShadowVarSymbol(parentAst)) {
     if (expr == svar->outerVarSE                          ||
         ( expr == svar->initBlock() && !svar->outerVarSE ) )
+      printf("\n");
+  } else if (const InterfaceSymbol* isym = toConstInterfaceSymbol(parentAst)) {
+    if (expr->list && expr->list->parent == isym)
+      printf("\n");
+  } else if (const ImplementsStmt* istm = toConstImplementsStmt(parentAst)) {
+    if (expr == istm->implBody)
       printf("\n");
   }
 }
@@ -243,17 +251,13 @@ static bool
 list_line(const Expr* expr, const BaseAST* parentAst) {
   if (expr->isStmt())
     return !*block_explanation(expr, parentAst);
-  if (const CondStmt* cond = toConstCondStmt(parentAst)) {
-    if (cond->condExpr == expr)
-      return false;
-  }
-  if (const GotoStmt* gts = toConstGotoStmt(parentAst)) {
-    if (gts->label == expr)
-      return false;
-  }
+  if (const CondStmt* cond = toConstCondStmt(parentAst))
+    return cond->condExpr != expr;
+  if (const GotoStmt* gts = toConstGotoStmt(parentAst))
+    return gts->label != expr;
   if (const Expr* pExpr = toConstExpr(parentAst))
-    if (pExpr->isStmt() && !isUseStmt(pExpr) && !isImportStmt(pExpr))
-      return true;
+    return pExpr->isStmt() &&
+      !isUseStmt(pExpr) && !isImportStmt(pExpr) && !isImplementsStmt(pExpr);
   if (isSymbol(parentAst))
     return true;
   return false;
@@ -317,6 +321,13 @@ list_ast(const BaseAST* ast, const BaseAST* parentAst = NULL, int indent = 0) {
       printf("use ");
     } else if (isImportStmt(expr)) {
       printf("import ");
+    } else if (isImplementsStmt(expr)) {
+      printf("implements stmt ");
+    } else if (isIfcConstraint(expr)) {
+      if (parentAst == NULL || !isImplementsStmt(parentAst))
+        printf("ifc constraint (");
+      else
+        printf("(");
     }
   }
 
@@ -340,7 +351,7 @@ list_ast(const BaseAST* ast, const BaseAST* parentAst = NULL, int indent = 0) {
       toConstCallExpr(parentAst)->isPrimitive(PRIM_BLOCK_C_FOR_LOOP);
     const CallExpr* parent_C_loop = parentIsCLoop ? toConstCallExpr(parentAst) :
       NULL;
-    if (isCallExpr(expr)) {
+    if (isCallExpr(expr) || isIfcConstraint(expr)) {
       printf(") ");
     }
     if (isBlockStmt(ast)) {
@@ -451,6 +462,20 @@ Expr* aidExpr(BaseAST* ast) {
   return NULL;
 }
 
+// inTree(): a workaround for an lldb bug
+bool inTree(BaseAST* ast) {
+  return ast->inTree();
+}
+bool inTree(int id) {
+  if (BaseAST* ast = aid(id)) {
+    return inTree(ast);
+  } else {
+    printf("%s\n", aidNotFoundError("inTree", id));
+    return false;
+  }
+}
+
+
 void viewFlags(int id) {
   if (BaseAST* ast = aidWithError(id, "viewFlags"))
     viewFlags(ast);
@@ -473,6 +498,8 @@ static void view_sym(Symbol* sym, bool number, int mark) {
     printf("arg ");
   } else if (toTypeSymbol(sym)) {
     printf("type ");
+  } else if (isInterfaceSymbol(sym)) {
+    printf("interface ");
   }
   printf("%s", sym->name);
   if (number)
@@ -806,7 +833,7 @@ const char* debugLoc(BaseAST* ast) {
   return debugShortLoc ? shortLoc(ast) : stringLoc(ast);
 }
 
-// helper for printing IDs
+// debugID: helper for printing IDs, opposite to aid()
 int debugID(int id) {
   return id;
 }
@@ -827,11 +854,15 @@ void debugSummary(BaseAST* ast) {
   else
     printf("<debugSummary: NULL>\n");
 }
+// these just print out the argument
 void debugSummary(const char* str) {
   if (str)
     printf("\"%s\"\n", str);
   else
     printf("<debugSummary: NULL string>\n");
+}
+void debugSummary(bool b) {
+  printf("%s\n", b ? "true" : "false");
 }
 
 // find the Parent Symbol
@@ -908,6 +939,7 @@ static const char* summarySymbolKind(Symbol* sym) {
   if (isVarSymbol(sym)) return "var";
   if (isTypeSymbol(sym)) return "type";
   if (isModuleSymbol(sym)) return "module";
+  if (isInterfaceSymbol(sym)) return "interface";
   return sym->astTagAsString();
 }
 static void summarySymbolPrint(Symbol* sym, const char* prefix = NULL,
@@ -994,12 +1026,21 @@ void map_view(SymbolMap& map) {
 //
 
 static void showFnSymbol(FnSymbol* fn) {
-        printf("  %8d  %c%c  %s\n", fn->id,
-               // "g"eneric, "r"esolved, "G"eneric+resolved, " " - neither
-               fn->isResolved() ? (fn->isKnownToBeGeneric() ? 'G' : 'r') :
-                                  (fn->isKnownToBeGeneric() ? 'g' : ' ') ,
-               fn->inTree() ? ' ' : '-',
-               debugLoc(fn));
+  printf("  %8d  %c%c  %s  %s\n", fn->id,
+         // "g"eneric, "r"esolved, "G"eneric+resolved, " " neither
+         fn->isResolved() ? (fn->isKnownToBeGeneric() ? 'G' : 'r') :
+         (fn->isKnownToBeGeneric() ? 'g' : ' ') ,
+         // "-" indicates not in tree
+         fn->inTree() ? ' ' : '-',
+         fn->name, debugLoc(fn));
+}
+
+static void showSymExpr(SymExpr* elm) {
+  Symbol* sym = elm->symbol();
+  if (sym)
+    printf("  %8d  %s[%d]\n", elm->id, sym->name, sym->id);
+  else
+    printf("  %8d  <null symbol>\n", elm->id);
 }
 
 void vec_view(Vec<Symbol*,VEC_INTEGRAL_SIZE>* v) {
@@ -1034,6 +1075,22 @@ void vec_view(Vec<FnSymbol*,VEC_INTEGRAL_SIZE>& v)
   }
 }
 
+void vec_view(Vec<SymExpr*,VEC_INTEGRAL_SIZE>* v) {
+  vec_view(*v);
+}
+
+void vec_view(Vec<SymExpr*,VEC_INTEGRAL_SIZE>& v)
+{
+  printf("Vec<SymExpr> %d elm(s)\n", v.n);
+  for (int i = 0; i < v.n; i++) {
+    SymExpr* elm = v.v[i];
+    if (elm)
+      printf("%3d", i), showSymExpr(elm);
+    else
+      printf("%3d  <null>\n", i);
+  }
+}
+
 void vec_view(std::vector<Symbol*>* syms) {
   vec_view(*syms);
 }
@@ -1059,6 +1116,21 @@ void vec_view(std::vector<FnSymbol*>& syms) {
     FnSymbol* elm = syms[i];
     if (elm)
       printf("%3d", i), showFnSymbol(elm);
+    else
+      printf("%3d  <null>\n", i);
+  }
+}
+
+void vec_view(std::vector<SymExpr*>* syms) {
+  vec_view(*syms);
+}
+
+void vec_view(std::vector<SymExpr*>& syms) {
+  printf("vector<SymExpr> %d elm(s)\n", (int)syms.size());
+  for (int i = 0; i < (int)syms.size(); i++) {
+    SymExpr* elm = syms[i];
+    if (elm)
+      printf("%3d", i), showSymExpr(elm);
     else
       printf("%3d  <null>\n", i);
   }
@@ -1152,6 +1224,30 @@ void set_view(std::set<BlockStmt*>& bss) {
   while (it != bss.end()) {
     debugSummary(*(it++));
   }
+}
+
+//
+// typesWithName: print all TypeSymbols with the given name
+//
+
+void typesWithName(const char* name) {
+  typesWithName(name, gTypeSymbols);
+}
+
+void typesWithName(const char* name, Vec<TypeSymbol*>& tyVec) {
+  printf("typesWithName(\"%s\")\n", name);
+  int count = 0, countNonNull = 0;
+  forv_Vec(TypeSymbol, ty, tyVec) {
+    if (ty) {
+      countNonNull++;
+      if (!strcmp(ty->name, name)) {
+        count++;
+        printf("  sym %8d   %s %d  %s\n", ty->id, ty->type->astTagAsString(),
+               ty->type->id, debugLoc(ty));
+      }
+    }
+  }
+  printf("  = %d type(s) of %d\n", count, countNonNull);
 }
 
 //

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -36,11 +36,8 @@ Expr*    aidExpr(int id);
 BaseAST* aid(BaseAST* ast);
 Expr*    aidExpr(BaseAST* ast);
 
-void        list_view_noline(const BaseAST* ast);
-void        nprint_view(BaseAST* ast);
-
-// defined in codegen/codegen.cpp
-void        nprint_view(GenRet& gen);
+bool inTree(BaseAST* ast);
+bool inTree(int id);
 
 // These are not used by the compiler but are available for use in GDB
 //
@@ -55,57 +52,67 @@ void        nprint_view(GenRet& gen);
 //    viewFlags
 //    stringLoc
 
-void        print_view(BaseAST* ast);
-void        print_view_noline(BaseAST* ast);
+void print_view(BaseAST* ast);
+void print_view_noline(BaseAST* ast);
 
-void        iprint_view(int id);
+void iprint_view(int id);
 
-void        nprint_view(int id);
-void        nprint_view_noline(BaseAST* ast);
+void nprint_view(int id);
+void nprint_view(BaseAST* ast);
+void nprint_view(GenRet& gen); // defined in codegen/codegen.cpp
+void nprint_view_noline(BaseAST* ast);
 
-void        mark_view(BaseAST* ast, int id);
+void mark_view(BaseAST* ast, int id);
 
-void        list_view(int id);
-void        list_view(const BaseAST* ast);
+void list_view(int id);
+void list_view(const BaseAST* ast);
+void list_view_noline(const BaseAST* ast);
 
-void        astDump_view(int id);
-void        astDump_view(BaseAST* ast);
-void        astDumpToNode_view(int id);
-void        astDumpToNode_view(BaseAST* ast);
+void astDump_view(int id);
+void astDump_view(BaseAST* ast);
+void astDumpToNode_view(int id);
+void astDumpToNode_view(BaseAST* ast);
 
-void        viewFlags(int id);
+void viewFlags(int id);
 
-void        map_view(SymbolMap* map);
-void        map_view(SymbolMap& map);
+void map_view(SymbolMap* map);
+void map_view(SymbolMap& map);
 
-void        set_view(std::set<BlockStmt*>* bss);
-void        set_view(std::set<BlockStmt*>& bss);
+void set_view(std::set<BlockStmt*>* bss);
+void set_view(std::set<BlockStmt*>& bss);
 
-void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>* v);
-void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>& v);
-void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>* v);
-void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>& v);
-void        vec_view(Vec<BlockStmt*, VEC_INTEGRAL_SIZE>* v);
-void        vec_view(Vec<BlockStmt*, VEC_INTEGRAL_SIZE>& v);
-void        vec_view(Vec<ResolutionCandidate*, VEC_INTEGRAL_SIZE>* v);
-void        vec_view(Vec<ResolutionCandidate*, VEC_INTEGRAL_SIZE>& v);
-void        vec_view(std::vector<Symbol*>* syms);
-void        vec_view(std::vector<Symbol*>& syms);
-void        vec_view(std::vector<FnSymbol*>* syms);
-void        vec_view(std::vector<FnSymbol*>& syms);
-void        vec_view(std::vector<BlockStmt*>* v);
-void        vec_view(std::vector<BlockStmt*>& v);
+void vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>* v);
+void vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>& v);
+void vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>* v);
+void vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>& v);
+void vec_view(Vec<SymExpr*,  VEC_INTEGRAL_SIZE>* v);
+void vec_view(Vec<SymExpr*,  VEC_INTEGRAL_SIZE>& v);
+void vec_view(Vec<BlockStmt*, VEC_INTEGRAL_SIZE>* v);
+void vec_view(Vec<BlockStmt*, VEC_INTEGRAL_SIZE>& v);
+void vec_view(Vec<ResolutionCandidate*, VEC_INTEGRAL_SIZE>* v);
+void vec_view(Vec<ResolutionCandidate*, VEC_INTEGRAL_SIZE>& v);
+void vec_view(std::vector<Symbol*>* syms);
+void vec_view(std::vector<Symbol*>& syms);
+void vec_view(std::vector<FnSymbol*>* syms);
+void vec_view(std::vector<FnSymbol*>& syms);
+void vec_view(std::vector<SymExpr*>* syms);
+void vec_view(std::vector<SymExpr*>& syms);
+void vec_view(std::vector<BlockStmt*>* v);
+void vec_view(std::vector<BlockStmt*>& v);
 
-void        fnsWithName(const char* name);
-void        fnsWithName(const char* name, Vec<FnSymbol*>& fnVec);
+void typesWithName(const char* name);
+void typesWithName(const char* name, Vec<TypeSymbol*>& tyVec);
 
-void        whocalls(int id);
-void        whocalls(BaseAST* ast);
+void fnsWithName(const char* name);
+void fnsWithName(const char* name, Vec<FnSymbol*>& fnVec);
 
-FnSymbol*   debugGetTheIteratorFn(int id);
-FnSymbol*   debugGetTheIteratorFn(BaseAST* ast);
-FnSymbol*   debugGetTheIteratorFn(Type* type);
-FnSymbol*   debugGetTheIteratorFn(ForLoop* forLoop);
+void whocalls(int id);
+void whocalls(BaseAST* ast);
+
+FnSymbol* debugGetTheIteratorFn(int id);
+FnSymbol* debugGetTheIteratorFn(BaseAST* ast);
+FnSymbol* debugGetTheIteratorFn(Type* type);
+FnSymbol* debugGetTheIteratorFn(ForLoop* forLoop);
 
 // NB these return the same static buffer
 const char* stringLoc(int id);
@@ -117,17 +124,22 @@ const char* shortLoc(BaseAST* ast);
 const char* debugLoc(int id);
 const char* debugLoc(BaseAST* ast);
 
-int debugID(int id);
-int debugID(BaseAST* ast);
-void debugSummary(int id);
-void debugSummary(BaseAST* ast);
-void debugSummary(const char* str);
+int     debugID(int id);
+int     debugID(BaseAST* ast);
+
+void    debugSummary(int id);
+void    debugSummary(BaseAST* ast);
+void    debugSummary(const char* str);
+void    debugSummary(bool b);
+
 Symbol* debugParentSym(int id);
 Symbol* debugParentSym(BaseAST* ast);
-Expr* debugParentExpr(int id);
-Expr* debugParentExpr(BaseAST* ast);
-void blockSummary(int id);
-void blockSummary(BaseAST* ast);
-void blockSummary(BlockStmt* block, Symbol* sym);
+
+Expr*   debugParentExpr(int id);
+Expr*   debugParentExpr(BaseAST* ast);
+
+void    blockSummary(int id);
+void    blockSummary(BaseAST* ast);
+void    blockSummary(BlockStmt* block, Symbol* sym);
 
 #endif


### PR DESCRIPTION
Adding debugging functions I have found helpful in my work
on constrained generics.

* Improved formatting for constraint datatypes in list_view().

* inTree() standalone function, because the corresponding method does not work in lldb.

* A boolean overload in the debugSummary() family, for convenience.

* vec_view() for vectors of SymExpr.
  Improved printing of FnSymbols.

* Added typesWithName() by analogy to fnsWithName()

Also reformatted some code for readability.
