### PR TITLE
Add memory leak annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1382,6 +1382,12 @@ memleaksfull:
     - Support fixed sized arrays of tuples containing non-nilable classes (#16802)
   02/21/21:
     - CG enable return types and calling required functions (#17197)
+  02/25/21:
+    - Deprecate regexp ok and error() methods (#17245)
+  03/02/21:
+    - File tests locking in fixes to issue #14226 (#17291)
+  03/03/21:
+    - Fix some issues with new tests locking in bug fixes (#17320)
 # End memleaksfull
 
 meteor:


### PR DESCRIPTION
Annotates the following PRs that changed memory leaks:

- This PR added a test that exercised a Regexp code that we have never before
  and that leaks:

  https://github.com/chapel-lang/chapel/pull/17245

  (This is resolved today)

- New leaky tests:

  https://github.com/chapel-lang/chapel/pull/17291

  - That were resolved by:

    https://github.com/chapel-lang/chapel/pull/17320
