### PR TITLE
Avoid using catfiles for lulesh testing

### DIFF
--- a/test/release/examples/benchmarks/lulesh/PRECOMP
+++ b/test/release/examples/benchmarks/lulesh/PRECOMP
@@ -1,2 +1,0 @@
-#!/bin/bash
-rm -f coords.out

--- a/test/release/examples/benchmarks/lulesh/lulesh-noargs.good
+++ b/test/release/examples/benchmarks/lulesh/lulesh-noargs.good
@@ -1,2 +1,1 @@
 ./luleshInit.chpl:25: error: halt reached - you must either set --filename or --elemsPerEdge to run LULESH
-cat: coords.out: No such file or directory

--- a/test/release/examples/benchmarks/lulesh/lulesh.catfiles
+++ b/test/release/examples/benchmarks/lulesh/lulesh.catfiles
@@ -1,1 +1,0 @@
-coords.out

--- a/test/release/examples/benchmarks/lulesh/lulesh.chpl
+++ b/test/release/examples/benchmarks/lulesh/lulesh.chpl
@@ -87,7 +87,8 @@ config const initialEnergy = 3.948746e+7;            // initial energy value
 config const showProgress = false,   // print time and dt values on each step
              debug = false,          // print various debug info
              doTiming = true,        // time the main timestep loop
-             printCoords = true;     // print the final computed coordinates
+             printCoords = true,     // print the final computed coordinates
+             coordsStdout = false;   // print coordinates to stdout or coords.out
 
 
 /* Compile-time constants */
@@ -314,14 +315,12 @@ proc main() {
   use IO;
 
   if printCoords {
-    var outfile = open("coords.out", iomode.cw);
-    var writer = outfile.writer();
+    var writer = if coordsStdout then stdout
+                                 else open("coords.out", iomode.cw).writer();
     var fmtstr = if debug then "%1.9re %1.9er %1.9er\n" 
                           else "%1.4er %1.4er %1.4er\n";
     for i in Nodes do
       writer.writef(fmtstr, x[i], y[i], z[i]);
-    writer.close();
-    outfile.close();
   }
 }
 

--- a/test/release/examples/benchmarks/lulesh/lulesh.cleanfiles
+++ b/test/release/examples/benchmarks/lulesh/lulesh.cleanfiles
@@ -1,1 +1,0 @@
-coords.out

--- a/test/release/examples/benchmarks/lulesh/lulesh.execopts
+++ b/test/release/examples/benchmarks/lulesh/lulesh.execopts
@@ -1,5 +1,5 @@
---doTiming=false                                      # lulesh-noargs.good
---filename=lmeshes/sedov2cube.lmesh --doTiming=false
---elemsPerEdge=2 --doTiming=false
---filename=lmeshes/sedov15oct.lmesh --doTiming=false  # lulesh-sedov15oct.good
---elemsPerEdge=3 --doTiming=false                     # lulesh-3cube.good
+--doTiming=false --coordsStdout=true                                      # lulesh-noargs.good
+--filename=lmeshes/sedov2cube.lmesh --doTiming=false --coordsStdout=true
+--elemsPerEdge=2 --doTiming=false --coordsStdout=true
+--filename=lmeshes/sedov15oct.lmesh --doTiming=false --coordsStdout=true  # lulesh-sedov15oct.good
+--elemsPerEdge=3 --doTiming=false --coordsStdout=true                     # lulesh-3cube.good

--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.catfiles
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.catfiles
@@ -1,1 +1,0 @@
-coords.out

--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.cleanfiles
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.cleanfiles
@@ -1,1 +1,0 @@
-coords.out

--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.execopts
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.execopts
@@ -1,3 +1,3 @@
---filename=lmeshes/sedov15oct.lmesh --doTiming=false
---doTiming=false                                      # lulesh-noargs.good
---elemsPerEdge=2 --doTiming=false                     # lulesh.good
+--filename=lmeshes/sedov15oct.lmesh --doTiming=false --coordsStdout=true
+--doTiming=false --coordsStdout=true                                      # lulesh-noargs.good
+--elemsPerEdge=2 --doTiming=false --coordsStdout=true                     # lulesh.good

--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.good
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.good
@@ -1,2 +1,1 @@
 ./lulesh.chpl:79: error: halt reached - The 3D representation does not support reading input from files
-cat: coords.out: No such file or directory


### PR DESCRIPTION
Add an option to lulesh to print coords to stdout instead of a file and
use that for correctness testing. Some launchers and systems do not
guarantee that files written by a job will be visible on disk by the
time the job completes. This was causing issues for lulesh where it
writes output to `coords.dat` and we then try to `cat` the file to our
output, but the file wasn't visible on disk when we tried to `cat`.

We have seen this in the past on systems using pure aprun (no qsub) and
recently on systems using lsf/bsub.