### PR TITLE
Use g++ to set COMPILER_PATH on whitebox and cs systems

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -27,7 +27,7 @@ else
 fi
 
 # Point clang to standard libraries
-export COMPILER_PATH=/opt/gcc/default/snos
+export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"
 
 # https://github.com/Cray/chapel-private/issues/1601
 export SLURM_CPU_FREQ_REQ=high

--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -27,7 +27,7 @@ else
 fi
 
 # Point clang to standard libraries
-export COMPILER_PATH=$GCC_X86_64
+export COMPILER_PATH=/opt/gcc/default/snos
 
 # https://github.com/Cray/chapel-private/issues/1601
 export SLURM_CPU_FREQ_REQ=high

--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -5,6 +5,8 @@
 #             Cray CS system, otherwise silent 
 #  output: iff this seems to be a CS, CHPL_HOST_PLATFORM=cray-cs
 
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
 function loadCSModule()
 {
   local m=$@
@@ -27,7 +29,7 @@ else
 fi
 
 # Point clang to standard libraries
-export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"
+source $CWD/common-llvm-comp-path.bash
 
 # https://github.com/Cray/chapel-private/issues/1601
 export SLURM_CPU_FREQ_REQ=high

--- a/util/cron/common-llvm-comp-path.bash
+++ b/util/cron/common-llvm-comp-path.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Set COMPILER_PATH to point to a gnu compiler/library install. This is
+# needed when using the clang in our "system" LLVM installs on systems that
+# have a different organization for libraries than where LLVM/clang were built.
+
+export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"

--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,11 +11,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
-if [[ ! -z ${GCC_X86_64} ]] ; then
-  export COMPILER_PATH=$GCC_X86_64
-elif [[ ! -z ${GCC_PATH} ]] ; then
-  export COMPILER_PATH=$GCC_PATH/snos
-fi
+export COMPILER_PATH=/opt/gcc/default/snos
 
 export CHPL_COMM=gasnet
 

--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,7 +11,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
-export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"
+source $CWD/common-llvm-comp-path.bash
 
 export CHPL_COMM=gasnet
 

--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,7 +11,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
-export COMPILER_PATH=/opt/gcc/default/snos
+export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"
 
 export CHPL_COMM=gasnet
 

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -137,7 +137,7 @@ if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
     source /cray/css/users/chapelu/setup_system_llvm.bash
   fi
   # Make clang aware of standard libraries
-  export COMPILER_PATH=$GCC_X86_64
+  export COMPILER_PATH=/opt/gcc/default/snos
 fi
 
 

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -137,7 +137,7 @@ if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
     source /cray/css/users/chapelu/setup_system_llvm.bash
   fi
   # Make clang aware of standard libraries
-  export COMPILER_PATH=/opt/gcc/default/snos
+  export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"
 fi
 
 

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -137,7 +137,7 @@ if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
     source /cray/css/users/chapelu/setup_system_llvm.bash
   fi
   # Make clang aware of standard libraries
-  export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"
+  source $CWD/common-llvm-comp-path.bash
 fi
 
 


### PR DESCRIPTION
Use g++ --print-file-name=libstdc++.so to define COMPILER_PATH

Use g++ to find the gnu libraries instead of trying to get it from an
environment variable or set it explicitly.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>