### PR TITLE
Unfuturize a test

### DIFF
--- a/test/multilocale/strings/remoteStringCast.bad
+++ b/test/multilocale/strings/remoteStringCast.bad
@@ -1,1 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:2265: error: follower iterators accepting a non-POD argument by in-intent are not implemented

--- a/test/multilocale/strings/remoteStringCast.future
+++ b/test/multilocale/strings/remoteStringCast.future
@@ -1,8 +1,0 @@
-bug: string:string cast within on-clause gives follower error
-
-While this pattern isn't particularly interesting or useful as written
-here, it seems that it ought to be legal, yet it gives an error:
-"follower iterators accepting a non-POD argument by in-intent are not
-implemented".  The pattern is more interesting/useful in the context
-of a generic function where you want to cast an incoming argument to
-'x' regardless of its type and want it to also work with strings.


### PR DESCRIPTION
This future was added in https://github.com/chapel-lang/chapel/pull/13658
The bug is resolved with https://github.com/chapel-lang/chapel/pull/17045

This PR removes `.future` and `.bad` files of the test.
