### PR TITLE
Pull in an upstream GASNet patch for a powerpc race fix

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -11,6 +11,15 @@ Any Chapel issues that seem to be related to GASNet should be directed
 to the Chapel team at https://chapel-lang.org/bugs.html.
 
 
+Chapel modifications to GASNet
+==============================
+The modifications that we have made to the official GASNet release are
+as follows:
+
+* Pulled in an upstream fix for an ibv race on powerpc
+   - https://bitbucket.org/berkeleylab/gasnet/commits/47e230a
+
+
 Upgrading GASNet versions
 =========================
 

--- a/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core_sndrcv.c
+++ b/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core_sndrcv.c
@@ -2007,7 +2007,7 @@ static void gasnetc_fh_do_put(gasnetc_sreq_t *sreq GASNETI_THREAD_FARG) {
 }
 
 #define gasnetc_sreq_is_ready(sreq) \
-  gasnetc_atomic_decrement_and_test(&((sreq)->fh_ready), GASNETI_ATOMIC_REL)
+  gasnetc_atomic_decrement_and_test(&((sreq)->fh_ready), GASNETI_ATOMIC_REL|GASNETI_ATOMIC_ACQ)
 
 static void gasnetc_fh_put_cb(void *context, const firehose_request_t *fh_rem, int allLocalHit) {
   gasnetc_sreq_t *sreq = context;


### PR DESCRIPTION
Pull in a patch that fixes an ibv race on powerpc. This pulls in
https://bitbucket.org/berkeleylab/gasnet/commits/47e230a

See https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4173 for more info