### PR TITLE
Use relative paths in compopts files

### DIFF
--- a/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.compopts
+++ b/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.compopts
@@ -1,1 +1,1 @@
--M $CHPL_HOME/test/release/examples/benchmarks/hpcc --auto-aggregation --report-auto-aggregation -sverboseAggregation=true --no-local
+-M ../../../release/examples/benchmarks/hpcc --auto-aggregation --report-auto-aggregation -sverboseAggregation=true --no-local

--- a/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.ml-compopts
+++ b/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.ml-compopts
@@ -1,2 +1,2 @@
--M $CHPL_HOME/test/release/examples/benchmarks/hpcc --auto-aggregation  #auto-aggregation
--M $CHPL_HOME/test/release/examples/benchmarks/hpcc --no-auto-aggregation  #no-auto-aggregation
+-M ../../../release/examples/benchmarks/hpcc --auto-aggregation  #auto-aggregation
+-M ../../../release/examples/benchmarks/hpcc --no-auto-aggregation  #no-auto-aggregation


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/17263 added some performance tests.
In compopts files I used `$CHPL_HOME` to refer to another module in `test` dir.
However, our XC testing uses a module-built Chapel that doesn't have `test` dir.
This PR uses relative paths to fix the issue.

I reproduced the failure with module Chapel, and that this fixes the issue.
