### PR TITLE
Removing unused variable isGPUBinaryFlag

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1531,10 +1531,6 @@ void setupClang(GenInfo* info, std::string mainFile)
   if (job == NULL)
     USR_FATAL("Could not find cc1 command from clang driver");
 
-  if ( gCodegenGPU == false && localeUsesGPU() == true && clangInfo->parseOnly == false) {
-    bool isGPUBinaryFlag = false;
-  }
-
   if( printSystemCommands && developer ) {
     printf("<internal clang cc> ");
     for ( auto a : job->getArguments() ) {


### PR DESCRIPTION
This PR is to remove the unused variable `isGPUBinaryFlag` in PR #17116 