### PR TITLE
Issue #17182: adding checksumming to mason

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -924,6 +924,11 @@ module DateTime {
     return this.now();
   }
 
+  /* Return a 'int' value representing the number of seconds from epoch */
+  proc type datetime.gettimestamp() {
+    return getTimeOfDay()[0];
+  }
+
   /* Return a `datetime` value representing the current time and date */
   proc type datetime.now(in tz: shared TZInfo? = nil) {
     if tz.borrow() == nil {

--- a/test/mason/build/_noDeps/Mason.toml
+++ b/test/mason/build/_noDeps/Mason.toml
@@ -1,5 +1,7 @@
+
 [brick]
 name = "noDeps"
+CheckSum = "58bbb5b97dcefc83772291c47954233dc39296e1c08ec10a560913147ff661c6"
 version = "0.1.0"
 chplVersion = "1.24.0"
 license = "None"

--- a/test/mason/build/noDeps.chpl
+++ b/test/mason/build/noDeps.chpl
@@ -6,6 +6,6 @@ use MasonBuild;
 proc main() {
   const package = '_noDeps';
   here.chdir(package);
-  const args = ["mason", "build"];
+  const args = ["mason", "build", "--no-checksum"];
   masonBuild(args);
 }

--- a/test/mason/build/noDepsWithChecksum.chpl
+++ b/test/mason/build/noDepsWithChecksum.chpl
@@ -1,0 +1,17 @@
+/* Test a package with Manifest.toml without [dependencies] table */
+use FileSystem;
+
+use MasonBuild;
+use MasonUtils;
+
+proc main() {
+  const package = '_noDeps';
+  var cwd = here.cwd();
+  var tf = "Mason.toml";
+  var projectHome = getProjectHome(cwd + '/' + package, tf);
+  removeHash(projectHome, tf);
+
+  here.chdir(package);
+  const args = ["mason", "build"];
+  masonBuild(args);
+}

--- a/test/mason/build/noDepsWithChecksum.good
+++ b/test/mason/build/noDepsWithChecksum.good
@@ -1,0 +1,4 @@
+Skipping registry update since no dependency found in manifest file.
+Compiling [debug] target: noDeps
+Build Successful
+

--- a/test/mason/chplVersion/mason-chpl-version-build.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-build.chpl
@@ -5,7 +5,7 @@ use IO;
 
 proc main() {
 
-  var checksum = true;
+  var checksum = false;
   const toml = open("Mason.toml", iomode.cw);
   var s      = toml.writer();
 

--- a/test/mason/chplVersion/mason-chpl-version-build.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-build.chpl
@@ -5,7 +5,7 @@ use IO;
 
 proc main() {
 
-  
+  var checksum = true;
   const toml = open("Mason.toml", iomode.cw);
   var s      = toml.writer();
 
@@ -34,5 +34,5 @@ proc main() {
 
   var compopts: list(string);
   compopts.append("");
-  buildProgram(false, false, false, compopts, "Mason.toml", "Mason.lock");
+  buildProgram(false, false, false, compopts, checksum, "Mason.toml", "Mason.lock");
 }

--- a/test/mason/chplVersion/mason-chpl-version-new-with-checksum.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-new-with-checksum.chpl
@@ -4,8 +4,8 @@ use MasonNew;
 use IO;
 
 proc main() {
-  const args : [0..3] string;
-  args = ['mason','new', 'newTest', '--no-checksum'];
+  const args : [0..2] string;
+  args = ['mason','new', 'newTest'];
 
   assert(isDir("newTest") == false);
 

--- a/test/mason/chplVersion/mason-chpl-version-new-with-checksum.good
+++ b/test/mason/chplVersion/mason-chpl-version-new-with-checksum.good
@@ -1,0 +1,12 @@
+Created new library project: newTest
+
+[brick]
+name = "newTest"
+CheckSum = "11ab7ee7f00c0425e9d5f12c8cf1f71a32b58837d85c38db2246707f43c2035c"
+version = "0.1.0"
+chplVersion = "1.24.0"
+license = "None"
+
+[dependencies]
+
+

--- a/test/mason/chplVersion/mason-chpl-version-update.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-update.chpl
@@ -7,10 +7,11 @@ use IO;
 use FileSystem;
 
 config const toml = "";
+var checksum = true;
 
 proc main() {
 
-  updateLock(true, tf=toml);
+  updateLock(true, checksum, tf=toml);
 
   if exists("Mason.lock") {
     writeln("----- lock file -----");

--- a/test/mason/chplVersion/mason-chpl-version-update.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-update.chpl
@@ -7,7 +7,7 @@ use IO;
 use FileSystem;
 
 config const toml = "";
-var checksum = true;
+var checksum = false;
 
 proc main() {
 

--- a/test/mason/init/project/Mason.toml
+++ b/test/mason/init/project/Mason.toml
@@ -1,5 +1,7 @@
+
 [brick]
 name = "project"
+CheckSum = "4ee4deaa06afdeb48c23147e6c7519950ca706466eec23dfe27ea0140d45b7f9"
 version = "1.2.3"
 chplVersion = "1.21.0"
 license = "MIT"

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -5,11 +5,11 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["mason", "--build", "--example", "--force"]);
+  masonBuild(["mason", "--build", "--example", "--force", "--no-checksum"]);
 
   // run each example
   // over 3 arguments runs all examples
-  var runArgs: [0..3] string = ["mason", "run", "--example", "--force"];
+  var runArgs: [0..4] string = ["mason", "run", "--example", "--force", "--no-checksum"];
   masonRun(runArgs);
 
 }

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -5,10 +5,10 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["mason", "--build", "--example", "--force"]);
+  masonBuild(["mason", "--build", "--example", "--force", "--no-checksum"]);
 
   // run each example
   // over 3 arguments runs all examples
-  masonRun(["mason", "run", "--example", "--force", "--no-update"]);
+  masonRun(["mason", "run", "--example", "--force", "--no-update", "--no-checksum"]);
 
 }

--- a/test/mason/mason-external/libtomlc99/mason-external.chpl
+++ b/test/mason/mason-external/libtomlc99/mason-external.chpl
@@ -24,7 +24,7 @@ proc main() {
   masonExternal(args);
 
   // build library that uses libtomlc99
-  var buildArgs = ["mason", "build", "--force"];
+  var buildArgs = ["mason", "build", "--force", "--no-checksum"];
   masonBuild(buildArgs);
 
 }

--- a/test/mason/mason-test/mason-test.chpl
+++ b/test/mason/mason-test/mason-test.chpl
@@ -4,6 +4,6 @@ use MasonTest;
 
 
 proc main() {
-  const args = ["mason", "test"];
+  const args = ["mason", "test", "--no-checksum"];
   masonTest(args);
 }

--- a/test/mason/mason-update-toml-error/mason-chpl-version-update.chpl
+++ b/test/mason/mason-update-toml-error/mason-chpl-version-update.chpl
@@ -7,9 +7,10 @@ use IO;
 use FileSystem;
 
 config const toml = "";
+var checksum = false;
 
 proc main() {
-  updateLock(true, tf=toml);
+  updateLock(true, checksum, tf=toml);
 
   if exists("Mason.lock") {
     writeln("----- lock file -----");

--- a/test/mason/masonTestSome/mason-test-some.chpl
+++ b/test/mason/masonTestSome/mason-test-some.chpl
@@ -4,6 +4,6 @@ use MasonTest;
 
 
 proc main() {
-  const args = ["mason", "test" , "test/test1.chpl", "test/testDir"];
+  const args = ["mason", "test" , "test/test1.chpl", "test/testDir", "--no-checksum"];
   masonTest(args);
 }

--- a/test/mason/masonTestSubString/mason-test-sub-string.chpl
+++ b/test/mason/masonTestSubString/mason-test-sub-string.chpl
@@ -1,6 +1,6 @@
 use MasonTest;
 
 proc main() {
-  const args = ["mason", "test" , "1", "3", "--no-update"];
+  const args = ["mason", "test" , "1", "3", "--no-update", "--no-checksum"];
   masonTest(args);
 }

--- a/test/mason/masonUpdateTest.chpl
+++ b/test/mason/masonUpdateTest.chpl
@@ -15,7 +15,7 @@ proc main() {
   // actual current version.
 
   const currentVersion = getChapelVersionStr();
-  var checksum = true;
+  var checksum = false;
 
   // file.good -> file.lock
   const lf = goodLock.replace('good', 'lock');

--- a/test/mason/masonUpdateTest.chpl
+++ b/test/mason/masonUpdateTest.chpl
@@ -15,6 +15,7 @@ proc main() {
   // actual current version.
 
   const currentVersion = getChapelVersionStr();
+  var checksum = true;
 
   // file.good -> file.lock
   const lf = goodLock.replace('good', 'lock');
@@ -26,7 +27,7 @@ proc main() {
     w.close();
   }
 
-  var configs = updateLock(true, tf=tf, lf=temp.tryGetPath());
+  var configs = updateLock(true, checksum, tf=tf, lf=temp.tryGetPath());
   var lock = open(temp.tryGetPath(), iomode.r);
   var lockFile = parseToml(lock);
   writeln(lockFile);

--- a/test/mason/new/project/Mason.toml
+++ b/test/mason/new/project/Mason.toml
@@ -1,8 +1,11 @@
+
 [brick]
 name = "project"
+CheckSum = "4ee4deaa06afdeb48c23147e6c7519950ca706466eec23dfe27ea0140d45b7f9"
 version = "1.2.3"
 chplVersion = "1.21.0"
 license = "MIT"
 
 [dependencies]
+
 

--- a/test/mason/pkgconfig-tests/pcTest.chpl
+++ b/test/mason/pkgconfig-tests/pcTest.chpl
@@ -15,7 +15,7 @@ proc main() {
   // actual current version.
 
   const currentVersion = getChapelVersionStr();
-  var checksum = true;
+  var checksum = false;
 
   // file.good -> file.lock
   const lf = goodLock.replace('good', 'lock');

--- a/test/mason/pkgconfig-tests/pcTest.chpl
+++ b/test/mason/pkgconfig-tests/pcTest.chpl
@@ -15,6 +15,7 @@ proc main() {
   // actual current version.
 
   const currentVersion = getChapelVersionStr();
+  var checksum = true;
 
   // file.good -> file.lock
   const lf = goodLock.replace('good', 'lock');
@@ -26,7 +27,7 @@ proc main() {
     w.close();
   }
 
-  var configs = updateLock(true, tf=tf, lf=temp.tryGetPath());
+  var configs = updateLock(true, checksum, tf=tf, lf=temp.tryGetPath());
   var lock = open(temp.tryGetPath(), iomode.r);
   var lockFile = parseToml(lock);
   writeln(lockFile);

--- a/test/mason/run/mason-run.chpl
+++ b/test/mason/run/mason-run.chpl
@@ -1,6 +1,6 @@
 use MasonRun;
 
 proc main() {
-  const args: [0..3] string = ["mason", "run", "--build", "--force"];
+  const args: [0..4] string = ["mason", "run", "--build", "--force", "--no-checksum"];
   masonRun(args);
 }

--- a/test/mason/subdir-commands/mason-run.chpl
+++ b/test/mason/subdir-commands/mason-run.chpl
@@ -1,6 +1,6 @@
 use MasonRun;
 
 proc main() {
-  const args: [0..3] string = ["mason", "run", "--build", "--force"];
+  const args: [0..4] string = ["mason", "run", "--build", "--force", "--no-checksum"];
   masonRun(args);
 }

--- a/tools/mason/FileHashing.chpl
+++ b/tools/mason/FileHashing.chpl
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 module FileHashing {
 
   /* SHA256Hash is a record storing a SHA256 hash value.

--- a/tools/mason/FileHashing.chpl
+++ b/tools/mason/FileHashing.chpl
@@ -1,0 +1,166 @@
+module FileHashing {
+
+  /* SHA256Hash is a record storing a SHA256 hash value.
+     It supports comparison and writeln.
+   */
+  record SHA256Hash {
+    /* The actual hash value */
+    var hash: 8*uint(32);
+
+    /* Help `writeln` and other calls output SHA256Hash value
+       in a good format.
+       */
+
+    proc writeThis(f) throws {
+      for component in hash {
+        var s = try! "%08xu".format(component);
+        f <~> s;
+      }
+    }
+
+    /* How to initialize an empty SHA256Hash */
+    proc init() {
+      // compiler adds initialization of hash to 0s
+    }
+    /* How to initialize a SHA256Hash from another SHA256Hash */
+    proc init=(from: SHA256Hash) {
+      this.hash = from.hash;
+    }
+    /* How to initialize a SHA256Hash from a hash tuple */
+    proc init(hash: 8*uint(32)) {
+      this.hash = hash;
+    }
+  }
+
+  /* Called when assigning between SHA256Hash values */
+  proc =(ref lhs: SHA256Hash, rhs: SHA256Hash) {
+    lhs.hash = rhs.hash;
+  }
+
+  /* Helps to implement comparisons between SHA256Hash values.
+     Returns -1 if a < b, 1 if a > b, or 0 if a == b.
+   */
+  proc compare(a: SHA256Hash, b: SHA256Hash): int {
+
+    for i in 0..7 {
+      var aa = a.hash[i];
+      var bb = b.hash[i];
+      if aa < bb {
+        return -1;
+      }
+      if aa > bb {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  proc <(a: SHA256Hash, b: SHA256Hash) {
+    return compare(a, b) < 0;
+  }
+  proc <=(a: SHA256Hash, b: SHA256Hash) {
+    return compare(a, b) <= 0;
+  }
+  proc ==(a: SHA256Hash, b: SHA256Hash) {
+    return compare(a, b) == 0;
+  }
+  proc !=(a: SHA256Hash, b: SHA256Hash) {
+    return compare(a, b) != 0;
+  }
+  proc >=(a: SHA256Hash, b: SHA256Hash) {
+    return compare(a, b) >= 0;
+  }
+  proc >(a: SHA256Hash, b: SHA256Hash) {
+    return compare(a, b) > 0;
+  }
+
+
+  /*
+     Returns the SHA256Hash for the file stored at `path`.
+     May throw an error if the file could not be openned, for example.
+   */
+  proc computeFileHash(path: string): SHA256Hash throws {
+    use IO;
+    use SHA256Implementation;
+
+    var f = open(path, iomode.r);
+    var len = f.size;
+    var r = f.reader(kind=iokind.big, locking=false,
+                     start=0, end=len);
+
+
+    var msg:16*uint(32); // aka 64 bytes
+    var offset = 0;
+    var state:SHA256State;
+
+    // Read as many full blocks as we can
+    // but don't ever read the last block in this loop
+    // since we need to pass that to state.lastblock
+    while offset+64 < len {
+      r.read(msg);
+      state.fullblock(msg);
+      offset += 64;
+    }
+
+
+    // clear msg before last block, so unused data are zeros
+    for i in 0..15 {
+      msg[i] = 0;
+    }
+
+    var nbits:uint = 0;
+    var msgi = 0;
+    // Now handle the last 4-byte words
+    while offset+4 <= len {
+      r.read(msg[msgi]);
+      msgi += 1;
+      offset += 4;
+      nbits += 32;
+    }
+
+    if offset < len {
+      var lastword:uint(32);
+      var byte:uint(8);
+      var bytei = 0;
+      // Now handle the last 1-byte portions
+      while offset < len {
+        r.read(byte);
+        lastword <<= 8;
+        lastword |= byte;
+        bytei += 1;
+        offset += 1;
+        nbits += 8;
+      }
+      // Shift left so the data is in the high order bits of lastword.
+      while bytei != 4 {
+        lastword <<= 8;
+        bytei += 1;
+      }
+      msg[msgi] = lastword;
+    }
+
+    var hash:8*uint(32) = state.lastblock(msg, nbits);
+
+    return new SHA256Hash(hash);
+  }
+
+  /*
+    Given a path argument, computes the realPath (that
+    is the path after symbolic links are processed),
+    and then computes a relative version of that to the
+    current directory. Returns the result.
+   */
+  proc relativeRealPath(path: string): string throws {
+    use Path only ;
+    var currentDirectory = Path.realPath(".");
+    var fullPath = Path.realPath(path);
+    if !currentDirectory.endsWith("/") {
+      currentDirectory += "/";
+    }
+    // If fullPath starts with currentDirectory, remove it
+    if fullPath.startsWith(currentDirectory) {
+      fullPath = fullPath[currentDirectory.size..];
+    }
+    return fullPath;
+  }
+}

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -98,6 +98,7 @@ proc masonBuild(args: [] string) throws {
     if show then compopts.append("--show");
     if release then compopts.append("--release");
     if force then compopts.append("--force");
+    if !checksum then compopts.append("--no-checksum");
     masonExample(compopts.toArray());
   }
   else {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -109,7 +109,7 @@ private proc getBuildInfo(projectHome: string) {
   getSrcCode(sourceList, false);
   const project = lockFile["root"]!["name"]!.s;
   const projectPath = "".join(projectHome, "/src/", project, ".chpl");
-  
+
   // get the example names from lockfile or from example directory
   const exampleNames = getExamples(tomlFile.borrow(), projectHome);
 

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -285,15 +285,6 @@ private proc masonExternalRemove(toml: unmanaged Toml, toRm: string) throws {
   return toml;
 }
 
-/* Generate the modified Mason.toml */
-proc generateToml(toml: borrowed Toml, tomlPath: string) {
-  const tomlFile = open(tomlPath, iomode.cw);
-  const tomlWriter = tomlFile.writer();
-  tomlWriter.writeln(toml);
-  tomlWriter.close();
-  tomlFile.close();
-}
-
 proc checkVersion(version: string) throws {
 
 //  const pattern = compile("([0-9].[0-9].[0-9][a-zA-Z]?)");

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -28,13 +28,6 @@ use MasonUtils;
 use MasonUpdate;
 use MasonHelp;
 use MasonEnv;
-use SHA256Implementation;
-use FileHashing;
-use Sort;
-use TOML;
-use DateTime;
-use FileSystem;
-
 /*
   Creates a new library project at a given directory
   mason new <projectName/directoryName>
@@ -314,18 +307,6 @@ proc addGitIgnore(dirName: string) {
   GIwriter.close();
 }
 
-/* Recursively finds the files & directories and adds
-   the candidate files to the `paths` set.
- */
-proc getPaths(dirName: string, ref paths: domain(string)) {
-  if isDir(dirName) {
-    for path in findfiles(dirName, recursive=true) {
-      paths += relativeRealPath(path);
-    }
-  } else {
-    writeln("Error: not a directory ", dirName);
-  }
-}
 
 proc getBaseTomlString(packageName: string, version: string, chapelVersion: string, license: string) {
   const baseToml = """[brick]
@@ -357,59 +338,6 @@ proc makeBasicToml(dirName: string, path: string, version: string,
   var tomlWriter = tomlFile.writer();
   tomlWriter.write(baseToml);
   tomlWriter.close();
-}
-
-/* Given the paths of the files, this method sorts all the paths
-   lexicographically, computes hash of all the files & its path
-   combined and returns the hash.
- */
-proc computeHash(ref paths: domain(string)){
-  // Preprocess and generate a file.. use this file to compute hash
-  // output of paths {example-files/c2, example-files/all-bytes1, example-files/all-bytes2, example-files/all-bytes-twice, example-files/d1, example-files/a3, example-files/a2, example-files/a1, example-files/b1, example-files/c1}
-  var sortedPaths:[0..<paths.size] string;
-  for (str, path) in zip(sortedPaths, paths) {
-    str = path;
-  }
-  sort(sortedPaths);
-  writeln(sortedPaths);
-
-  var s = datetime.gettimestamp():string;
-  var fout = open("temp_" + s + ".txt", iomode.cwr);
-  var wout = fout.writer();
-  for path in sortedPaths{
-    var f = open(path, iomode.r);
-    var r = f.reader();
-    var line = "";
-    wout.write(path);
-    while (r.readline(line)) {
-      wout.write(line);
-    }
-    r.close();
-    f.close();
-  }
-  var absPath = fout.absPath();
-  wout.close();
-  fout.close();
-  var hash = computeFileHash(absPath);
-  var hash_string = "";
-  for component in hash.hash {
-    hash_string += try! "%08xu".format(component);
-  }
-  remove(absPath);
-  return hash_string;
-}
-
-/* Updates the Mason.toml with checksum */
-proc updateTomlWithChecksum(path: string) {
-  var paths: domain(string);
-  // Find files based on arguments and store them in paths
-  getPaths(dirName=path, paths);
-  var hash = computeHash(paths);
-  var tomlPath = path+"/Mason.toml";
-  const toParse = open(tomlPath, iomode.r);
-  const tomlFile = owned.create(parseToml(toParse));
-  tomlFile["brick"]!.set("CheckSum", hash);
-  generateToml(tomlFile, tomlPath);
 }
 
 /* Creates the src directory */

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -40,6 +40,7 @@ proc masonNew(args: [] string) throws {
   var version = '';
   var chplVersion = '';
   var license = 'None';
+  var checksum = true;
   try! {
     if args.size < 3 {
       var metadata = beginInteractiveSession('','','','');
@@ -69,7 +70,10 @@ proc masonNew(args: [] string) throws {
             show = true;
           }
           when '--name' {
-              packageName = args[countArgs];
+            packageName = args[countArgs];
+          }
+          when '--no-checksum' {
+            checksum = false;
           }
           otherwise {
             if arg.startsWith('--name=') {
@@ -90,7 +94,7 @@ proc masonNew(args: [] string) throws {
       if isDir(dirName) {
         throw new owned MasonError("A directory named '" + dirName + "' already exists");
       }
-      InitProject(dirName, packageName, vcs, show, version, chplVersion, license);
+      InitProject(dirName, packageName, vcs, show, version, chplVersion, license, checksum);
     }
   }
   catch e: MasonError {
@@ -268,7 +272,7 @@ proc validatePackageName(dirName) throws {
   directories such as .git, src, example, test
 */
 proc InitProject(dirName, packageName, vcs, show,
-                  version: string, chplVersion: string, license: string) throws {
+                  version: string, chplVersion: string, license: string, checksum: bool) throws {
   if vcs {
     gitInit(dirName, show);
     addGitIgnore(dirName);
@@ -283,7 +287,9 @@ proc InitProject(dirName, packageName, vcs, show,
     makeModule(dirName, fileName=packageName);
     makeTestDir(dirName);
     makeExampleDir(dirName);
-    updateTomlWithChecksum(path=dirName);
+    if checksum then {
+      updateTomlWithChecksum(path=dirName);
+    }
     writeln("Created new library project: " + dirName);
   }
   else {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -203,6 +203,7 @@ private proc masonBuildRun(args: [?d] string) {
       if release then execopts.append("--release");
       if force then execopts.append("--force");
       if show then execopts.append("--show");
+      if !checksum then execopts.append("--no-checksum");
       masonExample(execopts.toArray());
     }
     else {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -155,6 +155,7 @@ private proc masonBuildRun(args: [?d] string) {
     var skipUpdate = MASON_OFFLINE;
     var execopts: list(string);
     var exampleProgram='';
+    var checksum = true;
     for arg in args[2..] {
       if exec == true {
         execopts.append(arg);
@@ -189,6 +190,9 @@ private proc masonBuildRun(args: [?d] string) {
       else if arg == '--update' {
         skipUpdate = false;
       }
+      else if arg == '--no-checksum' {
+        checksum = false;
+      }
       else {
         // could be examples or execopts
         execopts.append(arg);
@@ -210,6 +214,7 @@ private proc masonBuildRun(args: [?d] string) {
       if release then buildArgs.append("--release");
       if force then buildArgs.append("--force");
       if show then buildArgs.append("--show");
+      if !checksum then buildArgs.append("--no-checksum");
 
       masonBuild(buildArgs.toArray());
       runProjectBinary(show, release, execopts);
@@ -219,5 +224,3 @@ private proc masonBuildRun(args: [?d] string) {
     stderr.writeln(e.message());
   }
 }
-
-

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -75,6 +75,11 @@ proc masonUpdate(args: [?d] string) {
   return updateLock(skipUpdate, tf, lf);
 }
 
+/*
+Given a project Directory, this method removes the
+checksum field from the project's toml and regenerates
+a toml without the checksum field.
+*/
 proc removeHash(projectHome: string, tf: string){
   var hash = "";
   var tomlPath = projectHome + "/" + tf;
@@ -137,7 +142,7 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock") {
     delete lockFile;
     var newHash = updateTomlWithChecksum(projectHome);
     if previousHash != "" && previousHash != newHash {
-      writeln("Project has some changes, computing the new Hash");
+      writeln("Project had some updates, computing the new Hash");
     }
   }
   catch e: MasonError {

--- a/tools/mason/SHA256Implementation.chpl
+++ b/tools/mason/SHA256Implementation.chpl
@@ -1,0 +1,376 @@
+/*
+
+This module implements the SHA256 cryptographic hash algorithm.
+
+*/
+module SHA256Implementation {
+
+  // This implementation is based on FIPS 180-4 and uses some
+  // hints from other implementations for reducing the number
+  // of instructions in the basic functions.
+
+  /* This record stores the state of the hash. */
+  record SHA256State {
+    var length:uint(64); // length of hashed message, in bits
+    var H:8*uint(32);    // current hash
+  };
+
+  /* This function simply casts the passed integer to a uint(32) */
+  inline proc ul(x) {
+    return x:uint(32);
+  }
+  /* This function casts each portion of the passed tuple
+     to uint(32) and returns the result. */
+  inline proc ul(x:8*int) {
+    var ret:8*uint(32);
+    for i in 0..7 {
+      ret[i] = x[i]:uint(32);
+    }
+    return ret;
+  }
+
+
+  // The K constants
+  private
+  var K:64*uint(32) =
+(ul(0x428a2f98), ul(0x71374491), ul(0xb5c0fbcf), ul(0xe9b5dba5), ul(0x3956c25b),
+ ul(0x59f111f1), ul(0x923f82a4), ul(0xab1c5ed5), ul(0xd807aa98), ul(0x12835b01),
+ ul(0x243185be), ul(0x550c7dc3), ul(0x72be5d74), ul(0x80deb1fe), ul(0x9bdc06a7),
+ ul(0xc19bf174), ul(0xe49b69c1), ul(0xefbe4786), ul(0x0fc19dc6), ul(0x240ca1cc),
+ ul(0x2de92c6f), ul(0x4a7484aa), ul(0x5cb0a9dc), ul(0x76f988da), ul(0x983e5152),
+ ul(0xa831c66d), ul(0xb00327c8), ul(0xbf597fc7), ul(0xc6e00bf3), ul(0xd5a79147),
+ ul(0x06ca6351), ul(0x14292967), ul(0x27b70a85), ul(0x2e1b2138), ul(0x4d2c6dfc),
+ ul(0x53380d13), ul(0x650a7354), ul(0x766a0abb), ul(0x81c2c92e), ul(0x92722c85),
+ ul(0xa2bfe8a1), ul(0xa81a664b), ul(0xc24b8b70), ul(0xc76c51a3), ul(0xd192e819),
+ ul(0xd6990624), ul(0xf40e3585), ul(0x106aa070), ul(0x19a4c116), ul(0x1e376c08),
+ ul(0x2748774c), ul(0x34b0bcb5), ul(0x391c0cb3), ul(0x4ed8aa4a), ul(0x5b9cca4f),
+ ul(0x682e6ff3), ul(0x748f82ee), ul(0x78a5636f), ul(0x84c87814), ul(0x8cc70208),
+ ul(0x90befffa), ul(0xa4506ceb), ul(0xbef9a3f7), ul(0xc67178f2));
+
+  // The logical functions
+
+  // Rotate right
+  private inline
+  proc ROTR(x:uint(32), y:uint(32)):uint(32) {
+    use BitOps;
+    return rotr(x & ul(0xffffffff), y & 31);
+  }
+
+  private inline
+  proc Ch(x:uint(32), y:uint(32), z:uint(32)):uint(32) {
+    return z ^ (x & (y ^ z));
+  }
+
+  private inline
+  proc Maj(x:uint(32), y:uint(32), z:uint(32)):uint(32) {
+    return ((x | y) & z) | (x & y);
+  }
+
+  // Shift right
+  private inline
+  proc SHR(x:uint(32), n:uint(32)):uint(32) {
+    return (x & ul(0xffffffff)) >> n;
+  }
+
+  private inline
+  proc Sigma0(x:uint(32)):uint(32) {
+    return ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22);
+  }
+
+  private inline
+  proc Sigma1(x:uint(32)):uint(32) {
+    return ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25);
+  }
+
+  private inline
+  proc Gamma0(x:uint(32)):uint(32) {
+    return ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3);
+  }
+
+  private inline
+  proc Gamma1(x:uint(32)):uint(32) {
+    return ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10);
+  }
+
+  // hash computation
+  private
+  proc sha256_compute(ref state:SHA256State, msg:16*uint(32)) {
+    var W:64*uint(32);
+
+    // Prepare the message schedule
+    for i in 0..15 {
+      W[i] = msg[i];
+    }
+    for i in 16..63 {
+      W[i] = Gamma1(W[i - 2]) + W[i - 7] + Gamma0(W[i - 15]) + W[i - 16];
+    }
+
+    // Initialize the working variables
+    var a = state.H[0];
+    var b = state.H[1];
+    var c = state.H[2];
+    var d = state.H[3];
+    var e = state.H[4];
+    var f = state.H[5];
+    var g = state.H[6];
+    var h = state.H[7];
+
+    for i in 0..63 {
+      var t1:uint(32);
+      var t2:uint(32);
+      t1 = h + Sigma1(e) + Ch(e, f, g) + K[i] + W[i];
+      t2 = Sigma0(a) + Maj(a, b, c);
+      h = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+
+    // compute the intermediate hash value
+    state.H[0] += a;
+    state.H[1] += b;
+    state.H[2] += c;
+    state.H[3] += d;
+    state.H[4] += e;
+    state.H[5] += f;
+    state.H[6] += g;
+    state.H[7] += h;
+
+  }
+
+  // Set the bit numbered `bit` in `msg`.
+  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(1)
+  // and bit 0 is the most-significant.
+  private
+  proc set_bit(ref msg:16*uint(32), bit:uint) {
+    assert(bit < 512);
+    var whichword = ul(bit / 32);
+    var inword = ul(bit % 32);
+    msg[whichword] |= ul(1) << (31 - inword);
+  }
+
+  // Clear the bits after bit `nbits` in `msg`.
+  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(1)
+  // and bit 0 is the most-significant.
+  private
+  proc clear_bits_after(ref msg:16*uint(32), nbits:uint) {
+    assert(nbits < 512);
+    var whichword = ul(nbits / 32);
+    var inword = ul(nbits % 32);
+
+    var word:uint(32) = msg[whichword];
+    // Clear the bits after inword in word
+    var zero:uint(32) = 0;
+    var ones:uint(32) = ~zero;
+    var mask:uint(32);
+    if inword == 0 then
+      mask = 0;
+    else
+      mask = ones << (32-inword);
+    word &= mask;
+    msg[whichword] = word;
+
+    // Clear the remaining words
+    for i in whichword+1..15 {
+      msg[i] = 0;
+    }
+  }
+
+  /* Initialize a SHA256State so that it can perform hash computations. */
+  proc SHA256State.init() {
+    this.length = 0;
+
+    this.H = ul( (0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19) );
+  }
+
+  /* Processes 512 bits of message.
+     This function can be called an arbitrary number of times
+     to compute the hash for a long message.
+
+     Note, the `msg` words should already be in native byte order.
+     That means the caller probably needed to already run big-endian-to-host
+     on the message.
+   */
+  proc ref SHA256State.fullblock(msg:16*uint(32)) {
+    this.length += 512;
+    sha256_compute(this, msg);
+  }
+
+  /* Process the final <= 512 bits of message.
+     Computes and returns the final hash.
+
+     As with SHA256State.fullblock, the msg words should already be
+     in native byte order. That means the caller probably needed to already run
+     big-endian-to-host on the message.
+
+     nbits is the number of bits in msg to use
+   */
+  proc ref SHA256State.lastblock(in msg:16*uint(32), in nbits:uint):8*uint(32)
+  {
+    this.length += nbits;
+
+    // This routine is handling padding the message
+    if nbits == 512 {
+      sha256_compute(this, msg);
+      nbits = 0;
+    }
+    // Append the 1 bit
+    set_bit(msg, nbits);
+    nbits += 1;
+    // clear the last 512 - bits of the message
+    clear_bits_after(msg, nbits);
+
+    // Now we need to pad zeros so there is room to store the 8 bytes of
+    if nbits > 512 - 64 {
+      sha256_compute(this, msg);
+      nbits = 0;
+      clear_bits_after(msg, nbits);
+    }
+
+    // Now store the 64-bit length quantity in the last two words
+    // of the message.
+    msg[14] = ul((this.length >> 32) & ul(0xffffffff));
+    msg[15] = ul(this.length & ul(0xffffffff));
+
+    // hash the final block
+    sha256_compute(this, msg);
+
+    return this.H;
+  }
+
+  /* This function exists to test private methods in this module and can
+     be called to run a sequence of unit tests. */
+  proc unittest() {
+    var zeros:16*uint(32);
+    var ones:16*uint(32);
+    var msg:16*uint(32);
+
+    for i in 0..15 {
+      ones[i] = ~zeros[i];
+    }
+
+    msg = ones;
+    clear_bits_after(msg, 0);
+    assert(msg[0] == 0 && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 1);
+    assert(msg[0] == 0x80000000 && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 2);
+    assert(msg[0] == 0xc0000000 && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 31);
+    assert(msg[0] == 0xfffffffe && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 32);
+    assert(msg[0] == 0xffffffff && msg[1] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 33);
+    assert(msg[0] == 0xffffffff && msg[1] == 0x80000000 &&
+           msg[3] == 0 && msg[15] == 0);
+
+    msg = ones;
+    clear_bits_after(msg, 34);
+    assert(msg[0] == 0xffffffff && msg[1] == 0xc0000000 &&
+           msg[3] == 0 && msg[15] == 0);
+
+    msg = zeros;
+    set_bit(msg, 0);
+    assert(msg[0] == 0x80000000 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 1);
+    assert(msg[0] == 0x40000000 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 2);
+    assert(msg[0] == 0x20000000 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 31);
+    assert(msg[0] == 0x00000001 && msg[1] == 0);
+
+    msg = zeros;
+    set_bit(msg, 32);
+    assert(msg[0] == 0 && msg[1] == 0x80000000 && msg[3] == 0);
+
+    msg = zeros;
+    set_bit(msg, 33);
+    assert(msg[0] == 0 && msg[1] == 0x40000000 && msg[3] == 0);
+
+
+    var startingState:SHA256State;
+    var state:SHA256State;
+    var hash:8*uint(32);
+
+    state = startingState;
+    msg = zeros;
+    msg[0] = 0x61000000;
+    hash = state.lastblock(msg, 1*8);
+    assert(hash==ul( ( 0xca978112, 0xca1bbdca, 0xfac231b3, 0x9a23dc4d,
+                       0xa786eff8, 0x147c4e72, 0xb9807785, 0xafee48bb) ));
+
+    // Try hashing varying lengths of 0 bytes
+    // These tests help ensure we have the padding right
+
+    // 0 bytes
+    state = startingState;
+    hash = state.lastblock(zeros, 0);
+
+    assert(hash==ul( (0xe3b0c442, 0x98fc1c14, 0x9afbf4c8, 0x996fb924,
+		      0x27ae41e4, 0x649b934c, 0xa495991b, 0x7852b855) ));
+
+
+    // 55 bytes
+    state = startingState;
+    hash = state.lastblock(zeros, 55*8);
+
+    assert(hash==ul( (0x02779466, 0xcdec1638, 0x11d07881, 0x5c633f21,
+                      0x90141308, 0x1449002f, 0x24aa3e80, 0xf0b88ef7) ));
+
+    // 56 bytes
+    state = startingState;
+    hash = state.lastblock(zeros, 56*8);
+    assert(hash==ul( (0xd4817aa5, 0x497628e7, 0xc77e6b60, 0x6107042b,
+                      0xbba31308, 0x88c5f47a, 0x375e6179, 0xbe789fbb) ));
+
+    // 119 bytes
+    state = startingState;
+    state.fullblock(zeros); // 64 bytes
+    hash = state.lastblock(zeros, 55*8);
+    assert(hash==ul((0xf616b0d5, 0x4e78571a, 0x9611f343, 0xc9f8e022,
+                     0xe859e920, 0x381ab0e4, 0xd3da01e1, 0x93a7bd7e) ));
+
+    // 120 bytes
+    state = startingState;
+    state.fullblock(zeros); // 64 bytes
+    hash = state.lastblock(zeros, 56*8);
+    assert(hash==ul((0x6edd9f6f, 0x9cc92cde, 0xd36e6c4a, 0x580933f9,
+                     0xc9f1b905, 0x62b46903, 0xb806f219, 0x02a1a54f) ));
+
+    // 128 bytes
+    state = startingState;
+    state.fullblock(zeros);
+    hash = state.lastblock(zeros, 64*8);
+    assert(hash==ul( (0x38723a2e, 0x5e8a17aa, 0x7950dc00, 0x8209944e,
+                      0x898f69a7, 0xbd10a23c, 0x839d341e, 0x935fd5ca) ));
+
+    // 129 bytes
+    state = startingState;
+    state.fullblock(zeros);
+    state.fullblock(zeros);
+    hash = state.lastblock(zeros, 1*8);
+    assert(hash==ul( (0x2c80619d, 0x7e7c5825, 0x7293cda3, 0xa878c13e,
+                      0x5856f4e0, 0x6f6f9060, 0x1276f7b9, 0x179c9e07) ));
+  }
+}

--- a/tools/mason/SHA256Implementation.chpl
+++ b/tools/mason/SHA256Implementation.chpl
@@ -328,7 +328,7 @@ module SHA256Implementation {
     hash = state.lastblock(zeros, 0);
 
     assert(hash==ul( (0xe3b0c442, 0x98fc1c14, 0x9afbf4c8, 0x996fb924,
-		      0x27ae41e4, 0x649b934c, 0xa495991b, 0x7852b855) ));
+                     0x27ae41e4, 0x649b934c, 0xa495991b, 0x7852b855) ));
 
 
     // 55 bytes

--- a/tools/mason/SHA256Implementation.chpl
+++ b/tools/mason/SHA256Implementation.chpl
@@ -1,4 +1,23 @@
 /*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
 
 This module implements the SHA256 cryptographic hash algorithm.
 


### PR DESCRIPTION
1) Added capability to store a checksum for a mason package in its toml file.
Have sorted the file paths, and computed a single hash for the project and
stored it in toml.