### PR TITLE
Re-protect some debug-only variables from "unused variable" warnings.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2824,11 +2824,13 @@ void init_fixedHeap(void) {
   size += decrement;
   do {
     size -= decrement;
+#ifdef CHPL_COMM_DEBUG
     if (DBG_TEST_MASK(DBG_HEAP)) {
       char buf[10];
       DBG_PRINTF(DBG_HEAP, "try allocating fixed heap, size %s (%#zx)",
                  chpl_snprintf_KMG_z(buf, sizeof(buf), size), size);
     }
+#endif
     if (have_hugepages) {
       start = chpl_comm_ofi_hp_get_huge_pages(size);
     } else {
@@ -2841,12 +2843,14 @@ void init_fixedHeap(void) {
 
   chpl_comm_regMemHeapTouch(start, size);
 
+#ifdef CHPL_COMM_DEBUG
   if (DBG_TEST_MASK(DBG_HEAP)) {
     char buf[10];
     DBG_PRINTF(DBG_HEAP, "fixed heap on %spages, start=%p size=%s (%#zx)\n",
                have_hugepages ? "huge" : "regular ", start,
                chpl_snprintf_KMG_z(buf, sizeof(buf), size), size);
   }
+#endif
 
   fixedHeapSize  = size;
   fixedHeapStart = start;


### PR DESCRIPTION
Restore ifdefs that protected against "unused variable" warnings
(which we turn into errors) when debug code isn't included.  I removed
these in PR #17762 and failed to catch my mistake because I only did
an optimized+debug build, not an optimized+nondebug one.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>