### PR TITLE
IFC: late checking of generic implements statements

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -460,11 +460,6 @@ void ConstrainedType::verify() {
     // These arise during resolution and are pruned at resolution end.
     INT_FATAL(this, "unexpected");
     break;
-  }
-  case CT_GENERIC_STANDIN: {
-    // This/these arise during resolution and are pruned at resolution end.
-    INT_FATAL(this, "unexpected");
-    break;
   }}
 }
 
@@ -474,7 +469,6 @@ const char* ConstrainedType::useString() const {
   case CT_IFC_ASSOC_TYPE:   return "CT_IFC_ASSOC_TYPE";
   case CT_CGFUN_FORMAL:     return "CT_CGFUN_FORMAL";
   case CT_CGFUN_ASSOC_TYPE: return "CT_CGFUN_ASSOC_TYPE";
-  case CT_GENERIC_STANDIN:  return "CT_GENERIC_STANDIN";
   }
   INT_FATAL(this, "unknown ConstrainedType use");
   return NULL;

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -194,8 +194,8 @@ void adjustForCGinstantiation(FnSymbol* fn, SymbolMap& substitutions,
                               bool isInterimInstantiation);
 bool cgActualCanMatch(FnSymbol* fn, Type* formalT, ConstrainedType* actualCT);
 bool cgFormalCanMatch(FnSymbol* fn, Type* formalT);
-void createGenericStandins();
-void cleanupGenericStandins();
+void startInterfaceChecking();
+void finishInterfaceChecking();
 
 FnSymbol* instantiateWithoutCall(FnSymbol* fn, SymbolMap& subs);
 FnSymbol* instantiateSignature(FnSymbol* fn, SymbolMap& subs,

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -137,6 +137,13 @@ enum ShadowVarPrefix {
   SVP_VAR,
 };
 
+// Ensures consistent iteration order over std::map<const char*,...>
+struct CharStarComparator {
+  bool operator()(const char* lhs, const char* rhs) const {
+    return strcmp(lhs, rhs) < 0;
+  }
+};
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -594,7 +601,7 @@ public:
 
   // maps name to the ConstrainedType for an associated type
   // their DefExprs are in ifcBody
-  std::map<const char*, ConstrainedType*> associatedTypes;
+  std::map<const char*, ConstrainedType*, CharStarComparator> associatedTypes;
 
   // constraints to be checked for each implementation
   std::vector<IfcConstraint*> associatedConstraints;

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -388,9 +388,6 @@ private:
 *                  proc cgFun(arg: ?T) where T implements IFC { ..... }       *
 * CT_CGFUN_ASSOC_TYPE: an assoc. type of a CT_CGFUN_FORMAL type, ex. 'arg.AT' *
 *                      in proc cgFun(arg: ?T, arg2: arg.AT) where .....       *
-* CT_GENERIC_STANDIN: represents generic fields of an implementing type       *
-*                     in a generic implements statement, ex. for 'T' in       *
-*                     record R { type T; }  R implements IFC;                 *
 *                                                                             *
 ************************************** | *************************************/
 
@@ -398,8 +395,7 @@ enum ConstrainedTypeUse {
   CT_IFC_FORMAL,
   CT_IFC_ASSOC_TYPE,
   CT_CGFUN_FORMAL,
-  CT_CGFUN_ASSOC_TYPE,
-  CT_GENERIC_STANDIN
+  CT_CGFUN_ASSOC_TYPE
 };
 
 class ConstrainedType final : public Type {

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -239,7 +239,7 @@ static void removeRandomPrimitives() {
 
 
 // remove ASTs that supported CG (constrained generics / interfaces)
-// see also cleanupGenericStandins()
+// see also finishInterfaceChecking()
 static void cleanupConstrainedGenerics() {
   // This should be done before removing InterfaceSymbols
   // so we can get at and remove refTypes.

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9244,7 +9244,7 @@ static void adjustInternalSymbols() {
   gDummyRef->addFlag(FLAG_REF);
   gDummyRef->removeFlag(FLAG_CONST);
 
-  createGenericStandins();
+  startInterfaceChecking();
 }
 
 
@@ -9345,7 +9345,7 @@ void resolve() {
 
   USR_STOP();
 
-  cleanupGenericStandins();  // should happen before resolveAutoCopies
+  finishInterfaceChecking();  // should happen before resolveAutoCopies
 
   resolveExports();
 

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -861,9 +861,12 @@ static bool checkReturnIntent(InterfaceSymbol* isym,  ImplementsStmt* istm,
   if (target->retTag == reqFn->retTag)
     return true;
 
-  if ((reqFn->retTag == RET_VALUE || reqFn->retTag == RET_CONST_REF) &&
-      (target->retTag == RET_REF  || target->retTag == RET_CONST_REF) )
-    return true;
+  if (reqFn->retTag == RET_VALUE &&
+      (target->retTag == RET_REF  || target->retTag == RET_CONST_REF))
+    return true;  // ok to use a [const] ref as a value
+
+  if (reqFn->retTag == RET_CONST_REF && target->retTag == RET_REF)
+    return true;  // ok to use a ref as a const ref
 
   if (reportErrors) {
     USR_FATAL_CONT(istm, "when checking this implements statement");

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -858,21 +858,26 @@ static bool checkReturnType(InterfaceSymbol* isym,  ImplementsStmt* istm,
 static bool checkReturnIntent(InterfaceSymbol* isym,  ImplementsStmt* istm,
                               FnSymbol*      target,  FnSymbol*      reqFn,
                               bool   reportErrors) {
-  if (target->retTag != reqFn->retTag) {
-    if (reportErrors) {
-      USR_FATAL_CONT(istm, "when checking this implements statement");
-      USR_PRINT(target, "this implementation of the required function %s",
-                         reqFn->name);
-      USR_PRINT(target, "has return intent '%s'",
-                        retTagDescrString(target->retTag));
-      USR_PRINT(reqFn, "which does not match the required intent '%s'",
-                        retTagDescrString(reqFn->retTag));
-      USR_PRINT(reqFn, "the required function %s in the interface %s"
-                       " is declared here", reqFn->name, isym->name);
-    }
-    return false;
+  if (target->retTag == reqFn->retTag)
+    return true;
+
+  if ((reqFn->retTag == RET_VALUE || reqFn->retTag == RET_CONST_REF) &&
+      (target->retTag == RET_REF  || target->retTag == RET_CONST_REF) )
+    return true;
+
+  if (reportErrors) {
+    USR_FATAL_CONT(istm, "when checking this implements statement");
+    USR_PRINT(target, "this implementation of the required function %s",
+                       reqFn->name);
+    USR_PRINT(target, "has return intent '%s'",
+                      retTagDescrString(target->retTag));
+    USR_PRINT(reqFn, "which does not match the required intent '%s'",
+                      retTagDescrString(reqFn->retTag));
+    USR_PRINT(reqFn, "the required function %s in the interface %s"
+                     " is declared here", reqFn->name, isym->name);
   }
-  return true;
+
+  return false;
 }
 
 // Returns whether an implementation of 'reqFn has been established

--- a/test/constrained-generics/basic/generic/error-generic-implements-1.chpl
+++ b/test/constrained-generics/basic/generic/error-generic-implements-1.chpl
@@ -83,13 +83,13 @@ proc cgFun(cgArg: ?Q) where Q implements IFC1 {
   cgArg.reqMethod();
 }
 
-//inferred: MyRec implements IFC1;
+MyRec implements IFC1;
 cgFun(myInst1);
 cgFun(myInst2);
 
-//would be incorrect:
-NotherRec implements IFC1;  // error: reqFun is not implemented
-cgFun(myInst3);             // error; compilation aborts before checking this
+// The following implements stmt is generic, so is checked only when used.
+NotherRec implements IFC1;  // error: reqFun is not implemented (not reported)
+cgFun(myInst3);             // reports the error for the previous line
 
 //---------------------------------------------------------------------------
 

--- a/test/constrained-generics/basic/generic/error-generic-implements-6.chpl
+++ b/test/constrained-generics/basic/generic/error-generic-implements-6.chpl
@@ -26,3 +26,5 @@ proc reqFun(cgFormal1: MyRec1, cgFormal2: MyRec2): void {
 implements IFC2(MyRec1, MyRec2);  // ok
 
 implements IFC2(MyRec2, MyRec1);  // error: no reqFun(MyRec2,MyRec1)
+
+cgFun(new MyRec2("hello"), new MyRec1(locale));  // report the above error

--- a/test/constrained-generics/basic/generic/wrapping-cg-types.chpl
+++ b/test/constrained-generics/basic/generic/wrapping-cg-types.chpl
@@ -1,0 +1,26 @@
+// In this test, the return type of a required function
+// is a generic record wrapping an interface type.
+
+record RR {
+  var vv;
+}
+
+interface IFC {
+  proc reqFn(arg: Self): RR(Self);
+}
+
+RR implements IFC;
+
+proc reqFn(arg): RR(arg.type) {
+  writeln("reqFn(", arg, ")");
+  return new RR(arg);
+}
+
+implements IFC(RR(int));
+
+proc icFun(arg: ?Q) where Q implements IFC {
+  writeln("icFun");
+  reqFn(arg);
+}
+
+icFun(new RR("hello"));

--- a/test/constrained-generics/basic/generic/wrapping-cg-types.good
+++ b/test/constrained-generics/basic/generic/wrapping-cg-types.good
@@ -1,0 +1,2 @@
+icFun
+reqFn((vv = hello))

--- a/test/constrained-generics/basic/set2/error-return-intent.good
+++ b/test/constrained-generics/basic/set2/error-return-intent.good
@@ -1,23 +1,18 @@
 error-return-intent.chpl:19: error: interface functions with 'param' or 'type' return intent are currently not allowed
 error-return-intent.chpl:20: error: interface functions with 'param' or 'type' return intent are currently not allowed
-error-return-intent.chpl:20: note: the required function ftype in the interface IFC is declared here
-error-return-intent.chpl:20: note: which does not match the expected return type 'int(64)'
-error-return-intent.chpl:21: note: the required function fref in the interface IFC is declared here
-error-return-intent.chpl:21: note: which does not match the required intent 'ref'
-error-return-intent.chpl:22: note: the required function fconstref in the interface IFC is declared here
-error-return-intent.chpl:22: note: which does not match the required intent 'const ref'
-error-return-intent.chpl:23: note: the required function fdefault in the interface IFC is declared here
-error-return-intent.chpl:23: note: which does not match the required intent 'value'
 error-return-intent.chpl:26: In 'implements IFC' statement:
 error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:26: error: when checking this implements statement
-error-return-intent.chpl:28: note: has return type 'string'
 error-return-intent.chpl:28: note: this implementation of the required function ftype
-error-return-intent.chpl:29: note: has return intent 'value'
+error-return-intent.chpl:28: note: has return type 'string'
+error-return-intent.chpl:20: note: which does not match the expected return type 'int(64)'
+error-return-intent.chpl:20: note: the required function ftype in the interface IFC is declared here
+error-return-intent.chpl:26: error: when checking this implements statement
 error-return-intent.chpl:29: note: this implementation of the required function fref
-error-return-intent.chpl:30: note: has return intent 'value'
+error-return-intent.chpl:29: note: has return intent 'value'
+error-return-intent.chpl:21: note: which does not match the required intent 'ref'
+error-return-intent.chpl:21: note: the required function fref in the interface IFC is declared here
+error-return-intent.chpl:26: error: when checking this implements statement
 error-return-intent.chpl:30: note: this implementation of the required function fconstref
-error-return-intent.chpl:31: note: has return intent 'const ref'
-error-return-intent.chpl:31: note: this implementation of the required function fdefault
+error-return-intent.chpl:30: note: has return intent 'value'
+error-return-intent.chpl:22: note: which does not match the required intent 'const ref'
+error-return-intent.chpl:22: note: the required function fconstref in the interface IFC is declared here

--- a/test/constrained-generics/basic/set2/error-return-intent.prediff
+++ b/test/constrained-generics/basic/set2/error-return-intent.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-outfile=$2
-sort $outfile > $outfile.tmp
-mv $outfile.tmp $outfile

--- a/test/constrained-generics/basic/set2/error-return-type.good
+++ b/test/constrained-generics/basic/set2/error-return-type.good
@@ -1,35 +1,35 @@
-error-return-type.chpl:13: note: the required function dfltInt in the interface IFC is declared here
-error-return-type.chpl:13: note: which does not match the expected return type 'int(64)'
 error-return-type.chpl:17: error: interface function implicitSelf with inferred return type
 error-return-type.chpl:17: note: a non-void return type must be declared explicitly
-error-return-type.chpl:17: note: the required function implicitSelf in the interface IFC is declared here
-error-return-type.chpl:17: note: which does not match the expected return type 'string'
 error-return-type.chpl:21: error: interface function implicitInt with inferred return type
 error-return-type.chpl:21: note: a non-void return type must be declared explicitly
-error-return-type.chpl:21: note: the required function implicitInt in the interface IFC is declared here
-error-return-type.chpl:21: note: which does not match the expected return type 'int(64)'
 error-return-type.chpl:27: In 'implements IFC' statement:
 error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:27: error: when checking this implements statement
-error-return-type.chpl:29: note: has return type 'int(64)'
 error-return-type.chpl:29: note: this implementation of the required function reqSelf
-error-return-type.chpl:30: note: has return type 'string'
-error-return-type.chpl:30: note: this implementation of the required function reqInt
-error-return-type.chpl:31: note: has return type 'int(64)'
-error-return-type.chpl:31: note: this implementation of the required function dfltSelf
-error-return-type.chpl:32: note: has return type 'string'
-error-return-type.chpl:32: note: this implementation of the required function dfltInt
-error-return-type.chpl:33: note: has return type 'int(64)'
-error-return-type.chpl:33: note: this implementation of the required function implicitSelf
-error-return-type.chpl:34: note: has return type 'string'
-error-return-type.chpl:34: note: this implementation of the required function implicitInt
-error-return-type.chpl:7: note: the required function reqSelf in the interface IFC is declared here
+error-return-type.chpl:29: note: has return type 'int(64)'
 error-return-type.chpl:7: note: which does not match the expected return type 'string'
-error-return-type.chpl:8: note: the required function reqInt in the interface IFC is declared here
+error-return-type.chpl:7: note: the required function reqSelf in the interface IFC is declared here
+error-return-type.chpl:27: error: when checking this implements statement
+error-return-type.chpl:30: note: this implementation of the required function reqInt
+error-return-type.chpl:30: note: has return type 'string'
 error-return-type.chpl:8: note: which does not match the expected return type 'int(64)'
-error-return-type.chpl:9: note: the required function dfltSelf in the interface IFC is declared here
+error-return-type.chpl:8: note: the required function reqInt in the interface IFC is declared here
+error-return-type.chpl:27: error: when checking this implements statement
+error-return-type.chpl:31: note: this implementation of the required function dfltSelf
+error-return-type.chpl:31: note: has return type 'int(64)'
 error-return-type.chpl:9: note: which does not match the expected return type 'string'
+error-return-type.chpl:9: note: the required function dfltSelf in the interface IFC is declared here
+error-return-type.chpl:27: error: when checking this implements statement
+error-return-type.chpl:32: note: this implementation of the required function dfltInt
+error-return-type.chpl:32: note: has return type 'string'
+error-return-type.chpl:13: note: which does not match the expected return type 'int(64)'
+error-return-type.chpl:13: note: the required function dfltInt in the interface IFC is declared here
+error-return-type.chpl:27: error: when checking this implements statement
+error-return-type.chpl:33: note: this implementation of the required function implicitSelf
+error-return-type.chpl:33: note: has return type 'int(64)'
+error-return-type.chpl:17: note: which does not match the expected return type 'string'
+error-return-type.chpl:17: note: the required function implicitSelf in the interface IFC is declared here
+error-return-type.chpl:27: error: when checking this implements statement
+error-return-type.chpl:34: note: this implementation of the required function implicitInt
+error-return-type.chpl:34: note: has return type 'string'
+error-return-type.chpl:21: note: which does not match the expected return type 'int(64)'
+error-return-type.chpl:21: note: the required function implicitInt in the interface IFC is declared here

--- a/test/constrained-generics/basic/set2/error-return-type.prediff
+++ b/test/constrained-generics/basic/set2/error-return-type.prediff
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-outfile=$2
-sort $outfile > $outfile.tmp
-mv $outfile.tmp $outfile


### PR DESCRIPTION
The first commit here implements a part of #17612. Specifically,
it discontinues early checking of generic implements statements.

So far only traditional-generic implements statements have been allowed.
They will now be checked late, that is, upon being instantiated.
Once we introduce implements statements over interface generics,
as proposed in #17612, those will be checked early.

Early checking of generic implements statements was introduced in #17239.
The implementation introduced a stand-in type and a stand-in param.
Given a generic implements statement, the implementation instantiated
the generic type(s) using the stand-in type and/or param, then checked
the resulting implements statement as if it were concrete.
```chpl
    // For example, given this source code:
    interface IFC {...}
    record R { type T; param P; }

    R implements IFC;

    // the implementation was checking:
    R(T = dtGenericStandin, P = gGenericParam) implements IFC;
```
While this is an elegant idea, in practice such "stand-in" generic
instantiations could be checked only in simplest cases. Any attempts
to get closer to real code, such as the RandomStream interface,
either did not pass checking or caused compiler crash. We could
keep extending the set of cases that are handled by the compiler
successfully, however I consider this not suitable for real codes.

Affected tests:
```
M  test/constrained-generics/basic/generic/error-generic-implements-1.chpl
M  test/constrained-generics/basic/generic/error-generic-implements-6.chpl
A  test/constrained-generics/basic/generic/wrapping-cg-types.chpl
```

#### While there - the second commit

* Allow a required function with a default or const-ref return intent
  to be implemented by a function with a const-ref or ref return return.
  This way a default-intent function can be implemented with a field accessor.

* Impose lexical order of traversal of InterfaceSymbol::associatedTypes.

Affected tests:
```
M  test/constrained-generics/basic/set2/error-return-intent.good
D  test/constrained-generics/basic/set2/error-return-intent.prediff
M  test/constrained-generics/basic/set2/error-return-type.good
D  test/constrained-generics/basic/set2/error-return-type.prediff
```