### PR TITLE
Update docs version button to reflect staged documents

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -72,13 +72,13 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.24'                  # TODO -- parse from `chpl --version`
+chplversion = '1.25'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-# release = '1.24.0 (pre-release)'
-release = '1.24.0'
+release = '1.25.0 (pre-release)'
+# release = '1.24.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,7 +89,7 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "1.23"; // what does the public have?
   var stagedRelease = "1.24";  // is there a release staged but not yet public?
-  var nextRelease = "1.24";    // what's the next release? (on docs/master)
+  var nextRelease = "1.25";    // what's the next release? (on docs/master)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
This updates the docs button for the website to reflect the fact that the staged docs are for 1.24, the master/main branch is now 1.25.
