### PR TITLE
Remove a few more deprecated implicit sync operations

### DIFF
--- a/test/interop/python/multilocale/checkDiffModname.chpl
+++ b/test/interop/python/multilocale/checkDiffModname.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/interop/python/multilocale/checkExplicitLibname.chpl
+++ b/test/interop/python/multilocale/checkExplicitLibname.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);

--- a/test/interop/python/multilocale/testing.chpl
+++ b/test/interop/python/multilocale/testing.chpl
@@ -16,11 +16,11 @@ export proc parallelProg(numTasksToRun: int) {
 
 export proc threadring(passes: int, tasks: int) {
   var mailbox$: [1..tasks] sync int;
-  mailbox$[1] = 0;
+  mailbox$[1].writeEF(0);
   proc passTokens(tid) {
     do {
-      const numPasses = mailbox$[tid];
-      mailbox$[tid%tasks+1] = numPasses+1;
+      const numPasses = mailbox$[tid].readFE();
+      mailbox$[tid%tasks+1].writeEF(numPasses+1);
       if numPasses == passes then
         writeln(tid);
     } while (numPasses < passes);


### PR DESCRIPTION
Follow up to PR #17287 - that PR deprecated implicit sync/single operations.

This PR resolves testing failures in multilocale python interop
testing by changing implicit sync/single operations in the tests
to explicit operations.

Test change only - not reviewed.