### PR TITLE
Fix off-by-one error that resulted from #17309

### DIFF
--- a/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
+++ b/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
@@ -122,7 +122,7 @@ proc SPAdot(A: [?Adom], B: [?Bdom]) where isCSArr(A) && isCSArr(B) {
 
   // pre-allocate nnz(A) + nnz(B) -- TODO: shrink later
   const nnzAB = Adom.size + Bdom.size;
-  Cdom._value.nnzDom = {1..nnzAB};
+  Cdom._value.nnzDom = {0..<nnzAB};
 
   var spa = new _SPA(cols={D.dim(0)}, eltType=A.eltType);
 
@@ -190,7 +190,7 @@ record _SPA {
     this.ls.sort();
 
     for idx in this.ls {
-      if nzcur + nzi  > C.JC.size then break;
+      if nzcur + nzi  >= C.JC.size then break;
       C.JC[nzcur+nzi] = idx;
       C.NUM[nzcur+nzi] = w[idx];
       Cdom._value._nnz += 1;


### PR DESCRIPTION
This presumably got missed because it is skipped if BLAS and/or LAPACK
aren't available due to the directory SKIPIF?  Yet I'm able to run it
on my Mac where I'm not aware I have those available, so we may be
casting too wide a net in the SKIPIF?

Also interesting: part of the reason this test is sensitive to the numbering
is that it pokes into the sparse array's internals rather than just relying
on public interfaces.