### PR TITLE
Fix some issues with OrderedMap

### DIFF
--- a/modules/packages/OrderedMap.chpl
+++ b/modules/packages/OrderedMap.chpl
@@ -116,7 +116,7 @@ module OrderedMap {
 
     /* The underlying implementation */
     pragma "no doc"
-    var _set: orderedSet(_eltType, parSafe);
+    var _set: orderedSet;
 
 
     //TODO: Maybe we should use the lock from the underlying implementation

--- a/modules/packages/OrderedMap.chpl
+++ b/modules/packages/OrderedMap.chpl
@@ -87,16 +87,6 @@ module OrderedMap {
   class _valueWrapper {
     var val;
   }
-  /*
-    This doesn't indicate any comparing.
-    Just to make (keyType, shared _valueWrapper?) comparable.
-  */
-  proc <(a: shared _valueWrapper?, b: shared _valueWrapper?) {
-    return false;
-  }
-  proc >(a: shared _valueWrapper?, b: shared _valueWrapper?) {
-    return false;
-  }
 
   record orderedMap {
     /* Type of orderedMap keys. */

--- a/test/library/packages/OrderedMap/init/testInitGenericError.good
+++ b/test/library/packages/OrderedMap/init/testInitGenericError.good
@@ -2,4 +2,4 @@ $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: warning: creating a orderedMap with key type C
 $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: warning: which now means class type with generic management
 $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: error: orderedMap key type cannot currently be generic
-testInitGenericError.chpl:9: Initializer instantiated as: init(type keyType = C, type valType = int(64), param parSafe = 0, comparator: DefaultComparator)
+  testInitGenericError.chpl:9: called as orderedMap.init(type keyType = C, type valType = int(64), param parSafe = false, comparator: DefaultComparator)

--- a/test/library/packages/OrderedMap/init/testInitGenericError2.good
+++ b/test/library/packages/OrderedMap/init/testInitGenericError2.good
@@ -2,4 +2,4 @@ $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: warning: creating a orderedMap with value type C
 $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: warning: which now means class type with generic management
 $CHPL_HOME/modules/packages/OrderedMap.chpl:nnnn: error: orderedMap value type cannot currently be generic
-testInitGenericError2.chpl:9: Initializer instantiated as: init(type keyType = int(64), type valType = C, param parSafe = 0, comparator: DefaultComparator)
+  testInitGenericError2.chpl:9: called as orderedMap.init(type keyType = int(64), type valType = C, param parSafe = false, comparator: DefaultComparator)


### PR DESCRIPTION
This is a follow up to https://github.com/chapel-lang/chapel/pull/16271 and
should be merged after that.

Fixes 3 issues with OrderedMap:
- Update a good file with the improved compiler error message
- Fix a type mismatch between the internal `_set` field and the value assigned
  to it inside the initializer
- Remove unnecessary `proc <` workarounds

Test:
- [x] standard
- [x] gasnet
