### PR TITLE
Update Linear Algebra primer for #17080

### DIFF
--- a/test/release/examples/primers/LinearAlgebralib.chpl
+++ b/test/release/examples/primers/LinearAlgebralib.chpl
@@ -537,9 +537,9 @@ var M4 = CSRMatrix(I);              // From a dense matrix
 // Setup some sparse domains and arrays
 { // Operations scope
 
-var Adom = CSRDomain(100, 100),
-    Bdom = CSRDomain(100, 100),
-    Cdom = CSRDomain(100, 100);
+var Adom = CSRDomain(1..100, 1..100),
+    Bdom = CSRDomain(1..100, 1..100),
+    Cdom = CSRDomain(1..100, 1..100);
 
 Adom += (1,1);
 Bdom += (2,2);


### PR DESCRIPTION
I missed the linear algebra primer in testing for #17080.

This changes the primer to opt into 1-based indices for the sparse section, because sparse matrix-matrix multiplication still assumes 1-based indices (see #17080 for details). This change can be reverted once sparse domains, arrays, and matrix-matrix multiplication are updated to support 0-based indices.

Tested locally:

- [x] `start_test examples/primers/LinearAlgebralib.chpl`