### PR TITLE
Add prediff for the leaky test

### DIFF
--- a/test/memory/ferguson/test1.prediff
+++ b/test/memory/ferguson/test1.prediff
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+import os
+
+pattern = re.compile('=* Memory Leaks =*')
+
+filter_filename = sys.argv[2]
+tmp_filename = filter_filename + '.predifftmp'
+
+with open(tmp_filename, 'w') as out_file:
+  with open(filter_filename, 'r') as in_file:
+    prev_line = ""
+    scanned_first_line = False
+    for line in in_file:
+      match = pattern.match(line)
+      if match:
+        break
+
+      if scanned_first_line:
+        out_file.write(prev_line)
+      else:
+        scanned_first_line = True
+
+      prev_line = line
+
+os.replace(tmp_filename, filter_filename)


### PR DESCRIPTION
This PR adds a prediff for the only test that reports memory leaks.

This test is supposed to report a leak, and this prediff will make sure that
it will not be reported as error after
https://github.com/chapel-lang/chapel/pull/17528 goes in. I am planning to merge
this one day after that one goes in so that we can see that leaks are reported
as errors.
