### PR TITLE
Reduce printing of arg intents in list_view()

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -64,7 +64,7 @@ static void print_on_its_own_line(int indent, const char* msg,
 }
 
 static void
-list_sym(const Symbol* sym, bool type = true) {
+list_sym(const Symbol* sym, bool type = true, bool intents = true) {
   if (const VarSymbol* var = toConstVarSymbol(sym)) {
     if (var->immediate) {
       if (var->immediate->const_kind == NUM_KIND_INT) {
@@ -79,7 +79,8 @@ list_sym(const Symbol* sym, bool type = true) {
   if (isFnSymbol(sym)) {
     printf("fn ");
   } else if (const ArgSymbol* arg = toConstArgSymbol(sym)) {
-    printf("arg intent-%s ", arg->intentDescrString());
+    if (intents)
+      printf("arg intent-%s ", arg->intentDescrString());
   } else if (isTypeSymbol(sym)) {
     printf("type ");
   } else if (isInterfaceSymbol(sym)) {
@@ -314,7 +315,7 @@ list_ast(const BaseAST* ast, const BaseAST* parentAst = NULL, int indent = 0) {
         printf("def ");
       }
     } else if (const SymExpr* e = toConstSymExpr(expr)) {
-      list_sym(e->symbol(), false);
+      list_sym(e->symbol(), false, parentAst == nullptr);
     } else if (const UnresolvedSymExpr* e = toConstUnresolvedSymExpr(expr)) {
       printf("%s ", e->unresolved);
     } else if (isUseStmt(expr)) {


### PR DESCRIPTION
Do not print argument intents when `list_view()` prints a nested `SymExpr`.

For example, before:
```
207067  fn myfun[207067]:_unknown[54]
207066  def unknown arg intent-default intent x[207065]:_any[181]
207070  def ref arg intent-'ref' y[207069]:_any[181]
207068  {
729133    def unknown call_tmp[729132]:_unknown[54]
729135    move( call_tmp[729132] call( * arg intent-default intent x[207065] 3 ) )
729138    def unknown call_tmp[729137]:_unknown[54]
729140    move( call_tmp[729137] call( + call_tmp[729132] arg intent-'ref' y[207069] ) )
207079    call( = arg intent-'ref' y[207069] call_tmp[729137] )
548128    return( _void[58] )
207068  }
```

vs. with this change:
```
207067  fn myfun[207067]:_unknown[54]
207066  def unknown arg intent-default intent x[207065]:_any[181]
207070  def ref arg intent-'ref' y[207069]:_any[181]
207068  {
729133    def unknown call_tmp[729132]:_unknown[54]
729135    move( call_tmp[729132] call( * x[207065] 3 ) )
729138    def unknown call_tmp[729137]:_unknown[54]
729140    move( call_tmp[729137] call( + call_tmp[729132] y[207069] ) )
207079    call( = y[207069] call_tmp[729137] )
548128    return( _void[58] )
207068  }
```

where `x` and `y` are now printed compactly.

When `list_view()` is invoked directly on a `SymExpr` of an `ArgSymbol`,
the behavior remains the same: the intent is shown.
