### PR TITLE
Adjust correctness-test-python-modules.gasnet to use C backend

### DIFF
--- a/util/cron/test-python-modules.gasnet.bash
+++ b/util/cron/test-python-modules.gasnet.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 
 export CHPL_LIB_PIC=pic
+export CHPL_LLVM=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="python-modules.gasnet"
 export CHPL_NIGHTLY_TEST_DIRS="interop/python/multilocale"


### PR DESCRIPTION
Follow-up to PRs #17770 and #17782.

This PR adjusts the test configuration to use `CHPL_LLVM=none` since otherwise all tests are skipped.

Reviewed by @lydia-duncan - thanks!