### PR TITLE
Remove refs to our private libfabric from the built runtime tree.

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -95,9 +95,10 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     # We default to CHPL_LIBFABRIC=system for EX.  We need to point to
     # a libfabric install for the builds.  On EX a module will supply
-    # this but on XC we have to reference our own.
+    # this but on XC we have to reference a private build.
     if ! pkg-config --exists libfabric ; then
-      export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}/cray/css/users/chapelu/libfabric/install/cray-xc/lib/pkgconfig
+      private_libfab_dir=/cray/css/users/chapelu/libfabric/install
+      export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}${private_libfab_dir}/cray-xc/lib/pkgconfig
     fi
 
     # As a general rule, more CPUs --> faster make.
@@ -156,6 +157,17 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
         # NOTE: don't rebuild compiler above (or else problems with switching GCC versions)
         # NOTE: "--target-compiler" values shown above will be discarded by the setenv callback.
+
+        if [ $private_libfab_dir ] ; then
+          # Remove references to our private libfabric directory from
+          # the list* files in the built runtime library subdirs.  Our
+          # private dir won't be present in that environment and we'll
+          # be using the system libfabric module anyway.
+          log_info "Wipe $private_libfab_dir refs in $CHPL_HOME/lib/.../list-*"
+          find $CHPL_HOME/lib/. -type f -name list-\* \
+            | grep '\(list-includes-and-defines\|list-libraries\)$' \
+            | xargs sed --in-place "s= *[^ ]*${private_libfab_dir}/[^ ]*==g"
+        fi
         ;;
     ( * )
         log_info "NO building Chapel component: runtime"


### PR DESCRIPTION
(Duplicate PR #16822 from 1.23-for-EX to master.)

(Original PR reviewed by @karlonw.)

Remove references to our private libfabric directory from the `list-*`
files in the built runtime library subdirs.  Our private dir won't be
present in that environment and we'll be using the system libfabric
module anyway.

This addresses https://github.com/Cray/chapel-private/issues/1622 but does not fully resolve it.
This addresses https://github.com/Cray/chapel-private/issues/1619 but does not fully resolve it.