### PR TITLE
Remove deprecated implicit sync operations from a few more tests

### DIFF
--- a/test/interop/python/checkDiffModname.chpl
+++ b/test/interop/python/checkDiffModname.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/interop/python/checkExplicitLibname.chpl
+++ b/test/interop/python/checkExplicitLibname.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/interop/python/noLibFlag/checkDiffPythonModname.chpl
+++ b/test/interop/python/noLibFlag/checkDiffPythonModname.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/interop/python/noLibFlag/pythonCompile.chpl
+++ b/test/interop/python/noLibFlag/pythonCompile.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/interop/python/testing.chpl
+++ b/test/interop/python/testing.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/parallel/begin/stonea/reports.chpl
+++ b/test/parallel/begin/stonea/reports.chpl
@@ -3,10 +3,10 @@ var a$ : sync bool;
 
 begin {
     writeln("In thread");
-    if a$ then
+    if a$.readFE() then
         writeln("impossible");
 }
 
-if a$ then
+if a$.readFE() then
     writeln("impossible");
 

--- a/test/parallel/begin/stonea/reportsManyThreads.chpl
+++ b/test/parallel/begin/stonea/reportsManyThreads.chpl
@@ -3,20 +3,20 @@ var a$ : sync bool;
 begin {
     begin {
         begin {
-        if a$ then writeln("impossible");
+        if a$.readFE() then writeln("impossible");
         }
-        if a$ then writeln("impossible");
+        if a$.readFE() then writeln("impossible");
     }
 
     begin {
-        if a$ then writeln("impossible");
+        if a$.readFE() then writeln("impossible");
     }
-    if a$ then writeln("impossible");
+    if a$.readFE() then writeln("impossible");
 }
 
 begin {
-    if a$ then writeln("impossible");
+    if a$.readFE() then writeln("impossible");
 }
 
 
-if a$ then writeln("impossible");
+if a$.readFE() then writeln("impossible");

--- a/test/parallel/cobegin/stonea/reports.chpl
+++ b/test/parallel/cobegin/stonea/reports.chpl
@@ -3,10 +3,10 @@ use Time;
 var a$ : sync bool;
 
 cobegin {
-    {sleep(1); if a$ then writeln("impossible"); }
-    {sleep(1); if a$ then writeln("impossible"); }
-    {sleep(1); if a$ then writeln("impossible"); }
-    {sleep(1); if a$ then writeln("impossible"); }
+    {sleep(1); if a$.readFE() then writeln("impossible"); }
+    {sleep(1); if a$.readFE() then writeln("impossible"); }
+    {sleep(1); if a$.readFE() then writeln("impossible"); }
+    {sleep(1); if a$.readFE() then writeln("impossible"); }
 }
 
-if a$ then writeln("impossible");
+if a$.readFE() then writeln("impossible");

--- a/test/parallel/sync/diten/returnSync.chpl
+++ b/test/parallel/sync/diten/returnSync.chpl
@@ -3,7 +3,7 @@ proc retSync(x: ?t): sync t {
   return xx;
 }
 
-var x = retSync(3);
+var x = retSync(3).readFE();
 var y: sync int = retSync(4);
 
 writeln(x.type:string, ", ", y.type:string);

--- a/test/parallel/sync/figueroa/DeadLock.chpl
+++ b/test/parallel/sync/figueroa/DeadLock.chpl
@@ -7,12 +7,12 @@ proc foo(u, v) {
 
   begin {
     writeln("2: initial value is ", s.readFE());
-    done = true;
+    done.writeEF(true);
     writeln("2: value is now ", s.readFE());
-    done = true;
+    done.writeEF(true);
   }
-  if done then writeln("1: writing ", v);
-  if done then s = v;
+  if done.readFE() then writeln("1: writing ", v);
+  if done.readFE() then s.writeEF(v);
 }
 
 foo(1, 5);

--- a/test/parallel/taskPool/figueroa/QueuedTasks.chpl
+++ b/test/parallel/taskPool/figueroa/QueuedTasks.chpl
@@ -1,8 +1,8 @@
 var b1, b2, b3: single bool;
 
-begin b2 = b1;
+begin b2.writeEF(b1.readFF());
 
-begin b3 = b1;
+begin b3.writeEF(b1.readFF());
 
 writeln(here.queuedTasks(), " tasks are queued up at the moment.");
-b1 = true;
+b1.writeEF(true);

--- a/test/parallel/taskPool/figueroa/TooManyThreads.chpl
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.chpl
@@ -30,11 +30,11 @@ proc ensureDefaultInit(arg) { }
 
 proc foo (x) {
 
-  if ready {
+  if ready.readFE() {
     total += x;
     count -= 1;
-    if count == 0 then done = true;
-    ready = true;
+    if count == 0 then done.writeEF(true);
+    ready.writeEF(true);
   }
     
 }
@@ -49,5 +49,5 @@ begin
   coforall i in 1..numThreads do
     foo (i);
 sleep (10);
-ready = true;
-if done then writeln ("total is ", total);
+ready.writeEF(true);
+if done.readFE() then writeln ("total is ", total);

--- a/test/parallel/taskPool/figueroa/TotalThreads.chpl
+++ b/test/parallel/taskPool/figueroa/TotalThreads.chpl
@@ -3,16 +3,16 @@ use Time;
 var b: bool;
 var b1, b2, b3: single bool;
 
-begin with (ref b) {b1 = true; b = b3;}
+begin with (ref b) {b1.writeEF(true); b = b3.readFF();}
 
-begin with (ref b) {b2 = b1; b = b3;}
+begin with (ref b) {b2.writeEF(b1.readFF()); b = b3.readFF();}
 
-if b2 {
+if b2.readFF() {
   var s: bool;
   var s1, s2: single bool;
   cobegin with (ref s) {
-    {s1 = true; s = s2;}
-    s2 = s1;
+    {s1.writeEF(true); s = s2.readFF();}
+    s2.writeEF(s1.readFF());
   }
   writeln(here.totalThreads(), " threads have been created up till now.");
   sleep(5);
@@ -21,4 +21,4 @@ if b2 {
   writeln(here.blockedTasks(), " are blocked at the moment.");
 }
 
-b3 = true;
+b3.writeEF(true);

--- a/test/trivial/sungeun/runningTasks2.chpl
+++ b/test/trivial/sungeun/runningTasks2.chpl
@@ -6,15 +6,15 @@ var c: sync int = n;
 var s: single bool;
 
 coforall i in 1..n {
-  var myc:int = c-1;
-  if myc==0 then s=true; else c=myc;
+  var myc:int = c.readFE()-1;
+  if myc==0 then s.writeEF(true); else c.writeEF(myc);
   // wait for everyone to get here
-  s;
+  s.readFF();
 
   if i!=n then
-  t[i];
+  t[i].readFE();
   writeln(here.runningTasks());
   if i!=1 then
-    t[i-1] = true;
+    t[i-1].writeEF(true);
 }
 


### PR DESCRIPTION
Follow up to PR #17287 - that PR deprecated implicit sync/single operations.

This PR resolves testing failures in quickstart and python interop 
configurations by changing implicit sync/single operations in the tests
to explicit operations.

Test change only - not reviewed.
