### PR TITLE
Improve locality-based compiler optimizations

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -27,12 +27,6 @@
 
 ForallOptimizationInfo::ForallOptimizationInfo():
   infoGathered(false),
-  iterSym(NULL),
-  dotDomIterExpr(NULL),
-  dotDomIterSym(NULL),
-  dotDomIterSymDom(NULL),
-  iterCall(NULL),
-  iterCallTmp(NULL),
   autoLocalAccessChecked(false),
   hasAlignedFollowers(false),
   cloneType(NOT_CLONE)

--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -34,7 +34,7 @@ ForallOptimizationInfo::ForallOptimizationInfo():
   iterCall(NULL),
   iterCallTmp(NULL),
   autoLocalAccessChecked(false),
-  confirmedFastFollower(false),
+  hasAlignedFollowers(false),
   cloneType(NOT_CLONE)
 {
 }
@@ -70,7 +70,7 @@ ForallStmt::ForallStmt(BlockStmt* body):
 
 
   optInfo.autoLocalAccessChecked = false;
-  optInfo.confirmedFastFollower = false;
+  optInfo.hasAlignedFollowers = false;
 
   gForallStmts.add(this);
 }

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -973,7 +973,7 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
       leadForLoop->insertAtTail("'move'(%S, chpl__staticFastFollowCheckZip(%S))", T1, iterRec);
 
       // override the dynamic check if the compiler can prove it's safe
-      if (pfs->optInfo.confirmedFastFollower) {
+      if (pfs->optInfo.hasAlignedFollowers) {
         leadForLoop->insertAtTail(new_Expr("'move'(%S, %S)", T2, T1));
       }
       else {

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -58,7 +58,7 @@ class ForallOptimizationInfo {
     std::vector<Symbol *> staticCheckSymsForDynamicCandidates;
 
     bool autoLocalAccessChecked;
-    bool confirmedFastFollower;
+    bool hasAlignedFollowers;
 
     ForallAutoLocalAccessCloneType cloneType;
 

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -34,20 +34,20 @@ class ForallOptimizationInfo {
   public:
     bool infoGathered;
 
-    Symbol *iterSym;
-    Expr *dotDomIterExpr;
-    Symbol *dotDomIterSym;
-    Symbol *dotDomIterSymDom;
+    std::vector<Symbol *> iterSym;
+    std::vector<Expr *> dotDomIterExpr;
+    std::vector<Symbol *> dotDomIterSym;
+    std::vector<Symbol *> dotDomIterSymDom;
 
-    CallExpr *iterCall;  // refers to the original CallExpr
-    Symbol *iterCallTmp; // this is the symbol to use for checks
+    std::vector<CallExpr *> iterCall;  // refers to the original CallExpr
+    std::vector<Symbol *> iterCallTmp; // this is the symbol to use for checks
 
     // even if there are multiple indices we store them in a vector
-    std::vector<Symbol *> multiDIndices;
+    std::vector<std::vector<Symbol *>> multiDIndices;
 
     // calls in the loop that are candidates for optimization
-    std::vector<CallExpr *> staticCandidates;
-    std::vector<CallExpr *> dynamicCandidates;
+    std::vector<std::pair<CallExpr *, int>> staticCandidates;
+    std::vector<std::pair<CallExpr *, int>> dynamicCandidates;
 
     // the static check control symbol added for symbol
     std::map<Symbol *, Symbol *> staticCheckSymForSymMap;

--- a/compiler/include/forallOptimizations.h
+++ b/compiler/include/forallOptimizations.h
@@ -54,6 +54,7 @@ class AggregationCandidateInfo {
     AggregationCandidateInfo(CallExpr *candidate, ForallStmt *forall);
 
     void addAggregators();
+    void removeSideEffectsFromPrimitive();
     void transformCandidate();
 };
 

--- a/compiler/include/forallOptimizations.h
+++ b/compiler/include/forallOptimizations.h
@@ -66,6 +66,9 @@ Expr *preFoldMaybeLocalThis(CallExpr *call);
 Expr *preFoldMaybeLocalArrElem(CallExpr *call);
 Expr *preFoldMaybeAggregateAssign(CallExpr *call);
 
+// interface for lowerForalls
+void removeAggregationFromRecursiveForall(ForallStmt *forall);
+
 // interface for licm
 void transformConditionalAggregation(CondStmt *cond);
 void cleanupRemainingAggCondStmts();

--- a/compiler/include/forallOptimizations.h
+++ b/compiler/include/forallOptimizations.h
@@ -43,7 +43,7 @@ class AggregationCandidateInfo {
     LocalityInfo rhsLocalityInfo;
 
     CallExpr *lhsLogicalChild;
-    CallExpr *rhsLogicalChild;
+    Expr *rhsLogicalChild;
 
     // during normalize, we may generate aggregators for both sides of the
     // assignment. However, after resolve we can have at most one aggregator per

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -64,6 +64,7 @@ bool outlivesBlock(LifetimeInformation* info, Symbol* sym, BlockStmt* block);
 
 void checkLifetimesForForallUnorderedOps(FnSymbol* fn,
                                          LifetimeInformation* lifetimeInfo);
+std::vector<Expr *> getLastStmtsForForallUnorderedOps(ForallStmt *forall);
 void optimizeForallUnorderedOps();
 
 void liveVariableAnalysis(FnSymbol* fn,

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1543,17 +1543,11 @@ static CallExpr *getAggGenCallForChild(Expr *child, bool srcAggregation) {
         return new CallExpr(aggFnName, new SymExpr(arrSymExpr->symbol()));
       }
     }
-    else {
-      if (SymExpr *arrSymExpr = toSymExpr(childCall->baseExpr)) {
-        return new CallExpr(aggFnName, new SymExpr(arrSymExpr->symbol()));
-      }
+    else if (SymExpr *arrSymExpr = toSymExpr(childCall->baseExpr)) {
+      return new CallExpr(aggFnName, new SymExpr(arrSymExpr->symbol()));
     }
   }
-  else if (SymExpr *childSymExpr = toSymExpr(child)) {
-    const char *aggFnName = srcAggregation ? "chpl_srcAggregatorForLiteral" :
-                                             "chpl_dstAggregatorForLiteral";
-    return new CallExpr(aggFnName, new SymExpr(childSymExpr->symbol()));
-  }
+
   return NULL;
 }
 

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1594,7 +1594,8 @@ static bool assignmentSuitableForAggregation(CallExpr *call, ForallStmt *forall)
       }
     }
     else if (SymExpr *rightSymExpr = toSymExpr(call->get(2)))  {
-      if (rightSymExpr->symbol()->isImmediate()) {
+      if (rightSymExpr->symbol()->isImmediate() ||
+          rightSymExpr->symbol()->isParameter()) {
         if (!leftCall->isPrimitive(PRIM_MAYBE_LOCAL_THIS)) {
           return getCallBaseSymIfSuitable(leftCall, forall,
                                           /*checkArgs=*/false,

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1441,7 +1441,7 @@ static void autoAggregation(ForallStmt *forall) {
 
   for_vector(Expr, lastStmt, lastStmts) {
     if (CallExpr *lastCall = toCallExpr(lastStmt)) {
-      if (lastCall->isNamed("=")) {
+      if (lastCall->isNamedAstr(astrSassign)) {
         // no need to do anything if it is array access
         if (assignmentSuitableForAggregation(lastCall, forall)) {
           LOG_AA(1, "Found an aggregation candidate", lastCall);
@@ -1502,7 +1502,7 @@ static CondStmt *createAggCond(CallExpr *noOptAssign, Symbol *aggregator, SymExp
 }
 
 // PRIM_MAYBE_LOCAL_ARR_ELEM has a 2nd argument that is a copy of the expression
-// that we iterare. We add it there when we create the primitive, so that we can
+// that we iterate. We add it there when we create the primitive, so that we can
 // generate some checks outside the forall. However, keeping that expression
 // inside the forall body can have bunch of side effects. In some cases we
 // remove it when we use it, but we can also leave some untouched. This
@@ -1751,7 +1751,7 @@ void AggregationCandidateInfo::transformCandidate() {
   repl->insertAtTail(this->srcAggregator ? this->srcAggregator : gNil);
 
   // add bool flags that denote whether one side of the assignment is local.
-  // This is happening before normalization, so the only way we can now whether
+  // This is happening before normalization, so the only way we can know whether
   // something is local at this point is if that thing is a literal. And that
   // can only happen on RHS. However, I am checking for both sides for
   // completeness

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -2032,6 +2032,7 @@ static void findAndUpdateMaybeAggAssign(CallExpr *call, bool confirmed) {
   }
 }
 
+// the logic here is applicable for lowerForalls
 static void removeAggregationFromBlock(BlockStmt *block) {
   for_alist(stmt, block->body) {
     if (CondStmt *condStmt = toCondStmt(stmt)) {

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1478,19 +1478,28 @@ static CondStmt *createAggCond(CallExpr *noOptAssign, Symbol *aggregator, SymExp
   return aggCond;
 }
 
-
+// PRIM_MAYBE_LOCAL_ARR_ELEM has a 2nd argument that is a copy of the expression
+// that we iterare. We add it there when we create the primitive, so that we can
+// generate some checks outside the forall. However, keeping that expression
+// inside the forall body can have bunch of side effects. In some cases we
+// remove it when we use it, but we can also leave some untouched. This
+// function removes that argument if the primitive still has 3 arguments
 void AggregationCandidateInfo::removeSideEffectsFromPrimitive() {
   INT_ASSERT(this->candidate->isNamed("="));
 
   if (CallExpr *childCall = toCallExpr(this->candidate->get(1))) {
     if (childCall->isPrimitive(PRIM_MAYBE_LOCAL_ARR_ELEM)) {
-      childCall->get(2)->remove();
+      if (childCall->numActuals() == 3) {
+        childCall->get(2)->remove();
+      }
     }
   }
 
   if (CallExpr *childCall = toCallExpr(this->candidate->get(2))) {
     if (childCall->isPrimitive(PRIM_MAYBE_LOCAL_ARR_ELEM)) {
-      childCall->get(2)->remove();
+      if (childCall->numActuals() == 3) {
+        childCall->get(2)->remove();
+      }
     }
   }
 

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1806,18 +1806,19 @@ static bool handleYieldedArrayElementsInAssignment(CallExpr *call,
     }
   }
 
-  // stop if neither can be an array element symbol
-  if (!lhsMaybeArrSym && !rhsMaybeArrSym) return false;
-
-  // just to be sure, stop if someone's doing `a=a`;
-  if (lhsMaybeArrSym && rhsMaybeArrSym) return false;
-
-
   // For now, limit maybeArrExpr to be only SymExprs, I think we can relax that
   if (SymExpr *maybeArrExprSE = toSymExpr(maybeArrExpr)) {
     maybeArrSym = maybeArrExprSE->symbol();
   }
 
+  // doesn't look like this is something we can recognize
+  if (maybeArrSym == NULL) return false;
+
+  // stop if neither can be an array element symbol
+  if (!lhsMaybeArrSym && !rhsMaybeArrSym) return false;
+
+  // just to be sure, stop if someone's doing `a=a`;
+  if (lhsMaybeArrSym && rhsMaybeArrSym) return false;
 
   Expr *otherChild = lhsMaybeArrSym ? call->get(2) : call->get(1);
 

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1686,9 +1686,8 @@ Expr *preFoldMaybeAggregateAssign(CallExpr *call) {
 
   Expr *replacement = NULL;
 
-  if (lhsLocal || rhsLocal) {
-    INT_ASSERT(lhsLocal != rhsLocal);
-
+  // either side is local, but not both
+  if (lhsLocal != rhsLocal) {
     Symbol *aggregator = NULL;
 
     std::stringstream message;

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -806,7 +806,11 @@ static Symbol *getCallBaseSymIfSuitable(CallExpr *call, ForallStmt *forall,
       if (parentCall->isPrimitive(PRIM_NEW)) { return NULL; } 
     }
 
-    // give up if the access uses a different symbol
+    // don't analyze further if the call base is a yielded symbol
+    if (accBaseSym->hasFlag(FLAG_INDEX_VAR)) { return NULL; }
+
+    // give up if the access uses a different symbol than the symbols yielded by
+    // one of the iterators
     if (checkArgs) {
       int idx = -1;
       bool found = false;

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -333,6 +333,11 @@ void cleanupRemainingAggCondStmts() {
                 lhsSym->defPoint->remove();
                 deinitCall->remove();
               }
+              else if (parentCall->resolvedFunction()->hasFlag(FLAG_AUTO_DESTROY_FN)) {
+                // we bump into this case when inlining is disabled, we only
+                // need to remove the call
+                parentCall->remove();
+              }
               else {
                 INT_FATAL("Auto-aggregator is in an unexpected expression");
               }

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -759,39 +759,6 @@ static void gatherForallInfo(ForallStmt *forall) {
   forall->optInfo.infoGathered = true;
 }
 
-//static int isSymbolInDotDomIterSym(Symbol *sym, ForallStmt *forall) {
-  //int idx = 1;
-  //for_vector_allowing_0s(Symbol, tmp, forall->optInfo.dotDomIterSym) {
-    //if (tmp == sym) {
-      //return idx;
-    //}
-    //idx++;
-  //}
-  //return -1;
-//}
-
-//static int isSymbolInDotDomIterSymDom(Symbol *sym, ForallStmt *forall) {
-  //int idx = 1;
-  //for_vector_allowing_0s(Symbol, tmp, forall->optInfo.dotDomIterSymDom) {
-    //if (tmp == sym) {
-      //return idx;
-    //}
-    //idx++;
-  //}
-  //return -1;
-//}
-
-//static int isSymbolInIterSym(Symbol *sym, ForallStmt *forall) {
-  //int idx = 1;
-  //for_vector_allowing_0s(Symbol, tmp, forall->optInfo.iterSym) {
-    //if (tmp == sym) {
-      //return idx;
-    //}
-    //idx++;
-  //}
-  //return -1;
-//}
-
 static bool loopHasValidInductionVariables(ForallStmt *forall) {
   // if we understand the induction variables, then we can still take a look at
   // the loop body for some calls that we can optimize dynamically
@@ -1432,7 +1399,6 @@ static void autoAggregation(ForallStmt *forall) {
   if (CallExpr *lastCall = toCallExpr(forall->loopBody()->body.last())) {
 
     if (lastCall->isNamed("=")) {
-      if (strcmp(lastCall->fname(), "/Users/ekayraklio/code/chapel/versions/f01/chapel/test/optimizations/autoAggregation/arrElemFromAlignedFollower.chpl") == 0) { gdbShouldBreakHere(); }
       // no need to do anything if it is array access
       if (assignmentSuitableForAggregation(lastCall, forall)) {
         LOG_AA(1, "Found an aggregation candidate", lastCall);
@@ -1811,14 +1777,15 @@ static bool handleYieldedArrayElementsInAssignment(CallExpr *call,
     gatherForallInfo(forall);
   }
 
+  Symbol *maybeArrSym = NULL;
+  Symbol *maybeArrElemSym = NULL;
+  Expr *maybeArrExpr = NULL;
+
   bool lhsMaybeArrSym = false;
   bool rhsMaybeArrSym = false;
 
   SymExpr *lhsSymExpr = toSymExpr(call->get(1));
   SymExpr *rhsSymExpr = toSymExpr(call->get(2));
-
-  Symbol *maybeArrElemSym = NULL;
-  Expr *maybeArrExpr = NULL;
 
   // note that if we hit both inner if's below, that would mean we have
   // something like `a=a`. We check for this case right after and don't continue
@@ -1848,7 +1815,6 @@ static bool handleYieldedArrayElementsInAssignment(CallExpr *call,
 
 
   // For now, limit maybeArrExpr to be only SymExprs, I think we can relax that
-  Symbol *maybeArrSym = NULL;
   if (SymExpr *maybeArrExprSE = toSymExpr(maybeArrExpr)) {
     maybeArrSym = maybeArrExprSE->symbol();
   }

--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -180,7 +180,13 @@ static void helpGetLastStmts(Expr* last, std::vector<Expr*>& stmts) {
   stmts.push_back(last);
 }
 
-
+std::vector<Expr *> getLastStmtsForForallUnorderedOps(ForallStmt *forall) {
+  std::vector<Expr *> lastStmts;
+  for_vector(BlockStmt, block, forall->loopBodies()) {
+    getLastStmts(block, lastStmts);
+  }
+  return lastStmts;
+}
 
 // ---- mark optimizable foralls during lifetime checking
 

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -22,6 +22,7 @@
 #include "AstVisitorTraverse.h"
 #include "CForLoop.h"
 #include "ForLoop.h"
+#include "forallOptimizations.h"
 #include "ForallStmt.h"
 #include "iterator.h"
 #include "passes.h"
@@ -1140,6 +1141,10 @@ static void handleRecursiveIter(ForallStmt* fs,
                                 FnSymbol* parIterFn,  CallExpr* parIterCall)
 {
   SET_LINENO(parIterCall);
+
+  // aggregation uses task-private variables, we can't have them with a
+  // recursive iterator
+  removeAggregationFromRecursiveForall(fs);
 
   // Check for non-ref intents.
   SymbolMap sv2ov;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1005,6 +1005,10 @@ override proc BlockArr.dsiIteratorYieldsLocalElements() param {
   return true;
 }
 
+override proc BlockDom.dsiIteratorYieldsLocalElements() param {
+  return true;
+}
+
 //
 // NOTE: Each locale's myElems array must be initialized prior to
 // setting up the RAD cache.

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -203,6 +203,10 @@ class PrivateArr: BaseRectangularArr {
     // data is deinited in dsiDestroyArr if necessary.
 
   }
+
+  override proc dsiIteratorYieldsLocalElements() param {
+    return true;
+  }
 }
 
 override proc PrivateArr.dsiElementInitializationComplete() {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2275,6 +2275,10 @@ module ChapelArray {
       return _value.dsiSupportsAutoLocalAccess();
     }
 
+    proc iteratorYieldsLocalElements() param {
+      return _value.dsiIteratorYieldsLocalElements();
+    }
+
   }  // record _domain
 
   /* Cast a rectangular domain to a new rectangular domain type.  If the old

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -35,11 +35,6 @@ module ChapelAutoAggregation {
   }
 
   pragma "aggregator generator"
-  proc chpl_srcAggregatorForArr(type t) {
-    return new SrcAggregator(t);
-  }
-
-  pragma "aggregator generator"
   proc chpl_srcAggregatorForArr(arr) {
     return nil;  // return type signals that we shouldn't aggregate
   }
@@ -53,12 +48,6 @@ module ChapelAutoAggregation {
   pragma "aggregator generator"
   proc chpl_dstAggregatorForLiteral(a) {
     return new DstAggregator(a.eltType);
-  }
-
-
-  pragma "aggregator generator"
-  proc chpl_dstAggregatorForArr(type t) {
-    return new DstAggregator(t);
   }
 
   pragma "aggregator generator"

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -28,12 +28,6 @@ module ChapelAutoAggregation {
     return new SrcAggregator(arr.eltType);
   }
 
-  // the compiler will pass a literal as argument
-  pragma "aggregator generator"
-  proc chpl_srcAggregatorForLiteral(a) {
-    return new SrcAggregator(a.eltType);
-  }
-
   pragma "aggregator generator"
   proc chpl_srcAggregatorForArr(arr) {
     return nil;  // return type signals that we shouldn't aggregate
@@ -42,12 +36,6 @@ module ChapelAutoAggregation {
   pragma "aggregator generator"
   proc chpl_dstAggregatorForArr(arr: []) {
     return new DstAggregator(arr.eltType);
-  }
-
-  // the compiler will pass a literal as argument
-  pragma "aggregator generator"
-  proc chpl_dstAggregatorForLiteral(a) {
-    return new DstAggregator(a.eltType);
   }
 
   pragma "aggregator generator"

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -46,7 +46,13 @@ module ChapelAutoAggregation {
 
   pragma "aggregator generator"
   proc chpl_dstAggregatorFor(dom) where isDomain(dom) {
-    return new DstAggregator(dom.eltType); // TODO: this should never be called?
+    // this is only called if the user has:
+    // 
+    // forall i in myDomain { i = foo(); }
+    //
+    // We want that code to fail with proper error message, so we have this
+    // function but return nil from it.
+    return nil;
   }
 
   pragma "aggregator generator"

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -24,30 +24,44 @@ module ChapelAutoAggregation {
   config param verboseAggregation = false;
 
   pragma "aggregator generator"
-  proc chpl_srcAggregatorForArr(arr: []) {
+  proc chpl_srcAggregatorFor(arr: []) {
     return new SrcAggregator(arr.eltType);
   }
 
+  // we can't do dom: domain here, it causes resolution issues
   pragma "aggregator generator"
-  proc chpl_srcAggregatorForArr(arr) {
+  proc chpl_srcAggregatorFor(dom) where isDomain(dom) {
+    return new SrcAggregator(dom.idxType);
+  }
+
+  pragma "aggregator generator"
+  proc chpl_srcAggregatorFor(arr) {
     return nil;  // return type signals that we shouldn't aggregate
   }
 
   pragma "aggregator generator"
-  proc chpl_dstAggregatorForArr(arr: []) {
+  proc chpl_dstAggregatorFor(arr: []) {
     return new DstAggregator(arr.eltType);
   }
 
   pragma "aggregator generator"
-  proc chpl_dstAggregatorForArr(arr) {
+  proc chpl_dstAggregatorFor(dom) where isDomain(dom) {
+    return new DstAggregator(dom.eltType); // TODO: this should never be called?
+  }
+
+  pragma "aggregator generator"
+  proc chpl_dstAggregatorFor(arr) {
     return nil;  // return type signals that we shouldn't aggregate
   }
 
-  proc chpl__arrayIteratorYieldsLocalElements(a) param {
-    if isArray(a) {
-      if !isClass(a.eltType) { // I have no idea if we can do this for wide pointers
-        return a.iteratorYieldsLocalElements();
+  proc chpl__arrayIteratorYieldsLocalElements(x) param {
+    if isArray(x) {
+      if !isClass(x.eltType) { // I have no idea if we can do this for wide pointers
+        return x.iteratorYieldsLocalElements();
       }
+    }
+    else if isDomain(x) {
+      return x.iteratorYieldsLocalElements();
     }
     return false;
   }

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -28,6 +28,12 @@ module ChapelAutoAggregation {
     return new SrcAggregator(arr.eltType);
   }
 
+  // the compiler will pass a literal as argument
+  pragma "aggregator generator"
+  proc chpl_srcAggregatorForLiteral(a) {
+    return new SrcAggregator(a.eltType);
+  }
+
   pragma "aggregator generator"
   proc chpl_srcAggregatorForArr(type t) {
     return new SrcAggregator(t);
@@ -42,6 +48,13 @@ module ChapelAutoAggregation {
   proc chpl_dstAggregatorForArr(arr: []) {
     return new DstAggregator(arr.eltType);
   }
+
+  // the compiler will pass a literal as argument
+  pragma "aggregator generator"
+  proc chpl_dstAggregatorForLiteral(a) {
+    return new DstAggregator(a.eltType);
+  }
+
 
   pragma "aggregator generator"
   proc chpl_dstAggregatorForArr(type t) {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -323,6 +323,10 @@ module ChapelDistribution {
       return false;
     }
 
+    proc dsiIteratorYieldsLocalElements() param {
+      return false;
+    }
+
     proc type isDefaultRectangular() param return false;
     proc isDefaultRectangular() param return false;
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1533,6 +1533,10 @@ module DefaultRectangular {
     iter dsiLocalSubdomains(loc: locale) {
       yield dsiLocalSubdomain(loc);
     }
+
+    override proc dsiIteratorYieldsLocalElements() param {
+      return true;
+    }
   }
 
   pragma "order independent yielding loops"

--- a/test/optimizations/autoAggregation/arrElemFromAlignedFollower.chpl
+++ b/test/optimizations/autoAggregation/arrElemFromAlignedFollower.chpl
@@ -1,0 +1,68 @@
+writeln();
+
+use BlockDist;
+
+var dom = newBlockDom(0..10);
+
+var a: [dom] int, b: [dom] int;
+
+for i in a.domain {
+  a[i] = i;
+}
+
+// we want the follower's index to be recognized as local, and have destination
+// aggregation to fire
+writeln("Loop 1 -- expecting destination aggregation");
+forall (i, elem) in zip(a.domain, a) {
+  b[10-i] = elem;
+}
+writeln("End Loop 1");
+
+writeln(b);
+writeln();
+
+// this is just to make sure that the same optimization is thwarted very early
+// in compilation because the statement not being the last one in the body
+var dummy = 0;
+writeln("Loop 2 -- expecting no aggregation");
+forall (i, elem) in zip(a.domain, a) with (ref dummy) {
+  b[10-i] = elem;
+  dummy = b[10-i];
+}
+writeln("End Loop 2");
+
+writeln(b);
+writeln();
+
+// scatter-like pattern
+var randomIndices = [i in 0..10 by -1] i;
+writeln("Loop 3 -- expecting destination aggregation");
+forall (idx, elem) in zip(dom, a) {
+  b[randomIndices[idx]] = elem;  // expect two confirmations: fast follower, slow follower
+}
+writeln("End Loop 3");
+
+writeln(b);
+writeln();
+
+// gather-like pattern
+writeln("Loop 4 -- expecting source aggregation");
+forall (idx, elem) in zip(dom, a) {
+  elem = b[randomIndices[idx]];  // expect two confirmations: fast follower, slow follower
+}
+writeln("End Loop 4");
+
+writeln(a);
+writeln();
+
+
+// inspired by arkouda -- rhs is local but not leader, lhs is random access
+writeln("Loop 5 -- expecting destination aggregation");
+var otherArr: [dom] int;
+forall (aElem, bElem) in zip(a, b) {
+  otherArr[aElem] = bElem;
+}
+writeln("End Loop 5");
+
+writeln(otherArr);
+writeln();

--- a/test/optimizations/autoAggregation/arrElemFromAlignedFollower.good
+++ b/test/optimizations/autoAggregation/arrElemFromAlignedFollower.good
@@ -1,0 +1,131 @@
+Start analyzing forall for automatic aggregation (arrElemFromAlignedFollower.chpl:16)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:17)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:17)
+End analyzing forall for automatic aggregation (arrElemFromAlignedFollower.chpl:16)
+
+Start analyzing forall for automatic aggregation (arrElemFromAlignedFollower.chpl:28)
+End analyzing forall for automatic aggregation (arrElemFromAlignedFollower.chpl:28)
+
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromAlignedFollower.chpl:40)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:41)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:41)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromAlignedFollower.chpl:40)
+
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromAlignedFollower.chpl:50)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:51)
+|  Potential source aggregation (arrElemFromAlignedFollower.chpl:51)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromAlignedFollower.chpl:50)
+
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromAlignedFollower.chpl:62)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:63)
+|  Potential source aggregation (arrElemFromAlignedFollower.chpl:63)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:63)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromAlignedFollower.chpl:62)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromAlignedFollower.chpl:40)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:41)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:41)
+End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromAlignedFollower.chpl:40)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromAlignedFollower.chpl:40)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:41)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:41)
+End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromAlignedFollower.chpl:40)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromAlignedFollower.chpl:50)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:51)
+|  Potential source aggregation (arrElemFromAlignedFollower.chpl:51)
+End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromAlignedFollower.chpl:50)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromAlignedFollower.chpl:50)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:51)
+|  Potential source aggregation (arrElemFromAlignedFollower.chpl:51)
+End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromAlignedFollower.chpl:50)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromAlignedFollower.chpl:62)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:63)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:63)
+End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromAlignedFollower.chpl:62)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromAlignedFollower.chpl:62)
+| Found an aggregation candidate (arrElemFromAlignedFollower.chpl:63)
+|  Potential destination aggregation (arrElemFromAlignedFollower.chpl:63)
+End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromAlignedFollower.chpl:62)
+
+Aggregation candidate has confirmed local child  (arrElemFromAlignedFollower.chpl:17)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (arrElemFromAlignedFollower.chpl:17)
+Aggregation candidate has confirmed local child  (arrElemFromAlignedFollower.chpl:41)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (arrElemFromAlignedFollower.chpl:41)
+Aggregation candidate has confirmed local child  (arrElemFromAlignedFollower.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation  (arrElemFromAlignedFollower.chpl:51)
+Aggregation candidate has confirmed local child  (arrElemFromAlignedFollower.chpl:63)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (arrElemFromAlignedFollower.chpl:63)
+Replaced assignment with aggregation (arrElemFromAlignedFollower.chpl:17)
+Replaced assignment with aggregation (arrElemFromAlignedFollower.chpl:41)
+Replaced assignment with aggregation (arrElemFromAlignedFollower.chpl:51)
+Replaced assignment with aggregation (arrElemFromAlignedFollower.chpl:63)
+
+Loop 1 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 1
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 2 -- expecting no aggregation
+End Loop 2
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 3 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 3
+0 1 2 3 4 5 6 7 8 9 10
+
+Loop 4 -- expecting source aggregation
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+End Loop 4
+0 1 2 3 4 5 6 7 8 9 10
+
+Loop 5 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 5
+0 1 2 3 4 5 6 7 8 9 10
+

--- a/test/optimizations/autoAggregation/basicSourceAgg.chpl
+++ b/test/optimizations/autoAggregation/basicSourceAgg.chpl
@@ -23,7 +23,7 @@ b = 0;
 writeln("Loop 2");
 forall i in a.domain {
   a[i] = b[10-i];
-  b[10-i] = 5; // should thwart the optimization
+  b[10-i] += 5; // should thwart the optimization
 }
 writeln("End Loop 2");
 

--- a/test/optimizations/autoAggregation/domElemFromAlignedFollower.chpl
+++ b/test/optimizations/autoAggregation/domElemFromAlignedFollower.chpl
@@ -1,0 +1,58 @@
+writeln();
+
+use BlockDist;
+
+var dom = newBlockDom(0..10);
+
+var a: [dom] int, b: [dom] int;
+
+for i in a.domain {
+  a[i] = i;
+}
+
+// we want the follower's index to be recognized as local, and have destination
+// aggregation to fire
+writeln("Loop 1 -- expecting destination aggregation");
+forall (elem, i) in zip(a, a.domain) {
+  b[10-i] = i;
+}
+writeln("End Loop 1");
+
+writeln(b);
+writeln();
+
+// this is just to make sure that the same optimization is thwarted very early
+// in compilation because the statement not being the last one in the body
+var dummy = 0;
+writeln("Loop 2 -- expecting no aggregation");
+forall (elem, i) in zip(a, a.domain) with (ref dummy) {
+  b[10-i] = i;
+  dummy = b[10-i];
+}
+writeln("End Loop 2");
+
+writeln(b);
+writeln();
+
+// scatter-like pattern
+var randomIndices = [i in 0..10 by -1] i;
+writeln("Loop 3 -- expecting destination aggregation");
+forall (elem, idx) in zip(a, dom) {
+  b[randomIndices[elem]] = idx;  // expect two confirmations: fast follower, slow follower
+}
+writeln("End Loop 3");
+
+writeln(b);
+writeln();
+
+
+// inspired by arkouda -- rhs is local but not leader, lhs is random access
+writeln("Loop 4 -- expecting destination aggregation");
+var otherArr: [dom] int;
+forall (aElem, domElem) in zip(a, a.domain) {
+  otherArr[aElem] = domElem;
+}
+writeln("End Loop 4");
+
+writeln(otherArr);
+writeln();

--- a/test/optimizations/autoAggregation/domElemFromAlignedFollower.good
+++ b/test/optimizations/autoAggregation/domElemFromAlignedFollower.good
@@ -1,0 +1,98 @@
+Start analyzing forall for automatic aggregation (domElemFromAlignedFollower.chpl:16)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:17)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:17)
+End analyzing forall for automatic aggregation (domElemFromAlignedFollower.chpl:16)
+
+Start analyzing forall for automatic aggregation (domElemFromAlignedFollower.chpl:28)
+End analyzing forall for automatic aggregation (domElemFromAlignedFollower.chpl:28)
+
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (domElemFromAlignedFollower.chpl:40)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:41)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:41)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (domElemFromAlignedFollower.chpl:40)
+
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (domElemFromAlignedFollower.chpl:52)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:53)
+|  Potential source aggregation (domElemFromAlignedFollower.chpl:53)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:53)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (domElemFromAlignedFollower.chpl:52)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (domElemFromAlignedFollower.chpl:40)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:41)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:41)
+End analyzing forall for automatic aggregation [no ALA clone]  (domElemFromAlignedFollower.chpl:40)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (domElemFromAlignedFollower.chpl:40)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:41)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:41)
+End analyzing forall for automatic aggregation [static only ALA clone]  (domElemFromAlignedFollower.chpl:40)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (domElemFromAlignedFollower.chpl:52)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:53)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:53)
+End analyzing forall for automatic aggregation [no ALA clone]  (domElemFromAlignedFollower.chpl:52)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (domElemFromAlignedFollower.chpl:52)
+| Found an aggregation candidate (domElemFromAlignedFollower.chpl:53)
+|  Potential destination aggregation (domElemFromAlignedFollower.chpl:53)
+End analyzing forall for automatic aggregation [static only ALA clone]  (domElemFromAlignedFollower.chpl:52)
+
+Aggregation candidate has confirmed local child  (domElemFromAlignedFollower.chpl:17)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (domElemFromAlignedFollower.chpl:17)
+Aggregation candidate has confirmed local child  (domElemFromAlignedFollower.chpl:41)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (domElemFromAlignedFollower.chpl:41)
+Aggregation candidate has confirmed local child  (domElemFromAlignedFollower.chpl:53)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (domElemFromAlignedFollower.chpl:53)
+Replaced assignment with aggregation (domElemFromAlignedFollower.chpl:17)
+Replaced assignment with aggregation (domElemFromAlignedFollower.chpl:41)
+Replaced assignment with aggregation (domElemFromAlignedFollower.chpl:53)
+
+Loop 1 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 1
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 2 -- expecting no aggregation
+End Loop 2
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 3 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 3
+0 1 2 3 4 5 6 7 8 9 10
+
+Loop 4 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 4
+0 1 2 3 4 5 6 7 8 9 10
+

--- a/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.bad
+++ b/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.bad
@@ -1,0 +1,23 @@
+Start analyzing forall for automatic aggregation (dynamicallyAlignedFollowers.chpl:11)
+| Found an aggregation candidate (dynamicallyAlignedFollowers.chpl:13)
+|  Potential destination aggregation (dynamicallyAlignedFollowers.chpl:13)
+End analyzing forall for automatic aggregation (dynamicallyAlignedFollowers.chpl:11)
+
+LHS is nonlocal, RHS is local. Will use destination aggregation  (dynamicallyAlignedFollowers.chpl:13)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (dynamicallyAlignedFollowers.chpl:13)
+Replaced assignment with aggregation (dynamicallyAlignedFollowers.chpl:13)
+Replaced assignment with aggregation (dynamicallyAlignedFollowers.chpl:13)
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+1 1 1 1 1 1 1 1 1 1 1
+5 5 5 5 5 5 5 5 5 5 5
+

--- a/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.chpl
+++ b/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.chpl
@@ -1,0 +1,18 @@
+use BlockDist;
+
+var dom = newBlockDom(0..10);
+var a: [dom] int;
+var b: [dom] int;
+var c = newBlockArr(0..10, int);
+
+// as we can not statically say that the iterators are aligned, we never see
+// `a[i]` as local. So we'll aggregate the second assignment, though we
+// shouldn't.
+forall (elem,i) in zip(c, a.domain) {
+  elem = 5;
+  a[i] = 1;
+}
+
+writeln(a);
+writeln(c);
+writeln();

--- a/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.future
+++ b/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.future
@@ -1,0 +1,2 @@
+feature request: do not aggregate for dynamically aligned followers
+https://github.com/Cray/chapel-private/issues/1644

--- a/test/optimizations/autoAggregation/lastStmtIsConditional.chpl
+++ b/test/optimizations/autoAggregation/lastStmtIsConditional.chpl
@@ -1,0 +1,64 @@
+writeln();
+
+use BlockDist;
+
+config var flag = true;
+
+var alwaysTrue = true; // to make sure we run the ifs with no elses
+
+var a = newBlockArr(0..10, int);
+var b = newBlockArr(0..10, int);
+
+for i in b.domain {
+  b[i] = i;
+}
+
+writeln("Loop 1 -- expecting source aggregation");
+forall i in a.domain {
+  if flag {
+    a[i] = b[10-i];
+  }
+  else {
+    a[i] = b[10-i];
+  }
+}
+writeln("End Loop 1");
+
+writeln(a);
+writeln();
+
+writeln("Loop 2 -- expecting source aggregation");
+forall i in a.domain {
+  if flag || alwaysTrue {
+    a[i] = b[10-i];
+  }
+}
+writeln("End Loop 2");
+
+writeln(a);
+writeln();
+
+writeln("Loop 3 -- expecting destination aggregation");
+forall i in a.domain {
+  if flag {
+    b[10-i] = a[i];
+  }
+  else {
+    b[10-i] = a[i];
+  }
+}
+writeln("End Loop 3");
+
+writeln(a);
+writeln();
+
+writeln("Loop 4 -- expecting destination aggregation");
+forall i in a.domain {
+  if flag || alwaysTrue {
+    b[10-i] = a[i];
+  }
+}
+writeln("End Loop 4");
+
+writeln(a);
+writeln();

--- a/test/optimizations/autoAggregation/lastStmtIsConditional.execopts
+++ b/test/optimizations/autoAggregation/lastStmtIsConditional.execopts
@@ -1,0 +1,2 @@
+--flag=true
+--flag=false

--- a/test/optimizations/autoAggregation/lastStmtIsConditional.good
+++ b/test/optimizations/autoAggregation/lastStmtIsConditional.good
@@ -1,0 +1,115 @@
+Start analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:17)
+| Found an aggregation candidate (lastStmtIsConditional.chpl:19)
+|  Potential source aggregation (lastStmtIsConditional.chpl:19)
+| Found an aggregation candidate (lastStmtIsConditional.chpl:22)
+|  Potential source aggregation (lastStmtIsConditional.chpl:22)
+End analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:17)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:31)
+| Found an aggregation candidate (lastStmtIsConditional.chpl:33)
+|  Potential source aggregation (lastStmtIsConditional.chpl:33)
+End analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:31)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:42)
+| Found an aggregation candidate (lastStmtIsConditional.chpl:44)
+|  Potential destination aggregation (lastStmtIsConditional.chpl:44)
+| Found an aggregation candidate (lastStmtIsConditional.chpl:47)
+|  Potential destination aggregation (lastStmtIsConditional.chpl:47)
+End analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:42)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:56)
+| Found an aggregation candidate (lastStmtIsConditional.chpl:58)
+|  Potential destination aggregation (lastStmtIsConditional.chpl:58)
+End analyzing forall for automatic aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:56)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:17)
+End analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:17)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:31)
+End analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:31)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:42)
+End analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:42)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:56)
+End analyzing forall for automatic aggregation [no ALA clone]  (lastStmtIsConditional.chpl:56)
+
+Aggregation candidate has confirmed local child [static only ALA clone] (lastStmtIsConditional.chpl:19)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (lastStmtIsConditional.chpl:19)
+Aggregation candidate has confirmed local child [static only ALA clone] (lastStmtIsConditional.chpl:22)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (lastStmtIsConditional.chpl:22)
+Aggregation candidate has confirmed local child [static only ALA clone] (lastStmtIsConditional.chpl:33)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (lastStmtIsConditional.chpl:33)
+Aggregation candidate has confirmed local child [static only ALA clone] (lastStmtIsConditional.chpl:44)
+LHS is nonlocal, RHS is local. Will use destination aggregation [static only ALA clone] (lastStmtIsConditional.chpl:44)
+Aggregation candidate has confirmed local child [static only ALA clone] (lastStmtIsConditional.chpl:47)
+LHS is nonlocal, RHS is local. Will use destination aggregation [static only ALA clone] (lastStmtIsConditional.chpl:47)
+Aggregation candidate has confirmed local child [static only ALA clone] (lastStmtIsConditional.chpl:58)
+LHS is nonlocal, RHS is local. Will use destination aggregation [static only ALA clone] (lastStmtIsConditional.chpl:58)
+Replaced assignment with aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:19)
+Replaced assignment with aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:22)
+Replaced assignment with aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:33)
+Replaced assignment with aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:44)
+Replaced assignment with aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:47)
+Replaced assignment with aggregation [static only ALA clone]  (lastStmtIsConditional.chpl:58)
+
+Loop 1 -- expecting source aggregation
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+End Loop 1
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 2 -- expecting source aggregation
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+End Loop 2
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 3 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 3
+10 9 8 7 6 5 4 3 2 1 0
+
+Loop 4 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 4
+10 9 8 7 6 5 4 3 2 1 0
+

--- a/test/optimizations/autoAggregation/literalsAreLocal.chpl
+++ b/test/optimizations/autoAggregation/literalsAreLocal.chpl
@@ -1,0 +1,50 @@
+writeln();
+
+use BlockDist;
+
+var dom = newBlockDom(0..10);
+var a: [dom] int;
+var b: [dom] int;
+var c = newBlockArr(0..10, int);
+
+writeln("Loop 1 -- expecting destination aggregation");
+forall i in a.domain {
+  a[10-i] = 1;
+}
+writeln("End Loop 1");
+
+writeln(a);
+writeln();
+
+writeln("Loop 2 -- expecting no aggregation");
+forall i in a.domain {
+  a[i] = 1;
+}
+writeln("End Loop 2");
+
+writeln(a);
+writeln();
+
+// index is comming from an aligned follower
+writeln("Loop 3 -- expecting no aggregation");
+forall (elem,i) in zip(a, a.domain) {
+  elem = 5;
+  a[i] = 1;
+}
+writeln("End Loop 3");
+
+writeln(a);
+writeln();
+
+// index is comming from an aligned follower
+writeln("Loop 4 -- expecting no aggregation");
+forall (elem,i) in zip(b, a.domain) {
+  elem = 5;
+  a[i] = 1;
+}
+writeln("End Loop 4");
+
+writeln(a);
+writeln(b);
+writeln();
+

--- a/test/optimizations/autoAggregation/literalsAreLocal.good
+++ b/test/optimizations/autoAggregation/literalsAreLocal.good
@@ -1,0 +1,60 @@
+Start analyzing forall for automatic aggregation (literalsAreLocal.chpl:11)
+| Found an aggregation candidate (literalsAreLocal.chpl:12)
+|  Potential destination aggregation (literalsAreLocal.chpl:12)
+End analyzing forall for automatic aggregation (literalsAreLocal.chpl:11)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (literalsAreLocal.chpl:20)
+End analyzing forall for automatic aggregation [static only ALA clone]  (literalsAreLocal.chpl:20)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (literalsAreLocal.chpl:30)
+End analyzing forall for automatic aggregation [static only ALA clone]  (literalsAreLocal.chpl:30)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (literalsAreLocal.chpl:41)
+End analyzing forall for automatic aggregation [static only ALA clone]  (literalsAreLocal.chpl:41)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (literalsAreLocal.chpl:20)
+| Found an aggregation candidate (literalsAreLocal.chpl:21)
+|  Potential destination aggregation (literalsAreLocal.chpl:21)
+End analyzing forall for automatic aggregation [no ALA clone]  (literalsAreLocal.chpl:20)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (literalsAreLocal.chpl:30)
+| Found an aggregation candidate (literalsAreLocal.chpl:32)
+|  Potential destination aggregation (literalsAreLocal.chpl:32)
+End analyzing forall for automatic aggregation [no ALA clone]  (literalsAreLocal.chpl:30)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (literalsAreLocal.chpl:41)
+| Found an aggregation candidate (literalsAreLocal.chpl:43)
+|  Potential destination aggregation (literalsAreLocal.chpl:43)
+End analyzing forall for automatic aggregation [no ALA clone]  (literalsAreLocal.chpl:41)
+
+LHS is nonlocal, RHS is local. Will use destination aggregation  (literalsAreLocal.chpl:12)
+Replaced assignment with aggregation (literalsAreLocal.chpl:12)
+
+Loop 1 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 1
+1 1 1 1 1 1 1 1 1 1 1
+
+Loop 2 -- expecting no aggregation
+End Loop 2
+1 1 1 1 1 1 1 1 1 1 1
+
+Loop 3 -- expecting no aggregation
+End Loop 3
+1 1 1 1 1 1 1 1 1 1 1
+
+Loop 4 -- expecting no aggregation
+End Loop 4
+1 1 1 1 1 1 1 1 1 1 1
+5 5 5 5 5 5 5 5 5 5 5
+

--- a/test/optimizations/autoAggregation/paramsAreLocal.chpl
+++ b/test/optimizations/autoAggregation/paramsAreLocal.chpl
@@ -1,0 +1,52 @@
+writeln();
+
+use BlockDist;
+
+param dummy = 1;
+
+var dom = newBlockDom(0..10);
+var a: [dom] int;
+var b: [dom] int;
+var c = newBlockArr(0..10, int);
+
+writeln("Loop 1 -- expecting destination aggregation");
+forall i in a.domain {
+  a[10-i] = dummy;
+}
+writeln("End Loop 1");
+
+writeln(a);
+writeln();
+
+writeln("Loop 2 -- expecting no aggregation");
+forall i in a.domain {
+  a[i] = dummy;
+}
+writeln("End Loop 2");
+
+writeln(a);
+writeln();
+
+// index is comming from an aligned follower
+writeln("Loop 3 -- expecting no aggregation");
+forall (elem,i) in zip(a, a.domain) {
+  elem = 5;
+  a[i] = dummy;
+}
+writeln("End Loop 3");
+
+writeln(a);
+writeln();
+
+// index is comming from an aligned follower
+writeln("Loop 4 -- expecting no aggregation");
+forall (elem,i) in zip(b, a.domain) {
+  elem = 5;
+  a[i] = dummy;
+}
+writeln("End Loop 4");
+
+writeln(a);
+writeln(b);
+writeln();
+

--- a/test/optimizations/autoAggregation/paramsAreLocal.good
+++ b/test/optimizations/autoAggregation/paramsAreLocal.good
@@ -1,0 +1,60 @@
+Start analyzing forall for automatic aggregation (paramsAreLocal.chpl:13)
+| Found an aggregation candidate (paramsAreLocal.chpl:14)
+|  Potential destination aggregation (paramsAreLocal.chpl:14)
+End analyzing forall for automatic aggregation (paramsAreLocal.chpl:13)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (paramsAreLocal.chpl:22)
+End analyzing forall for automatic aggregation [static only ALA clone]  (paramsAreLocal.chpl:22)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (paramsAreLocal.chpl:32)
+End analyzing forall for automatic aggregation [static only ALA clone]  (paramsAreLocal.chpl:32)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (paramsAreLocal.chpl:43)
+End analyzing forall for automatic aggregation [static only ALA clone]  (paramsAreLocal.chpl:43)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (paramsAreLocal.chpl:22)
+| Found an aggregation candidate (paramsAreLocal.chpl:23)
+|  Potential destination aggregation (paramsAreLocal.chpl:23)
+End analyzing forall for automatic aggregation [no ALA clone]  (paramsAreLocal.chpl:22)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (paramsAreLocal.chpl:32)
+| Found an aggregation candidate (paramsAreLocal.chpl:34)
+|  Potential destination aggregation (paramsAreLocal.chpl:34)
+End analyzing forall for automatic aggregation [no ALA clone]  (paramsAreLocal.chpl:32)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (paramsAreLocal.chpl:43)
+| Found an aggregation candidate (paramsAreLocal.chpl:45)
+|  Potential destination aggregation (paramsAreLocal.chpl:45)
+End analyzing forall for automatic aggregation [no ALA clone]  (paramsAreLocal.chpl:43)
+
+LHS is nonlocal, RHS is local. Will use destination aggregation  (paramsAreLocal.chpl:14)
+Replaced assignment with aggregation (paramsAreLocal.chpl:14)
+
+Loop 1 -- expecting destination aggregation
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+End Loop 1
+1 1 1 1 1 1 1 1 1 1 1
+
+Loop 2 -- expecting no aggregation
+End Loop 2
+1 1 1 1 1 1 1 1 1 1 1
+
+Loop 3 -- expecting no aggregation
+End Loop 3
+1 1 1 1 1 1 1 1 1 1 1
+
+Loop 4 -- expecting no aggregation
+End Loop 4
+1 1 1 1 1 1 1 1 1 1 1
+5 5 5 5 5 5 5 5 5 5 5
+

--- a/test/optimizations/autoAggregation/removeAggCondInFastFollowers.chpl
+++ b/test/optimizations/autoAggregation/removeAggCondInFastFollowers.chpl
@@ -1,0 +1,38 @@
+use BlockDist;
+
+class Arr {
+  type t;
+  var d = newBlockDom(1..10);
+  var a: [d] t;
+
+}
+
+// this is a case I bumped into while trying to compile Arkouda. The
+// assignment's LHS doesn't outlive the forall and so we don't optimize. This
+// means we'll need to cleanup the aggregation code we have generated. However,
+// the tricky part is we have fast and slow followers within the same body that
+// are using the same aggregator symbol. So a single aggregator is actually used
+// in two aggregation blocks within the forall body. This was against my
+// assumptions while writing the cleanup code and it triggered an assertion.
+
+// In short, we don't expect this code to use aggregation, but it should compile
+// fine.
+
+proc sliceIndexMsg(): string throws {
+  var slice: range(stridable=true) = 1..10;
+
+  proc sliceHelper(type t) throws {
+      var e = new Arr(int);
+      var a = new Arr(int);
+      ref ea = e.a;
+      ref aa = a.a;
+      forall (elt,j) in zip(aa, slice) {
+        elt =ea[j];
+      }
+      return "Done";
+  }
+    
+  return sliceHelper(int);
+}
+
+writeln(sliceIndexMsg());

--- a/test/optimizations/autoAggregation/removeAggCondInFastFollowers.good
+++ b/test/optimizations/autoAggregation/removeAggCondInFastFollowers.good
@@ -1,0 +1,10 @@
+Start analyzing forall for automatic aggregation (removeAggCondInFastFollowers.chpl:29)
+| Found an aggregation candidate (removeAggCondInFastFollowers.chpl:30)
+|  Potential source aggregation (removeAggCondInFastFollowers.chpl:30)
+End analyzing forall for automatic aggregation (removeAggCondInFastFollowers.chpl:29)
+
+Aggregation candidate has confirmed local child  (removeAggCondInFastFollowers.chpl:30)
+LHS is local, RHS is nonlocal. Will use source aggregation  (removeAggCondInFastFollowers.chpl:30)
+Aggregation candidate has confirmed local child  (removeAggCondInFastFollowers.chpl:30)
+LHS is local, RHS is nonlocal. Will use source aggregation  (removeAggCondInFastFollowers.chpl:30)
+Done

--- a/test/optimizations/autoLocalAccess/alignedFollowers/COMPOPTS
+++ b/test/optimizations/autoLocalAccess/alignedFollowers/COMPOPTS
@@ -1,0 +1,1 @@
+../COMPOPTS

--- a/test/optimizations/autoLocalAccess/alignedFollowers/alignedFollowersBasic.chpl
+++ b/test/optimizations/autoLocalAccess/alignedFollowers/alignedFollowersBasic.chpl
@@ -1,0 +1,35 @@
+use common;
+
+{
+  var D = createDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  
+  forall (elem, i) in zip(A, D) {
+    elem = B[i] + C[i];
+  }
+  writeln(A);
+}
+
+{
+  var D = createDom({1..10});
+
+  var A: [D] real;
+  var B: [D] real;
+  var C: [D] real;
+
+  B = 3;
+  C = 7;
+
+  // this only optimizes `A[i]` can do more static tracing to optimize others
+  forall (elem, i) in zip(A, A.domain) {
+    elem = B[i] + C[i];
+  }
+  writeln(A);
+}

--- a/test/optimizations/autoLocalAccess/alignedFollowers/alignedFollowersBasic.good
+++ b/test/optimizations/autoLocalAccess/alignedFollowers/alignedFollowersBasic.good
@@ -1,0 +1,40 @@
+
+Start analyzing forall (alignedFollowersBasic.chpl:14)
+| Found loop domain (alignedFollowersBasic.chpl:6)
+| Will attempt static and dynamic optimizations (alignedFollowersBasic.chpl:14)
+|
+|  Start analyzing call (alignedFollowersBasic.chpl:15)
+|   Found the domain of the access base (alignedFollowersBasic.chpl:4)
+|   Can optimize: Access base's domain is the iterator (alignedFollowersBasic.chpl:15)
+|  This call is a static optimization candidate (alignedFollowersBasic.chpl:15)
+|
+|  Start analyzing call (alignedFollowersBasic.chpl:15)
+|   Found the domain of the access base (alignedFollowersBasic.chpl:4)
+|   Can optimize: Access base's domain is the iterator (alignedFollowersBasic.chpl:15)
+|  This call is a static optimization candidate (alignedFollowersBasic.chpl:15)
+|
+End analyzing forall (alignedFollowersBasic.chpl:14)
+
+
+Start analyzing forall (alignedFollowersBasic.chpl:31)
+| Found loop domain (alignedFollowersBasic.chpl:23)
+| Will attempt static and dynamic optimizations (alignedFollowersBasic.chpl:31)
+|
+|  Start analyzing call (alignedFollowersBasic.chpl:32)
+|   Found the domain of the access base (alignedFollowersBasic.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (alignedFollowersBasic.chpl:32)
+|  This call is a static optimization candidate (alignedFollowersBasic.chpl:32)
+|
+|  Start analyzing call (alignedFollowersBasic.chpl:32)
+|   Found the domain of the access base (alignedFollowersBasic.chpl:21)
+|   Can optimize: Access base has the same domain as iterator's base (alignedFollowersBasic.chpl:32)
+|  This call is a static optimization candidate (alignedFollowersBasic.chpl:32)
+|
+End analyzing forall (alignedFollowersBasic.chpl:31)
+
+Static check successful. Using localAccess (alignedFollowersBasic.chpl:15)
+Static check successful. Using localAccess (alignedFollowersBasic.chpl:15)
+Static check successful. Using localAccess (alignedFollowersBasic.chpl:32)
+Static check successful. Using localAccess (alignedFollowersBasic.chpl:32)
+10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0
+10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0 10.0

--- a/test/studies/bale/indexgather/ig-variants.compopts
+++ b/test/studies/bale/indexgather/ig-variants.compopts
@@ -1,1 +1,1 @@
---report-optimized-forall-unordered-ops
+--no-auto-aggregation --report-optimized-forall-unordered-ops


### PR DESCRIPTION
This PR improves how we determine something to be local while doing automatic
local access and automatic aggregation optimizations. At a high-level, this PR
currently covers the following cases.

Resolves https://github.com/Cray/chapel-private/issues/1585
Resolves https://github.com/Cray/chapel-private/issues/1625

- Start looking at all iterands in a `zip` for optimization opportunities.
  (While doing that rely on the analysis we make for static fast followers)

  So now `a` is recognized as local in the following loop's body:

  ```chapel
  forall (i,a) in zip(arr.domain, arr) {}
  ```

- While doing the initial analysis, handle the `CondStmt`s as the last statement
  within the loop body properly. Even though the unordered forall optimization
  was able to go into the branches of the `if` in the following snippet, auto
  aggregation wasn't firing. With this PR, auto aggregation uses the same
  infrastructure created for unordered forall to find the last statements
  within a loop body.

  ```chapel
  forall i in a.domain {
    if flag then a[i] = b[indices[i]];
    else         a[i] = b[otherIndices[i]];
  }
  ```

- Recognize literals/params as local for aggregation purposes

  So we can aggregate an assignment like the following if everything else checks
  out:

  ```chapel
  forall (i,a) in zip(arr.domain, arr) { otherArr[a] = 4; }
  ```

This changes increased the coverage of the optimization significantly, and that
uncovered some issues, so this PR includes the following implementation changes
as well:


- `gatherForallInfo` function and `ForallOptimizationInfo` is adjusted to
  analyze and store information for followers and yielded indices from them.

- Similarly, functions that we had to check whether a call is suitable for
  automatic local access have been adjusted to take an `iterandIdx`, which shows
  which iterand yields the same indices as are the ones that are used to access
  the array. So:

  ```chapel
  forall (x,y,z,t) zip(iter1, iter2, iter3, iter4) {
    ... a[y] ...   // this uses the 2nd iterand's elements
    ... b[t] ...   // this uses the 4th iterand's elements
  }
  ```

- `cleanupRemainingAggCondStmts` was being used to remove any aggregation code
  that's still remaining after the unordered forall optimization. This was
  implemented with the assumption that a compiler generated aggregator can be
  used for only one assignment. However, with this change, we are seeing that it
  could be used in two different locations (fast and slow follower bodies) in
  the AST.

  So, this PR adjusts the logic in that function to find suitable CondStmts for
  removal within a function first, then removing any distinct aggregators
  pertaining to those CondStmts.

- Foralls over recursive iterators cannot use task-private variables, but we
  need those for aggregation. So, if we encounter any compiler-generated
  aggregator while lowering foralls, we revert the aggregation inside that loop
  before lowering the forall. Unfortunately, the AST pattern at that point was a
  bit different than we face while we revert aggregation normally. So this PR
  adds new functions to remove aggregation from such foralls.

- During normalize, we now store static and dynamic candidates as `CallExpr *,
  int` pairs, where the `int` denotes the iterand idx for a given candidate.

- Rename `confirmedFastFollower` to `hasAlignedFollowers`, as this flag doesn't
  really guarantee that fast followers will be used.

- Adds `dsiIteratorYieldsAlignedElems` to bunch of domains.

Test:
- [x] gasnet --auto-aggregation
- [x] gasnet
- [x] standard
- [x] gasnet.asan in `release/examples` and `optimizations`
- [x] gasnet.asan --auto-aggregation in `release/examples` and `optimizations`
