### PR TITLE
Set CHPL_LLVM=none for no-local incremental compilation testing

### DIFF
--- a/util/cron/test-no-local.incr.bash
+++ b/util/cron/test-no-local.incr.bash
@@ -9,4 +9,7 @@ source $CWD/common.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-local.incr"
 export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-incremental-warning
 
+# incremental compilation not currently supported with LLVM
+export CHPL_LLVM=none
+
 $CWD/nightly -cron -no-local -examples -compopts --incremental


### PR DESCRIPTION
We don't currently support LLVM in this test configuration.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>