### PR TITLE
Added commutativity in String/Bytes multiplication

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1097,8 +1097,26 @@ module Bytes {
      :returns: A new :mod:`bytes <Bytes>` which is the result of repeating `s`
                `n` times.  If `n` is less than or equal to 0, an empty bytes is
                returned.
+     
+     The operation is commutative.
+     For example:
+
+     .. code-block:: chapel
+
+        writeln(b"Hello! "*3);
+        or
+        writeln(3*b"Hello! ");
+
+     Results in::
+
+        Hello! Hello! Hello!         
   */
   proc *(s: bytes, n: integral) {
+    return doMultiply(s, n);
+  }
+
+  pragma "no doc"
+  operator *(n: integral, s: bytes) {
     return doMultiply(s, n);
   }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2132,11 +2132,14 @@ module String {
      :returns: A new string which is the result of repeating `s` `n` times.
                If `n` is less than or equal to 0, an empty string is returned.
 
+     The operation is commutative.
      For example:
 
      .. code-block:: chapel
 
         writeln("Hello! " * 3);
+        or
+        writeln(3 * "Hello! ");
 
      Results in::
 
@@ -2144,6 +2147,11 @@ module String {
   */
   proc *(s: string, n: integral) {
     return doMultiply(s, n);
+  }
+
+  pragma "no doc"
+  operator *(n: integral, s: string) {
+    return doMultiply(s,n);
   }
 
   //

--- a/test/types/bytes/multiplication.chpl
+++ b/test/types/bytes/multiplication.chpl
@@ -1,0 +1,7 @@
+writeln(b"Hello! " * 3);
+writeln(3 * b"Hello! ");
+
+writeln(b"" * 3);
+writeln(3 * b"");
+
+writeln(b"" * 0);

--- a/test/types/bytes/multiplication.good
+++ b/test/types/bytes/multiplication.good
@@ -1,0 +1,5 @@
+Hello! Hello! Hello! 
+Hello! Hello! Hello! 
+
+
+

--- a/test/types/string/multiplication.chpl
+++ b/test/types/string/multiplication.chpl
@@ -1,0 +1,5 @@
+writeln("Hello !" * 5);
+writeln(5 * "Hello !");
+writeln("" * 4);
+writeln(4 * "");
+writeln(0 * "Hello !");

--- a/test/types/string/multiplication.good
+++ b/test/types/string/multiplication.good
@@ -1,0 +1,5 @@
+Hello !Hello !Hello !Hello !Hello !
+Hello !Hello !Hello !Hello !Hello !
+
+
+


### PR DESCRIPTION
I have added the feature of `int*string` and `int*bytes` multiplication and added some documentation in `Bytes.html` while explaining the example.
Resolve #17506 