### PR TITLE
Updated test/man/checkManPages to throw error when `--` is used instead of `\--` on flags

### DIFF
--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -139,6 +139,7 @@ def check_man_page(bin_name, additional_args=None):
 
         # Check if the manpage flags of this section have '\' , otherwise throws error
         for mflag in manflags:
+            # mflag[0] used for flags like "--baseline" and mflag[4] for comma separated flags like "-M, --module-dir"
             if mflag[0] == "\\" or mflag[4] == "\\":
                 continue
             else:

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -137,6 +137,19 @@ def check_man_page(bin_name, additional_args=None):
         helpflags = helpsections[section]
         manflags = mansections[section]
 
+        # Check if the manpage flags of this section have '\' , otherwise throws error
+        for mflag in manflags:
+            if mflag[0] == "\\" or mflag[4] == "\\":
+                continue
+            else:
+                numerrors+=1
+                _error('man section "{0}" has some misformatted flags:\
+                        {1}'.format(section, mflag))
+
+        # Removing '\' from manpage flags of this section to match with compiler's flags      
+        for i in range(len(manflags)):
+            manflags[i] = manflags[i].replace("\\", "")   
+
         if helpflags != manflags:
             helpdiff = list(set(helpflags) - set(manflags))
             mandiff = list(set(manflags) - set(helpflags))
@@ -169,7 +182,7 @@ def _get_man_page(bin_name):
 
 def _get_flags(s):
     """Get the flags in a string."""
-    s = s.replace("\\", "")
+
     rs = ''
     # Handle empty lines
     if not s.strip():
@@ -181,18 +194,22 @@ def _get_flags(s):
     # Look for all comma separated flags
     ls = ls.strip().split(',')
     for f in ls:
-        sf = f.strip();
+        sf = f.strip()
         try:
             if sf[0] == '-':
                 # Add flag to the return string
+                rs += sf.split()[0]+','
+            elif sf[0] == '\\':
                 rs += sf.split()[0]+','
             else:
                 break
         except IndexError:
             continue
+    if rs[2] == ",":
+        rs = rs[0:3] + " " + rs[3:len(rs)]
     if rs:
         # Remove any trailing text
-        return rs.strip().split()[0]
+        return rs.strip()
     else:
         return rs
 


### PR DESCRIPTION
This PR updated the script `test/man/checkManPages` that made it throw an error whenever `--` is used instead of `\--`
Resolve #17714 