### PR TITLE
Use LLVM by default if LLVM is available either as system or bundled

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1255,13 +1255,12 @@ static void setupLLVMCodeGen() {
     } else {
 #ifdef HAVE_LLVM
       const char* chpl_llvm_by_default = getenv("CHPL_LLVM_BY_DEFAULT");
-      if (chpl_llvm_by_default != NULL &&
+      if (chpl_llvm_by_default == NULL ||
           0 != strcmp(chpl_llvm_by_default, "0")) {
-        // LLVM-by-default was requested
+        // LLVM-by-default
         fLlvmCodegen = true;
       } else {
-        // LLVM-by-default not requested
-        // (in the future, this will change to `true`)
+        // No-LLVM-by-default was requested via environment variable
         fLlvmCodegen = false;
       }
 #else

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -53,7 +53,7 @@ $nolocal = 0;
 $verify = 0;
 $retaintree = 0;
 $dist = "";
-$llvm = 0;
+$llvm = 1;
 $memleaks = 0;
 $memleakslog = "";
 $multilocale = 0;
@@ -151,8 +151,8 @@ while (@ARGV) {
         $svnrevopt = "-r " . shift @ARGV;
     } elsif ($flag eq "-cron-recipient") {
         $cronrecipient = shift @ARGV;
-    } elsif ($flag eq "-llvm") {
-        $llvm = 1;
+    } elsif ($flag eq "-no-llvm") {
+        $llvm = 0;
     } elsif ($flag eq "-junit-xml") {
         $junit_xml = 1;
     } elsif ($flag eq "-asserts") {
@@ -696,6 +696,9 @@ if ($nolocal == 1) {
 }
 if ($verify == 1) {
     $testflags = "$testflags -compopts --verify";
+}
+if ($llvm == 0) {
+    $testflags = "$testflags -compopts --no-llvm";
 }
 if ($launchcmd) {
     $testflags = "-launchcmd \"$launchcmd\" $testflags";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -218,6 +218,7 @@ if ($printusage == 1) {
     print "\t-multilocale                   : run multilocale tests only\n";
     print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
     print "\t-no-futures                    : do not run future tests\n";
+    print "\t-no-llvm                       : run tests with --no-llvm\n";
     print "\t-no-local                      : run tests using --no-local\n";
     print "\t-noruntime                     : don't build the runtime or run the tests\n";
     print "\t-notest                        : don't run the tests (check the build only)\n";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -211,7 +211,7 @@ if ($printusage == 1) {
     print "\t-hello                         : run the release/examples/hello.chpl test only\n";
     print "\t-hellos                        : run the release/examples/hello*.chpl tests only\n";
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
-    print "\t-llvm                          : run tests using --llvm\n";
+    print "\t-llvm                          : run tests using llvm backend\n";
     print "\t-mason                         : build mason before running tests\n";
     print "\t-memleaks <log>                : run tests with --memLeaks\n";
     print "\t-memleakslog <log>             : run tests with --memLeaksLog\n";
@@ -696,9 +696,6 @@ if ($nolocal == 1) {
 }
 if ($verify == 1) {
     $testflags = "$testflags -compopts --verify";
-}
-if ($llvm == 1) {
-    $testflags = "$testflags -compopts --llvm";
 }
 if ($launchcmd) {
     $testflags = "-launchcmd \"$launchcmd\" $testflags";


### PR DESCRIPTION
Change the default to be the equivalent of using the --llvm flag if LLVM is
available. The C backend can still be used by either setting
CHPL_LLVM_BY_DEFAULT=0 or using the --no-llvm flag.

Update nightly testing script to stop adding -compopts --llvm for LLVM testing
and to add -no-llvm option that adds -compopts --no-llvm.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>