### PR TITLE
Allow requesting atomic capabilities in comm=ofi via the environment

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1238,8 +1238,9 @@ void init_ofiFabricDomain(void) {
 
   hints->caps = (FI_MSG | FI_MULTI_RECV
                  | FI_RMA | FI_LOCAL_COMM | FI_REMOTE_COMM);
-  if (strcmp(CHPL_TARGET_PLATFORM, "cray-xc") == 0
-      && (prov_name == NULL || isInProvName("gni", prov_name))) {
+  if ((strcmp(CHPL_TARGET_PLATFORM, "cray-xc") == 0
+       && (prov_name == NULL || isInProvName("gni", prov_name)))
+      || chpl_env_rt_get_bool("COMM_OFI_HINTS_CAPS_ATOMIC", false)) {
     hints->caps |= FI_ATOMIC;
   }
   hints->tx_attr->op_flags = FI_COMPLETION;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1018,6 +1018,38 @@ void debugOverrideHints(struct fi_info* hints) {
   uint64_t val;
 
   {
+    struct cfgHint hintVals[] = { CFG_HINT(FI_ATOMIC),
+                                  CFG_HINT(FI_DIRECTED_RECV),
+                                  CFG_HINT(FI_FENCE),
+                                  CFG_HINT(FI_HMEM),
+                                  CFG_HINT(FI_LOCAL_COMM),
+                                  CFG_HINT(FI_MSG),
+                                  CFG_HINT(FI_MULTICAST),
+                                  CFG_HINT(FI_MULTI_RECV),
+                                  CFG_HINT(FI_NAMED_RX_CTX),
+                                  CFG_HINT(FI_READ),
+                                  CFG_HINT(FI_RECV),
+                                  CFG_HINT(FI_REMOTE_COMM),
+                                  CFG_HINT(FI_REMOTE_READ),
+                                  CFG_HINT(FI_REMOTE_WRITE),
+                                  CFG_HINT(FI_RMA),
+                                  CFG_HINT(FI_RMA_EVENT),
+                                  CFG_HINT(FI_RMA_PMEM),
+                                  CFG_HINT(FI_SEND),
+                                  CFG_HINT(FI_SHARED_AV),
+                                  CFG_HINT(FI_SOURCE),
+                                  CFG_HINT(FI_SOURCE_ERR),
+                                  CFG_HINT(FI_TAGGED),
+                                  CFG_HINT(FI_TRIGGER),
+                                  CFG_HINT(FI_VARIABLE_MSG),
+                                  CFG_HINT(FI_WRITE), };
+    if (getCfgHint("COMM_OFI_HINTS_CAPS",
+                   hintVals, false /*justOne*/, &val)) {
+      hints->caps = val;
+    }
+  }
+
+  {
     struct cfgHint hintVals[] = { CFG_HINT(FI_COMMIT_COMPLETE),
                                   CFG_HINT(FI_COMPLETION),
                                   CFG_HINT(FI_DELIVERY_COMPLETE),
@@ -6211,8 +6243,8 @@ const char* amo_typeName(enum fi_datatype ofiType) {
   case FI_UINT32: return "uint32";
   case FI_INT64: return "int64";
   case FI_UINT64: return "uint64";
-  case FI_FLOAT: return "_real32";
-  case FI_DOUBLE: return "_real64";
+  case FI_FLOAT: return "real32";
+  case FI_DOUBLE: return "real64";
   default: return "amoType???";
   }
 }


### PR DESCRIPTION
Some providers that can do atomics nevertheless don't volunteer that in
their capabilities because supporting them adds overhead. Here, mainly
as an aid to investigating providers and experimenting with them, allow
for specifically requesting atomic capabilities via the environment.

While here, also provide for specifying the capabilities hints through
the environment, and make a workaround originally done for RxD available
with all providers, because I encountered another one that needs it.