### PR TITLE
Keep submitted shootout benchmarks directory in sync with website & running

### DIFF
--- a/test/studies/shootout/submitted/README.md
+++ b/test/studies/shootout/submitted/README.md
@@ -2,10 +2,18 @@
 
 Developer Note:
 
- *This directory is intended to reflect the code submitted to the
-  benchmarks game website. If tests in this directory start failing,
-  DO NOT update the tests. Instead, give them a .notest or .future
-  file to disable them causing testing noise.*
+> : warning: This directory is intended to reflect the versions of the
+  Chapel codes that currently live on the CLBG website. Please do not
+  update the source code of the tests without also updating the source
+  code on the benchmarks site so that the `./clbg-diff.py` script
+  indicates that they are in sync.  If the tests start generating
+  warnings due to changes in the language or libraries, please try to
+  keep them working by updating the `.good` files or suppressing
+  warnings, since warnings will not break the official entries, and
+  keeping the tests running will permit us to continue gathering
+  performance reults.  If that's not possible, give them a .notest or
+  .future file to disable them without causing testing noise.  Please
+  check with Brad if you have any questions here.*
 
 
 This directory contains 
@@ -15,44 +23,29 @@ that represent implementations of benchmark programs for the
 that have been submitted across time to the website. For Chapel versions that aren't in sync you can see the 
 [Legacy Benchmarks](##legacy-benchmarks) section.
 
-* [binarytrees.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/binarytrees-chapel-3.html)
+* [binarytrees3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/binarytrees-chapel-3.html)
     * Allocates and deallocates many, many binary trees.
-* [fannkuchredux.chpl #2](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fannkuchredux-chapel-2.html)
+* [fannkuchredux2.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fannkuchredux-chapel-2.html)
     * Performs many operations on small arrays.
-* [fasta.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fasta-chapel-3.html) |
-  [fasta.chpl #5](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fasta-chapel-5.html)
+* [fasta3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fasta-chapel-3.html) |
+  [fasta5.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fasta-chapel-5.html)
     * Generates and writes random DNA sequences.
-* [knucleotide.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/knucleotide-chapel-3.html)
+* [knucleotide3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/knucleotide-chapel-3.html)
     * Count the frequencies of specific nucleotide sequences.
 * [mandelbrot.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/mandelbrot-chapel-1.html) |
-  [mandelbrot.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/mandelbrot-chapel-3.html)
+  [mandelbrot3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/mandelbrot-chapel-3.html)
     * Plots the mandelbrot set [-1.5-i,0.5+i] on a bitmap.
-* [nbody.chpl #2](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-chapel-2.html)
+* [nbody2.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-chapel-2.html)
     * Performs an n-body simulation of the Jovian planets.
-* [pidigits.chpl #2](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-chapel-2.html) |
-  [pidigits.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-chapel-3.html) |
-  [pidigits.chpl #4](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-chapel-4.html)
+* [pidigits2.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-chapel-2.html) |
+  [pidigits3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-chapel-3.html) |
+  [pidigits4.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-chapel-4.html)
     * Computes digits of pi using GMP, if available.
-* [regex-redux.chpl #2](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/regexredux-chapel-2.html) |
-  [regex-redux.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/regexredux-chapel-3.html)
+* [regexredux2.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/regexredux-chapel-2.html) |
+  [regexredux3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/regexredux-chapel-3.html)
     * Performs DNA matching
-* [revcomp.chpl #2](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/revcomp-chapel-2.html) |
-  [revcomp.chpl #3](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/revcomp-chapel-3.html)
+* [revcomp2.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/revcomp-chapel-2.html) |
+  [revcomp3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/revcomp-chapel-3.html)
     * Calculate the strand to bind with a given DNA strand.
 * [spectralnorm.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/spectralnorm-chapel-1.html)
     * Calculates the spectral norm of an infinite matrix.
-
-## Legacy Benchmarks
-
-This is an archived list for the Chapel versions that aren't synced with the website.
-
-* meteor.chpl
-    * Performs a parallel search for all solutions to a puzzle.
-* meteor-fast.chpl
-    * A less readable, but much faster version of meteor.
-* threadring.chpl
-    * Passes a token between a large number of threads.
-
-For the latest versions of these benchmarks
-and more information on their implementations, see:
-[$CHPL_HOME/test/release/examples/benchmarks/shootout/](https://github.com/chapel-lang/chapel/tree/master/test/release/examples/benchmarks/shootout).

--- a/test/studies/shootout/submitted/README.md
+++ b/test/studies/shootout/submitted/README.md
@@ -2,7 +2,7 @@
 
 Developer Note:
 
-> : warning: This directory is intended to reflect the versions of the
+> :warning: *This directory is intended to reflect the versions of the
   Chapel codes that currently live on the CLBG website. Please do not
   update the source code of the tests without also updating the source
   code on the benchmarks site so that the `./clbg-diff.py` script

--- a/test/studies/shootout/submitted/mandelbrot3.compopts
+++ b/test/studies/shootout/submitted/mandelbrot3.compopts
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/submitted/regexredux2.chpl
+++ b/test/studies/shootout/submitted/regexredux2.chpl
@@ -5,7 +5,7 @@
    derived from the GNU C++ RE2 version by Alexey Zolotov
 */
 
-use IO, Regex;
+use IO, Regexp;
 
 proc main(args: [] string) {
   var variants = [
@@ -21,7 +21,7 @@ proc main(args: [] string) {
   ];
 
   var subst = [
-    ("tHa[Nt]", "<4>"), ("aND|caN|Ha[DS]|WaS", "<3>"), ("a[NSt]|BY", "<2>"),
+    ("tHa[Nt]", "<4>"), ("aND|caN|Ha[DS]|WaS", "<3>"), ("a[NSt]|BY", "<2>"), 
     ("<[^>]*>", "|"), ("\\|[^|][^|]*\\|", "-")
   ];
 

--- a/test/studies/shootout/submitted/regexredux2.good
+++ b/test/studies/shootout/submitted/regexredux2.good
@@ -1,3 +1,4 @@
+$CHPL_HOME/modules/standard/Regexp.chpl:23: warning: 'Regexp' module is deprecated; please use 'Regex' module instead.
 agggtaaa|tttaccct 1
 [cgt]gggtaaa|tttaccc[acg] 0
 a[act]ggtaaa|tttacc[agt]t 0

--- a/test/studies/shootout/submitted/regexredux3.chpl
+++ b/test/studies/shootout/submitted/regexredux3.chpl
@@ -6,7 +6,7 @@
    which was derived from the GNU C++ RE2 version by Alexey Zolotov
 */
 
-use IO, Regex;
+use IO, Regexp;
 
 proc main(args: [] string) {
   var variants = [

--- a/test/studies/shootout/submitted/regexredux3.good
+++ b/test/studies/shootout/submitted/regexredux3.good
@@ -1,3 +1,4 @@
+$CHPL_HOME/modules/standard/Regexp.chpl:23: warning: 'Regexp' module is deprecated; please use 'Regex' module instead.
 agggtaaa|tttaccct 1
 [cgt]gggtaaa|tttaccc[acg] 0
 a[act]ggtaaa|tttacc[agt]t 0


### PR DESCRIPTION
This makes some simple changes to the submitted shootout benchmarks
directory to bring them back in sync with the official website and
running correctly.  While here, I also updated the README to attempt to
clarify what should or shouldn't be done w.r.t. the tests when they break
over time (though I'm not surprised that this is forgotten or overlooked
in a given PR).

And while there, I updated the README to try and connect the dots between
the files in this directory and the official shootout codes a bit more clearly, and
dropped the mention of the retired benchmarks (which got introduced in #17745
due to some confusion on my part).