### PR TITLE
chpldoc: Don't emit a space after foo.type

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -512,7 +512,7 @@ bool AstToText::handleNormalizedTypeOf(BlockStmt* bs)
           {
             mText  += ": ";
             appendExpr(moveSrc, true);
-            mText  += ".type ";
+            mText  += ".type";
 
             retval =  true;
           }
@@ -1251,7 +1251,7 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
     if (expr->isPrimitive(PRIM_TYPEOF))
     {
       appendExpr(expr->get(1), printingType);
-      mText += ".type ";
+      mText += ".type";
     }
     else if (expr->isPrimitive(PRIM_NEW))
     {

--- a/test/chpldoc/functions/functionArgDefaults.doc.good
+++ b/test/chpldoc/functions/functionArgDefaults.doc.good
@@ -93,7 +93,7 @@ or
 
 .. function:: proc tuple3Default(arg = (x, y, z))
 
-.. function:: proc dotTypeDefault(arg = x.type )
+.. function:: proc dotTypeDefault(arg = x.type)
 
 .. function:: proc dotFieldDefault(arg = c!.aField)
 
@@ -129,15 +129,15 @@ or
 
    .. attribute:: param a: int
 
-   .. attribute:: param b: a.type 
+   .. attribute:: param b: a.type
 
 .. record:: R3
 
    .. attribute:: param a: int
 
-   .. attribute:: param b: a.type 
+   .. attribute:: param b: a.type
 
-   .. attribute:: param c: b.type 
+   .. attribute:: param c: b.type
 
 .. function:: proc R0TypedArgNoDefault(arg: R0)
 

--- a/test/chpldoc/globals/variableDefaultValues.doc.good
+++ b/test/chpldoc/globals/variableDefaultValues.doc.good
@@ -91,7 +91,7 @@ or
 
 .. data:: var tuple3Default = (x, y, z)
 
-.. data:: var dotTypeDefault = x.type 
+.. data:: var dotTypeDefault = x.type
 
 .. data:: var dotFieldDefault = c!.aField
 
@@ -123,15 +123,15 @@ or
 
    .. attribute:: param a: int
 
-   .. attribute:: param b: a.type 
+   .. attribute:: param b: a.type
 
 .. record:: R3
 
    .. attribute:: param a: int
 
-   .. attribute:: param b: a.type 
+   .. attribute:: param b: a.type
 
-   .. attribute:: param c: b.type 
+   .. attribute:: param c: b.type
 
 .. data:: var R0TypedArgNoDefault: R0
 

--- a/test/chpldoc/types/fields/fieldDefaultValues.doc.good
+++ b/test/chpldoc/types/fields/fieldDefaultValues.doc.good
@@ -33,15 +33,15 @@ or
 
    .. attribute:: param a: int
 
-   .. attribute:: param b: a.type 
+   .. attribute:: param b: a.type
 
 .. record:: R3
 
    .. attribute:: param a: int
 
-   .. attribute:: param b: a.type 
+   .. attribute:: param b: a.type
 
-   .. attribute:: param c: b.type 
+   .. attribute:: param c: b.type
 
 .. record:: R
 
@@ -113,7 +113,7 @@ or
 
    .. attribute:: var tuple3Default = (x, y, z)
 
-   .. attribute:: var dotTypeDefault = x.type 
+   .. attribute:: var dotTypeDefault = x.type
 
    .. attribute:: var dotFieldDefault = c!.aField
 


### PR DESCRIPTION
The space results in output like

  .. function:: proc <=>(ref lhs: owned, ref rhs: lhs.type )

and

  .. method:: proc init=(other: heap(this.type .eltType))

Update three .good files.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>