### PR TITLE
Add a new default value of 'unset' for CHPL_LLVM

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -204,7 +204,8 @@ system: $(LLVM_CLANG_CONFIG_FILE)
 system-minimal:
 
 none:
-ifndef CHPL_LLVM
+
+unset:
 	@echo "Error: Please set the environment variable CHPL_LLVM to a supported value."
 	@echo "Supported values are:"
 	@echo "  1) 'none' to build without LLVM support"
@@ -212,7 +213,6 @@ ifndef CHPL_LLVM
 	@echo "  3) 'system' to use a pre-installed system-wide LLVM"
 	@echo "See: https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-llvm"
 	@exit 1
-endif
 
 FORCE:
 

--- a/third-party/llvm/Makefile.include-unset
+++ b/third-party/llvm/Makefile.include-unset
@@ -1,0 +1,6 @@
+include $(THIRD_PARTY_DIR)/llvm/Makefile.share
+
+LLVM_CXXFLAGS=
+LLVM_CFLAGS=
+LLVM_INCLUDES=
+LLVM_LIBS=

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -65,7 +65,7 @@ def has_compatible_installed_llvm():
 def get():
     llvm_val = overrides.get('CHPL_LLVM')
     if not llvm_val:
-        llvm_val = 'none'
+        llvm_val = 'unset'
 
         if is_included_llvm_built():
             llvm_val = 'bundled'


### PR DESCRIPTION
If CHPL_LLVM is not set and no suitable 'system' or 'bundled' LLVM is found
then CHPL_LLVM will print as 'unset' from the chplenv scripts. If it is
'unset' the build will error out with the message asking the user to set it
to one of the three legal values.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>