### PR TITLE
Set COMPILER_PATH to $GCC_X86_64 instead of an explicit path

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -27,7 +27,7 @@ else
 fi
 
 # Point clang to standard libraries
-export COMPILER_PATH=/opt/gcc/9.1.0/snos
+export COMPILER_PATH=$GCC_X86_64
 
 # https://github.com/Cray/chapel-private/issues/1601
 export SLURM_CPU_FREQ_REQ=high

--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,7 +11,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
-export COMPILER_PATH=/opt/gcc/9.1.0/snos
+export COMPILER_PATH=$GCC_X86_64
 
 export CHPL_COMM=gasnet
 

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -137,7 +137,7 @@ if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
     source /cray/css/users/chapelu/setup_system_llvm.bash
   fi
   # Make clang aware of standard libraries
-  export COMPILER_PATH=/opt/gcc/10.3.0/snos
+  export COMPILER_PATH=$GCC_X86_64
 fi
 
 


### PR DESCRIPTION
On Systems with PrgEnv environments use an environment variable to set
COMPILER_PATH instead of using an explicit path.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>