### PR TITLE
Purge modules before loading the ones we want on Cray CS testing

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -18,6 +18,7 @@ function loadCSModule()
 if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
   export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
+  module purge
   loadCSModule gcc/8.1.0
   loadCSModule cray-fftw
   export LD_LIBRARY_PATH="$FFTW_DIR:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Historically, these machines have had pretty bare-bones default modules,
but with some recent changes more modules including mpich are loaded by
default. That causes gasnet to detect mpi/mpirun and use that for a
launcher, but we want to be using ssh on these systems. For now just
purge all modules before loading the ones we want.