### PR TITLE
Extend fix for initializer bug with operator methods to also fix the cast operator

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2098,7 +2098,7 @@ bool isAstrOpName(const char* name) {
       strcmp(name, "|=") == 0 || strcmp(name, "^=") == 0 ||
       strcmp(name, ">>=") == 0 || strcmp(name, "<<=") == 0 ||
       strcmp(name, "#") == 0 || strcmp(name, "by") == 0 ||
-      strcmp(name, "align") == 0) {
+      strcmp(name, "align") == 0 || name == astrScolon) {
     return true;
   } else {
     return false;

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -733,7 +733,7 @@ module Map {
   }
 
   pragma "no doc"
-  operator :(x: map(?k1, ?v1, ?p1), type t: map(?k2, ?v2, ?p2)) {
+  operator map.:(x: map(?k1, ?v1, ?p1), type t: map(?k2, ?v2, ?p2)) {
     // TODO: Allow coercion between element types? If we do then init=
     // should also be changed accordingly.
     if k1 != k2 then

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -798,7 +798,7 @@ module Set {
   }
 
   pragma "no doc"
-  operator :(x: set(?et1, ?p1), type t: set(?et2, ?p2)) {
+  operator set.:(x: set(?et1, ?p1), type t: set(?et2, ?p2)) {
     // TODO: Allow coercion between element types? If we do then init=
     // should also be changed accordingly.
     if et1 != et2 then


### PR DESCRIPTION
The cast operator hadn't been added to the list of operator names that calls were
checked against to determine if we should transform the call into a method call.
This meant that if an initializer was defined on a type that defined the cast operator as
a method and that initializer happened to contain a cast in its body before a
`this.complete()` call, the cast call would get transformed into a method call and
trigger the warning about not calling methods before the instance is fully initialized.
This simple change rectifies that error.

This enables map and set to define the cast operator as an operator method (which
I do as part of this PR).

Passed a full paratest with futures