### PR TITLE
Fix verboseComm test for asan

### DIFF
--- a/test/multilocale/engin/verboseComm.compopts
+++ b/test/multilocale/engin/verboseComm.compopts
@@ -1,2 +1,9 @@
---no-cache-remote # verboseComm.no-cache.good
---cache-remote    # verboseComm.cache.good
+#!/usr/bin/env python3
+
+import os
+
+do_cache = os.getenv('CHPL_SANITIZE_EXE', '') == 'none'
+
+print(  '--no-cache-remote # verboseComm.no-cache.good')
+if do_cache:
+  print('--cache-remote    # verboseComm.cache.good')


### PR DESCRIPTION
Follow-up to PR #17354.

This PR uses the approach from #16876 to get this verbose comms test working under gasnet+asan.

Test change only - not reviewed.