### PR TITLE
Close a leak in an LLVM test, strengthen its prediff

### DIFF
--- a/test/llvm/PREDIFF
+++ b/test/llvm/PREDIFF
@@ -22,4 +22,8 @@ fi
 
 mv $OUTFILE $TMPFILE
 $FILECHECK --input-file $TMPFILE $TESTNAME.chpl 2> $OUTFILE
+
+# Make sure to propagate memory leaks
+awk '/=* Memory Leaks =*/ {intable=1} {if (intable) {print($0);}}' <$TMPFILE >$OUTFILE
+
 rm $TMPFILE

--- a/test/llvm/tbaa/tbaa_scalar.chpl
+++ b/test/llvm/tbaa/tbaa_scalar.chpl
@@ -30,7 +30,7 @@ proc f() {
 }
 
 var got = f();
-writeln(f(), ", ", ivar, ", ", rvar);
+writeln(got, ", ", ivar, ", ", rvar);
 delete got;
 
 // Look for the tree of TBAA type descriptors that we will need to


### PR DESCRIPTION
`test/llvm/tbaa/tbaa_scalar.chpl` used to leak because of a trivial error. This
PR fixes that.

But more importantly, we weren't able to get leak errors in the nightly testing
but were able to see the increase in leaks in the plots. This was because of the
`PREDIFF` in the directory is using `FileCheck` tool from the LLVM suite which
only looks for matching patterns and seemingly ignores other stuff. And so the
memory leak table that we print at the exit of the application was simply being
ignored by the PREDIFF.

This PR adjusts the PREDIFF to propagate any leaks in the test to prevent future
slips in this test (as unlikely as it may be)

With this PR, `test/llvm/tbaa/` passes with and without `-memLeaks`
