### PR TITLE
Remove old chplenv launcher detection

### DIFF
--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -88,7 +88,6 @@ If ``CHPL_LAUNCHER`` is left unset, a default is picked as follows:
   =======================  ==============================================
   CHPL_COMM_SUBSTRATE=ibv  gasnetrun_ibv
   CHPL_COMM_SUBSTRATE=mpi  gasnetrun_mpi
-  CHPL_COMM_SUBSTRATE=mxm  gasnetrun_ibv
   CHPL_COMM_SUBSTRATE=smp  smp
   CHPL_COMM_SUBSTRATE=udp  amudprun
   otherwise                none

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -53,14 +53,10 @@ def get():
                 launcher_val = 'gasnetrun_ibv'
             elif substrate_val == 'ucx':
                 launcher_val = 'gasnetrun_ucx'
-            elif substrate_val == 'mxm':
-                launcher_val = 'gasnetrun_ibv'
             elif substrate_val == 'ofi':
                 launcher_val = 'gasnetrun_ofi'
             elif substrate_val == 'psm':
                 launcher_val = 'gasnetrun_psm'
-        elif comm_val == 'mpi':
-            launcher_val = 'mpirun'
         else:
             launcher_val = 'none'
 


### PR DESCRIPTION
There hasn't been an mxm conduit in gasnet for years and we haven't had
CHPL_COMM=mpi for even longer so remove detection for these configs.