### PR TITLE
Make the path to the MLI REAL_BINARY_NAME explicit

### DIFF
--- a/runtime/etc/Makefile.launcher
+++ b/runtime/etc/Makefile.launcher
@@ -47,7 +47,8 @@ all: FORCE
 	echo "#include \"chpl_compilation_config.c\"" >> $(LAUNCHER_SRC_NAME)
 	echo "const char launcher_real_suffix[] = \"$(REAL_SUFFIX)\";" >> $(LAUNCHER_SRC_NAME)
 	echo "const char launcher_exe_suffix[] = \"$(EXE_SUFFIX)\";" >> $(LAUNCHER_SRC_NAME)
-	echo "const char* launcher_mli_real_name = \"$(REAL_BINARY_NAME)\";" >> $(LAUNCHER_SRC_NAME)
+	# TODO would be nice to provide ABS path to REAL_BINARY_NAME instead of ./
+	echo "const char* launcher_mli_real_name = \"./$(REAL_BINARY_NAME)\";" >> $(LAUNCHER_SRC_NAME)
 ifneq ($(CHPL_MAKE_IS_MLI),1)
 	echo "const int launcher_is_mli = 0;" >> $(LAUNCHER_SRC_NAME)
 else


### PR DESCRIPTION
Convert the multi-locale interop binary from `filename` to `./filename`.
Previously, we were just specifying the basename of the file and not
giving an execution location. This used to work when gasnet used `execv`
to launch since `execv` will find executables just based on the name,
but in changing to `execvp` in the 2020.10.0 release this no longer
works for us. We should have always been specifying the execution
location, we just lucked out previously that gasnet was using `execv`.
Longer term we should probably find the absolute path to the filename
like we do for non-mli configurations but in the meantime this gets
testing working again.

Resolves https://github.com/Cray/chapel-private/issues/1670