### PR TITLE
Fix Arkouda release testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -32,6 +32,11 @@ fi
 
 # test against Chapel release (checking our current test/cron directories)
 function test_release() {
+  # Need to use a pre-built test-venv with 1.23 (uses python2 and doesn't build
+  # anymore, so have to use pre-built version)
+  export CHPL_DONT_BUILD_TEST_VENV=yes
+  export CHPL_TEST_VENV_DIR=$CSS_DIR/chapel-python2-test-venv/install/chpl-virtualenv/
+
   export CHPL_TEST_PERF_DESCRIPTION=release
   export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
   currentSha=`git rev-parse HEAD`


### PR DESCRIPTION
`make test-venv` was failing for the Arkouda configs that test with
Chapel 1.23. Chapel 1.23 requires python2 and some upstream support for
getting pip no longer works. To avoid this problem, just use a pre-built
test-venv and don't try to build the bundled one.