### PR TITLE
Add the missing iterator pragma in the UnrolledLinkedList module

### DIFF
--- a/modules/packages/UnrolledLinkedList.chpl
+++ b/modules/packages/UnrolledLinkedList.chpl
@@ -1108,6 +1108,7 @@ module UnrolledLinkedList {
 
       :yields: A reference to one of the elements contained in this unrolledLinkedList.
     */
+    pragma "order independent yielding loops"
     iter these() ref {
       var cur = _head;
       while cur != nil {


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/16244

The new UnrolledLinkedList module had an iterator without the "order
independent" pragma, that caused --verify failures. This PR adds that.
