### PR TITLE
Resurrect and modernize the lsf-gasnetrun_ibv launcher

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -174,6 +174,7 @@ Building Chapel for a Cray System from Source
       ========================================  =========================
       ...run jobs interactively on your system  gasnetrun_ibv
       ...queue jobs using SLURM (sbatch)        slurm-gasnetrun_ibv
+      ...queue jobs using LSF (bsub)            lsf-gasnetrun_ibv
       ========================================  =========================
 
       ========================================  =========================

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -53,6 +53,7 @@ aprun                Cray application launcher using aprun
 gasnetrun_ibv        GASNet launcher for programs running over Infiniband 
 gasnetrun_mpi        GASNet launcher for programs using the MPI conduit   
 mpirun4ofi           provisional launcher for ``CHPL_COMM=ofi`` on non-Cray X* systems
+lsf-gasnetrun_ibv    GASNet launcher using LSF (bsub) over Infiniband
 pbs-aprun            Cray application launcher using PBS (qsub) + aprun   
 pbs-gasnetrun_ibv    GASNet launcher using PBS (qsub) over Infiniband     
 slurm-gasnetrun_ibv  GASNet launcher using SLURM over Infiniband          

--- a/runtime/src/launch/lsf-gasnetrun_ibv/Makefile
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2004-2018 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/lsf-gasnetrun_ibv
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
+endif
+
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/lsf-gasnetrun_ibv/Makefile
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/Makefile
@@ -1,14 +1,14 @@
-# Copyright 2004-2018 Cray Inc.
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
-# 
+#
 # The entirety of this work is licensed under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.include
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.include
@@ -1,0 +1,24 @@
+# Copyright 2004-2018 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCH_SUBDIR = src/launch/lsf-gasnetrun_ibv
+
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.include
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.include
@@ -1,3 +1,20 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Copyright 2004-2018 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 

--- a/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.share
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.share
@@ -1,14 +1,14 @@
-# Copyright 2004-2018 Cray Inc.
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
-# 
+#
 # The entirety of this work is licensed under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.share
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/Makefile.share
@@ -1,0 +1,29 @@
+# Copyright 2004-2018 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCHER_SRCS = \
+        launch-lsf-gasnetrun_ibv.c \
+
+# from ../gasnetrun_ibv/Makefile.share:
+#
+RUNTIME_CFLAGS += -DLAUNCH_PATH="gasnet/$(GASNET_INSTALL_SUBDIR)/bin/"
+
+SVN_SRCS = $(LAUNCHER_SRCS)
+SRCS = $(SVN_SRCS)
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -1,15 +1,15 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -48,19 +48,22 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
 
-  const int largc = 9;
+  const int largc = 11;
   char *largv[largc];
+  
+  sprintf(_nlbuf, "%d", numLocales);
 
   largv[0] = (char *)"bsub";
   largv[1] = (char *)"-Ip";
   largv[2] = (char *)"-R";
   largv[3] = (char *)"span[ptile=1]";
   largv[4] = (char *)"-n";
-  sprintf(_nlbuf, "%d", numLocales);
   largv[5] = _nlbuf;
   largv[6] = cmd;
   largv[7] = (char *)"-n";
   largv[8] = _nlbuf;
+  largv[9] = (char *)"-N";
+  largv[10] = _nlbuf;
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -48,7 +48,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
 
-  const int largc = 13;
+  const int largc = 15;
   char *largv[largc];
   
   sprintf(_nlbuf, "%d", numLocales);
@@ -66,6 +66,8 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   largv[10] = _nlbuf;
   largv[11] = (char *)"-c";
   largv[12] = (char *)"0";
+  largv[13] = (char*)"-E";
+  largv[14] = chpl_get_enviro_keys(',');
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -48,11 +48,12 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
 
-  const int largc = 15;
-  char *largv[largc];
+  const int maxlargc = 15 + chpl_get_charset_env_nargs();
+  char *largv[maxlargc];
   
   sprintf(_nlbuf, "%d", numLocales);
 
+  int largc = 15;
   largv[0] = (char *)"bsub";
   largv[1] = (char *)"-Ip";
   largv[2] = (char *)"-R";
@@ -68,6 +69,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   largv[12] = (char *)"0";
   largv[13] = (char*)"-E";
   largv[14] = chpl_get_enviro_keys(',');
+  largc += chpl_get_charset_env_args(&largv[largc]);
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -48,7 +48,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
 
-  const int largc = 11;
+  const int largc = 13;
   char *largv[largc];
   
   sprintf(_nlbuf, "%d", numLocales);
@@ -64,6 +64,8 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   largv[8] = _nlbuf;
   largv[9] = (char *)"-N";
   largv[10] = _nlbuf;
+  largv[11] = (char *)"-c";
+  largv[12] = (char *)"0";
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "chplcgfns.h"
+#include "chpllaunch.h"
+#include "chpl-mem.h"
+#include "error.h"
+
+// from ../gasnetrun_ibv/launch-gasnetrun_ibv.c:
+#define WRAP_TO_STR(x) TO_STR(x)
+#define TO_STR(x) #x
+
+//
+// we will build this command:
+//   bsub ... LAUNCH_PATH/gasnetrun_ibv ... REAL_BINNAME ...
+//
+// bsub options used:
+//  -R span[ptile=1]   seems to request just 1 process per node
+//  -n NN              request NN processors (i.e. nodes?)
+//  -Ip                requests an interactive session with a pseudo-terminal
+//
+// bsub other options:
+//  -K  wait for job completion - could use instead of -Ip,
+//      but stdin/out/err are disconnected (use -i/-o/-e to direct to files)
+//  there does not seem to be a "quiet" option
+//
+
+static char _nlbuf[16];
+static char** chpl_launch_create_argv(int argc, char* argv[],
+                                      int32_t numLocales) {
+  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ibv") + 2;
+  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+  sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
+
+  const int largc = 9;
+  char *largv[largc];
+
+  largv[0] = (char *)"bsub";
+  largv[1] = (char *)"-Ip";
+  largv[2] = (char *)"-R";
+  largv[3] = (char *)"span[ptile=1]";
+  largv[4] = (char *)"-n";
+  sprintf(_nlbuf, "%d", numLocales);
+  largv[5] = _nlbuf;
+  largv[6] = cmd;
+  largv[7] = (char *)"-n";
+  largv[8] = _nlbuf;
+
+  return chpl_bundle_exec_args(argc, argv, largc, largv);
+}
+
+
+int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  return chpl_launch_using_exec("bsub",
+                                chpl_launch_create_argv(argc, argv, numLocales),
+                                argv[0]);
+}
+
+
+int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
+                           int32_t lineno, int32_t filename) {
+  return 0;
+}
+
+
+void chpl_launch_print_help(void) {
+}

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -23,11 +23,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "chplcgfns.h"
+#include "chpl-env.h"
 #include "chpllaunch.h"
 #include "chpl-mem.h"
 #include "error.h"
 
-// from ../gasnetrun_ibv/launch-gasnetrun_ibv.c:
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
 
@@ -39,11 +39,6 @@
 //  -R span[ptile=1]   seems to request just 1 process per node
 //  -n NN              request NN processors (i.e. nodes?)
 //  -Ip                requests an interactive session with a pseudo-terminal
-//
-// bsub other options:
-//  -K  wait for job completion - could use instead of -Ip,
-//      but stdin/out/err are disconnected (use -i/-o/-e to direct to files)
-//  there does not seem to be a "quiet" option
 //
 
 static char _nlbuf[16];
@@ -72,6 +67,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
 
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  chpl_env_set("BSUB_QUIET", "1", 0);
   return chpl_launch_using_exec("bsub",
                                 chpl_launch_create_argv(argc, argv, numLocales),
                                 argv[0]);

--- a/test/release/examples/benchmarks/shootout/mandelbrot-fast.skipif
+++ b/test/release/examples/benchmarks/shootout/mandelbrot-fast.skipif
@@ -1,0 +1,1 @@
+CHPL_LAUNCHER <= lsf-

--- a/test/release/examples/benchmarks/shootout/mandelbrot.skipif
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.skipif
@@ -1,0 +1,1 @@
+CHPL_LAUNCHER <= lsf-

--- a/util/test/prediff-for-lsf
+++ b/util/test/prediff-for-lsf
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+outfile=$2
+tr -d '\r' < $outfile > $outfile.tmp
+mv $outfile.tmp $outfile

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1121,6 +1121,12 @@ def set_up_executables():
         prediff_for_slurm = os.path.join(util_dir, "test", "prediff-for-slurm-srun")
         if prediff_for_slurm not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_slurm)
+    elif 'lsf-' in launcher:
+        # With lsf-based launcher, auto-run prediff-for-lsf.
+        prediff_for_lsf = os.path.join(util_dir, "test", "prediff-for-lsf")
+        if prediff_for_lsf not in chpl_system_prediff:
+            chpl_system_prediff.append(prediff_for_lsf)
+
     if chpl_system_prediff:
         os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(chpl_system_prediff)
 


### PR DESCRIPTION
It was originally removed in 329b75dfc1 due to lack of testing, but we now have
access to a machine to test it on again. Bring it back and catch it up with
other gasnetrun-based launchers:
- Improve how processes are mapped to locales (apply 874d05a3a6)
- Disable CPU binding (apply 3e43e04734)
- Propagate environment variables (apply 9ea3845496 / a851011a1e)
- Fix character set env var passing (apply cfc2c71d98)

This also adds a prediff to remove carriage returns because for some reason
LSF/bsub adds them. For more info about carriages returns being added see
https://www.ibm.com/support/pages/why-extra-character-m-added-if-you-redirect-bsub-ip-ouput-file

Resolves https://github.com/Cray/chapel-private/issues/1584