### PR TITLE
Estimate time-to-completion in many-to-one test better.

### DIFF
--- a/test/performance/comm/low-level/many-to-one.chpl
+++ b/test/performance/comm/low-level/many-to-one.chpl
@@ -126,7 +126,7 @@ proc main() {
             if nops == nopsAtCheck {
               tElapsed = t.elapsed();
               if tElapsed >= runSecs then break;
-              nopsAtCheck = (nops * (0.75 * runSecs / tElapsed)):int;
+              nopsAtCheck += (0.99 * nops * (runSecs / tElapsed - 1)):int;
               if nopsAtCheck - nops < minOpsPerTimerCheck then
                 nopsAtCheck = nops + minOpsPerTimerCheck;
             }


### PR DESCRIPTION
Long ago I screwed up the algebra when estimating how much more work
we will need to do to run for the desired length of time in the
many-to-one microbenchmark.  Fix that.  Now it only checks the time
a few times.  It used to do so hundreds of times.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>