### PR TITLE
File tests locking in fixes to issue #14185

### DIFF
--- a/test/functions/generic/poi/bug-14185-2.chpl
+++ b/test/functions/generic/poi/bug-14185-2.chpl
@@ -1,0 +1,24 @@
+module LibraryOne {
+  use GenericLibrary;
+  proc foo(i: int) {
+    writeln("LibraryOne.foo");
+  }
+  callFoo(1);
+}
+module GenericLibrary {
+  proc callFoo(param x) {
+    foo(x);
+  }
+}
+module LibraryTwo {
+  use GenericLibrary;
+  proc foo(i: int) {
+    writeln("LibraryTwo.foo");
+  }
+  callFoo(1);
+}
+module Application {
+  use LibraryOne;
+  use LibraryTwo;
+  proc main() { }
+}

--- a/test/functions/generic/poi/bug-14185-2.good
+++ b/test/functions/generic/poi/bug-14185-2.good
@@ -1,0 +1,2 @@
+LibraryOne.foo
+LibraryTwo.foo

--- a/test/functions/generic/poi/bug-14185-3.chpl
+++ b/test/functions/generic/poi/bug-14185-3.chpl
@@ -1,0 +1,24 @@
+module LibraryOne {
+  use GenericLibrary;
+  proc foo(i: int) {
+    writeln("LibraryOne.foo");
+  }
+  callFoo(1);
+}
+module GenericLibrary {
+  proc callFoo(param x) {
+    foo(x);
+  }
+}
+module LibraryTwo {
+  use GenericLibrary;
+  proc foo(i: int) {
+    writeln("LibraryTwo.foo");
+  }
+  callFoo(1);
+}
+module Application {
+  use LibraryTwo;
+  use LibraryOne;
+  proc main() { }
+}

--- a/test/functions/generic/poi/bug-14185-3.good
+++ b/test/functions/generic/poi/bug-14185-3.good
@@ -1,0 +1,2 @@
+LibraryTwo.foo
+LibraryOne.foo

--- a/test/functions/generic/poi/bug-14185.chpl
+++ b/test/functions/generic/poi/bug-14185.chpl
@@ -1,0 +1,30 @@
+module NewTypeMod {
+    record NewType {
+        var x: int;
+
+        proc writeThis(f) throws {
+            f <~> "NewType with " <~> x;
+        }
+    }
+}
+
+module Mod {
+    private use NewTypeMod;
+
+    proc makeNewType() {
+        return new NewType(42);
+    }
+    proc wr(x: NewType) {
+        writeln(x);
+    }
+}
+
+module User {
+    private use Mod;
+
+    proc main() {
+        var x = makeNewType();
+        writeln(x);
+        wr(x);
+    }
+}

--- a/test/functions/generic/poi/bug-14185.good
+++ b/test/functions/generic/poi/bug-14185.good
@@ -1,0 +1,2 @@
+NewType with 42
+NewType with 42


### PR DESCRIPTION
@cassella identified that Vass's POI improvements had
fixed the test cases in issue #14185.  This adds three
tests to lock that behavior in.
