### PR TITLE
compiler/next add Dot expression

### DIFF
--- a/compiler/next/include/chpl/uast/Dot.h
+++ b/compiler/next/include/chpl/uast/Dot.h
@@ -27,16 +27,21 @@ namespace chpl {
 namespace uast {
 
 /**
-  This class represents a dot expression. A dot expression might
-  indicate a method to be called or it might represent field access.
+  This class represents a dot expression. A dot expression might be:
 
-  For example, `a.b`, and `this.type` are dot expressions.
+   * a method call
+   * field access
+   * qualified access within a module or enum
+
+  For example, `a.b`, `this.type`, `Module.myFunc` are dot expressions.
 
   Consider `myObject.myMethod()`, or `x.f(a=3)`. These are method
   calls that also involve Dot expressions. These are represented as
   an FnCall containing a Dot expression. For example, for `x.f(a=3)`,
   it is represented as
+
     FnCall(calledExpression=`x.f`, actuals=[3], names=[a]);
+
   where the `x.f` is a Dot expression.
 
  */

--- a/compiler/next/include/chpl/uast/Dot.h
+++ b/compiler/next/include/chpl/uast/Dot.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UAST_DOT_H
+#define CHPL_UAST_DOT_H
+
+#include "chpl/queries/Location.h"
+#include "chpl/uast/Call.h"
+
+namespace chpl {
+namespace uast {
+
+/**
+  This class represents a dot expression. A dot expression might
+  indicate a method to be called or it might represent field access.
+
+  For example, `a.b`, and `this.type` are dot expressions.
+
+  Consider `myObject.myMethod()`, or `x.f(a=3)`. These are method
+  calls that also involve Dot expressions. These are represented as
+  an FnCall containing a Dot expression. For example, for `x.f(a=3)`,
+  it is represented as
+    FnCall(calledExpression=`x.f`, actuals=[3], names=[a]);
+  where the `x.f` is a Dot expression.
+
+ */
+class Dot final : public Call {
+ private:
+  // which field
+ UniqueString fieldName_;
+
+  Dot(ASTList children, UniqueString fieldName)
+    : Call(asttags::Dot, std::move(children),
+           /* hasCalledExpression */ true),
+      fieldName_(fieldName) {
+  }
+  bool contentsMatchInner(const ASTNode* other) const override;
+  void markUniqueStringsInner(Context* context) const override;
+
+ public:
+  ~Dot() override = default;
+  static owned<Dot> build(Builder* builder,
+                          Location loc,
+                          owned<Expression> receiver,
+                          UniqueString fieldName);
+
+  /** Returns the left-hand-side of the Dot expression */
+  const Expression* receiver() const { return calledExpression(); }
+  /** Returns the name of the field or method accessed by the Dot expression */
+  UniqueString field() const { return fieldName_; }
+};
+
+
+} // end namespace uast
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/uast/FnCall.h
+++ b/compiler/next/include/chpl/uast/FnCall.h
@@ -33,7 +33,7 @@ namespace uast {
 
   For example `f(1,2)`, is a call to a function `f`.
 
-  Note that calls to paren-less functions are not
+  Note that calls to paren-less free functions are not
   represented with this type since early in compilation
   they are just Identifiers.
 
@@ -77,6 +77,10 @@ class FnCall : public Call {
                              Location loc,
                              owned<Expression> calledExpression,
                              ASTList actuals,
+                             bool callUsedSquareBrackets);
+  static owned<FnCall> build(Builder* builder,
+                             Location loc,
+                             owned<Expression> calledExpression,
                              bool callUsedSquareBrackets);
 
   /** Returns whether actual i is named as with 'f(a=3)'

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -2635,11 +2635,26 @@ call_expr:
 ;
 
 dot_expr:
-  expr TDOT ident_use          { $$ = TODOEXPR(@$); }
-| expr TDOT TTYPE              { $$ = TODOEXPR(@$); }
-| expr TDOT TDOMAIN            { $$ = TODOEXPR(@$); }
-| expr TDOT TLOCALE            { $$ = TODOEXPR(@$); }
-| expr TDOT TBYTES TLP TRP     { $$ = TODOEXPR(@$); }
+  expr TDOT ident_use
+    { $$ = Dot::build(BUILDER, LOC(@$), toOwned($1), $3).release(); }
+| expr TDOT TTYPE
+    { $$ = Dot::build(BUILDER, LOC(@$), toOwned($1), $3).release(); }
+| expr TDOT TDOMAIN
+    { $$ = Dot::build(BUILDER, LOC(@$), toOwned($1), $3).release(); }
+| expr TDOT TLOCALE
+    { $$ = Dot::build(BUILDER, LOC(@$), toOwned($1), $3).release(); }
+| expr TDOT TBYTES TLP TRP
+    {
+      $$ = FnCall::build(BUILDER, LOC(@$),
+                         Dot::build(BUILDER, LOC(@$), toOwned($1), $3),
+                         false).release();
+    }
+| expr TDOT TBYTES TLSBR TRSBR
+    {
+      $$ = FnCall::build(BUILDER, LOC(@$),
+                         Dot::build(BUILDER, LOC(@$), toOwned($1), $3),
+                         true).release();
+    }
 ;
 
 /* ( <expr> ) -- A parenthesized expression.  The parens are stripped.

--- a/compiler/next/lib/frontend/Parser/parser-dependencies.h
+++ b/compiler/next/lib/frontend/Parser/parser-dependencies.h
@@ -30,6 +30,7 @@
 #include "chpl/uast/Call.h"
 #include "chpl/uast/Comment.h"
 #include "chpl/uast/Decl.h"
+#include "chpl/uast/Dot.h"
 #include "chpl/uast/ErroneousExpression.h"
 #include "chpl/uast/Expression.h"
 #include "chpl/uast/FnCall.h"

--- a/compiler/next/lib/uast/CMakeLists.txt
+++ b/compiler/next/lib/uast/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(libchplcomp-obj
                Call.cpp
                Comment.cpp
                Decl.cpp
+               Dot.cpp
                ErroneousExpression.cpp
                Expression.cpp
                FnCall.cpp

--- a/compiler/next/lib/uast/Dot.cpp
+++ b/compiler/next/lib/uast/Dot.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/uast/Dot.h"
+
+#include "chpl/uast/Builder.h"
+
+namespace chpl {
+namespace uast {
+
+bool Dot::contentsMatchInner(const ASTNode* other) const {
+  const Dot* lhs = this;
+  const Dot* rhs = (const Dot*) other;
+
+  if (lhs->fieldName_ != rhs->fieldName_)
+    return false;
+
+  if (!lhs->callContentsMatchInner(rhs))
+    return false;
+
+  return true;
+}
+void Dot::markUniqueStringsInner(Context* context) const {
+
+  callMarkUniqueStringsInner(context);
+
+  fieldName_.mark(context);
+}
+
+owned<Dot> Dot::build(Builder* builder,
+                      Location loc,
+                      owned<Expression> receiver,
+                      UniqueString fieldName) {
+  ASTList list;
+
+  list.push_back(std::move(receiver));
+
+  Dot* ret = new Dot(std::move(list), fieldName);
+  builder->noteLocation(ret, loc);
+  return toOwned(ret);
+}
+
+
+} // namespace uast
+} // namespace chpl

--- a/compiler/next/lib/uast/FnCall.cpp
+++ b/compiler/next/lib/uast/FnCall.cpp
@@ -84,6 +84,19 @@ owned<FnCall> FnCall::build(Builder* builder,
                        std::move(emptyActualNames),
                        callUsedSquareBrackets);
 }
+owned<FnCall> FnCall::build(Builder* builder,
+                            Location loc,
+                            owned<Expression> calledExpression,
+                            bool callUsedSquareBrackets) {
+  ASTList emptyActuals;
+  std::vector<UniqueString> emptyActualNames;
+
+  return FnCall::build(builder, loc,
+                       std::move(calledExpression),
+                       std::move(emptyActuals),
+                       std::move(emptyActualNames),
+                       callUsedSquareBrackets);
+}
 
 
 } // namespace uast

--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -31,3 +31,4 @@ cpp:identifier ASTList::const_iterator
 cpp:identifier size_t
 cpp:identifier detail
 cpp:identifier detail::PODUniqueString
+cpp:identifier ASTList::const_iterator::difference_type


### PR DESCRIPTION
This PR adds Dot AST nodes and parses dot expressions.

This class represents a dot expression. A dot expression might be:

 * a method call
 * field access
 * qualified access within a module or enum

For example, `a.b`, `this.type`, `Module.myFunc` are dot expressions.

Consider `myObject.myMethod()`, or `x.f(a=3)`. These are method
calls that also involve Dot expressions. These are represented as
an FnCall containing a Dot expression. For example, for `x.f(a=3)`,
it is represented as

    FnCall(calledExpression=x.f, actuals=[3], names=[a]);

where the `x.f` is a Dot expression.

To make parsing `myExpression.bytes()` easier, adds a `FnCall::build`.
overload accepting no actuals. Also, adjusts the parser to parse calls
like `myExpression.bytes[]` since this should be syntactically allowed,.
even if it is poor style.

Reviewed by @dlongnecke-cray and @lydia-duncan - thanks!