### PR TITLE
Keep checks on for tests that are sensitive to range bounds checking

### DIFF
--- a/test/modules/sungeun/init/printModuleInitOrder.compopts
+++ b/test/modules/sungeun/init/printModuleInitOrder.compopts
@@ -1,0 +1,1 @@
+--cast-checks

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.compopts
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.compopts
@@ -1,1 +1,1 @@
---report-dead-modules
+--report-dead-modules --cast-checks

--- a/test/types/range/elliot/rangeLength/rangeLengthOverflow.compopts
+++ b/test/types/range/elliot/rangeLength/rangeLengthOverflow.compopts
@@ -1,1 +1,1 @@
--ssizeReturnsInt=true
+-ssizeReturnsInt=true --checks

--- a/test/types/range/elliot/rangeLength/rangeLengthOverflow2.compopts
+++ b/test/types/range/elliot/rangeLength/rangeLengthOverflow2.compopts
@@ -1,8 +1,8 @@
--snumbits=8   # rangeLengthOverflow2-int8.good
--snumbits=16  # rangeLengthOverflow2-int16.good
--snumbits=32  # rangeLengthOverflow2-int32.good
--snumbits=64  # rangeLengthOverflow2-int64.good
--snumbits=8  -ssigned=false  # rangeLengthOverflow2-uint8.good
--snumbits=16 -ssigned=false  # rangeLengthOverflow2-uint16.good
--snumbits=32 -ssigned=false  # rangeLengthOverflow2-uint32.good
--snumbits=64 -ssigned=false  # rangeLengthOverflow2-uint64.good
+--checks -snumbits=8   # rangeLengthOverflow2-int8.good
+--checks -snumbits=16  # rangeLengthOverflow2-int16.good
+--checks -snumbits=32  # rangeLengthOverflow2-int32.good
+--checks -snumbits=64  # rangeLengthOverflow2-int64.good
+--checks -snumbits=8  -ssigned=false  # rangeLengthOverflow2-uint8.good
+--checks -snumbits=16 -ssigned=false  # rangeLengthOverflow2-uint16.good
+--checks -snumbits=32 -ssigned=false  # rangeLengthOverflow2-uint32.good
+--checks -snumbits=64 -ssigned=false  # rangeLengthOverflow2-uint64.good

--- a/test/types/range/elliot/rangeLength/uintRangeLength.compopts
+++ b/test/types/range/elliot/rangeLength/uintRangeLength.compopts
@@ -1,1 +1,1 @@
--ssizeReturnsInt=true
+-ssizeReturnsInt=true --checks


### PR DESCRIPTION
Here, I'm fixing my classic error of checking in tests that perform
runtime checks, that fail under --fast because the checks have been
turned off.  I took the approach of forcing checks on for each of
these cases.

The printModuleInitOrder and countDeadModules cases are a bit funny
because they are now sensitive to whether or not checking is on
because the only thing they require from Types.chpl is the safeCast()
check which is completely inlined when checks are off, but has a
helper routine that is not when checks are on.  So here, I just forced
the relevant checks to be on as well.
