### PR TITLE
responsive compiler prototype: query framework

### DIFF
--- a/compiler/next/include/chpl/AST/ErrorMessage.h
+++ b/compiler/next/include/chpl/AST/ErrorMessage.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_AST_ERRORMESSAGE_H
+#define CHPL_AST_ERRORMESSAGE_H
+
+#include "chpl/AST/Location.h"
+
+#include <string>
+
+namespace chpl {
+namespace ast {
+
+/**
+  This class represents an error/warning message. The message
+  is saved (in the event it needs to be reported again).
+ */
+class ErrorMessage final {
+ private:
+  int level_; // error? warning? performance hint?
+  Location location_;
+  std::string message_;
+
+  // TODO: how to handle a callstack of sorts?
+
+ public:
+  ErrorMessage();
+  ErrorMessage(Location location, std::string message);
+  ErrorMessage(Location location, const char* message);
+
+
+
+  static ErrorMessage build(Location loc, const char* fmt, ...)
+#ifndef DOXYGEN
+    // docs generator has trouble with the attribute applied to 'build'
+    // so the above ifndef works around the issue.
+    __attribute__ ((format (printf, 2, 3)))
+#endif
+  ;
+
+  inline bool operator==(const ErrorMessage& other) const {
+    return this->level_ == other.level_ &&
+           this->location_ == other.location_ &&
+           this->message_ == other.message_;
+  }
+  inline bool operator!=(const ErrorMessage& other) const {
+    return !(*this == other);
+  }
+
+  void swap(ErrorMessage& other);
+};
+
+} // end namespace ast
+
+// Allow chpl::ast::ErrorMessage to be just called chpl::ErrorMessage
+// TODO: Should it be moved out of the ast namespace? What directory
+// should it go in?
+using chpl::ast::ErrorMessage;
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/AST/Location.h
+++ b/compiler/next/include/chpl/AST/Location.h
@@ -85,10 +85,10 @@ class Location final {
 
 } // end namespace ast
 
-template<> struct combine<chpl::ast::Location> {
+template<> struct update<chpl::ast::Location> {
   bool operator()(chpl::ast::Location& keep,
                   chpl::ast::Location& addin) const {
-    return defaultCombine(keep, addin);
+    return defaultUpdate(keep, addin);
   }
 };
 

--- a/compiler/next/include/chpl/AST/Location.h
+++ b/compiler/next/include/chpl/AST/Location.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_AST_LOCATION_H
+#define CHPL_AST_LOCATION_H
+
+#include "chpl/AST/UniqueString.h"
+
+namespace chpl {
+namespace ast {
+
+/**
+  This class represents a source location.
+ */
+class Location final {
+ private:
+  UniqueString path_;
+  int firstLine_;
+  int firstColumn_;
+  int lastLine_;
+  int lastColumn_;
+ public:
+  Location()
+    : path_(),
+      firstLine_(-1), firstColumn_(-1),
+      lastLine_(-1), lastColumn_(-1) {
+  }
+
+  Location(UniqueString path,
+           int firstLine=-1, int firstColumn=-1,
+           int lastLine=-1, int lastColumn=-1)
+    : path_(path),
+      firstLine_(firstLine), firstColumn_(firstColumn),
+      lastLine_(lastLine), lastColumn_(lastColumn) {
+  }
+
+  UniqueString path() { return path_; }
+
+  inline bool operator==(const Location other) const {
+    return this->path_ == other.path_ &&
+           this->firstLine_ == other.firstLine_ &&
+           this->firstColumn_ == other.firstColumn_ &&
+           this->lastLine_ == other.lastLine_ &&
+           this->lastColumn_ == other.lastColumn_;
+  }
+  inline bool operator!=(const Location other) const {
+    return this->path_ != other.path_ ||
+           this->firstLine_ != other.firstLine_ ||
+           this->firstColumn_ != other.firstColumn_ ||
+           this->lastLine_ != other.lastLine_ ||
+           this->lastColumn_ != other.lastColumn_;
+  }
+
+  size_t hash() const {
+    size_t h = this->path_.hash();
+    h = hash_combine(h, this->firstLine_);
+    h = hash_combine(h, this->firstColumn_);
+    h = hash_combine(h, this->lastLine_);
+    h = hash_combine(h, this->lastColumn_);
+    return h;
+  }
+
+  void swap(Location& other) {
+    Location oldThis = *this;
+    *this = other;
+    other = oldThis;
+  }
+};
+
+} // end namespace ast
+
+template<> struct combine<chpl::ast::Location> {
+  bool operator()(chpl::ast::Location& keep,
+                  chpl::ast::Location& addin) const {
+    return defaultCombine(keep, addin);
+  }
+};
+
+
+// Allow chpl::ast::Location to be just called chpl::Location
+// TODO: Should it be moved out of the ast namespace? What directory
+// should it go in?
+
+using chpl::ast::Location;
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/AST/Location.h
+++ b/compiler/next/include/chpl/AST/Location.h
@@ -31,15 +31,13 @@ namespace ast {
 class Location final {
  private:
   UniqueString path_;
-  int firstLine_;
-  int firstColumn_;
-  int lastLine_;
-  int lastColumn_;
+  int firstLine_ = -1;
+  int firstColumn_ = -1;
+  int lastLine_ = -1;
+  int lastColumn_ = -1;
  public:
   Location()
-    : path_(),
-      firstLine_(-1), firstColumn_(-1),
-      lastLine_(-1), lastColumn_(-1) {
+    : path_() {
   }
 
   Location(UniqueString path,
@@ -60,11 +58,7 @@ class Location final {
            this->lastColumn_ == other.lastColumn_;
   }
   inline bool operator!=(const Location other) const {
-    return this->path_ != other.path_ ||
-           this->firstLine_ != other.firstLine_ ||
-           this->firstColumn_ != other.firstColumn_ ||
-           this->lastLine_ != other.lastLine_ ||
-           this->lastColumn_ != other.lastColumn_;
+    return !(*this == other);
   }
 
   size_t hash() const {

--- a/compiler/next/include/chpl/AST/UniqueString.h
+++ b/compiler/next/include/chpl/AST/UniqueString.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  This file implements a global table of strings which enables easier string
+  comparison and memory management.
+ */
+
+#ifndef CHPL_AST_UNIQUE_STRING_H
+#define CHPL_AST_UNIQUE_STRING_H
+
+#include "chpl/AST/UniqueStringDetail.h"
+
+#include <cassert>
+#include <cstring>
+#include <string>
+
+
+namespace chpl {
+class Context;
+
+namespace ast {
+
+/**
+  This class represents a unique'd NULL-terminated string.
+  Unique'd strings allow:
+    * fast == and !=
+    * not worrying about freeing them
+
+ */
+class UniqueString final {
+ friend class Context;
+
+ private:
+  detail::PODUniqueString s;
+
+ public:
+  /** create a UniqueString storing the empty string */
+  UniqueString() {
+    this->s.i = detail::InlinedString::buildFromAligned("", 0);
+  }
+  /** create a UniqueString from a PODUniqueString.
+      this constructor intentionally allows implicit conversion.
+   */
+  UniqueString(detail::PODUniqueString s) {
+    this->s = s;
+  }
+
+  /**
+    Get or create a unique string for a NULL-terminated C string.
+    If NULL is provided, this function will return the UniqueString
+    representing "".
+   */
+  static inline UniqueString build(Context* context, const char* s) {
+    detail::PODUniqueString ret = detail::PODUniqueString::build(context, s);
+    return UniqueString(ret);
+  }
+
+  /**
+    Get or create a unique string for a string from a pointer
+    and a length. If the length is 0, this function will return
+    the UniqueString representing "".
+   */
+  static inline UniqueString build(Context* context,
+                                   const char* s, size_t len) {
+    detail::PODUniqueString ret =
+      detail::PODUniqueString::build(context, s, len);
+    return UniqueString(ret);
+  }
+
+
+  /**
+    Get or create a unique string for a C++ string
+    \rst
+    .. note::
+
+      will not handle strings with embedded ``'\0'`` bytes
+    \endrst
+   */
+  static inline UniqueString build(Context* context, const std::string& s) {
+    return UniqueString::build(context, s.c_str());
+  }
+
+  /** return the null-terminated string */
+  const char* c_str() const {
+    return s.i.c_str();
+  }
+
+  bool isEmpty() const {
+    return s.i.c_str()[0] == '\0';
+  }
+
+  bool startsWith(const char* prefix) const {
+    return (0 == strncmp(this->c_str(), prefix, strlen(prefix)));
+  }
+  bool startsWith(const UniqueString prefix) const {
+    return this->startsWith(prefix.c_str());
+  }
+  bool startsWith(const std::string& prefix) const {
+    return this->startsWith(prefix.c_str());
+  }
+
+  inline bool operator==(const UniqueString other) const {
+    return this->s.i.v == other.s.i.v;
+  }
+  inline bool operator!=(const UniqueString other) const {
+    return this->s.i.v != other.s.i.v;
+  }
+  int compare(const UniqueString other) const {
+    if (this->s.i.v == other.s.i.v)
+      return 0;
+    else
+      return strcmp(this->c_str(), other.c_str());
+  }
+  int compare(const char* other) const {
+    return strcmp(this->c_str(), other);
+  }
+  size_t hash() const {
+    std::hash<size_t> hasher;
+    return hasher((size_t) s.i.v);
+  }
+  void swap(UniqueString& other) {
+    UniqueString oldThis = *this;
+    *this = other;
+    other = oldThis;
+  }
+};
+
+
+} // end namespace ast
+
+template<> struct combine<chpl::ast::UniqueString> {
+  bool operator()(chpl::ast::UniqueString& keep,
+                  chpl::ast::UniqueString& addin) const {
+    return defaultCombine(keep, addin);
+  }
+};
+
+// Allow chpl::ast::UniqueString to be just called chpl::UniqueString
+// TODO: Should it be moved out of the ast namespace? What directory
+// should it go in?
+using chpl::ast::UniqueString;
+
+
+} // end namespace chpl
+
+namespace std {
+  template<> struct less<chpl::ast::UniqueString> {
+    bool operator()(const chpl::ast::UniqueString lhs,
+                    const chpl::ast::UniqueString rhs) const {
+      return lhs.compare(rhs) < 0;
+    }
+  };
+  template<> struct hash<chpl::ast::UniqueString> {
+    size_t operator()(const chpl::ast::UniqueString key) const {
+      return (size_t) key.hash();
+    }
+  };
+  template<> struct equal_to<chpl::ast::UniqueString> {
+    bool operator()(const chpl::ast::UniqueString lhs,
+                    const chpl::ast::UniqueString rhs) const {
+      return lhs == rhs;
+    }
+  };
+} // end namespace std
+
+#endif

--- a/compiler/next/include/chpl/AST/UniqueString.h
+++ b/compiler/next/include/chpl/AST/UniqueString.h
@@ -145,10 +145,10 @@ class UniqueString final {
 
 } // end namespace ast
 
-template<> struct combine<chpl::ast::UniqueString> {
+template<> struct update<chpl::ast::UniqueString> {
   bool operator()(chpl::ast::UniqueString& keep,
                   chpl::ast::UniqueString& addin) const {
-    return defaultCombine(keep, addin);
+    return defaultUpdate(keep, addin);
   }
 };
 

--- a/compiler/next/include/chpl/AST/UniqueStringDetail.h
+++ b/compiler/next/include/chpl/AST/UniqueStringDetail.h
@@ -191,22 +191,22 @@ size_t hash_combine(size_t hash1, size_t hash2) {
   return hash;
 }
 
-template<typename T> struct combine {
+template<typename T> struct update {
   bool operator()(T& keep, T& addin) const = 0;
 };
 template<typename T>
-static inline bool defaultCombine(T& keep, T& addin) {
+static inline bool defaultUpdate(T& keep, T& addin) {
   std::equal_to<T> eq;
   if (eq(keep, addin)) {
-    return true;
+    return false;
   } else {
     keep.swap(addin);
-    return false;
+    return true;
   }
 }
-template<> struct combine<std::string> {
+template<> struct update<std::string> {
   bool operator()(std::string& keep, std::string& addin) const {
-    return defaultCombine(keep, addin);
+    return defaultUpdate(keep, addin);
   }
 };
 

--- a/compiler/next/include/chpl/AST/UniqueStringDetail.h
+++ b/compiler/next/include/chpl/AST/UniqueStringDetail.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  This file implements a global table of strings which enables easier string
+  comparison and memory management.
+ */
+
+#ifndef CHPL_AST_UNIQUE_STRING_DETAIL_H
+#define CHPL_AST_UNIQUE_STRING_DETAIL_H
+
+#include <cassert>
+#include <cstring>
+#include <string>
+
+/// \cond DO_NOT_DOCUMENT
+namespace chpl {
+class Context;
+namespace ast {
+namespace detail {
+
+// We can make it store 6 bytes in line this way:
+// alloc all such strings aligned to 2 bytes
+// store in the low-order byte an odd number
+// store in the last (memory order) byte, 6-length
+//   (so we store 0 if the length is 6, which is the terminator)a
+// fill any unused bytes with 0s
+//
+// This should work on both big and little endian systems.
+// Q: what is the string distribution in Chapel programs?
+//   compiling distributions primer with something like 1.24 we see:
+//
+//            ~1,075,000 table queries            vs English text (moby dick)
+//   of these,  ~526,000 (49%) are < 7 bytes      (78%)
+//              ~875,000 (81%) are < 13 bytes     (98%)
+//            ~1,008,000 (94%) are < 23 bytes
+//            ~1,034,000 (96%) are < 30 bytes
+//            ~1,050,000 (98%) are < 39 bytes
+//
+//            ~45,000 unique strings
+//   of these,  ~8,000 (18%) are < 7 bytes
+//             ~12,000 (25%) are < 13 bytes
+//             ~24,000 (53%) are < 23 bytes
+//             ~28,000 (62%) are < 30 bytes
+//             ~33,000 (73%) are < 39 bytes
+//
+// Q: does this improve performance?
+//   Yes, by about 5-10% in testUniqueString.cpp
+//   It might be more than that when the string references are
+//   not recently used.
+
+struct InlinedString {
+
+  // This union is only used to make the debugger output more reasonable.
+  // All reads/writes here go through the 'v' variable.
+  // Performance: Should we "inline" strings up to 14 bytes
+  // by using a 16 byte data region? To try that, some of the
+  // surrounding code will need adjustment.
+  union {
+    const char* v;
+    char data[sizeof(const char*)];
+  };
+
+  enum {
+    INLINE_TAG=0xbb, // could be any odd value
+    MAX_SIZE_INLINED=sizeof(uintptr_t)-2
+  };
+
+  static inline bool alignmentIndicatesTag(const char* s) {
+    uintptr_t val = (uintptr_t) s;
+    // check if the low-order bits are the tag indicating inline
+    return (val == 0) || ((val & 0xff) == INLINE_TAG);
+  }
+
+  // Performance: Does this function need to be inlined?
+  static char* dataAssumingTag(void* vptr);
+
+  /**
+    Creates an InlinedString from a pointer.
+    If strlen(s) <= MAX_SIZE_INLINED, it will store the data inline.
+    Otherwise, it will point to s and this code assumes
+    that alignmentIndicatesTag(s)==false.
+   */
+  static inline InlinedString buildFromAligned(const char* s, int len) {
+    // Store empty strings as nullptr
+    if (s == nullptr || len == 0) {
+      InlinedString ret;
+      ret.v = nullptr;
+      return ret;
+    }
+
+    // Would the tag, null terminator, and data fit?
+    if (len <= MAX_SIZE_INLINED) {
+      uintptr_t val = INLINE_TAG; // store the tag in the low-order bits, 0s
+      char* dst = dataAssumingTag(&val);
+      // store the data (possibly after the tag), not including null byte
+      // (since null byte will come from the zeros in val)
+      memcpy(dst, s, len);
+      // store the value we created into the struct and return it
+      InlinedString ret;
+      ret.v = (const char*) val;
+      return ret;
+    }
+
+    assert(!alignmentIndicatesTag(s));
+    InlinedString ret;
+    ret.v = s;
+    return ret;
+  }
+
+  static InlinedString buildUsingContextTable(Context* context,
+                                              const char* s, int len);
+
+  static InlinedString build(Context* context, const char* s, size_t len) {
+    if (len <= MAX_SIZE_INLINED) {
+      // if it fits inline, just return that
+      return InlinedString::buildFromAligned(s, len);
+    } else {
+      // otherwise, use the unique strings table
+      // which produces a string with even alignment
+      return InlinedString::buildUsingContextTable(context, s, len);
+    }
+  }
+  static InlinedString build(Context* context, const char* s) {
+    size_t len = 0;
+    if (s != NULL) len = strlen(s);
+    return InlinedString::build(context, s, len);
+  }
+
+  bool isInline() const {
+    return alignmentIndicatesTag(this->v);
+  }
+  const char* c_str() const {
+    if (this->isInline()) {
+      return dataAssumingTag((void*) &this->v);
+    }
+
+    // otherwise, s is a real pointer
+    return this->v;
+  }
+};
+
+// This class is POD and has only the trivial constructor to help the parser
+// (which uses it in a union).
+// All UniqueStrings are actually POD; the difference is that this one
+// does not have a default constructor.
+// TODO: rename it
+struct PODUniqueString {
+  InlinedString i;
+  static inline PODUniqueString build(Context* context,
+                                      const char* s, size_t len) {
+    PODUniqueString ret;
+    ret.i = InlinedString::build(context, s, len);
+    return ret;
+  }
+  static inline PODUniqueString build(Context* context, const char* s) {
+    PODUniqueString ret;
+    ret.i = InlinedString::build(context, s);
+    return ret;
+  }
+  const char* c_str() const {
+    return this->i.c_str();
+  }
+};
+
+} // end namespace detail
+} // end namespace ast
+
+// TODO: should these go somewhere else?
+static inline
+size_t hash_combine(size_t hash1, size_t hash2) {
+  size_t hash = hash1;
+  size_t other = hash2;
+  hash ^= other + 0x9e3779b9 + (other << 6) + (other >> 2);
+  return hash;
+}
+
+template<typename T> struct combine {
+  bool operator()(T& keep, T& addin) const = 0;
+};
+template<typename T>
+static inline bool defaultCombine(T& keep, T& addin) {
+  std::equal_to<T> eq;
+  if (eq(keep, addin)) {
+    return true;
+  } else {
+    keep.swap(addin);
+    return false;
+  }
+}
+template<> struct combine<std::string> {
+  bool operator()(std::string& keep, std::string& addin) const {
+    return defaultCombine(keep, addin);
+  }
+};
+
+} // end namespace chpl
+/// \endcond
+
+#endif

--- a/compiler/next/include/chpl/Queries/Context.h
+++ b/compiler/next/include/chpl/Queries/Context.h
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_QUERIES_CONTEXT_H
+#define CHPL_QUERIES_CONTEXT_H
+
+#include "chpl/AST/UniqueString.h"
+#include "chpl/AST/ID.h"
+#include "chpl/Queries/ContextDetail.h"
+#include "chpl/Util/memory.h"
+
+#include <unordered_map>
+
+namespace chpl {
+
+/**
+
+\rst
+
+This class stores the compilation-wide context. It handles unique'd strings
+and also a *program database* which is basically a bunch of maps storing the
+results of queries (so that they are are memoized) but that updates these
+results according to a dependency graph and revision number.
+
+Queries are just functions that are written in a stylized manner to interact
+with the program database in the context.
+
+To write a query, create a function that uses the ``QUERY_`` macros defined in
+QueryImpl.h. The arguments to the function need to be POD (so
+``UniqueString``, ``ID``, ``Location``, are OK but AST pointers or
+``std::vector`` e.g. are not). The function will return a result, which need
+not be POD and can include AST pointers (but see below). The function needs to
+be written in a stylized way to interact with the program database.
+
+For example, here is a query that computes MyResultType from myKey1 and
+myKey2:
+
+.. code-block:: c++
+
+    #include "chpl/Queries/QueryImpl.h"
+
+    const MyResultType& myQueryFunction(Context* context,
+                                        MyPodKeyType myKey1,
+                                        MyOtherPodKeyType myKey2) {
+      QUERY_BEGIN(context, MyResultType, myKey1, myKey2)
+      if (QUERY_USE_SAVED()) {
+        return QUERY_GET_SAVED();
+      }
+      // do steps to compute the result
+      MyResultType result = ...;
+      // if an error is encountered, it can be saved with QUERY_ERROR(error)
+
+      return QUERY_END(result);
+    }
+
+
+To call the query, just write e.g. ``myQueryFunction(context, key1, key2)``.
+
+The query function will check for a result stored already in the program
+database that can be reused and the first return accounts for that case.
+After that, the query proceeds to compute the result. It will then compare the
+computed result with the saved result, if any, and in some cases combine the
+results. Finally, the saved result (which might have been updated) is
+returned.
+
+The above is appropriate for value types  (``std::string``, ``int``, etc).
+For an object that should be managed as owned within the context,
+use this pattern:
+
+.. code-block:: c++
+
+   const MyClassType* myQueryFunction(Context* context, myKey1, myKey2) {
+     QUERY_BEGIN(context, owned<MyClassType>, myKey1, myKey2)
+     if (QUERY_USE_SAVED()) {
+       return QUERY_GET_SAVED().get();
+     }
+     // do steps to compute the result
+     owned<MyClassType> result = ...;
+     // if an error is encountered, it can be saved with QUERY_ERROR(error)
+
+     return QUERY_END(result).get();
+   }
+
+
+There are some requirements on query argument/key types and on result types.
+
+Since the argument/key types are stored in a hashtable, we need
+``std::hash<KeyType>`` and ``std::equal_to<KeyType>`` to be implemented, e.g.
+
+.. code-block:: c++
+
+    namespace std {
+      template<> struct hash<chpl::MyPodKeyType> {
+        size_t operator()(const chpl::ast::UniqueString key) const {
+          return doSomethingToComputeHash...;
+        }
+      };
+      template<> struct equal_to<chpl::MyPodKeyType> {
+        bool operator()(const chpl::MyPodKeyType lhs,
+                        const chpl::MyPodKeyType rhs) const {
+          return doSomethingToCheckIfEqual...;
+        }
+      };
+    }
+
+The process of computing a query and checking to see if it maches a saved
+result requires that the result type implement ``chpl::combine``:
+
+.. code-block:: c++
+
+    namespace chpl {
+      template<> struct combine<MyResultType> {
+        bool operator()(chpl::ast::UniqueString& keep,
+                        chpl::ast::UniqueString& addin) const {
+          return doSomethingToCombine...;
+        }
+      };
+
+On entry to the ``combine`` function, ``keep`` is the current value in the
+program database and ``addin`` is the newly computed value. The ``combine``
+function needs to:
+
+  * store the current, updated result in ``keep``
+  * store the unused result in ``addin``
+  * return ``true`` if ``keep`` matched ``addin``; that is, ``keep`` did not
+    need to be updated.
+
+For most result types, ``return defaultCombine(keep, addin);`` should be
+sufficient. In the event that a result is actually a collection of results
+that *owns* the elements (for example, when parsing, the result is
+conceptually a vector of top-level symbol), the ``combine`` function
+should try to update only those elements of ``keep`` that changed by swapping
+in the appropriate elements from ``addin``. This strategy allows later queries
+that depend on such a result to use pointers to the owned elements and to
+avoid updating everything if just one element changed.
+
+Queries *can* return results that contain non-owning pointers to results from
+dependent queries. In that event, the combine function should not rely on the
+contents of these pointers. The system will make sure that they refer to valid
+memory but they might be a combination of old results. Additionally, the system
+will ensure that any old results being replaced will remain allocated until the
+garbage collection runs outside of any query.
+
+For example, a ``parse`` query might result in a list of ``owned`` AST element
+pointers. A follow-on ``listSymbols`` result in something containing these AST
+element pointers, but not owning them. The ``listSymbols`` query needs to use a
+``combine`` function that does not look into these queries.
+
+\endrst
+
+ */
+class Context {
+ private:
+  // map that supports uniqueCString / UniqueString
+   typedef std::unordered_map<const char*, char*, chpl::detail::UniqueStrHash, chpl::detail::UniqueStrEqual> UniqueStringsTableType;
+  UniqueStringsTableType uniqueStringsTable;
+
+  // map from a query name to appropriate QueryMap object.
+  // maps to an 'owned' heap-allocated thing to manage having subclasses
+  // without slicing.
+  std::unordered_map<UniqueString, owned<chpl::querydetail::QueryMapBase>> queryDB;
+
+  // Since IDs include module names but not file paths, use this
+  // map to go from module name to file path.
+  // (If this proves too restrictive for some reason, we could
+  //  start including file path in IDs).
+  std::unordered_map<UniqueString, UniqueString> modNameToFilepath;
+
+  struct QueryDepsEntry {
+    UniqueString queryName;
+    chpl::querydetail::QueryDependencyVec dependencies;
+    std::vector<ErrorMessage> errors;
+    QueryDepsEntry(UniqueString queryName)
+      : queryName(queryName), dependencies(), errors() {
+    }
+  };
+
+  // this is used to compute the dependencies
+  std::vector<QueryDepsEntry> queryDeps;
+
+  chpl::querydetail::RevisionNumber currentRevisionNumber;
+  chpl::querydetail::RevisionNumber lastPrepareToGCRevisionNumber;
+  chpl::querydetail::RevisionNumber gcCounter;
+
+  Context();
+  const char* getOrCreateUniqueString(const char* s);
+  bool queryCanUseSavedResult(chpl::querydetail::QueryMapResultBase* resultEntry);
+  void saveDependenciesAndErrorsInParent(chpl::querydetail::QueryMapResultBase* resultEntry);
+  void endQueryHandleDependency(chpl::querydetail::QueryMapResultBase* result);
+
+  template<typename ResultType, typename... ArgTs>
+  chpl::querydetail::QueryMapResult<ResultType>*
+  updateResultForQuery(
+      const std::tuple<ArgTs...>& tupleOfArgs,
+      ResultType result,
+      bool& changedOut,
+      chpl::querydetail::QueryMap<ResultType,ArgTs...>* queryMap);
+
+  template<typename ResultType, typename... ArgTs>
+  chpl::querydetail::QueryMapResult<ResultType>*
+  updateResultForQuery(const std::tuple<ArgTs...>& tupleOfArgs,
+                       ResultType result,
+                       bool& changedOut,
+                       UniqueString queryName);
+
+  // Future Work: support marking used strings and garbage collecting the rest
+  // Could store an atomic uint_8 just after the string for the mark.
+
+  // Future Work: make the context thread-safe
+
+  // Future Work: allow moving some AST to a different context
+  //              (or, at least, that can handle the unique strings)
+
+  // Performance: Add fine-grained timing to measure
+  //  * the total time spent in each query
+  //  * the time spent in each query in Context functions
+  //    (i.e. hashtable manipulations)
+  //  * the time spent in each query in other queries
+  //  * the time spent in each query in other query code
+
+  // Performance: How can we arrange for better locality of reference/
+  // cache reuse for the maps from IDs? The IDs within a function could
+  // be just stored in a vector, but that would add an indirection to
+  // the hashtable. Is there a way to adjust the hashing function and
+  // tune the hashtable bucket size, or something? Do we need a custom
+  // hashtable?
+
+ public:
+  /**
+    Create a new AST Context.
+   */
+  static owned<Context> build();
+  ~Context();
+
+  /**
+    Get or create a unique string for a NULL-terminated C string
+    and return it as a C string. If the passed string is NULL,
+    this function will return an empty string.
+
+    Strings returned by this function will always be aligned to 2 bytes.
+
+    The function `UniqueString::build` returns such a string
+    with a wrapper type. It should be preferred for type safety
+    and to reduce redundant checks.
+   */
+  const char* uniqueCString(const char* s);
+
+  /**
+    Return the name of the module containing this ID.
+   */
+  UniqueString moduleNameForID(ID id);
+  /**
+    Return the file path for the file containing this ID.
+   */
+  UniqueString filePathForID(ID id);
+
+  /**
+    Query to get a file path given a module name
+   */
+  UniqueString filePathForModuleName(UniqueString modName);
+
+  /**
+    This function increments the current revision number stored
+    in the context. After it is called, the setters below can
+    be used to provide the input at that revision.
+
+    If the prepareToGC argument is true, when processing queries
+    in that revision, will prepare to garbage collect (by marking
+    elements appropriately).
+   */
+  void advanceToNextRevision(bool prepareToGC);
+
+  /**
+    This function runs garbage collection, but it only has an effect
+    if the last call to advanceToNextRevision passed
+    prepareToGC=true.
+   */
+  void collectGarbage();
+
+  // setters for named queries.
+
+  /**
+    Sets the file path for the given toplevel module name. It does not bump
+    the current revision counter so is suitable for calling from
+    a parse query.
+    Returns 'true' if this function caused a new result to be saved
+    in the context.
+   */
+  bool setFilePathForModuleName(UniqueString modName, UniqueString path);
+
+  /**
+    setFileText will set the text for a particular file path.
+    Returns 'true' if this function caused a new result to be saved
+    in the context. In that event, the revision updated for the
+    file text result will be updated.
+   */
+  bool setFileText(UniqueString path, std::string data);
+
+  // the following functions are called by the macros defined in QueryImpl.h
+  // and should not be called directly
+
+  /// \cond DO_NOT_DOCUMENT
+  template<typename... ArgTs>
+  void queryTraceBegin(UniqueString queryName, const char* func,
+                       const std::tuple<ArgTs...>& tupleOfArg);
+
+  template<typename... ArgTs>
+  void queryTraceEnd(UniqueString queryName, const char* func,
+                     const std::tuple<ArgTs...>& tupleOfArg,
+                     bool changed);
+
+
+  template<typename ResultType, typename... ArgTs>
+  chpl::querydetail::QueryMap<ResultType,ArgTs...>*
+    queryGetMap(UniqueString queryName, const std::tuple<ArgTs...>& tupleOfArgs);
+
+  // queryFunc is only used for tracing
+  bool queryCanUseSavedResultAndPushIfNot(UniqueString queryName,
+      const char* queryFunc,
+      chpl::querydetail::QueryMapResultBase* resultEntry);
+
+  template<typename ResultType>
+  const ResultType& queryGetSavedResult(chpl::querydetail::QueryMapResult<ResultType>* resultEntry);
+
+  void queryNoteError(ErrorMessage error);
+  template<typename ResultType, typename... ArgTs>
+  ResultType& queryEnd(UniqueString queryName, const char* func,
+                      ResultType result,
+                      const std::tuple<ArgTs...>& tupleOfArgs,
+                      chpl::querydetail::QueryMap<ResultType,ArgTs...>* queryMap);
+  /// \endcond
+};
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/Queries/ContextDetail.h
+++ b/compiler/next/include/chpl/Queries/ContextDetail.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_QUERIES_CONTEXT_DETAIL_H
+#define CHPL_QUERIES_CONTEXT_DETAIL_H
+
+#include "chpl/AST/UniqueString.h"
+#include "chpl/AST/ErrorMessage.h"
+#include "chpl/Util/memory.h"
+
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+/// \cond DO_NOT_DOCUMENT
+namespace chpl {
+namespace detail {
+
+struct UniqueStrEqual final {
+  bool operator()(const char* lhs, const char* rhs) const {
+    // pass the 2 metadata bytes
+    return strcmp(lhs, rhs) == 0;
+  }
+};
+
+struct UniqueStrHash final {
+  std::size_t operator()(const char* s) const {
+    // this hash is from StringHashFns in the old map.h
+    unsigned int h = 0;
+    while (*s) h = h * 27 + (unsigned char)*s++;
+    return h;
+  }
+};
+
+}
+
+namespace querydetail {
+
+typedef int64_t RevisionNumber;
+class QueryMapResultBase;
+
+// define a hash function for std::tuple since the standard doesn't
+// include one.
+template<typename T>
+static std::size_t queryArgsHashOne(const T& v) {
+  std::hash<T> hasher;
+  return hasher(v);
+}
+
+template<size_t I, typename... Ts>
+static std::size_t queryArgsHashImpl(const std::tuple<Ts...>& tuple) {
+  size_t myhash = queryArgsHashOne(std::get<I>(tuple));
+  if (I + 1 < sizeof...(Ts)) {
+    size_t resthash =
+      queryArgsHashImpl<(I + 1 < sizeof... (Ts) ? I + 1 : I)>(tuple);
+    return chpl::hash_combine(myhash, resthash);
+  } else {
+    return myhash;
+  }
+}
+
+template<typename... Ts>
+static std::size_t queryArgsHash(const std::tuple<Ts...>& tuple) {
+  return queryArgsHashImpl<0>(tuple);
+}
+template<>
+std::size_t queryArgsHash<>(const std::tuple<>& tuple);
+
+// define an equality function for std::tuple. the standard will call ==
+// but we want to always compare our keys with equal_to 
+template<typename T>
+static bool queryArgsEqualsOne(const T& lhs, const T& rhs) {
+  std::equal_to<T> eq;
+  return eq(lhs, rhs);
+}
+
+template<size_t I, typename... Ts>
+static bool queryArgsEqualsImpl(const std::tuple<Ts...>& lhs,
+                                const std::tuple<Ts...>& rhs) {
+  bool myeq = queryArgsEqualsOne(std::get<I>(lhs), std::get<I>(rhs));
+  if (myeq == false)
+    return false;
+
+  if (I + 1 < sizeof...(Ts)) {
+    return queryArgsEqualsImpl<(I + 1 < sizeof... (Ts) ? I + 1 : I)>(lhs, rhs);
+  } else {
+    return true;
+  }
+}
+
+template<typename... Ts>
+static bool queryArgsEquals(const std::tuple<Ts...>& lhs,
+                            const std::tuple<Ts...>& rhs) {
+  return queryArgsEqualsImpl<0>(lhs, rhs);
+}
+
+template<>
+bool queryArgsEquals<>(const std::tuple<>& lhs,
+                       const std::tuple<>& rhs);
+
+template<typename... Ts>
+struct QueryMapArgTupleHash final {
+  std::size_t operator()(const std::tuple<Ts...>& x) const {
+    return queryArgsHash(x);
+  }
+};
+
+
+template<typename... Ts>
+struct QueryMapArgTupleEqual final {
+  bool operator()(const std::tuple<Ts...>& lhs,
+                  const std::tuple<Ts...>& rhs) const {
+    return queryArgsEquals(lhs, rhs);
+  }
+};
+
+// define a way to debug-print out a tuple
+void queryArgsPrintSep();
+void queryArgsPrintUnknown();
+
+template<typename T>
+static void queryArgsPrintOne(const T& v) {
+  queryArgsPrintUnknown();
+}
+
+void queryArgsPrintOne(const ID& v);
+void queryArgsPrintOne(const UniqueString& v);
+
+template<size_t I, typename... Ts>
+static void queryArgsPrintImpl(const std::tuple<Ts...>& tuple) {
+  queryArgsPrintOne(std::get<I>(tuple));
+  if (I + 1 < sizeof...(Ts)) {
+    queryArgsPrintSep();
+    queryArgsPrintImpl<(I + 1 < sizeof... (Ts) ? I + 1 : I)>(tuple);
+  }
+}
+
+template<typename... Ts>
+static void queryArgsPrint(const std::tuple<Ts...>& tuple) {
+  queryArgsPrintImpl<0>(tuple);
+}
+template<>
+void queryArgsPrint<>(const std::tuple<>& tuple);
+
+typedef std::vector<QueryMapResultBase*> QueryDependencyVec;
+typedef std::vector<ErrorMessage> QueryErrorVec;
+
+class QueryMapResultBase {
+ public:
+  QueryDependencyVec dependencies;
+  RevisionNumber lastCheckedAndReused;
+  RevisionNumber lastComputed;
+  RevisionNumber lastChanged;
+  // errors includes errors from dependencies, transitively,
+  // so that the dependencies can be forgotten and errors still reported.
+  QueryErrorVec errors;
+
+  QueryMapResultBase(QueryDependencyVec deps,
+                     RevisionNumber lastCheckedAndReused,
+                     RevisionNumber lastComputed,
+                     RevisionNumber lastChanged,
+                     QueryErrorVec errors)
+    : dependencies(std::move(deps)),
+      lastCheckedAndReused(lastCheckedAndReused),
+      lastComputed(lastComputed),
+      lastChanged(lastChanged),
+      errors(std::move(errors)) {
+  }
+  virtual ~QueryMapResultBase() = 0; // this is an abstract base class
+};
+template<typename ResultType>
+class QueryMapResult final : public QueryMapResultBase {
+ public:
+  ResultType result;
+  QueryMapResult(QueryDependencyVec deps,
+                 RevisionNumber lastCheckedAndReused,
+                 RevisionNumber lastComputed,
+                 RevisionNumber lastChanged,
+                 QueryErrorVec errors,
+                 ResultType result)
+    : QueryMapResultBase(std::move(deps),
+                         lastCheckedAndReused, lastComputed, lastChanged,
+                         std::move(errors)),
+      result(std::move(result)) {
+  }
+};
+
+class QueryMapBase {
+ public:
+   UniqueString queryName;
+   const char* prettyFunc;
+
+   QueryMapBase(UniqueString queryName, const char* prettyFunc)
+     : queryName(queryName), prettyFunc(prettyFunc) {
+   }
+   virtual ~QueryMapBase() = 0; // this is an abstract base class
+   virtual void clearOldResults(RevisionNumber currentRevisionNumber) = 0;
+};
+
+template<typename ResultType, typename... ArgTs>
+class QueryMap final : public QueryMapBase {
+ public:
+  typedef QueryMapResult<ResultType> TheResultType;
+  typedef std::unordered_map<std::tuple<ArgTs...>,
+                     TheResultType,
+                     QueryMapArgTupleHash<ArgTs...>,
+                     QueryMapArgTupleEqual<ArgTs...>> MapType;
+  // the main map
+  MapType map;
+  // old results stores replaced results long enough for dependent
+  // queries to compare with them.
+  std::vector<ResultType> oldResults;
+
+  QueryMap(UniqueString queryName, const char* prettyFunc)
+     : QueryMapBase(queryName, prettyFunc), map(), oldResults() {
+  }
+  ~QueryMap() = default;
+  void clearOldResults(RevisionNumber currentRevisionNumber) override {
+    // Performance: Would it be better to move everything to a new map
+    // rather than modify it in place as is done here?
+    auto iter = map.begin();
+    while (iter != map.end()) {
+      TheResultType& result = iter->second;
+      if (result.lastCheckedAndReused >= currentRevisionNumber ||
+          result.lastComputed >= currentRevisionNumber ||
+          result.lastChanged >= currentRevisionNumber) {
+        // Keep the result
+        ++iter;
+      } else {
+        // Remove the result
+        iter = map.erase(iter);
+      }
+    }
+
+    oldResults.clear();
+  }
+};
+
+} // end namespace querydetail
+} // end namespace chpl
+/// \endcond
+
+#endif

--- a/compiler/next/include/chpl/Queries/ContextDetail.h
+++ b/compiler/next/include/chpl/Queries/ContextDetail.h
@@ -52,7 +52,7 @@ struct UniqueStrHash final {
 
 namespace querydetail {
 
-typedef int64_t RevisionNumber;
+using RevisionNumber = int64_t;
 class QueryMapResultBase;
 
 // define a hash function for std::tuple since the standard doesn't
@@ -83,7 +83,7 @@ template<>
 std::size_t queryArgsHash<>(const std::tuple<>& tuple);
 
 // define an equality function for std::tuple. the standard will call ==
-// but we want to always compare our keys with equal_to 
+// but we want to always compare our keys with equal_to
 template<typename T>
 static bool queryArgsEqualsOne(const T& lhs, const T& rhs) {
   std::equal_to<T> eq;
@@ -158,8 +158,8 @@ static void queryArgsPrint(const std::tuple<Ts...>& tuple) {
 template<>
 void queryArgsPrint<>(const std::tuple<>& tuple);
 
-typedef std::vector<QueryMapResultBase*> QueryDependencyVec;
-typedef std::vector<ErrorMessage> QueryErrorVec;
+using QueryDependencyVec = std::vector<QueryMapResultBase*>;
+using QueryErrorVec = std::vector<ErrorMessage>;
 
 class QueryMapResultBase {
  public:
@@ -216,11 +216,11 @@ class QueryMapBase {
 template<typename ResultType, typename... ArgTs>
 class QueryMap final : public QueryMapBase {
  public:
-  typedef QueryMapResult<ResultType> TheResultType;
-  typedef std::unordered_map<std::tuple<ArgTs...>,
-                     TheResultType,
-                     QueryMapArgTupleHash<ArgTs...>,
-                     QueryMapArgTupleEqual<ArgTs...>> MapType;
+  using TheResultType = QueryMapResult<ResultType>;
+  using MapType = std::unordered_map<std::tuple<ArgTs...>,
+                                     TheResultType,
+                                     QueryMapArgTupleHash<ArgTs...>,
+                                     QueryMapArgTupleEqual<ArgTs...>>;
   // the main map
   MapType map;
   // old results stores replaced results long enough for dependent

--- a/compiler/next/include/chpl/Queries/QueryImpl.h
+++ b/compiler/next/include/chpl/Queries/QueryImpl.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_QUERIES_QUERYIMPL_H
+#define CHPL_QUERIES_QUERYIMPL_H
+
+#include "chpl/Queries/Context.h"
+#include "chpl/Queries/ContextDetail.h"
+
+#ifndef QUERY_MAP_USE_PRETTYFUNC
+  #if defined(__clang__)
+    #define QUERY_MAP_USE_PRETTYFUNC
+  #elif defined(__GNUC__)
+    #define QUERY_MAP_USE_PRETTYFUNC
+  #endif
+#endif
+
+/**
+  This file should be included by .cpp files implementing queries.
+ */
+
+/// \cond DO_NOT_DOCUMENT
+namespace chpl {
+
+using namespace chpl::querydetail;
+
+template<typename... ArgTs>
+void Context::queryTraceBegin(UniqueString queryName, const char* func,
+                     const std::tuple<ArgTs...>& tupleOfArg) {
+  printf("QUERY BEGIN     %s (", func);
+  queryArgsPrint(tupleOfArg);
+  printf(")\n");
+}
+
+template<typename... ArgTs>
+void Context::queryTraceEnd(UniqueString queryName, const char* func,
+                   const std::tuple<ArgTs...>& tupleOfArg,
+                   bool changed) {
+  printf("QUERY END       %s (", func);
+  queryArgsPrint(tupleOfArg);
+  printf(") %s\n", changed?"UPDATED":"NO CHANGE");
+}
+
+template<typename ResultType, typename... ArgTs>
+QueryMap<ResultType,ArgTs...>* Context::queryGetMap(UniqueString queryName, const std::tuple<ArgTs...>& tupleOfArgs) {
+
+  const char* prettyFunc = "";
+#ifdef QUERY_MAP_USE_PRETTYFUNC
+    prettyFunc = __PRETTY_FUNCTION__;
+#endif
+
+  // Look up the map entry for this query name
+  auto search = this->queryDB.find(queryName);
+  if (search != this->queryDB.end()) {
+    // found an entry for this query name
+    QueryMapBase* base = search->second.get();
+    // check that the arg/result types match
+    assert(0 == strcmp(base->prettyFunc, prettyFunc));
+    // return the inner map
+    return (QueryMap<ResultType,ArgTs...>*)base;
+  }
+
+  // Otherwise, create the QueryMap entry for this query name
+  // and add it to the map
+  auto iter =
+    this->queryDB.emplace_hint(
+      search,
+      std::make_pair(queryName,
+                     toOwned(new QueryMap<ResultType,ArgTs...>(queryName,
+                                                               prettyFunc))));
+  // and return a pointer to the newly inserted map
+  QueryMapBase* newBase = iter->second.get();
+  return (QueryMap<ResultType,ArgTs...>*)newBase;
+}
+
+template<typename ResultType, typename... ArgTs>
+QueryMapResult<ResultType>*
+Context::updateResultForQuery(const std::tuple<ArgTs...>& tupleOfArgs,
+                              ResultType result,
+                              bool& changedOut,
+                              QueryMap<ResultType,ArgTs...>* queryMap) {
+  // Set the map element
+  auto search = queryMap->map.find(tupleOfArgs);
+  if (search != queryMap->map.end()) {
+   QueryMapResult<ResultType>* storedResult = &(search->second);
+
+   // Call a chpl::combine function. That leaves the result in the 1st argument
+   // and returns whether or not it needed to change. The 2nd argument contains
+   // junk. If we wait until a garbageCollect call to free the junk, we can
+   // avoid certain cases where a pointer could be allocated, freed, and then
+   // allocated; leading to a sort of ABA issue.
+   chpl::combine<ResultType> combiner;
+   bool match = combiner(storedResult->result, result);
+   // now storedResult is the new result
+   queryMap->oldResults.push_back(std::move(result));
+   if (match) {
+     changedOut = false;
+     storedResult->lastComputed = this->currentRevisionNumber;
+     return storedResult;
+   } else {
+     changedOut = true;
+     auto currentRevision = this->currentRevisionNumber;
+     storedResult->lastComputed = currentRevision;
+     storedResult->lastChanged  = currentRevision;
+     return storedResult;
+   }
+  } else {
+    auto iter =
+      queryMap->map.emplace_hint(
+        search,
+        std::make_pair(tupleOfArgs,
+                       QueryMapResult<ResultType>(QueryDependencyVec(),
+                                                  0,
+                                                  this->currentRevisionNumber,
+                                                  this->currentRevisionNumber,
+                                                  QueryErrorVec(),
+                                                  std::move(result))));
+    QueryMapResult<ResultType>* newResult = &(iter->second);
+    changedOut = true;
+    return newResult;
+  }
+}
+
+template<typename ResultType, typename... ArgTs>
+QueryMapResult<ResultType>*
+Context::updateResultForQuery(const std::tuple<ArgTs...>& tupleOfArgs,
+                              ResultType result,
+                              bool& changedOut,
+                              UniqueString queryName) {
+  // Look up the map entry for this query name
+  QueryMap<ResultType,ArgTs...>* queryMap =
+    queryGetMap<ResultType>(queryName, tupleOfArgs);
+  // Run the version of the function accepting the map
+  return
+    updateResultForQuery(tupleOfArgs, std::move(result), changedOut, queryMap);
+}
+
+template<typename ResultType>
+const ResultType& Context::queryGetSavedResult(QueryMapResult<ResultType>* resultEntry) {
+  this->saveDependenciesAndErrorsInParent(resultEntry);
+  return resultEntry->result;
+}
+
+template<typename ResultType, typename... ArgTs>
+ResultType& Context::queryEnd(UniqueString queryName, const char* func,
+                    ResultType result,
+                    const std::tuple<ArgTs...>& tupleOfArgs,
+                    QueryMap<ResultType,ArgTs...>* queryMap) {
+
+  // At this point, queryDeps is the dependency vector for this query
+  assert(queryDeps.size() > 0);
+  assert(queryDeps.back().queryName == queryName);
+
+  bool changed = false;
+  QueryMapResult<ResultType>* ret =
+    this->updateResultForQuery(tupleOfArgs, std::move(result),
+                               changed, queryMap);
+
+  queryTraceEnd(queryName, func, tupleOfArgs, changed);
+
+  endQueryHandleDependency(ret);
+
+  auto currentRevision = this->currentRevisionNumber;
+  if (changed == false) {
+    ret->lastComputed = currentRevision;
+  } else {
+    ret->lastComputed = currentRevision;
+    ret->lastChanged  = currentRevision;
+  }
+  return ret->result;
+}
+
+} // end namespace chpl
+
+#define STRINGIZE_LINE_DETAIL(x) #x
+#define STRINGIZE_LINE(x) STRINGIZE_LINE_DETAIL(x)
+
+/**
+  The following macros should be called within a query function in
+  a particular stylized manner:
+
+    const MyResultType& myQueryFunction(Context* context, myKey1, myKey2) {
+      QUERY_BEGIN(context, MyResultType, myKey1, myKey2)
+      if (QUERY_USE_SAVED()) {
+        return QUERY_GET_SAVED();
+      }
+      // do steps to compute the result
+      MyResultType result = ...;
+      // if an error is encountered, it can be saved with QUERY_ERROR(error)
+
+      return QUERY_END(result);
+    }
+
+  The above is appropriate for value types  (std::string, int, etc).
+  For an object that should be managed as owned within the context,
+  use this pattern:
+
+    const MyClassType* myQueryFunction(Context* context, myKey1, myKey2) {
+      QUERY_BEGIN(context, owned<MyClassType>, myKey1, myKey2)
+      if (QUERY_USE_SAVED()) {
+        return QUERY_GET_SAVED().get();
+      }
+      // do steps to compute the result
+      owned<MyClassType> result = ...;
+      // if an error is encountered, it can be saved with QUERY_ERROR(error)
+
+      return QUERY_END(result);
+    }
+
+  QUERY_BEGIN_NAMED can be used to provide a name for the query.
+  That is needed in order to allow Context to have a setter method
+  for that query.
+ */
+
+#define QUERY_BEGIN_NAMED(context, ResultType, queryName, ...) \
+  Context* BEGIN_QUERY_CONTEXT = context; \
+  const char* BEGIN_QUERY_FUNC = __func__; \
+  UniqueString BEGIN_QUERY_NAME = UniqueString::build(context, queryName); \
+  auto BEGIN_QUERY_ARGS = std::make_tuple(__VA_ARGS__); \
+  context->queryTraceBegin(BEGIN_QUERY_NAME, BEGIN_QUERY_FUNC, \
+                           BEGIN_QUERY_ARGS); \
+  auto BEGIN_QUERY_MAP = \
+    context->queryGetMap<ResultType>(BEGIN_QUERY_NAME, \
+                                     BEGIN_QUERY_ARGS); \
+  auto BEGIN_QUERY_SEARCH1 = BEGIN_QUERY_MAP->map.find(BEGIN_QUERY_ARGS); \
+  QueryMapResultBase* BEGIN_QUERY_FOUND1 = nullptr; \
+  if (BEGIN_QUERY_SEARCH1 != BEGIN_QUERY_MAP->map.end()) { \
+    BEGIN_QUERY_FOUND1 = &(BEGIN_QUERY_SEARCH1->second); \
+  }
+
+#define QUERY_BEGIN(context, ResultType, ...) \
+  const char* BEGIN_QUERY_FILE = __FILE__; \
+  int BEGIN_QUERY_LINE = __LINE__; \
+  const char* BEGIN_QUERY_FILE_LINE = __FILE__ ":" STRINGIZE_LINE(__LINE__); \
+  QUERY_BEGIN_NAMED(context, ResultType, BEGIN_QUERY_FILE_LINE, __VA_ARGS__);
+
+#define QUERY_USE_SAVED() \
+  (BEGIN_QUERY_CONTEXT->queryCanUseSavedResultAndPushIfNot(BEGIN_QUERY_NAME, BEGIN_QUERY_FUNC, BEGIN_QUERY_FOUND1))
+
+#define QUERY_GET_SAVED() \
+  (BEGIN_QUERY_CONTEXT->queryGetSavedResult(&(BEGIN_QUERY_SEARCH1->second)))
+
+#define QUERY_ERROR(error) \
+  BEGIN_QUERY_CONTEXT->queryNoteError(error)
+
+#define QUERY_END(result) \
+  /* must not use BEGIN_QUERY_SEARCH1 (iterator could be invalidated) */ \
+  (BEGIN_QUERY_CONTEXT->queryEnd(BEGIN_QUERY_NAME, BEGIN_QUERY_FUNC, result, BEGIN_QUERY_ARGS, BEGIN_QUERY_MAP))
+
+/// \endcond
+
+#endif

--- a/compiler/next/include/chpl/Queries/QueryImpl.h
+++ b/compiler/next/include/chpl/Queries/QueryImpl.h
@@ -100,16 +100,16 @@ Context::updateResultForQuery(const std::tuple<ArgTs...>& tupleOfArgs,
   if (search != queryMap->map.end()) {
    QueryMapResult<ResultType>* storedResult = &(search->second);
 
-   // Call a chpl::combine function. That leaves the result in the 1st argument
+   // Call a chpl::update function. That leaves the result in the 1st argument
    // and returns whether or not it needed to change. The 2nd argument contains
    // junk. If we wait until a garbageCollect call to free the junk, we can
    // avoid certain cases where a pointer could be allocated, freed, and then
    // allocated; leading to a sort of ABA issue.
-   chpl::combine<ResultType> combiner;
-   bool match = combiner(storedResult->result, result);
+   chpl::update<ResultType> combiner;
+   bool changed = combiner(storedResult->result, result);
    // now storedResult is the new result
    queryMap->oldResults.push_back(std::move(result));
-   if (match) {
+   if (changed == false) {
      changedOut = false;
      storedResult->lastComputed = this->currentRevisionNumber;
      return storedResult;

--- a/compiler/next/include/chpl/Util/memory.h
+++ b/compiler/next/include/chpl/Util/memory.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UTIL_MEMORY_H
+#define CHPL_UTIL_MEMORY_H
+
+#include <memory>
+
+namespace chpl {
+
+/**
+ owned<T> is just a synonym for 'std::unique_ptr<T>'.
+ It is shorter and uses the Chapel term for it.
+ */
+template<typename T>
+  using owned = std::unique_ptr<T>;
+/**
+ give a raw pointer to an owned<T> to manage it.
+ */
+template<typename T>
+static inline owned<T> toOwned(T* takeFrom) {
+  return owned<T>(takeFrom);
+}
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/lib/AST/ErrorMessage.cpp
+++ b/compiler/next/lib/AST/ErrorMessage.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/AST/ErrorMessage.h"
+
+#include <cassert>
+#include <cstdarg>
+#include <cstdlib>
+
+namespace chpl {
+namespace ast {
+
+static std::string vprint_to_string(const char* format, va_list vl) {
+  int size = 128;
+  char* buf = (char*) malloc(size);
+  int got = vsnprintf(buf, size, format, vl);
+  if (got >= size) {
+    // output was truncated, so try again
+    size = got+1;
+    buf = (char*) realloc(buf, size);
+    got = vsnprintf(buf, size, format, vl);
+    assert(got < size);
+    if (got >= size) return "<internal error in saving error>";
+  }
+  std::string ret(buf);
+  free(buf);
+  return ret;
+}
+
+ErrorMessage::ErrorMessage()
+  : level_(-1), location_(), message_() {
+}
+ErrorMessage::ErrorMessage(Location location, std::string message)
+  : level_(0), location_(location), message_(message) {
+}
+ErrorMessage::ErrorMessage(Location location, const char* message)
+  : level_(0), location_(location), message_(message) {
+}
+
+ErrorMessage ErrorMessage::build(Location loc, const char* fmt, ...) {
+  std::string ret;
+  va_list vl;
+  va_start(vl, fmt);
+  ret = vprint_to_string(fmt, vl);
+  va_end(vl);
+  return ErrorMessage(loc, ret);
+}
+
+void ErrorMessage::swap(ErrorMessage& other) {
+  int oldThisLevel = this->level_;
+  this->level_ = other.level_;
+  other.level_ = oldThisLevel;
+  this->location_.swap(other.location_);
+  this->message_.swap(other.message_);
+}
+
+} // namespace ast
+} // namespace chpl

--- a/compiler/next/lib/AST/UniqueString.cpp
+++ b/compiler/next/lib/AST/UniqueString.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// include these first since they set some things that
+// are used by system headers.
+#include "../Util/sys_basic.h"
+#include "../Util/bswap.h"
+
+#include "chpl/AST/UniqueString.h"
+
+#include "chpl/Queries/Context.h"
+
+#include <cassert>
+#include <cstring>
+
+namespace chpl {
+namespace ast {
+
+namespace detail {
+
+  char* InlinedString::dataAssumingTag(void* vptr) {
+    char* ptr = (char*) vptr;
+    // assuming the tag is present, where is the string data?
+    // on a little endian system, need to pass the tag.
+    // on big endian systems, the tag is after the null terminator,
+    // so no action is necessary.
+    #if __BYTE_ORDER == __LITTLE_ENDIAN
+      ptr += 1; // pass the tag
+    #endif
+    return ptr;
+  }
+
+
+  InlinedString InlinedString::buildUsingContextTable(Context* context,
+                                                      const char* s, int len) {
+    const char* u = context->uniqueCString(s);
+    // assert that the address returned is even
+    assert( (((uintptr_t)u)&1)==0 );
+    return InlinedString::buildFromAligned(u, len);
+  }
+
+} // end namespace detail
+
+} // end namespace ast
+} // end namespace chpl

--- a/compiler/next/lib/Queries/Context.cpp
+++ b/compiler/next/lib/Queries/Context.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/Queries/Context.h"
+
+#include "chpl/Queries/QueryImpl.h"
+
+#include <cstdlib>
+#include <cassert>
+
+namespace chpl {
+
+using namespace chpl::querydetail;
+
+Context::Context()
+  : uniqueStringsTable(), queryDB(), queryDeps(),
+    currentRevisionNumber(1), lastPrepareToGCRevisionNumber(0), gcCounter(1) {
+}
+
+owned<Context> Context::build() {
+  return toOwned(new Context());
+}
+
+Context::~Context() {
+  // free all of the unique'd strings
+  for (auto& item: this->uniqueStringsTable) {
+    const char* s = item.second;
+    free((void*)s);
+  }
+}
+
+#define ALIGN_DN(i, size)  ((i) & ~((size) - 1))
+#define ALIGN_UP(i, size)  ALIGN_DN((i) + (size) - 1, size)
+
+static char* allocateEvenAligned(size_t amt) {
+  char* buf = (char*) malloc(amt);
+  // Normally, malloc returns something that is aligned to 16 bytes,
+  // but it's technically possible that a platform library
+  // could not do so. So, here we check.
+  // We only need even alignment here.
+  if ((((uintptr_t)buf) & 1) != 0) {
+    free(buf);
+    // try again with an aligned allocation
+    size_t alignment = sizeof(void *);
+    size_t align_up_len = ALIGN_UP(amt, sizeof(void*));
+    buf = (char*) aligned_alloc(alignment, align_up_len);
+  }
+  assert(buf);
+  assert((((uintptr_t)buf) & 1) == 0);
+  return buf;
+}
+
+const char* Context::getOrCreateUniqueString(const char* str) {
+  char gcMark = this->gcCounter & 0xff;
+  auto search = this->uniqueStringsTable.find(str);
+  if (search != this->uniqueStringsTable.end()) {
+    char* buf = search->second;
+    // update the GC mark
+    // Performance: Would it be better to do this store unconditionally?
+    if (this->currentRevisionNumber == this->lastPrepareToGCRevisionNumber) {
+      buf[0] = gcMark;
+    }
+    const char* key = buf+2; // pass the 2 bytes of metadata
+    return key;
+  }
+  size_t strLen = strlen(str);
+  size_t allocLen = strLen+3; // 2 bytes of metadata, str data, '\0'
+  char* buf = allocateEvenAligned(allocLen);
+  // set the GC mark
+  buf[0] = gcMark;
+  // set the unused metadata (need to still have even alignment)
+  buf[1] = 0x02;
+  // copy the string data, including the null terminator
+  memcpy(buf+2, str, strLen+1);
+  const char* key = buf+2; // pass the 2 bytes of metadata
+  // Add it to the table
+  this->uniqueStringsTable.insert(search, {key, buf});
+  return key;
+}
+
+const char* Context::uniqueCString(const char* s) {
+  if (s == NULL) s = "";
+  return this->getOrCreateUniqueString(s);
+}
+
+UniqueString Context::moduleNameForID(ID id) {
+  // If the symbol path is empty, this ID doesn't have a module.
+  if (id.symbolPath().isEmpty()) {
+    UniqueString empty;
+    return empty;
+  }
+
+  // Otherwise, the module name is everything up to the first '.'
+  size_t len = 0;
+  const char* s = id.symbolPath().c_str();
+  while (true) {
+    if (s[len] == '\0' || s[len] == '.') break;
+    len++;
+  }
+
+  return UniqueString::build(this, s, len);
+}
+
+UniqueString Context::filePathForID(ID id) {
+  UniqueString modName = this->moduleNameForID(id);
+  return this->filePathForModuleName(modName);
+}
+
+UniqueString Context::filePathForModuleName(UniqueString modName) {
+  QUERY_BEGIN_NAMED(this, UniqueString, "filePathForModuleName", modName);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+  assert(false && "This query should always use a saved result");
+  auto result = UniqueString::build(this, "<unknown file path>");
+  return QUERY_END(result);
+}
+
+void Context::advanceToNextRevision(bool prepareToGC) {
+  this->currentRevisionNumber++;
+  if (prepareToGC) {
+    this->lastPrepareToGCRevisionNumber = this->currentRevisionNumber;
+    gcCounter++;
+  }
+  printf("CURRENT REVISION NUMBER IS NOW %i\n",
+         (int) this->currentRevisionNumber);
+}
+
+void Context::collectGarbage() {
+  // if there are no parent queries, we can clear out the saved oldResults
+  if (queryDeps.size() == 0 &&
+      this->lastPrepareToGCRevisionNumber == this->currentRevisionNumber) {
+    // warning: these loops proceeds in a nondeterministic order
+    for (auto& dbEntry: queryDB) {
+      QueryMapBase* queryMapBase = dbEntry.second.get();
+      queryMapBase->clearOldResults(this->currentRevisionNumber);
+    }
+    // Performance: Would it be better to modify the table in-place
+    // rather than creating a new table as is done here?
+    char gcMark = this->gcCounter & 0xff;
+    UniqueStringsTableType newTable;
+    std::vector<char*> toFree;
+    for (auto& e: uniqueStringsTable) {
+      const char* key = e.first;
+      char* buf = e.second;
+      if (buf[0] == gcMark) {
+        newTable.insert(std::make_pair(key, buf));
+      } else {
+        toFree.push_back(buf);
+      }
+    }
+    for (char* buf: toFree) {
+      free(buf);
+    }
+    uniqueStringsTable.swap(newTable);
+  }
+}
+
+bool Context::setFilePathForModuleName(UniqueString modName, UniqueString path) {
+  UniqueString queryName = UniqueString::build(this, "filePathForModuleName");
+  auto tupleOfArgs = std::make_tuple(modName);
+  bool changed = false;
+  auto queryMapResult = updateResultForQuery(tupleOfArgs, path,
+                                             changed, queryName);
+  return changed;
+}
+
+bool Context::setFileText(UniqueString path, std::string data) {
+  UniqueString queryName = UniqueString::build(this, "fileText");
+  auto tupleOfArgs = std::make_tuple(path);
+  bool changed = false;
+  auto queryMapResult = updateResultForQuery(tupleOfArgs, std::move(data),
+                                             changed, queryName);
+  return changed;
+}
+
+bool Context::queryCanUseSavedResult(QueryMapResultBase* resultEntry) {
+  // If there was no result, we can't reuse it
+  if (resultEntry == nullptr) {
+    return false;
+  }
+
+  // If we already checked this query in this revision,
+  // we can use this result
+  if (resultEntry->lastComputed == this->currentRevisionNumber ||
+      resultEntry->lastCheckedAndReused == this->currentRevisionNumber) {
+    return true;
+  }
+
+  // Otherwise, check the dependencies. Have any of them
+  // changed since the last revision in which we computed this?
+  if (resultEntry->dependencies.size() > 0) {
+    for (QueryMapResultBase* dependency : resultEntry->dependencies) {
+      if (dependency->lastChanged > resultEntry->lastComputed) {
+        return false;
+      }
+      // check the dependencies, transitively
+      if (!queryCanUseSavedResult(dependency)) {
+        return false;
+      }
+    }
+  } else {
+    // If there are no dependencies, assume it is some external
+    // input that is managed by the currentRevisionNumber.
+    // So, recompute it if the current revision number has changed.
+    if (this->currentRevisionNumber > resultEntry->lastComputed) {
+      return false;
+    }
+  }
+
+  // Otherwise, all of the inputs have not changed
+  // since this result was last computed.
+  resultEntry->lastCheckedAndReused = this->currentRevisionNumber;
+  return true;
+}
+
+bool Context::queryCanUseSavedResultAndPushIfNot(UniqueString queryName, const char* queryFunc, QueryMapResultBase* resultEntry) {
+  bool ret = this->queryCanUseSavedResult(resultEntry);
+  if (ret == false) {
+    printf("QUERY COMPUTING %s (...)\n", queryFunc);
+    // since the result cannot be used, the query will be evaluated
+    // so push something to queryDeps
+    queryDeps.push_back(QueryDepsEntry(queryName));
+  } else {
+    printf("QUERY END       %s (...) REUSING\n", queryFunc);
+  }
+  return ret;
+}
+
+void Context::saveDependenciesAndErrorsInParent(QueryMapResultBase* resultEntry) {
+  // Record that the parent query depends upon this one.
+  //
+  // we haven't pushed the query beginning yet, so the
+  // parent query is at queryDeps.back()
+  if (queryDeps.size() > 0) {
+    queryDeps.back().dependencies.push_back(resultEntry);
+    if (resultEntry->errors.size() > 0) {
+      for (const ErrorMessage& e : resultEntry->errors) {
+        queryDeps.back().errors.push_back(e);
+      }
+    }
+  }
+}
+void Context::endQueryHandleDependency(QueryMapResultBase* result) {
+  // queryDeps.back() is the dependency vector for this query
+  // which is now ending. So, replace result->dependencies with it.
+  result->dependencies.swap(queryDeps.back().dependencies);
+  result->errors.swap(queryDeps.back().errors);
+  queryDeps.pop_back();
+  // additionally, we've run a query and there might well be
+  // a parent query. In that event, we should update the dependency
+  // vector for the parent query.
+  saveDependenciesAndErrorsInParent(result);
+}
+
+void Context::queryNoteError(ErrorMessage error) {
+  assert(queryDeps.size() > 0);
+  queryDeps.back().errors.push_back(std::move(error));
+}
+
+
+namespace querydetail {
+
+
+template<>
+std::size_t queryArgsHash<>(const std::tuple<>& tuple) {
+  return 0;
+}
+
+template<>
+bool queryArgsEquals<>(const std::tuple<>& lhs,
+                       const std::tuple<>& rhs) {
+  return true;
+}
+
+template<>
+void queryArgsPrint<>(const std::tuple<>& tuple) {
+}
+
+void queryArgsPrintSep() {
+  printf(", ");
+}
+
+void queryArgsPrintUnknown() {
+  printf("?");
+}
+
+void queryArgsPrintOne(const ID& v) {
+  printf("ID(%s@%i)", v.symbolPath().c_str(), v.postOrderId());
+}
+void queryArgsPrintOne(const UniqueString& v) {
+  printf("\"%s\"", v.c_str());
+}
+
+QueryMapResultBase::~QueryMapResultBase() {
+}
+
+QueryMapBase::~QueryMapBase() {
+}
+
+
+} // end namespace querydetail
+} // end namespace chpl

--- a/compiler/next/lib/Queries/Context.cpp
+++ b/compiler/next/lib/Queries/Context.cpp
@@ -138,8 +138,6 @@ void Context::advanceToNextRevision(bool prepareToGC) {
     this->lastPrepareToGCRevisionNumber = this->currentRevisionNumber;
     gcCounter++;
   }
-  printf("CURRENT REVISION NUMBER IS NOW %i\n",
-         (int) this->currentRevisionNumber);
 }
 
 void Context::collectGarbage() {

--- a/compiler/next/lib/Queries/Context.cpp
+++ b/compiler/next/lib/Queries/Context.cpp
@@ -95,7 +95,7 @@ const char* Context::getOrCreateUniqueString(const char* str) {
 }
 
 const char* Context::uniqueCString(const char* s) {
-  if (s == NULL) s = "";
+  if (s == nullptr) s = "";
   return this->getOrCreateUniqueString(s);
 }
 

--- a/compiler/next/lib/Util/bswap.h
+++ b/compiler/next/lib/Util/bswap.h
@@ -1,0 +1,1 @@
+../../../../runtime/include/qio/bswap.h

--- a/compiler/next/lib/Util/files.cpp
+++ b/compiler/next/lib/Util/files.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "files.h"
+
+#include "./mystrerror.h"
+
+#include "chpl/AST/ErrorMessage.h"
+#include "chpl/AST/Location.h"
+
+#include <cerrno>
+
+namespace chpl {
+
+FILE* openfile(const char* path, const char* mode, ErrorMessage& errorOut) {
+  FILE* fp = fopen(path, mode);
+  if (fp == nullptr) {
+    std::string strerr = my_strerror(errno);
+    auto emptyLocation = Location();
+    // set errorOut. NULL will be returned.
+    errorOut = ErrorMessage::build(emptyLocation, "opening %s: %s",
+                                   path, strerr.c_str());
+  }
+
+  return fp;
+}
+
+bool closefile(FILE* fp, const char* path, ErrorMessage& errorOut) {
+  int rc = fclose(fp);
+  if (rc != 0) {
+    std::string strerr = my_strerror(errno);
+    auto emptyLocation = Location();
+    errorOut = ErrorMessage::build(emptyLocation, "closing %s: %s",
+                                   path, strerr.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool readfile(const char* path,
+              std::string& strOut,
+              ErrorMessage& errorOut) {
+
+  FILE* fp = openfile(path, "r", errorOut);
+  if (fp == nullptr) {
+    return false;
+  }
+
+  // Try to get the file length in order to optimize string allocation
+  long len = 0;
+  fseek(fp, 0, SEEK_END);
+  len = ftell(fp);
+  fseek(fp, 0, SEEK_SET);
+  if (len > 0) strOut.reserve(len);
+
+  char buf[256];
+  while (true) {
+    size_t got = fread(buf, 1, sizeof(buf), fp);
+    if (got > 0) {
+      strOut.append(buf, got);
+    } else {
+      if (ferror(fp)) {
+        auto emptyLocation = Location();
+        errorOut = ErrorMessage::build(emptyLocation, "reading %s", path);
+        ErrorMessage ignored;
+        closefile(fp, path, ignored);
+        return false;
+      }
+      // otherwise, end of file reached
+      break;
+    }
+  }
+  bool ok = closefile(fp, path, errorOut);
+  if (!ok) {
+    return false;
+  }
+
+  return true;
+}
+
+}

--- a/compiler/next/lib/Util/files.h
+++ b/compiler/next/lib/Util/files.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FILES_H
+#define FILES_H
+
+#include "chpl/AST/ErrorMessage.h"
+
+#include <cstdio>
+#include <string>
+
+namespace chpl {
+
+/**
+  Open a file. If the open failed, return nullptr and set errorOut.
+ */
+FILE* openfile(const char* path, const char* mode, ErrorMessage& errorOut);
+
+/**
+  Close a file. If the close failed, return false and set errorOut.
+ */
+bool closefile(FILE* fp, const char* path, ErrorMessage& errorOut);
+
+/**
+  Reads the contents of a file into a string.
+  If something failed, returns false and sets errorOut.
+ */
+bool readfile(const char* path, std::string& strOut, ErrorMessage& errorOut);
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/lib/Util/mystrerror.cpp
+++ b/compiler/next/lib/Util/mystrerror.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// make sure to get the XSI/POSIX.1-2001 strerror_r
+#define _POSIX_C_SOURCE 200112L
+#undef _GNU_SOURCE
+#include "./sys_basic.h"
+
+#include "mystrerror.h"
+
+#include <string>
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+
+namespace chpl {
+
+std::string my_strerror(int errno_) {
+  char errbuf[256];
+  int rc;
+  errbuf[0] = '\0';
+  rc = strerror_r(errno_, errbuf, sizeof(errbuf));
+  if (rc != 0)
+    strncpy(errbuf, "<unknown error>", sizeof(errbuf));
+  return std::string(errbuf);
+}
+
+} // end namespace chpl

--- a/compiler/next/lib/Util/mystrerror.h
+++ b/compiler/next/lib/Util/mystrerror.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MYSTRERROR_H
+#define MYSTRERROR_H
+
+#include <string>
+
+namespace chpl {
+
+std::string my_strerror(int errno_);
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/lib/Util/sys_basic.h
+++ b/compiler/next/lib/Util/sys_basic.h
@@ -1,0 +1,1 @@
+../../../../runtime/include/sys_basic.h


### PR DESCRIPTION
This PR contains a query framework and supporting classes as part of the
prototype compiler library effort.

Split out from PR #17583, which is a start at the compiler revamp effort
described in the
[1.24 release notes ongoing efforts](https://chapel-lang.org/releaseNotes/1.24/04-ongoing.pdf).

The new effort implements the early portions of the compiler as "queries"
that have no side-effects other than computing some output from some
input. These queries are memoized in a manner that allows recomputing
them when a dependency has changed. The idea is that this structure can
better support IDEs but at the very least it is highly incremental which
is one of the goals here. This strategy is based upon the approach used
in the Rust compiler (described in
[this talk](https://www.youtube.com/watch?v=N6b44kMS6OM)).

* Adds ErrorMessage and Location classes. ErrorMessage contains a
  Location. The query framework saves ErrorMessages along  with query
  results so needs to have these types available. That way, the
  ErrorMessage can be emitted again in an incremental setting when the
  query itself is not recomputed.
* Adds UniqueString, which is a type that represents a string unique'd in
  a table. This is similar to `astr` in the old compiler, with four
  differences:
  1. The UniqueString table is stored in the `Context` rather than as a
     global variable
  2. The UniqueString can store short strings inline
  3. Uses a different type for unique'd strings - namely UniqueString -
     where the `astr` mechanism just returned `const char*` which made it
     unclear whether or not the string was already unique'd.
  4. The UniqueString table can be garbage collected.
* The type PODUniqueString is used in the parser, where the results
  parser actions are stored in the union, so the types in that union
  can't have default constructors. It should not be used outside of such
  a restricted setting.
* Adds the Context type, which serves a sort of program database. See the
  comment at the start of Context for details. The saved state in the
  Context type can be garbage collected by 1) incrementing the revision
  counter and requesting garbage collection (so "mark" step can be done
  where appropriate); 2) running a toplevel query; and 3) calling
  `collectGarbage` after the toplevel query (and all other queries) are
  done running.

Some notes about the query implementation:
* The implementation uses C++11 variadic templates. I found these
  references useful in figuring out how to use them:
  https://medium.com/@matt.aubury/rip-index-sequence-2014-2017-9cc854aaad0
  https://eli.thegreenplace.net/2014/variadic-templates-in-c/
* The query implementation uses a lot of `std::unordered_map` and in
  implementing hash functions we sometimes need something to combine two
  hashes. I added a `hash_combine` function based on the Boost one which
  is documented here:
  https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
* The query implementation uses a `combine` operation on the results. The
  justification for this is that, during parsing, the AST tree being
  parsed might be substantially the same, with say one change in a block
  inside a block inside a function. In that event, we'd like to keep the
  old AST nodes where possible. That should allow:
     1. reuse of queries that referred to these old AST nodes
     2. queries that have pointers to AST nodes in their results,
        provided that they do pointer comparision (because if the pointer
        has changed, we have a new (and different) AST element; but if
        the pointer has not changed, we have reused the old AST element
        pointer).
* Related to the above, the query implementation is careful to store both
  the new and old results when doing a `combine` operation. The intention
  of this is to avoid ABA-like problems.
  * I have not observed such a problem with the combining but I think it
    is possible. The map could contain a value that contains a pointer to
    something old. If the map entry it depends upon it had no changes, it
    could also have no changes. That could be a problem if the pointer
    value was freed and then allocated in the time between checking the
    depended-upon entry and the map entry itself.
  * Anyway keeping the old values around fits in with the
    'context->collectGarbage()' mechanism. It should be possible to
    access memory inside of an old value, but the old value will be
    changed by combine calls, so if it's garbage the value won't match up
    anyway. As a result, after the parseFile call, AST elements in values
    should only have their pointers compared in combine calls.

Future Work:
 * Consider [FNV-1a](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function)
   instead of what is here for the string hash in ContextDetail.h.
 * Use C++14 index_sequence (perhaps drawing from
   https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/library/src/include/tuple_helper.hpp
   ) in the variadic templates

 - [x] full local testing
 
 Reviewed by @leekillough  @e-kayrakli and @dlongnecke-cray - thanks!