### PR TITLE
Refresh of parallel iterators primer

### DIFF
--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -3,121 +3,54 @@
 /*
   Parallel Iterators Primer
    
-  This primer shows how to use parallel iterators in Chapel.
-  Leader-follower iterators are used to implement zippered
-  forall loops in Chapel over data structures or iterators.
-  Standalone parallel iterators are used to implement non-zippered
-  forall loops when they exist, falling back to leader-follower when
-  standalone is not available. 
+  This primer explains how to write parallel iterators in Chapel,
+  which can be used to drive parallel ``forall`` loops.  It assumes
+  that the reader already knows how to define serial iterators in
+  Chapel, as summarized the `iterators`_ primer, for example.
 
-  For a more thorough introduction to leader-follower iterators,
-  refer to our PGAS 2011 paper, `User-Defined Parallel Zippered
-  Iterators in Chapel`_. We expect the parallel iterator interface
-  to change and improve over time, so this should be considered a
-  snapshot of their use in the current implementation.
+  Chapel has two main flavors of parallel iterators: `Standalone`
+  parallel iterators are the simplest form and can be used to define
+  parallelism for a simple forall loop like ``forall i in
+  myIter(...)``.  `Leader-follower` iterators are a more involved form
+  that support zippered forall loops, like ``forall (...,i,...) in
+  zip(..., myIter(...), ...)``.  Note that only defining
+  leader-follower iterators is sufficient for use in a non-zippered
+  forall loop, though often with additional overhead.
+
+  For a more thorough introduction to leader-follower iterators, refer
+  to our PGAS 2011 paper, `User-Defined Parallel Zippered Iterators in
+  Chapel`_. Note that there are known lacks and issues with Chapel's
+  current definition of parallel iterators, and that we anticipate
+  addressing these and improving them over time.  To that end, this
+  primer should be considered a snapshot of their status in the
+  current implementation.
 */
 
 /*
-.. primers-parIters-leader-follower:
-
-Leader-follower
----------------
-*/
-
-// Any zippered forall loop in Chapel will be implemented using
-// leader-follower iterators.  Generally speaking, a forall loop
-// of the following form:
-
-/* .. code-block:: chapel
-
-      forall (a, b, c) in zip(A, B, C) do
-         // ...loop body...
-*/
-
-// is semantically defined such that the first thing being iterated
-// over -- in this case, ``A`` -- is designated the 'leader.'  All things
-// being iterated over are 'followers' (so for this loop, ``A``,
-// ``B``, and ``C`` would be).
-//
-
-/*
-.. primers-parIters-semantics:
-
-Semantics
----------
-*/
-
-// Given such a loop, the compiler will roughly translate it into
-// the following loop structure:
-
-/* .. code-block:: chapel
-
-      for work in A.lead() do   // implemented by inlining the leader
-        for (a, b, c) in zip(A.follow(work), B.follow(work), C.follow(work)) do
-          // ...loop body...
-*/
-
-// where ``.lead()`` and ``.follow()`` represent the leader-follower iterators
-// using a simplified naming scheme.
-//
-// Note that since Chapel's implicitly parallel semantics are defined
-// in terms of zippered iteration, such cases are also implemented using
-// leader-follower iterators.  For example, ``A = B + C;`` will be converted to
-// an equivalent zippered parallel loop and then to the leader-follower idiom
-// shown above. ``foo(A, B, C)`` goes through a similar transformation, where
-// ``foo()`` is defined to take scalar arguments and is promoted in this call.
-
-/*
-.. primers-parIters-roles:
-
-Roles
------
-*/
-
-// At a high level, the role of a leader iterator is to:
-//
-//   a) create the parallel tasks used to implement the forall loop,
-//   b) associate the parallel tasks with specific locales as required/desired.
-//   c) assign work (e.g., iterations) to each parallel task
-//
-// The leader typically creates the parallelism using task parallel
-// features like coforall loops; and it associates tasks with locales
-// using locality features like on-clauses.  The leader specifies work
-// for tasks by having each task it creates yield some representation
-// of the work it owns.
-//
-// The role of the follower iterator is to take as an input argument
-// a chunk of work (as yielded by a leader) and to serially iterate
-// over and yield the elements/values corresponding to those
-// iterations in order.
-
-/*
-.. primers-parIters-count:
-
 Example: count
 --------------
 */
 
-// For this example, we're going to create a simple iterator named
-// ``count`` that will be able to be invoked in for or forall loops.
-// ``count`` will be defined to take an argument ``n`` as input and an
-// optional argument ``low`` (set to 1 by default), and it will yield ``n``
-// integers starting with ``low``.
+// In this primer, we're going to create a simple iterator named
+// ``count`` that will be able to be invoked in either ``for`` or
+// ``forall`` loops.  ``count`` will be defined to take an argument
+// ``n`` as input and an optional argument ``low`` (set to 1 by
+// default), and it will yield ``n`` integers starting with ``low``.
 //
-// We'll use the following config const ``numTasks`` to indicate the degree
-// of parallelism to use in the leader to implement forall loops. By default
-// we've set it to the tasking layer estimate of maximum parallelism on the
-// current locale, but it can be overridden on the executable command-line
-// using the ``--numTasks=<n>`` option.
+// We'll use the following config const ``numTasks`` to indicate the
+// degree of parallelism that count should use in its forall loops.
+// By default, we've set it to the maximum amount of parallelism
+// expected on the current locale, but this can be overridden on the
+// executable command-line using the ``--numTasks=<n>`` option.
 //
 config const numTasks = here.maxTaskPar;
-if (numTasks < 1) then
+if numTasks < 1 then
   halt("numTasks must be a positive integer");
 
 //
-// If compiled with ``verbose`` set to ``true``, the leader and follower will
-// print out some messages indicating what they're doing under the
-// covers.
+// If compiled with ``verbose`` set to ``true``, the parallel
+// iterators in this primer will print indications of what they're
+// doing under the covers.
 //
 config param verbose = false;
 
@@ -131,22 +64,25 @@ config param verbose = false;
 config const probSize = 15;
 var A: [1..probSize] real;
 
+
 //
-// When defining a leader-follower iterator pair, our current
-// implementation requires that you also define a serial iterator
-// of the same name that yields the same type as the follower iterator.
-// In this case, the serial iterator is simple:  We simply yield the
-// integers ``low..low+n-1`` (computed using the count operator, ``#``):
+// To get started, we'll define a traditional serial iterator for
+// ``count``.  In part, this is for purposes of illustration in this
+// primer.  However, it is also a requirement in that Chapel's current
+// implementation of parallel iterators requires there to be a serial
+// overload of the iterator as well, to model the expected signature
+// and yielded type.
 //
 iter count(n: int, low: int=1) {
   for i in low..#n do
     yield i;
 }
 
+
 //
-// Here are some simple loops using this iterator to demonstrate
+// Here are some simple loops using the serial iterator to demonstrate
 // it.  First we iterate over all indices in our problem size to
-// initialize ``A``:
+// initialize array ``A``:
 //
 for i in count(probSize) do
   A[i] = i:real;
@@ -156,7 +92,7 @@ writeln(A);
 writeln();
 
 //
-// Then we override the default value of low in order to negate
+// Then we override the default value of ``low`` in order to negate
 // the "middle" elements of ``A``:
 //
 for i in count(n=probSize/2, low=probSize/4) do
@@ -173,122 +109,9 @@ writeln();
 for (i, a) in zip(count(probSize), A) do
   a = i/10.0;
 
-writeln("After reassigning A using zippering:");
+writeln("After re-assigning A using zippering:");
 writeln(A);
 writeln();
-
-/*
-.. primers-parIters-leader
-
-count: leader
--------------
-*/
-
-// The leader and follower iterators are defined as overloads of the
-// serial version of the iterator, distinguished by an initial
-// param argument of the built-in enumerated type ``iterKind``.  To
-// invoke the leader iterator and differentiate it from the other
-// overloads, the compiler will pass in the value ``iterKind.leader`` to
-// this argument.  The author of the leader iterator should use a
-// ``where`` clause to distinguish this overload from the others.  After
-// this ``tag`` argument, the rest of the argument list should match
-// that of the serial iterator exactly.  For our example, this means
-// providing the same n and low arguments as before.
-//
-// The implementation of this leader iterator is relatively simple and
-// static.  It uses a coforall loop to create a number of tasks equal
-// to the number specified by our ``numTasks`` config const and then has
-// each yield a subset of the total work to perform.
-//
-// We compute the work that a task should yield by calling into the
-// ``computeChunk()`` helper function (defined at the bottom of this file)
-// to compute its subrange of the range ``low..#n`` owned by the task,
-// storing it in a variable called ``myIters.``
-//
-// To be a legal leader iterator, we could simply yield this range as
-// a representation of the work we want the follower to perform.
-// However, to support zippering our leader with follower iterators
-// written by others, we typically take the convention of having
-// iterators over 1D or dense rectangular index spaces yield tuples
-// of ranges shifted to a 0-based coordinate system.  In this way, the
-// leader-follower iterators have a common representation for the
-// work even though each may use its own indexing system.  This
-// permits, for example, arrays of the same size/shape to be zippered
-// together even if they have different domains.
-//
-// To this end, rather than yielding subranges of ``low..#n``, we'll yield
-// subranges of ``0..n-1`` and rely on the follower to shift it back to
-// the original coordinate system.  For this reason, we translate the
-// range by ``-low`` to shift it from low-based coordinates to 0-based
-// coordinates; and then we make a 1-tuple out of it.
-//
-// Note the debugging output inserted into this iterator.  While
-// learning about leader-follower iterators, it's useful to turn
-// this debugging output on by compiling with ``-sverbose=true``
-//
-iter count(param tag: iterKind, n: int, low: int=1)
-  where tag == iterKind.leader {
-
-  if (verbose) then
-    writeln("In count() leader, creating ", numTasks, " tasks");
-
-  coforall tid in 0..#numTasks {
-    const myIters = computeChunk(low..#n, tid, numTasks);
-    const zeroBasedIters = myIters.translate(-low);
-
-    if (verbose) then
-      writeln("task ", tid, " owns ", myIters, " yielded as: ", zeroBasedIters);
-
-    yield (zeroBasedIters,);
-  }
-}
-
-//
-// As mentioned at the outset, this leader is fairly static and
-// simple.  More generally, a leader can introduce tasks more
-// dynamically, partition work between the tasks more dynamically,
-// etc.  See :mod:`DynamicIters` for some more interesting examples
-// of leader iterators, including those that use dynamic partitioning.
-//
-
-/*
-.. primers-parIters-follower
-
-count: follower
----------------
-*/
-
-// The follower is another overload of the same iterator name, this
-// time taking the iterKind.follower param enumeration as its first
-// argument.  The next arguments should match the leader and serial
-// iterators exactly again (so, ``n`` and ``low`` for our example).  The
-// final argument must be called ``followThis`` which represents the data
-// yielded by the leader (in our case, the 1-tuple of ranges).
-//
-// The goal of the follower is to do the iteration specified by the
-// ``followThis`` argument, serially yielding the elements corresponding
-// to those iterations.  In our case, this involves plucking the
-// range back out of the tuple of ranges, and shifting it back to
-// our low-based coordinate system.  We then use a standard for loop
-// to iterate over that range and yield the corresponding indices.
-// Followers, as the name suggests, tend not to be very sophisticated,
-// and simply do what the leader tells them to.
-//
-// As with the leader, this follower has been authored to support
-// debugging output when compiled with ``-sverbose=true``.
-//
-iter count(param tag: iterKind, n: int, low: int=1, followThis)
-       where tag == iterKind.follower && followThis.size == 1 {
-  const (followInds,) = followThis;
-  const lowBasedIters = followInds.translate(low);
-
-  if (verbose) then
-    writeln("Follower received ", followThis, " as work chunk; shifting to ",
-            lowBasedIters);
-
-  for i in lowBasedIters do
-    yield i;
-}
 
 /*
 .. primers-parIters-standalone-parallel
@@ -297,44 +120,67 @@ count: standalone parallel
 --------------------------
 */
 
-// The standalone parallel iterator is another overload of the same name,
-// taking the ``iterKind.standalone`` param enumeration as its first argument.
-// The next arguments again match the serial iterator exactly. This iterator
-// generates parallelism and yields single elements in the low-based
-// coordinate system. The standalone parallel iterator is invoked in
-// forall loops that are not zippered.  Because this iterator will not
-// be zippered with others, it doesn't need to go to the trouble of
-// zero-shifting indices and putting them into a 1-tuple.
+
+// To create a parallel version of ``count``, we will declare a second
+// overload of the iterator with the same signature, but an additional
+// ``param`` argument named ``tag`` of built-in enumerated type
+// ``iterKind`` to distinguish it from the serial version.  The author
+// of a standalone parallel iterator should use a ``where`` clause to
+// distinguish this overload from others.  Specifically, when the
+// Chapel compiler attempts to implement a forall loop like ``forall
+// in in count(...)``, it will attempt to resolve the iterator by
+// passing in ``iterKind.standalone`` as its value, to distinguish it
+// from the serial iterator above.  This argument is what marks this
+// version of the iterator as a parallel iterator.  After this ``tag``
+// argument, the rest of the argument list should match that of the
+// serial iterator exactly.  For the ``count()`` example, this means
+// providing the same ``n`` and ``low`` arguments as before.
 //
-// This iterator has also been authored to include debugging output when
-// compiled with ``-sverbose=true``.
+// Unlike serial iterators, parallel iterators are allowed to contain
+// ``yield`` statements within parallel constructs like ``coforall``,
+// ``cobegin``, and ``forall``.  In our implementation of the
+// standalone parallel version of ``count`` here, we use a
+// ``coforall`` loop to define ``numTasks`` tasks and then divide the
+// iteration space up amongst them.  Specifically, each task calls
+// into a helper routine defined at the bottom of this file,
+// ``computeChunk()`` that computes its sub-range of the values to be
+// counted as a function of its task ID (``tid``) and the total number
+// of tasks (``numTasks``).  The iterator also contains debugging
+// output which can be enabled by compiling with ``-sverbose=true``.
 //
 iter count(param tag: iterKind, n: int, low: int = 1)
        where tag == iterKind.standalone {
-  if (verbose) then
-    writeln("In count() standalone, creating ", numTasks, " tasks");
+  if verbose then
+    writeln("Standalone parallel count() is creating ", numTasks, " tasks");
+
   coforall tid in 0..#numTasks {
     const myIters = computeChunk(low..#n, tid, numTasks);
-    if (verbose) then
+
+    if verbose then
       writeln("task ", tid, " owns ", myIters);
+
     for i in myIters do
       yield i;
   }
 }
 
-/*
-.. primers-parIters-usage
+// Though not shown in this example, standalone parallel iterators may
+// also target multiple locales using features like ``on`` statements
+// or distributed arrays.
 
-count: usage
-------------
+/*
+.. primers-parIters-standalone-usage
+
+Standalone parallel count(): usage
+----------------------------------
 */
 
-// Now that we've defined leader-follower and standalone iterators, we can
-// execute the same loops we did before, only this time using forall loops
-// to make the execution parallel.  We start with some simple invocations
-// as before.  In these invocations, the ``count()`` standalone parallel
-// iterator is used since it is the only thing being iterated over (``A`` is
-// being randomly accessed within the loop.)
+// Having defined a standalone parallel iterator, we can execute the
+// same loops as before, but using forall loops to make the execution
+// parallel.  We start with some simple invocations as before.  In
+// these invocations, the ``count()`` standalone parallel iterator is
+// used since it is the only thing being iterated over (``A`` is being
+// randomly accessed within the loop.)
 //
 forall i in count(probSize) do
   A[i] = i:real;
@@ -353,23 +199,214 @@ writeln("After negating the middle of A in parallel:");
 writeln(A);
 writeln();
 
+
+/*
+.. primers-parIters-leader-follower:
+
+Leader-follower iterators
+-------------------------
+*/
+
+// The parallel iterators for zippered forall loops are necessarily
+// more involved since each iterand expression may have its own
+// preferred way of doing parallel iteration, yet its yielded values
+// must be combined with the other iterands in a way that generates a
+// coherent result tuple.  To deal with this challenge, given a
+// forall loop of the form:
+
+/* .. code-block:: chapel
+
+      forall (a, b, c) in zip(A, B, C) do
+         // ...loop body...
+*/
+
+// Chapel's definition designates the first iterand -- in this case,
+// ``A`` -- as the 'leader'.  In addition, all iterands in the
+// zippering are considered 'followers' (so for this loop, ``A``,
+// ``B``, and ``C`` would be).
 //
-// Zippered iteration is now a bit more interesting.  In this
-// first loop, ``count()`` serves as the leader and follower while
-// the ``A`` array is a follower.  This works because ``A`` is a
-// rectangular array whose follower iterator accepts tuples of
-// 0-based ranges like the ones ``count()``'s leader is yielding.
-// If we were to have ``count()`` yield something else (like a raw
-// subrange of ``low..#n``), then the two things could not be
-// zippered correctly because they wouldn't be speaking the
-// same language -- either in terms of the type of work being
-// yielded (range vs. 1-tuple of range), nor the description of
-// the work (low-based indices vs. 0-based indices).
+
+// Given such a loop, the compiler will roughly translate it into
+// the following loop structure:
+
+/* .. code-block:: chapel
+
+      for work in A.lead() do   // implemented by inlining the leader
+        for (a, b, c) in zip(A.follow(work), B.follow(work), C.follow(work)) do
+          // ...loop body...
+*/
+
+// where ``.lead()`` and ``.follow()`` represent the leader-follower
+// iterators using a simplified naming scheme.
+//
+// Note that since Chapel's implicitly parallel features are defined
+// in terms of zippered iteration, they are also implemented using
+// leader-follower iterators.  For example, ``A = B + C;`` will be
+// converted to an equivalent zippered parallel loop and then to the
+// leader-follower idiom shown above. ``foo(A, B, C)`` goes through a
+// similar transformation, where ``foo()`` is defined to take scalar
+// arguments and is promoted in this call.  In both cases, ``A``
+// serves as the leader and ``A``, ``B``, and ``C`` are all followers.
+
+/*
+.. primers-parIters-roles:
+
+Leader-follower Roles
+---------------------
+*/
+
+// At a high level, the role of a leader iterator is to:
+//
+//   a) create the parallel tasks used to implement the forall loop,
+//   b) associate the parallel tasks with specific locales as required/desired.
+//   c) assign work (e.g., iterations) to each parallel task
+//
+// The leader typically creates the parallelism using task parallel
+// features like coforall loops; and it associates tasks with locales
+// using locality features like on-clauses.  The leader specifies work
+// for tasks by having each task it creates yield some representation
+// of the work it owns.
+//
+// The role of the follower iterator is to take as an input argument
+// a chunk of work (as yielded by a leader) and to serially iterate
+// over and yield the elements/values corresponding to those
+// iterations in order.
+//
+// Let's consider how these roles might play out for our ``count()``
+// iterator:
+
+
+/*
+.. primers-parIters-leader
+
+count: leader
+-------------
+*/
+
+// As with the standalone parallel iterator, leader and follower
+// iterators are defined as overloads of the serial version of the
+// iterator, once again distinguished by an initial
+// ``param`` argument of type ``iterKind``.  To
+// invoke the leader iterator and differentiate it from the other
+// overloads, the compiler will pass in the value ``iterKind.leader`` to
+// this argument.  The author of the leader iterator should use a
+// ``where`` clause to distinguish this overload from the others.  As
+// with the standalone iterator, the rest of the argument list should
+// match that of the serial iterator exactly.
+//
+// The implementation of our ``count()`` leader iterator is relatively
+// similar to the standalone case.  It again uses a coforall loop to
+// create a number of tasks equal to the number specified by our
+// ``numTasks`` configuration constant.  However, rather than iterating
+// over and yielding the values owned by each task, it will instead
+// yield a version of the range itself as a means of telling the follower
+// iterators what to do.
+//
+// To be a legal leader iterator, we could simply have each task yield
+// its range as the representation of the work we want the follower to
+// perform.  However, to support zippering our leader with follower
+// iterators written by others, we typically take the convention of
+// having iterators over 1D or dense rectangular index spaces yield
+// tuples of ranges shifted to a 0-based coordinate system.  In this
+// way, the leader-follower iterators have a common representation for
+// the work even though each may use its own indexing system.  This
+// permits, for example, arrays of the same size/shape to be zippered
+// together even if they have different indices.
+//
+// For this reason, rather than yielding subranges of ``low..#n``,
+// we'll yield subranges of ``0..n-1`` and rely on the follower to
+// shift the values back to their preferred coordinate system.  As
+// a result, we translate each task's range by ``-low`` to shift it
+// from ``low``-based coordinates to 0-based coordinates; and then we
+// make a 1-tuple out of it.
+//
+// Note the debugging output inserted into this iterator.  While
+// learning about leader-follower iterators, it's useful to turn
+// this debugging output on by compiling with ``-sverbose=true``
+//
+iter count(param tag: iterKind, n: int, low: int=1)
+  where tag == iterKind.leader {
+
+  if verbose then
+    writeln("In count() leader, creating ", numTasks, " tasks");
+
+  coforall tid in 0..#numTasks {
+    const myIters = computeChunk(low..#n, tid, numTasks);
+    const zeroBasedIters = myIters.translate(-low);
+
+    if verbose then
+      writeln("task ", tid, " owns ", myIters, " yielded as: ", zeroBasedIters);
+
+    yield (zeroBasedIters,); // yield a 1-tuple of our sub-range
+  }
+}
+
+//
+// As mentioned at the outset, this leader is fairly static and
+// simple.  More generally, a leader can introduce tasks more
+// dynamically, partition work between the tasks more dynamically,
+// etc.  See :mod:`DynamicIters` for some more interesting examples of
+// leader iterators, including those that use dynamic partitioning.
+//
+
+/*
+.. primers-parIters-follower
+
+count: follower
+---------------
+*/
+
+// The follower is another overload of the same iterator name, this
+// time taking the ``iterKind.follower`` param enumeration as its
+// first argument.  The subsequent arguments should match the leader
+// and serial iterators exactly again (so, ``n`` and ``low`` for our
+// example).  The final argument must be called ``followThis`` which
+// represents the data yielded by the leader (in our case, the 1-tuple
+// of 0-based ranges).
+//
+// The goal of the follower is to do the iteration specified by the
+// ``followThis`` argument, serially yielding the elements
+// corresponding to those iterations.  In our case, this involves
+// plucking the range back out of the 1-tuple of ranges, and shifting
+// it back to our ``low``-based coordinate system.  We then use a
+// standard for-loop to iterate over that range and yield the
+// corresponding indices.  Followers, as the name suggests, tend not
+// to be very sophisticated, and simply do what the leader tells them
+// to.
+//
+// As with the leader, this follower has been authored to support
+// debugging output when compiled with ``-sverbose=true``.
+//
+iter count(param tag: iterKind, n: int, low: int=1, followThis)
+       where tag == iterKind.follower && followThis.size == 1 {
+  const (followInds,) = followThis;
+  const lowBasedIters = followInds.translate(low);
+
+  if (verbose) then
+    writeln("Follower received ", followThis, " as work chunk; shifting to ",
+            lowBasedIters);
+
+  for i in lowBasedIters do
+    yield i;
+}
+
+//
+// Now let's use our leader/follower iterators.  In the following
+// loop, ``count()`` serves as the leader and follower while the ``A``
+// array is just a follower.  This works because ``A`` is a
+// rectangular array whose follower iterator also accepts tuples of
+// 0-based ranges like the ones ``count()``'s leader is yielding.  If
+// we were to have ``count()`` yield something else (like a raw
+// subrange of ``low..#n``), then the two things could not be zippered
+// correctly because they wouldn't be speaking the same language --
+// either in terms of the type of work being yielded (range
+// vs. 1-tuple of range), nor the description of the work
+// (``low``-based indices vs. 0-based indices).
 //
 forall (i, a) in zip(count(probSize), A) do
   a = i/10.0;
 
-writeln("After reassigning A using parallel zippering:");
+writeln("After re-assigning A using parallel zippering:");
 writeln(A);
 writeln();
 
@@ -380,12 +417,12 @@ writeln();
 // ``A``'s leader iterator (defined as part of its domain map) is invoked.
 // For standard Chapel arrays and domain maps, these leader-follower
 // iterators are controlled by the ``dataPar*`` configuration constants
-// as described in doc/rst/usingchapel/executing.rst.
+// described in doc/rst/usingchapel/executing.rst.
 //
 forall (a, i) in zip(A, count(probSize)) do
   a = i/100.0;
 
-writeln("After reassigning A using parallel zippering and A as the leader:");
+writeln("After re-assigning A using parallel zippering and A as the leader:");
 writeln(A);
 writeln();
 
@@ -397,7 +434,7 @@ writeln();
 //
 A = count(probSize, low=100);
 
-writeln("After reassigning A using whole-array assignment:");
+writeln("After re-assigning A using whole-array assignment:");
 writeln(A);
 writeln();
 
@@ -408,15 +445,17 @@ Closing notes
 -------------
 */
 
-// Chapel data types like records and classes can support iteration
-// by defining iterator methods (invoked by name) or ``these()`` iterators
-// which support iterating over variables of that type directly.  Such
-// iterator methods can be overloaded to support leader-follower
-// versions as well to permit parallel iteration over the variable.
+// Chapel data types like records and classes can support iteration by
+// defining iterator methods (invoked by name) or ``these()``
+// iterators which support iterating over variables of that type
+// directly.  Such iterator methods can be overloaded to support
+// standalone and/or leader-follower versions to support parallel
+// iteration over the variable.
 //
 // As mentioned at the outset, our leader-follower scheme has a number
 // of changes planned for it such as interface improvements and better
-// error checking.  We'll update this primer as we improve these features.
+// error checking.  We'll update this primer over time as we improve
+// these features.
 //
 // **Definition of helper function used above:**
 //

--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -4,10 +4,11 @@
   This primer explains how to write parallel iterators in Chapel,
   which can be used to drive parallel ``forall`` loops.  It assumes
   that the reader already knows how to define serial iterators in
-  Chapel, as summarized in the iterators primer, for example.
+  Chapel, as summarized in the :ref:`iterators primer (iterators.chpl)
+  <primers-iterators>` for example.
 
   Chapel has two main flavors of parallel iterators: `Standalone`
-  parallel iterators are the simplest form and can be used to define
+  parallel iterators are the simpler form and can be used to define
   parallelism for a simple forall loop like ``forall i in
   myIter(...)``.  `Leader-follower` iterators are a more involved form
   that support zippered forall loops, like ``forall (...,i,...) in
@@ -257,7 +258,7 @@ Leader-follower Roles
 // At a high level, the role of a leader iterator is to:
 //
 //   a) create the parallel tasks used to implement the forall loop,
-//   b) associate the parallel tasks with specific locales as required/desired.
+//   b) associate the tasks with specific locales, if desired,
 //   c) assign work (e.g., iterations) to each parallel task
 //
 // The leader typically creates the parallelism using task parallel

--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -418,31 +418,33 @@ Closing notes
 // of changes planned for it such as interface improvements and better
 // error checking.  We'll update this primer as we improve these features.
 //
-// Definitions of functions used above:
+// **Definition of helper function used above:**
 //
-// This is an optimal partitioning algorithm for unweighted problem.
-// The absolute difference between the size of ranges assigned to any two
-// tasks is atmost 1 (either 0 or 1). If the value of remainder ``rem`` is
-// equal to 0, then each of the tasks would be assigned with ``elemsPerChunk``,
-// equal to ``floor(numElements/NumChunks)`` work items. But if the ``rem`` is
-// not equal to 0, then the first rem tasks(from task id 0 to rem-1) get
-// (``elemsPerChunk``+ 1) work items and the rest of the tasks(for task id rem
-// to ``numTasks``-1) get ``elemsPerChunk`` tasks assigned. For simplicity it
-// only works for default index type ranges.  More work would be required
-// to generalize it for strided or unbounded ranges.
+// The following utility function partitions a range into
+// ``numChunks`` sub-ranges and returns a range representing the
+// indices for sub-range ``myChunk`` (counting from 0).  The absolute
+// difference between the size of the ranges returned is at most 1
+// (either 0 or 1). If the value of remainder ``rem`` is equal to 0,
+// then each sub-range contains ``elemsPerChunk`` indices, equal to
+// ``floor(numElements/numChunks)`` work items. But if ``rem`` is not
+// equal to 0, then the first ``rem`` sub-ranges get
+// (``elemsPerChunk+ 1``) indices and the rest (chunks ``rem`` to
+// ``numChunks-1``) get ``elemsPerChunk`` indices. For simplicity, this
+// routine works only for unstrided ranges with the default index type
+// of ``int``.  These contraints could be relaxed with more effort.
 // 
 proc computeChunk(r: range, myChunk, numChunks) where r.stridable == false {
   const numElems = r.size;
-  const elemsperChunk= numElems/numChunks;
-  const rem= numElems%numChunks;
-  var mylow= r.low;
-  if(myChunk<rem){
-    mylow+=(elemsperChunk+1)*myChunk;
+  const elemsperChunk = numElems/numChunks;
+  const rem = numElems%numChunks;
+  var mylow = r.low;
+  if myChunk < rem {
+    mylow += (elemsperChunk+1)*myChunk;
     return mylow..#(elemsperChunk + 1);
-  } else{
-    mylow+=((elemsperChunk+1)*rem + (elemsperChunk)*(myChunk-rem));
+  } else {
+    mylow += ((elemsperChunk+1)*rem + (elemsperChunk)*(myChunk-rem));
     return mylow..#elemsperChunk;
   }
 }
 
-// .. _User-Defined Parallel Zippered Iterators in Chapel: http://pgas11.rice.edu/papers/ChamberlainEtAl-Chapel-Iterators-PGAS11.pdf 
+// .. _User-Defined Parallel Zippered Iterators in Chapel: http://pgas11.rice.edu/papers/ChamberlainEtAl-Chapel-Iterators-PGAS11.pdf

--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -1,12 +1,10 @@
 // Parallel Iterators
 
 /*
-  Parallel Iterators Primer
-   
   This primer explains how to write parallel iterators in Chapel,
   which can be used to drive parallel ``forall`` loops.  It assumes
   that the reader already knows how to define serial iterators in
-  Chapel, as summarized the `iterators`_ primer, for example.
+  Chapel, as summarized in the iterators primer, for example.
 
   Chapel has two main flavors of parallel iterators: `Standalone`
   parallel iterators are the simplest form and can be used to define
@@ -27,8 +25,8 @@
 */
 
 /*
-Example: count
---------------
+Motivating Example: a `count` iterator
+--------------------------------------
 */
 
 // In this primer, we're going to create a simple iterator named
@@ -38,10 +36,11 @@ Example: count
 // default), and it will yield ``n`` integers starting with ``low``.
 //
 // We'll use the following config const ``numTasks`` to indicate the
-// degree of parallelism that count should use in its forall loops.
-// By default, we've set it to the maximum amount of parallelism
-// expected on the current locale, but this can be overridden on the
-// executable command-line using the ``--numTasks=<n>`` option.
+// degree of parallelism that ``count()`` should use in its forall
+// loops.  By default, we've set it to the maximum amount of
+// parallelism expected on the current locale, but this can be
+// overridden on the executable command-line using the
+// ``--numTasks=<n>`` option.
 //
 config const numTasks = here.maxTaskPar;
 if numTasks < 1 then
@@ -50,14 +49,14 @@ if numTasks < 1 then
 //
 // If compiled with ``verbose`` set to ``true``, the parallel
 // iterators in this primer will print indications of what they're
-// doing under the covers.
+// doing under the surface.
 //
 config param verbose = false;
 
 //
-// Declare a problem size for this test.  By default we use a small
-// problem size to make the output readable.  Of course, to use the
-// parallelism effectively you'd want to use a much larger problem
+// Next, we declare a problem size for this test.  By default we use a
+// small problem size to make the output readable.  Of course, to use
+// the parallelism effectively you'd want to use a much larger problem
 // size (override on the execution command-line using the
 // ``--probSize=<n>`` option).
 //
@@ -68,7 +67,7 @@ var A: [1..probSize] real;
 //
 // To get started, we'll define a traditional serial iterator for
 // ``count``.  In part, this is for purposes of illustration in this
-// primer.  However, it is also a requirement in that Chapel's current
+// primer.  However, it is also a necessity in that Chapel's current
 // implementation of parallel iterators requires there to be a serial
 // overload of the iterator as well, to model the expected signature
 // and yielded type.
@@ -116,25 +115,26 @@ writeln();
 /*
 .. primers-parIters-standalone-parallel
 
-count: standalone parallel
---------------------------
+A standalone parallel `count` iterator
+--------------------------------------
 */
 
 
 // To create a parallel version of ``count``, we will declare a second
 // overload of the iterator with the same signature, but an additional
 // ``param`` argument named ``tag`` of built-in enumerated type
-// ``iterKind`` to distinguish it from the serial version.  The author
-// of a standalone parallel iterator should use a ``where`` clause to
-// distinguish this overload from others.  Specifically, when the
-// Chapel compiler attempts to implement a forall loop like ``forall
-// in in count(...)``, it will attempt to resolve the iterator by
-// passing in ``iterKind.standalone`` as its value, to distinguish it
-// from the serial iterator above.  This argument is what marks this
-// version of the iterator as a parallel iterator.  After this ``tag``
-// argument, the rest of the argument list should match that of the
-// serial iterator exactly.  For the ``count()`` example, this means
-// providing the same ``n`` and ``low`` arguments as before.
+// ``iterKind``, to distinguish it from the serial version.  The
+// author of a standalone parallel iterator should use a ``where``
+// clause to distinguish this overload from others.  Specifically,
+// when the Chapel compiler attempts to implement a forall loop like
+// ``forall i in count(...)``, it will attempt to resolve the iterator
+// by passing in ``iterKind.standalone`` as its value, to distinguish
+// it from the serial iterator above.  This argument is what marks
+// this version of the iterator as a parallel iterator.  After the
+// ``tag`` argument, the rest of the argument list should exactly
+// match that of the serial iterator.  For the ``count()`` example,
+// this means providing the same ``n`` and ``low`` arguments as
+// before.
 //
 // Unlike serial iterators, parallel iterators are allowed to contain
 // ``yield`` statements within parallel constructs like ``coforall``,
@@ -171,16 +171,15 @@ iter count(param tag: iterKind, n: int, low: int = 1)
 /*
 .. primers-parIters-standalone-usage
 
-Standalone parallel count(): usage
-----------------------------------
+Using the standalone parallel 'count' iterator
+----------------------------------------------
 */
 
 // Having defined a standalone parallel iterator, we can execute the
 // same loops as before, but using forall loops to make the execution
-// parallel.  We start with some simple invocations as before.  In
-// these invocations, the ``count()`` standalone parallel iterator is
-// used since it is the only thing being iterated over (``A`` is being
-// randomly accessed within the loop.)
+// parallel.  Since these forall loops are not using zippered
+// iteration, the standalone version of the ``count()`` iterator is
+// used.
 //
 forall i in count(probSize) do
   A[i] = i:real;

--- a/test/release/examples/primers/parIters.good
+++ b/test/release/examples/primers/parIters.good
@@ -4,7 +4,7 @@ After serial initialization, A is:
 After negating the middle of A:
 1.0 2.0 -3.0 -4.0 -5.0 -6.0 -7.0 -8.0 -9.0 10.0 11.0 12.0 13.0 14.0 15.0
 
-After reassigning A using zippering:
+After re-assigning A using zippering:
 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5
 
 After parallel initialization, A is:
@@ -13,12 +13,12 @@ After parallel initialization, A is:
 After negating the middle of A in parallel:
 1.0 2.0 -3.0 -4.0 -5.0 -6.0 -7.0 -8.0 -9.0 10.0 11.0 12.0 13.0 14.0 15.0
 
-After reassigning A using parallel zippering:
+After re-assigning A using parallel zippering:
 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5
 
-After reassigning A using parallel zippering and A as the leader:
+After re-assigning A using parallel zippering and A as the leader:
 0.01 0.02 0.03 0.04 0.05 0.06 0.07 0.08 0.09 0.1 0.11 0.12 0.13 0.14 0.15
 
-After reassigning A using whole-array assignment:
+After re-assigning A using whole-array assignment:
 100.0 101.0 102.0 103.0 104.0 105.0 106.0 107.0 108.0 109.0 110.0 111.0 112.0 113.0 114.0
 


### PR DESCRIPTION
This PR does a few things with the parallel iterators primer:

* makes some minor style and documentation tweaks to the `computeChunk()` utility routine as a follow on to issue #16890 that felt too nitpicky to bother with during the review process
* takes a full pass over the full parIters primer while here, to define standalone parallel iterators before leader-follower iterators (because they're simpler to understand and arguably a more common case to want to support).

Resolves #6343.
