### PR TITLE
Adjust a leaky test to report leaks with cstdlib, too

### DIFF
--- a/test/memory/ferguson/test1.chpl
+++ b/test/memory/ferguson/test1.chpl
@@ -24,16 +24,6 @@ extern proc c_function_free(x:c_ptr(uint(64)));
   c_function_free(ptr);
 }
 
-// chapel allocate -> c free
-{
-  var ptr: c_ptr(uint(64));
-  writeln("Allocating in Chapel");
-  ptr = c_calloc(uint(64), 1);
-  ptr[0] = 55;
-  writeln("Freeing in C");
-  c_function_free(ptr);
-}
-
 // c malloc -> chapel free
 {
   var ptr: c_ptr(uint(64));
@@ -62,6 +52,20 @@ extern proc c_function_free(x:c_ptr(uint(64)));
   ptr[0] = 55;
   writeln("Freeing in Chapel");
   c_free(ptr);
+}
+
+// NOTE: this block needs to appear last, because we want to capture this
+// operation as leak. However, cstdlib allocators can interfere with our memory
+// allocators and tracking in a way that prevents that.
+// See: https://github.com/Cray/chapel-private/issues/1896
+// chapel allocate -> c free
+{
+  var ptr: c_ptr(uint(64));
+  writeln("Allocating in Chapel");
+  ptr = c_calloc(uint(64), 1);
+  ptr[0] = 55;
+  writeln("Freeing in C");
+  c_function_free(ptr);
 }
 
 

--- a/test/memory/ferguson/test1.good
+++ b/test/memory/ferguson/test1.good
@@ -6,10 +6,6 @@ exit c_function_malloc
 Freeing in C
 enter c_function_free
 exit c_function_free
-Allocating in Chapel
-Freeing in C
-enter c_function_free
-exit c_function_free
 Allocating with malloc in C
 enter c_function_malloc
 exit c_function_malloc
@@ -22,11 +18,15 @@ Allocating with strdup in C
 enter c_function_strdup
 exit c_function_strdup
 Freeing in Chapel
+Allocating in Chapel
+Freeing in C
+enter c_function_free
+exit c_function_free
 DONE
 
 ================================================= Memory Leaks ==================================================
 Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
 =================================================================================================================
-test1.chpl:31                    1        8        8        array elements                   prediffed  
+test1.chpl:65                    1        8        8        array elements                   prediffed  
 =================================================================================================================
 


### PR DESCRIPTION
This PR adjusts the test that's supposed to report leaks, so
that it can do that with cstdlib.

Before, it used to bump into an unexpected oddity where the entries
from the memtracking table could be removed through unrelated deallocations.

This PR adjusts the test so that the deallocation that's supposed to cause leak
reports happens the last.