### PR TITLE
Prevent spurious "used uninitialized" warnings.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4849,7 +4849,7 @@ chpl_comm_nb_handle_t rmaPutFn_selector(void* myAddr, void* mrDesc,
                                         uint64_t mrRaddr, uint64_t mrKey,
                                         size_t size,
                                         struct perTxCtxInfo_t* tcip) {
-  chpl_comm_nb_handle_t ret;
+  chpl_comm_nb_handle_t ret = NULL;
 
   switch (mcmMode) {
   case mcmm_msgOrdFence:
@@ -5308,7 +5308,7 @@ chpl_comm_nb_handle_t rmaGetFn_selector(void* myAddr, void* mrDesc,
                                         uint64_t mrRaddr, uint64_t mrKey,
                                         size_t size, void* ctx,
                                         struct perTxCtxInfo_t* tcip) {
-  chpl_comm_nb_handle_t ret;
+  chpl_comm_nb_handle_t ret = NULL;
 
   switch (mcmMode) {
   case mcmm_msgOrdFence:
@@ -5703,7 +5703,7 @@ static amoFn_t amoFn_dlvrCmplt;
 static inline
 chpl_comm_nb_handle_t amoFn_selector(struct amoBundle_t *ab,
                                      struct perTxCtxInfo_t* tcip) {
-  chpl_comm_nb_handle_t ret;
+  chpl_comm_nb_handle_t ret = NULL;
 
   switch (mcmMode) {
   case mcmm_msgOrdFence:


### PR DESCRIPTION
Initialize variables to prevent the compiler from warning that they
might be used uninitialized.  (They're not, but it cannot determine
that.)

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>