### PR TITLE
Disable remote cache for a commcount test

### DIFF
--- a/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.compopts
+++ b/test/optimizations/bulkcomm/ptrArray/widePtrArrayAssignment.compopts
@@ -1,12 +1,12 @@
 # test and make sure that arrays of unmanageds and records are transferred in
 # bulk with same amount of comm
 
--smode=0 -suseBulkPtrTransfer=true --fast
--smode=3 -suseBulkPtrTransfer=true --fast
+-smode=0 -suseBulkPtrTransfer=true --fast --no-cache-remote
+-smode=3 -suseBulkPtrTransfer=true --fast --no-cache-remote
 
 # the following two is about running this test with arrays of shareds and
 # owneds. As this is a commcount test, and their comm counts differ, I don't
 # want to test them right now and cause potential test maintanance headaches.
 #
-# -smode=1 -suseBulkPtrTransfer=true  --fast
-# -smode=2 -suseBulkPtrTransfer=true  --fast
+# -smode=1 -suseBulkPtrTransfer=true  --fast --no-cache-remote
+# -smode=2 -suseBulkPtrTransfer=true  --fast --no-cache-remote


### PR DESCRIPTION
I converted this test to a commcount test in

  https://github.com/chapel-lang/chapel/pull/17659

I must have been running it with remote cache disabled, as that's what the good
file has. To avoid tracking comm counts in too much detail, this PR disables the
remote cache for this test.
