### PR TITLE
Fix online man page bug with double-dash arguments

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -192,7 +192,7 @@ html_static_path = ['meta/static']
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 # We turn this off because it clobbers the man page documentation
-html_use_smartypants = False
+smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}


### PR DESCRIPTION
I have changed the configuration **html_use_smartypants** to **smartquotes** in doc/rst/conf.py that was causing this behavior (converting -- to n-dash) on Man page.
Resolve #17385 