### PR TITLE
Document that C++14 is required in prereqs.rst

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -26,7 +26,7 @@ about your environment for using Chapel:
 
   * You have access to gmake or a GNU-compatible version of make.
 
-  * You have access to standard C and C++11 compilers. We test our code
+  * You have access to standard C and C++14 compilers. We test our code
     using a range of compilers on a nightly basis; these include
     relatively recent versions of gcc/g++, clang, and compilers from
     HPE Cray and Intel. If using GCC, we recommend GCC version 5 or newer.

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -29,7 +29,7 @@ about your environment for using Chapel:
   * You have access to standard C and C++14 compilers. We test our code
     using a range of compilers on a nightly basis; these include
     relatively recent versions of gcc/g++, clang, and compilers from
-    HPE Cray and Intel. If using GCC, we recommend GCC version 5 or newer.
+    HPE Cray and Intel.
 
   * Building GMP requires an M4 macro processor.
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -26,10 +26,10 @@ about your environment for using Chapel:
 
   * You have access to gmake or a GNU-compatible version of make.
 
-  * You have access to standard C and C++14 compilers. We test our code
-    using a range of compilers on a nightly basis; these include
-    relatively recent versions of gcc/g++, clang, and compilers from
-    HPE Cray and Intel.
+  * You have access to standard C and C++14 compilers. The C++14 support
+    is required for building the compiler itself. For GCC specifically,
+    GCC 5 or newer is required for C++14 support. Note that C11 support,
+    while not required, will enable faster atomic operations.
 
   * Building GMP requires an M4 macro processor.
 


### PR DESCRIPTION
Resolves #10525

This PR updates prereqs.rst to indicate that the `chpl` requires C++14 in order to build.
We are moving to LLVM-by-default and LLVM has required C++14 since version 9.

Reviewed by @vasslitvinov and @gbtitus - thanks!