### PR TITLE
Improve support for using qthreads binders topology layer

### DIFF
--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -683,6 +683,10 @@ static void setupAffinity(void) {
   if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {
     chpl_qt_setenv("AFFINITY", "no", 0);
   }
+
+  // For the binders topo spread threads across sockets instead of packing.
+  // Only impacts binders, but it doesn't hurt to set it for other configs.
+  chpl_qt_setenv("LAYOUT", "BALANCED", 0);
 }
 
 void chpl_task_init(void)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -28,14 +28,22 @@ ifneq ($(CHPL_MAKE_HWLOC),none)
   # Have Qthreads get its hwloc topology from the Chapel runtime,
   # unless directed not to.
   ifeq (, $(call isTrue, $(CHPL_QTHREAD_DONT_GET_TOPO_FROM_RT)))
-    CHPL_QTHREAD_CFG_OPTIONS += --with-topology=hwloc_via_chapel
+    TOPOLOGY = hwloc_via_chapel
     CFLAGS_NEEDS_RT_INCLUDES = y
   else
-    CHPL_QTHREAD_CFG_OPTIONS += --with-topology=hwloc
+    TOPOLOGY = hwloc
   endif
   ifeq ($(CHPL_MAKE_HWLOC),bundled)
     CHPL_QTHREAD_CFG_OPTIONS += --with-hwloc=$(HWLOC_INSTALL_DIR)
   endif
+endif
+
+ifneq (, $(CHPL_QTHREAD_TOPOLOGY))
+TOPOLOGY = $(CHPL_QTHREAD_TOPOLOGY)
+endif
+
+ifneq (, $(TOPOLOGY))
+CHPL_QTHREAD_CFG_OPTIONS += --with-topology=$(TOPOLOGY)
 endif
 
 

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -24,3 +24,5 @@ as follows:
 
 * We added a simple mechanism to reset the automatic task spawning
   order for better affinity between consecutive parallel loops.
+
+* We fixed a bug in the binders topology layer.

--- a/third-party/qthread/qthread-src/src/affinity/binders.c
+++ b/third-party/qthread/qthread-src/src/affinity/binders.c
@@ -1,6 +1,7 @@
 #include <hwloc.h>
 #include <stdio.h>
 
+#include "qt_alloc.h"
 #include "qt_affinity.h"
 #include "qt_envariables.h"
 


### PR DESCRIPTION
Improve support the `binders` topology layer. By default we use the
`hwloc` topology layer, which packs threads to sockets and does not
offer any finer grain affinity options. We want to be able to spread
threads across sockets and have finer grainer control over affinity and
binding longer term. `binders` is what we imagine to do that, but for
now it's experimental. Note that binders still uses the hwloc library
under the covers, it's just a different layer in qthreads.

This fixes support for binders by adding a missing include, defaults to
having binders spread threads across sockets (`QT_LAYOUT=BALANCED`), and
adds a makefile option to enable building with binders instead of hwloc
(`CHPL_QTHREAD_TOPOLOGY=binders`).

Related to https://github.com/Cray/chapel-private/issues/1700