### PR TITLE
Update the spec and primers for changes to method visibility and to describe tertiary methods

### DIFF
--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -36,21 +36,22 @@ are referred to as *primary methods*. For such methods, the
 ``type-binding`` is omitted and is taken to be the innermost class,
 record, or union in which the method is defined.
 
-Methods defined outside of such scopes are known as *secondary methods*
-and must have a ``type-binding`` (otherwise, they would simply be
-standalone functions rather than methods). Note that secondary methods
-can be defined not only for classes, records, and unions, but also for
-any other type (e.g., integers, reals, strings).
+Methods defined outside of the lexical scope of a class, record, or union,
+but within the scope where the type itself is defined are known as
+*secondary methods*.  Methods defined outside of both the lexical scope and
+the scope where the type itself is defined are known as *tertiary methods*.
+Both secondary and tertiary methods must have a ``type-binding`` (otherwise,
+they would simply be standalone functions rather than methods). Note that
+secondary and tertiary methods can be defined not only for classes, records,
+and unions, but also for any other type (e.g., integers, reals, strings).
 
-.. _Secondary_Methods_with_Type_Expressions:
+.. _Secondary_And_Tertiary_Methods_with_Type_Expressions:
 
-Secondary methods can be
-declared with a type expression instead of a type identifier. In
-particular, if the ``type-binding`` is a parenthesized expression, the
-compiler will evaluate that expression to find the receiver type for the
-method. In that case, the method applies only to receivers of that type.
-See also
-:ref:`Creating_General_and_Specialized_Versions_of_a_Function`.
+Secondary and tertiary methods can be declared with a type expression instead of
+a type identifier. In particular, if the ``type-binding`` is a parenthesized
+expression, the compiler will evaluate that expression to find the receiver type
+for the method. In that case, the method applies only to receivers of that type.
+See also :ref:`Creating_General_and_Specialized_Versions_of_a_Function`.
 
 Method calls are described in :ref:`Method_Calls`.
 

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -125,6 +125,16 @@ arguments in the method declaration following the rules specified for
 procedures (:ref:`Chapter-Procedures`). The exception is the
 receiver :ref:`Method_receiver_and_this`.
 
+Primary or secondary methods can be called wherever an instance of the type is
+available.  Tertiary methods are only available if the module which defines them
+has been imported or used in such a way that allows these methods to be called
+(see :ref:`Using_Modules` and :ref:`Importing_Modules`).
+
+.. note::
+
+   Future work: privacy specifiers for methods are still under discussion and
+   will impact their visibility when implemented.
+
 .. _Method_receiver_and_this:
 
 The Method Receiver and the *this* Argument

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -125,15 +125,16 @@ arguments in the method declaration following the rules specified for
 procedures (:ref:`Chapter-Procedures`). The exception is the
 receiver :ref:`Method_receiver_and_this`.
 
-Primary or secondary methods can be called wherever an instance of the type is
-available.  Tertiary methods are only available if the module which defines them
-has been imported or used in such a way that allows these methods to be called
-(see :ref:`Using_Modules` and :ref:`Importing_Modules`).
+A primary or secondary method is always visible when the receiver is of the type
+to which the method is bound or of a subtype of such type.  Tertiary methods are
+only visible if the module which defines them has been imported or used in such
+a way that allows these methods to be called (see :ref:`Using_Modules` and
+:ref:`Importing_Modules`).
 
 .. note::
 
-   Future work: privacy specifiers for methods are still under discussion and
-   will impact their visibility when implemented.
+   Future work: the semantics of privacy specifiers for methods are still under
+   discussion.
 
 .. _Method_receiver_and_this:
 

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -576,13 +576,12 @@ not exist or is not visible in the respective module or enumerated type.
 If an ``only`` list is left empty or an ``except`` list is followed by :math:`*`
 then no symbols are made available to the scope without prefix.
 
-A type may be listed in a ``limitation clause`` for a use of a module which
-contains tertiary method definitions for that type.  Listing the type in this
-way will impact the visibility of such methods in scopes where the ``use``
-statement is visible.  These methods cannot be specified in a
-``limitation-clause`` on their own.  Methods and fields defined in the type's
-definition or secondary methods defined in the same scope as the type are
-already visible to any instance of the type, see :ref:`Method_Calls`.
+When the ``limitation-clause`` for a use of a module contains a type, the
+visibility of its tertiary methods that are defined in that module, if any, are
+affected in the same way as the visibility of the type itself.  Methods cannot
+be specified in a ``limitation-clause`` on their own.  Fields, and primary and
+secondary methods are visible to any instance of the type regardless of use
+statements, see :ref:`Method_Calls`.
 
 Within an ``only`` list, a visible symbol from that module may optionally be
 given a new name using the ``as`` keyword. This new name will be usable from the
@@ -768,13 +767,12 @@ to enable this behavior.  It is an error to provide a name in an
 ``unqualified-list`` that does not exist or is not visible in the respective
 module.
 
-A type may be listed in an ``unqualified-list`` for an import of a module which
-contains tertiary method definitions for that type.  Listing the type in this
-way will allow such methods to be visible in scopes where the ``import``
-statement is visible. These fields and methods cannot be specified in an
-``unqualified-list`` on their own.  Methods and fields defined in the type's
-definition or secondary methods defined in the same scope as the type are
-already visible to any instance of the type, see :ref:`Method_Calls`.
+When the ``unqualified-list`` for an import of a module contains a type, its
+tertiary methods that are defined in that module, if any, are visible in the
+scopes where the ``import`` statement is visible.  Methods cannot be specified
+in an ``unqualified-list`` on their own.  Fields, and primary and secondary
+methods are visible to any instance of the type regardless of import statements,
+see :ref:`Method_Calls`.
 
 Within an ``unqualified-list``, a visible symbol from that module may optionally
 be given a new name using the ``as`` keyword.  This new name will be usable from

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -573,15 +573,15 @@ enumerated type (unless the module has been renamed to ``_``, as described
 earlier). It is an error to provide a name in a ``limitation-clause`` that does
 not exist or is not visible in the respective module or enumerated type.
 
-If an ``only`` list is left empty or an ``except`` list is followed by :math:`*`
+If an ``only`` list is left empty or an ``except`` is followed by :math:`*`
 then no symbols are made available to the scope without prefix.
 
 When the ``limitation-clause`` for a use of a module contains a type, the
-visibility of its tertiary methods that are defined in that module, if any, are
-affected in the same way as the visibility of the type itself.  Methods cannot
-be specified in a ``limitation-clause`` on their own.  Fields, and primary and
-secondary methods are visible to any instance of the type regardless of use
-statements, see :ref:`Method_Calls`.
+visibility of its tertiary methods that are defined in that module, if any, is
+affected in the same way as the visibility of the type itself.  Fields and
+methods cannot be specified in a ``limitation-clause`` on their own.  Fields,
+and primary and secondary methods are visible to any instance of the type
+regardless of use statements, see :ref:`Method_Calls`.
 
 Within an ``only`` list, a visible symbol from that module may optionally be
 given a new name using the ``as`` keyword. This new name will be usable from the
@@ -769,10 +769,10 @@ module.
 
 When the ``unqualified-list`` for an import of a module contains a type, its
 tertiary methods that are defined in that module, if any, are visible in the
-scopes where the ``import`` statement is visible.  Methods cannot be specified
-in an ``unqualified-list`` on their own.  Fields, and primary and secondary
-methods are visible to any instance of the type regardless of import statements,
-see :ref:`Method_Calls`.
+scopes where the ``import`` statement is visible.  Fields and methods cannot be
+specified in an ``unqualified-list`` on their own.  Fields, and primary and
+secondary methods are visible to any instance of the type regardless of import
+statements, see :ref:`Method_Calls`.
 
 Within an ``unqualified-list``, a visible symbol from that module may optionally
 be given a new name using the ``as`` keyword.  This new name will be usable from

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -573,50 +573,16 @@ enumerated type (unless the module has been renamed to ``_``, as described
 earlier). It is an error to provide a name in a ``limitation-clause`` that does
 not exist or is not visible in the respective module or enumerated type.
 
-If a type or type's secondary methods are defined in the used module, then any
-instances of the type obtained in the scope of the use may access the fields and
-methods of that type, regardless of the ``limitation-clause``. These fields
-and methods cannot be specified in a ``limitation-clause`` on their own.  The
-privacy of use statements is also ignored when determining if an instance can
-access the fields and methods, for similar reasons.
+If an ``only`` list is left empty or an ``except`` list is followed by :math:`*`
+then no symbols are made available to the scope without prefix.
 
-If an ``only`` list is left empty or ``except`` is followed by :math:`*`
-then no symbols are made available to the scope without prefix. However,
-any methods or fields defined within a module used in this way will
-still be accessible on instances of the type. For example:
-
-   *Example (limited-access.chpl)*.
-
-
-
-   .. code-block:: chapel
-
-      module M1 {
-        record A {
-          var x = 1;
-
-          proc foo() {
-            writeln("In A.foo()");
-          }
-        }
-      }
-
-      module M2 {
-        proc main() {
-          use M1 only;
-
-          var a = new M1.A(3); // Only accessible via the module prefix
-          writeln(a.x); // Accessible because we have a record instance
-          a.foo(); // Ditto
-        }
-      }
-
-   will print out
-
-   .. code-block:: printoutput
-
-      3
-      In A.foo()
+A type may be listed in a ``limitation clause`` for a use of a module which
+contains tertiary method definitions for that type.  Listing the type in this
+way will impact the visibility of such methods in scopes where the ``use``
+statement is visible.  These methods cannot be specified in a
+``limitation-clause`` on their own.  Methods and fields defined in the type's
+definition or secondary methods defined in the same scope as the type are
+already visible to any instance of the type, see :ref:`Method_Calls`.
 
 Within an ``only`` list, a visible symbol from that module may optionally be
 given a new name using the ``as`` keyword. This new name will be usable from the
@@ -802,12 +768,13 @@ to enable this behavior.  It is an error to provide a name in an
 ``unqualified-list`` that does not exist or is not visible in the respective
 module.
 
-If a type or type's secondary methods are defined in the imported module, then
-any instances of the type obtained in the scope of the import may access the
-fields and methods of that type, regardless of the ``unqualified-list``. These
-fields and methods cannot be specified in an ``unqualified-list`` on their own.
-The privacy of import statements is also ignored when determining if an instance
-can access the fields and methods, for similar reasons.
+A type may be listed in an ``unqualified-list`` for an import of a module which
+contains tertiary method definitions for that type.  Listing the type in this
+way will allow such methods to be visible in scopes where the ``import``
+statement is visible. These fields and methods cannot be specified in an
+``unqualified-list`` on their own.  Methods and fields defined in the type's
+definition or secondary methods defined in the same scope as the type are
+already visible to any instance of the type, see :ref:`Method_Calls`.
 
 Within an ``unqualified-list``, a visible symbol from that module may optionally
 be given a new name using the ``as`` keyword.  This new name will be usable from

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -116,6 +116,7 @@ module DifferentArguments {
 module RecMoreMethods {
   private use modToUse;
 
+  /* ``method3`` is a tertiary method defined on ``Rec`` */
   proc Rec.method3() {
     writeln("In Rec.method3()");
   }
@@ -566,14 +567,14 @@ module MainModule {
       // writeln(bar);        // this won't resolve since bar isn't available
     }
 
-    /* Class and record instances obtained in scopes where the type is not
+    /* Class and record instances obtained in scopes where their type is not
        otherwise visible can still access any fields and any methods defined in
-       their original scope.
+       their type's original scope.
 
        To impact the visibility of methods defined in modules other than where
-       the type was defined, the type itself can be listed in an ``only`` or
-       ``except`` list for ``use`` statements, or as one of the symbols listed
-       in an ``import`` statement.
+       the type was defined, known as "tertiary methods", the type itself can be
+       listed in an ``only`` or ``except`` list for ``use`` statements, or as
+       one of the symbols listed in an ``import`` statement.
     */
     {
       use modToUse only;

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -113,6 +113,14 @@ module DifferentArguments {
   }
 } // end of DifferentArguments module
 
+module RecMoreMethods {
+  private use modToUse;
+
+  proc Rec.method3() {
+    writeln("In Rec.method3()");
+  }
+} // end of RecMoreMethods module
+
 module MainModule {
   proc main() {
     writeln("Access from outside a module");
@@ -558,8 +566,14 @@ module MainModule {
       // writeln(bar);        // this won't resolve since bar isn't available
     }
 
-    /* When any of these are present, any instances of classes or records
-       will be able to access their symbols defined in that module.
+    /* Class and record instances obtained in scopes where the type is not
+       otherwise visible can still access any fields and any methods defined in
+       their original scope.
+
+       To impact the visibility of methods defined in modules other than where
+       the type was defined, the type itself can be listed in an ``only`` or
+       ``except`` list for ``use`` statements, or as one of the symbols listed
+       in an ``import`` statement.
     */
     {
       use modToUse only;
@@ -567,6 +581,9 @@ module MainModule {
       writeln(rec.field);            // Accessible because we have an instance
       rec.method1();                 // Ditto to the field case
       rec.method2();
+
+      use RecMoreMethods only Rec;
+      rec.method3();                 // Enabled by previous use statement
     }
 
     writeln();

--- a/test/release/examples/primers/modules.good
+++ b/test/release/examples/primers/modules.good
@@ -66,6 +66,7 @@ Limiting a use
 4
 In Rec.method1()
 In Rec.method2()
+In Rec.method3()
 
 Application to enums
 blue

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -25,6 +25,10 @@ record ExampleRecord2 {
 }
 proc ExampleRecord2.secondaryMethod() { }
 
+// Methods declared outside of a class or record and outside of the scope where
+// the type is defined are called tertiary methods.  Tertiary methods follow the
+// same declaration syntax as secondary methods.
+
 // This primer will use the secondary method form, but all of the special
 // methods can also be written as primary methods.
 


### PR DESCRIPTION
The privacy and limitation clauses of use and import statements are now
respected for methods, so remove descriptions that say otherwise.  Call
out that primary and secondary methods are still available but are not
tied to use and import statements in any way.  Because the distinction is
relevant, add descriptions of tertiary methods so that the term may be
used when necessary.

Double checked the built documentation links are all capable of being
followed and tested the release/examples directory after a `make spectests`