### PR TITLE
Avoid using the Chapel built installs of llvm on system llvm testing

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -13,10 +13,12 @@ if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
     export CHPL_SOURCED_BASHRC=true
 fi
 
-if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
-  source /data/cf/chapel/setup_system_llvm.bash
-elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
-  source /cray/css/users/chapelu/setup_system_llvm.bash
+if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
+  if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+    source /data/cf/chapel/setup_system_llvm.bash
+  elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cray/css/users/chapelu/setup_system_llvm.bash
+  fi
 fi
 
 log_info "gcc version: $(which gcc)"

--- a/util/cron/test-llvm.system.bash
+++ b/util/cron/test-llvm.system.bash
@@ -6,10 +6,16 @@
 # No paratest.
 
 CWD=$(cd $(dirname $0) ; pwd)
+
+# use the official system installed LLVM instead of the versions in
+# /data/cf/chapel/llvm or /cray/css/users/chapelu/llvm
+export OFFICIAL_SYSTEM_LLVM=T
+
 source $CWD/common.bash
 source $CWD/common-llvm.bash system
 source $CWD/common-localnode-paratest.bash
 
+unset OFFICIAL_SYSTEM_LLVM
 
 # common-llvm restricts us to extern/ferguson, but we want all the tests
 unset CHPL_NIGHTLY_TEST_DIRS


### PR DESCRIPTION
This test configuration has an official install of llvm on the system that it
is intended to test with. Avoid introducing our Chapel built versions in this
configuration.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>