### PR TITLE
Add a bunch of temporary CHPL_LLVM != none skipifs to interop tests

### DIFF
--- a/test/interop/C/multilocale/SKIPIF
+++ b/test/interop/C/multilocale/SKIPIF
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-# The dynamic tests need to run either on a Mac or with CHPL_LIB_PIC=pic
-# Otherwise they will encounter symbol relocation errors
-if [[ $CHPL_TARGET_PLATFORM == darwin || $CHPL_LIB_PIC == pic ]] ; then
-   echo False
-else
+# Multilocale does not work with LLVM right now.
+if [[ $CHPL_LLVM != none ]]; then
   echo True
+else 
+  # The dynamic tests need to run either on a Mac or with CHPL_LIB_PIC=pic
+  # Otherwise they will encounter symbol relocation errors
+  if [[ $CHPL_TARGET_PLATFORM == darwin || $CHPL_LIB_PIC == pic ]] ; then
+     echo False
+  else
+    echo True
+  fi
 fi
+
+

--- a/test/interop/python/chapelBytes/SKIPIF
+++ b/test/interop/python/chapelBytes/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM != none ]] ; then
   echo True
+elif [[ $CHPL_LLVM != none ]]; then
+  echo True
 elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
   echo True
 elif command -v python3 >/dev/null; then

--- a/test/interop/python/chapelStrings/SKIPIF
+++ b/test/interop/python/chapelStrings/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM != none ]] ; then
   echo True
+elif [[ $CHPL_LLVM != none ]]; then
+  echo True
 elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
   echo True
 elif command -v python3 >/dev/null; then

--- a/test/interop/python/errorMessages/SKIPIF
+++ b/test/interop/python/errorMessages/SKIPIF
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Remove me when multi-locale libraries support LLVM.
+if [[ $CHPL_LLVM != none ]] ; then
+  echo True
+else
+  echo False
+fi
+

--- a/test/interop/python/multilocale/SKIPIF
+++ b/test/interop/python/multilocale/SKIPIF
@@ -2,6 +2,8 @@
 
 if [[ $CHPL_COMM == none ]] ; then
   echo True
+elif [[ $CHPL_LLVM != none ]]; then
+  echo True
 elif [[ $CHPL_TARGET_PLATFORM != darwin && $CHPL_LIB_PIC != pic ]] ; then
   echo True
 elif command -v python3 >/dev/null; then


### PR DESCRIPTION
Interop needs some more work before it plays well with LLVM,
particularly multi-locale interop (which currently does not work
at all, but even when turned on suffers from ABI issues).

Skipif some interop directories for now to clean up nightly testing.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>