### PR TITLE
Bump up sphinxcontrib version to 0.0.20

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -5,5 +5,5 @@ Pygments==2.7.1
 Sphinx==3.2.1
 docutils==0.16
 sphinx-rtd-theme==0.5.0
-sphinxcontrib-chapeldomain==0.0.19
+sphinxcontrib-chapeldomain==0.0.20
 babel==2.8.0


### PR DESCRIPTION
The new version has the new keywords we are adding in Chapel 1.24, as well as
the support for the new `:` operator.

