### PR TITLE
Make moveInitialize emit an error when 'in' formal 'rhs' is copied

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -283,6 +283,7 @@ symbolFlag( FLAG_NO_BORROW_CONVERT , ypr, "no borrow convert", "arguments that a
 symbolFlag( FLAG_NO_CAPTURE_FOR_TASKING , npr, "no capture for tasking", "does not need to be captured before spawning tasks" )
 symbolFlag( FLAG_NO_CODEGEN , ypr, "no codegen" , "do not generate e.g. C code defining this symbol" )
 symbolFlag( FLAG_NO_COPY , ypr, "no copy" , "do not apply chpl__initCopy to initialization of a variable" )
+symbolFlag( FLAG_ERROR_ON_COPY, ypr, "error on copy", "error if actual is copied at callsite" )
 symbolFlag( FLAG_NO_COPY_RETURN, ypr, "no copy return", ncm)
 symbolFlag( FLAG_NO_COPY_RETURNS_OWNED, ypr, "no copy returns owned", ncm)
 symbolFlag( FLAG_NO_DEFAULT_FUNCTIONS , ypr, "no default functions" , ncm )

--- a/modules/standard/Memory/Initialization.chpl
+++ b/modules/standard/Memory/Initialization.chpl
@@ -85,7 +85,9 @@ module Initialization {
 
     :arg rhs: A value to move-initialize from
   */
-  proc moveInitialize(ref lhs: ?t, pragma "no auto destroy" in rhs: t) {
+  proc moveInitialize(ref lhs: ?t,
+                      pragma "no auto destroy"
+                      pragma "error on copy" in rhs: t) {
     if lhs.type != nothing then
       _move(lhs, rhs);
   }

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.chpl
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.chpl
@@ -1,0 +1,12 @@
+use Memory.Initialization;
+use TrackingRecord;
+
+proc test1() {
+  pragma "no init"
+  var r1: r;
+  var r2 = new r();
+  moveInitialize(r1, r2);
+  writeln(r2);
+}
+test1();
+

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
@@ -1,2 +1,2 @@
 MoveInitializeCopyError.chpl:4: In function 'test1':
-MoveInitializeCopyError.chpl:8: error: actual is copied when passed to 'rhs' of 'moveInitialize'
+MoveInitializeCopyError.chpl:8: error: calling 'moveInitialize' with actual 'r2' would result in a copy

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
@@ -1,0 +1,2 @@
+MoveInitializeCopyError.chpl:4: In function 'test1':
+MoveInitializeCopyError.chpl:8: error: actual is copied when passed to 'rhs' of 'moveInitialize'


### PR DESCRIPTION
Make moveInitialize emit an error when 'in' formal 'rhs' is copied (#17265)

The pull #17118 added the module `Memory.Initialization` and the
function `moveInitialize`. The signature of `moveInitialize`
looks something like:

```chapel
proc moveInitialize(ref lhs, in rhs);
```

The formal `rhs` must have the `in` intent in order to take ownership
on argument types such as `owned`, and to interact properly with
copy elision.

Because `rhs` has the `in` intent, copies can occur for actuals passed
to `rhs` if they are live after the call.

The `moveInitialize` function is intended to be a move and not a copy,
so modify the compiler to emit an error when a copy is made for `rhs`.

The following code presents an invalid use of `moveInitialize`:

```chapel
record r { // Assume that 'r' is nontrivial and requires copy-init. }

pragma "no init"
var r1: r;
var r2 = new r();

// Error: calling 'moveInitialize' with actual 'r2' would result in a copy
moveInitialize(r1, r2);

writeln(r2);
```

With the compiler errors in place, users can write future-proofed
code using `moveInitialize`.

TESTING:

- [x] `ALL` on `linux64` when `COMM=none`

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>