### PR TITLE
Switch more form_Map to sorted iteration

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2334,18 +2334,18 @@ const char* toString(Symbol* sym, bool withType) {
 }
 
 struct SymbolPairComparator {
-  bool operator()(std::pair<Symbol*, Symbol*> lhs,
-                  std::pair<Symbol*, Symbol*> rhs) {
+  bool operator()(SymbolMapKeyValue lhs, SymbolMapKeyValue rhs) {
+    // use the same logic as other set/map ordering
     std::less<Symbol*> lessSym;
 
-    return lessSym(lhs.first, rhs.first);
+    return lessSym(lhs.key, rhs.key);
   }
 };
 
 SymbolMapVector sortedSymbolMapElts(const SymbolMap& map) {
-  std::vector<std::pair<Symbol*, Symbol*> > elts;
+  SymbolMapVector elts;
   form_Map(SymbolMapElem, e, map) {
-    elts.push_back(std::make_pair(e->key, e->value));
+    elts.push_back(SymbolMapKeyValue(e->key, e->value));
   }
   std::sort(elts.begin(), elts.end(), SymbolPairComparator());
   return elts;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -890,7 +890,11 @@ const char* toString(ArgSymbol* arg, bool withTypeAndIntent);
 const char* toString(VarSymbol* var, bool withType);
 const char* toString(Symbol* sym, bool withTypeAndIntent);
 
-typedef std::vector<std::pair<Symbol*, Symbol*> > SymbolMapVector;
+struct SymbolMapKeyValue {
+  Symbol *key, *value;
+  SymbolMapKeyValue(Symbol* k, Symbol* v): key(k), value(v) { }
+};
+typedef std::vector<SymbolMapKeyValue> SymbolMapVector;
 SymbolMapVector sortedSymbolMapElts(const SymbolMap& map);
 
 #endif

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -231,11 +231,8 @@ passByRef(Symbol* sym) {
 
 static void
 addVarsToFormals(FnSymbol* fn, SymbolMap* vars) {
-  SymbolMapVector elts = sortedSymbolMapElts(*vars);
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-
-    if (Symbol* sym = key) {
+  for (auto elem: sortedSymbolMapElts(*vars)) {
+    if (Symbol* sym = elem.key) {
       Type* type = sym->type;
       IntentTag intent = INTENT_BLANK;
 
@@ -305,10 +302,9 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
   if (fn->lifetimeConstraints)
     collectSymExprs(fn->lifetimeConstraints, symExprs);
 
-  SymbolMapVector elts = sortedSymbolMapElts(*vars);
-  for (auto pair: elts) {
-    Symbol* sym = pair.first; // this is the key
-    ArgSymbol* arg = toArgSymbol(pair.second); // this is the value
+  for (auto elem: sortedSymbolMapElts(*vars)) {
+    Symbol*    sym = elem.key;
+    ArgSymbol* arg = toArgSymbol(elem.value);
     Type*      type = arg->type;
 
     size_t i = 0;
@@ -382,10 +378,8 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
 
 static void
 addVarsToActuals(CallExpr* call, SymbolMap* vars, bool outerCall) {
-  SymbolMapVector elts = sortedSymbolMapElts(*vars);
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-    if (Symbol* sym = key) {
+  for (auto elem: sortedSymbolMapElts(*vars)) {
+    if (Symbol* sym = elem.key) {
       SET_LINENO(sym);
       call->insertAtTail(sym);
     }

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -926,14 +926,10 @@ void saveGenericSubstitutions() {
         // come up with compiler-generated tuple functions
         INT_ASSERT(fn->hasFlag(FLAG_INIT_TUPLE));
 
-        SymbolMapVector elts = sortedSymbolMapElts(fn->substitutions);
-        for (auto pair: elts) {
-          Symbol* key = pair.first;
-          Symbol* value = pair.second;
-
+        for (auto elem: sortedSymbolMapElts(fn->substitutions)) {
           NameAndSymbol ns;
-          ns.name = key->name;
-          ns.value = value;
+          ns.name = elem.key->name;
+          ns.value = elem.value;
           ns.isParam = false;
           ns.isType = false;
           fn->substitutionsPostResolve.push_back(ns);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -11280,12 +11280,11 @@ static CallExpr* createGenericRecordVarDefaultInitCall(Symbol* val,
 
   CallExpr* initCall = new CallExpr("init", gMethodToken, new NamedExpr("this", new SymExpr(val)));
 
-  SymbolMapVector elts = sortedSymbolMapElts(at->substitutions);
-  for (auto pair: elts) {
-    Symbol* key = pair.first;
-    Symbol* value = pair.second;
+  for (auto elem: sortedSymbolMapElts(at->substitutions)) {
+    const char* keyName = elem.key->name;
+    Symbol*     value   = elem.value;
 
-    Symbol* field = root->getField(key->name);
+    Symbol* field = root->getField(keyName);
     bool hasDefault = false;
     bool isGenericField = root->fieldIsGeneric(field, hasDefault);
 
@@ -11301,7 +11300,7 @@ static CallExpr* createGenericRecordVarDefaultInitCall(Symbol* val,
         // fields for default-initialized records, and avoid crashing.
         VarSymbol* tmp = newTemp("default_runtime_temp");
         tmp->addFlag(FLAG_TYPE_VARIABLE);
-        CallExpr* query = new CallExpr(PRIM_QUERY_TYPE_FIELD, at->symbol, new_CStringSymbol(key->name));
+        CallExpr* query = new CallExpr(PRIM_QUERY_TYPE_FIELD, at->symbol, new_CStringSymbol(keyName));
         CallExpr* move = new CallExpr(PRIM_MOVE, tmp, query);
 
         call->insertBefore(new DefExpr(tmp));
@@ -11349,7 +11348,7 @@ static CallExpr* createGenericRecordVarDefaultInitCall(Symbol* val,
       INT_FATAL("Unhandled case for default-init");
     }
 
-    appendExpr = new NamedExpr(key->name, appendExpr);
+    appendExpr = new NamedExpr(keyName, appendExpr);
 
     initCall->insertAtTail(appendExpr);
   }

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -76,9 +76,8 @@ explainInstantiation(FnSymbol* fn) {
   int len = sprintf(msg, "instantiated %s(", fn->name);
   bool first = true;
   for_formals(formal, fn) {
-    for (auto pair: elts) {
-      ArgSymbol* arg = toArgSymbol(pair.first); // this is the key
-      Symbol* value = pair.second;
+    for (auto elem: elts) {
+      ArgSymbol* arg = toArgSymbol(elem.key);
 
       if (!strcmp(formal->name, arg->name)) {
         if (first)
@@ -88,7 +87,7 @@ explainInstantiation(FnSymbol* fn) {
         INT_ASSERT(arg);
         if (strcmp(fn->name, tupleInitName))
           len += sprintf(msg+len, "%s = ", arg->name);
-        if (VarSymbol* vs = toVarSymbol(value)) {
+        if (VarSymbol* vs = toVarSymbol(elem.value)) {
           if (vs->immediate && vs->immediate->const_kind == NUM_KIND_INT)
             len += sprintf(msg+len, "%" PRId64, vs->immediate->int_value());
           else if (vs->immediate && vs->immediate->const_kind == CONST_KIND_STRING)
@@ -96,7 +95,7 @@ explainInstantiation(FnSymbol* fn) {
           else
             len += sprintf(msg+len, "%s", vs->name);
         }
-        else if (Symbol* s = toSymbol(value))
+        else if (Symbol* s = toSymbol(elem.value))
       // For a generic symbol, just print the name.
       // Additional clauses for specific symbol types should precede this one.
           len += sprintf(msg+len, "%s", s->name);


### PR DESCRIPTION
This propagates the work in #17412 into interfaceResolution.cpp

While there, switch the functionality added in #17412 from `std::pair`
to a meaningful `struct` and simplify its uses.
