### PR TITLE
Improve doc/Makefile readability

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -75,7 +75,7 @@ collect-syntax:
 
 module-docs:
 	@echo
-	@echo "Generating module docs from "'$$CHPL_HOME'"/modules/ into $(SOURCEDIR)/modules"
+	@echo "Generating module docs from '\$$CHPL_HOME/modules/' into '$(SOURCEDIR)/modules'"
 	@# modules/Makefile will
 	@#   store module docs in doc/rst/modules and doc/rst/builtins
 	@#   including meta/modules/* and meta/builtins/*
@@ -83,7 +83,7 @@ module-docs:
 
 primers:
 	@echo
-	@echo "Generating primers from "'$$CHPL_HOME'"/test/release/examples to $(SOURCEDIR)/primers"
+	@echo "Generating primers from '\$$CHPL_HOME/test/release/examples' to '$(SOURCEDIR)/primers'"
 	@rm -rf $(CHPL_DOC_PRIMERS_BUILD_DIR)
 	@mkdir -p $(CHPL_DOC_PRIMERS_BUILD_DIR)
 	@#Note - this assumes that we are not in a release tar ball
@@ -96,7 +96,7 @@ primers:
 
 examples:
 	@echo
-	@echo "Generating hellos from "'$$CHPL_HOME'"/test/release/examples to $(SOURCEDIR)/examples"
+	@echo "Generating hellos from '\$$CHPL_HOME/test/release/examples' to '$(SOURCEDIR)/examples'"
 	@rm -rf $(CHPL_DOC_EXAMPLES_BUILD_DIR)
 	@mkdir -p $(CHPL_DOC_EXAMPLES_BUILD_DIR)
 	@$(CHPL2RST) $(CHPL2RSTOPTS_HELLO) ../examples/hello*.chpl
@@ -107,13 +107,13 @@ examples:
 symlinks:
 	@echo
 	@echo "Creating symlinks"
-	@if [ ! -e $(SOURCEDIR)/usingchapel/man.rst ]; then ln -s $$CHPL_HOME/man/chpl.rst $(SOURCEDIR)/usingchapel/man.rst; fi
-	@if [ ! -e $(SOURCEDIR)/tools/chpldoc/man.rst ]; then ln -s $$CHPL_HOME/man/chpldoc.rst $(SOURCEDIR)/tools/chpldoc/man.rst; fi
-	@if [ ! -e $(SOURCEDIR)/tools/chplvis/examples ]; then ln -s $$CHPL_HOME/test/release/examples $(SOURCEDIR)/tools/chplvis/examples; fi
-	@if [ ! -e $(SOURCEDIR)/users-guide/base/examples ]; then ln -s $$CHPL_HOME/test/release/examples $(SOURCEDIR)/users-guide/base/examples; fi
-	@if [ ! -e $(SOURCEDIR)/users-guide/taskpar/examples ]; then ln -s $$CHPL_HOME/test/release/examples $(SOURCEDIR)/users-guide/taskpar/examples; fi
-	@if [ ! -e $(SOURCEDIR)/users-guide/datapar/examples ]; then ln -s $$CHPL_HOME/test/release/examples $(SOURCEDIR)/users-guide/datapar/examples; fi
-	@if [ ! -e $(SOURCEDIR)/users-guide/locality/examples ]; then ln -s $$CHPL_HOME/test/release/examples $(SOURCEDIR)/users-guide/locality/examples; fi
+	@ln -snf $(CHPL_HOME)/man/chpl.rst $(SOURCEDIR)/usingchapel/man.rst;
+	@ln -snf $(CHPL_HOME)/man/chpldoc.rst $(SOURCEDIR)/tools/chpldoc/man.rst;
+	@ln -snf $(CHPL_HOME)/test/release/examples $(SOURCEDIR)/tools/chplvis/examples;
+	@ln -snf $(CHPL_HOME)/test/release/examples $(SOURCEDIR)/users-guide/base/examples;
+	@ln -snf $(CHPL_HOME)/test/release/examples $(SOURCEDIR)/users-guide/taskpar/examples;
+	@ln -snf $(CHPL_HOME)/test/release/examples $(SOURCEDIR)/users-guide/datapar/examples;
+	@ln -snf $(CHPL_HOME)/test/release/examples $(SOURCEDIR)/users-guide/locality/examples;
 
 checkdocs: FORCE
 	$(MAKE) check


### PR DESCRIPTION
Trying to improve readability of `doc/Makefile` with the following:
- Change how `$CHPL_HOME` is escaped when used in text for echo commands: `"'$$CHPL_HOME'"` -> `\$$CHPL_HOME`

```
target: 
  @echo "This is a var "'$$CHPL_HOME'" and ... " -> @echo "This is a var \$$CHPL_HOME and ..."
```
both will render `This is a var $CHPL_HOME and ...`

```
CHPL_HOME = path/to/something
target:
  @echo "This is a var "'$(CHPL_HOME)'" and ..." -> @echo "This is a var $(CHPL_HOME) and ..."
```
both will render `This is a var path/to/something and ...`

If we want to escape `$(CHPL_HOME)`:

```
target:
  @echo "This is a var \$$(CHPL_HOME) and ..."
```
will render as `This is a var $(CHPL_HOME) and ...`

- Use double dollar sign (`$$CHPL_HOME`) for escaping in text to be printed. If variable should be evaluated  then use `$(CHPL_HOME)`.
e.g. `ln -s $$CHPL_HOME/something path/other` -> `ln -s $(CHPL_HOME)/something path/other`

- Create symlinks adding flags `-f` and `-n` for `ln` to avoid the need of checking if file exists.

This is my first PR to Chapel!