### PR TITLE
Changing Check for 4.9.0 to 4.9.4

### DIFF
--- a/util/cron/test-linux64-gcc49.bash
+++ b/util/cron/test-linux64-gcc49.bash
@@ -8,9 +8,9 @@ source $CWD/common.bash
 source /data/cf/chapel/setup_gcc49.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)
-if [ "$gcc_version" != "4.9.0" ]; then
+if [ "$gcc_version" != "4.9.4" ]; then
   echo "Wrong gcc version"
-  echo "Expected Version: 4.9.0 Actual Version: $gcc_version"
+  echo "Expected Version: 4.9.4 Actual Version: $gcc_version"
   exit 2
 fi
 


### PR DESCRIPTION
I wrote the check for 4.9.0, but the actual gcc version is 4.9.4

Signed-off-by: Joe Tursi <joe.p.tursi@gmail.com>