### PR TITLE
Adjust a directory-wide prediff

### DIFF
--- a/test/llvm/PREDIFF
+++ b/test/llvm/PREDIFF
@@ -24,6 +24,6 @@ mv $OUTFILE $TMPFILE
 $FILECHECK --input-file $TMPFILE $TESTNAME.chpl 2> $OUTFILE
 
 # Make sure to propagate memory leaks
-awk '/=* Memory Leaks =*/ {intable=1} {if (intable) {print($0);}}' <$TMPFILE >$OUTFILE
+awk '/=* Memory Leaks =*/ {intable=1} {if (intable) {print($0);}}' <$TMPFILE >>$OUTFILE
 
 rm $TMPFILE


### PR DESCRIPTION
I modified this PREDIFF in https://github.com/chapel-lang/chapel/pull/17665 to
make sure that we capture any potential leak. However, I didn't realize that the
PREDIFF was linked from elsewhere. So I haven't run tests there. This PR adjusts
the PREDIFF to append the memleak table at the end of the output file instead of
overwriting it.

Test:
- [x] `test/llvm` passes with `-futures -compopts --llvm`