### PR TITLE
Updated chpl2rst.py to fix Issue #12120

### DIFF
--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -222,6 +222,10 @@ def gen_rst(handle):
                 output.append(' '*indentation + '/*')
                 output.append(rstline)
                 output.append(' '*indentation + '*/')
+                if(foundCommentExample):
+                    print("Error: Found more than one line containing \"multi-line comment\" in \
+                        learnChapelInYMinutes.chpl")
+                    sys.exit(1)
                 foundCommentExample = True
             else:
                output.append(rstline)
@@ -238,7 +242,8 @@ def gen_rst(handle):
             output.append(codeline)
 
     if(islearnChapelInYMinutes and (not foundCommentExample)):
-        print('Warning: Failed to find special case of comment example in learnChapelInYMinutes.chpl')
+        print('Error: Failed to find special case of comment example in learnChapelInYMinutes.chpl')
+        sys.exit(1)
     return '\n'.join(output)
 
 

--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -218,11 +218,11 @@ def gen_rst(handle):
                 else:
                     rstline = rstline.lstrip(' ')
             # Special case for multi line comment in learnChapelInYMinutes
-            if(islearnChapelInYMinutes and ('multi-line comment' in rstline)):
+            if islearnChapelInYMinutes and 'multi-line comment' in rstline:
                 output.append(' '*indentation + '/*')
                 output.append(rstline)
                 output.append(' '*indentation + '*/')
-                if(foundCommentExample):
+                if foundCommentExample:
                     print("Error: Found more than one line containing \"multi-line comment\" in \
                         learnChapelInYMinutes.chpl")
                     sys.exit(1)
@@ -241,7 +241,7 @@ def gen_rst(handle):
             codeline = ''.join(['    ', line])
             output.append(codeline)
 
-    if(islearnChapelInYMinutes and (not foundCommentExample)):
+    if islearnChapelInYMinutes and not foundCommentExample:
         print('Error: Failed to find special case of comment example in learnChapelInYMinutes.chpl')
         sys.exit(1)
     return '\n'.join(output)

--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -148,6 +148,8 @@ def gen_rst(handle):
     commentdepth = 0
     state = ''
     indentation = -1
+    islearnChapelInYMinutes = (os.path.basename(handle.name)=='learnChapelInYMinutes.chpl')
+    foundCommentExample = False
 
     # Each line is rst or code-block
     for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
@@ -215,8 +217,14 @@ def gen_rst(handle):
                     rstline = rstline[indentation:]
                 else:
                     rstline = rstline.lstrip(' ')
-
-            output.append(rstline)
+            # Special case for multi line comment in learnChapelInYMinutes
+            if(islearnChapelInYMinutes and ('multi-line comment' in rstline)):
+                output.append(' '*indentation + '/*')
+                output.append(rstline)
+                output.append(' '*indentation + '*/')
+                foundCommentExample = True
+            else:
+               output.append(rstline)
         else:
             # Reset indentation as we enter codeblock state
             indentation = -1
@@ -229,6 +237,8 @@ def gen_rst(handle):
             codeline = ''.join(['    ', line])
             output.append(codeline)
 
+    if(islearnChapelInYMinutes and (not foundCommentExample)):
+        print('Warning: Failed to find special case of comment example in learnChapelInYMinutes.chpl')
     return '\n'.join(output)
 
 


### PR DESCRIPTION
The changes made are summarized as follows:
* If the script encounters a line having `multi-line comment` in it inside the `learnChapelInYMinutes.chpl` file, the script will put that line inside a multi-line comment block.
* If the script goes through the whole `learnChapelInYMinutes.chpl` file and does not encounter such a line, it will print out an error to the console and exit.
* If the script finds more than one line which matches the case, that is also an error and causes the script to exit

Resolves #12120 

Signed-off-by: Shreyas Khandekar <shreyaskhandekar@email.arizona.edu>