### PR TITLE
Update highlight/README.md to provide a more complete list of highlighters

### DIFF
--- a/highlight/README.md
+++ b/highlight/README.md
@@ -9,7 +9,7 @@ Highlighting for Editors
 ------------------------
 
 * emacs/ : support for highlighting in emacs (see `emacs/README.rst`
-* geany/ : support for highlighting in geany (see `geany/geany-README.md`)
+* geany/ : support for highlighting in geany (see `geany/README.md`)
 * vim/ : support for highlighting in 'vim' (see `vim/README.rst`)
 
 The emacs and vim modes for Chapel were created by modifying existing

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -1,15 +1,33 @@
 Chapel highlighting/formatting support
 ======================================
 
-This directory contains rudimentary support for code
-coloring/formatting in emacs and vim.  See the README files in the
-individual subdirectories for details on using the modes.
+This directory contains support for code coloring/formatting using
+various editors and highlighting tools.  The level of support and
+complete language coverage may vary between tools.
 
-It also contains support for and/or pointers to other syntax
-highlighting capabilities that Chapel supports.
+Highlighting for Editors
+------------------------
+
+* emacs/ : support for highlighting in emacs (see `emacs/README.rst`
+* geany/ : support for highlighting in geany (see `geany/geany-README.md`)
+* vim/ : support for highlighting in 'vim' (see `vim/README.rst`)
 
 Both the emacs and vim modes for Chapel were created by modifying
 existing language formatting modes for the respective editors and are
 therefore licensed according to the agreements of those packages
 (i.e., the GPL for emacs and the VIM license for vim).  See the
 LICENSE files in the emacs/ and vim/ subdirectories for details.
+
+Other Highlighting Options
+--------------------------
+
+* highlight/ : used by the Computer Lanugage Benchmarks Game
+* latex/ : support for Chapel in the lstlistings package in LaTeX
+* source-highlight/ : support for GNU source-highlight
+
+Pointers to other external highlighting technologies
+----------------------------------------------------
+
+* highlight.js : See https://github.com/chapel-lang/highlightjs-chapel
+* pygments/ : See `pygments/README.md` for more information
+* tmbundle/ : See `tmbundle/README.md` for more information

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -12,11 +12,11 @@ Highlighting for Editors
 * geany/ : support for highlighting in geany (see `geany/geany-README.md`)
 * vim/ : support for highlighting in 'vim' (see `vim/README.rst`)
 
-Both the emacs and vim modes for Chapel were created by modifying
-existing language formatting modes for the respective editors and are
-therefore licensed according to the agreements of those packages
-(i.e., the GPL for emacs and the VIM license for vim).  See the
-LICENSE files in the emacs/ and vim/ subdirectories for details.
+The emacs and vim modes for Chapel were created by modifying existing
+language formatting modes for the respective editors and are therefore
+licensed according to the agreements of those packages (i.e., the GPL
+for emacs and the VIM license for vim).  See the LICENSE files in the
+emacs/ and vim/ subdirectories for details.
 
 Other Highlighting Options
 --------------------------

--- a/highlight/geany/README.md
+++ b/highlight/geany/README.md
@@ -2,10 +2,6 @@
 
 Nelson Luís Dias (<nelsonluisdias@gmail.com>; <https://nldias.github.io>).  
 
-2021-02-27T12:14:00
-
-2021-03-01T11:52:30 including DCO in pull resquest
-
 Here is a small but usable Geany ([https://geany.org](URL))  syntax highlighting scheme for Chapel.  It was directly modified from the standard Geany (version 1.36) syntax highlighting for C.
 
 **Windows users**: Replace `~/.config/geany/` with `C:\Users\"user"\AppData\Roaming\geany\`,

--- a/highlight/geany/geany-README.md
+++ b/highlight/geany/geany-README.md
@@ -13,7 +13,7 @@ where "user" is your username.
 
 Instructions:
 
-   1. Copy `filetype.Chapel.conf` to `~/.config/geany/filedefs/`
+   1. Copy `filetypes.Chapel.conf` to `~/.config/geany/filedefs/`
 
    2. Either:
       1.  Copy filetype_extensions.conf to `~/.config/geany/` OR


### PR DESCRIPTION
This makes the top-level highlight/README.md file a bit more precise about what Chapel highlighters are supported.  While here, I also cleaned up some things about the geany README.md:

* fixed an incorrect filename
* removed some date/time stamps that seem potentially confusing to users
* renamed it from geany-README.md to README.md