### PR TITLE
Add future about confusing error when using ops on uints of mixed size

### DIFF
--- a/test/types/integral/uintMinusSmallUint.bad
+++ b/test/types/integral/uintMinusSmallUint.bad
@@ -1,0 +1,1 @@
+uintMinusSmallUint.chpl:4: error: illegal use of '-' on operands of type uint(64) and signed integer

--- a/test/types/integral/uintMinusSmallUint.chpl
+++ b/test/types/integral/uintMinusSmallUint.chpl
@@ -1,0 +1,5 @@
+var u: uint = 2;
+var u8: uint(8) = 1;
+
+writeln(u-u8);
+

--- a/test/types/integral/uintMinusSmallUint.future
+++ b/test/types/integral/uintMinusSmallUint.future
@@ -1,2 +1,3 @@
 semantic/error messge: Confusing error when subtracting uints of diff sizes
 
+#17756

--- a/test/types/integral/uintMinusSmallUint.future
+++ b/test/types/integral/uintMinusSmallUint.future
@@ -1,0 +1,2 @@
+semantic/error messge: Confusing error when subtracting uints of diff sizes
+

--- a/test/types/integral/uintMinusSmallUint.good
+++ b/test/types/integral/uintMinusSmallUint.good
@@ -1,0 +1,2 @@
+1
+(or maybe it should be an error message that doesn't talk about signed types)


### PR DESCRIPTION
This adds a future that demonstrates that we generate a confusing
error message when applying operations (subtraction here) to a pair of
'uint's of distinct size.  Specifically, it speaks in terms of not
being able to apply operators to a uint and a signed integer even
though there is no signed integer.

At the very least, we should make the error message less confusing.  But
this also raises questions about whether our coercion rules for uints are
poor; or whether we should be providing different overloads on mixed-size
uints to support these cases.
