### PR TITLE
Skip parallel_loop_access tests under baseline

### DIFF
--- a/test/llvm/parallel_loop_access/SKIPIF
+++ b/test/llvm/parallel_loop_access/SKIPIF
@@ -1,1 +1,2 @@
 CHPL_LLVM==none
+COMPOPTS <= --baseline

--- a/test/llvm/vectorization/simple_loop_novec.chpl
+++ b/test/llvm/vectorization/simple_loop_novec.chpl
@@ -2,12 +2,15 @@
 // LLVM backend cannot check whether A and B overlap
 // runtime check for overlap was turned off and --no-vectorize was set
 // to avoid adding parallel_loop_access metadata
+
+// CHECK: @loop_chpl
 proc loop (A, B, n) {
   for i in vectorizeOnly(1..n) {
     // CHECK-NOT: <4 x i32>
     A[i] = 3*B[i];
   }
 }
+// CHECK: ret void
 
 config const n = 1000;
 


### PR DESCRIPTION
These tests are checking that an optimization hint is being provided so 
they aren't particularly meaningful under baseline.

While there, updated `test/llvm/vectorization/simple_loop_novec.chpl` to 
better check for vectorization only within the routine in question.

Test change only - not reviewed.