### PR TITLE
Replace line referencing "QUICKSTART.rst" with a more general message

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -30,8 +30,8 @@ enable more features, such as distributed memory execution.
 
          tar xzf chapel-1.23.0.tar.gz
 
-   b. Make sure that your shell is in the directory you just created by
-      expanding the source release, for example:
+   b. Make sure that you are in the directory you just created by expanding the
+      source release, for example:
 
       .. code-block:: bash
 

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -30,8 +30,8 @@ enable more features, such as distributed memory execution.
 
          tar xzf chapel-1.23.0.tar.gz
 
-   b. Make sure that your shell is in the directory containing
-      QUICKSTART.rst, for example:
+   b. Make sure that your shell is in the directory you just created by
+      expanding the source release, for example:
 
       .. code-block:: bash
 


### PR DESCRIPTION
This line was from when QUICKSTART.rst lived at the top level of the
repository.  Since then, this file has been moved inside the doc
directory and thus is no longer accurate for the instructions.  It
has confused several new users.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>