### PR TITLE
Enable automatic local access optimization for local arrays

### DIFF
--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -23,6 +23,7 @@
 #include "astutil.h"
 #include "build.h"
 #include "ForallStmt.h"
+#include "LoopExpr.h"
 #include "LoopStmt.h"
 #include "passes.h"
 #include "preFold.h"
@@ -79,7 +80,7 @@ static Symbol *getDotDomBaseSym(Expr *expr);
 static Expr *getDomExprFromTypeExprOrQuery(Expr *e);
 static Symbol *getDomSym(Symbol *arrSym);
 static Symbol *getDomSymFromDomExpr(Expr *domExpr, bool allowQuery);
-static Stmt *getLocalityDominator(CallExpr* ce);
+static Expr *getLocalityDominator(CallExpr* ce);
 static bool isSubIndexAssignment(Expr *expr,
                                  Symbol *subIndex,
                                  int indexIndex,
@@ -736,7 +737,7 @@ static Symbol *getDomSym(Symbol *arrSym) {
 }
 
 // Return the closest parent of `ce` that can impact locality (forall or on)
-static Stmt *getLocalityDominator(CallExpr* ce) {
+static Expr *getLocalityDominator(CallExpr* ce) {
   Expr *cur = ce->parentExpr;
   while (cur != NULL) {
     if (BlockStmt *block = toBlockStmt(cur)) {
@@ -744,6 +745,13 @@ static Stmt *getLocalityDominator(CallExpr* ce) {
         return block;
       }
     }
+    
+    if (LoopExpr *loop = toLoopExpr(cur)) {
+      if (loop->forall) {
+        return loop;
+      }
+    }
+
     if (ForallStmt *forall = toForallStmt(cur)) {
       return forall;
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3368,7 +3368,7 @@ module ChapelArray {
     }
 
     proc chpl_isNonDistributedArray() param {
-     return domainDistIsLayout(_getDomain(_value.dom));
+      return domainDistIsLayout(_getDomain(chpl__getActualArray(_value).dom));
     }
 
   }  // record _array

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2740,10 +2740,13 @@ module ChapelArray {
       if boundsChecking then
         checkAccess(i, value=value);
 
-      if isRectangularArr(this) || isSparseArr(this) then
-        return value.dsiLocalAccess(i);
+      if chpl_isNonDistributedArray() then
+        return this(i);
       else
-        return value.dsiLocalAccess(i(0));
+        if isRectangularArr(this) || isSparseArr(this) then
+          return value.dsiLocalAccess(i);
+        else
+          return value.dsiLocalAccess(i(0));
     }
     pragma "no doc" // value version, for POD types
     pragma "alias scope from this"
@@ -2754,10 +2757,13 @@ module ChapelArray {
       if boundsChecking then
         checkAccess(i, value=value);
 
-      if isRectangularArr(this) || isSparseArr(this) then
-        return value.dsiLocalAccess(i);
+      if chpl_isNonDistributedArray() then
+        return this(i);
       else
-        return value.dsiLocalAccess(i(0));
+        if isRectangularArr(this) || isSparseArr(this) then
+          return value.dsiLocalAccess(i);
+        else
+          return value.dsiLocalAccess(i(0));
     }
     pragma "no doc" // const ref version, for not-POD types
     pragma "alias scope from this"
@@ -2768,10 +2774,13 @@ module ChapelArray {
       if boundsChecking then
         checkAccess(i, value=value);
 
-      if isRectangularArr(this) || isSparseArr(this) then
-        return value.dsiLocalAccess(i);
+      if chpl_isNonDistributedArray() then
+        return this(i);
       else
-        return value.dsiLocalAccess(i(0));
+        if isRectangularArr(this) || isSparseArr(this) then
+          return value.dsiLocalAccess(i);
+        else
+          return value.dsiLocalAccess(i(0));
     }
 
     pragma "no doc" // ref version
@@ -3356,6 +3365,10 @@ module ChapelArray {
 
     proc iteratorYieldsLocalElements() param {
       return _value.dsiIteratorYieldsLocalElements();
+    }
+
+    proc chpl_isNonDistributedArray() param {
+     return domainDistIsLayout(_getDomain(_value.dom));
     }
 
   }  // record _array

--- a/modules/internal/ChapelAutoLocalAccess.chpl
+++ b/modules/internal/ChapelAutoLocalAccess.chpl
@@ -99,6 +99,16 @@ module ChapelAutoLocalAccess {
   }
 
   proc chpl__isArrayViewWithDifferentDist(arr: []) param {
-    return chpl__getActualArray(arr._value).dom.type != arr.domain._value.type;
+    // Slices can have different distributions than the original array which can
+    // cause false optimizations
+    if arr._value.isSliceArrayView() {
+      return chpl__getActualArray(arr._value).dom.type != arr.domain._value.type;
+    }
+    else {
+      // Non-slice views have different domain types, but they do not impact how
+      // the values are distributed. So, they are safer from ALA standpoint
+      return false;
+    }
+
   }
 }

--- a/modules/internal/ChapelAutoLocalAccess.chpl
+++ b/modules/internal/ChapelAutoLocalAccess.chpl
@@ -26,7 +26,12 @@ module ChapelAutoLocalAccess {
   // forall's and we don't want to mess up the iterator
   proc chpl__staticAutoLocalCheck(accessBase: [], loopDomain: domain) param {
     if accessBase.domain.type == loopDomain.type {
-      return loopDomain.supportsAutoLocalAccess();
+      if chpl__isArrayViewWithDifferentDist(accessBase) {
+        return false;
+      }
+      else {
+        return loopDomain.supportsAutoLocalAccess();
+      }
     }
 
     // support forall i in a.domain.localSubdomain() do .... a[i] ....
@@ -91,5 +96,9 @@ module ChapelAutoLocalAccess {
   }
   proc chpl__dynamicAutoLocalCheck(type accessBase, loopDomain) {
     return false;
+  }
+
+  proc chpl__isArrayViewWithDifferentDist(arr: []) param {
+    return chpl__getActualArray(arr._value).dom.type != arr.domain._value.type;
   }
 }

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -32,6 +32,8 @@ module DefaultAssociative {
   config param debugDefaultAssoc = false;
   config param debugAssocDataPar = false;
 
+  config param defaultAssociativeSupportsAutoLocalAccess = true;
+
   // helps to move around array elements when rehashing the domain
   class DefaultAssociativeDomRehashHelper : chpl__rehashHelpers {
     var dom: unmanaged DefaultAssociativeDom;
@@ -438,6 +440,9 @@ module DefaultAssociative {
       }
     }
 
+    override proc dsiSupportsAutoLocalAccess() param {
+      return defaultAssociativeSupportsAutoLocalAccess;
+    }
   }
 
   class DefaultAssociativeArr: AbsBaseArr {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -52,7 +52,7 @@ module DefaultRectangular {
   config param earlyShiftData = true;
   config param usePollyArrayIndex = false;
 
-  config param defaultRectangularSupportsAutoLocalAccess = false;
+  config param defaultRectangularSupportsAutoLocalAccess = true;
 
   enum ArrayStorageOrder { RMO, CMO }
   config param defaultStorageOrder = ArrayStorageOrder.RMO;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1341,17 +1341,6 @@ module DefaultRectangular {
     }
 
 
-    inline proc dsiLocalAccess(i) ref
-      return dsiAccess(i);
-
-    inline proc dsiLocalAccess(i)
-    where shouldReturnRvalueByValue(eltType)
-      return dsiAccess(i);
-
-    inline proc dsiLocalAccess(i) const ref
-    where shouldReturnRvalueByConstRef(eltType)
-      return dsiAccess(i);
-
     inline proc dsiBoundsCheck(i) {
       return dom.dsiMember(i);
     }

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -439,11 +439,6 @@ module DefaultSparse {
       else // ?fromMMS: is this error message correct? Not actually looking at value.
         halt("attempting to assign a 'zero' value in a sparse array: ", ind);
     }
-
-    inline proc dsiLocalAccess(ind: idxType) ref where rank == 1 {
-      return dsiAccess(ind);
-    }
-
     // value version
     proc dsiAccess(ind: idxType) const ref where rank == 1 {
       // make sure we're in the dense bounding box
@@ -459,9 +454,6 @@ module DefaultSparse {
         return irv;
     }
 
-    inline proc dsiLocalAccess(ind: idxType) const ref where rank == 1 {
-      return dsiAccess(ind);
-    }
 
     // ref version
     proc dsiAccess(ind: rank*idxType) ref {
@@ -477,11 +469,6 @@ module DefaultSparse {
       else
         halt("attempting to assign a 'zero' value in a sparse array: ", ind);
     }
-
-    inline proc dsiLocalAccess(ind: rank*idxType) ref {
-      return dsiAccess(ind);
-    }
-
     // value version for POD types
     proc dsiAccess(ind: rank*idxType)
     where shouldReturnRvalueByValue(eltType) {
@@ -497,12 +484,6 @@ module DefaultSparse {
       else
         return irv;
     }
-
-    inline proc dsiLocalAccess(ind: rank*idxType)
-    where shouldReturnRvalueByValue(eltType) {
-      return dsiAccess(ind);
-    }
-
     // const ref version for types with copy ctors
     proc dsiAccess(ind: rank*idxType) const ref
     where shouldReturnRvalueByConstRef(eltType) {
@@ -517,11 +498,6 @@ module DefaultSparse {
         return data(loc);
       else
         return irv;
-    }
-
-    inline proc dsiAccess(ind: rank*idxType) const ref
-    where shouldReturnRvalueByConstRef(eltType) {
-      return dsiAccess(ind);
     }
 
     pragma "order independent yielding loops"

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -24,6 +24,9 @@ pragma "no doc"
 /* Debug flag */
 config param debugCS = false;
 
+pragma "no doc"
+config param csLayoutSupportsAutoLocalAccess = true;
+
 /* Default sparse dimension index sorting mode for LayoutCS.
 Sparse dimension indices will default to sorted order if true, inserted order if false */
 config param LayoutCSDefaultToSorted = true;
@@ -638,6 +641,10 @@ class CSDom: BaseSparseDomImpl {
       }
     }
     f <~> "}\n";
+  }
+
+  override proc dsiSupportsAutoLocalAccess() param {
+    return csLayoutSupportsAutoLocalAccess;
   }
 
 } // CSDom

--- a/test/arrays/localQueries/localAccess.chpl
+++ b/test/arrays/localQueries/localAccess.chpl
@@ -1,0 +1,51 @@
+var baseDom = {1..10};
+
+{
+  test(baseDom);
+}
+
+{
+  var cooDom: sparse subdomain(baseDom);
+  cooDom += [3,4,5];
+  test(cooDom);
+}
+
+{
+  use LayoutCS;
+
+  var dom2D = {1..10, 1..10};
+
+  var csrDom: sparse subdomain(dom2D) dmapped CS(compressRows=true);
+  csrDom += [(3,3),(4,4),(5,5)];
+  test(csrDom);
+
+  var cscDom: sparse subdomain(dom2D) dmapped CS(compressRows=false);
+  cscDom += [(3,3),(4,4),(5,5)];
+  test(cscDom);
+}
+
+{
+  var assocDom: domain(string);
+  assocDom += ["foo", "bar"];
+  test(assocDom);
+}
+
+
+proc test(dom: domain) {
+  var arr: [dom] int;
+
+  for i in dom {
+    arr.localAccess[i] = idxToInt(i);
+  }
+
+  for i in dom {
+    writeln("index = ", i, " arr.localAccess[i] = ", arr.localAccess[i]);
+  }
+  writeln();
+
+  inline proc idxToInt(i) {
+    if isTuple(i) then return i[0];
+    else if i.type == string then return i.byte(0):int;
+    else return i;
+  }
+}

--- a/test/arrays/localQueries/localAccess.good
+++ b/test/arrays/localQueries/localAccess.good
@@ -1,0 +1,26 @@
+index = 1 arr.localAccess[i] = 1
+index = 2 arr.localAccess[i] = 2
+index = 3 arr.localAccess[i] = 3
+index = 4 arr.localAccess[i] = 4
+index = 5 arr.localAccess[i] = 5
+index = 6 arr.localAccess[i] = 6
+index = 7 arr.localAccess[i] = 7
+index = 8 arr.localAccess[i] = 8
+index = 9 arr.localAccess[i] = 9
+index = 10 arr.localAccess[i] = 10
+
+index = 3 arr.localAccess[i] = 3
+index = 4 arr.localAccess[i] = 4
+index = 5 arr.localAccess[i] = 5
+
+index = (3, 3) arr.localAccess[i] = 3
+index = (4, 4) arr.localAccess[i] = 4
+index = (5, 5) arr.localAccess[i] = 5
+
+index = (3, 3) arr.localAccess[i] = 3
+index = (4, 4) arr.localAccess[i] = 4
+index = (5, 5) arr.localAccess[i] = 5
+
+index = foo arr.localAccess[i] = 102
+index = bar arr.localAccess[i] = 98
+

--- a/test/optimizations/autoAggregation/localArrays.chpl
+++ b/test/optimizations/autoAggregation/localArrays.chpl
@@ -1,0 +1,62 @@
+use LayoutCS;
+
+var baseDom1D = {1..10};
+var baseDom2D = {1..10, 1..10};
+
+{ // DR
+  test(baseDom1D, "1D DR");
+  test(baseDom2D, "2D DR");
+}
+
+{
+  var cooDom: sparse subdomain(baseDom1D);
+  cooDom += [1,2];
+  test(cooDom, "1D COO");
+}
+
+{
+  var cooDom: sparse subdomain(baseDom2D);
+  cooDom += [(1,1),(2,2)];
+  test(cooDom, "2D COO");
+}
+
+{
+  var csrDom: sparse subdomain(baseDom2D) dmapped CS();
+  csrDom += [(1,1),(2,2)];
+  test(csrDom, "CSR");
+}
+
+{
+  var cscDom: sparse subdomain(baseDom2D) dmapped CS(compressRows=false);
+  cscDom += [(1,1),(2,2)];
+  test(cscDom, "CSC");
+}
+
+{
+  var assocDom: domain(string);
+  assocDom += ["foo", "bar"];
+  test(assocDom, "associative domain with string keys");
+}
+
+proc test(dom:domain, name) {
+  use CyclicDist;
+
+  writeln("Testing ", name);
+
+  var destArr: [dom] int;
+  var sourceArr: [dom] int;
+
+
+  forall i in dom {
+    destArr[i] = sourceArr[generateIdx(i)]; // RHS will be seen as non-local
+  }
+
+  writeln(destArr);
+
+  writeln("End testing ", name);
+  writeln();
+
+  inline proc generateIdx(i) {
+    return i;
+  }
+}

--- a/test/optimizations/autoAggregation/localArrays.good
+++ b/test/optimizations/autoAggregation/localArrays.good
@@ -1,0 +1,80 @@
+Start analyzing forall for automatic aggregation [static only ALA clone]  (localArrays.chpl:50)
+| Found an aggregation candidate (localArrays.chpl:51)
+|  Potential source aggregation (localArrays.chpl:51)
+End analyzing forall for automatic aggregation [static only ALA clone]  (localArrays.chpl:50)
+
+Start analyzing forall for automatic aggregation [no ALA clone]  (localArrays.chpl:50)
+End analyzing forall for automatic aggregation [no ALA clone]  (localArrays.chpl:50)
+
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Aggregation candidate has confirmed local child [static only ALA clone] (localArrays.chpl:51)
+LHS is local, RHS is nonlocal. Will use source aggregation [static only ALA clone] (localArrays.chpl:51)
+Replaced assignment with aggregation [static only ALA clone]  (localArrays.chpl:51)
+Replaced assignment with aggregation [static only ALA clone]  (localArrays.chpl:51)
+Replaced assignment with aggregation [static only ALA clone]  (localArrays.chpl:51)
+Testing 1D DR
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+0 0 0 0 0 0 0 0 0 0
+End testing 1D DR
+
+Testing 2D DR
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+End testing 2D DR
+
+Testing 1D COO
+SrcAggregator.copy is called
+SrcAggregator.copy is called
+0 0
+End testing 1D COO
+
+Testing 2D COO
+0
+0
+
+End testing 2D COO
+
+Testing CSR
+0
+0
+
+End testing CSR
+
+Testing CSC
+0
+0
+
+End testing CSC
+
+Testing associative domain with string keys
+0 0
+End testing associative domain with string keys
+

--- a/test/optimizations/autoLocalAccess/differentDistView.chpl
+++ b/test/optimizations/autoLocalAccess/differentDistView.chpl
@@ -1,0 +1,11 @@
+use BlockDist;
+
+var arr = newBlockArr(1..10, int);
+
+ref localSlice = arr[{3..8}];
+
+forall i in localSlice.domain {
+  localSlice[i] = i;
+}
+
+writeln(arr);

--- a/test/optimizations/autoLocalAccess/differentDistView.good
+++ b/test/optimizations/autoLocalAccess/differentDistView.good
@@ -1,13 +1,13 @@
 
-Start analyzing forall (differntDistView.chpl:7)
-| Found loop domain (differntDistView.chpl:5)
-| Will attempt static and dynamic optimizations (differntDistView.chpl:7)
+Start analyzing forall (differentDistView.chpl:7)
+| Found loop domain (differentDistView.chpl:5)
+| Will attempt static and dynamic optimizations (differentDistView.chpl:7)
 |
-|  Start analyzing call (differntDistView.chpl:8)
-|   Can optimize: Access base is the iterator's base (differntDistView.chpl:8)
-|  This call is a static optimization candidate (differntDistView.chpl:8)
+|  Start analyzing call (differentDistView.chpl:8)
+|   Can optimize: Access base is the iterator's base (differentDistView.chpl:8)
+|  This call is a static optimization candidate (differentDistView.chpl:8)
 |
-End analyzing forall (differntDistView.chpl:7)
+End analyzing forall (differentDistView.chpl:7)
 
-Local access attempt reverted. All static checks failed or code is unreachable.(differntDistView.chpl:8)
+Local access attempt reverted. All static checks failed or code is unreachable.(differentDistView.chpl:8)
 0 0 3 4 5 6 7 8 0 0

--- a/test/optimizations/autoLocalAccess/differentDistView.good
+++ b/test/optimizations/autoLocalAccess/differentDistView.good
@@ -1,0 +1,13 @@
+
+Start analyzing forall (differntDistView.chpl:7)
+| Found loop domain (differntDistView.chpl:5)
+| Will attempt static and dynamic optimizations (differntDistView.chpl:7)
+|
+|  Start analyzing call (differntDistView.chpl:8)
+|   Can optimize: Access base is the iterator's base (differntDistView.chpl:8)
+|  This call is a static optimization candidate (differntDistView.chpl:8)
+|
+End analyzing forall (differntDistView.chpl:7)
+
+Local access attempt reverted. All static checks failed or code is unreachable.(differntDistView.chpl:8)
+0 0 3 4 5 6 7 8 0 0

--- a/test/optimizations/autoLocalAccess/interveningForallExpr.chpl
+++ b/test/optimizations/autoLocalAccess/interveningForallExpr.chpl
@@ -1,0 +1,14 @@
+use BlockDist;
+use CyclicDist;
+
+var blockArr = newBlockArr(1..10, int);
+var cyclicDom = newCyclicDom(1..10);
+
+var sums: [1..10] int;
+
+forall blockIdx in blockArr.domain {
+  var dummy = [cyclicIdx in cyclicDom] 2*blockArr[blockIdx];
+  sums[blockIdx] = + reduce dummy;
+}
+
+writeln(sums);

--- a/test/optimizations/autoLocalAccess/interveningForallExpr.good
+++ b/test/optimizations/autoLocalAccess/interveningForallExpr.good
@@ -1,0 +1,15 @@
+
+Start analyzing forall (interveningForallExpr.chpl:9)
+| Found loop domain (interveningForallExpr.chpl:4)
+| Will attempt static and dynamic optimizations (interveningForallExpr.chpl:9)
+|
+|  Start analyzing call (interveningForallExpr.chpl:10)
+|   Cannot optimize: call base is in a nested on and/or forall (interveningForallExpr.chpl:10)
+|  Start analyzing call (interveningForallExpr.chpl:11)
+|   Can't determine the domain of access base (interveningForallExpr.chpl:7)
+|  This call is a dynamic optimization candidate (interveningForallExpr.chpl:11)
+|
+End analyzing forall (interveningForallExpr.chpl:9)
+
+Local access attempt reverted. All static checks failed or code is unreachable.(interveningForallExpr.chpl:11)
+0 0 0 0 0 0 0 0 0 0

--- a/test/optimizations/autoLocalAccess/localArrays.chpl
+++ b/test/optimizations/autoLocalAccess/localArrays.chpl
@@ -1,0 +1,107 @@
+use LayoutCS;
+
+var thisCalls: atomic int;
+var localAccessCalls: atomic int;
+
+var baseDom1D = {1..10};
+var baseDom2D = {1..10, 1..10};
+
+{ // DR
+  test(baseDom1D, "1D DR");
+  test(baseDom2D, "2D DR");
+}
+
+{
+  var cooDom: sparse subdomain(baseDom1D);
+  cooDom += [1,2];
+  test(cooDom, "1D COO");
+}
+
+{
+  var cooDom: sparse subdomain(baseDom2D);
+  cooDom += [(1,1),(2,2)];
+  test(cooDom, "2D COO");
+}
+
+{
+  var csrDom: sparse subdomain(baseDom2D) dmapped CS();
+  csrDom += [(1,1),(2,2)];
+  test(csrDom, "CSR");
+}
+
+{
+  var cscDom: sparse subdomain(baseDom2D) dmapped CS(compressRows=false);
+  cscDom += [(1,1),(2,2)];
+  test(cscDom, "CSC");
+}
+
+{
+  var assocDom: domain(string);
+  assocDom += ["foo", "bar"];
+  test(assocDom, "associative domain with string keys");
+}
+
+// hijack these methods to provide some output
+inline proc _array.this(i: string) ref {
+  thisCalls.add(1);
+  return this._value.dsiAccess(i);
+}
+
+inline proc _array.localAccess(i: string) ref {
+  localAccessCalls.add(1);
+  return this._value.dsiAccess(i);
+}
+
+inline proc _array.this(i: int) ref {
+  thisCalls.add(1);
+  return this._value.dsiAccess((i:int,));
+}
+
+inline proc _array.this(i: 2*int) ref {
+  thisCalls.add(1);
+  return this._value.dsiAccess(i);
+}
+
+inline proc _array.localAccess(i: int) ref {
+  localAccessCalls.add(1);
+  return this._value.dsiAccess((i:int,));
+}
+
+inline proc _array.localAccess(i: 2*int) ref {
+  localAccessCalls.add(1);
+  return this._value.dsiAccess(i);
+}
+
+proc resetCounters() {
+  thisCalls.write(0);
+  localAccessCalls.write(0);
+}
+
+proc printCounters() {
+  writeln("Calls to `this`: ", thisCalls.read());
+  writeln("Calls to `localAccess`: ", localAccessCalls.read());
+}
+
+proc test(dom:domain, name) {
+  writeln("Testing ", name);
+
+  var arr: [dom] int;
+
+  forall i in dom {
+    arr[i] = idxToInt(i);
+  }
+
+  writeln(arr);
+
+  printCounters();
+  resetCounters();
+
+  writeln("End testing ", name);
+  writeln();
+
+  inline proc idxToInt(i) {
+    if isTuple(i) then return i[0];
+    else if i.type == string then return i.byte(0):int;
+    else return i;
+  }
+}

--- a/test/optimizations/autoLocalAccess/localArrays.chpl
+++ b/test/optimizations/autoLocalAccess/localArrays.chpl
@@ -1,3 +1,9 @@
+// Some of the cases in this test aren't optimized as expected. Creating futures
+// are somewhat difficult for auto aggregation tests, so I am keeping this as a
+// regular test for now.
+// 
+// See: https://github.com/Cray/chapel-private/issues/1897
+
 use LayoutCS;
 
 var thisCalls: atomic int;

--- a/test/optimizations/autoLocalAccess/localArrays.good
+++ b/test/optimizations/autoLocalAccess/localArrays.good
@@ -1,0 +1,76 @@
+
+Start analyzing forall (localArrays.chpl:90)
+| Found loop domain (localArrays.chpl:85)
+| Will attempt static and dynamic optimizations (localArrays.chpl:90)
+|
+|  Start analyzing call (localArrays.chpl:91)
+|   Found the domain of the access base (localArrays.chpl:85)
+|   Can optimize: Access base's domain is the iterator (localArrays.chpl:91)
+|  This call is a static optimization candidate (localArrays.chpl:91)
+|
+End analyzing forall (localArrays.chpl:90)
+
+Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:91)
+Testing 1D DR
+1 2 3 4 5 6 7 8 9 10
+Calls to `this`: 0
+Calls to `localAccess`: 10
+End testing 1D DR
+
+Testing 2D DR
+1 1 1 1 1 1 1 1 1 1
+2 2 2 2 2 2 2 2 2 2
+3 3 3 3 3 3 3 3 3 3
+4 4 4 4 4 4 4 4 4 4
+5 5 5 5 5 5 5 5 5 5
+6 6 6 6 6 6 6 6 6 6
+7 7 7 7 7 7 7 7 7 7
+8 8 8 8 8 8 8 8 8 8
+9 9 9 9 9 9 9 9 9 9
+10 10 10 10 10 10 10 10 10 10
+Calls to `this`: 0
+Calls to `localAccess`: 100
+End testing 2D DR
+
+Testing 1D COO
+1 2
+Calls to `this`: 0
+Calls to `localAccess`: 2
+End testing 1D COO
+
+Testing 2D COO
+1
+2
+
+Calls to `this`: 0
+Calls to `localAccess`: 2
+End testing 2D COO
+
+Testing CSR
+1
+2
+
+Calls to `this`: 0
+Calls to `localAccess`: 2
+End testing CSR
+
+Testing CSC
+1
+2
+
+Calls to `this`: 0
+Calls to `localAccess`: 2
+End testing CSC
+
+Testing associative domain with string keys
+102 98
+Calls to `this`: 0
+Calls to `localAccess`: 2
+End testing associative domain with string keys
+

--- a/test/optimizations/autoLocalAccess/localArrays.good
+++ b/test/optimizations/autoLocalAccess/localArrays.good
@@ -1,22 +1,22 @@
 
-Start analyzing forall (localArrays.chpl:90)
-| Found loop domain (localArrays.chpl:85)
-| Will attempt static and dynamic optimizations (localArrays.chpl:90)
+Start analyzing forall (localArrays.chpl:96)
+| Found loop domain (localArrays.chpl:91)
+| Will attempt static and dynamic optimizations (localArrays.chpl:96)
 |
-|  Start analyzing call (localArrays.chpl:91)
-|   Found the domain of the access base (localArrays.chpl:85)
-|   Can optimize: Access base's domain is the iterator (localArrays.chpl:91)
-|  This call is a static optimization candidate (localArrays.chpl:91)
+|  Start analyzing call (localArrays.chpl:97)
+|   Found the domain of the access base (localArrays.chpl:91)
+|   Can optimize: Access base's domain is the iterator (localArrays.chpl:97)
+|  This call is a static optimization candidate (localArrays.chpl:97)
 |
-End analyzing forall (localArrays.chpl:90)
+End analyzing forall (localArrays.chpl:96)
 
-Static check successful. Using localAccess (localArrays.chpl:91)
-Static check successful. Using localAccess (localArrays.chpl:91)
-Static check successful. Using localAccess (localArrays.chpl:91)
-Static check successful. Using localAccess (localArrays.chpl:91)
-Static check successful. Using localAccess (localArrays.chpl:91)
-Static check successful. Using localAccess (localArrays.chpl:91)
-Static check successful. Using localAccess (localArrays.chpl:91)
+Static check successful. Using localAccess (localArrays.chpl:97)
+Static check successful. Using localAccess (localArrays.chpl:97)
+Static check successful. Using localAccess (localArrays.chpl:97)
+Static check successful. Using localAccess (localArrays.chpl:97)
+Static check successful. Using localAccess (localArrays.chpl:97)
+Static check successful. Using localAccess (localArrays.chpl:97)
+Static check successful. Using localAccess (localArrays.chpl:97)
 Testing 1D DR
 1 2 3 4 5 6 7 8 9 10
 Calls to `this`: 0

--- a/test/parallel/forall/checks/const-indices-blc.good
+++ b/test/parallel/forall/checks/const-indices-blc.good
@@ -1,2 +1,3 @@
 const-indices-blc.chpl:5: error: cannot assign to const variable
 const-indices-blc.chpl:11: error: cannot assign to const variable
+const-indices-blc.chpl:11: error: cannot assign to const variable


### PR DESCRIPTION
This PR enables local arrays/domain to be subjected to automatic local access
optimization. The cases where the compiler uses `localAccess` does not impact
performance of the access itself, however, it signals automatic aggregation the
locality of the access.

#### Summary of changes:

- Turn `defaultRectangularSupportsAutoLocalAccess` to `true`-by-default

- Add similar flags and `dsiSupportsAutoLocalAccess` to `DefaultSparse`,
  `LayoutCS` and `DefaultAssociative`

- Add a check in `_array.localAccess` to call `this` for non-distributed arrays

  (This way we can avoid adding `dsiLocalAccess` to local array implementations,
   credit goes to @bradcray for the idea)

- Remove `dsiLocalAccess` implementations from `DefaultRectangularArr`

- Fix a bug with intervening forall expressions

  This PR increased the coverage of the optimization and revealed a bug where an
  intervening forall expression was not recognized as such. Down the road this
  caused assertion errors.

- Update an unrelated test's good file

  Automatic local access clones foralls and if the original loop has an compiler
  error, this cloning leads to duplicate error messages to be printed out. For
  now, this PR accepts this change in a test. This is recorded in

    https://github.com/Cray/chapel-private/issues/1095

- Tighten the static checks for slices

  We don't want this optimization to fire for slices that has a different distribution
  than the original array.

#### Future work:

- Bug with the forall expressions also made me realize that the optimization
  does not cover forall expressions, at all. It could be easy to address, but I
  don't know for sure, yet.

    https://github.com/Cray/chapel-private/issues/1900

- Compiler error message adjustments

    https://github.com/Cray/chapel-private/issues/1095


#### Test:
- [x] standard
- [x] gasnet
