### PR TITLE
Lower parallel/bundles/bundles problem size under valgrind

### DIFF
--- a/test/parallel/bundles/bundles.execopts
+++ b/test/parallel/bundles/bundles.execopts
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import os
+
+# Drop the problem size for valgrin
+if os.getenv('CHPL_TEST_VGRND_EXE') == 'on':
+    print('--niters=10')


### PR DESCRIPTION
This takes takes over 15 minutes under valgrind and occasionally times
out so lower the problem size. It should finish in under 5 seconds now.