### PR TITLE
Improve interface name checking

### DIFF
--- a/test/constrained-generics/basic/set1/error-not-visible.chpl
+++ b/test/constrained-generics/basic/set1/error-not-visible.chpl
@@ -1,6 +1,8 @@
 /*
 This is module-with-ifc.chpl
 with the "import" declaration removed.
+
+While there, also check an incorrect symbol in an 'implements'.
 */
 module Library {
   interface IFC(T) {
@@ -17,7 +19,17 @@ module Library {
   }
 }
 
+module Confused {
+  class MyClass { }
+  int implements MyClass;
+
+  record MyRecord { }
+  proc cgFun(cgArg: ?Q) where Q implements MyRecord { }
+}
+
 module User {
+  use Confused;
+
   proc reqFun(arg1: real, arg2: int) {
     writeln("in reqFun/real*int", (arg1, arg2));
   }

--- a/test/constrained-generics/basic/set1/error-not-visible.good
+++ b/test/constrained-generics/basic/set1/error-not-visible.good
@@ -1,1 +1,8 @@
-error-not-visible.chpl:25: error: 'IFC' undeclared (first use this function)
+error-not-visible.chpl:24: error: 'MyClass' is not an interface
+error-not-visible.chpl:24: note: an 'implements' keyword must be followed by an interface name
+error-not-visible.chpl:23: note: 'MyClass' is defined here
+error-not-visible.chpl:27: In function 'cgFun':
+error-not-visible.chpl:27: error: 'MyRecord' is not an interface
+error-not-visible.chpl:27: note: an 'implements' keyword must be followed by an interface name
+error-not-visible.chpl:26: note: 'MyRecord' is defined here
+error-not-visible.chpl:37: error: 'IFC' is undeclared


### PR DESCRIPTION
This is a rework of #17139 to:
* catch the "undefined" errors earlier, and
* also catch uses of non-interfaces in "implements" decls.
