### PR TITLE
Avoid compiler crash with CG

### DIFF
--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -438,6 +438,10 @@ static void verifyWrapImplementsStmt(ImplementsStmt* istm,
 
 FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm) {
   SET_LINENO(istm);
+  if (isUnresolvedSymExpr(istm->iConstraint->interfaceExpr)) {
+    INT_ASSERT(! normalized); // will report "undeclared" error later
+    return NULL;
+  }
   InterfaceSymbol* isym = istm->iConstraint->ifcSymbol();
   FnSymbol* wrapFn = new FnSymbol(implementsStmtWrapperName(isym));
   wrapFn->addFlag(FLAG_IMPLEMENTS_WRAPPER);
@@ -453,6 +457,7 @@ FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm) {
 void wrapImplementsStatements() {
   forv_Vec(ImplementsStmt, istm, gImplementsStmts) {
     FnSymbol* wrapFn = wrapOneImplementsStatement(istm);
+    if (!wrapFn) continue; // there was an error
     if (fVerify) verifyWrapImplementsStmt(istm, wrapFn);
   }
 }

--- a/test/constrained-generics/basic/set1/error-not-visible.chpl
+++ b/test/constrained-generics/basic/set1/error-not-visible.chpl
@@ -1,10 +1,6 @@
 /*
-This is basic-arg-query.chpl
-with the interface declaration and the CG function
-are wrapped in one module and "user" code in another.
-
-This way reqFun() implementation is not visible
-at call site within the CG function.
+This is module-with-ifc.chpl
+with the "import" declaration removed.
 */
 module Library {
   interface IFC(T) {
@@ -22,8 +18,6 @@ module Library {
 }
 
 module User {
-  use Library;
-
   proc reqFun(arg1: real, arg2: int) {
     writeln("in reqFun/real*int", (arg1, arg2));
   }

--- a/test/constrained-generics/basic/set1/error-not-visible.good
+++ b/test/constrained-generics/basic/set1/error-not-visible.good
@@ -1,0 +1,1 @@
+error-not-visible.chpl:25: error: 'IFC' undeclared (first use this function)

--- a/test/constrained-generics/basic/set1/module-with-ifc.bad
+++ b/test/constrained-generics/basic/set1/module-with-ifc.bad
@@ -1,8 +1,0 @@
-module-with-ifc.chpl:30: internal error: UTI-MIS-nnnn chpl version mmmm
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/constrained-generics/basic/set1/module-with-ifc.future
+++ b/test/constrained-generics/basic/set1/module-with-ifc.future
@@ -1,1 +1,0 @@
-bug: compiler crashes when CG declarations are in a module


### PR DESCRIPTION
The compiler used to crash when the interface declaration was not visible.
With this change, issue an error message instead.
