### PR TITLE
Set compiler path for non-module XC testing

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -9,6 +9,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
+source $CWD/common-llvm-comp-path.bash
 export ARKOUDA_NUMLOCALES=16
 
 module list


### PR DESCRIPTION
Get llvm working on XC testing that doesn't use the nightly module by
setting `COMPILER_PATH`. This is similar to #17651