### PR TITLE
Remove type information from function names in the cuBLAS module

### DIFF
--- a/test/gpu/interop/cuBLAS/cuBLAS.chpl
+++ b/test/gpu/interop/cuBLAS/cuBLAS.chpl
@@ -464,13 +464,6 @@ module cuBLAS {
     extern proc cublas_cswap(handle: c_void_ptr, n: c_int, x: c_ptr(complex(64)), incX: c_int, y: c_ptr(complex(64)), incY: c_int);
     extern proc cublas_zswap(handle: c_void_ptr, n: c_int, x: c_ptr(complex(128)), incX: c_int, y: c_ptr(complex(128)), incY: c_int);
 
-/*
-    extern proc cublas_sgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: c_float, A: c_ptr(c_float), lda: c_int, x: c_ptr(c_float), incX: c_int, ref beta: c_float, y: c_ptr(c_float), incY: c_int);
-    extern proc cublas_dgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: c_double, A: c_ptr(c_double), lda: c_int, x: c_ptr(c_double), incX: c_int, ref beta: c_double, y: c_ptr(c_double), incY: c_int);
-    extern proc cublas_cgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: complex(64), A: c_ptr(complex(64)), lda: c_int, x: c_ptr(complex(64)), incX: c_int, ref beta: complex(64), y: c_ptr(complex(64)), incY: c_int);
-    extern proc cublas_zgbmv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, kl: c_int, ku: c_int, ref alpha: complex(128), A: c_ptr(complex(128)), lda: c_int, x: c_ptr(complex(128)), incX: c_int, ref beta: complex(128), y: c_ptr(complex(128)), incY: c_int);
-*/
-
     extern proc cublas_sgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, alpha: c_float, A: c_ptr(c_float), lda: c_int, x: c_ptr(c_float), incX: c_int, beta: c_float, y: c_ptr(c_float), incY: c_int);
     extern proc cublas_dgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, alpha: c_double, A: c_ptr(c_double), lda: c_int, x: c_ptr(c_double), incX: c_int, beta: c_double, y: c_ptr(c_double), incY: c_int);
     extern proc cublas_cgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, alpha: complex(64), A: c_ptr(complex(64)), lda: c_int, x: c_ptr(complex(64)), incX: c_int, beta: complex(64), y: c_ptr(complex(64)), incY: c_int);
@@ -479,7 +472,7 @@ module cuBLAS {
     extern proc cublas_sger(handle: c_void_ptr, m: c_int, n: c_int, alpha: c_float, x: c_ptr(c_float), incX: c_int, y: c_ptr(c_float), incY: c_int, A: c_ptr(c_float), lda: c_int);
     extern proc cublas_dger(handle: c_void_ptr, m: c_int, n: c_int, alpha: c_double, x: c_ptr(c_double), incX: c_int, y: c_ptr(c_double), incY: c_int, A: c_ptr(c_double), lda: c_int);
     extern proc cublas_cgeru(handle: c_void_ptr, m: c_int, n: c_int, alpha: complex(64), x: c_ptr(complex(64)), incX: c_int, y: c_ptr(complex(64)), incY: c_int, A: c_ptr(complex(64)), lda: c_int);
-extern proc cublas_cgerc(handle: c_void_ptr, m: c_int, n: c_int, alpha: complex(64), x: c_ptr(complex(64)), incX: c_int, y: c_ptr(complex(64)), incY: c_int, A: c_ptr(complex(64)), lda: c_int);
+    extern proc cublas_cgerc(handle: c_void_ptr, m: c_int, n: c_int, alpha: complex(64), x: c_ptr(complex(64)), incX: c_int, y: c_ptr(complex(64)), incY: c_int, A: c_ptr(complex(64)), lda: c_int);
     extern proc cublas_zgeru(handle: c_void_ptr, m: c_int, n: c_int, alpha: complex(128), x: c_ptr(complex(128)), incX: c_int, y: c_ptr(complex(128)), incY: c_int, A: c_ptr(complex(128)), lda: c_int);
     extern proc cublas_zgerc(handle: c_void_ptr, m: c_int, n: c_int, alpha: complex(128), x: c_ptr(complex(128)), incX: c_int, y: c_ptr(complex(128)), incY: c_int, A: c_ptr(complex(128)), lda: c_int);
 

--- a/test/gpu/interop/cuBLAS/cuBLAS.chpl
+++ b/test/gpu/interop/cuBLAS/cuBLAS.chpl
@@ -37,277 +37,277 @@ module cuBLAS {
     to_cpu(dst_ptr, src_ptr.val, size);
   }
 
-  proc cu_saxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), ref alpha: c_float, incX: c_int = 1, incY: c_int = 1){
+  proc cu_axpy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), ref alpha: c_float, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_saxpy(handle, n, alpha, x.val, incX, y.val, incY);
   }
 
-  proc cu_daxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), ref alpha: c_double, incX: c_int = 1, incY: c_int = 1){
+  proc cu_axpy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), ref alpha: c_double, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_daxpy(handle, n, alpha, x.val, incX, y.val, incY);
   } 
 
-  proc cu_caxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), ref alpha: complex(64), incX: c_int = 1, incY: c_int = 1){
+  proc cu_axpy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), ref alpha: complex(64), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_caxpy(handle, n, alpha, x.val, incX, y.val, incY);
   }
 
-  proc cu_zaxpy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), ref alpha: complex(128), incX: c_int = 1, incY: c_int = 1){
+  proc cu_axpy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), ref alpha: complex(128), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zaxpy(handle, n, alpha, x.val, incX, y.val, incY);
   }
 
-  proc cu_isamax(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamax(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_isamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_idamax(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamax(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_idamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_icamax(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamax(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_icamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_izamax(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamax(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_izamax(handle, n, x.val, incX, result);
   }
 
-  proc cu_isamin(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamin(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_isamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_idamin(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamin(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_idamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_icamin(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamin(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_icamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_izamin(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_int)){
+  proc cu_iamin(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_int)){
     require "c_cublas.h", "c_cublas.o";
     cublas_izamin(handle, n, x.val, incX, result);
   }
 
-  proc cu_sasum(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_float)){
+  proc cu_asum(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), incX: c_int, result: c_ptr(c_float)){
     require "c_cublas.h", "c_cublas.o";
     cublas_sasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_dasum(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_double)){
+  proc cu_asum(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), incX: c_int, result: c_ptr(c_double)){
     require "c_cublas.h", "c_cublas.o";
     cublas_dasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_scasum(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_float)){
+  proc cu_asum(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), incX: c_int, result: c_ptr(c_float)){
     require "c_cublas.h", "c_cublas.o";
     cublas_scasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_dzasum(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_double)){
+  proc cu_asum(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), incX: c_int, result: c_ptr(c_double)){
     require "c_cublas.h", "c_cublas.o";
     cublas_dzasum(handle, n, x.val, incX, result);
   }
 
-  proc cu_scopy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_copy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_scopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_dcopy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_copy(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dcopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_ccopy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_copy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_ccopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_zcopy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_copy(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zcopy(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_sdot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), result: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), result: c_ptr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_sdot(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_ddot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), result: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), result: c_ptr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_ddot(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_cdotu(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dotu(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cdotu(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_cdotc(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dotc(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), result: c_ptr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cdotc(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_zdotu(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dotu(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zdotu(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_zdotc(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_dotc(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), result: c_ptr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zdotc(handle, n, x.val, incX, y.val, incY, result);
   }
 
-  proc cu_snrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), result: c_ptr(c_float), incX: c_int = 1){
+  proc cu_nrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), result: c_ptr(c_float), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_snrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_dnrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), result: c_ptr(c_double), incX: c_int = 1){
+  proc cu_nrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), result: c_ptr(c_double), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dnrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_scnrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), result: c_ptr(c_float), incX: c_int = 1){
+  proc cu_nrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), result: c_ptr(c_float), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_scnrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_dznrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), result: c_ptr(c_double), incX: c_int = 1){
+  proc cu_nrm2(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), result: c_ptr(c_double), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dznrm2(handle, n, x.val, incX, result);
   }
 
-  proc cu_srot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
+  proc cu_rot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_srot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_drot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
+  proc cu_rot(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_drot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_crot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), c: c_float, s: complex(64), incX: c_int = 1, incY: c_int = 1){
+  proc cu_rot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), c: c_float, s: complex(64), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_crot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_csrot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
+  proc cu_rot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), c: c_float, s: c_float, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_csrot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_zrot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), c: c_double, s: complex(128), incX: c_int = 1, incY: c_int = 1){
+  proc cu_rot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), c: c_double, s: complex(128), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zrot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_zdrot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
+  proc cu_rot(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), c: c_double, s: c_double, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zdrot(handle, n, x.val, incX, y.val, incY, c, s);
   }
 
-  proc cu_srotg(handle: c_void_ptr, a: c_float, b: c_float, ref c: c_float, ref s: c_float){
+  proc cu_rotg(handle: c_void_ptr, a: c_float, b: c_float, ref c: c_float, ref s: c_float){
     require "c_cublas.h", "c_cublas.o";
     cublas_srotg(handle, a, b, c, s);
   }
 
-  proc cu_drotg(handle: c_void_ptr, a: c_double, b: c_double, ref c: c_double, ref s: c_double){
+  proc cu_rotg(handle: c_void_ptr, a: c_double, b: c_double, ref c: c_double, ref s: c_double){
     require "c_cublas.h", "c_cublas.o";
     cublas_drotg(handle, a, b, c, s);
   }
 
-  proc cu_crotg(handle: c_void_ptr, a: complex(64), b: complex(64), ref c: c_float, ref s: complex(64)){
+  proc cu_rotg(handle: c_void_ptr, a: complex(64), b: complex(64), ref c: c_float, ref s: complex(64)){
     require "c_cublas.h", "c_cublas.o";
     cublas_crotg(handle, a, b, c, s);
   }
 
-  proc cu_zrotg(handle: c_void_ptr, a: complex(128), b: complex(128), ref c: c_double, ref s: complex(128)){
+  proc cu_rotg(handle: c_void_ptr, a: complex(128), b: complex(128), ref c: c_double, ref s: complex(128)){
     require "c_cublas.h", "c_cublas.o";
     cublas_zrotg(handle, a, b, c, s);
   }
 
-  proc cu_srotm(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), params: []real(32), incX: c_int = 1, incY: c_int = 1){
+  proc cu_rotm(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), params: []real(32), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_srotm(handle, n, x.val, incX, y.val, incY, params);
   }
 
-  proc cu_drotm(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), params: []real(64), incX: c_int = 1, incY: c_int = 1){
+  proc cu_rotm(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), params: []real(64), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_drotm(handle, n, x.val, incX, y.val, incY, params);
   }
 
-  proc cu_srotmg(handle: c_void_ptr, ref d1: c_float, ref d2: c_float, ref x1: c_float, ref y1: c_float, params: []real(32)){
+  proc cu_rotmg(handle: c_void_ptr, ref d1: c_float, ref d2: c_float, ref x1: c_float, ref y1: c_float, params: []real(32)){
     require "c_cublas.h", "c_cublas.o";
     cublas_srotmg(handle, d1, d2, x1, y1, params);
   }
 
-  proc cu_drotmg(handle: c_void_ptr, ref d1: c_double, ref d2: c_double, ref x1: c_double, ref y1: c_double, params: []real(64)){
+  proc cu_rotmg(handle: c_void_ptr, ref d1: c_double, ref d2: c_double, ref x1: c_double, ref y1: c_double, params: []real(64)){
     require "c_cublas.h", "c_cublas.o";
     cublas_drotmg(handle, d1, d2, x1, y1, params);
   }
 
-  proc cu_sscal(handle: c_void_ptr, n: c_int, alpha: c_float, x: DevicePtr(c_float), incX: c_int = 1){
+  proc cu_scal(handle: c_void_ptr, n: c_int, alpha: c_float, x: DevicePtr(c_float), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_sscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_dscal(handle: c_void_ptr, n: c_int, alpha: c_double, x: DevicePtr(c_double), incX: c_int = 1){
+  proc cu_scal(handle: c_void_ptr, n: c_int, alpha: c_double, x: DevicePtr(c_double), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_cscal(handle: c_void_ptr, n: c_int, alpha: complex(64), x: DevicePtr(complex(64)), incX: c_int = 1){
+  proc cu_scal(handle: c_void_ptr, n: c_int, alpha: complex(64), x: DevicePtr(complex(64)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_csscal(handle: c_void_ptr, n: c_int, alpha: c_float, x: DevicePtr(complex(64)), incX: c_int = 1){
+  proc cu_scal(handle: c_void_ptr, n: c_int, alpha: c_float, x: DevicePtr(complex(64)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_csscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_zscal(handle: c_void_ptr, n: c_int, alpha: complex(128), x: DevicePtr(complex(128)), incX: c_int = 1){
+  proc cu_scal(handle: c_void_ptr, n: c_int, alpha: complex(128), x: DevicePtr(complex(128)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_zdscal(handle: c_void_ptr, n: c_int, alpha: c_double, x: DevicePtr(complex(128)), incX: c_int = 1){
+  proc cu_scal(handle: c_void_ptr, n: c_int, alpha: c_double, x: DevicePtr(complex(128)), incX: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zdscal(handle, n, alpha, x.val, incX);
   }
 
-  proc cu_sswap(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_swap(handle: c_void_ptr, n: c_int, x: DevicePtr(c_float), y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_sswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_dswap(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_swap(handle: c_void_ptr, n: c_int, x: DevicePtr(c_double), y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_cswap(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_swap(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_zswap(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_swap(handle: c_void_ptr, n: c_int, x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zswap(handle, n, x.val, incX, y.val, incY);
   }
 
-  proc cu_sgemm(handle: c_void_ptr, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: c_float, A: DevicePtr(c_float), lda: c_int, B: DevicePtr(c_float), ldb: c_int, beta: c_float, c: DevicePtr(c_float), ldc: c_int){
+  proc cu_gemm(handle: c_void_ptr, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: c_float, A: DevicePtr(c_float), lda: c_int, B: DevicePtr(c_float), ldb: c_int, beta: c_float, c: DevicePtr(c_float), ldc: c_int){
     require "c_cublas.h", "c_cublas.o";
     cublas_sgemm(handle, transa, transb, m, n, k, alpha, A.val, lda, B.val, ldb, beta, c.val, ldc);
   }
@@ -334,52 +334,52 @@ module cuBLAS {
 }
 */
 
-  proc cu_sgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_float, A: DevicePtr(c_float), lda: c_int, x: DevicePtr(c_float), ref beta: c_float, y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
+  proc cu_gemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_float, A: DevicePtr(c_float), lda: c_int, x: DevicePtr(c_float), ref beta: c_float, y: DevicePtr(c_float), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_sgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_dgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_double, A: DevicePtr(c_double), lda: c_int, x: DevicePtr(c_double), ref beta: c_double, y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
+  proc cu_gemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: c_double, A: DevicePtr(c_double), lda: c_int, x: DevicePtr(c_double), ref beta: c_double, y: DevicePtr(c_double), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_cgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(64), A: DevicePtr(complex(64)), lda: c_int, x: DevicePtr(complex(64)), ref beta: complex(64), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_gemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(64), A: DevicePtr(complex(64)), lda: c_int, x: DevicePtr(complex(64)), ref beta: complex(64), y: DevicePtr(complex(64)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_zgemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(128), A: DevicePtr(complex(128)), lda: c_int, x: DevicePtr(complex(128)), ref beta: complex(128), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
+  proc cu_gemv(handle: c_void_ptr, trans: c_int, m: c_int, n: c_int, ref alpha: complex(128), A: DevicePtr(complex(128)), lda: c_int, x: DevicePtr(complex(128)), ref beta: complex(128), y: DevicePtr(complex(128)), incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zgemv(handle, trans, m, n, alpha, A.val, lda, x.val, incX, beta, y.val, incY);
 }
 
-  proc cu_sger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_float, x: DevicePtr(c_float), y: DevicePtr(c_float), A: DevicePtr(c_float), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_ger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_float, x: DevicePtr(c_float), y: DevicePtr(c_float), A: DevicePtr(c_float), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_sger(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_dger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_double, x: DevicePtr(c_double), y: DevicePtr(c_double), A: DevicePtr(c_double), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_ger(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: c_double, x: DevicePtr(c_double), y: DevicePtr(c_double), A: DevicePtr(c_double), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_dger(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_cgeru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), A: DevicePtr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_geru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), A: DevicePtr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cgeru(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_cgerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), A: DevicePtr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_gerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(64), x: DevicePtr(complex(64)), y: DevicePtr(complex(64)), A: DevicePtr(complex(64)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_cgrec(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_zgeru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), A: DevicePtr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_geru(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), A: DevicePtr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zgeru(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }
 
-  proc cu_zgerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), A: DevicePtr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
+  proc cu_gerc(handle: c_void_ptr, m: c_int, n: c_int, ref alpha: complex(128), x: DevicePtr(complex(128)), y: DevicePtr(complex(128)), A: DevicePtr(complex(128)), lda: c_int, incX: c_int = 1, incY: c_int = 1){
     require "c_cublas.h", "c_cublas.o";
     cublas_zgerc(handle, m, n, alpha, x.val, incX, y.val, incY, A.val, lda);
 }

--- a/test/gpu/interop/cuBLAS/level1/test_cublas1.chpl
+++ b/test/gpu/interop/cuBLAS/level1/test_cublas1.chpl
@@ -174,19 +174,9 @@ proc test_cuamax_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_isamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when real(64) do {
-        cu_idamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(64) do {
-        cu_icamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(128) do {
-        cu_izamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
+    if (t == real(32)    || t == real(64) ||
+        t == complex(64) || t == complex(128)) {
+      cu_iamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
     }
 
     var idx = r-1;
@@ -207,19 +197,9 @@ proc test_cuamax_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_isamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when real(64) do {
-        cu_idamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(64) do {
-        cu_icamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(128) do {
-        cu_izamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
+    if (t == real(32)    || t == real(64) ||
+        t == complex(64) || t == complex(128)) {
+      cu_iamax(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
     }
 
     var idx = r;
@@ -248,19 +228,10 @@ proc test_cuamin_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_isamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when real(64) do {
-        cu_idamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(64) do {
-        cu_icamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(128) do {
-        cu_izamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
+
+    if (t == real(32)    || t == real(64) ||
+        t == complex(64) || t == complex(128)) {
+      cu_iamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
     }
 
     var idx = r-1;
@@ -281,19 +252,9 @@ proc test_cuamin_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_isamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when real(64) do {
-        cu_idamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(64) do {
-        cu_icamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
-      when complex(128) do {
-        cu_izamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-      }
+    if (t == real(32)    || t == real(64) ||
+        t == complex(64) || t == complex(128)) {
+      cu_iamin(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
     }
 
     var idx = r;
@@ -336,27 +297,11 @@ proc test_cuasum_helper(type t) {
 
     var err = 1.0;
 
-    select t {
-      when real(32) do {
-        var r : real(32);
-        cu_sasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-        err = norm - r;
-      }
-      when real(64) do {
-        var r : real(64);
-        cu_dasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-        err = norm - r;
-      }
-      when complex(64) do {
-        var r : real(32);
-        cu_scasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-        err = norm - r;
-      }
-      when complex(128) do {
-        var r : real(64);
-        cu_dzasum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
-        err = norm - r;
-      }
+    if t == real(32)    || t == real(64) ||
+       t == complex(64) || t == complex(128) {
+      var r : if isComplexType(t) then real(numBits(t)/2) else t;
+      cu_asum(cublas_handle, N, gpu_ptr_X, 1, c_ptrTo(r));
+      err = norm - r;
     }
 
     trackErrors(name, err, errorThreshold, passed, failed, tests);
@@ -385,19 +330,9 @@ proc test_cucopy_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_scopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
-      when real(64) do {
-        cu_dcopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
-      when complex(64) do {
-        cu_ccopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
-      when complex(128) do {
-        cu_zcopy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
+    if t == real(32)    || t == real(64) ||
+       t == complex(64) || t == complex(128) {
+      cu_copy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
     }
 
     gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
@@ -433,19 +368,9 @@ proc test_cuaxpy_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_saxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
-      }
-      when real(64) do {
-        cu_daxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
-      }
-      when complex(64) do {
-        cu_caxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
-      }
-      when complex(128) do {
-        cu_zaxpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
-      }
+    if t == real(32)    || t == real(64) ||
+       t == complex(64) || t == complex(128) {
+      cu_axpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
     }
 
     gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
@@ -483,13 +408,8 @@ proc test_cudot_helper(type t) {
     var cublas_handle = cublas_create_handle();
     var r : t;
 
-    select t {
-      when real(32) do {
-        cu_sdot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(r));
-      }
-      when real(64) do {
-        cu_ddot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(r));
-      }
+    if t == real(32) || t == real(64) {
+      cu_dot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(r));
     }
 
     var err = abs(red - r);
@@ -523,13 +443,8 @@ proc test_cudotu_helper(type t) {
     var cublas_handle = cublas_create_handle();
     var res : t;
 
-    select t {
-      when complex(64) do {
-        cu_cdotu(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
-      }
-      when complex(128) do {
-        cu_zdotu(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
-      }
+    if t == complex(64) || t == complex(128) {
+      cu_dotu(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
     }
 
     var err = abs(red - res);
@@ -563,13 +478,8 @@ proc test_cudotc_helper(type t) {
     var cublas_handle = cublas_create_handle();
     var res : t;
 
-    select t {
-      when complex(64) do {
-        cu_cdotc(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
-      }
-      when complex(128) do {
-        cu_zdotc(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
-      }
+    if t == complex(64) || t == complex(128) {
+      cu_dotc(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c_ptrTo(res));
     }
 
     var err = abs(red - res);
@@ -602,27 +512,11 @@ proc test_cunrm2_helper(type t) {
     var cublas_handle = cublas_create_handle();
     var err = 1.0;
 
-    select t {
-      when real(32) do {
-        var r: real(32);
-        cu_snrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
-        err = norm - r;
-      }
-      when real(64) do {
-        var r: real(64);
-        cu_dnrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
-        err = norm - r;
-      }
-      when complex(64) do {
-        var r: real(32);
-        cu_scnrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
-        err = norm -r;
-      }
-      when complex(128) do {
-        var r: real(64);
-        cu_dznrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
-        err = norm - r;
-      }
+    if t == real(32)    || t == real(64) ||
+       t == complex(64) || t == complex(128) {
+      var r: if isComplexType(t) then real(numBits(t)/2) else t;
+      cu_nrm2(cublas_handle, N, gpu_ptr_X, c_ptrTo(r));
+      err = norm - r;
     }
 
     trackErrors(name, err, errorThreshold, passed, failed, tests);
@@ -659,13 +553,8 @@ proc test_curot_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_srot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
-      }
-      when real(64) do {
-        cu_drot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
-      }
+    if t == real(32) || t == real(64) {
+      cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -712,10 +601,8 @@ proc test_cucrot_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-     when complex(64) do {
-        cu_crot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
-     }
+    if t == complex(64) {
+      cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -762,10 +649,8 @@ proc test_cuzrot_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-     when complex(128) do {
-        cu_zrot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
-     }
+    if t == complex(128) {
+      cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -812,10 +697,8 @@ proc test_cucsrot_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-     when complex(64) do {
-        cu_csrot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
-     }
+    if t == complex(64) {
+      cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -863,10 +746,8 @@ proc test_cuzdrot_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-     when complex(128) do {
-        cu_zdrot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
-     }
+    if t == complex(128) {
+      cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -911,13 +792,8 @@ proc test_curotg_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_srotg(cublas_handle, a, b, c, s);
-      }
-      when real(64) do {
-        cu_drotg(cublas_handle, a, b, c, s);
-      }
+    if t == real(32) || t == real(64) {
+      cu_rotg(cublas_handle, a, b, c, s);
     }
 
     // rename outputs
@@ -976,10 +852,8 @@ proc test_cucrotg_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when complex(64) do {
-        cu_crotg(cublas_handle, a, b, c, s);
-      }
+    if t == complex(64) {
+      cu_rotg(cublas_handle, a, b, c, s);
     }
 
     // rename outputs
@@ -1037,10 +911,8 @@ proc test_cuzrotg_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when complex(128) do {
-        cu_zrotg(cublas_handle, a, b, c, s);
-      }
+    if t == complex(128) {
+      cu_rotg(cublas_handle, a, b, c, s);
     }
 
     // rename outputs
@@ -1104,13 +976,8 @@ proc test_curotm_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_srotm(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, P);
-      }
-      when real(64) do {
-        cu_drotm(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, P);
-      }
+    if t == real(32) || t == real(64) {
+      cu_rotm(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, P);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -1178,13 +1045,8 @@ proc test_curotmg_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_srotmg(cublas_handle, d1, d2, b1, b2, P);
-      }
-      when real(64) do {
-        cu_drotmg(cublas_handle, d1, d2, b1, b2, P);
-      }
+    if t == real(32) || t == real(64) {
+      cu_rotmg(cublas_handle, d1, d2, b1, b2, P);
     }
 
     var flag = P[0],
@@ -1243,19 +1105,9 @@ proc test_cuscal_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_sscal(cublas_handle, N, a, gpu_ptr_X);
-      }
-      when real(64) do {
-        cu_dscal(cublas_handle, N, a, gpu_ptr_X);
-      }
-      when complex(64) do {
-        cu_cscal(cublas_handle, N, a, gpu_ptr_X);
-      }
-      when complex(128) do {
-        cu_zscal(cublas_handle, N, a, gpu_ptr_X);
-      }
+    if t == real(32)    || t == real(64) ||
+       t == complex(64) || t == complex(128) {
+      cu_scal(cublas_handle, N, a, gpu_ptr_X);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -1290,10 +1142,8 @@ proc test_cucsscal_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when complex(64) do {
-        cu_csscal(cublas_handle, N, a, gpu_ptr_X);
-      }
+    if t == complex(64) {
+      cu_scal(cublas_handle, N, a, gpu_ptr_X);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -1328,10 +1178,8 @@ proc test_cuzdscal_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when complex(128) do {
-        cu_zdscal(cublas_handle, N, a, gpu_ptr_X);
-      }
+    if t == complex(128) {
+      cu_scal(cublas_handle, N, a, gpu_ptr_X);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
@@ -1369,19 +1217,9 @@ proc test_cuswap_helper(type t) {
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
 
-    select t {
-      when real(32) do {
-        cu_sswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
-      when real(64) do {
-        cu_dswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
-      when complex(64) do {
-        cu_cswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
-      when complex(128) do {
-        cu_zswap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
-      }
+    if t == real(32)    || t == real(64) ||
+       t == complex(64) || t == complex(128) {
+      cu_swap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
     }
 
     gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);


### PR DESCRIPTION
The extern cuBLAS functions encode their argument types into their names for
use from C which doesn't allow overloads. We do support overloads, so make
our versions nicer by removing the letter from the name that denotes the type
and letting the compiler choose the right version based on argument types.

Simplify the cuBLAS test based on this.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>