### PR TITLE
Retire innerArrComp.future

### DIFF
--- a/test/arrays/bugs/innerArrComp.bad
+++ b/test/arrays/bugs/innerArrComp.bad
@@ -1,8 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:948: internal error: RES-FUN-ION-10069 chpl version 1.23.0 pre-release (881e7d104d)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/arrays/bugs/innerArrComp.future
+++ b/test/arrays/bugs/innerArrComp.future
@@ -1,5 +1,0 @@
-bug: comparison of arrays within an array causes an internal error
-
-     issue: #15833
-
-Doing an array comparison within square brackets causes an internal error listed as an assertion error. Shouldn't result in an error, but should create an array with the result of the operation.


### PR DESCRIPTION
This retires @mcdobe100's innerArrComp.future which was fixed in David Longnecker's
PR #16802.
