### PR TITLE
Update LLVM tests to function with ASSERTS build

### DIFF
--- a/test/llvm/alignment/check-align16-field1.prediff
+++ b/test/llvm/alignment/check-align16-field1.prediff
@@ -6,6 +6,6 @@ TMPFILE="$outfile.prediff.tmp"
 mv $OUTFILE $TMPFILE
 cat $TMPFILE | grep R_chpl | grep alloca | \
                grep -ve 'R_chpl[*]' | \
-               sed -s 's/%[0-9][0-9]*/%r/g' |
+               sed -s 's/%.* = /%r = /' |
                sort -u > $OUTFILE
 rm $TMPFILE

--- a/test/llvm/alignment/check-align16.prediff
+++ b/test/llvm/alignment/check-align16.prediff
@@ -6,6 +6,6 @@ TMPFILE="$outfile.prediff.tmp"
 mv $OUTFILE $TMPFILE
 cat $TMPFILE | grep aligned16test | grep alloca | \
                grep -ve 'struct.aligned16test[*]' | \
-               sed -s 's/%[0-9][0-9]*/%r/g' |
+               sed -s 's/%.* = /%r = /' |
                sort -u > $OUTFILE
 rm $TMPFILE

--- a/test/llvm/llvm-invariant/function_local_const.chpl
+++ b/test/llvm/llvm-invariant/function_local_const.chpl
@@ -13,12 +13,12 @@ proc calculate(const ref a: A) {
 }
 
 // CHECK: @f_chpl
-// CHECK: call void @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9]+]],
-// CHECK: [[TMP1:%[0-9]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
-// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9]+]]
-// CHECK: [[TMP3:%[0-9]+]] = load %A_chpl, %A_chpl* [[TMP2]]
-// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[TMP4:%[0-9]+]]
-// CHECK: [[CAST:%[0-9]+]] = bitcast %A_chpl* [[TMP4]] to i8*
+// CHECK: call void @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9a-zA-Z_]+]],
+// CHECK: [[TMP1:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9a-zA-Z_]+]]
+// CHECK: [[TMP3:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[TMP4:%[0-9a-zA-Z_]+]]
+// CHECK: [[CAST:%[0-9a-zA-Z_]+]] = bitcast %A_chpl* [[TMP4]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST]])
 // CHECK: @calculate_chpl
 // CHECK-SAME:[[TMP4]]

--- a/test/llvm/llvm-invariant/program_constructs.chpl
+++ b/test/llvm/llvm-invariant/program_constructs.chpl
@@ -11,12 +11,12 @@ proc f(n)
   var sum = 0;
   for i in 1..10
   {
-// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9]+]],
-// CHECK: [[TMP1:%[0-9]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
-// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9]+]]
-// CHECK: [[TMP3:%[0-9]+]] = load %A_chpl, %A_chpl* [[TMP2]]
-// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR1:%[0-9]+]]
-// CHECK: [[CAST1:%[0-9]+]] = bitcast %A_chpl* [[PTR1]] to i8*
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9a-zA-Z_]+]],
+// CHECK: [[TMP1:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9a-zA-Z_]+]]
+// CHECK: [[TMP3:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR1:%[0-9a-zA-Z_]+]]
+// CHECK: [[CAST1:%[0-9a-zA-Z_]+]] = bitcast %A_chpl* [[PTR1]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST1]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR1]]
@@ -25,12 +25,12 @@ proc f(n)
   }
 
   if n < 10 {
-// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9]+]],
-// CHECK: [[TMP1:%[0-9]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
-// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9]+]]
-// CHECK: [[TMP3:%[0-9]+]] = load %A_chpl, %A_chpl* [[TMP2]]
-// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR2:%[0-9]+]]
-// CHECK: [[CAST2:%[0-9]+]] = bitcast %A_chpl* [[PTR2]] to i8*
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9a-zA-Z_]+]],
+// CHECK: [[TMP1:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9a-zA-Z_]+]]
+// CHECK: [[TMP3:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR2:%[0-9a-zA-Z_]+]]
+// CHECK: [[CAST2:%[0-9a-zA-Z_]+]] = bitcast %A_chpl* [[PTR2]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST2]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR2]]
@@ -38,12 +38,12 @@ proc f(n)
     return localConst.a;
   }
   else {
-// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9]+]],
-// CHECK: [[TMP1:%[0-9]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
-// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9]+]]
-// CHECK: [[TMP3:%[0-9]+]] = load %A_chpl, %A_chpl* [[TMP2]]
-// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR3:%[0-9]+]]
-// CHECK: [[CAST3:%[0-9]+]] = bitcast %A_chpl* [[PTR3]] to i8*
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* {{[^%]*}}[[NEW_TEMP:%[0-9a-zA-Z_]+]],
+// CHECK: [[TMP1:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%[0-9a-zA-Z_]+]]
+// CHECK: [[TMP3:%[0-9a-zA-Z_]+]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR3:%[0-9a-zA-Z_]+]]
+// CHECK: [[CAST3:%[0-9a-zA-Z_]+]] = bitcast %A_chpl* [[PTR3]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST3]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR3]]


### PR DESCRIPTION
We configure bundled LLVM with -DLLVM_ENABLE_DUMP=ON for `make ASSERTS=1`
builds (and for `CHPL_DEVELOPER` builds) which causes registers to have
names rather than just numbers.

This PR updates the tests to tolerate register names or numbers. An
alternative would be to use --ccflags -fdiscard-value-name to request
register names be discarded.

- [x] affected tests pass with bundled llvm with `CHPL_DEVELOPER`
- [x] affected tests pass with system llvm

Test change only - not reviewed.