### PR TITLE
Add temporaries for some 'new's that doesn't have an owning user variable

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2058,9 +2058,9 @@ static bool callNeedsAnOwner(CallExpr* call) {
 
   if (call->numActuals() >= 1) {
     if (SymExpr *typeSE = toSymExpr(call->get(1))) {
-      if (isDecoratedClassType(typeSE->symbol()->type)) {
+      //if (isDecoratedClassType(typeSE->symbol()->type)) {
         return true;
-      }
+      //}
     }
   }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -42,7 +42,6 @@
 #include "stringutil.h"
 #include "TransformLogicalShortCircuit.h"
 #include "typeSpecifier.h"
-#include "view.h"
 #include "wellknown.h"
 
 #include <cctype>

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -43,6 +43,7 @@
 #include "TransformLogicalShortCircuit.h"
 #include "typeSpecifier.h"
 #include "wellknown.h"
+#include "view.h"
 
 #include <cctype>
 #include <set>
@@ -2038,6 +2039,8 @@ static IfExpr* getParentIfExpr(CallExpr* call) {
 
 static bool callNeedsAnOwner(CallExpr* call) {
   INT_ASSERT(call->isPrimitive(PRIM_NEW));
+
+  if (isArgSymbol(call->parentSymbol)) return false;
 
   bool hasOwner = true;
   if (IfExpr* parentIf = getParentIfExpr(call)) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -43,7 +43,6 @@
 #include "TransformLogicalShortCircuit.h"
 #include "typeSpecifier.h"
 #include "wellknown.h"
-#include "view.h"
 
 #include <cctype>
 #include <set>
@@ -2042,26 +2041,13 @@ static bool callNeedsAnOwner(CallExpr* call) {
 
   if (isArgSymbol(call->parentSymbol)) return false;
 
-  bool hasOwner = true;
   if (IfExpr* parentIf = getParentIfExpr(call)) {
     if (parentIf == parentIf->getStmtExpr()) {
-      hasOwner = false;
+      return true;
     }
   }
-  else {
-    if (call == call->getStmtExpr()) {
-      hasOwner = false;
-    }
-  }
-
-  if (hasOwner) return false;
-
-  if (call->numActuals() >= 1) {
-    if (SymExpr *typeSE = toSymExpr(call->get(1))) {
-      //if (isDecoratedClassType(typeSE->symbol()->type)) {
-        return true;
-      //}
-    }
+  else if (call == call->getStmtExpr()) {
+    return true;
   }
 
   return false;

--- a/test/classes/delete-free/owned/bare-owned-leak-alias-typefunction.chpl
+++ b/test/classes/delete-free/owned/bare-owned-leak-alias-typefunction.chpl
@@ -1,0 +1,12 @@
+class C {}
+
+type t = owned C;
+
+new t();
+
+proc getType() type {
+  return owned C;
+}
+
+new getType()();
+

--- a/test/classes/delete-free/owned/bare-owned-leak-alias-typefunction.execopts
+++ b/test/classes/delete-free/owned/bare-owned-leak-alias-typefunction.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/classes/delete-free/owned/bare-owned-leak.chpl
+++ b/test/classes/delete-free/owned/bare-owned-leak.chpl
@@ -1,0 +1,111 @@
+config param flag = true;
+
+class C {
+  var x: int;
+  proc init(x: int) { writeln("C.init"); this.x = x; }
+  proc deinit() { writeln("C.deinit"); }
+}
+
+new C(10);
+new shared C(10);
+new owned C(10);
+
+writeln();
+
+writeln("Begin anonymous scope");
+{
+  var a = new C(10);
+  var b = new owned C(10);
+  var c = new shared C(10);
+  writeln(a);
+  writeln(b);
+  writeln(c);
+}
+writeln("End anonymous scope");
+writeln();
+
+writeln("Begin anonymous scope -- ifexpr");
+{
+  var a = if flag then new C(10) else 0;
+  var b = if flag then new owned C(10) else 0;
+  var c = if flag then new shared C(10) else 0;
+  writeln(a);
+  writeln(b);
+  writeln(c);
+}
+writeln("End anonymous scope -- ifexpr");
+writeln();
+
+writeln("Begin: Record -- ifexpr in field declaration");
+{
+  record R {
+    var field1 = if flag then new C(10) else 0;
+    var field2 = if flag then new owned C(10) else 0;
+    var field3 = if flag then new shared C(10) else 0;
+  }
+  writeln(new R());
+}
+writeln("End: Record -- ifexpr in field declaration");
+writeln();
+
+writeln("Begin: Record -- ifexpr in init");
+{
+  record R {
+    var field1: C?;
+    var field2: owned C?;
+    var field3: shared C?;
+
+    proc init() {
+      field1 = if flag then new C(10) else 0;
+      field2 = if flag then new owned C(10) else 0;
+      field3 = if flag then new shared C(10) else 0;
+    }
+  }
+  writeln(new R());
+}
+writeln("End: Record -- ifexpr in init");
+writeln();
+
+writeln("Begin: Function local scope");
+{
+  proc foo() {
+    new C(10);
+    new owned C(10);
+    new shared C(10);
+    return 1;
+  }
+
+  writeln(foo());
+}
+writeln("End: Function local scope");
+writeln();
+
+writeln("Begin: Function local scope -- local type");
+{
+  proc bar() {
+    class D { }
+    new D();
+    new owned D();
+    new shared D();
+    return 2;
+  }
+
+  writeln(bar());
+}
+writeln("End: Function local scope -- local type");
+writeln();
+
+writeln("Begin: forall expr");
+{
+  var a = [i in 1..2] new C(10);
+  var b = [i in 1..2] new owned C(10);
+  var c = [i in 1..2] new shared C(10);
+
+  writeln(a);
+  writeln(b);
+  writeln(c);
+}
+writeln("End: forall expr");
+writeln();
+
+

--- a/test/classes/delete-free/owned/bare-owned-leak.execopts
+++ b/test/classes/delete-free/owned/bare-owned-leak.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/classes/delete-free/owned/bare-owned-leak.good
+++ b/test/classes/delete-free/owned/bare-owned-leak.good
@@ -1,0 +1,83 @@
+C.init
+C.deinit
+C.init
+C.deinit
+C.init
+C.deinit
+
+Begin anonymous scope
+C.init
+C.init
+C.init
+{x = 10}
+{x = 10}
+{x = 10}
+C.deinit
+C.deinit
+C.deinit
+End anonymous scope
+
+Begin anonymous scope -- ifexpr
+C.init
+C.init
+C.init
+{x = 10}
+{x = 10}
+{x = 10}
+C.deinit
+C.deinit
+C.deinit
+End anonymous scope -- ifexpr
+
+Begin: Record -- ifexpr in field declaration
+C.init
+C.init
+C.init
+(field1 = {x = 10}, field2 = {x = 10}, field3 = {x = 10})
+C.deinit
+C.deinit
+C.deinit
+End: Record -- ifexpr in field declaration
+
+Begin: Record -- ifexpr in init
+C.init
+C.init
+C.init
+(field1 = {x = 10}, field2 = {x = 10}, field3 = {x = 10})
+C.deinit
+C.deinit
+C.deinit
+End: Record -- ifexpr in init
+
+Begin: Function local scope
+C.init
+C.deinit
+C.init
+C.deinit
+C.init
+C.deinit
+1
+End: Function local scope
+
+Begin: Function local scope -- local type
+2
+End: Function local scope -- local type
+
+Begin: forall expr
+C.init
+C.init
+C.init
+C.init
+C.init
+C.init
+{x = 10} {x = 10}
+{x = 10} {x = 10}
+{x = 10} {x = 10}
+C.deinit
+C.deinit
+C.deinit
+C.deinit
+C.deinit
+C.deinit
+End: forall expr
+

--- a/test/classes/delete-free/owned/bare-owned-leak2.chpl
+++ b/test/classes/delete-free/owned/bare-owned-leak2.chpl
@@ -1,0 +1,34 @@
+class C {
+  var x: int;
+  proc init(_x) {x = _x; writeln("init(",x,")"); }
+  proc deinit() { writeln("deinit(",x,")"); }
+}
+
+proc foo() {
+  writeln("entering foo");
+  new owned C(1);
+  writeln("exiting foo");
+}
+
+foo();
+writeln("returned from foo()");
+writeln();
+
+proc bar() {
+  writeln("entering bar");
+  new borrowed C(2);
+  writeln("exiting bar");
+}
+
+bar();
+writeln("returned from bar()");
+writeln();
+
+proc baz() {
+  writeln("entering baz");
+  new shared C(3);
+  writeln("exiting baz");
+}
+
+baz();
+writeln("returned from baz()");

--- a/test/classes/delete-free/owned/bare-owned-leak2.execopts
+++ b/test/classes/delete-free/owned/bare-owned-leak2.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/classes/delete-free/owned/bare-owned-leak2.good
+++ b/test/classes/delete-free/owned/bare-owned-leak2.good
@@ -1,0 +1,17 @@
+entering foo
+init(1)
+deinit(1)
+exiting foo
+returned from foo()
+
+entering bar
+init(2)
+deinit(2)
+exiting bar
+returned from bar()
+
+entering baz
+init(3)
+deinit(3)
+exiting baz
+returned from baz()


### PR DESCRIPTION
This PR captures some `new C()` into compiler temporaries if they aren't
already.

Without this, some similar statements leak.

Resolves https://github.com/chapel-lang/chapel/issues/11101
Resolves https://github.com/chapel-lang/chapel/issues/15613

#### Implementation notes
- During normalize we check if this expression, or the parent `IfExpr` if it
  exists, is a statement.

  If so, we call `insertCallTempsWithStmt`, on such calls.

- My initial tought was to capture these some way during callDestructors, but
  this felt easier and somewhat more natural.

#### Test status
- [x] standard
- [x] gasnet



