### PR TITLE
responsive compiler prototype: parser to produce new AST classes

### DIFF
--- a/compiler/next/include/chpl/Frontend/Parser.h
+++ b/compiler/next/include/chpl/Frontend/Parser.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_FRONTEND_PARSER_H
+#define CHPL_FRONTEND_PARSER_H
+
+#include "chpl/AST/BaseAST.h"
+#include "chpl/AST/Builder.h"
+#include "chpl/AST/Expr.h"
+#include "chpl/AST/ErrorMessage.h"
+#include "chpl/AST/Location.h"
+#include "chpl/Util/memory.h"
+
+#include <vector>
+
+namespace chpl {
+
+/**
+  A class for parsing
+ */
+class Parser final {
+ private:
+   // TODO: stuff to do with module search paths
+   // and then connect parsed modules to a query
+
+   // TODO: compile-time configuration variable settings
+   // need to be stored in here.
+
+   Context* context_;
+   Parser(Context* context);
+
+ public:
+   static owned<Parser> build(Context* context);
+   ~Parser() = default;
+
+   /**
+     Return the AST Context used by this Parser.
+    */
+   Context* context() { return context_; }
+
+   /**
+     Parse a file at a particular path.
+    */
+   ast::Builder::Result parseFile(const char* path);
+   /**
+     Parse source code in a string.
+     'path' is only used for certain errors.
+    */
+   ast::Builder::Result parseString(const char* path, const char* str);
+};
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/lib/Frontend/Parser.cpp
+++ b/compiler/next/lib/Frontend/Parser.cpp
@@ -85,7 +85,7 @@ Builder::Result Parser::parseFile(const char* path) {
     return builder->result();
   }
 
-  // Otherwise, we have successfully openned the file.
+  // Otherwise, we have successfully opened the file.
 
   // Set the (global) parser debug state
   if (DEBUG_PARSER)

--- a/compiler/next/lib/Frontend/Parser.cpp
+++ b/compiler/next/lib/Frontend/Parser.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/Frontend/Parser.h"
+
+#include "../Util/files.h"
+
+#include "chpl/AST/ErrorMessage.h"
+#include "chpl/AST/Comment.h"
+#include "chpl/AST/Expr.h"
+
+#include "Parser/bison-chapel.h"
+#include "Parser/flex-chapel.h"
+
+#include <cstdlib>
+#include <cstring>
+
+#define DEBUG_PARSER 0
+
+namespace chpl {
+
+using namespace ast;
+
+Parser::Parser(Context* context)
+  : context_(context) {
+}
+
+owned<Parser> Parser::build(Context* context) {
+  return toOwned(new Parser(context));
+}
+
+static void updateParseResult(ParserContext* parserContext) {
+
+  Builder* builder = parserContext->builder;
+
+  // Save the top-level exprs
+  if (parserContext->topLevelStatements != nullptr) {
+    for (Expr* stmt : *parserContext->topLevelStatements) {
+      builder->addToplevelExpr(toOwned(stmt));
+    }
+    delete parserContext->topLevelStatements;
+  }
+  // Save any remaining top-level comments
+  if (parserContext->comments != nullptr) {
+    for (ParserComment parserComment : *parserContext->comments) {
+      builder->addToplevelExpr(toOwned(parserComment.comment));
+    }
+    delete parserContext->comments;
+  }
+
+  Context* aCtx = parserContext->context();
+  // Save the parse errors
+  for (ParserError & parserError : parserContext->errors) {
+    // Need to convert the error to a regular ErrorMessage
+    Location loc = parserContext->convertLocation(parserError.location);
+    builder->addError(ErrorMessage(loc, parserError.message));
+  }
+}
+
+
+Builder::Result Parser::parseFile(const char* path) {
+  auto builder = Builder::build(this->context(), path);
+  ErrorMessage fileError;
+
+  FILE* fp = openfile(path, "r", fileError);
+  if (fp == NULL) {
+    builder->addError(fileError);
+    return builder->result();
+  }
+
+  // Otherwise, we have successfully openned the file.
+
+  // Set the (global) parser debug state
+  if (DEBUG_PARSER)
+    yydebug = DEBUG_PARSER;
+
+  // State for the lexer
+  int           lexerStatus  = 100;
+
+  // State for the parser
+  yypstate*     parser       = yypstate_new();
+  int           parserStatus = YYPUSH_MORE;
+  YYLTYPE       yylloc;
+  ParserContext parserContext(path, builder.get());
+
+  yylloc.first_line             = 1;
+  yylloc.first_column           = 1;
+  yylloc.last_line              = 1;
+  yylloc.last_column            = 1;
+
+  yylex_init_extra(&parserContext, &parserContext.scanner);
+
+  yyset_in(fp, parserContext.scanner);
+
+  while (lexerStatus != 0 && parserStatus == YYPUSH_MORE) {
+    YYSTYPE yylval;
+
+    lexerStatus = yylex(&yylval, &yylloc, parserContext.scanner);
+
+    if        (lexerStatus >= 0) {
+      parserStatus          = yypush_parse(parser,
+                                           lexerStatus,
+                                           &yylval,
+                                           &yylloc,
+                                           &parserContext);
+
+    } else if (lexerStatus == YYLEX_BLOCK_COMMENT) {
+      // comment should already be noted in processBlockComment
+    } else if (lexerStatus == YYLEX_SINGLE_LINE_COMMENT) {
+      // comment should already be noted in processSingleLineComment
+    }
+  }
+
+  // Cleanup after the parser
+  yypstate_delete(parser);
+
+  // Cleanup after the lexer
+  yylex_destroy(parserContext.scanner);
+
+  if (closefile(fp, path, fileError)) {
+    builder->addError(fileError);
+  }
+
+  updateParseResult(&parserContext);
+
+  // compute the result from the builder
+  return builder->result();
+}
+
+
+Builder::Result Parser::parseString(const char* path, const char* str) {
+  auto builder = Builder::build(this->context(), path);
+
+  // Set the (global) parser debug state
+  if (DEBUG_PARSER)
+    yydebug = DEBUG_PARSER;
+
+  // State for the lexer
+  YY_BUFFER_STATE handle       =   0;
+  int             lexerStatus  = 100;
+  YYLTYPE         yylloc;
+
+  // State for the parser
+  yypstate*     parser       = yypstate_new();
+  int           parserStatus = YYPUSH_MORE;
+  ParserContext parserContext(path, builder.get());
+
+  yylex_init_extra(&parserContext, &parserContext.scanner);
+
+  handle              = yy_scan_string(str, parserContext.scanner);
+
+  yylloc.first_line   = 1;
+  yylloc.first_column = 1;
+  yylloc.last_line    = 1;
+  yylloc.last_column  = 1;
+
+  while (lexerStatus != 0 && parserStatus == YYPUSH_MORE) {
+    YYSTYPE yylval;
+
+    lexerStatus  = yylex(&yylval, &yylloc, parserContext.scanner);
+
+    if (lexerStatus >= 0) {
+      parserStatus          = yypush_parse(parser,
+                                           lexerStatus,
+                                           &yylval,
+                                           &yylloc,
+                                           &parserContext);
+
+    } else if (lexerStatus == YYLEX_BLOCK_COMMENT) {
+      // comment should already be noted in processBlockComment
+    } else if (lexerStatus == YYLEX_SINGLE_LINE_COMMENT) {
+      // comment should already be noted in processSingleLineComment
+    }
+  }
+
+  // Cleanup after the parser
+  yypstate_delete(parser);
+
+  // Cleanup after the lexer
+  yy_delete_buffer(handle, parserContext.scanner);
+  yylex_destroy(parserContext.scanner);
+
+  updateParseResult(&parserContext);
+
+  return builder->result();
+}
+
+} // namespace chpl

--- a/compiler/next/lib/Frontend/Parser/ParserContext.h
+++ b/compiler/next/lib/Frontend/Parser/ParserContext.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is included at the right time in the generated bison .h/.cpp
+// so that it can depend upon YYLTYPE.
+//
+// It is split out into this separate file for easier maintenance.
+
+// Headers that this depends upon should be defined in ParserDependencies.h
+
+struct ParserError {
+  // Note that this does not include the filename;
+  // that should be known by whatever code is parsing something
+  // when it goes to report errors.
+  //
+  // When an error occurs during parsing, the parser should
+  // emit errors here and create a stand-in ErroneousExpr AST
+  // node.
+  YYLTYPE location;
+  std::string message;
+  ParserError(YYLTYPE location, std::string message)
+    : location(location), message(message) { }
+  ParserError(YYLTYPE location, const char* message)
+    : location(location), message(message) { }
+};
+
+struct ParserComment {
+  YYLTYPE location;
+  Comment* comment;
+};
+
+struct ParserContext {
+  yyscan_t scanner;
+  UniqueString filename;
+  Builder* builder;
+
+  ParserExprList* topLevelStatements;
+  std::vector<ParserError> errors;
+
+  // TODO: this should just hash on the pointer; the void* is a hack to do that
+  std::unordered_map<void*, YYLTYPE> commentLocations;
+
+  // comments are gathered here
+  // Consider a 'proc' declaration. Comments preceding it should be consumed
+  // when the decl_stmt starts. Then, after the decl_stmt is created, comments
+  // accumulated here should be cleared (since they must have come from inside
+  // the statement and should not apply later).
+  std::vector<ParserComment>* comments;
+
+  // Tracking a current state for these makes it easier to write
+  // the parser rules.
+  Symbol::Visibility visibility;
+  Variable::Tag varDeclTag;
+
+  ParserContext(const char* filename, Builder* builder)
+  {
+    auto uniqueFilename = UniqueString::build(builder->context(), filename);
+
+    this->scanner            = nullptr;
+    this->filename           = uniqueFilename;
+    this->builder            = builder;
+    this->topLevelStatements = nullptr;
+    this->comments           = nullptr;
+    this->visibility         = Symbol::VISIBILITY_DEFAULT;
+    this->varDeclTag         = Variable::VAR;
+  }
+
+  Context* context() { return builder->context(); }
+
+  void noteComment(YYLTYPE loc, const char* data, long size);
+  std::vector<ParserComment>* gatherComments(YYLTYPE location);
+  void clearComments();
+  ParserExprList* makeList();
+  ParserExprList* makeList(ParserExprList* lst);
+  ParserExprList* makeList(Expr* e);
+  ParserExprList* makeList(owned<Expr> e) {
+    return this->makeList(e.release());
+  }
+  ParserExprList* makeList(CommentsAndStmt cs);
+
+  void appendList(ParserExprList* dst, ParserExprList* lst);
+  void appendList(ParserExprList* dst, Expr* e);
+  void appendList(ParserExprList* dst, owned<Expr> e) {
+    this->appendList(dst, e.release());
+  }
+  void appendList(ParserExprList* dst, std::vector<ParserComment>* comments);
+  void appendList(ParserExprList* dst, CommentsAndStmt cs);
+  ASTList consumeList(ParserExprList* lst);
+
+  std::vector<ParserComment>* gatherCommentsFromList(ParserExprList* lst,
+                                                     YYLTYPE location);
+  void appendComments(CommentsAndStmt*cs, std::vector<ParserComment>* comments);
+
+  // clears the inner comments that should have already been captured
+  // to handle things like this
+  //     { /* doc comment } proc myproc()
+  CommentsAndStmt finishStmt(CommentsAndStmt cs);
+  CommentsAndStmt finishStmt(Expr* e);
+  CommentsAndStmt finishStmt(owned<Expr> e) {
+    return this->finishStmt(e.release());
+  }
+
+  // TODO: move these to astContext
+
+  // These adjust for the IDs
+  // and call enterStmt / exitStmt.
+  //ParserExprList* enterModule(YYLTYPE loc, const char* name, Expr* decl);
+  //ParserExprList* exitModule(ParserExprList* decl, ParserExprList* body);
+  //ParserExprList* enterFunction(YYLTYPE loc, const char* name, Expr* decl);
+  //ParserExprList* exitFunction(ParserExprList* decl, ParserExprList* body);
+
+  // This should consume the comments that occur before
+  // and return them. (Including looking at source locations).
+  // If there is any argument, it will
+  // be also appended to the returned list.
+  ParserExprList* enterStmt(YYLTYPE location, ParserExprList* lst);
+  ParserExprList* enterStmt(YYLTYPE location, Expr* e);
+  ParserExprList* enterStmt(YYLTYPE location, owned<Expr> e) {
+    return this->enterStmt(location, e.release());
+  }
+  ParserExprList* enterStmt(YYLTYPE location);
+
+  // These should clear the comments (since there might be some inside the stmt)
+  ParserExprList* exitStmt(ParserExprList* lst);
+  ParserExprList* exitStmt(Expr* e);
+  ParserExprList* exitStmt(owned<Expr> e) {
+    return this->exitStmt(e.release());
+  }
+
+  Location convertLocation(YYLTYPE location);
+
+  // Do we really need these?
+  /*
+  int         captureTokens; // no, new AST meant to be more faithful to src;
+                             // if we want source code we can read input again.
+  std::string captureString;
+  bool        parsingPrivate; // no, create config var and
+                              // replace its initialization with something
+                              // provided and separately parsed.
+   */
+};

--- a/compiler/next/lib/Frontend/Parser/ParserContextImpl.h
+++ b/compiler/next/lib/Frontend/Parser/ParserContextImpl.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+std::vector<ParserComment>* ParserContext::gatherComments(YYLTYPE location) {
+
+  // If there were no comments, there is nothing to do.
+  if (this->comments == nullptr) {
+    return nullptr;
+  }
+
+  if (this->comments->size() == 0) {
+    delete this->comments;
+    return nullptr;
+  }
+
+  // Otherwise, gather only those comments that appear before the location.
+  // This might be all of the comments or only some of them.
+
+  ssize_t lastCommentToGather = -1;
+  {
+    size_t i = 0;
+    for (ParserComment comment : *this->comments) {
+      if (comment.location.first_line <= location.first_line &&
+          comment.location.first_column <= location.first_column) {
+        // OK, we can gather this comment (and any earlier ones)
+        lastCommentToGather = i;
+      }
+      i++;
+    }
+  }
+
+  // now, return the comments up to and including lastCommentToGather
+
+  if (lastCommentToGather < 0) {
+    // don't need to return any comments
+    std::vector<ParserComment>* ret = nullptr;
+    return ret;
+  }
+
+  if (lastCommentToGather == this->comments->size()-1) {
+    // need to return all comments
+    std::vector<ParserComment>* ret = this->comments;
+    this->comments = nullptr;
+    return ret;
+  }
+
+  // general case: return only the comments up to lastCommentToGather
+  std::vector<ParserComment>* ret = new std::vector<ParserComment>();
+  for (size_t i = 0; i <= lastCommentToGather; i++) {
+    ret->push_back((*this->comments)[i]);
+  }
+  this->comments->erase(this->comments->begin(),
+                        this->comments->begin()+lastCommentToGather+1);
+  return ret;
+}
+
+void ParserContext::noteComment(YYLTYPE loc, const char* data, long size) {
+  if (this->comments == nullptr) {
+    this->comments = new std::vector<ParserComment>();
+  }
+  ParserComment c;
+  c.location = loc;
+  Location ll = this->convertLocation(loc);
+  auto comment = Comment::build(this->builder, ll, std::string(data, size));
+  free((void*)data);
+  c.comment = comment.release();
+  this->comments->push_back(c);
+}
+
+void ParserContext::clearComments() {
+  if (this->comments != nullptr) {
+    for (ParserComment parserComment : *this->comments) {
+      delete parserComment.comment;
+    }
+    this->comments->clear();
+  }
+}
+
+ParserExprList* ParserContext::makeList() {
+  return new ParserExprList();
+}
+ParserExprList* ParserContext::makeList(ParserExprList* lst) {
+  return lst;
+}
+ParserExprList* ParserContext::makeList(Expr* e) {
+  ParserExprList* ret = new ParserExprList();
+  ret->push_back(e);
+  return ret;
+}
+ParserExprList* ParserContext::makeList(CommentsAndStmt cs) {
+  ParserExprList* ret = new ParserExprList();
+  this->appendList(ret, cs);
+  return ret;
+}
+
+void ParserContext::appendList(ParserExprList* dst, ParserExprList* lst) {
+  for (Expr* elt : *lst) {
+    dst->push_back(elt);
+  }
+  delete lst;
+}
+
+void ParserContext::appendList(ParserExprList* dst, Expr* e) {
+  dst->push_back(e);
+}
+
+void ParserContext::appendList(ParserExprList* dst,
+                               std::vector<ParserComment>* comments) {
+  if (comments != nullptr) {
+    for (ParserComment parserComment : *comments) {
+      Comment* c = parserComment.comment;
+      dst->push_back(c);
+      this->commentLocations.insert({(void*)c, parserComment.location});
+    }
+    delete comments;
+  }
+}
+
+void ParserContext::appendList(ParserExprList* dst, CommentsAndStmt cs) {
+  // append the comments
+  this->appendList(dst, cs.comments);
+  // then append the statement
+  if (cs.stmt != nullptr) {
+    dst->push_back(cs.stmt);
+  }
+}
+
+ASTList ParserContext::consumeList(ParserExprList* lst) {
+  ASTList ret;
+  if (lst != nullptr) {
+    for (Expr* e : *lst) {
+      ret.push_back(toOwned(e));
+    }
+    delete lst;
+  }
+  return ret;
+}
+
+std::vector<ParserComment>*
+ParserContext::gatherCommentsFromList(ParserExprList* lst,
+                                      YYLTYPE location) {
+  if (lst == nullptr || lst->size() == 0) {
+    // no list, so nothing to do
+    return nullptr;
+  }
+
+  size_t nToMove = 0;
+  while (lst->size() > nToMove) {
+    Expr* e = (*lst)[nToMove];
+    if (Comment* c = e->toComment()) {
+      auto search = this->commentLocations.find(c);
+      assert(search != this->commentLocations.end());
+      YYLTYPE commentLocation = search->second;
+      if (commentLocation.first_line <= location.first_line &&
+          commentLocation.first_column <= location.first_column) {
+        nToMove++;
+        continue;
+      }
+    }
+    break;
+  }
+
+  if (nToMove == 0) {
+    return nullptr;
+  }
+
+  std::vector<ParserComment>* ret = new std::vector<ParserComment>();
+  for (size_t i = 0; i < nToMove; i++) {
+    Comment* c = (*lst)[i]->toComment();
+    assert(c);
+    auto search = this->commentLocations.find(c);
+    assert(search != this->commentLocations.end());
+    YYLTYPE commentLocation = search->second;
+    ParserComment pc;
+    pc.location = commentLocation;
+    pc.comment = c;
+    ret->push_back(pc);
+  }
+
+  lst->erase(lst->begin(), lst->begin()+nToMove);
+
+  return ret;
+}
+
+void ParserContext::appendComments(CommentsAndStmt*cs,
+                                   std::vector<ParserComment>* comments) {
+  if (cs->comments == nullptr) {
+    cs->comments = comments;
+    return;
+  }
+
+  // otherwise, append them and then delete comments
+  for (ParserComment parserComment : *comments) {
+    cs->comments->push_back(parserComment);
+  }
+
+  delete comments;
+}
+
+CommentsAndStmt ParserContext::finishStmt(CommentsAndStmt cs) {
+  this->clearComments();
+  return cs;
+}
+CommentsAndStmt ParserContext::finishStmt(Expr* e) {
+  this->clearComments();
+  return makeCommentsAndStmt(NULL, e);
+}
+
+Location ParserContext::convertLocation(YYLTYPE location) {
+  return Location(this->filename,
+                  location.first_line,
+                  location.first_column,
+                  location.last_line,
+                  location.last_column);
+}

--- a/compiler/next/lib/Frontend/Parser/ParserDependencies.h
+++ b/compiler/next/lib/Frontend/Parser/ParserDependencies.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is included at the right time in the generated bison .h/.cpp
+// It is split out into this separate file for easier maintenance.
+// It contains any #includes necessary for the parser.
+
+#include "chpl/AST/BaseAST.h"
+#include "chpl/AST/BlockStmt.h"
+#include "chpl/AST/Builder.h"
+#include "chpl/AST/Comment.h"
+#include "chpl/AST/Decl.h"
+#include "chpl/AST/ErroneousExpr.h"
+#include "chpl/AST/Expr.h"
+#include "chpl/AST/Identifier.h"
+#include "chpl/AST/Location.h"
+#include "chpl/AST/Module.h"
+#include "chpl/AST/ModuleDecl.h"
+#include "chpl/AST/UniqueString.h"
+#include "chpl/AST/Symbol.h"
+#include "chpl/AST/Variable.h"
+#include "chpl/AST/VariableDecl.h"
+#include "chpl/Queries/Context.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace chpl;
+using namespace ast;
+using chpl::ast::detail::PODUniqueString;
+
+struct ParserError;
+struct ParserComment;

--- a/compiler/next/lib/Frontend/Parser/README
+++ b/compiler/next/lib/Frontend/Parser/README
@@ -1,0 +1,54 @@
+This directory contains the parser for Chapel which is implemented
+using the bison/flex tool set. The sources for the parser are
+
+chapel.lex
+chapel.ypp
+
+and the generated files are
+
+flex-chapel.cpp,  ../include/flex-chapel.h
+bison-chapel.cpp, ../include/bison-chapel.h
+
+respectively.  The location for the generated files is
+defined using appropriate directives within the parser
+sources.
+
+
+
+
+
+Historically we included only the parser sources in the repository
+and relied on the target platform to construct the generated C files
+while the compiler is being installed.
+
+This policy was revised when we began to rely on features that were
+included starting in bison 2.5.  Although bison had already advanced
+to 3.*, some machines that we relied on still had bison 2.3 installed
+by default.  We judged that some potential users might have the same
+constraint. We addressed this by including the generated parser in the
+repository.
+
+Further we were required to disable the Makefile rule to rebuild the
+parser from the sources whenever the sources were changed as we could
+not control the date-stamp on the sources relative to the generated files
+when a user updates their repository.
+
+
+This means that we require that developers who work on the parser:
+
+1) have the following versions installed: Bison 2.5 or later; Flex 2.6 or later
+
+2) explicitly build the generated parser when they alter the parser
+sources.  One way to do this is to run "make parser" in this
+directory.
+
+
+3) when submitting a pull request to modify the parser sources, also include
+the generated parser.  We find it helpful to add the sources and the
+generated files as separate commits within the same pull request.
+This enables the reviewer to more easily ignore the extensive diffs
+that may appear in the generated parser.
+
+
+Note that if there is ever a case in which the generated parser becomes
+corrupted it can be restored using "git checkout".

--- a/compiler/next/lib/Frontend/Parser/chapel.lex
+++ b/compiler/next/lib/Frontend/Parser/chapel.lex
@@ -307,11 +307,11 @@ zip              return processToken(yyscanner, TZIP);
 "b\"\"\""        return processTripleStringLiteral(yyscanner, "\"", BYTESLITERAL);
 "b'''"           return processTripleStringLiteral(yyscanner, "'", BYTESLITERAL);
 "\""             return processStringLiteral(yyscanner, "\"", STRINGLITERAL);
-"\'"             return processStringLiteral(yyscanner, "\'", STRINGLITERAL);
+"'"              return processStringLiteral(yyscanner, "'", STRINGLITERAL);
 "b\""            return processStringLiteral(yyscanner, "\"", BYTESLITERAL);
-"b\'"            return processStringLiteral(yyscanner, "\'", BYTESLITERAL);
+"b'"             return processStringLiteral(yyscanner, "'", BYTESLITERAL);
 "c\""            return processStringLiteral(yyscanner, "\"", CSTRINGLITERAL);
-"c\'"            return processStringLiteral(yyscanner, "\'", CSTRINGLITERAL);
+"c'"             return processStringLiteral(yyscanner, "'", CSTRINGLITERAL);
 "//"             return processSingleLineComment(yyscanner);
 "/*"             return processBlockComment(yyscanner);
 

--- a/compiler/next/lib/Frontend/Parser/chapel.lex
+++ b/compiler/next/lib/Frontend/Parser/chapel.lex
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+%option outfile="flex-chapel.cpp"
+%option header-file="flex-chapel.h"
+
+%option noyywrap
+%option nounput
+
+/* These options create a re-entrant scanner that returns
+     * an integer to indicate the token type
+     * a bison-style YYSTYPE by reference. (value in yylval->pch)
+     * a bison-style YYLTYPE by reference.
+
+     i.e. int yylex(YYSTYPE*, YYLTYPE*, yyscan_t yyscanner);
+*/
+
+%option reentrant
+%option bison-bridge
+%option bison-locations
+
+%option extra-type="ParserContext*"
+
+/*
+   Provide a condition stack
+   This is used to alter the handling of "{" when it appears immediately after "extern"
+*/
+
+%option stack
+
+%{
+
+#include "bison-chapel.h"
+
+#include <cstdio>
+
+static int  processIdentifier(yyscan_t scanner, bool queried);
+static int  processToken(yyscan_t scanner, int t);
+static int  processStringLiteral(yyscan_t scanner, const char* q, int type);
+static int  processTripleStringLiteral(yyscan_t scanner, const char* q, int type);
+
+static int  processExtern(yyscan_t scanner);
+static int  processExternCode(yyscan_t scanner);
+
+static void processWhitespace(yyscan_t scanner);
+
+static int  processSingleLineComment(yyscan_t scanner);
+static int  processBlockComment(yyscan_t scanner);
+
+static void processInvalidToken(yyscan_t scanner);
+
+static bool yy_has_state(yyscan_t scanner);
+
+%}
+
+bit              [0-1]
+octDigit         [0-7]
+digit            [0-9]
+hexDigit         [0-9a-fA-F]
+
+letter           [_a-zA-Z]
+
+ident            {letter}({letter}|{digit}|"$")*
+queriedIdent     \?{ident}
+
+binaryLiteral    0[bB]{bit}(_|{bit})*
+octalLiteral     0[oO]{octDigit}(_|{octDigit})*
+decimalLiteral   {digit}(_|{digit})*
+hexLiteral       0[xX]{hexDigit}(_|{hexDigit})*
+intLiteral       {binaryLiteral}|{octalLiteral}|{decimalLiteral}|{hexLiteral}
+
+digitsOrSeps     {digit}(_|{digit})*
+exponent         [Ee][\+\-]?{digitsOrSeps}
+floatLiteral1    {digitsOrSeps}?"."{digitsOrSeps}({exponent})?
+floatLiteral2    {digitsOrSeps}"."{exponent}
+floatLiteral3    {digitsOrSeps}{exponent}
+
+/* hex float literals, have decimal exponents indicating the power of 2 */
+hexDigitsOrSeps  {hexDigit}(_|{hexDigit})*
+hexDecExponent   [Pp][\+\-]?{digitsOrSeps}
+floatLiteral4    0[xX]{hexDigitsOrSeps}?"."{hexDigitsOrSeps}({hexDecExponent})?
+floatLiteral5    0[xX]{hexDigitsOrSeps}"."{hexDecExponent}
+floatLiteral6    0[xX]{hexDigitsOrSeps}{hexDecExponent}
+
+decFloatLiteral  {floatLiteral1}|{floatLiteral2}|{floatLiteral3}
+hexFloatLiteral  {floatLiteral4}|{floatLiteral5}|{floatLiteral6}
+
+floatLiteral     {decFloatLiteral}|{hexFloatLiteral}
+
+%s               externmode
+
+%%
+
+align            return processToken(yyscanner, TALIGN);
+as               return processToken(yyscanner, TAS);
+atomic           return processToken(yyscanner, TATOMIC);
+begin            return processToken(yyscanner, TBEGIN);
+bool             return processToken(yyscanner, TBOOL);
+borrowed         return processToken(yyscanner, TBORROWED);
+break            return processToken(yyscanner, TBREAK);
+by               return processToken(yyscanner, TBY);
+bytes            return processToken(yyscanner, TBYTES);
+catch            return processToken(yyscanner, TCATCH);
+class            return processToken(yyscanner, TCLASS);
+cobegin          return processToken(yyscanner, TCOBEGIN);
+coforall         return processToken(yyscanner, TCOFORALL);
+complex          return processToken(yyscanner, TCOMPLEX);
+config           return processToken(yyscanner, TCONFIG);
+const            return processToken(yyscanner, TCONST);
+continue         return processToken(yyscanner, TCONTINUE);
+defer            return processToken(yyscanner, TDEFER);
+delete           return processToken(yyscanner, TDELETE);
+dmapped          return processToken(yyscanner, TDMAPPED);
+do               return processToken(yyscanner, TDO);
+domain           return processToken(yyscanner, TDOMAIN);
+else             return processToken(yyscanner, TELSE);
+enum             return processToken(yyscanner, TENUM);
+export           return processToken(yyscanner, TEXPORT);
+except           return processToken(yyscanner, TEXCEPT);
+extern           return processExtern(yyscanner);
+false            return processToken(yyscanner, TFALSE);
+for              return processToken(yyscanner, TFOR);
+forall           return processToken(yyscanner, TFORALL);
+foreach          return processToken(yyscanner, TFOREACH);
+forwarding       return processToken(yyscanner, TFORWARDING);
+if               return processToken(yyscanner, TIF);
+imag             return processToken(yyscanner, TIMAG);
+import           return processToken(yyscanner, TIMPORT);
+in               return processToken(yyscanner, TIN);
+include          return processToken(yyscanner, TINCLUDE);
+index            return processToken(yyscanner, TINDEX);
+inline           return processToken(yyscanner, TINLINE);
+inout            return processToken(yyscanner, TINOUT);
+int              return processToken(yyscanner, TINT);
+implements       return processToken(yyscanner, TIMPLEMENTS);
+interface        return processToken(yyscanner, TINTERFACE);
+iter             return processToken(yyscanner, TITER);
+label            return processToken(yyscanner, TLABEL);
+lambda           return processToken(yyscanner, TLAMBDA);
+let              return processToken(yyscanner, TLET);
+lifetime         return processToken(yyscanner, TLIFETIME);
+local            return processToken(yyscanner, TLOCAL);
+locale           return processToken(yyscanner, TLOCALE);
+module           return processToken(yyscanner, TMODULE);
+new              return processToken(yyscanner, TNEW);
+nil              return processToken(yyscanner, TNIL);
+noinit           return processToken(yyscanner, TNOINIT);
+none             return processToken(yyscanner, TNONE);
+nothing          return processToken(yyscanner, TNOTHING);
+on               return processToken(yyscanner, TON);
+only             return processToken(yyscanner, TONLY);
+operator         return processToken(yyscanner, TOPERATOR);
+otherwise        return processToken(yyscanner, TOTHERWISE);
+out              return processToken(yyscanner, TOUT);
+override         return processToken(yyscanner, TOVERRIDE);
+owned            return processToken(yyscanner, TOWNED);
+param            return processToken(yyscanner, TPARAM);
+pragma           return processToken(yyscanner, TPRAGMA);
+__primitive      return processToken(yyscanner, TPRIMITIVE);
+private          return processToken(yyscanner, TPRIVATE);
+proc             return processToken(yyscanner, TPROC);
+prototype        return processToken(yyscanner, TPROTOTYPE);
+public           return processToken(yyscanner, TPUBLIC);
+real             return processToken(yyscanner, TREAL);
+record           return processToken(yyscanner, TRECORD);
+reduce           return processToken(yyscanner, TREDUCE);
+ref              return processToken(yyscanner, TREF);
+require          return processToken(yyscanner, TREQUIRE);
+return           return processToken(yyscanner, TRETURN);
+scan             return processToken(yyscanner, TSCAN);
+select           return processToken(yyscanner, TSELECT);
+serial           return processToken(yyscanner, TSERIAL);
+shared           return processToken(yyscanner, TSHARED);
+single           return processToken(yyscanner, TSINGLE);
+sparse           return processToken(yyscanner, TSPARSE);
+string           return processToken(yyscanner, TSTRING);
+subdomain        return processToken(yyscanner, TSUBDOMAIN);
+sync             return processToken(yyscanner, TSYNC);
+then             return processToken(yyscanner, TTHEN);
+this             return processToken(yyscanner, TTHIS);
+throw            return processToken(yyscanner, TTHROW);
+throws           return processToken(yyscanner, TTHROWS);
+true             return processToken(yyscanner, TTRUE);
+try              return processToken(yyscanner, TTRY);
+"try!"           return processToken(yyscanner, TTRYBANG);
+type             return processToken(yyscanner, TTYPE);
+uint             return processToken(yyscanner, TUINT);
+union            return processToken(yyscanner, TUNION);
+unmanaged        return processToken(yyscanner, TUNMANAGED);
+use              return processToken(yyscanner, TUSE);
+var              return processToken(yyscanner, TVAR);
+void             return processToken(yyscanner, TVOID);
+when             return processToken(yyscanner, TWHEN);
+where            return processToken(yyscanner, TWHERE);
+while            return processToken(yyscanner, TWHILE);
+with             return processToken(yyscanner, TWITH);
+yield            return processToken(yyscanner, TYIELD);
+zip              return processToken(yyscanner, TZIP);
+
+"_"              return processToken(yyscanner, TUNDERSCORE);
+
+"="              return processToken(yyscanner, TASSIGN);
+"+="             return processToken(yyscanner, TASSIGNPLUS);
+"-="             return processToken(yyscanner, TASSIGNMINUS);
+"*="             return processToken(yyscanner, TASSIGNMULTIPLY);
+"/="             return processToken(yyscanner, TASSIGNDIVIDE);
+"**="            return processToken(yyscanner, TASSIGNEXP);
+"%="             return processToken(yyscanner, TASSIGNMOD);
+"&="             return processToken(yyscanner, TASSIGNBAND);
+"|="             return processToken(yyscanner, TASSIGNBOR);
+"^="             return processToken(yyscanner, TASSIGNBXOR);
+"&&="            return processToken(yyscanner, TASSIGNLAND);
+"||="            return processToken(yyscanner, TASSIGNLOR);
+"<<="            return processToken(yyscanner, TASSIGNSL);
+">>="            return processToken(yyscanner, TASSIGNSR);
+"reduce="        return processToken(yyscanner, TASSIGNREDUCE);
+
+"init="          return processToken(yyscanner, TINITEQUALS);
+
+"=>"             return processToken(yyscanner, TALIAS);
+
+"<=>"            return processToken(yyscanner, TSWAP);
+
+"#"              return processToken(yyscanner, THASH);
+".."             return processToken(yyscanner, TDOTDOT);
+"..<"            return processToken(yyscanner, TDOTDOTOPENHIGH);
+                 /* The following cases would extend the current '..<'
+                    open range interval constructor to also support
+                    '<..' and '<..<'.  This concept didn't win enough
+                    support to merge as present, but are here in case
+                    we change our minds in a future release. */
+                 /* "<.."            return processToken(yyscanner, TDOTDOTOPENLOW); */
+                 /* "<..<"           return processToken(yyscanner, TDOTDOTOPENBOTH); */
+"..."            return processToken(yyscanner, TDOTDOTDOT);
+
+"&&"             return processToken(yyscanner, TAND);
+"||"             return processToken(yyscanner, TOR);
+"!"              return processToken(yyscanner, TBANG);
+
+"&"              return processToken(yyscanner, TBAND);
+"|"              return processToken(yyscanner, TBOR);
+"^"              return processToken(yyscanner, TBXOR);
+"~"              return processToken(yyscanner, TBNOT);
+
+"<<"             return processToken(yyscanner, TSHIFTLEFT);
+">>"             return processToken(yyscanner, TSHIFTRIGHT);
+
+"=="             return processToken(yyscanner, TEQUAL);
+"!="             return processToken(yyscanner, TNOTEQUAL);
+"<="             return processToken(yyscanner, TLESSEQUAL);
+">="             return processToken(yyscanner, TGREATEREQUAL);
+"<"              return processToken(yyscanner, TLESS);
+">"              return processToken(yyscanner, TGREATER);
+
+"+"              return processToken(yyscanner, TPLUS);
+"-"              return processToken(yyscanner, TMINUS);
+"*"              return processToken(yyscanner, TSTAR);
+"/"              return processToken(yyscanner, TDIVIDE);
+"%"              return processToken(yyscanner, TMOD);
+"--"             return processToken(yyscanner, TMINUSMINUS);
+"++"             return processToken(yyscanner, TPLUSPLUS);
+
+"**"             return processToken(yyscanner, TEXP);
+
+":"              return processToken(yyscanner, TCOLON);
+";"              return processToken(yyscanner, TSEMI);
+","              return processToken(yyscanner, TCOMMA);
+"."              return processToken(yyscanner, TDOT);
+"("              return processToken(yyscanner, TLP);
+")"              return processToken(yyscanner, TRP);
+"["              return processToken(yyscanner, TLSBR);
+"]"              return processToken(yyscanner, TRSBR);
+<externmode>"{"  return processExternCode(yyscanner);
+<INITIAL>"{"     return processToken(yyscanner, TLCBR);
+"}"              return processToken(yyscanner, TRCBR);
+"<~>"            return processToken(yyscanner, TIO);
+"?"              return processToken(yyscanner, TQUESTION);
+
+{intLiteral}     return processToken(yyscanner, INTLITERAL);
+{floatLiteral}   return processToken(yyscanner, REALLITERAL);
+
+{intLiteral}i    return processToken(yyscanner, IMAGLITERAL);
+{floatLiteral}i  return processToken(yyscanner, IMAGLITERAL);
+
+{ident}          return processIdentifier(yyscanner, false);
+{queriedIdent}   return processIdentifier(yyscanner, true);
+
+"\"\"\""         return processTripleStringLiteral(yyscanner, "\"", STRINGLITERAL);
+"'''"            return processTripleStringLiteral(yyscanner, "'", STRINGLITERAL);
+"b\"\"\""        return processTripleStringLiteral(yyscanner, "\"", BYTESLITERAL);
+"b'''"           return processTripleStringLiteral(yyscanner, "'", BYTESLITERAL);
+"\""             return processStringLiteral(yyscanner, "\"", STRINGLITERAL);
+"\'"             return processStringLiteral(yyscanner, "\'", STRINGLITERAL);
+"b\""            return processStringLiteral(yyscanner, "\"", BYTESLITERAL);
+"b\'"            return processStringLiteral(yyscanner, "\'", BYTESLITERAL);
+"c\""            return processStringLiteral(yyscanner, "\"", CSTRINGLITERAL);
+"c\'"            return processStringLiteral(yyscanner, "\'", CSTRINGLITERAL);
+"//"             return processSingleLineComment(yyscanner);
+"/*"             return processBlockComment(yyscanner);
+
+\n               return processNewline(yyscanner);
+
+[ \t\r\f]        processWhitespace(yyscanner);
+.                processInvalidToken(yyscanner);
+
+%%
+
+#include "lexer-help.h"

--- a/compiler/next/lib/Frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/Frontend/Parser/chapel.ypp
@@ -151,8 +151,8 @@
     LinkageTag_EXPORT,
   };
 
-  typedef std::vector<Expr*> ParserExprList;
-  typedef std::vector<PODUniqueString> UniqueStrList;
+  using ParserExprList = std::vector<Expr*>;
+  using UniqueStrList = std::vector<PODUniqueString>;
 
   struct PotentialRename {
     enum {SINGLE, DOUBLE} tag;
@@ -179,7 +179,7 @@
 
   };
 
-  typedef std::vector<PotentialRename> RenameList;
+  using RenameList = std::vector<PotentialRename>;
 
   // these structures do not use constructors to avoid
   // errors about being in the union below. Additionally

--- a/compiler/next/lib/Frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/Frontend/Parser/chapel.ypp
@@ -104,7 +104,7 @@
     ThrowsTag_THROWS,
   };
 
-  enum NewTag {
+  enum NewTag { // TODO: mabye should be named ClassManageTag?
     NewTag_BLANK,
     NewTag_OWNED,
     NewTag_SHARED,
@@ -143,7 +143,7 @@
     IntentTag_TYPE,
   };
 
-  enum LinkageTag {
+  enum LinkageTag { // TODO: what about combinations of these?
     LinkageTag_DEFAULT,
     LinkageTag_INLINE,
     LinkageTag_OVERRIDE,
@@ -567,7 +567,7 @@
 %type <exprList> forall_intent_clause forall_intent_ls
 
 %type <commentsAndStmt> fn_decl_stmt_start fn_decl_stmt_inner
-%type <exprList> opt_formal_ls req_formal_ls formal_ls
+%type <exprList> opt_formal_ls req_formal_ls formal_ls formal_ls_inner
 %type <expr> fn_decl_receiver_expr
 %type <functionTag> proc_iter_or_op
 %type <linkageTag> linkage_spec
@@ -702,7 +702,7 @@ include_module_stmt:
    the statement level.
 */
 block_stmt:
-  TLCBR         TRCBR
+  TLCBR TRCBR
   {
     // gather the comments before the opening bracket
     CommentsAndStmt cs = STMT(@1, nullptr);
@@ -737,7 +737,7 @@ block_stmt:
     cs.stmt = blockstmt.release();
     $$ = cs;
   }
-| TLCBR error   TRCBR
+| TLCBR error TRCBR
   {
     // gather the comments before the opening bracket
     CommentsAndStmt cs = STMT(@1, nullptr);
@@ -1690,10 +1690,14 @@ req_formal_ls:
   TLP formal_ls TRP  { $$ = $2; }
 ;
 
+formal_ls_inner:
+  formal                         { $$ = TODOLIST(@$); }
+| formal_ls_inner TCOMMA formal  { $$ = TODOLIST(@$); }
+;
+
 formal_ls:
                            { $$ = TODOLIST(@$); }
-| formal                   { $$ = TODOLIST(@$); }
-| formal_ls TCOMMA formal  { $$ = TODOLIST(@$); }
+| formal_ls_inner          { $$ = $1; }
 ;
 
 formal:
@@ -2331,6 +2335,14 @@ expr:
     { $$ = TODOEXPR(@$); }
 | expr TDOTDOTOPENHIGH expr
     { $$ = TODOEXPR(@$); }
+| expr TDOTDOT
+    { $$ = TODOEXPR(@$); }
+| TDOTDOT expr
+    { $$ = TODOEXPR(@$); }
+| TDOTDOTOPENHIGH expr
+    { $$ = TODOEXPR(@$); }
+| TDOTDOT
+    { $$ = TODOEXPR(@$); }
 
 /* The following cases would extend the current '..<' open range
    interval constructor to also support '<..' and '<..<'.  This
@@ -2344,14 +2356,7 @@ expr:
 | expr TDOTDOTOPENLOW
     { $$ = TODOEXPR(@$); }
 */
-| expr TDOTDOT
-    { $$ = TODOEXPR(@$); }
-| TDOTDOT expr
-    { $$ = TODOEXPR(@$); }
-| TDOTDOTOPENHIGH expr
-    { $$ = TODOEXPR(@$); }
-| TDOTDOT
-    { $$ = TODOEXPR(@$); }
+
 ;
 
 opt_expr:

--- a/compiler/next/lib/Frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/Frontend/Parser/chapel.ypp
@@ -1,0 +1,2510 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Chapel Parser Conventions
+//
+// opt_       -- optional
+//      _expr -- expression
+//      _ls   -- list
+//      _stmt -- statement
+//      _type -- type
+//
+// The rules are listed in depth-first order from stmt and expr
+//
+
+// A note about parser actions:
+//
+//  $1 $2 etc refer to the result of the components of the nonterminal
+//        (and midrule actions count for these numbers)
+//  $$ is the result of this nonterminal
+//  @1 @2 etc refer to the locations
+//  @$ is the location of the entire construct
+
+// A note about memory management within the parser:
+//
+//  Several grammar rules produce an allocated type (e.g. Expr*
+//  pointing to some sort of allocated Expr). When one of these
+//  rules produces a result, that result needs to be either
+//  freed or wired up into another structure to be freed later.
+
+// "%code requires" puts the code in the .h and in the .cpp files
+// "%code" (without "requires") puts the code in the .cpp file
+// Note that the generated flex scanner includes the generated bison .h
+// file, so something in "%code requires" is available in the scanner, too.
+%code requires {
+  #include "ParserDependencies.h"
+}
+
+// It would be better if Flex could generate these for itself
+%code requires {
+  #ifndef _BISON_CHAPEL_DEFINES_0_
+  #define _BISON_CHAPEL_DEFINES_0_
+
+  #define YYLEX_NEWLINE                  -1
+  #define YYLEX_SINGLE_LINE_COMMENT      -2
+  #define YYLEX_BLOCK_COMMENT            -3
+
+  typedef void* yyscan_t;
+
+  int processNewline(yyscan_t scanner);
+
+  #endif
+}
+
+//
+// Definition of YYSTYPE - the "semantic value" type returned by parser
+// productions. Individual productions have a type specified with %type
+// but that's really just an element in the union defined below.
+//
+// We used to use %union but stopped doing that when defining the push
+// parser.
+//
+
+%code requires {
+  #ifndef _BISON_CHAPEL_DEFINES_1_
+  #define _BISON_CHAPEL_DEFINES_1_
+
+  enum FunctionTag {
+    FunctionTag_PROC,
+    FunctionTag_ITER,
+    FunctionTag_OPERATOR,
+  };
+
+  enum AggregateTag {
+    AggregateTag_CLASS,
+    AggregateTag_RECORD,
+    AggregateTag_UNION,
+  };
+
+  enum PrototypeTag {
+    PrototypeTag_DEFAULT,
+    PrototypeTag_PROTOTYPE,
+  };
+
+  enum ThrowsTag {
+    ThrowsTag_DEFAULT,
+    ThrowsTag_THROWS,
+  };
+
+  enum NewTag {
+    NewTag_BLANK,
+    NewTag_OWNED,
+    NewTag_SHARED,
+    NewTag_UNMANAGED,
+    NewTag_BORROWED,
+  };
+
+  enum ShadowTag {
+    ShadowTag_CONST,
+    ShadowTag_IN,
+    ShadowTag_CONST_IN,
+    ShadowTag_REF,
+    ShadowTag_CONST_REF,
+    ShadowTag_VAR,
+  };
+
+  enum ReturnTag {
+    ReturnTag_DEFAULT,
+    ReturnTag_CONST,
+    ReturnTag_CONST_REF,
+    ReturnTag_REF,
+    ReturnTag_PARAM,
+    ReturnTag_TYPE,
+  };
+
+  enum IntentTag {
+    IntentTag_DEFAULT,
+    IntentTag_CONST,
+    IntentTag_CONST_REF,
+    IntentTag_REF,
+    IntentTag_IN,
+    IntentTag_CONST_IN,
+    IntentTag_OUT,
+    IntentTag_INOUT,
+    IntentTag_PARAM,
+    IntentTag_TYPE,
+  };
+
+  enum LinkageTag {
+    LinkageTag_DEFAULT,
+    LinkageTag_INLINE,
+    LinkageTag_OVERRIDE,
+    LinkageTag_EXTERN,
+    LinkageTag_EXPORT,
+  };
+
+  typedef std::vector<Expr*> ParserExprList;
+  typedef std::vector<PODUniqueString> UniqueStrList;
+
+  struct PotentialRename {
+    enum {SINGLE, DOUBLE} tag;
+
+    Expr* elem;
+    std::pair<Expr*, Expr*> renamed;
+
+    PotentialRename(Expr* elem) {
+      this->tag = SINGLE;
+      this->elem = elem;
+      this->renamed = std::make_pair((Expr*)nullptr, (Expr*)nullptr);
+    }
+    PotentialRename(owned<Expr> elem) : PotentialRename(elem.release()) { }
+    PotentialRename(Expr* from, Expr* to)
+    {
+      this->tag = DOUBLE;
+      this->elem = nullptr;
+      this->renamed = std::make_pair(from, to);
+    }
+    PotentialRename(owned<Expr> from, owned<Expr> to)
+    : PotentialRename(from.release(), to.release()) { }
+    PotentialRename(Expr* from, owned<Expr> to)
+    : PotentialRename(from, to.release()) { }
+
+  };
+
+  typedef std::vector<PotentialRename> RenameList;
+
+  // these structures do not use constructors to avoid
+  // errors about being in the union below. Additionally
+  // they only have pointer or numeric fields.
+
+  struct WhereAndLifetime {
+    Expr* where;
+    ParserExprList* lifetime;
+  };
+  static inline
+  WhereAndLifetime makeWhereAndLifetime(Expr* w, ParserExprList* lt) {
+    WhereAndLifetime ret;
+    ret.where = w;
+    ret.lifetime = lt;
+    return ret;
+  }
+
+  struct CommentsAndStmt {
+    std::vector<ParserComment>* comments;
+    Expr* stmt;
+  };
+  static inline
+  CommentsAndStmt makeCommentsAndStmt(std::vector<ParserComment>* comments, Expr* stmt) {
+    CommentsAndStmt ret;
+    ret.comments = comments;
+    ret.stmt = stmt;
+    return ret;
+  }
+  static inline
+  CommentsAndStmt makeCommentsAndStmt(std::vector<ParserComment>* comments, owned<Expr> stmt) {
+    return makeCommentsAndStmt(comments, stmt.release());
+  }
+
+  struct SizedStr {
+    const char* allocatedData; // *not* a uniqued string!
+    long size;
+  };
+  static inline
+  SizedStr makeSizedStr(const char* allocatedData, long size) {
+    SizedStr ret;
+    ret.allocatedData = allocatedData;
+    ret.size = size;
+    return ret;
+  }
+
+
+  // These currently all need to be POD types (i.e. pointers and ints)
+  // rather than say std::vector to keep bison working with the current
+  // strategy. In the future we could probably switch to a more
+  // C++ mode of using bison.
+  union YYSTYPE {
+    // The lexer only uses these two
+    PODUniqueString            uniqueStr;
+    SizedStr                   sizedStr;
+
+    // The remaining types are for parser productions
+
+    // integer/enum values
+
+    AggregateTag               aggregateTag;
+    FunctionTag                functionTag;
+    IntentTag                  intentTag;
+    LinkageTag                 linkageTag;
+    NewTag                     newTag;
+    PrototypeTag               prototypeTag;
+    ReturnTag                  returnTag;
+    ShadowTag                  shadowTag;
+    ThrowsTag                  throwsTag;
+    Variable::Tag              variableTag;
+    Symbol::Visibility         visibilityTag;
+
+    // simple pointer values 
+    BlockStmt*                 blockStmt;
+    CallExpr*                  callExpr;
+    Decl*                      decl;
+    Expr*                      expr;
+    Function*                  function;
+    Module*                    module;
+
+    // values that are temporary groupings
+    CommentsAndStmt            commentsAndStmt;
+    ParserExprList*            exprList;
+    RenameList*                renameList;
+    UniqueStrList*             uniqueStrList;
+    WhereAndLifetime           lifetimeAndWhere;
+
+    // TODO
+    //Type*                     ptype;
+    //EnumType*                 penumtype;
+    //std::vector<DefExpr*>*    pvecOfDefs;
+    //ImportStmt*               pimportstmt;
+    //FlagSet*                  flagSet;
+    //ShadowVarSymbol*          pShadowVar;
+    //ShadowVarPrefix           pShadowVarPref;
+    //std::vector<PotentialRename*>* ponlylist;
+    //std::set<Flag>*           pflagset;
+  };
+
+  #endif
+}
+
+// YYLTYPE is the type that represents a source code location.
+// It is possible to define YYLTYPE (and this grammar used to in
+// order to handle chpldoc comments). This parser uses instead the
+// strategy of saving doc-comments in ParserContext.
+// The default YYLTYPE includes:
+//   first_line
+//   first_column
+//   last_line
+//   last_column
+
+//
+// Definition of the additional parameter to yypush_parse
+//
+
+%code requires {
+  // forward declare ParserContext
+  class ParserContext;
+}
+
+//
+// Provide declaration for debugging and yyerror
+//
+%code provides {
+  extern int yydebug;
+
+  void yyerror(YYLTYPE*       loc,
+               ParserContext* context,
+               const char*    errorMessage);
+
+  void noteError(YYLTYPE location,
+                 ParserContext* context,
+                 const char* errorMessage);
+
+  void noteError(YYLTYPE location,
+                 ParserContext* context,
+                 const std::string s);
+}
+
+%code provides {
+  // include ParserContext.h here because it depends
+  // uppon YYLTYPE and other types defined by the generated parser
+  // headers.
+  #include "ParserContext.h"
+}
+
+%code {
+  // include the definition of methods for ParserContext
+  #include "ParserContextImpl.h"
+  // include other helper functions for the parser
+  #include "parser-help.h"
+
+}
+
+%require "2.5"
+
+// The names for the output files
+%defines "bison-chapel.h"
+%output  "bison-chapel.cpp"
+
+%debug
+%verbose
+
+// These would print out expected token names, but that might just
+// add unnecessary complexity for someone new to the language ...
+//%define parse.lac full
+//%define parse.error verbose
+
+%locations
+%define api.pure full
+%define api.push-pull push
+
+%lex-param { ParserContext* context }
+%parse-param { ParserContext* context }
+
+%start program
+
+//
+// identifiers and literals
+//
+%token <uniqueStr> TIDENT
+%token <uniqueStr> TQUERIEDIDENT
+%token <uniqueStr> INTLITERAL
+%token <uniqueStr> REALLITERAL
+%token <uniqueStr> IMAGLITERAL
+%token <sizedStr> STRINGLITERAL
+%token <sizedStr> BYTESLITERAL
+%token <sizedStr> CSTRINGLITERAL
+%token <sizedStr> EXTERNCODE
+
+//
+// keywords (alphabetical)
+//
+%token TALIGN TAS TATOMIC
+%token TBEGIN TBREAK TBOOL TBORROWED TBY TBYTES
+%token TCATCH TCLASS TCOBEGIN TCOFORALL TCOMPLEX TCONFIG TCONST TCONTINUE
+%token TDEFER TDELETE TDMAPPED TDO TDOMAIN
+%token TELSE TENUM TEXCEPT TEXPORT TEXTERN
+%token TFALSE TFOR TFORALL TFOREACH TFORWARDING
+%token TIF TIMAG TIMPORT TIN TINCLUDE
+%token TINDEX TINLINE TINOUT TINT TITER TINITEQUALS
+%token TIMPLEMENTS TINTERFACE
+%token TLABEL TLAMBDA TLET TLIFETIME TLOCAL TLOCALE
+%token TMINUSMINUS TMODULE
+%token TNEW TNIL TNOINIT TNONE TNOTHING
+%token TON TONLY TOPERATOR TOTHERWISE TOUT TOVERRIDE TOWNED
+%token TPARAM TPLUSPLUS TPRAGMA TPRIMITIVE TPRIVATE TPROC TPROTOTYPE TPUBLIC
+%token TREAL TRECORD TREDUCE TREF TREQUIRE TRETURN
+%token TSCAN TSELECT TSERIAL TSHARED TSINGLE TSPARSE TSTRING TSUBDOMAIN TSYNC
+%token TTHEN TTHIS TTHROW TTHROWS TTRUE TTRY TTRYBANG TTYPE
+%token TUINT TUNDERSCORE TUNION TUNMANAGED TUSE
+%token TVAR TVOID
+%token TWHEN TWHERE TWHILE TWITH
+%token TYIELD
+%token TZIP
+
+//
+// operators and punctuation (alphabetical)
+//
+%token TALIAS TAND TASSIGN TASSIGNBAND TASSIGNBOR TASSIGNBXOR TASSIGNDIVIDE
+%token TASSIGNEXP TASSIGNLAND TASSIGNLOR TASSIGNMINUS TASSIGNMOD
+%token TASSIGNMULTIPLY TASSIGNPLUS TASSIGNREDUCE TASSIGNSL TASSIGNSR
+%token TBANG TBAND TBNOT TBOR TBXOR
+%token TCOLON TCOMMA
+%token TDIVIDE TDOT TDOTDOT TDOTDOTDOT
+%token TEQUAL TEXP TGREATER
+%token TGREATEREQUAL
+%token THASH
+%token TIO
+%token TLESS
+%token TLESSEQUAL
+%token TMINUS TMOD
+%token TNOTEQUAL
+%token TOR
+%token TPLUS
+%token TQUESTION
+%token TSEMI TSHIFTLEFT TSHIFTRIGHT TSTAR TSWAP
+
+//
+// braces
+//
+%token TLCBR TRCBR TLP TRP TLSBR TRSBR
+
+//
+// keywords, operators, and punctuation that requires precedence
+//
+%left TNOELSE
+%left TELSE
+%left TCOMMA
+%left TFOR TFORALL TFOREACH TIF TATOMIC TSYNC TSINGLE
+// %left TOWNED TUNMANAGED TSHARED
+%left TIN
+%left TALIGN TBY THASH
+%left TOR
+%left TAND
+%left TEQUAL TNOTEQUAL
+%left TLESSEQUAL TGREATEREQUAL TLESS TGREATER
+%left TDOTDOT TDOTDOTOPENHIGH
+// These are not currently supported, though we've discussed adding them
+//%left TDOTDOTOPENLOW TDOTDOTOPENBOTH
+%left TPLUS TMINUS
+%left TBOR
+%left TBXOR
+%left TBAND
+%left TSHIFTLEFT TSHIFTRIGHT
+%right TUPLUS TUMINUS
+%left TSTAR TDIVIDE TMOD
+%right TBNOT TLNOT
+%left TREDUCE TSCAN TDMAPPED
+%right TEXP
+%left TCOLON
+%right TBORROWED TOWNED TUNMANAGED TSHARED
+%left TQUESTION TBANG
+%right TNEW
+%left TDOT TLP TRSBR TLCBR
+%nonassoc TPRAGMA
+
+
+%type <throwsTag> opt_throws_error
+%type <prototypeTag> opt_prototype
+%type <visibilityTag> access_control
+%type <intentTag> required_intent_tag opt_intent_tag opt_this_intent_tag
+
+%type <returnTag>  opt_ret_tag
+%type <aggregateTag> class_tag
+
+%type <uniqueStr> ident_use ident_def ident_fn_def
+%type <uniqueStr> internal_type_ident_def reserved_type_ident_use
+%type <uniqueStr> fn_ident assignop_ident opt_label_ident
+%type <uniqueStr> implements_type_ident implements_type_error_ident
+
+%type <uniqueStrList>       pragma_ls
+
+// statement lists
+%type <exprList> program
+%type <exprList> toplevel_stmt_ls
+%type <exprList> stmt_ls
+
+// individual statements
+%type <commentsAndStmt> toplevel_stmt
+%type <commentsAndStmt> module_decl_start
+%type <commentsAndStmt> module_decl_stmt
+%type <commentsAndStmt> include_module_stmt
+%type <commentsAndStmt> block_stmt
+
+%type <expr> import_expr
+%type <commentsAndStmt> use_stmt import_stmt require_stmt
+%type <exprList> import_ls
+%type <renameList> renames_ls use_renames_ls opt_only_ls except_ls
+
+// These are exprList so that they can include preceeding comments
+%type <commentsAndStmt> implements_stmt interface_stmt
+%type <exprList>  ifc_formal_ls
+%type <expr>   ifc_formal
+
+%type <exprList> class_level_stmt_ls
+
+%type <commentsAndStmt> stmt
+%type <expr> do_stmt
+%type <commentsAndStmt> if_stmt loop_stmt
+%type <commentsAndStmt> select_stmt
+%type <commentsAndStmt> assignment_stmt
+
+%type <commentsAndStmt> class_level_stmt class_start
+%type <commentsAndStmt> inner_class_level_stmt
+%type <commentsAndStmt> forwarding_decl_stmt forwarding_decl_start
+%type <commentsAndStmt> extern_export_decl_stmt
+%type <commentsAndStmt> extern_export_decl_stmt_start
+%type <commentsAndStmt> extern_block_stmt
+%type <commentsAndStmt> return_stmt
+%type <commentsAndStmt> defer_stmt
+%type <commentsAndStmt> try_stmt
+%type <commentsAndStmt> throw_stmt
+%type <exprList> catch_expr_ls
+%type <expr> catch_expr
+%type <expr> catch_expr_inner
+
+%type <variableTag> var_decl_type
+
+%type <commentsAndStmt> type_alias_decl_stmt type_alias_decl_stmt_start
+%type <expr> type_alias_decl_stmt_inner
+%type <commentsAndStmt> fn_decl_stmt class_decl_stmt
+%type <commentsAndStmt> enum_decl_stmt
+
+%type <commentsAndStmt> var_decl_stmt
+%type <exprList> var_decl_stmt_inner_ls tuple_var_decl_stmt_inner_ls
+%type <expr> var_decl_stmt_inner
+
+
+%type <exprList> function_body_stmt opt_function_body_stmt
+
+%type <expr> when_stmt
+%type <exprList> when_stmt_ls
+
+%type <expr> array_type
+%type <expr> opt_type opt_ret_type ret_array_type
+%type <expr> opt_formal_type formal_array_type opt_formal_array_elt_type lambda_decl_expr
+%type <commentsAndStmt> enum_header
+%type <exprList> enum_ls
+
+%type <expr> zippered_iterator
+%type <expr> call_base_expr call_expr dot_expr
+%type <expr> lhs_expr
+%type <expr> unary_op_expr binary_op_expr
+%type <expr> parenthesized_expr expr actual_expr
+%type <expr> bool_literal str_bytes_literal literal_expr
+%type <expr> stmt_level_expr sub_type_level_expr type_level_expr scalar_type
+%type <exprList> lifetime_components_expr
+%type <expr> lifetime_expr lifetime_ident
+%type <lifetimeAndWhere> opt_lifetime_where
+%type <expr> ident_expr for_expr cond_expr nil_expr io_expr new_expr
+%type <expr> let_expr ifvar
+%type <expr> reduce_expr scan_expr reduce_scan_op_expr opt_init_expr
+%type <expr> opt_init_type var_arg_expr
+%type <expr> opt_try_expr opt_expr
+%type <expr> tuple_component tuple_var_decl_component
+%type <expr> formal
+%type <commentsAndStmt> enum_item
+%type <expr> query_expr ifc_constraint
+
+%type <newTag> new_maybe_decorated
+%type <exprList> opt_inherit simple_expr_ls expr_ls assoc_expr_ls tuple_expr_ls
+%type <exprList> opt_actual_ls actual_ls
+%type <exprList> opt_task_intent_ls task_intent_ls task_intent_clause
+%type <exprList> forall_intent_clause forall_intent_ls
+
+%type <commentsAndStmt> fn_decl_stmt_start fn_decl_stmt_inner
+%type <exprList> opt_formal_ls req_formal_ls formal_ls
+%type <expr> fn_decl_receiver_expr
+%type <functionTag> proc_iter_or_op
+%type <linkageTag> linkage_spec
+%type <linkageTag> extern_or_export
+%type <expr> intent_expr
+%type <shadowTag> shadow_var_prefix
+
+%%
+
+program:
+  toplevel_stmt_ls                    { context->topLevelStatements = $1; }
+;
+
+// 'toplevel_stmt_ls' is 'stmt_ls' plus resetTempID()
+toplevel_stmt_ls:
+                                      { $$ = context->makeList(); }
+| toplevel_stmt_ls toplevel_stmt      { context->appendList($1, $2); }
+;
+
+// Switch between plain statements and those preceded by pragmas
+toplevel_stmt:
+   stmt
+|  pragma_ls stmt                     { $$ = TODOSTMT(@$); }
+;
+
+// Sequence of pragmas
+pragma_ls:
+  TPRAGMA STRINGLITERAL
+    {
+      SizedStr ss = $2;
+      $$ = new UniqueStrList();
+      PODUniqueString u = STR(ss.allocatedData);
+      delete ss.allocatedData;
+      $$->push_back(u);
+    }
+| pragma_ls TPRAGMA STRINGLITERAL
+    {
+      SizedStr ss = $3;
+      PODUniqueString u = STR(ss.allocatedData);
+      delete ss.allocatedData;
+      $1->push_back(u);
+    }
+;
+
+stmt:
+  module_decl_stmt          { $$ = context->finishStmt($1); }
+| include_module_stmt       { $$ = context->finishStmt($1); }
+| block_stmt                { $$ = context->finishStmt($1); }
+| use_stmt                  { $$ = context->finishStmt($1); }
+| import_stmt               { $$ = context->finishStmt($1); }
+| require_stmt              { $$ = context->finishStmt($1); }
+| class_level_stmt          { $$ = context->finishStmt($1); }
+| assignment_stmt           { $$ = context->finishStmt($1); }
+| extern_block_stmt         { $$ = context->finishStmt($1); }
+| if_stmt                   { $$ = context->finishStmt($1); }
+| implements_stmt           { $$ = context->finishStmt($1); }
+| interface_stmt            { $$ = context->finishStmt($1); }
+| loop_stmt                 { $$ = context->finishStmt($1); }
+| select_stmt               { $$ = context->finishStmt($1); }
+| defer_stmt                { $$ = context->finishStmt($1); }
+| try_stmt                  { $$ = context->finishStmt($1); }
+| throw_stmt                { $$ = context->finishStmt($1); }
+| return_stmt               { $$ = context->finishStmt($1); }
+| stmt_level_expr TSEMI     { $$ = context->finishStmt(STMT(@$,$1)); }
+| TATOMIC stmt              { $$ = TODOSTMT(@$); }
+| TBEGIN opt_task_intent_ls stmt         { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TBREAK opt_label_ident TSEMI           { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TCOBEGIN opt_task_intent_ls block_stmt { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TCONTINUE opt_label_ident TSEMI        { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TDELETE simple_expr_ls TSEMI           { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TLABEL ident_def stmt     { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TLOCAL expr do_stmt       { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TLOCAL do_stmt            { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TON expr do_stmt          { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TSERIAL expr do_stmt      { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TSERIAL do_stmt           { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TSYNC stmt                { $$ = context->finishStmt(TODOSTMT(@$)); }
+| TYIELD expr TSEMI         { $$ = context->finishStmt(TODOSTMT(@$)); }
+| error TSEMI
+  {
+    $$ = STMT(@$, ErroneousExpr::build(BUILDER, LOC(@1)));
+  }
+;
+
+module_decl_start:
+  access_control opt_prototype TMODULE ident_def
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+;
+
+module_decl_stmt:
+   module_decl_start TLCBR TRCBR
+    { $$ = TODOSTMT(@$); }
+| module_decl_start TLCBR stmt_ls TRCBR
+    { $$ = TODOSTMT(@$); }
+| module_decl_start TLCBR error TRCBR
+    {
+      ParserExprList* errList = nullptr;
+      errList = context->makeList(ErroneousExpr::build(BUILDER, LOC(@3)));
+      $$ = TODOSTMT(@$); // should be a module containing errList
+    }
+;
+
+access_control:
+           { $$ = Symbol::VISIBILITY_DEFAULT; context->visibility = $$; }
+| TPUBLIC  { $$ = Symbol::VISIBILITY_PUBLIC;  context->visibility = $$; }
+| TPRIVATE { $$ = Symbol::VISIBILITY_PRIVATE; context->visibility = $$; }
+;
+
+opt_prototype:
+             { $$ = PrototypeTag_DEFAULT; }
+| TPROTOTYPE { $$ = PrototypeTag_PROTOTYPE;  }
+;
+
+include_module_stmt:
+ TINCLUDE access_control opt_prototype TMODULE ident_def TSEMI
+   {
+     $$ = TODOSTMT(@$);
+     context->visibility = Symbol::VISIBILITY_DEFAULT;
+   }
+;
+
+/* Grouping of statements into blocks.
+
+   Note:  There cannot be a blank production appearing immediately after TLCBR
+   as this results in a shift/reduce conflict with the statement level
+   expression expr TDOT expr (see domain literals).  This production (and the
+   the other productions on which it depends) were purposefully redefined
+   without blank productions to allow the full version of dot_expr to appear at
+   the statement level.
+*/
+block_stmt:
+  TLCBR         TRCBR
+  {
+    // gather the comments before the opening bracket
+    CommentsAndStmt cs = STMT(@1, nullptr);
+    // create a list of the statements
+    ParserExprList* lst = new ParserExprList();
+    // add also any comments appearing after all statements
+    // and before the closing close bracket.
+    context->appendList(lst, context->gatherComments(@2));
+    auto blockstmt = BlockStmt::build(BUILDER, LOC(@$), context->consumeList(lst));
+    cs.stmt = blockstmt.release();
+    $$ = cs;
+  }
+| TLCBR stmt_ls TRCBR
+  {
+    // create a list of the statements
+    ParserExprList* lst = $2;
+    assert(lst != nullptr);
+    // add also any comments appearing after all statements
+    // and before the closing close bracket.
+    context->appendList(lst, context->gatherComments(@3));
+
+    // comments from before the opening bracket will have been
+    // gathered into stmt_ls when that was parsed, so pull out any
+    // comments that occur before the opening bracket.
+    // (This would be simpler to handle with midrule actions but those
+    //  lead to parser conflicts).
+    CommentsAndStmt cs = {0};
+    cs.comments = context->gatherCommentsFromList(lst, @1);;
+
+    // create the BlockStmt
+    auto blockstmt = BlockStmt::build(BUILDER, LOC(@$), context->consumeList(lst));
+    cs.stmt = blockstmt.release();
+    $$ = cs;
+  }
+| TLCBR error   TRCBR
+  {
+    // gather the comments before the opening bracket
+    CommentsAndStmt cs = STMT(@1, nullptr);
+    // create a list of stmts that just has an ErroneousExpr
+    ParserExprList* lst = context->makeList(ErroneousExpr::build(BUILDER, LOC(@2)));
+    // create the BlockStmt
+    auto blockstmt = BlockStmt::build(BUILDER, LOC(@$), context->consumeList(lst));
+    cs.stmt = blockstmt.release();
+    $$ = cs;
+  }
+;
+
+// Sequence of toplevel_stmts
+stmt_ls:
+  toplevel_stmt                        { $$ = context->makeList($1); }
+| stmt_ls toplevel_stmt                { context->appendList($1, $2); }
+;
+
+renames_ls:
+  expr
+    {
+      $$ = new RenameList();
+      PotentialRename cur($1);;
+      $$->push_back(cur);
+    }
+| expr TAS expr
+    {
+      $$ = new RenameList();
+      PotentialRename cur($1, $3);
+      $$->push_back(cur);
+    }
+| renames_ls TCOMMA expr
+    {
+      PotentialRename cur($3);
+      $1->push_back(cur);
+    }
+| renames_ls TCOMMA expr TAS expr
+    {
+      PotentialRename cur($3, $5);
+      $1->push_back(cur);
+    }
+;
+
+/* Separated so that use statements can rename their module to "_", but nothing
+   else can */
+use_renames_ls:
+  expr
+    {
+      $$ = new RenameList();
+      PotentialRename cur($1);
+      $$->push_back(cur);
+    }
+| expr TAS expr
+    {
+      $$ = new RenameList();
+      PotentialRename cur($1, $3);
+      $$->push_back(cur);
+    }
+| expr TAS TUNDERSCORE
+    {
+      $$ = new RenameList();
+      PotentialRename cur($1, Identifier::build(BUILDER, LOC(@3), STR("_")));
+      $$->push_back(cur);
+    }
+| use_renames_ls TCOMMA expr
+    {
+      PotentialRename cur($3);
+      $1->push_back(cur);
+     }
+| use_renames_ls TCOMMA expr TAS expr
+     {
+       PotentialRename cur($3, $5);
+       $1->push_back(cur);
+     }
+| use_renames_ls TCOMMA expr TAS TUNDERSCORE
+     {
+       PotentialRename cur($3, Identifier::build(BUILDER, LOC(@5), STR("_")));
+       $1->push_back(cur);
+     }
+;
+
+
+opt_only_ls:
+  /* nothing */
+    {
+      $$ = new RenameList();
+      PotentialRename cur(Identifier::build(BUILDER, LOC(@$), STR("")));
+      $$->push_back(cur);
+    }
+| renames_ls
+;
+
+except_ls:
+  TSTAR
+    {
+      $$ = new RenameList();
+      PotentialRename cur(Identifier::build(BUILDER, LOC(@1), STR("")));
+      $$->push_back(cur);
+     }
+| renames_ls
+;
+
+use_stmt:
+  access_control TUSE use_renames_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| access_control TUSE expr TEXCEPT except_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| access_control TUSE expr TAS expr TEXCEPT except_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| access_control TUSE expr TAS TUNDERSCORE TEXCEPT except_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| access_control TUSE expr TONLY opt_only_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| access_control TUSE expr TAS expr TONLY opt_only_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| access_control TUSE expr TAS TUNDERSCORE TONLY opt_only_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+;
+
+import_stmt:
+  access_control TIMPORT import_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+;
+
+import_expr:
+  expr
+    { $$ = TODOEXPR(@$); }
+| expr TAS ident_use
+    { $$ = TODOEXPR(@$); }
+| expr TDOT TLCBR renames_ls TRCBR
+    { $$ = TODOEXPR(@$); }
+;
+
+import_ls:
+  import_expr
+    { $$ = context->makeList($1); }
+| import_ls TCOMMA import_expr
+    { context->appendList($1, $3); }
+;
+
+require_stmt:
+  TREQUIRE expr_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+assignment_stmt:
+  lhs_expr assignop_ident opt_try_expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| lhs_expr TSWAP           opt_try_expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| lhs_expr TASSIGNREDUCE   opt_try_expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| lhs_expr TASSIGNLAND     opt_try_expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| lhs_expr TASSIGNLOR      opt_try_expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| lhs_expr TASSIGN         TNOINIT TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+// Here are some nonterminals for identifiers
+
+opt_label_ident:
+         { $$ = STR(""); }
+| TIDENT { $$ = $1; }
+;
+
+ident_fn_def:
+  TIDENT                   { $$ = $1; }
+| TNONE                    { $$ = STR("none"); ERROR(@$, "redefining reserved word 'none'"); }
+| TTHIS                    { $$ = STR("this"); }
+| TFALSE                   { $$ = STR("false"); ERROR(@$, "redefining reserved word 'false'"); }
+| TTRUE                    { $$ = STR("true"); ERROR(@$, "redefining reserved word 'true'"); }
+| internal_type_ident_def  { $$ = $1; ERROR(@$, "redefining reserved word"); }
+
+ident_def:
+  TIDENT                   { $$ = $1; }
+| TNONE                    { $$ = STR("none"); ERROR(@$, "redefining reserved word 'none'"); }
+| TTHIS                    { $$ = STR("this"); ERROR(@$, "redefining reserved word 'this'"); }
+| TFALSE                   { $$ = STR("false"); ERROR(@$, "redefining reserved word 'false'"); }
+| TTRUE                    { $$ = STR("true"); ERROR(@$, "redefining reserved word 'true'"); }
+| internal_type_ident_def  { $$ = $1; ERROR(@$, "redefining reserved word"); }
+;
+
+/* Represents a use of an identifier. This is not used as often as you
+   might think for various reasons:
+     * things that allow scalar types more naturally use ident_expr,
+       which returns an Expr* rather than a const char*
+     * very special identifier-like things, like domain, borrowed, etc,
+       need separate parsing rules anyway. These are handled by
+       reserved_type_ident_use.
+ */
+ident_use:
+  TIDENT                   { $$ = $1; }
+| TTHIS                    { $$ = STR("this"); }
+;
+
+internal_type_ident_def:
+ /* These reserved words should generate an error if an attempt
+    is made to redefine them. The name returned from this nonterminal
+    will be used in the error message.
+
+    Uses of these types are parsed differently.
+    See scalar_type and reserved_type_ident_use.
+  */
+  TBOOL      { $$ = STR("bool"); }
+| TINT       { $$ = STR("int"); }
+| TUINT      { $$ = STR("uint"); }
+| TREAL      { $$ = STR("real"); }
+| TIMAG      { $$ = STR("imag"); }
+| TCOMPLEX   { $$ = STR("complex"); }
+| TBYTES     { $$ = STR("bytes"); }
+| TSTRING    { $$ = STR("string"); }
+| TSYNC      { $$ = STR("sync"); }
+| TSINGLE    { $$ = STR("single"); }
+| TOWNED     { $$ = STR("owned"); }
+| TSHARED    { $$ = STR("shared"); }
+| TBORROWED  { $$ = STR("borrowed"); }
+| TUNMANAGED { $$ = STR("unmanaged"); }
+| TDOMAIN    { $$ = STR("domain"); }
+| TINDEX     { $$ = STR("index"); }
+| TLOCALE    { $$ = STR("locale"); }
+| TNOTHING   { $$ = STR("nothing"); }
+| TVOID      { $$ = STR("void"); }
+;
+
+scalar_type:
+  TBOOL    { $$ = TODOEXPR(@$); }
+| TENUM    { $$ = TODOEXPR(@$); }
+| TINT     { $$ = TODOEXPR(@$); }
+| TUINT    { $$ = TODOEXPR(@$); }
+| TREAL    { $$ = TODOEXPR(@$); }
+| TIMAG    { $$ = TODOEXPR(@$); }
+| TCOMPLEX { $$ = TODOEXPR(@$); }
+| TBYTES   { $$ = TODOEXPR(@$); }
+| TSTRING  { $$ = TODOEXPR(@$); }
+| TLOCALE  { $$ = TODOEXPR(@$); }
+| TNOTHING { $$ = TODOEXPR(@$); }
+| TVOID    { $$ = TODOEXPR(@$); }
+;
+
+reserved_type_ident_use:
+  /* These reserved words can also be used as types but in fewer
+     places in the parser. Additionally their type versions have
+     different names. */
+  TSYNC      { $$ = STR("sync"); }
+| TSINGLE    { $$ = STR("single"); }
+| TDOMAIN    { $$ = STR("domain"); }
+| TINDEX     { $$ = STR("index"); }
+;
+
+do_stmt:
+  TDO stmt    { $$ = $2.stmt; delete $2.comments; }
+| block_stmt  { $$ = $1.stmt; delete $1.comments; }
+;
+
+return_stmt:
+  TRETURN TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TRETURN opt_try_expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+class_level_stmt:
+  TSEMI
+    {
+      $$ = STMT(@$, nullptr);
+    }
+| inner_class_level_stmt
+    {
+      // visibility should be default when inner_class_level_stmt is parsed
+      $$ = context->finishStmt($1);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| TPUBLIC {context->visibility = Symbol::VISIBILITY_PUBLIC;} inner_class_level_stmt
+    {
+      $$ = context->finishStmt($3);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+| TPRIVATE {context->visibility = Symbol::VISIBILITY_PRIVATE;} inner_class_level_stmt
+    {
+      $$ = context->finishStmt($3);
+      context->visibility = Symbol::VISIBILITY_DEFAULT;
+    }
+;
+
+inner_class_level_stmt:
+  fn_decl_stmt
+| var_decl_stmt
+| enum_decl_stmt
+| type_alias_decl_stmt
+| class_decl_stmt
+| forwarding_decl_stmt
+| extern_export_decl_stmt
+;
+
+forwarding_decl_stmt:
+  forwarding_decl_start expr TSEMI
+    {
+      CommentsAndStmt cs = $1;
+      //ForwardingDecl* decl = toForwardingDecl(cs.stmt);
+      // TODO: save expr
+      $$ = cs;
+    }
+| forwarding_decl_start expr TEXCEPT except_ls TSEMI
+    {
+      CommentsAndStmt cs = $1;
+      //ForwardingDecl* decl = toForwardingDecl(cs.stmt);
+      // TODO: save expr and except_ls
+      $$ = cs;
+    }
+| forwarding_decl_start expr TONLY opt_only_ls TSEMI
+    {
+      CommentsAndStmt cs = $1;
+      //ForwardingDecl* decl = toForwardingDecl(cs.stmt);
+      // TODO: save expr and opt_only_ls
+      $$ = cs;
+    }
+| forwarding_decl_start var_decl_stmt
+    {
+      CommentsAndStmt cs = $1;
+      //ForwardingDecl* decl = toForwardingDecl(cs.stmt);
+      // TODO: save var_decl_stmt
+      $$ = cs;
+    }
+;
+
+forwarding_decl_start:
+  TFORWARDING
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+extern_or_export:
+  TEXTERN { $$ = LinkageTag_EXTERN; }
+| TEXPORT { $$ = LinkageTag_EXPORT; }
+;
+
+extern_export_decl_stmt_start:
+  extern_or_export
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+extern_export_decl_stmt:
+  extern_export_decl_stmt_start TRECORD ident_def opt_inherit TLCBR class_level_stmt_ls TRCBR
+    {
+      CommentsAndStmt cs = $1;
+      cs.stmt = TODOEXPR(@$); // TODO
+      context->appendComments(&cs, context->gatherComments(@7));
+      $$ = cs;
+    }
+| extern_export_decl_stmt_start STRINGLITERAL TRECORD ident_def opt_inherit TLCBR class_level_stmt_ls TRCBR
+    {
+      CommentsAndStmt cs = $1;
+      cs.stmt = TODOEXPR(@$); // TODO
+      context->appendComments(&cs, context->gatherComments(@8));
+      $$ = cs;
+    }
+| extern_export_decl_stmt_start opt_expr fn_decl_stmt
+    {
+      CommentsAndStmt cs = $1;
+      cs.stmt = TODOEXPR(@$); // TODO
+      $$ = cs;
+    }
+| extern_export_decl_stmt_start opt_expr var_decl_type var_decl_stmt_inner_ls TSEMI
+    {
+      CommentsAndStmt cs = $1;
+      cs.stmt = TODOEXPR(@$); // TODO
+      $$ = cs;
+    }
+;
+
+extern_block_stmt:
+  TEXTERN EXTERNCODE
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+loop_stmt:
+  TDO stmt TWHILE expr TSEMI
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TWHILE expr do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TWHILE ifvar do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TCOFORALL expr TIN expr opt_task_intent_ls do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TCOFORALL expr TIN zippered_iterator opt_task_intent_ls do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TCOFORALL expr opt_task_intent_ls do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOR expr TIN expr do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOR expr TIN zippered_iterator do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOR expr do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOR zippered_iterator do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOR TPARAM ident_def TIN expr do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL expr TIN expr                                   do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL expr TIN expr              forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL expr TIN zippered_iterator                      do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL expr TIN zippered_iterator forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL          expr                                   do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL          expr              forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL          zippered_iterator                      do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFORALL          zippered_iterator forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH expr TIN expr                                   do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH expr TIN expr              forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH expr TIN zippered_iterator                      do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH expr TIN zippered_iterator forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH          expr                                   do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH          expr              forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH          zippered_iterator                      do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TFOREACH          zippered_iterator forall_intent_clause do_stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR expr_ls TIN expr TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR expr_ls TIN expr forall_intent_clause TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR expr_ls TIN zippered_iterator TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR expr_ls TIN zippered_iterator forall_intent_clause TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR expr_ls TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR expr_ls forall_intent_clause TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR zippered_iterator TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TLSBR zippered_iterator forall_intent_clause TRSBR stmt
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+zippered_iterator:
+    TZIP TLP expr_ls TRP    { $$ = TODOEXPR(@$); }
+;
+
+if_stmt:
+  TIF expr TTHEN stmt %prec TNOELSE
+    { $$ = TODOSTMT(@$); }
+| TIF expr block_stmt %prec TNOELSE
+    { $$ = TODOSTMT(@$); }
+| TIF expr TTHEN stmt TELSE stmt
+    { $$ = TODOSTMT(@$); }
+| TIF expr block_stmt TELSE stmt
+    { $$ = TODOSTMT(@$); }
+| TIF ifvar TTHEN stmt %prec TNOELSE
+    { $$ = TODOSTMT(@$); }
+| TIF ifvar block_stmt %prec TNOELSE
+    { $$ = TODOSTMT(@$); }
+| TIF ifvar TTHEN stmt TELSE stmt
+    { $$ = TODOSTMT(@$); }
+| TIF ifvar block_stmt TELSE stmt
+    { $$ = TODOSTMT(@$); }
+
+| TIF expr assignop_ident expr TTHEN stmt %prec TNOELSE
+    { $$ = TODOSTMT(@$); }
+| TIF expr assignop_ident expr block_stmt %prec TNOELSE 
+    { $$ = TODOSTMT(@$); }
+| TIF expr assignop_ident expr TTHEN stmt TELSE stmt
+    { $$ = TODOSTMT(@$); }
+| TIF expr assignop_ident expr block_stmt TELSE stmt
+    { $$ = TODOSTMT(@$); }
+;
+
+ifvar:
+  TVAR   ident_def TASSIGN expr { $$ = TODOEXPR(@$); }
+| TCONST ident_def TASSIGN expr { $$ = TODOEXPR(@$); }
+;
+
+interface_stmt:
+  TINTERFACE ident_def TLP ifc_formal_ls TRP block_stmt
+    { $$ = TODOSTMT(@$); }
+| TINTERFACE ident_def                       block_stmt
+    { $$ = TODOSTMT(@$); }
+;
+
+ifc_formal_ls:
+  ifc_formal                      { $$ = context->makeList($1); }
+| ifc_formal_ls TCOMMA ifc_formal { context->appendList($1, $3); }
+;
+
+ifc_formal:
+  // implicitly 'type' intent, could specify explicitly - see #16966
+  ident_def  { $$ = TODOEXPR(@$); }
+;
+
+// which types are allowed in 'T implements IFC'
+implements_type_ident:
+  TIDENT     { $$ = $1; }
+| TBOOL      { $$ = STR("bool"); }
+| TINT       { $$ = STR("int"); }
+| TUINT      { $$ = STR("uint"); }
+| TREAL      { $$ = STR("real"); }
+| TIMAG      { $$ = STR("imag"); }
+| TCOMPLEX   { $$ = STR("complex"); }
+| TBYTES     { $$ = STR("bytes"); }
+| TSTRING    { $$ = STR("string"); }
+| TLOCALE    { $$ = STR("locale"); }
+| TNOTHING   { $$ = STR("nothing"); }
+| TVOID      { $$ = STR("void"); }
+| implements_type_error_ident
+  {
+    std::string s = "type ";
+    s += "'"; s += $1.c_str(); s += "'";
+    s += " not allowed to implement an interface";
+    noteError(@$, context, s);
+    $$ = $1;
+  }
+;
+
+// these are not allowed as types in 'T implements IFC'
+implements_type_error_ident:
+  TNONE      { $$ = STR("none"); }
+| TTHIS      { $$ = STR("this"); }
+| TFALSE     { $$ = STR("false"); }
+| TTRUE      { $$ = STR("true"); }
+/* it would be nice to include these, alas they cause shift/reduce conflicts:
+| TSYNC      { $$ = STR("sync"); }
+| TSINGLE    { $$ = STR("single"); }
+| TOWNED     { $$ = STR("owned"); }
+| TSHARED    { $$ = STR("shared"); }
+| TBORROWED  { $$ = STR("borrowed"); }
+| TUNMANAGED { $$ = STR("unmanaged"); }
+*/
+| TDOMAIN    { $$ = STR("domain"); }
+| TINDEX     { $$ = STR("index"); }
+;
+
+implements_stmt:
+  TIMPLEMENTS ident_def TLP actual_ls TRP TSEMI
+    { $$ = TODOSTMT(@$); }
+| implements_type_ident TIMPLEMENTS ident_def TSEMI
+    { $$ = TODOSTMT(@$); }
+| implements_type_ident TIMPLEMENTS ident_def TLP actual_ls TRP TSEMI
+    { $$ = TODOSTMT(@$); }
+;
+
+ifc_constraint:
+  TIMPLEMENTS ident_def TLP actual_ls TRP
+    { $$ = TODOEXPR(@$); }
+| implements_type_ident TIMPLEMENTS ident_def
+    { $$ = TODOEXPR(@$); }
+| implements_type_ident TIMPLEMENTS ident_def TLP actual_ls TRP
+    { $$ = TODOEXPR(@$); }
+;
+
+defer_stmt:
+  TDEFER stmt
+    { $$ = TODOSTMT(@$); }
+
+try_stmt:
+  TTRY     expr            TSEMI
+    { $$ = TODOSTMT(@$); }
+| TTRYBANG expr            TSEMI
+    { $$ = TODOSTMT(@$); }
+| TTRY     assignment_stmt
+    { $$ = TODOSTMT(@$); }
+| TTRYBANG assignment_stmt
+    { $$ = TODOSTMT(@$); }
+| TTRY     block_stmt      catch_expr_ls
+    { $$ = TODOSTMT(@$); }
+| TTRYBANG block_stmt      catch_expr_ls
+    { $$ = TODOSTMT(@$); }
+;
+
+catch_expr_ls:
+                           { $$ = context->makeList(); }
+| catch_expr_ls catch_expr { context->appendList($1, $2); }
+;
+
+catch_expr:
+  TCATCH                          block_stmt { $$ = TODOEXPR(@$); }
+| TCATCH     catch_expr_inner     block_stmt { $$ = TODOEXPR(@$); }
+| TCATCH TLP catch_expr_inner TRP block_stmt { $$ = TODOEXPR(@$); }
+;
+
+catch_expr_inner:
+  ident_def             { $$ = TODOEXPR(@$); }
+| ident_def TCOLON expr { $$ = TODOEXPR(@$); }
+;
+
+throw_stmt:
+  TTHROW expr TSEMI
+    { $$ = TODOSTMT(@$); }
+
+select_stmt:
+  TSELECT expr TLCBR when_stmt_ls TRCBR
+    { $$ = TODOSTMT(@$); }
+| TSELECT expr TLCBR error TRCBR
+    { $$ = TODOSTMT(@$); }
+;
+
+when_stmt_ls:
+                          { $$ = context->makeList(); }
+| when_stmt_ls when_stmt  { context->appendList($1, $2); }
+;
+
+when_stmt:
+  TWHEN expr_ls do_stmt
+    { $$ = TODOEXPR(@$); }
+| TOTHERWISE stmt
+    { $$ = TODOEXPR(@$); }
+| TOTHERWISE TDO stmt
+    { $$ = TODOEXPR(@$); }
+;
+
+/** DECLARATION STATEMENTS ***************************************************/
+
+class_decl_stmt:
+  class_start opt_inherit TLCBR class_level_stmt_ls TRCBR
+    {
+      CommentsAndStmt cs = $1;
+      cs.stmt = TODOEXPR(@$);
+      context->appendComments(&cs, context->gatherComments(@5));
+      $$ = cs;
+    }
+| class_start opt_inherit TLCBR error TRCBR
+    {
+      CommentsAndStmt cs = $1;
+      cs.stmt = TODOEXPR(@$);
+      $$ = cs;
+    }
+  /* see also extern_export_decl_stmt */
+;
+
+class_start:
+  class_tag ident_def
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+class_tag:
+  TCLASS   { $$ = AggregateTag_CLASS; }
+| TRECORD  { $$ = AggregateTag_RECORD; }
+| TUNION   { $$ = AggregateTag_UNION; }
+;
+
+opt_inherit:
+                  { $$ = nullptr; }
+| TCOLON expr_ls  { $$ = $2; }
+;
+
+class_level_stmt_ls:
+  /* nothing */
+    { $$ = context->makeList(); }
+| class_level_stmt_ls class_level_stmt
+    { context->appendList($1, $2); }
+| class_level_stmt_ls pragma_ls class_level_stmt
+    { context->appendList($1, TODOEXPR(@$)); }
+;
+
+enum_decl_stmt:
+  enum_header TLCBR enum_ls TRCBR
+    {
+      /* TODO: attach enum values to the decl */
+      CommentsAndStmt cs = $1;
+      $$ = cs; 
+    }
+| enum_header TLCBR error TRCBR
+    {
+      CommentsAndStmt cs = $1;
+      if (cs.stmt) delete cs.stmt;
+      cs.stmt = ErroneousExpr::build(BUILDER, LOC(@3)).release();
+      $$ = cs;
+    }
+;
+
+enum_header:
+  TENUM ident_def 
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+enum_ls:
+  enum_item
+    {
+      $$ = context->makeList($1);
+    }
+| enum_ls TCOMMA
+    {
+      $$ = $1;
+    }
+| enum_ls TCOMMA enum_item
+    {
+      context->appendList($1, $3);
+    }
+;
+
+enum_item:
+  ident_def
+    { $$ = TODOSTMT(@$); }
+| ident_def TASSIGN expr
+    { $$ = TODOSTMT(@$); }
+;
+
+lambda_decl_expr:
+  TLAMBDA req_formal_ls opt_ret_tag opt_type opt_lifetime_where function_body_stmt
+    {
+      $$ = TODOEXPR(@$);
+    }
+;
+
+linkage_spec:
+                { $$ = LinkageTag_DEFAULT; }
+| TINLINE       { $$ = LinkageTag_INLINE; }
+| TOVERRIDE     { $$ = LinkageTag_OVERRIDE; }
+;
+
+fn_decl_stmt:
+  fn_decl_stmt_inner
+  opt_ret_tag opt_ret_type
+  opt_throws_error opt_lifetime_where opt_function_body_stmt
+    {
+      CommentsAndStmt cs = $1;
+      FnDecl* decl = cs.stmt->toFnDecl();
+      ParserExprList* body = TODOLIST(@$);
+      //decl->setBody(body); TODO
+      $$ = cs;
+    }
+;
+
+fn_decl_stmt_inner:
+  fn_decl_stmt_start opt_this_intent_tag fn_ident opt_formal_ls
+    {
+      $$ = TODOSTMT(@$);
+    }
+| fn_decl_stmt_start opt_this_intent_tag assignop_ident opt_formal_ls
+    {
+      $$ = TODOSTMT(@$);
+    }
+| fn_decl_stmt_start opt_this_intent_tag fn_decl_receiver_expr TDOT fn_ident opt_formal_ls
+    {
+      $$ = TODOSTMT(@$);
+    }
+| fn_decl_stmt_start opt_this_intent_tag fn_decl_receiver_expr TDOT assignop_ident opt_formal_ls
+    {
+      $$ = TODOSTMT(@$);
+    }
+| fn_decl_stmt_start opt_this_intent_tag error opt_formal_ls
+    {
+      // TODO
+      $$ = TODOSTMT(@$);
+    }
+;
+
+fn_decl_stmt_start:
+  linkage_spec proc_iter_or_op
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+fn_decl_receiver_expr:
+  ident_expr
+| TLP expr TRP        { $$ = $2; }
+;
+
+fn_ident:
+  ident_fn_def   { $$ = $1; }
+| TBAND          { $$ = STR("&"); }
+| TBOR           { $$ = STR("|"); }
+| TBXOR          { $$ = STR("^"); }
+| TBNOT          { $$ = STR("~"); }
+| TEQUAL         { $$ = STR("=="); }
+| TNOTEQUAL      { $$ = STR("!="); }
+| TLESSEQUAL     { $$ = STR("<="); }
+| TGREATEREQUAL  { $$ = STR(">="); }
+| TLESS          { $$ = STR("<"); }
+| TGREATER       { $$ = STR(">"); }
+| TPLUS          { $$ = STR("+"); }
+| TMINUS         { $$ = STR("-"); }
+| TSTAR          { $$ = STR("*"); }
+| TDIVIDE        { $$ = STR("/"); }
+| TSHIFTLEFT     { $$ = STR("<<"); }
+| TSHIFTRIGHT    { $$ = STR(">>"); }
+| TMOD           { $$ = STR("%"); }
+| TEXP           { $$ = STR("**"); }
+| TBANG          { $$ = STR("!"); }
+| TBY            { $$ = STR("by"); }
+| THASH          { $$ = STR("#"); }
+| TALIGN         { $$ = STR("align"); }
+| TSWAP          { $$ = STR("<=>"); }
+| TIO            { $$ = STR("<~>"); }
+| TINITEQUALS    { $$ = STR("init="); }
+| TCOLON         { $$ = STR(":"); }
+| ident_def TBANG
+  { std::string s = $1.c_str(); s += "!";
+    $$ = STR(s.c_str());
+  }
+;
+
+assignop_ident:
+  TASSIGN         { $$ = STR("="); }
+| TASSIGNPLUS     { $$ = STR("+="); }
+| TASSIGNMINUS    { $$ = STR("-="); }
+| TASSIGNMULTIPLY { $$ = STR("*="); }
+| TASSIGNDIVIDE   { $$ = STR("/="); }
+| TASSIGNMOD      { $$ = STR("%="); }
+| TASSIGNEXP      { $$ = STR("**="); }
+| TASSIGNBAND     { $$ = STR("&="); }
+| TASSIGNBOR      { $$ = STR("|="); }
+| TASSIGNBXOR     { $$ = STR("^="); }
+| TASSIGNSR       { $$ = STR(">>="); }
+| TASSIGNSL       { $$ = STR("<<="); }
+;
+
+opt_formal_ls:
+                     { $$ = nullptr; /* TODO: mark as no-parens */ }
+| TLP formal_ls TRP  { $$ = $2; }
+;
+
+req_formal_ls:
+  TLP formal_ls TRP  { $$ = $2; }
+;
+
+formal_ls:
+                           { $$ = TODOLIST(@$); }
+| formal                   { $$ = TODOLIST(@$); }
+| formal_ls TCOMMA formal  { $$ = TODOLIST(@$); }
+;
+
+formal:
+  opt_intent_tag ident_def opt_formal_type opt_init_expr
+    { $$ = TODOEXPR(@$); }
+| pragma_ls opt_intent_tag ident_def opt_formal_type opt_init_expr
+    { $$ = TODOEXPR(@$); }
+| opt_intent_tag ident_def opt_formal_type var_arg_expr
+    { $$ = TODOEXPR(@$); }
+| pragma_ls opt_intent_tag ident_def opt_formal_type var_arg_expr
+    { $$ = TODOEXPR(@$); }
+| opt_intent_tag TLP tuple_var_decl_stmt_inner_ls TRP opt_formal_type opt_init_expr
+    { $$ = TODOEXPR(@$); }
+| opt_intent_tag TLP tuple_var_decl_stmt_inner_ls TRP opt_formal_type var_arg_expr
+    {
+      $$ = ERROR(@$, "variable-length argument may not be grouped in a tuple");
+    }
+;
+
+opt_intent_tag:
+                      { $$ = IntentTag_DEFAULT; }
+| required_intent_tag { $$ = $1; }
+;
+
+required_intent_tag:
+  TIN         { $$ = IntentTag_IN; }
+| TINOUT      { $$ = IntentTag_INOUT; }
+| TOUT        { $$ = IntentTag_OUT; }
+| TCONST TIN  { $$ = IntentTag_CONST_IN; }
+| TCONST TREF { $$ = IntentTag_CONST_REF; }
+| TCONST      { $$ = IntentTag_CONST; }
+| TPARAM      { $$ = IntentTag_PARAM; }
+| TREF        { $$ = IntentTag_REF; }
+| TTYPE       { $$ = IntentTag_TYPE; }
+;
+
+opt_this_intent_tag:
+                { $$ = IntentTag_DEFAULT; }
+| TPARAM        { $$ = IntentTag_PARAM; }
+| TREF          { $$ = IntentTag_REF;   }
+| TCONST TREF   { $$ = IntentTag_CONST_REF;   }
+| TCONST        { $$ = IntentTag_CONST;   }
+| TTYPE         { $$ = IntentTag_TYPE;  }
+;
+
+proc_iter_or_op:
+  TPROC     { $$ = FunctionTag_PROC; }
+| TITER     { $$ = FunctionTag_ITER; }
+| TOPERATOR { $$ = FunctionTag_OPERATOR; }
+;
+
+opt_ret_tag:
+              { $$ = ReturnTag_DEFAULT; }
+| TCONST      { $$ = ReturnTag_CONST; }
+| TCONST TREF { $$ = ReturnTag_CONST_REF; }
+| TREF        { $$ = ReturnTag_REF; }
+| TPARAM      { $$ = ReturnTag_PARAM; }
+| TTYPE       { $$ = ReturnTag_TYPE; }
+;
+
+opt_throws_error:
+          { $$ = ThrowsTag_DEFAULT; }
+| TTHROWS { $$ = ThrowsTag_THROWS; }
+
+opt_function_body_stmt:
+  TSEMI               { $$ = nullptr; }
+| function_body_stmt  { $$ = $1; }
+;
+
+function_body_stmt:
+  block_stmt   { $$ = TODOLIST(@$); }
+| return_stmt  { $$ = TODOLIST(@$); }
+;
+
+query_expr:
+  TQUERIEDIDENT       { $$ = TODOEXPR(@$); }
+;
+
+var_arg_expr:
+  TDOTDOTDOT             { $$ = TODOEXPR(@$); }
+| TDOTDOTDOT expr        { $$ = $2; }
+| TDOTDOTDOT query_expr  { $$ = TODOEXPR(@$); }
+;
+
+opt_lifetime_where:
+  { $$ = makeWhereAndLifetime(nullptr, nullptr); }
+| TWHERE expr
+  { $$ = makeWhereAndLifetime($2, nullptr); }
+| TLIFETIME lifetime_components_expr
+  { $$ = makeWhereAndLifetime(nullptr, $2); }
+| TWHERE expr TLIFETIME lifetime_components_expr
+  { $$ = makeWhereAndLifetime($2, $4); }
+| TLIFETIME lifetime_components_expr TWHERE expr
+  { $$ = makeWhereAndLifetime($4, $2); }
+;
+
+lifetime_components_expr:
+  lifetime_expr
+  { $$ = TODOLIST(@$); }
+| lifetime_components_expr TCOMMA lifetime_expr
+  { $$ = TODOLIST(@$); }
+;
+
+lifetime_expr:
+  lifetime_ident TASSIGN      lifetime_ident  { $$ = TODOEXPR(@$); }
+| lifetime_ident TLESS        lifetime_ident  { $$ = TODOEXPR(@$); }
+| lifetime_ident TLESSEQUAL   lifetime_ident  { $$ = TODOEXPR(@$); }
+| lifetime_ident TEQUAL       lifetime_ident  { $$ = TODOEXPR(@$); }
+| lifetime_ident TGREATER     lifetime_ident  { $$ = TODOEXPR(@$); }
+| lifetime_ident TGREATEREQUAL lifetime_ident { $$ = TODOEXPR(@$); }
+| TRETURN lifetime_ident                      { $$ = TODOEXPR(@$); }
+;
+
+lifetime_ident:
+  TIDENT
+    { $$ = TODOEXPR(@$); }
+| TTHIS
+    { $$ = TODOEXPR(@$); }
+;
+
+type_alias_decl_stmt:
+  type_alias_decl_stmt_start type_alias_decl_stmt_inner TSEMI
+    {
+      $$ = context->finishStmt($1); // TODO
+    }
+;
+
+type_alias_decl_stmt_start:
+  TTYPE
+    {
+      $$ = TODOSTMT(@$);
+    }
+| TCONFIG TTYPE
+    {
+      $$ = TODOSTMT(@$);
+    }
+
+| TEXTERN TTYPE
+    {
+      $$ = TODOSTMT(@$);
+    }
+;
+
+
+type_alias_decl_stmt_inner:
+  ident_def opt_init_type
+    {
+      // set name to $1
+      $$ = TODOEXPR(@$);
+    }
+| ident_def opt_init_type TCOMMA type_alias_decl_stmt_inner
+    {
+      // set name to $1
+      // add new var to multivar
+      $$ = TODOEXPR(@$);
+    }
+;
+
+opt_init_type:
+    { $$ = nullptr; }
+| TASSIGN type_level_expr
+    { $$ = $2; }
+| TASSIGN array_type
+    { $$ = TODOEXPR(@$); } // Cannot be a type_level_expr as expr inherits from type_level_expr.
+;
+
+var_decl_type:
+  TPARAM      { $$ = Variable::PARAM;     context->varDeclTag = $$;}
+| TCONST TREF { $$ = Variable::CONST_REF; context->varDeclTag = $$;}
+| TREF        { $$ = Variable::REF;       context->varDeclTag = $$;}
+| TCONST      { $$ = Variable::CONST;     context->varDeclTag = $$;}
+| TVAR        { $$ = Variable::VAR;       context->varDeclTag = $$;}
+;
+
+var_decl_stmt:
+  TCONFIG var_decl_type var_decl_stmt_inner_ls TSEMI
+    {
+      $$ = TODOSTMT(@$);
+      context->varDeclTag = Variable::VAR;
+    }
+| var_decl_type var_decl_stmt_inner_ls TSEMI
+    {
+      ParserExprList* lst = $2;
+      if (lst->size() == 1) {
+        $$ = STMT(@$, (*lst)[0]);
+      } else {
+        $$ = TODOSTMT(@$);
+      }
+      delete lst;
+      context->varDeclTag = Variable::VAR;
+    }
+;
+
+var_decl_stmt_inner_ls:
+  var_decl_stmt_inner
+    {
+      $$ = context->makeList($1);
+    }
+| var_decl_stmt_inner_ls TCOMMA var_decl_stmt_inner
+    {
+      $$ = TODOLIST(@$);
+    }
+;
+
+var_decl_stmt_inner:
+  ident_def opt_type opt_init_expr
+    { $$ = VariableDecl::build(BUILDER, LOC(@$),
+                               $1, context->visibility,
+                               context->varDeclTag,
+                               toOwned($2), toOwned($3)).release(); }
+| TLP tuple_var_decl_stmt_inner_ls TRP opt_type opt_init_expr
+    { $$ = TODOEXPR(@$); }
+;
+
+tuple_var_decl_component:
+  TUNDERSCORE
+    { $$ = TODOEXPR(@$); }
+| ident_def
+    { $$ = TODOEXPR(@$); }
+| TLP tuple_var_decl_stmt_inner_ls TRP
+    { $$ = TODOEXPR(@$); }
+;
+
+tuple_var_decl_stmt_inner_ls:
+  tuple_var_decl_component
+    { $$ = TODOLIST(@$); }
+| tuple_var_decl_component TCOMMA
+    { $$ = TODOLIST(@$); }
+| tuple_var_decl_component TCOMMA tuple_var_decl_stmt_inner_ls
+    { $$ = TODOLIST(@$); }
+;
+
+/** TYPES ********************************************************************/
+
+opt_init_expr:
+                        { $$ = nullptr; }
+| TASSIGN TNOINIT       { $$ = TODOEXPR(@$); }
+| TASSIGN opt_try_expr  { $$ = $2; }
+;
+
+
+ret_array_type:
+  TLSBR TRSBR type_level_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR TRSBR
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR expr_ls TRSBR type_level_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR expr_ls TRSBR
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR TRSBR ret_array_type
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR expr_ls TRSBR ret_array_type
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR error TRSBR
+    {
+      $$ = TODOEXPR(@$);
+    }
+;
+
+opt_ret_type:
+                                 { $$ = nullptr; }
+| TCOLON type_level_expr         { $$ = $2; }
+| TCOLON ret_array_type          { $$ = $2; }
+| TCOLON reserved_type_ident_use { $$ = Identifier::build(BUILDER, LOC(@2), $2).release(); }
+| error                          { $$ = ErroneousExpr::build(BUILDER, LOC(@1)).release(); }
+;
+
+
+opt_type:
+                                 { $$ = nullptr; }
+| TCOLON type_level_expr         { $$ = $2; }
+| TCOLON array_type              { $$ = $2; }
+| TCOLON reserved_type_ident_use { $$ = Identifier::build(BUILDER, LOC(@2), $2).release(); }
+| error                          { $$ = ErroneousExpr::build(BUILDER, LOC(@1)).release(); }
+;
+
+/* NOTE: Some things about the following rule concern me (blc), but I
+   don't have the time to fix them now, so am noting them for the
+   future when someone runs into them:
+
+   (1) there are 3 cases rather than the 4 I would expect based on symmetry
+       ('in' vs. not x 'type_level_expr' vs. 'array_type')
+
+   (2) it seems strange to me that the thing being iterated over is an
+       'expr_ls' in the first two cases, but an 'expr' in the third
+
+   (3) it also seems strange that the stuff preceding TIN would be an
+       'expr_ls' rather than something simpler, like a nested
+       parenthesization of identifiers; perhaps this is to support the
+       establishment of an explicit type declaration, though I thought we
+       didn't support that yet
+*/
+array_type:
+  TLSBR expr_ls TRSBR type_level_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR expr_ls TRSBR array_type
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR expr_ls TIN expr TRSBR type_level_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR error TRSBR
+    {
+      $$ = ErroneousExpr::build(BUILDER, LOC(@2)).release();
+    }
+;
+
+opt_formal_array_elt_type:
+                        { $$ = nullptr; }
+| type_level_expr       { $$ = $1; }
+| query_expr            { $$ = $1; }
+;
+
+formal_array_type:
+  TLSBR TRSBR opt_formal_array_elt_type
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TRSBR opt_formal_array_elt_type
+    { $$ = TODOEXPR(@$); }
+
+// Johnk: Unclear to me what the type should be when [<range>][] <type> is encountered.
+//        At present buildArrayRuntimeType is undefined when gNil is passed and
+//        the second argument is a formal_array_type.
+| TLSBR TRSBR formal_array_type
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TRSBR formal_array_type
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TIN expr TRSBR opt_formal_array_elt_type
+    { $$ = TODOEXPR(@$); }
+;
+
+opt_formal_type:
+                                 { $$ = nullptr; }
+| TCOLON type_level_expr         { $$ = $2; }
+| TCOLON query_expr              { $$ = $2; }
+| TCOLON reserved_type_ident_use { $$ = Identifier::build(BUILDER, LOC(@2), $2).release(); }
+| TCOLON formal_array_type       { $$ = $2; }
+;
+
+/** EXPRESSIONS **************************************************************/
+
+expr_ls:
+  expr                       { $$ = TODOLIST(@$); }
+| query_expr                 { $$ = TODOLIST(@$); }
+| expr_ls TCOMMA expr        { $1->push_back($3); }
+| expr_ls TCOMMA query_expr  { $1->push_back($3); }
+;
+
+simple_expr_ls:
+  expr                             { $$ = TODOLIST(@$); }
+| simple_expr_ls TCOMMA expr       { $1->push_back($3); }
+;
+
+tuple_component:
+  TUNDERSCORE   { $$ = Identifier::build(BUILDER, LOC(@1), STR("_")).release(); }
+| opt_try_expr  { $$ = $1; }
+| query_expr    { $$ = $1; }
+;
+
+tuple_expr_ls:
+  tuple_component TCOMMA tuple_component { $$ = TODOLIST(@$); }
+| tuple_expr_ls TCOMMA tuple_component   { $$ = TODOLIST(@$); }
+;
+
+opt_actual_ls:
+             { $$ = TODOLIST(@$); }
+| actual_ls  { $$ = $1; }
+;
+
+actual_ls:
+  actual_expr                   { $$ = TODOLIST(@$); }
+| actual_ls TCOMMA actual_expr  { $$ = TODOLIST(@$); }
+;
+
+actual_expr:
+  ident_use TASSIGN query_expr   { $$ = TODOEXPR(@$); }
+| ident_use TASSIGN opt_try_expr { $$ = TODOEXPR(@$); }
+| query_expr                     { $$ = $1; }
+| opt_try_expr                   { $$ = $1; }
+;
+
+ident_expr:
+  ident_use      { $$ = Identifier::build(BUILDER, LOC(@1), $1).release(); }
+| scalar_type    { $$ = $1; }
+;
+
+/* Expressions which represent types.  type_level_exprs can appear within formal
+ * function parameter specifications as well as part of variable declarations.
+
+   NOTE: Array type expressions do not appear in this production as array type
+   specifications are different for formal array parameters and variable arrays.
+   As such, array type expressions are individually defined for formal array
+   parameters and variables. */
+type_level_expr:
+  sub_type_level_expr %prec TNOELSE
+    { $$ = $1; }
+| sub_type_level_expr TQUESTION %prec TQUESTION
+    { $$ = TODOEXPR(@$); }
+| TQUESTION
+    { $$ = TODOEXPR(@$); }
+;
+
+// TODO: It would be nice if '?' could be an `expr`, but then 'borrowed?' would not work.
+sub_type_level_expr:
+  nil_expr
+| lhs_expr                  // var b: a.type || (?,?) || foo()
+| cond_expr                 // type b = if b then uint else int
+| unary_op_expr             // We allow binary exprs as types...why not unary?
+| binary_op_expr            // tuples, expr dmapped expr, overloaded binary ops
+| TSINGLE expr
+    { $$ = TODOEXPR(@$); }
+| TINDEX TLP opt_actual_ls TRP
+    { $$ = TODOEXPR(@$); }
+| TDOMAIN TLP opt_actual_ls TRP
+    { $$ = TODOEXPR(@$); }
+| TSUBDOMAIN TLP opt_actual_ls TRP
+    { $$ = TODOEXPR(@$); }
+| TSPARSE TSUBDOMAIN TLP actual_expr TRP
+    { $$ = TODOEXPR(@$); }
+| TATOMIC expr
+    { $$ = TODOEXPR(@$); }
+| TSYNC expr
+    { $$ = TODOEXPR(@$); }
+
+| TOWNED
+    { $$ = TODOEXPR(@$); }
+| TOWNED expr
+    { $$ = TODOEXPR(@$); }
+| TUNMANAGED
+    { $$ = TODOEXPR(@$); }
+| TUNMANAGED expr
+    { $$ = TODOEXPR(@$); }
+| TSHARED
+    { $$ = TODOEXPR(@$); }
+| TSHARED expr
+    { $$ = TODOEXPR(@$); }
+| TBORROWED
+    { $$ = TODOEXPR(@$); }
+| TBORROWED expr
+    { $$ = TODOEXPR(@$); }
+
+| TCLASS
+    { $$ = TODOEXPR(@$); }
+| TRECORD
+    { $$ = TODOEXPR(@$); }
+;
+
+for_expr:
+  TFOR expr TIN expr TDO expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TFOR expr TIN zippered_iterator TDO expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TFOR expr TDO expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TFOR expr TIN expr TDO TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TFOR expr TIN zippered_iterator TDO TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TFOR expr TDO TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TFORALL expr TIN expr TDO expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TFORALL expr TIN zippered_iterator TDO expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TFORALL expr TDO expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TFORALL expr TIN expr TDO TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TFORALL expr TIN zippered_iterator TDO TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TFORALL expr TDO TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TRSBR expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TIN expr TRSBR expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TIN zippered_iterator TRSBR expr %prec TFOR
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TIN expr TRSBR TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TIN zippered_iterator TRSBR TIF expr TTHEN expr %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+;
+
+cond_expr:
+  TIF expr TTHEN expr TELSE expr
+    { $$ = TODOEXPR(@$); }
+/* MPF: it would be nice to match TIF expr TTHEN expr but
+   the attempt below leads to reduce-reduce conflicts:
+      TIF expr TTHEN expr %prec TNOELSE
+   with for_expr.
+ */
+;
+
+nil_expr:
+  TNIL      { $$ = Identifier::build(BUILDER, LOC(@1), STR("nil")).release(); }
+;
+
+/* Expressions permitted at the statement level as <stmt_level_expr> TSEMI.
+   Keeping stmt_level_expr from appearing in any other expression productions
+   was done intentionally to allow for easier promotion/demotion of expressions
+   to the statement level. */
+stmt_level_expr:
+  nil_expr
+| ident_expr
+| dot_expr
+| call_expr
+| lambda_decl_expr
+| new_expr
+| let_expr
+| io_expr TIO expr
+    { $$ = TODOEXPR(@$); }
+;
+
+opt_task_intent_ls:
+                                { $$ = nullptr; }
+| task_intent_clause
+;
+
+task_intent_clause:
+  TWITH TLP task_intent_ls TRP  { $$ = $3; }
+;
+
+task_intent_ls:
+  intent_expr                                       { $$ = TODOLIST(@$); }
+| task_intent_ls TCOMMA intent_expr                 { $$ = TODOLIST(@$); }
+;
+
+forall_intent_clause:
+  TWITH TLP forall_intent_ls TRP  { $$ = $3; }
+;
+
+forall_intent_ls:
+  intent_expr                          { $$ = TODOLIST(@$); }
+| forall_intent_ls TCOMMA intent_expr  { $$ = TODOLIST(@$); }
+;
+
+intent_expr:
+  shadow_var_prefix ident_expr opt_type opt_init_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+| reduce_scan_op_expr TREDUCE ident_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+| expr                TREDUCE ident_expr
+    {
+      $$ = TODOEXPR(@$);
+    }
+;
+
+shadow_var_prefix:
+  TCONST       { $$ = ShadowTag_CONST;     }
+| TIN          { $$ = ShadowTag_IN;        }
+| TCONST TIN   { $$ = ShadowTag_CONST_IN;  }
+| TREF         { $$ = ShadowTag_REF;       }
+| TCONST TREF  { $$ = ShadowTag_CONST_REF; }
+| TVAR         { $$ = ShadowTag_VAR;       }
+;
+
+io_expr:
+  lhs_expr
+| io_expr TIO expr
+    { $$ = TODOEXPR(@$); }
+;
+
+new_maybe_decorated:
+  TNEW         %prec TNOELSE
+    { $$ = NewTag_BLANK; }
+| TNEW TOWNED
+    { $$ = NewTag_OWNED; }
+| TNEW TSHARED
+    { $$ = NewTag_SHARED; }
+| TNEW TUNMANAGED
+    { $$ = NewTag_UNMANAGED; }
+| TNEW TBORROWED
+    { $$ = NewTag_BORROWED; }
+;
+
+new_expr:
+  /* handles the typical new cases, e.g. new C(); new owned C() */
+  new_maybe_decorated expr %prec TNEW
+    { TODOEXPR(@$); }
+  /* handles e.g. new (typefn())(initargs) */
+| TNEW TOWNED TLP expr TRP TLP opt_actual_ls TRP %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TNEW TSHARED TLP expr TRP TLP opt_actual_ls TRP %prec TNOELSE
+    { $$ = TODOEXPR(@$); }
+| TNEW TOWNED TLP expr TRP TLP opt_actual_ls TRP TQUESTION
+    { $$ = TODOEXPR(@$); }
+| TNEW TSHARED TLP expr TRP TLP opt_actual_ls TRP TQUESTION
+    { $$ = TODOEXPR(@$); }
+;
+
+let_expr:
+  TLET var_decl_stmt_inner_ls TIN expr
+    { $$ = TODOEXPR(@$); }
+;
+
+/* exprs represent valid values and types. Any expression with a valid
+   type also has a valid value as types can appear on the rhs during
+   type-aliasing.  Hence, type_level_expr must be a subset of expr. */
+expr:
+  literal_expr
+| type_level_expr
+| for_expr
+| reduce_expr
+| scan_expr
+| lambda_decl_expr
+| new_expr
+| let_expr
+| ifc_constraint
+| TLP TDOTDOTDOT expr TRP
+    { $$ = TODOEXPR(@$); }
+| expr TCOLON expr
+    { $$ = TODOEXPR(@$); }
+| expr TDOTDOT expr
+    { $$ = TODOEXPR(@$); }
+| expr TDOTDOTOPENHIGH expr
+    { $$ = TODOEXPR(@$); }
+
+/* The following cases would extend the current '..<' open range
+   interval constructor to also support '<..' and '<..<'.  This
+   concept didn't win enough support to merge as present, but are here
+   in case we change our minds in a future release.
+
+| expr TDOTDOTOPENLOW expr
+    { $$ = TODOEXPR(@$); }
+| expr TDOTDOTOPENBOTH expr
+    { $$ = TODOEXPR(@$); }
+| expr TDOTDOTOPENLOW
+    { $$ = TODOEXPR(@$); }
+*/
+| expr TDOTDOT
+    { $$ = TODOEXPR(@$); }
+| TDOTDOT expr
+    { $$ = TODOEXPR(@$); }
+| TDOTDOTOPENHIGH expr
+    { $$ = TODOEXPR(@$); }
+| TDOTDOT
+    { $$ = TODOEXPR(@$); }
+;
+
+opt_expr:
+                  { $$ = nullptr; }
+| expr            { $$ = $1; }
+;
+
+opt_try_expr:
+  TTRY expr       { $$ = TODOEXPR(@$); }
+| TTRYBANG expr   { $$ = TODOEXPR(@$); }
+| expr
+;
+
+lhs_expr:
+  ident_expr
+| call_expr
+| dot_expr
+| parenthesized_expr
+;
+
+/* Representations of values which can be invoked as functions.
+ *
+ * NOTE:  In order to allow expr to be invoked as a function
+ *        opt_actual_ls, and every production it relies on, would need to be
+ *        reworked to not permit the empty production. */
+call_base_expr:
+  lhs_expr
+| expr TBANG                    { $$ = TODOEXPR(@$); }
+| sub_type_level_expr TQUESTION { $$ = TODOEXPR(@$); }
+| lambda_decl_expr
+| str_bytes_literal
+;
+
+call_expr:
+  call_base_expr TLP opt_actual_ls TRP        { $$ = TODOEXPR(@$); }
+| call_base_expr TLSBR opt_actual_ls TRSBR    { $$ = TODOEXPR(@$); }
+| TPRIMITIVE TLP opt_actual_ls TRP            { $$ = TODOEXPR(@$); }
+;
+
+dot_expr:
+  expr TDOT ident_use          { $$ = TODOEXPR(@$); }
+| expr TDOT TTYPE              { $$ = TODOEXPR(@$); }
+| expr TDOT TDOMAIN            { $$ = TODOEXPR(@$); }
+| expr TDOT TLOCALE            { $$ = TODOEXPR(@$); }
+| expr TDOT TBYTES TLP TRP     { $$ = TODOEXPR(@$); }
+;
+
+/* ( <expr> ) -- A parenthesized expression.  The parens are stripped.
+ * ( <expr> , ) -- A one-tuple.  (Trailing comma is disallowed for longer tuples.)
+ * ( <tuple_expr_ls> ) -- Two-tuples and up.  A tuple_expr_ls contains at least 2 elements.
+ */
+parenthesized_expr:
+  TLP tuple_component TRP           { $$ = TODOEXPR(@$); }
+| TLP tuple_component TCOMMA TRP    { $$ = TODOEXPR(@$); }
+| TLP tuple_expr_ls TRP             { $$ = TODOEXPR(@$); }
+| TLP tuple_expr_ls TCOMMA TRP      { $$ = TODOEXPR(@$); }
+;
+
+bool_literal:
+  TFALSE { $$ = TODOEXPR(@$); }
+| TTRUE  { $$ = TODOEXPR(@$); }
+;
+
+str_bytes_literal:
+  STRINGLITERAL   { $$ = TODOEXPR(@$); }
+| BYTESLITERAL    { $$ = TODOEXPR(@$); }
+;
+
+literal_expr:
+  bool_literal
+| str_bytes_literal
+| INTLITERAL            { $$ = TODOEXPR(@$); }
+| REALLITERAL           { $$ = TODOEXPR(@$); }
+| IMAGLITERAL           { $$ = TODOEXPR(@$); }
+| CSTRINGLITERAL        { $$ = TODOEXPR(@$); }
+| TNONE                 { $$ = TODOEXPR(@$); }
+| TLCBR expr_ls TRCBR          { $$ = TODOEXPR(@$); }
+| TLCBR expr_ls TCOMMA TRCBR   { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TRSBR          { $$ = TODOEXPR(@$); }
+| TLSBR expr_ls TCOMMA TRSBR   { $$ = TODOEXPR(@$); }
+| TLSBR assoc_expr_ls TRSBR
+    {
+      $$ = TODOEXPR(@$);
+    }
+| TLSBR assoc_expr_ls TCOMMA TRSBR
+    {
+      $$ = TODOEXPR(@$);
+    }
+
+;
+
+assoc_expr_ls:
+  expr TALIAS expr                      { $$ = TODOLIST(@$); }
+| assoc_expr_ls TCOMMA expr TALIAS expr { $1->push_back(TODOEXPR(@$)); }
+;
+
+binary_op_expr:
+  expr TPLUS expr          { $$ = TODOEXPR(@$); }
+| expr TMINUS expr         { $$ = TODOEXPR(@$); }
+| expr TSTAR expr          { $$ = TODOEXPR(@$); }
+| expr TDIVIDE expr        { $$ = TODOEXPR(@$); }
+| expr TSHIFTLEFT expr     { $$ = TODOEXPR(@$); }
+| expr TSHIFTRIGHT expr    { $$ = TODOEXPR(@$); }
+| expr TMOD expr           { $$ = TODOEXPR(@$); }
+| expr TEQUAL expr         { $$ = TODOEXPR(@$); }
+| expr TNOTEQUAL expr      { $$ = TODOEXPR(@$); }
+| expr TLESSEQUAL expr     { $$ = TODOEXPR(@$); }
+| expr TGREATEREQUAL expr  { $$ = TODOEXPR(@$); }
+| expr TLESS expr          { $$ = TODOEXPR(@$); }
+| expr TGREATER expr       { $$ = TODOEXPR(@$); }
+| expr TBAND expr          { $$ = TODOEXPR(@$); }
+| expr TBOR expr           { $$ = TODOEXPR(@$); }
+| expr TBXOR expr          { $$ = TODOEXPR(@$); }
+| expr TAND expr           { $$ = TODOEXPR(@$); }
+| expr TOR  expr           { $$ = TODOEXPR(@$); }
+| expr TEXP expr           { $$ = TODOEXPR(@$); }
+| expr TBY expr            { $$ = TODOEXPR(@$); }
+| expr TALIGN expr         { $$ = TODOEXPR(@$); }
+| expr THASH expr          { $$ = TODOEXPR(@$); }
+| expr TDMAPPED expr       { $$ = TODOEXPR(@$); }
+;
+
+unary_op_expr:
+  TPLUS expr %prec TUPLUS         { $$ = TODOEXPR(@$); }
+| TMINUS expr %prec TUMINUS       { $$ = TODOEXPR(@$); }
+| TMINUSMINUS expr %prec TUMINUS  { $$ = TODOEXPR(@$); /* warn */ }
+| TPLUSPLUS expr %prec TUPLUS     { $$ = TODOEXPR(@$); /* warn */ }
+| TBANG expr %prec TLNOT          { $$ = TODOEXPR(@$); }
+| expr TBANG                      { $$ = TODOEXPR(@$); }
+| TBNOT expr                      { $$ = TODOEXPR(@$); }
+;
+
+reduce_expr:
+  expr TREDUCE expr                              { $$ = TODOEXPR(@$); }
+| expr TREDUCE zippered_iterator                 { $$ = TODOEXPR(@$); }
+| reduce_scan_op_expr TREDUCE expr               { $$ = TODOEXPR(@$); }
+| reduce_scan_op_expr TREDUCE zippered_iterator  { $$ = TODOEXPR(@$); }
+;
+
+scan_expr:
+  expr TSCAN expr                              { $$ = TODOEXPR(@$); }
+| expr TSCAN zippered_iterator                 { $$ = TODOEXPR(@$); }
+| reduce_scan_op_expr TSCAN expr               { $$ = TODOEXPR(@$); }
+| reduce_scan_op_expr TSCAN zippered_iterator  { $$ = TODOEXPR(@$); }
+;
+
+
+reduce_scan_op_expr:
+  TPLUS  { $$ = TODOEXPR(@$); }
+| TSTAR  { $$ = TODOEXPR(@$); }
+| TAND   { $$ = TODOEXPR(@$); }
+| TOR    { $$ = TODOEXPR(@$); }
+| TBAND  { $$ = TODOEXPR(@$); }
+| TBOR   { $$ = TODOEXPR(@$); }
+| TBXOR  { $$ = TODOEXPR(@$); }
+;

--- a/compiler/next/lib/Frontend/Parser/lexer-help.h
+++ b/compiler/next/lib/Frontend/Parser/lexer-help.h
@@ -1,0 +1,681 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+#include <cstring>
+#include <cctype>
+#include <string>
+#include <algorithm>
+
+static int   getNextYYChar(yyscan_t scanner);
+
+static void updateLocation(YYLTYPE* loc, int nLines, int nCols) {
+  loc->first_line = loc->last_line;
+  loc->first_column = loc->last_column;
+  loc->last_line = loc->first_line + nLines;
+  int startColumn = (nLines==0)?(loc->first_column):(1);
+  loc->last_column = startColumn + nCols;
+}
+
+int processNewline(yyscan_t scanner) {
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 1, 0);
+  return YYLEX_NEWLINE;
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static int processIdentifier(yyscan_t scanner, bool queried) {
+  YYSTYPE* val = yyget_lval(scanner);
+  int retval = processToken(scanner, queried ? TQUERIEDIDENT : TIDENT);
+  // note: processToken calls updateLocation.
+
+  const char* pch = yyget_text(scanner);
+  ParserContext* context = yyget_extra(scanner);
+  val->uniqueStr = PODUniqueString::build(context->context(), pch);
+
+  return retval;
+}
+
+static int processToken(yyscan_t scanner, int t) {
+  YYSTYPE* val = yyget_lval(scanner);
+
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+
+  ParserContext* context = yyget_extra(scanner);
+  val->uniqueStr = PODUniqueString::build(context->context(), pch);
+
+  // If the stack has a value then we must be in externmode.
+  // Return to INITIAL
+  if (yy_has_state(scanner) == true) {
+    yy_pop_state(scanner);
+  }
+
+  return t;
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static SizedStr eatStringLiteral(yyscan_t scanner, const char* startChar);
+static SizedStr eatTripleStringLiteral(yyscan_t scanner, const char* startChar);
+
+static int processStringLiteral(yyscan_t scanner,
+                                const char* startChar,
+                                int type) {
+  // update the location for the string start (e.g. b" )
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+
+  YYSTYPE* val = yyget_lval(scanner);
+  val->sizedStr = eatStringLiteral(scanner, startChar);
+  return type;
+}
+
+static int processTripleStringLiteral(yyscan_t scanner,
+                                      const char* startChar,
+                                      int type) {
+  // update the location for the string start (e.g. b" )
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+
+  YYSTYPE* val = yyget_lval(scanner);
+  val->sizedStr = eatTripleStringLiteral(scanner, startChar);
+  return type;
+}
+
+static
+void noteErrInString(yyscan_t scanner, int nLines, int nCols, const char* msg) {
+  ParserContext* context = yyget_extra(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  YYLTYPE myloc = *loc;
+  updateLocation(&myloc, nLines, nCols);
+  noteError(myloc, context, msg);
+}
+
+static
+char simpleEscape(int c) {
+  if (c == '\'')
+    return '\'';
+  if (c == '"')
+    return '"';
+  if (c == '?')
+    return '?';
+  if (c == '\\')
+    return '\\';
+  if (c == 'a')
+    return '\a';
+  if (c == 'b')
+    return '\b';
+  if (c == 'f')
+    return '\f';
+  if (c == 'n')
+    return '\n';
+  if (c == 'r')
+    return '\r';
+  if (c == 't')
+    return '\t';
+  if (c == 'v')
+    return '\v';
+  if (c == '\n')
+    // to allow newline followed by \ at the end of the line
+    return '\n';
+
+  return '\0';
+}
+
+static SizedStr eatStringLiteral(yyscan_t scanner, const char* startChar) {
+  ParserContext* context = yyget_extra(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  const char startCh = *startChar;
+  int        c       = 0;
+  int nLines = 0;
+  int nCols = 0;
+  std::string s;
+
+  c = getNextYYChar(scanner);
+  nCols++; // if it's newline, this will immediately be reset
+
+  while (c != startCh && c != 0) {
+    if (c == '\n') {
+      // TODO: string literals with newline after backslash
+      // are not documented in the spec
+      noteErrInString(scanner, nLines, nCols, "end-of-line in a string literal without a preceding backslash");
+      s += c;
+      nLines++;
+      nCols = 0;
+    } else {
+      s += c;
+    }
+
+    if (c == '\\') {
+      c = getNextYYChar(scanner);
+      nCols++;
+
+      // account for newlines after \ at the end
+      if (c == '\n') {
+        nLines++;
+        nCols = 0;
+      }
+
+      // handle the escapes described in the spec
+      //   \' \" \? \\ \a \b \f \n \r \t \v and \xDIGITS
+      char esc = simpleEscape(c);
+      if (esc != 0) {
+        s += esc;
+      } else if (c == 'x') {
+        // Read hexadecimal digits until we run out
+        char buf[3] = {'\0', '\0', '\0'};
+        bool foundNonHex = false;
+        bool overflow = false;
+        for (int i = 0; true; i++) {
+          c = getNextYYChar(scanner);
+          nCols++;
+          // TODO the exact behavior here is not documented in the spec
+          if (('0' <= c && c <= '9') ||
+              ('A' <= c && c <= 'F') ||
+              ('a' <= c && c <= 'f')) {
+            if (i < 2)
+              buf[i] = c;
+            else
+              overflow = true;
+          } else {
+            foundNonHex = true;
+            break;
+          }
+        }
+        if (overflow)
+          noteErrInString(scanner, nLines, nCols,
+                          "overflow when reading \\x escape");
+        if (foundNonHex)
+          continue; // need to process c as the next character
+
+      } else if (c == 'u' || c == 'U') {
+        noteErrInString(scanner, nLines, nCols, "universal character name not yet supported in string literal");
+        s += "\\u"; // this is a dummy value
+      } else if ('0' <= c && c <= '7' ) {
+        noteErrInString(scanner, nLines, nCols, "octal escape not supported in string literal");
+        s += "\\";
+        s += c; // a dummy value
+      } else if (c == 0) {
+        // we've reached EOF
+        s += "\\";
+        break; // EOF reached, so stop
+      } else {
+        s += "\\"; // TODO exact behavior here is not documented in the spec
+        s += c;
+      }
+    }
+    c = getNextYYChar(scanner);
+    nCols++;
+  } /* eat up string */
+
+  if (c == 0) {
+    noteErrInString(scanner, nLines, nCols, "EOF in string");
+  }
+
+  // update the location 
+  updateLocation(loc, nLines, nCols);
+
+  // allocate the value to return
+  long size = s.size();
+  char* buf = (char*) malloc(size+1);
+  memcpy(buf, s.c_str(), size+1);
+
+  return makeSizedStr(buf, size);
+}
+
+static SizedStr eatTripleStringLiteral(yyscan_t scanner,
+                                       const char* startChar) {
+  ParserContext* context = yyget_extra(scanner);
+  YYLTYPE* loc       = yyget_lloc(scanner);
+  const char startCh = *startChar;
+  int startChCount   = 0;
+  int c              = 0;
+  int nLines = 0;
+  int nCols = 0;
+  std::string s;
+
+  while (true) {
+    c = getNextYYChar(scanner);
+    if (c == 0) {
+      break;
+    }
+
+    if (c == '\n') {
+      nLines++;
+      nCols = 0;
+    } else {
+      nCols++;
+    }
+
+    if (c == startCh) {
+      startChCount++;
+      if (startChCount == 3) {
+        break;
+      }
+    } else {
+      startChCount = 0;
+    }
+
+    s += c;
+  } /* eat up string */
+
+  if (c == 0) {
+    noteErrInString(scanner, nLines, nCols, "EOF in string");
+  }
+
+  // update the location 
+  updateLocation(loc, nLines, nCols);
+
+  long size = s.size();
+  // Remove two quotes from the end of the string that are
+  // actually part of the string closing token.
+  for (int i = 0; i < 2; i++) {
+    if (s[size-1] == startCh) size--;
+  }
+  char* buf = (char*) malloc(size+1);
+  memcpy(buf, s.c_str(), size);
+  buf[size] = '\0';
+
+  return makeSizedStr(buf, size);
+}
+
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static int processExtern(yyscan_t scanner) {
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+
+  // Push a state to record that "extern" has been seen
+  yy_push_state(externmode, scanner);
+
+  return TEXTERN;
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static SizedStr eatExternCode(yyscan_t scanner);
+
+// When the lexer calls this function, it has already consumed the first '{'
+static int processExternCode(yyscan_t scanner) {
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+
+  YYSTYPE* val = yyget_lval(scanner);
+  val->sizedStr = eatExternCode(scanner);
+
+  return EXTERNCODE;
+}
+
+static SizedStr eatExternCode(yyscan_t scanner) {
+  const int in_code                          = 0;
+  const int in_single_quote                  = 1;
+  const int in_single_quote_backslash        = 2;
+  const int in_double_quote                  = 3;
+  const int in_double_quote_backslash        = 4;
+  const int in_single_line_comment           = 5;
+  const int in_single_line_comment_backslash = 6;
+  const int in_multi_line_comment            = 7;
+
+  YYLTYPE*  loc                              = yyget_lloc(scanner);
+
+  int       depth                            = 1;
+  int       c                                = 0;
+  int       lastc                            = 0;
+  int       state                            = 0;
+
+  ParserContext* context = yyget_extra(scanner);
+
+  int nLines = 0;
+  int nCols = 0;
+  std::string s;
+
+  const char* filename = context->filename.c_str();
+
+  if (filename != NULL && filename[0] != '\0') {
+    // First, store the line information.
+    s += "#line ";
+    s += std::to_string(loc->first_line + nLines);
+    s += " \"";
+    s += filename;
+    s += "\" \n";
+  }
+
+  // Now, append the C code until we get to a }.
+  while (depth > 0) {
+    lastc = c;
+    c     = getNextYYChar(scanner);
+
+    if (c == 0) {
+      ParserContext* context = yyget_extra(scanner);
+
+      switch (state) {
+        case in_code:
+          // there was no match to the {
+          noteErrInString(scanner, nLines, nCols,
+                          "Missing } in extern block");
+          break;
+
+        case in_single_quote:
+        case in_single_quote_backslash:
+          noteErrInString(scanner, nLines, nCols,
+                          "Runaway \'string\' in extern block");
+          break;
+
+        case in_double_quote:
+        case in_double_quote_backslash:
+          noteErrInString(scanner, nLines, nCols,
+                          "Runaway \"string\" in extern block");
+          break;
+
+        case in_single_line_comment:
+          noteErrInString(scanner, nLines, nCols,
+                          "Missing newline after extern block // comment");
+          break;
+
+        case in_multi_line_comment:
+          noteErrInString(scanner, nLines, nCols,
+                          "Runaway /* comment */ in extern block");
+          break;
+      }
+      break;
+    }
+
+    s += c;
+
+    if (c == '\n') {
+      nCols = 0;
+      nLines++;
+    }
+
+    // Now update state (are we in a comment? a string?)
+    switch (state) {
+      case in_code:
+        if (c == '\'')
+          state = in_single_quote;
+
+        else if (c == '"')
+          state = in_double_quote;
+
+        else if (lastc == '/' && c == '/')
+          state = in_single_line_comment;
+
+        else if (lastc == '/' && c == '*')
+          state = in_multi_line_comment;
+
+        else if (c == '{' )
+          depth++;
+
+        else if (c == '}' )
+          depth--;
+
+        break;
+
+      case in_single_quote:
+        if (c == '\\')
+          state = in_single_quote_backslash;
+
+        else if (c == '\'')
+          state = in_code;
+
+        break;
+
+      case in_single_quote_backslash:
+        state = in_single_quote;
+        break;
+
+      case in_double_quote:
+        if (c == '\\')
+          state = in_double_quote_backslash;
+
+        else if (c == '"')
+          state = in_code;
+
+        break;
+
+      case in_double_quote_backslash:
+        state = in_double_quote;
+        break;
+
+      case in_single_line_comment:
+        if (c == '\n')
+          state = in_code;
+        break;
+
+      case in_single_line_comment_backslash:
+        if (c == ' ' || c == '\t' || c == '\n')
+          state = in_single_line_comment_backslash;
+
+        else
+          state = in_single_line_comment;
+
+        break;
+
+      case in_multi_line_comment:
+        if (lastc == '*' && c == '/')
+          state = in_code;
+        break;
+    }
+  }
+
+  // update the location 
+  updateLocation(loc, nLines, nCols);
+
+  //save the C String
+  //eliminate the final '}'
+  long size = s.size();
+  if (s[size-1] == '}') size--;
+  char* buf = (char*) malloc(size+1);
+  memcpy(buf, s.c_str(), size);
+  buf[size] = '\0';
+
+  return makeSizedStr(buf, size);
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static void processWhitespace(yyscan_t scanner) {
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static int processSingleLineComment(yyscan_t scanner) {
+  YYSTYPE* val = yyget_lval(scanner);
+  int      c   = 0;
+
+  // start with the comment introduction
+  std::string s;
+  s += yyget_text(scanner);
+
+  // Read until the end of the line
+  while ((c = getNextYYChar(scanner)) != '\n' && c != 0) {
+    s += c;
+  }
+
+  YYLTYPE* loc = yyget_lloc(scanner);
+  int nLines = 1;
+  int nCols = 0;
+  if (c == 0) {
+    nCols = s.size();
+    nLines = 0;
+  }
+  updateLocation(loc, nLines, nCols);
+
+  // allocate the value to return
+  long size = s.size();
+  char* buf = (char*) malloc(size+1);
+  memcpy(buf, s.c_str(), size+1);
+
+  ParserContext* context = yyget_extra(scanner);
+  context->noteComment(*loc, buf, size);
+
+  return YYLEX_SINGLE_LINE_COMMENT;
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static int processBlockComment(yyscan_t scanner) {
+  YYSTYPE*    val       = yyget_lval(scanner);
+  YYLTYPE*    loc       = yyget_lloc(scanner);
+
+  int nestedStartLine = -1;
+  int nestedStartCol = -1;
+  int startLine = loc->first_line;
+  int startCol = loc->first_column;
+
+  int         c            = 0;
+  bool        badComment = false;
+  int         lastc        = 0;
+  int         depth        = 1;
+
+  int nLines = 0;
+  int nCols = 0;
+  // start with the comment introduction
+  std::string s;
+  s += yyget_text(scanner);
+  nCols += s.size();
+
+  while (depth > 0) {
+    int lastlastc = lastc;
+
+    lastc = c;
+    c     = getNextYYChar(scanner);
+
+    if (c == '\n') {
+      nCols = 0;
+      nLines++;
+    } else {
+      nCols++;
+    }
+    s += c;
+
+    if (lastc == '*' && c == '/' && lastlastc != '/') { // close comment
+      depth--;
+    } else if (lastc == '/' && c == '*') { // start nested
+      depth++;
+      // keep track of the start of the last nested comment
+      nestedStartLine = nLines;
+      nestedStartCol = nCols;
+    } else if (c == 0) {
+      noteErrInString(scanner, nLines, nCols, "EOF in comment");
+      noteErrInString(scanner, 0, 0, "unterminated comment started here");
+      if( nestedStartLine >= 0 ) {
+        noteErrInString(scanner, nestedStartLine, nestedStartCol,
+                        "nested comment started here");
+      }
+      break;
+    }
+  }
+
+  updateLocation(loc, nLines, nCols);
+
+  // allocate the value to return
+  long size = s.size();
+  char* buf = (char*) malloc(size+1);
+  memcpy(buf, s.c_str(), size+1);
+
+  ParserContext* context = yyget_extra(scanner);
+  context->noteComment(*loc, buf, size);
+
+  return YYLEX_BLOCK_COMMENT;
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static void processInvalidToken(yyscan_t scanner) {
+  const char* pch = yyget_text(scanner);
+  YYLTYPE* loc = yyget_lloc(scanner);
+  updateLocation(loc, 0, strlen(pch));
+  ParserContext* context = yyget_extra(scanner);
+  yyerror(loc, context, "Invalid token");
+}
+
+static int getNextYYChar(yyscan_t scanner) {
+  int retval = yyinput(scanner);
+
+  if (retval == EOF) {
+    retval = 0;
+  }
+
+  return retval;
+}
+
+/************************************ | *************************************
+*                                                                           *
+*                                                                           *
+*                                                                           *
+************************************* | ************************************/
+
+static bool yy_has_state(yyscan_t yyscanner)
+{
+  // This is only to suppress a compiler warning
+  (void) yy_top_state;
+
+  struct yyguts_t * yyg = (struct yyguts_t*) yyscanner;
+
+  return yyg->yy_start_stack_ptr > 0;
+}

--- a/compiler/next/lib/Frontend/Parser/parser-help.h
+++ b/compiler/next/lib/Frontend/Parser/parser-help.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void yyerror(YYLTYPE*       loc,
+             ParserContext* context,
+             const char*    errorMessage) {
+  context->errors.push_back(ParserError(*loc, errorMessage));
+}
+
+void noteError(YYLTYPE location, ParserContext* context, const char* s) {
+  context->errors.push_back(ParserError(location, s));
+}
+void noteError(YYLTYPE location, ParserContext* context, const std::string s) {
+  context->errors.push_back(ParserError(location, s));
+}
+
+static ErroneousExpr* raiseError(YYLTYPE location,
+                                 ParserContext* context,
+                                 const char* errorMessage) {
+  // note the error for printing
+  yyerror(&location, context, errorMessage);
+  Location ll = context->convertLocation(location);
+  // return an error sentinel
+  return ErroneousExpr::build(context->builder, ll).release();
+}
+
+// these helpers can be used in the semantic actions
+#define BUILDER (context->builder)
+#define STMT(LOC,AST) makeCommentsAndStmt(context->gatherComments(LOC), AST)
+#define ENDSTMT() context->clearComments();
+
+#define STR(s) PODUniqueString::build(context->context(), s)
+#define LOC(loc) context->convertLocation(loc)
+
+// ERROR creates an error and returns an error sentinel Expr
+#define ERROR(LOC,MSG) raiseError(LOC, context, MSG)
+
+#define TODOEXPR(LOC) raiseError(LOC, context, "not implemented yet")
+#define TODOSTMT(LOC) makeCommentsAndStmt(context->gatherComments(LOC), raiseError(LOC, context, "not implemented yet"))
+#define TODOLIST(LOC) context->makeList(raiseError(LOC, context, "not implemented yet"))
+


### PR DESCRIPTION
This PR contains a separate parser for the compiler revamp effort.

Split out from PR #17583, which is a start at the compiler revamp effort
described in the
[1.24 release notes ongoing efforts](https://chapel-lang.org/releaseNotes/1.24/04-ongoing.pdf).

The flex/bison files started out as copies of the parser from the main
compiler. I removed all semantic actions and adjusted these to not use
global variables. Additionally, instead of storing comments in bison
locations, it stores a vector of comments not yet consumed in the
ParserContext structure. Along with removing the semantic actions I have
adjusted the types of these rules and made a couple of minor changes to
get the comments processing correctly. As far as I know, this parser no
longer uses any global state. Several rules that used to return a
BlockStmt (because they are a "statement) now return CommentsAndStmt. The
idea here is that, during parsing, when we create a statement, we gather
comments that appeared before it. We include those in the result of
parsing that statement. Additionally there is some logic to clear the
comments when we reach the end of a statement.

While working on the parser, I moved lots of the C++ support code that
used to be in chapel.flex/chapel.bison to other files that are
`#included` in these. That way, we don't have to regenerate the parser if
they change.

Note that in the lexer, I've changed the handling of comments to include
recording the entire comment (rather than leaving out the introduction or
dealing with other formatting). That way, tools like `chpldoc` can
separately decide which comment introductions require further processing.

Additionally, in the lexer, I've changed the parsing of string literals
to record string data in the unescaped form. Previously, the compiler
stored string literals with C escapes. Storing the escapes has led to a
variety of bugs over time (because things like string.length for param
strings needs to handle the escapes). But more importantly, as the
default backend switches to LLVM, these C escapes don't make sense
anymore in the default configuration. Instead, we will need to add the
necessary escapes when generating C code.

The parser in this PR has the ability to parse a simple subset of the
language (including `{ }` blocks, trivial variable declarations like `var
a;`, and identifier statements like `a;`). Other language elements still
have parser rules but their semantic actions just create error sentinel
nodes.

The parser currently stores the results from the rules in a union. As a
result, we can't have types that have default constructors. (This is the
reason for the `PODUniqueString` type and also a reason that the parser
code has its own kind of expression list type, etc). Bison has some
support for C++ variants but I did not take on the task of updating our
parser to use those. As it is today, the nested rules from a parser rule
generally return a pointer that needs to be stored somewhere or deleted.
This is manageable, although it makes the parser code less elegant than
it could be.

Lastly, I created several helper `#define`s that can be used in the
semantic actions. This was important because for now most of the semantic
actions are "TODO" and so I needed a short way of putting that. But,
these macros also help with things like handling comments appropriately
when parsing a Statement. These macros like `TODOSTMT` `LOC` `STR` etc
are defined in parser-help.h.

 - [x] full local testing

Reviewed by @lydia-duncan - thanks!