### PR TITLE
Fix range.chpl__unTranslate()

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -501,6 +501,7 @@ module ChapelRange {
   //################################################################################
   //# Predicates
   //#
+
   /* Return true if argument ``t`` is a range type, false otherwise */
   proc isRangeType(type t) param {
     proc isRangeHelp(type t: range(?)) param  return true;
@@ -2425,18 +2426,10 @@ proc _cast(type t: range(?), r: range(?)) {
   //################################################################################
   //# Internal helper functions.
   //#
-  pragma "no doc"
-  inline proc range.chpl__unTranslate(i: intIdxType)
-    return this - i;
 
   pragma "no doc"
   inline proc range.chpl__unTranslate(i)
-  {
-    if isIntType(i.type) then
-      return this - i;
-    else
-      return this + abs(i);
-  }
+    return this - i;
 
   // Determine if a strided range has a definite alignment.
   proc chpl__hasAlignment(r : range(?))


### PR DESCRIPTION
This removes the following overload:
```chpl
    inline proc range.chpl__unTranslate(i)
    {
      if isIntType(i.type) then
	return this - i;
      else
	return this + abs(i);
    }
```
because the action in the 'else' branch is incorrect.
This also updates the other overload:
```chpl
    inline proc range.chpl__unTranslate(i: intIdxType)
      return this - i;
```
to accept any argument type.

The first overload was added in 44027d0714 to handle calls to
chpl__unTranslate whose argument is not of an index type.
For example, untranslating an int range by a unit or visa versa.
We have not hit the bug because that would require the argument
to be unsigned and not of the index type.

Having a single overload accepting any argument removes the bug
and simplifies the code, while addressing that earlier motivation.

Testing: standard paratest, gasnet multilocale, gasnet robustness for block, cyclic, replicated.