### PR TITLE
Quiet yet another Tcl module collection-related message.

### DIFF
--- a/util/test/prediff-for-slurm
+++ b/util/test/prediff-for-slurm
@@ -23,6 +23,8 @@ msgs = (
 """,
 """cp: cannot create regular file .*/[.]module/PrgEnv-.*: File exists
 """,
+"""cp: failed to close .*/[.]module/PrgEnv-.*: Stale file handle
+""",
 """diff: .*/[.]module/PrgEnv-.*: No such file or directory
 """,
 )


### PR DESCRIPTION
We've encountered yet another message caused by the race during module
collection creation in multi-node jobs on systems using Tcl v4 modules
where the user home dir is NFS-mounted. Filter this one out along with
the others.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>