### PR TITLE
Fix a test issue with UnrolledLinkedList

### DIFF
--- a/test/library/packages/UnrolledLinkedList/types/testBorrowed.good
+++ b/test/library/packages/UnrolledLinkedList/types/testBorrowed.good
@@ -1,4 +1,4 @@
 $CHPL_HOME/modules/packages/UnrolledLinkedList.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/packages/UnrolledLinkedList.chpl:nnnn: error: unrolledLinkedList element type must be default-initializable
-  ./ListTest.chpl:15: called as unrolledLinkedList.init(type eltType = borrowed T, param parSafe = 0, nodeCapacity: int(64)) from function 'testList'
+  ./ListTest.chpl:15: called as unrolledLinkedList.init(type eltType = borrowed T, param parSafe = false, nodeCapacity: int(64)) from function 'testList'
   testBorrowed.chpl:9: called as testList(type t = borrowed T)


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/16244

One of the tests that got merged with that PR had an older error message in its
good file. I have realized it before merging, but to keep things moving, merged
it anyways. This PR fixes the issue.

`library/packages/UnrolledLinkedList/types/testBorrowed` passes with this.
