### PR TITLE
Quiet another Tcl module collection-related message.

### DIFF
--- a/util/test/prediff-for-slurm
+++ b/util/test/prediff-for-slurm
@@ -23,6 +23,8 @@ msgs = (
 """,
 """cp: cannot create regular file .*/[.]module/PrgEnv-.*: File exists
 """,
+"""diff: .*/[.]module/PrgEnv-.*: No such file or directory
+""",
 )
 
 outfname = sys.argv[2]


### PR DESCRIPTION
We've encountered another message caused by the race during module
collection creation in multi-node jobs on systems using Tcl v4 modules
where the user home dir is NFS-mounted. Filter it out.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>