### PR TITLE
SKIPIF a directory with baseline

### DIFF
--- a/test/optimizations/autoLocalAccess/alignedFollowers/SKIPIF
+++ b/test/optimizations/autoLocalAccess/alignedFollowers/SKIPIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
`test/optimizations/autoLocalAccess/alignedFollowers` was added to test an
optimization that fires when fast followers are enabled. `--baseline` disables
that optimization and so this directory must be skipped with it.


