### PR TITLE
Increase timeout and limit trials for Arkouda CS testing

### DIFF
--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -24,5 +24,9 @@ export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
+# workaround for https://github.com/Cray/chapel-private/issues/1598
+export CHPL_TEST_TIMEOUT=3000
+export CHPL_TEST_NUM_TRIALS=1
+
 test_nightly
 sync_graphs

--- a/util/cron/test-perf.cray-cs.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.release.bash
@@ -27,5 +27,9 @@ export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
+# workaround for https://github.com/Cray/chapel-private/issues/1598
+export CHPL_TEST_TIMEOUT=3000
+export CHPL_TEST_NUM_TRIALS=1
+
 test_release
 sync_graphs


### PR DESCRIPTION
Continuation of #17016/#17021, further bump the timeout for Arkouda, and
limit the number of trials we're doing while we're dealing with fallout
from the new CS.