### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -467,6 +467,8 @@ all:
   04/01/21:
     - text: Upgrade to GASNet-EX 2021.3.0 (#17505)
       config: 16-node-cs, 16-node-cs-hdr
+  05/14/21:
+    - Use LLVM by default if LLVM is available either as system or bundled (#17079)
 
 # End all
 
@@ -515,6 +517,8 @@ AllCompTime: &timecomp-base
   02/25/21:
     - Restore timing for makeBinary (#17253)
     - Stop converting PRIM_ZIP to tuples for forall statements (#17212)
+  05/14/21:
+    - Resolve some issues with finding primary and secondary operator methods (#17684)
 
 allocate:
   06/11/20:


### PR DESCRIPTION
Adds annotations for

- LLVM-as-default change, that had widespread impact on performance
  - Tracked in https://github.com/Cray/chapel-private/issues/2054
- Resolution performance regression:
  https://chapel-lang.org/perf/comp-default/?startdate=2021/05/06&enddate=2021/05/20&graphs=averagecompilationtimeperpass
  PR: https://github.com/chapel-lang/chapel/pull/17684
