### PR TITLE
Move typeExpr/initExpr to Formal/Variable Decl

### DIFF
--- a/compiler/next/include/chpl/uast/ASTClassesList.h
+++ b/compiler/next/include/chpl/uast/ASTClassesList.h
@@ -114,7 +114,7 @@ AST_BEGIN_SUBCLASSES(Expression)       // old AST: Expr
   AST_END_SUBCLASSES(Call)
 
 
-//  AST_BEGIN_SUBCLASSES(Decl)
+  AST_BEGIN_SUBCLASSES(Decl)
     AST_NODE(MultiDecl)
     AST_NODE(TupleDecl)
 
@@ -127,7 +127,7 @@ AST_BEGIN_SUBCLASSES(Expression)       // old AST: Expr
       //AST_NODE(TypeDecl)
       AST_NODE(VariableDecl)
     AST_END_SUBCLASSES(SymDecl)
-//  AST_END_SUBCLASSES(Decl)
+  AST_END_SUBCLASSES(Decl)
 
 AST_END_SUBCLASSES(Expression)
 

--- a/compiler/next/include/chpl/uast/ASTClassesList.h
+++ b/compiler/next/include/chpl/uast/ASTClassesList.h
@@ -133,11 +133,11 @@ AST_END_SUBCLASSES(Expression)
 
 AST_BEGIN_SUBCLASSES(Sym)              // old AST: Symbol
   AST_NODE(EnumElement)                // old AST: EnumSymbol
-  AST_NODE(Formal)                     // old AST: ArgSymbol
+  AST_LEAF(Formal)                     // old AST: ArgSymbol
   AST_NODE(Function)                   // old AST: FnSymbol
   AST_NODE(Interface)                  // old AST: InterfaceSymbol
   AST_NODE(Module)                     // old AST: ModuleSymbol
-  AST_NODE(Variable)                   // old AST: VarSymbol
+  AST_LEAF(Variable)                   // old AST: VarSymbol
                                        // old AST: ShadowVarSymbol
 
   AST_BEGIN_SUBCLASSES(TypeSym)        // old AST: TypeSymbol/Type

--- a/compiler/next/include/chpl/uast/Formal.h
+++ b/compiler/next/include/chpl/uast/Formal.h
@@ -59,25 +59,11 @@ class Formal final : public Sym {
 
  private:
   Intent intent_;
-  int8_t typeExpressionChildNum;
-  int8_t initExpressionChildNum;
 
-  Formal(ASTList children,
-         UniqueString name,
-         Formal::Intent intent,
-         int8_t typeExpressionChildNum,
-         int8_t initExpressionChildNum)
-    : Sym(asttags::Formal, std::move(children),
-          name, Sym::DEFAULT_VISIBILITY),
-      intent_(intent),
-      typeExpressionChildNum(typeExpressionChildNum),
-      initExpressionChildNum(initExpressionChildNum) {
-
-    assert(-1 <= typeExpressionChildNum && typeExpressionChildNum <= 1);
-    assert(-1 <= initExpressionChildNum && initExpressionChildNum <= 1);
-    assert(numChildren() <= 2);
-    assert(isExpressionASTList(children_));
+  Formal(UniqueString name, Formal::Intent intent)
+    : Sym(asttags::Formal, name, Sym::DEFAULT_VISIBILITY), intent_(intent) {
   }
+
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 
@@ -89,38 +75,6 @@ class Formal final : public Sym {
    the formal `y` has intent `const ref`.
    */
   const Intent intent() const { return this->intent_; }
-
-  /**
-   Returns the type expression used in the formal's declaration, or nullptr
-   if there wasn't one.
-
-   For example, in `proc f(y: int)`, the formal `y` has type expression `int`.
-   */
-  const Expression* typeExpression() const {
-    if (typeExpressionChildNum >= 0) {
-      const ASTNode* ast = this->child(typeExpressionChildNum);
-      assert(ast->isExpression());
-      return (const Expression*)ast;
-    } else {
-      return nullptr;
-    }
-  }
-
-  /**
-    Returns the init expression used in the formal's declaration, or nullptr
-    if there wasn't one.
-
-    For example, in `proc f(z = 3)`, the formal `z` has init expression `3`.
-    */
-  const Expression* initExpression() const {
-    if (initExpressionChildNum >= 0) {
-      const ASTNode* ast = this->child(initExpressionChildNum);
-      assert(ast->isExpression());
-      return (const Expression*)ast;
-    } else {
-      return nullptr;
-    }
-  }
 };
 
 

--- a/compiler/next/include/chpl/uast/SymDecl.h
+++ b/compiler/next/include/chpl/uast/SymDecl.h
@@ -34,11 +34,16 @@ namespace uast {
  */
 class SymDecl : public Decl {
  protected:
+  int8_t symChildNum_;
   SymDecl(ASTTag tag, owned<Sym> sym)
-    : Decl(tag, makeASTList(std::move(sym))) {
+    : Decl(tag, makeASTList(std::move(sym))), symChildNum_(0) {
+  }
+  SymDecl(ASTTag tag, ASTList children, int8_t symChildNum)
+    : Decl(tag, std::move(children)), symChildNum_(symChildNum) {
   }
   bool symDeclContentsMatchInner(const SymDecl* other) const {
-    return declContentsMatchInner(other);
+    return this->symChildNum_ == other->symChildNum_ &&
+           declContentsMatchInner(other);
   }
   void symDeclMarkUniqueStringsInner(Context* context) const {
     declMarkUniqueStringsInner(context);
@@ -49,7 +54,7 @@ class SymDecl : public Decl {
 
   /** Returns the symbol declared by the declaration. */
   const Sym* sym() const {
-    const ASTNode* ast = child(0);
+    const ASTNode* ast = child(symChildNum_);
     assert(ast->isSym());
     return (const Sym*) ast;
   }

--- a/compiler/next/include/chpl/uast/Variable.h
+++ b/compiler/next/include/chpl/uast/Variable.h
@@ -58,24 +58,11 @@ class Variable final : public Sym {
 
  private:
   Kind kind_;
-  int8_t typeExpressionChildNum;
-  int8_t initExpressionChildNum;
 
-  Variable(ASTList children,
-           UniqueString name, Sym::Visibility vis,
-           Variable::Kind kind,
-           int8_t typeExpressionChildNum,
-           int8_t initExpressionChildNum)
-    : Sym(asttags::Variable, std::move(children), name, vis),
-      kind_(kind),
-      typeExpressionChildNum(typeExpressionChildNum),
-      initExpressionChildNum(initExpressionChildNum) {
-
-    assert(-1 <= typeExpressionChildNum && typeExpressionChildNum <= 1);
-    assert(-1 <= initExpressionChildNum && initExpressionChildNum <= 1);
-    assert(numChildren() <= 2);
-    assert(isExpressionASTList(children_));
+  Variable(UniqueString name, Sym::Visibility vis, Variable::Kind kind)
+    : Sym(asttags::Variable, name, vis), kind_(kind) {
   }
+
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
 
@@ -85,32 +72,6 @@ class Variable final : public Sym {
     Returns the kind of the variable (`var` / `const` / `param` etc).
    */
   const Kind kind() const { return this->kind_; }
-  /**
-    Returns the type expression used in the variable's declaration, or nullptr
-    if there wasn't one.
-    */
-  const Expression* typeExpression() const {
-    if (typeExpressionChildNum >= 0) {
-      const ASTNode* ast = this->child(typeExpressionChildNum);
-      assert(ast->isExpression());
-      return (const Expression*)ast;
-    } else {
-      return nullptr;
-    }
-  }
-  /**
-    Returns the init expression used in the variable's declaration, or nullptr
-    if there wasn't one.
-    */
-  const Expression* initExpression() const {
-    if (initExpressionChildNum >= 0) {
-      const ASTNode* ast = this->child(initExpressionChildNum);
-      assert(ast->isExpression());
-      return (const Expression*)ast;
-    } else {
-      return nullptr;
-    }
-  }
 };
 
 

--- a/compiler/next/lib/uast/Formal.cpp
+++ b/compiler/next/lib/uast/Formal.cpp
@@ -29,9 +29,7 @@ bool Formal::contentsMatchInner(const ASTNode* other) const {
   const Formal* lhs = this;
   const Formal* rhs = (const Formal*) other;
   return lhs->symContentsMatchInner(rhs) &&
-         lhs->intent_ == rhs->intent_ &&
-         lhs->typeExpressionChildNum == rhs->typeExpressionChildNum &&
-         lhs->initExpressionChildNum == rhs->initExpressionChildNum;
+         lhs->intent_ == rhs->intent_;
 }
 void Formal::markUniqueStringsInner(Context* context) const {
   symMarkUniqueStringsInner(context);

--- a/compiler/next/lib/uast/Variable.cpp
+++ b/compiler/next/lib/uast/Variable.cpp
@@ -29,9 +29,7 @@ bool Variable::contentsMatchInner(const ASTNode* other) const {
   const Variable* lhs = this;
   const Variable* rhs = (const Variable*) other;
   return lhs->symContentsMatchInner(rhs) &&
-         lhs->kind_ == rhs->kind_ &&
-         lhs->typeExpressionChildNum == rhs->typeExpressionChildNum &&
-         lhs->initExpressionChildNum == rhs->initExpressionChildNum;
+         lhs->kind_ == rhs->kind_;
 }
 void Variable::markUniqueStringsInner(Context* context) const {
   symMarkUniqueStringsInner(context);

--- a/compiler/next/test/frontend/testParseFunctions.cpp
+++ b/compiler/next/test/frontend/testParseFunctions.cpp
@@ -314,14 +314,17 @@ static void test2(Parser* parser) {
   assert(function->linkageNameExpression() == nullptr);
   assert(function->numFormals() == 1);
   auto formal = function->formal(0);
+  auto formalDecl = function->formalDecl(0);
   assert(formal);
+  assert(formalDecl);
+  assert(formalDecl->formal() == formal);
   assert(formal->intent() == Formal::DEFAULT_INTENT);
   assert(formal->name().compare("a") == 0);
-  auto typeExpr = formal->typeExpression();
+  auto typeExpr = formalDecl->typeExpression();
   assert(typeExpr);
   assert(typeExpr->isIdentifier());
   assert(typeExpr->toIdentifier()->name().compare("int") == 0);
-  assert(formal->initExpression() == nullptr);
+  assert(formalDecl->initExpression() == nullptr);
   assert(function->thisFormal() == nullptr);
   assert(function->returnType() == nullptr);
   assert(function->numLifetimeClauses() == 0);
@@ -350,24 +353,30 @@ static void test3(Parser* parser) {
   assert(function->numFormals() == 2); // 'this' and 'a'
 
   auto thisFormal = function->formal(0);
+  auto thisFormalDecl = function->formalDecl(0);
   assert(thisFormal);
+  assert(thisFormalDecl);
+  assert(thisFormalDecl->formal() == thisFormal);
   assert(thisFormal->intent() == Formal::CONST);
   assert(thisFormal->name().compare("this") == 0);
-  auto thisTypeExpr = thisFormal->typeExpression();
+  auto thisTypeExpr = thisFormalDecl->typeExpression();
   assert(thisTypeExpr);
   assert(thisTypeExpr->isIdentifier());
   assert(thisTypeExpr->toIdentifier()->name().compare("R") == 0);
-  assert(thisFormal->initExpression() == nullptr);
+  assert(thisFormalDecl->initExpression() == nullptr);
 
   auto formal = function->formal(1);
+  auto formalDecl = function->formalDecl(1);
   assert(formal);
+  assert(formalDecl);
+  assert(formalDecl->formal() == formal);
   assert(formal->intent() == Formal::REF);
   assert(formal->name().compare("a") == 0);
-  auto typeExpr = formal->typeExpression();
+  auto typeExpr = formalDecl->typeExpression();
   assert(typeExpr);
   assert(typeExpr->isIdentifier());
   assert(typeExpr->toIdentifier()->name().compare("int") == 0);
-  auto initExpr = formal->initExpression();
+  auto initExpr = formalDecl->initExpression();
   assert(initExpr);
   assert(initExpr->isIdentifier());
   assert(initExpr->toIdentifier()->name().compare("b") == 0);


### PR DESCRIPTION
This PR changes the typeExpr and initExpr for Formal and Variable to be
stored in the FormalDecl or VariableDecl rather than in the Sym.

There are three reasons for this.

First, the previous strategy was intended to preserve a property that all
Decls will have just one child. That's no longer true now that we have
MultiDecl (and we will soon also have TupleDecl).

Second, when we assign IDs to Symbols, we do that in a different manner
for Syms vs Expressions. Syms are named with the symbol name but
Expressions just get a postorder traversal integer within the parent Sym.
I'd like scope-resolution to be able to use these IDs in a natural
manner. So, I'd like only those Syms that create a new scope to contain
children. (E.g. Function creates a scope for the formals and body; but
Variable does not introduce a new scope). So it is more natural for the
VariableDecl/FormalDecl to contain the typeExpr/initExpr.

Third, storing the typeExpr/initExpr in the FormalDecl/VariableDecl was
requested by a reviewer in earlier discussions.

Reviewed by @lydia-duncan - thanks!