### PR TITLE
Adjust spacing in compiler code to be able to compile with gcc 4.9

### DIFF
--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -43,11 +43,11 @@ class ForallOptimizationInfo {
     std::vector<Symbol *> iterCallTmp; // this is the symbol to use for checks
 
     // even if there are multiple indices we store them in a vector
-    std::vector<std::vector<Symbol *>> multiDIndices;
+    std::vector< std::vector<Symbol *> > multiDIndices;
 
     // calls in the loop that are candidates for optimization
-    std::vector<std::pair<CallExpr *, int>> staticCandidates;
-    std::vector<std::pair<CallExpr *, int>> dynamicCandidates;
+    std::vector< std::pair<CallExpr *, int> > staticCandidates;
+    std::vector< std::pair<CallExpr *, int> > dynamicCandidates;
 
     // the static check control symbol added for symbol
     std::map<Symbol *, Symbol *> staticCheckSymForSymMap;

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -847,7 +847,7 @@ static Symbol *getCallBaseSymIfSuitable(CallExpr *call, ForallStmt *forall,
       int idx = -1;
       bool found = false;
 
-      std::vector<std::vector<Symbol *>>::iterator it;
+      std::vector< std::vector<Symbol *> >::iterator it;
       for (it = forall->optInfo.multiDIndices.begin();
            it != forall->optInfo.multiDIndices.end();
            it++) {
@@ -1028,11 +1028,11 @@ static void optimizeLoop(ForallStmt *forall,
                          Expr *&staticCond, CallExpr *&dynamicCond,
                          bool doStatic) {
 
-  std::vector<std::pair<CallExpr *, int>> candidates = doStatic ?
+  std::vector< std::pair<CallExpr *, int> > candidates = doStatic ?
       forall->optInfo.staticCandidates :
       forall->optInfo.dynamicCandidates;
 
-  std::vector<std::pair<CallExpr *, int>>::iterator it;
+  std::vector< std::pair<CallExpr *, int> >::iterator it;
   for(it = candidates.begin() ; it != candidates.end() ; it++) {
     CallExpr *candidate = it->first;
     int iterandIdx = it->second;
@@ -1159,8 +1159,8 @@ static void constructCondStmtFromLoops(Expr *condExpr,
 // be duplicate loops at the end of normalize, but after resolution we expect
 // them to go away.
 static void generateOptimizedLoops(ForallStmt *forall) {
-  std::vector<std::pair<CallExpr *, int>> &sOptCandidates = forall->optInfo.staticCandidates;
-  std::vector<std::pair<CallExpr *, int>> &dOptCandidates = forall->optInfo.dynamicCandidates;
+  std::vector< std::pair<CallExpr *, int> > &sOptCandidates = forall->optInfo.staticCandidates;
+  std::vector< std::pair<CallExpr *, int> > &dOptCandidates = forall->optInfo.dynamicCandidates;
 
   const int totalNumCandidates = sOptCandidates.size() + dOptCandidates.size();
   if (totalNumCandidates == 0) return;


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/17035.

gcc 4.9 doesn't like nested templates when you have `>>` without space. This PR
adjusts whitespace around such declarations.

Compiler builds and `make check` passes with gcc 4.9 on linux64 after this PR.