### PR TITLE
Set CHPL_LLVM=none for linux32 --no-local testing

### DIFF
--- a/util/cron/test-no-local.linux32.bash
+++ b/util/cron/test-no-local.linux32.bash
@@ -8,4 +8,7 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-local.linux32"
 
+# Linux32 doesn't currently support LLVM
+export CHPL_LLVM=none
+
 $CWD/nightly -cron -examples -no-local


### PR DESCRIPTION
We don't currently support LLVM for linux32. Set CHPL_LLVM=none.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>