### PR TITLE
Fixed a small typo in C-interoperability docs

### DIFF
--- a/test/extern/ferguson/externblock/readme_examples2.chpl
+++ b/test/extern/ferguson/externblock/readme_examples2.chpl
@@ -36,7 +36,7 @@ module OuterModule {
       *x = space;
     }
     // translates automatically into
-    //  extern proc returnSpace( x:c_ptr(c_ptr(c_int)) );
+    //  extern proc setSpace( x:c_ptr(c_ptr(c_int)) );
 
     static void setString(const char** x) { *x = "My String"; }
   }


### PR DESCRIPTION
Signed-off-by: Yudhishthira1406 <divyen1406@gmail.com>

There was a small typo in the C-interoperability doc where the comment of how the function `setSpace` in C was translated to `returnSpace` in chapel.  