### PR TITLE
Enable LLVM by default

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -204,6 +204,15 @@ system: $(LLVM_CLANG_CONFIG_FILE)
 system-minimal:
 
 none:
+ifndef CHPL_LLVM
+	@echo "Error: Please set the environment variable CHPL_LLVM to a supported value."
+	@echo "Supported values are:"
+	@echo "  1) 'none' to build without LLVM support"
+	@echo "  2) 'bundled' to build with the LLVM packaged in the third-party directory"
+	@echo "  3) 'system' to use a pre-installed system-wide LLVM"
+	@echo "See: https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-llvm"
+	@exit 1
+endif
 
 FORCE:
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -53,7 +53,9 @@ def has_compatible_installed_llvm():
 
     got = run_command([find_llvm_config, preferred_vers])
     got = got.strip()
-    if got and got != "missing-llvm-config":
+    platform = chpl_platform.get('target')
+    # We have a problem with homebrew installed system llvm
+    if platform != "darwin" and got and got != "missing-llvm-config":
         return True
     else:
         return False
@@ -66,14 +68,9 @@ def get():
 
         if is_included_llvm_built():
             llvm_val = 'bundled'
-        elif ("CHPL_LLVM_BY_DEFAULT" in os.environ and
-               os.environ["CHPL_LLVM_BY_DEFAULT"] != "0" and
-               # CHPL_LLVM_BY_DEFAULT is an enviro var to help us transition
-               compatible_platform_for_llvm_default()):
+        elif (compatible_platform_for_llvm_default()):
             if has_compatible_installed_llvm():
                 llvm_val = 'system'
-            else:
-                llvm_val = 'bundled'
 
     if llvm_val == 'llvm':
         sys.stderr.write("Warning: CHPL_LLVM=llvm is deprecated. "


### PR DESCRIPTION
If CHPL_LLVM is set to a valid value, do what it requests.  Otherwise, if the
bundled LLVM is already built, use it. Otherwise, if there is a system LLVM,
use it. Otherwise, issue an error requesting that the user set CHPL_LLVM
to a valid value.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>