### PR TITLE
Add documentation related to PR #16896 (restrict sort to 1D rectangular)

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -424,8 +424,8 @@ proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
 
 /*
 
-Sort the elements in an array. It is up to the implementation to choose
-the sorting algorithm.
+Sort the elements in a 1D rectangular array.  The choice of sorting
+algorithm used is made by the implementation.
 
 .. note::
   This function currently either uses a parallel radix sort or a serial


### PR DESCRIPTION
This documentation should have been part of PR #16896, but I
overlooked it.  This just states in the documentation the restriction
that had been implicit before, but is now explicit.  I also
word-smithed a nearby sentence while here.
