### PR TITLE
Upgrade pycparser (used by c2chapel) to 2.20

### DIFF
--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,2 +1,2 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
-pycparser==2.17
+pycparser==2.20

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -35,7 +35,7 @@ link=$(bdir)/c2chapel
 
 # Note, this version is used only for the fake headers,
 # but it should probably match third-party/chpl-venv/c2chapel-requirements.txt
-VERSION=2.17
+VERSION=2.20
 TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -574,7 +574,11 @@ def findIgnores():
                     if line.startswith("typedef"):
                         rhs = line.replace(";", "")
                         rhs = rhs.replace("typedef int ", "")
+                        rhs = rhs.replace("typedef uint32_t ", "")
                         rhs = rhs.replace("typedef _Bool ", "")
+                        rhs = rhs.replace("typedef void* ", "")
+                        if "typedef struct" in rhs:
+                            rhs = rhs.split()[-1]
 
                         ret.add(rhs.strip())
 

--- a/tools/c2chapel/test/justC.chpl
+++ b/tools/c2chapel/test/justC.chpl
@@ -11,6 +11,37 @@ extern proc main() : c_int;
 /*
 extern type FILE = c_int;
 
+// Opaque struct?
+extern record MirBlob {};
+
+// Opaque struct?
+extern record MirBufferStream {};
+
+// Opaque struct?
+extern record MirConnection {};
+
+// Opaque struct?
+extern record MirDisplayConfig {};
+
+extern type MirEGLNativeDisplayType = c_void_ptr;
+
+extern type MirEGLNativeWindowType = c_void_ptr;
+
+// Opaque struct?
+extern record MirPersistentId {};
+
+// Opaque struct?
+extern record MirPromptSession {};
+
+// Opaque struct?
+extern record MirScreencast {};
+
+// Opaque struct?
+extern record MirSurface {};
+
+// Opaque struct?
+extern record MirSurfaceSpec {};
+
 extern type _LOCK_RECURSIVE_T = c_int;
 
 extern type _LOCK_T = c_int;
@@ -280,6 +311,13 @@ extern type va_list = c_int;
 extern type wchar_t = c_int;
 
 extern type wint_t = c_int;
+
+// Opaque struct?
+extern record xcb_connection_t {};
+
+extern type xcb_visualid_t = uint(32);
+
+extern type xcb_window_t = uint(32);
 
 extern type z_stream = c_int;
 

--- a/tools/c2chapel/test/sysCTypes.chpl
+++ b/tools/c2chapel/test/sysCTypes.chpl
@@ -32,6 +32,37 @@ extern proc unsignedWidths(a : uint(8), b : uint(16), c : uint(32), d : uint(64)
 /*
 extern type FILE = c_int;
 
+// Opaque struct?
+extern record MirBlob {};
+
+// Opaque struct?
+extern record MirBufferStream {};
+
+// Opaque struct?
+extern record MirConnection {};
+
+// Opaque struct?
+extern record MirDisplayConfig {};
+
+extern type MirEGLNativeDisplayType = c_void_ptr;
+
+extern type MirEGLNativeWindowType = c_void_ptr;
+
+// Opaque struct?
+extern record MirPersistentId {};
+
+// Opaque struct?
+extern record MirPromptSession {};
+
+// Opaque struct?
+extern record MirScreencast {};
+
+// Opaque struct?
+extern record MirSurface {};
+
+// Opaque struct?
+extern record MirSurfaceSpec {};
+
 extern type _LOCK_RECURSIVE_T = c_int;
 
 extern type _LOCK_T = c_int;
@@ -301,6 +332,13 @@ extern type va_list = c_int;
 extern type wchar_t = c_int;
 
 extern type wint_t = c_int;
+
+// Opaque struct?
+extern record xcb_connection_t {};
+
+extern type xcb_visualid_t = uint(32);
+
+extern type xcb_window_t = uint(32);
 
 extern type z_stream = c_int;
 


### PR DESCRIPTION
Upgrade pycparser from 2.17 to 2.20. Note that new fake typedefs were
added in https://github.com/eliben/pycparser/commit/c7b929c so we need
to adjust our code that ignores fake typedefs to account for these new
patterns. In particular we now ignore things like:

```c
typedef uint32_t xcb_window_t;
typedef void* MirEGLNativeWindowType;
typedef struct MirDisplayConfig MirDisplayConfig;
```

The current code we use to ignore fake typedefs hardcodes a few known
idioms, but longer term I think we could generalize this.