### PR TITLE
responsive compiler prototype: frontend queries and tests

### DIFF
--- a/compiler/next/include/chpl/Frontend/FrontendQueries.h
+++ b/compiler/next/include/chpl/Frontend/FrontendQueries.h
@@ -37,11 +37,11 @@ namespace FrontendQueries {
   const std::string& fileText(Context* context, UniqueString path);
   const ast::Builder::Result* parseFile(Context* context, UniqueString path);
 
-  typedef std::unordered_map<ID, Location> LocationsMap;
+  using LocationsMap = std::unordered_map<ID, Location>;
   const LocationsMap& fileLocations(Context* context, UniqueString path);
   Location locate(Context* context, ID id);
 
-  typedef std::vector<const ast::ModuleDecl*> ModuleDeclVec;
+  using ModuleDeclVec = std::vector<const ast::ModuleDecl*>;
   const ModuleDeclVec& parse(Context* context, UniqueString path);
 
   /*
@@ -84,7 +84,7 @@ namespace FrontendQueries {
       : module(module), topLevelNames(std::move(topLevelNames)) {
     }
   };
-  typedef std::vector<DefinedTopLevelNames> DefinedTopLevelNamesVec;
+  using DefinedTopLevelNamesVec = std::vector<DefinedTopLevelNames>;
 
   const DefinedTopLevelNamesVec& moduleLevelDeclNames(Context* context,
                                                       UniqueString path);
@@ -93,10 +93,10 @@ namespace FrontendQueries {
     // index is the postorder ID
     std::vector<Symbol*> idToSymbol;
   };
-  typedef std::unordered_map<Module*,owned<ResolutionGroup>>
-    ModuleInitResolutionResult;*/
-  /*typedef std::unordered_map<FnSymbol*,owned<ResolutionResult>>
-    FunctionResolutionResult;*/
+  using ModuleInitResolutionResult = std::unordered_map<Module*,owned<ResolutionGroup>>;
+    */
+  /*using FunctionResolutionResult =
+    std::unordered_map<FnSymbol*,owned<ResolutionResult>>; */
 
   //const ast::BaseAST* ast(Context* context, ID id);
 };

--- a/compiler/next/include/chpl/Frontend/FrontendQueries.h
+++ b/compiler/next/include/chpl/Frontend/FrontendQueries.h
@@ -44,6 +44,36 @@ namespace FrontendQueries {
   typedef std::vector<const ast::ModuleDecl*> ModuleDeclVec;
   const ModuleDeclVec& parse(Context* context, UniqueString path);
 
+  /*
+  typedef std::unordered_map<UniqueString, Symbol*> SymbolsByName;
+  const SymbolsByName& symbolsDeclaredIn(Context* context, Expr* expr);
+
+  struct ResolutionResult {
+    // the expr that is resolved
+    Expr* expr;
+    // in simple cases, this is set
+    Symbol* symbol;
+    // TODO:
+    //  return-intent overloading
+    //  generic instantiation
+    //  establish concrete intents
+    //  establish copy-init vs move
+    ResolutionResult() : expr(NULL), symbol(NULL) { }
+  };
+
+  typedef std::vector<ResolutionResult> ResolutionResultByPostorderID;
+
+    If resolve is called on a Decl, it will traverse into the declared
+    Symbol. So to resolve a function, run resolve on the FunctionDecl.
+  const ResolutionResultByPostorderID& resolve(Context* context, Expr* e);
+  */
+
+  /*
+  struct DeclaredByName {
+    std::unordered_map<UniqueString, Symbol*> declaredSymbols;
+  };*/
+
+
   struct DefinedTopLevelNames {
     // the module
     const ast::Module* module;
@@ -58,7 +88,6 @@ namespace FrontendQueries {
 
   const DefinedTopLevelNamesVec& moduleLevelDeclNames(Context* context,
                                                       UniqueString path);
-
 
   /*struct ResolutionGroup {
     // index is the postorder ID

--- a/compiler/next/include/chpl/Frontend/FrontendQueries.h
+++ b/compiler/next/include/chpl/Frontend/FrontendQueries.h
@@ -1,0 +1,59 @@
+#ifndef CHPL_FRONTEND_FRONTENDQUERIES_H
+#define CHPL_FRONTEND_FRONTENDQUERIES_H
+
+#include "chpl/AST/BaseAST.h"
+#include "chpl/AST/Builder.h"
+#include "chpl/AST/Expr.h"
+#include "chpl/AST/ID.h"
+#include "chpl/AST/Location.h"
+#include "chpl/AST/ModuleDecl.h"
+#include "chpl/Queries/Context.h"
+
+#include <vector>
+
+namespace chpl {
+
+// This could alternatively be a class with static methods
+namespace FrontendQueries {
+  const std::string& fileText(Context* context, UniqueString path);
+  const ast::Builder::Result* parseFile(Context* context, UniqueString path);
+
+  typedef std::unordered_map<ID, Location> LocationsMap;
+  const LocationsMap& fileLocations(Context* context, UniqueString path);
+  Location locate(Context* context, ID id);
+
+  typedef std::vector<const ast::ModuleDecl*> ModuleDeclVec;
+  const ModuleDeclVec& parse(Context* context, UniqueString path);
+
+  struct DefinedTopLevelNames {
+    // the module
+    const ast::Module* module;
+    // these are in program order
+    std::vector<UniqueString> topLevelNames;
+    DefinedTopLevelNames(const ast::Module* module,
+                         std::vector<UniqueString> topLevelNames)
+      : module(module), topLevelNames(std::move(topLevelNames)) {
+    }
+  };
+  typedef std::vector<DefinedTopLevelNames> DefinedTopLevelNamesVec;
+
+  const DefinedTopLevelNamesVec& moduleLevelDeclNames(Context* context,
+                                                      UniqueString path);
+
+
+  /*struct ResolutionGroup {
+    // index is the postorder ID
+    std::vector<Symbol*> idToSymbol;
+  };
+  typedef std::unordered_map<Module*,owned<ResolutionGroup>>
+    ModuleInitResolutionResult;*/
+  /*typedef std::unordered_map<FnSymbol*,owned<ResolutionResult>>
+    FunctionResolutionResult;*/
+
+  //const ast::BaseAST* ast(Context* context, ID id);
+};
+
+} // end namespace chpl
+
+
+#endif

--- a/compiler/next/include/chpl/Frontend/FrontendQueries.h
+++ b/compiler/next/include/chpl/Frontend/FrontendQueries.h
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef CHPL_FRONTEND_FRONTENDQUERIES_H
 #define CHPL_FRONTEND_FRONTENDQUERIES_H
 

--- a/compiler/next/lib/Frontend/FrontendQueries.cpp
+++ b/compiler/next/lib/Frontend/FrontendQueries.cpp
@@ -1,0 +1,200 @@
+#include "chpl/Frontend/FrontendQueries.h"
+
+#include "chpl/AST/ErrorMessage.h"
+#include "chpl/AST/Module.h"
+#include "chpl/Frontend/Parser.h"
+#include "chpl/Queries/QueryImpl.h"
+
+#include "../Util/files.h"
+
+#include <cstdio>
+
+namespace chpl {
+
+template<> struct combine<FrontendQueries::LocationsMap> {
+  bool operator()(FrontendQueries::LocationsMap& keep,
+                  FrontendQueries::LocationsMap& addin) const {
+    return defaultCombine(keep, addin);
+  }
+};
+template<> struct combine<FrontendQueries::ModuleDeclVec> {
+  bool operator()(FrontendQueries::ModuleDeclVec& keep,
+                  FrontendQueries::ModuleDeclVec& addin) const {
+    return defaultCombine(keep, addin);
+  }
+};
+template<> struct combine<FrontendQueries::DefinedTopLevelNamesVec> {
+  bool operator()(FrontendQueries::DefinedTopLevelNamesVec& keep,
+                  FrontendQueries::DefinedTopLevelNamesVec& addin) const {
+
+    size_t nKeep = keep.size();
+    size_t nAddin = addin.size();
+    bool match = true;
+    if (nKeep == nAddin) {
+      for (size_t i = 0; i < nKeep; i++) {
+        FrontendQueries::DefinedTopLevelNames& keepElt = keep[i];
+        FrontendQueries::DefinedTopLevelNames& addinElt = addin[i];
+        if (keepElt.module != addinElt.module ||
+            keepElt.topLevelNames != addinElt.topLevelNames) {
+          match = false;
+          break;
+        }
+      }
+    } else {
+      match = false;
+    }
+
+    if (match) {
+      return true;
+    } else {
+      keep.swap(addin);
+      return false;
+    }
+  }
+};
+
+namespace FrontendQueries {
+
+const std::string& fileText(Context* context, UniqueString path) {
+  QUERY_BEGIN_NAMED(context, std::string, "fileText", path);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  ErrorMessage error;
+  std::string result;
+  bool ok = readfile(path.c_str(), result, error);
+  if (!ok) {
+    QUERY_ERROR(std::move(error));
+  }
+
+  return QUERY_END(result);
+}
+
+const ast::Builder::Result* parseFile(Context* context, UniqueString path) {
+  QUERY_BEGIN(context, owned<ast::Builder::Result>, path);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED().get();
+  }
+
+  // Run the fileText query to get the file contents
+  const std::string& text = fileText(context, path);
+
+  ast::Builder::Result* result = new ast::Builder::Result();
+  auto parser = Parser::build(context);
+  const char* pathc = path.c_str();
+  const char* textc = text.c_str();
+  ast::Builder::Result tmpResult = parser->parseString(pathc, textc);
+  result->topLevelExprs.swap(tmpResult.topLevelExprs);
+  result->locations.swap(tmpResult.locations);
+  for (ErrorMessage& e : tmpResult.errors) {
+    ErrorMessage tmp;
+    tmp.swap(e);
+    QUERY_ERROR(std::move(tmp));
+  }
+
+  // Update the filePathForModuleName query
+  for (auto & topLevelExpr : result->topLevelExprs) {
+    UniqueString moduleName = context->moduleNameForID(topLevelExpr->id());
+    context->setFilePathForModuleName(moduleName, path);
+  }
+
+  return QUERY_END(toOwned(result)).get();
+}
+
+const LocationsMap& fileLocations(Context* context, UniqueString path) {
+  QUERY_BEGIN(context, LocationsMap, path);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  // Get the result of parsing
+  const ast::Builder::Result* p = parseFile(context, path);
+  // Create a map of ID to Location
+  std::unordered_map<ID, Location> result;
+  for (auto pair : p->locations) {
+    ID id = pair.first;
+    Location loc = pair.second;
+    result.insert({id, loc});
+  }
+  
+  return QUERY_END(result);
+}
+
+Location locate(Context* context, ID id) {
+  QUERY_BEGIN(context, Location, id);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  // Ask the context for the filename from the ID
+  UniqueString path = context->filePathForID(id);
+  // Get the map of ID to Location
+  Location result(path);
+  const LocationsMap& map = fileLocations(context, path);
+  auto search = map.find(id);
+  if (search != map.end()) {
+    result = search->second;
+  }
+
+  return QUERY_END(result);
+}
+
+const ModuleDeclVec& parse(Context* context, UniqueString path) {
+  QUERY_BEGIN(context, ModuleDeclVec, path);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  // Get the result of parsing
+  const ast::Builder::Result* p = parseFile(context, path);
+  // Compute a vector of ModuleDecls
+  ModuleDeclVec result;
+  for (auto & topLevelExpr : p->topLevelExprs) {
+    if (const ast::ModuleDecl* modDecl = topLevelExpr->toModuleDecl()) {
+      result.push_back(modDecl);
+    }
+  }
+
+  return QUERY_END(result);
+}
+
+static std::vector<UniqueString> getTopLevelNames(const ast::Module* module) {
+  std::vector<UniqueString> result;
+  int nStmts = module->numStmts();
+  for (int i = 0; i < nStmts; i++) {
+    const ast::Expr* expr = module->stmt(i);
+    if (const ast::Decl* decl = expr->toDecl()) {
+      const ast::Symbol* sym = decl->symbol();
+      result.push_back(sym->name());
+    }
+  }
+  return result;
+}
+
+const DefinedTopLevelNamesVec& moduleLevelDeclNames(Context* context,
+                                                    UniqueString path) {
+  QUERY_BEGIN(context, DefinedTopLevelNamesVec, path);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  DefinedTopLevelNamesVec result;
+
+  // Get the result of parsing modules
+  const ModuleDeclVec& p = parse(context, path);
+  for (const ast::ModuleDecl* modDecl : p) {
+    const ast::Module* module = modDecl->module();
+    result.push_back(DefinedTopLevelNames(module, getTopLevelNames(module)));
+  }
+
+  return QUERY_END(result);
+}
+
+
+/*const ast::BaseAST* ast(Context* context, ID id) {
+  return nullptr;
+}*/
+
+} // end namespace FrontendQueries
+} // end namespace chpl

--- a/compiler/next/lib/Frontend/FrontendQueries.cpp
+++ b/compiler/next/lib/Frontend/FrontendQueries.cpp
@@ -30,19 +30,19 @@
 
 namespace chpl {
 
-template<> struct combine<FrontendQueries::LocationsMap> {
+template<> struct update<FrontendQueries::LocationsMap> {
   bool operator()(FrontendQueries::LocationsMap& keep,
                   FrontendQueries::LocationsMap& addin) const {
-    return defaultCombine(keep, addin);
+    return defaultUpdate(keep, addin);
   }
 };
-template<> struct combine<FrontendQueries::ModuleDeclVec> {
+template<> struct update<FrontendQueries::ModuleDeclVec> {
   bool operator()(FrontendQueries::ModuleDeclVec& keep,
                   FrontendQueries::ModuleDeclVec& addin) const {
-    return defaultCombine(keep, addin);
+    return defaultUpdate(keep, addin);
   }
 };
-template<> struct combine<FrontendQueries::DefinedTopLevelNamesVec> {
+template<> struct update<FrontendQueries::DefinedTopLevelNamesVec> {
   bool operator()(FrontendQueries::DefinedTopLevelNamesVec& keep,
                   FrontendQueries::DefinedTopLevelNamesVec& addin) const {
 
@@ -64,10 +64,10 @@ template<> struct combine<FrontendQueries::DefinedTopLevelNamesVec> {
     }
 
     if (match) {
-      return true;
+      return false;
     } else {
       keep.swap(addin);
-      return false;
+      return true;
     }
   }
 };
@@ -177,6 +177,60 @@ const ModuleDeclVec& parse(Context* context, UniqueString path) {
 
   return QUERY_END(result);
 }
+
+/*
+const SymbolsByName& symbolsDeclaredIn(Context* context, Expr* expr) {
+  QUERY_BEGIN(context, SymbolsByName, expr);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  // TODO
+
+  return QUERY_END(result);
+}
+*/
+
+/*
+// TODO: it would be reasonable for this to be an AST visitor
+static void gatherPostorderForResolve(Expr* e,
+                                      ResolutionResultByPostorderID& r) {
+  if (e->isComment()) return;
+  if (child->isDecl()) continue;
+
+  // otherwise, gather children
+  int nChildren = e->numChildren();
+  for (int i = 0; i < nChildren; i++) {
+    BaseAST* child = e->child(i);
+    gatherPostorderForResolve(e, r);
+  }
+
+  // then gather this expr
+  int postOrderId = e->id().postOrderId();
+  if (postOrderId >= 0) {
+    assert(postOrderId < r.size());
+    r[postOrderId].expr = e;
+  }
+}
+
+const ResolutionResultByPostorderID& resolve(Context* context, Expr* e) {
+  QUERY_BEGIN(context, ResolutionResultByPostorderID, expr);
+  if (QUERY_USE_SAVED()) {
+    return QUERY_GET_SAVED();
+  }
+
+  ResolutionResultByPostorderID result;
+  result.resize(e->id().postOrderId());
+  gatherPostorderForResolve(e, result);
+
+  // now go through the vector updating the ResolutionResults
+  for (ResolutionResult& rr : result) {
+
+  }
+
+  return QUERY_END(result);
+}
+*/
 
 static std::vector<UniqueString> getTopLevelNames(const ast::Module* module) {
   std::vector<UniqueString> result;

--- a/compiler/next/lib/Frontend/FrontendQueries.cpp
+++ b/compiler/next/lib/Frontend/FrontendQueries.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "chpl/Frontend/FrontendQueries.h"
 
 #include "chpl/AST/ErrorMessage.h"

--- a/compiler/next/test/AST/testBuildIDs.cpp
+++ b/compiler/next/test/AST/testBuildIDs.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/AST/BlockStmt.h"
+#include "chpl/AST/Builder.h"
+#include "chpl/AST/ErrorMessage.h"
+#include "chpl/AST/Expr.h"
+#include "chpl/AST/Identifier.h"
+#include "chpl/AST/Location.h"
+#include "chpl/AST/ModuleDecl.h"
+#include "chpl/AST/UniqueString.h"
+#include "chpl/Queries/Context.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+using namespace chpl;
+using namespace ast;
+
+void test0() {
+  // test some operations on locations
+  auto context = Context::build();
+  Context* ctx = context.get();
+  Location locOne(UniqueString::build(ctx, "a.chpl"));
+  Location locTwo(UniqueString::build(ctx, "aVeryLongFilenameIndeed.chpl"));
+  Location locOneCopy(locOne.path());
+  Location locTwoCopy(locTwo.path());
+  Location locOneA(locOne.path(),  1, -1, -1, -1);
+  Location locOneB(locOne.path(), -1,  1, -1, -1);
+  Location locOneC(locOne.path(), -1, -1,  1, -1);
+  Location locOneD(locOne.path(), -1, -1, -1,  1);
+  Location emptyLoc;
+
+  assert(emptyLoc == emptyLoc);
+  assert(!(emptyLoc != emptyLoc));
+  assert(emptyLoc != locOne);
+  assert(!(emptyLoc == locOne));
+  assert(locOne == locOne);
+  assert(!(locOne != locOne));
+  assert(locOne != locTwo);
+  assert(!(locOne == locTwo));
+  assert(locOneCopy == locOne);
+  assert(!(locOneCopy != locOne));
+  assert(locTwoCopy == locTwo);
+  assert(!(locTwoCopy != locTwo));
+  assert(locOneA != locOne);
+  assert(!(locOneA == locOne));
+  assert(locOneB != locOne);
+  assert(!(locOneB == locOne));
+  assert(locOneC != locOne);
+  assert(!(locOneC == locOne));
+  assert(locOneD != locOne);
+  assert(!(locOneD == locOne));
+
+  Location locA(locOne.path(), 1, 2, 3, 4);
+  Location locB(locTwo.path(), 10, 20, 30, 40);
+  // test copy init
+  Location locACopy = locA;
+  Location locBCopy = locB;
+  assert(locACopy == locA);
+  assert(locBCopy == locB);
+  // test =
+  Location locAassign;
+  Location locBassign;
+  locAassign = locA;
+  locBassign = locB;
+  assert(locAassign == locA);
+  assert(locBassign == locB);
+  // test swap
+  locACopy.swap(locBCopy);
+  assert(locACopy == locB);
+  assert(locBCopy == locA);
+
+  // test hash compiles and doesn't happen to collide these two
+  assert(locOne.hash() != locTwo.hash());
+}
+
+void test1() {
+  // test some operations on IDs
+  auto context = Context::build();
+  Context* ctx = context.get();
+  auto shortpath = UniqueString::build(ctx, "a.chpl");
+  auto longpath = UniqueString::build(ctx, "aVeryLongFilenameIndeed.chpl");
+
+  ID emptyID;
+
+  assert(emptyID == emptyID);
+  assert(!(emptyID != emptyID));
+
+  ID idA(shortpath, 1, 2);
+  ID idB(longpath,  1, 2);
+  ID idC(shortpath, 9, 2);
+  ID idD(shortpath, 1, 9);
+
+  assert(idA != idB);
+  assert(!(idA == idB));
+  assert(idA != idC);
+  assert(!(idA == idC));
+
+  assert(idA == idD);    // idD == idA because the num child ids
+  assert(!(idA != idD)); // is not important for comparison
+
+  // test copy init
+  ID idACopy = idA;
+  ID idBCopy = idB;
+  assert(idACopy == idA);
+  assert(idBCopy == idB);
+
+  // test assign
+  ID idAassign;
+  ID idBassign;
+  idAassign = idA;
+  idBassign = idB;
+  assert(idAassign == idA);
+  assert(idBassign == idB);
+
+  // test swap
+  idACopy.swap(idBCopy);
+  assert(idACopy == idB);
+  assert(idBCopy == idA);
+
+  // test hash compiles and doesn't happen to collide these two
+  assert(idA.hash() != idB.hash());
+}
+
+void test2() {
+  auto context = Context::build();
+  Context* ctx = context.get();
+  auto builder = Builder::build(ctx, "path/to/test.chpl");
+  Builder* b   = builder.get();
+  Location emptyLoc;
+
+  {
+    // Create the AST for { a; b; c; }
+    auto strA = UniqueString::build(ctx, "a");
+    auto strB = UniqueString::build(ctx, "b");
+    auto strC = UniqueString::build(ctx, "c");
+    ASTList children;
+
+    children.push_back(Identifier::build(b, emptyLoc, strA));
+    children.push_back(Identifier::build(b, emptyLoc, strB));
+    children.push_back(Identifier::build(b, emptyLoc, strC));
+    auto block = BlockStmt::build(b, emptyLoc, std::move(children));
+    b->addToplevelExpr(std::move(block));
+  }
+
+  Builder::Result r = b->result();
+  assert(r.errors.size() == 0);
+  assert(r.topLevelExprs.size() == 1);
+  assert(r.topLevelExprs[0]->isModuleDecl());
+  auto module = r.topLevelExprs[0]->toModuleDecl()->module();
+  assert(r.locations.size() == 6); // +1 module decl +1 module sym
+  assert(module->stmt(0)->isBlockStmt());
+  const BlockStmt* block = module->stmt(0)->toBlockStmt();
+  assert(block);
+  assert(block->numStmts() == 3);
+  assert(block->stmt(0)->isIdentifier());
+  assert(block->stmt(1)->isIdentifier());
+  assert(block->stmt(2)->isIdentifier());
+
+  // now check the IDs
+  assert(block->stmt(0)->id().postOrderId() == 0);
+  assert(block->stmt(0)->id().numContainedChildren() == 0);
+  assert(block->stmt(1)->id().postOrderId() == 1);
+  assert(block->stmt(1)->id().numContainedChildren() == 0);
+  assert(block->stmt(2)->id().postOrderId() == 2);
+  assert(block->stmt(2)->id().numContainedChildren() == 0);
+  assert(block->id().postOrderId() == 3);
+  assert(block->id().numContainedChildren() == 3);
+  assert(module->id().postOrderId() == 4);
+  assert(module->id().numContainedChildren() == 4);
+
+  // now check containment on the ids
+  assert(block->id().contains(block->id()));
+  assert(block->id().contains(block->stmt(0)->id()));
+  assert(block->id().contains(block->stmt(1)->id()));
+  assert(block->id().contains(block->stmt(2)->id()));
+ 
+  assert(module->id().contains(module->id()));
+  assert(module->id().contains(block->id()));
+  assert(module->id().contains(block->stmt(0)->id()));
+  assert(module->id().contains(block->stmt(1)->id()));
+  assert(module->id().contains(block->stmt(2)->id()));
+
+  assert(!block->stmt(0)->id().contains(block->id()));
+  assert(!block->stmt(0)->id().contains(block->stmt(1)->id()));
+  assert(!block->stmt(0)->id().contains(block->stmt(2)->id()));
+  assert(!block->stmt(1)->id().contains(block->id()));
+  assert(!block->stmt(1)->id().contains(block->stmt(0)->id()));
+  assert(!block->stmt(1)->id().contains(block->stmt(2)->id()));
+  assert(!block->stmt(2)->id().contains(block->id()));
+  assert(!block->stmt(2)->id().contains(block->stmt(0)->id()));
+  assert(!block->stmt(2)->id().contains(block->stmt(1)->id()));
+
+  // now check comparison on the IDs
+  assert(block->id().compare(block->id()) == 0);
+  assert(block->id() == block->id());
+  assert(!(block->id() != block->id()));
+  assert(block->id().compare(block->stmt(0)->id()) > 0);
+  assert(!(block->id() == block->stmt(0)->id()));
+  assert(block->id() != block->stmt(0)->id());
+  assert(block->id().compare(block->stmt(1)->id()) > 0);
+  assert(!(block->id() == block->stmt(1)->id()));
+  assert(block->id() != block->stmt(1)->id());
+  assert(block->id().compare(block->stmt(2)->id()) > 0);
+  assert(!(block->id() == block->stmt(2)->id()));
+  assert(block->id() != block->stmt(2)->id());
+
+  assert(block->stmt(0)->id().compare(block->stmt(0)->id()) == 0);
+  assert(block->stmt(0)->id().compare(block->stmt(1)->id()) < 0);
+  assert(block->stmt(1)->id().compare(block->stmt(2)->id()) < 0);
+}
+
+void test3() {
+  auto context = Context::build();
+  Context* ctx = context.get();
+  auto builder = Builder::build(ctx, "path/to/test.chpl");
+  Builder* b   = builder.get();
+  Location emptyLoc;
+
+  {
+    // Create the AST for { a; { } { b; } c; }
+    auto strA = UniqueString::build(ctx, "a");
+    auto strB = UniqueString::build(ctx, "b");
+    auto strC = UniqueString::build(ctx, "c");
+
+    ASTList outer;
+    outer.push_back(Identifier::build(b, emptyLoc, strA));
+    {
+      ASTList empty;
+      outer.push_back(BlockStmt::build(b, emptyLoc, std::move(empty)));
+    }
+    {
+      ASTList block;
+      block.push_back(Identifier::build(b, emptyLoc, strB));
+      outer.push_back(BlockStmt::build(b, emptyLoc, std::move(block)));
+    }
+    outer.push_back(Identifier::build(b, emptyLoc, strC));
+    auto block = BlockStmt::build(b, emptyLoc, std::move(outer));
+    b->addToplevelExpr(std::move(block));
+  }
+
+  Builder::Result r = b->result();
+  assert(r.errors.size() == 0);
+  assert(r.topLevelExprs.size() == 1);
+  assert(r.topLevelExprs[0]->isModuleDecl());
+  auto module = r.topLevelExprs[0]->toModuleDecl()->module();
+  assert(r.locations.size() == 8); // +1 module decl +1 module sym
+  assert(module->stmt(0)->isBlockStmt());
+  const BlockStmt* outer = module->stmt(0)->toBlockStmt();
+  assert(outer);
+  assert(outer->numStmts() == 4);
+  assert(outer->stmt(0)->isIdentifier());
+  assert(outer->stmt(1)->isBlockStmt());
+  assert(outer->stmt(2)->isBlockStmt());
+  assert(outer->stmt(3)->isIdentifier());
+  const BlockStmt* empty = outer->stmt(1)->toBlockStmt();
+  assert(empty->numStmts() == 0);
+  const BlockStmt* block = outer->stmt(2)->toBlockStmt();
+  assert(block->numStmts() == 1);
+
+  // now check the IDs
+  assert(outer->stmt(0)->id().postOrderId() == 0);
+  assert(outer->stmt(0)->id().numContainedChildren() == 0);
+  assert(empty->id().postOrderId() == 1);
+  assert(empty->id().numContainedChildren() == 0);
+  assert(block->stmt(0)->id().postOrderId() == 2);
+  assert(block->stmt(0)->id().numContainedChildren() == 0);
+  assert(block->id().postOrderId() == 3);
+  assert(block->id().numContainedChildren() == 1);
+  assert(outer->stmt(3)->id().postOrderId() == 4);
+  assert(outer->stmt(3)->id().numContainedChildren() == 0);
+}
+
+int main(int argc, char** argv) {
+  test0();
+  test1();
+  test2();
+  test3();
+  return 0;
+}

--- a/compiler/next/test/AST/testUniqueString.cpp
+++ b/compiler/next/test/AST/testUniqueString.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/Queries/Context.h"
+#include "chpl/AST/UniqueString.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <chrono>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <iostream>
+#include <cassert>
+
+using namespace chpl;
+using namespace ast;
+
+void testPerformance(Context* ctx, const char* inputFile, bool printTiming) {
+  int outerRepeat = 10;
+  int innerRepeat = 1;
+
+  bool dohisto = false;
+  int querybysize[41];
+  int nqueries = 0;
+  for(int i = 0; i < 41; i++) querybysize[i] = 0;
+
+  auto start = std::chrono::steady_clock::now();
+  for (int i = 0; i < outerRepeat; i++) {
+    std::ifstream file(inputFile);
+    if (file.is_open()) {
+      std::string line;
+      std::string word;
+      while (std::getline(file, line)) {
+        for (int j = 0; j < innerRepeat; j++) {
+          std::istringstream iss(line, std::istringstream::in);
+          while (iss >> word) {
+            // double the word length to better match
+            // statistics of Chapel code
+            word += word;
+
+            if (dohisto) {
+              int len = word.size();
+              if (len > 40) len = 40;
+              querybysize[len]++;
+              nqueries++;
+            }
+            UniqueString::build(ctx, word);
+          }
+        }
+      }
+      file.close();
+    } else {
+      std::cerr << "could not open file " << inputFile << "\n";
+      exit(-1);
+    }
+  }
+
+  auto end = std::chrono::steady_clock::now();
+
+  std::chrono::duration<double> elapsed = end - start;
+
+  if (printTiming) {
+    std::cout << "unordered map elapsed time: " << elapsed.count() << " s\n";
+
+    if (dohisto) {
+      std::cout << "Queried " << nqueries << " strings\n";
+      int sum = 0;
+      for(int i = 0; i < 40; i++) {
+        std::cout << "length < " << i << " -- " << sum << "\n";
+        sum += querybysize[i];
+        std::cout << "length " << i << " -- " << querybysize[i] << "\n";
+      }
+      std::cout << "length >= 40 " << " -- " << querybysize[40] << "\n";
+    }
+  }
+}
+
+void test0() {
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  // First, add some strings to the map and make sure we get uniqueness.
+  // needs to be long enough to require strdup etc.
+  #define TEST1STRING "this is a very very very long string"
+  std::string test1 = TEST1STRING;
+  std::string test1Copy = test1;
+  assert(test1.c_str() != test1Copy.c_str());
+  const char* t1 = ctx->uniqueCString(test1.c_str());
+  const char* t2 = ctx->uniqueCString(test1Copy.c_str());
+  const char* t3 = ctx->uniqueCString(TEST1STRING);
+  assert(t1 == t2);
+  assert(t2 == t3);
+
+  // this string is short enough to be inlined
+  std::string hello = "hello";
+  const char* h1 = ctx->uniqueCString("hello");
+  const char* h2 = ctx->uniqueCString(hello.c_str());
+  assert(h1 == h2);
+
+  // check that uniqueString(NULL) == uniqueString("")
+  assert(ctx->uniqueCString(nullptr) == ctx->uniqueCString(""));
+
+  // check that uniqueString(NULL) != nullptr
+  assert(ctx->uniqueCString(nullptr) != nullptr);
+
+  const char* x = ctx->uniqueCString("aVeryLongIdentifierName");
+}
+
+
+void test1() {
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  // First, add some strings to the map and make sure we get uniqueness.
+  // needs to be long enough to require strdup etc.
+  #define TEST1STRING "this is a very very very long string"
+  std::string test1 = TEST1STRING;
+  std::string test1Copy = test1;
+  assert(test1.c_str() != test1Copy.c_str());
+  UniqueString t1 = UniqueString::build(ctx, test1);
+  UniqueString t2 = UniqueString::build(ctx, test1Copy);
+  UniqueString t3 = UniqueString::build(ctx, TEST1STRING);
+  assert(t1.c_str() == t2.c_str());
+  assert(t2.c_str() == t3.c_str());
+
+  // this string is short enough to be inlined
+  std::string hello = "hello";
+  UniqueString h1 = UniqueString::build(ctx, "hello");
+  UniqueString h2 = UniqueString::build(ctx, hello);
+  assert(h1 == h2);
+
+  // check that uniqueString(NULL) == uniqueString("")
+  assert(UniqueString::build(ctx, NULL) == UniqueString::build(ctx, ""));
+
+  // check that default-constructed unique string matches one from ""
+  UniqueString empty;
+  assert(empty == UniqueString::build(ctx, ""));
+
+  // check ==
+  assert(t1 == t2);
+  assert(!(t1 != t2));
+  assert(h1 != t1);
+  assert(!(h1 == t1));
+
+  // test copy init
+  UniqueString t1Copy = t1;
+  UniqueString h1Copy = h1;
+  assert(t1Copy == t1);
+  assert(h1Copy == h1);
+
+  // test assignment
+  UniqueString t1assign;
+  UniqueString h1assign;
+  t1assign = t1;
+  h1assign = h1;
+  assert(t1assign == t1);
+  assert(h1assign == h1);
+
+  // test swap
+  t1Copy.swap(h1Copy);
+  assert(t1Copy == h1);
+  assert(h1Copy == t1);
+
+  // test hash
+  assert(t1.hash() != h1.hash());
+}
+
+
+int main(int argc, char** argv) {
+  const char* inputFile = "moby.txt";
+  int repeat = 10;
+  std::string timingArg = "--timing";
+  bool printTiming = false;
+  for (int i = 1; i < argc; i++) {
+    if (argv[i] == timingArg)
+      printTiming = true;
+    else
+      inputFile = argv[i];
+  }
+
+  test0();
+  test1();
+
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  // Next, measure performance
+  testPerformance(ctx, inputFile, printTiming);
+  return 0;
+}

--- a/compiler/next/test/Frontend/testFrontendQueries.cpp
+++ b/compiler/next/test/Frontend/testFrontendQueries.cpp
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/Frontend/FrontendQueries.h"
+
+#include "chpl/AST/ModuleDecl.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+
+using namespace chpl;
+using namespace ast;
+
+static void test0() {
+  printf("test0\n");
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  auto path = UniqueString::build(ctx, "input.chpl");
+  std::string contents = "/* this is a test */";
+  ctx->setFileText(path, contents);
+ 
+  std::string gotContents = FrontendQueries::fileText(ctx, path);
+  assert(gotContents == contents);
+}
+
+static void test1() {
+  printf("test1\n");
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  auto path = UniqueString::build(ctx, "input.chpl");
+  std::string contents = "/* this is a test */";
+  ctx->setFileText(path, contents);
+ 
+  FrontendQueries::parse(ctx, path);
+}
+
+static const Module* parseOneModule(Context* ctx, UniqueString filepath) {
+  const FrontendQueries::ModuleDeclVec& v =
+    FrontendQueries::parse(ctx, filepath);
+  assert(v.size() == 1);
+  return v[0]->module();
+}
+
+static void test2() {
+  printf("test2\n");
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  ctx->advanceToNextRevision(true);
+  auto modOnePath = UniqueString::build(ctx, "modOne.chpl");
+  std::string modOneContents = "/* this is a test */\n"
+                               "a;\n";
+  ctx->setFileText(modOnePath, modOneContents);
+  auto modTwoPath = UniqueString::build(ctx, "modTwo.chpl");
+  std::string modTwoContents = "/* this is a another test */"
+                               "a;\n";
+  ctx->setFileText(modTwoPath, modTwoContents);
+ 
+  const Module* moduleOne = nullptr;
+  const Module* moduleTwo = nullptr;
+
+  moduleOne = parseOneModule(ctx, modOnePath);
+  moduleTwo = parseOneModule(ctx, modTwoPath);
+  assert(moduleOne->numStmts() == 2);
+  assert(moduleTwo->numStmts() == 2);
+  BaseAST::dump(moduleOne);
+  BaseAST::dump(moduleTwo);
+
+  const Module* oldModuleOne = moduleOne;
+  const Module* oldModuleTwo = moduleTwo;
+  ctx->collectGarbage();
+
+  printf("test2 changing whitespace in modOne.chpl\n");
+  ctx->advanceToNextRevision(true);
+
+  modOneContents = "/* this is a test */\n"
+                   "\n"
+                   "\n"
+                   "a;\n";
+  ctx->setFileText(modOnePath, modOneContents);
+  ctx->setFileText(modTwoPath, modTwoContents);
+
+  printf("test2 parsing modOne.chpl\n");
+  moduleOne = parseOneModule(ctx, modOnePath);
+  printf("test2 parsing modTwo.chpl\n");
+  moduleTwo = parseOneModule(ctx, modTwoPath);
+  assert(moduleOne->numStmts() == 2);
+  assert(moduleTwo->numStmts() == 2);
+  BaseAST::dump(moduleOne);
+  BaseAST::dump(moduleTwo);
+
+  // Check that the pointer values didn't change
+  // (they shouldn't because we should have reused the modules).
+  assert(moduleOne == oldModuleOne);
+  assert(moduleTwo == oldModuleTwo);
+
+  ctx->collectGarbage();
+}
+
+static void test3() {
+  printf("test3\n");
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  auto modulePath = UniqueString::build(ctx, "MyModule.chpl");
+  const Module* module = nullptr;
+  const Comment* comment = nullptr;
+  const Identifier* identifierA = nullptr;
+  const Identifier* identifierB = nullptr;
+  const BlockStmt* block = nullptr;
+
+  std::string moduleContents;
+
+  moduleContents = "/* this is a test */\n"
+                   "a;\n"
+                   "b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+  assert(module->numStmts() == 3);
+  comment = module->stmt(0)->toComment();
+  identifierA = module->stmt(1)->toIdentifier();
+  identifierB = module->stmt(2)->toIdentifier();
+  assert(comment);
+  assert(identifierA);
+  assert(identifierB);
+  const Comment* oldComment = comment;
+  const Identifier* oldIdentifierA = identifierA;
+  const Identifier* oldIdentifierB = identifierB;
+
+  printf("test3 adding BlockStmts\n");
+  moduleContents = "/* this is a test */\n"
+                   "{ x; }\n"
+                   "a;\n"
+                   "{ y; }\n"
+                   "b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the pointer values didn't change
+  // (they shouldn't because we should have reused the parts that didn't change)
+  assert(module->numStmts() == 5);
+  comment = module->stmt(0)->toComment();
+  block = module->stmt(1)->toBlockStmt();
+  identifierA = module->stmt(2)->toIdentifier();
+  identifierB = module->stmt(4)->toIdentifier();
+  assert(comment);
+  assert(identifierA);
+  assert(identifierB);
+  assert(comment == oldComment);
+  assert(identifierA == oldIdentifierA);
+  assert(identifierB == oldIdentifierB);
+  const BlockStmt* oldBlock = block;
+
+  printf("test3 changing Identifier in Blocks\n");
+  moduleContents = "/* this is a test */\n"
+                   "{ xx; }\n"
+                   "a;\n"
+                   "{ yy; }\n"
+                   "b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the block and identifiers match
+  assert(module->numStmts() == 5);
+  comment = module->stmt(0)->toComment();
+  block = module->stmt(1)->toBlockStmt();
+  identifierA = module->stmt(2)->toIdentifier();
+  identifierB = module->stmt(4)->toIdentifier();
+  assert(comment);
+  assert(identifierA);
+  assert(identifierB);
+  assert(comment == oldComment);
+  assert(block == oldBlock);
+  assert(identifierA == oldIdentifierA);
+  assert(identifierB == oldIdentifierB);
+  oldBlock = nullptr; // it will be invalid after this point
+
+  printf("test3 removing the Blocks\n");
+  moduleContents = "/* this is a test */\n"
+                   "a;\n"
+                   "b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the comment and identifiers match
+  assert(module->numStmts() == 3);
+  comment = module->stmt(0)->toComment();
+  identifierA = module->stmt(1)->toIdentifier();
+  identifierB = module->stmt(2)->toIdentifier();
+  assert(comment);
+  assert(identifierA);
+  assert(identifierB);
+  assert(comment == oldComment);
+  assert(identifierA == oldIdentifierA);
+  assert(identifierB == oldIdentifierB);
+  oldIdentifierA = nullptr; // it will be invalid after this point
+
+  printf("test3 replacing first Identifier\n");
+  moduleContents = "/* this is a test */\n"
+                   "aa;\n"
+                   "b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the comment and identifiers match
+  assert(module->numStmts() == 3);
+  comment = module->stmt(0)->toComment();
+  identifierA = module->stmt(1)->toIdentifier();
+  identifierB = module->stmt(2)->toIdentifier();
+  assert(comment);
+  assert(identifierA);
+  assert(identifierB);
+  assert(comment == oldComment);
+  assert(identifierB == oldIdentifierB);
+}
+
+static void test4() {
+  printf("test4\n");
+  auto context = Context::build();
+  Context* ctx = context.get();
+
+  auto modulePath = UniqueString::build(ctx, "MyModule.chpl");
+  const Module* module = nullptr;
+  const Comment* comment = nullptr;
+  const Decl* declA = nullptr;
+  const Decl* declB = nullptr;
+  const BlockStmt* block = nullptr;
+
+  std::string moduleContents;
+
+  moduleContents = "/* this is a test */\n"
+                   "var a;\n"
+                   "var b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+  assert(module->numStmts() == 3);
+  comment = module->stmt(0)->toComment();
+  declA = module->stmt(1)->toDecl();
+  declB = module->stmt(2)->toDecl();
+  assert(comment);
+  assert(declA);
+  assert(declB);
+  const Comment* oldComment = comment;
+  const Decl* oldDeclA = declA;
+  const Decl* oldDeclB = declB;
+
+  printf("test4 adding BlockStmts\n");
+  moduleContents = "/* this is a test */\n"
+                   "{ var x; }\n"
+                   "var a;\n"
+                   "{ var y; }\n"
+                   "var b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the pointer values didn't change
+  // (they shouldn't because we should have reused the parts that didn't change)
+  assert(module->numStmts() == 5);
+  comment = module->stmt(0)->toComment();
+  block = module->stmt(1)->toBlockStmt();
+  declA = module->stmt(2)->toDecl();
+  declB = module->stmt(4)->toDecl();
+  assert(comment);
+  assert(declA);
+  assert(declB);
+  assert(comment == oldComment);
+  assert(declA == oldDeclA);
+  assert(declB == oldDeclB);
+  const BlockStmt* oldBlock = block;
+
+  printf("test4 changing Identifier in Blocks\n");
+  moduleContents = "/* this is a test */\n"
+                   "{ var xx; }\n"
+                   "var a;\n"
+                   "{ var yy; }\n"
+                   "var b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the block and identifiers match
+  assert(module->numStmts() == 5);
+  comment = module->stmt(0)->toComment();
+  block = module->stmt(1)->toBlockStmt();
+  declA = module->stmt(2)->toDecl();
+  declB = module->stmt(4)->toDecl();
+  assert(comment);
+  assert(declA);
+  assert(declB);
+  assert(comment == oldComment);
+  assert(block == oldBlock);
+  assert(declA == oldDeclA);
+  assert(declB == oldDeclB);
+  oldBlock = nullptr; // it will be invalid after this point
+
+  printf("test4 removing the Blocks\n");
+  moduleContents = "/* this is a test */\n"
+                   "var a;\n"
+                   "var b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the comment and identifiers match
+  assert(module->numStmts() == 3);
+  comment = module->stmt(0)->toComment();
+  declA = module->stmt(1)->toDecl();
+  declB = module->stmt(2)->toDecl();
+  assert(comment);
+  assert(declA);
+  assert(declB);
+  assert(comment == oldComment);
+  assert(declA == oldDeclA);
+  assert(declB == oldDeclB);
+  oldDeclA = nullptr; // it will be invalid after this point
+
+  printf("test4 replacing first Decl\n");
+  moduleContents = "/* this is a test */\n"
+                   "var aa;\n"
+                   "var b;\n";
+  ctx->advanceToNextRevision(true);
+  ctx->setFileText(modulePath, moduleContents);
+  module = parseOneModule(ctx, modulePath);
+  ctx->collectGarbage();
+
+  BaseAST::dump(module);
+
+  // Check that the comment and identifiers match
+  assert(module->numStmts() == 3);
+  comment = module->stmt(0)->toComment();
+  declA = module->stmt(1)->toDecl();
+  declB = module->stmt(2)->toDecl();
+  assert(comment);
+  assert(declA);
+  assert(declB);
+  assert(comment == oldComment);
+  assert(declB == oldDeclB);
+}
+
+// TODO: test locate
+
+int main() {
+  test0();
+  test1();
+  test2();
+  test3();
+  test4();
+
+  return 0;
+}

--- a/compiler/next/test/Frontend/testInteractive.cpp
+++ b/compiler/next/test/Frontend/testInteractive.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/Frontend/FrontendQueries.h"
+
+#include "chpl/AST/ModuleDecl.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+
+using namespace chpl;
+using namespace ast;
+
+int main(int argc, char** argv) {
+
+  if (argc == 1) {
+    printf("Usage: %s file.chpl otherFile.chpl ...\n", argv[0]);
+    return 0; // need this to return 0 for testing to be happy
+  }
+
+  auto context = Context::build();
+  Context* ctx = context.get();
+  while (true) {
+    ctx->advanceToNextRevision(true);
+    for (int i = 1; i < argc; i++) {
+      auto filepath = UniqueString::build(ctx, argv[i]);
+      //const FrontendQueries::ModuleDeclVec& mods
+      //  = FrontendQueries::parse(ctx, filepath);
+
+      const FrontendQueries::DefinedTopLevelNamesVec& vec =
+        FrontendQueries::moduleLevelDeclNames(ctx, filepath);
+
+      for (const auto& elt : vec) {
+        const ast::Module* module = elt.module;
+        const std::vector<UniqueString>& topLevelNames = elt.topLevelNames;
+
+        printf("Module %s:\n", module->name().c_str());
+        BaseAST::dump(module);
+
+        printf("Defines these toplevel names:\n");
+        for (const UniqueString& name : topLevelNames) {
+          printf("%s\n", name.c_str());
+        }
+      }
+    }
+    ctx->collectGarbage();
+
+    // ask the user if they want to run it again
+    printf ("Would you like to incrementally parse again? [Y]: ");
+    int ch = getc(stdin);
+    if (!(ch == 'Y' || ch == 'y' || ch == '\n'))
+      break;
+    printf("\n");
+  }
+
+  return 0;
+}

--- a/compiler/next/test/Frontend/testParse.cpp
+++ b/compiler/next/test/Frontend/testParse.cpp
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/AST/BlockStmt.h"
+#include "chpl/AST/Expr.h"
+#include "chpl/AST/Identifier.h"
+#include "chpl/AST/ModuleDecl.h"
+#include "chpl/Frontend/Parser.h"
+#include "chpl/Queries/Context.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+
+using namespace chpl;
+using namespace ast;
+
+static void test0(Parser* parser) {
+  auto parseResult = parser->parseString("test0.chpl", "");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->name().compare("test0") == 0);
+  assert(module->numStmts() == 0);
+}
+
+static void test1(Parser* parser) {
+  auto parseResult = parser->parseString("test1.chpl", "x;");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->name().compare("test1") == 0);
+  assert(module->numStmts() == 1);
+  assert(module->stmt(0)->isIdentifier());
+  auto identifier = module->stmt(0)->toIdentifier();
+  assert(identifier->name().compare("x") == 0);
+}
+
+static void test2(Parser* parser) {
+  auto parseResult = parser->parseString("test2.chpl", "x; y;");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->name().compare("test2") == 0);
+  assert(module->numStmts() == 2);
+  assert(module->stmt(0)->isIdentifier());
+  assert(module->stmt(1)->isIdentifier());
+}
+
+static void test3(Parser* parser) {
+  auto parseResult = parser->parseString("test3.chpl", "/* hi */ y;");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->name().compare("test3") == 0);
+  assert(module->numStmts() == 2);
+  assert(module->stmt(0)->isComment());
+  assert(module->stmt(1)->isIdentifier());
+}
+
+static void test4(Parser* parser) {
+  auto parseResult = parser->parseString("test4.chpl", "/* hi */ y; /* bye */");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->name().compare("test4") == 0);
+  assert(module->numStmts() == 3);
+  assert(module->stmt(0)->isComment());
+  assert(module->stmt(1)->isIdentifier());
+  assert(module->stmt(2)->isComment());
+}
+
+static void test5(Parser* parser) {
+  auto parseResult = parser->parseString("test5.chpl",
+                                         "// hi\n"
+                                         "a;\n"
+                                         "// bye\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 3);
+  assert(module->stmt(0)->isComment());
+  assert(module->stmt(1)->isIdentifier());
+  assert(module->stmt(2)->isComment());
+}
+
+static void test6(Parser* parser) { 
+  auto parseResult = parser->parseString("test6.chpl",
+                                         "{ }");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 1);
+  assert(module->stmt(0)->isBlockStmt());
+}
+
+static void test7(Parser* parser) {
+  auto parseResult = parser->parseString("test7.chpl",
+                                         "{ a; }");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 1);
+  assert(module->stmt(0)->isBlockStmt());
+  const BlockStmt* block = module->stmt(0)->toBlockStmt();
+  assert(block->numStmts()==1);
+  assert(block->stmt(0)->isIdentifier());
+}
+
+static void test8(Parser* parser) {
+  auto parseResult = parser->parseString("t.chpl", "aVeryLongIdentifierName;");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 1);
+  assert(module->stmt(0)->isIdentifier());
+}
+
+static void test9(Parser* parser) {
+  auto parseResult = parser->parseString("test9.chpl",
+                                         "{ /* this is a comment */ }");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 1);
+  assert(module->stmt(0)->isBlockStmt());
+  const BlockStmt* block = module->stmt(0)->toBlockStmt();
+  assert(block->numStmts()==1);
+  assert(block->stmt(0)->isComment());
+}
+
+static void test10(Parser* parser) {
+  auto parseResult = parser->parseString("test10.chpl",
+                                         "{\n"
+                                         "/* this is comment 2 */\n"
+                                         "aVeryLongIdentifierName;\n"
+                                         "/* this is comment 3 */\n"
+                                         "}\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 1);
+  assert(module->stmt(0)->isBlockStmt());
+  const BlockStmt* block = module->stmt(0)->toBlockStmt();
+  assert(block->numStmts()==3);
+  assert(block->stmt(0)->isComment());
+  assert(block->stmt(1)->isIdentifier());
+  assert(block->stmt(2)->isComment());
+}
+
+
+static void test11(Parser* parser) {
+  auto parseResult = parser->parseString("test11.chpl",
+                                         "/* this is comment 1 */\n"
+                                         "{\n"
+                                         "/* this is comment 2 */\n"
+                                         "aVeryLongIdentifierName;\n"
+                                         "/* this is comment 3 */\n"
+                                         "}\n"
+                                         "/* this is comment 4 */");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 3);
+  assert(module->stmt(0)->isComment());
+  assert(module->stmt(1)->isBlockStmt());
+  assert(module->stmt(2)->isComment());
+  const BlockStmt* block = module->stmt(1)->toBlockStmt();
+  assert(block->numStmts()==3);
+  assert(block->stmt(0)->isComment());
+  assert(block->stmt(1)->isIdentifier());
+  assert(block->stmt(2)->isComment());
+}
+
+static void test12(Parser* parser) {
+  auto parseResult = parser->parseString("test12.chpl",
+                                         "/* this is comment 1 */\n"
+                                         "/* this is comment 2 */\n"
+                                         "{\n"
+                                         "/* this is comment 2 */\n"
+                                         "/* this is comment 3 */\n"
+                                         "aVeryLongIdentifierName;\n"
+                                         "/* this is comment 3 */\n"
+                                         "/* this is comment 4 */\n"
+                                         "}\n"
+                                         "/* this is comment 5 */\n"
+                                         "/* this is comment 6 */");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 5);
+  assert(module->stmt(0)->isComment());
+  assert(module->stmt(1)->isComment());
+  assert(module->stmt(2)->isBlockStmt());
+  assert(module->stmt(3)->isComment());
+  assert(module->stmt(4)->isComment());
+  const BlockStmt* block = module->stmt(2)->toBlockStmt();
+  assert(block->numStmts()==5);
+  assert(block->stmt(0)->isComment());
+  assert(block->stmt(1)->isComment());
+  assert(block->stmt(2)->isIdentifier());
+  assert(block->stmt(3)->isComment());
+  assert(block->stmt(4)->isComment());
+}
+
+static void test13(Parser* parser) {
+  auto parseResult = parser->parseString("test13.chpl",
+                                         "var a;\n"
+                                         "a;");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExprs.size() == 1);
+  assert(parseResult.topLevelExprs[0]->isModuleDecl());
+  auto module = parseResult.topLevelExprs[0]->toModuleDecl()->module();
+  assert(module->numStmts() == 2);
+  assert(module->stmt(0)->isVariableDecl());
+  assert(module->stmt(1)->isIdentifier());
+}
+
+
+int main() {
+  auto context = Context::build();
+  Context* ctx = context.get();
+  auto parser = Parser::build(ctx);
+  Parser* p = parser.get();
+
+  test0(p);
+  test1(p);
+  test2(p);
+  test3(p);
+  test4(p);
+  test5(p);
+  test6(p);
+  test7(p);
+  test8(p);
+  test9(p);
+  test10(p);
+  test11(p);
+  test12(p);
+  test13(p);
+
+  return 0;
+}


### PR DESCRIPTION
This PR builds upon previous PRs to add frontend queries for parsing and
some C++ tests of the new compiler code. This PR completes the series of
PRs #17585, #17586, #17587, #17588, #17589.

Split out from PR #17583, which is a start at the compiler revamp effort
described in the
[1.24 release notes ongoing efforts](https://chapel-lang.org/releaseNotes/1.24/04-ongoing.pdf).

This PR adds Frontend queries and C++ tests of several of the features
added to the compiler in the previous PRs. The Frontend queries implement
parsing and one that (as a demonstration) lists the defined top-level
names in each module parsed.

Closes #17583.

 - [x] full local testing
 
Reviewed by @e-kayrakli  and @dlongnecke-cray - thanks!