### PR TITLE
`no doc` an internal formatted IO helper

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6115,6 +6115,7 @@ proc channel._read_complex(width:uint(32), out t:complex, i:int)
 // note here that the main benefit of this helper is that we don't pass all the
 // arguments from writef. This way, we can use the same code for an `arg` type
 // for which we have already created and instantiation of this.
+pragma "no doc"
 proc channel._writefOne(fmtStr, ref arg, i: int,
                         ref cur: size_t, ref j: int,
                         ref r: unmanaged _channel_regex_info?,


### PR DESCRIPTION
I have added this helper in https://github.com/chapel-lang/chapel/pull/16303 to
improve compilation speed. It is only used internally and not user-facing. It
should have been `no doc`'ed from the beginning.
