### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -743,6 +743,8 @@ distCreate-arrays-deinit.cc-perf: &distCreate-base
     - Address performance issues with stencil and block-cyclic array init (#15741)
   03/23/21:
     - A few communication micro-optimizations to improve Block array creation (#17354)
+  04/07/21:
+    - Revert a recent change in block array creation that caused performance regression (#17531)
 
 distCreate-arrays-init.cc-perf:
   <<: *distCreate-base
@@ -2126,7 +2128,9 @@ arkouda: &arkouda-base
   02/19/21:
     - Skip long string partitioning in string argsort (mhmerrill/arkouda#681)
   03/25/21:
-    - fix groupby benchmark bug (mhmerrill/arkoud#712)
+    - fix groupby benchmark bug (mhmerrill/arkouda#712)
+  04/07/21:
+    - Increase the aggregation buffer sizes for non-ugni configurations (mhmerrill/arkouda#732)
 
 arkouda-string:
   <<: *arkouda-base

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2127,10 +2127,13 @@ arkouda: &arkouda-base
     - Increase the problem size for string benchmarks (mhmerrill/arkouda#676)
   02/19/21:
     - Skip long string partitioning in string argsort (mhmerrill/arkouda#681)
+  03/23/21:
+    - A few communication micro-optimizations to improve Block array creation (#17354)
   03/25/21:
     - fix groupby benchmark bug (mhmerrill/arkouda#712)
   04/07/21:
     - Increase the aggregation buffer sizes for non-ugni configurations (mhmerrill/arkouda#732)
+    - Revert a recent change in block array creation that caused performance regression (#17531)
 
 arkouda-string:
   <<: *arkouda-base


### PR DESCRIPTION
Adds annotations for:

- Reverting a regression in block array creation

Plot: https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2021/02/24&enddate=2021/04/08&graphs=creatingdistributedarrays
PR: https://github.com/chapel-lang/chapel/pull/17531

  (Also adds the regression and this one to Arkouda plots)

- Change in aggregation buffer sizes in Arkouda

Plot: https://chapel-lang.org/perf/arkouda/16-node-cs-hdr/?startdate=2021/03/03&enddate=2021/04/08&configs=release,nightly&graphs=all
PR: https://github.com/mhmerrill/arkouda/pull/732
