### PR TITLE
Define chpl__defaultHash for record used in setRecordEqualityOverload

### DIFF
--- a/test/library/standard/Set/setRecordEqualityOverload.bad
+++ b/test/library/standard/Set/setRecordEqualityOverload.bad
@@ -1,1 +1,0 @@
-setRecordEqualityOverload.chpl:21: error: assert failed

--- a/test/library/standard/Set/setRecordEqualityOverload.chpl
+++ b/test/library/standard/Set/setRecordEqualityOverload.chpl
@@ -3,7 +3,7 @@ use Set;
 class C { var x = 0; }
 
 record r {
-  var c = new shared C(-1);;
+  var c = new shared C(-1);
 
   proc init(id: int) {
     this.c = new shared C(id);

--- a/test/library/standard/Set/setRecordEqualityOverload.chpl
+++ b/test/library/standard/Set/setRecordEqualityOverload.chpl
@@ -3,16 +3,23 @@ use Set;
 class C { var x = 0; }
 
 record r {
-  var c = new shared C(-1);
+  var c = new shared C(-1);;
 
   proc init(id: int) {
     this.c = new shared C(id);
   }
+}
 
-  operator ==(lhs: r, rhs: r) {
-    writeln('r==');
-    return lhs.c.x == rhs.c.x;
-  }
+// There isn't a public interface for this yet, but we need to override the
+// hash function for 'r' in order to avoid hashing on the address contained
+// in 'c', which will vary from instance to instance.
+proc chpl__defaultHash(x: r) {
+  return chpl__defaultHash(x.c.x);
+}
+
+operator r.==(lhs: r, rhs: r) {
+  writeln('r==');
+  return lhs.c.x == rhs.c.x;
 }
 
 proc test() {

--- a/test/library/standard/Set/setRecordEqualityOverload.future
+++ b/test/library/standard/Set/setRecordEqualityOverload.future
@@ -1,2 +1,0 @@
-Set should use the user defined operator==, but uses the compiler
-generated one instead.


### PR DESCRIPTION
Define chpl__defaultHash for record used in setRecordEqualityOverload (#17817)

Turns out that the reason why this test failed sporadically was due
to the compiler generated `chpl__defaultHash` for `r` hashing the
address of the class field (which varies from instance to instance).

Thanks to @bradcray for discovering my mistake!

Add a user defined `chpl__defaultHash` that just hashes the int field
in `r.c`. It's OK that `chpl__defaultHash` is defined even if it isn't user
facing, because this test is just checking to make sure `set` does the
right thing.

De-futurize this test. Passed `10000` trials locally.

Change to test, so not reviewed.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>