### PR TITLE
Fix problems with ARM ABI support in multilocale compilation

### DIFF
--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -99,6 +99,8 @@ struct GenInfo {
   int lineno;
   const char* filename;
 
+  std::map<const char*, FnSymbol*> functionCNameAstrToSymbol;
+
 #ifdef HAVE_LLVM
   // stores parsed C stuff for extern blocks
   LayeredValueTable *lvt;
@@ -114,6 +116,8 @@ struct GenInfo {
   const clang::CodeGen::CGFunctionInfo* currentFunctionABI;
 
   llvm::LLVMContext llvmContext;
+
+  // tbaa information
   llvm::MDNode* tbaaRootNode;
   llvm::MDNode* tbaaUnionsNode;
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -168,7 +168,9 @@ WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 5; echo "$$?"),0)
-WARN_CXXFLAGS += -Wsuggest-override
+# We'd like to know about missing overrides but don't let it
+# abort the build since there might be some in LLVM headers.
+WARN_CXXFLAGS += -Wsuggest-override -Wno-error=suggest-override
 endif
 
 #


### PR DESCRIPTION
We were seeing internal errors for compilation on multilocale ARM
configurations.  Debugging the issue, I found that the code generator was
generating a call to `chpl_executeOnFast` but doing so without the
benefit of ABI information. The ABI support added in PRs starting with
#15903 was applying to the `export proc` declaration and the generated
function body but when generating the call, the compiler was not figuring
out that it should generate an ABI-compatible version. That is because
the code generator calls a lot of functions with a particular C string as
the function to call. The problem was that, when that happened, the
compiler didn't have anywhere to check that it's an `extern`/`export`
function.

This PR addresses the problem by arranging for almost all calls with such
a C string for function name to go through a process of finding the Clang
FunctionDecl or Chapel FnSymbol if they exist. To that end, added a
functionCNameAstrToSymbol map to GenInfo. While there, it annoyed me to
debug the many overloads of `codegenCall` and `codegenCallExpr` and so I
renamed the ones accepting a vector of arguments to `codegenCallWithArgs`
etc which make sure to look up the Clang FunctionDecl or Chapel FnSymbol
by name. These in turn call `codegenCallExprInner` which contains most of
the ABI logic.

While working on an ARM system, I noticed that the `make` process failed
initially due to missing `override` keywords in LLVM header files. So,
this PR adjusts our Makefile configuring GCC to ask for `override`
warnings but not errors.

Reviewed by @e-kayrakli - thanks!

- [x] hellos pass on multilocale arm
- [x] test/runtime/configMatters pass on multilocale arm
- [x] full local testing