### PR TITLE
Removed syntax highlighting for list of keywords in lexical-structure.rst

### DIFF
--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -129,7 +129,7 @@ The following identifiers are reserved as keywords:
 
 
 
-.. code-block:: chapel
+.. code-block:: text
 
    _
    align
@@ -233,7 +233,7 @@ The following identifiers are keywords reserved for future use:
 
 
 
-.. code-block:: chapel
+.. code-block:: text
 
    lambda
    pragma


### PR DESCRIPTION
This PR fixes #17386 

Changed the code-block from `chapel` to `text` in [lexical-structure.rst](https://github.com/chapel-lang/chapel/blob/master/doc/rst/language/spec/lexical-structure.rst), disabling syntax highlighting which fixes the issue.

Signed-off-by: venkat <venkat.r300@gmail.com>