### PR TITLE
Look inside refs when instantiating copy type for in/inout

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -572,8 +572,15 @@ Type* getInstantiationType(Type* actualType, Symbol* actualSym,
 
   // memoize unaliasing for in/inout/out/value return
   if (inOrOtherValue) {
-    if (Type* copyType = getCopyTypeDuringResolution(actualType)) {
-      actualType = copyType;
+    Type* valType = actualType->getValType();
+    if (Type* copyType = getCopyTypeDuringResolution(valType)) {
+      if (isReferenceType(actualType)) {
+        // make the new actual type also a reference type
+        INT_ASSERT(copyType->refType);
+        actualType = copyType->refType;
+      } else {
+        actualType = copyType;
+      }
     }
   }
 

--- a/test/functions/intents/inout/in-conversion-inout-slice-formal-generic.future
+++ b/test/functions/intents/inout/in-conversion-inout-slice-formal-generic.future
@@ -1,2 +1,0 @@
-bug: core dump when passing a slice to a generic inout formal
-#17241 

--- a/test/functions/intents/inout/in-conversion-inout-slice-formal-generic.good
+++ b/test/functions/intents/inout/in-conversion-inout-slice-formal-generic.good
@@ -1,4 +1,4 @@
-bb.chpl:9: warning: [domain(1,int(64),false)] int(64)
+in-conversion-inout-slice-formal-generic.chpl:9: warning: in f, arg.type is [domain(1,int(64),false)] int(64)
 in f, arg= 0 0 0
 1 1 1
 1 1 1 0 0 0 0 0 0 0

--- a/test/functions/intents/inout/in-conversion-inout-slice-formal-generic.skipif
+++ b/test/functions/intents/inout/in-conversion-inout-slice-formal-generic.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_EXE!=on


### PR DESCRIPTION
Resolves #17241

The issue is that the compiler resolves signatures for `in` / `inout`
functions as `ref` types today. But the code in `getInstantiationType`
that was intended to handle type conversion when instantiating (from say
`sync int` to `int` or array slice to non-slice array -- to match
`var x = actualArg` behavior) was not handling the case that the
formal type is a `ref`.

Reviewed by @e-kayrakli - thanks!

- [x] full local testing
- [x] primers pass with valgrind+verify and do not leak