### PR TITLE
Formatting settings same for both `type` and `var` typeexpr

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -1624,9 +1624,9 @@ void AstToText::appendExpr(DefExpr* expr, bool printingType)
       if (expr->init) {
         mText += " = ";
         if (SymExpr* sym = toSymExpr(expr->init))
-          appendExpr(sym, false, true);
+          appendExpr(sym, true, true);
         else
-          appendExpr(expr->init, false);
+          appendExpr(expr->init, true);
       }
     }
 }


### PR DESCRIPTION
Signed-off-by: piyush0411 <piyush04111999@gmail.com>