### PR TITLE
Update PrivateDistNonNilableDefaultInit.good

### DIFF
--- a/test/distributions/private/PrivateDistNonNilableDefaultInit.good
+++ b/test/distributions/private/PrivateDistNonNilableDefaultInit.good
@@ -1,7 +1,7 @@
 $CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: In initializer:
-$CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: error: Cannot default-initialize default: shared C
+$CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: error: cannot default-initialize default: shared C
 $CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: error: use here prevents split-init
-note: non-nil class types do not support default initialization
+note: non-nilable class type 'borrowed C' does not support default initialization
 note: Consider using the type shared C? instead
 PrivateDistNonNilableDefaultInit.chpl:6: error: cannot default-initialize the array a because it has a non-nilable element type 'shared C'
   $CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: called as PrivateArr.init(type eltType = shared C, param rank = 1, type idxType = int(64), param stridable = false, dom: unmanaged PrivateDom(1,int(64),false), param initElts = true) from method 'dsiBuildArray'


### PR DESCRIPTION
This .good was created against an earlier version of master.
The error message reported by the compiler now is slightly different.
Updating the .good correspondingly.

Trivial, not reviewed.