### PR TITLE
Enable "In module MMM:" error annotation

### DIFF
--- a/test/classes/generic/with-runtime-fields-ok.good
+++ b/test/classes/generic/with-runtime-fields-ok.good
@@ -1,3 +1,4 @@
+with-runtime-fields-ok.chpl:2: In module 'w':
 with-runtime-fields-ok.chpl:27: warning: ==== owned CC("default",int(64),[domain(1,int(64),false)] int(64))
 with-runtime-fields-ok.chpl:27: warning: default
 with-runtime-fields-ok.chpl:27: warning: default

--- a/test/classes/initializers/qualified/modTypeShareName.bad
+++ b/test/classes/initializers/qualified/modTypeShareName.bad
@@ -1,1 +1,2 @@
+modTypeShareName.chpl:11: In module 'M1':
 modTypeShareName.chpl:14: error: invalid use of 'new'

--- a/test/classes/nilability/demo1.good
+++ b/test/classes/nilability/demo1.good
@@ -1,3 +1,4 @@
+demo1.chpl:1: In module 'demo':
 demo1.chpl:10: error: unresolved call 'getTheValue(nil)'
 demo1.chpl:4: note: this candidate did not match: getTheValue(x: borrowed C)
 demo1.chpl:10: note: because actual argument #1 with type 'nil'

--- a/test/classes/nilability/demo2.good
+++ b/test/classes/nilability/demo2.good
@@ -1,3 +1,4 @@
+demo2.chpl:1: In module 'demo':
 demo2.chpl:11: error: cannot default-initialize a: borrowed C
 note: non-nilable class type 'borrowed C' does not support default initialization
 note: Consider using the type borrowed C? instead

--- a/test/classes/nilability/demo3.good
+++ b/test/classes/nilability/demo3.good
@@ -1,3 +1,4 @@
+demo3.chpl:1: In module 'demo':
 demo3.chpl:13: error: unresolved call 'getTheValue(borrowed C?)'
 demo3.chpl:4: note: this candidate did not match: getTheValue(x: borrowed C)
 demo3.chpl:13: note: because actual argument #1 with type 'borrowed C?'

--- a/test/classes/nilability/demo4.good
+++ b/test/classes/nilability/demo4.good
@@ -1,3 +1,4 @@
+demo4.chpl:1: In module 'demo':
 demo4.chpl:17: error: unresolved call 'getTheValue(borrowed C?)'
 demo4.chpl:4: note: this candidate did not match: getTheValue(x: borrowed C)
 demo4.chpl:17: note: because actual argument #1 with type 'borrowed C?'

--- a/test/classes/nilability/demo5.good
+++ b/test/classes/nilability/demo5.good
@@ -1,2 +1,3 @@
+demo5.chpl:1: In module 'demo':
 demo5.chpl:14: error: applying postfix-! to nil
 demo5.chpl:12: note: 'x' is set to nil here

--- a/test/classes/nilability/error-method-on-nilable-borrow.good
+++ b/test/classes/nilability/error-method-on-nilable-borrow.good
@@ -1,3 +1,4 @@
+error-method-on-nilable-borrow.chpl:1: In module 'mymod':
 error-method-on-nilable-borrow.chpl:13: warning: borrowed MyClass?
 error-method-on-nilable-borrow.chpl:5: In function 'test':
 error-method-on-nilable-borrow.chpl:10: error: unresolved call 'borrowed MyClass?.mymethod()'

--- a/test/classes/nilability/error-method-on-nilable-owned.good
+++ b/test/classes/nilability/error-method-on-nilable-owned.good
@@ -1,3 +1,4 @@
+error-method-on-nilable-owned.chpl:1: In module 'mymod':
 error-method-on-nilable-owned.chpl:14: warning: borrowed MyClass?
 error-method-on-nilable-owned.chpl:5: In function 'test':
 error-method-on-nilable-owned.chpl:11: error: unresolved call 'owned MyClass?.mymethod()'

--- a/test/classes/nilability/error-method-on-nilable-shared.good
+++ b/test/classes/nilability/error-method-on-nilable-shared.good
@@ -1,3 +1,4 @@
+error-method-on-nilable-shared.chpl:1: In module 'mymodule':
 error-method-on-nilable-shared.chpl:14: warning: borrowed MyClass?
 error-method-on-nilable-shared.chpl:5: In function 'test':
 error-method-on-nilable-shared.chpl:11: error: unresolved call 'shared MyClass?.mymethod()'

--- a/test/constrained-generics/basic/set1/error-not-visible.good
+++ b/test/constrained-generics/basic/set1/error-not-visible.good
@@ -1,3 +1,4 @@
+error-not-visible.chpl:22: In module 'Confused':
 error-not-visible.chpl:24: error: 'MyClass' is not an interface
 error-not-visible.chpl:24: note: an 'implements' keyword must be followed by an interface name
 error-not-visible.chpl:23: note: 'MyClass' is defined here
@@ -5,4 +6,5 @@ error-not-visible.chpl:27: In function 'cgFun':
 error-not-visible.chpl:27: error: 'MyRecord' is not an interface
 error-not-visible.chpl:27: note: an 'implements' keyword must be followed by an interface name
 error-not-visible.chpl:26: note: 'MyRecord' is defined here
+error-not-visible.chpl:30: In module 'User':
 error-not-visible.chpl:37: error: 'IFC' is undeclared

--- a/test/expressions/new-expr/has-arg-list.good
+++ b/test/expressions/new-expr/has-arg-list.good
@@ -1,3 +1,4 @@
+has-arg-list.chpl:1: In module 'OuterModule':
 has-arg-list.chpl:19: error: type in 'new' expression is missing its argument list
 has-arg-list.chpl:20: error: type in 'new' expression is missing its argument list
 has-arg-list.chpl:27: In initializer:

--- a/test/functions/bradc/resolveConfig.bad
+++ b/test/functions/bradc/resolveConfig.bad
@@ -1,1 +1,2 @@
+resolveConfig.chpl:10: In module 'B':
 resolveConfig.chpl:13: error: use of 'n' before encountering its definition, type unknown

--- a/test/modules/deitz/test_module_access4.good
+++ b/test/modules/deitz/test_module_access4.good
@@ -1,3 +1,4 @@
+test_module_access4.chpl:1: In module 'OuterModule':
 test_module_access4.chpl:8: error: unresolved call 'M.foo(3.0)'
 test_module_access4.chpl:5: note: this candidate did not match: foo(i: int)
 test_module_access4.chpl:8: note: because actual argument #1 with type 'real(64)'

--- a/test/modules/deitz/test_module_mutual_use.bad
+++ b/test/modules/deitz/test_module_mutual_use.bad
@@ -1,1 +1,2 @@
+test_module_mutual_use.chpl:26: In module 'M2':
 test_module_mutual_use.chpl:29: error: use of 'a' before encountering its definition, type unknown

--- a/test/modules/diten/mutualuse.bad
+++ b/test/modules/diten/mutualuse.bad
@@ -1,1 +1,2 @@
+mutualuse.chpl:30: In module 'M2':
 mutualuse.chpl:33: error: use of 'a' before encountering its definition, type unknown

--- a/test/modules/diten/mutualuse2.bad
+++ b/test/modules/diten/mutualuse2.bad
@@ -1,1 +1,2 @@
+mutualuse2.chpl:30: In module 'M2':
 mutualuse2.chpl:33: error: cannot initialize 'n' of type 'borrowed C' from a '<type unknown>'

--- a/test/modules/diten/mutualuse3.bad
+++ b/test/modules/diten/mutualuse3.bad
@@ -1,1 +1,2 @@
+mutualuse3.chpl:26: In module 'M2':
 mutualuse3.chpl:29: error: use of 'a' before encountering its definition, type unknown

--- a/test/modules/use/parentSymRequiresUse.good
+++ b/test/modules/use/parentSymRequiresUse.good
@@ -1,1 +1,2 @@
+parentSymRequiresUse.chpl:3: In module 'N':
 parentSymRequiresUse.chpl:4: error: 'xyz' undeclared (first use this function)

--- a/test/modules/use/parentSymRequiresUse2.good
+++ b/test/modules/use/parentSymRequiresUse2.good
@@ -1,2 +1,3 @@
+parentSymRequiresUse2.chpl:3: In module 'N':
 parentSymRequiresUse2.chpl:4: error: unresolved call 'foo()'
 parentSymRequiresUse2.chpl:4: note: because no functions named foo found in scope

--- a/test/modules/use/topLevel/noUseTop2.good
+++ b/test/modules/use/topLevel/noUseTop2.good
@@ -1,1 +1,2 @@
+noUseTop2.chpl:7: In module 'NNN':
 noUseTop2.chpl:8: error: 'MMM' undeclared (first use this function)

--- a/test/visibility/except/blockSecondaryMethod.good
+++ b/test/visibility/except/blockSecondaryMethod.good
@@ -1,2 +1,3 @@
+blockSecondaryMethod.chpl:1: In module 'OuterModule':
 blockSecondaryMethod.chpl:9: error: unresolved call 'Foo.newMethod(1)'
 blockSecondaryMethod.chpl:9: note: because no functions named newMethod found in scope

--- a/test/visibility/except/blockSecondaryTypeMethod.good
+++ b/test/visibility/except/blockSecondaryTypeMethod.good
@@ -1,2 +1,3 @@
+blockSecondaryTypeMethod.chpl:1: In module 'OuterModule':
 blockSecondaryTypeMethod.chpl:9: error: unresolved call 'type Foo.newMethod(1)'
 blockSecondaryTypeMethod.chpl:9: note: because no functions named newMethod found in scope

--- a/test/visibility/except/cannotSeeSecondaryMethod.good
+++ b/test/visibility/except/cannotSeeSecondaryMethod.good
@@ -1,2 +1,3 @@
+cannotSeeSecondaryMethod.chpl:1: In module 'OuterModule':
 cannotSeeSecondaryMethod.chpl:10: error: unresolved call 'owned Foo.newMethod(1)'
 cannotSeeSecondaryMethod.chpl:10: note: because no functions named newMethod found in scope

--- a/test/visibility/type-shadow.good
+++ b/test/visibility/type-shadow.good
@@ -1,3 +1,4 @@
+type-shadow.chpl:1: In module 'X':
 type-shadow.chpl:12: error: invalid type specifier 'R(type int(64))'
 type-shadow.chpl:11: note: type 'R' is not generic
 type-shadow.chpl:12: note: did you forget the 'new' keyword?


### PR DESCRIPTION
Print a line saying `In module MMM:` when the compiler prints
an error message for a module-level code, analogously to printing
`In function FFF:` for an error in a function.

Such a line is already printed in the developer mode, however it used
to be suppressed upon --no-devel. This PR enables it for the latter
as well.

This PR chooses to suppress it, however, when the name of the module
is the same as the name of the file where, the error occurred.
If so, this additional line is more noise than helpful.
here are ~1,200 tests in our test suite where this happens.

This replaces #17204.
