### PR TITLE
Add missing 'override' in compiler/llvm

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1402,7 +1402,7 @@ class CCodeGenAction final : public ASTFrontendAction {
   CCodeGenAction() { }
  protected:
   std::unique_ptr<ASTConsumer>
-  CreateASTConsumer(CompilerInstance &CI, StringRef InFile);
+  CreateASTConsumer(CompilerInstance &CI, StringRef InFile) override;
 };
 
 std::unique_ptr<ASTConsumer>

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -451,7 +451,7 @@ void MemOpRanges::addRange(int64_t Start, int64_t Size, int64_t Slack, Value *Pt
     }
 
 
-    bool runOnFunction(Function &F);
+    bool runOnFunction(Function &F) override;
 
   private:
     void getAnalysisUsage(AnalysisUsage &AU) const override {

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -311,7 +311,7 @@ namespace {
   public:
     /// remapType - The client should implement this method if they want to
     /// remap types while mapping values.
-    virtual Type *remapType(Type *SrcTy) = 0;
+    Type *remapType(Type *SrcTy) override = 0;
 
     // When remapping things with remapped types, these functions
     // provide an opportunity to do the remapping. They should return
@@ -971,13 +971,13 @@ namespace {
       }
     }
 
-    Type *remapType(Type *SrcTy) {
+    Type *remapType(Type *SrcTy) override {
       return convertTypeGlobalToWide(&M, info, SrcTy);
     }
 
     Constant* remapConstant(const Constant* C,
                           ValueToValueMapTy &VM,
-                          RemapFlags Flags) {
+                          RemapFlags Flags) override {
       Type* CT = C->getType();
       if( isa<PointerType>(CT) &&
           CT->getPointerAddressSpace() == info->globalSpace) {


### PR DESCRIPTION
These annotations were missed in #17150, preventing the compiler
from building with CHPL_LLVM=system.

Merging right away - aiming to avoid failures in nightly testing.
@mppf or others - please review post-merge
to ensure that these were indeed intended to be overrides.
