### PR TITLE
Convert memleaks nightly script into a correctness test on memory leaks

### DIFF
--- a/util/cron/test-memleaks.bash
+++ b/util/cron/test-memleaks.bash
@@ -9,5 +9,5 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks"
 
-$CWD/nightly -cron -memleakslog $(memleaks_log full) -no-futures $(get_nightly_paratest_args)
+$CWD/nightly -cron -memleaks -memleakslog $(memleaks_log full) -no-futures $(get_nightly_paratest_args)
 save_memleaks_log full

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -69,11 +69,11 @@ sub main {
     $valgrind = "-valgrindexe" if ($ARGV[5] == 2);
 
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
-    if ($#ARGV>=7) {
-        $compopts = "-compopts \"" . $ARGV[7] . "\"";
-    }
     if ($#ARGV>=8) {
-        $execopts = "-execopts \"" . $ARGV[8] . "\"";
+        $compopts = "-compopts \"" . $ARGV[8] . "\"";
+    }
+    if ($#ARGV>=9) {
+        $execopts = "-execopts \"" . $ARGV[9] . "\"";
     }
 
     $synchfile = "$synchdir/$node.$id";
@@ -104,7 +104,7 @@ sub main {
     $memleaks = "-memleaks" if ($ARGV[6] == 1);
 
     $memleakslog = "";
-    $memleakslog = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[7] == 2);
+    $memleakslog = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[7] == 1);
 
     $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks $memleakslog";
     $testarg = "$testarg $testdir -norecurse";

--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -3,7 +3,7 @@
 # Client-side of the parallel testing script, paratest.server.
 # Used remotely by paratest.server to run start_test locally.
 #
-# Usage: paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks [compopts [execopts]]
+# Usage: paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks memleakslog [compopts [execopts]]
 #  
 #  id - used to create a file to synchronize with paratest.server
 #  chapeltestdir - root dir of Chapel test infrastructure
@@ -11,7 +11,8 @@
 #  chplenv - Chapel environment variables
 #  futures-mode - include .futures (0=no, 1=all, 2=futures only, 3=futures with skipifs)
 #  valgrind - run valgrind (0=no, 1=both compiler and executable, 2=executable only)
-#  memleaks - check for memleaks (0=no, 1=use -memleaks, 2=use -memleakslog)
+#  memleaks    - check for memleaks (0=no, 1=yes)
+#  memleakslog - check for memleaks creating a log file (0=no, 1=yes)
 #  compopts - optional Chapel compiler options
 #  execopts - optional test execution options
 #
@@ -51,9 +52,9 @@ sub main {
     chomp $node;
     ($node) = split (/\./, $node);
 
-    if ($#ARGV < 6) {
+    if ($#ARGV < 7) {
         fatal("insufficient arguments: '@ARGV'\n" .
-	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks [compopts [execopts]]");
+	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks memleakslog [compopts [execopts]]");
     }
 
     $id = $ARGV[0];
@@ -101,9 +102,11 @@ sub main {
 
     $memleaks = "";
     $memleaks = "-memleaks" if ($ARGV[6] == 1);
-    $memleaks = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[6] == 2);
 
-    $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks";
+    $memleakslog = "";
+    $memleakslog = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[7] == 2);
+
+    $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks $memleakslog";
     $testarg = "$testarg $testdir -norecurse";
 
     # Set up the Chapel environment passed in by paratest.server

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -277,7 +277,7 @@ sub feed_nodes {
                       $execopts = "\\\"$execopts\\\"";
                   }
                   # If the command line gets too long, consider using xargs
-                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $compopts $execopts";
+                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $memleakslog $compopts $execopts";
                   if ($verbose) {
                       systemd ($rem_cmd);
                   } else {
@@ -355,9 +355,9 @@ sub feed_nodes {
 
       $endtime = `date`; chomp $endtime;
       print "\n";
-      if ($memleaksflag == 2) {
-          print "Collecting memleaks logs to $memleakslog\n";
-          systemd("cat $logdir/tmp.*.memleaks > $memleakslog");
+      if ($memleakslog == 1) {
+          print "Collecting memleaks logs to $memleakslogfile\n";
+          systemd("cat $logdir/tmp.*.memleaks > $memleakslogfile");
           # Keep the individual logs upon failure.
           !$? or die "Could not collect memleaks logs: $?\n";
           systemd("rm -f $logdir/tmp.*.memleaks");
@@ -639,7 +639,7 @@ sub main {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $memleakslogfile = $ARGV[0];
-                $memleakslogflag = 1;
+                $memleakslog = 1;
             } else {
                 print "missing -memleakslog arg\n";
                 exit (8);

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -45,8 +45,8 @@ $dirs = "";
 $node_para = 1;                        # the number of tasks to run on each node
 $valgrind = 0;
 $memleaks = 0;
-$memleakslog = "/dev/null";
-$memleaksflag = 0;
+$memleakslog = 0;
+$memleakslogfile = "/dev/null";
 $show_all_errors = 0;
 $junit_xml = 0;
 $junit_xml_file = "";
@@ -638,8 +638,8 @@ sub main {
         } elsif (/^-memleakslog$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
-                $memleakslog = $ARGV[0];
-                $memleaksflag = 2;
+                $memleakslogfile = $ARGV[0];
+                $memleakslogflag = 1;
             } else {
                 print "missing -memleakslog arg\n";
                 exit (8);


### PR DESCRIPTION
This PR makes memory leaks correctness tests in the nightly testing.

The changes are made in two steps:

- Adjust `paratest.server` and `paratest.client` so that they can use
  `-memleaks` and `-memleakslog` flags independently

- Throw `-memleaks` in `test-memleaks.bash`

NOTE: This PR does *not* adjust `test/memory/ferguson/test1.chpl` to filter out
the memory leak. I am planning to merge this and use that test as the
in-production test for this PR before I fix it.

PR that'll adjust that test: https://github.com/chapel-lang/chapel/pull/17529

Test:
- [x] paratest.chapcs on `test/memory` works as expected
  
  When I `analyzeMemLeaksLog` on the generated file, I see the leaky test while
  it is also being reported as an error

- [x] full standard paratest
