### PR TITLE
Fix sanitizer error in Regex

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -412,7 +412,7 @@ class BadRegexError : Error {
 }
 
 // Until Issue 17275 is fixed:
-type BadRegexpError = BadRegexError;
+type BadRegexpError = owned BadRegexError;
 
 // When Issue 17275 is fixed:
 


### PR DESCRIPTION
Fixes an error in the sanitizer and `--verify` tests.

The root cause is still unknown*. An AST node is accessed after it is freed.

Thanks to @bradcray , @mppf and @e-kayrakli for helping track this down.

*Working theory: 
The current type alias is generic, because it doesn’t qualify the memory management. And I think we resolve Errors late in compilation. So what happens in during resolution is that your type alias is left alone as generic. But at the end of resolution, we expect all generics to have disappeared. And the cleanup “pass” thinks that still-generic type alias is leftover from some operation and removes it from the AST. Then, error handling pass fails.