### PR TITLE
CG: disallow iterators and inferred return types

### DIFF
--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -79,8 +79,12 @@ DefExpr* InterfaceSymbol::buildDef(const char* name,
   for_alist(expr, isym->ifcBody->body) {
     SET_LINENO(expr); // does not matter since we are parsing?
 
-    if (toInterfaceFunDecl(expr) != NULL) {
-      // ok
+    if (FnSymbol* ifun = toInterfaceFunDecl(expr)) {
+      if (ifun->isIterator())
+        // Iterators bring along a lot of complications,
+        // which we do not handle at the moment.
+        USR_FATAL_CONT(ifun, "iterators at present are not allowed"
+                             " in an interface");
 
     } else if (VarSymbol* AT = toAssociatedTypeDecl(expr)) {
       // not allowing defaults for now

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1937,6 +1937,26 @@ void resolveIfExprType(CondStmt* stmt) {
   // resolveFunction() will insert casts later
 }
 
+// Issue an error if this is an interface function whose return type
+// is inferred and is not 'void'. Require explicit return type if so.
+// This does not cater to iterators as currently those are not allowed
+// in an interface.
+static void checkInterfaceFunctionRetType(FnSymbol* fn, Type* retType,
+                                          bool isIterator) {
+  if (! isInterfaceSymbol(fn->defPoint->parentSymbol))
+    return; // not an interface function
+
+  if (retType == dtVoid)
+    return; // nothing will be returned
+
+  if (fn->retExprType != nullptr)
+    return; // the return type is declared explicitly - good
+
+  USR_FATAL_CONT(fn, "interface function %s with inferred return type",
+                 fn->name);
+  USR_PRINT(fn, "a non-void return type must be declared explicitly");
+}
+
 // Resolves an inferred return type.
 // resolveSpecifiedReturnType handles the case that the type is
 // specified explicitly.
@@ -2056,6 +2076,8 @@ void resolveReturnTypeAndYieldedType(FnSymbol* fn, Type** yieldedType) {
       }
     }
   }
+
+  checkInterfaceFunctionRetType(fn, retType, isIterator);
 }
 
 void resolveReturnType(FnSymbol* fn) {

--- a/test/constrained-generics/basic/set2/call-reqfns-from-dfltimpls.chpl
+++ b/test/constrained-generics/basic/set2/call-reqfns-from-dfltimpls.chpl
@@ -1,3 +1,12 @@
+/*
+This code tests these features:
+* An interface function has a non-void return type.
+* The return type of an interface function is 'Self'.
+* The default implementation of an interface function
+  invokes other interface functions.
+* Test the above when the interface function has
+  a default implementation or not.
+*/
 
 interface IFC {
   proc reqSelf(formal1: Self): Self;
@@ -10,11 +19,14 @@ interface IFC {
     writeln("in dfltInt");
     return reqInt(dfltSelf(formal4)) * 1000;
   }
-  proc implicitSelf(formal5: Self) {
+  // These used to have inferred return types. This is no longer allowed,
+  // so these do not differ from dfltSelf/dfltInt significantly.
+  // They are left around to avoid editing the .good file.
+  proc implicitSelf(formal5: Self): Self {
     writeln("in implicitSelf");
     return dfltSelf(reqSelf(formal5));
   }
-  proc implicitInt(formal6: Self) {
+  proc implicitInt(formal6: Self): int {
     writeln("in implicitInt");
     return dfltInt(implicitSelf(formal6)) * 1000;
   }

--- a/test/constrained-generics/basic/set2/error-dfltimpl-rettype.chpl
+++ b/test/constrained-generics/basic/set2/error-dfltimpl-rettype.chpl
@@ -1,0 +1,12 @@
+// This test ensures that the compiler issues an error
+// when the return type of a default implementation is inferred.
+// Exception: no error if the return type is 'void'.
+
+interface IFC {
+  proc dfltVoid() { // ok: void return type does not need explicit declaration
+    writeln("in dfltVoid");
+  }
+  proc dfltInt() {  // error: 'int' return type must be declared explicilty
+    return 5;
+  }
+}

--- a/test/constrained-generics/basic/set2/error-dfltimpl-rettype.good
+++ b/test/constrained-generics/basic/set2/error-dfltimpl-rettype.good
@@ -1,0 +1,2 @@
+error-dfltimpl-rettype.chpl:9: error: interface function dfltInt with inferred return type
+error-dfltimpl-rettype.chpl:9: note: a non-void return type must be declared explicitly

--- a/test/constrained-generics/basic/set2/iterator-in-ifc.chpl
+++ b/test/constrained-generics/basic/set2/iterator-in-ifc.chpl
@@ -1,0 +1,9 @@
+// What happens if the interface contains an iterator?
+// Currently not implemented.
+
+interface IFC {
+  iter reqIter();
+  iter dfltIter() { // MUST BE AN ERROR even if iterators are allowed:
+    yield 5;        // a non-void yield type must be declared explicitly
+  }
+}

--- a/test/constrained-generics/basic/set2/iterator-in-ifc.good
+++ b/test/constrained-generics/basic/set2/iterator-in-ifc.good
@@ -1,0 +1,2 @@
+iterator-in-ifc.chpl:5: error: iterators at present are not allowed in an interface
+iterator-in-ifc.chpl:6: error: iterators at present are not allowed in an interface


### PR DESCRIPTION
Adds two checks:

* Reject iterators in an interface as they are not implemented.
  Proper handling is future work.

* Require that the return type of interface functions with default
  implementations be declared explicitly, unless it is 'void'.
