### PR TITLE
Improve error message emitted when moveInitialize() would copy

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1812,14 +1812,19 @@ static void checkForErroneousInitCopies() {
 
     forv_Vec(CallExpr, call, *fn->calledBy) {
       if (SymExpr* actual = getActualBeforeCopyInit(call, formal)) {
+        SymExpr* nextUse = nullptr;
 
-        // TODO: Tweak output if it prints something like 'with <temp>'.
-        // Not sure if that can ever happen, thanks to copy elision, but
-        // leave this comment just in case.
-        USR_FATAL_CONT(call, "calling '%s' with actual '%s' would result "
-                             "in a copy",
-                             fn->name,
-                             toString(actual->symbol(), false));
+        if (nextUse) {
+          USR_FATAL_CONT(call, "cannot call '%s' because this is not the "
+                               "last use of '%s'",
+                               fn->name,
+                               toString(actual->symbol(), false));
+        } else {
+          USR_FATAL_CONT(call, "cannot call '%s' because '%s' might be "
+                               "used elsewhere",
+                               fn->name,
+                               toString(actual->symbol(), false));
+        }
       }
     }
   }

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.chpl
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.chpl
@@ -6,7 +6,10 @@ proc test1() {
   var r1: r;
   var r2 = new r();
   moveInitialize(r1, r2);
-  writeln(r2);
+
+  {
+    writeln(r2);
+  }
 }
 test1();
 

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.chpl
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.chpl
@@ -13,3 +13,17 @@ proc test1() {
 }
 test1();
 
+proc test2() {
+  pragma "no init"
+  var r1: r;
+  param flag = false;
+  var r2 = new r();
+
+  if flag {
+    writeln(r2);
+  } else {
+    moveInitialize(r1, r2);
+  }
+}
+test2();
+

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
@@ -1,2 +1,3 @@
 MoveInitializeCopyError.chpl:4: In function 'test1':
-MoveInitializeCopyError.chpl:8: error: cannot call 'moveInitialize' because 'r2' might be used elsewhere
+MoveInitializeCopyError.chpl:8: error: cannot call 'moveInitialize' because this is not the last use of 'r2'
+MoveInitializeCopyError.chpl:11: note: next use of 'r2' is here

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
@@ -1,3 +1,5 @@
 MoveInitializeCopyError.chpl:4: In function 'test1':
 MoveInitializeCopyError.chpl:8: error: cannot call 'moveInitialize' because this is not the last use of 'r2'
 MoveInitializeCopyError.chpl:11: note: next use of 'r2' is here
+MoveInitializeCopyError.chpl:16: In function 'test2':
+MoveInitializeCopyError.chpl:25: error: cannot call 'moveInitialize' because 'r2' might be used elsewhere

--- a/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
+++ b/test/library/standard/Memory/Initialization/MoveInitializeCopyError.good
@@ -1,2 +1,2 @@
 MoveInitializeCopyError.chpl:4: In function 'test1':
-MoveInitializeCopyError.chpl:8: error: calling 'moveInitialize' with actual 'r2' would result in a copy
+MoveInitializeCopyError.chpl:8: error: cannot call 'moveInitialize' because 'r2' might be used elsewhere


### PR DESCRIPTION
Improve error message emitted when moveInitialize() would copy (#17566)

This PR adjusts the error message that is emitted when the actual for
a formal marked with `pragma "error on copy"` would be copied. This
pragma is used to implement move semantics for the `moveInitialize()`
function.

Conservatively scroll forward and look for the next following use of
the problematic actual. If such a use is found, emit an error saying
so along with a note mentioning the use. If no such use could be
found (and the actual was not copy-elided for other reasons, such as
appearing in only one branch of a conditional), use a more obscure
error message.

TESTING:

- [x] `ALL` on `linux64` when `COMM=none`

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>
