### PR TITLE
Disable remote cache for some comm count futures

### DIFF
--- a/test/distributions/privatization/commForDistArrField.compopts
+++ b/test/distributions/privatization/commForDistArrField.compopts
@@ -1,1 +1,1 @@
---no-checks
+--no-checks --no-cache-remote

--- a/test/optimizations/remoteValueForwarding/bharshbarg/constDuringOn.compopts
+++ b/test/optimizations/remoteValueForwarding/bharshbarg/constDuringOn.compopts
@@ -1,0 +1,1 @@
+--no-cache-remote


### PR DESCRIPTION
These futures try to lock in cases where we want zero communication, but
we currently have some. Disable the cache for them to avoid hiding comm.