### PR TITLE
Change some Formal Names in Path Module

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -140,7 +140,7 @@ pragma "no doc"
 pragma "last resort"
 proc absPath(name: string): string throws {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return absPath(name:path);
+  return absPath(path=name);
 }
 
 /*
@@ -192,7 +192,7 @@ pragma "no doc"
 pragma "last resort"
 proc basename(name: string): string {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return basename(name:path);
+  return basename(path=name);
 }
 
 /* Determines and returns the longest common path prefix of
@@ -365,7 +365,7 @@ pragma "no doc"
 pragma "last resort"
 proc dirname(name: string): string {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return dirname(name:path);
+  return dirname(path=name);
 }
 
 /* Expands any environment variables in the path of the form ``$<name>`` or
@@ -500,7 +500,7 @@ pragma "no doc"
 pragma "last resort"
 proc isAbsPath(name: string): bool {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return isAbsPath(name:path);
+  return isAbsPath(path=name);
 }
 
 /* Build up path components as described in joinPath(). */
@@ -569,7 +569,7 @@ pragma "no doc"
 pragma "last resort"
 private proc normalizeLeadingSlashCount(name: string): int {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return normalizeLeadingSlashCount(name:path);
+  return normalizeLeadingSlashCount(path=name);
 }
 
 /*
@@ -631,7 +631,7 @@ pragma "no doc"
 pragma "last resort"
 proc normPath(name: string): string {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return normPath(name:path);
+  return normPath(path=name);
 }
 
 /* Given a path ``path``, attempts to determine the canonical path referenced.
@@ -662,7 +662,7 @@ pragma "no doc"
 pragma "last resort"
 proc realPath(name: string): string throws {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return realPath(name:path);
+  return realPath(path=name);
 }
 
 
@@ -684,7 +684,7 @@ pragma "no doc"
 pragma "last resort"
 proc realPath(out error: syserr, name: string): string {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return realPath(error,name:path);
+  return realPath(error,path=name);
 }
 
 /* Determines the canonical path referenced by the :type:`~IO.file` record
@@ -799,7 +799,7 @@ pragma "no doc"
 pragma "last resort"
 proc relPath(name: string, start:string=curDir): string throws {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return relPath(name:path,start);
+  return relPath(path=name,start);
 }
 
 /*
@@ -887,11 +887,11 @@ proc file.relPath(start:string=curDir): string throws {
      return ("", path);
    }
  }
-}
 
 pragma "no doc"
 pragma "last resort"
  proc splitPath(name: string): (string, string) {
   compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return splitPath(name:path);
+  return splitPath(path=name);
+ }
 }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -139,7 +139,7 @@ proc absPath(path: string): string throws {
 pragma "no doc"
 pragma "last resort"
 proc absPath(name: string): string throws {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.absPath: Argument 'name' is deprecated - use 'path' instead");
   return absPath(path=name);
 }
 
@@ -191,7 +191,7 @@ proc basename(path: string): string {
 pragma "no doc"
 pragma "last resort"
 proc basename(name: string): string {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.basename: Argument 'name' is deprecated - use 'path' instead");
   return basename(path=name);
 }
 
@@ -364,7 +364,7 @@ proc dirname(path: string): string {
 pragma "no doc"
 pragma "last resort"
 proc dirname(name: string): string {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.dirname: Argument 'name' is deprecated - use 'path' instead");
   return dirname(path=name);
 }
 
@@ -499,7 +499,7 @@ proc isAbsPath(path: string): bool {
 pragma "no doc"
 pragma "last resort"
 proc isAbsPath(name: string): bool {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.isAbsPath: Argument 'name' is deprecated - use 'path' instead");
   return isAbsPath(path=name);
 }
 
@@ -568,7 +568,7 @@ private proc normalizeLeadingSlashCount(path: string): int {
 pragma "no doc"
 pragma "last resort"
 private proc normalizeLeadingSlashCount(name: string): int {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.normalizeLeadingSlashCount: Argument 'name' is deprecated - use 'path' instead");
   return normalizeLeadingSlashCount(path=name);
 }
 
@@ -630,7 +630,7 @@ proc normPath(path: string): string {
 pragma "no doc"
 pragma "last resort"
 proc normPath(name: string): string {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.normPath: Argument 'name' is deprecated - use 'path' instead");
   return normPath(path=name);
 }
 
@@ -661,30 +661,8 @@ proc realPath(path: string): string throws {
 pragma "no doc"
 pragma "last resort"
 proc realPath(name: string): string throws {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.realPath: Argument 'name' is deprecated - use 'path' instead");
   return realPath(path=name);
-}
-
-
-pragma "no doc"
-proc realPath(out error: syserr, path: string): string {
-  compilerWarning("This version of realPath() is deprecated; " +
-                  "please switch to a throwing version");
-  try {
-    return realPath(path);
-  } catch e: SystemError {
-    error = e.err;
-  } catch {
-    error = EINVAL;
-  }
-  return "";
-}
-
-pragma "no doc"
-pragma "last resort"
-proc realPath(out error: syserr, name: string): string {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
-  return realPath(error,path=name);
 }
 
 /* Determines the canonical path referenced by the :type:`~IO.file` record
@@ -798,7 +776,7 @@ proc relPath(path: string, start:string=curDir): string throws {
 pragma "no doc"
 pragma "last resort"
 proc relPath(name: string, start:string=curDir): string throws {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.relPath: Argument 'name' is deprecated - use 'path' instead");
   return relPath(path=name,start);
 }
 
@@ -891,7 +869,7 @@ proc file.relPath(start:string=curDir): string throws {
 pragma "no doc"
 pragma "last resort"
  proc splitPath(name: string): (string, string) {
-  compilerWarning('Argument `name` is deprecated - use `path` instead');
+  compilerWarning("Path.splitPath: Argument 'name' is deprecated - use 'path' instead");
   return splitPath(path=name);
  }
 }

--- a/test/deprecated/formalNameChange.chpl
+++ b/test/deprecated/formalNameChange.chpl
@@ -1,0 +1,15 @@
+use Path;
+use SysBasic;
+
+var path = "/";
+var error:syserr;
+
+absPath(name=path);
+basename(name=path);
+dirname(name=path);
+isAbsPath(name=path);
+normPath(name=path);
+realPath(name=path);
+realPath(error,name=path);
+relPath(name=path);
+splitPath(name=path);

--- a/test/deprecated/formalNameChange.chpl
+++ b/test/deprecated/formalNameChange.chpl
@@ -1,8 +1,6 @@
 use Path;
-use SysBasic;
 
 var path = "/";
-var error:syserr;
 
 absPath(name=path);
 basename(name=path);
@@ -10,6 +8,5 @@ dirname(name=path);
 isAbsPath(name=path);
 normPath(name=path);
 realPath(name=path);
-realPath(error,name=path);
 relPath(name=path);
 splitPath(name=path);

--- a/test/deprecated/formalNameChange.good
+++ b/test/deprecated/formalNameChange.good
@@ -1,11 +1,8 @@
-formalNameChange.chpl:7: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:8: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:9: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:10: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:11: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:12: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:13: warning: Argument `name` is deprecated - use `path` instead
-$CHPL_HOME/modules/standard/Path.chpl:685: In function 'realPath':
-$CHPL_HOME/modules/standard/Path.chpl:687: warning: This version of realPath() is deprecated; please switch to a throwing version
-formalNameChange.chpl:14: warning: Argument `name` is deprecated - use `path` instead
-formalNameChange.chpl:15: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:5: warning: Path.absPath: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:6: warning: Path.basename: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:7: warning: Path.dirname: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:8: warning: Path.isAbsPath: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:9: warning: Path.normPath: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:10: warning: Path.realPath: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:11: warning: Path.relPath: Argument 'name' is deprecated - use 'path' instead
+formalNameChange.chpl:12: warning: Path.splitPath: Argument 'name' is deprecated - use 'path' instead

--- a/test/deprecated/formalNameChange.good
+++ b/test/deprecated/formalNameChange.good
@@ -1,0 +1,11 @@
+formalNameChange.chpl:7: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:8: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:9: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:10: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:11: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:12: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:13: warning: Argument `name` is deprecated - use `path` instead
+$CHPL_HOME/modules/standard/Path.chpl:685: In function 'realPath':
+$CHPL_HOME/modules/standard/Path.chpl:687: warning: This version of realPath() is deprecated; please switch to a throwing version
+formalNameChange.chpl:14: warning: Argument `name` is deprecated - use `path` instead
+formalNameChange.chpl:15: warning: Argument `name` is deprecated - use `path` instead


### PR DESCRIPTION
The goal of this PR is to make the argument names in the Path module consistent. I have done the following:
-Changed any arguments named 'name' to 'path'
-Deprecated old procs using 'name' argument
-Changed documentation to reflect new argument names
-Created deprecation tests to confirm all deprecated methods are behaving properly

The code is finished and the Path tests are succeeding, I still need to run the paratest before finalizing this PR.