### PR TITLE
Throw --bounds-checks for some tests designed to test bounds checks

### DIFF
--- a/test/arrays/slices/sliceAssocOOB.compopts
+++ b/test/arrays/slices/sliceAssocOOB.compopts
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/arrays/slices/sliceAssocOOB2.compopts
+++ b/test/arrays/slices/sliceAssocOOB2.compopts
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/types/range/enum/singleValEnum-errors.compopts
+++ b/test/types/range/enum/singleValEnum-errors.compopts
@@ -1,4 +1,4 @@
 -serrorCase=1  # singleValEnum-errors-xlate.good
--serrorCase=2  # singleValEnum-errors-interior.good
+-serrorCase=2 --bounds-checks  # singleValEnum-errors-interior.good
 -serrorCase=3  # singleValEnum-errors-exterior.good
 -serrorCase=4  # singleValEnum-errors-expand.good


### PR DESCRIPTION
(in order to guarantee their behavior is consistent for --fast testing)
