### PR TITLE
Make paratest.chapcs change the working directory to the test directory

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -23,6 +23,7 @@ import os.path
 import sys
 import timeit
 
+os.chdir(os.path.join(os.path.dirname(__file__), '..', '..', 'test'))
 chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 

--- a/util/test/paratest.local
+++ b/util/test/paratest.local
@@ -16,6 +16,7 @@ import sys
 import timeit
 import multiprocessing
 
+os.chdir(os.path.join(os.path.dirname(__file__), '..', '..', 'test'))
 chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 


### PR DESCRIPTION
This makes `paratest.chapcs` `cd` to the `test` directory regardless of the caller's working directory, preventing errors if they are not in the `test` directory.