### PR TITLE
Re-enable submitted version of knucleotide-3

### DIFF
--- a/test/studies/shootout/submitted/knucleotide3.chpl
+++ b/test/studies/shootout/submitted/knucleotide3.chpl
@@ -76,18 +76,18 @@ proc writeCount(data, param str) {
 proc calculate(data, param nclSize) {
   var freqs = new map(int, int);
 
-  var lock$: sync bool = true;
+  var lock: sync bool = true;
   const numTasks = here.maxTaskPar;
-  coforall tid in 1..numTasks {
+  coforall tid in 1..numTasks with (ref freqs) {
     var myFreqs = new map(int, int);
 
     for i in tid..(data.size-nclSize) by numTasks do
       myFreqs[hash(data, i, nclSize)] += 1;
 
-    lock$;        // acquire lock
+    lock.readFE();      // acquire lock
     for (k,v) in myFreqs.items() do
       freqs[k] += v;
-    lock$ = true; // release lock
+    lock.writeEF(true); // release lock
   }
 
   return freqs;


### PR DESCRIPTION
This test has been disabled for nearly a year now, though the version
at the CLBG site has continued to function (and is more up-to-date
than this one in that it applies a 'with' clause to a parallel
loop... not quite sure how they got out of sync without also
re-enabling this test).  Here, I'm updating the test to use explicit
reads/writes of syncs now that the implicit reads/writes are
deprecated.
