### PR TITLE
Support copy elision for local variables of if/else blocks

### DIFF
--- a/compiler/passes/splitInit.cpp
+++ b/compiler/passes/splitInit.cpp
@@ -897,7 +897,9 @@ static bool doFindCopyElisionPoints(Expr* start,
 
       // Neither if nor else block returns. Migrate variables copied in
       // both blocks into the parent copy elision map. If a variable is
-      // not copied in both blocks, then we cannot elide it.
+      // defined in a higher scope and not copied in both blocks, then we
+      // cannot elide it. If it is local to a block, then we will elide
+      // it later.
       } else if (!ifRet && !elseRet) {
 
         // The loop below relies on the maps being ordered.

--- a/compiler/passes/splitInit.cpp
+++ b/compiler/passes/splitInit.cpp
@@ -895,11 +895,11 @@ static bool doFindCopyElisionPoints(Expr* start,
       if (ifRet && elseRet) {
         return true;
 
-      // Neither if nor else block returns. Migrate variables copied in
-      // both blocks into the parent copy elision map. If a variable is
+      // Neither if nor else block returns. Migrate elision points from 
+      // each block into the parent copy elision map. If a variable is
       // defined in a higher scope and not copied in both blocks, then we
-      // cannot elide it. If it is local to a block, then we can migrate
-      // it freely and it will be elided later. 
+      // cannot migrate it. If it is local to a block, then we can migrate
+      // it freely.
       } else if (!ifRet && !elseRet) {
 
         // The loop below relies on the maps being ordered.

--- a/test/types/records/copy-elision/CopyElisionIfBlock.chpl
+++ b/test/types/records/copy-elision/CopyElisionIfBlock.chpl
@@ -49,6 +49,7 @@ proc test3() {
 }
 test3();
 
+// Check copy elision for locals in conditional blocks.
 proc test4() {
   writeln('T4');
   var doBlock = true;
@@ -62,6 +63,7 @@ proc test4() {
 }
 test4();
 
+// Same as above, but from other direction.
 proc test5() {
   writeln('T5');
   var doBlock = false;
@@ -74,4 +76,27 @@ proc test5() {
   }
 }
 test5();
+
+proc test6() {
+  writeln('T6');
+
+  proc innerTest6(doBlock: bool) {
+    var branchName = if doBlock then "if" else "else";
+    writeln(branchName);
+
+    var x = new r();
+    if doBlock {
+      var a = x;
+      consumeElement(a);
+    } else {
+      var b = x;
+      return b;
+    }
+    return new r();
+  }
+
+  var x1 = innerTest6(doBlock=true);
+  var x2 = innerTest6(doBlock=false);
+}
+test6();
 

--- a/test/types/records/copy-elision/CopyElisionIfBlock.chpl
+++ b/test/types/records/copy-elision/CopyElisionIfBlock.chpl
@@ -1,0 +1,77 @@
+record r {
+  proc init() { writeln('default init'); }
+  proc init=(other: r) { writeln('init='); }
+  proc deinit() { writeln('deinit'); }
+}
+
+proc =(ref lhs: r, rhs: r) { writeln('assign'); }
+
+proc consumeElement(in elem) {}
+
+// I would expect elision to occur here for 'x', but it does not.
+proc test1() {
+  writeln('T1');
+  var doBlock = true;
+  if doBlock {
+    var x = new r();
+    consumeElement(x);
+  }
+}
+test1();
+
+// Same test but in an on block.
+proc test2() {
+  writeln('T2');
+  on Locales[0] {
+    var doBlock = true;
+    if doBlock {
+      var x = new r();
+      consumeElement(x);
+    }
+  }
+}
+test2();
+
+// This test mimics what I am trying to do in 'set._addElem()'.
+proc test3() {
+  use Memory.Initialization;
+
+  writeln('T3');
+  pragma "no auto destroy"
+  var x = new r();
+  on Locales[0] {
+    var doBlock = true;
+    if doBlock {
+      var moved = moveToValue(x);
+      consumeElement(moved);
+    }
+  }
+}
+test3();
+
+proc test4() {
+  writeln('T4');
+  var doBlock = true;
+  if doBlock {
+    var x = new r();
+    consumeElement(x);
+  } else {
+    var y = new r();
+    consumeElement(y);
+  }
+}
+test4();
+
+proc test5() {
+  writeln('T5');
+  var doBlock = false;
+  if doBlock {
+    var x = new r();
+    consumeElement(x);
+  } else {
+    var y = new r();
+    consumeElement(y);
+  }
+}
+test5();
+

--- a/test/types/records/copy-elision/CopyElisionIfBlock.chpl
+++ b/test/types/records/copy-elision/CopyElisionIfBlock.chpl
@@ -100,3 +100,23 @@ proc test6() {
 }
 test6();
 
+proc test7() {
+  use Memory.Initialization;
+
+  writeln('T7');
+
+  pragma "no auto destroy"
+  var x = new r();
+
+  on Locales[0] {
+    var moved = moveToValue(x);
+    var doBlock = true;
+    if doBlock {
+      consumeElement(moved);
+    } else {
+      var last = moved;
+    }
+  }
+}
+test7();
+

--- a/test/types/records/copy-elision/CopyElisionIfBlock.good
+++ b/test/types/records/copy-elision/CopyElisionIfBlock.good
@@ -13,3 +13,12 @@ deinit
 T5
 default init
 deinit
+T6
+if
+default init
+deinit
+default init
+else
+default init
+deinit
+deinit

--- a/test/types/records/copy-elision/CopyElisionIfBlock.good
+++ b/test/types/records/copy-elision/CopyElisionIfBlock.good
@@ -1,0 +1,15 @@
+T1
+default init
+deinit
+T2
+default init
+deinit
+T3
+default init
+deinit
+T4
+default init
+deinit
+T5
+default init
+deinit

--- a/test/types/records/copy-elision/CopyElisionIfBlock.good
+++ b/test/types/records/copy-elision/CopyElisionIfBlock.good
@@ -22,3 +22,6 @@ else
 default init
 deinit
 deinit
+T7
+default init
+deinit

--- a/test/types/records/copy-elision/CopyElisionIfBlockNested.bad
+++ b/test/types/records/copy-elision/CopyElisionIfBlockNested.bad
@@ -1,0 +1,5 @@
+T1
+default init
+init=
+deinit
+deinit

--- a/test/types/records/copy-elision/CopyElisionIfBlockNested.chpl
+++ b/test/types/records/copy-elision/CopyElisionIfBlockNested.chpl
@@ -1,0 +1,35 @@
+record r {
+  proc init() { writeln('default init'); }
+  proc init=(other: r) { writeln('init='); }
+  proc deinit() { writeln('deinit'); }
+}
+
+proc =(ref lhs: r, rhs: r) { writeln('assign'); }
+
+proc consumeElement(in elem) {}
+
+proc test1() {
+  writeln('T1');
+  var doBlock = false;
+  if doBlock {
+    var x = new r();
+    if doBlock {
+      var a = x;
+      consumeElement(a);
+    } else {
+      var b = x;
+      consumeElement(b);
+    }
+  } else {
+    var y = new r();
+    if doBlock {
+      var a = y;
+      consumeElement(a);
+    } else {
+      var b = y;
+      consumeElement(b);
+    }
+  }
+}
+test1();
+

--- a/test/types/records/copy-elision/CopyElisionIfBlockNested.future
+++ b/test/types/records/copy-elision/CopyElisionIfBlockNested.future
@@ -1,0 +1,1 @@
+Copy elision is not working for some styles of nested if/else

--- a/test/types/records/copy-elision/CopyElisionIfBlockNested.good
+++ b/test/types/records/copy-elision/CopyElisionIfBlockNested.good
@@ -1,0 +1,2 @@
+default init
+deinit

--- a/test/types/records/copy-elision/CopyElisionIfBlockNested.good
+++ b/test/types/records/copy-elision/CopyElisionIfBlockNested.good
@@ -1,2 +1,3 @@
+T1
 default init
 deinit


### PR DESCRIPTION
Support copy elision for local variables of if/else blocks (#17321)

Resolves #17307.

Adjust the logic that handles copy elision for if/else blocks so that
variables local to either block of a conditional are copy elided
if the normal prerequisites are met.

The following code no longer produces a copy for either `x` or `y`:

```chapel
proc consumeElement(in elem) {}

proc test1() {
  var doBlock = true;
  if doBlock {
    var x = new r();
    consumeElement(x);
  } else {
    var y = new r();
    consumeElement(y);
  }
}
test1();
```

Reviewed by @mppf. Thanks!

TESTING:

- [x] `ALL` on `linux64` when `COMM=none`
- [x] `ALL` on `linux64` when `COMM=gasnet`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>