### PR TITLE
Update pycparser and PyYAML versions

### DIFF
--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,2 +1,2 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
-pycparser==2.17
+pycparser==2.20

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,7 @@
+six
+appdirs
+packaging
+ordered_set
 PyYAML==5.3.1
 filelock==3.0.12
 argcomplete==1.12.1

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,7 +1,3 @@
-six
-appdirs
-packaging
-ordered_set
-PyYAML==5.3.1
+PyYAML==5.4.1
 filelock==3.0.12
 argcomplete==1.12.1

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -35,7 +35,7 @@ link=$(bdir)/c2chapel
 
 # Note, this version is used only for the fake headers,
 # but it should probably match third-party/chpl-venv/c2chapel-requirements.txt
-VERSION=2.17
+VERSION=2.20
 TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)


### PR DESCRIPTION
This PR addresses issues encountered during a white box build for Chapel on Shasta. Specifically, the current version build for Shasta was encountering "ModuleNotFoundError: No module named 'six'".  Updating the pycparser and PyYAML have resolved that issue.