### PR TITLE
CG: Implement associated types, constraints

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -151,6 +151,16 @@ bool AggregateType::isUnion() const {
   return aggregateTag == AGGREGATE_UNION;
 }
 
+const char* AggregateType::aggregateString() const {
+  switch (aggregateTag) {
+  case AGGREGATE_CLASS:   return "class";
+  case AGGREGATE_RECORD:  return "record";
+  case AGGREGATE_UNION:   return "union";
+  }
+  INT_FATAL(this, "unknown AggregateType tag");
+  return NULL;
+}
+
 bool AggregateType::isGeneric() const {
   return mIsGeneric;
 }

--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -81,22 +81,18 @@ bool viewFlagsExtras  = true;
 static void viewSymbolFlags(Symbol* sym) {
     for (int flagNum = FLAG_FIRST; flagNum <= FLAG_LAST; flagNum++) {
       if (sym->flags[flagNum]) {
-        if (viewFlagsName) {
+        if (viewFlagsName)
           printf("%s ", flagNames[flagNum]);
-        }
 
-        if (viewFlagsPragma) {
+        if (viewFlagsPragma)
           printf("%s", flagPragma[flagNum] ? "ypr " : "npr ");
-        }
 
-        if (viewFlagsShort) {
+        if (viewFlagsShort)
           printf("\"%s\" ", flagShortNames[flagNum]);
-        }
 
-        if (viewFlagsComment) {
+        if (viewFlagsComment)
           printf("// %s",
                  *flagComments[flagNum] ? flagComments[flagNum] : "ncm");
-        }
 
         printf("\n");
       }
@@ -118,8 +114,17 @@ static void viewSymbolFlags(Symbol* sym) {
         printf("%s arg  qual %s\n",
                as->intentDescrString(), qualifierToStr(as->qual));
 
-      } else if (toTypeSymbol(sym)) {
-        printf("a TypeSymbol\n");
+      } else if (TypeSymbol* ts = toTypeSymbol(sym)) {
+        if (Type* tp = ts->type) {
+          printf("TypeSymbol  %s", tp->astTagAsString());
+          if (AggregateType* at = toAggregateType(tp))
+            printf(" %s", at->aggregateString());
+          else if (ConstrainedType* ct = toConstrainedType(tp))
+            printf(" %s", ct->useString());
+          printf("\n");
+        } else {
+          printf("TypeSymbol  type=NULL\n");
+        }
 
       } else if (FnSymbol* fs = toFnSymbol(sym)) {
         printf("isGeneric %s\n", fs->isGenericIsValid() ?
@@ -141,6 +146,9 @@ static void viewSymbolFlags(Symbol* sym) {
 
       } else if (toLabelSymbol(sym)) {
         printf("a LabelSymbol\n");
+
+      } else if (toInterfaceSymbol(sym)) {
+        printf("an InterfaceSymbol\n");
 
       } else {
         printf("unknown symbol kind\n");

--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -51,6 +51,14 @@ static FnSymbol* toInterfaceFunDecl(Expr* expr) {
   return NULL;
 }
 
+static VarSymbol* toAssociatedTypeDecl(Expr* expr) {
+  if (DefExpr* def = toDefExpr(expr))
+    if (VarSymbol* AT = toVarSymbol(def->sym))
+      if (AT->hasFlag(FLAG_TYPE_VARIABLE))
+        return AT;
+  return NULL;
+}
+
 DefExpr* InterfaceSymbol::buildDef(const char* name,
                                    CallExpr*   formals,
                                    BlockStmt*  body)
@@ -68,12 +76,41 @@ DefExpr* InterfaceSymbol::buildDef(const char* name,
                    "  at least one formal argument is required", isym->name);
 
   // ifcBody can be empty; check that the content is appropriate
-  for_alist(expr, isym->ifcBody->body)
-    if (toInterfaceFunDecl(expr) == NULL) {
-      USR_FATAL_CONT(expr, "not a 'proc' or 'iter' declaration");
-      USR_PRINT(expr,"  only function declarations"
-                     " are currently allowed in an interface");
+  for_alist(expr, isym->ifcBody->body) {
+    SET_LINENO(expr); // does not matter since we are parsing?
+
+    if (toInterfaceFunDecl(expr) != NULL) {
+      // ok
+
+    } else if (VarSymbol* AT = toAssociatedTypeDecl(expr)) {
+      // not allowing defaults for now
+      if (AT->defPoint->init != NULL || AT->defPoint->exprType != NULL)
+        USR_FATAL_CONT(expr, "an associated type at present cannot have"
+                             " a default value");
+      // support for multi-argument inferfaces is pending #17008
+      if (isym->ifcFormals.length > 1)
+        USR_FATAL_CONT(expr, "associated types at present are not allowed"
+                       " for multi-argument interfaces");
+      // replace with a fresh ConstrainedType
+      TypeSymbol* ACT = ConstrainedType::build(AT->name, CT_IFC_ASSOC_TYPE);
+      isym->associatedTypes[ACT->name] = (ConstrainedType*)ACT->type;
+      reset_ast_loc(ACT, expr);
+      AT->defPoint->replace(new DefExpr(ACT));
+
+    } else if (ImplementsStmt* istm = toImplementsStmt(expr)) {
+      if (istm->implBody->body.length != 0)
+        USR_FATAL_CONT(istm, "an associated constraint is not allowed"
+                       " to have a block statement");
+      isym->associatedConstraints.push_back(istm);
+
+    } else {
+      USR_FATAL_CONT(expr,
+        "this statement is illegal in an interface declaration");
+      USR_PRINT(expr,
+        "only functions, associated types, and associated constraints"
+        " are allowed at this point");
     }
+  }
 
   return new DefExpr(isym);
 }
@@ -83,7 +120,7 @@ DefExpr* InterfaceSymbol::buildFormal(const char* name,
 {
   Symbol* formal = NULL;
   if (intent == INTENT_TYPE) {
-    formal = ConstrainedType::build(name);
+    formal = ConstrainedType::build(name, CT_IFC_FORMAL);
   } else {
     INT_FATAL(formal, "unexpected intent");
   }
@@ -236,11 +273,11 @@ ImplementsStmt* ImplementsStmt::copyInner(SymbolMap* map) {
                             COPY_INT(implBody));
 }
 
-static void verifyWitnesses(ImplementsStmt* istmt) {
+static void verifyWitnesses(ImplementsStmt* istm) {
   if (!normalized) return;
-  IfcConstraint* icon = istmt->iConstraint;
+  IfcConstraint* icon = istm->iConstraint;
   InterfaceSymbol* isym = icon->ifcSymbol();
-  form_Map(SymbolMapElem, witn, istmt->witnesses) {
+  form_Map(SymbolMapElem, witn, istm->witnesses) {
     INT_ASSERT(witn->key->defPoint->parentSymbol == isym);
     // witn->value can be defined anywhere
   }
@@ -310,7 +347,7 @@ void introduceConstrainedTypes(FnSymbol* fn) {
       SET_LINENO(def);
       Symbol* queryT = def->sym;
       // introduce a ConstrainedType
-      TypeSymbol* CT = ConstrainedType::build(queryT->name);
+      TypeSymbol* CT = ConstrainedType::build(queryT->name, CT_CGFUN_FORMAL);
       fn->interfaceInfo->addConstrainedType(new DefExpr(CT));
 
       // replace queryT with CT throughout
@@ -342,7 +379,8 @@ Type* desugarInterfaceAsType(ArgSymbol* arg, SymExpr* se,
   SET_LINENO(se);
 
   // introduce a ConstrainedType
-  TypeSymbol* CT = ConstrainedType::build(astr("t_", isym->name));
+  TypeSymbol* CT = ConstrainedType::build(astr("t_", isym->name),
+                                          CT_CGFUN_FORMAL);
   ifcInfo->addConstrainedType(new DefExpr(CT));
 
   // add an interface constraint
@@ -418,22 +456,25 @@ FnSymbol* wrapperFnForImplementsStmt(ImplementsStmt* istm) {
   return toFnSymbol(istm->parentSymbol);
 }
 
-void markImplStmtWrapFnAsFailure(FnSymbol* wrapFn) {
-  AList& body = wrapFn->body->body;
-  INT_ASSERT(isImplementsStmt(body.head));
-  body.insertAtHead(new CallExpr(PRIM_ERROR));
-}
-
 // Verify that the above functions work correctly.
-static void verifyWrapImplementsStmt(ImplementsStmt* istm,
-                                     FnSymbol* wrapFn) {
-  InterfaceSymbol* isym = istm->iConstraint->ifcSymbol();
+static void verifyWrapImplementsStmt(FnSymbol* wrapFn, ImplementsStmt* istm,
+                                     bool successful) {
+  InterfaceSymbol* isym = istm->ifcSymbol();
 
   INT_ASSERT(wrapFn->name == implementsStmtWrapperName(isym));
   INT_ASSERT(interfaceNameForWrapperFn(wrapFn) == isym->name);
   bool isSuccess;
   INT_ASSERT(implementsStmtForWrapperFn(wrapFn, isSuccess) == istm);
+  INT_ASSERT(isSuccess == successful);
   INT_ASSERT(wrapperFnForImplementsStmt(istm) == wrapFn);
+}
+
+void markImplStmtWrapFnAsFailure(FnSymbol* wrapFn) {
+  AList& body = wrapFn->body->body;
+  ImplementsStmt* istm = toImplementsStmt(body.head);
+  INT_ASSERT(istm != NULL);
+  body.insertAtHead(new CallExpr(PRIM_ERROR));
+  if (fVerify) verifyWrapImplementsStmt(wrapFn, istm, false);
 }
 
 FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm) {
@@ -442,12 +483,13 @@ FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm) {
     INT_ASSERT(! normalized); // will report "undeclared" error later
     return NULL;
   }
-  InterfaceSymbol* isym = istm->iConstraint->ifcSymbol();
+  InterfaceSymbol* isym = istm->ifcSymbol();
   FnSymbol* wrapFn = new FnSymbol(implementsStmtWrapperName(isym));
   wrapFn->addFlag(FLAG_IMPLEMENTS_WRAPPER);
   istm->insertBefore(new DefExpr(wrapFn));
   wrapFn->insertAtTail(istm->remove());
   wrapFn->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
+  if (fVerify) verifyWrapImplementsStmt(wrapFn, istm, true);
   return wrapFn;
 }
 
@@ -455,9 +497,6 @@ FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm) {
 // Places this wrapper function where the implements statement used to be.
 // Currently the wrapper function has a formal for each interface formal.
 void wrapImplementsStatements() {
-  forv_Vec(ImplementsStmt, istm, gImplementsStmts) {
-    FnSymbol* wrapFn = wrapOneImplementsStatement(istm);
-    if (!wrapFn) continue; // there was an error
-    if (fVerify) verifyWrapImplementsStmt(istm, wrapFn);
-  }
+  forv_Vec(ImplementsStmt, istm, gImplementsStmts)
+    wrapOneImplementsStatement(istm);
 }

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -422,44 +422,85 @@ void PrimitiveType::accept(AstVisitor* visitor) {
 }
 
 
-ConstrainedType::ConstrainedType() :
-  Type(E_ConstrainedType, NULL)
+ConstrainedType::ConstrainedType(ConstrainedTypeUse use) :
+  Type(E_ConstrainedType, NULL), ctUse(use)
 {
   gConstrainedTypes.add(this);
 }
 
-
 ConstrainedType* ConstrainedType::copyInner(SymbolMap* map) {
-  return new ConstrainedType();
+  return new ConstrainedType(ctUse);
 }
-
 
 void ConstrainedType::replaceChild(BaseAST* old_ast, BaseAST* new_ast) {
   INT_FATAL(this, "Unexpected case in ConstrainedType::replaceChild");
 }
 
-
 void ConstrainedType::verify() {
   Type::verify();
   INT_ASSERT(astTag == E_ConstrainedType);
+
+  DefExpr* def = symbol->defPoint;  // assumes this->inTree()
+  switch (ctUse) {
+  case CT_IFC_FORMAL: {
+    InterfaceSymbol* isym = toInterfaceSymbol(def->parentSymbol);
+    INT_ASSERT(def->list == &(isym->ifcFormals));
+    break;
+  }
+  case CT_IFC_ASSOC_TYPE: {
+    InterfaceSymbol* isym = toInterfaceSymbol(def->parentSymbol);
+    INT_ASSERT(def->parentExpr == isym->ifcBody);
+    break;
+  }
+  case CT_CGFUN_FORMAL: {
+    FnSymbol* fn = toFnSymbol(def->parentSymbol);
+    INT_ASSERT(def->list == &(fn->interfaceInfo->constrainedTypes));
+    break;
+  }
+  case CT_CGFUN_ASSOC_TYPE: {
+    // These arise during resolution and are pruned at resolution end.
+    INT_FATAL(this, "unexpected");
+    break;
+  }}
 }
 
+const char* ConstrainedType::useString() const {
+  switch (ctUse) {
+  case CT_IFC_FORMAL:       return "CT_IFC_FORMAL";
+  case CT_IFC_ASSOC_TYPE:   return "CT_IFC_ASSOC_TYPE";
+  case CT_CGFUN_FORMAL:     return "CT_CGFUN_FORMAL";
+  case CT_CGFUN_ASSOC_TYPE: return "CT_CGFUN_ASSOC_TYPE";
+  }
+  INT_FATAL(this, "unknown ConstrainedType use");
+  return NULL;
+}
 
 void ConstrainedType::printDocs(std::ostream *file, unsigned int tabs) {
   return;  // not to be printed
 }
 
-
 void ConstrainedType::accept(AstVisitor* visitor) {
   visitor->visitConstrainedType(this);
 }
 
-
-TypeSymbol* ConstrainedType::build(const char* name) {
-  Type* ct = new ConstrainedType();
+TypeSymbol* ConstrainedType::build(const char* name, ConstrainedTypeUse use) {
+  Type* ct = new ConstrainedType(use);
   return new TypeSymbol(name, ct);
 }
 
+bool isConstrainedType(Type* t, ConstrainedTypeUse use) {
+  if (ConstrainedType* ct = toConstrainedType(t))
+    if (ct->ctUse == use)
+      return true;
+  return false;
+}
+
+bool isConstrainedTypeSymbol(Symbol* s, ConstrainedTypeUse use) {
+  if (TypeSymbol* ts = toTypeSymbol(s))
+    if (isConstrainedType(ts->type, use))
+      return true;
+  return false;
+}
 
 EnumType::EnumType() :
   Type(E_EnumType, NULL),

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -64,6 +64,7 @@ public:
   bool                        isClass()                                  const;
   bool                        isRecord()                                 const;
   bool                        isUnion()                                  const;
+  const char*                 aggregateString()                          const;
 
   // is it a generic type (e.g. contains a type field with or without default)
   // e.g. this would return true for

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -58,14 +58,18 @@ public:
   // an interface constraint of this function
   AList interfaceConstraints;
 
-  // contains one SymbolMap per IfcConstraint in 'interfaceConstraints'
-  // with mapping: the FnSymbol for a required function in the interface def
-  //   -> the FnSymbol used to represent calls to that required function
-  //      throughout the body of this function
+  //
+  // Contains one SymbolMap per IfcConstraint in 'interfaceConstraints'.
+  // If IFC is the constraint's interface, the corresponding SymbolMap
+  // is a mapping:
+  // - from each symbol defined in IFC body, such as a required function or
+  //   an associated type,
+  // - to the symbol that represents that throughout the body of this function
   //
   // a single SymbolMap for all constraints in a CG function is not sufficient
   // when the same interface is implemented by different ConstrainedTypes
-  std::vector<SymbolMap> repsForRequiredFns;
+  //
+  std::vector<SymbolMap> repsForIfcSymbols;
 };
 
 class FnSymbol final : public Symbol {

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -176,11 +176,14 @@ void resolveInterfaceSymbol(InterfaceSymbol* isym);
 void resolveImplementsStmt(ImplementsStmt* istm);
 void resolveConstrainedGenericFun(FnSymbol* fn);
 void resolveConstrainedGenericSymbol(Symbol* sym, bool mustBeCG);
+Expr* resolveCallToAssociatedType(CallExpr* call, ConstrainedType* recv);
 ImplementsStmt* constraintIsSatisfiedAtCallSite(CallExpr* call,
                                                 IfcConstraint* constraint,
                                                 SymbolMap& substitutions);
-void cleanupInstantiatedCGfun(FnSymbol* fn,
-                              std::vector<ImplementsStmt*>& witnesses);
+void copyIfcRepsToSubstitutions(FnSymbol* fn, int indx,
+                                ImplementsStmt* istm,
+                                SymbolMap& substitutions);
+void adjustForCGinstantiation(FnSymbol* fn, SymbolMap& substitutions);
 
 FnSymbol* instantiateWithoutCall(FnSymbol* fn, SymbolMap& subs);
 FnSymbol* instantiateSignature(FnSymbol* fn, SymbolMap& subs,

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -301,7 +301,8 @@ public:
   Expr*  getFirstExpr()                             override;
   Expr*  getNextExpr(Expr* expr)                    override;
 
-  int    numActuals() const { return iConstraint->numActuals(); }
+  InterfaceSymbol* ifcSymbol()  const { return iConstraint->ifcSymbol(); }
+  int              numActuals() const { return iConstraint->numActuals(); }
 
   // the constraint being implemented, always non-null
   IfcConstraint* iConstraint;
@@ -309,7 +310,8 @@ public:
   // (possibly empty) body of this statement, always non-null
   BlockStmt*     implBody;
 
-  // mapping: required interface function -> its implementation
+  // for each associated type or required function in the interface,
+  // the map points to its implementation for this ImplementsStmt
   SymbolMap      witnesses;
 };
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -595,6 +595,13 @@ public:
   // the body block of the interface declaration, always non-null
   BlockStmt* ifcBody;
 
+  // maps name to the ConstrainedType for an associated type
+  // their DefExprs are in ifcBody
+  std::map<const char*, ConstrainedType*> associatedTypes;
+
+  // constraints to be checked for each implementation
+  std::vector<ImplementsStmt*> associatedConstraints;
+
   // each FnSymbol for the interface's required function is mapped
   //  - to itself, if there is a default implementation
   //  - to gDummyWitness, otherwise

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -378,25 +378,39 @@ private:
 
 /************************************* | **************************************
 *                                                                             *
-* a ConstrainedType is the type of:                                           *
-* (1) a formal of a CG function if it is subject to interface constraint(s)   *
-*     ex. T in: proc cgFun(arg: ?T) where T implements IFC {....}             *
-* (2) a formal of an InterfaceSymbol                                          *
-*     ex. Q in: interface IFC(Q) {....}                                       *
+* a ConstrainedType can be used as indicated by its 'ctUse' field:            *
+* CT_IFC_FORMAL: a formal of an interface declaration                         *
+*                ex. 'Q' in interface IFC(Q) { ..... }                        *
+* CT_IFC_ASSOC_TYPE: an associated type in an interface declaration           *
+*                    ex. 'AT' in interface IFC(Q) { type AT; ..... }          *
+* CT_CGFUN_FORMAL: the type of a formal of a CG function that is subject to   *
+*                  interface constraint(s), ex. 'T' in                        *
+*                  proc cgFun(arg: ?T) where T implements IFC { ..... }       *
+* CT_CGFUN_ASSOC_TYPE: an assoc. type of a CT_CGFUN_FORMAL type, ex. 'arg.AT' *
+*                      in proc cgFun(arg: ?T, arg2: arg.AT) where .....       *
 *                                                                             *
 ************************************** | *************************************/
 
+enum ConstrainedTypeUse {
+  CT_IFC_FORMAL,
+  CT_IFC_ASSOC_TYPE,
+  CT_CGFUN_FORMAL,
+  CT_CGFUN_ASSOC_TYPE
+};
+
 class ConstrainedType final : public Type {
 public:
-  ConstrainedType();
+  ConstrainedTypeUse ctUse;
+  ConstrainedType(ConstrainedTypeUse use);
   void verify()                                          override;
   void accept(AstVisitor* visitor)                       override;
   DECLARE_COPY(ConstrainedType);
   ConstrainedType* copyInner(SymbolMap* map)             override;
   void replaceChild(BaseAST* old_ast, BaseAST* new_ast)  override;
   void codegenDef()                                      override;
+  const char* useString() const;
 
-  static TypeSymbol* build(const char* name);
+  static TypeSymbol* build(const char* name, ConstrainedTypeUse use);
 
   void printDocs(std::ostream *file, unsigned int tabs);
 };
@@ -554,6 +568,9 @@ bool needsCapture(Type* t);
 VarSymbol* resizeImmediate(VarSymbol* s, PrimitiveType* t);
 
 bool isPOD(Type* t);
+
+bool isConstrainedType(Type* t, ConstrainedTypeUse use);
+bool isConstrainedTypeSymbol(Symbol* s, ConstrainedTypeUse use);
 
 bool isNumericParamDefaultType(Type* type);
 

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -60,15 +60,88 @@ static const char* idstring(const char* prefix, BaseAST* ast) {
   return idBuff;
 }
 
+static void cgprintAssocConstraint(IfcConstraint* icon) {
+  cgprint("  assoc cons  %s(%s%s) %s\n",
+          icon->ifcSymbol()->name,
+          toSymExpr(icon->consActuals.head)->symbol()->name,
+          icon->consActuals.length > 1 ? ",..." : "", idstring("", icon));
+}
+
 #else
 #define cgprint(...)
+#define cgprintAssocConstraint(...)
 #endif
 
+
+static bool resolveImplementsStmt(ImplementsStmt* istm,
+                                  bool nested, //used only for debugging output
+                                  bool reportErrors);
+
+static void resolveIStmActuals(FnSymbol* wrapFn, ImplementsStmt* istm);
+
+
+/*********** resolveInterfaceSymbol ***********/
+
+// An associated type. Nothing to do.
+static void resolveISymAssocType(InterfaceSymbol* isym, TypeSymbol* at) {
+  cgprint("  assoc type  %s\n", symstring(at));
+  INT_ASSERT(isConstrainedTypeSymbol(at, CT_IFC_ASSOC_TYPE));
+}
+
+// This is really a constraint, even though syntactically it looks like
+// an ImplementsStmt.
+static void resolveISymAssocConstraint(InterfaceSymbol* isym,
+                                       FnSymbol* wrapFn) {
+  bool isSuccess;
+  ImplementsStmt* istm = implementsStmtForWrapperFn(wrapFn, isSuccess);
+  INT_ASSERT(isSuccess && istm->implBody->body.length == 0);
+  cgprintAssocConstraint(istm->iConstraint);
+
+  resolveIStmActuals(wrapFn, istm);
+}
+
+// A function required by the interface.
+static void resolveISymRequiredFun(InterfaceSymbol* isym, FnSymbol* fn) {
+  cgprint("  required fn %s%s\n", symstring(fn),
+    fn->hasFlag(FLAG_NO_FN_BODY) ? "" : "  with a default implementation");
+
+  if (fn->hasFlag(FLAG_NO_FN_BODY))
+    isym->requiredFns.put(fn, gDummyWitness);
+  else
+    isym->requiredFns.put(fn, fn); // with a default implementation
+
+  if (fn->where != NULL)
+    USR_FATAL_CONT(fn->where, "the interface function %s%s", fn->name,
+          " contains a where clause, which is currently not supported");
+
+  resolveFunction(fn);
+}
+
+void resolveInterfaceSymbol(InterfaceSymbol* isym) {
+  cgprint("resolving interface declaration %s  %s\n",
+          symstring(isym), debugLoc(isym));
+
+  for_alist(stmt, isym->ifcBody->body) {
+   if (FnSymbol* fn = toFnSymbol(toDefExpr(stmt)->sym))
+     if (fn->hasFlag(FLAG_IMPLEMENTS_WRAPPER))
+       resolveISymAssocConstraint(isym, fn);
+     else
+       resolveISymRequiredFun(isym, fn);
+   else if (TypeSymbol* at = toTypeSymbol(toDefExpr(stmt)->sym))
+    resolveISymAssocType(isym, at);
+   else
+    INT_FATAL(stmt, "should have ruled this out earlier");
+  }
+  cgprint("\n");
+}
+
+
+/*********** resolveConstrainedGenericFun ***********/
 
 static void buildAndCheckFormals2Actuals(InterfaceSymbol* isym,
                                          IfcConstraint* icon,
                                          const char* context,
-                                         SymbolMap& result) {
+                                         SymbolMap& fml2act) {
   if (isym->numFormals() != icon->numActuals()) {
     USR_FATAL(icon, "the number of actuals in the %s (%d)"
       " does not match the number of the interface formals (%d)",
@@ -78,45 +151,8 @@ static void buildAndCheckFormals2Actuals(InterfaceSymbol* isym,
   for (Expr *curFml = isym->ifcFormals.head, *curAct = icon->consActuals.head;
        curFml != NULL;
        curFml = curFml->next, curAct = curAct->next)
-   result.put(toDefExpr(curFml)->sym, toSymExpr(curAct)->symbol());
+   fml2act.put(toDefExpr(curFml)->sym, toSymExpr(curAct)->symbol());
 }
-
-
-/*********** resolveInterfaceSymbol ***********/
-
-void resolveInterfaceSymbol(InterfaceSymbol* isym) {
-  cgprint("resolving interface declaration %s  %s\n",
-          symstring(isym), debugLoc(isym));
-
-  for_alist(stmt, isym->ifcBody->body) {
-    // A function required by the interface.
-    FnSymbol* fn = toFnSymbol(toDefExpr(stmt)->sym);
-    cgprint("  required fn %s%s\n", symstring(fn),
-      fn->hasFlag(FLAG_NO_FN_BODY) ? "" : "  with a default implementation");
-
-    if (fn->hasFlag(FLAG_NO_FN_BODY))
-      isym->requiredFns.put(fn, gDummyWitness);
-    else
-      isym->requiredFns.put(fn, fn); // with a default implementation
-
-    if (fn->where != NULL)
-      USR_FATAL_CONT(fn->where, "the interface function %s%s", fn->name,
-            " contains a where clause, which is currently not supported");
-
-    resolveFunction(fn);
-  }
-  cgprint("\n");
-}
-
-
-/*********** InterfaceFunctionMap ***********/
-//
-// Implements visibility of interface functions within a CG function.
-// Ex. worker() should be visible within fun():
-//
-//   interface IFC(T) { proc worker(arg:T); }
-//   proc fun(x) where implements IFC(x.type) { worker(x); }
-//
 
 static FnSymbol* instantiateRequiredFn(FnSymbol* required, SymbolMap& fml2act)
 {
@@ -127,18 +163,24 @@ static FnSymbol* instantiateRequiredFn(FnSymbol* required, SymbolMap& fml2act)
   instantiated->addFlag(FLAG_RESOLVED); // this is white lie
   for_formals(formal, instantiated) {
     TypeSymbol* fml = formal->type->symbol;
-    if (Symbol* act = fml2act.get(fml))  // is this needed?
+    if (Symbol* act = fml2actDup.get(fml))  // is this needed?
       formal->type = toTypeSymbol(act)->type;
   }
   return instantiated;
 }
 
-
-static void createRepsForRequiredFns(FnSymbol* fn, InterfaceInfo* ifcInfo) {
-  INT_ASSERT(ifcInfo->repsForRequiredFns.empty()); // first time resolving 'fn'
+//
+// Implements visibility of interface functions within a CG function.
+// Ex. worker() should be visible within fun():
+//
+//   interface IFC(T) { proc worker(arg:T); }
+//   proc fun(x) where implements IFC(x.type) { worker(x); }
+//
+static void createRepsForIfcSymbols(FnSymbol* fn, InterfaceInfo* ifcInfo) {
+  INT_ASSERT(ifcInfo->repsForIfcSymbols.empty()); // first time resolving 'fn'
 
   // we could resize this up front (does not work with gcc 4.8)
-  //ifcInfo->repsForRequiredFns.resize(ifcInfo->interfaceConstraints.length);
+  //ifcInfo->repsForIfcSymbols.resize(ifcInfo->interfaceConstraints.length);
 
   // For each required function of each interface, make an instantiation of
   // its signature visible to the function body.
@@ -149,6 +191,19 @@ static void createRepsForRequiredFns(FnSymbol* fn, InterfaceInfo* ifcInfo) {
     SymbolMap fml2act;
     buildAndCheckFormals2Actuals(isym, icon, "interface constraint", fml2act);
 
+    // Create reps for isym's associated types.
+    // Do this before instantiating the required functions
+    // because those can reference associated types.
+    for (auto& elem: isym->associatedTypes) {
+      ConstrainedType* required = elem.second;
+      TypeSymbol*  instantiated = ConstrainedType::build(elem.first,
+                                                         CT_CGFUN_ASSOC_TYPE);
+      ifcInfo->constrainedTypes.insertAtTail(new DefExpr(instantiated));
+      INT_ASSERT(instantiated->inTree()); //CG TODO: this assert is not needed
+      reps.put(required->symbol, instantiated);
+      fml2act.put(required->symbol, instantiated);
+    }
+
     form_Map(SymbolMapElem, elem, isym->requiredFns) {
       FnSymbol* required = toFnSymbol(elem->key);
       FnSymbol* instantiated = instantiateRequiredFn(required, fml2act);
@@ -157,12 +212,9 @@ static void createRepsForRequiredFns(FnSymbol* fn, InterfaceInfo* ifcInfo) {
       reps.put(required, instantiated);
     }
 
-    ifcInfo->repsForRequiredFns.push_back(reps);
+    ifcInfo->repsForIfcSymbols.push_back(reps);
   }
 }
-
-
-/*********** resolveConstrainedGenericFun ***********/
 
 // If 'fn' is a CG function and has not been resolved yet, resolve it.
 void resolveConstrainedGenericFun(FnSymbol* fn) {
@@ -171,24 +223,32 @@ void resolveConstrainedGenericFun(FnSymbol* fn) {
   if (ifcInfo == NULL) return;  // not a CG
   cgprint("resolving CG function early %s  %s\n", symstring(fn), debugLoc(fn));
 
-  createRepsForRequiredFns(fn, ifcInfo);
+  createRepsForIfcSymbols(fn, ifcInfo);
 
   // Seems like we do not need fn->setGeneric(false) for resolveFunction()
   // NB we want 'fn' to be generic later, when checking isApplicable()
+  resolveSignature(fn);
   resolveFunction(fn);
 
   for_alist(expr, ifcInfo->constrainedTypes)
-    toDefExpr(expr)->sym->addFlag(FLAG_GENERIC);
+    if (Symbol* s = toDefExpr(expr)->sym) {
+      if (isConstrainedTypeSymbol(s, CT_CGFUN_FORMAL))
+        s->addFlag(FLAG_GENERIC);
+      else
+        // keep these "concrete"
+        INT_ASSERT(isConstrainedTypeSymbol(s, CT_CGFUN_ASSOC_TYPE));
+    }
 
-  // Remove the reps created in createRepsForRequiredFns()
-  // that were needed during resolveFunction(fn).
+  // Remove the reps created in createRepsForIfcSymbols(),
+  // which were needed during resolveFunction(fn).
   // This way they do not show in instantiations of 'fn'.
-  // 'fn' itself will be pruned as it is considered generic.
-  for (int indx = 0; indx < (int)ifcInfo->repsForRequiredFns.size(); indx++) {
-    form_Map(SymbolMapElem, elem, ifcInfo->repsForRequiredFns[indx]) {
-      FnSymbol* instantiated = toFnSymbol(elem->value);
-      INT_ASSERT(instantiated->defPoint->parentExpr == fn->body);
-      instantiated->defPoint->remove();
+  // No need to clean 'fn' -- it will be pruned as it is considered generic.
+  for (SymbolMap& reps: ifcInfo->repsForIfcSymbols) {
+    form_Map(SymbolMapElem, elem, reps) {
+      if (FnSymbol* instantiated = toFnSymbol(elem->value)) {
+        INT_ASSERT(instantiated->defPoint->parentExpr == fn->body);
+        instantiated->defPoint->remove();
+      }
     }
   }
   cgprint("\n");
@@ -197,51 +257,173 @@ void resolveConstrainedGenericFun(FnSymbol* fn) {
 
 /*********** resolveImplementsStmt ***********/
 
-// Returns whether a witness has been established successfully.
-static bool resolveWitness(InterfaceSymbol* isym, ImplementsStmt* istm,
-                           SymbolMap& fml2act, BlockStmt* holder,
-                           //CG TODO: 'indent' is used only for debug. output
-                           const char* indent,
-                           bool reportErrors,
-                           FnSymbol* reqFn, Symbol*& implRef) {
+static void resolveIStmActuals(FnSymbol* wrapFn, ImplementsStmt* istm) {
+  // ideally, removing and re-inserting 'istm' would not be needed
+  Expr* anchor = istm->next;
+  istm->remove();
+  resolveFunction(wrapFn);  // resolve the actuals of istm
+  anchor->insertBefore(istm);
+}
+
+static void cleanupHolder(BlockStmt* holder) {
+  do { holder->body.tail->remove(); } while (holder->body.tail != NULL);
+}
+
+// Computes and stores the associated type for this implementations
+// that corresponds to the associated type 'ifcAT' in the interface, ex.
+//
+//   interface IFC(Self) { type AssocType; }
+//   record R { proc AssocType type return int; }
+//   R implements IFC;
+//   ===> AssocType -> int
+//
+// Returns whether this was successful.
+static bool resolveOneAssocType(InterfaceSymbol* isym, ImplementsStmt* istm,
+                                SymbolMap& fml2act, BlockStmt* holder,
+                                const char* indent, bool reportErrors,
+                                ConstrainedType* ifcAT) {
   INT_ASSERT(holder->body.empty());
+  INT_ASSERT(ifcAT->ctUse == CT_IFC_ASSOC_TYPE);
+  cgprint("%s  assoc type  %s\n", indent, symstring(ifcAT->symbol));
+
+  // To find the corresponding associated type, create a call and resolve it.
+  // It is a method call, the receiver's type is the first actual of istm.
+  Symbol* ifcFormal = toDefExpr(isym->ifcFormals.head)->sym;
+  Type* recvType = fml2act.get(ifcFormal)->typeInfo();
+
+  VarSymbol* recv = newTemp("atype_tmp", recvType);
+  CallExpr* call = new CallExpr(ifcAT->symbol->name, gMethodToken, recv);
+  holder->insertAtTail(call);
+  FnSymbol* target = tryResolveCall(call);
+  Type* gcfunAT = NULL;
+  if (target != NULL) {
+    if (target->retTag == RET_TYPE) {
+      resolveFunction(target); // aborts if there are errors
+      gcfunAT = target->retType;
+      cgprint("%s           -> %s  %s\n", indent,
+              symstring(gcfunAT->symbol), gcfunAT->symbol->getModule()
+              ->modTag == MOD_INTERNAL ? "" : debugLoc(gcfunAT));
+    } else {
+      if (reportErrors) {
+        USR_FATAL_CONT(istm, "when checking this implements statement");
+        USR_PRINT(target, "this implementation of the associated type %s"
+                  " is not or does not provide a type", ifcAT->symbol->name);
+        USR_PRINT(ifcAT->symbol, "the associated type %s in the interface %s"
+                  " is declared here", ifcAT->symbol->name, isym->name);
+      }
+    }
+  } else {
+    if (reportErrors) {
+      USR_FATAL_CONT(istm, "when checking this implements statement");
+      USR_PRINT(istm, "the associated type %s is not implemented",
+                ifcAT->symbol->name);
+      USR_PRINT(ifcAT->symbol, "the associated type %s in the interface %s"
+                " is declared here", ifcAT->symbol->name, isym->name);
+    }
+  }
+
+  cleanupHolder(holder);
+  if (gcfunAT != NULL) {
+    fml2act.put(ifcAT->symbol, gcfunAT->symbol);
+    istm->witnesses.put(ifcAT->symbol, gcfunAT->symbol);
+    if (gcfunAT->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE))
+      USR_FATAL_CONT(istm, "the associated type %s is instantiated with a"
+                     " runtime type '%s', which is currently not implemented",
+                     ifcAT->symbol->name, toString(gcfunAT));
+  }
+
+  return gcfunAT != NULL;
+}
+
+static bool resolveAssociatedTypes(InterfaceSymbol* isym, ImplementsStmt* istm,
+                                   SymbolMap& fml2act, BlockStmt* holder,
+                                   bool nested, const char* indent,
+                                   bool reportErrors) {
+  bool atSuccess = true;
+
+  for (auto& elem: isym->associatedTypes)
+    atSuccess &= resolveOneAssocType(isym, istm, fml2act, holder,
+                                     indent, reportErrors, elem.second);
+
+  return atSuccess;
+}
+
+static bool checkAssocConstraints(InterfaceSymbol* isym, ImplementsStmt* istm,
+                                  SymbolMap& fml2act, BlockStmt* holder,
+                                  //bool nested, const char* indent,
+                                  CallExpr* callsite, bool reportErrors) {
+  bool acSuccess = true;
+
+  for (ImplementsStmt* assocIS: isym->associatedConstraints) {
+    cgprintAssocConstraint(assocIS->iConstraint);
+    ImplementsStmt* instantiated = toImplementsStmt(assocIS->copy(&fml2act));
+    holder->insertAtTail(instantiated);
+    ImplementsStmt* resolved = constraintIsSatisfiedAtCallSite(callsite,
+                                       instantiated->iConstraint, fml2act);
+    //CG TODO: incorporate resolved->witnesses
+    cleanupHolder(holder);
+
+    if (resolved == NULL) {
+      if (! reportErrors) return false;
+      USR_FATAL_CONT(istm, "when checking this implements statement");
+      USR_PRINT(assocIS, "this associated constraint is not satisfied");
+      acSuccess = false;
+    }
+  }
+
+  return acSuccess;
+}
+
+
+// Returns whether a witness has been established successfully.
+static bool resolveOneWitness(InterfaceSymbol* isym, ImplementsStmt* istm,
+                              SymbolMap& fml2act, BlockStmt* holder,
+                              const char* indent, bool reportErrors,
+                              FnSymbol* reqFn, Symbol*& implRef) {
+  INT_ASSERT(holder->body.empty());
+  cgprint("%s  required fn %s\n", indent, symstring(reqFn));
+
+  // Create a call to the required function inside 'holder'.
   CallExpr* call = new CallExpr(reqFn->name);
   for_formals(formal, reqFn)
     call->insertAtTail(formal->copy(&fml2act));
   holder->insertAtTail(call);
+
+  // Resolve the call and see if we got a witness.
   FnSymbol* target = tryResolveCall(call);
   if (target != NULL) {
-    cgprint("%s  witness %s  %s\n", indent,
+    cgprint("%s           -> %s  %s\n", indent,
             symstring(target), debugLoc(target));
     resolveFunction(target); // aborts if there are errors
 
     call->remove();
     if (holder->body.tail != NULL) {
       if (reportErrors) {
-        USR_FATAL_CONT(istm, "the implementation for the required function %s"
+        USR_FATAL_CONT(istm, "when checking this implements statement");
+        USR_PRINT(target, "this implementation of the required function %s"
           " requires implicit conversion(s), which is currently disallowed",
           reqFn->name);
-        USR_PRINT(target, "the implementation is here");
-        USR_PRINT(reqFn, "the required function in the interface %s is here",
-                         isym->name);
+        USR_PRINT(reqFn, "the required function %s in the interface %s"
+                         " is declared here", reqFn->name, isym->name);
       }
       target = NULL;
-      do { holder->body.tail->remove(); } while (holder->body.tail != NULL);
+      cleanupHolder(holder);
     }
   } else {
     if (implRef == gDummyWitness) {
       if (reportErrors) {
-        USR_FATAL_CONT(istm, "the required function %s is not implemented",
-                              reqFn->name);
-        USR_PRINT(reqFn, "the required function in the interface %s is here",
-                         isym->name);
+        USR_FATAL_CONT(istm, "when checking this implements statement");
+        USR_PRINT(istm, "the required function %s is not implemented",
+                  reqFn->name);
+        USR_PRINT(reqFn, "the required function %s in the interface %s"
+                  " is declared here", reqFn->name, isym->name);
       }
     } else {
       SymbolMap fml2actDup = fml2act; // avoid fml2act updates by copy()
       target = toFnSymbol(implRef->copy(&fml2actDup));
       holder->insertBefore(new DefExpr(target));
       INT_ASSERT(target->isResolved()); // the dflt impl was resolved with isym
-      cgprint("%s  default %s  %s\n", indent,
+      cgprint("%s      dflt -> %s  %s\n", indent,
               symstring(target), debugLoc(target));
     }
     call->remove();
@@ -251,54 +433,98 @@ static bool resolveWitness(InterfaceSymbol* isym, ImplementsStmt* istm,
   return target != NULL;
 }
 
+static bool resolveWitnesses(InterfaceSymbol* isym, ImplementsStmt* istm,
+                             SymbolMap& fml2act, BlockStmt* holder,
+                             const char* indent, bool reportErrors) {
+  bool witSuccess = true;
+
+  form_Map(SymbolMapElem, wit, istm->witnesses) {
+    if (FnSymbol* reqFn = toFnSymbol(wit->key))
+      witSuccess &= resolveOneWitness(isym, istm, fml2act, holder,
+                                   indent, reportErrors, reqFn, wit->value);
+    else
+      INT_ASSERT(isConstrainedTypeSymbol(wit->key, CT_IFC_ASSOC_TYPE));
+  }
+
+  return witSuccess;
+}
+
+
 //
 // Ensures this ImplementsStmt indeed implements the interface, ex.
+// * determine each associated type
+// * verify the associated constraints are satisfied
 // * determine each witness, default or otherwise
 // * resolve each witness
-// Returns false otherwise.
+// Returns true if so, false otherwise.
 //
-// CG TODO: 'nested' is used only for debugging output
-static bool resolveImplementsStmt(ImplementsStmt* istm, bool nested,
+static bool resolveImplementsStmt(ImplementsStmt* istm,
+                                  bool nested, //used only for debugging output
                                   bool reportErrors) {
   if (istm->id == breakOnResolveID) gdbShouldBreakHere();
   IfcConstraint* icon = istm->iConstraint;
   InterfaceSymbol* isym = icon->ifcSymbol();
   FnSymbol* wrapFn = wrapperFnForImplementsStmt(istm);
+
   INT_ASSERT(wrapFn->hasFlag(FLAG_IMPLEMENTS_WRAPPER));
   if (wrapFn->isResolved()) {
-    INT_ASSERT(reportErrors);
-    return true; // no need to resolve again; we must have succeeded before.
+    // no need to resolve again
+    bool isSuccess;
+    implementsStmtForWrapperFn(wrapFn, isSuccess);
+    // if isSuccess can legitimately be false, return it and remove the assert
+    INT_ASSERT(isSuccess);
+    return true;
   }
 
+  const char* indent = nested ? "  " : ""; //used only for debugging output
   if (nested) cgprint("    resolving it...\n");
   else cgprint("resolving implements statement%s for ifc %s  %s\n",
                idstring("", istm), symstring(isym), debugLoc(istm));
 
-  // ideally, removing and re-inserting 'istm' would not be needed
-  Expr* anchor = istm->next;
-  istm->remove();
-  resolveFunction(wrapFn);
-  anchor->insertBefore(istm);
+  // This CallExpr will represent the checking of 'istm'.
+  CallExpr* callsite = new CallExpr(wrapFn);
+  wrapFn->defPoint->insertBefore(callsite);
+  callStack.add(callsite);
+
+  resolveIStmActuals(wrapFn, istm);
+
+  SET_LINENO(istm->implBody);
+  BlockStmt* holder = new BlockStmt();
+  istm->implBody->insertAtTail(holder);
+
+  INT_ASSERT(istm->witnesses.n == 0);      // we have not filled it yet
+  istm->witnesses.copy(isym->requiredFns); // start with the defaults impls
 
   SymbolMap fml2act; // isym formal -> istm actual
   buildAndCheckFormals2Actuals(isym, icon, "implements statement", fml2act);
 
-  INT_ASSERT(istm->witnesses.n == 0);      // we have not filled it yet
-  istm->witnesses.copy(isym->requiredFns); // start with the defaults impls
-  SET_LINENO(istm->implBody);
-  BlockStmt* holder = new BlockStmt();
-  istm->implBody->insertAtTail(holder);
-  bool witSuccess = true;
-  form_Map(SymbolMapElem, wit, istm->witnesses)
-    witSuccess &= resolveWitness(isym, istm, fml2act, holder,
-                                 nested ? "  " : "", reportErrors,
-                                 toFnSymbol(wit->key), wit->value);
-  holder->remove();
-  wrapFn->addFlag(FLAG_RESOLVED);
-  if (reportErrors && ! witSuccess) USR_STOP();
+  // check each category of istm contents
+  bool rSuccess = true;
+
+  if (rSuccess)
+    rSuccess = resolveAssociatedTypes(isym, istm, fml2act, holder,
+                                      nested, indent, reportErrors);
+  if (rSuccess)
+    rSuccess = checkAssocConstraints(isym, istm, fml2act, holder,
+                                     callsite, reportErrors);
+
+  if (rSuccess)
+    rSuccess = resolveWitnesses(isym, istm, fml2act, holder,
+                                indent, reportErrors);
 
   cgprint(nested ? "    ...done\n" : "\n");
-  return witSuccess;
+  holder->remove();
+  wrapFn->addFlag(FLAG_RESOLVED);
+  CallExpr* popped = callStack.pop();
+  INT_ASSERT(popped == callsite);
+  callsite->remove();  
+
+  if (!rSuccess) {
+    if (reportErrors) USR_STOP();
+    markImplStmtWrapFnAsFailure(wrapFn);
+  }
+
+  return rSuccess;
 }
 
 void resolveImplementsStmt(ImplementsStmt* istm) {
@@ -361,6 +587,7 @@ static void pickMatchingImplementsStmt(Vec<FnSymbol*>&  visibleFns,
     bool isSuccess;
     if (ImplementsStmt* match = matchingImplStm(wrapFn, call2wf, isSuccess)) {
       if (isSuccess) {
+        resolveImplementsStmt(match, true, true);
         firstSuccess = match;
         return;
       } else {
@@ -369,6 +596,33 @@ static void pickMatchingImplementsStmt(Vec<FnSymbol*>&  visibleFns,
       }
     }
   }
+}
+
+static void cgprintCheckedConstraint(InterfaceSymbol* isym,
+                                     IfcConstraint* constraint,
+                                     CallExpr* callsite,
+                                     ImplementsStmt *bestIstm) {
+#ifdef PRINT_CG
+  cgprint("checked constraint for %s  %s\n",
+          symstring(isym), debugLoc(constraint));
+
+  if (UnresolvedSymExpr* use = toUnresolvedSymExpr(callsite->baseExpr))
+    cgprint("  for call to %s  at %s\n", use->unresolved, debugLoc(callsite));
+  else {
+    FnSymbol* wrapFn = toFnSymbol(toSymExpr(callsite->baseExpr)->symbol());
+    if (wrapFn != NULL) {
+      // This is the only use case.
+      INT_ASSERT(wrapFn->hasFlag(FLAG_IMPLEMENTS_WRAPPER));
+      cgprint("  when checking the constraint at %s\n", debugLoc(wrapFn));
+    }
+  }
+
+  if (bestIstm)
+    cgprint("  satisfied with implements stmt%s  %s\n\n",
+            idstring("", bestIstm), debugLoc(bestIstm));
+  else
+    cgprint("  not satisfied\n\n");
+#endif
 }
 
 // Traverse lexical scopes starting with callsite's.
@@ -444,18 +698,14 @@ static ImplementsStmt* checkInferredImplStmt(CallExpr* callsite,
     return NULL;
 
   // Try to infer as if we are in anchor's scope.
-  // Place the outcome - positive or negative - next to 'anchor'.
+  // Retain the outcome - positive or negative - next to 'anchor'.
 
   ImplementsStmt* istm = buildInferredImplStmt(isym, call2wf);
   anchor->insertBefore(istm);
-  FnSymbol* wrapFn = wrapOneImplementsStatement(istm);
+  wrapOneImplementsStatement(istm);
   bool success = resolveImplementsStmt(istm, true, false);
-  if (success) {
-    return istm;
-  } else {
-    markImplStmtWrapFnAsFailure(wrapFn);
-    return NULL;
-  }
+
+  return success ? istm : NULL;
 }
 
 /*
@@ -525,15 +775,9 @@ ImplementsStmt* constraintIsSatisfiedAtCallSite(CallExpr* callsite,
 
   call2wf = NULL; // call2wf is cleared in checkInferredImplStmt
 
-  cgprint("checked constraint for %s  %s\n",
-          symstring(isym), debugLoc(constraint));
-  cgprint("  for call to %s  at %s\n",
-          toUnresolvedSymExpr(callsite->baseExpr)->unresolved,
-          debugLoc(callsite));
-  if (bestIstm) cgprint("  satisfied with implements stmt%s  %s\n\n",
-                         idstring("", bestIstm), debugLoc(bestIstm));
-  else          cgprint("  not satisfied\n\n");
+  cgprintCheckedConstraint(isym, constraint, callsite, bestIstm);
 
+  // It is resolved, if non-null.
   return bestIstm;
 }
 
@@ -541,71 +785,62 @@ ImplementsStmt* constraintIsSatisfiedAtCallSite(CallExpr* callsite,
 /*********** other ***********/
 
 //
-// 'fn' was created by FnSymbol::partialCopy() from an early-resolved
-// CG function, specializing it for the given witness(es).
-// We need to adjust the outcome. For example, set up the substitutions
-// from the FnSymbols representing interface functions within the
-// early-resolved CG function to the FnSymbols of the corresponding
-// witnesses. These substitutions will be applied in FnSymbol::finalizeCopy().
-//
-void cleanupInstantiatedCGfun(FnSymbol* fn,
-                              std::vector<ImplementsStmt*>& witnesses)
-{
-  if (fatalErrorsEncountered())
-    return; // got errors, do not proceed
-
-  cgprint("considering CG candidate %s%s  %s\n", symstring(fn),
-          idstring("  from", fn->instantiatedFrom), debugLoc(fn));
-#ifdef PRINT_CG
-  cgprint("  witness(es):\n");
-  for_vector(ImplementsStmt, istm, witnesses) {
-    IfcConstraint* icon = istm->iConstraint;
-    InterfaceSymbol* isym = icon->ifcSymbol();
-    cgprint("  implements stmt%s for ifc %s  %s\n",
-            idstring("", istm), symstring(isym), debugLoc(istm));
+// This populates 'substitutions' with the mapping from each associated type
+// in 'fn' for indx-th constraint to the A.T.'s instantiation.
+// 
+void copyIfcRepsToSubstitutions(FnSymbol* fn, int indx, ImplementsStmt* istm,
+                                SymbolMap& substitutions) {
+  form_Map(SymbolMapElem, elem,
+           fn->interfaceInfo->repsForIfcSymbols[indx])
+  {
+    Symbol* required = elem->key;
+    Symbol* usedInFn = elem->value;
+    Symbol* implem   = istm->witnesses.get(required);
+    if (isFnSymbol(required)) {
+      INT_ASSERT(isFnSymbol(usedInFn));
+      INT_ASSERT(isFnSymbol(implem));
+    } else {
+      INT_ASSERT(isConstrainedTypeSymbol(required, CT_IFC_ASSOC_TYPE));
+      INT_ASSERT(isConstrainedTypeSymbol(usedInFn, CT_CGFUN_ASSOC_TYPE));
+    }
+    substitutions.put(usedInFn, implem);
   }
-#endif
 
-  PartialCopyData* pcd = getPartialCopyData(fn);
-  INT_ASSERT((pcd == NULL) == (fn->interfaceInfo == NULL));
-  if (pcd == NULL)
-    return; // this function has been cleaned up already
+  for_formals(formal, fn)
+    // CG TODO: also handle a nested AT, ex. [1..3] AT
+    if (Symbol* sym = substitutions.get(formal->type->symbol))
+      substitutions.put(formal, sym);
+}
 
-  SymbolMap& substitutions = pcd->partialCopyMap;
+//
+// The substitutions from repsForIfcSymbols to their implementations,
+// which we worked so hard to compute, are dropped on the floor
+// by instantiateSignature() -> partialCopy().
+// Recover them so they take effect later upon finalizeCopy().
+//
+void adjustForCGinstantiation(FnSymbol* fn, SymbolMap& substitutions) {
+  PartialCopyData* pci = getPartialCopyData(fn);
+  if (! pci)
+    return; // already finalizeCopy-ed
+  if (! pci->partialCopySource->isConstrainedGeneric())
+    return; // works fine as-is
 
-  // Resolve ImplementsStmts that haven't been already.
-  // Extend 'substitutions'.
-  for (int indx = 0; indx < (int)witnesses.size(); indx++) {
-    ImplementsStmt* istm = witnesses[indx];
-    resolveImplementsStmt(istm, true, true);
-    SymbolMap& reps = fn->instantiatedFrom->interfaceInfo
-                       ->repsForRequiredFns[indx];
-    form_Map(SymbolMapElem, elem, reps) {
-      Symbol* required = elem->key;
-      Symbol* usedInFn = elem->value;
-      Symbol* implem   = istm->witnesses.get(required);
-      INT_ASSERT(isFnSymbol(required) && isFnSymbol(usedInFn) &&
-                 isFnSymbol(implem));
-      substitutions.put(usedInFn, implem);
+  // This is how we copy a CG function.
+  INT_ASSERT(fn->interfaceInfo == NULL);
+  INT_ASSERT(! fn->hasFlag(FLAG_GENERIC));
+
+  SymbolMap& pciMap = pci->partialCopyMap;
+
+  form_Map(SymbolMapElem, elem, substitutions) {
+    if (isArgSymbol(elem->key)) {
+      // The formals are already mapped.
+      // NB 'substitutions' map formals to their types.
+      Symbol* alreadyMapped = pciMap.get(elem->key);
+      INT_ASSERT(alreadyMapped->type->symbol == elem->value);
+    } else {
+      pciMap.put(elem->key, elem->value);
     }
   }
-
-  // remove fn->interfaceInfo
-
-  INT_ASSERT(fn->interfaceInfo->repsForRequiredFns.empty());
-  INT_ASSERT(! fn->interfaceInfo->interfaceConstraints.empty());
-  for_alist(expr, fn->interfaceInfo->constrainedTypes)
-    expr->remove();
-  for_alist(expr, fn->interfaceInfo->interfaceConstraints)
-    expr->remove();
-  delete fn->interfaceInfo;
-  fn->interfaceInfo = NULL;
-
-  // 'fn' is concrete now
-
-  fn->setGeneric(false);
-
-  cgprint("\n");
 }
 
 void resolveConstrainedGenericSymbol(Symbol* sym, bool mustBeCG) {
@@ -628,4 +863,75 @@ void resolveConstrainedGenericSymbol(Symbol* sym, bool mustBeCG) {
 
   // Not an expected case. Ignore unless mustBeCG.
   INT_ASSERT(!mustBeCG);
+}
+
+static void issueAssocTypeAmbiguousError(IfcConstraint*   assocCons1,
+                                         IfcConstraint*   assocCons2,
+                                         CallExpr*        call,
+                                         const char*      atName) {
+  USR_FATAL_CONT(call, "the associated type '%s' is ambiguous", atName);
+  USR_PRINT(assocCons1, "it can come from interface '%s' in this constraint",
+                        assocCons1->ifcSymbol()->name);
+  USR_PRINT(assocCons2, "or from interface '%s' in this constraint",
+                        assocCons2->ifcSymbol()->name);
+  USR_STOP();
+}
+
+// Convert the call 'CT.assocType' to the corresponding entry
+// from 'repsForIfcSymbols'.
+Expr* resolveCallToAssociatedType(CallExpr* call, ConstrainedType* recv) {
+  if (recv->ctUse != CT_CGFUN_FORMAL)
+    USR_FATAL(call, "this use of a constrained type '%s'"
+              " is at present not supported", recv->symbol->name);
+  FnSymbol* parentFn = call->getFunction();
+  INT_ASSERT(recv->symbol->defPoint->parentSymbol == parentFn);
+  InterfaceInfo* ifcInfo = parentFn->interfaceInfo;
+  const char* atName = toUnresolvedSymExpr(call->baseExpr)->unresolved;
+
+  ConstrainedType* assocType = NULL;
+  IfcConstraint*   assocCon  = NULL;
+  int indx = -1;
+
+  // Find the constraint(s) where 'recv' is an implementer.
+  // This search below succeeds whether 'recv' is the single actual
+  // to an interface constraint or one of the several actuals.
+  for_alist(iconExpr, ifcInfo->interfaceConstraints) {
+    IfcConstraint* icon = toIfcConstraint(iconExpr);
+    indx++;
+    bool found = false;
+    for_alist(arg, icon->consActuals)
+      if (arg->typeInfo() == recv)
+        { found = true; break; }  // yes, it is an implementer
+    if (!found)
+      continue;
+
+    // See if the corresponding interface has an assoc type named atName.
+    InterfaceSymbol* isym = icon->ifcSymbol();
+    auto assocTypeIT = isym->associatedTypes.find(atName);
+    if (assocTypeIT == isym->associatedTypes.end())
+      continue;
+
+    // Ensure it is unambiguous.
+    if (assocCon != NULL)
+      issueAssocTypeAmbiguousError(assocCon, icon, call, atName);
+    assocCon = icon;
+
+    // Fetch the corresponding ConstrainedType from repsForIfcSymbols.
+    // We could have lazy creation of these ConstrainedTypes here, i.e.
+    // create one if it is not already in repsForIfcSymbols. However,
+    // we will use repsForIfcSymbols in a copy() later, which does not
+    // give us an option for lazy creation.
+    Symbol* atRep = ifcInfo->repsForIfcSymbols[indx].get(
+                               assocTypeIT->second->symbol);
+    assocType = toConstrainedType(toTypeSymbol(atRep)->type);
+    INT_ASSERT(assocType->ctUse == CT_CGFUN_ASSOC_TYPE);
+  }
+
+  if (assocType == NULL)
+    // This was not a reference to an associated type
+    return call;
+
+  SymExpr* result = new SymExpr(assocType->symbol);
+  call->replace(result);
+  return result;
 }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2309,6 +2309,12 @@ static Expr* preFoldNamed(CallExpr* call) {
       if (retval != NULL)
         call->replace(retval);
     }
+  } else if (call->numActuals() == 2  &&
+             call->get(1)->typeInfo() == dtMethodToken ) {
+    // Handle a reference to an interface associated type, if applicable.
+    if (ConstrainedType* recv = toConstrainedType(call->get(2)->typeInfo())) {
+      retval = resolveCallToAssociatedType(call, recv);
+    }
   }
 
   return retval;

--- a/test/constrained-generics/basic/associated/associated-constraint-empty.chpl
+++ b/test/constrained-generics/basic/associated/associated-constraint-empty.chpl
@@ -1,0 +1,46 @@
+// This is associated-type-query.chpl
+// plus it adds a constraint on the associated type.
+
+interface IFC {
+  type AT;
+  AT implements Helper;
+  proc Self.reqFun(formal: AT);
+  proc Self.dfltImpl(formal: AT) {
+    writeln("in IFC.dfltImpl");
+  }
+}
+
+interface Helper { }
+
+proc cgFun(cgArg: ?Q, atArg: Q.AT) where Q implements IFC {
+  writeln("in cgFun");
+  cgArg.reqFun(atArg);
+  cgArg.dfltImpl(atArg);
+}
+
+record R1 {
+  type AT;          // AT is implemented with a type field
+  var x1: AT;
+  proc reqFun(arg: AT) {
+    writeln("R1.reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+int implements Helper;
+implements IFC(R1(int));
+
+cgFun(new R1(int, 55), 66);
+
+record R2 {
+  var xx;
+  proc AT type      // AT is implemented with a type method
+    return xx.type;
+  proc reqFun(arg: AT) {
+    writeln("R2(", xx, ").reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+string implements Helper;
+implements IFC(R2(string));
+
+cgFun(new R2("hello"), "world");

--- a/test/constrained-generics/basic/associated/associated-constraint-empty.good
+++ b/test/constrained-generics/basic/associated/associated-constraint-empty.good
@@ -1,0 +1,6 @@
+in cgFun
+R1.reqFun(66: int(64))
+in IFC.dfltImpl
+in cgFun
+R2(hello).reqFun(world: string)
+in IFC.dfltImpl

--- a/test/constrained-generics/basic/associated/associated-constraint-used.bad
+++ b/test/constrained-generics/basic/associated/associated-constraint-used.bad
@@ -1,0 +1,3 @@
+associated-constraint-used.chpl:8: In method 'dfltImpl':
+associated-constraint-used.chpl:10: error: unresolved call 'helpme(AT)'
+associated-constraint-used.chpl:10: note: because no functions named helpme found in scope

--- a/test/constrained-generics/basic/associated/associated-constraint-used.chpl
+++ b/test/constrained-generics/basic/associated/associated-constraint-used.chpl
@@ -1,0 +1,50 @@
+// This is associated-constraint-empty.chpl
+// where Helper defines a function that is used.
+
+interface IFC {
+  type AT;
+  AT implements Helper;
+  proc Self.reqFun(formal: AT);
+  proc Self.dfltImpl(formal: AT) {
+    writeln("in IFC.dfltImpl");
+    helpme(formal);
+  }
+}
+
+interface Helper {
+  proc helpme(arg: Self) { writeln("Helper.helpme"); }
+}
+
+proc cgFun(cgArg: ?Q, atArg: Q.AT) where Q implements IFC {
+  writeln("in cgFun");
+  cgArg.reqFun(atArg);
+  cgArg.dfltImpl(atArg);
+  helpme(atArg);
+}
+
+record R1 {
+  type AT;          // AT is implemented with a type field
+  var x1: AT;
+  proc reqFun(arg: AT) {
+    writeln("R1.reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+int implements Helper;
+implements IFC(R1(int));
+
+cgFun(new R1(int, 55), 66);
+
+record R2 {
+  var xx;
+  proc AT type      // AT is implemented with a type method
+    return xx.type;
+  proc reqFun(arg: AT) {
+    writeln("R2(", xx, ").reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+string implements Helper;
+implements IFC(R2(string));
+
+cgFun(new R2("hello"), "world");

--- a/test/constrained-generics/basic/associated/associated-constraint-used.future
+++ b/test/constrained-generics/basic/associated/associated-constraint-used.future
@@ -1,0 +1,1 @@
+bug: cannot use functions due to associated constraint

--- a/test/constrained-generics/basic/associated/associated-constraint-used.good
+++ b/test/constrained-generics/basic/associated/associated-constraint-used.good
@@ -1,0 +1,8 @@
+in cgFun
+R1.reqFun(66: int(64))
+in IFC.dfltImpl
+Helper.helpme
+in cgFun
+R2(hello).reqFun(world: string)
+in IFC.dfltImpl
+Helper.helpme

--- a/test/constrained-generics/basic/associated/associated-type-query.chpl
+++ b/test/constrained-generics/basic/associated/associated-type-query.chpl
@@ -1,0 +1,42 @@
+// Check that the associated type 'AT' is inferred properly.
+// Uses type query for the CG formal.
+// The CG function includes a formal of the associated type.
+
+interface IFC {
+  type AT;
+  proc Self.reqFun(formal: AT);
+  proc Self.dfltImpl(formal: AT) {
+    writeln("in IFC.dfltImpl");
+  }
+}
+
+proc cgFun(cgArg: ?Q, atArg: Q.AT) where Q implements IFC {
+  writeln("in cgFun");
+  cgArg.reqFun(atArg);
+  cgArg.dfltImpl(atArg);
+}
+
+record R1 {
+  type AT;          // AT is implemented with a type field
+  var x1: AT;
+  proc reqFun(arg: AT) {
+    writeln("R1.reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+implements IFC(R1(int));
+
+cgFun(new R1(int, 55), 66);
+
+record R2 {
+  var xx;
+  proc AT type      // AT is implemented with a type method
+    return xx.type;
+  proc reqFun(arg: AT) {
+    writeln("R2(", xx, ").reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+implements IFC(R2(string));
+
+cgFun(new R2("hello"), "world");

--- a/test/constrained-generics/basic/associated/associated-type-query.good
+++ b/test/constrained-generics/basic/associated/associated-type-query.good
@@ -1,0 +1,6 @@
+in cgFun
+R1.reqFun(66: int(64))
+in IFC.dfltImpl
+in cgFun
+R2(hello).reqFun(world: string)
+in IFC.dfltImpl

--- a/test/constrained-generics/basic/associated/associated-type-three.chpl
+++ b/test/constrained-generics/basic/associated/associated-type-three.chpl
@@ -1,0 +1,73 @@
+// This is associated-type-query.chpl
+// with three associated types.
+
+interface IFC {
+  type AT1;
+  type AT2;
+  type AT3;
+
+  proc reqFunS(formal: Self);
+  proc reqFun123(formal1: AT1, formal2: AT2, formal3: AT3);
+  proc Self.reqMeth1(formal1: AT1);
+  proc Self.reqMeth23(formal2: AT2, formal3: AT3);
+
+  proc dfltFunS(formal: Self)
+  {  writeln("IFC.dfltFunS");    }
+  proc dfltFun123(formal1: AT1, formal2: AT2, formal3: AT3)
+  {  writeln("IFC.dfltFun123");  }
+  proc Self.dfltMeth1(formal1: AT1)
+  {  writeln("IFC.dfltMeth1");   }
+  proc Self.dfltMeth23(formal2: AT2, formal3: AT3)
+  {  writeln("IFC.dfltMeth23");  }
+}
+
+proc cgFun(cgArg: ?Q, arg1: Q.AT3, arg2: Q.AT2, arg3: cgArg.AT1)
+    where Q implements IFC
+{
+  writeln("in cgFun#1");
+}
+
+proc cgFun(cgArg: ?Q, arg1: Q.AT1, arg2: Q.AT2, arg3: cgArg.AT3)
+    where Q implements IFC
+{
+  writeln("in cgFun#2");
+
+  reqFunS(cgArg);
+  reqFun123(arg1, arg2, arg3);
+  cgArg.reqMeth1(arg1);
+  cgArg.reqMeth23(arg2, arg3);
+
+  dfltFunS(cgArg);
+  dfltFun123(arg1, arg2, arg3);
+  cgArg.dfltMeth1(arg1);
+  cgArg.dfltMeth23(arg2, arg3);
+}
+
+record RR {
+  type AT1;
+  proc AT2 type return AT1;
+  proc AT3 type return bool;
+  var xx: AT1;
+
+  proc reqMeth1(formal1: AT1) {
+    writeln("RR(", xx, "): ", this.type:string, ").reqMeth1(",
+            formal1, ": ", formal1.type:string, ")");
+  }
+}
+
+proc RR.reqMeth23(formal2: int, formal3: AT3) {
+  writeln("RR(", xx, "): ", this.type:string, ").reqMeth23(",
+          formal2, ", ", formal3, ": ", formal3.type:string, ")");
+}
+
+proc reqFunS(formal: RR) {
+  writeln("reqFunS(", formal, ": ", formal.type:string, ")");
+}
+proc reqFun123(formal1: int, formal2, formal3: bool) {
+  writeln("reqFun123(", formal1, ", ", formal2, ", ", formal3, ")");
+}
+
+implements IFC(RR(int));
+
+// should call cgFun#2
+cgFun(new RR(int, 55), 66, 77, true);

--- a/test/constrained-generics/basic/associated/associated-type-three.good
+++ b/test/constrained-generics/basic/associated/associated-type-three.good
@@ -1,0 +1,9 @@
+in cgFun#2
+reqFunS((xx = 55): RR(int(64)))
+reqFun123(66, 77, true)
+RR(55): RR(int(64))).reqMeth1(66: int(64))
+RR(55): RR(int(64))).reqMeth23(77, true: bool)
+IFC.dfltFunS
+IFC.dfltFun123
+IFC.dfltMeth1
+IFC.dfltMeth23

--- a/test/constrained-generics/basic/associated/error-acons-not-sat.chpl
+++ b/test/constrained-generics/basic/associated/error-acons-not-sat.chpl
@@ -1,0 +1,36 @@
+// This is associated-constraint-empty.chpl
+// where the associated constraint is not satisfied.
+// cgFun() is removed because its presence should not affect checking.
+
+interface IFC {
+  type AT;
+  AT implements Helper;
+  proc Self.reqFun(formal: AT);
+  proc Self.dfltImpl(formal: AT) {
+    writeln("in IFC.dfltImpl");
+  }
+}
+
+interface Helper { }
+
+record R1 {
+  type AT;          // AT is implemented with a type field
+  var x1: AT;
+  proc reqFun(arg: AT) {
+    writeln("R1.reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+int implements Helper;
+implements IFC(R1(int)); // ok
+
+record R2 {
+  var xx;
+  proc AT type      // AT is implemented with a type method
+    return xx.type;
+  proc reqFun(arg: AT) {
+    writeln("R2(", xx, ").reqFun(", arg, ": ", AT:string, ")");
+  }
+}
+
+implements IFC(R2(string)); // error: AT=string does not implement Helper

--- a/test/constrained-generics/basic/associated/error-acons-not-sat.good
+++ b/test/constrained-generics/basic/associated/error-acons-not-sat.good
@@ -1,0 +1,3 @@
+error-acons-not-sat.chpl:36: In 'implements IFC' statement:
+error-acons-not-sat.chpl:36: error: when checking this implements statement
+error-acons-not-sat.chpl:7: note: this associated constraint is not satisfied

--- a/test/constrained-generics/basic/associated/error-actual-mismatch.chpl
+++ b/test/constrained-generics/basic/associated/error-actual-mismatch.chpl
@@ -1,0 +1,31 @@
+// This is a part of associated-type-three.chpl
+// where the actuals' types are mismatched.
+
+interface IFC {
+  type AT1;
+  type AT2;
+  type AT3;
+
+  proc reqFunS(formal: Self);
+}
+
+proc cgFun(cgArg: ?Q, arg1: Q.AT3, arg2: Q.AT2, arg3: cgArg.AT1)
+    where Q implements IFC
+{
+  writeln("in cgFun#1");
+  reqFunS(cgArg);
+}
+
+record RR {
+  type AT1;
+  proc AT2 type return AT1;
+  proc AT3 type return bool;
+}
+
+// RR implements IFC implicitly, thanks to this fn.
+proc reqFunS(formal: RR) {
+  writeln("reqFunS(", formal, ": ", formal.type:string, ")");
+}
+
+cgFun(new RR(int), true, 66, 77);  // ok
+cgFun(new RR(int), 66, 77, true);  // error

--- a/test/constrained-generics/basic/associated/error-actual-mismatch.good
+++ b/test/constrained-generics/basic/associated/error-actual-mismatch.good
@@ -1,0 +1,4 @@
+error-actual-mismatch.chpl:31: error: unresolved call 'cgFun(RR(int(64)), 66, 77, 1)'
+error-actual-mismatch.chpl:12: note: this candidate did not match: cgFun(cgArg: ?Q, arg1: Q.AT3, arg2: Q.AT2, arg3: cgArg.AT1)
+error-actual-mismatch.chpl:31: note: because actual argument #2 with type 'int(64)'
+error-actual-mismatch.chpl:12: note: is passed to formal 'arg1: bool'

--- a/test/constrained-generics/basic/associated/error-atype-not-impl.chpl
+++ b/test/constrained-generics/basic/associated/error-atype-not-impl.chpl
@@ -1,0 +1,21 @@
+// This is associated-type-query.chpl
+// where the associated type is not implemented.
+// cgFun() is removed because its presence should not affect checking.
+
+interface IFC {
+  type AT;
+  proc Self.reqFun(formal: AT);
+  proc Self.dfltImpl(formal: AT) {
+    writeln("in IFC.dfltImpl");
+  }
+}
+
+record R1 {
+  type AQ;
+  var x1: AQ;
+  proc reqFun(arg: AQ) {
+    writeln("R1.reqFun(", arg, ": ", AQ:string, ")");
+  }
+}
+
+implements IFC(R1(int));  // error: 'AT' is not implemented

--- a/test/constrained-generics/basic/associated/error-atype-not-impl.good
+++ b/test/constrained-generics/basic/associated/error-atype-not-impl.good
@@ -1,0 +1,4 @@
+error-atype-not-impl.chpl:21: In 'implements IFC' statement:
+error-atype-not-impl.chpl:21: error: when checking this implements statement
+error-atype-not-impl.chpl:21: note: the associated type AT is not implemented
+error-atype-not-impl.chpl:6: note: the associated type AT in the interface IFC is declared here

--- a/test/constrained-generics/basic/set1/basic-ref-args.bad
+++ b/test/constrained-generics/basic/set1/basic-ref-args.bad
@@ -1,0 +1,7 @@
+basic-ref-args.chpl:13: internal error: PAS-RES-NTS-nnnn chpl version mmmm
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/constrained-generics/basic/set1/basic-ref-args.future
+++ b/test/constrained-generics/basic/set1/basic-ref-args.future
@@ -1,0 +1,1 @@
+bug: compiler crash upon ref formals

--- a/test/constrained-generics/basic/set1/error-implements-stmt.good
+++ b/test/constrained-generics/basic/set1/error-implements-stmt.good
@@ -1,3 +1,4 @@
 error-implements-stmt.chpl:25: In 'implements IFC' statement:
-error-implements-stmt.chpl:25: error: the required function reqFun is not implemented
-error-implements-stmt.chpl:7: note: the required function in the interface IFC is here
+error-implements-stmt.chpl:25: error: when checking this implements statement
+error-implements-stmt.chpl:25: note: the required function reqFun is not implemented
+error-implements-stmt.chpl:7: note: the required function reqFun in the interface IFC is declared here


### PR DESCRIPTION
With this PR, users can declare associated types and impose constraints on them. An associated type can be implemented with either a `type` field or a `type` method. Associated types are disallowed on interfaces with >1 formal, pending resolution of #17008.

For example:
```chpl
interface IFC {
  type AT;
  AT implements Helper;
  ......
}

interface Helper { ...... }

record R1 {
  type AT;   // could also be 'proc AT type ...'
  ......
}

int implements Helper;
implements IFC(R1(int));  // AT = int
```

While there, improve debugging support.

Futurized one test that now fails while passing a `ref` formal of one CG function to a default-intent formal of another CG function, where both formals are of the same interface type.

Next steps: allow calling functions defined in the interface like `Helper` from CG functions constrained by interface `IFC`.

Testing: standard paratest + gasnet multilocale tests