### PR TITLE
Update a .good file that I missed / forgot about in my replicated changes

### DIFF
--- a/test/distributions/robust/arithmetic/basics/test_scan1.replicated.good
+++ b/test/distributions/robust/arithmetic/basics/test_scan1.replicated.good
@@ -1,4 +1,3 @@
-test_scan1.chpl:8: warning: scan has been serialized (see issue #12482)
 test_scan1.chpl:9: warning: scan has been serialized (see issue #12482)
 test_scan1.chpl:10: warning: scan has been serialized (see issue #12482)
 test_scan1.chpl:11: warning: scan has been serialized (see issue #12482)


### PR DESCRIPTION
This adjusts a test's output that improved as a result of #17211,
but which I'd overlooked because I always forget we have replicated
distribution robustness testing.  Specifically, a scan that was previously
serial no longer is, so I removed the old warning.
