### PR TITLE
Try to resolve some testing issues on new CS machine

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -24,3 +24,9 @@ if module avail craype- 2>&1 | grep -q craype- ; then
 else
   [ "$1" == y ] && log_info "Expected Cray CS, but does not seem to be one."
 fi
+
+# https://github.com/Cray/chapel-private/issues/1601
+export SLURM_CPU_FREQ_REQ=high
+
+# workaround for https://github.com/Cray/chapel-private/issues/1598
+export CHPL_TEST_TIMEOUT=1000


### PR DESCRIPTION
While we're dealing with the fallout of migrating to a new Cray CS, bump
our test timeout to avoid noisy regression testing. Also tell slurm to
use a high cpu frequency. This was the default on the old system, but
has to be specifically requested now.

Part of https://github.com/Cray/chapel-private/issues/1598
Resolved https://github.com/Cray/chapel-private/issues/1601