### PR TITLE
Avoid adding -DCHPL_OPTIMIZE, CHPL_DEBUG, NDEBUG to list-includes-and-defines

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2025,6 +2025,8 @@ void runClang(const char* just_parse_filename) {
   }
 
   // Remove -DCHPL_DEBUG, -DCHPL_OPTIMIZE, -DNDEBUG from the args
+  // They are settings from the runtime build and we want to
+  // use flags appropriate to the compilation instead of the runtime build
   std::vector<std::string>::iterator pos =
     std::find(args.begin(), args.end(), "-DCHPL_DEBUG");
   if (pos != args.end())

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2024,6 +2024,21 @@ void runClang(const char* just_parse_filename) {
     }
   }
 
+  // Remove -DCHPL_DEBUG, -DCHPL_OPTIMIZE, -DNDEBUG from the args
+  std::vector<std::string>::iterator pos =
+    std::find(args.begin(), args.end(), "-DCHPL_DEBUG");
+  if (pos != args.end())
+    args.erase(pos);
+
+  pos = std::find(args.begin(), args.end(), "-DCHPL_OPTIMIZE");
+  if (pos != args.end())
+    args.erase(pos);
+
+
+  pos = std::find(args.begin(), args.end(), "-DNDEBUG");
+  if (pos != args.end())
+    args.erase(pos);
+
   std::string dashImodules = "-I";
   dashImodules += CHPL_HOME;
   dashImodules += "/modules";

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2054,11 +2054,15 @@ void runClang(const char* just_parse_filename) {
     }
   }
 
-  if (debugCCode)
+  if (debugCCode) {
     args.push_back(clang_debug);
+    args.push_back("-DCHPL_DEBUG");
+  }
 
-  if (optimizeCCode)
+  if (optimizeCCode) {
     args.push_back(clang_opt);
+    args.push_back("-DCHPL_OPTIMIZE");
+  }
 
   if (specializeCCode &&
       CHPL_TARGET_CPU_FLAG != NULL &&

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -103,7 +103,7 @@ x:
 	@echo $(CHPL_MAKE_RUNTIME_LIB)
 
 printincludesanddefines:
-	@echo $(CHPL_MAKE_BASE_CFLAGS) $(RUNTIME_DEFS) $(RUNTIME_INCLS)
+	@echo $(CHPL_MAKE_BASE_CFLAGS) $(patsubst -DNDEBUG,,$(patsubst -DCHPL_OPTIMIZE,,$(patsubst -DCHPL_DEBUG,,$(RUNTIME_DEFS)))) $(RUNTIME_INCLS)
 
 printcompileline:
 	@echo $(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) $(CHPL_RT_INC_DIR)

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -103,7 +103,7 @@ x:
 	@echo $(CHPL_MAKE_RUNTIME_LIB)
 
 printincludesanddefines:
-	@echo $(CHPL_MAKE_BASE_CFLAGS) $(patsubst -DNDEBUG,,$(patsubst -DCHPL_OPTIMIZE,,$(patsubst -DCHPL_DEBUG,,$(RUNTIME_DEFS)))) $(RUNTIME_INCLS)
+	@echo $(CHPL_MAKE_BASE_CFLAGS) $(RUNTIME_DEFS) $(RUNTIME_INCLS)
 
 printcompileline:
 	@echo $(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) $(CHPL_RT_INC_DIR)


### PR DESCRIPTION
These were being passed to the backend clang compiler for --llvm compiles
based on how the runtime was built instead of based on how the user program
was built. Avoid adding them to the list-includes-and-defines file, and
instead choose to set them or not based on chpl compiler flags.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>