### PR TITLE
Header generation when  CHPL_LOCALE_MODEL=gpu

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2184,10 +2184,34 @@ void runClang(const char* just_parse_filename) {
   clangOtherArgs.push_back("sys_basic.h");
 
   if (!just_parse_filename) {
+
+    if (localeUsesGPU()) {
+      //create a header file to include header files from the command line
+      std::string genHeaderFilename;
+      genHeaderFilename = genIntermediateFilename("generated_header.h");
+      FILE* fp =  openfile(genHeaderFilename.c_str(), "w");
+
+      std::string ifdefStrBegin("#ifdef __cplusplus\nextern \"C\" {\n#endif");
+      fprintf(fp, "%s\n", ifdefStrBegin.c_str());
+
+      int filenum = 0;
+      while (const char* inputFilename = nthFilename(filenum++)) {
+        if (isCHeader(inputFilename)) {
+          fprintf(fp, "%s%s%s\n", "#include <", inputFilename,">");
+        }
+      }
+
+      std::string ifdefStrEnd("#ifdef __cplusplus\n}\n#endif");
+      fprintf(fp, "%s", ifdefStrEnd.c_str());
+      closefile(fp);
+      clangOtherArgs.push_back("-include");
+      clangOtherArgs.push_back(genHeaderFilename.c_str());
+    }
+
     // Running clang to compile all runtime and extern blocks
 
     // Include header files from the command line.
-    {
+    else {
       int filenum = 0;
       while (const char* inputFilename = nthFilename(filenum++)) {
         if (isCHeader(inputFilename)) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2188,21 +2188,26 @@ void runClang(const char* just_parse_filename) {
     if (localeUsesGPU()) {
       //create a header file to include header files from the command line
       std::string genHeaderFilename;
-      genHeaderFilename = genIntermediateFilename("generated_header.h");
+      genHeaderFilename = genIntermediateFilename("command-line-includes.h");
       FILE* fp =  openfile(genHeaderFilename.c_str(), "w");
 
-      std::string ifdefStrBegin("#ifdef __cplusplus\nextern \"C\" {\n#endif");
-      fprintf(fp, "%s\n", ifdefStrBegin.c_str());
+      const char* ifdefStrBegin = "#ifdef __cplusplus\n"
+                                  "extern \"C\" {\n"
+                                  "#endif";
+
+      fprintf(fp, "%s\n", ifdefStrBegin);
 
       int filenum = 0;
       while (const char* inputFilename = nthFilename(filenum++)) {
         if (isCHeader(inputFilename)) {
-          fprintf(fp, "%s%s%s\n", "#include <", inputFilename,">");
+          fprintf(fp, "%s%s%s\n", "#include \"", inputFilename,"\"");
         }
       }
 
-      std::string ifdefStrEnd("#ifdef __cplusplus\n}\n#endif");
-      fprintf(fp, "%s", ifdefStrEnd.c_str());
+      const char* ifdefStrEnd = "#ifdef __cplusplus\n"
+                                "}\n"
+                                "#endif";
+      fprintf(fp, "%s", ifdefStrEnd);
       closefile(fp);
       clangOtherArgs.push_back("-include");
       clangOtherArgs.push_back(genHeaderFilename.c_str());


### PR DESCRIPTION
Currently when CHPL_LOCALE_MODEL=gpu, files are compiled with clang cuda. As a result, files specified in the command line are assumed to be c++ code, resulting in mangled function names. To resolve this, this PR generates a header where headers specified in the command line are put in an extern "C" block.

- [x] full local testing