### PR TITLE
Revert a recent change in block array creation that caused performance regression

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -906,14 +906,12 @@ proc BlockDom.dsiBuildArray(type eltType, param initElts:bool) {
   var myLocArrTemp: unmanaged LocBlockArr(eltType, rank, idxType, stridable)?;
 
   // formerly in BlockArr.setup()
-  coforall (loc, locDomsElt, locArrTempElt)
-           in zip(dom.dist.targetLocales, dom.locDoms, locArrTemp)
-           with (ref myLocArrTemp) {
-    on loc {
+  coforall localeIdx in dom.dist.targetLocDom with (ref myLocArrTemp) {
+    on dom.dist.targetLocales(localeIdx) {
       const LBA = new unmanaged LocBlockArr(eltType, rank, idxType, stridable,
-                                            locDomsElt,
+                                            dom.getLocDom(localeIdx),
                                             initElts=initElts);
-      locArrTempElt = LBA;
+      locArrTemp(localeIdx) = LBA;
       if here.id == creationLocale then
         myLocArrTemp = LBA;
     }

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 5, put = 1, execute_on = 2) (get = 5, put = 1) (get = 5, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2) (get = 9, put = 1) (get = 9, put = 1)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2) (get = 9, put = 1) (get = 9, put = 1)
-Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 12, put = 1, execute_on = 2) (get = 12, put = 1) (get = 12, put = 1)
-Dom4D
 (execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2) (get = 15, put = 1) (get = 15, put = 1)
+Dom3D
+(execute_on = 4, execute_on_nb = 6) (get = 20, put = 1, execute_on = 2) (get = 20, put = 1) (get = 20, put = 1)
+Dom4D
+(execute_on = 4, execute_on_nb = 6) (get = 25, put = 1, execute_on = 2) (get = 25, put = 1) (get = 25, put = 1)
 Dom2D32
-(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2) (get = 9, put = 1) (get = 9, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2) (get = 15, put = 1) (get = 15, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.na-none.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 5, put = 1, execute_on = 2, execute_on_fast = 2) (get = 5, put = 1, execute_on_fast = 2) (get = 5, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2)
-Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 12, put = 1, execute_on = 2, execute_on_fast = 2) (get = 12, put = 1, execute_on_fast = 2) (get = 12, put = 1, execute_on_fast = 2)
-Dom4D
 (execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2)
+Dom3D
+(execute_on = 4, execute_on_nb = 6) (get = 20, put = 1, execute_on = 2, execute_on_fast = 2) (get = 20, put = 1, execute_on_fast = 2) (get = 20, put = 1, execute_on_fast = 2)
+Dom4D
+(execute_on = 4, execute_on_nb = 6) (get = 25, put = 1, execute_on = 2, execute_on_fast = 2) (get = 25, put = 1, execute_on_fast = 2) (get = 25, put = 1, execute_on_fast = 2)
 Dom2D32
-(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 15, put = 6, execute_on = 16, execute_on_nb = 9) (get = 15, put = 3, execute_on = 11, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 27, put = 6, execute_on = 16, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D
-(get = 27, put = 6, execute_on = 16, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6)
-Dom3D
-(get = 36, put = 6, execute_on = 16, execute_on_nb = 9) (get = 36, put = 3, execute_on = 11, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_nb = 6)
-Dom4D
 (get = 45, put = 6, execute_on = 16, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6)
+Dom3D
+(get = 60, put = 6, execute_on = 16, execute_on_nb = 9) (get = 60, put = 3, execute_on = 11, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6)
+Dom4D
+(get = 75, put = 6, execute_on = 16, execute_on_nb = 9) (get = 75, put = 3, execute_on = 11, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D32
-(get = 27, put = 6, execute_on = 16, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 45, put = 6, execute_on = 16, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.na-none.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 15, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 15, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 27, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D
-(get = 27, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
-Dom3D
-(get = 36, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 36, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
-Dom4D
 (get = 45, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+Dom3D
+(get = 60, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 60, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+Dom4D
+(get = 75, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 75, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D32
-(get = 27, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 45, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)


### PR DESCRIPTION
The change reverted here was introduced in
https://github.com/chapel-lang/chapel/pull/17354.

Resolves https://github.com/Cray/chapel-private/issues/1836

This change did reduce the amount of communication but hurt the overall
performance nonetheless. The reasons are not clear yet. This PR reverts the
change to get the performance where it had been.

See https://github.com/Cray/chapel-private/issues/1850 which will track the
investigation about this matter.

Test:
- [x] standard
- [x] gasnet
