### PR TITLE
Improve error message for applying 'dmapped' to an illegal expression type

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -741,16 +741,9 @@ module ChapelArray {
     }
   }
 
-  proc chpl__distributed(d: _distribution, ranges..., definedConst: bool)
-  where chpl__isTupleOfRanges(ranges) {
-    return chpl__distributed(d, chpl__buildDomainExpr((...ranges),
-                                                      definedConst=definedConst),
-                             definedConst=definedConst);
-  }
-
   pragma "last resort"
   proc chpl__distributed(d: _distribution, expr, definedConst: bool) {
-    compilerError("'dmapped' can currently only be applied to domains or to tuples of ranges.");
+    compilerError("'dmapped' can currently only be applied to domains.");
   }
   
   //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -748,6 +748,11 @@ module ChapelArray {
                              definedConst=definedConst);
   }
 
+  pragma "last resort"
+  proc chpl__distributed(d: _distribution, expr, definedConst: bool) {
+    compilerError("'dmapped' can currently only be applied to domains or to tuples of ranges.");
+  }
+  
   //
   // Array-view utility functions
   //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -745,7 +745,7 @@ module ChapelArray {
   proc chpl__distributed(d: _distribution, expr, definedConst: bool) {
     compilerError("'dmapped' can currently only be applied to domains.");
   }
-  
+
   //
   // Array-view utility functions
   //

--- a/test/distributions/errors/dmapRange.chpl
+++ b/test/distributions/errors/dmapRange.chpl
@@ -1,0 +1,4 @@
+use BlockDist;
+
+var Space = 1..10 dmapped Block({1..10});
+

--- a/test/distributions/errors/dmapRange.good
+++ b/test/distributions/errors/dmapRange.good
@@ -1,1 +1,1 @@
-dmapRange.chpl:3: error: 'dmapped' can currently only be applied to domains or to tuples of ranges.
+dmapRange.chpl:3: error: 'dmapped' can currently only be applied to domains.

--- a/test/distributions/errors/dmapRange.good
+++ b/test/distributions/errors/dmapRange.good
@@ -1,0 +1,1 @@
+dmapRange.chpl:3: error: 'dmapped' can currently only be applied to domains or to tuples of ranges.


### PR DESCRIPTION
This PR adds an error overload for the case when a user applies a `dmapped` clause to something other than a domain.  Previously, this led to a confusing error message that said more about the internal implementation than was useful.

While here, I also noticed that we had the ability to apply `dmapped` to a tuple of ranges, yet this is not a feature that is documented in the spec or seems to be used in testing, so I removed that support.  This also made for a simpler error message describing the cases that are supported.