### PR TITLE
Set CHPL_LLVM=none for gpu-interop testing

### DIFF
--- a/util/cron/test-cray-cs-gpu-interop.bash
+++ b/util/cron/test-cray-cs-gpu-interop.bash
@@ -7,6 +7,7 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-interop"
 
+export CHPL_LLVM=none
 export CHPL_COMM_SUBSTRATE=ibv
 
 module load cudatoolkit


### PR DESCRIPTION
Quiet gpu-interop testing by setting CHPL_LLVM=none for now.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>