### PR TITLE
Make sure all '.size' methods return int

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -659,8 +659,8 @@ class LocUserMapAssocDom {
   // TODO: I believe these are only used by the random number generator
   // in stream -- will they always be required once that is rewritten?
   //
-  proc size {
-    return myInds.size;
+  proc size: int {
+    return myInds.sizeAs(int);
   }
 }
 
@@ -1032,8 +1032,8 @@ class LocUserMapAssocArr {
   //
   // query for the number of local array elements
   //
-  proc size {
-    return myElems.size;
+  proc size: int {
+    return myElems.sizeAs(int);
   }
 
   // INTERNAL INTERFACE:

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -372,7 +372,7 @@ module Bytes {
   /*
     :returns: The number of bytes in the :mod:`bytes <Bytes>`.
     */
-  inline proc bytes.size return buffLen;
+  inline proc bytes.size: int return buffLen;
 
   /*
     :returns: The indices that can be used to index into the bytes

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -479,7 +479,7 @@ module EpochManager {
         forall a in this.arr[0..#sz] do yield a;
       }
 
-      proc size return sz;
+      proc size: int return sz;
 
       proc clear() {
         this.sz = 0;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1631,7 +1631,7 @@ change if other channels, tasks or programs are writing to the file.
 
 :throws SystemError: Thrown if the size could not be retrieved.
 */
-proc file.size:int(64) throws {
+proc file.size: int throws {
   var err:syserr = ENOERR;
   var len:int(64) = 0;
   on this.home {


### PR DESCRIPTION
This is the result of a sweep I took to see that all 'size' methods
return integers.  I found that most did, but that:

* HashedDist had a (private) interface that called .size() on domains
  and arrays rather than .sizeAs(), which would've resulted in a
  warning if that code path is still used (it doesn't seem to be in our
  testing).

* Some other cases didn't declare the return type of .size, so I
  updated them to do so for the sake of documentation / sanity.

This leaves:

* ranges, domains, and arrays which return various types depending on
  whether one uses the sizeReturnsInt toggle (can be updated to return
  `int` when we remove the old return `idxType` behavior.

* .size() on BigInteger, which is different and being discussed in
  https://github.com/chapel-lang/chapel/issues/17693

Resolves #17643