### PR TITLE
Add initial support for the GASNet UCX conduit

### DIFF
--- a/runtime/src/launch/gasnetrun_ucx/Makefile
+++ b/runtime/src/launch/gasnetrun_ucx/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/gasnetrun_ucx
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
+endif
+
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/gasnetrun_ucx/Makefile.include
+++ b/runtime/src/launch/gasnetrun_ucx/Makefile.include
@@ -1,0 +1,25 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCH_SUBDIR = src/launch/gasnetrun_ucx
+
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/gasnetrun_ucx/Makefile.share
+++ b/runtime/src/launch/gasnetrun_ucx/Makefile.share
@@ -1,0 +1,31 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCHER_SRCS = \
+        launch-gasnetrun_ucx.c \
+
+#
+# is this the right time to set this variable?  Or is user code
+# compile time
+#
+RUNTIME_CFLAGS += -DLAUNCH_PATH="gasnet/$(GASNET_INSTALL_SUBDIR)/bin/"
+
+SRCS = $(LAUNCHER_SRCS)
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/gasnetrun_ucx/launch-gasnetrun_ucx.c
+++ b/runtime/src/launch/gasnetrun_ucx/launch-gasnetrun_ucx.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define GASNETRUN_LAUNCHER "gasnetrun_ucx"
+#include "../gasnetrun_common/gasnetrun_common.h"

--- a/runtime/src/launch/slurm-gasnetrun_ucx/Makefile
+++ b/runtime/src/launch/slurm-gasnetrun_ucx/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/slurm-gasnetrun_ucx
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
+endif
+
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/slurm-gasnetrun_ucx/Makefile.include
+++ b/runtime/src/launch/slurm-gasnetrun_ucx/Makefile.include
@@ -1,0 +1,25 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCH_SUBDIR = src/launch/slurm-gasnetrun_ucx
+
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/slurm-gasnetrun_ucx/Makefile.share
+++ b/runtime/src/launch/slurm-gasnetrun_ucx/Makefile.share
@@ -1,0 +1,27 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCHER_SRCS = \
+        launch-slurm-gasnetrun_ucx.c \
+
+RUNTIME_CFLAGS += -DLAUNCH_PATH="gasnet/$(GASNET_INSTALL_SUBDIR)/bin/"
+
+SRCS = $(LAUNCHER_SRCS)
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/slurm-gasnetrun_ucx/launch-slurm-gasnetrun_ucx.c
+++ b/runtime/src/launch/slurm-gasnetrun_ucx/launch-slurm-gasnetrun_ucx.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define GASNETRUN_LAUNCHER "gasnetrun_ucx"
+#include "../slurm-gasnetrun_common/slurm-gasnetrun_common.h"

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -12,7 +12,7 @@ def get():
         segment_val = overrides.get('CHPL_GASNET_SEGMENT')
         if not segment_val:
             substrate_val = chpl_comm_substrate.get()
-            if substrate_val in ('aries', 'smp'):
+            if substrate_val in ('aries', 'smp', 'ucx'):
                 segment_val = 'fast'
             elif substrate_val == 'ibv':
                 segment_val = 'large'

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -44,6 +44,8 @@ def get():
                 launcher_val = 'gasnetrun_mpi'
             elif substrate_val == 'ibv':
                 launcher_val = 'gasnetrun_ibv'
+            elif substrate_val == 'ucx':
+                launcher_val = 'gasnetrun_ucx'
             elif substrate_val == 'mxm':
                 launcher_val = 'gasnetrun_ibv'
             elif substrate_val == 'ofi':

--- a/util/test/prediff-for-ucx
+++ b/util/test/prediff-for-ucx
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+#
+# Remove warning about UCX being experiemntal
+#
+import sys, re
+
+outfname = sys.argv[2]
+with open(outfname, "r") as f:
+    outText = f.read()
+
+msg = """ WARNING: ucx-conduit is experimental and should not be used for
+          performance measurements.
+          Please see `ucx-conduit/README` for more details.
+"""
+outText = re.sub(msg, "", outText, flags = re.MULTILINE)
+
+with open(outfname, "w") as f:
+    f.write(outText)

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1033,6 +1033,7 @@ def set_up_executables():
 
     comm = chpl_comm.get()
     network_atomics = chpl_atomics.get('network')
+    comm_substrate = chpl_comm_substrate.get()
     launcher = chpl_launcher.get()
     locale_model = chpl_locale_model.get()
 
@@ -1121,11 +1122,16 @@ def set_up_executables():
         prediff_for_slurm = os.path.join(util_dir, "test", "prediff-for-slurm")
         if prediff_for_slurm not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_slurm)
-    elif 'lsf-' in launcher:
+    if 'lsf-' in launcher:
         # With lsf-based launcher, auto-run prediff-for-lsf.
         prediff_for_lsf = os.path.join(util_dir, "test", "prediff-for-lsf")
         if prediff_for_lsf not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_lsf)
+    if 'ucx' in comm_substrate:
+        # With ucx-based launcher, auto-run prediff-for-ucx.
+        prediff_for_ucx = os.path.join(util_dir, "test", "prediff-for-ucx")
+        if prediff_for_ucx not in chpl_system_prediff:
+            chpl_system_prediff.append(prediff_for_ucx)
 
     if chpl_system_prediff:
         os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(chpl_system_prediff)


### PR DESCRIPTION
Add initial support for the GASNet UCX conduit. From the conduit README:
"Ucx-conduit implements GASNet over the Unified Communication X (UCX)
framework (see http://www.openucx.org/ for general information on UCX)"

The UCX conduit is still labeled as experimental, so I haven't added any
documentation for this yet, we just want to experiment with it
internally for now.

In terms of actual changes, this defaults ucx to segment `fast` since
`everything` is not supported. For ucx `large` and `fast` are the same,
and will both statically register memory. We use `fast` since that's
what we tend to associate with static registration but `large` works
too. This also adds `gasnetrun_ucx` and `slurm-gasnetrun_ucx` launchers.

This also adds a prediff to remove an always on runtime warning about
UCX being experimental. With that, correctness testing passes for
`release/examples/ runtime/configMatters/` with the exception of
`runtime/configMatters/comm/task-overload.chpl`. That's a stress test
that has all tasks on the last node doing non-blocking AMs to node 0. I
haven't looked into the failure mode yet.

For performance -- UCX is experimental, but I wanted to check what the
current performance is like. Here's some results from 16 nodes of a
system with HDR InfiniBand and 48 core Cascade Lake CPUs comparing
gasnet-ibv-{large,fast} to gasnet-ucx-fast. In ibv-large, registration
is dynamic so we get good numa affinity, but bulk comm performance
suffers. ibv-fast does static registration so numa affinity is poor,
but bulk comm performance is good. ucx fast and large are identical and
both are static registration so I'm just testing with ucx-fast, which
should be closer to ibv-fast.

I ran 4 benchmarks that expose different patterns we care about. From least
communication to most:

- Stream (no communication, numa affinity sensitive)
- PRK-stencil (little comm, numa affinity sensitive)
- ISx (concurrent bulk comm, numa affinity sensitive)
- RA (lots of concurrent fine-grained comm -- we have RDMA (rmo) and active-message (on) variants)


```
chpl --fast test/release/examples/benchmarks/hpcc/stream.chpl
./stream -nl 16

chpl --fast test/studies/prk/Stencil/optimized/stencil-opt.chpl -sorder="sqrt(16e9*numLocales / 8):int"
./stencil-opt -nl 16

chpl --fast test/studies/isx/isx-hand-optimized.chpl
./isx-hand-optimized --mode=weakISO -nl 16

chpl --fast test/release/examples/benchmarks/hpcc/ra.chpl -suseOn=false -sN_U="2**(n-12)" -o ra-rmo
./ra-rmo -nl 16

chpl --fast test/release/examples/benchmarks/hpcc/ra.chpl -suseOn=true -sN_U="2**(n-12)" -o ra-on
./ra-on -nl 16
```

| Config       | Stream      | PRK-Stencil    | Isx     | RA-rmo        | RA-on         |
| ------------ | ----------: | -------------: | ------: | ------------: | ------------: |
| gn-ibv-large | ~2600 GB/s  | ~1260 GFlops/s | ~50.3 s | ~0.00096 GUPS | ~0.00184 GUPS |
| gn-ibv-fast  |  ~990 GB/s  |  ~550 GFlops/s |  ~7.7 s | ~0.00186 GUPS | ~0.00184 GUPS |
| gn-ucx-fast  |  ~975 GB/s  |  ~550 GFlops/s |  ~7.7 s | ~0.00316 GUPS | ~0.00242 GUPS |

Generally speaking performance is really close or slightly better than
gasnet-ibv-fast, which is great given the experimental label. Stream
performance is a little worse, possibly because ucx doesn't have a
blocking progress thread (#9067). PRK-Stencil and ISx performance is
identical, and RA performance is a little better under ucx than ibv.

See #14438 for discussion of improving gasnet ibv performance and the
trade offs between segment large and fast. Much of that discussion
should apply to ucx as well.