### PR TITLE
Remove calls in flattenFunctions that delete FnSymbol::calledBy

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -387,16 +387,7 @@ addVarsToActuals(CallExpr* call, SymbolMap* vars, bool outerCall) {
   }
 }
 
-static void deleteCalledby(FnSymbol* fn) {
-  if (fn->calledBy != NULL)  { delete fn->calledBy; fn->calledBy = NULL; }
-}
-static void deleteAllCalledby() {
-  for_alive_in_Vec(FnSymbol, fn, gFnSymbols)  deleteCalledby(fn);
-}
-
 void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions) {
-  if (fVerify) deleteAllCalledby();
-
   Vec<FnSymbol*> outerFunctionSet;
   Vec<FnSymbol*> nestedFunctionSet;
 
@@ -423,7 +414,6 @@ void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions) {
     change = false;
 
     forv_Vec(FnSymbol, fn, nestedFunctions) {
-      if (!fVerify) deleteCalledby(fn);
       computeAllCallSites(fn);
 
       std::vector<BaseAST*> asts;

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1784,6 +1784,8 @@ static void checkForErroneousInitCopies() {
     if (!fn->inTree())
       continue;
 
+    computeAllCallSites(fn);
+
     forv_Vec(CallExpr, call, *fn->calledBy) {
       if (SymExpr* actual = getActualBeforeCopyInit(call, formal)) {
 


### PR DESCRIPTION
Remove calls in flattenFunctions that delete FnSymbol::calledBy (#17290)

Remove two functions in `flattenFunctions.cpp` that conditionally
removed the `calledBy` of all `FnSymbol` depending on if `--verify`
was thrown or not.

In `callDestructors`, recompute the callsites of functions containing
"error on copy" formals instead of assuming that they are
current.

TESTING:

- [x] `ALL` on `linux64` with `COMM=none` and `--verify`

Reviewed by @vasslitvinov. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>