### PR TITLE
Disable llvm for whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -128,17 +128,9 @@ fi
 export CHPL_LAUNCHER=none
 export CHPL_COMM=none
 
-# Make LLVM available. This has to happen after loading the PrgEnv or else
-# CCE's LLVM is added to PATHs etc. ahead of ours.
-if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
-  if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
-    source /data/cf/chapel/setup_system_llvm.bash
-  elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
-    source /cray/css/users/chapelu/setup_system_llvm.bash
-  fi
-  # Make clang aware of standard libraries
-  source $CWD/common-llvm-comp-path.bash
-fi
+# Disable llvm for now, since we're explicitly trying to test different C
+# backends
+export CHPL_LLVM=none
 
 
 # Set some vars that nightly cares about.


### PR DESCRIPTION
Whitebox testing is explicitly trying to test with different backend C
compilers, so disable llvm testing here.