### PR TITLE
Fix uninitialized variables in the compiler

### DIFF
--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -726,8 +726,8 @@ static void gatherForallInfo(ForallStmt *forall) {
     Symbol *dotDomIterSym = NULL;
     Symbol *dotDomIterSymDom = NULL;
 
-    CallExpr *iterCall;
-    Symbol *iterCallTmp;
+    CallExpr *iterCall = NULL;
+    Symbol *iterCallTmp = NULL;
 
     std::vector<Symbol *> multiDIndices;
 


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/17035.

That PR added two variables in the compiler code that were uninitialized. This
PR initializes them to NULL.
