### PR TITLE
Look for gcc libs using multiple environment variables

### DIFF
--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,7 +11,11 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
-export COMPILER_PATH=$GCC_X86_64
+if [[ ! -z ${GCC_X86_64} ]] ; then
+  export COMPILER_PATH=$GCC_X86_64
+elif [[ ! -z ${GCC_PATH} ]] ; then
+  export COMPILER_PATH=$GCC_PATH/snos
+fi
 
 export CHPL_COMM=gasnet
 


### PR DESCRIPTION
Our nightly cray-cs testing didn't have the variable GCC_X86_64 set so it
didn't set COMPILER_PATH correctly. Try looking at both GCC_X86_64 and
GCC_PATH to find what the path should be.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>