### PR TITLE
Add AST nodes for operator calls and parse them

### DIFF
--- a/compiler/next/include/chpl/uast/ASTList.h
+++ b/compiler/next/include/chpl/uast/ASTList.h
@@ -71,6 +71,11 @@ bool updateASTList(ASTList& keep, ASTList& addin);
 void markASTList(Context* context, const ASTList& keep);
 
 /**
+ Returns true if this list only contains Expressions.
+ */
+bool isExpressionASTList(const ASTList& list);
+
+/**
  Defines an iterator over the AST list elements.
  The iterator hides the ownership (it always returns a pointer e.g. ASTNode*)
  and casts elements to a particular type.

--- a/compiler/next/include/chpl/uast/Block.h
+++ b/compiler/next/include/chpl/uast/Block.h
@@ -32,7 +32,12 @@ namespace uast {
  */
 class Block final : public Expression {
  private:
-  Block(ASTList stmts);
+  Block(ASTList stmts)
+    : Expression(asttags::Block, std::move(stmts)) {
+
+    assert(isExpressionASTList(children_));
+  }
+
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/include/chpl/uast/Call.h
+++ b/compiler/next/include/chpl/uast/Call.h
@@ -39,7 +39,7 @@ class Call : public Expression {
   Call(ASTTag tag)
     : Expression(tag), hasCalledExpression_(false) {
   }
-  Call(ASTTag tag, ASTList children, int8_t hasCalledExpression)
+  Call(ASTTag tag, ASTList children, bool hasCalledExpression)
     : Expression(tag, std::move(children)),
       hasCalledExpression_(hasCalledExpression) {
 

--- a/compiler/next/include/chpl/uast/Call.h
+++ b/compiler/next/include/chpl/uast/Call.h
@@ -36,8 +36,16 @@ namespace uast {
 class Call : public Expression {
  protected:
   bool hasCalledExpression_;
-  Call(ASTTag tag);
-  Call(ASTTag tag, ASTList children, int8_t hasCalledExpression);
+  Call(ASTTag tag)
+    : Expression(tag), hasCalledExpression_(false) {
+  }
+  Call(ASTTag tag, ASTList children, int8_t hasCalledExpression)
+    : Expression(tag, std::move(children)),
+      hasCalledExpression_(hasCalledExpression) {
+
+    assert(isExpressionASTList(children_));
+  }
+
   bool callContentsMatchInner(const Call* other) const {
     return true;
   }

--- a/compiler/next/include/chpl/uast/Decl.h
+++ b/compiler/next/include/chpl/uast/Decl.h
@@ -33,7 +33,9 @@ namespace uast {
  */
 class Decl : public Expression {
  protected:
-  Decl(ASTTag tag, owned<Sym> symbol);
+  Decl(ASTTag tag, owned<Sym> sym)
+    : Expression(tag, makeASTList(std::move(sym))) {
+  }
   bool declContentsMatchInner(const Decl* other) const {
     return true;
   }

--- a/compiler/next/include/chpl/uast/ErroneousExpression.h
+++ b/compiler/next/include/chpl/uast/ErroneousExpression.h
@@ -32,7 +32,9 @@ namespace uast {
  */
 class ErroneousExpression final : public Expression {
  private:
-  ErroneousExpression();
+  ErroneousExpression()
+    : Expression(asttags::ErroneousExpression) {
+  }
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/include/chpl/uast/Expression.h
+++ b/compiler/next/include/chpl/uast/Expression.h
@@ -31,8 +31,12 @@ namespace uast {
  */
 class Expression : public ASTNode {
  protected:
-  Expression(ASTTag tag);
-  Expression(ASTTag tag, ASTList children);
+   Expression(asttags::ASTTag tag)
+    : ASTNode(tag) {
+  }
+  Expression(asttags::ASTTag tag, ASTList children)
+    : ASTNode(tag, std::move(children)) {
+  }
   bool expressionContentsMatchInner(const Expression* other) const {
     return true;
   }

--- a/compiler/next/include/chpl/uast/FnCall.h
+++ b/compiler/next/include/chpl/uast/FnCall.h
@@ -35,15 +35,20 @@ namespace uast {
  */
 class FnCall : public Call {
  private:
-  FnCall(ASTList children, std::vector<UniqueString> actualNames,
-         bool callUsedSquareBrackets);
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
   // For each actual (matching Call's actuals), what are the names?
   // if the actual is unnamed, it is the empty string.
   // If no actuals are named, it is the empty vector.
   std::vector<UniqueString> actualNames_;
   bool callUsedSquareBrackets_;
+
+  FnCall(ASTList children, std::vector<UniqueString> actualNames,
+         bool callUsedSquareBrackets)
+    : Call(asttags::FnCall, std::move(children), /* hasCalledExpression */ 1),
+      actualNames_(std::move(actualNames)),
+      callUsedSquareBrackets_(callUsedSquareBrackets) {
+  }
+  bool contentsMatchInner(const ASTNode* other) const override;
+  void markUniqueStringsInner(Context* context) const override;
 
  public:
   ~FnCall() override = default;

--- a/compiler/next/include/chpl/uast/Identifier.h
+++ b/compiler/next/include/chpl/uast/Identifier.h
@@ -44,7 +44,12 @@ class Identifier final : public Expression {
  private:
   UniqueString name_;
 
-  Identifier(UniqueString name);
+  Identifier(UniqueString name)
+    : Expression(asttags::Identifier), name_(name) {
+
+    assert(!name.isEmpty());
+  }
+
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/include/chpl/uast/Literal.h
+++ b/compiler/next/include/chpl/uast/Literal.h
@@ -20,7 +20,7 @@
 #ifndef CHPL_UAST_LITERAL_H
 #define CHPL_UAST_LITERAL_H
 
-#include "chpl/uast/Exp.h"
+#include "chpl/uast/Expression.h"
 
 namespace chpl {
 namespace uast {
@@ -37,7 +37,7 @@ namespace uast {
     1 2.0 3.0i "string" b"bytes"
   \endrst
  */
-class Literal final : public Exp {
+class Literal final : public Expression {
   // TODO: move over 'ifa' code
 };
 

--- a/compiler/next/include/chpl/uast/Module.h
+++ b/compiler/next/include/chpl/uast/Module.h
@@ -51,9 +51,12 @@ class Module final : public Sym {
  private:
   Tag tag_;
 
-  Module(ASTList children,
-         UniqueString name, Sym::Visibility vis,
-         Module::Tag tag);
+  Module(ASTList children, UniqueString name,
+         Sym::Visibility vis, Module::Tag tag)
+    : Sym(asttags::Module, std::move(children), name, vis), tag_(tag) {
+
+    assert(isExpressionASTList(children_));
+  }
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/include/chpl/uast/ModuleDecl.h
+++ b/compiler/next/include/chpl/uast/ModuleDecl.h
@@ -41,7 +41,9 @@ namespace uast {
  */
 class ModuleDecl final : public Decl {
  private:
-  ModuleDecl(owned<Module> module);
+  ModuleDecl(owned<Module> module)
+    : Decl(asttags::ModuleDecl, std::move(module)) {
+  }
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/include/chpl/uast/OpCall.h
+++ b/compiler/next/include/chpl/uast/OpCall.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UAST_OPCALL_H
 #define CHPL_UAST_OPCALL_H
 
+#include "chpl/queries/Location.h"
+#include "chpl/queries/UniqueString.h"
 #include "chpl/uast/Call.h"
 
 namespace chpl {
@@ -34,13 +36,31 @@ class OpCall final : public Call {
   // which operator
   UniqueString op_;
 
-  bool matchesInner(const ASTNode* other) const override;
+  OpCall(ASTList children, UniqueString op)
+    : Call(asttags::OpCall, std::move(children), /* hasCalledExpression */ 0),
+      op_(op) {
+  }
+  bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
+
  public:
   ~OpCall() override = default;
+  static owned<OpCall> build(Builder* builder,
+                             Location loc,
+                             UniqueString op,
+                             owned<Expression> lhs,
+                             owned<Expression> rhs);
+  static owned<OpCall> build(Builder* builder,
+                             Location loc,
+                             UniqueString op,
+                             owned<Expression> expr);
 
   /** Returns the name of the operator called */
-  UniqueString operatorName() const { return op_; }
+  UniqueString op() const { return op_; }
+  /** Returns true if this is a binary operator */
+  bool isBinaryOp() const { return children_.size() == 2; }
+  /** Returns true if this is a unary operator */
+  bool isUnaryOp() const { return children_.size() == 1; }
 };
 
 

--- a/compiler/next/include/chpl/uast/OpCall.h
+++ b/compiler/next/include/chpl/uast/OpCall.h
@@ -37,7 +37,8 @@ class OpCall final : public Call {
   UniqueString op_;
 
   OpCall(ASTList children, UniqueString op)
-    : Call(asttags::OpCall, std::move(children), /* hasCalledExpression */ 0),
+    : Call(asttags::OpCall, std::move(children),
+           /* hasCalledExpression */ false),
       op_(op) {
   }
   bool contentsMatchInner(const ASTNode* other) const override;

--- a/compiler/next/include/chpl/uast/Variable.h
+++ b/compiler/next/include/chpl/uast/Variable.h
@@ -62,8 +62,20 @@ class Variable final : public Sym {
   int8_t initExpressionChildNum;
 
   Variable(ASTList children,
-           UniqueString name, Sym::Visibility vis, Tag tag,
-           int8_t typeExpressionChildNum, int8_t initExpressionChildNum);
+           UniqueString name, Sym::Visibility vis,
+           Variable::Tag tag,
+           int8_t typeExpressionChildNum,
+           int8_t initExpressionChildNum)
+    : Sym(asttags::Variable, std::move(children), name, vis),
+      tag_(tag),
+      typeExpressionChildNum(typeExpressionChildNum),
+      initExpressionChildNum(initExpressionChildNum) {
+
+    assert(-1 <= typeExpressionChildNum && typeExpressionChildNum <= 1);
+    assert(-1 <= initExpressionChildNum && initExpressionChildNum <= 1);
+    assert(numChildren() <= 2);
+    assert(isExpressionASTList(children_));
+  }
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/include/chpl/uast/VariableDecl.h
+++ b/compiler/next/include/chpl/uast/VariableDecl.h
@@ -48,7 +48,9 @@ namespace uast {
  */
 class VariableDecl final : public Decl {
  private:
-  VariableDecl(owned<Variable> variable);
+  VariableDecl(owned<Variable> variable)
+    : Decl(asttags::VariableDecl, std::move(variable)) {
+  }
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 

--- a/compiler/next/lib/frontend/Parser/ParserContext.h
+++ b/compiler/next/lib/frontend/Parser/ParserContext.h
@@ -155,6 +155,15 @@ struct ParserContext {
 
   Location convertLocation(YYLTYPE location);
 
+  Identifier* buildEmptyIdent(YYLTYPE location);
+  Identifier* buildIdent(YYLTYPE location, PODUniqueString name);
+  OpCall* buildBinOp(YYLTYPE location,
+                     Expression* lhs, PODUniqueString op, Expression* rhs);
+  OpCall* buildUnaryOp(YYLTYPE location,
+                       PODUniqueString op, Expression* expr);
+
+
+
   // Do we really need these?
   /*
   int         captureTokens; // no, new AST meant to be more faithful to src;

--- a/compiler/next/lib/frontend/Parser/ParserContextImpl.h
+++ b/compiler/next/lib/frontend/Parser/ParserContextImpl.h
@@ -264,3 +264,25 @@ Location ParserContext::convertLocation(YYLTYPE location) {
                   location.last_line,
                   location.last_column);
 }
+
+Identifier* ParserContext::buildEmptyIdent(YYLTYPE location) {
+  UniqueString empty;
+  return Identifier::build(builder, convertLocation(location), empty).release();
+}
+Identifier* ParserContext::buildIdent(YYLTYPE location, PODUniqueString name) {
+  return Identifier::build(builder, convertLocation(location), name).release();
+}
+
+OpCall* ParserContext::buildBinOp(YYLTYPE location,
+                                  Expression* lhs,
+                                  PODUniqueString op,
+                                  Expression* rhs) {
+  return OpCall::build(builder, convertLocation(location),
+                       op, toOwned(lhs), toOwned(rhs)).release();
+}
+OpCall* ParserContext::buildUnaryOp(YYLTYPE location,
+                                    PODUniqueString op,
+                                    Expression* expr) {
+  return OpCall::build(builder, convertLocation(location),
+                       op, toOwned(expr)).release();
+}

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -400,50 +400,57 @@
 //
 // keywords (alphabetical)
 //
-%token TALIGN TAS TATOMIC
-%token TBEGIN TBREAK TBOOL TBORROWED TBY TBYTES
-%token TCATCH TCLASS TCOBEGIN TCOFORALL TCOMPLEX TCONFIG TCONST TCONTINUE
-%token TDEFER TDELETE TDMAPPED TDO TDOMAIN
-%token TELSE TENUM TEXCEPT TEXPORT TEXTERN
-%token TFALSE TFOR TFORALL TFOREACH TFORWARDING
-%token TIF TIMAG TIMPORT TIN TINCLUDE
-%token TINDEX TINLINE TINOUT TINT TITER TINITEQUALS
-%token TIMPLEMENTS TINTERFACE
-%token TLABEL TLAMBDA TLET TLIFETIME TLOCAL TLOCALE
-%token TMINUSMINUS TMODULE
-%token TNEW TNIL TNOINIT TNONE TNOTHING
-%token TON TONLY TOPERATOR TOTHERWISE TOUT TOVERRIDE TOWNED
-%token TPARAM TPLUSPLUS TPRAGMA TPRIMITIVE TPRIVATE TPROC TPROTOTYPE TPUBLIC
-%token TREAL TRECORD TREDUCE TREF TREQUIRE TRETURN
-%token TSCAN TSELECT TSERIAL TSHARED TSINGLE TSPARSE TSTRING TSUBDOMAIN TSYNC
-%token TTHEN TTHIS TTHROW TTHROWS TTRUE TTRY TTRYBANG TTYPE
-%token TUINT TUNDERSCORE TUNION TUNMANAGED TUSE
-%token TVAR TVOID
-%token TWHEN TWHERE TWHILE TWITH
-%token TYIELD
-%token TZIP
+%token <uniqueStr> TALIGN TAS TATOMIC
+%token <uniqueStr> TBEGIN TBREAK TBOOL TBORROWED TBY TBYTES
+%token <uniqueStr> TCATCH TCLASS TCOBEGIN TCOFORALL TCOMPLEX
+%token <uniqueStr> TCONFIG TCONST TCONTINUE
+%token <uniqueStr> TDEFER TDELETE TDMAPPED TDO TDOMAIN
+%token <uniqueStr> TELSE TENUM TEXCEPT TEXPORT TEXTERN
+%token <uniqueStr> TFALSE TFOR TFORALL TFOREACH TFORWARDING
+%token <uniqueStr> TIF TIMAG TIMPORT TIN TINCLUDE
+%token <uniqueStr> TINDEX TINLINE TINOUT TINT TITER TINITEQUALS
+%token <uniqueStr> TIMPLEMENTS TINTERFACE
+%token <uniqueStr> TLABEL TLAMBDA TLET TLIFETIME TLOCAL TLOCALE
+%token <uniqueStr> TMINUSMINUS TMODULE
+%token <uniqueStr> TNEW TNIL TNOINIT TNONE TNOTHING
+%token <uniqueStr> TON TONLY TOPERATOR TOTHERWISE TOUT TOVERRIDE TOWNED
+%token <uniqueStr> TPARAM TPLUSPLUS TPRAGMA TPRIMITIVE TPRIVATE
+%token <uniqueStr> TPROC TPROTOTYPE TPUBLIC
+%token <uniqueStr> TREAL TRECORD TREDUCE TREF TREQUIRE TRETURN
+%token <uniqueStr> TSCAN TSELECT TSERIAL TSHARED TSINGLE TSPARSE
+%token <uniqueStr> TSTRING TSUBDOMAIN TSYNC
+%token <uniqueStr> TTHEN TTHIS TTHROW TTHROWS TTRUE TTRY TTRYBANG TTYPE
+%token <uniqueStr> TUINT TUNDERSCORE TUNION TUNMANAGED TUSE
+%token <uniqueStr> TVAR TVOID
+%token <uniqueStr> TWHEN TWHERE TWHILE TWITH
+%token <uniqueStr> TYIELD
+%token <uniqueStr> TZIP
 
 //
 // operators and punctuation (alphabetical)
 //
-%token TALIAS TAND TASSIGN TASSIGNBAND TASSIGNBOR TASSIGNBXOR TASSIGNDIVIDE
-%token TASSIGNEXP TASSIGNLAND TASSIGNLOR TASSIGNMINUS TASSIGNMOD
-%token TASSIGNMULTIPLY TASSIGNPLUS TASSIGNREDUCE TASSIGNSL TASSIGNSR
-%token TBANG TBAND TBNOT TBOR TBXOR
-%token TCOLON TCOMMA
-%token TDIVIDE TDOT TDOTDOT TDOTDOTDOT
-%token TEQUAL TEXP TGREATER
-%token TGREATEREQUAL
-%token THASH
-%token TIO
-%token TLESS
-%token TLESSEQUAL
-%token TMINUS TMOD
-%token TNOTEQUAL
-%token TOR
-%token TPLUS
-%token TQUESTION
-%token TSEMI TSHIFTLEFT TSHIFTRIGHT TSTAR TSWAP
+%token <uniqueStr> TALIAS TAND
+%token <uniqueStr> TASSIGN
+%token <uniqueStr> TASSIGNBAND TASSIGNBOR TASSIGNBXOR
+%token <uniqueStr> TASSIGNDIVIDE TASSIGNEXP
+%token <uniqueStr> TASSIGNLAND TASSIGNLOR TASSIGNMINUS TASSIGNMOD
+%token <uniqueStr> TASSIGNMULTIPLY TASSIGNPLUS TASSIGNREDUCE
+%token <uniqueStr> TASSIGNSL TASSIGNSR
+%token <uniqueStr> TBANG TBAND TBNOT TBOR TBXOR
+%token <uniqueStr> TCOLON TCOMMA
+%token <uniqueStr> TDIVIDE TDOT TDOTDOT TDOTDOTDOT
+%token <uniqueStr> TEQUAL TEXP TGREATER
+%token <uniqueStr> TGREATEREQUAL
+%token <uniqueStr> THASH
+%token <uniqueStr> TIO
+%token <uniqueStr> TLESS
+%token <uniqueStr> TLESSEQUAL
+%token <uniqueStr> TMINUS TMOD
+%token <uniqueStr> TNOTEQUAL
+%token <uniqueStr> TOR
+%token <uniqueStr> TPLUS
+%token <uniqueStr> TQUESTION
+%token <uniqueStr> TSEMI TSHIFTLEFT TSHIFTRIGHT TSTAR TSWAP
 
 //
 // braces
@@ -850,7 +857,7 @@ use_renames_ls:
 | expr TAS TUNDERSCORE
     {
       $$ = new RenameList();
-      PotentialRename cur($1, Identifier::build(BUILDER, LOC(@3), STR("_")));
+      PotentialRename cur($1, context->buildIdent(@3, $3));
       $$->push_back(cur);
     }
 | use_renames_ls TCOMMA expr
@@ -865,7 +872,7 @@ use_renames_ls:
      }
 | use_renames_ls TCOMMA expr TAS TUNDERSCORE
      {
-       PotentialRename cur($3, Identifier::build(BUILDER, LOC(@5), STR("_")));
+       PotentialRename cur($3, context->buildIdent(@5, $5));
        $1->push_back(cur);
      }
 ;
@@ -875,7 +882,7 @@ opt_only_ls:
   /* nothing */
     {
       $$ = new RenameList();
-      PotentialRename cur(Identifier::build(BUILDER, LOC(@$), STR("")));
+      PotentialRename cur(context->buildEmptyIdent(@$));
       $$->push_back(cur);
     }
 | renames_ls
@@ -885,7 +892,7 @@ except_ls:
   TSTAR
     {
       $$ = new RenameList();
-      PotentialRename cur(Identifier::build(BUILDER, LOC(@1), STR("")));
+      PotentialRename cur(context->buildEmptyIdent(@1));
       $$->push_back(cur);
      }
 | renames_ls
@@ -963,27 +970,27 @@ require_stmt:
 assignment_stmt:
   lhs_expr assignop_ident opt_try_expr TSEMI
     {
-      $$ = TODOSTMT(@$);
+      $$ = STMT(@$, context->buildBinOp(@$, $1, $2, $3));
     }
 | lhs_expr TSWAP           opt_try_expr TSEMI
     {
-      $$ = TODOSTMT(@$);
+      $$ = STMT(@$, context->buildBinOp(@$, $1, $2, $3));
     }
 | lhs_expr TASSIGNREDUCE   opt_try_expr TSEMI
     {
-      $$ = TODOSTMT(@$);
+      $$ = STMT(@$, context->buildBinOp(@$, $1, $2, $3));
     }
 | lhs_expr TASSIGNLAND     opt_try_expr TSEMI
     {
-      $$ = TODOSTMT(@$);
+      $$ = STMT(@$, context->buildBinOp(@$, $1, $2, $3));
     }
 | lhs_expr TASSIGNLOR      opt_try_expr TSEMI
     {
-      $$ = TODOSTMT(@$);
+      $$ = STMT(@$, context->buildBinOp(@$, $1, $2, $3));
     }
 | lhs_expr TASSIGN         TNOINIT TSEMI
     {
-      $$ = TODOSTMT(@$);
+      $$ = STMT(@$, context->buildBinOp(@$, $1, $2, context->buildIdent(@3, $3)));
     }
 ;
 
@@ -996,18 +1003,18 @@ opt_label_ident:
 
 ident_fn_def:
   TIDENT                   { $$ = $1; }
-| TNONE                    { $$ = STR("none"); ERROR(@$, "redefining reserved word 'none'"); }
-| TTHIS                    { $$ = STR("this"); }
-| TFALSE                   { $$ = STR("false"); ERROR(@$, "redefining reserved word 'false'"); }
-| TTRUE                    { $$ = STR("true"); ERROR(@$, "redefining reserved word 'true'"); }
+| TNONE                    { $$ = $1; ERROR(@$, "redefining reserved word 'none'"); }
+| TTHIS                    { $$ = $1; }
+| TFALSE                   { $$ = $1; ERROR(@$, "redefining reserved word 'false'"); }
+| TTRUE                    { $$ = $1; ERROR(@$, "redefining reserved word 'true'"); }
 | internal_type_ident_def  { $$ = $1; ERROR(@$, "redefining reserved word"); }
 
 ident_def:
   TIDENT                   { $$ = $1; }
-| TNONE                    { $$ = STR("none"); ERROR(@$, "redefining reserved word 'none'"); }
-| TTHIS                    { $$ = STR("this"); ERROR(@$, "redefining reserved word 'this'"); }
-| TFALSE                   { $$ = STR("false"); ERROR(@$, "redefining reserved word 'false'"); }
-| TTRUE                    { $$ = STR("true"); ERROR(@$, "redefining reserved word 'true'"); }
+| TNONE                    { $$ = $1; ERROR(@$, "redefining reserved word 'none'"); }
+| TTHIS                    { $$ = $1; ERROR(@$, "redefining reserved word 'this'"); }
+| TFALSE                   { $$ = $1; ERROR(@$, "redefining reserved word 'false'"); }
+| TTRUE                    { $$ = $1; ERROR(@$, "redefining reserved word 'true'"); }
 | internal_type_ident_def  { $$ = $1; ERROR(@$, "redefining reserved word"); }
 ;
 
@@ -1021,7 +1028,7 @@ ident_def:
  */
 ident_use:
   TIDENT                   { $$ = $1; }
-| TTHIS                    { $$ = STR("this"); }
+| TTHIS                    { $$ = $1; }
 ;
 
 internal_type_ident_def:
@@ -1032,25 +1039,25 @@ internal_type_ident_def:
     Uses of these types are parsed differently.
     See scalar_type and reserved_type_ident_use.
   */
-  TBOOL      { $$ = STR("bool"); }
-| TINT       { $$ = STR("int"); }
-| TUINT      { $$ = STR("uint"); }
-| TREAL      { $$ = STR("real"); }
-| TIMAG      { $$ = STR("imag"); }
-| TCOMPLEX   { $$ = STR("complex"); }
-| TBYTES     { $$ = STR("bytes"); }
-| TSTRING    { $$ = STR("string"); }
-| TSYNC      { $$ = STR("sync"); }
-| TSINGLE    { $$ = STR("single"); }
-| TOWNED     { $$ = STR("owned"); }
-| TSHARED    { $$ = STR("shared"); }
-| TBORROWED  { $$ = STR("borrowed"); }
-| TUNMANAGED { $$ = STR("unmanaged"); }
-| TDOMAIN    { $$ = STR("domain"); }
-| TINDEX     { $$ = STR("index"); }
-| TLOCALE    { $$ = STR("locale"); }
-| TNOTHING   { $$ = STR("nothing"); }
-| TVOID      { $$ = STR("void"); }
+  TBOOL
+| TINT
+| TUINT
+| TREAL
+| TIMAG
+| TCOMPLEX
+| TBYTES
+| TSTRING
+| TSYNC
+| TSINGLE
+| TOWNED
+| TSHARED
+| TBORROWED
+| TUNMANAGED
+| TDOMAIN
+| TINDEX
+| TLOCALE
+| TNOTHING
+| TVOID
 ;
 
 scalar_type:
@@ -2025,7 +2032,7 @@ opt_ret_type:
                                  { $$ = nullptr; }
 | TCOLON type_level_expr         { $$ = $2; }
 | TCOLON ret_array_type          { $$ = $2; }
-| TCOLON reserved_type_ident_use { $$ = Identifier::build(BUILDER, LOC(@2), $2).release(); }
+| TCOLON reserved_type_ident_use { $$ = context->buildIdent(@2, $2); }
 | error                          { $$ = ErroneousExpression::build(BUILDER, LOC(@1)).release(); }
 ;
 
@@ -2034,7 +2041,7 @@ opt_type:
                                  { $$ = nullptr; }
 | TCOLON type_level_expr         { $$ = $2; }
 | TCOLON array_type              { $$ = $2; }
-| TCOLON reserved_type_ident_use { $$ = Identifier::build(BUILDER, LOC(@2), $2).release(); }
+| TCOLON reserved_type_ident_use { $$ = context->buildIdent(@2, $2); }
 | error                          { $$ = ErroneousExpression::build(BUILDER, LOC(@1)).release(); }
 ;
 
@@ -2100,7 +2107,7 @@ opt_formal_type:
                                  { $$ = nullptr; }
 | TCOLON type_level_expr         { $$ = $2; }
 | TCOLON query_expr              { $$ = $2; }
-| TCOLON reserved_type_ident_use { $$ = Identifier::build(BUILDER, LOC(@2), $2).release(); }
+| TCOLON reserved_type_ident_use { $$ = context->buildIdent(@2, $2); }
 | TCOLON formal_array_type       { $$ = $2; }
 ;
 
@@ -2119,7 +2126,7 @@ simple_expr_ls:
 ;
 
 tuple_component:
-  TUNDERSCORE   { $$ = Identifier::build(BUILDER, LOC(@1), STR("_")).release(); }
+  TUNDERSCORE   { $$ = context->buildIdent(@1, $1); }
 | opt_try_expr  { $$ = $1; }
 | query_expr    { $$ = $1; }
 ;
@@ -2156,7 +2163,7 @@ actual_expr:
 ;
 
 ident_expr:
-  ident_use      { $$ = Identifier::build(BUILDER, LOC(@1), $1).release(); }
+  ident_use      { $$ = context->buildIdent(@1, $1); }
 | scalar_type    { $$ = $1; }
 ;
 
@@ -2269,7 +2276,7 @@ cond_expr:
 ;
 
 nil_expr:
-  TNIL      { $$ = Identifier::build(BUILDER, LOC(@1), STR("nil")).release(); }
+  TNIL      { $$ = context->buildIdent(@1, $1); }
 ;
 
 /* Expressions permitted at the statement level as <stmt_level_expr> TSEMI.
@@ -2536,39 +2543,41 @@ assoc_expr_ls:
 ;
 
 binary_op_expr:
-  expr TPLUS expr          { $$ = TODOEXPR(@$); }
-| expr TMINUS expr         { $$ = TODOEXPR(@$); }
-| expr TSTAR expr          { $$ = TODOEXPR(@$); }
-| expr TDIVIDE expr        { $$ = TODOEXPR(@$); }
-| expr TSHIFTLEFT expr     { $$ = TODOEXPR(@$); }
-| expr TSHIFTRIGHT expr    { $$ = TODOEXPR(@$); }
-| expr TMOD expr           { $$ = TODOEXPR(@$); }
-| expr TEQUAL expr         { $$ = TODOEXPR(@$); }
-| expr TNOTEQUAL expr      { $$ = TODOEXPR(@$); }
-| expr TLESSEQUAL expr     { $$ = TODOEXPR(@$); }
-| expr TGREATEREQUAL expr  { $$ = TODOEXPR(@$); }
-| expr TLESS expr          { $$ = TODOEXPR(@$); }
-| expr TGREATER expr       { $$ = TODOEXPR(@$); }
-| expr TBAND expr          { $$ = TODOEXPR(@$); }
-| expr TBOR expr           { $$ = TODOEXPR(@$); }
-| expr TBXOR expr          { $$ = TODOEXPR(@$); }
-| expr TAND expr           { $$ = TODOEXPR(@$); }
-| expr TOR  expr           { $$ = TODOEXPR(@$); }
-| expr TEXP expr           { $$ = TODOEXPR(@$); }
-| expr TBY expr            { $$ = TODOEXPR(@$); }
-| expr TALIGN expr         { $$ = TODOEXPR(@$); }
-| expr THASH expr          { $$ = TODOEXPR(@$); }
-| expr TDMAPPED expr       { $$ = TODOEXPR(@$); }
+  expr TPLUS expr          { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TMINUS expr         { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TSTAR expr          { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TDIVIDE expr        { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TSHIFTLEFT expr     { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TSHIFTRIGHT expr    { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TMOD expr           { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TEQUAL expr         { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TNOTEQUAL expr      { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TLESSEQUAL expr     { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TGREATEREQUAL expr  { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TLESS expr          { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TGREATER expr       { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TBAND expr          { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TBOR expr           { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TBXOR expr          { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TAND expr           { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TOR  expr           { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TEXP expr           { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TBY expr            { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TALIGN expr         { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr THASH expr          { $$ = context->buildBinOp(@$, $1, $2, $3); }
+| expr TDMAPPED expr       { $$ = context->buildBinOp(@$, $1, $2, $3); }
 ;
 
 unary_op_expr:
-  TPLUS expr %prec TUPLUS         { $$ = TODOEXPR(@$); }
-| TMINUS expr %prec TUMINUS       { $$ = TODOEXPR(@$); }
-| TMINUSMINUS expr %prec TUMINUS  { $$ = TODOEXPR(@$); /* warn */ }
-| TPLUSPLUS expr %prec TUPLUS     { $$ = TODOEXPR(@$); /* warn */ }
-| TBANG expr %prec TLNOT          { $$ = TODOEXPR(@$); }
-| expr TBANG                      { $$ = TODOEXPR(@$); }
-| TBNOT expr                      { $$ = TODOEXPR(@$); }
+  TPLUS expr %prec TUPLUS        { $$ = context->buildUnaryOp(@$, $1, $2); }
+| TMINUS expr %prec TUMINUS      { $$ = context->buildUnaryOp(@$, $1, $2); }
+| TMINUSMINUS expr %prec TUMINUS { $$ = TODOEXPR(@$); /* warn */ }
+| TPLUSPLUS expr %prec TUPLUS    { $$ = TODOEXPR(@$); /* warn */ }
+| TBANG expr %prec TLNOT         { $$ = context->buildUnaryOp(@$, $1, $2); }
+| expr TBANG                     { $$ = context->buildUnaryOp(@$,
+                                                              STR("postfix!"),
+                                                              $1); }
+| TBNOT expr                     { $$ = context->buildUnaryOp(@$, $1, $2); }
 ;
 
 reduce_expr:

--- a/compiler/next/lib/frontend/Parser/parser-dependencies.h
+++ b/compiler/next/lib/frontend/Parser/parser-dependencies.h
@@ -37,6 +37,7 @@
 #include "chpl/uast/Local.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/ModuleDecl.h"
+#include "chpl/uast/OpCall.h"
 #include "chpl/uast/Serial.h"
 #include "chpl/uast/Sym.h"
 #include "chpl/uast/Variable.h"

--- a/compiler/next/lib/uast/ASTList.cpp
+++ b/compiler/next/lib/uast/ASTList.cpp
@@ -183,6 +183,14 @@ void markASTList(Context* context, const ASTList& keep) {
   }
 }
 
+bool isExpressionASTList(const ASTList& list) {
+  for (const auto& elt: list) {
+    if (!elt->isExpression())
+      return false;
+  }
+  return true;
+}
+
 
 } // end namespace uast
 } // end namespace chpl

--- a/compiler/next/lib/uast/Block.cpp
+++ b/compiler/next/lib/uast/Block.cpp
@@ -25,17 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-Block::Block(ASTList stmts) :
-  Expression(asttags::Block, std::move(stmts)) {
-
-#ifndef NDEBUG
-  // check that all children are exprs (and not, say, Symbols)
-  for (const ASTNode* child : this->children()) {
-    assert(child->isExpression());
-  }
-#endif
-}
-
 bool Block::contentsMatchInner(const ASTNode* other) const {
   const Block* lhs = this;
   const Block* rhs = (const Block*) other;

--- a/compiler/next/lib/uast/CMakeLists.txt
+++ b/compiler/next/lib/uast/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(libchplcomp-obj
                Local.cpp
                Module.cpp
                ModuleDecl.cpp
+               OpCall.cpp
                Serial.cpp
                Sym.cpp
                Variable.cpp

--- a/compiler/next/lib/uast/Call.cpp
+++ b/compiler/next/lib/uast/Call.cpp
@@ -23,23 +23,6 @@ namespace chpl {
 namespace uast {
 
 
-Call::Call(ASTTag tag)
-  : Expression(tag), hasCalledExpression_(0) {
-}
-
-Call::Call(ASTTag tag, ASTList children, int8_t hasCalledExpression)
-  : Expression(tag, std::move(children)),
-    hasCalledExpression_(hasCalledExpression) {
-
-  assert(0 <= hasCalledExpression_ && hasCalledExpression_ <= 1);
-#ifndef NDEBUG
-  // check that all children are exprs (and not, say, Syms)
-  for (const ASTNode* child : this->children()) {
-    assert(child->isExpression());
-  }
-#endif
-}
-
 Call::~Call() {
 }
 

--- a/compiler/next/lib/uast/Decl.cpp
+++ b/compiler/next/lib/uast/Decl.cpp
@@ -23,10 +23,6 @@ namespace chpl {
 namespace uast {
 
 
-Decl::Decl(ASTTag tag, owned<Sym> sym)
-  : Expression(tag, makeASTList(std::move(sym))) {
-}
-
 Decl::~Decl() {
 }
 

--- a/compiler/next/lib/uast/ErroneousExpression.cpp
+++ b/compiler/next/lib/uast/ErroneousExpression.cpp
@@ -25,10 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-ErroneousExpression::ErroneousExpression()
-  : Expression(asttags::ErroneousExpression) {
-}
-
 bool ErroneousExpression::contentsMatchInner(const ASTNode* other) const {
   const ErroneousExpression* lhs = this;
   const ErroneousExpression* rhs = (const ErroneousExpression*) other;

--- a/compiler/next/lib/uast/Expression.cpp
+++ b/compiler/next/lib/uast/Expression.cpp
@@ -23,14 +23,6 @@ namespace chpl {
 namespace uast {
 
 
-Expression::Expression(asttags::ASTTag tag)
-  : ASTNode(tag) {
-}
-
-Expression::Expression(asttags::ASTTag tag, ASTList children)
-  : ASTNode(tag, std::move(children)) {
-}
-
 Expression::~Expression() {
 }
 

--- a/compiler/next/lib/uast/FnCall.cpp
+++ b/compiler/next/lib/uast/FnCall.cpp
@@ -24,14 +24,6 @@
 namespace chpl {
 namespace uast {
 
-FnCall::FnCall(ASTList children,
-               std::vector<UniqueString> actualNames,
-               bool callUsedSquareBrackets)
-  : Call(asttags::FnCall, std::move(children), /* hasCalledExpression */ 1),
-    actualNames_(std::move(actualNames)),
-    callUsedSquareBrackets_(callUsedSquareBrackets) {
-}
-
 bool FnCall::contentsMatchInner(const ASTNode* other) const {
   const FnCall* lhs = this;
   const FnCall* rhs = (const FnCall*) other;

--- a/compiler/next/lib/uast/Identifier.cpp
+++ b/compiler/next/lib/uast/Identifier.cpp
@@ -25,10 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-Identifier::Identifier(UniqueString name)
-  : Expression(asttags::Identifier), name_(name) {
-}
-
 bool Identifier::contentsMatchInner(const ASTNode* other) const {
   const Identifier* lhs = this;
   const Identifier* rhs = (const Identifier*) other;

--- a/compiler/next/lib/uast/Module.cpp
+++ b/compiler/next/lib/uast/Module.cpp
@@ -25,18 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-Module::Module(ASTList children, UniqueString name, Sym::Visibility vis,
-               Module::Tag tag)
-  : Sym(asttags::Module, std::move(children), name, vis), tag_(tag) {
-
-#ifndef NDEBUG
-  // check that all children are exprs (and not, say, Syms)
-  for (const ASTNode* child : this->children()) {
-    assert(child->isExpression());
-  }
-#endif
-}
-
 bool Module::contentsMatchInner(const ASTNode* other) const {
   const Module* lhs = this;
   const Module* rhs = (const Module*) other;

--- a/compiler/next/lib/uast/ModuleDecl.cpp
+++ b/compiler/next/lib/uast/ModuleDecl.cpp
@@ -25,10 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-ModuleDecl::ModuleDecl(owned<Module> module)
-  : Decl(asttags::ModuleDecl, std::move(module)) {
-}
-
 bool ModuleDecl::contentsMatchInner(const ASTNode* other) const {
   const ModuleDecl* lhs = this;
   const ModuleDecl* rhs = (const ModuleDecl*) other;

--- a/compiler/next/lib/uast/OpCall.cpp
+++ b/compiler/next/lib/uast/OpCall.cpp
@@ -28,10 +28,10 @@ bool OpCall::contentsMatchInner(const ASTNode* other) const {
   const OpCall* lhs = this;
   const OpCall* rhs = (const OpCall*) other;
 
-  if (!lhs->callContentsMatchInner(rhs))
+  if (lhs->op_ != rhs->op_)
     return false;
 
-  if (lhs->op_ != rhs->op_)
+  if (!lhs->callContentsMatchInner(rhs))
     return false;
 
   return true;
@@ -48,12 +48,12 @@ owned<OpCall> OpCall::build(Builder* builder,
                             UniqueString op,
                             owned<Expression> lhs,
                             owned<Expression> rhs) {
-  ASTList lst;
+  ASTList list;
 
-  lst.push_back(std::move(lhs));
-  lst.push_back(std::move(rhs));
+  list.push_back(std::move(lhs));
+  list.push_back(std::move(rhs));
 
-  OpCall* ret = new OpCall(std::move(lst), op);
+  OpCall* ret = new OpCall(std::move(list), op);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }
@@ -61,11 +61,11 @@ owned<OpCall> OpCall::build(Builder* builder,
                             Location loc,
                             UniqueString op,
                             owned<Expression> expr) {
-  ASTList lst;
+  ASTList list;
 
-  lst.push_back(std::move(expr));
+  list.push_back(std::move(expr));
 
-  OpCall* ret = new OpCall(std::move(lst), op);
+  OpCall* ret = new OpCall(std::move(list), op);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/lib/uast/OpCall.cpp
+++ b/compiler/next/lib/uast/OpCall.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/uast/OpCall.h"
+
+#include "chpl/uast/Builder.h"
+
+namespace chpl {
+namespace uast {
+
+bool OpCall::contentsMatchInner(const ASTNode* other) const {
+  const OpCall* lhs = this;
+  const OpCall* rhs = (const OpCall*) other;
+
+  if (!lhs->callContentsMatchInner(rhs))
+    return false;
+
+  if (lhs->op_ != rhs->op_)
+    return false;
+
+  return true;
+}
+void OpCall::markUniqueStringsInner(Context* context) const {
+
+  callMarkUniqueStringsInner(context);
+
+  op_.mark(context);
+}
+
+owned<OpCall> OpCall::build(Builder* builder,
+                            Location loc,
+                            UniqueString op,
+                            owned<Expression> lhs,
+                            owned<Expression> rhs) {
+  ASTList lst;
+
+  lst.push_back(std::move(lhs));
+  lst.push_back(std::move(rhs));
+
+  OpCall* ret = new OpCall(std::move(lst), op);
+  builder->noteLocation(ret, loc);
+  return toOwned(ret);
+}
+owned<OpCall> OpCall::build(Builder* builder,
+                            Location loc,
+                            UniqueString op,
+                            owned<Expression> expr) {
+  ASTList lst;
+
+  lst.push_back(std::move(expr));
+
+  OpCall* ret = new OpCall(std::move(lst), op);
+  builder->noteLocation(ret, loc);
+  return toOwned(ret);
+}
+
+
+} // namespace uast
+} // namespace chpl

--- a/compiler/next/lib/uast/Variable.cpp
+++ b/compiler/next/lib/uast/Variable.cpp
@@ -25,27 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-Variable::Variable(ASTList children,
-                   UniqueString name, Sym::Visibility vis,
-                   Variable::Tag tag,
-                   int8_t typeExpressionChildNum,
-                   int8_t initExpressionChildNum)
-  : Sym(asttags::Variable, std::move(children), name, vis),
-    tag_(tag),
-    typeExpressionChildNum(typeExpressionChildNum),
-    initExpressionChildNum(initExpressionChildNum) {
-
-  assert(-1 <= typeExpressionChildNum && typeExpressionChildNum <= 1);
-  assert(-1 <= initExpressionChildNum && initExpressionChildNum <= 1);
-  assert(numChildren() <= 2);
-#ifndef NDEBUG
-  // check that all children are exprs (and not, say, Syms)
-  for (const ASTNode* child : this->children()) {
-    assert(child->isExpression());
-  }
-#endif
-}
-
 bool Variable::contentsMatchInner(const ASTNode* other) const {
   const Variable* lhs = this;
   const Variable* rhs = (const Variable*) other;

--- a/compiler/next/lib/uast/VariableDecl.cpp
+++ b/compiler/next/lib/uast/VariableDecl.cpp
@@ -25,10 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-VariableDecl::VariableDecl(owned<Variable> variable)
-  : Decl(asttags::VariableDecl, std::move(variable)) {
-}
-
 bool VariableDecl::contentsMatchInner(const ASTNode* other) const {
   const VariableDecl* lhs = this;
   const VariableDecl* rhs = (const VariableDecl*) other;


### PR DESCRIPTION
This PR adds support for expressions like `a+b` or `a = c` or even
`a = b + c` to compiler/next.

Some details: 

 * Move lots of AST node constructors from .cpp to .h files following the
   suggested approach in #17648. The rationale for this is that it will
   be easier to maintain and they are relatively trivial. To enable that,
   added a helper function in ASTList to check if one is just
   Expressions.
 * Adjusts the parser's `%token` declarations to include a type so that
   they can be used in semantic actions. The lexer was already storing
   the token text in the `uniqueStr` union field.
 * Added several helper methods in ParserContext for common scenarios:
   buildEmptyIdent, buildIdent
 * Added OpCall AST nodes, buildBinOp/buildUnaryOp ParserContext methods,
   and parser rules to parse them

Reviewed by @lydia-duncan - thanks!