### PR TITLE
Set linux32 as not a compatible platform for llvm

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -39,7 +39,8 @@ def is_included_llvm_built():
 
 def compatible_platform_for_llvm_default():
   target_arch = chpl_arch.get('target')
-  return (target_arch != "i368")
+  target_platform = chpl_platform.get('target')
+  return (target_arch != "i368" and target_platform != "linux32")
 
 def has_compatible_installed_llvm():
     preferred_vers_file = os.path.join(get_chpl_third_party(),


### PR DESCRIPTION
Update util/chplenv/chpl_llvm.py to not allow linux32 as a compatible platform.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>