### PR TITLE
Add -llvm option back to nightly

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -154,6 +154,8 @@ while (@ARGV) {
         $svnrevopt = "-r " . shift @ARGV;
     } elsif ($flag eq "-cron-recipient") {
         $cronrecipient = shift @ARGV;
+    } elsif ($flag eq "-llvm") {
+        $llvm = 1;
     } elsif ($flag eq "-no-llvm") {
         $llvm = 0;
     } elsif ($flag eq "-junit-xml") {


### PR DESCRIPTION
Yesterday I removed parsing the -llvm option from the nightly test script, but
testing jobs still use it and nightly errors out on an unrecognized option.

Add -llvm back to the list of options it handles.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>