### PR TITLE
Add test locking in behavior of chaining calls returning 'void' type

### DIFF
--- a/test/types/void/void-chain.chpl
+++ b/test/types/void/void-chain.chpl
@@ -1,0 +1,10 @@
+proc foo(): void {
+  writeln("In foo()");
+}
+
+proc bar(): void {
+  writeln("In bar()");
+  return foo();
+}
+
+bar();

--- a/test/types/void/void-chain.good
+++ b/test/types/void/void-chain.good
@@ -1,0 +1,2 @@
+void-chain.chpl:5: In function 'bar':
+void-chain.chpl:7: error: illegal use of function that does not return a value: 'foo'


### PR DESCRIPTION
While describing @leekillough's recent work in PR #17007 to someone this week, I got myself re-stewing on a question that came up while it was being developed about whether we should permit chaining of `void`-returning routines, like:

```chapel
proc foo(): void {
}

proc bar(): void {
  return foo();
}

bar();
```

At the time, there was a lot of uncertain mmmmmaybe-ing in the chatroom (myself included), but after having to describe the effort out loud this week, I became more convinced that we should not permit it.  This matches the current behavior of the compiler, but I couldn't find a test that explicitly locked the behavior in, so am doing so in this PR.

Specifically, the reason I think we split our original `void` type into `void` vs. `none`/`nothing` was to distinguish between: 
* procedures that return nothing interesting but do return some value/expression (`none`/`nothing` — the "unit type") vs. 
* those that simply return nothing (`void` — the "bottom type") — that is, all return statements are simply `return;` (or we fall out of the end of the routine)

An implication of this is that if I wanted to write the pattern above, I could do so, but would need to use the none/nothing types to do so:

```chapel
proc foo(): nothing {
  return none;
}

proc bar(): nothing {
  return foo();
}

bar();
```

Yes, it's a bit more typing, but I think nothing significant is lost and it avoids slippery slopes from the void case like "why can't I capture the result of `foo()` into a temp variable and then return that variable?  (answer: that's what `none`/`nothing` are for).