### PR TITLE
Disable llvm for linux32 and asan testing

### DIFF
--- a/util/cron/common-asan.bash
+++ b/util/cron/common-asan.bash
@@ -6,5 +6,6 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 export CHPL_MEM=cstdlib
 export CHPL_TASKS=fifo
+export CHPL_LLVM=none
 export CHPL_SANITIZE=address
 export ASAN_OPTIONS=detect_leaks=0

--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -6,6 +6,8 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-localnode-paratest.bash
 
+export CHPL_LLVM=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
 $CWD/nightly -cron $(get_nightly_paratest_args)


### PR DESCRIPTION
llvm does not currently support 32-bit platforms so don't use it there.
We also don't support asan for llvm, because we currently rely on the
backend C compiler to add sanitizing for us and that's not something
we've wired through llvm.