### PR TITLE
Set -no-llvm in test-linux64.incr.bash

### DIFF
--- a/util/cron/test-linux64.incr.bash
+++ b/util/cron/test-linux64.incr.bash
@@ -9,4 +9,4 @@ source $CWD/common.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64.incr"
 export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-incremental-warning
 
-$CWD/nightly -cron -examples -compopts --incremental
+$CWD/nightly -cron -examples -no-llvm -compopts --incremental


### PR DESCRIPTION
The incremental compilation testing doesn't support llvm, so throw -no-llvm.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>