### PR TITLE
Address non-determinism due to map iteration

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2332,3 +2332,21 @@ const char* toString(Symbol* sym, bool withType) {
 
   return sym->name;
 }
+
+struct SymbolPairComparator {
+  bool operator()(std::pair<Symbol*, Symbol*> lhs,
+                  std::pair<Symbol*, Symbol*> rhs) {
+    std::less<Symbol*> lessSym;
+
+    return lessSym(lhs.first, rhs.first);
+  }
+};
+
+SymbolMapVector sortedSymbolMapElts(const SymbolMap& map) {
+  std::vector<std::pair<Symbol*, Symbol*> > elts;
+  form_Map(SymbolMapElem, e, map) {
+    elts.push_back(std::make_pair(e->key, e->value));
+  }
+  std::sort(elts.begin(), elts.end(), SymbolPairComparator());
+  return elts;
+}

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -890,4 +890,7 @@ const char* toString(ArgSymbol* arg, bool withTypeAndIntent);
 const char* toString(VarSymbol* var, bool withType);
 const char* toString(Symbol* sym, bool withTypeAndIntent);
 
+typedef std::vector<std::pair<Symbol*, Symbol*> > SymbolMapVector;
+SymbolMapVector sortedSymbolMapElts(const SymbolMap& map);
+
 #endif

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -28,8 +28,6 @@
 #include "stlUtil.h"
 #include "wellknown.h"
 
-#include <algorithm>
-
 // 'markPruned' replaced deletion from SymbolMap, which does not work well.
 Symbol*           markPruned      = NULL;
 
@@ -537,15 +535,6 @@ static void pruneOuterVars(Symbol* parent, SymbolMap& uses) {
   }
 }
 
-struct SymbolPairComparator {
-  bool operator()(std::pair<Symbol*, Symbol*> lhs,
-                  std::pair<Symbol*, Symbol*> rhs) {
-    std::less<Symbol*> lessSym;
-
-    return lessSym(lhs.first, rhs.first);
-  }
-};
-
 //
 // The 'vars' map describes the outer variables referenced
 // in the task function 'fn', which is invoked by 'call'.
@@ -587,12 +576,7 @@ addVarsToFormalsActuals(FnSymbol* fn, SymbolMap& vars,
 {
   Expr *redRef1 = NULL, *redRef2 = NULL;
 
-  std::vector<std::pair<Symbol*, Symbol*> > elts;
-  form_Map(SymbolMapElem, e, vars) {
-    elts.push_back(std::make_pair(e->key, e->value));
-  }
-  std::sort(elts.begin(), elts.end(), SymbolPairComparator());
-
+  SymbolMapVector elts = sortedSymbolMapElts(vars);
   for (auto pair: elts) {
       Symbol* key = pair.first;
       Symbol* value = pair.second;

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -231,8 +231,11 @@ passByRef(Symbol* sym) {
 
 static void
 addVarsToFormals(FnSymbol* fn, SymbolMap* vars) {
-  form_Map(SymbolMapElem, e, *vars) {
-    if (Symbol* sym = e->key) {
+  SymbolMapVector elts = sortedSymbolMapElts(*vars);
+  for (auto pair: elts) {
+    Symbol* key = pair.first;
+
+    if (Symbol* sym = key) {
       Type* type = sym->type;
       IntentTag intent = INTENT_BLANK;
 
@@ -302,9 +305,13 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
   if (fn->lifetimeConstraints)
     collectSymExprs(fn->lifetimeConstraints, symExprs);
 
-  form_Map(SymbolMapElem, e, *vars) {
-    if (Symbol* sym = e->key) {
-      ArgSymbol* arg  = toArgSymbol(e->value);
+  SymbolMapVector elts = sortedSymbolMapElts(*vars);
+  for (auto pair: elts) {
+    Symbol* key = pair.first;
+    Symbol* value = pair.second;
+
+    if (Symbol* sym = key) {
+      ArgSymbol* arg  = toArgSymbol(value);
       Type*      type = arg->type;
 
       size_t i = 0;
@@ -379,8 +386,10 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
 
 static void
 addVarsToActuals(CallExpr* call, SymbolMap* vars, bool outerCall) {
-  form_Map(SymbolMapElem, e, *vars) {
-    if (Symbol* sym = e->key) {
+  SymbolMapVector elts = sortedSymbolMapElts(*vars);
+  for (auto pair: elts) {
+    Symbol* key = pair.first;
+    if (Symbol* sym = key) {
       SET_LINENO(sym);
       call->insertAtTail(sym);
     }

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -307,78 +307,74 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
 
   SymbolMapVector elts = sortedSymbolMapElts(*vars);
   for (auto pair: elts) {
-    Symbol* key = pair.first;
-    Symbol* value = pair.second;
+    Symbol* sym = pair.first; // this is the key
+    ArgSymbol* arg = toArgSymbol(pair.second); // this is the value
+    Type*      type = arg->type;
 
-    if (Symbol* sym = key) {
-      ArgSymbol* arg  = toArgSymbol(value);
-      Type*      type = arg->type;
+    size_t i = 0;
+    for_vector(SymExpr, se, symExprs) {
+      if (se->symbol() == sym) {
+        if (type == sym->type) {
+          se->setSymbol(arg);
 
-      size_t i = 0;
-      for_vector(SymExpr, se, symExprs) {
-        if (se->symbol() == sym) {
-          if (type == sym->type) {
-            se->setSymbol(arg);
+        } else if (CallExpr* call = toCallExpr(se->parentExpr)) {
+          FnSymbol* fnc         = call->resolvedFunction();
+          bool      canPassToFn = false;
 
-          } else if (CallExpr* call = toCallExpr(se->parentExpr)) {
-            FnSymbol* fnc         = call->resolvedFunction();
-            bool      canPassToFn = false;
+          if (fnc) {
+            ArgSymbol* form = actual_to_formal(se);
 
-            if (fnc) {
-              ArgSymbol* form = actual_to_formal(se);
-
-              if (arg->isRef()                            &&
-                  form->isRef()                           &&
-                  arg->getValType() == form->getValType()) {
-                canPassToFn = true;
-              } else if (arg->type == form->type) {
-                canPassToFn = true;
-              }
-            }
-
-            // check if call is in a lifetime clause
-            if (i >= firstInLifetimeConstraint)
+            if (arg->isRef()                            &&
+                form->isRef()                           &&
+                arg->getValType() == form->getValType()) {
               canPassToFn = true;
-
-            if (( (call->isPrimitive(PRIM_MOVE)       ||
-                   call->isPrimitive(PRIM_ASSIGN)     ||
-                   call->isPrimitive(PRIM_SET_MEMBER) )
-                  && call->get(1) == se)                                   ||
-                call->isPrimitive(PRIM_GET_MEMBER)                         ||
-                call->isPrimitive(PRIM_GET_MEMBER_VALUE)                   ||
-                call->isPrimitive(PRIM_WIDE_GET_LOCALE)                    ||
-                call->isPrimitive(PRIM_WIDE_GET_NODE)                      ||
-                call->isPrimitive(PRIM_END_OF_STATEMENT)                   ||
-                canPassToFn) {
-              se->setSymbol(arg); // do not dereference argument in these cases
-
-            } else if (call->isPrimitive(PRIM_ADDR_OF)) {
-              SET_LINENO(se);
-              call->replace(new SymExpr(arg));
-
-            } else {
-              SET_LINENO(se);
-
-              VarSymbol* tmp   = newTemp(sym->type);
-              CallExpr*  deref = new CallExpr(PRIM_DEREF, arg);
-              CallExpr*  move  = new CallExpr(PRIM_MOVE,  tmp, deref);
-
-              se->getStmtExpr()->insertBefore(new DefExpr(tmp));
-              se->getStmtExpr()->insertBefore(move);
-
-              se->setSymbol(tmp);
+            } else if (arg->type == form->type) {
+              canPassToFn = true;
             }
+          }
+
+          // check if call is in a lifetime clause
+          if (i >= firstInLifetimeConstraint)
+            canPassToFn = true;
+
+          if (( (call->isPrimitive(PRIM_MOVE)       ||
+                 call->isPrimitive(PRIM_ASSIGN)     ||
+                 call->isPrimitive(PRIM_SET_MEMBER) )
+                && call->get(1) == se)                                   ||
+              call->isPrimitive(PRIM_GET_MEMBER)                         ||
+              call->isPrimitive(PRIM_GET_MEMBER_VALUE)                   ||
+              call->isPrimitive(PRIM_WIDE_GET_LOCALE)                    ||
+              call->isPrimitive(PRIM_WIDE_GET_NODE)                      ||
+              call->isPrimitive(PRIM_END_OF_STATEMENT)                   ||
+              canPassToFn) {
+            se->setSymbol(arg); // do not dereference argument in these cases
+
+          } else if (call->isPrimitive(PRIM_ADDR_OF)) {
+            SET_LINENO(se);
+            call->replace(new SymExpr(arg));
 
           } else {
-            // So far, the only other known case is when 'se' is some
-            // shadow variable's outer sym. If so, just replace the symbol.
-            ShadowVarSymbol* svar = toShadowVarSymbol(se->parentSymbol);
-            INT_ASSERT(svar && se == svar->outerVarSE);
-            se->setSymbol(arg);
+            SET_LINENO(se);
+
+            VarSymbol* tmp   = newTemp(sym->type);
+            CallExpr*  deref = new CallExpr(PRIM_DEREF, arg);
+            CallExpr*  move  = new CallExpr(PRIM_MOVE,  tmp, deref);
+
+            se->getStmtExpr()->insertBefore(new DefExpr(tmp));
+            se->getStmtExpr()->insertBefore(move);
+
+            se->setSymbol(tmp);
           }
+
+        } else {
+          // So far, the only other known case is when 'se' is some
+          // shadow variable's outer sym. If so, just replace the symbol.
+          ShadowVarSymbol* svar = toShadowVarSymbol(se->parentSymbol);
+          INT_ASSERT(svar && se == svar->outerVarSE);
+          se->setSymbol(arg);
         }
-        i++;
       }
+      i++;
     }
   }
 }

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -925,10 +925,15 @@ void saveGenericSubstitutions() {
         // This case is a workaround for patterns that
         // come up with compiler-generated tuple functions
         INT_ASSERT(fn->hasFlag(FLAG_INIT_TUPLE));
-        form_Map(SymbolMapElem, e, fn->substitutions) {
+
+        SymbolMapVector elts = sortedSymbolMapElts(fn->substitutions);
+        for (auto pair: elts) {
+          Symbol* key = pair.first;
+          Symbol* value = pair.second;
+
           NameAndSymbol ns;
-          ns.name = e->key->name;
-          ns.value = e->value;
+          ns.name = key->name;
+          ns.value = value;
           ns.isParam = false;
           ns.isType = false;
           fn->substitutionsPostResolve.push_back(ns);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -70,12 +70,18 @@ explainInstantiation(FnSymbol* fn) {
   if (explainInstantiationLine != -1 && explainInstantiationLine != fn->defPoint->linenum())
     return;
 
+  SymbolMapVector elts = sortedSymbolMapElts(fn->substitutions);
+
   char msg[1024] = "";
   int len = sprintf(msg, "instantiated %s(", fn->name);
   bool first = true;
   for_formals(formal, fn) {
-    form_Map(SymbolMapElem, e, fn->substitutions) {
-      ArgSymbol* arg = toArgSymbol(e->key);
+
+    for (auto pair: elts) {
+      Symbol* key = pair.first;
+      Symbol* value = pair.second;
+
+      ArgSymbol* arg = toArgSymbol(key);
       if (!strcmp(formal->name, arg->name)) {
         if (first)
           first = false;
@@ -84,7 +90,7 @@ explainInstantiation(FnSymbol* fn) {
         INT_ASSERT(arg);
         if (strcmp(fn->name, tupleInitName))
           len += sprintf(msg+len, "%s = ", arg->name);
-        if (VarSymbol* vs = toVarSymbol(e->value)) {
+        if (VarSymbol* vs = toVarSymbol(value)) {
           if (vs->immediate && vs->immediate->const_kind == NUM_KIND_INT)
             len += sprintf(msg+len, "%" PRId64, vs->immediate->int_value());
           else if (vs->immediate && vs->immediate->const_kind == CONST_KIND_STRING)
@@ -92,7 +98,7 @@ explainInstantiation(FnSymbol* fn) {
           else
             len += sprintf(msg+len, "%s", vs->name);
         }
-        else if (Symbol* s = toSymbol(e->value))
+        else if (Symbol* s = toSymbol(value))
       // For a generic symbol, just print the name.
       // Additional clauses for specific symbol types should precede this one.
           len += sprintf(msg+len, "%s", s->name);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -76,12 +76,10 @@ explainInstantiation(FnSymbol* fn) {
   int len = sprintf(msg, "instantiated %s(", fn->name);
   bool first = true;
   for_formals(formal, fn) {
-
     for (auto pair: elts) {
-      Symbol* key = pair.first;
+      ArgSymbol* arg = toArgSymbol(pair.first); // this is the key
       Symbol* value = pair.second;
 
-      ArgSymbol* arg = toArgSymbol(key);
       if (!strcmp(formal->name, arg->name)) {
         if (first)
           first = false;

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -186,13 +186,8 @@ static void addArgForGenericField(CallExpr* genCall, Symbol* gf) {
 
 static bool applyStandinsToGenerics(BlockStmt* holder, SymbolMap& fml2act) {
   bool gotGenerics = false;
-
-  SymbolMapVector elts = sortedSymbolMapElts(fml2act);
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-    Symbol* value = pair.second;
-
-    Type* targetOrig = value->type;
+  form_Map(SymbolMapElem, elem, fml2act) {
+    Type* targetOrig = elem->value->type;
     Type* targetVal  = targetOrig->getValType();
     // CG TODO: also handle DecoratedClassType
     if (AggregateType* at = toAggregateType(targetVal)) {
@@ -210,7 +205,7 @@ static bool applyStandinsToGenerics(BlockStmt* holder, SymbolMap& fml2act) {
       if (targetVal != targetOrig && instType->refType != nullptr)
         instType = instType->refType;
 
-      fml2act.put(key, instType->symbol);
+      elem->value = instType->symbol; // aka fml2act.put(elem->key, instType);
       genCall->remove();
     }
   }
@@ -513,14 +508,9 @@ static Type* instantiateOneAggregateType(SymbolMap &fml2act,
   // We may or may not use its contents.
   std::vector<Type*> subs;  // used only when there are new substitution(s)
   bool gotSub = false;
-
-  SymbolMapVector elts = sortedSymbolMapElts(at->substitutions);
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-    Symbol* value = pair.second;
-
-    if (key->hasFlag(FLAG_PARAM)) continue;
-    Type* srcT = value->type;
+  form_Map(SymbolMapElem, elem, at->substitutions) {
+    if (elem->key->hasFlag(FLAG_PARAM)) continue;
+    Type* srcT = elem->value->type;
     Type* inst = instantiateOneAggregateType(fml2act, anchor, srcT, markRm);
     subs.push_back(inst != nullptr ? inst : srcT);
     if (inst != nullptr) gotSub = true;
@@ -532,16 +522,14 @@ static Type* instantiateOneAggregateType(SymbolMap &fml2act,
   CallExpr* genCall = new CallExpr(atgen->symbol);
   anchor->insertBefore(genCall);
   int i = 0;
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-    Symbol* value = pair.second;
+  form_Map(SymbolMapElem, elem, at->substitutions) {
     Symbol* instSym = nullptr;
     // follow addArgForGenericField()
-    if (key->hasFlag(FLAG_PARAM)) // param field
-      instSym = value; // apply the same substitution as for 'at'
+    if (elem->key->hasFlag(FLAG_PARAM)) // param field
+      instSym = elem->value; // apply the same substitution as for 'at'
     else // var or type field
       instSym = subs[i++]->symbol;
-    genCall->insertAtTail(new NamedExpr(key->name, new SymExpr(instSym)));
+    genCall->insertAtTail(new NamedExpr(elem->key->name, new SymExpr(instSym)));
   }
 
   AggregateType* instT = atgen->generateType(genCall, "<internal error>");
@@ -613,11 +601,8 @@ static void createRepsForIfcSymbols(FnSymbol* fn, InterfaceInfo* ifcInfo) {
       fml2act.put(required->symbol, instantiated);
     }
 
-    SymbolMapVector elts = sortedSymbolMapElts(isym->requiredFns);
-    for (auto pair: elts) {
-      Symbol* key = pair.first;
-
-      FnSymbol* required = toFnSymbol(key);
+    form_Map(SymbolMapElem, elem, isym->requiredFns) {
+      FnSymbol* required = toFnSymbol(elem->key);
       FnSymbol* instantiated = makeRepForRequiredFn(fn, fml2act, required);
       // We may also want to make 'instantiated' visible in fn->where.
       fn->body->insertAtHead(new DefExpr(instantiated));
@@ -1069,17 +1054,13 @@ static bool resolveRequiredFns(InterfaceSymbol* isym,  ImplementsStmt* istm,
   bool rfSuccess = true;
   std::vector<FnSymbol*> instantiatedDefaults;
 
-  SymbolMapVector elts = sortedSymbolMapElts(istm->witnesses);
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-    Symbol* value = pair.second;
-
-    if (FnSymbol* reqFn = toFnSymbol(key))
+  form_Map(SymbolMapElem, wit, istm->witnesses) {
+    if (FnSymbol* reqFn = toFnSymbol(wit->key))
       rfSuccess &= resolveOneRequiredFn(isym, istm, fml2act, gotGenerics,
                                         instantiatedDefaults, holder, indent,
-                                        reportErrors, reqFn, value);
+                                        reportErrors, reqFn, wit->value);
     else
-      INT_ASSERT(isConstrainedTypeSymbol(key, CT_IFC_ASSOC_TYPE));
+      INT_ASSERT(isConstrainedTypeSymbol(wit->key, CT_IFC_ASSOC_TYPE));
   }
 
   if (rfSuccess) {


### PR DESCRIPTION
Follow-up to #6876

For https://github.com/Cray/chapel-private/issues/1788

I noticed several places in the compiler where a loop iterating over a 
map with `form_Map` is adding AST nodes. This results in nondeterminism
because the map iteration order is not deterministic.

To address it, this PR adds a new function, `sortedSymbolMapElts`, which 
returns a vector of key-value pairs for a `SymbolMap`. This vector is 
sorted by AST id of the keys before it is returned.  Then, I looked at 
all of the calls to `form_Map`. Some of them do not do anything that 
depends on the order, but others appeared to potentially depend on the
order. For calls that could depend on the order, I updated them to call
`sortedSymbolMapElts`, to use C++ range iteration, and to create `key`
and `value` variables for the iteration.

The changes to `compiler/resolution/interfaceResolution.cpp` were causing 
test failures somehow. I will leave it to @vasslitvinov to update the
`form_Map` calls in that file as needed.

- [x] full local testing
- [x] full gasnet testing

Reviewed by @vasslitvinov - thanks!