### PR TITLE
Remove "pre-release" tags from 1.24 version and bump remaining 1.23 labels

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -32,6 +32,6 @@ static const char* BUILD_VERSION =
 // Flip this to 'true' when we're ready to roll out a release; then
 // back after branching
 //
-static bool officialRelease = false;
+static bool officialRelease = true;
 
 #endif

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -77,8 +77,8 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.24.0 (pre-release)'
-# release = '1.23.0'
+# release = '1.24.0 (pre-release)'
+release = '1.24.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -6,6 +6,7 @@ Documentation Archives
 Online Documentation Archives
 -----------------------------
 
+* `Chapel 1.23 <https://chapel-lang.org/docs/1.23/index.html>`_
 * `Chapel 1.22 <https://chapel-lang.org/docs/1.22/index.html>`_
 * `Chapel 1.21 <https://chapel-lang.org/docs/1.21/index.html>`_
 * `Chapel 1.20 <https://chapel-lang.org/docs/1.20/index.html>`_

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -16,7 +16,7 @@ enable more features, such as distributed memory execution.
 0) See :ref:`prereqs.rst <readme-prereqs>` for more information about system
    tools and packages you may need to have installed to build and run Chapel.
 
-1) If you don't already have Chapel 1.23, see
+1) If you don't already have Chapel 1.24, see
    https://chapel-lang.org/download.html .
 
 2) If you are using a source release, build Chapel in a *quickstart*
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.23.0.tar.gz
+         tar xzf chapel-1.24.0.tar.gz
 
    b. Make sure that you are in the directory you just created by expanding the
       source release, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.23.0
+         cd chapel-1.24.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -37,7 +37,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.23.0
+        export CHPL_HOME=~/chapel-1.24.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.24.0 pre-release
+:Version: 1.24.0
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.24.0 pre-release
+:Version: 1.24.0
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -4,8 +4,7 @@ compiler=$3
 
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
Update the version number to be ready for the 1.24 release branch.
This is based on PR #16556.  I didn't see signs that anything else
had changed since then.
