### PR TITLE
Add skipif for a Regexp module test

### DIFF
--- a/test/regexp/compileFailLeak.skipif
+++ b/test/regexp/compileFailLeak.skipif
@@ -1,0 +1,1 @@
+CHPL_REGEXP==none


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/17331 added a Regexp module test.
This PR adds a skipif for the test when `CHPL_REGEXP==none`.
