### PR TITLE
Fix bug with isSubtype and equally generic child/parent types

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -73,6 +73,8 @@ bool       canInstantiate(Type* actualType, Type* formalType);
 
 Type*      getConcreteParentForGenericFormal(Type* actualType,
                                              Type* formalType);
+Type*      getMoreInstantiatedParentForGenericFormal(Type* actualType,
+                                                     Type* formalType);
 
 bool       isInstantiation(Type* sub, Type* super);
 

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -697,10 +697,17 @@ static Type* getBasicInstantiationType(Type* actualType, Symbol* actualSym,
       // we should instantiate the parent actual type
       if (allowCoercion && useType == NULL) {
         if (AggregateType* at = toAggregateType(canonicalActual)) {
-          if (at->instantiatedFrom                           != NULL  &&
-              canonicalFormal->symbol->hasFlag(FLAG_GENERIC) == true) {
-            if (Type* c = getConcreteParentForGenericFormal(at, canonicalFormal)) {
-              useType = c;
+          if (canonicalFormal->symbol->hasFlag(FLAG_GENERIC) == true) {
+            if (at->symbol->hasFlag(FLAG_GENERIC) == true) {
+              // The actual type is still somewhat generic, but may still be
+              // a subtype of the parent.
+              if (Type* c = getMoreInstantiatedParentForGenericFormal(at, canonicalFormal)) {
+                useType = c;
+              }
+            } else if (at->instantiatedFrom != NULL) {
+              if (Type* c = getConcreteParentForGenericFormal(at, canonicalFormal)) {
+                useType = c;
+              }
             }
           }
         }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -779,7 +779,6 @@ Type* getMoreInstantiatedParentForGenericFormal(Type* actualType,
     if (retval == NULL) {
       if (isClass(formalType)) {
         // Handle e.g. Owned(GenericClass) passed to a formal : GenericClass
-        // TODO: Why is this here and not in getBasicInstantiationType?
         if (isManagedPtrType(at)) {
           Type* classType = getManagedPtrBorrowType(actualType);
           if (canInstantiate(classType, formalType)) {

--- a/test/classes/generic/genericChildIsNotSubtype.chpl
+++ b/test/classes/generic/genericChildIsNotSubtype.chpl
@@ -1,0 +1,14 @@
+class GenericParentClass {
+  type t;
+
+  proc init(type t) {
+    this.t = t;
+  }
+}
+class ChildClass: GenericParentClass {}
+
+class ParentClass {}
+class ChildClass2: ParentClass {}
+
+writeln(isSubtype(ChildClass, GenericParentClass(int)));
+writeln(isSubtype(ChildClass2, ParentClass));

--- a/test/classes/generic/genericChildIsNotSubtype.good
+++ b/test/classes/generic/genericChildIsNotSubtype.good
@@ -1,0 +1,2 @@
+false
+true

--- a/test/classes/generic/genericChildIsSubtype.chpl
+++ b/test/classes/generic/genericChildIsSubtype.chpl
@@ -1,0 +1,14 @@
+class GenericParentClass {
+  type t;
+
+  proc init(type t) {
+    this.t = t;
+  }
+}
+class ChildClass: GenericParentClass {}
+
+class ParentClass {}
+class ChildClass2: ParentClass {}
+
+writeln(isSubtype(ChildClass, GenericParentClass));
+writeln(isSubtype(ChildClass2, ParentClass));

--- a/test/classes/generic/genericChildIsSubtype.good
+++ b/test/classes/generic/genericChildIsSubtype.good
@@ -1,0 +1,2 @@
+true
+true

--- a/test/types/partial/partialIsSubtype.chpl
+++ b/test/types/partial/partialIsSubtype.chpl
@@ -1,0 +1,23 @@
+class QuiteGeneric {
+  type t;
+  param p: int;
+  var x;
+}
+
+type partial1 = QuiteGeneric(int);
+writeln(partial1: string);
+writeln(isSubtype(partial1, QuiteGeneric)); // true
+
+type partial2 = QuiteGeneric(int, 3);
+writeln(partial2: string);
+writeln(isSubtype(partial2, QuiteGeneric)); // true
+writeln(isSubtype(partial2, partial1)); // true
+writeln(isSubtype(partial1, partial2)); // false
+
+type complete = QuiteGeneric(int, 3, real);
+writeln(complete: string);
+writeln(isSubtype(complete, QuiteGeneric)); // true
+writeln(isSubtype(complete, partial1)); // true
+writeln(isSubtype(complete, partial2)); // true
+writeln(isSubtype(partial1, complete)); // false
+writeln(isSubtype(partial2, complete)); // false

--- a/test/types/partial/partialIsSubtype.good
+++ b/test/types/partial/partialIsSubtype.good
@@ -1,0 +1,12 @@
+QuiteGeneric(int(64))
+true
+QuiteGeneric(int(64),3)
+true
+true
+false
+QuiteGeneric(int(64),3,real(64))
+true
+true
+true
+false
+false


### PR DESCRIPTION
Prior to this change, we would falsely report that a fully generic child type
was not a subtype of the fully generic parent type, but would report
appropriately that an instantiation of the child was a subtype of the parent.

This was because we weren't appropriately traversing when the child type was
generic.  To fix that, add a check before we look at if it is an instantiation
that will return the parent type, even if it is a direct match (rather than an
instantiation).

With this change, the test that failed before now passes
Resolves #17572 

Add three tests of isSubtype that didn't seem to be covered before

Two behave as expected, the third is a user reported bug.  Covers:
- that partial instantiations are considered subtypes of more generic forms
- that a generic child is not considered a subtype of an instantiation of the
parent type
- that a generic child is a subtype of a fully generic parent (the bug that got
fixed)

Passed a full paratest with futures