### PR TITLE
Locally overrided man page configuration

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -192,7 +192,7 @@ html_static_path = ['meta/static']
 # If true, smartquotes will be used to convert quotes and dashes to
 # typographically correct entities.
 # We turned this off because it clobbers the man page documentation
-smartquotes = False
+smartquotes = True
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -189,11 +189,6 @@ html_static_path = ['meta/static']
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'
 
-# If true, smartquotes will be used to convert quotes and dashes to
-# typographically correct entities.
-# We turned this off because it clobbers the man page documentation
-smartquotes = True
-
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -672,7 +672,7 @@ OPTIONS
     flag corresponds with and overrides the $CHPL\_MEM environment variable
     (defaults to a best guess based on $CHPL\_COMM).
 
-**\--re2 <re2>**
+**\--regexp <regexp>**
 
     Specify the regular expression library to use. This flag corresponds
     with and overrides the $CHPL\_REGEXP environment variable (defaults to

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -52,19 +52,19 @@ OPTIONS
 
 *Module Processing Options*
 
-**--[no-]count-tokens**
+**\--[no-]count-tokens**
 
     Prints the total number of static lexical tokens in the Chapel code
     files named on the command line.
 
-**--main-module <module>**
+**\--main-module <module>**
 
     For programs that supply multiple possible entry points (main()
     functions or module initializers that can serve as an entry point), this
     option can be used to specify which module should serve as the starting
     point for program execution.
 
-**-M, --module-dir <**\ *directory*\ **>**
+**-M, \--module-dir <**\ *directory*\ **>**
 
     Add the specified *directory* to the module search path. The module
     search path is used to satisfy module 'use' statements. In the current
@@ -74,7 +74,7 @@ OPTIONS
     files listed by the programmer on the compiler's command line do not
     define a module named 'foo', the compiler will search for files named
     'foo.chpl' in the module search path. The complete path that will be
-    searched can be displayed using the **--print-search-dirs** flag and is
+    searched can be displayed using the **\--print-search-dirs** flag and is
     composed of (1) the directories containing the .\ **chpl** files that
     were specified on the compiler command-line (in left-to-right order),
     (2) all directories specified by **-M** flags (in left-to-right order),
@@ -82,7 +82,7 @@ OPTIONS
     variable (colon-separated directories), (4) the compiler's standard
     module search path.
 
-**--[no-]print-code-size**
+**\--[no-]print-code-size**
 
     Prints out the size of the Chapel code files named on the command line
     in great detail: For each code file, first the code is echoed back to
@@ -96,17 +96,17 @@ OPTIONS
     file, a grand total of the number of tokens across all the files is
     displayed.
 
-**--print-module-files**
+**\--print-module-files**
 
     Prints the Chapel module source files parsed by the Chapel compiler.
 
-**--[no-]print-search-dirs**
+**\--[no-]print-search-dirs**
 
     Print the module search path used to resolve module for further details.
 
 *Warning and Language Control Options*
 
-**--[no-]permit-unhandled-module-errors**
+**\--[no-]permit-unhandled-module-errors**
 
     Normally, the compiler ensures that all errors are handled for code
     inside of a module declaration (unless the module overrides that
@@ -114,177 +114,177 @@ OPTIONS
     will compile code in a module that does not handle its errors. If any
     error comes up during execution, it will cause the program to halt.
 
-**--[no-]warn-unstable**
+**\--[no-]warn-unstable**
 
     Enable [disable] warnings for code that has recently or will recently
     change in meaning due to language changes.
 
-**--[no-]warnings**
+**\--[no-]warnings**
 
     Enable [disable] the printing of compiler warnings. Defaults to printing
     warnings.
 
 *Parallelism Control Options*
 
-**--[no-]local**
+**\--[no-]local**
 
     Compile code for single/[multi-] *locale* execution, changing *on
     blocks* to normal blocks, evaluating the *locale* expression for side
     effects, and optimizing away all remote references in the code. When
-    $CHPL\_COMM is set to "none", **--local** is the default; otherwise
-    **--no-local** is the default.
+    $CHPL\_COMM is set to "none", **\--local** is the default; otherwise
+    **\--no-local** is the default.
 
 *Optimization Control Options*
 
-**--baseline**
+**\--baseline**
 
     Turns off all optimizations in the Chapel compiler and generates naive C
     code with many temporaries.
 
-**--[no-]cache-remote**
+**\--[no-]cache-remote**
 
     Enables the cache for remote data. This cache can improve communication
     performance for some programs by adding aggregation, write behind, and
     read ahead.
 
-**--[no-]copy-propagation**
+**\--[no-]copy-propagation**
 
     Enable [disable] copy propagation.
 
-**--[no-]dead-code-elimination**
+**\--[no-]dead-code-elimination**
 
     Enable [disable] dead code elimination.
 
-**--fast**
+**\--fast**
 
-    Turns off all runtime checks using **--no-checks**, turns on **-O** and
-    **--specialize**.
+    Turns off all runtime checks using **\--no-checks**, turns on **-O** and
+    **\--specialize**.
 
-**--[no-]fast-followers**
+**\--[no-]fast-followers**
 
     Enable [disable] the fast follower optimization in which fast
     implementations of followers will be invoked for specific leaders.
 
-**--[no-]ieee-float**
+**\--[no-]ieee-float**
 
     Disable [enable] optimizations that may affect IEEE floating point
     conformance. The default is whatever level of optimization/IEEE floating
     point support your C compiler provides at the optimization level
     provided by '\ **chpl**\ '.
 
-**--[no-]loop-invariant-code-motion**
+**\--[no-]loop-invariant-code-motion**
 
     Enable [disable] the optimization that moves loop invariant code from
     loop runs into the loop's "pre-header." By default invariant code is
     moved. This is currently a rather conservative pass in the sense that it
     may not identify all code that is truly invariant.
 
-**--[no-]optimize-forall-unordered-ops**
+**\--[no-]optimize-forall-unordered-ops**
 
     Enable [disable] optimization of the last statement in forall statements
     to use unordered communication. This optimization works with runtime
     support for unordered operations with CHPL_COMM=ugni.
 
-**--[no-]ignore-local-classes**
+**\--[no-]ignore-local-classes**
 
     Disable [enable] local classes
 
-**--[no-]inline**
+**\--[no-]inline**
 
     Enable [disable] function inlining.
 
-**--[no-]inline-iterators**
+**\--[no-]inline-iterators**
 
     Enable [disable] iterator inlining. When possible, the compiler
     optimizes the invocation of an iterator in a loop header by inlining the
     iterator's definition around the loop body.
 
-**--inline-iterators-yield-limit**
+**\--inline-iterators-yield-limit**
 
     Limit on the number of yield statements permitted in an inlined iterator.
     The default value is 10.
 
-**--[no-]live-analysis**
+**\--[no-]live-analysis**
 
     Enable [disable] live variable analysis, which is currently only used to
     optimize iterators that are not inlined.
 
-**--[no-]optimize-range-iteration**
+**\--[no-]optimize-range-iteration**
 
     Enable [disable] anonymous range iteration optimizations. This allows the
     compiler to avoid creating ranges when they are only used for iteration.
     By default this is enabled.
 
-**--[no-]optimize-loop-iterators**
+**\--[no-]optimize-loop-iterators**
 
     Enable [disable] optimizations to aggressively optimize iterators that
     are defined in terms of a single loop. By default this is enabled.
 
-**--[no-]vectorize**
+**\--[no-]vectorize**
 
     Enable [disable] generating vectorization hints for the target compiler.
     If enabled, hints will always be generated, but the effects on performance
     (and in some cases correctness) will vary based on the target compiler.
 
-**--[no-]optimize-on-clauses**
+**\--[no-]optimize-on-clauses**
 
     Enable [disable] optimization of on clauses in which qualifying on
     statements may be optimized in the runtime if supported by the
     $CHPL\_COMM layer.
 
-**--optimize-on-clause-limit**
+**\--optimize-on-clause-limit**
 
     Limit on the function call depth to allow for on clause optimization.
     The default value is 20.
 
-**--[no-]privatization**
+**\--[no-]privatization**
 
     Enable [disable] privatization of distributed arrays and domains if the
     distribution supports it.
 
-**--[no-]remove-copy-calls**
+**\--[no-]remove-copy-calls**
 
     Enable [disable] removal of copy calls (including calls to what amounts
     to a copy constructor for records) that ensure Chapel semantics but
     which can often be optimized away.
 
-**--[no-]remote-value-forwarding**
+**\--[no-]remote-value-forwarding**
 
     Enable [disable] remote value forwarding of read-only values to remote
     threads if reading them early does not violate program semantics.
 
-**--[no-]remote-serialization**
+**\--[no-]remote-serialization**
 
     Enable [disable] serialization for globals and remote constants.
 
-**--[no-]scalar-replacement**
+**\--[no-]scalar-replacement**
 
     Enable [disable] scalar replacement of records and classes for some
     compiler-generated data structures that support language features such
     as tuples and iterators.
 
-**--scalar-replace-limit**
+**\--scalar-replace-limit**
 
     Limit on the size of tuples being replaced during scalar replacement.
     The default value is 8.
 
-**--[no-]tuple-copy-opt**
+**\--[no-]tuple-copy-opt**
 
     Enable [disable] the tuple copy optimization in which whole tuple copies
     of homogeneous tuples are replaced with explicit assignment of each
     tuple component.
 
-**--tuple-copy-limit**
+**\--tuple-copy-limit**
 
     Limit on the size of tuples considered for the tuple copy optimization.
     The default value is 8.
 
-**--[no-]infer-local-fields**
+**\--[no-]infer-local-fields**
 
     Enable [disable] analysis to infer local fields in classes and records
     (experimental)
 
-**--[no-]auto-local-access**
+**\--[no-]auto-local-access**
 
     Enable [disable] an optimization applied to forall loops over domains in
     which accesses of the form of `A[i]` within the loop are transformed to use
@@ -293,85 +293,85 @@ OPTIONS
     and adds calls that can further analyze alignment dynamically during
     execution time.
 
-**--[no-]dynamic-auto-local-access**
+**\--[no-]dynamic-auto-local-access**
 
     Enable [disable] the dynamic portion of the analysis described in
-    `--[no-]auto-local-access`.  This dynamic analysis can result in loop
+    `\--[no-]auto-local-access`.  This dynamic analysis can result in loop
     duplication that increases executable size and compilation time. There
     may also be execution time overheads independent of loop domain size.
 
-**--[no-]auto-aggregation**
+**\--[no-]auto-aggregation**
 
     Enable [disable] optimization of the last statement in forall statements to
     use aggregated communication. This optimization is disabled by default.
 
 *Run-time Semantic Check Options* 
 
-**--[no-]checks**
+**\--[no-]checks**
 
     Enable [disable] all of the run-time checks in this section of the man page.
-    Currently, it is typically necessary to use this flag (or **--fast**,
-    which implies **--no-checks**) to achieve performance competitive with
+    Currently, it is typically necessary to use this flag (or **\--fast**,
+    which implies **\--no-checks**) to achieve performance competitive with
     hand-coded C or Fortran.
 
-**--[no-]bounds-checks**
+**\--[no-]bounds-checks**
 
     Enable [disable] run-time bounds checking, e.g. during slicing and array
     indexing.
 
-**--[no-]cast-checks**
+**\--[no-]cast-checks**
 
     Enable [disable] run-time checks in safeCast calls for casts that
     wouldn't preserve the logical value being cast.
 
-**--[no-]div-by-zero-checks**
+**\--[no-]div-by-zero-checks**
 
     Enable [disable] run-time checks in integer division and modulus operations
     to guard against dividing by zero.
 
-**--[no-]formal-domain-checks**
+**\--[no-]formal-domain-checks**
 
     Enable [disable] run-time checks to ensure that an actual array
     argument's domain matches its formal array argument's domain in terms of
     (a) describing the same index set and (b) having an equivalent domain
     map (if the formal domain explicitly specifies a domain map).
 
-**--[no-]local-checks**
+**\--[no-]local-checks**
 
     Enable [disable] run-time checking of the locality of references within
     local blocks.
 
-**--[no-]nil-checks**
+**\--[no-]nil-checks**
 
     Enable [disable] run-time checking for accessing nil object references.
 
-**--[no-]stack-checks**
+**\--[no-]stack-checks**
 
     Enable [disable] run-time checking for stack overflow.
 
 *C Code Generation Options* 
 
-**--[no-]codegen**
+**\--[no-]codegen**
 
     Enable [disable] generating C code and the binary executable. Disabling
     code generation is useful to reduce compilation time, for example, when
     only Chapel compiler warnings/errors are of interest.
 
-**--[no-]cpp-lines**
+**\--[no-]cpp-lines**
 
     Causes the compiler to emit cpp #line directives into the generated code
     in order to help map generated C code back to the Chapel source code
     that it implements. The [no-] version of this flag turns this feature
     off.
 
-**--max-c-ident-len**
+**\--max-c-ident-len**
 
     Limits the length of identifiers in the generated code, except when set
     to 0. The default is 0, except when $CHPL\_TARGET\_COMPILER indicates a
     PGI compiler (pgi or cray-prgenv-pgi), in which case the default is
     1020.
 
-**--[no-]munge-user-idents**
+**\--[no-]munge-user-idents**
 
     By default, **chpl** munges all user identifiers in the generated C code
     in order to minimize the chances of conflict with an identifier or
@@ -381,7 +381,7 @@ OPTIONS
     perform additional munging in order to implement Chapel semantics in C,
     or for other reasons.
 
-**--savec <dir>**
+**\--savec <dir>**
 
     Saves the compiler-generated C code in the specified *directory*,
     creating the *directory* if it does not already exist. This option may
@@ -389,28 +389,28 @@ OPTIONS
 
 *C Code Compilation Options*
 
-**--ccflags <flags>**
+**\--ccflags <flags>**
 
     Add the specified flags to the C compiler command line when compiling
-    the generated code. Multiple **--ccflags** *options* can be provided and
+    the generated code. Multiple **\--ccflags** *options* can be provided and
     in that case the combination of the flags will be forwarded to the C
     compiler.
 
-**-g, --[no-]debug**
+**-g, \--[no-]debug**
 
     Causes the generated C code to be compiled with debugging turned on. If
     you are trying to debug a Chapel program, this flag is virtually
-    essential along with the **--savec** flag. This flag also turns on the
-    **--cpp-lines** option unless compiling as a developer (for example, via
-    **--devel**).
+    essential along with the **\--savec** flag. This flag also turns on the
+    **\--cpp-lines** option unless compiling as a developer (for example, via
+    **\--devel**).
 
-**--dynamic**
+**\--dynamic**
 
     Use dynamic linking when generating the final binary. If neither
-    **--dynamic** or **--static** are specified, use the backend compiler's
+    **\--dynamic** or **\--static** are specified, use the backend compiler's
     default.
 
-**-I, --hdr-search-path <dir>**
+**-I, \--hdr-search-path <dir>**
 
     Add the specified dir[ectories] to the back-end C compiler's
     search path for header files along with any directories in the
@@ -418,19 +418,19 @@ OPTIONS
     variable and this flag accept a colon-separated list of
     directories.
 
-**--ldflags <flags>**
+**\--ldflags <flags>**
 
     Add the specified flags to the back-end C compiler link line when
-    linking the generated code. Multiple **--ldflags** *options* can
+    linking the generated code. Multiple **\--ldflags** *options* can
     be provided and in that case the combination of the flags will be
     forwarded to the C compiler.
 
-**-l, --lib-linkage <library>**
+**-l, \--lib-linkage <library>**
 
     Specify a C library to link to on the back-end C compiler command
     line.
 
-**-L, --lib-search-path <dir>**
+**-L, \--lib-search-path <dir>**
 
     Add the specified dir[ectories] to the back-end C compiler's
     search path for libraries along with any directories in the
@@ -438,51 +438,51 @@ OPTIONS
     variable and this flag accept a colon-separated list of
     directories.
 
-**-O, --[no-]optimize**
+**-O, \--[no-]optimize**
 
     Causes the generated C code to be compiled with [without] optimizations
     turned on. The specific set of flags used by this option is
-    platform-dependent; use the **--print-commands** option to view the C
+    platform-dependent; use the **\--print-commands** option to view the C
     compiler command used. If you would like additional flags to be used
-    with the C compiler command, use the **--ccflags** option.
+    with the C compiler command, use the **\--ccflags** option.
 
-**--[no-]specialize**
+**\--[no-]specialize**
 
     Causes the generated C code to be compiled with flags that specialize
     the executable to the architecture that is defined by
     CHPL\_TARGET\_CPU. The effects of this flag will vary based on choice
     of back-end compiler and the value of CHPL\_TARGET\_CPU.
 
-**-o, --output <filename>**
+**-o, \--output <filename>**
 
     Specify the name of the compiler-generated executable. Defaults to
     the filename of the main module (minus its `.chpl` extension), if
     unspecified.
 
-**--static**
+**\--static**
 
     Use static linking when generating the final binary. If neither
-    **--static** or **--dynamic** are specified, use the backend compiler's
+    **\--static** or **\--dynamic** are specified, use the backend compiler's
     default.
 
 *LLVM Code Generation Options*
 
-**--[no-]llvm**
+**\--[no-]llvm**
 
     Use LLVM as the code generation target rather than C. See
     $CHPL\_HOME/doc/rst/technotes/llvm.rst for details.
 
-**--[no-]llvm-wide-opt**
+**\--[no-]llvm-wide-opt**
 
     Enable [disable] LLVM wide pointer communication optimizations. This
-    option requires **--llvm** and packed wide pointers. Packed wide
+    option requires **\--llvm** and packed wide pointers. Packed wide
     pointers are enabled by setting CHPL\_WIDE\_POINTERS = node16. You must
-    also supply **--fast** to enable wide pointer optimizations. This flag
+    also supply **\--fast** to enable wide pointer optimizations. This flag
     allows existing LLVM optimizations to work with wide pointers - for
     example, they might be able to hoist a 'get' out of a loop. See
     $CHPL\_HOME/doc/rst/technotes/llvm.rst for details.
 
-**--mllvm <option>**
+**\--mllvm <option>**
 
     Pass an option to the LLVM optimization and transformation passes.
     This option can be specified multiple times.
@@ -490,12 +490,12 @@ OPTIONS
 
 *Compilation Trace Options*
 
-**--[no-]print-commands**
+**\--[no-]print-commands**
 
     Prints the system commands that the compiler executes in order to
     compile the Chapel program.
 
-**--[no-]print-passes**
+**\--[no-]print-passes**
 
     Prints the compiler passes during compilation and the amount of wall
     clock time required for the pass. After compilation is complete two
@@ -505,7 +505,7 @@ OPTIONS
     table is sorted by pass and the second table is sorted by the time for
     the pass in descending order.
 
-**--print-passes-file <filename>**
+**\--print-passes-file <filename>**
 
     Saves the compiler passes and the amount of wall clock time required for
     the pass to <filename>. An error is displayed if the file cannot be
@@ -513,46 +513,46 @@ OPTIONS
 
 *Miscellaneous Options*
 
-**--[no-]devel**
+**\--[no-]devel**
 
     Puts the compiler into [out of] developer mode, which takes off some of
     the safety belts, changes default behaviors, and exposes additional
     undocumented command-line *options*. Use at your own risk and direct any
     questions to the Chapel team.
 
-**--explain-call <call>[:<module>][:<line>]**
+**\--explain-call <call>[:<module>][:<line>]**
 
     Helps explain the function resolution process for the named function by
     printing out the visible and candidate functions. Specifying a module
     name and/or line number can focus the explanation to those calls within
     a specific module or at a particular line number.
 
-**--explain-instantiation <function\|type>[:<module>][:<line>]**
+**\--explain-instantiation <function\|type>[:<module>][:<line>]**
 
     Lists all of the instantiations of a function or type. The location of
     one of possibly many points of instantiation is shown. Specifying a
     module name and/or line number can focus the explanation to those calls
     within a specific module or at a particular line number.
 
-**--[no-]explain-verbose**
+**\--[no-]explain-verbose**
 
     In combination with explain-call or explain-instantiation, causes the
     compiler to output more debug information related to disambiguation.
 
-**--instantiate-max <max>**
+**\--instantiate-max <max>**
 
     In order to avoid infinite loops when instantiating generic functions,
     the compiler limits the number of times a single function can be
     instantiated. This flag raises that maximum in the event that a legal
     instantiation is being pruned too aggressively.
 
-**--[no-]print-all-candidates**
+**\--[no-]print-all-candidates**
 
     By default, function resolution errors show only a few candidates.
     Use this flag to see all of the candidates for a call that could
     not be resolved.
 
-**--[no-]print-callgraph**
+**\--[no-]print-callgraph**
 
     Print a textual call graph representing the program being compiled. The
     output is in top-down and depth first order. Recursive calls are marked
@@ -560,25 +560,25 @@ OPTIONS
     Only a single call to each function is displayed from within any given
     parent function.
 
-**--[no-]print-callstack-on-error**
+**\--[no-]print-callstack-on-error**
 
     Accompany certain error and warning messages with the Chapel call stack
     that the compiler was working on when it reached the error or warning
     location. This is useful when the underlying cause of the issue is in
     one of the callers.
 
-**--[no-]print-unused-functions**
+**\--[no-]print-unused-functions**
 
     Print the names and source locations of unused functions within the
     user program.
 
-**-s, --set <config>[=<value>]**
+**-s, \--set <config>[=<value>]**
 
     Overrides the default value of a configuration param, type, var,
     or const in the code.  If the value is omitted, it will default
     to the value `true`.
 
-**--[no-]task-tracking**
+**\--[no-]task-tracking**
 
     Enable [disable] the Chapel-implemented task tracking table that
     supports the execution-time **-b** / **-t** flags. This option is
@@ -589,50 +589,50 @@ OPTIONS
 
 *Compiler Configuration Options*
 
-**--home <path>**
+**\--home <path>**
 
     Specify the location of the Chapel installation *directory*. This flag
     corresponds with and overrides the $CHPL\_HOME environment variable.
 
-**--atomics <atomics-impl>**
+**\--atomics <atomics-impl>**
 
     Specify the implementation to use for Chapel's atomic variables. This
     flag corresponds with and overrides the $CHPL\_ATOMICS environment
     variable. (defaults to a best guess based on $CHPL\_TARGET\_COMPILER,
     $CHPL\_TARGET\_PLATFORM, and $CHPL\_COMM)
 
-**--network-atomics <network>**
+**\--network-atomics <network>**
 
     Specify the network atomics implementation for all atomic variables.
     This flag corresponds with and overrides the $CHPL\_NETWORK\_ATOMICS
     environment variable (defaults to best guess based on $CHPL\_COMM).
 
-**--aux-filesys <aio-system>**
+**\--aux-filesys <aio-system>**
 
     Specify runtime support for additional file systems. This flag
     corresponds with and overrides the $CHPL\_AUX\_FILESYS environment
     variable (defaults to 'none').
 
-**--comm <comm-impl>**
+**\--comm <comm-impl>**
 
     Specify the communication implementation to use for inter-\ *locale*
     data transfers. This flag corresponds with and overrides the $CHPL\_COMM
     environment variable (defaults to 'none').
 
-**--comm-substrate <conduit>**
+**\--comm-substrate <conduit>**
 
     Specify the communication conduit for the communication implementation.
     This flag corresponds with and overrides the $CHPL\_COMM\_SUBSTRATE
     environment variable (defaults to best guess based on
     $CHPL\_TARGET\_PLATFORM).
 
-**--gasnet-segment <segment>**
+**\--gasnet-segment <segment>**
 
     Specify memory segment to use with GASNet. This flag corresponds with
     and overrides the $CHPL\_GASNET\_SEGMENT environment variable. (defaults
     to best guess based on $CHPL\_COMM\_SUBSTRATE).
 
-**--gmp <gmp-version>**
+**\--gmp <gmp-version>**
 
     Specify the GMP library implementation to be used by the GMP module.
     This flag corresponds with and overrides the $CHPL\_GMP environment
@@ -640,52 +640,52 @@ OPTIONS
     whether you've built the included GMP library in the third-party
     *directory*).
 
-**--hwloc <hwloc-impl>**
+**\--hwloc <hwloc-impl>**
 
     Specify whether or not to use the hwloc library. This flag corresponds
     with and overrides the $CHPL\_HWLOC environment variable (defaults to a
     best guess based on whether you've built the included library in the
     third-party hwloc *directory*).
 
-**--launcher <launcher-system>**
+**\--launcher <launcher-system>**
 
     Specify the launcher, if any, used to start job execution. This flag
     corresponds with and overrides the $CHPL\_LAUNCHER environment variable
     (defaults to a best guess based on $CHPL\_COMM and
     $CHPL\_TARGET\_PLATFORM).
 
-**--locale-model <locale-model>**
+**\--locale-model <locale-model>**
 
     Specify the *locale* model to use for describing your *locale*
     architecture. This flag corresponds with and overrides the
     $CHPL\_LOCALE\_MODEL environment variable (defaults to 'flat').
 
-**--make <make utility>**
+**\--make <make utility>**
 
     Specify the GNU compatible make utility. This flag corresponds with and
     overrides the $CHPL\_MAKE environment variable (defaults to a best guess
     based on $CHPL\_HOST\_PLATFORM).
 
-**--mem <mem-impl>**
+**\--mem <mem-impl>**
 
     Specify the memory allocator used for dynamic memory management. This
     flag corresponds with and overrides the $CHPL\_MEM environment variable
     (defaults to a best guess based on $CHPL\_COMM).
 
-**--regexp <regexp>**
+**\--regexp <regexp>**
 
     Specify the regular expression library to use. This flag corresponds
     with and overrides the $CHPL\_REGEXP environment variable (defaults to
     'none' or 're2' if you've installed the re2 package in the third-party
     *directory*).
 
-**--target-arch <architecture>**
+**\--target-arch <architecture>**
 
     Specify the machine type or general architecture to use.
     This flag corresponds with and overrides the $CHPL\_TARGET\_ARCH
     environment variable (defaults to the result of `uname -m`).
 
-**--target-compiler <compiler>**
+**\--target-compiler <compiler>**
 
     Specify the compiler suite that should be used to build the generated C
     code for a Chapel program and the Chapel runtime. This flag corresponds
@@ -693,28 +693,28 @@ OPTIONS
     (defaults to a best guess based on $CHPL\_HOST\_PLATFORM,
     $CHPL\_TARGET\_PLATFORM, and $CHPL\_HOST\_COMPILER).
 
-**--target-cpu <cpu>**
+**\--target-cpu <cpu>**
 
     Specify the cpu model that the compiled executable will be
-    specialized to when **--specialize** is enabled. This flag corresponds
+    specialized to when **\--specialize** is enabled. This flag corresponds
     with and overrides the $CHPL\_TARGET\_CPU environment variable
     (defaults to a best guess based on $CHPL\_COMM, $CHPL\_TARGET\_COMPILER,
     and $CHPL\_TARGET\_PLATFORM).
 
-**--target-platform <platform>**
+**\--target-platform <platform>**
 
     Specify the platform on which the target executable is to be run for the
     purposes of cross-compiling. This flag corresponds with and overrides
     the $CHPL\_TARGET\_PLATFORM environment variable (defaults to
     $CHPL\_HOST\_PLATFORM).
 
-**--tasks <task-impl>**
+**\--tasks <task-impl>**
 
     Specify the tasking layer to use for implementing tasks. This flag
     corresponds with and overrides the $CHPL\_TASKS environment variable
     (defaults to a best guess based on $CHPL\_TARGET\_PLATFORM).
 
-**--timers <timer-impl>**
+**\--timers <timer-impl>**
 
     Specify a timer implementation to be used by the Time module. This flag
     corresponds with and overrides the $CHPL\_TIMERS environment variable
@@ -722,32 +722,32 @@ OPTIONS
 
 *Compiler Information Options*
 
-**--copyright**
+**\--copyright**
 
     Print the compiler's copyright information.
 
-**-h, --help**
+**-h, \--help**
 
     Print a list of the command line *options*, indicating the arguments
     that they expect and a brief summary of their purpose.
 
-**--help-env**
+**\--help-env**
 
     Print the command line option help message, listing the environment
     variable equivalent for each flag (see ENVIRONMENT) and its current
     value.
 
-**--help-settings**
+**\--help-settings**
 
     Print the command line option help message, listing the current setting
     of each option as specified by environment variables and other flags on
     the command line.
 
-**--license**
+**\--license**
 
     Print the compiler's license information.
 
-**--version**
+**\--version**
 
     Print the version number of the compiler.
 
@@ -755,7 +755,7 @@ ENVIRONMENT
 -----------
 
 Most compiler command-line *options* have an environment variable that
-can be used to specify a default value. Use the **--help-env** option to
+can be used to specify a default value. Use the **\--help-env** option to
 list the environment variable equivalent for each option. Command-line
 *options* will always override environment variable settings in the
 event of a conflict, except for ccflags and ldflags, which stack.
@@ -763,16 +763,16 @@ event of a conflict, except for ccflags and ldflags, which stack.
 If the environment variable equivalent is set to empty, it is considered
 unset. This does not apply to *options* expecting a string or a path.
 
-For *options* that can be used with or without the leading **--no**
+For *options* that can be used with or without the leading **\--no**
 (they are shown with "[no-]" in the help text), the environment variable
 equivalent, when set to a non-empty string, has the following effect.
 When the first character of the string is one of:
 
 |
 
-    Y y T t 1 - same as passing the option without --no,
+    Y y T t 1 - same as passing the option without \--no,
 
-    N n F f 0 - same as passing the option with --no,
+    N n F f 0 - same as passing the option with \--no,
 
     anything else - generates an error.
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -8,9 +8,9 @@ chpl
 SYNOPSIS
 --------
 
-|   **chpl** [**-O**] [**--no-checks**] [**--fast**]
-|            [**-g**] [**--savec** *directory*]
-|            [**-M** *directory*...] [**--main-module** *mod*]
+|   **chpl** [**-O**] [**\--no-checks**] [**\--fast**]
+|            [**-g**] [**\--savec** *directory*]
+|            [**-M** *directory*...] [**\--main-module** *mod*]
 |            [**-o** *outfile*] [*options*] source-files...
 |
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -672,7 +672,7 @@ OPTIONS
     flag corresponds with and overrides the $CHPL\_MEM environment variable
     (defaults to a best guess based on $CHPL\_COMM).
 
-**\--regexp <regexp>**
+**\--re2 <re2>**
 
     Specify the regular expression library to use. This flag corresponds
     with and overrides the $CHPL\_REGEXP environment variable (defaults to

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -18,13 +18,13 @@ import sys
 def main():
     results = []
     chpl = sys.argv[1]
-    chpldoc = chpl + 'doc'
+    chpldoc = chpl + "doc"
 
     # Test chpl
-    results.append( check_man_page(chpl, ['--no-devel']) )
+    results.append(check_man_page(chpl, ["--no-devel"]))
 
     # Test chpldoc
-    results.append( check_man_page(chpldoc) )
+    results.append(check_man_page(chpldoc))
 
     # Exit clean if no errors.
     if not reduce(operator.and_, results):
@@ -50,13 +50,16 @@ def check_man_page(bin_name, additional_args=None):
     help_cmd = [bin_name]
     if additional_args is not None:
         help_cmd.extend(additional_args)
-    help_cmd.append('--help')
+    help_cmd.append("--help")
     helptxt, help_exit = _run_cmd(help_cmd)
 
     if help_exit != 0:
-        _error('failed to get help text with:',
-               ' '.join(help_cmd).replace(chpl_home, '$CHPL_HOME'),
-               'exited with non-zero status code', help_exit)
+        _error(
+            "failed to get help text with:",
+            " ".join(help_cmd).replace(chpl_home, "$CHPL_HOME"),
+            "exited with non-zero status code",
+            help_exit,
+        )
         return False
 
     # Get the man page text
@@ -77,15 +80,15 @@ def check_man_page(bin_name, additional_args=None):
     for hline in [l.strip() for l in helptxt.splitlines() if l.strip()]:
 
         # Line is section
-        if hline[-1] == ':':
-            section = hline.strip(':')
+        if hline[-1] == ":":
+            section = hline.strip(":")
             helpsections[section] = []
             currentsection = section
         # Line is flag
-        elif hline[0:2] == '\-':
+        elif hline[0] == "-":
             if currentsection is None:
                 numerrors += 1
-                _error(sl, 'not in a {0} man page section'.format(short_bin_name))
+                _error(sl, "not in a {0} man page section".format(short_bin_name))
                 notFound.append(hline)
                 continue
 
@@ -100,15 +103,19 @@ def check_man_page(bin_name, additional_args=None):
     for mline in [l.strip() for l in manpage if len(l.strip()) > 2]:
 
         # Line is flag
-        if mline[0:4] == '**\-' and mline[-2:] == '**' and currentsection:
+        if (
+            (mline[0:5] == "**\--" or mline[4:5] == "," or mline[0:3] == "**-")
+            and mline[-2:] == "**"
+            and currentsection
+        ):
 
             mflags = _get_flags(mline)
 
             if mflags:
                 mansections[section].append(mflags)
         # Line is section
-        elif mline[0] == '*' and mline[-1] == '*' and mline[1] != '*':
-            section = mline.strip('*')
+        elif mline[0] == "*" and mline[-1] == "*" and mline[1] != "*":
+            section = mline.strip("*")
             mansections[section] = []
             currentsection = section
 
@@ -125,9 +132,9 @@ def check_man_page(bin_name, additional_args=None):
         numerrors += len(helpdiff) + len(mandiff)
 
         if helpdiff:
-            _error('help output has additional sections: {0}'.format(helpdiff))
+            _error("help output has additional sections: {0}".format(helpdiff))
         if mandiff:
-            _error('man page has additional sections: {0}'.format(mandiff))
+            _error("man page has additional sections: {0}".format(mandiff))
 
         # We require same sections to continue, return early
         return numerrors
@@ -144,47 +151,58 @@ def check_man_page(bin_name, additional_args=None):
             numerrors += len(helpdiff) + len(mandiff)
 
             if helpdiff:
-                _error('help section "{0}" has additional flags:\
-                        {1}'.format(section, helpdiff))
+                _error(
+                    'help section "{0}" has additional flags:\
+                        {1}'.format(
+                        section, helpdiff
+                    )
+                )
             if mandiff:
-                _error('man section "{0}" has additional flags:\
-                        {1}'.format(section, mandiff))
+                _error(
+                    'man section "{0}" has additional flags:\
+                        {1}'.format(
+                        section, mandiff
+                    )
+                )
 
     # Return True if no error (man/help text match). False otherwise.
     return numerrors == 0
 
 
 def _get_chpl_home():
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '../..'))
-    chpl_home = os.environ.get('CHPL_HOME', repo_root)
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+    chpl_home = os.environ.get("CHPL_HOME", repo_root)
     return chpl_home
 
+
 def _get_man_page(bin_name):
-    man_file = os.path.join(_get_chpl_home(), 'man', os.path.basename(bin_name) + '.rst')
-    with open(man_file, 'r') as fp:
+    man_file = os.path.join(
+        _get_chpl_home(), "man", os.path.basename(bin_name) + ".rst"
+    )
+    with open(man_file, "r") as fp:
         man_rst = fp.readlines()
     return man_rst
 
 
 def _get_flags(s):
     """Get the flags in a string."""
-    rs = ''
+    s = s.replace("\\", "")
+    rs = ""
     # Handle empty lines
     if not s.strip():
         return rs
 
     # Remove rst formatting of **bold text**
-    ls = s.strip('*')
+    ls = s.strip("*")
 
     # Look for all comma separated flags
-    ls = ls.strip().split(',')
+    ls = ls.strip().split(",")
     for f in ls:
-        sf = f.strip();
+        sf = f.strip()
         try:
-            if sf[0] == '-':
+            if sf[0] == "-":
                 # Add flag to the return string
-                rs += sf.split()[0]+','
+                rs += sf.split()[0] + ","
             else:
                 break
         except IndexError:
@@ -204,17 +222,17 @@ def _run_cmd(cmd):
 
 
 def _msg(level, *args):
-    log_msg = ' '.join([str(arg) for arg in args])
-    print('{level}: {msg}'.format(level=level.upper(), msg=log_msg))
+    log_msg = " ".join([str(arg) for arg in args])
+    print("{level}: {msg}".format(level=level.upper(), msg=log_msg))
 
 
 def _warn(*args):
-    _msg('Warning', *args)
+    _msg("Warning", *args)
 
 
 def _error(*args):
-    _msg('Error', *args)
+    _msg("Error", *args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -84,7 +84,7 @@ def check_man_page(bin_name, additional_args=None):
             helpsections[section] = []
             currentsection = section
         # Line is flag
-        elif hline[0] == '-':
+        elif hline[0:2] == '\-':
             if currentsection is None:
                 numerrors += 1
                 _error(sl, 'not in a {0} man page section'.format(short_bin_name))
@@ -102,7 +102,7 @@ def check_man_page(bin_name, additional_args=None):
     for mline in [l.strip() for l in manpage if len(l.strip()) > 2]:
 
         # Line is flag
-        if mline[0:3] == '**-' and mline[-2:] == '**' and currentsection:
+        if mline[0:4] == '**\-' and mline[-2:] == '**' and currentsection:
 
             mflags = _get_flags(mline)
 

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 """Compare the help page and man page for chpl and chpldoc.
-
 Make sure every flag in the help page is present in the man page. Also, for
 chpl check that all top-level CHPL variables from $CHPL_HOME/util/printchplenv
 are included in the man page's ENVIRONMENT section.
@@ -37,7 +36,6 @@ def main():
 def check_man_page(bin_name, additional_args=None):
     """Verify man page match -h options for given program. Returns True if help
     text and man text match. Returns False if not.
-
     :arg bin_name: Program to call with --help and name of .1 man page.
     :arg additional_args: Additional arguments list to call program with.
     """


### PR DESCRIPTION
hey @bradcray, I finally got the solution to locally override it to the man page. I changed the configuration smartquotes from False to True and then I converted  -- to (backslash--) in man.rst file so the double dash is only visible in man page.