### PR TITLE
Make LLVM visible to XC whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -128,6 +128,15 @@ fi
 export CHPL_LAUNCHER=none
 export CHPL_COMM=none
 
+# Make LLVM available
+if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
+  if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+    source /data/cf/chapel/setup_system_llvm.bash
+  elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cray/css/users/chapelu/setup_system_llvm.bash
+  fi
+fi
+
 # Set some vars that nightly cares about.
 export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"


### PR DESCRIPTION
Add `source setup_system_llvm.bash` at the install location to
common-whitebox.bash.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>