### PR TITLE
Updated documentation for Error.message() to reflect `string` return type

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -59,9 +59,10 @@ module ChapelError {
     }
 
     /* Override this method to provide an error message
-       in case the error is printed out or never caught.
+       of type string in case the error is printed out or never caught.
+       :rtype: string
      */
-    proc message() {
+    proc message():string {
       return _msg;
     }
   }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -60,8 +60,9 @@ module ChapelError {
 
     /* Override this method to provide an error message
        of type string in case the error is printed out or never caught.
+      
        :rtype: string
-     */
+    */
     proc message():string {
       return _msg;
     }


### PR DESCRIPTION
This updates the documentation for `Error.message()` to clarify that it returns a string (which was true, but only implied before).

Resolve #17469 