### PR TITLE
Replace dotnl with dotAll, remove default from inline docs

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -439,7 +439,7 @@ class BadRegexpError : Error {
                    of a line instead of just the beginning and end of the text.
                    Note that this can be set inside a regular expression
                    with ``(?m)``.
-   :arg dotnl: (optional, default false) set to true in order to allow ``.``
+   :arg dotAll: (optional) set to true in order to allow ``.``
                to match a newline. Note that this can be set inside the
                regular expression with ``(?s)``.
    :arg nonGreedy: (optional) set to true in order to prefer shorter matches for
@@ -452,7 +452,7 @@ class BadRegexpError : Error {
 
  */
 proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
-             /*i*/ ignoreCase=false, /*m*/ multiLine=false, /*s*/ dotnl=false,
+             /*i*/ ignoreCase=false, /*m*/ multiLine=false, /*s*/ dotAll=false,
              /*U*/ nonGreedy=false): regexp(t) throws where t==string || t==bytes {
 
   if CHPL_REGEXP == "none" {
@@ -470,7 +470,7 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
   opts.nocapture = noCapture;
   opts.ignorecase = ignoreCase;
   opts.multiline = multiLine;
-  opts.dotnl = dotnl;
+  opts.dotnl = dotAll;
   opts.nongreedy = nonGreedy;
 
   var ret: regexp(t);
@@ -481,12 +481,21 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
     var err_str = qio_regexp_error(ret._regexp);
     var err_msg: string;
     try! {
-      err_msg = createStringWithNewBuffer(err_str) + 
+      err_msg = createStringWithNewBuffer(err_str) +
                   " when compiling regexp '" + patternStr + "'";
     }
     throw new owned BadRegexpError(err_msg);
   }
   return ret;
+}
+
+pragma "no doc"
+pragma "last resort"
+proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
+             /*i*/ ignoreCase=false, /*m*/ multiLine=false, /*s*/ dotnl=false,
+             /*U*/ nonGreedy=false): regexp(t) throws where t==string || t==bytes {
+  compilerWarning("Regexp.compile: 'dotnl' is deprecated. Use 'dotAll' instead.");
+  return compile(pattern, posix, literal, noCapture, ignoreCase, multiLine, dotnl, nonGreedy);
 }
 
 /*  The reMatch record records a regular expression search match
@@ -955,7 +964,7 @@ record regexp {
         try! {
           pattern = createStringWithNewBuffer(patternTemp);
         }
-      } 
+      }
       else {
         pattern = createBytesWithNewBuffer(patternTemp);
       }

--- a/test/deprecated/dotnl.chpl
+++ b/test/deprecated/dotnl.chpl
@@ -1,0 +1,5 @@
+use Regexp;
+var re1 = Regexp.compile("a.b", dotnl=true);
+writeln(re1.match("a\nb").matched);
+var re2 = Regexp.compile("a.b", dotAll=true);
+writeln(re2.match("a\nb").matched);

--- a/test/deprecated/dotnl.good
+++ b/test/deprecated/dotnl.good
@@ -1,0 +1,3 @@
+dotnl.chpl:2: warning: Regexp.compile: 'dotnl' is deprecated. Use 'dotAll' instead.
+true
+true


### PR DESCRIPTION
Replace `dotnl` `Regexp` option name with `dotAll`, and remove default comment from inline docs, since it's generated automatically in the docs already.
