### PR TITLE
Quiet a Tcl module collection-related message.

### DIFF
--- a/util/test/prediff-for-slurm-srun
+++ b/util/test/prediff-for-slurm-srun
@@ -21,7 +21,8 @@ msgs = (
 """,
 """srun: error: spank: /opt/cray/pe/atp/libAtpSLaunch.so: Plugin file not found
 """,
-
+"""cp: cannot create regular file .*/[.]module/PrgEnv-.*: File exists
+""",
 )
 
 outfname = sys.argv[2]


### PR DESCRIPTION
There is a rare (we're told) race that causes module collection creation
to fail because it's already been done, in multi-node jobs on systems
using Tcl v4 modules where the user home dir is NFS-mounted. We've seen
a failure caused by this message on our CS system, so here, filter it
out.