### PR TITLE
Change uses of `proc` to `operator` when defining operators in test

### DIFF
--- a/test/types/chplhashtable/Issue11613.chpl
+++ b/test/types/chplhashtable/Issue11613.chpl
@@ -2,10 +2,12 @@ record R {
 	type t;
 	var a : [1..10] t;
 }
-proc ==(a: R, b: R) {
+
+operator R.==(a: R, b: R) {
   return && reduce (a.a == b.a);
 }
-proc !=(a: R, b: R) {
+
+operator R.!=(a: R, b: R) {
   return || reduce (a.a != b.a);
 }
 


### PR DESCRIPTION
Change uses of 'proc' to 'operator' when defining operators in test (#17547)

The pull #17533 added a new test which defines the `==` operator on
a record. Change the syntax from `proc==` to `operator R.==`.

Tests in `test/types/chplhashtable` pass locally.

Change to test, trivial and not reviewed.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>