### PR TITLE
IFC: enable interface-constrained required functions

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -498,7 +498,7 @@ void FnSymbol::finalizeCopy() {
 
     // For CG fns calling to other CG fns.
     if (InterfaceInfo* ifcInfo = partialCopySource->interfaceInfo)
-      handleCallsToOtherCGfuns(partialCopySource, ifcInfo, this);
+      handleCallsToOtherCGfuns(partialCopySource, ifcInfo, *map, this);
 
     // Clean up book keeping information.
     clearPartialCopyData(this);

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -1227,6 +1227,16 @@ void set_view(std::set<BlockStmt*>& bss) {
   }
 }
 
+void set_view(std::set<FnSymbol*>* bss) {
+  set_view(*bss);
+}
+
+void set_view(std::set<FnSymbol*>& bss) {
+  printf("set<FnSymbol> %d elm(s)\n", (int)bss.size());
+  for (FnSymbol* elm: bss)
+    showFnSymbol(elm);
+}
+
 //
 // typesWithName: print all TypeSymbols with the given name
 //

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -1221,10 +1221,9 @@ void set_view(std::set<BlockStmt*>* bss) {
 
 void set_view(std::set<BlockStmt*>& bss) {
   printf("set<BlockStmt> %d elm(s)\n", (int)bss.size());
-  std::set<BlockStmt*>::iterator it = bss.begin();
-  while (it != bss.end()) {
-    debugSummary(*(it++));
-  }
+  for (BlockStmt* elm: bss)
+    if (elm) showBlock(elm);
+    else     printf("  <null>\n");
 }
 
 void set_view(std::set<FnSymbol*>* bss) {
@@ -1234,7 +1233,8 @@ void set_view(std::set<FnSymbol*>* bss) {
 void set_view(std::set<FnSymbol*>& bss) {
   printf("set<FnSymbol> %d elm(s)\n", (int)bss.size());
   for (FnSymbol* elm: bss)
-    showFnSymbol(elm);
+    if (elm) showFnSymbol(elm);
+    else     printf("  <null>\n");
 }
 
 //

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -124,7 +124,7 @@ void  markImplStmtWrapFnAsFailure(FnSymbol* wrapFn);
 void  wrapImplementsStatements();
 FnSymbol* wrapOneImplementsStatement(ImplementsStmt* istm);
 void  handleCallsToOtherCGfuns(FnSymbol* origFn, InterfaceInfo* ifcInfo,
-                               FnSymbol* newFn);
+                               SymbolMap& copyMap, FnSymbol* newFn);
 
 // iterator.cpp
 CallExpr* setIteratorRecordShape(Expr* ref, Symbol* ir, Symbol* shapeSpec,

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -80,6 +80,8 @@ void map_view(SymbolMap& map);
 
 void set_view(std::set<BlockStmt*>* bss);
 void set_view(std::set<BlockStmt*>& bss);
+void set_view(std::set<FnSymbol*>& bss);
+void set_view(std::set<FnSymbol*>* bss);
 
 void vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>* v);
 void vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>& v);

--- a/test/constrained-generics/basic/generic/ic-req-function.chpl
+++ b/test/constrained-generics/basic/generic/ic-req-function.chpl
@@ -1,0 +1,22 @@
+// interface with an IC function
+
+interface HLP { }
+
+interface IFC {
+  proc reqFn(formal: ?T) where T implements HLP;
+}
+
+int implements IFC;
+real implements HLP;
+
+proc reqFn(formal: ?R) where R implements HLP {
+  writeln("in reqFn.R");
+}
+
+proc icFun(arg1: ?Q1, arg2: ?Q2)
+  where arg1 implements IFC && arg2 implements HLP
+{
+  reqFn(arg2);
+}
+
+icFun(55, 66.77);

--- a/test/constrained-generics/basic/generic/ic-req-function.good
+++ b/test/constrained-generics/basic/generic/ic-req-function.good
@@ -1,0 +1,1 @@
+in reqFn.R


### PR DESCRIPTION
This PR enables IC functions within an interface declaration, ex.:
```chpl
    interface IFC(Self) {
      proc requiredFun(arg1: Self, arg2: ?Q) where Q implements IFC2;
    }
```
The implementation extends support for calling from one IC function
into another IC function to handle this case as well.

While there, add another overload of set_view().
