### PR TITLE
Sort test output to ensure match against .good

### DIFF
--- a/test/constrained-generics/basic/set2/error-return-intent.good
+++ b/test/constrained-generics/basic/set2/error-return-intent.good
@@ -1,23 +1,23 @@
 error-return-intent.chpl:19: error: interface functions with 'param' or 'type' return intent are currently not allowed
 error-return-intent.chpl:20: error: interface functions with 'param' or 'type' return intent are currently not allowed
+error-return-intent.chpl:20: note: the required function ftype in the interface IFC is declared here
+error-return-intent.chpl:20: note: which does not match the expected return type 'int(64)'
+error-return-intent.chpl:21: note: the required function fref in the interface IFC is declared here
+error-return-intent.chpl:21: note: which does not match the required intent 'ref'
+error-return-intent.chpl:22: note: the required function fconstref in the interface IFC is declared here
+error-return-intent.chpl:22: note: which does not match the required intent 'const ref'
+error-return-intent.chpl:23: note: the required function fdefault in the interface IFC is declared here
+error-return-intent.chpl:23: note: which does not match the required intent 'value'
 error-return-intent.chpl:26: In 'implements IFC' statement:
 error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:31: note: this implementation of the required function fdefault
-error-return-intent.chpl:31: note: has return intent 'const ref'
-error-return-intent.chpl:23: note: which does not match the required intent 'value'
-error-return-intent.chpl:23: note: the required function fdefault in the interface IFC is declared here
 error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:28: note: this implementation of the required function ftype
+error-return-intent.chpl:26: error: when checking this implements statement
+error-return-intent.chpl:26: error: when checking this implements statement
 error-return-intent.chpl:28: note: has return type 'string'
-error-return-intent.chpl:20: note: which does not match the expected return type 'int(64)'
-error-return-intent.chpl:20: note: the required function ftype in the interface IFC is declared here
-error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:29: note: this implementation of the required function fref
+error-return-intent.chpl:28: note: this implementation of the required function ftype
 error-return-intent.chpl:29: note: has return intent 'value'
-error-return-intent.chpl:21: note: which does not match the required intent 'ref'
-error-return-intent.chpl:21: note: the required function fref in the interface IFC is declared here
-error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:30: note: this implementation of the required function fconstref
+error-return-intent.chpl:29: note: this implementation of the required function fref
 error-return-intent.chpl:30: note: has return intent 'value'
-error-return-intent.chpl:22: note: which does not match the required intent 'const ref'
-error-return-intent.chpl:22: note: the required function fconstref in the interface IFC is declared here
+error-return-intent.chpl:30: note: this implementation of the required function fconstref
+error-return-intent.chpl:31: note: has return intent 'const ref'
+error-return-intent.chpl:31: note: this implementation of the required function fdefault

--- a/test/constrained-generics/basic/set2/error-return-intent.prediff
+++ b/test/constrained-generics/basic/set2/error-return-intent.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+outfile=$2
+sort $outfile > $outfile.tmp
+mv $outfile.tmp $outfile

--- a/test/constrained-generics/basic/set2/error-return-type.good
+++ b/test/constrained-generics/basic/set2/error-return-type.good
@@ -1,31 +1,31 @@
+error-return-type.chpl:13: note: the required function dfltInt in the interface IFC is declared here
+error-return-type.chpl:13: note: which does not match the expected return type 'int(64)'
+error-return-type.chpl:17: note: the required function implicitSelf in the interface IFC is declared here
+error-return-type.chpl:17: note: which does not match the expected return type 'string'
+error-return-type.chpl:21: note: the required function implicitInt in the interface IFC is declared here
+error-return-type.chpl:21: note: which does not match the expected return type 'int(64)'
 error-return-type.chpl:27: In 'implements IFC' statement:
 error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:32: note: this implementation of the required function dfltInt
-error-return-type.chpl:32: note: has return type 'string'
-error-return-type.chpl:13: note: which does not match the expected return type 'int(64)'
-error-return-type.chpl:13: note: the required function dfltInt in the interface IFC is declared here
 error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:31: note: this implementation of the required function dfltSelf
-error-return-type.chpl:31: note: has return type 'int(64)'
-error-return-type.chpl:9: note: which does not match the expected return type 'string'
-error-return-type.chpl:9: note: the required function dfltSelf in the interface IFC is declared here
 error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:30: note: this implementation of the required function reqInt
-error-return-type.chpl:30: note: has return type 'string'
-error-return-type.chpl:8: note: which does not match the expected return type 'int(64)'
-error-return-type.chpl:8: note: the required function reqInt in the interface IFC is declared here
 error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:29: note: this implementation of the required function reqSelf
+error-return-type.chpl:27: error: when checking this implements statement
+error-return-type.chpl:27: error: when checking this implements statement
 error-return-type.chpl:29: note: has return type 'int(64)'
-error-return-type.chpl:7: note: which does not match the expected return type 'string'
-error-return-type.chpl:7: note: the required function reqSelf in the interface IFC is declared here
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:34: note: this implementation of the required function implicitInt
-error-return-type.chpl:34: note: has return type 'string'
-error-return-type.chpl:21: note: which does not match the expected return type 'int(64)'
-error-return-type.chpl:21: note: the required function implicitInt in the interface IFC is declared here
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:33: note: this implementation of the required function implicitSelf
+error-return-type.chpl:29: note: this implementation of the required function reqSelf
+error-return-type.chpl:30: note: has return type 'string'
+error-return-type.chpl:30: note: this implementation of the required function reqInt
+error-return-type.chpl:31: note: has return type 'int(64)'
+error-return-type.chpl:31: note: this implementation of the required function dfltSelf
+error-return-type.chpl:32: note: has return type 'string'
+error-return-type.chpl:32: note: this implementation of the required function dfltInt
 error-return-type.chpl:33: note: has return type 'int(64)'
-error-return-type.chpl:17: note: which does not match the expected return type 'string'
-error-return-type.chpl:17: note: the required function implicitSelf in the interface IFC is declared here
+error-return-type.chpl:33: note: this implementation of the required function implicitSelf
+error-return-type.chpl:34: note: has return type 'string'
+error-return-type.chpl:34: note: this implementation of the required function implicitInt
+error-return-type.chpl:7: note: the required function reqSelf in the interface IFC is declared here
+error-return-type.chpl:7: note: which does not match the expected return type 'string'
+error-return-type.chpl:8: note: the required function reqInt in the interface IFC is declared here
+error-return-type.chpl:8: note: which does not match the expected return type 'int(64)'
+error-return-type.chpl:9: note: the required function dfltSelf in the interface IFC is declared here
+error-return-type.chpl:9: note: which does not match the expected return type 'string'

--- a/test/constrained-generics/basic/set2/error-return-type.prediff
+++ b/test/constrained-generics/basic/set2/error-return-type.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+outfile=$2
+sort $outfile > $outfile.tmp
+mv $outfile.tmp $outfile


### PR DESCRIPTION
The compiler report errors for several erroneous statements
in each of these tests. It looks like it visit those statements
in a nondeterministic order, so the order of the compiler output
is also nondeterministic.

In order to ensure deterministic match against .good in our testing
system, this PR takes the simplest approach to sort the compiler output.
We can do something fancier later if desired.

The nondeterminism perhaps stems from the compiler code traversing
map(s) whose keys are C strings (const char*) in CG (constrained generics)
implementation. While maps over AST classes are traversed deterministically
because the keys are ordered by comparing the node IDs, maps over strings
are not.

Not reviewed.