### PR TITLE
Address issues with the widePtrArrayAssignment test

### DIFF
--- a/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.chpl
+++ b/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.chpl
@@ -46,82 +46,27 @@ record R {
   }
 }
 
-var a: [LocaleSpace] srcType;
+config const elemPerLocale = 10;
+const elemRange = 0..#(numLocales*elemPerLocale);
+
+var a: [elemRange] srcType;
 for l in Locales do on l {
-  a[here.id] = createObj(here.id);
+  for i in 0..#elemPerLocale {
+    a[here.id*elemPerLocale+i] = createObj(here.id);
+  }
 }
 
 on Locales[1] {
-  var b: [LocaleSpace] dstType;
+  var b: [elemRange] dstType;
 
   if verboseComm then startVerboseCommHere();
   startCommDiagnosticsHere();
+
   b = a;
+
   stopCommDiagnosticsHere();
   if verboseComm then stopVerboseCommHere();
-  /*writeln(getCommDiagnosticsHere());*/
-
-  if mode==0 {
-    if ptrArrEq(a, b) {
-      writeln("Success");
-    }
-    else {
-      writeln("Pointer arrays differ");
-      writeln("Post assignment a");
-      arrPrint(a);
-      writeln("Post assignment b");
-      arrPrint(b);
-      writeln();
-    }
-  }
-  // owned transfer can't be done in bulk
-  // record arrays are transferred by value
-  else {
-    if ptrArrEq(a, b) {
-      writeln("FAILED, pointer arrays should be different");
-      writeln("Post assignment a");
-      arrPrint(a);
-      writeln("Post assignment b");
-      arrPrint(b);
-      writeln();
-    }
-    else {
-      writeln("Success");
-    }
-  }
+  writeln(getCommDiagnosticsHere());
 }
 
 cleanup(a);
-
-proc getWidePtrTup(p) {
-  if !__primitive("is wide pointer", p) {
-    writeln("You have to pass a wide pointer to this helper");
-  }
-  const locID = __primitive("_wide_get_locale", p);
-  const nodeID = chpl_nodeFromLocaleID(locID);
-  const sublocID = chpl_sublocFromLocaleID(locID);
-  const addr = __primitive("_wide_get_addr", p);
-
-  return (nodeID, sublocID, addr);
-}
-
-proc arrPrint(a) {
-  for elem in a{
-    const (nodeID, sublocID, addr) = getWidePtrTup(elem);
-    writeln("nodeID: ", nodeID, " sublocID ", sublocID, " addr ", addr);
-  }
-}
-
-proc ptrEq(p1, p2) {
-  return getWidePtrTup(p1) == getWidePtrTup(p2);
-}
-
-proc ptrArrEq(a, b) {
-  var eq = true;
-  for (aa, bb) in zip(a, b) {
-    if !ptrEq(aa, bb) then eq = false;
-  }
-  return eq;
-}
-
-

--- a/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.compopts
+++ b/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.compopts
@@ -1,4 +1,12 @@
--smode=0 -suseBulkPtrTransfer=true
--smode=1 -suseBulkPtrTransfer=true
--smode=2 -suseBulkPtrTransfer=true
--smode=3 -suseBulkPtrTransfer=true
+# test and make sure that arrays of unmanageds and records are transferred in
+# bulk with same amount of comm
+
+-smode=0 -suseBulkPtrTransfer=true --fast
+-smode=3 -suseBulkPtrTransfer=true --fast
+
+# the following two is about running this test with arrays of shareds and
+# owneds. As this is a commcount test, and their comm counts differ, I don't
+# want to test them right now and cause potential test maintanance headaches.
+#
+# -smode=1 -suseBulkPtrTransfer=true  --fast
+# -smode=2 -suseBulkPtrTransfer=true  --fast

--- a/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.good
+++ b/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.good
@@ -1,1 +1,1 @@
-Success
+(get = 5)


### PR DESCRIPTION
This test was failing sporadically. It was due to my wrong assumptions while
writing this test. This PR adjusts that.

Resolves https://github.com/Cray/chapel-private/issues/1597

Assume you have an array of `unmanaged` classes. This array is basically an
array of pointers. When bulk-copied, to check for correctness of the copy, we
compare (wide) pointers in the source and destination arrays. In this test, we
do this by looking at the address and the locale of the wide pointers using
compiler primitives

Now, because `owned` and `shared` classes cannot be copied in bulk (at least not
easily), we don't do bulk transfer for those. I wanted this test to make sure we
don't bulk copy such arrays. And my mistake was there. I naively compared wide
pointers to `owned`s and `shared`s, thinking that they should differ between the
source and destination arrays because we don't bulk-copy them. My thinking there
was that bulk-copying them creates different instances, so those wide pointers
should point to strictly different addresses. This is not the right way to think
about this copy.

But more than that; `owned` and `shared` are actually record-wrapped classes.
And what this test was comparing was the location of those records on both
locales. Which doesn't really mean anything and can be the same based on the
memory allocator's decisions (which had been brought up by @ronawho before).
i.e. the DR array's data that contains the shared/owned records that wrap the
actual instances can be on the same address in different locales. 

To address that this PR makes the test into a commcount test. It also comments
out the options that checks transfer of shared and owned arrays. Those cases
aren't optimized and show different behaviors. I think tracking their commcounts
does not bring too much value and can create test maintanance burden.

Test:

- [x] gasnet.asan with 1000 trials (which used to fail >10 times before)
