### PR TITLE
Set the number of launcher cores per locale for Cray CS perf testing

### DIFF
--- a/util/cron/common-perf-cray-cs.bash
+++ b/util/cron/common-perf-cray-cs.bash
@@ -3,6 +3,7 @@
 # Configure settings for Cray CS performance testing.
 
 export CHPL_LAUNCHER_PARTITION=bdw18
+export CHPL_LAUNCHER_CORES_PER_LOCALE=72
 export CHPL_TARGET_CPU=broadwell
 
 # the lengths we go to, to avoid line wrap ...


### PR DESCRIPTION
Some nodes in the partition have hyperthreading disabled, which changes
the automatic core counting with do with `sinfo`. Hard code to 72 to
avoid that. For configs that use slurm-srun (ofi) this was causing us to
only request access to half the cores, which limited performance.