### PR TITLE
Improve launcher detection, especially on Cray CS systems

### DIFF
--- a/util/cron/test-cray-cs-gpu-interop.bash
+++ b/util/cron/test-cray-cs-gpu-interop.bash
@@ -8,7 +8,6 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-interop"
 
 export CHPL_COMM_SUBSTRATE=ibv
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 
 module load cudatoolkit
 export CHPL_TEST_GPU=true

--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -8,7 +8,6 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
 
 export CHPL_COMM=none
-export CHPL_LAUNCHER=slurm-srun
 
 module load cudatoolkit
 export CHPL_LLVM=bundled

--- a/util/cron/test-perf.cray-cs-hdr.arkouda.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.bash
@@ -22,7 +22,6 @@ module list
 
 export GASNET_PHYSMEM_MAX="9/10"
 export GASNET_ODP_VERBOSE=0
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_nightly

--- a/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
@@ -25,7 +25,6 @@ module list
 
 export GASNET_PHYSMEM_MAX="9/10"
 export GASNET_ODP_VERBOSE=0
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_release

--- a/util/cron/test-perf.cray-cs.arkouda.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.bash
@@ -21,7 +21,6 @@ module list
 
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
 # workaround for https://github.com/Cray/chapel-private/issues/1598

--- a/util/cron/test-perf.cray-cs.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.release.bash
@@ -24,7 +24,6 @@ module list
 
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
 # workaround for https://github.com/Cray/chapel-private/issues/1598

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -21,7 +21,6 @@ export CHPL_TEST_TIMEOUT=1800
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX=83G
 export CHPL_GASNET_MORE_CFG_OPTIONS=--disable-ibv-odp
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance-description gn-ibv-fast -numtrials 1"
 

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
@@ -16,7 +16,6 @@ source $CWD/common-perf-cray-cs.bash
 
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance-description gn-ibv-large -numtrials 3"
 

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -18,7 +18,6 @@ module load openmpi/gcc
 
 export CHPL_COMM_SUBSTRATE=mpi
 export GASNET_QUIET=y
-export CHPL_LAUNCHER=slurm-gasnetrun_mpi
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance-description gn-mpi -numtrials 1"
 

--- a/util/cron/test-slurm-gasnet-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-ibv.fast.bash
@@ -10,7 +10,6 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.fast"
 
 export CHPL_COMM_SUBSTRATE=ibv
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 
 # Test a GASNet compile using the fast segment
 export CHPL_GASNET_SEGMENT=fast

--- a/util/cron/test-slurm-gasnet-ibv.large.bash
+++ b/util/cron/test-slurm-gasnet-ibv.large.bash
@@ -10,7 +10,6 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.large"
 
 export CHPL_COMM_SUBSTRATE=ibv
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 
 # Test a GASNet compile using the large segment
 export CHPL_GASNET_SEGMENT=large

--- a/util/cron/test-slurm-gasnet-ibv.llvm.bash
+++ b/util/cron/test-slurm-gasnet-ibv.llvm.bash
@@ -12,6 +12,5 @@ source $CWD/common-llvm.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ibv.llvm"
 
 export CHPL_COMM_SUBSTRATE=ibv
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 
 $CWD/nightly -cron -examples ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-mpi.bash
+++ b/util/cron/test-slurm-gasnet-mpi.bash
@@ -10,6 +10,5 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-mpi"
 # setup for mpi
 module load openmpi/gcc
 export CHPL_COMM_SUBSTRATE=mpi
-export CHPL_LAUNCHER=slurm-gasnetrun_mpi
 
 $CWD/nightly -cron -hellos ${nightly_args}


### PR DESCRIPTION
This improves our `CHPL_LAUNCHER` autodetection to pick better defaults
for gasnet, especially on Cray CS systems. Previously, on cray-cs
systems we'd usually default to `slurm-srun`, but for gasnet we want a
`slurm-gasnetrun_*` launcher (or just gasnetrun_* if it's not a slurm
system, but slurm is the common case.) This improves that detection, but
will still default to `slurm-srun` for ofi or comm=none.

Now that we're auto-detecting `CHPL_LAUNCHER` better we don't need to
explicitly set it as much in our nightly testing scripts.