### PR TITLE
Put the minlen condition back in quicksort

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1241,7 +1241,7 @@ module QuickSort {
         var mid = lo + (hi - lo + 1) / 2;
         var piv = mid;
 
-        if hi - lo < 0 { // minlen {
+        if hi - lo < minlen { // minlen {
           // base case -- use insertion sort
           InsertionSort.insertionSortMoveElts(Data, comparator=comparator, lo, hi);
           return;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -428,6 +428,12 @@ Sort the elements in a 1D rectangular array.  The choice of sorting
 algorithm used is made by the implementation.
 
 .. note::
+
+  This function does not run a stable sort. Elements that compare
+  the same can be rearranged by this call.
+
+.. note::
+
   This function currently either uses a parallel radix sort or a serial
   quickSort. The algorithms used will change over time.
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1247,7 +1247,7 @@ module QuickSort {
         var mid = lo + (hi - lo + 1) / 2;
         var piv = mid;
 
-        if hi - lo < minlen { // minlen {
+        if hi - lo < minlen {
           // base case -- use insertion sort
           InsertionSort.insertionSortMoveElts(Data, comparator=comparator, lo, hi);
           return;

--- a/test/mason/env/mason-registry.good
+++ b/test/mason/env/mason-registry.good
@@ -3,5 +3,5 @@ MASON_REGISTRY: mason-registry|$PWD/tempHome/uncached/mason-registry *
 MASON_OFFLINE: false
 SPACK_ROOT: $PWD/mason_home/spack *
 Updating mason-registry
-simple (0.1.0)
 multiple (0.2.0)
+simple (0.1.0)

--- a/test/mason/search/no-pattern.good
+++ b/test/mason/search/no-pattern.good
@@ -1,3 +1,3 @@
-multiVersion (1.0.0)
 WithCaps (0.1.0)
 capsize (0.1.0)
+multiVersion (1.0.0)

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -167,10 +167,37 @@ proc splitNameVersion(ref package: string, original: bool) {
 
 record RankResultsComparator {
   var query: string;
+  var packageScores;
   proc compare(a, b) {
-    if a.toLower().startsWith(query) && !b.toLower().startsWith(query) then return -1;
-    else if !a.toLower().startsWith(query) && b.toLower().startsWith(query) then return 1;
-    else return 1;
+    // starting with the query puts it first, if query is not ""
+    if query != "" {
+      if a.toLower().startsWith(query) &&
+         !b.toLower().startsWith(query) {
+        return -1;
+      } else if !a.toLower().startsWith(query) &&
+                b.toLower().startsWith(query) {
+        return 1;
+      }
+    }
+
+    // then sort by score
+    var scoreA = packageScores[a];
+    var scoreB = packageScores[b];
+    if scoreA > scoreB {
+      return -1;
+    } else if scoreA < scoreB {
+      return 1;
+    }
+
+    // then sort by name
+    if a < b {
+      return -1;
+    } else if a > b {
+      return 1;
+    }
+
+    // consider them the same
+    return 0;
   }
 }
 
@@ -179,11 +206,13 @@ record RankResultsComparator {
 proc rankResults(results: list(string), query: string): [] string {
   use Sort;
   var r = results.toArray();
-  sort(r);
-  var res = rankOnScores(r);
-  var cmp = new RankResultsComparator(query);
-  if query != ".*" then sort(res, comparator=cmp);
-  return res;
+  var q = query;
+  if query == ".*" then
+    q = "";
+
+  var cmp = new RankResultsComparator(q, getPackageScores(r));
+  sort(r, comparator=cmp);
+  return r;
 }
 
 /* Creates an empty cache file if its not found in registry */
@@ -216,23 +245,6 @@ proc getPackageScores(res: [] string) {
     } else packageScores.add(packageName, defaultScore);
   }
   return packageScores;
-}
-
-record RankScoresComparator {
-  var packageScores;
-  proc compare(a, b) {
-    if packageScores[a] > packageScores[b] then return -1;
-    else return 1;
-  }
-}
-
-/* Sort based on scores from cache file */
-proc rankOnScores(results: [] string) {
-  use Sort;
-  var rankCmp = new RankScoresComparator(getPackageScores(results));
-  var res = results;
-  sort(res, comparator=rankCmp);
-  return res;
 }
 
 proc isHidden(name : string) : bool {


### PR DESCRIPTION
It was accidentally removed in PR #15239. Putting it back caused problems with some `mason search` testing, but that was because the code sorting the results for `mason search` assumed that the sort was stable. It is not, so this PR updates that `mason search` implementation to work with unstable sort and the sort documentation to make it clear that it is not a stable sort.

Reviewed by @arezaii - thanks!

- [x] full local testing
- [x] check sort test directory with valgrind and memleaks