### PR TITLE
IFC: Invoke required functions through associated constraints

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -133,7 +133,7 @@ void FnSymbol::verify() {
     for_alist(ic, ifcInfo->interfaceConstraints)
       INT_ASSERT(isIfcConstraint(ic));
 
-    // ifcInfo->repsForIfcSymbols is created during resolution
+    // ifcInfo->ifcReps is created during resolution
     // and disappears together with its parent function at the end of
     // resolution, so we never see it here.
 

--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -273,7 +273,7 @@ ImplementsStmt::ImplementsStmt(IfcConstraint* con, BlockStmt* body)
 }
 
 ImplementsStmt* ImplementsStmt::copyInner(SymbolMap* map) {
-  if (witnesses.n > 0 || aconsWitnesses.size() > 0)
+  if (! witnesses.empty())
     USR_FATAL(this,
       "implements statements in this context are currently unsupported");
 
@@ -285,7 +285,7 @@ static void verifyWitnesses(ImplementsStmt* istm) {
   if (!normalized) return;
   IfcConstraint* icon = istm->iConstraint;
   InterfaceSymbol* isym = icon->ifcSymbol();
-  form_Map(SymbolMapElem, witn, istm->witnesses) {
+  form_Map(SymbolMapElem, witn, istm->witnesses.symWits) {
     INT_ASSERT(witn->key->defPoint->parentSymbol == isym);
     // witn->value can be defined anywhere
   }
@@ -311,7 +311,7 @@ void ImplementsStmt::accept(AstVisitor* visitor) {
 
 void ImplementsStmt::replaceChild(Expr* oldAst, Expr* newAst) {
   // CG TODO: update 'witnesses' appropriately if there are any?
-  if (witnesses.n > 0)
+  if (! witnesses.empty())
     USR_FATAL(this, "unsupported copying of this implements statement");
 
   if (oldAst == iConstraint)

--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -101,7 +101,7 @@ public:
   std::vector<ArgSymbol*> actualIdxToFormal;
 
   // One ImplementsStmt per IfcConstraint when 'fn' is CG
-  std::vector<ImplementsStmt*> witnesses;
+  std::vector<ImplementsStmt*> witnessIstms;
   // Is this a CG "interim instantiation"?
   bool                    isInterimInstantiation;
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -185,9 +185,10 @@ class ConstraintSat { public: ImplementsStmt* istm; IfcConstraint* icon;
 ConstraintSat constraintIsSatisfiedAtCallSite(CallExpr* call,
                                                 IfcConstraint* constraint,
                                                 SymbolMap& substitutions);
-void copyIfcRepsToSubstitutions(FnSymbol* fn, Expr* anchor, int indx,
-                                ImplementsStmt* istm,
-                                SymbolMap& substitutions);
+void cgAddRepsToSubstitutions(FnSymbol* fn, SymbolMap& substitutions,
+                              ImplementsStmt* istm, int indx);
+void cgConvertAggregateTypes(FnSymbol* fn, Expr* anchor,
+                             SymbolMap& substitutions);
 void recordCGInterimInstantiations(CallExpr* call, ResolutionCandidate* best1,
                        ResolutionCandidate* best2, ResolutionCandidate* best3);
 void adjustForCGinstantiation(FnSymbol* fn, SymbolMap& substitutions,

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -284,7 +284,19 @@ class GotoStmt final : public Stmt {
 *                                                                             *
 ************************************** | *************************************/
 
-typedef std::map<IfcConstraint*, ImplementsStmt*> aconsWitnMap;
+// This helper class shows how the interface requirements are satisfied.
+struct Witnesses {
+  // for each associated type or required function in the interface,
+  // this map points to its implementation for this ImplementsStmt
+  SymbolMap symWits;
+
+  // for each associated constraint in the interface,
+  // this vector contains the istm that satisfies it
+  std::vector<ImplementsStmt*> conWits;
+
+  int  numAssocCons() const { return conWits.size(); }
+  bool empty()        const { return symWits.n == 0 && conWits.empty(); }
+};
 
 class ImplementsStmt final : public Stmt {
 public:
@@ -312,12 +324,8 @@ public:
   // (possibly empty) body of this statement, always non-null
   BlockStmt*     implBody;
 
-  // for each associated type or required function in the interface,
-  // the map points to its implementation for this ImplementsStmt
-  SymbolMap      witnesses;
-
-  // each associated constraint in the ifc --> its implementation
-  aconsWitnMap   aconsWitnesses;
+  // info on how the interface requirements are satisfied by this istm
+  Witnesses      witnesses;
 };
 
 // support for implements wrapper functions

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -591,7 +591,8 @@ public:
   void  replaceChild(BaseAST* oldAst, BaseAST* newAst)   override;
   void  printDocs(std::ostream* file, unsigned int tabs);
 
-  int   numFormals() const { return ifcFormals.length; }
+  int   numFormals()   const { return ifcFormals.length; }
+  int   numAssocCons() const { return associatedConstraints.size(); }
 
   // the DefExprs for each interface formal
   AList      ifcFormals;

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -155,7 +155,7 @@ bool ResolutionCandidate::isApplicableGeneric(CallInfo& info,
 }
 
 // Computes whether fn's interface constraints are satisfied at the call site.
-// Stores witnesses in this->witnesses, if yes.
+// Stores witnesses in this->witnessIstms, if yes.
 // Should this be entirely in interfaceResolution.cpp ?
 bool ResolutionCandidate::isApplicableCG(CallInfo& info,
                                          VisibilityInfo* visInfo) {
@@ -165,9 +165,8 @@ bool ResolutionCandidate::isApplicableCG(CallInfo& info,
                              toIfcConstraint(iconExpr), substitutions);
     if (csat.istm != nullptr) {
       // satisfied with an implements statement
-      witnesses.push_back(csat.istm);
-      copyIfcRepsToSubstitutions(fn, info.call, indx++,
-                                 csat.istm, substitutions);
+      witnessIstms.push_back(csat.istm);
+      cgAddRepsToSubstitutions(fn, substitutions, csat.istm, indx++);
 
     } else if (csat.icon != nullptr) {
       // satisfied with a constraint of the enclosing GC function
@@ -178,6 +177,8 @@ bool ResolutionCandidate::isApplicableCG(CallInfo& info,
       return false;
     }
   }
+
+  cgConvertAggregateTypes(fn, info.call, substitutions);
 
   return true; // all constraints are satisfied
 }

--- a/test/constrained-generics/basic/associated/using-acons-functions.chpl
+++ b/test/constrained-generics/basic/associated/using-acons-functions.chpl
@@ -1,0 +1,88 @@
+// IC function calls required functions on the interfaces
+// of the associated constraints.
+
+interface I1 {
+  proc chpl__initCopy(arg: Self, definedConst: bool): Self;
+  proc write(arg: Self): void;
+  proc reqFn1(arg: Self);
+  proc get1(arg: Self): AT1;
+  type AT1;
+  AT1 implements I2;
+}
+
+interface I2 {
+  proc chpl__initCopy(arg: Self, definedConst: bool): Self;
+  proc write(arg: Self): void;
+  proc reqFn2(arg: Self);
+  proc get2(arg: Self): AT2;
+  type AT2;
+  AT2 implements I3;
+}
+
+interface I3 {
+  proc chpl__initCopy(arg: Self, definedConst: bool): Self;
+  proc write(arg: Self): void;
+  proc reqFn3(arg: Self);
+  proc get3(arg: Self): AT3;
+  type AT3;
+  // AT3 implements ... //and so on
+}
+
+/////////////////////////////////
+
+proc icFun(x1: ?Q1) where Q1 implements I1 {
+  writeln("icFun()");
+
+  reqFn1(x1);  // this is the base case, see the previous example
+
+  const x2 = get1(x1);  // x2: x1.AT1
+  reqFn2(x2);   // legal because AT1 implements I2
+
+  const x3 = get2(x2);   // x3: x1.AT1.AT2
+  reqFn3(x3);   // legal because AT2 implements I3
+
+  get3(x3);   // x1.AT1.AT2.AT3
+  // and so on
+}
+
+/////////////////////////////////
+
+icFun(1);
+
+// int --> all ATs are ints
+
+int implements I1;
+proc reqFn1(arg: int) { writeln("reqFn1.int(", arg, ")"); }
+proc get1(arg: int) return arg * 10;
+proc int.AT1 type return get1(this).type;
+
+int implements I2;
+proc reqFn2(arg: int) { writeln("reqFn2.int(", arg, ")"); }
+proc get2(arg: int) return arg * 20;
+proc int.AT2 type return get2(this).type;
+
+int implements I3;
+proc reqFn3(arg: int) { writeln("reqFn3.int(", arg, ")"); }
+proc get3(arg: int) return arg * 30;
+proc int.AT3 type return get3(this).type;
+
+/////////////////////////////////
+
+icFun(2.2);
+
+// real --> ATs are: complex -> string -> int
+
+real implements I1;
+proc reqFn1(arg: real) { writeln("reqFn1.real(", arg, ")"); }
+proc get1(arg: real) return (arg, -arg): complex;
+proc real.AT1 type return get1(this).type;
+
+complex implements I2;
+proc reqFn2(arg: complex) { writeln("reqFn2.complex(", arg, ")"); }
+proc get2(arg: complex) return arg: string;
+proc complex.AT2 type return get2(this).type;
+
+string implements I3;
+proc reqFn3(arg: string) { writeln("reqFn3.string(", arg, ")"); }
+proc get3(arg: string) return arg.size;
+proc string.AT3 type return get3(this).type;

--- a/test/constrained-generics/basic/associated/using-acons-functions.good
+++ b/test/constrained-generics/basic/associated/using-acons-functions.good
@@ -1,0 +1,8 @@
+icFun()
+reqFn1.int(1)
+reqFn2.int(10)
+reqFn3.int(200)
+icFun()
+reqFn1.real(2.2)
+reqFn2.complex(2.2 - 2.2i)
+reqFn3.string(2.2 - 2.2i)


### PR DESCRIPTION
This PR implements support for invoking required functions that are available
due to associated constraints. For example:

```chpl
interface IFC(Self) {
  type AT;
  AT implements Comparable;
  proc reqFn(arg1: AT, arg2: AT) {
    if arg1 == arg2 then ...;      // invokes operator == from Comparable
  }
}

interface Comparable(Self) {
  operator ==(arg1: AT, arg2: AT): bool;
}
```

#### Implementation notes

* Modifies the current implementation based on introducing "representatives"
  for required functions to add those for associated constraints as well.
  Introduces recursion in execution and in data structures to handle
  associated constraints of associated constraints etc.  In the future
  we will want to switch from introducing representatives to another
  approach that scales well to large interfaces.  Arbitrarily cuts recursion
  at the depth of 3.

* For storing the implementations of associated constraints,
  switches from a map ImplementsStmt::aconsWitnMap
  to a vector ImplementsStmt::witnesses.conWits, storing them in the order
  those constraints are listed in InterfaceSymbol::associatedConstraints

* Overloads the term "witness" to mean one of:
  - an ImplementsStmt that satisfies the interface constraint at hand
  - the implementation of a required function provided by this ImplementsStmt
  - the instantiation of an associated type provided by this ImplementsStmt

  One potential alternative for the last two is "implementors".

  Correspondingly, we now have these fields
  - ResolutionCandidate::witnessIstms
  - ImplementsStmt::witnesses.symWits

* More comments.
