### PR TITLE
Fix a bug in detecting `in` formals in follower iterators

### DIFF
--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -33,6 +33,7 @@ void  resolveFunction(FnSymbol* fn, CallExpr* forCall = 0);
 
 bool  isParallelIterator(FnSymbol* fn);
 bool  isLeaderIterator(FnSymbol* fn);
+bool  isFollowerIterator(FnSymbol* fn);
 bool  isStandaloneIterator(FnSymbol* fn);
 
 // If yieldType is not NULL, the type yielded by an iterator will

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -637,6 +637,10 @@ bool isLeaderIterator(FnSymbol* fn) {
   return isIteratorOfType(fn, gLeaderTag);
 }
 
+bool isFollowerIterator(FnSymbol* fn) {
+  return isIteratorOfType(fn, gFollowerTag);
+}
+
 bool isStandaloneIterator(FnSymbol* fn) {
   return isIteratorOfType(fn, gStandaloneTag);
 }

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1520,7 +1520,7 @@ static bool checkAnotherFunctionsFormal(FnSymbol* calleeFn, CallExpr* call,
 
   if (result                                   &&
       propagateNotPOD(actualSym->getValType()) &&
-      ! isLeaderIterator(calleeFn)             )
+      isFollowerIterator(calleeFn)             )
     USR_FATAL_CONT(calleeFn, "follower iterators accepting a non-POD argument by in-intent are not implemented");
 
   return result;


### PR DESCRIPTION
We don't currently support `in` intents for non-POD types in follower iterators.
See https://github.com/chapel-lang/chapel/issues/13299.

A test that I merged yesterday
(`library/packages/UnrolledLinkedList/insert/testInsertRecordLeak.chpl`) failed
hitting that check. It appears the way that that check was implemented sometimes
capture `proc`s, too. This PR fixes that.

Test:
- [x] standard
- [x] gasnet
