### PR TITLE
Use large problem size in the auto-aggregated indexgather

### DIFF
--- a/test/studies/bale/indexgather/ig-auto-agg.ml-execopts
+++ b/test/studies/bale/indexgather/ig-auto-agg.ml-execopts
@@ -9,9 +9,6 @@ comm_sub = os.getenv('CHPL_COMM_SUBSTRATE')
 ugni = comm == 'ugni'
 gn_aries = comm == 'gasnet' and comm_sub  == 'aries'
 
-N  = 10000
 NL = 1000000
-if ugni or gn_aries:
-  N = NL
 
-print('--N={0} --printStats --mode=Mode.ordered    # bale-ig-auto-aggregated'.format(N))
+print('--N={0} --printStats --mode=Mode.ordered    # bale-ig-auto-aggregated'.format(NL))

--- a/test/studies/bale/indexgather/ig-auto-agg.ml-execopts
+++ b/test/studies/bale/indexgather/ig-auto-agg.ml-execopts
@@ -1,14 +1,4 @@
-#!/usr/bin/env python3
-
-# Run bale index gather with 1 million updates per task. Use a smaller problem
-# size for non-aggregated configurations with low small-messages rates.
-import os
-
-comm = os.getenv('CHPL_COMM')
-comm_sub = os.getenv('CHPL_COMM_SUBSTRATE')
-ugni = comm == 'ugni'
-gn_aries = comm == 'gasnet' and comm_sub  == 'aries'
-
-NL = 1000000
-
-print('--N={0} --printStats --mode=Mode.ordered    # bale-ig-auto-aggregated'.format(NL))
+# other versions of this test chooses N based on the comm layer and the version
+# of the benchmark kernel. However, in auto/manual aggregation we always use
+# larger N. See ig.ml-execopts
+--N=1000000 --printStats --mode=Mode.ordered    # bale-ig-auto-aggregated


### PR DESCRIPTION
When I created this test, I just used the execopts for the unoptimized version
which is too small for CS. It causes a big difference between the manual and
auto aggregated versions:

https://chapel-lang.org/perf/16-node-cs-hdr/?startdate=2021/01/21&enddate=2021/03/15&graphs=baleaggregatedindexgatherperfmbspernode

This PR makes the auto-aggregated version always use the large problem size.
