### PR TITLE
CG: Fix memory leaks with strings

### DIFF
--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -830,7 +830,7 @@ bool requiresImplicitDestroy(CallExpr* call) {
 
   if (FnSymbol* fn = call->resolvedFunction()) {
 
-    if (isRecord(fn->retType)                                 == true  &&
+    if ((isRecord(fn->retType) || isConstrainedType(fn->retType))      &&
         fn->hasFlag(FLAG_NO_IMPLICIT_COPY)                    == false &&
         fn->isIterator()                                      == false &&
         fn->retType->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE) == false &&


### PR DESCRIPTION
This fixes memory leaks arising when CG functions pass around the values
of interface types and get instantiated with strings.

The fix is to ensure that FLAG_INSERT_AUTO_DESTROY is added on CG
variables when it would be for a record.

I did not add any new tests because the previously-leaked tests
are here to stay:
```
test/constrained-generics/basic/set2/call-reqfns-from-dfltimpls.chpl
test/constrained-generics/basic/set2/returning-self.chpl
```

We have discussed making CG types behave like records w.r.t. memory
management throughout resolution. This remains outside the scope
of this PR.

Testing:
* [x] standard paratest
* [x] -memleaks over CG tests
* [x] valgrind over CG tests
