### PR TITLE
Adjust some tests for LLVM backend

### DIFF
--- a/test/library/packages/EpochManager/atomicObjects/atomicObjectsTest.chpl
+++ b/test/library/packages/EpochManager/atomicObjects/atomicObjectsTest.chpl
@@ -47,4 +47,7 @@ proc main() {
   var deltaABACnt = atomicObj.readABA().getABACount() - currABACnt;
   writeln(deltaABACnt);
   assert(deltaABACnt == 1024 * 1024);
+
+  delete x;
+  delete w;
 }

--- a/test/library/packages/EpochManager/atomicObjects/atomicObjectsTest.skipif
+++ b/test/library/packages/EpochManager/atomicObjects/atomicObjectsTest.skipif
@@ -1,0 +1,1 @@
+CHPL_SANITIZE_EXE != none

--- a/test/library/packages/EpochManager/distributedMemory/distributedMemory.bad
+++ b/test/library/packages/EpochManager/distributedMemory/distributedMemory.bad
@@ -1,0 +1,26 @@
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+
+================================================= Memory Leaks ==================================================
+Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
+=================================================================================================================
+distributedMemory.chpl:15        1        24       24       _token                           prediffed  
+distributedMemory.chpl:15        1        24       24       _token                           prediffed  
+distributedMemory.chpl:15        1        24       24       _token                           prediffed  
+distributedMemory.chpl:15        1        24       24       _token                           prediffed  
+=================================================================================================================
+

--- a/test/library/packages/EpochManager/distributedMemory/distributedMemory.execopts
+++ b/test/library/packages/EpochManager/distributedMemory/distributedMemory.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/packages/EpochManager/distributedMemory/distributedMemory.future
+++ b/test/library/packages/EpochManager/distributedMemory/distributedMemory.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/EpochManager/distributedMemory/distributedMemory.prediff
+++ b/test/library/packages/EpochManager/distributedMemory/distributedMemory.prediff
@@ -1,0 +1,1 @@
+../leak.prediff

--- a/test/library/packages/EpochManager/leak.prediff
+++ b/test/library/packages/EpochManager/leak.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -E "s/0x[0-9a-f]*/prediffed/" <$2 >$2.predifftmp
+mv $2.predifftmp $2

--- a/test/library/packages/EpochManager/sharedMemory/sharedMemory.bad
+++ b/test/library/packages/EpochManager/sharedMemory/sharedMemory.bad
@@ -1,0 +1,18 @@
+Reclaimed.
+Reclaimed.
+Reclaimed.
+Reclaimed.
+
+================================================= Memory Leaks ==================================================
+Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
+=================================================================================================================
+sharedMemory.chpl:25             1        24       24       Node                             prediffed  
+sharedMemory.chpl:25             1        24       24       Node                             prediffed  
+sharedMemory.chpl:25             1        24       24       Node                             prediffed  
+sharedMemory.chpl:25             1        24       24       Node                             prediffed  
+sharedMemory.chpl:14             1        24       24       _token                           prediffed  
+sharedMemory.chpl:14             1        24       24       _token                           prediffed  
+sharedMemory.chpl:14             1        24       24       _token                           prediffed  
+sharedMemory.chpl:14             1        24       24       _token                           prediffed  
+=================================================================================================================
+

--- a/test/library/packages/EpochManager/sharedMemory/sharedMemory.execopts
+++ b/test/library/packages/EpochManager/sharedMemory/sharedMemory.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/packages/EpochManager/sharedMemory/sharedMemory.future
+++ b/test/library/packages/EpochManager/sharedMemory/sharedMemory.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/EpochManager/sharedMemory/sharedMemory.prediff
+++ b/test/library/packages/EpochManager/sharedMemory/sharedMemory.prediff
@@ -1,0 +1,1 @@
+../leak.prediff

--- a/test/library/packages/LockFreeQueue/EXECOPTS
+++ b/test/library/packages/LockFreeQueue/EXECOPTS
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/packages/LockFreeQueue/PREDIFF
+++ b/test/library/packages/LockFreeQueue/PREDIFF
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -E "s/0x[0-9a-f]*/prediffed/" <$2 >$2.predifftmp
+grep prediffed $2.predifftmp | uniq -c >$2
+rm $2.predifftmp

--- a/test/library/packages/LockFreeQueue/consistencyCheck.future
+++ b/test/library/packages/LockFreeQueue/consistencyCheck.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/LockFreeQueue/interleavedTest.future
+++ b/test/library/packages/LockFreeQueue/interleavedTest.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/LockFreeStack/EXECOPTS
+++ b/test/library/packages/LockFreeStack/EXECOPTS
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/packages/LockFreeStack/PREDIFF
+++ b/test/library/packages/LockFreeStack/PREDIFF
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -E "s/0x[0-9a-f]*/prediffed/" <$2 >$2.predifftmp
+grep prediffed $2.predifftmp | uniq -c >$2
+rm $2.predifftmp

--- a/test/library/packages/LockFreeStack/consistencyCheck.future
+++ b/test/library/packages/LockFreeStack/consistencyCheck.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/LockFreeStack/interleavedTest.future
+++ b/test/library/packages/LockFreeStack/interleavedTest.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory


### PR DESCRIPTION
Supersedes https://github.com/chapel-lang/chapel/pull/17627

Adjusts the following tests:

1. `library/packages/EpochManager/atomicObjects/atomicObjectsTest.chpl`

    This test used to leak because of a test error, this PR fixes that.

    The test also fails with ASAN. The reason is not obvious to me and
    @louisjenkinscs is aware of the issue. This PR skipifs that test under ASAN.

2. `library/packages/EpochManager/sharedMemory/sharedMemory.chpl`
   `library/packages/EpochManager/distributedMemory/distributedMemory.chpl`

   These tests leak in a manageable/deterministic way. The reason is not
   obvious to me. This PR makes them into a future where the bad file contains
   the prediffed leak table to prevent further slips.

3.  `library/packages/LockFreeQueue/interleavedTest.chpl`
    `library/packages/LockFreeStack/interleavedTest.chpl`
    `library/packages/LockFreeQueue/consistencyCheck.chpl`
    `library/packages/LockFreeStack/consistencyCheck.chpl`

    These leak a lot (the table is about 300MB for some), and in a more
    indeterministic fashion. It looks like some locations in the file doesn't leak
    at each run etc. This PR makes these tests into futures without bad files. I kept
    the prediff attempt that would `uniq -c` leaks in case it helps diagnose the issue
