### PR TITLE
Fix a .bad mismatch

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1981,6 +1981,17 @@ static Expr* unrollHetTupleLoop(CallExpr* call, Expr* tupExpr, Type* iterType) {
 }
 
 
+static bool isMethodCall(CallExpr* call) {
+  // The first argument could be DefExpr for a query expr, see
+  //   test/arrays/formals/queryArrOfArr2.chpl
+  if (call->numActuals() == 2)
+    if (SymExpr* arg1 = toSymExpr(call->get(1)))
+      if (arg1->typeInfo() == dtMethodToken )
+        return true;
+  return false;
+}
+
+
 static Expr* preFoldNamed(CallExpr* call) {
   Expr* retval = NULL;
 
@@ -2309,8 +2320,7 @@ static Expr* preFoldNamed(CallExpr* call) {
       if (retval != NULL)
         call->replace(retval);
     }
-  } else if (call->numActuals() == 2  &&
-             call->get(1)->typeInfo() == dtMethodToken ) {
+  } else if (isMethodCall(call)) {
     // Handle a reference to an interface associated type, if applicable.
     if (ConstrainedType* recv = toConstrainedType(call->get(2)->typeInfo())) {
       retval = resolveCallToAssociatedType(call, recv);


### PR DESCRIPTION
Compiler code added #17114 did not account for a corner case
where typeInfo() got invoked on a DefExpr, resulting in .bad mismatch in
`test/arrays/formals/queryArrOfArr2.chpl`

With this change, that case is handled properly.

Trivial, not reviewed.