### PR TITLE
Don't discard command output until we know we don't need it.

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -12,10 +12,10 @@ def get():
         libfabric_val = overrides.get('CHPL_LIBFABRIC')
         platform_val = chpl_platform.get('target')
         if not libfabric_val:
-            exists, returncode = try_run_command(['pkg-config',
-                                                  '--exists',
-                                                  'libfabric'])[0:2]
-            if exists and returncode == 0:
+            cmd_exists, returncode = try_run_command(['pkg-config',
+                                                      '--exists',
+                                                      'libfabric'])[0:2]
+            if cmd_exists and returncode == 0:
                 libfabric_val = 'system'
             else:
                 libfabric_val = 'bundled'

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -62,14 +62,22 @@ def try_run_command(command, stdout=True, stderr=False, cmd_input=None):
 def run_command(command, stdout=True, stderr=False, cmd_input=None):
     """Command subprocess wrapper.
        This is the usual way to run a command and collect its output."""
-    exists, returncode, output = try_run_command(command, stdout, stderr,
-                                                 cmd_input)
+    exists, returncode, myOutput = try_run_command(command, True, True,
+                                                   cmd_input)
     if not exists:
         error("command not found: {0}".format(command[0]), OSError)
     if returncode != 0:
-        error("command failed: {0}\noutput was:\n{1}".format(
-            command, output[1]), CommandError)
-    return output
+        error("command failed: {0}\noutput was:\n{1}".format(command,
+                                                             myOutput[1]),
+              CommandError)
+    if stdout and stderr:
+        return myOutput
+    elif stdout:
+        return myOutput[0]
+    elif stderr:
+        return myOutput[1]
+    else:
+        return None
 
 
 def run_live_command(command):

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -45,7 +45,7 @@ def try_run_command(command, cmd_input=None):
                                    stderr=subprocess.PIPE,
                                    stdin=subprocess.PIPE)
     except OSError:
-        return False, 0, None, None
+        return (False, 0, None, None)
     byte_cmd_input = str.encode(cmd_input, "utf-8") if cmd_input else None
     output = process.communicate(input=byte_cmd_input)
     return (True, process.returncode, output[0].decode("utf-8"),

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -33,7 +33,7 @@ class CommandError(Exception):
     pass
 
 
-def try_run_command(command, stdout=True, stderr=False, cmd_input=None):
+def try_run_command(command, cmd_input=None):
     """Command subprocess wrapper tolerating failure to find or run the cmd.
        For normal usage the vanilla run_command() may be simpler to use.
        This should be the only invocation of subprocess in all chplenv scripts.
@@ -45,37 +45,30 @@ def try_run_command(command, stdout=True, stderr=False, cmd_input=None):
                                    stderr=subprocess.PIPE,
                                    stdin=subprocess.PIPE)
     except OSError:
-        return False, 0, ''
+        return False, 0, None, None
     byte_cmd_input = str.encode(cmd_input, "utf-8") if cmd_input else None
     output = process.communicate(input=byte_cmd_input)
-    output = (output[0].decode("utf-8"), output[1].decode("utf-8"))
-    if stdout and stderr:
-        return True, process.returncode, output
-    elif stdout:
-        return True, process.returncode, output[0]
-    elif stderr:
-        return True, process.returncode, output[1]
-    else:
-        return True, process.returncode, ''
+    return (True, process.returncode, output[0].decode("utf-8"),
+            output[1].decode("utf-8"))
 
 
 def run_command(command, stdout=True, stderr=False, cmd_input=None):
     """Command subprocess wrapper.
        This is the usual way to run a command and collect its output."""
-    exists, returncode, myOutput = try_run_command(command, True, True,
-                                                   cmd_input)
+    exists, returncode, my_stdout, my_stderr = try_run_command(command,
+                                                               cmd_input)
     if not exists:
         error("command not found: {0}".format(command[0]), OSError)
     if returncode != 0:
         error("command failed: {0}\noutput was:\n{1}".format(command,
-                                                             myOutput[1]),
+                                                             my_stderr),
               CommandError)
     if stdout and stderr:
-        return myOutput
+        return my_stdout, my_stderr
     elif stdout:
-        return myOutput[0]
+        return my_stdout
     elif stderr:
-        return myOutput[1]
+        return my_stderr
     else:
         return None
 


### PR DESCRIPTION
We got 'IndexError: string index out of range' from python in
run_command() because we tried to print what the target command had
produced to stderr, but our caller had told us not to collect that.
The details were: CHPL_HOST_PLATFORM was set to hpe-cray-ex and
CHPL_LIBFABRIC was set to system, but there was no libfabric module
loaded. Thus the 'pkg-config --exists libfabric' command run from
pkgconfig_get_compile_args() for a 'printchplenv --internal' failed,
and then we tried to print stderr.  But we hadn't asked for it.

Here, adjust: always collect stdout and stderr but only return to the
user the one(s) they asked for.  (I started to just collect stderr
always, since that's the only one run_command() itself might need,
but that actually ends up requiring even more control flow.)

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>