### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -991,6 +991,8 @@ jacobi:
     - Catch blocks catch owned, test code throws owned (#12090)
   04/23/19:
     - Denormalize the test in CondStmts (#12867)
+  01/26/21:
+    - Automatically aggregate some communication in foralls (#16965)
 
 knucleotide: &knucleotide-base
   10/17/15:
@@ -1365,6 +1367,8 @@ memleaksfull:
     - Add tests and futures looking at I/O on class hierarchies (#16920)
   01/15/21:
     - Fix memory leak for classes/io/classToString (#16949)
+  01/26/21:
+    - Support fixed sized arrays of tuples containing non-nilable classes (#16802)
 # End memleaksfull
 
 meteor:


### PR DESCRIPTION
- Memory leak

https://chapel-lang.org/perf/chapcs/?startdate=2021/01/14&enddate=2021/01/28&graphs=memoryleaksforalltests,numberoftestswithleaks
PR: https://github.com/chapel-lang/chapel/pull/16802

DavidL has a fix.

- Increased emitted code size in jacobi

https://chapel-lang.org/perf/chapcs/?startdate=2020/08/26&enddate=2021/01/28&suite=codesizetracking
PR: https://github.com/chapel-lang/chapel/pull/16965

This is expected because of the new internal module added by that PR. I don't
see any impact on compilation time, though.
