### PR TITLE
Improve arg parsing in mason with some helper classes/routines

### DIFF
--- a/tools/mason/MasonArguments.chpl
+++ b/tools/mason/MasonArguments.chpl
@@ -1,0 +1,252 @@
+use List;
+
+class ArgumentError : Error {
+  var msg:string;
+  proc init(msg:string) {
+    this.msg = msg;
+  }
+  override proc message() {
+    return msg;
+  }
+}
+
+class Flag {
+  // was the flag present?
+  var present: bool;
+  // start index where the flag was present
+  var startIndex: int;
+
+  proc init() {
+    this.complete();
+    this.present = false;
+  }
+
+  proc noteMatch(startIndex: int) {
+    present = true;
+    this.startIndex = startIndex;
+  }
+
+  // consumes matching arguments starting at args[i]
+  // possibly by appending some to otherArgs
+  // returns the number of arguments consumed 
+  proc consume(i: int, const args: list(string),
+               ref otherArgs: list(string)):int throws {
+    return 0;
+  }
+}
+
+class HelpFlag : Flag {
+  var names: list(string);
+
+  proc init() {
+    super.init();
+    this.complete();
+    this.names.append('-h');
+    this.names.append('--help');
+  }
+
+  proc init(names...) {
+    super.init();
+    this.complete();
+    for name in names {
+      this.names.append(name);
+    }
+  }
+ 
+  override proc consume(i: int, const args: list(string),
+                        ref otherArgs: list(string)):int throws {
+    if this.names.contains(args[i]) {
+      this.noteMatch(i);
+      // consume all remaining args.
+      return args.size - i;
+    }
+    return 0;
+  }
+}
+
+class BooleanFlag : Flag {
+  var yesNames: list(string);
+  var noNames: list(string);
+  var value: bool;
+
+  proc init(name: string) {
+    super.init();
+    this.complete();
+    this.yesNames.append(name);
+    this.value = false;
+  }
+  proc init(yesName: string, noName:string, default:bool) {
+    super.init();
+    this.complete();
+    this.yesNames.append(yesName);
+    this.noNames.append(noName);
+    this.value = default;
+  }
+  proc init(yesNames, noNames, default: bool) {
+    super.init();
+    this.complete();
+    if !isNothingType(yesNames.type) {
+      for name in yesNames {
+        this.yesNames.append(name);
+      }
+    }
+    if !isNothingType(noNames.type) {
+      for name in noNames {
+        this.noNames.append(name);
+      }
+    }
+    this.value = default;
+  }
+
+  override proc consume(i: int, const args: list(string),
+                        ref otherArgs: list(string)):int throws {
+    if this.yesNames.contains(args[i]) {
+      this.noteMatch(i);
+      this.value = true;
+      return 1;
+    }
+    if this.noNames.contains(args[i]) {
+      this.noteMatch(i);
+      this.value = false;
+      return 1;
+    }
+    return 0;
+  }
+}
+
+class ValueFlag : Flag {
+  var names: list(string);
+  var valueSet: bool;
+  var value: string;
+  proc init(names...) {
+    this.complete();
+    for name in names {
+      this.names.append(name);
+    }
+  }
+  override proc consume(i: int, const args: list(string),
+                        ref otherArgs: list(string)):int throws {
+    for name in this.names {
+      const ref arg = args[i]; 
+      if arg == name {
+        if !args.indices.contains(i+1) {
+          throw new ArgumentError("missing additional argument");
+        }
+        if this.valueSet {
+          throw new ArgumentError("cannot provide " + name + " more than once");
+        }
+        this.noteMatch(i);
+        this.value = args[i+1]; 
+        return 2;
+      } else if arg.startsWith(name + "=") {
+        if this.valueSet {
+          throw new ArgumentError("cannot provide " + name + " more than once");
+        }
+        this.noteMatch(i);
+        var res = arg.split("=", maxsplit=2);
+        this.value = res[1];
+        return 2;
+      }
+    }
+    return 0;
+  }
+}
+
+class OtherArgsFlag : Flag {
+  var names: list(string);
+
+  proc init() {
+    super.init();
+    this.complete();
+    names.append('-');
+    names.append('--');
+  }
+
+  proc init(names...) {
+    super.init();
+    this.complete();
+    for name in names {
+      this.names.append(name);
+    }
+  }
+ 
+  override proc consume(i: int, const args: list(string),
+                        ref otherArgs: list(string)):int throws {
+    if this.names.contains(args[i]) {
+      this.noteMatch(i);
+      // consume all remaining args and put them all in otherArgs
+      for j in (i+1)..<args.size {
+        otherArgs.append(args[j]);
+      }
+      return args.size - i;
+    }
+    return 0;
+  }
+}
+
+class SubcommandFlag : Flag {
+  var names: list(string);
+  var args: list(string);
+
+  proc init(names...) {
+    super.init();
+    this.complete();
+    for name in names {
+      this.names.append(name);
+    }
+  }
+ 
+  override proc consume(i: int, const args: list(string),
+                        ref otherArgs: list(string)):int throws {
+    if this.names.contains(args[i]) {
+      this.noteMatch(i);
+      // consume all remaining args and put them all in this.args
+      for j in (i+1)..<args.size {
+        this.args.append(args[j]);
+      }
+      return args.size - i;
+    }
+    return 0;
+  }
+}
+
+
+/* future work -- 
+
+  multi-value flags
+  flags with optional values
+*/
+
+// Returns true if the arguments were well formed.
+// In that event, the 'present' and 'values' fields of the flags
+// will be set and any other args will be stored in otherArgs.
+proc processArgs(args: list(string),
+                 ref otherArgs: list(string),
+                 flags: borrowed Flag ...) throws {
+
+  otherArgs.clear();
+  try {
+    var i = 0;
+    while i < args.size {
+      // Give each flag a chance to consume some args
+      var consumed = false;
+      for f in flags {
+        var amt = f.consume(i, args, otherArgs);
+        if amt > 0 {
+          i += amt;
+          consumed = true;
+          break;
+        }
+      }
+      if !consumed {
+        // Didn't find a flag so put the value into otherArgs.
+        otherArgs.append(args[i]);
+        i += 1;
+      }
+    }
+    return true;
+  } catch e: ArgumentError {
+    return false;
+  }
+  return false;
+}

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -19,14 +19,20 @@
  */
 
 
-private use FileSystem;
-private use MasonHelp;
-private use IO;
-private use MasonUtils;
+use List;
+use FileSystem;
+use MasonHelp;
+use IO;
+use MasonUtils;
+use MasonArguments;
 
-proc masonDoc(args: [] string) throws {
+proc masonDoc(args: list(string)) throws {
   try! {
-    if args.size > 2 {
+    var helpFlag = new HelpFlag();
+    var otherArgs: list(string);
+    var ok = processArgs(args, otherArgs, helpFlag);
+
+    if !ok || helpFlag.present || !otherArgs.isEmpty() {
       masonDocHelp();
       exit(0);
     }

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -18,9 +18,10 @@
  * limitations under the License.
  */
 
-private use List;
+use List;
 use MasonUtils;
 public use MasonHelp;
+use MasonArguments;
 const regUrl: string = "https://github.com/chapel-lang/mason-registry";
 
 proc MASON_HOME : string {
@@ -111,13 +112,18 @@ proc MASON_REGISTRY {
   return registries;
 }
 
-proc masonEnv(args) {
-  if hasOptions(args, "-h", "--help") {
+proc masonEnv(args: list(string)) {
+  var helpFlag = new HelpFlag();
+  var debugFlag = new BooleanFlag("--debug");
+  var otherArgs: list(string);
+  var ok = processArgs(args, otherArgs, helpFlag);
+
+  if !ok || helpFlag.present || !otherArgs.isEmpty() {
     masonEnvHelp();
     exit(0);
   }
 
-  const debug = hasOptions(args, "--debug");
+  const debug = debugFlag.value;
 
   proc printVar(name : string, in val : string) {
     if getEnv(name) != "" then

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -104,14 +104,14 @@ proc masonBuildHelp() {
 
 proc masonNewHelp() {
   writeln('Usage:');
-  writeln('    mason new [options] <project name>');
+  writeln('    mason new [options] <directory name>');
   writeln('    mason new                    Starts an interactive session');
   writeln();
   writeln('Options:');
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --no-vcs                 Do not initialize a git repository');
-  writeln('    --name <legalName>           Specify package name different from directory name');
+  writeln('    --name <legalName>           Specify package name (default is directory name)');
 }
 
 proc masonInitHelp(){

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -19,32 +19,37 @@
  */
 
 
-private use List;
-private use Map;
-use Path;
-use MasonUtils;
+use MasonArguments;
 use MasonHelp;
+use MasonUtils;
+
+use List;
+use Map;
+use Path;
 use Regexp;
 
 /* Entry point for mason system commands */
-proc masonSystem(args: [] string) {
+proc masonSystem(args: list(string)) {
   try! {
-    if args.size < 3 {
+    var helpFlag = new HelpFlag();
+    var pcFlag = new SubcommandFlag('pc');
+    var searchFlag = new SubcommandFlag('search');
+    var otherArgs: list(string);
+
+    var ok = processArgs(args, otherArgs,
+                         helpFlag, pcFlag, searchFlag);
+    if !ok || helpFlag.present {
       masonSystemHelp();
-      exit(0);
+      exit(1);
     }
-    else if args[2] == "--help" || args[2] == "-h" {
-      masonSystemHelp();
-      exit(0);
-    }
-    else if pkgConfigExists() {
-      if args[2] == "pc" {
-        printPkgPc(args);
+
+    if pkgConfigExists() {
+      if pcFlag.present {
+        printPkgPc(pcFlag.args);
       }
-      else if args[2] == "search" {
-        pkgSearch(args);
-      }
-      else {
+      if searchFlag.present {
+        pkgSearch(searchFlag.args);
+      } else {
         masonSystemHelp();
         exit(0);
       }
@@ -71,34 +76,32 @@ proc pkgConfigExists() throws {
 }
 
 /* Searches available system packages */
-proc pkgSearch(args) throws {
+proc pkgSearch(args: list(string)) throws {
+  var helpFlag = new HelpFlag();
+  var descFlag = new BooleanFlag('--desc');
+  var quietFlag = new BooleanFlag('--no-show-desc');
+  var otherArgs: list(string);
+  var ok = processArgs(args, otherArgs,
+                       helpFlag, descFlag, quietFlag);
+  if !ok || helpFlag.present {
+    masonSystemSearchHelp();
+    exit(1);
+  }
 
-  var desc = false;
-  var quiet = false;
+  var desc = descFlag.value;
+  var quiet = quietFlag.value;
   var pkgName = "";
-  if args.size < 4 {
+
+  if otherArgs.size == 0 {
     listAllPkgs();
     exit(0);
-  }
-  else {
-    for arg in args[3..] {
-      if arg == '-h' || arg == '--help' {
-        masonSystemSearchHelp();
-        exit(0);
-      }
-      else if arg == "--desc" {
-        desc=true;
-      }
-      else if arg == "--no-show-desc" {
-        quiet = true;
-      }
-      else {
-        pkgName = arg;
-      }
-    }
+  } else if otherArgs.size > 1 {
+    throw new MasonError("Must include one package name");
+  } else {
+    pkgName = otherArgs.first();
   }
   if pkgName == "" {
-    throw new owned MasonError("Must include a package name");
+    throw new MasonError("Must include a package name");
   }
   const pattern = compile(pkgName, ignoreCase=true);
   const command = "pkg-config --list-all";
@@ -137,43 +140,43 @@ proc listAllPkgs() {
 
 /* Prints a pc for user debugging */
 proc printPkgPc(args) throws {
-  if args.size < 4 {
+  var helpFlag = new HelpFlag();
+  var otherArgs: list(string);
+  var ok = processArgs(args, otherArgs, helpFlag);
+  if !ok || helpFlag.present {
     masonSystemPcHelp();
-    exit(0);
+    exit(1);
   }
-  else if args[3] == "-h" || args[3] == "--help" {
-    masonSystemPcHelp();
-    exit(0);
+  if otherArgs.size != 1 {
+    throw new MasonError("expected one package name");
   }
-  else {
-    try! {
-      const pkgName = args[3];
-      if pkgExists(pkgName) {
-        //
-        // Add a these call, since `string.join` has an iterator overload but
-        // not one for list.
-        //
-        var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir").these()).strip();
-        var pcFile = joinPath(pcDir, pkgName + ".pc");
-        var pc = open(pcFile, iomode.r);
-        writeln("\n------- " + pkgName + ".pc -------\n");
-        for line in pc.lines() {
-          write(line);
-        }
-        writeln("\n-------------------\n");
+  const pkgName = otherArgs.first();
+  try! {
+    if pkgExists(pkgName) {
+      //
+      // Add a these call, since `string.join` has an iterator overload but
+      // not one for list.
+      //
+      var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir").these()).strip();
+      var pcFile = joinPath(pcDir, pkgName + ".pc");
+      var pc = open(pcFile, iomode.r);
+      writeln("\n------- " + pkgName + ".pc -------\n");
+      for line in pc.lines() {
+        write(line);
       }
-      else {
-        throw new owned MasonError("Mason could not find " + pkgName + " on your system");
-      }
+      writeln("\n-------------------\n");
     }
-    catch e: FileNotFoundError {
-      stderr.writeln("Package exists but Mason could not find it's .pc file");
-      exit(1);
+    else {
+      throw new owned MasonError("Mason could not find " + pkgName + " on your system");
     }
-    catch e: MasonError {
-      stderr.writeln(e.message());
-      exit(1);
-    }
+  }
+  catch e: FileNotFoundError {
+    stderr.writeln("Package exists but Mason could not find it's .pc file");
+    exit(1);
+  }
+  catch e: MasonError {
+    stderr.writeln(e.message());
+    exit(1);
   }
 }
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -18,17 +18,17 @@
  * limitations under the License.
  */
 
-private use List;
-private use Map;
-
-use TOML;
-use FileSystem;
 use MasonUtils;
 use MasonEnv;
 use MasonSystem;
 use MasonExternal;
 use MasonHelp;
+use MasonArguments;
 
+use FileSystem;
+use List;
+use Map;
+use TOML;
 
 /*
 Update: Performs the upfront dependency resolution and generates the lock file.
@@ -47,31 +47,22 @@ The current resolution strategy for Mason 0.1.0 is the IVRS as described below:
 
 private var failedChapelVersion: list(string);
 
-proc masonUpdate(args: [?d] string) {
+proc masonUpdate(args: list(string)) {
+
+  var helpFlag = new HelpFlag();
+  var updateFlag = new BooleanFlag('--update', '--no-update', !MASON_OFFLINE);
+  var otherArgs: list(string);
+
+  var ok = processArgs(args, otherArgs, helpFlag, updateFlag);
+  if !ok || helpFlag.present || !otherArgs.isEmpty() {
+    masonUpdateHelp();
+    exit(1);
+  }
+
   var tf = "Mason.toml";
   var lf = "Mason.lock";
-  var skipUpdate = MASON_OFFLINE;
+  var skipUpdate = updateFlag.value;
 
-  var listArgs: list(string);
-  for arg in args {
-    listArgs.append(arg);
-    select (arg) {
-      when '-h' {
-        masonUpdateHelp();
-        exit(0);
-      }
-      when '--help' {
-        masonUpdateHelp();
-        exit(0);
-      }
-      when '--no-update' {
-        skipUpdate = true;
-      }
-      when '--update' {
-        skipUpdate = false;
-      }
-    }
-  }
   return updateLock(skipUpdate, tf, lf);
 }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -21,8 +21,8 @@
 
 
 /* A helper file of utilities for Mason */
-private use List;
-private use Map;
+use List;
+use Map;
 
 public use Spawn;
 public use FileSystem;
@@ -217,35 +217,21 @@ proc runSpackCommand(command) {
 }
 
 
-proc hasOptions(args: list(string), const opts: string ...) {
-  var ret = false;
-
-  for o in opts {
-    const found = args.count(o) != 0;
-    if found {
-      ret = true;
-      break;
-    }
-  }
-
-  return ret;
+proc hasHelpOption(args: list(string)) {
+  return args.count("-h") > 0 || args.count("--help");
 }
 
-
-proc hasOptions(args : [] string, const opts : string ...) {
-  var ret = false;
-
-  for o in opts {
-    const (found, idx) = args.find(o);
-    if found {
-      ret = true;
-      break;
-    }
+proc hasHelpOption(args: [] string) {
+  {
+    const (found, idx) = args.find("-h");
+    if found then return true;
   }
-
-  return ret;
+  {
+    const (found, idx) = args.find("---help");
+    if found then return true;
+  }
+  return false;
 }
-
 
 record VersionInfo {
   var major = -1, minor = -1, bug = 0;

--- a/tools/mason/SpecParser.chpl
+++ b/tools/mason/SpecParser.chpl
@@ -19,9 +19,10 @@
  */
 
 
-private use List;
 use MasonUtils;
 use MasonExternal;
+
+use List;
 use Regexp;
 
 config const debugSpecParser=false;

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -39,6 +39,8 @@ use MasonExternal;
 use MasonPublish;
 use MasonInit;
 
+use List;
+
 /*
 
 The Design of Mason
@@ -72,6 +74,18 @@ Full documentation is located in the chapel release in $CHPL_HOME/doc/rst/tools/
 
 
 
+// Return just the list of arguments for the subcommand, i.e.
+// for
+//   mason init -d mydir
+// it would return
+//   -d mydir
+proc subcommandArgs(args: [] string) {
+  var ret:list(string);
+  for i in 2..args.size {
+    ret.append(args[i]);
+  }
+  return ret;
+}
 
 proc main(args: [] string) throws {
   try! {
@@ -80,21 +94,21 @@ proc main(args: [] string) throws {
       exit(0);
     }
     select (args[1]) {
-      when 'new' do masonNew(args);
-      when 'init' do masonInit(args);
-      when 'add' do masonModify(args);
-      when 'rm' do masonModify(args);
-      when 'build' do masonBuild(args);
-      when 'update' do masonUpdate(args);
-      when 'run' do masonRun(args);
-      when 'search' do masonSearch(args);
-      when 'system' do masonSystem(args);
-      when 'external' do masonExternal(args);
-      when 'test' do masonTest(args);
-      when 'env' do masonEnv(args);
-      when 'doc' do masonDoc(args);
-      when 'publish' do masonPublish(args);
-      when 'clean' do masonClean(args);
+      when 'new' do masonNew(subcommandArgs(args));
+      when 'init' do masonInit(subcommandArgs(args));
+      when 'add' do masonModify('add', subcommandArgs(args));
+      when 'rm' do masonModify('rm', subcommandArgs(args));
+      when 'build' do masonBuild(subcommandArgs(args));
+      when 'update' do masonUpdate(subcommandArgs(args));
+      when 'run' do masonRun(subcommandArgs(args));
+      when 'search' do masonSearch(subcommandArgs(args));
+      when 'system' do masonSystem(subcommandArgs(args));
+      when 'external' do masonExternal(subcommandArgs(args));
+      when 'test' do masonTest(subcommandArgs(args));
+      when 'env' do masonEnv(subcommandArgs(args));
+      when 'doc' do masonDoc(subcommandArgs(args));
+      when 'publish' do masonPublish(subcommandArgs(args));
+      when 'clean' do masonClean(subcommandArgs(args));
       when 'help' do masonHelp();
       when 'version' do printVersion();
       when '-h' do masonHelp();


### PR DESCRIPTION
- [ ] add optional argument for `--example` cases
- [ ] double check the change, including that all the Flag classes are passed to the processArgs