### PR TITLE
Add perf annotations for 2021-03-19

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -456,6 +456,12 @@ all:
     - Improve the speed of tracking arrays declared over a domain (#16740)
   02/01/21:
     - Enable the cache for remote data by default (#17044)
+  03/18/21:
+    - text: Improve NUMA affinity and startup times for configs that use a fixed heap (#17405)
+      config: 16-node-xc, 16-node-cs, 16-node-cs-hdr
+    - text: Set the number of launcher cores per locale for Cray CS perf testing (#17407)
+      config: 16-node-cs
+
 # End all
 
 AllCompTime: &timecomp-base

--- a/util/cron/common-perf-cray-cs-hdr.bash
+++ b/util/cron/common-perf-cray-cs-hdr.bash
@@ -9,5 +9,5 @@ export CHPL_TARGET_CPU=none
 pcca=(-performance-configs gn-ibv-large:v,gn-ibv-fast:v \
       -performance \
       -perflabel ml- \
-      -startdate 07/01/19)
+      -startdate 03/11/21)
 perf_cray_cs_args=${pcca[*]}

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -91,7 +91,7 @@ def check_graph_names(ann_data, graph_list):
 def check_configs(ann_data):
     """Check that all the configs used in the annotation file are 'known'"""
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
-                     '16-node-xc', '1-node-xc', '16-node-cs',
+                     '16-node-xc', '1-node-xc', '16-node-cs', '16-node-cs-hdr',
                      'chapcs.comm-counts'}
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():


### PR DESCRIPTION
Add annotations for:
 - improved numa affinity and startup time from parallel heap init
 - improved ofi perf from setting launcher cores per locale

While here also fix the start date for 16-node-cs-hdr