### PR TITLE
Revert "Move resolveSpecifiedReturnType()"

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -77,6 +77,15 @@ bool ResolutionCandidate::isApplicable(CallInfo& info,
     retval = isApplicableGeneric(info, visInfo);
   }
 
+  // Note: for generic instantiations, this code will be executed twice.
+  // This is because by the time the generic branch returns, its function will
+  // have been replaced by the instantiation, which will have already had this
+  // function called on it.  However, reducing the scope for this operation does
+  // not seem to have a noticeable impact.
+  if (retval && fn->retExprType != NULL && fn->retType == dtUnknown) {
+    resolveSpecifiedReturnType(fn);
+  }
+
   return retval;
 }
 
@@ -94,13 +103,7 @@ bool ResolutionCandidate::isApplicableConcrete(CallInfo& info,
   if (computeAlignment(info) == false)
     return false;
 
-  if (checkResolveFormalsWhereClauses(info, visInfo) == false)
-    return false;
-  
-  if (fn->retExprType != NULL && fn->retType == dtUnknown)
-    resolveSpecifiedReturnType(fn);
-
-  return true;
+  return checkResolveFormalsWhereClauses(info, visInfo);
 }
 
 bool ResolutionCandidate::isApplicableGeneric(CallInfo& info,


### PR DESCRIPTION
This reverts commit 2224ca95075a6d1b070b69cbed9a7e6467c83aba.

This commit caused an exceedingly large amount of errors of the form: "error:
'param' functions cannot return non-'param' values" for two tests of the Version
module, library/standard/Version/compareChplVersion.chpl and
library/standard/Version/compareChplVersionErrors.chpl when merged onto my
operators branch.  Since the original PR itself was uncertain of why the code
was in the previous state, it made sense to just undo the change.

Discussed with Vass, who made the original PR.

Passed a full paratest with futures