### PR TITLE
Fix a case where AtomicObject would call memcpy with overflowing size

### DIFF
--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -315,13 +315,16 @@ prototype module AtomicObjects {
     // faster compression method so we need to decompress it in the same way...
     var locId = descr >> compressedLocIdOffset;
     var addr = descr & compressedAddrMask;
-    if locId == here.id then return castToObj(objType, addr);
+    if _local || locId == here.id then return castToObj(objType, addr);
 
     // We've created the wide pointer, but unfortunately Chapel does not support
     // the ability to cast it to the actual object, so we have to do some
     // trickery to get it to work. What we do is we allocate a wide pointer on
     // the stack and memcpy our wideptr into the other. This is needed so we
     // have the same type.
+    //
+    // It would be better if we could write something like
+    //    return wideptr: objType?;
     var wideptr = chpl_return_wide_ptr_node(locId, uintToCVoidPtr(addr));
     var newObj : objType?;
     // Ensure that newObj is a wide pointer


### PR DESCRIPTION
AtomicObject has a 'decompress' routine that unpacks a packed pointer and
returns it. It uses memcpy to copy an untyped wide pointer into a typed
one. This memcpy is only actually run if the locale field differs, which
should not happen in single locale compilation

At the same time, a C compiler doing static analysis of this memcpy would
notice that, in a single locale compilation, it overflows the destination
(since in that event the destination is only 8 bytes but it's copying
16).

This commit just includes `_local` in the earlier condition to make the
memcpy not be emitted for single-locale builds.

- test/library/packages/{LockFreeStack,LockFreeQueue,EpochManager} passes with
  - [x] quickstart + system LLVM
  - [x] quickstart + gasnet + system LLVM
  - [x] default config + system LLVM
  - [x] default config + gasnet + system LLVM

Reviewed by @daviditen - thanks!