### PR TITLE
update spec to clarify that serial,local blocks allowed for split-init, copy-elision

### DIFF
--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -132,11 +132,11 @@ omitted, the compiler will search forward in the function for the
 earliest assignment statement(s) setting that variable that occur before
 the variable is otherwise mentioned. It will consider the variable passed
 to an ``out`` intent argument as an assignment statement for this
-purpose.  It will search only within block declarations ``{ }``, ``try``
-blocks, ``try!`` blocks, and conditionals.  These assignment statements
-and calls to functions with ``out`` intent are called applicable
-assignment statements.  They perform initialization, not assignment, of
-that variable.
+purpose.  It will search only within block declarations ``{ }``,
+``local`` blocks, ``serial`` blocks, ``try`` blocks, ``try!`` blocks, and
+conditionals.  These assignment statements and calls to functions with
+``out`` intent are called applicable assignment statements.  They perform
+initialization, not assignment, of that variable.
 
    *Example (simple-split-init.chpl)*
 
@@ -906,8 +906,8 @@ is not mentioned again, the copy will be elided.  Since a ``return`` or
 ``throw`` exits a function, a copy can be elided if it is followed
 immediately by a ``return`` or ``throw``. When searching forward from
 variable declarations, copy elision considers eliding copies only within
-block declarations ``{ }``, ``try`` blocks, ``try!`` blocks, and
-conditionals.
+block declarations ``{ }``, ``local`` blocks, ``serial`` blocks, ``try``
+blocks, ``try!`` blocks, and conditionals.
 
    *Example (copy-elision.chpl)*
 

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -128,11 +128,11 @@ expression for a variable to be in a statement after the variable
 declaration statement.
 
 If the ``initialization-part`` of a local variable declaration is
-omitted, the compiler will search forward in the function for the
-earliest assignment statement(s) setting that variable that occur before
+omitted, the compiler will search forward in that scope for the
+earliest assignment statement(s) setting that variable that occurs before
 the variable is otherwise mentioned. It will consider the variable passed
 to an ``out`` intent argument as an assignment statement for this
-purpose.  It will search only within block declarations ``{ }``,
+purpose.  It will search only within block statements ``{ }``,
 ``local`` blocks, ``serial`` blocks, ``try`` blocks, ``try!`` blocks, and
 conditionals.  These assignment statements and calls to functions with
 ``out`` intent are called applicable assignment statements.  They perform
@@ -906,7 +906,7 @@ is not mentioned again, the copy will be elided.  Since a ``return`` or
 ``throw`` exits a function, a copy can be elided if it is followed
 immediately by a ``return`` or ``throw``. When searching forward from
 variable declarations, copy elision considers eliding copies only within
-block declarations ``{ }``, ``local`` blocks, ``serial`` blocks, ``try``
+block statements ``{ }``, ``local`` blocks, ``serial`` blocks, ``try``
 blocks, ``try!`` blocks, and conditionals.
 
    *Example (copy-elision.chpl)*


### PR DESCRIPTION
Follow-up to PRs #17258 and #17285.

Document in spec that serial and local blocks are allowed for split init
and copy elision.

Note that the local block is documented in the technote:

  https://chapel-lang.org/docs/technotes/local.html

but the serial block is in the spec

  https://chapel-lang.org/docs/language/spec/task-parallelism-and-synchronization.html#the-serial-statement

Reviewed by @bradcray - thanks!
