### PR TITLE
[Docs] [NFC] Mention `check` target of make

### DIFF
--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -103,6 +103,8 @@ Makefiles support the following targets:
   | default   | libraries, executables                               |
   | all       |                                                      |
   +-----------+------------------------------------------------------+
+  | check     | verify basic functionality of chapel build           |
+  +-----------+------------------------------------------------------+
   | clean     | Remove the intermediate files for this configuration |
   +-----------+------------------------------------------------------+
   | cleanall  | Remove the intermediate files for all configurations |


### PR DESCRIPTION
`check` is use to verify basic functionality of chapel build. It will run the test cases under the directory of chapel/test/.