### PR TITLE
List intent overload

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -770,7 +770,7 @@ module List {
       ref result = _firstHelper();
       return result;
     }
-    
+
     pragma "no doc"
     proc const ref first() const ref{
       const ref result = _firstHelper();
@@ -813,13 +813,13 @@ module List {
       ref result = _lastHelper();
       return result;
     }
-    
+
     pragma "no doc"
     proc const ref last() const ref{
       const ref result = _lastHelper();
       return result;
     }
-    
+
     pragma "no doc"
     inline proc ref _extendGeneric(collection) {
 

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -746,7 +746,8 @@ module List {
       :return: A reference to the first item in this list.
       :rtype: `ref eltType`
     */
-    proc ref first() ref {
+    pragma "no doc"
+    proc const ref _firstHelper() ref {
       if parSafe then
         compilerWarning('Calling `first()` on a list initialized with ' +
                         '`parSafe=true` has been deprecated, consider ' +
@@ -765,25 +766,15 @@ module List {
       return result;
     }
     
-    proc const ref first() const ref {
-      if parSafe then
-        compilerWarning('Calling `first()` on a list initialized with ' +
-                        '`parSafe=true` has been deprecated, consider ' +
-                        'using `set()` or `update()` instead');
-      _enter();
-
-      if boundsChecking && _size == 0 {
-        _leave();
-        boundsCheckHalt("Called \"list.first\" on an empty list.");
-      }
-
-      // TODO: How to make this work with on clauses?
-      ref result = _getRef(0);
-      _leave();
-
+    proc ref first() ref{
+      ref result = _firstHelper();
       return result;
     }
     
+    proc const ref first() const ref{
+      const ref result = _firstHelper();
+      return result;
+    }
 
     /*
       Returns a reference to the last item in this list.
@@ -797,7 +788,8 @@ module List {
       :return: A reference to the last item in this list.
       :rtype: `ref eltType`
     */
-    proc ref last() ref {
+    pragma "no doc"
+    proc const ref _lastHelper() ref {
       if parSafe then
         compilerWarning('Calling `last()` on a list initialized with ' +
                         '`parSafe=true` has been deprecated, consider ' +
@@ -816,22 +808,13 @@ module List {
       return result;
     }
 
-    proc const ref last() ref {
-      if parSafe then
-        compilerWarning('Calling `last()` on a list initialized with ' +
-                        '`parSafe=true` has been deprecated, consider ' +
-                        'using `set()` or `update()` instead');
-      _enter();
-
-      if boundsChecking && _size == 0 {
-        _leave();
-        boundsCheckHalt("Called \"list.last\" on an empty list.");
-      }
-
-      // TODO: How to make this work with on clauses?
-      ref result = _getRef(_size-1);
-      _leave();
-
+    proc ref last() ref{
+      ref result = _lastHelper();
+      return result;
+    }
+    
+    proc const ref last() const ref{
+      const ref result = _lastHelper();
       return result;
     }
     

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -734,18 +734,6 @@ module List {
       return result;
     }
 
-    /*
-      Returns a reference to the first item in this list.
-
-      .. warning::
-
-        Calling this method on an empty list will cause the currently running
-        program to halt. If the `--fast` flag is used, no safety checks will
-        be performed.
-
-      :return: A reference to the first item in this list.
-      :rtype: `ref eltType`
-    */
     pragma "no doc"
     proc const ref _firstHelper() ref {
       if parSafe then
@@ -765,19 +753,9 @@ module List {
 
       return result;
     }
-    
-    proc ref first() ref{
-      ref result = _firstHelper();
-      return result;
-    }
-    
-    proc const ref first() const ref{
-      const ref result = _firstHelper();
-      return result;
-    }
 
     /*
-      Returns a reference to the last item in this list.
+      Returns a reference to the first item in this list.
 
       .. warning::
 
@@ -785,9 +763,20 @@ module List {
         program to halt. If the `--fast` flag is used, no safety checks will
         be performed.
 
-      :return: A reference to the last item in this list.
+      :return: A reference to the first item in this list.
       :rtype: `ref eltType`
     */
+    proc ref first() ref{
+      ref result = _firstHelper();
+      return result;
+    }
+    
+    pragma "no doc"
+    proc const ref first() const ref{
+      const ref result = _firstHelper();
+      return result;
+    }
+
     pragma "no doc"
     proc const ref _lastHelper() ref {
       if parSafe then
@@ -808,11 +797,24 @@ module List {
       return result;
     }
 
+    /*
+      Returns a reference to the last item in this list.
+
+      .. warning::
+
+        Calling this method on an empty list will cause the currently running
+        program to halt. If the `--fast` flag is used, no safety checks will
+        be performed.
+
+      :return: A reference to the last item in this list.
+      :rtype: `ref eltType`
+    */
     proc ref last() ref{
       ref result = _lastHelper();
       return result;
     }
     
+    pragma "no doc"
     proc const ref last() const ref{
       const ref result = _lastHelper();
       return result;

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -764,6 +764,7 @@ module List {
 
       return result;
     }
+    
     proc const ref first() const ref {
       if parSafe then
         compilerWarning('Calling `first()` on a list initialized with ' +

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -764,6 +764,25 @@ module List {
 
       return result;
     }
+    proc const ref first() const ref {
+      if parSafe then
+        compilerWarning('Calling `first()` on a list initialized with ' +
+                        '`parSafe=true` has been deprecated, consider ' +
+                        'using `set()` or `update()` instead');
+      _enter();
+
+      if boundsChecking && _size == 0 {
+        _leave();
+        boundsCheckHalt("Called \"list.first\" on an empty list.");
+      }
+
+      // TODO: How to make this work with on clauses?
+      ref result = _getRef(0);
+      _leave();
+
+      return result;
+    }
+    
 
     /*
       Returns a reference to the last item in this list.
@@ -796,6 +815,25 @@ module List {
       return result;
     }
 
+    proc const ref last() ref {
+      if parSafe then
+        compilerWarning('Calling `last()` on a list initialized with ' +
+                        '`parSafe=true` has been deprecated, consider ' +
+                        'using `set()` or `update()` instead');
+      _enter();
+
+      if boundsChecking && _size == 0 {
+        _leave();
+        boundsCheckHalt("Called \"list.last\" on an empty list.");
+      }
+
+      // TODO: How to make this work with on clauses?
+      ref result = _getRef(_size-1);
+      _leave();
+
+      return result;
+    }
+    
     pragma "no doc"
     inline proc ref _extendGeneric(collection) {
 

--- a/test/library/standard/List/firstLastOverload.chpl
+++ b/test/library/standard/List/firstLastOverload.chpl
@@ -1,0 +1,26 @@
+use List;
+
+proc f(args: list(string)){
+    var lower = args[0].toLower();
+    writeln(lower);
+}
+
+proc ref_fun(ref arr: list(string)){
+    writeln(arr.first().toLower());
+    writeln(arr.last().toLower());
+}
+
+proc constref_fun(const ref arr: list(string)){
+    writeln(arr.first().toLower());
+    writeln(arr.last().toLower());
+}
+
+proc main(){
+    var args: list(string);
+    args.append("HELLO");
+    args.append("CHAPEL");
+    f(args);
+    ref_fun(args);
+    writeln(args);
+    constref_fun(args);
+}

--- a/test/library/standard/List/firstLastOverload.good
+++ b/test/library/standard/List/firstLastOverload.good
@@ -1,0 +1,6 @@
+hello
+hello
+chapel
+[HELLO, CHAPEL]
+hello
+chapel


### PR DESCRIPTION
Added a const ref overload to the methods first() and last() using helpers. Previously the methods did not accept the usage of const ref intent types.
Resolves #17259 
