### PR TITLE
Improve spec for out intent

### DIFF
--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1304,9 +1304,12 @@ Legal Argument Mapping
 ^^^^^^^^^^^^^^^^^^^^^^
 
 An actual argument :math:`A` of type :math:`T_A` can be legally mapped to
-a formal argument of :math:`F_X` according to the following rules.
+a formal argument :math:`F_X` according to the following rules.
 
-First, if :math:`F_X` is a generic argument:
+First, if :math:`F_X` uses the ``out`` intent, it is always a legal argument
+mapping. ``out`` intent arguments do not impact candidate selection.
+
+Then, if :math:`F_X` is a generic argument:
 
  * if :math:`F_X` uses ``param`` intent, then :math:`A` must also be a
    ``param``
@@ -1321,7 +1324,7 @@ formal argument :math:`F_X` if it is concrete or the instantiated type if
 :math:`F_X` is generic - must be compatible with the type :math:`T_A`
 according to the concrete intent of :math:`F_X`:
 
- * if :math:`F_X` uses ``ref`` or ``out`` intent, then :math:`T_A`
+ * if :math:`F_X` uses ``ref`` intent, then :math:`T_A`
    must be the same type as :math:`T_X`
  * if :math:`F_X` uses ``const ref`` intent, then :math:`T_A` and
    :math:`T_X` must be the same type or a subtype of :math:`T_X`

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -529,8 +529,8 @@ intents:
 ================================ ====== ========= ========= =========== ============ =============
 \                                ``in`` ``out``   ``inout`` ``ref``     ``const in`` ``const ref``
 ================================ ====== ========= ========= =========== ============ =============
-copied in on function call?      yes    no        yes       no          yes          no
-copied out on function return?   no     yes       yes       no          no           no
+can copy in on function call?    yes    no        yes       no          yes          no
+can copy out on function return? no     yes       yes       no          no           no
 refers to actual argument?       no     no        no        yes         no           yes
 formal can be read?              yes    yes       yes       yes         yes          yes
 formal can be modified?          yes    yes       yes       yes         no           no
@@ -1332,6 +1332,9 @@ according to the concrete intent of :math:`F_X`:
    :math:`T_X`.
  * if :math:`F_X` uses  the ``out`` intent, it is always a legal
    argument mapping regardless of the type of the actual and formal.
+   In the event that assignment to :math:`T_A` from :math:`F_X` is not
+   possible then a compilation error will be emitted if this function
+   is chosen as the best candidate.
 
 Finally, if the above compatibility cannot be established, the mapping is
 checked for promotion. If :math:`T_A` is scalar promotable to :math:`T_X`

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -458,11 +458,11 @@ The Out Intent
 
 When ``out`` is specified as the intent, the actual argument is ignored
 when the call is made, but when the function returns, the actual argument
-is assigned to the value of the formal argument.  An implicit conversion
-occurs from the type of the formal to the type of the actual. The actual
-argument must be a valid lvalue. Within the function body, the formal
-argument is initialized to its default value if one is supplied, or to
-its type’s default value otherwise. The formal argument can be modified
+is assigned to the value of the formal argument. The actual argument must
+be a valid lvalue. Within the function body, the formal argument is
+initialized according :ref:`Split_Initialization`.  It will start with
+its default value if one is supplied and can use the type's default value
+if no initialization point is found.  The formal argument can be modified
 within the function.
 
 The assignment implementing the ``out`` intent is a candidate for
@@ -477,8 +477,7 @@ The Inout Intent
 When ``inout`` is specified as the intent, the actual argument is copied
 into the formal argument as with the ``in`` intent and then copied back
 out as with the ``out`` intent. The actual argument must be a valid
-lvalue. The formal argument can be modified within the function. The
-type of the actual argument must be the same as the type of the formal.
+lvalue. The formal argument can be modified within the function.
 
 .. _The_Ref_Intent:
 
@@ -1306,8 +1305,8 @@ Legal Argument Mapping
 An actual argument :math:`A` of type :math:`T_A` can be legally mapped to
 a formal argument :math:`F_X` according to the following rules.
 
-First, if :math:`F_X` uses the ``out`` intent, it is always a legal argument
-mapping. ``out`` intent arguments do not impact candidate selection.
+First, if :math:`A` is a ``type`` but :math:`F_X` does not use the
+``type`` intent, then it is not a legal argument mapping.
 
 Then, if :math:`F_X` is a generic argument:
 
@@ -1331,14 +1330,15 @@ according to the concrete intent of :math:`F_X`:
  * if :math:`F_X` uses ``in`` or ``inout`` intent, then :math:`T_A`
    must be the same type, a subtype of, or implicitly convertible to
    :math:`T_X`.
+ * if :math:`F_X` uses  the ``out`` intent, it is always a legal
+   argument mapping regardless of the type of the actual and formal.
 
 Finally, if the above compatibility cannot be established, the mapping is
-checked for promotion.  Then, the mapping is checked for promotion. If
-:math:`T_A` is scalar promotable to :math:`T_X` (see :ref:`Promotion`),
-then the above rules are checked with the element type, index type, or
-yielded type.  For example, if :math:`T_A` is an array of ``int`` and
-:math:`T_X` is ``int``, then promotion occurs and the above rules will be
-checked with :math:`T_A` == ``int``.
+checked for promotion. If :math:`T_A` is scalar promotable to :math:`T_X`
+(see :ref:`Promotion`), then the above rules are checked with the element
+type, index type, or yielded type.  For example, if :math:`T_A` is an
+array of ``int`` and :math:`T_X` is ``int``, then promotion occurs and
+the above rules will be checked with :math:`T_A` == ``int``.
 
 .. _Determining_More_Specific_Functions:
 


### PR DESCRIPTION
This PR updates the spec to describe changes in `out` and `inout
 intents as a follow-up to PRs #16990 and #17231.

Reviewed by @vasslitvinov - thanks!