### PR TITLE
Respect the down domain's support for automatic local access

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -429,7 +429,7 @@ module ArrayViewRankChange {
     }
 
     override proc dsiSupportsAutoLocalAccess() param {
-      return true;
+      return downDomInst!.dsiSupportsAutoLocalAccess();
     }
 
  } // end of class ArrayViewRankChangeDom


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/17009 added support for automatic
local access using rank-change views. However, that support didn't care whether
base domain supported that optimization. This PR fixes that.

Test:
- [x] gasnet `-sdistType=DistType.replicated` in `distributions/robust/arithmetic`
- [x] gasnet in `optimizations`
