### PR TITLE
Adjust prediff that was missed when adding Memory.Diagnostics

### DIFF
--- a/test/studies/hpcc/common/testProbSize.prediff
+++ b/test/studies/hpcc/common/testProbSize.prediff
@@ -2,7 +2,7 @@
 
 $hostname = `hostname -s`; chomp($hostname);
 
-$countMemoryDir="../../../library/standard/Memory/countMemory";
+$countMemoryDir="../../../library/standard/Memory/Diagnostics/countMemory";
 $countMemoryFile="$countMemoryDir/countMemory.$hostname.good";
 
 system("cd $countMemoryDir && ./countMemory.prediff");


### PR DESCRIPTION
Adjust prediff that was missed when adding Memory.Diagnostics (#17099)

The test `studies/hpcc/common/testProbSize.chpl` relies on the output
of the test `library/standard/Memory/Diagnostics/countMemory.chpl`.

The prediff hardcodes the path to the above test. Adjust the path to
point to the `Diagnostics` subfolder.

Trivial and not reviewed.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>