### PR TITLE
Fix bug causing us to improperly resolve other conversions for operator methods

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -606,7 +606,7 @@ static void resolveAlsoConversions(FnSymbol* fn, CallExpr* forCall) {
 
   if (fn->name == astrSassign) {
     int i = 1;
-    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i++;
+    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i = i + 2;
     toType = fn->getFormal(i)->getValType(); i++;
     fromType = fn->getFormal(i)->getValType();
   } else if (fn->name == astrInitEquals) {
@@ -615,7 +615,7 @@ static void resolveAlsoConversions(FnSymbol* fn, CallExpr* forCall) {
     fromType = fn->getFormal(3)->getValType();
   } else if (fn->name == astr_cast) {
     int i = 1;
-    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i++;
+    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i = i + 2;
     toType = fn->getFormal(i)->getValType(); i++;
     fromType = fn->getFormal(i)->getValType();
   } else {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -606,7 +606,8 @@ static void resolveAlsoConversions(FnSymbol* fn, CallExpr* forCall) {
 
   if (fn->name == astrSassign) {
     int i = 1;
-    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i = i + 2;
+    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i++;
+    if (fn->getFormal(i)->hasFlag(FLAG_ARG_THIS)) i++;
     toType = fn->getFormal(i)->getValType(); i++;
     fromType = fn->getFormal(i)->getValType();
   } else if (fn->name == astrInitEquals) {
@@ -615,7 +616,8 @@ static void resolveAlsoConversions(FnSymbol* fn, CallExpr* forCall) {
     fromType = fn->getFormal(3)->getValType();
   } else if (fn->name == astr_cast) {
     int i = 1;
-    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i = i + 2;
+    if (fn->getFormal(i)->typeInfo() == dtMethodToken) i++;
+    if (fn->getFormal(i)->hasFlag(FLAG_ARG_THIS)) i++;
     toType = fn->getFormal(i)->getValType(); i++;
     fromType = fn->getFormal(i)->getValType();
   } else {

--- a/test/classes/assignments/noAssignClass.chpl
+++ b/test/classes/assignments/noAssignClass.chpl
@@ -94,6 +94,95 @@ proc =(ref lhs: A, rhs: R) {
   lhs.x = rhs.x;
 }
 
+class L {
+  var x: int;
+}
+
+class M {
+  var x: int;
+}
+
+class N {
+  var x: int;
+}
+
+class O {
+  var x: int;
+}
+
+class P {
+  var x: int;
+}
+
+class Q {
+  var x: int;
+}
+
+class S {
+  var x: int;
+}
+
+class T {
+  var x: int;
+}
+
+class U {
+  var x: int;
+}
+
+class V {
+  var x: int;
+}
+
+class W {
+  var x: int;
+}
+
+operator L.=(lhs: L, rhs: L) {
+  lhs.x = rhs.x;
+}
+
+operator M.=(lhs: unmanaged M, rhs: M) {
+  lhs.x = rhs.x;
+}
+
+operator N.=(lhs: borrowed N, rhs: N) {
+  lhs.x = rhs.x;
+}
+
+operator O.=(lhs: shared O, rhs: O) {
+  lhs.x = rhs.x;
+}
+
+operator P.=(lhs: owned P, rhs: P) {
+  lhs.x = rhs.x;
+}
+
+operator Q.=(ref lhs: Q, rhs: Q) {
+  lhs.x = rhs.x;
+}
+
+operator S.=(ref lhs: owned S, rhs: S) {
+  lhs.x = rhs.x;
+}
+
+operator T.=(ref lhs: borrowed T, rhs: T) {
+  lhs.x = rhs.x;
+}
+
+operator U.=(ref lhs: U?, rhs: U) {
+  lhs!.x = rhs.x;
+}
+
+operator V.=(ref lhs: owned V?, rhs: V) {
+  lhs!.x = rhs.x;
+}
+
+operator W.=(ref lhs: borrowed W?, rhs: W) {
+  lhs!.x = rhs.x;
+}
+
+
 record R {
   var x: int;
 }
@@ -147,3 +236,47 @@ writeln(myA);
 
 myA = new R(33);
 writeln(myA);
+
+var myL = new L(42), myL2 = new L(33);
+myL = myL2;
+writeln(myL, myL2);
+
+var myM = new unmanaged M(42), myM2 = new M(33);
+myM = myM2;
+writeln(myM, myM2);
+
+var myN = new borrowed N(42), myN2 = new N(33);
+myN = myN2;
+writeln(myN, myN2);
+
+var myO = new shared O(42), myO2 = new O(33);
+myO = myO2;
+writeln(myO, myO2);
+
+var myP = new P(42), myP2 = new P(33);
+myP = myP2;
+writeln(myP, myP2);
+
+var myQ = new Q(42), myQ2 = new Q(33);
+myQ = myQ2;
+writeln(myQ, myQ2);
+
+var myS = new S(42), myS2 = new S(33);
+myS = myS2;
+writeln(myS, myS2);
+
+var myT = new borrowed T(42), myT2 = new T(33);
+myT = myT2;
+writeln(myT, myT2);
+
+var myU = new U(42), myU2 = new U(33);
+myU = myU2;
+writeln(myU, myU2);
+
+var myV: V? = new owned V(42), myV2 = new V(33);
+myV = myV2;
+writeln(myV, myV2);
+
+var myW = new W(42), myW2 = new W(33);
+myW = myW2;
+writeln(myW, myW2);

--- a/test/classes/assignments/noAssignClass.good
+++ b/test/classes/assignments/noAssignClass.good
@@ -11,3 +11,14 @@ noAssignClass.chpl:81: error: Can't overload assignments for class types
 noAssignClass.chpl:85: error: Can't overload assignments for class types
 noAssignClass.chpl:89: error: Can't overload assignments for class types
 noAssignClass.chpl:93: error: Can't overload assignments for class types
+noAssignClass.chpl:141: error: Can't overload assignments for class types
+noAssignClass.chpl:145: error: Can't overload assignments for class types
+noAssignClass.chpl:149: error: Can't overload assignments for class types
+noAssignClass.chpl:153: error: Can't overload assignments for class types
+noAssignClass.chpl:157: error: Can't overload assignments for class types
+noAssignClass.chpl:161: error: Can't overload assignments for class types
+noAssignClass.chpl:165: error: Can't overload assignments for class types
+noAssignClass.chpl:169: error: Can't overload assignments for class types
+noAssignClass.chpl:173: error: Can't overload assignments for class types
+noAssignClass.chpl:177: error: Can't overload assignments for class types
+noAssignClass.chpl:181: error: Can't overload assignments for class types


### PR DESCRIPTION
resolveAlsoConversions was expecting dtMethodToken to be the only potential
additional argument but when dtMethodToken is present, there's also a "this"
argument that should be skipped as well.  Because we were grabbing the wrong
"toType", we thought the function was generic and would skip analyzing it
appropriately.

In the case of the test that showed this issue, this meant failing to generate
an error message about overloading assignment for classes when other error
messages were triggered due to standalone overloads.  However, we would
eventually generate those error messages (just at a later pass)

Fix resolveAlsoConversions to skip both the methodToken and the this argument
instead of just the method token argument.

Updated the relevant test to ensure that all the error messages happen at the same
time.

Passed a full paratest with futures