### PR TITLE
Add support for open-interval enum ranges

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2510,36 +2510,27 @@ BlockStmt* handleConfigTypes(BlockStmt* blk) {
   return blk;
 }
 
-static VarSymbol* one = NULL;
-
-static SymExpr* buildOneExpr() {
-  if (one == NULL) {
-    one = new_IntSymbol(1);
-  }
-  return new SymExpr(one);
-}
-
 CallExpr* buildBoundedRange(Expr* low, Expr* high,
                             bool openlow, bool openhigh) {
   if (openlow) {
-    low = new CallExpr("+", low, buildOneExpr());
+    low = new CallExpr("chpl__nudgeLowBound", low);
   }
   if (openhigh) {
-    high = new CallExpr("-", high, buildOneExpr());
+    high = new CallExpr("chpl__nudgeHighBound", high);
   }
   return new CallExpr("chpl_build_bounded_range",low, high);
 }
 
 CallExpr* buildLowBoundedRange(Expr* low, bool open) {
   if (open) {
-    low = new CallExpr("+", low, buildOneExpr());
+    low = new CallExpr("chpl__nudgeLowBound", low);
   }
   return new CallExpr("chpl_build_low_bounded_range", low);
 }
 
 CallExpr* buildHighBoundedRange(Expr* high, bool open) {
   if (open) {
-    high = new CallExpr("-", high, buildOneExpr());
+    high = new CallExpr("chpl__nudgeHighBound", high);
   }
   return new CallExpr("chpl_build_high_bounded_range", high);
 }

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -344,6 +344,13 @@ module ChapelRange {
     compilerError("Bounds of 'low..high' must be integers of compatible types.");
   }
 
+  proc chpl__nudgeLowBound(low) {
+    return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
+  }
+  proc chpl__nudgeHighBound(high) {
+    return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
+  }
+
   // Range builders for low bounded ranges
   proc chpl_build_low_bounded_range(low: integral)
     return new range(low.type, BoundedRangeType.boundedLow, _low=low);

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -347,15 +347,19 @@ module ChapelRange {
   proc chpl__nudgeLowBound(low) {
     return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
   }
-  proc chpl__nudgeHighBound(high) {
-    return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
-  }
   proc chpl__nudgeLowBound(param low) param {
     return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
   }
-  // would really like to remove the type constraints here, but it
+  proc chpl__nudgeHighBound(high) {
+    return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
+  }
+  // We would really like to remove the type constraints in the
+  // following overloads, as in chpl__nudgeLowBound() above, but it
   // breaks enum ranges until we support a param chpl__intToIdx()
-  // routine for bools
+  // routine for enums.  The reason chpl__nudgeLowBound() gets away
+  // with it is that it isn't currently used (because we don't
+  // currently / yet support '<..' ranges).
+  //
   proc chpl__nudgeHighBound(param high: integral) param {
     return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
   }

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -353,7 +353,13 @@ module ChapelRange {
   proc chpl__nudgeLowBound(param low) param {
     return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
   }
-  proc chpl__nudgeHighBound(param high) param {
+  // would really like to remove the type constraints here, but it
+  // breaks enum ranges until we support a param chpl__intToIdx()
+  // routine for bools
+  proc chpl__nudgeHighBound(param high: integral) param {
+    return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
+  }
+  proc chpl__nudgeHighBound(param high: bool) param {
     return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
   }
 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -350,6 +350,12 @@ module ChapelRange {
   proc chpl__nudgeHighBound(high) {
     return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
   }
+  proc chpl__nudgeLowBound(param low) param {
+    return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
+  }
+  proc chpl__nudgeHighBound(param high) param {
+    return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
+  }
 
   // Range builders for low bounded ranges
   proc chpl_build_low_bounded_range(low: integral)
@@ -2621,7 +2627,7 @@ operator :(r: range(?), type t: range(?)) {
       return i: idxType;
   }
 
-  inline proc chpl__intToIdx(type idxType: integral, param i: integral) {
+  inline proc chpl__intToIdx(type idxType: integral, param i: integral) param {
     if (i.type == idxType) then
       return i;
     else
@@ -2631,6 +2637,12 @@ operator :(r: range(?), type t: range(?)) {
   inline proc chpl__intToIdx(type idxType: enum, i: integral) {
     return chpl__orderToEnum(i, idxType);
   }
+
+  /* Doesn't work yet:  Need to implement a param chpl__orderToEnum?
+  inline proc chpl__intToIdx(type idxType: enum, param i: integral) param {
+    return chpl__orderToEnum(i, idxType);
+  }
+*/
 
   inline proc chpl__intToIdx(type idxType, i: integral) where isBoolType(idxType) {
     return i: bool;
@@ -2653,6 +2665,10 @@ operator :(r: range(?), type t: range(?)) {
   }
 
   inline proc chpl__idxToInt(i: enum) {
+    return chpl__enumToOrder(i);
+  }
+
+  inline proc chpl__idxToInt(param i: enum) param {
     return chpl__enumToOrder(i);
   }
 

--- a/test/types/range/open/openBoolRange.chpl
+++ b/test/types/range/open/openBoolRange.chpl
@@ -1,0 +1,7 @@
+for f in false..<true do
+  writeln(f);
+
+for param f in false..<true {
+  compilerWarning(f:string);
+  writeln(f);
+}

--- a/test/types/range/open/openBoolRange.good
+++ b/test/types/range/open/openBoolRange.good
@@ -1,0 +1,3 @@
+openBoolRange.chpl:5: warning: false
+false
+false

--- a/test/types/range/open/openEnumRange.chpl
+++ b/test/types/range/open/openEnumRange.chpl
@@ -1,0 +1,7 @@
+enum color { red, green, blue };
+
+for c in color.red..<color.blue do
+  writeln(c);
+
+for c in (color.green..color.blue)[..<color.blue] do
+  writeln(c);

--- a/test/types/range/open/openEnumRange.good
+++ b/test/types/range/open/openEnumRange.good
@@ -1,0 +1,3 @@
+red
+green
+green

--- a/test/types/range/open/paramEnumRange.bad
+++ b/test/types/range/open/paramEnumRange.bad
@@ -1,0 +1,1 @@
+paramEnumRange.chpl:3: error: Range bounds must be integers of compatible types in param for-loops

--- a/test/types/range/open/paramEnumRange.chpl
+++ b/test/types/range/open/paramEnumRange.chpl
@@ -1,0 +1,11 @@
+enum color { red, green, blue };
+
+for param c in color.red..color.blue {
+  compilerWarning(c:string);
+  writeln(c);
+}
+
+for param c in color.red..<color.blue {
+  compilerWarning(c:string);
+  writeln(c);
+}

--- a/test/types/range/open/paramEnumRange.future
+++ b/test/types/range/open/paramEnumRange.future
@@ -1,0 +1,3 @@
+feature requst: param ranges over enums
+
+It seems we currently don't support these, but should and easily could.

--- a/test/types/range/open/paramEnumRange.good
+++ b/test/types/range/open/paramEnumRange.good
@@ -1,0 +1,10 @@
+paramEnumRange.chpl:4: warning: red
+paramEnumRange.chpl:4: warning: green
+paramEnumRange.chpl:4: warning: blue
+paramEnumRange.chpl:9: warning: red
+paramEnumRange.chpl:9: warning: green
+red
+green
+blue
+red
+green


### PR DESCRIPTION
This PR adds support for open-interval ranges (`..<`) over enum values.
This didn't work previously because the implementation subtracted 1
from the high bound and enums don't (currently) support +/- with
integers to advance/rewind along the enumeration (issue #9784).
Here, I'm changing the implementation to move the logic that bumps the
bounds into the ChapelRange module, and then using conversions between
the idx and int types are used to accomplish the same effect.

In order to make this work while continuing to support param ranges of
integers and bools, I had to make both param and non-param versions
of the routines.  Doing this revealed that our chpl__intToIndex() routine
for `param` `int` values didn't actually return a `param` value... (weird).
It also revealed that we didn't have a param version of chpl__idxtoInt()
for enums, which was easy to add (we also don't have a chpl__intToIndex()
for param enums, but that will require the compiler to generate a param
`chpl__orderToEnum` routine).

Added new tests:
* openBoolRange: locks in that open interval ranges work for bools
* openEnumRange: locks in that they work for enums
* paramEnumRange: a future for param loops over open interval ranges
  (which will more generally require support for param loops over enum ranges)
