### PR TITLE
Add a future on a case of a formal's type

### DIFF
--- a/test/functions/typeMethods/arg-type-type-method.bad
+++ b/test/functions/typeMethods/arg-type-type-method.bad
@@ -1,0 +1,2 @@
+arg-type-type-method.chpl:6: In function 'test':
+arg-type-type-method.chpl:6: error: '.' undeclared (first use this function)

--- a/test/functions/typeMethods/arg-type-type-method.chpl
+++ b/test/functions/typeMethods/arg-type-type-method.chpl
@@ -1,0 +1,10 @@
+
+
+class CC { }
+proc type CC.typemethod type return int;
+
+proc test(arg: CC.typemethod) {
+  compilerError("success");
+}
+
+test(5);

--- a/test/functions/typeMethods/arg-type-type-method.future
+++ b/test/functions/typeMethods/arg-type-type-method.future
@@ -1,0 +1,2 @@
+bug: formal's type that is a type method on a class does not work
+#17777

--- a/test/functions/typeMethods/arg-type-type-method.good
+++ b/test/functions/typeMethods/arg-type-type-method.good
@@ -1,0 +1,1 @@
+arg-type-type-method.chpl:10: error: success


### PR DESCRIPTION
The compiler reports a bogus user error when a formal's
declared type is a call of a paren-less type method
on a class. (Is this also a problem with a record?)
See Issue #17777.

This PR adds a .future test for that:

    test/functions/typeMethods/arg-type-type-method.chpl
