### PR TITLE
Add a draft for a standard module style guide

### DIFF
--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -1,0 +1,67 @@
+Standard Module Style
+=====================
+
+This document describes general guidance for style when writing a
+standard module. Of course there will be exceptions to this guidance when
+there is a good reason.
+
+Background
+----------
+
+Chapel does not use a separate namespace for types vs. module names vs
+local variables. As a result, it's generally a goal to avoid using the
+same name for, say, a type and a module.
+
+CamelCase
+---------
+
+Pefer CamelCase or camelCase to separating_with_underscores. The rest of
+this document will use CamelCase or camelCase to signify camel-case
+starting with an upper case or lower case letter, respectively.
+
+Modules
+-------
+
+Module names should be CamelCase.
+
+Classes
+-------
+
+Class type names should be CamelCase. The idea is that starting with an
+uppercase letter is the convention for by-reference types.
+
+Records
+-------
+
+Record type names should be camelCase. The idea is that starting with a
+lowercase letter is the convention for by-value types.
+
+Enums
+-----
+
+Enum type names should be camelCase. The enum values should also be
+camelCase.
+
+Methods
+-------
+
+Method names should be camelCase.
+
+Use parentheses-less methods only for simple properties that could be
+reasonably implemented as fields.
+
+Try to make methods that take some notable action be verbs. In particular,
+a method that modifies an argument in-place should be a verb.
+
+Functions
+---------
+
+Non-method functions should be camelCase.
+
+Generally speaking it's desireable use methods when there is a clear type
+responsible for the operation.
+
+Global Variable Names
+---------------------
+
+Variables should be camelCase or CamelCase.

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -5,29 +5,30 @@ This document describes general guidance for style when writing a
 standard module. Of course there will be exceptions to this guidance when
 there is a good reason.
 
-Background
-----------
+PascalCase and camelCase
+------------------------
 
-Chapel does not use a separate namespace for types vs. module names vs
-local variables. As a result, it's generally a goal to avoid using the
-same name for, say, a type and a module.
-
-CamelCase
----------
-
-Pefer CamelCase or camelCase to separating_with_underscores. The rest of
-this document will use CamelCase or camelCase to signify camel-case
-starting with an upper case or lower case letter, respectively.
+Prefer PascalCase or camelCase to separating_with_underscores. The rest
+of this document will use PascalCase or camelCase to signify the pattern
+of indicating new words with an upper case letter and starting the
+identifier; where PascalCase starts the name with an upper case letter
+and camelCase starts with a lower case letter.
 
 Modules
 -------
 
-Module names should be CamelCase.
+Module names should be PascalCase.
+
+.. note::
+
+  Chapel does not use a separate namespace for types vs. module names. As
+  a result, it's generally a goal to avoid using the same name for, say,
+  a type and a module.
 
 Classes
 -------
 
-Class type names should be CamelCase. The idea is that starting with an
+Class type names should be PascalCase. The idea is that starting with an
 uppercase letter is the convention for by-reference types.
 
 Records
@@ -42,26 +43,26 @@ Enums
 Enum type names should be camelCase. The enum values should also be
 camelCase.
 
-Methods
--------
-
-Method names should be camelCase.
-
-Use parentheses-less methods only for simple properties that could be
-reasonably implemented as fields.
-
-Try to make methods that take some notable action be verbs. In particular,
-a method that modifies an argument in-place should be a verb.
-
-Functions
----------
-
-Non-method functions should be camelCase.
-
-Generally speaking it's desireable use methods when there is a clear type
-responsible for the operation.
-
-Global Variable Names
+Functions and Methods
 ---------------------
 
-Variables should be camelCase or CamelCase.
+Function and method names should be camelCase.
+
+Generally speaking, it's desireable to use methods on a value (vs
+functions that aren't methods) when there is a clear type responsible for
+the operation.
+
+Use parentheses-less methods only for returning properties that could be
+reasonably implemented as fields. However, if such a method is named
+named isXYZ or hasXYZ it should use parentheses (so, use
+`proc isReal() { ...  }` rather than `proc isReal { ... }`).
+Parentheses-less functions that aren't methods should be avoided.
+
+Many paren-ful methods take some notable action. Try to make these
+methods method names be a verb. In particular, a method that modifies an
+argument in-place should be a verb.
+
+Other Identifiers
+-----------------
+
+Variables, fields, and argument names should be camelCase or CamelCase.


### PR DESCRIPTION
This PR adds a draft standard module style guide as an aid for the effort of stabilizing the standard modules.
Based in large part upon #6698.

Discussed with lots of people but final review by @bradcray - thanks!