### PR TITLE
Path module Replacement Procedures

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -51,8 +51,8 @@
    :proc:`file.absPath`
    :proc:`expandVars`
    :proc:`joinPath`
-   :proc:`replaceDirname`
    :proc:`replaceBasename`
+   :proc:`replaceDirname`
    :proc:`replaceExt`
    :proc:`splitExt`
    :proc:`splitPath`
@@ -814,34 +814,18 @@ proc file.relPath(start:string=curDir): string throws {
 }
 
 /*
-  Returns a new path with dirname replaced with the provided
-  new argument of dirname. If path had no dirname the argument is
-  added to the path.
+  Returns a new path with basename in `path` replaced with `newBasename`.
+  If `path` had no basename then `newBasename` is added to the path or if
+  the `newBasename` is an empty string then basename is removed from `path`.
 
-  :arg path: `string` Original Path.
-  :newDirname path: `string` for the new dirname
+  :arg path: A path which the caller would like to access.
+  :type path: `string`
 
-  :returns: The new path after replacing dirname.
+  :arg newBasename: A basename to replace the current one
+  :type newBasename: `string`
+
+  :returns: a new path after replacing the basename.
   :rtype: `string`
-
-*/
-proc replaceDirname(path: string, newDirname: string): string {
-    const (dirname, basename) = splitPath(path);
-    return joinPath(newDirname, basename);
-}
-
-/*
-  Returns a new path with basename replaced with the provided
-  new argument of basename. If path had no basename the argument is
-  added to the path or if the provided new basename is empty string then basename is removed from path.
-
-  :arg path: `string` Original Path.
-  :newBasename path: `string` for the new dirname
-
-  :returns: The new path after replacing basename if valid basename is
-            provided else throws illegal argument error.
-  :rtype: `string`
-
 */
 proc replaceBasename(path: string, newBasename: string): string {
     const (dirname, basename) = splitPath(path);
@@ -849,18 +833,43 @@ proc replaceBasename(path: string, newBasename: string): string {
 }
 
 /*
-  Returns a new path with extension replaced with the provided
-  new argument of extension. If path had no extension the argument is
-  added to the path. extension has to be of form `.name` ,`name` or it can be an empty string.
+  Returns a new path with the dirname in `path` replaced with `newDirname`.
+  If path had no dirname `newDirname` is added to the `path` or if the
+  `newDirname` is an empty string then dirname is removed from the `path`.
 
-  :arg path: `string` Original Path.
-  :newExt path: `string` for the new extension
+  :arg path: A path which the caller would like to access.
+  :type path: `string`
 
-  :returns: The new path after replacing extension if valid argument is
-            provided else throws illegal argument error is either basename
-            is missing or extension is not valid.
+  :arg newDirname: dirname to replace the current one
+  :type newDirname: `string`
+
+  :returns: The new path after replacing dirname.
+  :rtype: `string`
+*/
+proc replaceDirname(path: string, newDirname: string): string {
+    const (dirname, basename) = splitPath(path);
+    return joinPath(newDirname, basename);
+}
+
+/*
+  Returns a new path with extension in `path` replaced with `newExt`.
+  If `path` had no extension `newExt` is added to the path or if
+  `newExt` is an empty string then extension is removed from the `path`.
+  Extension has to be of form `.name`,`name` or it can be an empty
+  string and shouldn't contain spaces.
+
+  :arg path: A path which the caller would like to access.
+  :type path: `string`
+
+  :arg newExt: extension to replace the current one
+  :type newExt: `string`
+
+  :returns: The new path after replacing extension if a valid `newExt`
+            is provided.
   :rtype: `string`
 
+  :throws IllegalArgumentError: Upon failure to provide a valid `newExt`
+                                or if the `path` had no basename.
 */
 proc replaceExt(path: string, newExt: string): string throws {
     const (extLessPath, ext) = splitExt(path);
@@ -876,11 +885,11 @@ proc replaceExt(path: string, newExt: string): string throws {
     }
     // if extension is not blank then check it shouldn't end with ''.' and isn't just '.'
     else if newExt == "." || newExt.endsWith(".") {
-      throw new owned IllegalArgumentError(newExt,"extension can't end with '.'");
+      throw new owned IllegalArgumentError(newExt, "extension can't end with '.'");
     }
     // remove leading '.' if any for uniform support to both
     const strippedExt = newExt.strip(".", leading=true);
-    // check for presence of spaces in stripedExt
+    // check for presence of spaces in strippedExt
     for c in strippedExt {
       if c.isSpace() {
         throw new owned IllegalArgumentError(newExt, "extension can't contain spaces");

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -886,8 +886,11 @@ proc replaceExt(path: string, newExt: string): string throws {
         throw new owned IllegalArgumentError(newExt, "extension can't contain spaces");
       }
     }
-
-    return replaceBasename(path, basename + "." + strippedExt);
+    var updatedExt = strippedExt;
+    if !strippedExt.isEmpty(){
+      updatedExt = "."+strippedExt;
+    }
+    return replaceBasename(path, basename + updatedExt);
 }
 
 /*

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -814,9 +814,9 @@ proc file.relPath(start:string=curDir): string throws {
 }
 
 /*
-  Returns the provided path with dirname replaced with the provided
+  Returns a new path with dirname replaced with the provided
   new argument of dirname. If path had no dirname the argument is
-  added to the path if it had one then it is replaced.
+  added to the path.
 
   :arg path: `string` Original Path.
   :newDirname path: `string` for the new dirname
@@ -825,16 +825,15 @@ proc file.relPath(start:string=curDir): string throws {
   :rtype: `string`
 
 */
-proc replaceDirname(path:string,newDirname:string):string {
+proc replaceDirname(path: string, newDirname: string): string {
     const (dirname, basename) = splitPath(path);
-    return joinPath(newDirname,basename);
+    return joinPath(newDirname, basename);
 }
 
 /*
-  Returns the provided path with basename replaced with the provided
+  Returns a new path with basename replaced with the provided
   new argument of basename. If path had no basename the argument is
-  added to the path if it had one then it is replaced if the provided
-  new basename is empty string then basename is removed from path.
+  added to the path or if the provided new basename is empty string then basename is removed from path.
 
   :arg path: `string` Original Path.
   :newBasename path: `string` for the new dirname
@@ -844,7 +843,7 @@ proc replaceDirname(path:string,newDirname:string):string {
   :rtype: `string`
 
 */
-proc replaceBasename(const path:string,const newBasename:string):string throws {
+proc replaceBasename(path: string, newBasename: string): string throws {
     const (dirname, basename) = splitPath(path);
     if(newBasename.endsWith(pathSep)) {
       throw new owned IllegalArgumentError(newBasename,"is not a invalid basename");
@@ -853,10 +852,9 @@ proc replaceBasename(const path:string,const newBasename:string):string throws {
 }
 
 /*
-  Returns the provided path with extension replaced with the provided
+  Returns a new path with extension replaced with the provided
   new argument of extension. If path had no extension the argument is
-  added to the path if it had one then it is replaced. extension has to
-  be of form `.name` or it can be an empty string.
+  added to the path. extension has to be of form `.name` ,`name` or it can be an empty string.
 
   :arg path: `string` Original Path.
   :newExt path: `string` for the new extension
@@ -867,30 +865,30 @@ proc replaceBasename(const path:string,const newBasename:string):string throws {
   :rtype: `string`
 
 */
-proc replaceExt(in path:string,in newExt:string):string throws {
+proc replaceExt(path: string, newExt: string): string throws {
     const (extLessPath, ext) = splitExt(path);
     const (dirname, basename) = splitPath(extLessPath);
 
     // Check for empty basename as extension can't be appended
-    if (basename.isEmpty()){
-      throw new owned IllegalArgumentError(path,"has an empty basename");
+    if  basename.isEmpty() {
+      throw new owned IllegalArgumentError(path, "has an empty basename");
     }
     // check is extension contains spearator.
-    else if(newExt.find(pathSep) != -1){
-      throw new owned IllegalArgumentError(newExt,"=extension can't contain path separators");
+    else if newExt.find(pathSep) != -1 {
+      throw new owned IllegalArgumentError(newExt, "extension can't contain path separators");
     }
     // if extension is not blank then check it shouldn't end with ''.' and isn't just '.'
-    else if(!newExt.isEmpty() && newExt == "." || newExt.endsWith(".")) {
+    else if newExt == "." || newExt.endsWith(".") {
       throw new owned IllegalArgumentError(newExt,"extension can't end with '.'");
     }
     // remove leading '.' if any for uniform support to both
-    const strippedExt = newExt.strip(".",leading=true);
+    const strippedExt = newExt.strip(".", leading=true);
     // check for presence of spaces in stripedExt
     if(strippedExt.find(" ") != -1){
       throw new owned IllegalArgumentError(newExt,"extension can't contain spaces");
     }
 
-    return replaceBasename(path,basename+"."+strippedExt);
+    return replaceBasename(path, basename + "." + strippedExt);
 }
 
 /*

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -843,12 +843,9 @@ proc replaceDirname(path: string, newDirname: string): string {
   :rtype: `string`
 
 */
-proc replaceBasename(path: string, newBasename: string): string throws {
+proc replaceBasename(path: string, newBasename: string): string {
     const (dirname, basename) = splitPath(path);
-    if(newBasename.endsWith(pathSep)) {
-      throw new owned IllegalArgumentError(newBasename,"is not a invalid basename");
-    }
-    return joinPath(dirname,newBasename);
+    return joinPath(dirname, newBasename);
 }
 
 /*
@@ -884,8 +881,10 @@ proc replaceExt(path: string, newExt: string): string throws {
     // remove leading '.' if any for uniform support to both
     const strippedExt = newExt.strip(".", leading=true);
     // check for presence of spaces in stripedExt
-    if(strippedExt.find(" ") != -1){
-      throw new owned IllegalArgumentError(newExt,"extension can't contain spaces");
+    for c in strippedExt {
+      if c.isSpace() {
+        throw new owned IllegalArgumentError(newExt, "extension can't contain spaces");
+      }
     }
 
     return replaceBasename(path, basename + "." + strippedExt);

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -53,6 +53,7 @@
    :proc:`joinPath`
    :proc:`replaceDirname`
    :proc:`replaceBasename`
+   :proc:`replaceExt`
    :proc:`splitExt`
    :proc:`splitPath`
 
@@ -850,6 +851,43 @@ proc replaceBasename(const path:string,const newBasename:string):string throws {
       throw new owned IllegalArgumentError(newBasename,"is not a invalid basename");
     }
     return joinPath(dirname,newBasename);
+}
+
+/*
+  Returns the provided path with extension replaced with the provided
+  new argument of extension. If path had no extension the argument is
+  added to the path if it had one then it is replaced. extension has to
+  be of form `.name` or it can be an empty string.
+
+  :arg path: `string` Original Path.
+  :newExt path: `string` for the new extension
+
+  :returns: The new path after replacing extension if valid argument is
+            provided else throws illegal argument error is either basename
+            is missing or extension is not valid.
+  :rtype: `string`
+
+*/
+proc replaceExt(in path:string,in newExt:string):string throws {
+    const (extLessPath, ext) = splitExt(path);
+    const (dirname, basename) = splitPath(extLessPath);
+    // altsep for windows only future
+    const altsep = "", sep = "/";
+
+    // Check for empty basename as extension can't be appended
+    if (basename.isEmpty()){
+      throw new owned IllegalArgumentError(path,"has an empty basename");
+    }
+    // check is extension contains spearator.
+    else if(newExt.find(sep) != -1 || (!altsep.isEmpty() && newExt.find(altsep) != -1)){
+      throw new owned IllegalArgumentError(newExt,"is an invalid suffix");
+    }
+    // if extension is not blank then check it starts with ''.' and isn't just '.'
+    else if(!newExt.isEmpty() && !newExt.startsWith(".") || newExt == ".") {
+      throw new owned IllegalArgumentError(newExt,"is an invalid suffix");
+    }
+
+    return replaceBasename(path,basename+newExt);
 }
 
 /*

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -52,6 +52,7 @@
    :proc:`expandVars`
    :proc:`joinPath`
    :proc:`replaceDirname`
+   :proc:`replaceBasename`
    :proc:`splitExt`
    :proc:`splitPath`
 
@@ -826,6 +827,29 @@ proc file.relPath(start:string=curDir): string throws {
 proc replaceDirname(path:string,newDirname:string):string {
     const (dirname, basename) = splitPath(path);
     return joinPath(newDirname,basename);
+}
+
+/*
+  Returns the provided path with basename replaced with the provided
+  new argument of basename. If path had no basename the argument is
+  added to the path if it had one then it is replaced if the provided
+  new basename is empty string then basename is removed from path.
+
+  :arg path: `string` Original Path.
+  :newBasename path: `string` for the new dirname
+
+  :returns: The new path after replacing basename if valid basename is
+            provided else throws illegal argument error.
+  :rtype: `string`
+
+*/
+proc replaceBasename(const path:string,const newBasename:string):string throws {
+    const (dirname, basename) = splitPath(path);
+    const sep = "/";
+    if(newBasename.endsWith(sep)) {
+      throw new owned IllegalArgumentError(newBasename,"is not a invalid basename");
+    }
+    return joinPath(dirname,newBasename);
 }
 
 /*

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -51,6 +51,7 @@
    :proc:`file.absPath`
    :proc:`expandVars`
    :proc:`joinPath`
+   :proc:`replaceDirname`
    :proc:`splitExt`
    :proc:`splitPath`
 
@@ -810,6 +811,22 @@ proc file.relPath(start:string=curDir): string throws {
   return Path.relPath(this.path, start);
 }
 
+/*
+  Returns the provided path with dirname replaced with the provided
+  new argument of dirname. If path had no dirname the argument is
+  added to the path if it had one then it is replaced.
+
+  :arg path: `string` Original Path.
+  :newDirname path: `string` for the new dirname
+
+  :returns: The new path after replacing dirname.
+  :rtype: `string`
+
+*/
+proc replaceDirname(path:string,newDirname:string):string {
+    const (dirname, basename) = splitPath(path);
+    return joinPath(newDirname,basename);
+}
 
 /*
   Splits the given path into its root and extension.

--- a/test/library/standard/Path/king-11/replaceBasename/cases.chpl
+++ b/test/library/standard/Path/king-11/replaceBasename/cases.chpl
@@ -1,0 +1,19 @@
+import Path.{replaceBasename};
+
+// the original path doesn't have a basename. returns "/foo/bar/baz"
+writeln(replaceBasename("/foo/bar/", "baz"));
+writeln(replaceBasename("", ""));
+writeln(replaceBasename("/", ""));
+writeln(replaceBasename("foo/", ""));
+writeln(replaceBasename("foo/bar", ""));
+writeln(replaceBasename("", "foo"));
+writeln(replaceBasename("foo/bar.txt", "baz"));
+
+writeln(replaceBasename("foo.c","d.chpl"));
+writeln(replaceBasename("/foo/baz.c","d.chpl"));
+writeln(replaceBasename("foo/baz ending.","d.chpl"));
+writeln(replaceBasename("baz ending.","d.chpl"));
+writeln(replaceBasename("baz/ending.","d.chpl"));
+writeln(replaceBasename("../foo","d.chpl"));
+writeln(replaceBasename(".foo","d.chpl"));
+writeln(replaceBasename("bar/foo.c/","d.chpl/"));

--- a/test/library/standard/Path/king-11/replaceBasename/cases.good
+++ b/test/library/standard/Path/king-11/replaceBasename/cases.good
@@ -1,0 +1,15 @@
+/foo/bar/baz
+
+/
+foo/
+foo/
+foo
+foo/baz
+d.chpl
+/foo/d.chpl
+foo/d.chpl
+d.chpl
+baz/d.chpl
+../d.chpl
+d.chpl
+bar/foo.c/d.chpl/

--- a/test/library/standard/Path/king-11/replaceDirname/cases.chpl
+++ b/test/library/standard/Path/king-11/replaceDirname/cases.chpl
@@ -1,0 +1,20 @@
+import Path.{replaceDirname};
+
+writeln(replaceDirname("foo.c","chapel"));
+writeln(replaceDirname("/foo.c","chapel"));
+writeln(replaceDirname("foo/baz","chapel"));
+writeln(replaceDirname("foo/baz","chapel/"));
+writeln(replaceDirname("foo/baz ending.","chapel"));
+writeln(replaceDirname("baz ending.","chapel"));
+writeln(replaceDirname("../foo","chapel"));
+writeln(replaceDirname(".foo","chapel"));
+writeln(replaceDirname("bar/../foo","chapel/../"));
+writeln(replaceDirname("/.././bar/../foo","chapel"));
+writeln(replaceDirname("", ""));
+writeln(replaceDirname("/", ""));
+writeln(replaceDirname("foo/", ""));
+writeln(replaceDirname("foo/bar", ""));
+writeln(replaceDirname("", "/"));
+writeln(replaceDirname("", "foo"));
+writeln(replaceDirname("/bar.txt", "baz"));
+writeln(replaceDirname("/foo//./../bar.txt", "baz"));

--- a/test/library/standard/Path/king-11/replaceDirname/cases.good
+++ b/test/library/standard/Path/king-11/replaceDirname/cases.good
@@ -1,0 +1,18 @@
+chapel/foo.c
+chapel/foo.c
+chapel/baz
+chapel/baz
+chapel/baz ending.
+chapel/baz ending.
+chapel/foo
+chapel/.foo
+chapel/../foo
+chapel/foo
+
+
+
+bar
+/
+foo/
+baz/bar.txt
+baz/bar.txt

--- a/test/library/standard/Path/king-11/replaceExt/cases.chpl
+++ b/test/library/standard/Path/king-11/replaceExt/cases.chpl
@@ -1,0 +1,45 @@
+import Path.{replaceExt};
+// the original path doesn't have an extension.  returns "foo.txt"
+writeln(replaceExt("foo", ".txt"));
+// preceding . in extension is optional
+writeln(replaceExt("foo.bar", "txt"));
+writeln(replaceExt("foo.bar", ".txt"));
+// no basename throw error
+try {
+  writeln(replaceExt("foo/", "txt"));
+}
+catch e {
+  writeln(e.message());
+}
+// remove ext
+writeln(replaceExt("foo.chpl",""));
+// path separator error throw
+try {
+  writeln(replaceExt("/foo/baz/go",".chp/l"));
+} catch e {
+  writeln(e.message());
+}
+// spaces in ext error throw
+try {
+  writeln(replaceExt("/foo/baz/go",".chpl       henlo"));
+} catch e {
+  writeln(e.message());
+}
+try {
+  writeln(replaceExt("", ""));
+}
+catch e {
+  writeln(e.message());
+}
+// basename starting with .
+writeln(replaceExt(".bashrc", "newext"));
+// basename starting with . and containing .
+writeln(replaceExt(".exec.out.tmp", "newext"));
+writeln(replaceExt("./foo", "newext"));
+writeln(replaceExt("/./foo", "newext"));
+try {
+  writeln(replaceExt("/./", "newext"));
+}
+catch e {
+  writeln(e.message());
+}

--- a/test/library/standard/Path/king-11/replaceExt/cases.good
+++ b/test/library/standard/Path/king-11/replaceExt/cases.good
@@ -1,0 +1,13 @@
+foo.txt
+foo.txt
+foo.txt
+illegal argument 'foo/': has an empty basename
+foo
+illegal argument '.chp/l': extension can't contain path separators
+illegal argument '.chpl       henlo': extension can't contain spaces
+illegal argument '': has an empty basename
+.bashrc.newext
+.exec.out.newext
+./foo.newext
+/./foo.newext
+illegal argument '/./': has an empty basename


### PR DESCRIPTION
Closes #16767 

This PR adds:

- `replaceDirname`
- `replaceBasename`
- `replaceExt`

to the Path module. These functions can be used to replace different parts
of a path string. The design for these functions is here:

  https://github.com/chapel-lang/chapel/issues/16767#issuecomment-806061865

Tests:
- [x] added tests pass with darwin, asan, memleaks
- [x] full linux64