### PR TITLE
Update the documentation for operator changes

### DIFF
--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -62,7 +62,7 @@ An external procedure declaration has the following syntax:
 .. code-block:: syntax
 
    external-procedure-declaration-statement:
-     'extern' external-name[OPT] 'proc' function-name argument-list return-intent[OPT] return-type[OPT]
+     'extern' external-name[OPT] 'proc' identifier argument-list return-intent[OPT] return-type[OPT]
 
 Chapel code will call the external function using the parameter types
 supplied in the ``extern`` declaration. Therefore, in general, the type
@@ -140,7 +140,7 @@ An exported procedure declaration has the following syntax:
 .. code-block:: syntax
 
    exported-procedure-declaration-statement:
-     'export' external-name[OPT] 'proc' function-name argument-list return-intent[OPT] return-type[OPT]
+     'export' external-name[OPT] 'proc' identifier argument-list return-intent[OPT] return-type[OPT]
        function-body
 
    external-name:

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -13,7 +13,7 @@ Methods are declared with the following syntax:
 .. code-block:: syntax
 
    method-declaration-statement:
-     procedure-kind[OPT] proc-or-iter this-intent[OPT] type-binding[OPT] function-name argument-list[OPT]
+     procedure-kind[OPT] proc-or-iter this-intent[OPT] type-binding[OPT] identifier argument-list[OPT]
        return-intent[OPT] return-type[OPT] where-clause[OPT] function-body
 
    proc-or-iter:

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1185,7 +1185,7 @@ binary   ``==`` ``<=`` ``>=`` ``<`` ``>``
 binary   ``<<`` ``>>`` ``&`` ``|`` ``^`` ``#`` ``align`` ``by``
 binary   ``=`` ``+=`` ``-=`` ``*=`` ``/=`` ``%=`` ``**=``
 binary   ``&=`` ``|=`` ``^=`` ``<<=`` ``>>=`` ``<=>`` ``<~>``
-======== ==============================
+======== ===============================
 
 The arity and precedence of the operator must be maintained when it is
 overloaded. Operator resolution follows the same algorithm as function

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -111,10 +111,8 @@ Procedures are defined with the following syntax:
 .. code-block:: syntax
 
    procedure-declaration-statement:
-     privacy-specifier[OPT] procedure-kind[OPT] 'proc' identifier argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
-       function-body
-     privacy-specifier[OPT] procedure-kind[OPT] 'operator' operator-name argument-list return-intent[OPT] return-type[OPT] where-clause[OPT]
-       function-body
+     privacy-specifier[OPT] procedure-kind[OPT] 'proc' identifier argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT] function-body
+     privacy-specifier[OPT] procedure-kind[OPT] 'operator' operator-name argument-list return-intent[OPT] return-type[OPT] where-clause[OPT] function-body
 
    procedure-kind:
      'inline'
@@ -124,8 +122,9 @@ Procedures are defined with the following syntax:
 
    operator-name: one of
      + - * / % ** : ! == != <= >= < > << >> & | ^ ~
-     = += -= *= /= %= **= &= |= ^= <<= >>= <=> <~>
-     'by' 'align'
+     = += -= *= /= %= **= &= |= ^= <<= >>= <=> <~> #
+     'by'
+     'align'
 
    argument-list:
      ( formals[OPT] )
@@ -1172,9 +1171,9 @@ called overloaded functions. Function calls to overloaded functions are
 resolved according to the function resolution algorithm
 in :ref:`Function_Resolution`.
 
-Operator overloading is achieved by defining a function with a name specified by
-that operator.  This function is declared with the ``operator`` keyword.  The
-operators that may be overloaded are listed in the following table:
+To define an overloaded operator, use the ``operator`` keyword to define a
+function with the same name as the operator.  The operators that may be
+overloaded are listed in the following table:
 
 ======== ===============================
 arity    operators

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -111,7 +111,9 @@ Procedures are defined with the following syntax:
 .. code-block:: syntax
 
    procedure-declaration-statement:
-     privacy-specifier[OPT] procedure-kind[OPT] 'proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+     privacy-specifier[OPT] procedure-kind[OPT] 'proc' identifier argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+       function-body
+     privacy-specifier[OPT] procedure-kind[OPT] 'operator' operator-name argument-list return-intent[OPT] return-type[OPT] where-clause[OPT]
        function-body
 
    procedure-kind:
@@ -120,13 +122,10 @@ Procedures are defined with the following syntax:
      'extern'
      'override'
 
-   function-name:
-     identifier
-     operator-name
-
    operator-name: one of
      + - * / % ** : ! == != <= >= < > << >> & | ^ ~
      = += -= *= /= %= **= &= |= ^= <<= >>= <=> <~>
+     'by' 'align'
 
    argument-list:
      ( formals[OPT] )
@@ -1173,10 +1172,11 @@ called overloaded functions. Function calls to overloaded functions are
 resolved according to the function resolution algorithm
 in :ref:`Function_Resolution`.
 
-Operator overloading is achieved by defining a function with a name
-specified by that operator. The operators that may be overloaded are
-listed in the following table:
+Operator overloading is achieved by defining a function with a name specified by
+that operator.  This function is declared with the ``operator`` keyword.  The
+operators that may be overloaded are listed in the following table:
 
+======== ===============================
 arity    operators
 ======== ===============================
 unary    ``+`` ``-`` ``!`` ``~``
@@ -1185,6 +1185,7 @@ binary   ``==`` ``<=`` ``>=`` ``<`` ``>``
 binary   ``<<`` ``>>`` ``&`` ``|`` ``^`` ``#`` ``align`` ``by``
 binary   ``=`` ``+=`` ``-=`` ``*=`` ``/=`` ``%=`` ``**=``
 binary   ``&=`` ``|=`` ``^=`` ``<<=`` ``>>=`` ``<=>`` ``<~>``
+======== ==============================
 
 The arity and precedence of the operator must be maintained when it is
 overloaded. Operator resolution follows the same algorithm as function

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -121,10 +121,9 @@ Procedures are defined with the following syntax:
      'override'
 
    operator-name: one of
+     'align' 'by'
      + - * / % ** : ! == != <= >= < > << >> & | ^ ~
      = += -= *= /= %= **= &= |= ^= <<= >>= <=> <~> #
-     'by'
-     'align'
 
    argument-list:
      ( formals[OPT] )

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -620,8 +620,8 @@ following signatures for a record ``R``:
 
 .. code-block:: chapel
 
-   proc ==(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
-   proc !=(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
+   operator ==(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
+   operator !=(lhs:R, rhs:R) : bool where lhs.type == rhs.type;
 
 Other comparison operator overloads (namely ``<``, ``<=``, ``>``, and ``>=``)
 have similar signatures but their where clauses also check whether the relevant

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -21,6 +21,7 @@ Base Language Features
    Including Sub-Modules from Separate Files <module_include>
    main() Functions <main>
    Module Search Paths <module_search>
+   Operator Methods <operatorMethods>
 
 
 Initializers and Generic Programming

--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -1,0 +1,55 @@
+.. _readme-operator-methods:
+
+.. default-domain:: chpl
+
+================
+Operator Methods
+================
+
+This README describes support in the Chapel compiler for defining operators
+as methods on types.  These features are still in the process of being improved.
+This README is intended to cover the expected behavior, but the expected
+behavior may change as experience with the feature is gained.
+
+Defining Operators
+------------------
+
+Operators may be overloaded to support new behavior on one or more types using
+the `operator` keyword.  Such overloads may be defined as stand-alone functions,
+e.g.
+
+.. code-block:: chapel
+
+   operator +(lhs: t1, rhs: t2) { ... }
+
+or as methods defined on a particular type.  Operator methods are equivalent to
+type methods - their behavior is not tied to a particular instance of the type
+with which they are associated.
+
+Operator methods may be defined as primary, secondary, or tertiary methods.  For
+example, the following code defines a primary ``+`` operator and a secondary
+``-`` operator on a record:
+
+.. code-block:: chapel
+
+   record R {
+     var intField: int;
+
+     operator +(lhs: R, rhs: R) {
+       return new R(lhs.intField + rhs.intField);
+     }
+   }
+
+   operator R.-(lhs: R, rhs: R) {
+     return new R(lhs.intField - rhs.intField);
+   }
+
+
+.. warning::
+
+   Standalone operator overloads defined without the ``operator`` keyword are
+   expected to be deprecated soon.  Operator methods may not be defined without
+   the ``operator`` keyword.
+
+Operator methods are not required to be defined on the same type as a particular
+argument or any argument to the function.

--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -15,8 +15,8 @@ Defining Operators
 ------------------
 
 Operators may be overloaded to support new behavior on one or more types using
-the `operator` keyword.  Such overloads may be defined as standalone functions,
-e.g.
+the ``operator`` keyword.  Such overloads may be defined as standalone
+functions, e.g.
 
 .. code-block:: chapel
 

--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -22,10 +22,23 @@ functions, e.g.
 
    operator +(lhs: t1, rhs: t2) { ... }
 
-or as methods defined on a particular type.  Operator methods are equivalent to
-type methods - their behavior is not tied to a particular instance of the type
-with which they are associated unless such an instance is provided as one of the
-arguments to the method.
+or as methods defined on a particular type, e.g.
+
+.. code-block:: chapel
+
+   record R {
+     var intField: int;
+
+     operator +(lhs: R, rhs: R) {
+       return new R(lhs.intField + rhs.intField);
+     }
+   }
+
+This README will focus on operator methods.
+
+Operator methods are equivalent to type methods - the type on which the operator
+is declared causes the operator to have method-like visibility for that type,
+and the ``this`` receiver is a ``type``.
 
 Operator methods may be defined as primary, secondary, or tertiary methods.  For
 example, the following code defines a primary ``+`` operator and a secondary
@@ -46,50 +59,50 @@ example, the following code defines a primary ``+`` operator and a secondary
    }
 
 
-.. warning::
+The method receiver for an operator method will be used to determine when that
+operator is visible.  This behavior is most useful when the method receiver
+matches the type of at least one of the other arguments to the operator.
+However, it is possible to define an operator method where the receiver type
+does not match the type for any other argument.
 
-   Standalone operator overloads defined without the ``operator`` keyword are
-   expected to be deprecated soon.  Operator methods may not be defined without
-   the ``operator`` keyword.
-
-There is no required relationship between the argument types and the method
-receiver.  An operator method can be associated with a type that matches the
-type of every argument, or that matches the type of only some of the
-arguments, or even a type that does not match the type of any argument (though
-the latter case may be of limited value).
-
-Operator methods are not required to be defined on concrete types.  They may be
-defined on generic types, or on particular instantiations of generic types.
+Operator methods can be defined on concrete types, generic types, or particular
+instantiations of generic types.
 
 Calling Operator Methods
 ------------------------
 
-An operator method call is identical to a call to a standalone operator
-overload.  The compiler will distinguish which operator overload is most
-appropriate and adjust the call accordingly, if necessary.
+A call to an operator - such as ``a + b`` which calls ``+`` - may resolve to any
+visible operator method or standalone operator function.
 
 Operator Method Visibility
 --------------------------
 
-The visibility of operator methods is the same as the visibility of other
-methods defined on the type.  The type definition point and any inherited type
-definition points of each argument will be searched for operator methods defined
-on it, and ``import`` and ``use`` statements can be used to control the
-visibility of tertiary operator methods.
+Primary and secondary operator methods have similar visibility to other primary
+and secondary methods.  In both cases, these methods can be viewed as part of
+the type and will be available along with the type.  For regular methods, the
+compiler searches for the method using the receiver's type (e.g. ``R`` in
+``myR.method()`` supposing ``myR`` has type ``R``) definition point as well as
+any type definition points for parent classes.  However, operator invocations
+(such as ``a + b``) don't have a method receiver in the same way.  Instead, the
+compiler uses te types of all the operator's arguments to find operator methods
+defined along with the type.
+
+As with tertiary methods, ``import`` and ``use`` statements can be used to
+control the visibility of tertiary operator methods.
 
 Determining Operator Candidate Functions
 ----------------------------------------
 
 When determining if an operator method or function is an appropriate candidate,
 only the arguments to the operator method or function will be considered.  The
-presence or absence of a type receiver is only used to determine visibility, it
-will not eliminate an overload from candidate consideration.
+presence or absence of a type receiver is only used to determine visibility, and
+it will not eliminate an overload from candidate consideration.
 
 Determining More Specific Operators
 -----------------------------------
 
 When determining which operator method or function is more specific, only the
 arguments to the operator method or function will be considered.  The presence
-or absence of a type receiver is only used to determine visibility, it will not
-make a particular operator method or function be deemed more specific than
-another.
+or absence of a type receiver is only used to determine visibility and does not
+impact the process of determining the best function (see
+:ref:`Determining_Best_Functions`).

--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -15,7 +15,7 @@ Defining Operators
 ------------------
 
 Operators may be overloaded to support new behavior on one or more types using
-the `operator` keyword.  Such overloads may be defined as stand-alone functions,
+the `operator` keyword.  Such overloads may be defined as standalone functions,
 e.g.
 
 .. code-block:: chapel
@@ -24,7 +24,8 @@ e.g.
 
 or as methods defined on a particular type.  Operator methods are equivalent to
 type methods - their behavior is not tied to a particular instance of the type
-with which they are associated.
+with which they are associated unless such an instance is provided as one of the
+arguments to the method.
 
 Operator methods may be defined as primary, secondary, or tertiary methods.  For
 example, the following code defines a primary ``+`` operator and a secondary
@@ -51,5 +52,44 @@ example, the following code defines a primary ``+`` operator and a secondary
    expected to be deprecated soon.  Operator methods may not be defined without
    the ``operator`` keyword.
 
-Operator methods are not required to be defined on the same type as a particular
-argument or any argument to the function.
+There is no required relationship between the argument types and the method
+receiver.  An operator method can be associated with a type that matches the
+type of every argument, or that matches the type of only some of the
+arguments, or even a type that does not match the type of any argument (though
+the latter case may be of limited value).
+
+Operator methods are not required to be defined on concrete types.  They may be
+defined on generic types, or on particular instantiations of generic types.
+
+Calling Operator Methods
+------------------------
+
+An operator method call is identical to a call to a standalone operator
+overload.  The compiler will distinguish which operator overload is most
+appropriate and adjust the call accordingly, if necessary.
+
+Operator Method Visibility
+--------------------------
+
+The visibility of operator methods is the same as the visibility of other
+methods defined on the type.  The type definition point and inherited type
+definition point of each argument will be searched for operator methods defined
+on it, and ``import`` and ``use`` statements can be used to control the
+visibility of tertiary operator methods.
+
+Determining Operator Candidate Functions
+----------------------------------------
+
+When determining if an operator method or function is an appropriate candidate,
+only the arguments to the operator method or function will be considered.  The
+presence or absence of a type receiver is only used to determine visibility, it
+will not eliminate an overload from candidate consideration.
+
+Determining More Specific Operators
+-----------------------------------
+
+When determining which operator method or function is more specific, only the
+arguments to the operator method or function will be considered.  The presence
+or absence of a type receiver is only used to determine visibility, it will not
+make a particular operator method or function be deemed more specific than
+another.

--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -72,8 +72,8 @@ Operator Method Visibility
 --------------------------
 
 The visibility of operator methods is the same as the visibility of other
-methods defined on the type.  The type definition point and inherited type
-definition point of each argument will be searched for operator methods defined
+methods defined on the type.  The type definition point and any inherited type
+definition points of each argument will be searched for operator methods defined
 on it, and ``import`` and ``use`` statements can be used to control the
 visibility of tertiary operator methods.
 

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -190,5 +190,4 @@ proc R.readWriteThis(ch: channel) throws {
 // Operators can be overloaded for record types to support
 // assignment (``=``), comparisons, (``<``, ``<=``, ``>``, ``>=``, ``==``,
 // ``!=``), and other general operators (``+``, ``-``, ``*``, ``/``, ...).
-// These are declared as regular functions with two arguments, not as methods
-// on the record.
+// These are declared as regular functions using the ``operator`` keyword.


### PR DESCRIPTION
Adds a special production using the `operator` keyword to the syntax tree for
procedures.  In doing so, remove the operator names from the potential naming
scope of other procedures, and remove the production that enabled both to be
used.  In doing so, explicitly call out `by` and `align` as operator names, as they
would no longer be covered otherwise.

In the operator overloading section, explicitly call out that operator overloads
should be defined using the keyword, and fix the table so it renders properly.

Replace `proc` in the records section demonstrating overloading `==` and `!=`
with `operator`.

Adds a new technote for operator methods, since those are still in progress.

Updates the specialMethods primer to no longer say operators need two
arguments (which was never true), to no longer say they can't be methods (but
not to explicitly say they can be until we are more certain of their stability), and
to say to use the `operator` keyword.

Resolves Cray/chapel-private#1764

Double checked result of `make docs` and that test/release/examples all passed
after a `make spectests`