### PR TITLE
Adjust sortAllIdxTypes to call isSorted, fix isSorted for differing idxType

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -493,7 +493,7 @@ proc sort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
 proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
   chpl_check_comparator(comparator, eltType);
 
-  const stride = if Dom.stridable then abs(Dom.stride) else 1;
+  const stride = if Dom.stridable then abs(Dom.stride) else 1:Dom.idxType;
   var sorted = true;
   forall (element, i) in zip(Data, Dom) with (&& reduce sorted) {
     if i > Dom.alignedLow {

--- a/test/library/packages/Sort/correctness/sortAllIdxTypes.chpl
+++ b/test/library/packages/Sort/correctness/sortAllIdxTypes.chpl
@@ -9,12 +9,15 @@ proc test(X) {
   sort(Y);
   writeln("  sorted: ", Y);
   writeln();
+  assert(isSorted(X));
+  assert(isSorted(Y));
 }
 
 proc testsize(param s) {
   var A : [1:uint(s)..10:uint(s)] int;
   forall i in A.domain do
     A[i] = (10-i):int;
+
   test(A);
 
   var B : [1:uint(s)..254:uint(s)] int;


### PR DESCRIPTION
This PR adjusts sortAllIdxTypes to call isSorted and adjusted the 
implementation of isSorted implementation to work with non-`int` index
types.

Reviewed by @bradcray - thanks!

- [x] full local testing