### PR TITLE
Adjust several tests for LLVM baseline testing

### DIFF
--- a/test/associative/ferguson/check-hashing-statistics.skipif
+++ b/test/associative/ferguson/check-hashing-statistics.skipif
@@ -1,2 +1,1 @@
-CHPL_LLVM==none
 COMPOPTS <= --baseline

--- a/test/types/cptr/func_ptr_as_c_fn_ptr.compopts
+++ b/test/types/cptr/func_ptr_as_c_fn_ptr.compopts
@@ -1,1 +1,1 @@
-struct_with_fn_ptr.h struct_with_fn_ptr.c --ccflags -Wincompatible-pointer-types
+--no-llvm struct_with_fn_ptr.h struct_with_fn_ptr.c --ccflags -Wincompatible-pointer-types


### PR DESCRIPTION
`types/cptr/func_ptr_as_c_fn_ptr` is checking an issue from the C type 
checker so this PR adds `--no-llvm` to it.

`llvm/vectorization/parallel_loop` is testing an optimization so this PR 
skips it under `--baseline`

`associative/ferguson/check-hashing-statistics` takes too long under 
`--baseline` with `--llvm`. It already adds `-O` so this PR skips it for
baseline.

Test change only, not reviewed.