### PR TITLE
Fix some issues with new tests locking in bug fixes

### DIFF
--- a/test/types/tuple/multilocale/bug-14226-simpler.chpl
+++ b/test/types/tuple/multilocale/bug-14226-simpler.chpl
@@ -38,4 +38,7 @@ proc main() {
    writeln("r2.y = ", r2.y);
    writeln("r2.y has locale ", r2.y.locale);
   }
+
+  delete r.y;
+  delete buff[0].y;
 }

--- a/test/types/tuple/multilocale/bug-14226.chpl
+++ b/test/types/tuple/multilocale/bug-14226.chpl
@@ -1,7 +1,9 @@
+use CPtr;
+
 proc getAddr(obj) {
-  return __primitive("cast", uint(64), __primitive("_wide_get_addr", obj));
+  return __primitive("_wide_get_addr", obj);
 }
-proc getAddrAndLocality(obj) : (locale, uint(64)) {
+proc getAddrAndLocality(obj) : (locale, c_void_ptr) {
   return (obj.locale, getAddr(obj));
 }
 class A {
@@ -14,7 +16,7 @@ class A {
  
 record B {
   var y : unmanaged A?;
-  var yinfo :(locale, uint(64));
+  var yinfo :(locale, c_void_ptr);
  
   proc init() {
 
@@ -45,4 +47,8 @@ on Locales[numLocales-1] {
     assert(x.y!.loc == Locales[0], "Bad object: ", x.y, ", locality info is ", getAddrAndLocality(x.y), " but should be ", x.yinfo);
   }
 }
+
+for b in buff do
+  delete b.y;
+
 writeln("Nothing to see here");


### PR DESCRIPTION
* I did not think to run memleaks testing on these tests, and hadn't
realized that they hadn't freed their unmanaged classes.  Do so here.

* There was a portability issue on linux32 due to casting a c_void_ptr
to a 64-bit integer.  I've rewritten the test to avoid the cast, which
I believe should resolve the issue, and via inspection of the generated
code it seems to.  That said, due to a lack of time today, I haven't
had the chance to run the test on linux32, so am relying on the nightly
run to do that where, if I haven't fixed it, there shouldn't be any new
noise.