### PR TITLE
Retire arrOfTupleOfArr.future

### DIFF
--- a/test/arrays/bugs/arrOfTupleOfArr.bad
+++ b/test/arrays/bugs/arrOfTupleOfArr.bad
@@ -1,2 +1,0 @@
-arrOfTupleOfArr.chpl:2: warning: [domain(1,int(64),false)] 2*[domain(1,int(64),false)] int(64)
-arrOfTupleOfArr.chpl:1: error: default initialization of tuple containing array or domain type not yet implemented

--- a/test/arrays/bugs/arrOfTupleOfArr.future
+++ b/test/arrays/bugs/arrOfTupleOfArr.future
@@ -1,5 +1,0 @@
-bug: arrays of tuples of arrays result in a nil dereference
-
-Not sure why this is, but BenA identified it in issue #7628 which
-I stumbled across this afternoon while looking for zipper-related
-issues.


### PR DESCRIPTION
In #16802, @dlongnecke-cray became my new hero by retiring this
future which was the lynchpin in a number of problems that I was
running into last summer, and also that a user was hitting back
in October 2017.  This resolves issues #7628 and #13149.  Thanks
David!
