### PR TITLE
Source a system LLVM setup script from util/cron/common.bash

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -13,6 +13,12 @@ if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
     export CHPL_SOURCED_BASHRC=true
 fi
 
+if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+  source /data/cf/chapel/setup_system_llvm.bash
+elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+  source /cray/css/users/chapelu/setup_system_llvm.bash
+fi
+
 log_info "gcc version: $(which gcc)"
 gcc --version
 


### PR DESCRIPTION
Either /data/cf/chapel/ or /cray/css/users/chapelu are visible from all of our
testing systems and there are builds of LLVM in both locations. Source the
setup script to make LLVM visible to our test runs.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>