### PR TITLE
Close an EndCount leak in throwing foralls

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1782,8 +1782,12 @@ findFollowingCheckErrorBlock(SymExpr* se, LabelSymbol*& outHandlerLabel,
         // handling label, to make sure that the end count is not leaked.
         else if (CallExpr* call = toCallExpr(cur)) {
           if (call->isNamed("_endCountFree")) {
-            INT_ASSERT(endCountFree == NULL);
-            endCountFree = call;
+            if (endCountFree == NULL) {
+              endCountFree = call;
+            }
+            else {
+              USR_WARN(call, "An unexpected pattern encountered. Your application may leak memory");
+            }
           }
         }
       }

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1746,7 +1746,7 @@ fixupErrorHandlingExits(BlockStmt* body, bool& adjustCaller) {
 
 static bool
 findFollowingCheckErrorBlock(SymExpr* se, LabelSymbol*& outHandlerLabel,
-    Symbol*& outErrorSymbol) {
+    Symbol*& outErrorSymbol, CallExpr*& endCountFree) {
   Expr* stmt = se->getStmtExpr(); // aka last scope
   Expr* scope = stmt->parentExpr;
 
@@ -1755,8 +1755,8 @@ findFollowingCheckErrorBlock(SymExpr* se, LabelSymbol*& outHandlerLabel,
       // Consider statements that appear before stmt
       // We are looking for a DefExpr of an error label
       for(Expr* cur = stmt->next; cur != NULL; cur = cur->next) {
-        if (DefExpr* def = toDefExpr(cur))
-          if (LabelSymbol* label = toLabelSymbol(def->sym))
+        if (DefExpr* def = toDefExpr(cur)) {
+          if (LabelSymbol* label = toLabelSymbol(def->sym)) {
             if (label->hasFlag(FLAG_ERROR_LABEL)) {
               outHandlerLabel = label;
               // find the error that this block is working with
@@ -1774,6 +1774,18 @@ findFollowingCheckErrorBlock(SymExpr* se, LabelSymbol*& outHandlerLabel,
               }
               INT_FATAL("Could not find error variable for handler");
             }
+          }
+        }
+        // in case there's an endCountFree between this expression and the
+        // label, we want to record it. The caller can use that information to
+        // insert a copy of that call right before jumping to the error
+        // handling label, to make sure that the end count is not leaked.
+        else if (CallExpr* call = toCallExpr(cur)) {
+          if (call->isNamed("_endCountFree")) {
+            INT_ASSERT(endCountFree == NULL);
+            endCountFree = call;
+          }
+        }
       }
     }
     stmt = scope;
@@ -1788,8 +1800,12 @@ void handleChplPropagateErrorCall(CallExpr* call) {
   INT_ASSERT(errSe && errSe->typeInfo() == dtError);
   LabelSymbol* label = NULL;
   Symbol* error = NULL;
-  if (findFollowingCheckErrorBlock(errSe, label, error)) {
+  CallExpr *endCountFree = NULL;
+  if (findFollowingCheckErrorBlock(errSe, label, error, endCountFree)) {
     errSe->remove();
+    if (endCountFree != NULL) {
+      call->insertBefore(endCountFree->copy());
+    }
     call->insertBefore(new CallExpr(PRIM_MOVE, error, errSe));
     call->insertBefore(new GotoStmt(GOTO_ERROR_HANDLING, label));
     call->remove();
@@ -1831,7 +1847,8 @@ replaceErrorFormalWithEnclosingError(SymExpr* se) {
     }
     INT_ASSERT(fixGoto);
 
-    if (findFollowingCheckErrorBlock(se, newLabel, newError)) {
+    CallExpr *dummy = NULL;
+    if (findFollowingCheckErrorBlock(se, newLabel, newError, dummy)) {
       // Adjust the current error handling block.
       // 1. Change the use of the error argument to use the
       // identified error variable.


### PR DESCRIPTION
This PR closes a leak with foralls whose body throw error(s).

Resolves https://github.com/chapel-lang/chapel/issues/12511

@mppf summarized the problem under that issue:

> We had defer blocks for the EndCount to make sure it is deleted. But these are
> processed (and changed to delete calls at the end of a block) in
> callDestructors. Then, lowerIterators lowers the ForallStmt into a more
> complex structure and no longer calls the delete if the body of the forall
> threw an error. I believe that this is only a problem now that ForallStmts get
> lowered later.

With this PR, `lowerIterators` now finds any `endCountFree` calls that show up
between the error's goto and the associated label, and creates a copy of that
`endCountFree` right before the goto.

#### Test Status

- [x] asan --memLeaks `errhandling/forall`
- [x] quickstart asan
- [x] standard
- [x] gasnet
