### PR TITLE
Fix alloca generation for aligned extern types

### DIFF
--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -78,9 +78,16 @@ int getCRecordMemberGEP(const char* typeName, const char* fieldName, bool& isCAr
 
 #if HAVE_LLVM_VER >= 100
 llvm::MaybeAlign getPointerAlign(int addrSpace);
+llvm::MaybeAlign getCTypeAlignment(const clang::TypeDecl* td);
+llvm::MaybeAlign getCTypeAlignment(const clang::QualType &qt);
+llvm::MaybeAlign getAlignment(Type* type);
 #else
 uint64_t getPointerAlign(int addrSpace);
+unsigned getCTypeAlignment(const clang::TypeDecl* td);
+unsigned getCTypeAlignment(const clang::QualType &qt);
+unsigned getAlignment(Type* type);
 #endif
+
 
 const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD);
 const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn);
@@ -107,6 +114,8 @@ void checkAdjustedDataLayout();
 extern fileinfo gAllExternCode;
 
 void print_clang(clang::Decl* d);
+void print_clang(clang::TypeDecl* td);
+void print_clang(clang::ValueDecl* vd);
 
 #endif // HAVE_LLVM
 

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -110,7 +110,7 @@ struct GenInfo {
   llvm::TargetMachine* targetMachine;
 
   std::vector<LoopData> loopStack;
-  std::vector<std::pair<llvm::Value*, llvm::Type*> > currentStackVariables;
+  std::vector<std::pair<llvm::AllocaInst*, llvm::Type*> > currentStackVariables;
   const clang::CodeGen::CGFunctionInfo* currentFunctionABI;
 
   llvm::LLVMContext llvmContext;

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -29,6 +29,14 @@
 
 #include <ostream>
 
+#ifdef HAVE_LLVM
+// Forward declare AllocaInst.
+namespace llvm
+{
+  class AllocaInst;
+}
+#endif
+
 class PrimitiveOp;
 
 
@@ -426,8 +434,8 @@ bool hasOptimizationFlag(Expr* anchor, Flag flag);
 
 
 #ifdef HAVE_LLVM
-llvm::Value* createVarLLVM(llvm::Type* type, const char* name);
-llvm::Value* createVarLLVM(llvm::Type* type);
+llvm::AllocaInst* createVarLLVM(llvm::Type* type, const char* name);
+llvm::AllocaInst* createVarLLVM(llvm::Type* type);
 
 llvm::Value *convertValueToType(llvm::Value *value, llvm::Type *newType,
                                 bool isSigned = false, bool force = false);

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -45,13 +45,14 @@ llvm::Constant* codegenSizeofLLVM(llvm::Type* type);
 // 0 means undefined alignment
 llvm::AllocaInst* makeAlloca(llvm::Type* type, const char* name, llvm::Instruction* insertBefore, unsigned n=1, unsigned align=0);
 
-llvm::Value* createLLVMAlloca(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
+llvm::AllocaInst* createLLVMAlloca(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
+
 PromotedPair convertValuesToLarger(llvm::IRBuilder<> *irBuilder, llvm::Value *value1, llvm::Value *value2, bool isSigned1 = false, bool isSigned2 = false);
 llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
                                 const llvm::DataLayout& layout,
                                 llvm::LLVMContext &ctx,
                                 llvm::Value *value, llvm::Type *newType,
-                                llvm::Value **alloca, // an alloca generated
+                                llvm::AllocaInst **alloca, // an alloca generated
                                 bool isSigned=false, bool force=false);
 
 void makeLifetimeStart(llvm::IRBuilder<>* irBuilder,
@@ -60,7 +61,7 @@ void makeLifetimeStart(llvm::IRBuilder<>* irBuilder,
                        llvm::Type *valType, llvm::Value *addr);
 
 // Returns an alloca
-llvm::Value* makeAllocaAndLifetimeStart(llvm::IRBuilder<>* irBuilder,
+llvm::AllocaInst* makeAllocaAndLifetimeStart(llvm::IRBuilder<>* irBuilder,
                                         const llvm::DataLayout& layout,
                                         llvm::LLVMContext &ctx,
                                         llvm::Type* type, const char* name);
@@ -71,6 +72,7 @@ bool isTypeSizeSmallerThan(const llvm::DataLayout& layout, llvm::Type* ty, uint6
 void print_llvm(llvm::Type* t);
 void print_llvm(llvm::Value* v);
 void print_llvm(llvm::Module* m);
+// print_clang is also available in another file
 
 #endif //HAVE_LLVM
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2372,22 +2372,13 @@ llvm::Type* codegenCType(const TypeDecl* td)
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
   INT_ASSERT(cCodeGen);
 
-  //CodeGen::CodeGenTypes & cdt = info->cgBuilder->getTypes();
   QualType qType;
 
   // handle TypedefDecl
   if( const TypedefNameDecl* tnd = dyn_cast<TypedefNameDecl>(td) ) {
     qType = tnd->getCanonicalDecl()->getUnderlyingType();
-    // had const Type *ctype = td->getUnderlyingType().getTypePtrOrNull();
-    //could also do:
-    //  qType =
-    //   tnd->getCanonicalDecl()->getTypeForDecl()->getCanonicalTypeInternal();
   } else if( const EnumDecl* ed = dyn_cast<EnumDecl>(td) ) {
     qType = ed->getCanonicalDecl()->getIntegerType();
-    // could also use getPromotionType()
-    //could also do:
-    //  qType =
-    //   tnd->getCanonicalDecl()->getTypeForDecl()->getCanonicalTypeInternal();
   } else if( const RecordDecl* rd = dyn_cast<RecordDecl>(td) ) {
     RecordDecl *def = rd->getDefinition();
     INT_ASSERT(def);
@@ -2989,10 +2980,6 @@ static unsigned helpGetCTypeAlignment(const clang::TypeDecl* td) {
     qType = tnd->getCanonicalDecl()->getUnderlyingType();
   } else if (const EnumDecl* ed = dyn_cast<EnumDecl>(td)) {
     qType = ed->getCanonicalDecl()->getIntegerType();
-    // could also use getPromotionType()
-    //could also do:
-    //  qType =
-    //   tnd->getCanonicalDecl()->getTypeForDecl()->getCanonicalTypeInternal();
   } else if (const RecordDecl* rd = dyn_cast<RecordDecl>(td)) {
     RecordDecl *def = rd->getDefinition();
     INT_ASSERT(def);

--- a/test/llvm/alignment/SKIPIF
+++ b/test/llvm/alignment/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_LLVM==none

--- a/test/llvm/alignment/check-align-padding.bad
+++ b/test/llvm/alignment/check-align-padding.bad
@@ -1,0 +1,7 @@
+%int32int64_chpl = type { i32, i64 }
+%int64aligned16b_chpl = type { i64, %struct.aligned16test }
+%int8int16int64_chpl = type { i8, i16, i64 }
+%int8int32_chpl = type { i8, i32 }
+%int8int64_chpl = type { i8, i64 }
+%int8int8int64_chpl = type { i8, i8, i64 }
+%struct.aligned16test = type { i64, [8 x i8], i64, [8 x i8] }

--- a/test/llvm/alignment/check-align-padding.chpl
+++ b/test/llvm/alignment/check-align-padding.chpl
@@ -1,0 +1,58 @@
+extern {
+  #include <stdio.h>
+  #include <stdbool.h>
+  #include <inttypes.h>
+  #include <complex.h>
+  #include <string.h>
+
+  struct aligned16test {
+    uint64_t x;
+    uint64_t a __attribute__((aligned (16)));
+  };
+}
+
+record int8int64 {
+  var field1: int(8);
+  var field2: int;
+}
+record int8int32 {
+  var field1: int(8);
+  var field2: int(32);
+}
+record int32int64 {
+  var field1: int(32);
+  var field2: int(64);
+}
+record int8int8int64 {
+  var field1: int(8);
+  var field2: int(8);
+  var field3: int(64);
+}
+record int8int16int64 {
+  var field1: int(8);
+  var field2: int(16);
+  var field3: int(64);
+}
+record int64aligned16b {
+  var field1: int;
+  var field2: aligned16test;
+}
+
+proc compute(arg) {
+  writeln(arg);
+}
+
+proc main() {
+  var v1: int8int64;
+  compute(v1);
+  var v2: int8int32;
+  compute(v2);
+  var v3: int32int64;
+  compute(v3);
+  var v4: int8int8int64;
+  compute(v4);
+  var v5: int8int16int64;
+  compute(v5);
+  var v6: int64aligned16b;
+  compute(v6);
+}

--- a/test/llvm/alignment/check-align-padding.compopts
+++ b/test/llvm/alignment/check-align-padding.compopts
@@ -1,0 +1,2 @@
+--llvm --llvm-print-ir-stage basic --llvm-print-ir  main,compute 
+

--- a/test/llvm/alignment/check-align-padding.future
+++ b/test/llvm/alignment/check-align-padding.future
@@ -1,0 +1,2 @@
+bug: llvm backend is not emitting structure padding
+#17141

--- a/test/llvm/alignment/check-align-padding.good
+++ b/test/llvm/alignment/check-align-padding.good
@@ -1,0 +1,7 @@
+%int32int64_chpl = type { i32, [4 x i8], i64 }
+%int64aligned16b_chpl = type { i64, [8 x i8], %struct.aligned16test }
+%int8int16int64_chpl = type { i8, [1 x i8], i16, [4 x i8], i64 }
+%int8int32_chpl = type { i8, [3 x i8], i32 }
+%int8int64_chpl = type { i8, [7 x i8], i64 }
+%int8int8int64_chpl = type { i8, i8, [6 x i8], i64 }
+%struct.aligned16test = type { i64, [8 x i8], i64, [8 x i8] }

--- a/test/llvm/alignment/check-align-padding.prediff
+++ b/test/llvm/alignment/check-align-padding.prediff
@@ -1,0 +1,8 @@
+#!/bin/sh
+TESTNAME=$1
+OUTFILE=$2
+
+TMPFILE="$outfile.prediff.tmp"
+mv $OUTFILE $TMPFILE
+cat $TMPFILE | grep '= type' | sort > $OUTFILE
+rm $TMPFILE

--- a/test/llvm/alignment/check-align16-field1.chpl
+++ b/test/llvm/alignment/check-align16-field1.chpl
@@ -1,0 +1,49 @@
+import IO;
+
+extern {
+  #include <stdio.h>
+  #include <stdbool.h>
+  #include <inttypes.h>
+  #include <complex.h>
+  #include <string.h>
+
+  struct aligned16test {
+    uint64_t x;
+    uint64_t a __attribute__((aligned (16)));
+  };
+  struct aligned16test struct_aligned16test_return_c_____(void);
+  void struct_aligned16test_arg_c_____(struct aligned16test arg);
+
+  struct aligned16test struct_aligned16test_return_c_____(void) {
+    struct aligned16test t;
+    memset(&t, 0, sizeof(t));
+    t.x = 123456789;
+    t.a = 987654321;
+    return t;
+  }
+  void struct_aligned16test_arg_c_____(struct aligned16test arg) {
+    printf("arg.x %li arg.a %li\n", arg.x, arg.a);
+  }
+}
+
+record R {
+  var field1: aligned16test;
+  var field2: int;
+}
+
+proc returnR(): R {
+  var tt:R;
+  tt.field1 = struct_aligned16test_return_c_____();
+  tt.field2 = 1;
+  return tt;
+}
+proc acceptR(in arg: R) {
+  struct_aligned16test_arg_c_____(arg.field1);
+}
+
+proc main() {
+  var ttt:R;
+  ttt = returnR();
+  acceptR(ttt);
+  acceptR(ttt);
+}

--- a/test/llvm/alignment/check-align16-field1.compopts
+++ b/test/llvm/alignment/check-align16-field1.compopts
@@ -1,0 +1,1 @@
+--llvm --llvm-print-ir-stage basic --llvm-print-ir struct_aligned16test_return_c_____,struct_aligned16test_arg_c_____,returnR,acceptR,main 

--- a/test/llvm/alignment/check-align16-field1.good
+++ b/test/llvm/alignment/check-align16-field1.good
@@ -1,0 +1,1 @@
+  %r = alloca %R_chpl, align 16

--- a/test/llvm/alignment/check-align16-field1.prediff
+++ b/test/llvm/alignment/check-align16-field1.prediff
@@ -1,0 +1,11 @@
+#!/bin/sh
+TESTNAME=$1
+OUTFILE=$2
+
+TMPFILE="$outfile.prediff.tmp"
+mv $OUTFILE $TMPFILE
+cat $TMPFILE | grep R_chpl | grep alloca | \
+               grep -ve 'R_chpl[*]' | \
+               sed -s 's/%[0-9][0-9]*/%r/g' |
+               sort -u > $OUTFILE
+rm $TMPFILE

--- a/test/llvm/alignment/check-align16.chpl
+++ b/test/llvm/alignment/check-align16.chpl
@@ -1,0 +1,44 @@
+import IO;
+
+extern {
+  #include <stdio.h>
+  #include <stdbool.h>
+  #include <inttypes.h>
+  #include <complex.h>
+  #include <string.h>
+
+  struct aligned16test {
+    uint64_t x;
+    uint64_t a __attribute__((aligned (16)));
+  };
+  struct aligned16test struct_aligned16test_return_c_____(void);
+  void struct_aligned16test_arg_c_____(struct aligned16test arg);
+
+  struct aligned16test struct_aligned16test_return_c_____(void) {
+    struct aligned16test t;
+    memset(&t, 0, sizeof(t));
+    t.x = 123456789;
+    t.a = 987654321;
+    return t;
+  }
+  void struct_aligned16test_arg_c_____(struct aligned16test arg) {
+    printf("arg.x %li arg.a %li\n", arg.x, arg.a);
+  }
+}
+
+export proc struct_aligned16test_return_chapel(): aligned16test {
+  var tt:aligned16test;
+  tt = struct_aligned16test_return_c_____();
+  return tt;
+}
+export proc struct_aligned16test_arg_chapel(in arg: aligned16test) {
+  struct_aligned16test_arg_c_____(arg);
+}
+
+proc main() {
+  var ttt:aligned16test;
+  ttt = struct_aligned16test_return_c_____();
+  struct_aligned16test_arg_c_____(ttt);
+  ttt = struct_aligned16test_return_chapel();
+  struct_aligned16test_arg_chapel(ttt);
+}

--- a/test/llvm/alignment/check-align16.compopts
+++ b/test/llvm/alignment/check-align16.compopts
@@ -1,0 +1,2 @@
+--llvm --llvm-print-ir-stage basic --llvm-print-ir  struct_aligned16test_return_c_____,struct_aligned16test_arg_c_____,struct_aligned16test_return_chapel,struct_aligned16test_arg_chapel,main 
+

--- a/test/llvm/alignment/check-align16.good
+++ b/test/llvm/alignment/check-align16.good
@@ -1,0 +1,1 @@
+  %r = alloca %struct.aligned16test, align 16

--- a/test/llvm/alignment/check-align16.prediff
+++ b/test/llvm/alignment/check-align16.prediff
@@ -1,0 +1,11 @@
+#!/bin/sh
+TESTNAME=$1
+OUTFILE=$2
+
+TMPFILE="$outfile.prediff.tmp"
+mv $OUTFILE $TMPFILE
+cat $TMPFILE | grep aligned16test | grep alloca | \
+               grep -ve 'struct.aligned16test[*]' | \
+               sed -s 's/%[0-9][0-9]*/%r/g' |
+               sort -u > $OUTFILE
+rm $TMPFILE


### PR DESCRIPTION
PR #17046 was running into problems with core dumps for
test/llvm/abi/x86-64/export-vs-c.chpl. Upon investigating the issue I
noticed that the stack local variables of type `struct aligned16test`
were not being aligned to the expected 16 byte alignment but rather were
unaligned. This PR fixes that - which also resolves the core dumps in
PR #17046.

Future Work:
 * issue #17141 - the LLVM backend isn't emitting structure padding

Reviewed by @e-kayrakli - thanks!

- [x] full local testing
- [x] full local --llvm testing