### PR TITLE
 Update the compiler to fix some bugs with initializers and operator methods

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2081,6 +2081,30 @@ void initAstrConsts() {
   astr_coerceMove = astr("chpl__coerceMove");
 }
 
+bool matchesOp(const char* name) {
+  if (name == astrSassign || name == astrSeq || name == astrSne ||
+      name == astrSgt || name == astrSgte || name == astrSlt ||
+      name == astrSlte || name == astrSswap || strcmp(name, "&") == 0 ||
+      strcmp(name, "|") == 0 || strcmp(name, "^") == 0 ||
+      strcmp(name, "~") == 0 || strcmp(name, "+") == 0 ||
+      strcmp(name, "-") == 0 || strcmp(name, "*") == 0 ||
+      strcmp(name, "/") == 0 || strcmp(name, "<<") == 0 ||
+      strcmp(name, ">>") == 0 || strcmp(name, "%") == 0 ||
+      strcmp(name, "**") == 0 || strcmp(name, "!") == 0 ||
+      strcmp(name, "<~>") == 0 || strcmp(name, "+=") == 0 ||
+      strcmp(name, "-=") == 0 || strcmp(name, "*=") == 0 ||
+      strcmp(name, "/=") == 0 || strcmp(name, "%=") == 0 ||
+      strcmp(name, "**=") == 0 || strcmp(name, "&=") == 0 ||
+      strcmp(name, "|=") == 0 || strcmp(name, "^=") == 0 ||
+      strcmp(name, ">>=") == 0 || strcmp(name, "<<=") == 0 ||
+      strcmp(name, "#") == 0 || strcmp(name, "by") == 0 ||
+      strcmp(name, "align") == 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 /************************************* | **************************************
 *                                                                             *
 * Create a temporary, with FLAG_TEMP and (optionally) FLAG_CONST.             *

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2081,7 +2081,7 @@ void initAstrConsts() {
   astr_coerceMove = astr("chpl__coerceMove");
 }
 
-bool matchesOp(const char* name) {
+bool isAstrOpName(const char* name) {
   if (name == astrSassign || name == astrSeq || name == astrSne ||
       name == astrSgt || name == astrSgte || name == astrSlt ||
       name == astrSlte || name == astrSswap || strcmp(name, "&") == 0 ||

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -775,7 +775,7 @@ extern const char* astr_coerceCopy;
 extern const char* astr_coerceCopy;
 extern const char* astr_coerceMove;
 
-bool matchesOp(const char* name);
+bool isAstrOpName(const char* name);
 
 void initAstrConsts();
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -775,6 +775,8 @@ extern const char* astr_coerceCopy;
 extern const char* astr_coerceCopy;
 extern const char* astr_coerceMove;
 
+bool matchesOp(const char* name);
+
 void initAstrConsts();
 
 // Return true if the arg must use a C pointer whether or not

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -283,6 +283,16 @@ static FnSymbol* functionExists(const char* name,
                          formalType1, formalType2, formalType3, NULL, kind);
 }
 
+static FnSymbol* functionExists(const char* name,
+                                Type* formalType1,
+                                Type* formalType2,
+                                Type* formalType3,
+                                Type* formalType4,
+                                functionExistsKind kind=FIND_EITHER) {
+  return functionExists(name, 4, formalType1, formalType2, formalType3,
+                        formalType4, kind);
+}
+
 static void fixupAccessor(AggregateType* ct, Symbol *field,
                            bool fieldIsConst, bool recordLike,
                            FnSymbol* fn)
@@ -1405,8 +1415,11 @@ static void buildEnumOrderFunctions(EnumType* et) {
 
 
 static void buildRecordAssignmentFunction(AggregateType* ct) {
-  if (functionExists("=", ct, ct))
+  if (functionExists("=", ct, ct)) {
     return;
+  } else if (functionExists("=", dtMethodToken, dtAny, ct, ct)) {
+    return;
+  }
 
   bool externRecord = ct->symbol->hasFlag(FLAG_EXTERN);
 

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -449,7 +449,7 @@ checkFunction(FnSymbol* fn) {
 
 static void checkOperator(FnSymbol* fn) {
   if (!fn->hasFlag(FLAG_OPERATOR) && !fn->hasFlag(FLAG_METHOD)) {
-    if (matchesOp(fn->name)) {
+    if (isAstrOpName(fn->name)) {
       // When deprecate non-operator keyword declarations, add deprecation
       // warning here.
       fn->addFlag(FLAG_OPERATOR);

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -449,23 +449,7 @@ checkFunction(FnSymbol* fn) {
 
 static void checkOperator(FnSymbol* fn) {
   if (!fn->hasFlag(FLAG_OPERATOR) && !fn->hasFlag(FLAG_METHOD)) {
-    if (fn->name == astrSassign || fn->name == astrSeq || fn->name == astrSne ||
-        fn->name == astrSgt || fn->name == astrSgte || fn->name == astrSlt ||
-        fn->name == astrSlte || fn->name == astrSswap ||
-        strcmp(fn->name, "&") == 0 || strcmp(fn->name, "|") == 0 ||
-        strcmp(fn->name, "^") == 0 || strcmp(fn->name, "~") == 0 ||
-        strcmp(fn->name, "+") == 0 || strcmp(fn->name, "-") == 0 ||
-        strcmp(fn->name, "*") == 0 || strcmp(fn->name, "/") == 0 ||
-        strcmp(fn->name, "<<") == 0 || strcmp(fn->name, ">>") == 0 ||
-        strcmp(fn->name, "%") == 0 || strcmp(fn->name, "**") == 0 ||
-        strcmp(fn->name, "!") == 0 || strcmp(fn->name, "<~>") == 0 ||
-        strcmp(fn->name, "+=") == 0 || strcmp(fn->name, "-=") == 0 ||
-        strcmp(fn->name, "*=") == 0 || strcmp(fn->name, "/=") == 0 ||
-        strcmp(fn->name, "%=") == 0 || strcmp(fn->name, "**=") == 0 ||
-        strcmp(fn->name, "&=") == 0 || strcmp(fn->name, "|=") == 0 ||
-        strcmp(fn->name, "^=") == 0 || strcmp(fn->name, ">>=") == 0 ||
-        strcmp(fn->name, "<<=") == 0 || strcmp(fn->name, "#") == 0 ||
-        strcmp(fn->name, "by") == 0 || strcmp(fn->name, "align") == 0) {
+    if (matchesOp(fn->name)) {
       // When deprecate non-operator keyword declarations, add deprecation
       // warning here.
       fn->addFlag(FLAG_OPERATOR);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -933,7 +933,7 @@ static void updateMethod(UnresolvedSymExpr* usymExpr,
           Type*       type = method->_this->type;
 
           if ((method->name == astrInit || method->name == astrInitEquals) &&
-              matchesOp(name)) {
+              isAstrOpName(name)) {
             break;
           }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -932,6 +932,11 @@ static void updateMethod(UnresolvedSymExpr* usymExpr,
           const char* name = usymExpr->unresolved;
           Type*       type = method->_this->type;
 
+          if ((method->name == astrInit || method->name == astrInitEquals) &&
+              matchesOp(name)) {
+            break;
+          }
+
           if (isAggr == true || isMethodName(name, type) == true) {
             if (isFunctionNameWithExplicitScope(expr) == false) {
               insertFieldAccess(method, usymExpr, sym, expr);

--- a/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.bad
+++ b/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.bad
@@ -1,3 +1,0 @@
-assignmentOpMethod.chpl:4: In initializer:
-assignmentOpMethod.chpl:6: error: cannot call a method on a record before this.complete()
-assignmentOpMethod.chpl:6: error: field "x" used before it is initialized

--- a/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.chpl
@@ -6,8 +6,9 @@ record Foo {
     this.x = x;
   }
 }
-operator Foo.=(val: Foo) {
-  return new Foo(val.x);
+operator Foo.=(ref lhs: Foo, val: Foo) {
+  writeln("In user =");
+  lhs.x = val.x;
 }
 proc main() {
   var x: Foo = new Foo(7);

--- a/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.future
+++ b/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.future
@@ -1,2 +1,0 @@
-bug: Cannot define = operator as method if have explicit initializer on type
-#17156

--- a/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.good
+++ b/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod.good
@@ -1,1 +1,3 @@
+In user init
+In user init
 (x = 3)

--- a/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod2.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod2.chpl
@@ -1,0 +1,32 @@
+record Foo {
+  var x: int;
+
+  proc init(x: int) {
+    writeln("In user init");
+    this.x = x;
+  }
+
+  proc init=(other: Foo) {
+    writeln("In user init=");
+    this.x = other.x;
+  }
+
+  proc init=(other: int) {
+    writeln("In user init=");
+    this.x = other;
+  }
+}
+operator Foo.=(ref lhs: Foo, val: Foo) {
+  writeln("In user =");
+  lhs.x = val.x;
+}
+
+inline operator :(src: int, type toType: Foo) {
+  return new Foo(src);
+}
+proc main() {
+  var x: Foo = new Foo(7);
+  var y: Foo = 3;
+  x = y;
+  writeln(x);
+}

--- a/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod2.good
+++ b/test/functions/operatorOverloads/operatorMethods/assignmentOpMethod2.good
@@ -1,4 +1,4 @@
 In user init
-In user init
+In user init=
 In user =
 (x = 3)


### PR DESCRIPTION
This issue fixes two bugs: first, it allows types to define initializers that call
operators which the type happens to have its own definition for; second, it stops
generating a default assignment operator for types that have an assignment
operator method.  The latter was causing problems for determining if the type
needed to define an overload for the assignment operator due to the presence of
an init= method or cast operator.

Resolves the original future and adds a new test to lock in the same behavior but
for init=.

Passed a full paratest with futures