### PR TITLE
Update error message for non-working sync types & update spec

### DIFF
--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -154,24 +154,17 @@ written, its state transitions to full.
 
 ``sync`` and ``single`` are type qualifiers and precede the type of the
 variable’s value in the declaration. Sync and single are supported for
-all Chapel primitive types ( :ref:`Primitive_Types`) except
-complex. They are also supported for enumerated types
-( :ref:`Enumerated_Types`) and variables of class type
-( :ref:`Class_Types`). For sync variables of class type, the
-full/empty state applies to the reference to the class object, not to
-its member fields.
+the primitive types ``nothing``, ``bool``, ``int``, ``uint``, ``real``,
+``imag`` ( :ref:`Primitive_Types`); for enumerated types
+( :ref:`Enumerated_Types`); and for nilable unmanaged or nilable borrowed
+class types ( :ref:`Class_Types`). For sync variables of class type, the
+full/empty state applies to the reference to the class object, not to its
+member fields.
 
-   *Rationale*.
+   *Note*.
 
-   It is only well-formed to apply full-empty semantics to types that
-   have no more than a single logical value. Booleans, integers, real
-   and imaginary numbers, enums, and class references all meet this
-   criteria. Since it is possible to read/write the individual elements
-   of a complex value, it’s not obvious how the full-empty semantics
-   would interact with such operations. While one could argue that
-   record types with a single field could also be included, the user can
-   more directly express such cases by declaring the field itself to be
-   of sync type.
+   In the future, ``sync`` and ``single`` might be extended to support
+   more types, including ``complex`` record types.
 
 If a task attempts to read or write a synchronization variable that is
 not in the correct state, the task is suspended. When the variable

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -155,16 +155,17 @@ written, its state transitions to full.
 ``sync`` and ``single`` are type qualifiers and precede the type of the
 variable’s value in the declaration. Sync and single are supported for
 the primitive types ``nothing``, ``bool``, ``int``, ``uint``, ``real``,
-``imag`` ( :ref:`Primitive_Types`); for enumerated types
-( :ref:`Enumerated_Types`); and for nilable unmanaged or nilable borrowed
-class types ( :ref:`Class_Types`). For sync variables of class type, the
-full/empty state applies to the reference to the class object, not to its
-member fields.
+``imag``, ``string`` ( :ref:`Primitive_Types`); for enumerated types
+( :ref:`Enumerated_Types`); and for nilable class types that have
+``unmanaged``, ``borrowed``, or ``shared`` memory management strategy
+( :ref:`Class_Types`). For sync variables of class type, the full/empty
+state applies to the reference to the class object, not to its member
+fields.
 
    *Note*.
 
    In the future, ``sync`` and ``single`` might be extended to support
-   more types, including ``complex`` record types.
+   more types, including ``complex``, ``owned`` classes, and record types.
 
 If a task attempts to read or write a synchronization variable that is
 not in the correct state, the task is suspended. When the variable

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -155,7 +155,7 @@ written, its state transitions to full.
 ``sync`` and ``single`` are type qualifiers and precede the type of the
 variable’s value in the declaration. Sync and single are supported for
 the primitive types ``nothing``, ``bool``, ``int``, ``uint``, ``real``,
-``imag``, ``string`` ( :ref:`Primitive_Types`); for enumerated types
+``imag``, and ``string`` ( :ref:`Primitive_Types`); for enumerated types
 ( :ref:`Enumerated_Types`); and for nilable class types that have
 ``unmanaged``, ``borrowed``, or ``shared`` memory management strategy
 ( :ref:`Class_Types`). For sync variables of class type, the full/empty

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -75,19 +75,29 @@ module ChapelSyncvar {
            isRealType(t)          ||
            isImagType(t)          ||
            isEnumType(t)          ||
-           isUnmanagedClassType(t) ||
-           isBorrowedClassType(t)  ||
+           isClassType(t)         ||
+           isStringType(t)        ||
            t == chpl_taskID_t;
 
   private proc ensureFEType(type t) {
     if isSupported(t) == false then
       compilerError("sync/single types cannot contain type '", t : string, "'");
 
-    if isNonNilableClass(t) then
-      compilerError("sync/single types cannot contain non-nilable classes");
-
     if isGenericType(t) then
       compilerError("sync/single types cannot contain generic types");
+
+    if isNonNilableClass(t) then
+      compilerError("sync/single types cannot yet contain non-nilable classes");
+
+    if isOwnedClassType(t) then
+      compilerError("sync/single types cannot yet contain owned class types");
+
+    if !isDefaultInitializableType(t) then
+      compilerError("sync/single types cannot yet contain a type that cannot be default initialized");
+
+    if !isConstCopyableType(t) then
+      compilerError("sync/single types cannot yet contain a type is not const-copyable");
+
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -75,8 +75,8 @@ module ChapelSyncvar {
            isRealType(t)          ||
            isImagType(t)          ||
            isEnumType(t)          ||
-           isClassType(t)         ||
-           isStringType(t)        ||    // Should this be allowed?
+           isUnmanagedClassType(t) ||
+           isBorrowedClassType(t)  ||
            t == chpl_taskID_t;
 
   private proc ensureFEType(type t) {

--- a/test/parallel/single/figueroa/ReadWriteMethods.chpl
+++ b/test/parallel/single/figueroa/ReadWriteMethods.chpl
@@ -31,6 +31,6 @@ foo(real(32), 8.0: real(32), "real(32)");
 foo(real(64), 9.0, "real(64)");
 //foo(complex(64), 10.0: complex(64), "complex(64)");
 //foo(complex(128), 11.0: complex(128), "complex(128)");
-foo(string, "Hello!", "string");
+//foo(string, "Hello!", "string");
 //type r = range;
 //foo(r, 1..3, "range");

--- a/test/parallel/single/figueroa/ReadWriteMethods.good
+++ b/test/parallel/single/figueroa/ReadWriteMethods.good
@@ -38,7 +38,3 @@
 1: woke up. writing 9.0
 2: got 9.0
 2: got 9.0
-1: going to sleep with Hello! of type string
-1: woke up. writing Hello!
-2: got Hello!
-2: got Hello!

--- a/test/parallel/sync/figueroa/ReadMethods.chpl
+++ b/test/parallel/sync/figueroa/ReadMethods.chpl
@@ -44,6 +44,6 @@ foo(real(64), 9.0, 13.0, "real(64)");
 //foo(complex(64), 10.0: complex(64), 14.0: complex(64), "complex(64)");
 //foo(complex(128), 11.0: complex(128), 15.0: complex(128), "complex(128)");
 foo(imag, 12.0i, 16.0i, "imag");
-foo(string, "Hello,", "world!", "string");
+//foo(string, "Hello,", "world!", "string");
 //type r = range;
 //foo(r, 1..3, 4..7, "range");

--- a/test/parallel/sync/figueroa/ReadMethods.good
+++ b/test/parallel/sync/figueroa/ReadMethods.good
@@ -75,10 +75,3 @@
 2: value has changed to 16.0i and it is full
 2: after sleeping, value is still 16.0i
 2: value has been reset to 12.0i
-1: going to sleep ... 
-2: initial value is  of type string
-1: woke up. writing Hello,
-2: value is now Hello, and it is empty
-2: value has changed to world! and it is full
-2: after sleeping, value is still world!
-2: value has been reset to Hello,

--- a/test/parallel/sync/figueroa/WriteMethods.chpl
+++ b/test/parallel/sync/figueroa/WriteMethods.chpl
@@ -34,6 +34,6 @@ foo(real(64), 9.0, 13.0, "real(64)");
 //foo(complex(64), 10.0: complex(64), 14.0: complex(64), "complex(64)");
 //foo(complex(128), 11.0: complex(128), 15.0: complex(128), "complex(128)");
 foo(imag, 12.0i, 16.0i, "imag");
-foo(string, "Hello,", "world!", "string");
+//foo(string, "Hello,", "world!", "string");
 //type r = range;
 //foo(r, 1..3, 4..7, "range");

--- a/test/parallel/sync/figueroa/WriteMethods.good
+++ b/test/parallel/sync/figueroa/WriteMethods.good
@@ -53,8 +53,3 @@ woke up. initial value is 0.0i of type imag
 value is now 12.0i
 value has changed to 16.0i
 The final value is 12.0i, but it was reset to 0.0i
-going to sleep ... 
-woke up. initial value is  of type string
-value is now Hello,
-value has changed to world!
-The final value is Hello,, but it was reset to 

--- a/test/types/single/sungeun/single-cannot-coerce.chpl
+++ b/test/types/single/sungeun/single-cannot-coerce.chpl
@@ -1,3 +1,3 @@
 
-var i : single int = 100;
-var s : single string = i;
+var r : single real = 100;
+var i : single int = r;

--- a/test/types/single/sungeun/single-cannot-coerce.good
+++ b/test/types/single/sungeun/single-cannot-coerce.good
@@ -1,3 +1,3 @@
 single-cannot-coerce.chpl:3: warning: Initializing a type-inferred variable from a 'single' is deprecated; apply a 'read??()' method to the right-hand side
-single-cannot-coerce.chpl:3: error: cannot initialize 'single string' from 'single int(64)' because 'int(64)' is not coercible to 'string'
+single-cannot-coerce.chpl:3: error: cannot initialize 'single int(64)' from 'single real(64)' because 'real(64)' is not coercible to 'int(64)'
 note: An additional error is hidden. Use --print-additional-errors to see it.

--- a/test/types/sync/ferguson/non-nilable-single-error.good
+++ b/test/types/sync/ferguson/non-nilable-single-error.good
@@ -1,1 +1,1 @@
-non-nilable-single-error.chpl:2: error: sync/single types cannot contain non-nilable classes
+non-nilable-single-error.chpl:2: error: sync/single types cannot yet contain non-nilable classes

--- a/test/types/sync/ferguson/non-nilable-sync-error.good
+++ b/test/types/sync/ferguson/non-nilable-sync-error.good
@@ -1,1 +1,1 @@
-non-nilable-sync-error.chpl:2: error: sync/single types cannot contain non-nilable classes
+non-nilable-sync-error.chpl:2: error: sync/single types cannot yet contain non-nilable classes

--- a/test/types/sync/ferguson/sync-borrowed-nilable.chpl
+++ b/test/types/sync/ferguson/sync-borrowed-nilable.chpl
@@ -1,0 +1,9 @@
+class C { var x: int; }
+
+proc main() {
+  var x = new C(1);
+  var v: sync borrowed C?;
+  v.writeEF(x.borrow());
+  var y = v.readFE();
+  assert(y == x.borrow());
+}

--- a/test/types/sync/ferguson/sync-borrowed-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-borrowed-nonnil.chpl
@@ -1,0 +1,8 @@
+class C { var x: int; }
+
+proc main() {
+  var x = new C(1);
+  var v: sync borrowed C = x.borrow();
+  var y = v.readFE();
+  assert(y == x.borrow());
+}

--- a/test/types/sync/ferguson/sync-borrowed-nonnil.good
+++ b/test/types/sync/ferguson/sync-borrowed-nonnil.good
@@ -1,0 +1,13 @@
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: error: cannot default-initialize field value: borrowed C
+note: non-nilable class type 'borrowed C' does not support default initialization
+note: Consider using the type borrowed C? instead
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: called as _synccls.init(type valType = borrowed C)
+  within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In method 'readFE':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: error: cannot default-initialize ret: borrowed C
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: error: use here prevents split-init
+note: non-nilable class type 'borrowed C' does not support default initialization
+note: Consider using the type borrowed C? instead
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: called as (_synccls(C)).readFE()
+  within internal functions (use --print-callstack-on-error to see)

--- a/test/types/sync/ferguson/sync-borrowed-nonnil.prediff
+++ b/test/types/sync/ferguson/sync-borrowed-nonnil.prediff
@@ -1,0 +1,1 @@
+../../../../util/test/prediff-obscure-module-linenos

--- a/test/types/sync/ferguson/sync-bytes.chpl
+++ b/test/types/sync/ferguson/sync-bytes.chpl
@@ -1,0 +1,5 @@
+var x: sync bytes;
+
+x.writeEF(b"hi "*23);
+
+writeln(x.readFE());

--- a/test/types/sync/ferguson/sync-bytes.good
+++ b/test/types/sync/ferguson/sync-bytes.good
@@ -1,0 +1,1 @@
+sync-bytes.chpl:1: error: sync/single types cannot contain type 'bytes'

--- a/test/types/sync/ferguson/sync-complex.chpl
+++ b/test/types/sync/ferguson/sync-complex.chpl
@@ -1,0 +1,2 @@
+var x: sync complex;
+x.writeEF(1.0 + 3.0i);

--- a/test/types/sync/ferguson/sync-complex.good
+++ b/test/types/sync/ferguson/sync-complex.good
@@ -1,0 +1,1 @@
+sync-complex.chpl:1: error: sync/single types cannot contain type 'complex(128)'

--- a/test/types/sync/ferguson/sync-copy-init-cannot-coerce.chpl
+++ b/test/types/sync/ferguson/sync-copy-init-cannot-coerce.chpl
@@ -1,3 +1,3 @@
 
-var i : sync int = 100;
-var s : sync string = i;
+var r : sync real = 100.0;
+var i : sync int = r;

--- a/test/types/sync/ferguson/sync-copy-init-cannot-coerce.good
+++ b/test/types/sync/ferguson/sync-copy-init-cannot-coerce.good
@@ -1,3 +1,3 @@
 sync-copy-init-cannot-coerce.chpl:3: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
-sync-copy-init-cannot-coerce.chpl:3: error: cannot initialize 'sync string' from 'sync int(64)' because 'int(64)' is not coercible to 'string'
+sync-copy-init-cannot-coerce.chpl:3: error: cannot initialize 'sync int(64)' from 'sync real(64)' because 'real(64)' is not coercible to 'int(64)'
 note: An additional error is hidden. Use --print-additional-errors to see it.

--- a/test/types/sync/ferguson/sync-copy-init-cannot-coerce2.good
+++ b/test/types/sync/ferguson/sync-copy-init-cannot-coerce2.good
@@ -1,6 +1,6 @@
 sync-copy-init-cannot-coerce2.chpl:3: error: could not find a copy initializer ('init=') for type 'sync string' from type 'int(64)'
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:148: note: this candidate did not match: _syncvar.init=(const ref other: _syncvar(?))
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note: this candidate did not match: _syncvar.init=(const ref other: _syncvar(?))
 sync-copy-init-cannot-coerce2.chpl:3: note: because actual argument #1 with type 'int(64)'
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:148: note: is passed to formal 'const ref other: _syncvar'
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note: is passed to formal 'const ref other: _syncvar'
 sync-copy-init-cannot-coerce2.chpl:3: note: other candidates are:
-$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:163: note:   _syncvar.init=(const other: this.valType)
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note:   _syncvar.init=(const other: this.valType)

--- a/test/types/sync/ferguson/sync-copy-init-cannot-coerce2.prediff
+++ b/test/types/sync/ferguson/sync-copy-init-cannot-coerce2.prediff
@@ -1,0 +1,1 @@
+../../../../util/test/prediff-obscure-module-linenos

--- a/test/types/sync/ferguson/sync-owned-nilable.chpl
+++ b/test/types/sync/ferguson/sync-owned-nilable.chpl
@@ -1,0 +1,3 @@
+class C { var x: int; }
+
+var x: sync owned C?;

--- a/test/types/sync/ferguson/sync-owned-nilable.chpl
+++ b/test/types/sync/ferguson/sync-owned-nilable.chpl
@@ -1,3 +1,7 @@
 class C { var x: int; }
 
 var x: sync owned C?;
+
+x.writeEF(new owned C?(1));
+
+writeln(x.readFE());

--- a/test/types/sync/ferguson/sync-owned-nilable.good
+++ b/test/types/sync/ferguson/sync-owned-nilable.good
@@ -1,0 +1,1 @@
+sync-owned-nilable.chpl:3: error: sync/single types cannot contain type 'owned C?'

--- a/test/types/sync/ferguson/sync-owned-nilable.good
+++ b/test/types/sync/ferguson/sync-owned-nilable.good
@@ -1,1 +1,5 @@
-sync-owned-nilable.chpl:3: error: sync/single types cannot contain type 'owned C?'
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:508: In method 'writeEF':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:513: error: cannot assign to const variable
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:252: called as (_synccls(owned C?)).writeEF(val: owned C?)
+  within internal functions (use --print-callstack-on-error to see)
+sync-owned-nilable.chpl:3: error: sync/single types cannot yet contain owned class types

--- a/test/types/sync/ferguson/sync-owned-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-owned-nonnil.chpl
@@ -1,3 +1,7 @@
 class C { var x: int; }
 
 var x: sync owned C;
+
+x.writeEF(new owned C(1));
+
+writeln(x.readFE());

--- a/test/types/sync/ferguson/sync-owned-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-owned-nonnil.chpl
@@ -1,0 +1,3 @@
+class C { var x: int; }
+
+var x: sync owned C;

--- a/test/types/sync/ferguson/sync-owned-nonnil.good
+++ b/test/types/sync/ferguson/sync-owned-nonnil.good
@@ -1,0 +1,1 @@
+sync-owned-nonnil.chpl:3: error: sync/single types cannot contain type 'owned C'

--- a/test/types/sync/ferguson/sync-owned-nonnil.good
+++ b/test/types/sync/ferguson/sync-owned-nonnil.good
@@ -1,1 +1,12 @@
-sync-owned-nonnil.chpl:3: error: sync/single types cannot contain type 'owned C'
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:508: In method 'writeEF':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:513: error: cannot assign to const variable
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:252: called as (_synccls(owned C)).writeEF(val: owned C)
+  within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:448: In method 'readFE':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:449: error: cannot default-initialize ret: owned C
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:462: error: use here prevents split-init
+note: non-nilable class type 'borrowed C' does not support default initialization
+note: Consider using the type owned C? instead
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:220: called as (_synccls(owned C)).readFE()
+  within internal functions (use --print-callstack-on-error to see)
+sync-owned-nonnil.chpl:3: error: sync/single types cannot yet contain non-nilable classes

--- a/test/types/sync/ferguson/sync-shared-nilable.chpl
+++ b/test/types/sync/ferguson/sync-shared-nilable.chpl
@@ -1,0 +1,3 @@
+class C { var x: int; }
+
+var x: sync shared C?;

--- a/test/types/sync/ferguson/sync-shared-nilable.chpl
+++ b/test/types/sync/ferguson/sync-shared-nilable.chpl
@@ -1,3 +1,7 @@
 class C { var x: int; }
 
 var x: sync shared C?;
+
+x.writeEF(new shared C?(1));
+
+writeln(x.readFE());

--- a/test/types/sync/ferguson/sync-shared-nilable.good
+++ b/test/types/sync/ferguson/sync-shared-nilable.good
@@ -1,0 +1,1 @@
+sync-shared-nilable.chpl:3: error: sync/single types cannot contain type 'shared C?'

--- a/test/types/sync/ferguson/sync-shared-nilable.good
+++ b/test/types/sync/ferguson/sync-shared-nilable.good
@@ -1,1 +1,1 @@
-sync-shared-nilable.chpl:3: error: sync/single types cannot contain type 'shared C?'
+{x = 1}

--- a/test/types/sync/ferguson/sync-shared-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-shared-nonnil.chpl
@@ -1,3 +1,7 @@
 class C { var x: int; }
 
 var x: sync shared C;
+
+x.writeEF(new shared C(1));
+
+writeln(x.readFE());

--- a/test/types/sync/ferguson/sync-shared-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-shared-nonnil.chpl
@@ -1,0 +1,3 @@
+class C { var x: int; }
+
+var x: sync shared C;

--- a/test/types/sync/ferguson/sync-shared-nonnil.good
+++ b/test/types/sync/ferguson/sync-shared-nonnil.good
@@ -1,0 +1,1 @@
+sync-shared-nonnil.chpl:3: error: sync/single types cannot contain type 'shared C'

--- a/test/types/sync/ferguson/sync-shared-nonnil.good
+++ b/test/types/sync/ferguson/sync-shared-nonnil.good
@@ -1,1 +1,8 @@
-sync-shared-nonnil.chpl:3: error: sync/single types cannot contain type 'shared C'
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:448: In method 'readFE':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:449: error: cannot default-initialize ret: shared C
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:462: error: use here prevents split-init
+note: non-nilable class type 'borrowed C' does not support default initialization
+note: Consider using the type shared C? instead
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:220: called as (_synccls(shared C)).readFE()
+  within internal functions (use --print-callstack-on-error to see)
+sync-shared-nonnil.chpl:3: error: sync/single types cannot yet contain non-nilable classes

--- a/test/types/sync/ferguson/sync-string.chpl
+++ b/test/types/sync/ferguson/sync-string.chpl
@@ -1,0 +1,2 @@
+var x: sync string;
+x.writeEF("hello");

--- a/test/types/sync/ferguson/sync-string.chpl
+++ b/test/types/sync/ferguson/sync-string.chpl
@@ -1,2 +1,5 @@
 var x: sync string;
-x.writeEF("hello");
+
+x.writeEF("hi "*23);
+
+writeln(x.readFE());

--- a/test/types/sync/ferguson/sync-string.good
+++ b/test/types/sync/ferguson/sync-string.good
@@ -1,1 +1,1 @@
-sync-string.chpl:1: error: sync/single types cannot contain type 'string'
+hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi hi 

--- a/test/types/sync/ferguson/sync-string.good
+++ b/test/types/sync/ferguson/sync-string.good
@@ -1,0 +1,1 @@
+sync-string.chpl:1: error: sync/single types cannot contain type 'string'

--- a/test/types/sync/ferguson/sync-unmanaged-nilable.chpl
+++ b/test/types/sync/ferguson/sync-unmanaged-nilable.chpl
@@ -1,0 +1,9 @@
+class C { var x: int; }
+
+proc main() {
+  var x = new unmanaged C?(1);
+  var v: sync unmanaged C?;
+  v.writeEF(x);
+  var y = v.readFE();
+  assert(y == x);
+}

--- a/test/types/sync/ferguson/sync-unmanaged-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-unmanaged-nonnil.chpl
@@ -1,0 +1,11 @@
+class C { var x: int; }
+
+proc main() {
+  compilerWarning(isNonNilableClass(unmanaged C):string);
+
+  var x: unmanaged C = new unmanaged C(1);
+  var v: sync unmanaged C = x;
+  var y = v.readFE();
+  assert(y == x);
+  delete x;
+}

--- a/test/types/sync/ferguson/sync-unmanaged-nonnil.good
+++ b/test/types/sync/ferguson/sync-unmanaged-nonnil.good
@@ -1,0 +1,14 @@
+sync-unmanaged-nonnil.chpl:3: warning: true
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: error: cannot default-initialize field value: unmanaged C
+note: non-nilable class type 'unmanaged C' does not support default initialization
+note: Consider using the type unmanaged C? instead
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: called as _synccls.init(type valType = unmanaged C)
+  within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In method 'readFE':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: error: cannot default-initialize ret: unmanaged C
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: error: use here prevents split-init
+note: non-nilable class type 'unmanaged C' does not support default initialization
+note: Consider using the type unmanaged C? instead
+  $CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: called as (_synccls(unmanaged C)).readFE()
+  within internal functions (use --print-callstack-on-error to see)

--- a/test/types/sync/ferguson/sync-unmanaged-nonnil.prediff
+++ b/test/types/sync/ferguson/sync-unmanaged-nonnil.prediff
@@ -1,0 +1,1 @@
+../../../../util/test/prediff-obscure-module-linenos


### PR DESCRIPTION
This PR:
 * adds tests for a few cases with sync variables that were not very well tested
 * updates the implementation to try to give clearer errors for which types are allowed (though sometimes we get other errors first)
 * updates the language specification to specifically list which types can be used in a sync/single
 
see also issue #17176 and issue #17177

- [x] full local testing

Reviewed by @lydia-duncan - thanks!
