### PR TITLE
Add standlone iterators for Block domains and arrays

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -807,6 +807,36 @@ iter BlockDom.these() {
     yield i;
 }
 
+iter BlockDom.these(param tag: iterKind) where tag == iterKind.standalone {
+  const maxTasks = dist.dataParTasksPerLocale;
+  const ignoreRunning = dist.dataParIgnoreRunningTasks;
+  const minSize = dist.dataParMinGranularity;
+
+  // If this is the only task running on this locale, we don't want to
+  // count it when we try to determine how many tasks to use.  Here we
+  // check if we are the only one running, and if so, use
+  // ignoreRunning=true for this locale only.  Obviously there's a bit
+  // of a race condition if some other task starts after we check, but
+  // in that case there is no correct answer anyways.
+  //
+  // Note that this code assumes that any locale will only be in the
+  // targetLocales array once.  If this is not the case, then the
+  // tasks on this locale will *all* ignoreRunning, which may have
+  // performance implications.
+  const hereId = here.id;
+  const hereIgnoreRunning = if here.runningTasks() == 1 then true
+                            else ignoreRunning;
+  coforall locDom in locDoms do on locDom {
+    const myIgnoreRunning = if here.id == hereId then hereIgnoreRunning
+      else ignoreRunning;
+    // Use the internal function for untranslate to avoid having to do
+    // extra work to negate the offset
+    for i in locDom.myBlock._value.these(tag, tasksPerLocale=maxTasks, myIgnoreRunning, minSize) {
+      yield i;
+    }
+  }
+}
+
 iter BlockDom.these(param tag: iterKind) where tag == iterKind.leader {
   const maxTasks = dist.dataParTasksPerLocale;
   const ignoreRunning = dist.dataParIgnoreRunningTasks;
@@ -1153,6 +1183,16 @@ pragma "order independent yielding loops"
 iter BlockArr.these() ref {
   for i in dom do
     yield dsiAccess(i);
+}
+
+//
+// TODO: Rewrite this to reuse more of the global domain iterator
+// logic?  (e.g., can we forward the forall to the global domain
+// somehow?
+//
+iter BlockArr.these(param tag: iterKind) where tag == iterKind.standalone {
+  for i in dom.these(tag) do
+    yield this.dsiLocalAccess(chpl__tuplify(i));
 }
 
 //


### PR DESCRIPTION
While helping Michelle with some background for her talk, I noticed
that we didn't have any standalone parallel iterators for Block
domains and arrays, which seems like a wasted opportunity.  Even if it
has no real performance improvement, it should hopefully simplify the
generated code slightly for non-zippered forall loops (?).

And hopefully I haven't done anything in simplifying things to hurt
performance...
