### PR TITLE
Change the partition we use for cray-cs-hdr arkouda testing

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.arkouda.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.bash
@@ -15,7 +15,7 @@ module list
 
 # setup for CS perf (gasnet-large, gnu, 128-core Rome)
 source $CWD/common-cray-cs.bash
-export CHPL_LAUNCHER_PARTITION=rome64
+export CHPL_LAUNCHER_PARTITION=rome64Share
 export CHPL_TARGET_CPU=none
 
 module list

--- a/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
@@ -15,7 +15,7 @@ module list
 
 # setup for CS perf (gasnet-large, gnu, 128-core Rome)
 source $CWD/common-cray-cs.bash
-export CHPL_LAUNCHER_PARTITION=rome64
+export CHPL_LAUNCHER_PARTITION=rome64Share
 export CHPL_TARGET_CPU=none
 
 # python2 required for chapel 1.23, will not be required with 1.24+


### PR DESCRIPTION
Use a partition with more nodes to limit how often we get stuck waiting
for other jobs to finish.