### PR TITLE
Revert "At Brad's suggestion, transform these operators on iterators into methods"

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -364,15 +364,14 @@ module ChapelIteratorSupport {
     }
   }
 
-  operator _iteratorRecord.=(ref ic: _iteratorRecord, xs) {
+  operator =(ref ic: _iteratorRecord, xs) {
     for (e, x) in zip(ic, xs) do
       e = x;
   }
 
   // TODO: replace use of iteratorIndexType?
   pragma "suppress lvalue error"
-  operator _iteratorRecord.=(ref ic: _iteratorRecord,
-                             x: iteratorIndexType(ic)) {
+  operator =(ref ic: _iteratorRecord, x: iteratorIndexType(ic)) {
     for e in ic do
       e = x;
   }


### PR DESCRIPTION
This reverts #17551 

This change was causing issues with `--baseline` testing because the `this`
type argument was not getting dead code eliminated and referred to
_iteratorRecord, a type that is not put into the generated code normally
(because it is the generic template for iterator records rather than a specific
instance).  It is not strictly necessary for iterator records to use operator
methods rather than operator standalone functions, so just back out the changes
(and maybe investigate it more later)

Resolves Cray/chapel-private#1988
Resolves Cray/chapel-private#2047

Testing:
- [x] full paratest with futures
- [x] full baseline paratest with futures