### PR TITLE
Ensure nilability is reflected is "called as" messages

### DIFF
--- a/compiler/AST/DecoratedClassType.cpp
+++ b/compiler/AST/DecoratedClassType.cpp
@@ -495,6 +495,8 @@ static void convertClassTypes(Type* (*convert)(Type*)) {
 }
 
 void convertClassTypesToCanonical() {
+  USR_STOP();
+
   // Anything that has unmanaged pointer type should be using the canonical
   // type instead.
   convertClassTypes(convertToCanonical);

--- a/test/classes/delete-free/lifetimes/errors-called-as.chpl
+++ b/test/classes/delete-free/lifetimes/errors-called-as.chpl
@@ -1,0 +1,19 @@
+// Test various successful scenarios of iterating over a linked list (owned)
+
+class clist {
+  var elm: int;
+  var next: owned clist?;
+}
+
+proc showU1(name: string, list) {
+  write("showU1 ", name, ":");
+  var curr = list: borrowed class?;
+  while const cur = curr {
+    write(" ", cur.elm);
+    curr = cur.next;
+  }
+  writeln();
+}
+
+var c0: owned clist? = nil;
+showU1("c0", c0);

--- a/test/classes/delete-free/lifetimes/errors-called-as.compopts
+++ b/test/classes/delete-free/lifetimes/errors-called-as.compopts
@@ -1,0 +1,4 @@
+--devel    --verify
+--no-devel --verify
+--devel    --no-verify
+--no-devel --no-verify

--- a/test/classes/delete-free/lifetimes/errors-called-as.good
+++ b/test/classes/delete-free/lifetimes/errors-called-as.good
@@ -1,0 +1,4 @@
+errors-called-as.chpl:8: In function 'showU1':
+errors-called-as.chpl:13: error: Scoped variable curr would outlive the value it is set to
+errors-called-as.chpl:11: note: consider scope of cur
+  errors-called-as.chpl:19: called as showU1(name: string, list: owned clist?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:10: error: cannot initialize 'owned MyClass' from a 'unmanaged MyClass'
-  init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-borrowed.good
@@ -1,4 +1,4 @@
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:10: error: invalid copy-initialization
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:10: error: cannot initialize 'owned MyClass' from a 'borrowed MyClass?'
-  init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:10: error: cannot initialize 'owned MyClass' from a 'unmanaged MyClass?'
-  init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:10: error: cannot initialize 'shared MyClass' from a 'unmanaged MyClass'
-  init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-borrowed.good
@@ -1,4 +1,4 @@
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:10: error: invalid copy-initialization
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:10: error: cannot initialize 'shared MyClass' from a 'borrowed MyClass?'
-  init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:10: error: cannot initialize 'shared MyClass' from a 'unmanaged MyClass?'
-  init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:10: error: cannot initialize 'owned MyClass?' from a 'unmanaged MyClass'
-  init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-borrowed.good
@@ -1,4 +1,4 @@
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:10: error: invalid copy-initialization
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:10: error: cannot initialize 'owned MyClass?' from a 'borrowed MyClass?'
-  init-field-arg-oknil-owned-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-oknil-owned-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:10: error: cannot initialize 'owned MyClass?' from a 'unmanaged MyClass?'
-  init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:10: error: cannot initialize 'shared MyClass?' from a 'unmanaged MyClass'
-  init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-borrowed.good
@@ -1,4 +1,4 @@
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:10: error: invalid copy-initialization
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:10: error: cannot initialize 'shared MyClass?' from a 'borrowed MyClass?'
-  init-field-arg-oknil-shared-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-oknil-shared-from-oknil-borrowed.chpl:14: called as MyRecord.init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-unmanaged.good
@@ -1,4 +1,4 @@
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:10: error: invalid copy-initialization
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:10: error: cannot initialize 'shared MyClass?' from a 'unmanaged MyClass?'
-  init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: borrowed MyClass)
+  init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:14: called as MyRecord.init(rhs: unmanaged MyClass?)


### PR DESCRIPTION
This ensures that the argument type is shown as nilable when appropriate
in the "called as" lines of error messages, for example:
```
    errors-called-as.chpl:8: In function 'showU1':
    errors-called-as.chpl:13: error: Scoped variable curr would outlive the value it is set to
    errors-called-as.chpl:11: note: consider scope of cur
      errors-called-as.chpl:19: called as showU1(name: string, list: owned clist?)
```

#### Details

When compiling this test:
```
    test/classes/delete-free/lifetimes/errors-called-as.chpl
```
the compiler gives the above error in checkLifetimesAndNilDereferences()
during the callDestructors pass.

The last line of it ("called as ....") is, however, printed after the pass
completes and USR_STOP() is invoked, calling printCallstackForLastError().
Therefore this is after callDestructors runs convertClassTypesToCanonical(),
which eliminates nilability declarations from all class types. This makes
the argument type non-nilable and the message showing a non-nilable type
incorrectly.

To fix this, issue USR_STOP() as start of convertClassTypesToCanonical(),
so that the types remains unaffected, should they need to be printed out.

Updated a couple of .good files that previously showed non-nilable borrowed
types instead of nilable and/or unmanaged types in the "called as" messages.

Whether this symptom occurred depended on the test and on the combination
of ``--devel`` and ``--verify`` compilation options.
