### PR TITLE
Fix Wrong types for attribute LLVM Function Verify error

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1779,9 +1779,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
 
     if (fn->hasFlag(FLAG_LLVM_RETURN_NOALIAS)) {
       // Add NoAlias on return for allocator-like functions
-      llvm::AttrBuilder b;
-      b.addAttribute(llvm::Attribute::NoAlias);
-      attrs = attrs.addAttributes(ctx, llvm::AttributeList::ReturnIndex, b);
+      if (returnTy->isPointerTy()) {
+        llvm::AttrBuilder b;
+        b.addAttribute(llvm::Attribute::NoAlias);
+        attrs = attrs.addAttributes(ctx, llvm::AttributeList::ReturnIndex, b);
+      }
     }
   }
 


### PR DESCRIPTION
E.g.
```
  $ chpl --verify --no-local --no-inline test/memory/figueroa/LeakedMemory6.chpl
  $ chpl --baseline --no-local --verify test/functions/iterators/vass/forall-in-standalone-iterator.chpl

  Wrong types for attribute: ....
  %chpl____wide__ddata_uint64_t (i64, i8*, i32, i64, i32)* @_ddata_allocate_noinit_chpl2
```

The issue here was that we were trying to add the `noalias` attribute to
`_ddata_allocate_noinit` but that was not well formed in `--no-local`
compilation because it is returning a struct (representing a wide
pointer).

This PR adjusts the code adding this attribute to only do so when the
return type is a pointer type. That will allow the `noalias` attribute to
apply even with `--llvm-wide-opt`.

Reviewed by @daviditen - thanks!

- [x] full local testing