### PR TITLE
Change getCwd() to call sys_getcwd()

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -1115,9 +1115,12 @@ static int sys_getcwd(char** path_out)
  * sys_getcwd() if you need error reports.
  */
 const char* getCwd() {
-  const char* result = getcwd(NULL, PATH_MAX);
-  if (result) {
-    return result;
+  char *ret;
+  int rc;
+
+  rc = sys_getcwd(&ret);
+  if (rc == 0) {
+    return ret;
   } else {
     return "";
   }


### PR DESCRIPTION
The glibc I've just updated to (2.32) changed getcwd(buf,size)'s
prototype to include the write_only(1,2) attribute.  gcc's
interpretation of that attribute disallows passing a NULL buf with a
non-zero size as documented in getcwd()'s man page, and as getCwd()
does.

See e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96832

This seems like a problem between glibc and gcc, but it leaves the
compiler unbuildable.

At @vasslitvinov's suggestion, change getCwd() to call sys_getcwd()
instead of getcwd().

Resolves #17160

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>