### PR TITLE
Add environment variable to common-slurm-gasnet-cray-cs.bash to point at C libs

### DIFF
--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,6 +11,8 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
+export COMPILER_PATH=/opt/gcc/9.1.0/snos
+
 export CHPL_COMM=gasnet
 
 unset CHPL_START_TEST_ARGS


### PR DESCRIPTION
Add an environment variable to point at C libraries in slurm testing.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>