### PR TITLE
Refactor regexp methods to avoid code duplication

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -481,7 +481,7 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
     var err_str = qio_regexp_error(ret._regexp);
     var err_msg: string;
     try! {
-      err_msg = createStringWithNewBuffer(err_str) + 
+      err_msg = createStringWithNewBuffer(err_str) +
                   " when compiling regexp '" + patternStr + "'";
     }
     throw new owned BadRegexpError(err_msg);
@@ -659,54 +659,15 @@ record regexp {
     */
   proc search(text: exprType, ref captures ...?k):reMatch
   {
-    var ret:reMatch;
-    on this.home {
-      var pos:byteIndex;
-      var endpos:byteIndex;
-
-      pos = 0;
-      endpos = pos + text.numBytes;
-
-      var matches:_ddata(qio_regexp_string_piece_t);
-      var nmatches = 1 + captures.size;
-      matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
-      var got:bool;
-      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
-                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED,
-                             matches, nmatches);
-      // Now try to coerce the read strings into the captures.
-      _handle_captures(text, matches, nmatches, captures);
-      // Now return where we matched.
-      ret = new reMatch(got, matches[0].offset:byteIndex, matches[0].len);
-      _ddata_free(matches, nmatches);
-    }
-    return ret;
+    return _search_match(text, QIO_REGEXP_ANCHOR_UNANCHORED, true, captures);
   }
 
   // documented in the captures version
   pragma "no doc"
   proc search(text: exprType):reMatch
   {
-    var ret:reMatch;
-    on this.home {
-      var pos:byteIndex;
-      var endpos:byteIndex;
-
-      pos = 0;
-      endpos = pos + text.numBytes;
-
-      var matches:_ddata(qio_regexp_string_piece_t);
-      var nmatches = 1;
-      matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
-      var got:bool;
-      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
-                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_UNANCHORED,
-                             matches, nmatches);
-      // Now return where we matched.
-      ret = new reMatch(got, matches[0].offset:byteIndex, matches[0].len);
-      _ddata_free(matches, nmatches);
-    }
-    return ret;
+    var dummy: int;
+    return _search_match(text, QIO_REGEXP_ANCHOR_UNANCHORED, false, dummy);
   }
 
   /*
@@ -733,33 +694,49 @@ record regexp {
    */
   proc match(text: exprType, ref captures ...?k):reMatch
   {
-    var ret:reMatch;
-    on this.home {
-      var pos:byteIndex;
-      var endpos:byteIndex;
-
-      pos = 0;
-      endpos = pos + text.numBytes;
-
-      var matches:_ddata(qio_regexp_string_piece_t);
-      var nmatches = 1 + captures.size;
-      matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
-      var got:bool;
-      got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
-                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_START,
-                             matches, nmatches);
-      // Now try to coerce the read strings into the captures.
-      _handle_captures(text, matches, nmatches, captures);
-      // Now return where we matched.
-      ret = new reMatch(got, matches[0].offset:byteIndex, matches[0].len);
-      _ddata_free(matches, nmatches);
-    }
-    return ret;
+    return _search_match(text, QIO_REGEXP_ANCHOR_START, true, captures);
   }
 
   // documented in the version taking captures.
   pragma "no doc"
   proc match(text: exprType):reMatch
+  {
+    var dummy: int;
+    return _search_match(text, QIO_REGEXP_ANCHOR_START, false, dummy);
+  }
+
+  /*
+     Check for a match to this regular expression in the full passed text.
+     If a capture group was not matched, the corresponding argument will
+     get the default value for its type.
+
+     :arg text: a string or bytes to search
+     :arg captures: what to capture from the regular expression.
+                    If the class:`regexp` was based on string, then, these
+                    should be strings or types that strings can cast to. Same
+                    applies for bytes.
+     :returns: an :record:`reMatch` object representing the offset in text
+               where a match occurred
+
+  proc fullmatch(text: exprType, ref captures ...?k):reMatch
+  {
+    return _search_match(text, QIO_REGEXP_ANCHOR_BOTH, true, captures);
+  }
+
+  // documented in the version taking captures.
+  pragma "no doc"
+  proc fullmatch(text: exprType):reMatch
+  {
+    var dummy: int;
+    return _search_match(text, QIO_REGEXP_ANCHOR_BOTH, false, dummy);
+  }
+   */
+
+  // Note - we would not need to use has_captures
+  // if we had args ...?k supporting 0 args, or if tuples support zero length
+
+  pragma "no doc"
+  proc _search_match(text: exprType, anchor: c_int, param has_captures, ref captures):reMatch
   {
     var ret:reMatch;
     on this.home {
@@ -770,19 +747,20 @@ record regexp {
       endpos = pos + text.numBytes;
 
       var matches:_ddata(qio_regexp_string_piece_t);
-      var nmatches = 1;
+      param nmatches = if has_captures then 1 + captures.size else 1;
       matches = _ddata_allocate(qio_regexp_string_piece_t, nmatches);
       var got:bool;
       got = qio_regexp_match(_regexp, text.localize().c_str(), text.numBytes,
-                             pos:int, endpos:int, QIO_REGEXP_ANCHOR_START,
+                             pos:int, endpos:int, anchor,
                              matches, nmatches);
+      // Now try to coerce the read strings into the captures.
+      if has_captures then _handle_captures(text, matches, nmatches, captures);
       // Now return where we matched.
       ret = new reMatch(got, matches[0].offset:byteIndex, matches[0].len);
       _ddata_free(matches, nmatches);
     }
     return ret;
   }
-
 
   /*
      Split the text by occurrences of this regular expression.
@@ -968,7 +946,7 @@ record regexp {
         try! {
           pattern = createStringWithNewBuffer(patternTemp);
         }
-      } 
+      }
       else {
         pattern = createBytesWithNewBuffer(patternTemp);
       }


### PR DESCRIPTION
This combines the `search` and `match` methods, both with and without captures, as well as prepares for the future `fullmatch` method (not implemented here except in comments), by combining all into one function which accepts a `bool` `param` indicating whether there are any captures, and an anchor argument indicating whether it's unanchored, anchored on the left, or anchored on both the left and right. This function could be simplified if 0-length tuples and 0-length variable argument lists were supported. Right now a `dummy` capture has to be passed when `has_captures=false`, just to satisfy at least one vararg.

`paratest` output: `[Summary: #Successes = 12535 | #Failures = 0 | #Futures = 0]`