### PR TITLE
Generalize the slurm-srun system prediffer to apply to all slurm.

### DIFF
--- a/util/test/prediff-for-slurm
+++ b/util/test/prediff-for-slurm
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# This script is a system-wide prediff for use with the slurm-srun
-# launcher.
+# This script is a system-wide prediff for use with slurm-based
+# launchers.
 #
 import sys, re
 

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1116,9 +1116,9 @@ def set_up_executables():
                         "{0}".format(prediff))
                 finish()
             chpl_system_prediff.append(prediff)
-    if launcher == "slurm-srun":
-        # With Slurm-based launcher, auto-run prediff-for-slurm-srun.
-        prediff_for_slurm = os.path.join(util_dir, "test", "prediff-for-slurm-srun")
+    if "slurm" in launcher:
+        # With Slurm-based launcher, auto-run prediff-for-slurm.
+        prediff_for_slurm = os.path.join(util_dir, "test", "prediff-for-slurm")
         if prediff_for_slurm not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_slurm)
     elif 'lsf-' in launcher:


### PR DESCRIPTION
We've had a system prediff script for slurm-srun launchers for a while
now. Here, adjust so that we use it for all slurm-based launchers.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>