### PR TITLE
Explicitly set launcher for arkouda release testing

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
@@ -25,6 +25,7 @@ module list
 
 export GASNET_PHYSMEM_MAX="9/10"
 export GASNET_ODP_VERBOSE=0
+export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_release

--- a/util/cron/test-perf.cray-cs.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs.arkouda.release.bash
@@ -24,6 +24,7 @@ module list
 
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
+export CHPL_LAUNCHER=slurm-gasnetrun_ibv
 nightly_args="${nightly_args} -no-buildcheck"
 
 # workaround for https://github.com/Cray/chapel-private/issues/1598


### PR DESCRIPTION
In #17302 I stopped explicitly setting the launcher for many Cray CS
systems since we now infer the launcher correctly. However, I should not
have removed it for Arkouda release testing since that won't use the new
code that infers the launcher correctly. Re-add that here.