### PR TITLE
Add GPU testing configurations

### DIFF
--- a/util/cron/test-cray-cs-gpu-interop.bash
+++ b/util/cron/test-cray-cs-gpu-interop.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# GPU interop testing on a Cray CS
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-cray-cs.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-interop"
+
+export CHPL_COMM_SUBSTRATE=ibv
+export CHPL_LAUNCHER=slurm-gasnetrun_ibv
+
+module load cudatoolkit
+export CHPL_TEST_GPU=true
+export CHPL_LAUNCHER_PARTITION=stormP100
+export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"
+
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# GPU itiventerop testing on a Cray CS
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-cray-cs.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
+
+export CHPL_COMM=none
+export CHPL_LAUNCHER=slurm-srun
+
+module load cudatoolkit
+export CHPL_LLVM=bundled
+export CHPL_LOCALE_MODEL=gpu
+export CHPL_TEST_GPU=true
+export CHPL_LAUNCHER_PARTITION=stormP100
+export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
+
+$CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Add nightly test configurations to run the native and interop GPU tests
on a Cray CS. See #17207 for more information about the configuration
being set up.

Part of Cray/chapel-private#1449