### PR TITLE
Adjust find-llvm-config.sh to also check for header

### DIFF
--- a/third-party/llvm/find-llvm-config.sh
+++ b/third-party/llvm/find-llvm-config.sh
@@ -69,6 +69,35 @@ done
 
 if [ "$FOUND" != "" ]
 then
+  # check also that the header directory exists
+  INCLUDEDIR=`$FOUND --includedir`
+  if [ ! -d "$INCLUDEDIR" ]
+  then
+    echo "Could not find the include directory $INCLUDEDIR" 1>&2
+    FOUND=""
+  else
+    LLVMHEADER="$INCLUDEDIR/llvm/Config/llvm-config.h"
+    CLANGHEADER="$INCLUDEDIR/clang/Basic/Version.h"
+    if [ ! -f "$LLVMHEADER" ]
+    then
+      echo "Could not find the LLVM header $LLVMHEADER" 1>&2
+      FOUND=""
+    fi
+    if [ ! -f "$CLANGHEADER" ]
+    then
+      echo "Could not find the clang header $CLANGHEADER" 1>&2
+      FOUND=""
+    fi
+  fi
+
+  if [ "$FOUND" == "" ]
+  then
+    echo "Perhaps you need to install clang and llvm dev packages" 1>&2
+  fi
+fi
+
+if [ "$FOUND" != "" ]
+then
   echo "$FOUND"
 else
   echo "Could not find an installed LLVM with version $ALLOW_VERS" 1>&2


### PR DESCRIPTION
With LLVM becoming the default backend we need to take more care to make 
sure it is detected appropriately and that helpful error messages are
shown if something isn't right. One common error is to install llvm and
clang but not versions of these packages that include the header files.
(On Ubuntu, these are `llvm-11-dev` and `libclang-11-dev`). Before this
PR, we would auto-detect that a system LLVM was available and then run
into errors during compilation.

This PR changes `find-llvm-config.sh` to not consider it a "found" LLVM 
configuration if an LLVM header and a clang header are not available.

- [x] checked that the expected error appears when removing `llvm-11-dev` 
  and `libclang-11-dev` on an Ubuntu system
- [x] full local testing

Reviewed by @daviditen - thanks!