### PR TITLE
Add some more top level skipifs to interop

### DIFF
--- a/test/interop/C/errorMessage.skipif
+++ b/test/interop/C/errorMessage.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/interop/C/exportArray.skipif
+++ b/test/interop/C/exportArray.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/interop/C/multilocale.skipif
+++ b/test/interop/C/multilocale.skipif
@@ -18,8 +18,11 @@ zmq_found = find_library('zmq') is not None
 # Are we configured for multilocale?
 is_not_local = os.getenv('CHPL_COMM', 'none') != 'none'
 
+# Multilocale stuff does not work with LLVM right now.
+is_llvm = os.getenv('CHPL_LLVM', 'none') != 'none'
+
 # OK contains the conditions that must be met to run the test
-OK = is_not_local and zmq_found
+OK = is_not_local and zmq_found and not is_llvm
 
 # Skip if not OK
 print(not OK)

--- a/test/interop/python/multilocale.skipif
+++ b/test/interop/python/multilocale.skipif
@@ -15,8 +15,11 @@ import os
 # Is ZMQ available?
 zmq_found = find_library('zmq') is not None
 
+# Multilocale stuff does not work with LLVM right now.
+is_llvm = os.getenv('CHPL_LLVM', 'none') != 'none'
+
 # OK contains the conditions that must be met to run the test
-OK = zmq_found
+OK = zmq_found and not is_llvm
 
 # Skip if not OK
 print(not OK)


### PR DESCRIPTION
While adding temporary skipifs in #17770, I forgot that `SKIPIF` are
not recursive. To get the correct behavior, attach skipifs to the
entire directory, e.g. `interop/C/multilocale.skipif`.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>