### PR TITLE
Add a missing "In module MMM:" note

### DIFF
--- a/test/extern/ferguson/externblock/two-modules2-error.good
+++ b/test/extern/ferguson/externblock/two-modules2-error.good
@@ -1,1 +1,2 @@
+two-modules2-error.chpl:1: In module 'OuterModule':
 two-modules2-error.chpl:12: error: 'x' undeclared (first use this function)


### PR DESCRIPTION
I missed this test in #17483.

Trivial, not reviewed.