### PR TITLE
Set CHPL_LLVM=none for pre-merge CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make check
       run: |
-        ./util/buildRelease/smokeTest
+        CHPL_LLVM=none ./util/buildRelease/smokeTest
 
   make_doc:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make check-chpldoc && make docs
       run: |
-        ./util/buildRelease/smokeTest
+        CHPL_LLVM=none ./util/buildRelease/smokeTest
     - name: upload docs
       uses: actions/upload-artifact@v2
       with:
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make mason
       run: |
-        ./util/buildRelease/smokeTest
+        CHPL_LLVM=none ./util/buildRelease/smokeTest
 
   check_annotations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI testing environment appears to have llvm-11 installed, but we're not
finding header files we expect to build the compiler. Until that is fixed,
set CHPL_LLVM=none there.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>