### PR TITLE
next: Parse bracket loops at the statement level

### DIFF
--- a/compiler/next/include/chpl/uast/ASTClassesList.h
+++ b/compiler/next/include/chpl/uast/ASTClassesList.h
@@ -82,6 +82,7 @@ AST_BEGIN_SUBCLASSES(Expression)       // old AST: Expr
       AST_NODE(DoWhile)                // old AST: DoWhileStmt
 
       AST_BEGIN_SUBCLASSES(IndexableLoop)
+        AST_NODE(BracketLoop)
         AST_NODE(Coforall)
         AST_NODE(For)                    // old AST: ForLoop / LoopExpr
         AST_NODE(Forall)                 // old AST: ForallStmt / LoopExpr

--- a/compiler/next/include/chpl/uast/BracketLoop.h
+++ b/compiler/next/include/chpl/uast/BracketLoop.h
@@ -47,27 +47,26 @@ class BracketLoop final : public IndexableLoop {
          int8_t withClauseChildNum,
          int loopBodyChildNum,
          int numLoopBodyStmts,
-         bool isExpressionLevel,
-         bool isBodyBlock)
+         bool usesImplicitBlock,
+         bool isExpressionLevel)
     : IndexableLoop(asttags::BracketLoop, std::move(children),
                     indexChildNum,
                     iterandChildNum,
                     withClauseChildNum,
                     loopBodyChildNum,
                     numLoopBodyStmts,
-                    /*usesDo*/ false,
-                    isExpressionLevel),
-      isBodyBlock_(isBodyBlock) {
+                    usesImplicitBlock,
+                    isExpressionLevel) {
     assert(isExpressionASTList(children_));
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    return indexableLoopContentsMatchInner(other->toIndexableLoop());
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     indexableLoopMarkUniqueStringsInner(context);
   }
-
-  bool isBodyBlock_;
 
  public:
   ~BracketLoop() override = default;
@@ -80,15 +79,9 @@ class BracketLoop final : public IndexableLoop {
                                   owned<Expression> iterand,
                                   owned<WithClause> withClause,
                                   ASTList stmts,
-                                  bool isExpressionLevel,
-                                  bool isBodyBlock);
+                                  bool usesImplicitBlock,
+                                  bool isExpressionLevel);
 
-  /**
-    Returns true if this bracket loop's body is a block.
-  */
-  bool isBodyBlock() const {
-    return isBodyBlock_;
-  }
 
 };
 

--- a/compiler/next/include/chpl/uast/BracketLoop.h
+++ b/compiler/next/include/chpl/uast/BracketLoop.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UAST_BRACKETLOOP_H
+#define CHPL_UAST_BRACKETLOOP_H
+
+#include "chpl/queries/Location.h"
+#include "chpl/uast/IndexableLoop.h"
+#include "chpl/uast/WithClause.h"
+
+namespace chpl {
+namespace uast {
+
+
+/**
+  This class represents a bracket loop. For example:
+
+  \rst
+  .. code-block:: chapel
+
+      // Example 1:
+      [i in 0..15] writeln(i);
+
+  \endrst
+
+ */
+class BracketLoop final : public IndexableLoop {
+ private:
+  BracketLoop(ASTList children, int8_t indexChildNum,
+         int8_t iterandChildNum,
+         int8_t withClauseChildNum,
+         int loopBodyChildNum,
+         int numLoopBodyStmts,
+         bool isExpressionLevel,
+         bool isBodyBlock)
+    : IndexableLoop(asttags::BracketLoop, std::move(children),
+                    indexChildNum,
+                    iterandChildNum,
+                    withClauseChildNum,
+                    loopBodyChildNum,
+                    numLoopBodyStmts,
+                    /*usesDo*/ false,
+                    isExpressionLevel),
+      isBodyBlock_(isBodyBlock) {
+    assert(isExpressionASTList(children_));
+  }
+
+  bool contentsMatchInner(const ASTNode* other) const override;
+
+  void markUniqueStringsInner(Context* context) const override {
+    indexableLoopMarkUniqueStringsInner(context);
+  }
+
+  bool isBodyBlock_;
+
+ public:
+  ~BracketLoop() override = default;
+
+  /**
+    Create and return a bracket loop. 
+  */
+  static owned<BracketLoop> build(Builder* builder, Location loc,
+                                  owned<Decl> index,
+                                  owned<Expression> iterand,
+                                  owned<WithClause> withClause,
+                                  ASTList stmts,
+                                  bool isExpressionLevel,
+                                  bool isBodyBlock);
+
+  /**
+    Returns true if this bracket loop's body is a block.
+  */
+  bool isBodyBlock() const {
+    return isBodyBlock_;
+  }
+
+};
+
+
+} // end namespace uast
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/uast/BracketLoop.h
+++ b/compiler/next/include/chpl/uast/BracketLoop.h
@@ -43,12 +43,12 @@ namespace uast {
 class BracketLoop final : public IndexableLoop {
  private:
   BracketLoop(ASTList children, int8_t indexChildNum,
-         int8_t iterandChildNum,
-         int8_t withClauseChildNum,
-         int loopBodyChildNum,
-         int numLoopBodyStmts,
-         bool usesImplicitBlock,
-         bool isExpressionLevel)
+              int8_t iterandChildNum,
+              int8_t withClauseChildNum,
+              int loopBodyChildNum,
+              int numLoopBodyStmts,
+              bool usesImplicitBlock,
+              bool isExpressionLevel)
     : IndexableLoop(asttags::BracketLoop, std::move(children),
                     indexChildNum,
                     iterandChildNum,

--- a/compiler/next/include/chpl/uast/DoWhile.h
+++ b/compiler/next/include/chpl/uast/DoWhile.h
@@ -88,7 +88,7 @@ class DoWhile final : public Loop {
   }
 
   /**
-    Returns true if this do-while loop body is a block.
+    Returns true if this do-while loop's body is a block.
   */
   bool isBodyBlock() const {
     return isBodyBlock_;

--- a/compiler/next/include/chpl/uast/DoWhile.h
+++ b/compiler/next/include/chpl/uast/DoWhile.h
@@ -47,13 +47,12 @@ class DoWhile final : public Loop {
  private:
   DoWhile(ASTList children, int loopBodyChildNum, int numLoopBodyStmts,
           int conditionChildNum,
-          bool isBodyBlock)
+          bool usesImplicitBlock)
     : Loop(asttags::DoWhile, std::move(children),
            loopBodyChildNum,
            numLoopBodyStmts,
-           /*usesDo*/ true),
-      conditionChildNum_(conditionChildNum),
-      isBodyBlock_(isBodyBlock) {
+           usesImplicitBlock),
+      conditionChildNum_(conditionChildNum) {
     assert(isExpressionASTList(children_));
     assert(condition());
   }
@@ -65,7 +64,6 @@ class DoWhile final : public Loop {
   }
 
   int conditionChildNum_;
-  bool isBodyBlock_;
 
  public:
   ~DoWhile() override = default;
@@ -85,13 +83,6 @@ class DoWhile final : public Loop {
     auto ret = child(conditionChildNum_);
     assert(ret->isExpression());
     return (const Expression*)ret;
-  }
-
-  /**
-    Returns true if this do-while loop's body is a block.
-  */
-  bool isBodyBlock() const {
-    return isBodyBlock_;
   }
 
 };

--- a/compiler/next/include/chpl/uast/For.h
+++ b/compiler/next/include/chpl/uast/For.h
@@ -47,7 +47,7 @@ class For final : public IndexableLoop {
       int8_t iterandChildNum,
       int loopBodyChildNum,
       int numLoopBodyStmts,
-      bool usesDo,
+      bool usesImplicitBlock,
       bool isExpressionLevel,
       bool isParam)
     : IndexableLoop(asttags::For, std::move(children),
@@ -56,7 +56,7 @@ class For final : public IndexableLoop {
                     /*withClauseChildNum*/ -1,
                     loopBodyChildNum,
                     numLoopBodyStmts,
-                    usesDo,
+                    usesImplicitBlock,
                     isExpressionLevel),
       isParam_(isParam) {
 
@@ -82,7 +82,7 @@ class For final : public IndexableLoop {
                           owned<Decl> index,
                           owned<Expression> iterand,
                           ASTList stmts,
-                          bool usesDo,
+                          bool usesImplicitBlock,
                           bool isExpressionLevel,
                           bool isParam);
 

--- a/compiler/next/include/chpl/uast/Forall.h
+++ b/compiler/next/include/chpl/uast/Forall.h
@@ -50,7 +50,7 @@ class Forall final : public IndexableLoop {
          int8_t withClauseChildNum,
          int loopBodyChildNum,
          int numLoopBodyStmts,
-         bool usesDo,
+         bool usesImplicitBlock,
          bool isExpressionLevel)
     : IndexableLoop(asttags::Forall, std::move(children),
                     indexChildNum,
@@ -58,7 +58,7 @@ class Forall final : public IndexableLoop {
                     withClauseChildNum,
                     loopBodyChildNum,
                     numLoopBodyStmts,
-                    usesDo,
+                    usesImplicitBlock,
                     isExpressionLevel) {
     assert(isExpressionASTList(children_));
   }
@@ -82,7 +82,7 @@ class Forall final : public IndexableLoop {
                              owned<Expression> iterand,
                              owned<WithClause> withClause,
                              ASTList stmts,
-                             bool usesDo,
+                             bool usesImplicitBlock,
                              bool isExpressionLevel);
 
 };

--- a/compiler/next/include/chpl/uast/Foreach.h
+++ b/compiler/next/include/chpl/uast/Foreach.h
@@ -50,14 +50,14 @@ class Foreach final : public IndexableLoop {
           int8_t withClauseChildNum,
           int loopBodyChildNum,
           int numLoopBodyStmts,
-          bool usesDo)
+          bool usesImplicitBlock)
     : IndexableLoop(asttags::Foreach, std::move(children),
                     indexChildNum,
                     iterandChildNum,
                     withClauseChildNum,
                     loopBodyChildNum,
                     numLoopBodyStmts,
-                    usesDo,
+                    usesImplicitBlock,
                     /*isExpressionLevel*/ false) {
 
     assert(isExpressionASTList(children_));
@@ -82,7 +82,7 @@ class Foreach final : public IndexableLoop {
                               owned<Expression> iterand,
                               owned<WithClause> withClause,
                               ASTList stmts,
-                              bool usesDo);
+                              bool usesImplicitBlock);
 
 };
 

--- a/compiler/next/include/chpl/uast/IndexableLoop.h
+++ b/compiler/next/include/chpl/uast/IndexableLoop.h
@@ -39,11 +39,11 @@ class IndexableLoop : public Loop {
                 int8_t withClauseChildNum,
                 int loopBodyChildNum,
                 int numLoopBodyStmts,
-                bool usesDo,
+                bool usesImplicitBlock,
                 bool isExpressionLevel)
     : Loop(tag, std::move(children), loopBodyChildNum,
            numLoopBodyStmts,
-           usesDo),
+           usesImplicitBlock),
       indexChildNum_(indexChildNum),
       iterandChildNum_(iterandChildNum),
       withClauseChildNum_(withClauseChildNum),

--- a/compiler/next/include/chpl/uast/Local.h
+++ b/compiler/next/include/chpl/uast/Local.h
@@ -48,17 +48,17 @@ namespace uast {
  */
 class Local final : public Expression {
  private:
-  Local(ASTList stmts, int8_t condChildNum, bool usesDo)
+  Local(ASTList stmts, int8_t condChildNum, bool usesImplicitBlock)
     : Expression(asttags::Local, std::move(stmts)),
       condChildNum_(condChildNum),
-      usesDo_(usesDo) {
+      usesImplicitBlock_(usesImplicitBlock) {
     assert(isExpressionASTList(children_));
   }
 
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
   int8_t condChildNum_;
-  bool usesDo_;
+  bool usesImplicitBlock_;
 
  public:
 
@@ -67,7 +67,7 @@ class Local final : public Expression {
   */
   static owned<Local> build(Builder* builder, Location loc,
                             ASTList stmts,
-                            bool usesDo);
+                            bool usesImplicitBlock);
 
   /**
     Create and return a local statement with the given condition and
@@ -76,7 +76,7 @@ class Local final : public Expression {
   static owned<Local> build(Builder* builder, Location loc,
                             owned<Expression> condition,
                             ASTList stmts,
-                            bool usesDo);
+                            bool usesImplicitBlock);
 
   /**
     Return a way to iterate over the statements.
@@ -117,8 +117,8 @@ class Local final : public Expression {
     Returns true if the first child statement of this local statement is
     preceded by a 'do'.
   */
-  bool usesDo() const {
-    return usesDo_;
+  bool usesImplicitBlock() const {
+    return usesImplicitBlock_;
   }
 
 };

--- a/compiler/next/include/chpl/uast/Loop.h
+++ b/compiler/next/include/chpl/uast/Loop.h
@@ -34,11 +34,11 @@ class Loop: public ControlFlow {
  protected:
   Loop(asttags::ASTTag tag, ASTList children, int loopBodyChildNum,
        int numLoopBodyStmts,
-       bool usesDo)
+       bool usesImplicitBlock)
     : ControlFlow(tag, std::move(children)),
       loopBodyChildNum_(loopBodyChildNum),
       numLoopBodyStmts_(numLoopBodyStmts),
-      usesDo_(usesDo) {
+      usesImplicitBlock_(usesImplicitBlock) {
     assert(loopBodyChildNum_ >= 0 && numLoopBodyStmts_ >= 0);
     assert((loopBodyChildNum_ + numLoopBodyStmts_) <= this->numChildren());
   }
@@ -51,7 +51,7 @@ class Loop: public ControlFlow {
 
   int loopBodyChildNum_;
   int numLoopBodyStmts_;
-  bool usesDo_;
+  bool usesImplicitBlock_;
 
  public:
   virtual ~Loop() override = 0; // this is an abstract base class
@@ -83,10 +83,24 @@ class Loop: public ControlFlow {
   }
 
   /**
-    Returns true if the body of this loop is introduced by a 'do' keyword.
+    Returns true if the body of this loop introduces an implicit block.
+    For example:
+
+    \rst
+    .. code-block:: chapel
+
+        // Example 1:
+        [i in 0..15] writeln(i);
+
+        // Example 2:
+        for i in 0..15 do writeln(i);
+
+    \endrst
+
+    Both introduce an implicit block. 
   */
-  bool usesDo() const {
-    return usesDo_;
+  bool usesImplicitBlock() const {
+    return usesImplicitBlock_;
   }
 };
 

--- a/compiler/next/include/chpl/uast/Serial.h
+++ b/compiler/next/include/chpl/uast/Serial.h
@@ -48,17 +48,17 @@ namespace uast {
  */
 class Serial final : public Expression {
  private:
-  Serial(ASTList stmts, int8_t condChildNum, bool usesDo)
+  Serial(ASTList stmts, int8_t condChildNum, bool usesImplicitBlock)
     : Expression(asttags::Serial, std::move(stmts)),
       condChildNum_(condChildNum),
-      usesDo_(usesDo) {
+      usesImplicitBlock_(usesImplicitBlock) {
     assert(isExpressionASTList(children_));
   }
 
   bool contentsMatchInner(const ASTNode* other) const override;
   void markUniqueStringsInner(Context* context) const override;
   int8_t condChildNum_;
-  bool usesDo_;
+  bool usesImplicitBlock_;
 
  public:
 
@@ -67,7 +67,7 @@ class Serial final : public Expression {
   */
   static owned<Serial> build(Builder* builder, Location loc,
                             ASTList stmts,
-                            bool usesDo);
+                            bool usesImplicitBlock);
 
   /**
     Create and return a serial statement with the given condition and
@@ -76,7 +76,7 @@ class Serial final : public Expression {
   static owned<Serial> build(Builder* builder, Location loc,
                             owned<Expression> condition,
                             ASTList stmts,
-                            bool usesDo);
+                            bool usesImplicitBlock);
 
   /**
     Return a way to iterate over the statements.
@@ -117,8 +117,8 @@ class Serial final : public Expression {
     Returns true if the first child statement of this serial statement is
     preceded by a 'do'.
   */
-  bool usesDo() const {
-    return usesDo_;
+  bool usesImplicitBlock() const {
+    return usesImplicitBlock_;
   }
 
 };

--- a/compiler/next/include/chpl/uast/While.h
+++ b/compiler/next/include/chpl/uast/While.h
@@ -48,10 +48,10 @@ class While final : public Loop {
   While(ASTList children,  int8_t conditionChildNum,
         int loopBodyChildNum,
         int numLoopBodyStmts,
-        bool usesDo)
+        bool usesImplicitBlock)
     : Loop(asttags::While, std::move(children), loopBodyChildNum,
            numLoopBodyStmts,
-           usesDo),
+           usesImplicitBlock),
       conditionChildNum_(conditionChildNum) {
     assert(isExpressionASTList(children_));
     assert(condition());
@@ -74,7 +74,7 @@ class While final : public Loop {
   static owned<While> build(Builder* builder, Location loc,
                             owned<Expression> condition,
                             ASTList stmts,
-                            bool usesDo);
+                            bool usesImplicitBlock);
 
   /**
     Return the condition of this while loop.

--- a/compiler/next/lib/frontend/Parser/ParserContext.h
+++ b/compiler/next/lib/frontend/Parser/ParserContext.h
@@ -180,6 +180,33 @@ struct ParserContext {
                                     New::Management management,
                                     FnCall* fnCall);
 
+  CommentsAndStmt buildBracketLoopStmt(YYLTYPE locLeftBracket,
+                                       YYLTYPE locIndex,
+                                       Expression* indexExpr,
+                                       Expression* iterandExpr,
+                                       WithClause* withClause,
+                                       CommentsAndStmt stmt);
+
+  CommentsAndStmt buildForallLoopStmt(YYLTYPE locForall,
+                                      YYLTYPE locIndex,
+                                      Expression* indexExpr,
+                                      Expression* iterandExpr,
+                                      WithClause* withClause,
+                                      BlockOrDo blockOrDo);
+
+  CommentsAndStmt buildForeachLoopStmt(YYLTYPE locForall,
+                                       YYLTYPE locIndex,
+                                       Expression* indexExpr,
+                                       Expression* iterandExpr,
+                                       WithClause* withClause,
+                                       BlockOrDo blockOrDo);
+
+  CommentsAndStmt buildForLoopStmt(YYLTYPE locForall,
+                                   YYLTYPE locIndex,
+                                   Expression* indexExpr,
+                                   Expression* iterandExpr,
+                                   BlockOrDo blockOrDo);
+
   // Do we really need these?
   /*
   int         captureTokens; // no, new AST meant to be more faithful to src;

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -1578,38 +1578,130 @@ loop_stmt:
                                $4.usesDo);
     $$ = { .comments=comments, .stmt=node.release() };
   }
-| TLSBR expr_ls TIN expr TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
-| TLSBR expr_ls TIN expr forall_intent_clause TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
-| TLSBR expr_ls TIN zippered_iterator TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
-| TLSBR expr_ls TIN zippered_iterator forall_intent_clause TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
-| TLSBR expr_ls TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
-| TLSBR expr_ls forall_intent_clause TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
+| TLSBR expr TIN expr TRSBR stmt
+  {
+    const bool isBodyBlock = $6.stmt->isBlock();
+    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
+    auto exprLst = context->makeList($6);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
+                                   toOwned($4),
+                                   /*withClause*/ nullptr,
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
+| TLSBR expr TIN expr forall_intent_clause TRSBR stmt
+  {
+    const bool isBodyBlock = $7.stmt->isBlock();
+    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
+    auto exprLst = context->makeList($7);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
+                                   toOwned($4),
+                                   toOwned($5),
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
+| TLSBR expr TIN zippered_iterator TRSBR stmt
+  {
+    const bool isBodyBlock = $6.stmt->isBlock();
+    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
+    auto exprLst = context->makeList($6);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
+                                   toOwned($4),
+                                   /*withClause*/ nullptr,
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
+| TLSBR expr TIN zippered_iterator forall_intent_clause TRSBR stmt
+  {
+    const bool isBodyBlock = $7.stmt->isBlock();
+    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
+    auto exprLst = context->makeList($7);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
+                                   toOwned($4),
+                                   toOwned($5),
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
+| TLSBR expr TRSBR stmt
+  {
+    const bool isBodyBlock = $4.stmt->isBlock();
+    auto exprLst = context->makeList($4);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
+                                   toOwned($2),
+                                   /*withClause*/ nullptr,
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
+| TLSBR expr forall_intent_clause TRSBR stmt
+  {
+    const bool isBodyBlock = $5.stmt->isBlock();
+    auto exprLst = context->makeList($5);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
+                                   toOwned($2),
+                                   toOwned($3),
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
     }
 | TLSBR zippered_iterator TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
+  {
+    const bool isBodyBlock = $4.stmt->isBlock();
+    auto exprLst = context->makeList($4);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
+                                   toOwned($2),
+                                   /*withClause*/ nullptr,
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
 | TLSBR zippered_iterator forall_intent_clause TRSBR stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
+  {
+    const bool isBodyBlock = $5.stmt->isBlock();
+    auto exprLst = context->makeList($5);
+    auto comments = context->gatherCommentsFromList(exprLst, @1);
+    auto astLst = context->consumeList(exprLst);
+    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
+    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
+                                   toOwned($2),
+                                   toOwned($3),
+                                   std::move(statements),
+                                   /*isExpressionLevel*/ false,
+                                   isBodyBlock);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
 ;
 
 zippered_iterator:

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -1301,7 +1301,7 @@ extern_block_stmt:
 loop_stmt:
   TDO stmt TWHILE expr TSEMI
   {
-    const bool isBodyBlock = $2.stmt->isBlock();
+    const bool usesImplicitBlock = !($2.stmt->isBlock());
     auto exprLst = context->makeList($2);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
 
@@ -1312,7 +1312,7 @@ loop_stmt:
     auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
     auto node = DoWhile::build(BUILDER, LOC(@1), std::move(statements),
                                toOwned($4),
-                               isBodyBlock);
+                               usesImplicitBlock);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TWHILE expr do_stmt
@@ -1580,7 +1580,7 @@ loop_stmt:
   }
 | TLSBR expr TIN expr TRSBR stmt
   {
-    const bool isBodyBlock = $6.stmt->isBlock();
+    const bool usesImplicitBlock = !($6.stmt->isBlock());
     auto index = context->buildLoopIndexDecl(@2, toOwned($2));
     auto exprLst = context->makeList($6);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
@@ -1590,13 +1590,13 @@ loop_stmt:
                                    toOwned($4),
                                    /*withClause*/ nullptr,
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TLSBR expr TIN expr forall_intent_clause TRSBR stmt
   {
-    const bool isBodyBlock = $7.stmt->isBlock();
+    const bool usesImplicitBlock = !($7.stmt->isBlock());
     auto index = context->buildLoopIndexDecl(@2, toOwned($2));
     auto exprLst = context->makeList($7);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
@@ -1606,13 +1606,13 @@ loop_stmt:
                                    toOwned($4),
                                    toOwned($5),
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TLSBR expr TIN zippered_iterator TRSBR stmt
   {
-    const bool isBodyBlock = $6.stmt->isBlock();
+    const bool usesImplicitBlock = !($6.stmt->isBlock());
     auto index = context->buildLoopIndexDecl(@2, toOwned($2));
     auto exprLst = context->makeList($6);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
@@ -1622,13 +1622,13 @@ loop_stmt:
                                    toOwned($4),
                                    /*withClause*/ nullptr,
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TLSBR expr TIN zippered_iterator forall_intent_clause TRSBR stmt
   {
-    const bool isBodyBlock = $7.stmt->isBlock();
+    const bool usesImplicitBlock = !($7.stmt->isBlock());
     auto index = context->buildLoopIndexDecl(@2, toOwned($2));
     auto exprLst = context->makeList($7);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
@@ -1638,13 +1638,13 @@ loop_stmt:
                                    toOwned($4),
                                    toOwned($5),
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TLSBR expr TRSBR stmt
   {
-    const bool isBodyBlock = $4.stmt->isBlock();
+    const bool usesImplicitBlock = !($4.stmt->isBlock());
     auto exprLst = context->makeList($4);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
     auto astLst = context->consumeList(exprLst);
@@ -1653,13 +1653,13 @@ loop_stmt:
                                    toOwned($2),
                                    /*withClause*/ nullptr,
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TLSBR expr forall_intent_clause TRSBR stmt
   {
-    const bool isBodyBlock = $5.stmt->isBlock();
+    const bool usesImplicitBlock = !($5.stmt->isBlock());
     auto exprLst = context->makeList($5);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
     auto astLst = context->consumeList(exprLst);
@@ -1668,13 +1668,13 @@ loop_stmt:
                                    toOwned($2),
                                    toOwned($3),
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
-    }
+  }
 | TLSBR zippered_iterator TRSBR stmt
   {
-    const bool isBodyBlock = $4.stmt->isBlock();
+    const bool usesImplicitBlock = !($4.stmt->isBlock());
     auto exprLst = context->makeList($4);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
     auto astLst = context->consumeList(exprLst);
@@ -1683,13 +1683,13 @@ loop_stmt:
                                    toOwned($2),
                                    /*withClause*/ nullptr,
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TLSBR zippered_iterator forall_intent_clause TRSBR stmt
   {
-    const bool isBodyBlock = $5.stmt->isBlock();
+    const bool usesImplicitBlock = !($5.stmt->isBlock());
     auto exprLst = context->makeList($5);
     auto comments = context->gatherCommentsFromList(exprLst, @1);
     auto astLst = context->consumeList(exprLst);
@@ -1698,8 +1698,8 @@ loop_stmt:
                                    toOwned($2),
                                    toOwned($3),
                                    std::move(statements),
-                                   /*isExpressionLevel*/ false,
-                                   isBodyBlock);
+                                   usesImplicitBlock,
+                                   /*isExpressionLevel*/ false);
     $$ = { .comments=comments, .stmt=node.release() };
   }
 ;

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -1345,49 +1345,19 @@ loop_stmt:
     }
 | TFOR expr TIN expr do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($5.exprList, @1);
-    auto node = For::build(BUILDER, LOC(@1), std::move(index),
-                           toOwned($4),
-                           context->consumeList($5.exprList),
-                           $5.usesDo,
-                           /*isExpressionLevel*/ false,
-                           /*isParam*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForLoopStmt(@1, @2, $2, $4, $5);
   }
 | TFOR expr TIN zippered_iterator do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($5.exprList, @1);
-    auto node = For::build(BUILDER, LOC(@1), std::move(index),
-                           toOwned($4),
-                           context->consumeList($5.exprList),
-                           $5.usesDo,
-                           /*isExpressionLevel*/ false,
-                           /*isParam*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForLoopStmt(@1, @2, $2, $4, $5);
   }
 | TFOR expr do_stmt
   {
-    auto comments = context->gatherCommentsFromList($3.exprList, @1);
-    auto node = For::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                           toOwned($2),
-                           context->consumeList($3.exprList),
-                           $3.usesDo,
-                           /*isExpressionLevel*/ false,
-                           /*isParam*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForLoopStmt(@1, @1, nullptr, $2, $3);
   }
 | TFOR zippered_iterator do_stmt
   {
-    auto comments = context->gatherCommentsFromList($3.exprList, @1);
-    auto node = For::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                           toOwned($2),
-                           context->consumeList($3.exprList),
-                           $3.usesDo,
-                           /*isExpressionLevel*/ false,
-                           /*isParam*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForLoopStmt(@1, @1, nullptr, $2, $3);
   }
 | TFOR TPARAM ident_def TIN expr do_stmt
   {
@@ -1404,303 +1374,99 @@ loop_stmt:
   }
 | TFORALL expr TIN expr                                   do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($5.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), std::move(index),
-                              toOwned($4),
-                              /*withClause*/ nullptr,
-                              context->consumeList($5.exprList),
-                              $5.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @2, $2, $4, nullptr, $5);
   }
 | TFORALL expr TIN expr              forall_intent_clause do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($6.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), std::move(index),
-                              toOwned($4),
-                              toOwned($5),
-                              context->consumeList($6.exprList),
-                              $6.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @2, $2, $4, $5, $6);
   }
 | TFORALL expr TIN zippered_iterator                      do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($5.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), std::move(index),
-                              toOwned($4),
-                              /*withClause*/ nullptr,
-                              context->consumeList($5.exprList),
-                              $5.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @2, $2, $4, nullptr, $5);
   }
 | TFORALL expr TIN zippered_iterator forall_intent_clause do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($6.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), std::move(index),
-                              toOwned($4),
-                              toOwned($5),
-                              context->consumeList($6.exprList),
-                              $6.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @2, $2, $4, $5, $6);
   }
 | TFORALL          expr                                   do_stmt
   {
-    auto comments = context->gatherCommentsFromList($3.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                              toOwned($2),
-                              /*withClause*/ nullptr,
-                              context->consumeList($3.exprList),
-                              $3.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @1, nullptr, $2, nullptr, $3);
   }
 | TFORALL          expr              forall_intent_clause do_stmt
   {
-    auto comments = context->gatherCommentsFromList($4.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                              toOwned($2),
-                              toOwned($3),
-                              context->consumeList($4.exprList),
-                              $4.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @1, nullptr, $2, $3, $4);
   }
 | TFORALL          zippered_iterator                      do_stmt
   {
-    auto comments = context->gatherCommentsFromList($3.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                              toOwned($2),
-                              /*withClause*/ nullptr,
-                              context->consumeList($3.exprList),
-                              $3.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @1, nullptr, $2, nullptr, $3);
   }
 | TFORALL          zippered_iterator forall_intent_clause do_stmt
   {
-    auto comments = context->gatherCommentsFromList($4.exprList, @1);
-    auto node = Forall::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                              toOwned($2),
-                              toOwned($3),
-                              context->consumeList($4.exprList),
-                              $4.usesDo,
-                              /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForallLoopStmt(@1, @1, nullptr, $2, $3, $4);
   }
 | TFOREACH expr TIN expr                                   do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($5.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), std::move(index),
-                               toOwned($4),
-                               /*withClause*/ nullptr,
-                               context->consumeList($5.exprList),
-                               $5.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @2, $2, $4, nullptr, $5);
   }
 | TFOREACH expr TIN expr              forall_intent_clause do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($6.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), std::move(index),
-                               toOwned($4),
-                               toOwned($5),
-                               context->consumeList($6.exprList),
-                               $6.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @2, $2, $4, $5, $6);
   }
 | TFOREACH expr TIN zippered_iterator                      do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($5.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), std::move(index),
-                               toOwned($4),
-                               /*withClause*/ nullptr,
-                               context->consumeList($5.exprList),
-                               $5.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @2, $2, $4, nullptr, $5);
   }
 | TFOREACH expr TIN zippered_iterator forall_intent_clause do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($6.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), std::move(index),
-                               toOwned($4),
-                               toOwned($5),
-                               context->consumeList($6.exprList),
-                               $6.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @2, $2, $4, $5, $6);
   }
 | TFOREACH          expr                                   do_stmt
   {
-    auto comments = context->gatherCommentsFromList($3.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                               toOwned($2),
-                               /*withClause*/ nullptr,
-                               context->consumeList($3.exprList),
-                               $3.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @1, nullptr, $2, nullptr, $3);
   }
 | TFOREACH          expr              forall_intent_clause do_stmt
   {
-    auto comments = context->gatherCommentsFromList($4.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                               toOwned($2),
-                               toOwned($3),
-                               context->consumeList($4.exprList),
-                               $4.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @1, nullptr, $2, $3, $4);
   }
 | TFOREACH          zippered_iterator                      do_stmt
   {
-    auto comments = context->gatherCommentsFromList($3.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                               toOwned($2),
-                               /*withClause*/ nullptr,
-                               context->consumeList($3.exprList),
-                               $3.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @1, nullptr, $2, nullptr, $3);
   }
 | TFOREACH          zippered_iterator forall_intent_clause do_stmt
   {
-    auto comments = context->gatherCommentsFromList($4.exprList, @1);
-    auto node = Foreach::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                               toOwned($2),
-                               toOwned($3),
-                               context->consumeList($4.exprList),
-                               $4.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildForeachLoopStmt(@1, @1, nullptr, $2, $3, $4);
   }
 | TLSBR expr TIN expr TRSBR stmt
   {
-    const bool usesImplicitBlock = !($6.stmt->isBlock());
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto exprLst = context->makeList($6);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
-                                   toOwned($4),
-                                   /*withClause*/ nullptr,
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, nullptr, $6);
   }
 | TLSBR expr TIN expr forall_intent_clause TRSBR stmt
   {
-    const bool usesImplicitBlock = !($7.stmt->isBlock());
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto exprLst = context->makeList($7);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
-                                   toOwned($4),
-                                   toOwned($5),
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, $5, $7);
   }
 | TLSBR expr TIN zippered_iterator TRSBR stmt
   {
-    const bool usesImplicitBlock = !($6.stmt->isBlock());
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto exprLst = context->makeList($6);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
-                                   toOwned($4),
-                                   /*withClause*/ nullptr,
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, nullptr, $6);
   }
 | TLSBR expr TIN zippered_iterator forall_intent_clause TRSBR stmt
   {
-    const bool usesImplicitBlock = !($7.stmt->isBlock());
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto exprLst = context->makeList($7);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), std::move(index),
-                                   toOwned($4),
-                                   toOwned($5),
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, $5, $7);
   }
 | TLSBR expr TRSBR stmt
   {
-    const bool usesImplicitBlock = !($4.stmt->isBlock());
-    auto exprLst = context->makeList($4);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                                   toOwned($2),
-                                   /*withClause*/ nullptr,
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, nullptr, $4);
   }
 | TLSBR expr forall_intent_clause TRSBR stmt
   {
-    const bool usesImplicitBlock = !($5.stmt->isBlock());
-    auto exprLst = context->makeList($5);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                                   toOwned($2),
-                                   toOwned($3),
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, $3, $5);
   }
 | TLSBR zippered_iterator TRSBR stmt
   {
-    const bool usesImplicitBlock = !($4.stmt->isBlock());
-    auto exprLst = context->makeList($4);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                                   toOwned($2),
-                                   /*withClause*/ nullptr,
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, nullptr, $4);
   }
 | TLSBR zippered_iterator forall_intent_clause TRSBR stmt
   {
-    const bool usesImplicitBlock = !($5.stmt->isBlock());
-    auto exprLst = context->makeList($5);
-    auto comments = context->gatherCommentsFromList(exprLst, @1);
-    auto astLst = context->consumeList(exprLst);
-    auto statements = BUILDER->flattenTopLevelBlocks(std::move(astLst));
-    auto node = BracketLoop::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                                   toOwned($2),
-                                   toOwned($3),
-                                   std::move(statements),
-                                   usesImplicitBlock,
-                                   /*isExpressionLevel*/ false);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, $3, $5);
   }
 ;
 

--- a/compiler/next/lib/frontend/Parser/parser-dependencies.h
+++ b/compiler/next/lib/frontend/Parser/parser-dependencies.h
@@ -26,6 +26,7 @@
 #include "chpl/queries/UniqueString.h"
 #include "chpl/uast/ASTNode.h"
 #include "chpl/uast/Block.h"
+#include "chpl/uast/BracketLoop.h"
 #include "chpl/uast/Builder.h"
 #include "chpl/uast/Call.h"
 #include "chpl/uast/Comment.h"

--- a/compiler/next/lib/uast/BracketLoop.cpp
+++ b/compiler/next/lib/uast/BracketLoop.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/uast/BracketLoop.h"
+
+#include "chpl/uast/Builder.h"
+
+namespace chpl {
+namespace uast {
+
+
+bool BracketLoop::contentsMatchInner(const ASTNode* other) const {
+  const BracketLoop* lhs = this;
+  const BracketLoop* rhs = other->toBracketLoop();
+
+  if (lhs->isBodyBlock_ != rhs->isBodyBlock_)
+    return false;
+
+  if (!lhs->indexableLoopContentsMatchInner(rhs))
+    return false;
+
+  return true;
+}
+
+owned<BracketLoop> BracketLoop::build(Builder* builder, Location loc,
+                                      owned<Decl> index,
+                                      owned<Expression> iterand,
+                                      owned<WithClause> withClause,
+                                      ASTList stmts,
+                                      bool isExpressionLevel,
+                                      bool isBodyBlock) {
+  assert(iterand.get() != nullptr);
+
+  ASTList lst;
+  int8_t indexChildNum = -1;
+  int8_t iterandChildNum = -1;
+  int8_t withClauseChildNum = -1;
+
+  if (index.get() != nullptr) {
+    indexChildNum = lst.size();
+    lst.push_back(std::move(index));
+  }
+
+  if (iterand.get() != nullptr) {
+    iterandChildNum = lst.size();
+    lst.push_back(std::move(iterand));
+  }
+
+  if (withClause.get() != nullptr) {
+    withClauseChildNum = lst.size();
+    lst.push_back(std::move(withClause));
+  }
+
+  const int loopBodyChildNum = lst.size();
+  const int numLoopBodyStmts = stmts.size();
+
+  for (auto& stmt : stmts) {
+    lst.push_back(std::move(stmt));
+  }
+
+  BracketLoop* ret = new BracketLoop(std::move(lst), indexChildNum,
+                                     iterandChildNum,
+                                     withClauseChildNum,
+                                     loopBodyChildNum,
+                                     numLoopBodyStmts,
+                                     isExpressionLevel,
+                                     isBodyBlock);
+  builder->noteLocation(ret, loc);
+  return toOwned(ret);
+}
+
+
+} // namespace uast
+} // namespace chpl

--- a/compiler/next/lib/uast/BracketLoop.cpp
+++ b/compiler/next/lib/uast/BracketLoop.cpp
@@ -25,26 +25,14 @@ namespace chpl {
 namespace uast {
 
 
-bool BracketLoop::contentsMatchInner(const ASTNode* other) const {
-  const BracketLoop* lhs = this;
-  const BracketLoop* rhs = other->toBracketLoop();
-
-  if (lhs->isBodyBlock_ != rhs->isBodyBlock_)
-    return false;
-
-  if (!lhs->indexableLoopContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<BracketLoop> BracketLoop::build(Builder* builder, Location loc,
                                       owned<Decl> index,
                                       owned<Expression> iterand,
                                       owned<WithClause> withClause,
                                       ASTList stmts,
-                                      bool isExpressionLevel,
-                                      bool isBodyBlock) {
+                                      bool usesImplicitBlock,
+                                      bool isExpressionLevel) {
+
   assert(iterand.get() != nullptr);
 
   ASTList lst;
@@ -79,8 +67,9 @@ owned<BracketLoop> BracketLoop::build(Builder* builder, Location loc,
                                      withClauseChildNum,
                                      loopBodyChildNum,
                                      numLoopBodyStmts,
-                                     isExpressionLevel,
-                                     isBodyBlock);
+                                     usesImplicitBlock,
+                                     isExpressionLevel);
+
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/lib/uast/CMakeLists.txt
+++ b/compiler/next/lib/uast/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(libchplcomp-obj
                ASTNode.cpp
                ASTTag.cpp
                Block.cpp
+               BracketLoop.cpp
                Builder.cpp
                Call.cpp
                Comment.cpp

--- a/compiler/next/lib/uast/DoWhile.cpp
+++ b/compiler/next/lib/uast/DoWhile.cpp
@@ -32,7 +32,7 @@ bool DoWhile::contentsMatchInner(const ASTNode* other) const {
   if (lhs->conditionChildNum_ != rhs->conditionChildNum_)
     return false;
 
-  if (lhs->isBodyBlock_ != rhs->isBodyBlock_)
+  if (lhs->usesImplicitBlock_ != rhs->usesImplicitBlock_)
     return false;
 
   if (!lhs->loopContentsMatchInner(rhs))
@@ -44,7 +44,7 @@ bool DoWhile::contentsMatchInner(const ASTNode* other) const {
 owned<DoWhile> DoWhile::build(Builder* builder, Location loc,
                               ASTList stmts,
                               owned<Expression> condition,
-                              bool isBodyBlock) {
+                              bool usesImplicitBlock) {
   assert(condition.get() != nullptr);
 
   ASTList lst;
@@ -61,7 +61,7 @@ owned<DoWhile> DoWhile::build(Builder* builder, Location loc,
   DoWhile* ret = new DoWhile(std::move(lst), loopBodyChildNum,
                              numLoopBodyStmts,
                              conditionChildNum,
-                             isBodyBlock);
+                             usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/lib/uast/DoWhile.cpp
+++ b/compiler/next/lib/uast/DoWhile.cpp
@@ -32,9 +32,6 @@ bool DoWhile::contentsMatchInner(const ASTNode* other) const {
   if (lhs->conditionChildNum_ != rhs->conditionChildNum_)
     return false;
 
-  if (lhs->usesImplicitBlock_ != rhs->usesImplicitBlock_)
-    return false;
-
   if (!lhs->loopContentsMatchInner(rhs))
     return false;
 

--- a/compiler/next/lib/uast/For.cpp
+++ b/compiler/next/lib/uast/For.cpp
@@ -43,7 +43,7 @@ owned<For> For::build(Builder* builder,
                       owned<Decl> index,
                       owned<Expression> iterand,
                       ASTList stmts,
-                      bool usesDo,
+                      bool usesImplicitBlock,
                       bool isExpressionLevel,
                       bool isParam) {
   assert(iterand.get() != nullptr);
@@ -74,7 +74,7 @@ owned<For> For::build(Builder* builder,
                      iterandChildNum,
                      loopBodyChildNum,
                      numLoopBodyStmts,
-                     usesDo,
+                     usesImplicitBlock,
                      isExpressionLevel,
                      isParam);
   builder->noteLocation(ret, loc);

--- a/compiler/next/lib/uast/Forall.cpp
+++ b/compiler/next/lib/uast/Forall.cpp
@@ -30,7 +30,7 @@ owned<Forall> Forall::build(Builder* builder, Location loc,
                             owned<Expression> iterand,
                             owned<WithClause> withClause,
                             ASTList stmts,
-                            bool usesDo,
+                            bool usesImplicitBlock,
                             bool isExpressionLevel) {
   assert(iterand.get() != nullptr);
 
@@ -66,7 +66,7 @@ owned<Forall> Forall::build(Builder* builder, Location loc,
                            withClauseChildNum,
                            loopBodyChildNum,
                            numLoopBodyStmts,
-                           usesDo,
+                           usesImplicitBlock,
                            isExpressionLevel);
   builder->noteLocation(ret, loc);
   return toOwned(ret);

--- a/compiler/next/lib/uast/Foreach.cpp
+++ b/compiler/next/lib/uast/Foreach.cpp
@@ -31,7 +31,7 @@ owned<Foreach> Foreach::build(Builder* builder,
                               owned<Expression> iterand,
                               owned<WithClause> withClause,
                               ASTList stmts,
-                              bool usesDo) {
+                              bool usesImplicitBlock) {
   assert(iterand.get() != nullptr);
 
   ASTList lst;
@@ -66,7 +66,7 @@ owned<Foreach> Foreach::build(Builder* builder,
                            withClauseChildNum,
                            loopBodyChildNum,
                            numLoopBodyStmts,
-                           usesDo);
+                           usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/lib/uast/Local.cpp
+++ b/compiler/next/lib/uast/Local.cpp
@@ -37,7 +37,7 @@ void Local::markUniqueStringsInner(Context* context) const {
 owned<Local> Local::build(Builder* builder,
                           Location loc,
                           ASTList stmts,
-                          bool usesDo) {
+                          bool usesImplicitBlock) {
   ASTList lst;
   int8_t condChildNum = -1;
 
@@ -45,7 +45,7 @@ owned<Local> Local::build(Builder* builder,
     lst.push_back(std::move(stmt));
   }
 
-  Local* ret = new Local(std::move(lst), condChildNum, usesDo);
+  Local* ret = new Local(std::move(lst), condChildNum, usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }
@@ -54,7 +54,7 @@ owned<Local> Local::build(Builder* builder,
                           Location loc,
                           owned<Expression> condition,
                           ASTList stmts,
-                          bool usesDo) {
+                          bool usesImplicitBlock) {
 #ifndef NDEBUG
   assert(condition.get() != nullptr);
 #endif
@@ -71,7 +71,7 @@ owned<Local> Local::build(Builder* builder,
     lst.push_back(std::move(stmt));
   }
 
-  Local* ret = new Local(std::move(lst), condChildNum, usesDo);
+  Local* ret = new Local(std::move(lst), condChildNum, usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/lib/uast/Loop.cpp
+++ b/compiler/next/lib/uast/Loop.cpp
@@ -32,7 +32,7 @@ bool Loop::loopContentsMatchInner(const Loop* other) const {
   if (lhs->numLoopBodyStmts_ != rhs->numLoopBodyStmts_)
     return false;
 
-  if (lhs->usesDo_ != rhs->usesDo_)
+  if (lhs->usesImplicitBlock_ != rhs->usesImplicitBlock_)
     return false;
 
   return true;

--- a/compiler/next/lib/uast/Serial.cpp
+++ b/compiler/next/lib/uast/Serial.cpp
@@ -37,7 +37,7 @@ void Serial::markUniqueStringsInner(Context* context) const {
 owned<Serial> Serial::build(Builder* builder,
                           Location loc,
                           ASTList stmts,
-                          bool usesDo) {
+                          bool usesImplicitBlock) {
   ASTList lst;
   int8_t condChildNum = -1;
 
@@ -45,7 +45,7 @@ owned<Serial> Serial::build(Builder* builder,
     lst.push_back(std::move(stmt));
   }
 
-  Serial* ret = new Serial(std::move(lst), condChildNum, usesDo);
+  Serial* ret = new Serial(std::move(lst), condChildNum, usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }
@@ -54,7 +54,7 @@ owned<Serial> Serial::build(Builder* builder,
                           Location loc,
                           owned<Expression> condition,
                           ASTList stmts,
-                          bool usesDo) {
+                          bool usesImplicitBlock) {
 #ifndef NDEBUG
   assert(condition.get() != nullptr);
 #endif
@@ -71,7 +71,7 @@ owned<Serial> Serial::build(Builder* builder,
     lst.push_back(std::move(stmt));
   }
 
-  Serial* ret = new Serial(std::move(lst), condChildNum, usesDo);
+  Serial* ret = new Serial(std::move(lst), condChildNum, usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/lib/uast/While.cpp
+++ b/compiler/next/lib/uast/While.cpp
@@ -41,7 +41,7 @@ bool While::contentsMatchInner(const ASTNode* other) const {
 owned<While> While::build(Builder* builder, Location loc,
                       owned<Expression> condition,
                       ASTList stmts,
-                      bool usesDo) {
+                      bool usesImplicitBlock) {
   assert(condition.get() != nullptr);
 
   ASTList lst;
@@ -59,7 +59,7 @@ owned<While> While::build(Builder* builder, Location loc,
   While* ret = new While(std::move(lst), conditionChildNum,
                          loopBodyChildNum,
                          numLoopBodyStmts,
-                         usesDo);
+                         usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/test/frontend/CMakeLists.txt
+++ b/compiler/next/test/frontend/CMakeLists.txt
@@ -35,6 +35,7 @@
 comp_unit_test(testFrontendQueries)
 comp_unit_test(testInteractive)
 comp_unit_test(testParse)
+comp_unit_test(testParseBracketLoop)
 comp_unit_test(testParseEnums)
 comp_unit_test(testParseFor)
 comp_unit_test(testParseForall)

--- a/compiler/next/test/frontend/testParseBracketLoop.cpp
+++ b/compiler/next/test/frontend/testParseBracketLoop.cpp
@@ -62,9 +62,8 @@ static void test0(Parser* parser) {
   assert(bracketLoop->iterand() != nullptr);
   assert(bracketLoop->iterand()->isIdentifier());
   assert(bracketLoop->withClause() == nullptr);
-  assert(!bracketLoop->usesDo());
+  assert(bracketLoop->usesImplicitBlock());
   assert(!bracketLoop->isExpressionLevel());
-  assert(!bracketLoop->isBodyBlock());
   assert(bracketLoop->numStmts() == 2);
   assert(bracketLoop->stmt(0)->isComment());
   assert(bracketLoop->stmt(1)->isFnCall());
@@ -101,9 +100,8 @@ static void test1(Parser* parser) {
   assert(!taskVar->typeExpression());
   assert(!taskVar->initExpression());
   assert(taskVar->intent() == TaskVar::REF);
-  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->usesImplicitBlock());
   assert(!bracketLoop->isExpressionLevel());
-  assert(bracketLoop->isBodyBlock());
   assert(bracketLoop->numStmts() == 3);
   assert(bracketLoop->stmt(0)->isComment());
   assert(bracketLoop->stmt(1)->isFnCall());
@@ -135,9 +133,8 @@ static void test2(Parser* parser) {
   assert(zip->numActuals() == 2);
   assert(zip->actual(0)->isIdentifier());
   assert(zip->actual(1)->isIdentifier());
-  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->usesImplicitBlock());
   assert(!bracketLoop->isExpressionLevel());
-  assert(bracketLoop->isBodyBlock());
   assert(bracketLoop->numStmts() == 1);
   assert(bracketLoop->stmt(0)->isFnCall());
 }
@@ -183,9 +180,8 @@ static void test3(Parser* parser) {
   assert(taskVar1->initExpression());
   assert(taskVar1->initExpression()->isIdentifier());
   assert(taskVar1->intent() == TaskVar::IN);
-  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->usesImplicitBlock());
   assert(!bracketLoop->isExpressionLevel());
-  assert(bracketLoop->isBodyBlock());
   assert(bracketLoop->numStmts() == 2);
   assert(bracketLoop->stmt(0)->isFnCall());
   assert(bracketLoop->stmt(1)->isOpCall());
@@ -213,9 +209,8 @@ static void test4(Parser* parser) {
   assert(bracketLoop->iterand()->isFnCall());
   assert(bracketLoop->withClause() == nullptr);
   assert(bracketLoop->numStmts() == 2);
-  assert(!bracketLoop->usesDo());
+  assert(bracketLoop->usesImplicitBlock());
   assert(!bracketLoop->isExpressionLevel());
-  assert(!bracketLoop->isBodyBlock());
   assert(bracketLoop->stmt(0)->isComment());
   assert(bracketLoop->stmt(1)->isFnCall());
 }
@@ -252,9 +247,8 @@ static void test5(Parser* parser) {
   assert(!taskVar0->typeExpression());
   assert(taskVar0->initExpression());
   assert(taskVar0->intent() == TaskVar::VAR);
-  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->usesImplicitBlock());
   assert(!bracketLoop->isExpressionLevel());
-  assert(bracketLoop->isBodyBlock());
   assert(bracketLoop->numStmts() == 1);
   assert(bracketLoop->stmt(0)->isFnCall());
 }

--- a/compiler/next/test/frontend/testParseBracketLoop.cpp
+++ b/compiler/next/test/frontend/testParseBracketLoop.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/uast/Block.h"
+#include "chpl/uast/BracketLoop.h"
+#include "chpl/uast/Expression.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/TaskVar.h"
+#include "chpl/uast/WithClause.h"
+#include "chpl/uast/Zip.h"
+#include "chpl/frontend/Parser.h"
+#include "chpl/queries/Context.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+#include <iostream>
+
+using namespace chpl;
+using namespace uast;
+using namespace frontend;
+
+static void test0(Parser* parser) {
+  auto parseResult = parser->parseString("test0.chpl",
+      "/* comment 1 */\n"
+      "[x in foo]\n"
+      "  /* comment 2 */\n"
+      "  foo();\n"
+      "/* comment 3 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isBracketLoop());
+  assert(mod->stmt(2)->isComment());
+  const BracketLoop* bracketLoop = mod->stmt(1)->toBracketLoop();
+  assert(bracketLoop != nullptr);
+  assert(bracketLoop->index() != nullptr);
+  assert(bracketLoop->index()->isVariable());
+  assert(bracketLoop->iterand() != nullptr);
+  assert(bracketLoop->iterand()->isIdentifier());
+  assert(bracketLoop->withClause() == nullptr);
+  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->isExpressionLevel());
+  assert(!bracketLoop->isBodyBlock());
+  assert(bracketLoop->numStmts() == 2);
+  assert(bracketLoop->stmt(0)->isComment());
+  assert(bracketLoop->stmt(1)->isFnCall());
+}
+
+static void test1(Parser* parser) {
+  auto parseResult = parser->parseString("test1.chpl",
+      "/* comment 1 */\n"
+      "[x in foo with (ref thing)] {\n"
+      "  /* comment 2 */\n"
+      "  foo();\n"
+      "  /* comment 3 */\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isBracketLoop());
+  assert(mod->stmt(2)->isComment());
+  const BracketLoop* bracketLoop = mod->stmt(1)->toBracketLoop();
+  assert(bracketLoop != nullptr);
+  assert(bracketLoop->index() != nullptr);
+  assert(bracketLoop->index()->isVariable());
+  assert(bracketLoop->iterand() != nullptr);
+  assert(bracketLoop->iterand()->isIdentifier());
+  const WithClause* withClause = bracketLoop->withClause();
+  assert(withClause);
+  assert(withClause->numExprs() == 1);
+  const TaskVar* taskVar = withClause->expr(0)->toTaskVar();
+  assert(taskVar);
+  assert(!taskVar->typeExpression());
+  assert(!taskVar->initExpression());
+  assert(taskVar->intent() == TaskVar::REF);
+  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->isExpressionLevel());
+  assert(bracketLoop->isBodyBlock());
+  assert(bracketLoop->numStmts() == 3);
+  assert(bracketLoop->stmt(0)->isComment());
+  assert(bracketLoop->stmt(1)->isFnCall());
+  assert(bracketLoop->stmt(2)->isComment());
+}
+
+static void test2(Parser* parser) {
+  auto parseResult = parser->parseString("test2.chpl",
+      "/* comment 1 */\n"
+      "[x in zip(a, b)] {\n"
+      "  foo();\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isBracketLoop());
+  assert(mod->stmt(2)->isComment());
+  const BracketLoop* bracketLoop = mod->stmt(1)->toBracketLoop();
+  assert(bracketLoop != nullptr);
+  assert(bracketLoop->index() != nullptr);
+  assert(bracketLoop->index()->isVariable());
+  assert(bracketLoop->iterand() != nullptr);
+  const Zip* zip = bracketLoop->iterand()->toZip();
+  assert(zip);
+  assert(zip->numActuals() == 2);
+  assert(zip->actual(0)->isIdentifier());
+  assert(zip->actual(1)->isIdentifier());
+  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->isExpressionLevel());
+  assert(bracketLoop->isBodyBlock());
+  assert(bracketLoop->numStmts() == 1);
+  assert(bracketLoop->stmt(0)->isFnCall());
+}
+
+static void test3(Parser* parser) {
+  auto parseResult = parser->parseString("test3.chpl",
+      "/* comment 1 */\n"
+      "[x in zip(a, b, foo()) with (const ref thing1, in thing2=d)] {\n"
+      "  writeln(thing1);\n"
+      "  thing2 = thing3;\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isBracketLoop());
+  assert(mod->stmt(2)->isComment());
+  const BracketLoop* bracketLoop = mod->stmt(1)->toBracketLoop();
+  assert(bracketLoop != nullptr);
+  assert(bracketLoop->index() != nullptr);
+  assert(bracketLoop->index()->isVariable());
+  assert(bracketLoop->iterand() != nullptr);
+  const Zip* zip = bracketLoop->iterand()->toZip();
+  assert(zip);
+  assert(zip->numActuals() == 3);
+  assert(zip->actual(0)->isIdentifier());
+  assert(zip->actual(1)->isIdentifier());
+  assert(zip->actual(2)->isFnCall());
+  const WithClause* withClause = bracketLoop->withClause();
+  assert(withClause);
+  assert(withClause->numExprs() == 2);
+  const TaskVar* taskVar0 = withClause->expr(0)->toTaskVar();
+  assert(taskVar0);
+  assert(!taskVar0->typeExpression());
+  assert(!taskVar0->initExpression());
+  assert(taskVar0->intent() == TaskVar::CONST_REF);
+  const TaskVar* taskVar1 = withClause->expr(1)->toTaskVar();
+  assert(taskVar1);
+  assert(!taskVar1->typeExpression());
+  assert(taskVar1->initExpression());
+  assert(taskVar1->initExpression()->isIdentifier());
+  assert(taskVar1->intent() == TaskVar::IN);
+  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->isExpressionLevel());
+  assert(bracketLoop->isBodyBlock());
+  assert(bracketLoop->numStmts() == 2);
+  assert(bracketLoop->stmt(0)->isFnCall());
+  assert(bracketLoop->stmt(1)->isOpCall());
+}
+
+static void test4(Parser* parser) {
+  auto parseResult = parser->parseString("test4.chpl",
+      "/* comment 1 */\n"
+      "[foo()]\n"
+      "  /* comment 2 */\n"
+      "  bar();\n"
+      "/* comment 3 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isBracketLoop());
+  assert(mod->stmt(2)->isComment());
+  const BracketLoop* bracketLoop = mod->stmt(1)->toBracketLoop();
+  assert(bracketLoop != nullptr);
+  assert(bracketLoop->index() == nullptr);
+  assert(bracketLoop->iterand() != nullptr);
+  assert(bracketLoop->iterand()->isFnCall());
+  assert(bracketLoop->withClause() == nullptr);
+  assert(bracketLoop->numStmts() == 2);
+  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->isExpressionLevel());
+  assert(!bracketLoop->isBodyBlock());
+  assert(bracketLoop->stmt(0)->isComment());
+  assert(bracketLoop->stmt(1)->isFnCall());
+}
+
+static void test5(Parser* parser) {
+  auto parseResult = parser->parseString("test5.chpl",
+      "/* comment 1 */\n"
+      "[zip(a, b) with (var r=thing1)] {\n"
+      "  writeln(r);\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isBracketLoop());
+  assert(mod->stmt(2)->isComment());
+  const BracketLoop* bracketLoop = mod->stmt(1)->toBracketLoop();
+  assert(bracketLoop != nullptr);
+  assert(bracketLoop->index() == nullptr);
+  assert(bracketLoop->iterand() != nullptr);
+  const Zip* zip = bracketLoop->iterand()->toZip();
+  assert(zip);
+  assert(zip->numActuals() == 2);
+  assert(zip->actual(0)->isIdentifier());
+  assert(zip->actual(1)->isIdentifier());
+  const WithClause* withClause = bracketLoop->withClause();
+  assert(withClause);
+  assert(withClause->numExprs() == 1);
+  const TaskVar* taskVar0 = withClause->expr(0)->toTaskVar();
+  assert(taskVar0);
+  assert(!taskVar0->typeExpression());
+  assert(taskVar0->initExpression());
+  assert(taskVar0->intent() == TaskVar::VAR);
+  assert(!bracketLoop->usesDo());
+  assert(!bracketLoop->isExpressionLevel());
+  assert(bracketLoop->isBodyBlock());
+  assert(bracketLoop->numStmts() == 1);
+  assert(bracketLoop->stmt(0)->isFnCall());
+}
+
+int main() {
+  Context context;
+  Context* ctx = &context;
+
+  auto parser = Parser::build(ctx);
+  Parser* p = parser.get();
+
+  test0(p);
+  test1(p);
+  test2(p);
+  test3(p);
+  test4(p);
+  test5(p);
+
+  return 0;
+}

--- a/compiler/next/test/frontend/testParseDoWhile.cpp
+++ b/compiler/next/test/frontend/testParseDoWhile.cpp
@@ -57,8 +57,7 @@ static void test0(Parser* parser) {
   assert(mod->stmt(2)->isComment());
   const DoWhile* doWhile = mod->stmt(1)->toDoWhile();
   assert(doWhile);
-  assert(doWhile->usesDo());
-  assert(doWhile->isBodyBlock());
+  assert(!doWhile->usesImplicitBlock());
   assert(doWhile->condition());
   assert(doWhile->condition()->isFnCall());
   assert(doWhile->numStmts() == 3);
@@ -87,8 +86,7 @@ static void test1(Parser* parser) {
   assert(mod->stmt(2)->isComment());
   const DoWhile* doWhile = mod->stmt(1)->toDoWhile();
   assert(doWhile);
-  assert(doWhile->usesDo());
-  assert(!doWhile->isBodyBlock());
+  assert(doWhile->usesImplicitBlock());
   assert(doWhile->condition());
   assert(doWhile->condition()->isIdentifier());
   // Comment between 'while' and condition is discarded.
@@ -98,6 +96,7 @@ static void test1(Parser* parser) {
   assert(doWhile->stmt(2)->isComment());
   const For* forLoop = doWhile->stmt(1)->toFor();
   assert(forLoop);
+  assert(forLoop->usesImplicitBlock());
   assert(forLoop->index());
   assert(forLoop->index()->isVariable());
   assert(forLoop->iterand() && forLoop->iterand()->isIdentifier());
@@ -130,8 +129,7 @@ static void test2(Parser* parser) {
   assert(mod->stmt(2)->isComment());
   const DoWhile* doWhile = mod->stmt(1)->toDoWhile();
   assert(doWhile);
-  assert(doWhile->usesDo());
-  assert(!doWhile->isBodyBlock());
+  assert(doWhile->usesImplicitBlock());
   assert(doWhile->condition());
   assert(doWhile->condition()->isIdentifier());
   // Comment between 'while' and condition is discarded.
@@ -141,8 +139,7 @@ static void test2(Parser* parser) {
   assert(doWhile->stmt(2)->isComment());
   const DoWhile* doWhileInner = doWhile->stmt(1)->toDoWhile();
   assert(doWhileInner);
-  assert(doWhileInner->usesDo());
-  assert(doWhileInner->isBodyBlock());
+  assert(!doWhileInner->usesImplicitBlock());
   assert(doWhileInner->condition()->isIdentifier());
   assert(doWhileInner->numStmts() == 5);
   assert(doWhileInner->stmt(0)->isComment());

--- a/compiler/next/test/frontend/testParseFor.cpp
+++ b/compiler/next/test/frontend/testParseFor.cpp
@@ -56,7 +56,7 @@ static void test0(Parser* parser) {
   assert(forLoop->iterand() != nullptr);
   assert(forLoop->iterand()->isIdentifier());
   assert(forLoop->numStmts() == 2);
-  assert(forLoop->usesDo());
+  assert(forLoop->usesImplicitBlock());
   assert(!forLoop->isExpressionLevel());
   assert(!forLoop->isParam());
   assert(forLoop->stmt(0)->isComment());
@@ -83,7 +83,7 @@ static void test1(Parser* parser) {
   assert(forLoop->iterand() != nullptr);
   assert(forLoop->iterand()->isIdentifier());
   assert(forLoop->numStmts() == 2);
-  assert(forLoop->usesDo());
+  assert(forLoop->usesImplicitBlock());
   assert(!forLoop->isExpressionLevel());
   assert(!forLoop->isParam());
   assert(forLoop->stmt(0)->isComment());
@@ -110,7 +110,7 @@ static void test2(Parser* parser) {
   assert(forLoop->iterand() != nullptr);
   assert(forLoop->iterand()->isIdentifier());
   assert(forLoop->numStmts() == 2);
-  assert(forLoop->usesDo());
+  assert(forLoop->usesImplicitBlock());
   assert(!forLoop->isExpressionLevel());
   assert(forLoop->isParam());
   assert(forLoop->stmt(0)->isComment());
@@ -139,7 +139,7 @@ static void test3(Parser* parser) {
   assert(forLoop->iterand() != nullptr);
   assert(forLoop->iterand()->isIdentifier());
   assert(forLoop->numStmts() == 3);
-  assert(!forLoop->usesDo());
+  assert(!forLoop->usesImplicitBlock());
   assert(!forLoop->isExpressionLevel());
   assert(!forLoop->isParam());
   assert(forLoop->stmt(0)->isComment());
@@ -171,7 +171,7 @@ static void test4(Parser* parser) {
   assert(forLoop->iterand() != nullptr);
   assert(forLoop->iterand()->isIdentifier());
   assert(forLoop->numStmts() == 2);
-  assert(forLoop->usesDo());
+  assert(forLoop->usesImplicitBlock());
   assert(!forLoop->isExpressionLevel());
   assert(!forLoop->isParam());
   assert(forLoop->stmt(0)->isComment());

--- a/compiler/next/test/frontend/testParseForall.cpp
+++ b/compiler/next/test/frontend/testParseForall.cpp
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
   assert(forall->iterand()->isIdentifier());
   assert(forall->withClause() == nullptr);
   assert(forall->numStmts() == 2);
-  assert(forall->usesDo());
+  assert(forall->usesImplicitBlock());
   assert(!forall->isExpressionLevel());
   assert(forall->stmt(0)->isComment());
   assert(forall->stmt(1)->isFnCall());
@@ -100,7 +100,7 @@ static void test1(Parser* parser) {
   assert(!taskVar->typeExpression());
   assert(!taskVar->initExpression());
   assert(taskVar->intent() == TaskVar::REF);
-  assert(!forall->usesDo());
+  assert(!forall->usesImplicitBlock());
   assert(!forall->isExpressionLevel());
   assert(forall->numStmts() == 3);
   assert(forall->stmt(0)->isComment());
@@ -133,7 +133,7 @@ static void test2(Parser* parser) {
   assert(zip->numActuals() == 2);
   assert(zip->actual(0)->isIdentifier());
   assert(zip->actual(1)->isIdentifier());
-  assert(!forall->usesDo());
+  assert(!forall->usesImplicitBlock());
   assert(!forall->isExpressionLevel());
   assert(forall->numStmts() == 1);
   assert(forall->stmt(0)->isFnCall());
@@ -180,7 +180,7 @@ static void test3(Parser* parser) {
   assert(taskVar1->initExpression());
   assert(taskVar1->initExpression()->isIdentifier());
   assert(taskVar1->intent() == TaskVar::IN);
-  assert(!forall->usesDo());
+  assert(!forall->usesImplicitBlock());
   assert(!forall->isExpressionLevel());
   assert(forall->numStmts() == 2);
   assert(forall->stmt(0)->isFnCall());
@@ -209,7 +209,7 @@ static void test4(Parser* parser) {
   assert(forall->iterand()->isFnCall());
   assert(forall->withClause() == nullptr);
   assert(forall->numStmts() == 2);
-  assert(forall->usesDo());
+  assert(forall->usesImplicitBlock());
   assert(!forall->isExpressionLevel());
   assert(forall->stmt(0)->isComment());
   assert(forall->stmt(1)->isFnCall());
@@ -247,7 +247,7 @@ static void test5(Parser* parser) {
   assert(!taskVar0->typeExpression());
   assert(taskVar0->initExpression());
   assert(taskVar0->intent() == TaskVar::VAR);
-  assert(!forall->usesDo());
+  assert(!forall->usesImplicitBlock());
   assert(!forall->isExpressionLevel());
   assert(forall->numStmts() == 1);
   assert(forall->stmt(0)->isFnCall());

--- a/compiler/next/test/frontend/testParseForeach.cpp
+++ b/compiler/next/test/frontend/testParseForeach.cpp
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
   assert(foreach->iterand()->isIdentifier());
   assert(foreach->withClause() == nullptr);
   assert(foreach->numStmts() == 2);
-  assert(foreach->usesDo());
+  assert(foreach->usesImplicitBlock());
   assert(foreach->stmt(0)->isComment());
   assert(foreach->stmt(1)->isFnCall());
 }
@@ -99,7 +99,7 @@ static void test1(Parser* parser) {
   assert(!taskVar->typeExpression());
   assert(!taskVar->initExpression());
   assert(taskVar->intent() == TaskVar::REF);
-  assert(!foreach->usesDo());
+  assert(!foreach->usesImplicitBlock());
   assert(foreach->numStmts() == 3);
   assert(foreach->stmt(0)->isComment());
   assert(foreach->stmt(1)->isFnCall());
@@ -131,7 +131,7 @@ static void test2(Parser* parser) {
   assert(zip->numActuals() == 2);
   assert(zip->actual(0)->isIdentifier());
   assert(zip->actual(1)->isIdentifier());
-  assert(!foreach->usesDo());
+  assert(!foreach->usesImplicitBlock());
   assert(foreach->numStmts() == 1);
   assert(foreach->stmt(0)->isFnCall());
 }
@@ -177,7 +177,7 @@ static void test3(Parser* parser) {
   assert(taskVar1->initExpression());
   assert(taskVar1->initExpression()->isIdentifier());
   assert(taskVar1->intent() == TaskVar::IN);
-  assert(!foreach->usesDo());
+  assert(!foreach->usesImplicitBlock());
   assert(foreach->numStmts() == 2);
   assert(foreach->stmt(0)->isFnCall());
   assert(foreach->stmt(1)->isOpCall());
@@ -205,7 +205,7 @@ static void test4(Parser* parser) {
   assert(foreach->iterand()->isFnCall());
   assert(foreach->withClause() == nullptr);
   assert(foreach->numStmts() == 2);
-  assert(foreach->usesDo());
+  assert(foreach->usesImplicitBlock());
   assert(foreach->stmt(0)->isComment());
   assert(foreach->stmt(1)->isFnCall());
 }
@@ -242,7 +242,7 @@ static void test5(Parser* parser) {
   assert(!taskVar0->typeExpression());
   assert(taskVar0->initExpression());
   assert(taskVar0->intent() == TaskVar::VAR);
-  assert(!foreach->usesDo());
+  assert(!foreach->usesImplicitBlock());
   assert(foreach->numStmts() == 1);
   assert(foreach->stmt(0)->isFnCall());
 }

--- a/compiler/next/test/frontend/testParseLocal.cpp
+++ b/compiler/next/test/frontend/testParseLocal.cpp
@@ -51,7 +51,7 @@ static void test0(Parser* parser) {
   assert(local != nullptr);
   assert(local->condition() == nullptr);
   assert(local->numStmts() == 1);
-  assert(local->usesDo());
+  assert(local->usesImplicitBlock());
   assert(local->stmt(0)->isVariable());
 }
 
@@ -71,7 +71,7 @@ static void test1(Parser* parser) {
   assert(local->condition() != nullptr);
   assert(local->condition()->isIdentifier());
   assert(local->numStmts() == 1);
-  assert(local->usesDo());
+  assert(local->usesImplicitBlock());
   assert(local->stmt(0)->isVariable());
 }
 
@@ -90,7 +90,7 @@ static void test2(Parser* parser) {
   assert(local != nullptr);
   assert(local->condition() == nullptr);
   assert(local->numStmts() == 1);
-  assert(!local->usesDo());
+  assert(!local->usesImplicitBlock());
   assert(local->stmt(0)->isVariable());
 }
 
@@ -110,7 +110,7 @@ static void test3(Parser* parser) {
   assert(local->condition() != nullptr);
   assert(local->condition()->isIdentifier());
   assert(local->numStmts() == 1);
-  assert(!local->usesDo());
+  assert(!local->usesImplicitBlock());
   assert(local->stmt(0)->isVariable());
 }
 
@@ -129,7 +129,7 @@ static void test4(Parser* parser) {
   assert(local != nullptr);
   assert(local->condition() == nullptr);
   assert(local->numStmts() == 1);
-  assert(local->usesDo());
+  assert(local->usesImplicitBlock());
   assert(local->stmt(0)->isBlock());
   const Block* block = local->stmt(0)->toBlock();
   assert(block != nullptr);
@@ -153,7 +153,7 @@ static void test5(Parser* parser) {
   assert(local->condition() != nullptr);
   assert(local->condition()->isIdentifier());
   assert(local->numStmts() == 1);
-  assert(local->usesDo());
+  assert(local->usesImplicitBlock());
   assert(local->stmt(0)->isBlock());
   const Block* block = local->stmt(0)->toBlock();
   assert(block != nullptr);
@@ -179,7 +179,7 @@ static void test6(Parser* parser) {
   assert(mod->stmt(1)->isLocal());
   const Local* local = mod->stmt(1)->toLocal();
   assert(local != nullptr);
-  assert(!local->usesDo());
+  assert(!local->usesImplicitBlock());
   assert(local->condition() != nullptr);
   assert(local->condition()->isIdentifier());
   assert(local->numStmts() == 3);
@@ -201,7 +201,7 @@ static void test7(Parser* parser) {
   auto mod = parseResult.topLevelExpressions[0]->toModule();
   const Local* local = mod->stmt(1)->toLocal();
   assert(local != nullptr);
-  assert(local->usesDo());
+  assert(local->usesImplicitBlock());
   assert(local->condition() == nullptr);
   assert(local->numStmts() == 2);
   assert(local->stmt(0)->isComment());

--- a/compiler/next/test/frontend/testParseSerial.cpp
+++ b/compiler/next/test/frontend/testParseSerial.cpp
@@ -51,7 +51,7 @@ static void test0(Parser* parser) {
   assert(serial != nullptr);
   assert(serial->condition() == nullptr);
   assert(serial->numStmts() == 1);
-  assert(serial->usesDo());
+  assert(serial->usesImplicitBlock());
   assert(serial->stmt(0)->isVariable());
 }
 
@@ -71,7 +71,7 @@ static void test1(Parser* parser) {
   assert(serial->condition() != nullptr);
   assert(serial->condition()->isIdentifier());
   assert(serial->numStmts() == 1);
-  assert(serial->usesDo());
+  assert(serial->usesImplicitBlock());
   assert(serial->stmt(0)->isVariable());
 }
 
@@ -90,7 +90,7 @@ static void test2(Parser* parser) {
   assert(serial != nullptr);
   assert(serial->condition() == nullptr);
   assert(serial->numStmts() == 1);
-  assert(!serial->usesDo());
+  assert(!serial->usesImplicitBlock());
   assert(serial->stmt(0)->isVariable());
 }
 
@@ -110,7 +110,7 @@ static void test3(Parser* parser) {
   assert(serial->condition() != nullptr);
   assert(serial->condition()->isIdentifier());
   assert(serial->numStmts() == 1);
-  assert(!serial->usesDo());
+  assert(!serial->usesImplicitBlock());
   assert(serial->stmt(0)->isVariable());
 }
 
@@ -129,7 +129,7 @@ static void test4(Parser* parser) {
   assert(serial != nullptr);
   assert(serial->condition() == nullptr);
   assert(serial->numStmts() == 1);
-  assert(serial->usesDo());
+  assert(serial->usesImplicitBlock());
   assert(serial->stmt(0)->isBlock());
   const Block* block = serial->stmt(0)->toBlock();
   assert(block != nullptr);
@@ -153,7 +153,7 @@ static void test5(Parser* parser) {
   assert(serial->condition() != nullptr);
   assert(serial->condition()->isIdentifier());
   assert(serial->numStmts() == 1);
-  assert(serial->usesDo());
+  assert(serial->usesImplicitBlock());
   assert(serial->stmt(0)->isBlock());
   const Block* block = serial->stmt(0)->toBlock();
   assert(block != nullptr);
@@ -179,7 +179,7 @@ static void test6(Parser* parser) {
   assert(mod->stmt(1)->isSerial());
   const Serial* serial = mod->stmt(1)->toSerial();
   assert(serial != nullptr);
-  assert(!serial->usesDo());
+  assert(!serial->usesImplicitBlock());
   assert(serial->condition() != nullptr);
   assert(serial->condition()->isIdentifier());
   assert(serial->numStmts() == 3);
@@ -201,7 +201,7 @@ static void test7(Parser* parser) {
   auto mod = parseResult.topLevelExpressions[0]->toModule();
   const Serial* serial = mod->stmt(1)->toSerial();
   assert(serial != nullptr);
-  assert(serial->usesDo());
+  assert(serial->usesImplicitBlock());
   assert(serial->condition() == nullptr);
   assert(serial->numStmts() == 2);
   assert(serial->stmt(0)->isComment());

--- a/compiler/next/test/frontend/testParseWhile.cpp
+++ b/compiler/next/test/frontend/testParseWhile.cpp
@@ -52,7 +52,7 @@ static void test0(Parser* parser) {
   assert(mod->stmt(1)->isWhile());
   const While* whileLoop = mod->stmt(1)->toWhile();
   assert(whileLoop != nullptr);
-  assert(whileLoop->usesDo());
+  assert(whileLoop->usesImplicitBlock());
   assert(whileLoop->condition() != nullptr);
   assert(whileLoop->condition()->isFnCall());
   assert(whileLoop->numStmts() == 2);
@@ -76,7 +76,7 @@ static void test1(Parser* parser) {
   assert(mod->stmt(1)->isWhile());
   const While* whileLoop = mod->stmt(1)->toWhile();
   assert(whileLoop != nullptr);
-  assert(!whileLoop->usesDo());
+  assert(!whileLoop->usesImplicitBlock());
   assert(whileLoop->condition() != nullptr);
   assert(whileLoop->condition()->isFnCall());
   assert(whileLoop->numStmts() == 2);
@@ -100,7 +100,7 @@ static void test2(Parser* parser) {
   assert(mod->stmt(1)->isWhile());
   const While* whileLoop = mod->stmt(1)->toWhile();
   assert(whileLoop != nullptr);
-  assert(whileLoop->usesDo());
+  assert(whileLoop->usesImplicitBlock());
   assert(whileLoop->condition() != nullptr);
   assert(whileLoop->condition()->isFnCall());
   assert(whileLoop->numStmts() == 1);
@@ -126,7 +126,7 @@ static void test3(Parser* parser) {
   assert(mod->stmt(1)->isWhile());
   const While* whileLoop = mod->stmt(1)->toWhile();
   assert(whileLoop != nullptr);
-  assert(!whileLoop->usesDo());
+  assert(!whileLoop->usesImplicitBlock());
   assert(whileLoop->condition() != nullptr);
   assert(whileLoop->condition()->isIdentifier());
   assert(whileLoop->numStmts() == 3);
@@ -135,7 +135,7 @@ static void test3(Parser* parser) {
   assert(whileLoop->stmt(2)->isComment());
   const While* whileLoopInner = whileLoop->stmt(1)->toWhile();
   assert(whileLoopInner);
-  assert(whileLoopInner->usesDo());
+  assert(whileLoopInner->usesImplicitBlock());
   assert(whileLoopInner->numStmts() == 2);
   assert(whileLoopInner->stmt(0)->isComment());
   assert(whileLoopInner->stmt(1)->isFnCall());


### PR DESCRIPTION
next: Parse bracket loops at the statement level (#17822)

This is for `compiler/next`.

A "bracket loop" is a loop construct that looks like:

```chapel
[i in 0..15] writeln(i);
```

A bracket loop is different from a forall loop in that it will try to
use a serial iterator if a parallel iterator is not available.

Add the header `BracketLoop`, and parse bracket loops that appear at
a statement level.

Rename `usesDo` to `usesImplicitBlock`. Remove `isBodyBlock` from
the `DoWhile` and `BracketLoop` nodes. Rewire the parser accordingly.

Clean up parser actions for loops by adding helpers to `ParserContext`.

Reviewed by @lydia-duncan and @mppf. Thanks!

TESTING:

- [x] All `compiler/next` tests pass

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>