### PR TITLE
Close the leak coming from regexp.compile's error message

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -481,7 +481,7 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
     var err_str = qio_regexp_error(ret._regexp);
     var err_msg: string;
     try! {
-      err_msg = createStringWithNewBuffer(err_str) +
+      err_msg = createStringWithOwnedBuffer(err_str) +
                   " when compiling regexp '" + patternStr + "'";
     }
     throw new owned BadRegexpError(err_msg);

--- a/test/regexp/compileFailLeak.chpl
+++ b/test/regexp/compileFailLeak.chpl
@@ -1,0 +1,13 @@
+use Regexp;
+
+{
+  var re : regexp(string);
+  writeln("111111111111111111111");
+  try! {
+    re = compile("*");
+    writeln("Should not reach here");
+  } catch (e: BadRegexpError) {
+    writeln("222222222222222222222");
+    writeln(e.message());
+  }
+}

--- a/test/regexp/compileFailLeak.execopts
+++ b/test/regexp/compileFailLeak.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/regexp/compileFailLeak.good
+++ b/test/regexp/compileFailLeak.good
@@ -1,0 +1,3 @@
+111111111111111111111
+222222222222222222222
+no argument for repetition operator: * when compiling regexp '*'


### PR DESCRIPTION
QIO creates an error message when it fails to compile a regular expression. It
returns a `const char *`. Then, we create a Chapel string from it. However, we
aren't owning the error string buffer returned by QIO and that causes memory
leaks. This PR makes the Chapel string own the buffer.

This was a leak that we didn't know until @leekillough added deprecation test
that hit that leak in https://github.com/chapel-lang/chapel/pull/17245.

But that test will disappear once we remove the functionality, so this PR adds
a watered down version of the test to lock the behavior.

#### Test status
- [x] quickstart asan in `release/examples` and `regexp`
- [x] standard

