### PR TITLE
Limit when we auto-detect slurm-srun to cray-* systems

### DIFF
--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -63,7 +63,7 @@ def get():
             elif substrate_val == 'psm':
                 launcher_val = 'gasnetrun_psm'
         else:
-            if find_executable('srun'):
+            if platform_val == 'cray-cs' and find_executable('srun'):
                 launcher_val = 'slurm-srun'
             else:
                 launcher_val = 'none'


### PR DESCRIPTION
In 17302 I changed out chplenv launcher detection to use slurm-srun if
srun is found and we're using `CHPL_COMM=none`, but that was triggering
for cases like chapcs where we want to run locally, but  slurm happens
to be available. For now just restrict the slurm-srun to cray-* systems
(in this case limiting to cray-cs since other cases will catch cray-x*)