### PR TITLE
Use --no-llvm in this future to show the problem

### DIFF
--- a/test/extern/ferguson/externblock/struct-fn-ptr.compopts
+++ b/test/extern/ferguson/externblock/struct-fn-ptr.compopts
@@ -1,0 +1,2 @@
+# C backend shows compilation error from not handling const-ness
+--no-llvm

--- a/test/extern/ferguson/externblock/struct-fn-ptr.future
+++ b/test/extern/ferguson/externblock/struct-fn-ptr.future
@@ -1,1 +1,2 @@
 feature request: respect const variables used in extern code
+#14214


### PR DESCRIPTION
This PR arranges for the future

    extern/ferguson/externblock/struct-fn-ptr

to use `--no-llvm` since that is the easiest way to see the problem.
(The feature this future is requesting is that the Chapel compiler should 
have an idea of`const` C pointers).

I also updated this future to refer to #14214 which is the issue 
requesting e.g. `c_ptr_const`.

Test change only - not reviewed.