### PR TITLE
CG: Fix some compiler crashes

### DIFF
--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -424,7 +424,7 @@ Type* desugarInterfaceAsType(ArgSymbol* arg, SymExpr* se,
 // and did not succeed.
 //
 
-const char* implementsStmtWrapperName(InterfaceSymbol* isym) {
+const char* implementsWrapperName(InterfaceSymbol* isym) {
   return astr("|", isym->name);
 }
 
@@ -465,7 +465,7 @@ static void verifyWrapImplementsStmt(FnSymbol* wrapFn, ImplementsStmt* istm,
                                      bool isSuccess) {
   InterfaceSymbol* isym = istm->ifcSymbol();
 
-  INT_ASSERT(wrapFn->name == implementsStmtWrapperName(isym));
+  INT_ASSERT(wrapFn->name == implementsWrapperName(isym));
   INT_ASSERT(interfaceNameForWrapperFn(wrapFn) == isym->name);
   IstmAndSuccess iss = implementsStmtForWrapperFn(wrapFn);
   INT_ASSERT(iss.istm == istm);
@@ -488,7 +488,7 @@ FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm) {
     return NULL;
   }
   InterfaceSymbol* isym = istm->ifcSymbol();
-  FnSymbol* wrapFn = new FnSymbol(implementsStmtWrapperName(isym));
+  FnSymbol* wrapFn = new FnSymbol(implementsWrapperName(isym));
   wrapFn->addFlag(FLAG_IMPLEMENTS_WRAPPER);
   istm->insertBefore(new DefExpr(wrapFn));
   wrapFn->insertAtTail(istm->remove());

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -322,7 +322,7 @@ public:
 
 // support for implements wrapper functions
 class IstmAndSuccess { public: ImplementsStmt* istm; bool isSuccess; };
-const char*     implementsStmtWrapperName(InterfaceSymbol* isym);
+const char*     implementsWrapperName(InterfaceSymbol* isym);
 const char*     interfaceNameForWrapperFn(FnSymbol* fn);
 IstmAndSuccess  implementsStmtForWrapperFn(FnSymbol* wrapFn);
 FnSymbol*       wrapperFnForImplementsStmt(ImplementsStmt* istm);

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_increasing_constraints.bad
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_increasing_constraints.bad
@@ -1,3 +1,0 @@
-tier_2_increasing_constraints.chpl:37: error: unresolved call 'writeln(T)'
-tier_2_increasing_constraints.chpl:37: note: because actual argument #1 of an interface type T
-tier_2_increasing_constraints.chpl:37: note: other candidates are:

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_increasing_constraints.future
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_increasing_constraints.future
@@ -1,5 +1,0 @@
-bug: incorrect compiler reasoning with cgfun calling cgfun
-
-This test exposes at least two issues:
-* early compilation of 'minFn' succeeds when it shouldn't
-* writeln() gets invoked on a GC type, which it shouldn't

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_increasing_constraints.good
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_increasing_constraints.good
@@ -1,3 +1,4 @@
+tier_2_increasing_constraints.chpl:29: In function 'minFn':
 tier_2_increasing_constraints.chpl:31: error: unresolved call 'minFnPrime(T, T, T)'
 tier_2_increasing_constraints.chpl:17: note: this candidate did not match: minFnPrime(x: ?T, y: T, ifeq: T)
 tier_2_increasing_constraints.chpl:17: note: because interface constraint(s) were not satisfied

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_independent_check_single_model.future
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_independent_check_single_model.future
@@ -1,1 +1,0 @@
-bug: unhandled return value of cgfun called from cgfun

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_model_duplication.bad
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_model_duplication.bad
@@ -1,8 +1,1 @@
-tier_2_model_duplication.chpl:26: internal error: UTI-MIS-0894 chpl version 1.24.0 pre-release (81371c9883)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+84

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_model_duplication.future
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_model_duplication.future
@@ -1,1 +1,1 @@
-bug: compiler crash with cgfun calling cgfun
+bug: incorrect witness is used for a call to CG function

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_single_interface_multi_model.bad
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_single_interface_multi_model.bad
@@ -1,8 +1,1 @@
-tier_2_single_interface_multi_model.chpl:31: internal error: UTI-MIS-nnnn chpl version mmmm
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+41

--- a/test/constrained-generics/ucol/cwailes-2/tier_2_single_interface_multi_model.future
+++ b/test/constrained-generics/ucol/cwailes-2/tier_2_single_interface_multi_model.future
@@ -1,1 +1,1 @@
-bug: compiler crash
+bug: incorrect witness is used for a call to CG function


### PR DESCRIPTION
In this PR:
* instantiate the return type of a CG function when resolving a call to it
* do not try to match constraints for different InterfaceSymbols
  in satisfyingEnclConstraint()
* adjust CG tests accordingly
* minor renaming and reformatting of CG code

Non-CG code is not affected.

Trivial, not reviewed.