### PR TITLE
Fix commcounts for the assignSlice test

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.cyclic.na-none.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_nb = 9) (get = 48, put = 1, execute_on = 2, execute_on_fast = 3) (get = 48, put = 1, execute_on_fast = 3) (get = 48, put = 1, execute_on_fast = 3)
+(execute_on = 4, execute_on_nb = 9) (get = 42, put = 1, execute_on = 2, execute_on_fast = 3) (get = 42, put = 1, execute_on_fast = 3) (get = 42, put = 1, execute_on_fast = 3)


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/17212 caused some positive commcount
changes for the `assignSlice` test when run with Cyclic arrays. This PR updates
the good file of the test.

For other distributions or network atomics count doesn't seem to have changed.
