### PR TITLE
Override virtual dtors, use = default where simple

### DIFF
--- a/compiler/AST/AstCount.cpp
+++ b/compiler/AST/AstCount.cpp
@@ -38,9 +38,6 @@ AstCount::AstCount() {
   numParamForLoop = 0;
 }
 
-AstCount::~AstCount() {
-}
-
 int AstCount::total() {
   int sum = 0;
 

--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -21,15 +21,6 @@
 #include "AstLogger.h"
 #include "stlUtil.h"
 
-
-
-AstLogger::AstLogger() {
-
-}
-
-AstLogger::~AstLogger() {
-}
-
 bool AstLogger::enterAggrType(AggregateType* node) {
   return true;
 }

--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -28,16 +28,6 @@
 #include "IfExpr.h"
 #include "LoopExpr.h"
 
-AstToText::AstToText()
-{
-
-}
-
-AstToText::~AstToText()
-{
-
-}
-
 const std::string& AstToText::text() const
 {
   return mText;
@@ -626,7 +616,7 @@ bool AstToText::isTypeDefault(Expr* expr) const
 void AstToText::appendDomain(CallExpr* expr, bool printingType)
 {
   mText += "domain(";
-              
+
   for(int i=2; i<=expr->numActuals(); i++)
   {
     if (i != 2)
@@ -959,7 +949,7 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
       {
         mText += "{";
         appendExpr(expr->get(1), printingType);
-        
+
         // last argument to chpl__buildDomainExpr is definedConst
         for (int index = 2; index <= expr->numActuals()-1; index++)
         {

--- a/compiler/AST/AstVisitor.cpp
+++ b/compiler/AST/AstVisitor.cpp
@@ -17,13 +17,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include "AstVisitor.h"
-
-AstVisitor::AstVisitor() {
-
-}
-
-AstVisitor::~AstVisitor() {
-
-}

--- a/compiler/AST/AstVisitorTraverse.cpp
+++ b/compiler/AST/AstVisitorTraverse.cpp
@@ -22,16 +22,6 @@
 
 #include "ImportStmt.h"
 
-AstVisitorTraverse::AstVisitorTraverse()
-{
-
-}
-
-AstVisitorTraverse::~AstVisitorTraverse()
-{
-
-}
-
 bool AstVisitorTraverse::enterAggrType(AggregateType* node)
 {
   return true;

--- a/compiler/AST/CForLoop.cpp
+++ b/compiler/AST/CForLoop.cpp
@@ -122,11 +122,6 @@ CForLoop::CForLoop(BlockStmt* initBody) : LoopStmt(initBody)
   mIncrClause = 0;
 }
 
-CForLoop::~CForLoop()
-{
-
-}
-
 CForLoop* CForLoop::copyInner(SymbolMap* map)
 {
   CForLoop*  retval    = new CForLoop();

--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -144,10 +144,6 @@ static void callExprHelper(CallExpr* call, BaseAST* arg) {
   }
 }
 
-CallExpr::~CallExpr() {
-}
-
-
 bool CallExpr::isEmpty() const {
   return primitive == NULL && baseExpr == NULL;
 }

--- a/compiler/AST/CatchStmt.cpp
+++ b/compiler/AST/CatchStmt.cpp
@@ -54,10 +54,6 @@ CatchStmt::CatchStmt(const char* name, Expr* type, BlockStmt* body)
   gCatchStmts.add(this);
 }
 
-CatchStmt::~CatchStmt() {
-
-}
-
 const char* CatchStmt::name() const {
   return _name;
 }

--- a/compiler/AST/CollapseBlocks.cpp
+++ b/compiler/AST/CollapseBlocks.cpp
@@ -84,16 +84,6 @@
 #include "ImportStmt.h"
 #include "stmt.h"
 
-CollapseBlocks::CollapseBlocks()
-{
-
-}
-
-CollapseBlocks::~CollapseBlocks()
-{
-
-}
-
 bool CollapseBlocks::enterBlockStmt(BlockStmt* node)
 {
   AList shuffle;

--- a/compiler/AST/DecoratedClassType.cpp
+++ b/compiler/AST/DecoratedClassType.cpp
@@ -132,10 +132,6 @@ DecoratedClassType::DecoratedClassType(AggregateType* cls, ClassTypeDecorator d)
   gDecoratedClassTypes.add(this);
 }
 
-
-DecoratedClassType::~DecoratedClassType() {
-}
-
 void DecoratedClassType::accept(AstVisitor* visitor) {
   if (visitor->enterDecoratedClassType(this)) {
     visitor->exitDecoratedClassType(this);

--- a/compiler/AST/DeferStmt.cpp
+++ b/compiler/AST/DeferStmt.cpp
@@ -46,11 +46,6 @@ DeferStmt::DeferStmt(CallExpr* call)
   gDeferStmts.add(this);
 }
 
-
-DeferStmt::~DeferStmt() {
-
-}
-
 BlockStmt* DeferStmt::body() const {
   return _body;
 }
@@ -205,7 +200,7 @@ namespace {
 void checkDefersAfterParsing()
 {
   forv_Vec(DeferStmt, defer, gDeferStmts) {
-  
+
     // Check that there are no top-level defers;
     // each defer must be in a function (other than module init).
     ModuleSymbol* mod = toModuleSymbol(defer->parentSymbol);

--- a/compiler/AST/DoWhileStmt.cpp
+++ b/compiler/AST/DoWhileStmt.cpp
@@ -80,11 +80,6 @@ DoWhileStmt::DoWhileStmt(VarSymbol* var, BlockStmt* body) :
 
 }
 
-DoWhileStmt::~DoWhileStmt()
-{
-
-}
-
 DoWhileStmt* DoWhileStmt::copyInner(SymbolMap* map)
 {
   Expr*        cond   = NULL;
@@ -94,11 +89,6 @@ DoWhileStmt* DoWhileStmt::copyInner(SymbolMap* map)
   retval->copyInnerShare(*this, map);
 
   return retval;
-}
-
-bool DoWhileStmt::isDoWhileStmt() const
-{
-  return true;
 }
 
 void DoWhileStmt::accept(AstVisitor* visitor)

--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -348,11 +348,6 @@ ForLoop::ForLoop(VarSymbol* index,
   mIsForExpr = isForExpr;
 }
 
-ForLoop::~ForLoop()
-{
-
-}
-
 ForLoop* ForLoop::copyInner(SymbolMap* map)
 {
   ForLoop*   retval         = new ForLoop();
@@ -415,12 +410,6 @@ void ForLoop::copyBodyHelper(Expr* beforeHere, int64_t i, SymbolMap* map,
   map->put(continueSym, continueLabel);
 
   defContinueLabel->insertBefore(copyBody(map));
-}
-
-
-bool ForLoop::isForLoop() const
-{
-  return true;
 }
 
 // TODO (Elliot 03/03/15): coforall loops are currently represented

--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -181,8 +181,8 @@ static void addIterRecShape(CallExpr* forallExprCall,
 class LowerLoopExprVisitor final : public AstVisitorTraverse
 {
   public:
-    LowerLoopExprVisitor() { }
-    ~LowerLoopExprVisitor() { }
+    LowerLoopExprVisitor()          = default;
+   ~LowerLoopExprVisitor() override = default;
 
     bool enterLoopExpr(LoopExpr* node) override;
 };

--- a/compiler/AST/LoopStmt.cpp
+++ b/compiler/AST/LoopStmt.cpp
@@ -30,16 +30,6 @@ LoopStmt::LoopStmt(BlockStmt* initBody) : BlockStmt(initBody)
   mParallelAccessVectorizationHazard = false;
 }
 
-LoopStmt::~LoopStmt()
-{
-
-}
-
-bool LoopStmt::isLoopStmt() const
-{
-  return true;
-}
-
 LabelSymbol* LoopStmt::breakLabelGet() const
 {
   return mBreakLabel;

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -235,12 +235,6 @@ ModuleSymbol::ModuleSymbol(const char* iName,
   gModuleSymbols.add(this);
 }
 
-
-ModuleSymbol::~ModuleSymbol() {
-
-}
-
-
 void ModuleSymbol::verify() {
   Symbol::verify();
 

--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -183,11 +183,6 @@ ParamForLoop::ParamForLoop(VarSymbol*   indexVar,
                               strideVar);
 }
 
-ParamForLoop::~ParamForLoop()
-{
-
-}
-
 ParamForLoop* ParamForLoop::copyInner(SymbolMap* map)
 {
   ParamForLoop* retval    = new ParamForLoop();
@@ -204,11 +199,6 @@ ParamForLoop* ParamForLoop::copyInner(SymbolMap* map)
     retval->insertAtTail(expr->copy(map, true));
 
   return retval;
-}
-
-bool ParamForLoop::isParamForLoop() const
-{
-  return true;
 }
 
 SymExpr* ParamForLoop::indexExprGet() const

--- a/compiler/AST/TransformLogicalShortCircuit.cpp
+++ b/compiler/AST/TransformLogicalShortCircuit.cpp
@@ -31,15 +31,6 @@
 #include "IfExpr.h"
 #include "stmt.h"
 
-TransformLogicalShortCircuit::TransformLogicalShortCircuit()
-{
-}
-
-TransformLogicalShortCircuit::~TransformLogicalShortCircuit()
-{
-
-}
-
 bool TransformLogicalShortCircuit::enterCallExpr(CallExpr* call)
 {
   // Lowering of LoopExprs will handle short-circuits itself

--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -61,10 +61,6 @@ TryStmt::TryStmt(bool tryBang, BlockStmt* body, BlockStmt* catches,
   gTryStmts.add(this);
 }
 
-TryStmt::~TryStmt() {
-
-}
-
 BlockStmt* TryStmt::body() const {
   return _body;
 }

--- a/compiler/AST/WhileDoStmt.cpp
+++ b/compiler/AST/WhileDoStmt.cpp
@@ -86,23 +86,6 @@ bool WhileDoStmt::isPrimitiveCForLoop(Expr* cond)
 *                                                                           *
 ************************************* | ************************************/
 
-WhileDoStmt::WhileDoStmt(Expr* cond, BlockStmt* body) :
-WhileStmt(cond, body)
-{
-
-}
-
-WhileDoStmt::WhileDoStmt(VarSymbol* var, BlockStmt* body) :
-  WhileStmt(var, body)
-{
-
-}
-
-WhileDoStmt::~WhileDoStmt()
-{
-
-}
-
 WhileDoStmt* WhileDoStmt::copyInner(SymbolMap* map)
 {
   Expr*        condExpr = 0;
@@ -112,11 +95,6 @@ WhileDoStmt* WhileDoStmt::copyInner(SymbolMap* map)
   retval->copyInnerShare(*this, map);
 
   return retval;
-}
-
-bool WhileDoStmt::isWhileDoStmt() const
-{
-  return true;
 }
 
 void WhileDoStmt::accept(AstVisitor* visitor)

--- a/compiler/AST/WhileStmt.cpp
+++ b/compiler/AST/WhileStmt.cpp
@@ -36,11 +36,6 @@ WhileStmt::WhileStmt(VarSymbol* var, BlockStmt* body) :
   mCondExpr = (var != 0) ? new SymExpr(var) : 0;
 }
 
-WhileStmt::~WhileStmt()
-{
-
-}
-
 void WhileStmt::copyInnerShare(const WhileStmt& ref,
                                SymbolMap*       map)
 {

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -362,12 +362,7 @@ BaseAST::BaseAST(AstTag type) :
   }
 }
 
-
 const std::string BaseAST::tabText = "   ";
-
-
-BaseAST::~BaseAST() {
-}
 
 int BaseAST::linenum() const {
   return astloc.lineno;

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -64,10 +64,6 @@ Expr::Expr(AstTag astTag) :
   next(NULL)
 { }
 
-Expr::~Expr() {
-
-}
-
 bool Expr::isStmt() const {
   return false;
 }

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -48,27 +48,7 @@ Vec<LabelSymbol*> removedIterResumeLabels;
 *                                                                             *
 ************************************** | *************************************/
 
-Stmt::Stmt(AstTag astTag) : Expr(astTag) {
-
-}
-Stmt::~Stmt() {
-
-}
-
-bool Stmt::isStmt() const {
-  return true;
-}
-
-/************************************* | **************************************
-*                                                                             *
-*                                                                             *
-*                                                                             *
-************************************** | *************************************/
-
 VisibilityStmt::VisibilityStmt(AstTag astTag): Stmt(astTag) {
-}
-
-VisibilityStmt::~VisibilityStmt() {
 }
 
 // Specifically for when the module being used or imported is renamed

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -511,11 +511,6 @@ LcnSymbol::LcnSymbol(AstTag      astTag,
   mOffset = -1;
 }
 
-LcnSymbol::~LcnSymbol()
-{
-
-}
-
 void LcnSymbol::locationSet(int depth, int offset)
 {
   mDepth  = depth;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -54,10 +54,6 @@ Type::Type(AstTag astTag, Symbol* iDefaultVal) : BaseAST(astTag) {
   scalarPromotionType = NULL;
 }
 
-Type::~Type() {
-
-}
-
 const char* Type::name() const {
   return symbol->name;
 }
@@ -75,7 +71,6 @@ bool Type::inTree() {
   else
     return false;
 }
-
 
 QualifiedType Type::qualType() {
   return QualifiedType(this);
@@ -510,10 +505,6 @@ EnumType::EnumType() :
   gEnumTypes.add(this);
   constants.parent = this;
 }
-
-
-EnumType::~EnumType() { }
-
 
 void EnumType::verify() {
   Type::verify();

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -48,7 +48,7 @@ public:
 
 public:
                               AggregateType(AggregateTag initTag);
-                             ~AggregateType();
+                             ~AggregateType() override;
 
   DECLARE_COPY(AggregateType);
   AggregateType*      copyInner(SymbolMap* map) override;

--- a/compiler/include/AstCount.h
+++ b/compiler/include/AstCount.h
@@ -43,7 +43,7 @@ foreach_ast(decl_members);
   int numParamForLoop;
 
    AstCount();
-  ~AstCount();
+  ~AstCount() override = default;
 
   int total();
 

--- a/compiler/include/AstDump.h
+++ b/compiler/include/AstDump.h
@@ -46,7 +46,7 @@ public:
   static  void     view(const char* passName, int passNum);
 
                    AstDump(FILE* fp);
-                  ~AstDump();
+                  ~AstDump() override;
 
   //
   // These functions are the "implementation" interface for the

--- a/compiler/include/AstDumpToHtml.h
+++ b/compiler/include/AstDumpToHtml.h
@@ -107,7 +107,7 @@ public:
 
 private:
                    AstDumpToHtml();
-                  ~AstDumpToHtml();
+                  ~AstDumpToHtml() override;
 
   bool             open(ModuleSymbol* module, const char* passName);
   bool             close();

--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -68,7 +68,7 @@ public:
   //
 public:
    AstDumpToNode(FILE* fp, int offset = 0);
-  ~AstDumpToNode();
+  ~AstDumpToNode() override;
 
   void offsetSet(int offset);
 

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -29,8 +29,8 @@
 
 class AstLogger : public AstVisitor {
 public:
-                 AstLogger();
-  virtual       ~AstLogger();
+   AstLogger()          = default;
+  ~AstLogger() override = default;
 
   //
   // The sub-classes of Type

--- a/compiler/include/AstPrintDocs.h
+++ b/compiler/include/AstPrintDocs.h
@@ -31,7 +31,7 @@
 class AstPrintDocs final : public AstVisitorTraverse {
 public:
    AstPrintDocs(std::string moduleName, std::string path, std::string parentName);
-  ~AstPrintDocs();
+  ~AstPrintDocs() override;
 
   bool   enterAggrType    (AggregateType*     node) override;
   void   exitAggrType     (AggregateType*     node) override;

--- a/compiler/include/AstToText.h
+++ b/compiler/include/AstToText.h
@@ -70,8 +70,8 @@ class LoopExpr;
 class AstToText
 {
 public:
-                         AstToText();
-                        ~AstToText();
+  AstToText() = default;
+ ~AstToText() = default;
 
   // A reference to the generate text
   const std::string&     text()                                        const;

--- a/compiler/include/AstVisitor.h
+++ b/compiler/include/AstVisitor.h
@@ -67,8 +67,8 @@ class ExternBlockStmt;
 class AstVisitor
 {
 public:
-                 AstVisitor();
-  virtual       ~AstVisitor();
+                 AstVisitor() = default;
+  virtual       ~AstVisitor() = default;
 
   // Generally an AST visitor has one or two routine per type of AST node.
   // For nodes that can contain other nodes, it has 2 routines:

--- a/compiler/include/AstVisitorTraverse.h
+++ b/compiler/include/AstVisitorTraverse.h
@@ -37,8 +37,8 @@
 class AstVisitorTraverse : public AstVisitor
 {
 public:
-                 AstVisitorTraverse();
-  virtual       ~AstVisitorTraverse();
+  AstVisitorTraverse()          = default;
+ ~AstVisitorTraverse() override = default;
 
   //
   // The sub-classes of Type

--- a/compiler/include/CForLoop.h
+++ b/compiler/include/CForLoop.h
@@ -42,7 +42,7 @@ public:
   // Instance Interface
   //
 public:
-  ~CForLoop();
+  ~CForLoop() override = default;
 
   DECLARE_COPY(CForLoop);
   CForLoop* copyInner(SymbolMap* map) override;
@@ -83,4 +83,3 @@ private:
 };
 
 #endif
-

--- a/compiler/include/CallExpr.h
+++ b/compiler/include/CallExpr.h
@@ -69,7 +69,7 @@ public:
            BaseAST*     arg4 = NULL,
            BaseAST*     arg5 = NULL);
 
-  ~CallExpr();
+  ~CallExpr() override = default;
 
   void    verify() override;
 

--- a/compiler/include/CatchStmt.h
+++ b/compiler/include/CatchStmt.h
@@ -53,7 +53,7 @@ public:
   static CatchStmt* build(BlockStmt* body);
 
    CatchStmt(const char* name, Expr* type, BlockStmt* body);
-  ~CatchStmt();
+  ~CatchStmt() override = default;
 
   const char* name() const;
   Expr*       type() const;

--- a/compiler/include/CollapseBlocks.h
+++ b/compiler/include/CollapseBlocks.h
@@ -25,8 +25,8 @@
 
 class CollapseBlocks final : public AstVisitor {
 public:
-   CollapseBlocks();
-  ~CollapseBlocks();
+   CollapseBlocks()          = default;
+  ~CollapseBlocks() override = default;
 
   //
   // The sub-classes of Type

--- a/compiler/include/DecoratedClassType.h
+++ b/compiler/include/DecoratedClassType.h
@@ -52,7 +52,7 @@ class DecoratedClassType final : public Type {
 public:
                           DecoratedClassType(AggregateType* cls,
                                              ClassTypeDecorator d);
-                         ~DecoratedClassType();
+                         ~DecoratedClassType() override = default;
 
   void                    accept(AstVisitor* visitor) override;
   void              replaceChild(BaseAST* oldAst, BaseAST* newAst) override;

--- a/compiler/include/DeferStmt.h
+++ b/compiler/include/DeferStmt.h
@@ -36,7 +36,7 @@ public:
 
                       DeferStmt(BlockStmt* body);
                       DeferStmt(CallExpr* call);
-                     ~DeferStmt();
+                     ~DeferStmt() override = default;
 
   void                accept(AstVisitor* visitor) override;
   void                replaceChild(Expr* old_ast, Expr* new_ast) override;

--- a/compiler/include/DoWhileStmt.h
+++ b/compiler/include/DoWhileStmt.h
@@ -36,12 +36,13 @@ public:
   // Instance interface
   //
 public:
-  ~DoWhileStmt();
+  ~DoWhileStmt() override = default;
 
   DECLARE_COPY(DoWhileStmt);
   DoWhileStmt*   copyInner(SymbolMap* map)                          override;
 
-  bool           isDoWhileStmt()                              const override;
+  bool           isDoWhileStmt()                              const override
+                 { return true; }
 
   GenRet         codegen()                                          override;
   void           accept(AstVisitor* visitor)                        override;
@@ -50,11 +51,8 @@ public:
   Expr*          getNextExpr(Expr* expr)                            override;
 
 private:
-                         DoWhileStmt();
-
-                         DoWhileStmt(Expr*      cond, BlockStmt* body);
-                         DoWhileStmt(VarSymbol* var,  BlockStmt* body);
+                 DoWhileStmt(Expr*      cond, BlockStmt* body);
+                 DoWhileStmt(VarSymbol* var,  BlockStmt* body);
 };
 
 #endif
-

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -133,16 +133,16 @@ public:
 
 
                              FnSymbol(const char* initName);
-                            ~FnSymbol();
+                            ~FnSymbol() override;
 
   void                       verify() override;
-  void               accept(AstVisitor* visitor) override;
+  void                       accept(AstVisitor* visitor) override;
 
   DECLARE_SYMBOL_COPY(FnSymbol);
   FnSymbol* copyInner(SymbolMap* map) override;
 
   FnSymbol*                  copyInnerCore(SymbolMap* map);
-  void               replaceChild(BaseAST* oldAst, BaseAST* newAst) override;
+  void                       replaceChild(BaseAST* oldAst, BaseAST* newAst) override;
 
   FnSymbol*                  partialCopy(SymbolMap* map);
   void                       finalizeCopy();

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -68,17 +68,18 @@ private:
   // Instance Interface
   //
 public:
+
+                        ~ForLoop() override = default;
                          ForLoop(VarSymbol* index,
                                  VarSymbol* iterator,
                                  BlockStmt* initBody,
                                  bool       zippered,
                                  bool       isLoweredForall,
                                  bool       isForExpr);
-                        ~ForLoop();
 
   DECLARE_COPY(ForLoop);
   ForLoop* copyInner(SymbolMap* map) override;
- 
+
   GenRet         codegen()                                         override;
   void           verify()                                          override;
   void           accept(AstVisitor* visitor)                       override;
@@ -88,7 +89,9 @@ public:
   Expr*          getFirstExpr()                                    override;
   Expr*          getNextExpr(Expr* expr)                           override;
 
-  bool           isForLoop()                                 const override;
+  bool           isForLoop()                                 const override
+                 { return true; }
+
   bool           isCoforallLoop()                            const override;
 
   bool           deadBlockCleanup()                                override;
@@ -128,4 +131,3 @@ private:
 };
 
 #endif
-

--- a/compiler/include/LoopStmt.h
+++ b/compiler/include/LoopStmt.h
@@ -33,7 +33,8 @@ public:
   static Stmt*           findEnclosingLoopOrForall(Expr* expr);
 
 public:
-  bool           isLoopStmt()                                   const override;
+  bool                   isLoopStmt()                                    const override
+                         { return true; }
 
   LabelSymbol*           breakLabelGet()                                 const;
   void                   breakLabelSet(LabelSymbol* sym);
@@ -56,9 +57,10 @@ public:
   bool                   isVectorizable()                               const;
   // for llvm.loop.parallel_accesses (and C pragmas)
   bool                   isParallelAccessVectorizable()                 const;
+
 protected:
                          LoopStmt(BlockStmt* initBody);
-  virtual               ~LoopStmt();
+                        ~LoopStmt() override = default;
 
   LabelSymbol*           mBreakLabel;
   LabelSymbol*           mContinueLabel;

--- a/compiler/include/ModuleSymbol.h
+++ b/compiler/include/ModuleSymbol.h
@@ -54,7 +54,7 @@ public:
                                        ModTag      iModTag,
                                        BlockStmt*  iBlock);
 
-                         ~ModuleSymbol();
+                         ~ModuleSymbol() override = default;
 
   // Interface to BaseAST
   void            verify() override;

--- a/compiler/include/ParamForLoop.h
+++ b/compiler/include/ParamForLoop.h
@@ -48,7 +48,8 @@ public:
                                       LabelSymbol* continueLabel,
                                       LabelSymbol* breakLabel,
                                       BlockStmt*   initBody);
-                        ~ParamForLoop();
+
+                        ~ParamForLoop() override = default;
 
   DECLARE_COPY(ParamForLoop);
   ParamForLoop* copyInner(SymbolMap* map) override;
@@ -60,7 +61,8 @@ public:
   Expr*                  getFirstExpr()                            override;
   Expr*                  getNextExpr(Expr* expr)                   override;
 
-  bool                   isParamForLoop()                    const override;
+  bool                   isParamForLoop()                    const override
+                         { return true; }
 
   CallExpr*              blockInfoGet()                      const override;
   CallExpr*              blockInfoSet(CallExpr* expr)              override;
@@ -98,4 +100,3 @@ private:
 };
 
 #endif
-

--- a/compiler/include/PartialCopyData.h
+++ b/compiler/include/PartialCopyData.h
@@ -33,7 +33,7 @@
 class ArgSymbol;
 class FnSymbol;
 
-class PartialCopyData {
+class PartialCopyData final {
 public:
                           PartialCopyData();
                          ~PartialCopyData();

--- a/compiler/include/TransformLogicalShortCircuit.h
+++ b/compiler/include/TransformLogicalShortCircuit.h
@@ -41,8 +41,8 @@ class Expr;
 class TransformLogicalShortCircuit final : public AstVisitorTraverse
 {
 public:
-                 TransformLogicalShortCircuit();
-                ~TransformLogicalShortCircuit();
+  TransformLogicalShortCircuit() = default;
+ ~TransformLogicalShortCircuit() override = default;
 
   // Transform performed pre-order
   bool   enterCallExpr (CallExpr* node) override;

--- a/compiler/include/TryStmt.h
+++ b/compiler/include/TryStmt.h
@@ -35,7 +35,8 @@ public:
 
   TryStmt(bool tryBang, BlockStmt* body, BlockStmt* catches,
           bool isSyncTry = false);
- ~TryStmt();
+ ~TryStmt() override = default;
+
   BlockStmt*          body() const;
   bool                tryBang() const;
   bool                isSyncTry() const;

--- a/compiler/include/WhileDoStmt.h
+++ b/compiler/include/WhileDoStmt.h
@@ -39,13 +39,15 @@ private:
   // Instance interface
   //
 public:
-                         WhileDoStmt(Expr*      cond, BlockStmt* body);
-                        ~WhileDoStmt();
+                        ~WhileDoStmt() override = default;
+                         WhileDoStmt(Expr* cond, BlockStmt* body)
+                           : WhileStmt(cond, body) { }
 
   DECLARE_COPY(WhileDoStmt);
   WhileDoStmt*           copyInner(SymbolMap* map)                   override;
 
-  bool                   isWhileDoStmt()                       const override;
+  bool                   isWhileDoStmt()                             const override
+                         { return true; }
 
   GenRet                 codegen()                                   override;
   void                   accept(AstVisitor* visitor)                 override;
@@ -54,10 +56,9 @@ public:
   Expr*                  getNextExpr(Expr* expr)                     override;
 
 private:
-                         WhileDoStmt();
-
-                         WhileDoStmt(VarSymbol* var,  BlockStmt* body);
+                         WhileDoStmt(VarSymbol* var,  BlockStmt* body)
+                           : WhileStmt(var, body) {
+                         }
 };
 
 #endif
-

--- a/compiler/include/WhileStmt.h
+++ b/compiler/include/WhileStmt.h
@@ -33,7 +33,7 @@ public:
 protected:
   WhileStmt(Expr*      sym, BlockStmt* initBody);
   WhileStmt(VarSymbol* sym, BlockStmt* initBody);
-  virtual ~WhileStmt();
+ ~WhileStmt() override = default;
 
   void      copyInnerShare(const WhileStmt& ref, SymbolMap* map);
 
@@ -51,7 +51,6 @@ protected:
   CallExpr* blockInfoSet(CallExpr* expr)             override;
 
 private:
-  WhileStmt();
 
   // Helper functions for checkConstLoops()
   SymExpr*               getWhileCondDef(VarSymbol* condSym);

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -286,7 +286,7 @@ public:
 
 protected:
                     BaseAST(AstTag type);
-  virtual          ~BaseAST();
+  virtual          ~BaseAST() = default;
 
 private:
                     BaseAST();

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -42,8 +42,8 @@ class PrimitiveOp;
 
 class Expr : public BaseAST {
 public:
-                  Expr(AstTag astTag);
-  virtual        ~Expr();
+   Expr(AstTag astTag);
+  ~Expr() override = default;
 
   // Interface for BaseAST
           bool    inTree()                                        override;
@@ -117,9 +117,10 @@ private:
 
 class DefExpr final : public Expr {
 public:
-                  DefExpr(Symbol*  initSym      = NULL,
-                          BaseAST* initInit     = NULL,
-                          BaseAST* initExprType = NULL);
+  DefExpr(Symbol*  initSym      = NULL,
+          BaseAST* initInit     = NULL,
+          BaseAST* initExprType = NULL);
+ ~DefExpr() override = default;
 
   void    verify()                                   override;
 
@@ -158,6 +159,7 @@ class SymExpr final : public Expr {
   SymExpr* symbolSymExprsNext;
 
   SymExpr(Symbol* init_var);
+ ~SymExpr() override = default;
 
   DECLARE_COPY(SymExpr);
   SymExpr* copyInner(SymbolMap* map)                  override;
@@ -185,6 +187,7 @@ class UnresolvedSymExpr final : public Expr {
   const char* unresolved;
 
   UnresolvedSymExpr(const char* init_var);
+ ~UnresolvedSymExpr() override = default;
 
   DECLARE_COPY(UnresolvedSymExpr);
   UnresolvedSymExpr* copyInner(SymbolMap* map)        override;
@@ -231,7 +234,8 @@ class UnresolvedSymExpr final : public Expr {
 //
 class ContextCallExpr final : public Expr {
 public:
-                         ContextCallExpr();
+  ContextCallExpr();
+ ~ContextCallExpr() override = default;
 
   DECLARE_COPY(ContextCallExpr);
   ContextCallExpr* copyInner(SymbolMap* map)              override;
@@ -273,6 +277,7 @@ class NamedExpr final : public Expr {
   Expr*           actual;
 
   NamedExpr(const char* init_name, Expr* init_actual);
+ ~NamedExpr() override = default;
 
   void    verify()                                    override;
 
@@ -293,12 +298,13 @@ class NamedExpr final : public Expr {
 //   implements InterfaceName(actualType...)
 // or
 //   actualType implements InterfaceName
-//   
+//
 class IfcConstraint final : public Expr {
 public:
   static IfcConstraint* build(const char* name,
                               CallExpr* actuals);
   IfcConstraint(Expr* iifc);
+ ~IfcConstraint() override = default;
 
   DECLARE_COPY(IfcConstraint);
   IfcConstraint* copyInner(SymbolMap* map)            override;
@@ -321,7 +327,7 @@ public:
 
 // valid after scopeResolve
 inline InterfaceSymbol* IfcConstraint::ifcSymbol() const {
-  return toInterfaceSymbol(toSymExpr(interfaceExpr)->symbol());  
+  return toInterfaceSymbol(toSymExpr(interfaceExpr)->symbol());
 }
 
 

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -45,11 +45,11 @@
 
 class Stmt : public Expr {
 public:
-                 Stmt(AstTag astTag);
-  virtual       ~Stmt();
+  Stmt(AstTag astTag) : Expr(astTag) {}
+ ~Stmt() override = default;
 
   // Interface to Expr
-  bool isStmt()  const override;
+  bool isStmt() const override { return true; }
 };
 
 /************************************* | **************************************
@@ -61,8 +61,8 @@ class ResolveScope;
 // parent base class for UseStmt and ImportStmt
 class VisibilityStmt : public Stmt {
  public:
-           VisibilityStmt(AstTag astTag);
-  virtual ~VisibilityStmt();
+  VisibilityStmt(AstTag astTag);
+ ~VisibilityStmt() override = default;
 
   bool isARename() const;
   bool isARenamedSym(const char* name) const;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -232,11 +232,9 @@ protected:
                             const char* init_name,
                             Type*       init_type = dtUnknown);
 
-  virtual           ~Symbol();
+                    ~Symbol() override;
 
 private:
-                     Symbol();
-
   virtual void       codegenPrototype(); // ie type decl
   virtual Symbol*    copyInner(SymbolMap* map) = 0;
 
@@ -285,10 +283,9 @@ protected:
                       const char* initName,
                       Type*       initType);
 
-  virtual  ~LcnSymbol();
+           ~LcnSymbol() override = default;
 
 private:
-            LcnSymbol();
 
   int       mDepth;                // Lexical depth relative to root
   int       mOffset;               // Byte offset within frame
@@ -309,7 +306,7 @@ public:
   //changed isconstant flag to reflect var, const, param: 0, 1, 2
   VarSymbol(const char* init_name, Type* init_type = dtUnknown);
   VarSymbol(const char* init_name, QualifiedType qType);
-  virtual ~VarSymbol();
+ ~VarSymbol() override;
 
   void   verify()                                            override;
   void   accept(AstVisitor* visitor)                         override;

--- a/compiler/include/timer.h
+++ b/compiler/include/timer.h
@@ -2,15 +2,15 @@
  * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@
 class Timer {
 public:
                  Timer();
-                ~Timer();
+                ~Timer() = default;
 
   void           clear();
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -115,8 +115,8 @@ public:
   std::map<std::string, int> GEPMap;
 
 protected:
-                   Type(AstTag astTag, Symbol* init_defaultVal);
-  virtual         ~Type();
+  Type(AstTag astTag, Symbol* init_defaultVal);
+ ~Type() override = default;
 
 private:
   virtual void     replaceChild(BaseAST* old_ast, BaseAST* new_ast) = 0;
@@ -321,8 +321,8 @@ class EnumType final : public Type {
  public:
   const char* doc;
 
-   EnumType();
-  ~EnumType();
+  EnumType();
+ ~EnumType() override = default;
 
   void verify()                                         override;
   void accept(AstVisitor* visitor)                      override;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1205,7 +1205,7 @@ class CCodeGenConsumer final : public ASTConsumer {
       }
     }
 
-    ~CCodeGenConsumer() { }
+    ~CCodeGenConsumer() override = default;
 
     // Start ASTVisitor Overrides
     void Initialize(ASTContext &Context) override {
@@ -1913,7 +1913,7 @@ struct ExternBlockInfo {
   GenInfo* gen_info;
   fileinfo file;
   ExternBlockInfo() : gen_info(NULL), file() { }
-  ~ExternBlockInfo() { }
+ ~ExternBlockInfo() = default;
 };
 
 typedef std::set<ModuleSymbol*> module_set_t;

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -899,7 +899,7 @@ static bool isThisDot(CallExpr* call) {
       retval = true;
     }
   }
-  
+
   return retval;
 }
 
@@ -945,10 +945,10 @@ static bool typeHasMethod(AggregateType* type, const char* methodName) {
 class ProcessThisUses final : public AstVisitorTraverse
 {
   public:
-    ProcessThisUses(const InitNormalize* state) {
-      this->state = state;
+    ProcessThisUses(const InitNormalize* state)
+      : state(state) {
     }
-    ~ProcessThisUses() { }
+    ~ProcessThisUses() override = default;
 
     void visitSymExpr(SymExpr* node) override;
     bool enterCallExpr(CallExpr* node) override;

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1218,10 +1218,10 @@ static bool isSuperPostInit(CallExpr* stmt) {
 
 class PostinitVisitor final : public AstVisitorTraverse {
   public:
-    PostinitVisitor() : found(false) { }
-    ~PostinitVisitor() { }
+    PostinitVisitor()          = default;
+   ~PostinitVisitor() override = default;
 
-    bool found;
+    bool found = false;
 
     bool enterCondStmt(CondStmt* node) override;
     bool enterCallExpr(CallExpr* node) override;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -961,8 +961,8 @@ static void normalizeIfExprBranch(VarSymbol* cond, VarSymbol* result, BlockStmt*
 class LowerIfExprVisitor final : public AstVisitorTraverse
 {
   public:
-    LowerIfExprVisitor() { }
-    ~LowerIfExprVisitor() { }
+    LowerIfExprVisitor()          = default;
+   ~LowerIfExprVisitor() override = default;
 
     void exitIfExpr(IfExpr* node) override;
 };

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -336,7 +336,7 @@ public:
 
   ExpandVisitor(ForallStmt* fs, SymbolMap& map);
   ExpandVisitor(ExpandVisitor* parentEV, SymbolMap& map);
-  ~ExpandVisitor();
+ ~ExpandVisitor() override;
 
   bool enterCallExpr(CallExpr* node) override {
     if (node->isPrimitive(PRIM_YIELD)) {
@@ -1300,7 +1300,7 @@ static Symbol* inlineRetArgFunction(CallExpr* defCall, FnSymbol* defFn,
     INT_ASSERT(fn->hasFlag(FLAG_AUTO_DESTROY_FN));
     retAssign = toCallExpr(prev->prev);
     prev->remove();
-  }    
+  }
 
   INT_ASSERT(retAssign && retAssign->isPrimitive(PRIM_ASSIGN));
 

--- a/compiler/util/timer.cpp
+++ b/compiler/util/timer.cpp
@@ -2,15 +2,15 @@
  * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,10 +24,6 @@
 
 Timer::Timer() {
   clear();
-}
-
-Timer::~Timer() {
-
 }
 
 void Timer::clear() {
@@ -74,7 +70,7 @@ unsigned long Timer::diffUsec() const {
 
   gettimeofday(&now, 0);
 
-  /* 
+  /*
      Careful: The arithmetic is based on unsigned longs.
 
      If now.tv_usec < mRefTime.tv_usec then now.tv_sec > mRefTime.tv.usec


### PR DESCRIPTION
Finish work started by @vasslitvinov in  #17150

1. Use C++11 `override` instead of `virtual` when overriding virtual destructors
2. Use C++11 `= default` for trivial constructors and destructors with empty bodies, moving them from `.cpp` files to `.h` header files
