### PR TITLE
Fix bug with operator call and mismatched `this` arg

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -243,48 +243,35 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
         }
 
         if (fn->hasFlag(FLAG_OPERATOR)) {
-          if (formal->typeInfo() == dtMethodToken &&
-              info.actuals.v[i]->typeInfo() != dtMethodToken) {
-            // Formal is a method token and the actual is not (but this was an
-            // operator call so that's okay)
+          if (formal->typeInfo() == dtMethodToken) {
+            // Don't care about method token arguments to operator functions,
+            // or the next argument (which should be "this")
             formal = next_formal(formal);
             j++;
             skipNextFormal = true;
-            continue;
+          }
 
-          } else if (skipNextFormal) {
+          if (skipNextFormal) {
             INT_ASSERT(formal->hasFlag(FLAG_ARG_THIS));
             formal = next_formal(formal);
             j++;
             skipNextFormal = false; // clear
             continue;
 
-          } else if (formal->typeInfo() != dtMethodToken &&
-                     info.actuals.v[i]->typeInfo() == dtMethodToken) {
-            // actual is a method token but the formal is not (but this was an
-            // operator call so that's okay)
+          }
+
+          if (info.actuals.v[i]->typeInfo() == dtMethodToken) {
+            // Don't care about method token actuals to operator calls, or
+            // the next actual (which should correspond to the "this" argument)
             skippedThisActual = true;
             skipNextActual = true;
             break;
-          } else if (skipNextActual) {
-            // previous actual was a method token, so this is intended to be for
-            // a "this" argument that doesn't exist (but that's okay because
-            // this is an operator call).
+          }
+
+          if (skipNextActual) {
             skippedThisActual = true;
-            skipNextActual = false;
+            skipNextActual = false; // clear
             break;
-          } else if (formal->typeInfo() == dtMethodToken &&
-                     info.actuals.v[i]->typeInfo() == dtMethodToken) {
-            // both the actual and the formal were method tokens, but the this
-            // args could still be different.  Since this is an operator call,
-            // we don't actually care if the this args are different, so skip
-            // them, as well as the method tokens.
-            skipNextFormal = true;
-            formal = next_formal(formal);
-            j++;
-            skipNextActual = true;
-            skippedThisActual = true;
-            continue;
           }
         }
 

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -273,6 +273,18 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
             skippedThisActual = true;
             skipNextActual = false;
             break;
+          } else if (formal->typeInfo() == dtMethodToken &&
+                     info.actuals.v[i]->typeInfo() == dtMethodToken) {
+            // both the actual and the formal were method tokens, but the this
+            // args could still be different.  Since this is an operator call,
+            // we don't actually care if the this args are different, so skip
+            // them, as well as the method tokens.
+            skipNextFormal = true;
+            formal = next_formal(formal);
+            j++;
+            skipNextActual = true;
+            skippedThisActual = true;
+            continue;
           }
         }
 

--- a/test/functions/operatorOverloads/operatorMethods/callOtherMethod.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/callOtherMethod.chpl
@@ -1,0 +1,38 @@
+// This test is to lock in that you can call another type's operator method from
+// within a method on a type that also defines an operator method for the same
+// operator.
+record A {
+  var x: int;
+
+  operator *(lhs: A, rhs: A) {
+    return new A(lhs.x * rhs.x);
+  }
+}
+
+record B {
+  var a: int;
+
+  operator *(lhs: B, rhs: B) {
+    return new B(lhs.a * rhs.a);
+  }
+
+  proc otherMethod(one: A, two: A) {
+    var combo = one * two;
+    if (combo.x > 10) {
+      writeln("multi-digit");
+    } else if (combo.x > -1) {
+      writeln("single digit");
+    } else {
+      halt("result was negative");
+    }
+    return new B (this.a * combo.x);
+  }
+}
+
+proc main() {
+  var a1 = new A(2);
+  var a2 = new A(3);
+  var b1 = new B(2);
+  var b2 = b1.otherMethod(a1, a2);
+  writeln(b2);
+}

--- a/test/functions/operatorOverloads/operatorMethods/callOtherMethod.good
+++ b/test/functions/operatorOverloads/operatorMethods/callOtherMethod.good
@@ -1,0 +1,2 @@
+single digit
+(a = 12)


### PR DESCRIPTION
If the function we're examining is an operator method and the call is already
adjusted to be a method call, we could get into a situation where we'd
accidentally reject an appropriate match because the `this` actual did not have
the same type as the `this` formal.  But we shouldn't care about the `this`
arg at all for operator calls, so in the case where we could end up in this
situation, just skip the `this` actual and formal.

Add a test to lock in the appropriate behavior.

I encountered this issue while experimenting with using operator methods in the
internal, standard and package modules. After this change I did not see further
related failures, but they may potentially have been hidden by other errors.

Passed a full paratest with futures