### PR TITLE
Move resolveSpecifiedReturnType()

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -77,15 +77,6 @@ bool ResolutionCandidate::isApplicable(CallInfo& info,
     retval = isApplicableGeneric(info, visInfo);
   }
 
-  // Note: for generic instantiations, this code will be executed twice.
-  // This is because by the time the generic branch returns, its function will
-  // have been replaced by the instantiation, which will have already had this
-  // function called on it.  However, reducing the scope for this operation does
-  // not seem to have a noticeable impact.
-  if (retval && fn->retExprType != NULL && fn->retType == dtUnknown) {
-    resolveSpecifiedReturnType(fn);
-  }
-
   return retval;
 }
 
@@ -103,7 +94,13 @@ bool ResolutionCandidate::isApplicableConcrete(CallInfo& info,
   if (computeAlignment(info) == false)
     return false;
 
-  return checkResolveFormalsWhereClauses(info, visInfo);
+  if (checkResolveFormalsWhereClauses(info, visInfo) == false)
+    return false;
+  
+  if (fn->retExprType != NULL && fn->retType == dtUnknown)
+    resolveSpecifiedReturnType(fn);
+
+  return true;
 }
 
 bool ResolutionCandidate::isApplicableGeneric(CallInfo& info,


### PR DESCRIPTION
Execute resolveSpecifiedReturnType() for concrete functions only, for clarity.

It used to be executed for generic functions as well,
however that seems unnecessary and raises the question "why".
