### PR TITLE
Add primers for forall loops and task intents

### DIFF
--- a/doc/rst/meta/primers/index.rst
+++ b/doc/rst/meta/primers/index.rst
@@ -64,6 +64,7 @@ Data Parallelism
    Reductions <reductions>
    Distributions <distributions>
    Replicated Distribution <replicated>
+   Forall Loops <forallLoops>
 
 Library Utilities
 -----------------

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -13,6 +13,7 @@ TARGETS = \
 	domains \
 	errorHandling \
 	fileIO \
+	forallLoops \
 	genericClasses \
 	iterators \
 	learnChapelInYMinutes \

--- a/test/release/examples/primers/README
+++ b/test/release/examples/primers/README
@@ -15,6 +15,7 @@ demonstrate Chapel feature areas in detail.
      errorHandling.chpl          : Error handling system
      FFTWlib.chpl                : the FFTW standard library
      fileIO.chpl                 : File I/O example using arrays
+     forallLoops.chpl            : Forall loops - data parallel constructs
      genericClasses.chpl         : Defining and using generic classes
      iterators.chpl              : Iterator examples
      LAPACKlib.chpl              : the LAPACK standard library

--- a/test/release/examples/primers/arrays.chpl
+++ b/test/release/examples/primers/arrays.chpl
@@ -261,7 +261,8 @@ writeln("B[ProbSpaceSlice] is:\n", B[ProbSpaceSlice], "\n");
 //
 // Forall loops over domains and arrays can be written using the
 // syntax ``[<ind> in <Dom>] ...`` which is shorthand for
-// ``forall <ind> in <Dom> do ...``
+// ``forall <ind> in <Dom> do ...`` Forall loops are discussed
+// in the :ref:`foralls primer (forallLoops.chpl)<primers-forallLoops>`.
 //
 
 const offset = (1,1); // a 2-tuple offset

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -9,7 +9,7 @@ Like serial for-loops, forall loops can iterate over a data structure,
 an iterator, or a zippered combination of these. Unlike for-loops,
 multiple iterations of a forall loop can potentially execute in parallel.
 Parallelism is determined by the data structure or iterator being iterated
-over.
+over, also known as the "iterable".
 
 Chapel has forall statements and forall expressions. Each form has
 two varieties: "must-parallel" and "may-parallel".
@@ -23,11 +23,11 @@ two varieties: "must-parallel" and "may-parallel".
  - The may-parallel forms are written using brackets ``[ ]``
    (:ref:`primers-forallLoops-may-parallel`).
    They invoke the parallel iterator if the iterable provides it,
-   and otherwise will fall back on the serial iterator.
+   and otherwise fall back on the serial iterator.
 
-As with for-loops, the body of a forall statement is a statement or a
-a block statement, whereas the body of a forall expression is an expression.
-Both kinds are shown in the following sections.
+As with for-loops, the body of a forall statement is a statement
+or a block statement, whereas the body of a forall expression is
+an expression. Both kinds are shown in the following sections.
 
 "Must-parallel" forall statement
 --------------------------------
@@ -147,8 +147,8 @@ writeln();
 As with must-parallel zippered loops, here A is the leader iterable
 (:ref:`primers-forallLoops-must-parallel-zippered`).
 Its parallel iterator will determine how this loop is parallelized.
-if A were a distributed array, its leader iterator, if defined,
-would also determine iteration locality.
+if A were a distributed array, its parallel iterator would also
+determine iteration locality.
 
 Domains declared without a ``dmapped`` clause, including
 default rectangular and default associative domains, as well as

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -102,11 +102,11 @@ writeln();
 Using the following must-parallel loop instead would cause
 a "parallel iterator is not found" error:
 
-.. code-block:: chapel
+  .. code-block:: chapel
 
-    forall i in onlySerial(n) {
-      writeln("in iteration #", i);
-    }
+      forall i in onlySerial(n) {
+        writeln("in iteration #", i);
+      }
 
 "May-parallel" forall expression
 --------------------------------

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -250,7 +250,7 @@ writeln();
 A reduce intent can be used to compute reductions.
 The value of each reduce-intent shadow variable at the end of its task
 is combined into its outer variable according to the specified reduction
-operation. Within loop body, the shadow variable represents the
+operation. Within the loop body, the shadow variable represents the
 accumulation state produced by this task so far, starting from
 the reduction identity value at task startup. Values can be
 combined onto this accumulation state using the reduction-specific

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -1,0 +1,304 @@
+// Forall Loops
+
+/*
+This primer illustrates forall loops, which are a way to leverage
+data parallelism or engage :ref:`user-defined parallel iterators
+<primers-parIters>`. 
+
+Like serial for-loops, forall loops can iterate over a data structure,
+an iterator, or a zippered combination of these. Unlike for-loops,
+multiple iterations of a forall-loop can potentially execute in parallel.
+Parallelism is determined by the data structure or iterator being iterated
+over. For a zippered forall loop, parallelism is determined by the "leader",
+which is the first data structure or iterator in the zippered list.
+
+Chapel has forall statements and forall expressions. Each form has
+two varieties, "must-parallel" and "may-parallel".
+
+ - The must-parallel forms are written using the ``forall`` keyword.
+   They require that the leader iterable provide a parallel iterator.
+   Note that there are no requirements on the behavior of the parallel
+   iterator. For example, it can execute serially, in which case
+   the "must-parallel" loop that invokes it also executes serially.
+
+ - The may-parallel forms are written using ``[ ]``.
+   They invoke the parallel iterator if the leader provides it,
+   otherwise fall back on the serial iterator.
+
+As with for-loops, the body of a forall statement is a statement or a
+a block statement, whereas the body of a forall expression is an expression.
+
+"Must-parallel" forall statement
+--------------------------------
+
+In the following example, the forall loop iterates over the array indices
+in parallel:
+*/
+
+config const n = 9;
+var A: [1..n] real;
+
+forall i in 1..n {
+  A[i] = i;
+}
+
+writeln("After setting up, A is:");
+writeln(A);
+writeln();
+
+/*
+If ``A`` were a distributed array, each loop iteration would be
+executed on the locale where the corresponding array element resides.
+
+"Must-parallel" forall expression
+---------------------------------
+
+The following forall-expression produces new values in parallel.
+We store these values in a new array.
+*/
+
+var B = forall a in A do a * 3;
+
+writeln("After initialization, B is:");
+writeln(B);
+writeln();
+
+/*
+Zippered "must-parallel" forall statement
+-----------------------------------------
+
+We can iterate over multiple arrays in parallel with a zippered loop.
+Here we illustrate zippering arrays and domains:
+*/
+
+var C: [1..n] real;
+forall (a, b, i) in zip(A, B, C.domain) do
+  C[i] = a * 10 + b / 10;
+
+writeln("After a zippered loop, C is:");
+writeln(C);
+writeln();
+
+/*
+"May-parallel" forall statement
+-------------------------------
+
+The iterator ``onlySerial`` defined below does not have any parallel
+forms. Therefore the may-parallel loop ``[i in onlySerial(n)]``
+will accept it, executing its iterations serially:
+*/
+
+iter onlySerial(m: int) {
+  for j in 1..m do
+    yield j;
+}
+
+[i in onlySerial(n)] {
+  writeln("in onlySerial iteration #", i);
+}
+writeln();
+
+/*
+Using the following must-parallel loop instead would cause
+a "parallel iterator is not found" error:
+
+.. code-block:: chapel
+
+    forall i in onlySerial(n) {
+      writeln("in iteration #", i);
+    }
+
+"May-parallel" forall expression
+--------------------------------
+
+Given that these arrays provide parallel iteration, the following
+may-parallel expression will be computed in parallel:
+*/
+
+var D = [(a,b,c) in zip(A,B,C)] a + c - b;
+
+writeln("The result of may-parallel expression, D is:");
+writeln(D);
+writeln();
+
+/*
+As with must-parallel loops, if A were a distributed array,
+iteration locality while computing the above expression
+would be determined by A's domain map.
+
+Forall Intents and Shadow Variables
+-----------------------------------
+
+A forall loop may name some variables declared outside the loop,
+or "outer variables". If so, "shadow variables" are introduced.
+Each task created by the parallel iterator gets its own set of
+shadow variables, one per outer variable.
+
+ - Each shadow variable behaves as if it were a formal argument
+   of the task function for the task. The outer variable is passed
+   to this formal argument according to the argument intent
+   associated with the shadow variable, which is called a
+   "forall intent".
+
+ - The name of an outer variable lexically in the loop body implicitly
+   refers to the corresonding shadow variable. If the parallel iterator
+   causes multiple iterations of the loop to be executed by the
+   same task, these iterations refer to the same set of shadow
+   variables.
+
+ - Each shadow variable is deallocated at the end of its task.
+
+The default argument intent is used by default. For numeric types,
+this implies capturing the value of the outer variable by the time
+the task starts executing. Arrays are passed by reference, and so are
+sync, single, and atomic variables.
+*/
+
+var outerIntVariable = 1;
+proc updateOuterVariable() {
+  outerIntVariable += 1;  // always refers to the outer variable
+}
+var outerAtomicVariable: atomic int;
+
+forall i in 1..n {
+  if i == 1 then
+    updateOuterVariable();     // beware of potential for data races
+
+  // the shadow variable always contains the value as of loop start
+  writeln("shadow outerIntVariable is: ", outerIntVariable);
+
+  D[i] += 0.5;                 // beware of potential for data races
+
+  outerAtomicVariable.add(3);  // ok: concurrent updates are atomic
+}
+
+writeln();
+writeln("After a loop with default intents, D is:");
+writeln(D);
+writeln("outerIntVariable is: ", outerIntVariable);
+writeln("outerAtomicVariable is: ", outerAtomicVariable.read());
+writeln();
+
+/*
+The forall intents ``in``, ``const in``, ``ref``, ``const ref``,
+and ``reduce`` can be specified explicitly using a ``with`` clause.
+
+An ``in`` or ``const in`` intent creates a copy of the outer variable
+for each task. A ``ref`` or ``const ref`` makes the
+shadow variable an aliass for the outer variable.
+*/
+
+var outerRealVariable = 1.0;
+
+forall i in 1..n with (in outerIntVariable,
+                       ref outerRealVariable) {
+  outerIntVariable += 1; // a per-task copy, never accessed concurrently
+
+  if i == 1 then
+    outerRealVariable *= 2;  // beware of potential for data races
+}
+
+writeln("After a loop with explicit intents:");
+writeln("outerIntVariable is: ", outerIntVariable);
+writeln("outerRealVariable is: ", outerRealVariable);
+writeln();
+
+/*
+A reduce intent can be used to compute reductions.
+The values of each reduce-intent shadow variable at the end of its task
+is combined onto its outer variable according to the specified reduction
+operation. Within loop body, the shadow variable represents the
+accumulation state produced so far by this task, starting from
+the reduction identity value at task startup. Values can be
+combined onto this accumulation state using the reduction-specific
+operation or the ``reduce=`` operator.
+*/
+
+var outerMaxVariable = 0;
+// outerIntVariable's value before the loop will be included in the sum
+
+forall i in 1..n with (+ reduce outerIntVariable,
+                       max reduce outerMaxVariable) {
+  outerIntVariable += i;
+  if i % 2 == 0 then
+    outerMaxVariable reduce= i;
+
+  // The loop body can contain other code
+  // regardless of reduce-related operations.
+}
+
+writeln("After a loop with reduce intents:");
+writeln("outerIntVariable = ", outerIntVariable);
+writeln("outerMaxVariable = ", outerMaxVariable);
+writeln();
+
+/*
+A with-clause can be used in a similar fashion with any flavor
+of forall loop.
+
+Task-Private Variables
+----------------------
+
+A task-private variable is similar to an in-intent or ref-intent
+shadow variable in that it is initialized at the beginning of its
+task, shared by all loop iterations executed by the task, and
+deallocated at the end of the task. However, a task-private
+variable is initialized without regard to any outer variable.
+
+A task-private variable is introduce using a with-clause
+in a way similar to a regular ``var``, ``const``, ``ref``,
+or ``const ref`` variable. A ``var`` or ``const`` variable
+must provide its type or initializing expression or both.
+As with a regular variable, it will be initialized
+to the default value of its type the initializing expression
+is not given. A ``ref`` or ``const ref`` variable must
+have the initializing expression and cannot declare its type.
+
+A ``var`` task-private variable could be used, for example,
+as a per-task scratch space that is never accessed concurrently.
+*/
+
+forall i in 1..n with (var myReal: real,  // starts at 0 for each task
+                       ref outerIntVariable, // a shadow variable
+                       ref myRef = outerIntVariable) {
+
+  myReal += 0.1;   // ok: never accessed concurrently
+
+  if i == 1 then
+    myRef *= 3;    // beware of potential for data races
+}
+
+writeln("After a loop with task-private variables:");
+writeln("outerIntVariable is: ", outerIntVariable);
+writeln();
+
+/*
+Forall Intents Inside Record Methods
+------------------------------------
+
+When the forall loop occurs inside a method on a record,
+the fields of the receiver record are represented in the loop body
+with shadow variables as if they were outer variables.
+
+At present, the record fields, as well as the method receiver ``this``,
+are always passed by default intent and cannot be listed in a with-clause.
+*/
+
+record MyRecord {
+  var arrField: [1..n] int;
+  var intField: int;
+}
+
+proc MyRecord.myMethod() {
+  forall i in 1..n {
+    arrField[i] = i * 2;  // beware of potential for data races
+    // intField += 1;     // would cause "illegal assignment" error
+  }
+}
+
+var myR = new MyRecord();
+myR.myMethod();
+
+writeln("After MyRecord.myMethod, myR is:");
+writeln(myR);
+writeln();

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -163,31 +163,31 @@ Task Intents and Shadow Variables
 ---------------------------------
 
 A forall loop may refer to some variables declared outside the loop,
-known as "outer variables". If so, "shadow variables" are introduced.
-Each task created by the parallel iterator gets its own set of
-shadow variables, one per outer variable.
+known as "outer variables". When it does, "shadow variables" are
+introduced. Each task created by the parallel iterator gets its own set
+of shadow variables, one per outer variable.
 
  - Each shadow variable behaves as if it were a formal argument
-   of the task function for the task. (Task functions are described in
-   :ref:`the language spec <Chapter-Task_Parallelism_and_Synchronization>`).
+   of a function that implements the task's work. (These "task
+   functions" are described in :ref:`the language spec
+   <Chapter-Task_Parallelism_and_Synchronization>`).
    The outer variable is passed to this formal argument according to
-   the :ref:`argument intent <Argument_Intents>`  associated with
+   the :ref:`argument intent <Argument_Intents>` associated with
    the shadow variable, which is called a "task intent".
 
- - The name of an outer variable within the lexical scope of the loop
-   body refers implicitly to the corresponding shadow variable. If the
-   parallel iterator causes multiple iterations of the loop to be
-   executed by the same task, these iterations refer to the same set
-   of shadow variables.
+ - References within a task that seem to refer to an outer variable
+   will actually be referring to the corresponding shadow variable
+   owned by the task. If the parallel iterator causes multiple
+   iterations of the loop to be executed by the same task, these
+   iterations refer to the same set of shadow variables.
 
  - Each shadow variable is deallocated at the end of its task.
 
 The default argument intent (:ref:`The_Default_Intent`) is used by default.
 For numeric types, this implies capturing the value of the outer
 variable by the time the task starts executing. Arrays are passed by
-reference, and so are sync, single, and atomic variables
+reference, as are sync, single, and atomic variables
 (:ref:`primers-syncsingle`, :ref:`primers-atomics`).
-
 */
 
 var outerIntVariable = 0;

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -21,7 +21,7 @@ two varieties, "must-parallel" and "may-parallel".
    iterator. For example, it can execute serially, in which case
    the "must-parallel" loop that invokes it also executes serially.
 
- - The may-parallel forms are written using ``[ ]``.
+ - The may-parallel forms are written using brackets ``[ ]``.
    They invoke the parallel iterator if the leader provides it,
    otherwise fall back on the serial iterator.
 
@@ -126,8 +126,8 @@ As with must-parallel loops, if A were a distributed array,
 iteration locality while computing the above expression
 would be determined by A's domain map.
 
-Forall Intents and Shadow Variables
------------------------------------
+Task Intents and Shadow Variables
+---------------------------------
 
 A forall loop may name some variables declared outside the loop,
 or "outer variables". If so, "shadow variables" are introduced.
@@ -137,14 +137,13 @@ shadow variables, one per outer variable.
  - Each shadow variable behaves as if it were a formal argument
    of the task function for the task. The outer variable is passed
    to this formal argument according to the argument intent
-   associated with the shadow variable, which is called a
-   "forall intent".
+   associated with the shadow variable, which is called a "task intent".
 
- - The name of an outer variable lexically in the loop body implicitly
-   refers to the corresonding shadow variable. If the parallel iterator
-   causes multiple iterations of the loop to be executed by the
-   same task, these iterations refer to the same set of shadow
-   variables.
+ - The name of an outer variable within the lexical scope of the loop
+   body refers implicitly to the corresonding shadow variable. If the
+   parallel iterator causes multiple iterations of the loop to be
+   executed by the same task, these iterations refer to the same set
+   of shadow variables.
 
  - Each shadow variable is deallocated at the end of its task.
 
@@ -180,7 +179,7 @@ writeln("outerAtomicVariable is: ", outerAtomicVariable.read());
 writeln();
 
 /*
-The forall intents ``in``, ``const in``, ``ref``, ``const ref``,
+The task intents ``in``, ``const in``, ``ref``, ``const ref``,
 and ``reduce`` can be specified explicitly using a ``with`` clause.
 
 An ``in`` or ``const in`` intent creates a copy of the outer variable
@@ -208,7 +207,7 @@ A reduce intent can be used to compute reductions.
 The values of each reduce-intent shadow variable at the end of its task
 is combined onto its outer variable according to the specified reduction
 operation. Within loop body, the shadow variable represents the
-accumulation state produced so far by this task, starting from
+accumulation state produced by this task so far, starting from
 the reduction identity value at task startup. Values can be
 combined onto this accumulation state using the reduction-specific
 operation or the ``reduce=`` operator.
@@ -273,12 +272,14 @@ writeln("outerIntVariable is: ", outerIntVariable);
 writeln();
 
 /*
-Forall Intents Inside Record Methods
-------------------------------------
+Task Intents Inside Record Methods
+----------------------------------
 
 When the forall loop occurs inside a method on a record,
 the fields of the receiver record are represented in the loop body
 with shadow variables as if they were outer variables.
+This, for example, allows the forall loop body to update
+record fields of array types.
 
 At present, the record fields, as well as the method receiver ``this``,
 are always passed by default intent and cannot be listed in a with-clause.

--- a/test/release/examples/primers/forallLoops.good
+++ b/test/release/examples/primers/forallLoops.good
@@ -1,0 +1,51 @@
+After setting up, A is:
+1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0
+
+After initialization, B is:
+3.0 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0
+
+After a zippered loop, C is:
+10.3 20.6 30.9 41.2 51.5 61.8 72.1 82.4 92.7
+
+in onlySerial iteration #1
+in onlySerial iteration #2
+in onlySerial iteration #3
+in onlySerial iteration #4
+in onlySerial iteration #5
+in onlySerial iteration #6
+in onlySerial iteration #7
+in onlySerial iteration #8
+in onlySerial iteration #9
+
+The result of may-parallel expression, D is:
+8.3 16.6 24.9 33.2 41.5 49.8 58.1 66.4 74.7
+
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+shadow outerIntVariable is: 1
+
+After a loop with default intents, D is:
+8.8 17.1 25.4 33.7 42.0 50.3 58.6 66.9 75.2
+outerIntVariable is: 2
+outerAtomicVariable is: 27
+
+After a loop with explicit intents:
+outerIntVariable is: 2
+outerRealVariable is: 2.0
+
+After a loop with reduce intents:
+outerIntVariable = 47
+outerMaxVariable = 8
+
+After a loop with task-private variables:
+outerIntVariable is: 141
+
+After MyRecord.myMethod, myR is:
+(arrField = 2 4 6 8 10 12 14 16 18, intField = 0)
+

--- a/test/release/examples/primers/forallLoops.good
+++ b/test/release/examples/primers/forallLoops.good
@@ -1,51 +1,44 @@
 After setting up, A is:
-1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0
+1.0 2.0 3.0 4.0 5.0
 
 After initialization, B is:
-3.0 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0
+3.0 6.0 9.0 12.0 15.0
 
 After a zippered loop, C is:
-10.301 20.602 30.903 41.204 51.505 61.806 72.107 82.408 92.709
+10.301 20.602 30.903 41.204 51.505
 
 in onlySerial iteration #1
 in onlySerial iteration #2
 in onlySerial iteration #3
 in onlySerial iteration #4
 in onlySerial iteration #5
-in onlySerial iteration #6
-in onlySerial iteration #7
-in onlySerial iteration #8
-in onlySerial iteration #9
 
 The result of may-parallel expression, D is:
-8.301 16.602 24.903 33.204 41.505 49.806 58.107 66.408 74.709
+8.301 16.602 24.903 33.204 41.505
 
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
-shadow outerIntVariable is: 1
+shadow outerIntVariable is: 0
+shadow outerIntVariable is: 0
+shadow outerIntVariable is: 0
+shadow outerIntVariable is: 0
+shadow outerIntVariable is: 0
 
 After a loop with default intents, D is:
-8.801 17.102 25.403 33.704 42.005 50.306 58.607 66.908 75.209
-outerIntVariable is: 2
-outerAtomicVariable is: 27
+8.801 17.102 25.403 33.704 42.005
+outerIntVariable is: 1
+outerAtomicVariable is: 5
 
 After a loop with explicit intents:
-outerIntVariable is: 2
+outerIntVariable is: 1
 outerRealVariable is: 2.0
 
+outerIntVariable before the loop is: 1
 After a loop with reduce intents:
-outerIntVariable = 47
-outerMaxVariable = 8
+outerIntVariable = 16
+outerMaxVariable = 4
 
 After a loop with task-private variables:
-outerIntVariable is: 141
+outerIntVariable is: 48
 
 After MyRecord.myMethod, myR is:
-(arrField = 2 4 6 8 10 12 14 16 18, intField = 0)
+(arrField = 2 4 6 8 10, intField = 0)
 

--- a/test/release/examples/primers/forallLoops.good
+++ b/test/release/examples/primers/forallLoops.good
@@ -5,7 +5,7 @@ After initialization, B is:
 3.0 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0
 
 After a zippered loop, C is:
-10.3 20.6 30.9 41.2 51.5 61.8 72.1 82.4 92.7
+10.301 20.602 30.903 41.204 51.505 61.806 72.107 82.408 92.709
 
 in onlySerial iteration #1
 in onlySerial iteration #2
@@ -18,7 +18,7 @@ in onlySerial iteration #8
 in onlySerial iteration #9
 
 The result of may-parallel expression, D is:
-8.3 16.6 24.9 33.2 41.5 49.8 58.1 66.4 74.7
+8.301 16.602 24.903 33.204 41.505 49.806 58.107 66.408 74.709
 
 shadow outerIntVariable is: 1
 shadow outerIntVariable is: 1
@@ -31,7 +31,7 @@ shadow outerIntVariable is: 1
 shadow outerIntVariable is: 1
 
 After a loop with default intents, D is:
-8.8 17.1 25.4 33.7 42.0 50.3 58.6 66.9 75.2
+8.801 17.102 25.403 33.704 42.005 50.306 58.607 66.908 75.209
 outerIntVariable is: 2
 outerAtomicVariable is: 27
 

--- a/test/release/examples/primers/parIters.chpl
+++ b/test/release/examples/primers/parIters.chpl
@@ -201,7 +201,7 @@ writeln();
 
 
 /*
-.. primers-parIters-leader-follower:
+.. _primers-parIters-leader-follower:
 
 Leader-follower iterators
 -------------------------

--- a/test/release/examples/primers/taskParallel.chpl
+++ b/test/release/examples/primers/taskParallel.chpl
@@ -97,33 +97,35 @@ coforall i in 1..n {
 // The order of output is undefined.
 writeln("5: output from main task");
 
-// .. _primers-taskparallel-task-intents:
-//
-// Task Intents
-// ------------
-//
-// The body of a task construct name some variables declared outside,
-// or "outer variables". If so, "shadow variables" are introduced.
-// Each task created by the task construct gets its own set of
-// shadow variables, one per outer variable.
-//
-//  - Each shadow variable behaves as if it were a formal argument
-//    of the task function for the task. The outer variable is passed
-//    to this formal argument according to the argument intent
-//    associated with the shadow variable, which is called a "task intent".
-//
-//  - The name of an outer variable lexically in the task construct
-//    implicitly refers to the corresonding shadow variable.
-//
-//  - Each shadow variable is deallocated at the end of its task.
-//
-// The default argument intent is used by default. For numeric types,
-// this implies capturing the value of the outer variable by the time
-// the task starts executing. Arrays are passed by reference, and so are
-// sync, single, and atomic variables. For ``begin`` statements, for example,
-// this means that the captured value of an outer numeric variable
-// can be accessed even after its scope exits, while an outer array variable
-// cannot.
+/*
+.. _primers-taskparallel-task-intents:
+
+Task Intents
+------------
+
+The body of a task construct name some variables declared outside,
+or "outer variables". If so, "shadow variables" are introduced.
+Each task created by the task construct gets its own set of
+shadow variables, one per outer variable.
+
+ - Each shadow variable behaves as if it were a formal argument
+   of the task function for the task. The outer variable is passed
+   to this formal argument according to the argument intent
+   associated with the shadow variable, which is called a "task intent".
+
+ - The name of an outer variable lexically in the task construct
+   implicitly refers to the corresonding shadow variable.
+
+ - Each shadow variable is deallocated at the end of its task.
+
+The default argument intent is used by default. For numeric types,
+this implies capturing the value of the outer variable by the time
+the task starts executing. Arrays are passed by reference, and so are
+sync, single, and atomic variables. For ``begin`` statements, for example,
+this means that the captured value of an outer numeric variable
+can be accessed even after its scope exits, while an outer array variable
+cannot.
+*/
 var outerIntVariable = 2;  
 begin assert(outerIntVariable == 2);
 

--- a/test/release/examples/primers/taskParallel.chpl
+++ b/test/release/examples/primers/taskParallel.chpl
@@ -163,7 +163,7 @@ var outerMinVariable = 0;
 coforall i in 1..n with (+ reduce outerIntVariable,
                          max reduce outerMaxVariable,
                          min reduce outerMinVariable) {
-  outerIntVariable += i;
+  outerIntVariable = i;
 
   if i % 2 == 0 then
     outerMaxVariable = i;  // compute the max of even indices


### PR DESCRIPTION
* Adds `forallLoops.chpl` - a new primer about forall loops,
  task intents including reduce intents, shadow variables,
  and task-private variables.

* Adds task intents, including reduce intents, to the `taskParallel` primer.

* Fixes up a couple of anchors that needed a leading underscore.

Extensively tested with start_test.

Reviewed and otherwise contributed by: @bradcray, @lydia-duncan, @leekillough, @cassella.
