### PR TITLE
Adjust Chapel XC Lmod/Lua modulefile path.

### DIFF
--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -221,14 +221,17 @@ log_debug "Generate chapel.spec ..."
 (
     if [ "$chpl_platform" = hpe-cray-ex ]; then
         lmod_network=ofi
+        lmod_mpich_compat_ver=8.0
         platform_prefix=/opt/cray
         set_def_subdir=admin-pe/set_default_files
     else
+        lmod_network=aries
+        lmod_mpich_compat_ver=7.0
         platform_prefix=/opt
         set_def_subdir=cray/admin-pe/set_default_files
     fi
     lmod_prefix=/opt/cray/pe/lmod/modulefiles/mpi
-    lmod_suffix=${lmod_network}/1.0/cray-mpich/8.0
+    lmod_suffix=${lmod_network}/1.0/cray-mpich/${lmod_mpich_compat_ver}
     $cwd/process-template.py basename_of_CHPL_HOME="${CHPL_HOME##*/}" \
                              chpl_platform="$chpl_platform" \
                              lmod_prefix="$lmod_prefix" \


### PR DESCRIPTION
In the XC module build, the network component of the modulefile path for
the Chapel Lmod/Lua module was missing and the cray-mpich compatible
version number was wrong.  As a result, the modulefile dir was here:
  /opt/cray/pe/lmod/modulefiles/mpi/gnu/8.0//1.0/cray-mpich/8.0/chapel/
when it should have been here:
  /opt/cray/pe/lmod/modulefiles/mpi/gnu/8.0/aries/1.0/cray-mpich/7.0/chapel/

Correct this.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>