### PR TITLE
Default to a large fixed heap on systems we expect to benefit from it.

### DIFF
--- a/doc/rst/platforms/libfabric.rst
+++ b/doc/rst/platforms/libfabric.rst
@@ -185,33 +185,45 @@ should concern themselves with providers.  Providers are simply the
 mechanism of portability when using libfabric.
 
 
-The gni Provider, Memory Registration, and the Heap
-___________________________________________________
-
-(Before you get any further into this section, you should probably
-re-read the note above about performance being better with the native
-ugni communication layer than with the ofi communication layer and gni
-provider.)
+Memory Registration and the Heap
+________________________________
 
 Network technologies sometimes require *memory registration*, meaning
 that ranges of memory which will be the source or target of
 communication operations must be made known to the network before any
 such operations can occur.  When the ofi communication layer is used
-with the gni provider, memory has to be registered.  This has certain
-implications for users, the most notable being that the heap must have a
-fixed size.
+with either the verbs provider on InfiniBand-based platforms including
+HPE Cray EX systems, or with the gni provider on Cray XC systems, memory
+has to be registered.  This has certain implications for users, the most
+notable being that the heap must have a fixed size.
 
 The *heap* is an area of memory used for dynamic allocation of
 everything from user data to task stacks to internal management data
-structures.  When memory must be registered, the ofi communication layer
+structures.  When memory must be registered, the communication layer
 needs to know the maximum size the heap will grow to during execution.
-The default heap size is 16 GiB, but you can change this by setting the
+By default, the ofi communication layer creates a fixed heap whose size
+is 85% of compute node physical memory when it predicts that doing so
+will result in better network performance.
+
+You can adjust this by setting the
 ``CHPL_RT_MAX_HEAP_SIZE`` environment variable.  Set it to a positive
 number for the desired heap size in bytes optionally followed by ``k``
 or ``K`` for KiB, ``m`` or ``M`` for MiB, ``g`` or ``G`` for GiB, or to
 a positive integer followed by ``%`` to indicate a percentage of the
 node real memory.  Either ``CHPL_RT_MAX_HEAP_SIZE=12g`` or ``=20%``
 specifies roughly a 12 GiB heap on a 64 GiB compute node, for example.
+
+Alternatively, you can prevent creation of a fixed heap entirely by
+setting ``CHPL_RT_MAX_HEAP_SIZE=0``.  This may cause the selection of a
+different provider than the highest-performing one, however.
+
+.. note::
+  In the future we hope to be able to reduce the user impact of memory
+  registration and fixed heaps when using the ofi communication layer.
+
+
+Hugepages on Cray XC Systems
+____________________________
 
 We have not yet quantified the effects, but performance with the gni
 provider may be improved if you have a ``craype-hugepages`` module
@@ -225,9 +237,6 @@ hugepage modules, and the heap size.  Note, however, that anything there
 about a dynamically sized heap does not apply to the ofi communication
 layer and the libfabric gni provider.
 
-.. note::
-  In the future we hope to be able to reduce the user impact of memory
-  registration when using the ofi communication layer.
 
 .. _mpirun4ofi-launcher:
 

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -55,7 +55,7 @@ static inline c_nodeid_t get_chpl_nodeID(void) {
 
 extern int32_t chpl_numNodes; // number of nodes
 
-size_t chpl_comm_getenvMaxHeapSize(void);
+ssize_t chpl_comm_getenvMaxHeapSize(void);
 
 
 //

--- a/runtime/include/chpl-format.h
+++ b/runtime/include/chpl-format.h
@@ -28,10 +28,11 @@ extern "C" {
 #endif
 
 //
-// snprintf() a size as nnn[KMG]
+// These snprintf() a size as nnn[KMG] into the given buffer, but
+// unlike snprintf() itself, they return the buffer.
 //
-int chpl_snprintf_KMG_z(char* buf, int bufSize, size_t val);
-int chpl_snprintf_KMG_f(char* buf, int bufSize, double val);
+char* chpl_snprintf_KMG_z(char* buf, int bufSize, size_t val);
+char* chpl_snprintf_KMG_f(char* buf, int bufSize, double val);
 
 #ifdef __cplusplus
 }

--- a/runtime/src/chpl-format.c
+++ b/runtime/src/chpl-format.c
@@ -39,23 +39,29 @@ static const size_t GiB = (size_t) (1UL << 30);
 // snprintf() a size as nnn[KMG]
 //
 
-int chpl_snprintf_KMG_z(char* buf, int bufSize, size_t val) {
-  if (val >= GiB)
-    return snprintf(buf, bufSize, "%zdG", val / GiB);
-  else if (val >= MiB)
-    return snprintf(buf, bufSize, "%zdM", val / MiB);
-  else if (val >= KiB)
-    return snprintf(buf, bufSize, "%zdK", val / KiB);
-  return snprintf(buf, bufSize, "%zd", val);
+char* chpl_snprintf_KMG_z(char* buf, int bufSize, size_t val) {
+  if (val >= GiB) {
+    (void) snprintf(buf, bufSize, "%zdG", val / GiB);
+  } else if (val >= MiB) {
+    (void) snprintf(buf, bufSize, "%zdM", val / MiB);
+  } else if (val >= KiB) {
+    (void) snprintf(buf, bufSize, "%zdK", val / KiB);
+  } else {
+    (void) snprintf(buf, bufSize, "%zd", val);
+  }
+  return buf;
 }
 
 
-int chpl_snprintf_KMG_f(char* buf, int bufSize, double val) {
-  if (val >= GiB)
-    return snprintf(buf, bufSize, "%.1fG", val / GiB);
-  else if (val >= MiB)
-    return snprintf(buf, bufSize, "%.1fM", val / MiB);
-  else if (val >= KiB)
-    return snprintf(buf, bufSize, "%.1fK", val / KiB);
-  return snprintf(buf, bufSize, "%.1f", val);
+char* chpl_snprintf_KMG_f(char* buf, int bufSize, double val) {
+  if (val >= GiB) {
+    (void) snprintf(buf, bufSize, "%.1fG", val / GiB);
+  } else if (val >= MiB) {
+    (void) snprintf(buf, bufSize, "%.1fM", val / MiB);
+  } else if (val >= KiB) {
+    (void) snprintf(buf, bufSize, "%.1fK", val / KiB);
+  } else {
+    (void) snprintf(buf, bufSize, "%.1f", val);
+  }
+  return buf;
 }

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -797,12 +797,12 @@ static void set_max_segsize_env_var(size_t size) {
 }
 
 static void set_max_segsize() {
-  size_t size;
+  ssize_t size;
 
   // GASNet defaults to 85% of physical memory, which is a good default for us,
   // so only override if a user explicitly set CHPL_RT_MAX_HEAP_SIZE
-  if ((size = (size_t) chpl_comm_getenvMaxHeapSize()) != 0) {
-    set_max_segsize_env_var(size);
+  if ((size = chpl_comm_getenvMaxHeapSize()) > 0) {
+    set_max_segsize_env_var((size_t) size);
     return;
   }
 }

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -69,6 +69,7 @@ extern "C" {
   m(AMO_UNORD,              "AMOs: unordered operations")               \
   m(ACK,                    "tx acknowledgements")                      \
   m(ORDER,                  "ops done only for ordering")               \
+  m(HEAP,                   "layer-provided fixed heap")                \
   m(MR,                     "mem reg: regions")                         \
   m(MR_DESC,                "mem reg: local region descs")              \
   m(MR_KEY,                 "mem reg: remote region keys")              \

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2613,7 +2613,7 @@ void init_fixedHeap(void) {
   // on a Cray XC system or the user has explicitly specified a heap
   // size.
   //
-  size_t size = chpl_comm_getenvMaxHeapSize();
+  ssize_t size = chpl_comm_getenvMaxHeapSize();
   if ( ! (chpl_numNodes > 1
           && (strcmp(CHPL_TARGET_PLATFORM, "cray-xc") == 0 || size > 0))) {
     return;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3077,14 +3077,13 @@ void make_registered_heap(void)
   if (size > max_heap_size) {
     if (chpl_nodeID == 0) {
       char buf1[20], buf2[20], buf3[20], msg[200];
-      chpl_snprintf_KMG_z(buf1, sizeof(buf1), nic_max_mem);
-      chpl_snprintf_KMG_z(buf2, sizeof(buf2), page_size);
-      chpl_snprintf_KMG_f(buf3, sizeof(buf3), size);
       (void) snprintf(msg, sizeof(msg),
                       "Aries TLB cache can cover %s with %s pages; "
                       "with %s heap,\n"
                       "         cache refills may reduce performance",
-                      buf1, buf2, buf3);
+                      chpl_snprintf_KMG_z(buf1, sizeof(buf1), nic_max_mem),
+                      chpl_snprintf_KMG_z(buf2, sizeof(buf2), page_size),
+                      chpl_snprintf_KMG_f(buf3, sizeof(buf3), size));
       chpl_warning(msg, 0, 0);
     }
   }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1955,7 +1955,7 @@ void chpl_comm_post_task_init(void)
       chpl_warning("without hugepages, communication performance will suffer",
                    0, 0);
     }
-  } else if (chpl_comm_getenvMaxHeapSize() == 0) {
+  } else if (chpl_comm_getenvMaxHeapSize() <= 0) {
     if (chpl_nodeID == 0) {
       if (getenv("HUGETLB_NO_RESERVE") == NULL) {
         chpl_warning("dynamic heap on hugepages "
@@ -2985,11 +2985,11 @@ static
 void make_registered_heap(void)
 {
   size_t page_size = get_hugepage_size();
-  size_t size_from_env;
+  ssize_t size_from_env;
 
   if (page_size == 0
       || getenv("HUGETLB_MORECORE") == NULL
-      || (size_from_env = chpl_comm_getenvMaxHeapSize()) == 0) {
+      || (size_from_env = chpl_comm_getenvMaxHeapSize()) <= 0) {
     registered_heap_size  = 0;
     registered_heap_start = NULL;
     registered_heap_info_set = 1;

--- a/test/runtime/configMatters/comm/maxHeapSizeAsPct.chpl
+++ b/test/runtime/configMatters/comm/maxHeapSizeAsPct.chpl
@@ -3,7 +3,7 @@ use SysCTypes;
 extern proc chpl_sys_physicalMemoryBytes(): uint(64);
 const physMemSize_1pct: real = chpl_sys_physicalMemoryBytes():real * 0.01;
 
-extern proc chpl_comm_getenvMaxHeapSize(): size_t;
+extern proc chpl_comm_getenvMaxHeapSize(): ssize_t;
 const maxHeapSize: real = chpl_comm_getenvMaxHeapSize():real;
 
 writeln(if abs(maxHeapSize - physMemSize_1pct) / physMemSize_1pct < 0.001


### PR DESCRIPTION
On the target platforms with the most capable networks (InfiniBand, for
example) the ofi comm layer cannot use the best-performing providers
(verbs, for example) unless there is a fixed heap.  But in the past the
comm layer hasn't created a fixed heap by default, meaning that users
had to force it to do so through the `CHPL_RT_MAX_HEAP_SIZE` environment
variable in order to get good performance.

Here, when a tentative provider search indicates that a fixed heap could
improve performance by enabling use of a better provider, create one by
default and make it large: 85% of the compute node's physical memory.
We have to use a tentative provider search because we usually need to
make this decision early, when initializing the memory layer, which is
done long before the bulk of comm layer initialization.  And we need
this so early because some memory layers including the default jemalloc
based one initialize quite differently with and without a fixed heap.
"Tentative" here means that the provider search uses just the base
libfabric capabilities that we require.  In particular we don't look at
anything related to MCM conformance like the full provider search that
comes later does.

Users can override this by setting `CHPL_RT_MAX_HEAP_SIZE=0` in the
environment.

As part of this, adjust the verbose output from comm=ofi to include
whether or not a fixed heap exists and if so, how big it is.

This resolves https://github.com/Cray/chapel-private/issues/1959.
This resolves https://github.com/Cray/chapel-private/issues/1928.