### PR TITLE
Repair and retire chpldoc futures privateClasses, privateTypeAlias

### DIFF
--- a/test/chpldoc/nodoc/privateClasses.doc.bad
+++ b/test/chpldoc/nodoc/privateClasses.doc.bad
@@ -1,1 +1,0 @@
-cat: docs/source/modules/privateClasses.rst: No such file or directory

--- a/test/chpldoc/nodoc/privateClasses.doc.catfiles
+++ b/test/chpldoc/nodoc/privateClasses.doc.catfiles
@@ -1,1 +1,1 @@
-docs/source/modules/privateClasses.rst
+docs/source/modules/privateClasses.doc.rst

--- a/test/chpldoc/nodoc/privateClasses.doc.future
+++ b/test/chpldoc/nodoc/privateClasses.doc.future
@@ -1,5 +1,0 @@
-feature request: private classes, and fields and methods
-
-When private classes are allowed, this test should prove that chpldoc
-ignores them, as it ignores other private symbols.  When private fields and
-methods are allowed, chpldoc should similarly ignore them.

--- a/test/chpldoc/nodoc/privateClasses.doc.good
+++ b/test/chpldoc/nodoc/privateClasses.doc.good
@@ -1,23 +1,23 @@
 .. default-domain:: chpl
 
-.. module:: privateClasses
+.. module:: privateClasses.doc
 
-privateClasses
-==============
+privateClasses.doc
+==================
 **Usage**
 
 .. code-block:: chapel
 
-   use privateClasses;
+   use privateClasses.doc;
 
 
 or
 
 .. code-block:: chapel
 
-   import privateClasses;
+   import privateClasses.doc;
 
-.. class: bar
+.. class:: bar
 
-   ..attribute:: var showMe: bool
+   .. attribute:: var showMe: bool
 

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.bad
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.bad
@@ -1,1 +1,0 @@
-cat: docs/source/modules/privateTypeAlias.rst: No such file or directory

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.catfiles
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.catfiles
@@ -1,1 +1,1 @@
-docs/source/modules/privateTypeAlias.rst
+docs/source/modules/privateTypeAlias.doc.rst

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.future
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.future
@@ -1,4 +1,0 @@
-feature request: private type aliases
-
-When private type aliases are allowed, this test should prove that chpldoc
-ignores them, as it ignores other private symbols.

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.good
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.good
@@ -1,19 +1,19 @@
 .. default-domain:: chpl
 
-.. module:: privateTypeAlias
+.. module:: privateTypeAlias.doc
 
-privateTypeAlias
-================
+privateTypeAlias.doc
+====================
 **Usage**
 
 .. code-block:: chapel
 
-   use privateTypeAlias;
+   use privateTypeAlias.doc;
 
 
 or
 
 .. code-block:: chapel
 
-   import privateTypeAlias;
+   import privateTypeAlias.doc;
 


### PR DESCRIPTION
Update the .catfiles to include the .doc part of the filename.

Update the .good file to include the .doc part of the module name, and
a few bits of formatting to match the actual output.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>