### PR TITLE
Remove forgotten debugging code

### DIFF
--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1635,10 +1635,6 @@ static bool handleYieldedArrayElementsInAssignment(CallExpr *call,
 
   INT_ASSERT(call->isNamed("="));
 
-  if (call->id == 203728) {
-    gdbShouldBreakHere();
-  }
-
   if (!forall->optInfo.infoGathered) {
     gatherForallInfo(forall);
   }


### PR DESCRIPTION
I bumped into some debugging code that I left in in
https://github.com/chapel-lang/chapel/pull/16965. This PR removes it.

(I did some grepping to see if I left anything else in, but couldn't see any)
