### PR TITLE
In comm=ofi, add message-order-fence MCM mode and heavily restructure.

### DIFF
--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -41,7 +41,6 @@ typedef struct {
   chpl_bool taskIsEnding;       // task is ending? (anticipate _downEndCount())
   chpl_bool amDonePending;      // some delayed AM 'done' is expected?
   uint8_t amDone;               // delayed 'done' indicator
-  void* putBitmap;              // PUT target nodes
   chpl_cache_taskPrvData_t cache_data;
   void* amo_nf_buff;
   void* get_buff;

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -59,7 +59,6 @@ typedef struct {
   void* pAmDone;                // initiator's 'amDone' flag; NULL means nonblk
 #ifdef CHPL_COMM_DEBUG
   uint64_t seq;
-  uint32_t crc;
 #endif
 } chpl_comm_bundleData_t;
 

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -72,6 +72,7 @@ extern "C" {
   m(MR,                     "mem reg: regions")                         \
   m(MR_DESC,                "mem reg: local region descs")              \
   m(MR_KEY,                 "mem reg: remote region keys")              \
+  m(MR_BB,                  "mem reg: bounce buffers")                  \
   m(HUGEPAGES,              "hugepages")                                \
   m(TCIPS,                  "tx context alloc/free")                    \
   m(OOB,                    "out-of-band calls")                        \

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -128,11 +128,6 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 
 #define DBG_VAL(pV, typ) chpl_comm_ofi_dbg_val(pV, typ)
 
-//#define DEBUG_CRC_MSGS
-#ifdef DEBUG_CRC_MSGS
-#include <libiberty.h>
-#endif
-
 #else // CHPL_COMM_DEBUG
 
 #define DBG_INIT()

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -253,12 +253,10 @@ enum mcmMode_t {
 
 static enum mcmMode_t mcmMode;          // overall operational mode
 
-#ifdef CHPL_COMM_DEBUG
 static const char* mcmModeNames[] = { "undefined",
-                                      "atomic message orderings w/ fences",
-                                      "message orderings",
+                                      "message-order-fence",
+                                      "message-order",
                                       "delivery-complete", };
-#endif
 
 
 ////////////////////////////////////////
@@ -1815,8 +1813,8 @@ void init_ofiFabricDomain(void) {
 
   if (verbosity >= 2) {
     if (chpl_nodeID == 0) {
-      printf("COMM=ofi: using \"%s\" provider\n",
-             ofi_info->fabric_attr->prov_name);
+      printf("COMM=ofi: in %s MCM mode, using the \"%s\" provider\n",
+             mcmModeNames[mcmMode], ofi_info->fabric_attr->prov_name);
     }
   }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -6611,7 +6611,7 @@ void do_remote_amo_nf_buff(void* opnd, c_nodeid_t node,
   info->opnd_v[vi]      = size == 4 ? *(uint32_t*) opnd:
                                       *(uint64_t*) opnd;
   info->locale_v[vi]    = node;
-  info->object_v[vi]    = object;
+  info->object_v[vi]    = (void*) mrRaddr;
   info->size_v[vi]      = size;
   info->cmd_v[vi]       = ofiOp;
   info->type_v[vi]      = ofiType;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -266,41 +266,39 @@ static const char* mcmModeNames[] = { "undefined",
 
 static void emit_delayedFixedHeapMsgs(void);
 
-static inline struct perTxCtxInfo_t* tciAlloc(void);
-static inline struct perTxCtxInfo_t* tciAllocForAmHandler(void);
-static inline chpl_bool tciAllocTabEntry(struct perTxCtxInfo_t*);
-static inline void tciFree(struct perTxCtxInfo_t*);
-static inline void waitForCQSpace(struct perTxCtxInfo_t*, size_t);
-static inline chpl_comm_nb_handle_t ofi_put(const void*, c_nodeid_t,
-                                            void*, size_t);
+static struct perTxCtxInfo_t* tciAlloc(void);
+static struct perTxCtxInfo_t* tciAllocForAmHandler(void);
+static chpl_bool tciAllocTabEntry(struct perTxCtxInfo_t*);
+static void tciFree(struct perTxCtxInfo_t*);
+static void waitForCQSpace(struct perTxCtxInfo_t*, size_t);
+static chpl_comm_nb_handle_t ofi_put(const void*, c_nodeid_t, void*, size_t);
 static void ofi_put_lowLevel(const void*, void*, c_nodeid_t,
                              uint64_t, uint64_t, size_t, void*,
                              uint64_t, struct perTxCtxInfo_t*);
-static inline void do_remote_put_buff(void*, c_nodeid_t, void*, size_t);
-static inline chpl_comm_nb_handle_t ofi_get(void*, c_nodeid_t,
-                                            void*, size_t);
+static void do_remote_put_buff(void*, c_nodeid_t, void*, size_t);
+static chpl_comm_nb_handle_t ofi_get(void*, c_nodeid_t, void*, size_t);
 static void ofi_get_lowLevel(void*, void*, c_nodeid_t,
                              uint64_t, uint64_t, size_t, void*,
                              uint64_t, struct perTxCtxInfo_t*);
-static inline void do_remote_get_buff(void*, c_nodeid_t, void*, size_t);
-static inline void do_remote_amo_nf_buff(void*, c_nodeid_t, void*, size_t,
-                                         enum fi_op, enum fi_datatype);
+static void do_remote_get_buff(void*, c_nodeid_t, void*, size_t);
+static void do_remote_amo_nf_buff(void*, c_nodeid_t, void*, size_t,
+                                  enum fi_op, enum fi_datatype);
 static void amEnsureProgress(struct perTxCtxInfo_t*);
 static void checkRxRmaCmplsCQ(void);
 static void checkRxRmaCmplsCntr(void);
 static void checkTxCmplsCQ(struct perTxCtxInfo_t*);
 static void checkTxCmplsCntr(struct perTxCtxInfo_t*);
-static inline size_t readCQ(struct fid_cq*, void*, size_t);
+static size_t readCQ(struct fid_cq*, void*, size_t);
 static void reportCQError(struct fid_cq*);
-static inline void waitForTxnComplete(struct perTxCtxInfo_t*, void* ctx);
-static inline void forceMemFxVisOneNode(c_nodeid_t, chpl_bool, chpl_bool,
-                                        struct perTxCtxInfo_t*);
-static inline void forceMemFxVisAllNodes(chpl_bool, chpl_bool, c_nodeid_t,
-                                         struct perTxCtxInfo_t*);
-static inline void forceMemFxVisAllNodes_noTcip(chpl_bool, chpl_bool);
+static void waitForTxnComplete(struct perTxCtxInfo_t*, void* ctx);
+static void forceMemFxVisOneNode(c_nodeid_t, chpl_bool, chpl_bool,
+                                 struct perTxCtxInfo_t*);
+static void forceMemFxVisAllNodes(chpl_bool, chpl_bool, c_nodeid_t,
+                                  struct perTxCtxInfo_t*);
+static void forceMemFxVisAllNodes_noTcip(chpl_bool, chpl_bool);
 static void* allocBounceBuf(size_t);
 static void freeBounceBuf(void*);
-static inline void local_yield(void);
+static void local_yield(void);
 
 static void time_init(void);
 
@@ -938,9 +936,9 @@ static void init_broadcast_private(void);
 //
 // forward decls
 //
-static inline chpl_bool mrGetKey(uint64_t*, uint64_t*, int, void*, size_t);
-static inline chpl_bool mrGetLocalKey(void*, size_t);
-static inline chpl_bool mrGetDesc(void**, void*, size_t);
+static chpl_bool mrGetKey(uint64_t*, uint64_t*, int, void*, size_t);
+static chpl_bool mrGetLocalKey(void*, size_t);
+static chpl_bool mrGetDesc(void**, void*, size_t);
 
 void chpl_comm_init(int *argc_p, char ***argv_p) {
   chpl_comm_ofi_abort_on_error =
@@ -2353,7 +2351,7 @@ void init_ofiForAms(void) {
 }
 
 
-static inline void amRequestNop(c_nodeid_t, chpl_bool, struct perTxCtxInfo_t*);
+static void amRequestNop(c_nodeid_t, chpl_bool, struct perTxCtxInfo_t*);
 
 static
 void init_ofiConnections(void) {
@@ -2956,7 +2954,7 @@ void* mrLocalizeTargetRemote(const void* addr, size_t size,
 // Interface: memory consistency
 //
 
-static inline void retireDelayedAmDone(chpl_bool);
+static void retireDelayedAmDone(chpl_bool);
 
 
 static inline
@@ -3166,11 +3164,11 @@ static void amRequestRmaGet(c_nodeid_t, void*, void*, size_t);
 static void amRequestAMO(c_nodeid_t, void*, const void*, const void*, void*,
                          int, enum fi_datatype, size_t);
 static void amRequestFree(c_nodeid_t, void*);
-static inline void amRequestNop(c_nodeid_t, chpl_bool, struct perTxCtxInfo_t*);
+static void amRequestNop(c_nodeid_t, chpl_bool, struct perTxCtxInfo_t*);
 static void amRequestCommon(c_nodeid_t, amRequest_t*, size_t,
                             amDone_t**, chpl_bool, struct perTxCtxInfo_t*);
-static inline void amWaitForDone(amDone_t*);
-static inline chpl_bool setUpDelayedAmDone(chpl_comm_taskPrvData_t**, void**);
+static void amWaitForDone(amDone_t*);
+static chpl_bool setUpDelayedAmDone(chpl_comm_taskPrvData_t**, void**);
 
 
 void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
@@ -3851,17 +3849,17 @@ static pthread_mutex_t amStartStopMutex = PTHREAD_MUTEX_INITIALIZER;
 static void amHandler(void*);
 static void processRxAmReq(struct perTxCtxInfo_t*);
 static void amHandleExecOn(chpl_comm_on_bundle_t*);
-static inline void amWrapExecOnBody(void*);
+static void amWrapExecOnBody(void*);
 static void amHandleExecOnLrg(chpl_comm_on_bundle_t*);
 static void amWrapExecOnLrgBody(struct amRequest_execOnLrg_t*);
 static void amWrapGet(struct taskArg_RMA_t*);
 static void amWrapPut(struct taskArg_RMA_t*);
 static void amHandleAMO(struct amRequest_AMO_t*);
-static inline void amPutDone(c_nodeid_t, amDone_t*);
-static inline void amCheckLiveness(void);
+static void amPutDone(c_nodeid_t, amDone_t*);
+static void amCheckLiveness(void);
 
-static inline void doCpuAMO(void*, const void*, const void*, void*,
-                            enum fi_op, enum fi_datatype, size_t size);
+static void doCpuAMO(void*, const void*, const void*, void*,
+                     enum fi_op, enum fi_datatype, size_t size);
 
 
 static
@@ -4636,7 +4634,7 @@ void chpl_comm_getput_unordered_task_fence(void) {
 // Internal communication support
 //
 
-static inline struct perTxCtxInfo_t* tciAllocCommon(chpl_bool);
+static struct perTxCtxInfo_t* tciAllocCommon(chpl_bool);
 static struct perTxCtxInfo_t* findFreeTciTabEntry(chpl_bool);
 
 static __thread struct perTxCtxInfo_t* _ttcip;
@@ -6304,8 +6302,8 @@ void local_yield(void) {
 // Interface: network atomics
 //
 
-static inline void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
-                         int, enum fi_datatype, size_t);
+static void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
+                  int, enum fi_datatype, size_t);
 
 
 //


### PR DESCRIPTION
Until now, the ofi comm layer has had two ways of achieving MCM
conformance, particular with regard to the memory visibility of values
stored by PUTs and AMOs.  One method uses delivery-complete completion
semantics which guarantee such visibility once the completion event is
delivered.  This mode is slow because we have to wait for an entire
network round trip on every operation.  The other mode uses default
completions, but adds required message ordering capabilities for RMA
read-after-write and others, and also does synthetic visibility-forcing
operations such as dummy GETs to achieve things like ensuring all
outstanding PUTs are memory-visible before the we do an on-stmt or start
a parallel task.  These two modes for conforming to the Chapel MCM were
called "delivery-complete" and "message-order", respectively.  The code
had a simple boolean flag that told which mode it was operating in.

Here, we add a third mode called "message-order-fence".  This is like
the message-order mode in that it uses the default completion level
along with message ordering settings, but it requires the atomic
capability and only asks the provider to order atomic operations that
write.  This fulfills the MCM ordering requirements for AMOs directly.
It also requires the fenced-operation capability, and uses fenced ops to
enforce the ordering and visibility requirements in other circumstances.
This new mode is only enabled only when the tasking layer uses a fixed
number of worker threads and and the provider can supply enough transmit
contexts (regular endpoints, or actual contexts with a scalable transmit
endpoint) that every worker thread can have its own dedicated transmit
context.  Because libfabric can only guarantee order for operations
between a given pair of endpoints, this fixed binding between endpoints
and tasks allows delaying operations or kinds of operations (fenced, for
example) until such time as the ordering or visibility effects those ops
provide are actually needed, thus improving performance.  Or to put the
other way around, message ordering guarantees are of limited usefulness
without dedicated transmit endpoints, because if a task initiates an
operation on a dynamically acquired transmit context it must ensure that
operation is complete and visible before releasing the transmit context
anyway.

The code now has an enumerated type for the operating modes and a global
variable that tells which mode it's operating in.

Provider selection and the actual per-operation code are both affected
significantly by this.

First, provider selection has been heavily restructured.  We used to
just have two alternatives, and we looked for a provider that could do
one and then the other.  Now we have three and want to be extensible to
more, so there's a list of functions to call that will find a provider
(if one is available) that can do a given mode, starting from the one we
expect to perform best (the new message-order-fence) to the one we
expect to be worst (delivery-complete).  As before with the two-mode
code, we still first go through the modes looking for a "good" provider,
and only if we fail to find one do we go through them again accepting a
"not as good" one.  ("Good" here means "not tcp or sockets", the same as
it did in the old code.)  But since the comm layer has to work properly
whether it finds a provider on its own or has one forced upon it via the
environment, for each mode there is a single function that encapsulates
the corresponding capabilities and other requirements, and which is used
both when finding all providers that can support that mode and when
deciding whether a given forced provider can support it.

Because the new message-order-fence MCM mode has a requirement for a
fixed number of worker threads and a dedicated transmit context for each
thread, the logic associated with deciding whether those requirements
hold has been moved from the endpoint setup code where it used to be,
into code called much earlier during provider selection.  Endpoint setup
now just uses the information developed during those earlier calls.

There are also a couple of endpoint-related changes made as part of this
portion of the work.  We've reduced from two receive endpoints per
locale/node, one for send/receive (AM) traffic and one for RMA, down to
just one for all traffic.  The original code separated these, with the
thinking being that there would be a load distribution benefit, but we
never saw any such.  In addition, we've simplified the logic having to
do with whether or not we're using a single scalable transmit endpoint
with multiple transmit contexts, or just multiple transmit endpoints.

Finally, the line of output produced by the comm layer in "verbose" mode
(-v) now includes the MCM conformance mode in addition to the provider.

The largest part of the restructuring is that the bottom-level operation
functions, by which is meant the ones that called libfabric to do the
actual work and wait for completion if necessary, now do so through
mode-specific implementation functions.  The old code had a fair amount
of mode-related control flow to initiate operations and/or wait for
completions, doing things one way for one mode and another way for the
other.  With three modes now and maybe more in the future this seemed
unworkable, so now for each kind of operation (AM, PUT, GET, and AMO)
there are mode-specific functions to do the libfabric interactions for
that operation when the comm layer is operating in that mode.  Thus for
example `amReqFn_msgOrdFence()` handles all the libfabric interactions for
AM requests when the comm layer is in message-order-fence mode.  These
mode-specific implementation functions only need control flow related to
libfabric itself, things like how best to initiate the operation and
what kind of completion to ask for.  They don't need MCM mode-related
control flow, because they're only called when we're in the specific MCM
mode they implement.  Going forward, these will allow for mode-specific
development and maintenance to be done without having to worry about
breaking the comm layer's behavior with providers and networks that use
other modes.

As part of this, the `mcmRelease*Node*()` and `forceMemFxVis*()` functions
(the latter renamed from `waitForPutsVis*()` to say more accurately what
they do) have been updated to work with the new message-order-fence mode
as well.

Also as part of this portion of the work, we've moved the bitmap that
records nodes to which we've done PUTs whose memory effects might not
yet be visible from task-private data to the transmit context table, and
added a corresponding bitmap of nodes to which we've done AMOs.  This
move was possible because we don't use these bitmaps without transmit
contexts dedicated to worker threads in either message-order based mode,
so a context-private bitmap is by definition also private to its task.
This removes a memory allocation and free from the task creation and
destruction path.  Related to having two bitmaps of nodes on which the
memory effects of operations may not yet be visibility, we added a
bitmap `FOREACH` macro that performs its loop body for each bit set in the
OR of two bitmaps.  We also got rid of the node bitmap in the unbuffered
AMO support, since the information it held can now be put in the AMO
bitmap in the transmit context table.  The unbuffered operation structs
thus don't have to be variable-length any more, simplifying the shared
(among PUT, GET, and AMO) code that creates them.

Finally, while here we made rather a laundry list of other changes.

Several have to do with managing registered memory.  New `mrLocalize*()`
and `mrUnlocalize*()` functions take care of ensuring that operands which
must be accessible locally or remotely as operation sources or targets
are appropriately localized and copied in and out.  In essence these
encapsulate bounce-buffering.  We now record the memory region local
descriptor and remote key of the dummy variable that serves as the
source and sink of GETs and PUTs done only for memory visibility just
once, at the beginning, and distribute those around the job instead of
looking them up over and over.  Finally, we reworked the functions that
get memory region local descriptors and remote keys to return boolean
instead of plain int.

Lastly, we renamed the operands of AMOs, which used to be called various
forms of "operand 1" and "operand 2", as "operand" and "comparand" to
clarify what they contain.  We removed CRC-32 support for AM requests,
since the last time it was used was over a year ago and the comm layer
seems mature enough that we should not be corrupting messages any more.
And, we removed the 'inline' keyword from static function declarators
that are not definitions.  It's not meaningful for those.