### PR TITLE
Fix "may be used uninitialized" build error

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -1115,15 +1115,14 @@ static int sys_getcwd(char** path_out)
  * sys_getcwd() if you need error reports.
  */
 const char* getCwd() {
-  char *ret;
+  char* ret = nullptr;;
   int rc;
 
   rc = sys_getcwd(&ret);
-  if (rc == 0) {
+  if (rc == 0)
     return ret;
-  } else {
+  else
     return "";
-  }
 }
 
 


### PR DESCRIPTION
Tidy up the code introduced in #17161
to avoid the "may be used uninitialized" error
when building our compiler in some configurations.

Trivial, not reviewed.
