### PR TITLE
Quiet some slurm spank plugin errors

### DIFF
--- a/util/test/prediff-for-slurm-srun
+++ b/util/test/prediff-for-slurm-srun
@@ -19,6 +19,9 @@ msgs = (
 """,
 """slurmstepd: error: .+ \[[0-9]+] .*
 """,
+"""srun: error: spank: /opt/cray/pe/atp/libAtpSLaunch.so: Plugin file not found
+""",
+
 )
 
 outfname = sys.argv[2]


### PR DESCRIPTION
Quiet some warnings we're seeing from slurm plugins. These should be
fixed on the system soon, but in the meantime get nightly testing quiet
again.