### PR TITLE
Set CHPL_LLVM=none in clang testing

### DIFF
--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
 export CHPL_HOST_COMPILER=clang
+export CHPL_LLVM=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang"
 

--- a/util/cron/test-linux64-clang38.bash
+++ b/util/cron/test-linux64-clang38.bash
@@ -7,6 +7,7 @@ source $CWD/common.bash
 
 source /data/cf/chapel/setup_clang38.bash     # host-specific setup for target compiler
 export CHPL_HOST_COMPILER=clang
+export CHPL_LLVM=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang38"
 

--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -9,6 +9,7 @@ source $CWD/common-perf.bash
 
 source /data/cf/chapel/setup_clang38.bash
 export CHPL_HOST_COMPILER=clang
+export CHPL_LLVM=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.clang"
 


### PR DESCRIPTION
These tests are testing specific clang backends and are interfering with
CHPL_LLVM=system because their provided llvm is getting used instead. Set
CHPL_LLVM=none to continue testing the clang backends intended.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>