### PR TITLE
Fix .bad mismatch in canSeeTertiaryOperator.chpl

### DIFF
--- a/test/visibility/only/canSeeTertiaryOperator.bad
+++ b/test/visibility/only/canSeeTertiaryOperator.bad
@@ -1,3 +1,4 @@
+canSeeTertiaryOperator.chpl:1: In module 'OuterModule':
 canSeeTertiaryOperator.chpl:11: error: unresolved call '+(owned Foo, owned Foo)'
 $CHPL_HOME/modules/internal/String.chpl:370: note: this candidate did not match: +(x: bufferType, y: byteIndex)
 canSeeTertiaryOperator.chpl:11: note: because actual argument #1 with type 'owned Foo'


### PR DESCRIPTION
The mismatch was due to crossed wires between #17483 and #17476.

Trivial, not reviewed.