### PR TITLE
Implemented Merge Shuffle

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1186,11 +1186,12 @@ module Random {
         var PCGRandomStreamPrivate_rngs: numGenerators(eltType) * pcg_setseq_64_xsh_rr_32_rng;
         var PCGRandomStreamPrivate_count: int(64) = this.PCGRandomStreamPrivate_count;
         var i = start, j = mid;
-        var k: D.idxType;
+        if(mid > n) then return;
+        var k: int;
         const stride = D.stride;
 
         while true{
-          k = randlc_bounded(D.idxType,
+          k = randlc_bounded(int,
                           PCGRandomStreamPrivate_rngs,
                           seed, PCGRandomStreamPrivate_count,
                           0, 1);
@@ -1207,10 +1208,11 @@ module Random {
         }
 
         while i < n {
-          k = randlc_bounded(D.idxType,
+          k = randlc_bounded(int,
                           PCGRandomStreamPrivate_rngs,
                           seed, PCGRandomStreamPrivate_count,
                           0, (i - start) / stride);
+
           arr[i] <=> arr[start + k * stride];
           i += stride;
         }
@@ -1240,7 +1242,7 @@ module Random {
             var start = it, mid = it + numSize, n = min(hi, it + 2 * numSize - stride) + stride;
             _Merge(arr, start, mid, n);
           }
-          numSize <<= 1;
+          numSize += numSize;
         }
         
       }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1182,10 +1182,10 @@ module Random {
         }
       }
 
-      inline proc _Merge(arr : [?D] ?eltType, start: int, j : int, n : int) {
+      inline proc _Merge(arr: [?D] ?eltType, start: int, mid: int, n: int) {
         var PCGRandomStreamPrivate_rngs: numGenerators(eltType) * pcg_setseq_64_xsh_rr_32_rng;
         var PCGRandomStreamPrivate_count: int(64) = this.PCGRandomStreamPrivate_count;
-        var i = start;
+        var i = start, j = mid;
         var k: D.idxType;
         const stride = D.stride;
 
@@ -1237,8 +1237,8 @@ module Random {
         var numSize = blockSize * stride;
         while (numSize / stride) < size {
           forall it in lo..hi by (2 * numSize) {
-            var start = it, j = it + numSize, n = min(hi, it + 2 * numSize - stride) + stride;
-            _Merge(arr, start, j, n);
+            var start = it, mid = it + numSize, n = min(hi, it + 2 * numSize - stride) + stride;
+            _Merge(arr, start, mid, n);
           }
           numSize <<= 1;
         }

--- a/test/library/standard/Random/performance/shuffle.chpl
+++ b/test/library/standard/Random/performance/shuffle.chpl
@@ -1,0 +1,15 @@
+use Random;
+use Time;
+
+config const correctness = false; // disables output
+config const size = 100000;
+
+var t: Timer;
+
+var data: [1..size] int;
+t.start();
+shuffle(data, seed=10);
+t.stop();
+if !correctness {
+  writeln('Time: ', t.elapsed());
+}


### PR DESCRIPTION
Signed-off-by: Yudhishthira1406 <divyen1406@gmail.com>

In reference to #14388 
This PR introduces the implementation of Merge Shuffle in the Random Module.
Following are some test results on my local machine i5 9thgen(4 cores) on a data of 2^26 real values.
Compiled with `--fast` flag

| shuffle(master) | Merge-shuffle |
| --- | --- |
| 2.35381 | 2.1176 |
| 2.37549 | 2.12351 |
| 2.38759 | 2.13009 |

I think the difference would be much more prominent with a multicore processor.


