### PR TITLE
Infer locality within fast follower bodies and use it for copy aggregation 

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -22,6 +22,7 @@
 #include "AstVisitor.h"
 #include "DeferStmt.h"
 #include "driver.h"
+#include "forallOptimizations.h"
 #include "ForallStmt.h"
 #include "ForLoop.h"
 #include "iterator.h"
@@ -987,14 +988,7 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
     map.put(followIdx, fastFollowIdx);
     BlockStmt* userBodyForFast = userBody->copy(&map);
 
-
-    std::vector<CallExpr *> calls;
-    collectCallExprs(userBodyForFast, calls);
-    for_vector(CallExpr, call, calls) {
-      if (call->isPrimitive(PRIM_MAYBE_LOCAL_ARR_ELEM)) {
-        call->get(3)->replace(new SymExpr(gTrue));
-      }
-    }
+    adjustPrimsInFastFollowerBody(userBodyForFast);
 
     fastFollowBlock = buildFollowLoop(iterRec,
                                       leadIdxCopy,

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -33,6 +33,8 @@
 #include "stlUtil.h"
 #include "stringutil.h"
 
+#include "view.h"
+
 const char* forallIntentTagDescription(ForallIntentTag tfiTag) {
   switch (tfiTag) {
     case TFI_DEFAULT:       return "default";
@@ -986,6 +988,18 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
     SymbolMap map;
     map.put(followIdx, fastFollowIdx);
     BlockStmt* userBodyForFast = userBody->copy(&map);
+
+    if (strcmp(userBodyForFast->fname(), "ffLocal.chpl") == 0) {
+      nprint_view(userBodyForFast);
+
+      std::vector<CallExpr *> calls;
+      collectCallExprs(userBodyForFast, calls);
+      for_vector(CallExpr, call, calls) {
+        if (call->isPrimitive(PRIM_MAYBE_LOCAL_ARR_ELEM)) {
+          call->get(3)->replace(new SymExpr(gTrue));
+        }
+      }
+    }
 
     fastFollowBlock = buildFollowLoop(iterRec,
                                       leadIdxCopy,

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -33,8 +33,6 @@
 #include "stlUtil.h"
 #include "stringutil.h"
 
-#include "view.h"
-
 const char* forallIntentTagDescription(ForallIntentTag tfiTag) {
   switch (tfiTag) {
     case TFI_DEFAULT:       return "default";
@@ -989,15 +987,12 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
     map.put(followIdx, fastFollowIdx);
     BlockStmt* userBodyForFast = userBody->copy(&map);
 
-    if (strcmp(userBodyForFast->fname(), "ffLocal.chpl") == 0) {
-      nprint_view(userBodyForFast);
 
-      std::vector<CallExpr *> calls;
-      collectCallExprs(userBodyForFast, calls);
-      for_vector(CallExpr, call, calls) {
-        if (call->isPrimitive(PRIM_MAYBE_LOCAL_ARR_ELEM)) {
-          call->get(3)->replace(new SymExpr(gTrue));
-        }
+    std::vector<CallExpr *> calls;
+    collectCallExprs(userBodyForFast, calls);
+    for_vector(CallExpr, call, calls) {
+      if (call->isPrimitive(PRIM_MAYBE_LOCAL_ARR_ELEM)) {
+        call->get(3)->replace(new SymExpr(gTrue));
       }
     }
 

--- a/compiler/include/forallOptimizations.h
+++ b/compiler/include/forallOptimizations.h
@@ -66,6 +66,7 @@ Symbol *earlyNormalizeForallIterand(CallExpr *call, ForallStmt *forall);
 Expr *preFoldMaybeLocalThis(CallExpr *call);
 Expr *preFoldMaybeLocalArrElem(CallExpr *call);
 Expr *preFoldMaybeAggregateAssign(CallExpr *call);
+void adjustPrimsInFastFollowerBody(BlockStmt *body);
 
 // interface for lowerForalls
 void removeAggregationFromRecursiveForall(ForallStmt *forall);

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1439,6 +1439,10 @@ static void autoAggregation(ForallStmt *forall) {
     autoLocalAccess(forall);
   }
 
+  if (!forall->optInfo.infoGathered) {
+    gatherForallInfo(forall);
+  }
+
   LOG_AA(0, "Start analyzing forall for automatic aggregation", forall);
 
   if (loopHasValidInductionVariables(forall)) {

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1946,8 +1946,6 @@ static bool handleYieldedArrayElementsInAssignment(CallExpr *call,
                                     new SymExpr(checkSym),
                                     fastFollowerControl);
 
-  nprint_view(primCall);
-
   symExprToReplace->replace(primCall);
 
   return true;

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -789,12 +789,6 @@ static void gatherForallInfo(ForallStmt *forall) {
 
       forall->optInfo.multiDIndices.push_back(multiDIndices);
     }
-
-    if (!forall->optInfo.hasAlignedFollowers) {
-      // this means we couldn't prove that the followers are aligned, so, we'll
-      // not look at the indices yielded by the followers
-      break;
-    }
   }
 
   forall->optInfo.infoGathered = true;

--- a/test/optimizations/autoAggregation/arrElemFromDynFastFollower.chpl
+++ b/test/optimizations/autoAggregation/arrElemFromDynFastFollower.chpl
@@ -1,0 +1,13 @@
+use BlockDist;
+
+var A = newBlockArr(0..10, int);
+var B = newBlockArr(0..10, int);
+var someOther = newBlockArr(0..10, int);
+
+
+forall (a,b) in zip(A,B) {
+  b = someOther[a];
+}
+
+writeln(B);
+

--- a/test/optimizations/autoAggregation/arrElemFromDynFastFollower.chpl
+++ b/test/optimizations/autoAggregation/arrElemFromDynFastFollower.chpl
@@ -4,9 +4,17 @@ var A = newBlockArr(0..10, int);
 var B = newBlockArr(0..10, int);
 var someOther = newBlockArr(0..10, int);
 
-
+// B is a dynamic fast follower, so we should be able to see `b` as local within
+// the fast follower body, and source-aggregate
 forall (a,b) in zip(A,B) {
   b = someOther[a];
+}
+
+writeln(B);
+
+// same idea, but for destination aggregation
+forall (a,b) in zip(A,B) {
+  someOther[a] = b;
 }
 
 writeln(B);

--- a/test/optimizations/autoAggregation/arrElemFromDynFastFollower.good
+++ b/test/optimizations/autoAggregation/arrElemFromDynFastFollower.good
@@ -1,0 +1,32 @@
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:9)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:9)
+|  Potential destination aggregation (arrElemFromDynFastFollower.chpl:9)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:9)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:9)
+End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:9)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:9)
+End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+
+Aggregation candidate has confirmed local child  (arrElemFromDynFastFollower.chpl:9)
+LHS is local, RHS is nonlocal. Will use source aggregation  (arrElemFromDynFastFollower.chpl:9)
+Aggregation candidate has reverted local child  (arrElemFromDynFastFollower.chpl:9)
+Replaced assignment with aggregation (arrElemFromDynFastFollower.chpl:9)
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+0 0 0 0 0 0 0 0 0 0 0

--- a/test/optimizations/autoAggregation/arrElemFromDynFastFollower.good
+++ b/test/optimizations/autoAggregation/arrElemFromDynFastFollower.good
@@ -1,23 +1,43 @@
-Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:8)
-| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:9)
-|  Potential source aggregation (arrElemFromDynFastFollower.chpl:9)
-|  Potential destination aggregation (arrElemFromDynFastFollower.chpl:9)
-End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:9)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:10)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:10)
+|  Potential destination aggregation (arrElemFromDynFastFollower.chpl:10)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:9)
 
-Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:8)
-| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:9)
-|  Potential source aggregation (arrElemFromDynFastFollower.chpl:9)
-End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:16)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:17)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:17)
+|  Potential destination aggregation (arrElemFromDynFastFollower.chpl:17)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (arrElemFromDynFastFollower.chpl:16)
 
-Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:8)
-| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:9)
-|  Potential source aggregation (arrElemFromDynFastFollower.chpl:9)
-End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:8)
+Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:9)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:10)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:10)
+End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:9)
 
-Aggregation candidate has confirmed local child  (arrElemFromDynFastFollower.chpl:9)
-LHS is local, RHS is nonlocal. Will use source aggregation  (arrElemFromDynFastFollower.chpl:9)
-Aggregation candidate has reverted local child  (arrElemFromDynFastFollower.chpl:9)
-Replaced assignment with aggregation (arrElemFromDynFastFollower.chpl:9)
+Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:9)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:10)
+|  Potential source aggregation (arrElemFromDynFastFollower.chpl:10)
+End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:9)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:16)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:17)
+|  Potential destination aggregation (arrElemFromDynFastFollower.chpl:17)
+End analyzing forall for automatic aggregation [no ALA clone]  (arrElemFromDynFastFollower.chpl:16)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:16)
+| Found an aggregation candidate (arrElemFromDynFastFollower.chpl:17)
+|  Potential destination aggregation (arrElemFromDynFastFollower.chpl:17)
+End analyzing forall for automatic aggregation [static only ALA clone]  (arrElemFromDynFastFollower.chpl:16)
+
+Aggregation candidate has confirmed local child  (arrElemFromDynFastFollower.chpl:10)
+LHS is local, RHS is nonlocal. Will use source aggregation  (arrElemFromDynFastFollower.chpl:10)
+Aggregation candidate has reverted local child  (arrElemFromDynFastFollower.chpl:10)
+Aggregation candidate has confirmed local child  (arrElemFromDynFastFollower.chpl:17)
+LHS is nonlocal, RHS is local. Will use destination aggregation  (arrElemFromDynFastFollower.chpl:17)
+Aggregation candidate has reverted local child  (arrElemFromDynFastFollower.chpl:17)
+Replaced assignment with aggregation (arrElemFromDynFastFollower.chpl:10)
+Replaced assignment with aggregation (arrElemFromDynFastFollower.chpl:17)
 SrcAggregator.copy is called
 SrcAggregator.copy is called
 SrcAggregator.copy is called
@@ -29,4 +49,16 @@ SrcAggregator.copy is called
 SrcAggregator.copy is called
 SrcAggregator.copy is called
 SrcAggregator.copy is called
+0 0 0 0 0 0 0 0 0 0 0
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
+DstAggregator.copy is called
 0 0 0 0 0 0 0 0 0 0 0

--- a/test/optimizations/autoAggregation/removeAggCondInFastFollowers.good
+++ b/test/optimizations/autoAggregation/removeAggCondInFastFollowers.good
@@ -1,7 +1,18 @@
-Start analyzing forall for automatic aggregation (removeAggCondInFastFollowers.chpl:29)
+Start analyzing forall for automatic aggregation [static and dynamic ALA clone]  (removeAggCondInFastFollowers.chpl:29)
 | Found an aggregation candidate (removeAggCondInFastFollowers.chpl:30)
 |  Potential source aggregation (removeAggCondInFastFollowers.chpl:30)
-End analyzing forall for automatic aggregation (removeAggCondInFastFollowers.chpl:29)
+|  Potential destination aggregation (removeAggCondInFastFollowers.chpl:30)
+End analyzing forall for automatic aggregation [static and dynamic ALA clone]  (removeAggCondInFastFollowers.chpl:29)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (removeAggCondInFastFollowers.chpl:29)
+| Found an aggregation candidate (removeAggCondInFastFollowers.chpl:30)
+|  Potential source aggregation (removeAggCondInFastFollowers.chpl:30)
+End analyzing forall for automatic aggregation [no ALA clone]  (removeAggCondInFastFollowers.chpl:29)
+
+Start analyzing forall for automatic aggregation [static only ALA clone]  (removeAggCondInFastFollowers.chpl:29)
+| Found an aggregation candidate (removeAggCondInFastFollowers.chpl:30)
+|  Potential source aggregation (removeAggCondInFastFollowers.chpl:30)
+End analyzing forall for automatic aggregation [static only ALA clone]  (removeAggCondInFastFollowers.chpl:29)
 
 Aggregation candidate has confirmed local child  (removeAggCondInFastFollowers.chpl:30)
 LHS is local, RHS is nonlocal. Will use source aggregation  (removeAggCondInFastFollowers.chpl:30)


### PR DESCRIPTION
This PR adjusts the automatic aggregation to fire for dynamic fast follower
arrays in zip clauses.

Before this PR, we were able to aggregate fast follower arrays only if that's
statically provable. For example:

```chapel
var A = newBlockArr(...);

forall (idx,elem) in zip(A.domain, A) {
  elem = A[foo(idx)];  // we can see that elem is local
}
```

However, consider:

```chapel
var A = newBlockArr(...);
var B = newBlockArr(...);

forall (aElem, bElem) in zip(A, B) {
  bElem = otherArr[aElem];
} 
```

In this example, `bElem` is local, if we use fast followers (we do). However,
before this PR, we weren't making use of fast followers in such dynamic
scenarios.

#### Implementation Details

- `PRIM_MAYBE_LOCAL_ARR_ELEM` has an additional argument.
   - This argument is set to `false` if the symbol in question is local only if
     it is inside a fast follower body. It is set to `true` otherwise.
- `adjustPrimsInFastFollowerBody` sets these arguments to `true` for primitives
  in fast follower bodies
- `preFoldMaybeLocalArrElem` now checks this flag, too.
- `removeAggregatorFromFunction` is adjusted to handle multiple aggregation
  calls using the same aggregator within the function body.

#### Future Work

- Can we implement a similar idea for automatic local access?

  I tried this a bit, but it requires a deeper change in the module support, so
  I shied away from it. I don't know any user code that can benefit from that
  today. But it'll be good to add that for completeness.

#### Test Status
- [x] standard
- [x] gasnet
- [x] gasnet --auto-aggregation
