### PR TITLE
chpldoc: emit spaces around binary operators when not in type context

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -1026,6 +1026,18 @@ static bool needParens(const char *outer, const char *inner,
 }
 
 /*
+ * Do we want to print spaces around this binary operator?
+ */
+static bool wantSpaces(const char *op, bool printingType)
+{
+  if (strcmp(op, "**") == 0)
+    return false;
+  if (printingType)
+    return false;
+  return true;
+}
+
+/*
  * Args needed just for needsParens() call above, described in more
  * detail there:
  *
@@ -1395,10 +1407,18 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType, const char *outer,
           // Binary operator, infix notation
           bool needsParens = needParens(outer, fnName, unary, postfix,
                                         false, false, isRHS);
+          bool wantsSpaces = wantSpaces(fnName, printingType);
+
           if (needsParens)
             mText += "(";
           appendExpr(expr->get(1), printingType, fnName, false, false, false);
+
+          if (wantsSpaces)
+            mText += " ";
           appendExpr(expr->baseExpr, printingType);
+          if (wantsSpaces)
+            mText += " ";
+
           appendExpr(expr->get(2), printingType, fnName, false, false, true);
           if (needsParens)
             mText += ")";

--- a/test/chpldoc/functions/functionArgDefaultWithParens.doc.good
+++ b/test/chpldoc/functions/functionArgDefaultWithParens.doc.good
@@ -17,5 +17,5 @@ or
 
    import functionArgDefaultWithParens.doc;
 
-.. function:: proc foo(arg = 1+2*(3+4))
+.. function:: proc foo(arg = 1 + 2 * (3 + 4))
 

--- a/test/chpldoc/functions/functionArgDefaults.doc.good
+++ b/test/chpldoc/functions/functionArgDefaults.doc.good
@@ -41,51 +41,51 @@ or
 
 .. function:: proc isNilDefault(arg = nil)
 
-.. function:: proc plusDefault(arg = x+y)
+.. function:: proc plusDefault(arg = x + y)
 
-.. function:: proc minusDefault(arg = x-y)
+.. function:: proc minusDefault(arg = x - y)
 
-.. function:: proc multDefault(arg = x*y)
+.. function:: proc multDefault(arg = x * y)
 
-.. function:: proc divDefault(arg = x/y)
+.. function:: proc divDefault(arg = x / y)
 
-.. function:: proc modDefault(arg = x%y)
+.. function:: proc modDefault(arg = x % y)
 
-.. function:: proc orDefault(arg = x||y)
+.. function:: proc orDefault(arg = x || y)
 
-.. function:: proc binOrDefault(arg = x|y)
+.. function:: proc binOrDefault(arg = x | y)
 
-.. function:: proc andDefault(arg = x&&y)
+.. function:: proc andDefault(arg = x && y)
 
-.. function:: proc binAndDefault(arg = x&y)
+.. function:: proc binAndDefault(arg = x & y)
 
-.. function:: proc binXorDefault(arg = x^y)
+.. function:: proc binXorDefault(arg = x ^ y)
 
-.. function:: proc threeOrDefault(arg = x||y||z)
+.. function:: proc threeOrDefault(arg = x || y || z)
 
-.. function:: proc threeBinOrDefault(arg = x|y|z)
+.. function:: proc threeBinOrDefault(arg = x | y | z)
 
-.. function:: proc threeAndDefault(arg = x&&y&&z)
+.. function:: proc threeAndDefault(arg = x && y && z)
 
-.. function:: proc threeBinAndDefault(arg = x&y&z)
+.. function:: proc threeBinAndDefault(arg = x & y & z)
 
 .. function:: proc powDefault(arg = x**y)
 
-.. function:: proc lshiftDefault(arg = x<<y)
+.. function:: proc lshiftDefault(arg = x << y)
 
-.. function:: proc rshiftDefault(arg = x>>y)
+.. function:: proc rshiftDefault(arg = x >> y)
 
-.. function:: proc eqDefault(arg = x==y)
+.. function:: proc eqDefault(arg = x == y)
 
-.. function:: proc neqDefault(arg = x!=y)
+.. function:: proc neqDefault(arg = x != y)
 
-.. function:: proc lessDefault(arg = x<y)
+.. function:: proc lessDefault(arg = x < y)
 
-.. function:: proc gtDefault(arg = x>y)
+.. function:: proc gtDefault(arg = x > y)
 
-.. function:: proc lessEqDefault(arg = x<=y)
+.. function:: proc lessEqDefault(arg = x <= y)
 
-.. function:: proc gtEqDefault(arg = x>=y)
+.. function:: proc gtEqDefault(arg = x >= y)
 
 .. function:: proc minDefault(arg = min(int))
 
@@ -121,9 +121,9 @@ or
 
 .. function:: proc threeArgFuncDefault(arg = f3(x, y, z))
 
-.. function:: proc twoArgsWithDefaults(arg1 = x+y, arg2 = x-y)
+.. function:: proc twoArgsWithDefaults(arg1 = x + y, arg2 = x - y)
 
-.. function:: proc threeArgsWithDefaults(arg1 = x*y, arg2 = x/y, arg3 = x**y)
+.. function:: proc threeArgsWithDefaults(arg1 = x * y, arg2 = x / y, arg3 = x**y)
 
 .. record:: R0
 

--- a/test/chpldoc/globals/typeVars.doc.good
+++ b/test/chpldoc/globals/typeVars.doc.good
@@ -30,7 +30,7 @@ This module has some global scoped types.
 
    This is an opaque type from external source. 
 
-.. type:: type myFloats = 2*real(64)
+.. type:: type myFloats = 2 * real(64)
 
    This is a non-opaque type from external source. 
 

--- a/test/chpldoc/globals/variableDefaultValues.doc.good
+++ b/test/chpldoc/globals/variableDefaultValues.doc.good
@@ -39,51 +39,51 @@ or
 
 .. data:: var isNilDefault: nilable C = nil
 
-.. data:: var plusDefault = x+y
+.. data:: var plusDefault = x + y
 
-.. data:: var minusDefault = x-y
+.. data:: var minusDefault = x - y
 
-.. data:: var multDefault = x*y
+.. data:: var multDefault = x * y
 
-.. data:: var divDefault = x/y
+.. data:: var divDefault = x / y
 
-.. data:: var modDefault = x%y
+.. data:: var modDefault = x % y
 
-.. data:: var orDefault = x||y
+.. data:: var orDefault = x || y
 
-.. data:: var binOrDefault = x|y
+.. data:: var binOrDefault = x | y
 
-.. data:: var andDefault = x&&y
+.. data:: var andDefault = x && y
 
-.. data:: var binAndDefault = x&y
+.. data:: var binAndDefault = x & y
 
-.. data:: var binXorDefault = x^y
+.. data:: var binXorDefault = x ^ y
 
-.. data:: var threeOrDefault = x||y||z
+.. data:: var threeOrDefault = x || y || z
 
-.. data:: var threeBinOrDefault = x|y|z
+.. data:: var threeBinOrDefault = x | y | z
 
-.. data:: var threeAndDefault = x&&y&&z
+.. data:: var threeAndDefault = x && y && z
 
-.. data:: var threeBinAndDefault = x&y&z
+.. data:: var threeBinAndDefault = x & y & z
 
 .. data:: var powDefault = x**y
 
-.. data:: var lshiftDefault = x<<y
+.. data:: var lshiftDefault = x << y
 
-.. data:: var rshiftDefault = x>>y
+.. data:: var rshiftDefault = x >> y
 
-.. data:: var eqDefault = x==y
+.. data:: var eqDefault = x == y
 
-.. data:: var neqDefault = x!=y
+.. data:: var neqDefault = x != y
 
-.. data:: var lessDefault = x<y
+.. data:: var lessDefault = x < y
 
-.. data:: var gtDefault = x>y
+.. data:: var gtDefault = x > y
 
-.. data:: var lessEqDefault = x<=y
+.. data:: var lessEqDefault = x <= y
 
-.. data:: var gtEqDefault = x>=y
+.. data:: var gtEqDefault = x >= y
 
 .. data:: var minDefault = min(int)
 

--- a/test/chpldoc/globals/variablePrecedence.doc.good
+++ b/test/chpldoc/globals/variablePrecedence.doc.good
@@ -17,33 +17,33 @@ or
 
    import variablePrecedence;
 
-.. data:: var pp = a+b+c
+.. data:: var pp = a + b + c
 
-.. data:: var Pp = a+b+c
+.. data:: var Pp = a + b + c
 
-.. data:: var pP = a+b+c
+.. data:: var pP = a + b + c
 
-.. data:: var pppp = a+b+c+d+e
+.. data:: var pppp = a + b + c + d + e
 
-.. data:: var PpPp = a+b+c+d+e
+.. data:: var PpPp = a + b + c + d + e
 
-.. data:: var mm = a-b-c
+.. data:: var mm = a - b - c
 
-.. data:: var Mm = a-b-c
+.. data:: var Mm = a - b - c
 
-.. data:: var mM = a-(b-c)
+.. data:: var mM = a - (b - c)
 
-.. data:: var pm = a+b-c
+.. data:: var pm = a + b - c
 
-.. data:: var Pm = a+b-c
+.. data:: var Pm = a + b - c
 
-.. data:: var pM = a+b-c
+.. data:: var pM = a + b - c
 
-.. data:: var mp = a-b+c
+.. data:: var mp = a - b + c
 
-.. data:: var Mp = a-b+c
+.. data:: var Mp = a - b + c
 
-.. data:: var mP = a-(b+c)
+.. data:: var mP = a - (b + c)
 
 .. data:: var unarypunaryp = ++a
 
@@ -53,21 +53,21 @@ or
 
 .. data:: var unarymunaryp = -+a
 
-.. data:: var unarypP = +(a+b)
+.. data:: var unarypP = +(a + b)
 
-.. data:: var unarypM = +(a-b)
+.. data:: var unarypM = +(a - b)
 
-.. data:: var unarymP = -(a+b)
+.. data:: var unarymP = -(a + b)
 
-.. data:: var unarymM = -(a-b)
+.. data:: var unarymM = -(a - b)
 
-.. data:: var unarynp = ~(a+b)
+.. data:: var unarynp = ~(a + b)
 
-.. data:: var binpunarym = a+-b
+.. data:: var binpunarym = a + -b
 
-.. data:: var andub = a&&!b
+.. data:: var andub = a && !b
 
-.. data:: var andubor = a&&!(b||c)
+.. data:: var andubor = a && !(b || c)
 
 .. data:: var unarympow = -a**b
 
@@ -75,47 +75,47 @@ or
 
 .. data:: var powunarym = a**-b
 
-.. data:: var powunarymP = a**-(b+c)
+.. data:: var powunarymP = a**-(b + c)
 
 .. data:: var unarymcast = -a: uint
 
 .. data:: var Unarymcast = (-a): uint
 
-.. data:: var tp = a*b+c
+.. data:: var tp = a * b + c
 
-.. data:: var Tp = a*b+c
+.. data:: var Tp = a * b + c
 
-.. data:: var tP = a*(b+c)
+.. data:: var tP = a * (b + c)
 
-.. data:: var pt = a+b*c
+.. data:: var pt = a + b * c
 
-.. data:: var Pt = (a+b)*c
+.. data:: var Pt = (a + b) * c
 
-.. data:: var pT = a+b*c
+.. data:: var pT = a + b * c
 
-.. data:: var td = a*b/c
+.. data:: var td = a * b / c
 
-.. data:: var Td = a*b/c
+.. data:: var Td = a * b / c
 
-.. data:: var tD = a*b/c
+.. data:: var tD = a * b / c
 
-.. data:: var dt = a/b*c
+.. data:: var dt = a / b * c
 
-.. data:: var Dt = a/b*c
+.. data:: var Dt = a / b * c
 
-.. data:: var dT = a/(b*c)
+.. data:: var dT = a / (b * c)
 
-.. data:: var ll = a<<b<<c
+.. data:: var ll = a << b << c
 
-.. data:: var Ll = a<<b<<c
+.. data:: var Ll = a << b << c
 
-.. data:: var lL = a<<(b<<c)
+.. data:: var lL = a << (b << c)
 
-.. data:: var ee = a==b==c
+.. data:: var ee = a == b == c
 
-.. data:: var Ee = a==b==c
+.. data:: var Ee = a == b == c
 
-.. data:: var eE = a==(b==c)
+.. data:: var eE = a == (b == c)
 
 .. data:: var xx = a**b**c
 
@@ -123,71 +123,71 @@ or
 
 .. data:: var Xx = (a**b)**c
 
-.. data:: var xpx = a**b+c**d
+.. data:: var xpx = a**b + c**d
 
-.. data:: var xPx = a**(b+c)**d
+.. data:: var xPx = a**(b + c)**d
 
-.. data:: var xPX = a**(b+c**d)
+.. data:: var xPX = a**(b + c**d)
 
-.. data:: var ooo = a||b||c||d
+.. data:: var ooo = a || b || c || d
 
-.. data:: var oao = a||b&&c||d
+.. data:: var oao = a || b && c || d
 
-.. data:: var Oao = (a||b)&&c||d
+.. data:: var Oao = (a || b) && c || d
 
-.. data:: var OAo = (a||b)&&c||d
+.. data:: var OAo = (a || b) && c || d
 
-.. data:: var OaO = (a||b)&&(c||d)
+.. data:: var OaO = (a || b) && (c || d)
 
-.. data:: var oaO = a||b&&(c||d)
+.. data:: var oaO = a || b && (c || d)
 
-.. data:: var oAO = a||b&&(c||d)
+.. data:: var oAO = a || b && (c || d)
 
-.. data:: var oAo = a||b&&c||d
+.. data:: var oAo = a || b && c || d
 
-.. data:: var unarybo = !a||b
+.. data:: var unarybo = !a || b
 
-.. data:: var unarybO = !(a||b)
+.. data:: var unarybO = !(a || b)
 
-.. data:: var booo = a|b|c|d
+.. data:: var booo = a | b | c | d
 
-.. data:: var boao = a|b&c|d
+.. data:: var boao = a | b & c | d
 
-.. data:: var bOao = (a|b)&c|d
+.. data:: var bOao = (a | b) & c | d
 
-.. data:: var bOAo = (a|b)&c|d
+.. data:: var bOAo = (a | b) & c | d
 
-.. data:: var bOaO = (a|b)&(c|d)
+.. data:: var bOaO = (a | b) & (c | d)
 
-.. data:: var boaO = a|b&(c|d)
+.. data:: var boaO = a | b & (c | d)
 
-.. data:: var boAO = a|b&(c|d)
+.. data:: var boAO = a | b & (c | d)
 
-.. data:: var boAo = a|b&c|d
+.. data:: var boAo = a | b & c | d
 
-.. data:: var boxo = a|b^c|d
+.. data:: var boxo = a | b ^ c | d
 
-.. data:: var bOxo = (a|b)^c|d
+.. data:: var bOxo = (a | b) ^ c | d
 
-.. data:: var bOxO = (a|b)^(c|d)
+.. data:: var bOxO = (a | b) ^ (c | d)
 
-.. data:: var boXo = a|b^c|d
+.. data:: var boXo = a | b ^ c | d
 
-.. data:: var bxxx = a^b^c^d
+.. data:: var bxxx = a ^ b ^ c ^ d
 
-.. data:: var bxax = a^b&c^d
+.. data:: var bxax = a ^ b & c ^ d
 
-.. data:: var bXax = (a^b)&c^d
+.. data:: var bXax = (a ^ b) & c ^ d
 
-.. data:: var bXaX = (a^b)&(c^d)
+.. data:: var bXaX = (a ^ b) & (c ^ d)
 
-.. data:: var bxAx = a^b&c^d
+.. data:: var bxAx = a ^ b & c ^ d
 
 .. function:: proc foo(x)
 
-.. data:: var addfoo = a+foo(b)
+.. data:: var addfoo = a + foo(b)
 
-.. data:: var fooadd = foo(a)+b
+.. data:: var fooadd = foo(a) + b
 
-.. data:: var fooAdd = foo(a+b)
+.. data:: var fooAdd = foo(a + b)
 

--- a/test/chpldoc/types/fields/complexes.doc.good
+++ b/test/chpldoc/types/fields/complexes.doc.good
@@ -19,17 +19,17 @@ or
 
 .. record:: Foo
 
-   .. attribute:: var aComplex: complex = 1.0+2.0i
+   .. attribute:: var aComplex: complex = 1.0 + 2.0i
 
-   .. attribute:: const bar = 0.0+1.0i
+   .. attribute:: const bar = 0.0 + 1.0i
 
    .. attribute:: param baz: complex
 
-   .. attribute:: var aComplex2: complex = 1.0+2.0i
+   .. attribute:: var aComplex2: complex = 1.0 + 2.0i
 
       This one has a comment 
 
-   .. attribute:: const bar2 = 0.0+1.0i
+   .. attribute:: const bar2 = 0.0 + 1.0i
 
       So does this one 
 

--- a/test/chpldoc/types/fields/fieldDefaultValues.doc.good
+++ b/test/chpldoc/types/fields/fieldDefaultValues.doc.good
@@ -61,51 +61,51 @@ or
 
    .. attribute:: var isNilDefault: nilable C = nil
 
-   .. attribute:: var plusDefault = x+y
+   .. attribute:: var plusDefault = x + y
 
-   .. attribute:: var minusDefault = x-y
+   .. attribute:: var minusDefault = x - y
 
-   .. attribute:: var multDefault = x*y
+   .. attribute:: var multDefault = x * y
 
-   .. attribute:: var divDefault = x/y
+   .. attribute:: var divDefault = x / y
 
-   .. attribute:: var modDefault = x%y
+   .. attribute:: var modDefault = x % y
 
-   .. attribute:: var orDefault = x||y
+   .. attribute:: var orDefault = x || y
 
-   .. attribute:: var binOrDefault = x|y
+   .. attribute:: var binOrDefault = x | y
 
-   .. attribute:: var andDefault = x&&y
+   .. attribute:: var andDefault = x && y
 
-   .. attribute:: var binAndDefault = x&y
+   .. attribute:: var binAndDefault = x & y
 
-   .. attribute:: var binXorDefault = x^y
+   .. attribute:: var binXorDefault = x ^ y
 
-   .. attribute:: var threeOrDefault = x||y||z
+   .. attribute:: var threeOrDefault = x || y || z
 
-   .. attribute:: var threeBinOrDefault = x|y|z
+   .. attribute:: var threeBinOrDefault = x | y | z
 
-   .. attribute:: var threeAndDefault = x&&y&&z
+   .. attribute:: var threeAndDefault = x && y && z
 
-   .. attribute:: var threeBinAndDefault = x&y&z
+   .. attribute:: var threeBinAndDefault = x & y & z
 
    .. attribute:: var powDefault = x**y
 
-   .. attribute:: var lshiftDefault = x<<y
+   .. attribute:: var lshiftDefault = x << y
 
-   .. attribute:: var rshiftDefault = x>>y
+   .. attribute:: var rshiftDefault = x >> y
 
-   .. attribute:: var eqDefault = x==y
+   .. attribute:: var eqDefault = x == y
 
-   .. attribute:: var neqDefault = x!=y
+   .. attribute:: var neqDefault = x != y
 
-   .. attribute:: var lessDefault = x<y
+   .. attribute:: var lessDefault = x < y
 
-   .. attribute:: var gtDefault = x>y
+   .. attribute:: var gtDefault = x > y
 
-   .. attribute:: var lessEqDefault = x<=y
+   .. attribute:: var lessEqDefault = x <= y
 
-   .. attribute:: var gtEqDefault = x>=y
+   .. attribute:: var gtEqDefault = x >= y
 
    .. attribute:: var minDefault = min(int)
 

--- a/test/chpldoc/types/fields/sizedTypes.doc.catfiles
+++ b/test/chpldoc/types/fields/sizedTypes.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/sizedTypes.rst

--- a/test/chpldoc/types/fields/sizedTypes.doc.chpl
+++ b/test/chpldoc/types/fields/sizedTypes.doc.chpl
@@ -1,0 +1,14 @@
+module sizedTypes {
+  config param w: int;
+  var fullInt: int(w);
+  var halfInt: int(w/2);
+
+  var fullReal: real(w);
+  var halfReal: real(w/2);
+
+  var fullImag: imag(w);
+  var halfImag: imag(w/2);
+
+  var fullComp: complex(w);
+  var halfComp: complex(w/2);
+}

--- a/test/chpldoc/types/fields/sizedTypes.doc.good
+++ b/test/chpldoc/types/fields/sizedTypes.doc.good
@@ -1,0 +1,37 @@
+.. default-domain:: chpl
+
+.. module:: sizedTypes
+
+sizedTypes
+==========
+**Usage**
+
+.. code-block:: chapel
+
+   use sizedTypes;
+
+
+or
+
+.. code-block:: chapel
+
+   import sizedTypes;
+
+.. data:: config param w: int
+
+.. data:: var fullInt: int(w)
+
+.. data:: var halfInt: int(w/2)
+
+.. data:: var fullReal: real(w)
+
+.. data:: var halfReal: real(w/2)
+
+.. data:: var fullImag: imag(w)
+
+.. data:: var halfImag: imag(w/2)
+
+.. data:: var fullComp: complex(w)
+
+.. data:: var halfComp: complex(w/2)
+


### PR DESCRIPTION
except **, which never gets spaces.

Update output of existing tests.

Add a test of var x: int(w/2), for a few different types.

Resolves #17336 

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>