### PR TITLE
Add perf annotations for 2021-04-01

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -461,6 +461,12 @@ all:
       config: 16-node-xc, 16-node-cs, 16-node-cs-hdr
     - text: Set the number of launcher cores per locale for Cray CS perf testing (#17407)
       config: 16-node-cs
+  03/30/21:
+    - text: OS upgrade
+      config: 16-node-cs-hdr
+  04/01/21:
+    - text: Upgrade to GASNet-EX 2021.3.0 (#17505)
+      config: 16-node-cs, 16-node-cs-hdr
 
 # End all
 
@@ -1398,6 +1404,10 @@ memleaksfull:
     - Fix some issues with new tests locking in bug fixes (#17320)
   03/24/21:
     - Add module OrderedMap (#16271)
+  03/26/21:
+    - Two fixes in OrderedMap (#17463)
+  03/27/21:
+    - CG Adjust in-intent handling to fix a memleak (#17480)
 # End memleaksfull
 
 meteor:
@@ -2115,6 +2125,8 @@ arkouda: &arkouda-base
     - Increase the problem size for string benchmarks (mhmerrill/arkouda#676)
   02/19/21:
     - Skip long string partitioning in string argsort (mhmerrill/arkouda#681)
+  03/25/21:
+    - fix groupby benchmark bug (mhmerrill/arkoud#712)
 
 arkouda-string:
   <<: *arkouda-base


### PR DESCRIPTION
Add annotations for:
 - 16-node-cs-hdr OS upgrade
 - huge IB improvements from gasnet upgrade
 - memory leak fixes
 - change in how the rate is calculate for arkouda groupby