### PR TITLE
Fix Cray CS HDR Arkouda testing after OS upgrade

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.arkouda.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.bash
@@ -9,6 +9,8 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs-hdr.arkouda"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
+unset ARKOUDA_ZMQ_PATH
+unset ARKOUDA_HDF5_PATH
 export ARKOUDA_NUMLOCALES=16
 
 module list

--- a/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
@@ -9,6 +9,8 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs-hdr.arkouda.release"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
+unset ARKOUDA_ZMQ_PATH
+unset ARKOUDA_HDF5_PATH
 export ARKOUDA_NUMLOCALES=16
 
 module list
@@ -19,7 +21,7 @@ export CHPL_LAUNCHER_PARTITION=rome64Share
 export CHPL_TARGET_CPU=none
 
 # python2 required for chapel 1.23, will not be required with 1.24+
-module load python/2.7.6
+source ~/.setup_python2.bash
 
 module list
 


### PR DESCRIPTION
Change how we get python2 and avoid using /cray/css which isn't mounted
on the compute nodes at the moment.