### PR TITLE
Enable calls from CG functions to CG functions

### DIFF
--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -70,6 +70,10 @@ public:
   // when the same interface is implemented by different ConstrainedTypes
   //
   std::vector<SymbolMap> repsForIfcSymbols;
+
+  // "Interim instantiation" copies of CG functions invoked from this function
+  // for those calls that rely on this function's interfaceConstraints.
+  std::set<FnSymbol*> invokedCGfns;
 };
 
 class FnSymbol final : public Symbol {

--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -102,6 +102,8 @@ public:
 
   // One ImplementsStmt per IfcConstraint when 'fn' is CG
   std::vector<ImplementsStmt*> witnesses;
+  // Is this a CG "interim instantiation"?
+  bool                    isInterimInstantiation;
 
   Symbol*                 failingArgument; // actual or formal
   ResolutionCandidateFailureReason reason;

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -428,24 +428,32 @@ symbolFlag( FLAG_RUNTIME_TYPE_VALUE , npr, "runtime type value" , "associated ru
 symbolFlag( FLAG_SAFE, ypr, "safe", "safe (activate lifetime checking)")
 symbolFlag( FLAG_SCOPE, npr, "scope", "scoped (lifetime checking like a local variable)")
 symbolFlag( FLAG_SHOULD_NOT_PASS_BY_REF, npr, "should not pass by ref", "this symbol should be passed by value (not by reference) for performance, not for correctness")
-symbolFlag( FLAG_SINGLE , ypr, "single" , ncm )
-// Based on how this is used, I suggest renaming it to return_value_has_initializer
-// or something similar <hilde>.
-symbolFlag( FLAG_STAR_TUPLE , ypr, "star tuple" , "mark tuple types as star tuple types" )
-symbolFlag( FLAG_STAR_TUPLE_ACCESSOR , ypr, "star tuple accessor" , "this function for star tuple types" )
+
 symbolFlag( FLAG_SUPER_CLASS , npr, "super class" , ncm )
 symbolFlag( FLAG_SUPER_TEMP, npr, "temporary of super field", ncm)
 symbolFlag( FLAG_SUPPRESS_LVALUE_ERRORS , ypr, "suppress lvalue error" , "do not report an lvalue error if it occurs in a function with this flag" )
+
+// represents an interface formal, assoc. type, or required function
+// within a constrained generic function
+symbolFlag( FLAG_CG_REPRESENTATIVE, npr, "cg representative", ncm )
+// this instantiation does not need to be resolved
+symbolFlag( FLAG_CG_INTERIM_INST, npr, "cg interim instantiation", ncm)
+
+symbolFlag( FLAG_SINGLE , ypr, "single" , ncm )
 symbolFlag( FLAG_SYNC , ypr, "sync" , ncm )
+
 symbolFlag( FLAG_SYNTACTIC_DISTRIBUTION , ypr, "syntactic distribution" , ncm )
 symbolFlag( FLAG_TASK_FN_FROM_ITERATOR_FN , npr, "task fn from iterator fn" , ncm )
 symbolFlag( FLAG_TASK_SPAWN_IMPL_FN , ypr, "task spawn impl fn" , ncm )
 symbolFlag( FLAG_TASK_COMPLETE_IMPL_FN , ypr, "task complete impl fn" , ncm )
 symbolFlag( FLAG_TASK_JOIN_IMPL_FN , ypr, "task join impl fn" , ncm )
 symbolFlag( FLAG_TEMP , npr, "temp" , "compiler-inserted temporary" )
+
 symbolFlag( FLAG_TUPLE , ypr, "tuple" , ncm )
 symbolFlag( FLAG_TUPLE_CAST_FN , ypr, "tuple cast fn" , ncm )
 symbolFlag( FLAG_TUPLE_WITH_REF , npr, "tuple contains ref" , ncm )
+symbolFlag( FLAG_STAR_TUPLE , ypr, "star tuple" , "mark tuple types as star tuple types" )
+symbolFlag( FLAG_STAR_TUPLE_ACCESSOR , ypr, "star tuple accessor" , "this function for star tuple types" )
 
 symbolFlag( FLAG_TYPE_ASSIGN_FROM_CONST, npr, "type has = from const", "type supports assignment from a const rhs" )
 symbolFlag( FLAG_TYPE_ASSIGN_FROM_REF, npr, "type has = from ref", "type supports assignment from a potentially non-const rhs" )

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -116,13 +116,15 @@ void checkTypeParamTaskIntent(SymExpr* outerSE);
 // inlineFunctions.cpp
 BlockStmt* copyFnBodyForInlining(CallExpr* call, FnSymbol* fn, Expr* anchor);
 
-// interfaces.cpp
+// interfaces.cpp, interfaceResolution.cpp
 void  introduceConstrainedTypes(FnSymbol* fn);
 Type* desugarInterfaceAsType(ArgSymbol* arg, SymExpr* se,
                              InterfaceSymbol* isym);
 void  markImplStmtWrapFnAsFailure(FnSymbol* wrapFn);
 void  wrapImplementsStatements();
 FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm);
+void  handleCallsToOtherCGfuns(FnSymbol* origFn, InterfaceInfo* ifcInfo,
+                               FnSymbol* newFn);
 
 // iterator.cpp
 CallExpr* setIteratorRecordShape(Expr* ref, Symbol* ir, Symbol* shapeSpec,

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -178,13 +178,19 @@ void resolveImplementsStmt(ImplementsStmt* istm);
 void resolveConstrainedGenericFun(FnSymbol* fn);
 void resolveConstrainedGenericSymbol(Symbol* sym, bool mustBeCG);
 Expr* resolveCallToAssociatedType(CallExpr* call, ConstrainedType* recv);
-ImplementsStmt* constraintIsSatisfiedAtCallSite(CallExpr* call,
+class ConstraintSat { public: ImplementsStmt* istm; IfcConstraint* icon;
+  ConstraintSat(ImplementsStmt* s, IfcConstraint* c): istm(s), icon(c) { } };
+ConstraintSat constraintIsSatisfiedAtCallSite(CallExpr* call,
                                                 IfcConstraint* constraint,
                                                 SymbolMap& substitutions);
 void copyIfcRepsToSubstitutions(FnSymbol* fn, int indx,
                                 ImplementsStmt* istm,
                                 SymbolMap& substitutions);
-void adjustForCGinstantiation(FnSymbol* fn, SymbolMap& substitutions);
+void recordCGInterimInstantiations(CallExpr* call, ResolutionCandidate* best1,
+                       ResolutionCandidate* best2, ResolutionCandidate* best3);
+void adjustForCGinstantiation(FnSymbol* fn, SymbolMap& substitutions,
+                              bool isInterimInstantiation);
+bool cgActualCanMatch(FnSymbol* fn, Type* formalT, ConstrainedType* actualCT);
 void createGenericStandins();
 void cleanupGenericStandins();
 

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -964,11 +964,11 @@ bool ResolutionCandidate::checkGenericFormals(Expr* ctx) {
       }
 
       if (ConstrainedType* actCT = toConstrainedType(actual->getValType())) {
-        if (actCT == formal->type)
+        if (actCT == formal->type) {
           ; // ok: a CG actual matches against the same type
-        else if (cgActualCanMatch(fn, formal->getValType(), actCT))
+        } else if (cgActualCanMatch(fn, formal->getValType(), actCT)) {
           ; // other matching cases
-        else {
+        } else {
           // cannot pass a CG actual to an unconstrained-generic formal
           failingArgument = actual;
           reason = RESOLUTION_CANDIDATE_INTERFACE_FORMAL_AS_ACTUAL;

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -50,6 +50,7 @@ std::map<Type*,std::map<Type*,bool> > actualFormalCoercible;
 
 ResolutionCandidate::ResolutionCandidate(FnSymbol* function) {
   fn = function;
+  isInterimInstantiation = false;
   failingArgument = NULL;
   reason = RESOLUTION_CANDIDATE_MATCH;
 }
@@ -138,7 +139,7 @@ bool ResolutionCandidate::isApplicableGeneric(CallInfo& info,
    * filtering and disambiguation processes.
    */
   fn = instantiateSignature(fn, substitutions, visInfo);
-  adjustForCGinstantiation(fn, substitutions);
+  adjustForCGinstantiation(fn, substitutions, isInterimInstantiation);
 
   if (fn == NULL) {
     reason = RESOLUTION_CANDIDATE_OTHER;
@@ -160,14 +161,19 @@ bool ResolutionCandidate::isApplicableCG(CallInfo& info,
                                          VisibilityInfo* visInfo) {
   int indx = 0;
   for_alist(iconExpr, fn->interfaceInfo->interfaceConstraints) {
-    IfcConstraint* icon = toIfcConstraint(iconExpr);
-    if (ImplementsStmt* istm =
-          constraintIsSatisfiedAtCallSite(info.call, icon, substitutions))
-    {
-      // success
-      witnesses.push_back(istm);
-      copyIfcRepsToSubstitutions(fn, indx++, istm, substitutions);
+    ConstraintSat csat = constraintIsSatisfiedAtCallSite(info.call,
+                             toIfcConstraint(iconExpr), substitutions);
+    if (csat.istm != nullptr) {
+      // satisfied with an implements statement
+      witnesses.push_back(csat.istm);
+      copyIfcRepsToSubstitutions(fn, indx++, csat.istm, substitutions);
+
+    } else if (csat.icon != nullptr) {
+      // satisfied with a constraint of the enclosing GC function
+      isInterimInstantiation = true;
+
     } else {
+      // not satisfied, making this CG fn not applicable
       return false;
     }
   }
@@ -957,18 +963,18 @@ bool ResolutionCandidate::checkGenericFormals(Expr* ctx) {
         return false;
       }
 
-      if (ConstrainedType* cat = toConstrainedType(actual->getValType()))
-        // a CT actual matches only against itself
-        if (cat != formal->type)
-          // allow stand-in types to match any generic formal at this point
-          if (! (cat->ctUse == CT_GENERIC_STANDIN &&
-                 (formal->type == dtUnknown ||
-                  formal->type == dtAny     ||
-                  formal->type->symbol->hasFlag(FLAG_GENERIC))) ) {
-            failingArgument = actual;
-            reason = RESOLUTION_CANDIDATE_INTERFACE_FORMAL_AS_ACTUAL;
-            return false;
-          }
+      if (ConstrainedType* actCT = toConstrainedType(actual->getValType())) {
+        if (actCT == formal->type)
+          ; // ok: a CG actual matches against the same type
+        else if (cgActualCanMatch(fn, formal->getValType(), actCT))
+          ; // other matching cases
+        else {
+          // cannot pass a CG actual to an unconstrained-generic formal
+          failingArgument = actual;
+          reason = RESOLUTION_CANDIDATE_INTERFACE_FORMAL_AS_ACTUAL;
+          return false;
+        }
+      }
 
       if (formalIsTypeAlias == false &&
           isInitThis == false &&

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3490,9 +3490,12 @@ static FnSymbol* resolveNormalCall(CallInfo& info, check_state_t checkState) {
     }
   }
 
-  if (! overloadSetsOK(info.call, checkState, candidates,
-                       bestRef, bestCref, bestVal)) {
-    return NULL; // overloadSetsOK() found an error
+  if (numMatches > 0) {
+    if (! overloadSetsOK(info.call, checkState, candidates,
+                         bestRef, bestCref, bestVal))
+      return NULL; // overloadSetsOK() found an error
+
+    recordCGInterimInstantiations(info.call, bestRef, bestCref, bestVal);
   }
 
   if (numMatches == 0) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -509,7 +509,7 @@ static void markTypesWithDefaultInitEqOrAssign(FnSymbol* fn);
 static void resolveAlsoConversions(FnSymbol* fn, CallExpr* forCall);
 
 void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
-  if (fn->isResolved() == false) {
+  if (! fn->isResolved() && ! fn->hasFlag(FLAG_CG_INTERIM_INST)) {
     if (fn->id == breakOnResolveID) {
       printf("breaking on resolve fn %s[%d] (%d args)\n",
              fn->name, fn->id, fn->numFormals());

--- a/test/constrained-generics/basic/set2/cgfun-call-cgfun-1.chpl
+++ b/test/constrained-generics/basic/set2/cgfun-call-cgfun-1.chpl
@@ -1,0 +1,25 @@
+/*
+CG function #1 invokes CG function #2
+where the interface constraint of #2 is satisfied with that of #1.
+*/
+
+interface IFC {
+  proc show(msg: string, arg: Self);
+  proc writeln(msg: string, arg: Self);
+}
+
+int implements IFC;
+proc show(msg: string, arg: int) { writeln(msg, arg); }
+
+cgFun1(123);
+
+proc cgFun1(arg1: ?Q1) where Q1 implements IFC {
+  show("cgFun1: ", arg1);
+  writeln("cgFun1: ", arg1);
+  cgFun2(arg1);
+}
+
+proc cgFun2(arg2: ?Q2) where Q2 implements IFC {
+  show("cgFun2: ", arg2);
+  writeln("cgFun2: ", arg2);
+}

--- a/test/constrained-generics/basic/set2/cgfun-call-cgfun-1.good
+++ b/test/constrained-generics/basic/set2/cgfun-call-cgfun-1.good
@@ -1,0 +1,4 @@
+cgFun1: 123
+cgFun1: 123
+cgFun2: 123
+cgFun2: 123


### PR DESCRIPTION
This enables calling a CG function from another CG function
when the callee's interface constraint(s) are satisfied with
the caller's CG constraints. For example:
```chpl
proc f1(arg1: ?Q1) where Q1 implements IFC {
  f2(arg1);   // relies on 'Q1 implements IFC'
}
proc f2(arg2: ?Q2) where Q2 implements IFC {
  .....
}
```

Implementation outline is described in a `CGfun1 calls CGfun2` comment
in interfaceResolution.cpp .

While there, minor reshuffle in flags_list.h and functionResolution.cpp .
