### PR TITLE
Add tests of copy elision/split init with serial block

### DIFF
--- a/test/types/records/copy-elision/copy-elision-serial-local.chpl
+++ b/test/types/records/copy-elision/copy-elision-serial-local.chpl
@@ -1,0 +1,80 @@
+config param printInitDeinit = true;
+
+class C {
+  var xx: int = 0;
+}
+
+record R {
+  var x: int = 0;
+  var ptr: shared C = new shared C(0);
+  proc init() {
+    this.x = 0;
+    this.ptr = new shared C(0);
+    if printInitDeinit then writeln("init (default)");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    this.ptr = new shared C(arg);
+    if printInitDeinit then writeln("init ", arg, " ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    this.ptr = new shared C(other.ptr.xx);
+    if printInitDeinit then writeln("init= ", other.x, " ", other.ptr.xx);
+  }
+  proc postinit() {
+    if printInitDeinit then writeln("postinit ", x, " ", ptr.xx);
+  }
+  proc deinit() {
+    if printInitDeinit then writeln("deinit ", x, " ", ptr.xx);
+  }
+  proc toString() {
+    return "(" + this.x:string + " " + this.ptr.xx:string + ")";
+  }
+  proc ref set1() ref {
+    this.x = 1;
+    this.ptr.xx = 1;
+    return this;
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  if printInitDeinit then writeln("lhs", lhs.toString(), " = rhs", rhs.toString());
+  lhs.x = rhs.x;
+  lhs.ptr = new shared C(rhs.ptr.xx);
+}
+
+proc test100() {
+  writeln("test100");
+  var x = new R(1);
+  serial {
+    var y = x;
+  }
+}
+test100();
+
+proc test101() {
+  writeln("test101");
+  serial {
+    var x = new R(1);
+    var y = x;
+  }
+}
+test101();
+
+proc test200() {
+  writeln("test200");
+  var x = new R(1);
+  local {
+    var y = x;
+  }
+}
+test200();
+
+proc test201() {
+  writeln("test201");
+  local {
+    var x = new R(1);
+    var y = x;
+  }
+}
+test201();

--- a/test/types/records/copy-elision/copy-elision-serial-local.good
+++ b/test/types/records/copy-elision/copy-elision-serial-local.good
@@ -1,0 +1,16 @@
+test100
+init 1 1
+postinit 1 1
+deinit 1 1
+test101
+init 1 1
+postinit 1 1
+deinit 1 1
+test200
+init 1 1
+postinit 1 1
+deinit 1 1
+test201
+init 1 1
+postinit 1 1
+deinit 1 1

--- a/test/types/records/split-init/split-init-serial-local.chpl
+++ b/test/types/records/split-init/split-init-serial-local.chpl
@@ -1,0 +1,64 @@
+config const cond = false;
+config const otherCond = true;
+
+class C { }
+record R {
+  var x: int = 0;
+  var ptr: owned C = new owned C();
+  proc init() {
+    this.x = 0;
+    writeln("init");
+  }
+  proc init(arg:int) {
+    this.x = arg;
+    writeln("init ", arg);
+  }
+  proc init=(other: R) {
+    this.x = other.x;
+    writeln("init= ", other.x);
+  }
+}
+proc =(ref lhs:R, rhs:R) {
+  writeln("= ", lhs.x, " ", rhs.x);
+  lhs.x = rhs.x;
+}
+
+proc test100() {
+  writeln("test100");
+  var b;
+  serial {
+    b = new R(1);
+  }
+  writeln(b);
+}
+test100();
+
+proc test101() {
+  writeln("test101");
+  var b: R;
+  serial {
+    b = new R(1);
+  }
+  writeln(b);
+}
+test101();
+
+proc test200() {
+  writeln("test200");
+  var b;
+  local {
+    b = new R(1);
+  }
+  writeln(b);
+}
+test200();
+
+proc test201() {
+  writeln("test201");
+  var b: R;
+  local {
+    b = new R(1);
+  }
+  writeln(b);
+}
+test201();

--- a/test/types/records/split-init/split-init-serial-local.good
+++ b/test/types/records/split-init/split-init-serial-local.good
@@ -1,0 +1,12 @@
+test100
+init 1
+(x = 1, ptr = {})
+test101
+init 1
+(x = 1, ptr = {})
+test200
+init 1
+(x = 1, ptr = {})
+test201
+init 1
+(x = 1, ptr = {})


### PR DESCRIPTION
PRs #17285 and #17258 fix problems with split init and copy elision with 
local blocks. I realized that I don't think we have testing for the same
issue within serial blocks, so this PR just adds test that do that to
make sure it continues to work in the future. The new tests check both
serial and local blocks for records.

Test change only - not reviewed.