### PR TITLE
Add missing casts to NetworkAtomics.chpl

### DIFF
--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -134,6 +134,11 @@ module NetworkAtomics {
 
   }
 
+  proc _cast(type t:RAtomicBool, rhs: bool) {
+    var lhs: RAtomicBool = rhs; // use init=
+    return lhs;
+  }
+
   pragma "atomic type"
   pragma "ignore noinit"
   record RAtomicT {
@@ -329,6 +334,10 @@ module NetworkAtomics {
 
   }
 
+  proc _cast(type t:RAtomicT(?T), rhs: T) {
+    var lhs: RAtomicT(T) = rhs; // use init=
+    return lhs;
+  }
 
   inline proc =(ref a:RAtomicBool, const b:RAtomicBool) {
     a.write(b.read());


### PR DESCRIPTION
Follow-up to PR #17092. This PR updates NetworkAtomics.chpl in a manner
similar to the change in that PR for Atomics.chpl to avoid errors about
missing casts.

Reviewed by @ronawho - thanks!

- [x] failing tests no longer have missing cast errors
