### PR TITLE
Deprecate regexp ok and error() methods

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -597,6 +597,23 @@ record regexp {
     }
   }
 
+  /* did this regular expression compile ? */
+  pragma "no doc"
+  proc ok:bool {
+    compilerWarning("regexp: 'ok' is deprecated; errors are used to detect regexp compile errors");
+    return qio_regexp_ok(_regexp);
+  }
+  /*
+     returns a string describing any error encountered when compiling this
+               regular expression
+   */
+  pragma "no doc"
+  proc error():string {
+    param msg = "regexp: 'error()' is deprecated; errors are used to detect regexp compile errors";
+    compilerWarning(msg);
+    return msg;
+  }
+
   // note - more = overloads are below.
   pragma "no doc"
   proc ref deinit() {

--- a/runtime/src/qio/regexp/re2/re2-interface.cc
+++ b/runtime/src/qio/regexp/re2/re2-interface.cc
@@ -88,6 +88,7 @@ void qio_re_options_to_re2_options(const qio_regexp_options_t* options, RE2::Opt
   opts->set_one_line(!options->multiline);
   opts->set_dot_nl(options->dotnl);
   opts->set_longest_match(!options->nongreedy);
+  opts->set_log_errors(false);
 }
 
 static
@@ -262,13 +263,13 @@ int64_t qio_regexp_get_ncaptures(const qio_regexp_t* regexp)
 qio_bool qio_regexp_ok(const qio_regexp_t* regexp)
 {
   RE2* re2 = (RE2*) regexp->regexp;
-  return re2->ok();
+  return re2 && re2->ok();
 }
 
 const char* qio_regexp_error(const qio_regexp_t* regexp)
 {
   RE2* re2 = (RE2*) regexp->regexp;
-  return qio_strdup(re2->error().c_str());
+  return qio_strdup(re2 ? re2->error().c_str() : "");
 }
 
 qio_bool qio_regexp_match(qio_regexp_t* regexp, const char* text, int64_t text_len, int64_t startpos, int64_t endpos, int anchor, qio_regexp_string_piece_t* submatch, int64_t nsubmatch)

--- a/test/deprecated/regexp_error.chpl
+++ b/test/deprecated/regexp_error.chpl
@@ -1,0 +1,24 @@
+use Regexp;
+
+{
+  var re : regexp(string);
+  writeln(re.ok);
+  writeln("111111111111111111111");
+  try! {
+    re = compile("*");
+    writeln("Should not reach here");
+  } catch (e: BadRegexpError) {
+    writeln("222222222222222222222");
+    writeln(re.ok);
+    writeln("333333333333333333333");
+    writeln(re.error());
+    writeln("444444444444444444444");
+    writeln(e.message());
+  }
+}
+
+{
+  writeln("555555555555555555555");
+  var re = compile(".");
+  writeln(re.ok);
+}

--- a/test/deprecated/regexp_error.good
+++ b/test/deprecated/regexp_error.good
@@ -1,0 +1,14 @@
+regexp_error.chpl:5: warning: regexp: 'ok' is deprecated; errors are used to detect regexp compile errors
+regexp_error.chpl:12: warning: regexp: 'ok' is deprecated; errors are used to detect regexp compile errors
+regexp_error.chpl:14: warning: regexp: 'error()' is deprecated; errors are used to detect regexp compile errors
+regexp_error.chpl:23: warning: regexp: 'ok' is deprecated; errors are used to detect regexp compile errors
+false
+111111111111111111111
+222222222222222222222
+false
+333333333333333333333
+regexp: 'error()' is deprecated; errors are used to detect regexp compile errors
+444444444444444444444
+no argument for repetition operator: * when compiling regexp '*'
+555555555555555555555
+true


### PR DESCRIPTION
This deprecates the `regexp` `ok` and `error()` methods, since they were replaced with exceptions.

This also fixes segfaults in `ok` and `error()` when the `regexp` is not successfully compiled, or when it is default-initialized.

The `error()` method returns the same string as the compiler deprecation warning, since we do not have an easy way to access the original error message, because the `regexp` being returned from `compile()` is not assigned to a variable if an exception is thrown, so even if the exception is caught, the variable being assigned the `compile()` result does not contain the error message -- only the exception does.

This deserves a separate PR from #17189, since it is actually adding functionality, not removing it. It is not simply a reversion of PR #17189.
