### PR TITLE
Remove an unused function.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -734,18 +734,6 @@ struct bitmap_t* bitmapAlloc(size_t len) {
   return b;
 }
 
-static inline
-void bitmapFree(struct bitmap_t* b) {
-  if (DBG_TEST_MASK(DBG_ORDER)) {
-    BITMAP_FOREACH_SET(b, node) {
-      INTERNAL_ERROR_V("bitmapFree(): bitmap is not empty; first node %d",
-                       (int) node);
-    } BITMAP_FOREACH_SET_END
-  }
-
-  CHPL_FREE(b);
-}
-
 
 ////////////////////////////////////////
 //


### PR DESCRIPTION
In #17630 the only call(s) to `bitmapFree()` were removed, but the
function itself was not.  This resulted in "unused function" errors in
certain build environments.  Here, remove the function.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>