### PR TITLE
Restore some 'inline' markings to IO.chpl

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2218,7 +2218,7 @@ proc channel._ch_ioerror(errstr:string, msg:string) throws {
 
    :throws SystemError: Thrown if the lock could not be acquired.
  */
-proc channel.lock() throws {
+inline proc channel.lock() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
@@ -2235,7 +2235,7 @@ proc channel.lock() throws {
 /*
    Release a channel's lock.
  */
-proc channel.unlock() {
+inline proc channel.unlock() {
   if locking {
     on this.home {
       qio_channel_unlock(_channel_internal);
@@ -3574,7 +3574,7 @@ private proc _args_to_proto(const args ...?k, preArg:string) {
 
 // better documented in the style= version
 /* returns true if read successfully, false if we encountered EOF */
-proc channel.read(ref args ...?k):bool throws {
+inline proc channel.read(ref args ...?k):bool throws {
   if writing then compilerError("read on write-only channel");
   const origLocale = this.getLocaleOfIoRequest();
 
@@ -3989,7 +3989,7 @@ proc channel.read(type t ...?numTypes) throws where numTypes > 1 {
 
 // documented in style= error= version
 pragma "no doc"
-proc channel.write(const args ...?k):bool throws {
+inline proc channel.write(const args ...?k):bool throws {
   if !writing then compilerError("write on read-only channel");
 
   const origLocale = this.getLocaleOfIoRequest();
@@ -5211,7 +5211,7 @@ proc _toIntegral(x:?t) where isIntegralType(t)
 {
   return (x, true);
 }
-private
+private inline
 proc _toIntegral(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
@@ -5253,7 +5253,7 @@ proc _toSigned(x:uint(64))
   return (x:int(64), true);
 }
 
-private
+private inline
 proc _toSigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (int, bool);
@@ -5296,7 +5296,7 @@ proc _toUnsigned(x:int(64))
 }
 
 
-private
+private inline
 proc _toUnsigned(x:?t) throws where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
   var ret: (uint, bool);
@@ -5318,7 +5318,7 @@ proc _toReal(x:?t) where isRealType(t)
 {
   return (x, true);
 }
-private
+private inline
 proc _toReal(x:?t) throws where _isIoPrimitiveType(t) && !isRealType(t)
 {
   var ret: (real, bool);
@@ -5339,7 +5339,7 @@ proc _toImag(x:?t) where isImagType(t)
 {
   return (x, true);
 }
-private
+private inline
 proc _toImag(x:?t) throws where _isIoPrimitiveType(t) && !isImagType(t)
 {
   var ret: (imag, bool);
@@ -5361,7 +5361,7 @@ proc _toComplex(x:?t) where isComplexType(t)
 {
   return (x, true);
 }
-private
+private inline
 proc _toComplex(x:?t) throws where _isIoPrimitiveType(t) && !isComplexType(t)
 {
   var ret: (complex, bool);
@@ -5403,7 +5403,7 @@ proc _toNumeric(x:?t) where isNumericType(t)
 {
   return (x, true);
 }
-private
+private inline
 proc _toNumeric(x:?t) throws where _isIoPrimitiveType(t) && !isNumericType(t)
 {
   // enums, bools get cast to int.


### PR DESCRIPTION
This restores some of the 'inline' markings to IO.chpl that were
removed in PR #16887.  They were removed hoping that they would speed
up compilation, but turned out not to have that large of an impact, at
least for things we measure, or in aggregate, in our testing system.
However, they did have a somewhat adverse effect on one of our fasta
implementations, which is IO-heavy, which gave us pause about the
implications for other IO-heavy programs.

This PR restores some, but not all, of those 'inline's for the following
reasons:

* restores them to lock() and unlock() because for unlocked
  files, the amount of code in those routines is minimal, and
  these proved to be on the critical path in Elliot's experiments

* restored them for read() and write() because these are the
  powerhouses of I/O, and most of the heavy lifting is done
  in per-argument subroutines, so we don't expect them to hurt
  much.

* restored them for the _to*() overloads on enums because what little
  complexity was in those routines is a param conditional, so they're
  really no more complex than the others

We thought about restoring all of them just to return to the status
quo, but I left them off the following routines:

* left them off of mark/offset because these don't seem obviously
  deeply time-critical to me and seem nontrivial

* left them off of _read_binary_internal/_write_binary_internal/
  _read_one_internal/_write_one_internal because these seem like
  precisely the type of routine that we'd want to stamp out once
  per type being read/written, and they're not obviously trivial.

* left them off of readbits and chpl_do_format for similar reasons.

Number of lines in generated code *.c for a --fast compile of fasta.chpl:

            caseyb/fasta   arkouda
    master:    31682       894627
    this:      31990       908974
    % increase   <1%         1.6%

As a note if people wanted to mess with this more in the future:
* We noted that we could potentially create clones of routines (like lock/unlock)
  where we used `where` clauses to inline in the no-locking case because the
  routines are virtually no-ops there; but to not inline in the locking case where
  things are going to be more expensive anyway
* We also noted that for `--no-local` compilations where many of these
  routines contain on-clauses, the inlining will really only be inlining the arg
  bundlings, since the on-clauses will already be pushed out into their own
  functions (for `--local` compilations, those on-clauses are dropped on the
  floor).

Should at least partially address the regressions in https://github.com/Cray/chapel-private/issues/1787