### PR TITLE
Clean up a very small section of compiler/util/files.cpp

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -90,7 +90,7 @@ void genIncludeCommandLineHeaders(FILE* outfile);
 
 const char* createDebuggerFile(const char* debugger, int argc, char* argv[]);
 
-std::string runPrintChplEnv(std::map<std::string, const char*> varMap);
+std::string runPrintChplEnv(const std::map<std::string, const char*>& varMap);
 std::string getChplDepsApp();
 bool compilingWithPrgEnv();
 std::string runCommand(std::string& command);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -547,15 +547,13 @@ const char* createDebuggerFile(const char* debugger, int argc, char* argv[]) {
   return dbgfilename;
 }
 
-std::string runPrintChplEnv(std::map<std::string, const char*> varMap) {
+std::string runPrintChplEnv(const std::map<std::string, const char*>& varMap) {
   // Run printchplenv script, passing currently known CHPL_vars as well
-  std::string command = "";
+  std::string command;
 
-  // Pass known variables in varMap into printchplenv by appending to command
-  for (std::map<std::string, const char*>::iterator ii=varMap.begin(); ii!=varMap.end(); ++ii)
-  {
-    command += ii->first + "=" + std::string(ii->second) + " ";
-  }
+  // Pass known variables in varMap into printchplenv by prepending to command
+  for (auto& ii : varMap)
+    command += ii.first + "=" + ii.second + " ";
 
   // Toss stderr away until printchplenv supports a '--suppresswarnings' flag
   command += std::string(CHPL_HOME) + "/util/printchplenv --all --internal --no-tidy --simple 2> /dev/null";
@@ -675,8 +673,7 @@ void genIncludeCommandLineHeaders(FILE* outfile) {
   }
 }
 
-std::string genMakefileEnvCache(void);
-std::string genMakefileEnvCache(void) {
+static std::string genMakefileEnvCache() {
   std::string result;
   std::map<std::string, const char*>::iterator env;
 


### PR DESCRIPTION
Clean up a very small section of `compiler/util/files.cpp`, noticed while refactoring `CHPL_REGEXP` -> `CHPL_REGEX`.

Pass `varMap` by `const` reference to `runPrintChplEnv()`, to avoid making a deep copy of `varMap`
Use C++11 range-based-`for` with `auto` in `runPrintChplEnv()`, for simpler code
Remove redundant predeclaration of `genMakefileEnvCache(void)` and make it `static genMakefileEnvCache()`
Remove redundant `std::string()` cast
Fix typo (`appending` -> `prepending`)
Use default initialization of `std::string` instead of with `""` (slightly faster)
