### PR TITLE
Fix c_ptr conditional checks for --baseline runs

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -741,6 +741,7 @@ module ChapelBase {
 
   inline proc _cond_test(param x: bool) param return x;
   inline proc _cond_test(param x: integral) param return x != 0:x.type;
+  inline proc _cond_test(x: c_ptr) return x != c_nil;
 
   inline proc _cond_test(x) {
     if !( x.type <= _iteratorRecord ) {

--- a/modules/standard/CPtr.chpl
+++ b/modules/standard/CPtr.chpl
@@ -400,9 +400,6 @@ module CPtr {
   }
 
   pragma "no doc"
-  inline proc c_ptr.chpl_cond_test_method() return this != c_nil;
-
-  pragma "no doc"
   inline operator c_ptr.!(x: c_ptr) return x == c_nil;
 
   pragma "no doc"


### PR DESCRIPTION
My previous approach to supporting 'if c_ptr' in an import-based
setting relied on being able to call a method on a null c_ptr pointer
value, but this didn't work when we compile with --baseline.  Here,
I'm reverting the routine to a standalone function for this case, but
moving it from CPtr to ChapelBase, so that it's always available
(ChapelBase already used CPtr, so this doesn't add any new
inter-module dependencies).
