### PR TITLE
Update cuBLAS to use a record to refer to device memory

### DIFF
--- a/test/gpu/interop/cuBLAS/cuBLAS.chpl
+++ b/test/gpu/interop/cuBLAS/cuBLAS.chpl
@@ -5,6 +5,11 @@ module cuBLAS {
   public use SysBasic;
   public use SysCTypes;
 
+  record DevicePtr {
+    type eltType;
+    var val: c_ptr(eltType);
+  }
+
   proc cublas_create_handle(){
     return cublas_create();
   }
@@ -20,196 +25,196 @@ module cuBLAS {
      return x;
   }
 
-  proc cpu_to_gpu(src_ptr: c_ptr, size: size_t){
+  proc cpu_to_gpu(src_ptr: c_ptr(?t), size: size_t){
     require "c_cublas.h", "c_cublas.o";
-    var gpu_ptr;
-    gpu_ptr = to_gpu(src_ptr, size);
+    var gpu_ptr: DevicePtr(t);
+    gpu_ptr.val = to_gpu(src_ptr, size): c_ptr(t);
     return gpu_ptr;
   }
 
-  proc gpu_to_cpu(dst_ptr: c_void_ptr, src_ptr: c_void_ptr, size: size_t){
+  proc gpu_to_cpu(dst_ptr: c_void_ptr, src_ptr: DevicePtr, size: size_t){
     require "c_cublas.h", "c_cublas.o";
-    to_cpu(dst_ptr, src_ptr, size);
+    to_cpu(dst_ptr, src_ptr.val, size);
   }
 
-  proc cu_saxpy(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), y: c_ptr(c_float), ref alpha: c_float, incX: c_int = 1, incY: c_int = 1){
+  proc cu_saxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), ref alpha: c_float, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_saxpy(handle, n, alpha, x, incX, y, incY);
+    cublas_saxpy(handle, n, alpha, x.val, incX, y.val, incY);
   }
 
-  proc cu_daxpy(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), y: c_ptr(c_double), ref alpha: c_double, incX: c_int = 1, incY: c_int = 1){
+  proc cu_daxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), ref alpha: c_double, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_daxpy(handle, n, alpha, x, incX, y, incY);
+    cublas_daxpy(handle, n, alpha, x.val, incX, y.val, incY);
   } 
 
-  proc cu_caxpy(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), ref alpha: complex(64), incX: c_int = 1, incY: c_int = 1){
+  proc cu_caxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), ref alpha: complex(64), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_caxpy(handle, n, alpha, x, incX, y, incY);
+    cublas_caxpy(handle, n, alpha, x.val, incX, y.val, incY);
   }
 
-  proc cu_zaxpy(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), ref alpha: complex(128), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zaxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), ref alpha: complex(128), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zaxpy(handle, n, alpha, x, incX, y, incY);
+    cublas_zaxpy(handle, n, alpha, x.val, incX, y.val, incY);
   }
 
-  proc cu_isamax(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), incX: c_int, result: c_ptr(c_int)){
+  proc cu_isamax(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_isamax(handle, n, x, incX, result);
+    cublas_isamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_idamax(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), incX: c_int, result: c_ptr(c_int)){
+  proc cu_idamax(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_idamax(handle, n, x, incX, result);
+    cublas_idamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_icamax(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_icamax(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_icamax(handle, n, x, incX, result);
+    cublas_icamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_izamax(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_izamax(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_izamax(handle, n, x, incX, result);
+    cublas_izamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_isamin(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), incX: c_int, result: c_ptr(c_int)){
+  proc cu_isamin(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_isamin(handle, n, x, incX, result);
+    cublas_isamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_idamin(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), incX: c_int, result: c_ptr(c_int)){
+  proc cu_idamin(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_idamin(handle, n, x, incX, result);
+    cublas_idamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_icamin(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_icamin(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_icamin(handle, n, x, incX, result);
+    cublas_icamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_izamin(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_izamin(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_izamin(handle, n, x, incX, result);
+    cublas_izamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_sasum(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), incX: c_int, result: c_ptr(c_float)){
+  proc cu_sasum(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_float)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sasum(handle, n, x, incX, result);
+    cublas_sasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_dasum(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), incX: c_int, result: c_ptr(c_double)){
+  proc cu_dasum(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_double)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dasum(handle, n, x, incX, result);
+    cublas_dasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_scasum(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), incX: c_int, result: c_ptr(c_float)){
+  proc cu_scasum(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_float)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_scasum(handle, n, x, incX, result);
+    cublas_scasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_dzasum(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), incX: c_int, result: c_ptr(c_double)){
+  proc cu_dzasum(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_double)){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dzasum(handle, n, x, incX, result);
+    cublas_dzasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_scopy(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), y: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_scopy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_scopy(handle, n, x, incX, y, incY);
+    cublas_scopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_dcopy(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), y: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dcopy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dcopy(handle, n, x, incX, y, incY);
+    cublas_dcopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_ccopy(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_ccopy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_ccopy(handle, n, x, incX, y, incY);
+    cublas_ccopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_zcopy(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zcopy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zcopy(handle, n, x, incX, y, incY);
+    cublas_zcopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_sdot(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), y: c_ptr(c_float), result: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_sdot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), result: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sdot(handle, n, x, incX, y, incY, result);
+    cublas_sdot(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_ddot(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), y: c_ptr(c_double), result: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_ddot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), result: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_ddot(handle, n, x, incX, y, incY, result);
+    cublas_ddot(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_cdotu(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_cdotu(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cdotu(handle, n, x, incX, y, incY, result);
+    cublas_cdotu(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_cdotc(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_cdotc(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cdotc(handle, n, x, incX, y, incY, result);
+    cublas_cdotc(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_zdotu(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zdotu(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zdotu(handle, n, x, incX, y, incY, result);
+    cublas_zdotu(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_zdotc(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zdotc(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zdotc(handle, n, x, incX, y, incY, result);
+    cublas_zdotc(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_snrm2(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), result: c_ptr(c_float), incX: c_int = 1){
+  proc cu_snrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), result: c_ptr(c_float), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_snrm2(handle, n, x, incX, result);
+    cublas_snrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_dnrm2(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), result: c_ptr(c_double), incX: c_int = 1){
+  proc cu_dnrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), result: c_ptr(c_double), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dnrm2(handle, n, x, incX, result);
+    cublas_dnrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_scnrm2(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), result: c_ptr(c_float), incX: c_int = 1){
+  proc cu_scnrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), result: c_ptr(c_float), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_scnrm2(handle, n, x, incX, result);
+    cublas_scnrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_dznrm2(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), result: c_ptr(c_double), incX: c_int = 1){
+  proc cu_dznrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), result: c_ptr(c_double), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dznrm2(handle, n, x, incX, result);
+    cublas_dznrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_srot(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), y: c_ptr(c_float), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
+  proc cu_srot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_srot(handle, n, x, incX, y, incY, c, s);
+    cublas_srot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_drot(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), y: c_ptr(c_double), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
+  proc cu_drot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_drot(handle, n, x, incX, y, incY, c, s);
+    cublas_drot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_crot(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), c: c_float, s: complex(64), incX: c_int = 1, incY: c_int = 1){
+  proc cu_crot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), c: c_float, s: complex(64), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_crot(handle, n, x, incX, y, incY, c, s);
+    cublas_crot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_csrot(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
+  proc cu_csrot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_csrot(handle, n, x, incX, y, incY, c, s);
+    cublas_csrot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_zrot(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), c: c_double, s: complex(128), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zrot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), c: c_double, s: complex(128), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zrot(handle, n, x, incX, y, incY, c, s);
+    cublas_zrot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_zdrot(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
+  proc cu_zdrot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zdrot(handle, n, x, incX, y, incY, c, s);
+    cublas_zdrot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
   proc cu_srotg(handle: c_void_ptr, a: c_float, b: c_float, ref c: c_float, ref s: c_float){
@@ -232,14 +237,14 @@ module cuBLAS {
     cublas_zrotg(handle, a, b, c, s);
   }
 
-  proc cu_srotm(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), y: c_ptr(c_float), params: []real(32), incX: c_int = 1, incY: c_int = 1){
+  proc cu_srotm(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), params: []real(32), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_srotm(handle, n, x, incX, y, incY, params);
+    cublas_srotm(handle, n, x.val, incX, y.val, incY, params);
   }
 
-  proc cu_drotm(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), y: c_ptr(c_double), params: []real(64), incX: c_int = 1, incY: c_int = 1){
+  proc cu_drotm(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), params: []real(64), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_drotm(handle, n, x, incX, y, incY, params);
+    cublas_drotm(handle, n, x.val, incX, y.val, incY, params);
   }
 
   proc cu_srotmg(handle: c_void_ptr, ref d1: c_float, ref d2: c_float, ref x1: c_float, ref y1: c_float, params: []real(32)){
@@ -252,131 +257,131 @@ module cuBLAS {
     cublas_drotmg(handle, d1, d2, x1, y1, params);
   }
 
-  proc cu_sscal(handle: c_void_ptr, n: c_int, alpha: c_float, x: c_ptr(c_float), incX: c_int = 1){
+  proc cu_sscal(handle: c_void_ptr, n: c_int, alpha: c_float, x: DevicePtr(c_float), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sscal(handle, n, alpha, x, incX);
+    cublas_sscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_dscal(handle: c_void_ptr, n: c_int, alpha: c_double, x: c_ptr(c_double), incX: c_int = 1){
+  proc cu_dscal(handle: c_void_ptr, n: c_int, alpha: c_double, x: DevicePtr(c_double), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dscal(handle, n, alpha, x, incX);
+    cublas_dscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_cscal(handle: c_void_ptr, n: c_int, alpha: complex(64), x: c_ptr(complex(64)), incX: c_int = 1){
+  proc cu_cscal(handle: c_void_ptr, n: c_int, alpha: complex(64), x: DevicePtr(complex(64)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cscal(handle, n, alpha, x, incX);
+    cublas_cscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_csscal(handle: c_void_ptr, n: c_int, alpha: c_float, x: c_ptr(complex(64)), incX: c_int = 1){
+  proc cu_csscal(handle: c_void_ptr, n: c_int, alpha: c_float, x: DevicePtr(complex(64)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_csscal(handle, n, alpha, x, incX);
+    cublas_csscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_zscal(handle: c_void_ptr, n: c_int, alpha: complex(128), x: c_ptr(complex(128)), incX: c_int = 1){
+  proc cu_zscal(handle: c_void_ptr, n: c_int, alpha: complex(128), x: DevicePtr(complex(128)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zscal(handle, n, alpha, x, incX);
+    cublas_zscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_zdscal(handle: c_void_ptr, n: c_int, alpha: c_double, x: c_ptr(complex(128)), incX: c_int = 1){
+  proc cu_zdscal(handle: c_void_ptr, n: c_int, alpha: c_double, x: DevicePtr(complex(128)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zdscal(handle, n, alpha, x, incX);
+    cublas_zdscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_sswap(handle: c_void_ptr, n: c_int, x: c_ptr(c_float), y: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_sswap(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sswap(handle, n, x, incX, y, incY);
+    cublas_sswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_dswap(handle: c_void_ptr, n: c_int, x: c_ptr(c_double), y: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dswap(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dswap(handle, n, x, incX, y, incY);
+    cublas_dswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_cswap(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), y: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_cswap(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cswap(handle, n, x, incX, y, incY);
+    cublas_cswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_zswap(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), y: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zswap(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zswap(handle, n, x, incX, y, incY);
+    cublas_zswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_sgemm(handle: c_void_ptr, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: c_float, A: c_ptr(c_float), lda: c_int, B: c_ptr(c_float), ldb: c_int, beta: c_float, c: c_ptr(c_float), ldc: c_int){
+  proc cu_sgemm(handle: c_void_ptr, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: c_float, A: DevicePtr(c_float), lda: c_int, B: DevicePtr(c_float), ldb: c_int, beta: c_float, c: DevicePtr(c_float), ldc: c_int){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, c, ldc);
+    cublas_sgemm(handle, transa, transb, m, n, k, alpha, A.val, lda, B.val, ldb, beta, c.val, ldc);
   }
 
 /*
-  proc cu_sgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: c_float, A: c_ptr(c_float), lda: c_int, x: c_ptr(c_float), incX: c_int, ref beta: c_float, y: c_ptr(c_float), incY: c_int){
+  proc cu_sgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: c_float, A: DevicePtr(c_float), lda: c_int, x: DevicePtr(c_float), incX: c_int, ref beta: c_float, y: DevicePtr(c_float), incY: c_int){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sgbmv(handle, m, n, kl, ku, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_sgbmv(handle, m, n, kl, ku, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_dgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: c_double, A: c_ptr(c_double), lda: c_int, x: c_ptr(c_double), incX: c_int, ref beta: c_double, y: c_ptr(c_double), incY: c_int){
+  proc cu_dgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: c_double, A: DevicePtr(c_double), lda: c_int, x: DevicePtr(c_double), incX: c_int, ref beta: c_double, y: DevicePtr(c_double), incY: c_int){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dgbmv(handle, m, n, kl, ku, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_dgbmv(handle, m, n, kl, ku, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_cgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: complex(64), A: c_ptr(complex(64)), lda: c_int, x: c_ptr(complex(64)), incX: c_int, ref beta: complex(64), y: c_ptr(complex(64)), incY: c_int){
+  proc cu_cgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: complex(64), A: DevicePtr(complex(64)), lda: c_int, x: DevicePtr(complex(64)), incX: c_int, ref beta: complex(64), y: DevicePtr(complex(64)), incY: c_int){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cgbmv(handle, m, n, kl, ku, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_cgbmv(handle, m, n, kl, ku, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_zgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: complex(128), A: c_ptr(complex(128)), lda: c_int, x: c_ptr(complex(128)), incX: c_int, ref beta: complex(128), y: c_ptr(complex(128)), incY: c_int){
+  proc cu_zgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: complex(128), A: DevicePtr(complex(128)), lda: c_int, x: DevicePtr(complex(128)), incX: c_int, ref beta: complex(128), y: DevicePtr(complex(128)), incY: c_int){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zgbmv(handle, m, n, kl, ku, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_zgbmv(handle, m, n, kl, ku, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 */
 
-  proc cu_sgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_float, A: c_ptr(c_float), lda: c_int, x: c_ptr(c_float), ref beta: c_float, y: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_sgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_float, A: DevicePtr(c_float), lda: c_int, x: DevicePtr(c_float), ref beta: c_float, y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sgemv(handle, trans, m, n, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_sgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_dgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_double, A: c_ptr(c_double), lda: c_int, x: c_ptr(c_double), ref beta: c_double, y: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_double, A: DevicePtr(c_double), lda: c_int, x: DevicePtr(c_double), ref beta: c_double, y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dgemv(handle, trans, m, n, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_dgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_cgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(64), A: c_ptr(complex(64)), lda: c_int, x: c_ptr(complex(64)), ref beta: complex(64), y: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_cgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(64), A: DevicePtr(complex(64)), lda: c_int, x: DevicePtr(complex(64)), ref beta: complex(64), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cgemv(handle, trans, m, n, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_cgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_zgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(128), A: c_ptr(complex(128)), lda: c_int, x: c_ptr(complex(128)), ref beta: complex(128), y: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_zgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(128), A: DevicePtr(complex(128)), lda: c_int, x: DevicePtr(complex(128)), ref beta: complex(128), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zgemv(handle, trans, m, n, alpha, A, lda, x, incX, beta, y, incY);
+    cublas_zgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_sger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_float, x: c_ptr(c_float), y: c_ptr(c_float), A: c_ptr(c_float), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_sger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_float, x: DevicePtr(c_float), y: DevicePtr(c_float), A: DevicePtr(c_float), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_sger(handle, m, n, alpha, x, incX, y, incY, A, lda);
+    cublas_sger(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_dger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_double, x: c_ptr(c_double), y: c_ptr(c_double), A: c_ptr(c_double), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_dger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_double, x: DevicePtr(c_double), y: DevicePtr(c_double), A: DevicePtr(c_double), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_dger(handle, m, n, alpha, x, incX, y, incY, A, lda);
+    cublas_dger(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_cgeru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: c_ptr(complex(64)), y: c_ptr(complex(64)), A: c_ptr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_cgeru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), A: DevicePtr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cgeru(handle, m, n, alpha, x, incX, y, incY, A, lda);
+    cublas_cgeru(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_cgerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: c_ptr(complex(64)), y: c_ptr(complex(64)), A: c_ptr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_cgerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), A: DevicePtr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_cgrec(handle, m, n, alpha, x, incX, y, incY, A, lda);
+    cublas_cgrec(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_zgeru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: c_ptr(complex(128)), y: c_ptr(complex(128)), A: c_ptr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_zgeru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), A: DevicePtr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zgeru(handle, m, n, alpha, x, incX, y, incY, A, lda);
+    cublas_zgeru(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_zgerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: c_ptr(complex(128)), y: c_ptr(complex(128)), A: c_ptr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_zgerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), A: DevicePtr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
-    cublas_zgerc(handle, m, n, alpha, x, incX, y, incY, A, lda);
+    cublas_zgerc(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
   module C_CUBLAS {

--- a/test/gpu/interop/cuBLAS/level1/test_cublas1.chpl
+++ b/test/gpu/interop/cuBLAS/level1/test_cublas1.chpl
@@ -176,16 +176,16 @@ proc test_cuamax_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_isamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_isamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when real(64) do {
-        cu_idamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_idamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(64) do {
-        cu_icamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_icamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(128) do {
-        cu_izamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_izamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
     }
 
@@ -209,16 +209,16 @@ proc test_cuamax_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_isamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_isamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when real(64) do {
-        cu_idamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_idamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(64) do {
-        cu_icamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_icamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(128) do {
-        cu_izamax(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_izamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
     }
 
@@ -250,16 +250,16 @@ proc test_cuamin_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_isamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_isamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when real(64) do {
-        cu_idamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_idamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(64) do {
-        cu_icamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_icamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(128) do {
-        cu_izamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_izamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
     }
 
@@ -283,16 +283,16 @@ proc test_cuamin_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_isamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_isamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when real(64) do {
-        cu_idamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_idamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(64) do {
-        cu_icamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_icamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
       when complex(128) do {
-        cu_izamin(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_izamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
       }
     }
 
@@ -339,22 +339,22 @@ proc test_cuasum_helper(type t) {
     select t {
       when real(32) do {
         var r : real(32);
-        cu_sasum(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_sasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
         err = norm - r;
       }
       when real(64) do {
         var r : real(64);
-        cu_dasum(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_dasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
         err = norm - r;
       }
       when complex(64) do {
         var r : real(32);
-        cu_scasum(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_scasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
         err = norm - r;
       }
       when complex(128) do {
         var r : real(64);
-        cu_dzasum(cublas_handle, N, gpu_ptr_X:c_ptr(t), 1, c_ptrTo(r));
+        cu_dzasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
         err = norm - r;
       }
     }
@@ -387,16 +387,16 @@ proc test_cucopy_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_scopy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_scopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
       when real(64) do {
-        cu_dcopy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_dcopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
       when complex(64) do {
-        cu_ccopy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_ccopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
       when complex(128) do {
-        cu_zcopy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_zcopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
     }
 
@@ -435,16 +435,16 @@ proc test_cuaxpy_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_saxpy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), a);
+        cu_saxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
       }
       when real(64) do {
-        cu_daxpy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), a);
+        cu_daxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
       }
       when complex(64) do {
-        cu_caxpy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), a);
+        cu_caxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
       }
       when complex(128) do {
-        cu_zaxpy(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), a);
+        cu_zaxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
       }
     }
 
@@ -485,10 +485,10 @@ proc test_cudot_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_sdot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c_ptrTo(r));
+        cu_sdot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(r));
       }
       when real(64) do {
-        cu_ddot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c_ptrTo(r));
+        cu_ddot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(r));
       }
     }
 
@@ -525,10 +525,10 @@ proc test_cudotu_helper(type t) {
 
     select t {
       when complex(64) do {
-        cu_cdotu(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c_ptrTo(res));
+        cu_cdotu(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
       }
       when complex(128) do {
-        cu_zdotu(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c_ptrTo(res));
+        cu_zdotu(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
       }
     }
 
@@ -565,10 +565,10 @@ proc test_cudotc_helper(type t) {
 
     select t {
       when complex(64) do {
-        cu_cdotc(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c_ptrTo(res));
+        cu_cdotc(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
       }
       when complex(128) do {
-        cu_zdotc(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c_ptrTo(res));
+        cu_zdotc(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
       }
     }
 
@@ -605,22 +605,22 @@ proc test_cunrm2_helper(type t) {
     select t {
       when real(32) do {
         var r: real(32);
-        cu_snrm2(cublas_handle, N, gpu_ptr_X:c_ptr(t), c_ptrTo(r));
+        cu_snrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
         err = norm - r;
       }
       when real(64) do {
         var r: real(64);
-        cu_dnrm2(cublas_handle, N, gpu_ptr_X:c_ptr(t), c_ptrTo(r));
+        cu_dnrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
         err = norm - r;
       }
       when complex(64) do {
         var r: real(32);
-        cu_scnrm2(cublas_handle, N, gpu_ptr_X:c_ptr(t), c_ptrTo(r));
+        cu_scnrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
         err = norm -r;
       }
       when complex(128) do {
         var r: real(64);
-        cu_dznrm2(cublas_handle, N, gpu_ptr_X:c_ptr(t), c_ptrTo(r));
+        cu_dznrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
         err = norm - r;
       }
     }
@@ -661,10 +661,10 @@ proc test_curot_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_srot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c, s);
+        cu_srot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
       }
       when real(64) do {
-        cu_drot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c, s);
+        cu_drot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
       }
     }
 
@@ -714,7 +714,7 @@ proc test_cucrot_helper(type t) {
 
     select t {
      when complex(64) do {
-        cu_crot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c, s);
+        cu_crot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
      }
     }
 
@@ -764,7 +764,7 @@ proc test_cuzrot_helper(type t) {
 
     select t {
      when complex(128) do {
-        cu_zrot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c, s);
+        cu_zrot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
      }
     }
 
@@ -814,7 +814,7 @@ proc test_cucsrot_helper(type t) {
 
     select t {
      when complex(64) do {
-        cu_csrot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c, s);
+        cu_csrot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
      }
     }
 
@@ -865,7 +865,7 @@ proc test_cuzdrot_helper(type t) {
 
     select t {
      when complex(128) do {
-        cu_zdrot(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), c, s);
+        cu_zdrot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
      }
     }
 
@@ -1106,10 +1106,10 @@ proc test_curotm_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_srotm(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), P);
+        cu_srotm(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, P);
       }
       when real(64) do {
-        cu_drotm(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t), P);
+        cu_drotm(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, P);
       }
     }
 
@@ -1245,16 +1245,16 @@ proc test_cuscal_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_sscal(cublas_handle, N, a, gpu_ptr_X:c_ptr(t));
+        cu_sscal(cublas_handle, N, a, gpu_ptr_X);
       }
       when real(64) do {
-        cu_dscal(cublas_handle, N, a, gpu_ptr_X:c_ptr(t));
+        cu_dscal(cublas_handle, N, a, gpu_ptr_X);
       }
       when complex(64) do {
-        cu_cscal(cublas_handle, N, a, gpu_ptr_X:c_ptr(t));
+        cu_cscal(cublas_handle, N, a, gpu_ptr_X);
       }
       when complex(128) do {
-        cu_zscal(cublas_handle, N, a, gpu_ptr_X:c_ptr(t));
+        cu_zscal(cublas_handle, N, a, gpu_ptr_X);
       }
     }
 
@@ -1292,7 +1292,7 @@ proc test_cucsscal_helper(type t) {
 
     select t {
       when complex(64) do {
-        cu_csscal(cublas_handle, N, a, gpu_ptr_X:c_ptr(t));
+        cu_csscal(cublas_handle, N, a, gpu_ptr_X);
       }
     }
 
@@ -1330,7 +1330,7 @@ proc test_cuzdscal_helper(type t) {
 
     select t {
       when complex(128) do {
-        cu_zdscal(cublas_handle, N, a, gpu_ptr_X:c_ptr(t));
+        cu_zdscal(cublas_handle, N, a, gpu_ptr_X);
       }
     }
 
@@ -1371,16 +1371,16 @@ proc test_cuswap_helper(type t) {
 
     select t {
       when real(32) do {
-        cu_sswap(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_sswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
       when real(64) do {
-        cu_dswap(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_dswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
       when complex(64) do {
-        cu_cswap(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_cswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
       when complex(128) do {
-        cu_zswap(cublas_handle, N, gpu_ptr_X:c_ptr(t), gpu_ptr_Y:c_ptr(t));
+        cu_zswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
       }
     }
 


### PR DESCRIPTION
Add a `DevicePtr` record that is returned from cpu_to_gpu that keeps track of
the pointed-to type along with the pointer.

Update functions to use the new record where device memory is expected.
Update tests to use the new type when calling those functions.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>