### PR TITLE
touch parser files before running CMake to prevent dependency errors

### DIFF
--- a/compiler/next/Makefile.help
+++ b/compiler/next/Makefile.help
@@ -58,6 +58,7 @@ CMAKE ?= cmake
 $(LIBCOMPILER_BUILD_DIR):
 	@echo "Configuring the compiler library..."
 	@mkdir -p $(LIBCOMPILER_BUILD_DIR)
+	@touch $(CHPL_MAKE_HOME)/compiler/next/lib/frontend/Parser/{bison-chapel.cpp,bison-chapel.h,flex-chapel.cpp,flex-chapel.h}
 	cd $(LIBCOMPILER_BUILD_DIR) && \
 	  $(CMAKE) $(CHPL_MAKE_HOME)/compiler/next \
 	    $(LIB_CMAKE_ARG) \


### PR DESCRIPTION
This creates the parser source files with `touch` before calling `cmake`, because if the parser source files do not exist when `cmake` is run, it can cause build dependencies later.

This is a workaround, but it should be future-proof, because it only uses `touch`.