### PR TITLE
Use `CHPL_LLVM=bundled` for make install testing

### DIFF
--- a/util/buildRelease/test_install.bash
+++ b/util/buildRelease/test_install.bash
@@ -10,6 +10,8 @@ unset CHPL_HOME
 export CHPL_CHECK_HOME=`pwd`
 wd=`pwd`
 
+export CHPL_LLVM=bundled
+
 mytmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
 myprefix="$mytmpdir/prefix"
 myhome="$mytmpdir/chplhome"


### PR DESCRIPTION
Our testing for `make install` intentionally doesn't source our
common.bash scripts that set up paths to llvm and other things because
it's trying to test the install from a user perspective. We now have to
set CHPL_LLVM to some value, so choose bundled since that's what we're
expecting to become the default.