### PR TITLE
Further bump Cray CS timeouts

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -29,4 +29,4 @@ fi
 export SLURM_CPU_FREQ_REQ=high
 
 # workaround for https://github.com/Cray/chapel-private/issues/1598
-export CHPL_TEST_TIMEOUT=1000
+export CHPL_TEST_TIMEOUT=2000


### PR DESCRIPTION
Bumping to 1000 in #17016 wasn't quite enough so bump to 2000.
