### PR TITLE
Bump version to 1.25 pre-release

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -22,7 +22,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION 24
+#define MINOR_VERSION 25
 #define UPDATE_VERSION 0
 
 static const char* BUILD_VERSION =
@@ -32,6 +32,6 @@ static const char* BUILD_VERSION =
 // Flip this to 'true' when we're ready to roll out a release; then
 // back after branching
 //
-static bool officialRelease = true;
+static bool officialRelease = false;
 
 #endif

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.24.0
+:Version: 1.25.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.24.0
+:Version: 1.25.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.24.0
+ version 1.25.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -4,7 +4,11 @@ compiler=$3
 
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
-echo ""
+# During pre-release mode
+diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+        { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+# During release mode:
+# echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
This updates the version of the main development branch to 1.25 and restores the pre-release labels.
