### PR TITLE
Skip test-memLog with --llvm for now.

### DIFF
--- a/test/memory/gbt/test-memLog.skipif
+++ b/test/memory/gbt/test-memLog.skipif
@@ -1,1 +1,4 @@
 CHPL_COMM == none
+# Skip with --llvm until we resolve the #1677/#1681/#1682 weirdness
+# and can make verbose mem logging work predictably.
+COMPOPTS <= --llvm


### PR DESCRIPTION
Whether or not verbose memory logging actually produces any output
depends on some subtleties with which LLVM codegen is a bit unevenly
burdened right now.  These are addressed by issues 1677, 1681, and
1682.  Until this situation improves, skip this verbose memory
logging test when LLVM codegen is in use.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>