### PR TITLE
Update these .good files to reflect location of ChapelIO

### DIFF
--- a/test/runtime/stacktrace/fact-linenum.good
+++ b/test/runtime/stacktrace/fact-linenum.good
@@ -1,7 +1,7 @@
 fact-linenum.chpl:2: error: halt reached
 Stacktrace
 
-halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:nnnn
+halt() at $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn
 fact() at fact-linenum.chpl:2
 fact() at fact-linenum.chpl:3
 fact() at fact-linenum.chpl:3

--- a/test/runtime/stacktrace/fact-stacktrace.good
+++ b/test/runtime/stacktrace/fact-stacktrace.good
@@ -1,7 +1,7 @@
 fact-stacktrace.chpl:2: error: halt reached
 Stacktrace
 
-halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:nnnn
+halt() at $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn
 fact() at fact-stacktrace.chpl:1
 fact() at fact-stacktrace.chpl:1
 fact() at fact-stacktrace.chpl:1

--- a/test/runtime/stacktrace/stacktrace.good
+++ b/test/runtime/stacktrace/stacktrace.good
@@ -1,7 +1,7 @@
 stacktrace.chpl:2: error: halt reached
 Stacktrace
 
-halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:nnnn
+halt() at $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn
 a() at stacktrace.chpl:1
 b() at stacktrace.chpl:5
 c() at stacktrace.chpl:9


### PR DESCRIPTION
PR #16849 moved ChapelIO to modules/standard. Update the .good files for
the libunwind tests to reflect that.

Test change only - not reviewed.

Future Work:
 * CHPL_UNWIND=libunwind nightly testing #5017 