### PR TITLE
Bump host gcc version to 10.2.0.

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -326,7 +326,7 @@ else
         list_loaded_modules
     fi
 
-    gen_version_gcc=10.1.0
+    gen_version_gcc=10.2.0
     #[TODO] gen_version_intel=16.0.3.210
     gen_version_cce=10.0.2
 


### PR DESCRIPTION
(Duplicate PR #16833 from 1.23-for-EX to master.)

(Original PR reviewed by @mppf.)

When we build our bundled LLVM, we use the host gcc compiler version to
configure where the clang included therein tries to find gcc-related
libraries to link with eventual user programs.  We've been using gcc
10.1.0 as our host compiler for the EX module builds.  Unfortunately,
gcc 10.1.0 isn't installed on the EX systems.  The earliest gcc on them
is 10.2.0.  As a result, Chapel --llvm compiles get a link-time error
because they can't find certain gcc-related files, notably crtbegin.o
and crtend.o.  This dependence between target and host configurations
seems like a problem, but it's not clear what it will take to fix it.
So here, work around the issue for now by bumping the host gcc version
to 10.2.0, which does exist on the target.  (Note that this version bump
would have been needed if we started building the EX module natively on
EX systems anyway, because again, 10.2.0 is the earliest gcc there.)

This addresses https://github.com/Cray/chapel-private/issues/1622 but does not fully resolve it.
This addresses https://github.com/Cray/chapel-private/issues/1619 but does not fully resolve it.