### PR TITLE
Update documentation for changes relating to comm=ofi and HPE Cray EX.

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -617,7 +617,7 @@ The gasnet communication layer has not yet been built or tested on EX
 systems.  We expect to provide it in the pre-built module no later than
 the 1.25.0 release.
 
-The new PALS launcher for EX systems is supported by CHapel 1.24.0, but
+The new PALS launcher for EX systems is supported by Chapel 1.24.0, but
 it has to be selected manually, by setting ``CHPL_LAUNCHER=pals``.  The
 default launcher selection cannot pick it by default.  We expect to add
 that support as soon as possible.

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -12,122 +12,52 @@ series systems.
 .. contents::
 
 
-----------------------------------------------------
-Getting Started with Chapel on Cray X-Series Systems
-----------------------------------------------------
+-------------------------------------------------------------
+Getting Started with Chapel on Cray XC or HPE Cray EX Systems
+-------------------------------------------------------------
 
-Chapel is available as a module for Cray X-series systems.  When it is
-installed on your system, you do not need to build Chapel from the
-source release (though you can). To use Chapel with the default settings and
-confirm it is correctly installed, do the following:
-
-1) Load the Chapel module::
-
-     module load chapel
-
-
-2) Compile an example program using::
-
-     chpl $CHPL_HOME/examples/hello6-taskpar-dist.chpl
-
-
-3) Execute the resulting executable (on four locales)::
-
-     ./hello6-taskpar-dist -nl 4
-
-
-This may be all that is necessary to use Chapel on a Cray X-Series system.
-If the installation setup by your system administrator deviates from
-the default settings, or you are interested in other configuration
-options, see `Using Chapel on a Cray System`_ below.  If instead you wish to
-build Chapel from source, continue on to
-`Building Chapel for a Cray System from Source`_ just below.
-
-For information on obtaining and installing the Chapel module please
-contact your system administrator.
-
-
---------------------------------------------------
-Getting Started with Chapel on HPE Cray EX Systems
---------------------------------------------------
-
-Chapel is available as a module for HPE Cray EX systems.  It should be
-installed on your system already.  If it is not, contact your system
-administrator for information on obtaining and installing the Chapel
-module.
-
-To use Chapel with the default settings and confirm it is correctly
+Chapel is available as a module for Cray XC and HPE Cray EX systems.
+When it is installed on your system, you do not need to build Chapel
+from the source release (though you can).  With either the traditional
+Tcl-based module system or the newer Lua-based Lmod module system, to
+use Chapel with the default settings and confirm it is correctly
 installed, do the following:
 
-1) Load the Chapel module:
-
-   If you are using the Tcl module system, first load these required
-   modules:
-
-   .. code-block:: sh
+1) Ensure this required module is loaded.  Normally it will be loaded
+   for you, but under some circumstances you may need to load or
+   restore it yourself::
 
       PrgEnv-cray or PrgEnv-gnu
-      cray-mpich
 
-   Alternatively, if you are using the Lmod module system and the HPE
-   Cray Programming Environment Lmod Hierarchy, first load these
-   required modules:
 
-   .. code-block:: sh
-
-      craype
-      both cpe-cray and cce, or both cpe-gnu and gcc
-      craype-network-ofi
-      craype-x86-rome
-      cray-mpich
-
-   Then, with either module system, load the Chapel module:
-
-   .. code-block:: sh
+2) Load the Chapel module::
 
       module load chapel
 
 
-2) Compile an example program like this::
+3) Compile an example program using::
 
      chpl $CHPL_HOME/examples/hello6-taskpar-dist.chpl
 
 
-3) Execute the resulting executable (on four locales)::
+4) Execute the resulting executable (on four locales)::
 
      ./hello6-taskpar-dist -nl 4
 
 
-Currently the number of Chapel configurations available on
-HPE Cray EX systems is somewhat limited.  Only the following have been built
-into the module::
+This should be all that is necessary to use Chapel on a Cray XC or HPE
+Cray EX system.  If the installation setup by your system administrator
+deviates from the default settings, or you are interested in other
+configuration options, see `Using Chapel on a Cray System`_ below.  If
+instead you wish to build Chapel from source, continue on to `Building
+Chapel for a Cray System from Source`_ just below.
 
-  CHPL_TARGET_PLATFORM: hpe-cray-ex
-  CHPL_TARGET_COMPILER: cray-prgenv-cray, cray-prgenv-gnu
-  CHPL_TARGET_ARCH: x86_64
-  CHPL_TARGET_CPU: x86-rome
-  CHPL_LOCALE_MODEL: flat
-  CHPL_COMM: none, ofi
-  CHPL_TASKS: qthreads
-  CHPL_LAUNCHER: none, pals, slurm-srun
-  CHPL_TIMERS: generic
-  CHPL_UNWIND: none
-  CHPL_MEM: jemalloc
-  CHPL_ATOMICS: cstdlib
-    CHPL_NETWORK_ATOMICS: none, ofi
-  CHPL_GMP: bundled
-  CHPL_HWLOC: bundled
-  CHPL_REGEXP: re2
-  CHPL_LLVM: bundled
-  CHPL_AUX_FILESYS: none, lustre
-  CHPL_LIB_PIC: none, pic
+Note that the Chapel module for HPE Cray EX systems does not yet have
+the gasnet communication layer built into it.  For multilocale execution
+on EX systems please use the ofi communication layer instead.
 
-You may be able to build Chapel from source on an EX system if you do
-not have a module already.  Generally you should be able to follow the
-instructions below for building from source, but be advised that so far
-only the above configurations have been built.  Also, you'll probably
-find that the module settings shown in 1) above will be required during
-the build.
+For information on obtaining and installing the Chapel module please
+contact your system administrator.
 
 
 ----------------------------------------------
@@ -145,7 +75,7 @@ built from source on Cray CS systems using the
 Building Chapel for a Cray System from Source
 ---------------------------------------------
 
-1) If using an XC system, continue to step 2. If using a CS series
+1) If using an XC or EX system, continue to step 2. If using a CS series
    system, set ``CHPL_HOST_PLATFORM`` to ``cray-cs``.
 
    For example:
@@ -163,6 +93,7 @@ Building Chapel for a Cray System from Source
        =========  ==================
        CS series  cray-cs
        XC series  cray-xc
+       EX series  hpe-cray-ex
        =========  ==================
 
 
@@ -178,11 +109,17 @@ Building Chapel for a Cray System from Source
       ========================================  =========================
 
       ========================================  =========================
-      On a Cray X-series system, to...          set CHPL_LAUNCHER to...
+      On a Cray XC system, to...                set CHPL_LAUNCHER to...
       ========================================  =========================
       ...run jobs interactively on your system  aprun
       ...queue jobs using PBS (qsub)            pbs-aprun
       ...queue jobs using SLURM (sbatch)        slurm-srun
+      ========================================  =========================
+
+      ========================================  =========================
+      On an HPE Cray EX system, ...             set CHPL_LAUNCHER to...
+      ========================================  =========================
+      ...in all cases                           slurm-srun
       ========================================  =========================
 
    You can also set CHPL_LAUNCHER to ``none`` if you prefer to manually
@@ -190,9 +127,12 @@ Building Chapel for a Cray System from Source
 
    On Cray CS systems, ``CHPL_LAUNCHER`` defaults to ``gasnetrun_ibv``.
 
-   On Cray X-Series systems, ``CHPL_LAUNCHER`` defaults to ``aprun`` if
+   On Cray XC systems, ``CHPL_LAUNCHER`` defaults to ``aprun`` if
    ``aprun`` is in your path, ``slurm-srun`` if ``srun`` is in your path
    and ``none`` otherwise.
+
+   On HPE Cray EX systems, ``CHPL_LAUNCHER`` defaults to ``slurm-srun``
+   if ``srun`` is in your path and ``none`` otherwise.
 
    For more information on Chapel's launcher capabilities and options,
    refer to :ref:`readme-launcher`.
@@ -212,8 +152,9 @@ Building Chapel for a Cray System from Source
       ...the Intel compiler (icc)  intel
       ===========================  ==============================
 
-   On a Cray X-series system, ensure that you have one of the following
-   Programming Environment modules loaded to specify your target compiler::
+   On a Cray XC or HPE Cray EX system, ensure that you have one of the
+   following Programming Environment modules loaded to specify your
+   target compiler::
 
        PrgEnv-allinea (ARM only)
        PrgEnv-cray
@@ -666,6 +607,20 @@ synonymous with ``GASNET_MAX_SEGSIZE``, and the former overrides the
 latter if both are set.
 
 
+-------------------------------------
+Special Notes for HPE Cray EX Systems
+-------------------------------------
+
+The gasnet communication layer has not yet been built or tested on EX
+systems.  We expect to provide it in the pre-built module no later than
+the 1.25.0 release.
+
+The new PALS launcher for EX systems is supported by CHapel 1.24.0, but
+it has to be selected manually, by setting ``CHPL_LAUNCHER=pals``.  The
+default launcher selection cannot pick it by default.  We expect to add
+that support as soon as possible.
+
+
 .. _readme-cray-constraints:
 
 --------------------------
@@ -688,7 +643,7 @@ Known Constraints and Bugs
 * Redirecting stdin when executing a Chapel program under PBS/qsub
   may not work due to limitations of qsub.
 
-* For X-series systems, there is a known issue with the Cray MPI
+* For XC and EX systems, there is a known issue with the Cray MPI
   release that causes some programs to assert and then hang during
   exit.  A workaround is to set the environment variable,
   ``MPICH_GNI_DYNAMIC_CONN`` to ``disabled``.  Setting this environment

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -25,7 +25,9 @@ installed, do the following:
 
 1) Ensure this required module is loaded.  Normally it will be loaded
    for you, but under some circumstances you may need to load or
-   restore it yourself::
+   restore it yourself:
+
+   .. code-block:: sh
 
       PrgEnv-cray or PrgEnv-gnu
 

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -614,13 +614,12 @@ Special Notes for HPE Cray EX Systems
 -------------------------------------
 
 The gasnet communication layer has not yet been built or tested on EX
-systems.  We expect to provide it in the pre-built module no later than
-the 1.25.0 release.
+systems, although we expect to add support in the future.
 
 The new PALS launcher for EX systems is supported by Chapel 1.24.0, but
 it has to be selected manually, by setting ``CHPL_LAUNCHER=pals``.  The
-default launcher selection cannot pick it by default.  We expect to add
-that support as soon as possible.
+default launcher selection does not pick it by default.  We expect to
+add that support in the future.
 
 
 .. _readme-cray-constraints:

--- a/doc/rst/users-guide/locality/compilingAndExecutingMultiLocalePrograms.rst
+++ b/doc/rst/users-guide/locality/compilingAndExecutingMultiLocalePrograms.rst
@@ -21,10 +21,9 @@ options for communication include:
 
 * ``ofi``: specifies that communication should be implemented using
   the open-source libfabric library component of OpenFabrics Interfaces
-  (OFI).   This configuration is preliminary; see :ref:`readme-libfabric` for
-  more information.
+  (OFI).   See :ref:`readme-libfabric` for more information.
 
-When using the Chapel module on Cray systems, a third option is also
+When using the Chapel module on Cray XC systems, a third option is also
 available:
 
 * ``ugni``: specifies that communication should be implemented using

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -73,7 +73,7 @@ Platform Support
 ----------------
 
 Currently supported platforms include 32- and 64-bit Linux, Mac OS X,
-Cygwin (Windows), SunOS, a variety of current Cray platforms, and a
+Cygwin (Windows), SunOS, a variety of current HPE and Cray platforms, and a
 few systems by other vendors.  Most UNIX-based environments ought to
 support Chapel (subject to the assumptions in :ref:`readme-prereqs`), but may
 not be supported "out-of-the-box" by our current Makefile structure.

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -198,16 +198,19 @@ CHPL_*_COMPILER
    The default for ``CHPL_*_COMPILER`` depends on the value of the corresponding
    ``CHPL_*_PLATFORM`` environment variable:
 
-        ============  ==================================================
-        Platform      Compiler
-        ============  ==================================================
-        cray-x*,      - gnu (for ``CHPL_HOST_COMPILER``)
-        hpe-cray-ex   - cray-prgenv-$PE_ENV (for ``CHPL_TARGET_COMPILER``,
-                        where PE_ENV is set by PrgEnv-* modules)
-        darwin        clang if available, otherwise gnu
-        pwr6          ibm
-        other         gnu
-        ============  ==================================================
+        +-------------+------------------------------------------------------+
+        | Platform    | Compiler                                             |
+        +=============+======================================================+
+        | cray-xc,    | - gnu (for ``CHPL_HOST_COMPILER``)                   |
+        | hpe-cray-ex | - cray-prgenv-$PE_ENV (for ``CHPL_TARGET_COMPILER``, |
+        |             |   where PE_ENV is set by PrgEnv-* modules)           |
+        +-------------+------------------------------------------------------+
+        | darwin      | clang if available, otherwise gnu                    |
+        +-------------+------------------------------------------------------+
+        | pwr6        | ibm                                                  |
+        +-------------+------------------------------------------------------+
+        | other       | gnu                                                  |
+        +-------------+------------------------------------------------------+
 
    If ``CHPL_HOST_PLATFORM == CHPL_TARGET_PLATFORM`` and is not ``cray-x*``
    or ``hpe-cray-ex``,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -105,6 +105,7 @@ CHPL_HOST_PLATFORM
         sunos        SunOS platforms
         cray-cs      Cray CS\ |trade|
         cray-xc      Cray XC\ |trade|
+        hpe-cray-ex  HPE Cray EX\ |trade|
         ===========  ==================================
 
    Platform-specific documentation is available for most of these platforms in
@@ -200,15 +201,16 @@ CHPL_*_COMPILER
         ============  ==================================================
         Platform      Compiler
         ============  ==================================================
-        cray-x*       - gnu (for ``CHPL_HOST_COMPILER``)
-                      - cray-prgenv-$PE_ENV (for ``CHPL_TARGET_COMPILER``,
+        cray-x*,      - gnu (for ``CHPL_HOST_COMPILER``)
+        hpe-cray-ex   - cray-prgenv-$PE_ENV (for ``CHPL_TARGET_COMPILER``,
                         where PE_ENV is set by PrgEnv-* modules)
         darwin        clang if available, otherwise gnu
         pwr6          ibm
         other         gnu
         ============  ==================================================
 
-   If ``CHPL_HOST_PLATFORM == CHPL_TARGET_PLATFORM`` and is not ``cray-x*``,
+   If ``CHPL_HOST_PLATFORM == CHPL_TARGET_PLATFORM`` and is not ``cray-x*``
+   or ``hpe-cray-ex``,
    ``CHPL_TARGET_COMPILER`` will default to the same value as ``CHPL_HOST_COMPILER``.
 
    .. note::
@@ -390,7 +392,7 @@ CHPL_COMM
         ======= ============================================
         none    only supports single-locale execution
         gasnet  use the GASNet-based communication layer
-        ofi     use the (preliminary) libfabric-based communication layer
+        ofi     use the libfabric-based communication layer
         ugni    Cray-specific native communication layer
         ======= ============================================
 

--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -308,7 +308,7 @@ tasks only for data parallelism it may be unnecessarily large.  Stacks
 that are unnecessarily large are typically only a problem for programs
 in which many tasks (thus their stacks) exist at once, when using a comm
 layer that has to pre-register memory.  For the particular case of using
-the native runtime communication and tasking layers on Cray X* systems,
+the native runtime communication layers on Cray XC and HPE Cray EX systems,
 further discussion about this can be found in :ref:`readme-cray`.
 
 The following environment variable can be used to change the task call

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -52,8 +52,9 @@ amudprun             GASNet launcher for programs running over UDP
 aprun                Cray application launcher using aprun                
 gasnetrun_ibv        GASNet launcher for programs running over Infiniband 
 gasnetrun_mpi        GASNet launcher for programs using the MPI conduit   
-mpirun4ofi           provisional launcher for ``CHPL_COMM=ofi`` on non-Cray X* systems
+mpirun4ofi           provisional launcher for ``CHPL_COMM=ofi`` on non-Cray systems
 lsf-gasnetrun_ibv    GASNet launcher using LSF (bsub) over Infiniband
+pals                 Cray application launcher using PALS on HPE Cray EX systems
 pbs-aprun            Cray application launcher using PBS (qsub) + aprun   
 pbs-gasnetrun_ibv    GASNet launcher using PBS (qsub) over Infiniband     
 slurm-gasnetrun_ibv  GASNet launcher using SLURM over Infiniband          

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -10,7 +10,7 @@ platform that supports multilocale Chapel.  However, there are also other
 communication configurations that work in specific situations.  On Cray
 XC systems, using native communication as described in :ref:`Using
 Chapel on Cray Systems <readme-cray>` will probably give the best performance.
-For instructions on using the preliminary OpenFabrics Interfaces
+For instructions on using the OpenFabrics Interfaces
 libfabric-based ``ofi`` communication layer, see :ref:`readme-libfabric`.
 
 Steps 2-3 describe how to build a multilocale Chapel, and steps 4-6 cover

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -29,7 +29,7 @@ about your environment for using Chapel:
   * You have access to standard C and C++11 compilers. We test our code
     using a range of compilers on a nightly basis; these include
     relatively recent versions of gcc/g++, clang, and compilers from
-    Cray and Intel. If using GCC, we recommend GCC version 5 or newer.
+    HPE Cray and Intel. If using GCC, we recommend GCC version 5 or newer.
 
   * Building GMP requires an M4 macro processor.
 


### PR DESCRIPTION
Update the documentation to reflect that both the libfabric-based comm
layer and the HPE Cray EX platform support are pretty well mature.  In
particular, unify the documentation for Cray XC and HPE Cray EX in a
number of places.

This resolves https://github.com/Cray/chapel-private/issues/1762.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>