### PR TITLE
Update preFold's handling of == and != to adjust for when they are method calls

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -156,7 +156,7 @@ Expr* preFold(CallExpr* call) {
 
       callExpr->replace(callExpr->baseExpr->remove());
 
-      if (Expr* tmp = preFoldNamed(callExpr)) {
+      if (Expr* tmp = preFoldNamed(call)) {
         retval = tmp;
       }
 
@@ -2230,9 +2230,19 @@ static Expr* preFoldNamed(CallExpr* call) {
 
   // BHARSH TODO: Move the dtUninstantiated stuff over to resolveTypeComparisonCall
   } else if (call->isNamed("==")) {
-    if (isTypeExpr(call->get(1)) && isTypeExpr(call->get(2))) {
-      Type* lt = call->get(1)->getValType();
-      Type* rt = call->get(2)->getValType();
+    bool isMethodCall = false;
+    if (call->partialTag == false) {
+      if (SymExpr* se = toSymExpr(call->get(1))) {
+        if (se->symbol() == gMethodToken) {
+          isMethodCall = true;
+        }
+      }
+    }
+    int lhsNum = isMethodCall ? 3 : 1;
+    int rhsNum = isMethodCall ? 4 : 2;
+    if (isTypeExpr(call->get(lhsNum)) && isTypeExpr(call->get(rhsNum))) {
+      Type* lt = call->get(lhsNum)->getValType();
+      Type* rt = call->get(rhsNum)->getValType();
 
       if (lt                                != dtUnknown &&
           rt                                != dtUnknown &&
@@ -2241,24 +2251,34 @@ static Expr* preFoldNamed(CallExpr* call) {
         retval = (lt == rt) ? new SymExpr(gTrue) : new SymExpr(gFalse);
         call->replace(retval);
       }
-    } else if (call->get(2)->getValType() == dtUninstantiated) {
-      retval = (call->get(1)->getValType() == dtUninstantiated) ? new SymExpr(gTrue) : new SymExpr(gFalse);
+    } else if (call->get(rhsNum)->getValType() == dtUninstantiated) {
+      retval = (call->get(lhsNum)->getValType() == dtUninstantiated) ? new SymExpr(gTrue) : new SymExpr(gFalse);
       call->replace(retval);
     }
 
 
   } else if (call->isNamed("!=")) {
-    if (isTypeExpr(call->get(1)) && isTypeExpr(call->get(2))) {
-      Type* lt = call->get(1)->getValType();
-      Type* rt = call->get(2)->getValType();
+    bool isMethodCall = false;
+    if (call->partialTag == false) {
+      if (SymExpr* se = toSymExpr(call->get(1))) {
+        if (se->symbol() == gMethodToken) {
+          isMethodCall = true;
+        }
+      }
+    }
+    int lhsNum = isMethodCall ? 3 : 1;
+    int rhsNum = isMethodCall ? 4 : 2;
+    if (isTypeExpr(call->get(lhsNum)) && isTypeExpr(call->get(rhsNum))) {
+      Type* lt = call->get(lhsNum)->getValType();
+      Type* rt = call->get(rhsNum)->getValType();
 
       if (lt                                != dtUnknown &&
           rt                                != dtUnknown) {
         retval = (lt != rt) ? new SymExpr(gTrue) : new SymExpr(gFalse);
         call->replace(retval);
       }
-    } else if (call->get(2)->getValType() == dtUninstantiated) {
-      retval = (call->get(1)->getValType() != dtUninstantiated) ? new SymExpr(gTrue) : new SymExpr(gFalse);
+    } else if (call->get(rhsNum)->getValType() == dtUninstantiated) {
+      retval = (call->get(rhsNum)->getValType() != dtUninstantiated) ? new SymExpr(gTrue) : new SymExpr(gFalse);
       call->replace(retval);
     }
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2278,7 +2278,7 @@ static Expr* preFoldNamed(CallExpr* call) {
         call->replace(retval);
       }
     } else if (call->get(rhsNum)->getValType() == dtUninstantiated) {
-      retval = (call->get(rhsNum)->getValType() != dtUninstantiated) ? new SymExpr(gTrue) : new SymExpr(gFalse);
+      retval = (call->get(lhsNum)->getValType() != dtUninstantiated) ? new SymExpr(gTrue) : new SymExpr(gFalse);
       call->replace(retval);
     }
 

--- a/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs.chpl
@@ -1,0 +1,22 @@
+record Foo {
+  var x: int;
+
+  proc myMethod(x, y) {
+    if (x.type == y.type) {
+      writeln("They match");
+    } else {
+      writeln("They don't");
+    }
+  }
+
+  operator ==(lhs: Foo, rhs: Foo) {
+    return lhs.x == rhs.x;
+  }
+}
+
+proc main() {
+  var foo: Foo;
+
+  foo.myMethod(2, 3);
+  foo.myMethod(2, false);
+}

--- a/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs.good
+++ b/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs.good
@@ -1,0 +1,2 @@
+They match
+They don't

--- a/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs2.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs2.chpl
@@ -1,0 +1,22 @@
+record Foo {
+  var x: int;
+
+  proc myMethod(x, y) {
+    if (x.type != y.type) {
+      writeln("They don't match");
+    } else {
+      writeln("They do");
+    }
+  }
+
+  operator !=(lhs: Foo, rhs: Foo) {
+    return lhs.x != rhs.x;
+  }
+}
+
+proc main() {
+  var foo: Foo;
+
+  foo.myMethod(2, 3);
+  foo.myMethod(2, false);
+}

--- a/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs2.good
+++ b/test/functions/operatorOverloads/operatorMethods/calledOnTypeArgs2.good
@@ -1,0 +1,2 @@
+They do
+They don't match


### PR DESCRIPTION
This only matters for when the arguments are type variables - function
resolution would normally replace such comparisons on type arguments with the
result instead of following resolution for the call.  However, in the case where
the == call is inside a method of a type with its own == definition, we think
that it might be a call to that method so insert the method token and this
arguments.  This prevented the preFold analysis from happening prior to this
change.

In order to perform this change, I needed to fix a typo in preFold while dealing
with partial calls - as it stood before, it was always calling preFoldNamed on an
empty callExpr (because the baseExpr for the outer call had already been removed).
I verified that this change on its own did not cause problems in a normal paratest
run.

Added two tests, one for the `==` case and one for the `!=` case on type arguments.

Passed a full paratest with futures