### PR TITLE
Remove some unnecessary order-independent pragmas that snuck past

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -836,7 +836,6 @@ class UserMapAssocArr: AbsBaseArr {
 
   proc dsiHasSingleLocalSubdomain() param return false;
 
-  pragma "order independent yielding loops"
   iter dsiLocalSubdomains(loc: locale) {
     for locdom in dom.dsiLocalSubdomains(loc) do
       yield locdom;

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -289,7 +289,6 @@ module ArrayViewSlice {
       return privDom.dsiLocalSubdomain(loc);
     }
 
-    pragma "order independent yielding loops"
     iter dsiLocalSubdomains(loc: locale) {
       for l in privDom.dsiLocalSubdomains(loc) do
         yield l;


### PR DESCRIPTION
These only show up with '--verify' testing which has been broken
for a bit now.  Found them during a manual run this afternoon once
we realized.