### PR TITLE
next: Add Coforall AST node and parse coforalls

### DIFF
--- a/compiler/next/include/chpl/uast/Coforall.h
+++ b/compiler/next/include/chpl/uast/Coforall.h
@@ -49,14 +49,14 @@ class Coforall final : public IndexableLoop {
            int8_t withClauseChildNum,
            int loopBodyChildNum,
            int numLoopBodyStmts,
-           bool usesDo)
+           bool usesImplicitBlock)
     : IndexableLoop(asttags::Coforall, std::move(children),
                     indexChildNum,
                     iterandChildNum,
                     withClauseChildNum,
                     loopBodyChildNum,
                     numLoopBodyStmts,
-                    usesDo,
+                    usesImplicitBlock,
                     /*isExpressionLevel*/ false) {
     assert(isExpressionASTList(children_));
   }
@@ -80,7 +80,7 @@ class Coforall final : public IndexableLoop {
                                owned<Expression> iterand,
                                owned<WithClause> withClause,
                                ASTList stmts,
-                               bool usesDo);
+                               bool usesImplicitBlock);
 
 };
 

--- a/compiler/next/include/chpl/uast/Coforall.h
+++ b/compiler/next/include/chpl/uast/Coforall.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UAST_COFORALL_H
+#define CHPL_UAST_COFORALL_H
+
+#include "chpl/queries/Location.h"
+#include "chpl/uast/IndexableLoop.h"
+#include "chpl/uast/WithClause.h"
+
+namespace chpl {
+namespace uast {
+
+
+/**
+  This class represents a coforall loop. For example:
+
+  \rst
+  .. code-block:: chapel
+
+      // Example 1:
+      coforall i in 0..15 {
+        writeln(i);
+      }
+
+  \endrst
+
+ */
+class Coforall final : public IndexableLoop {
+ private:
+  Coforall(ASTList children, int8_t indexChildNum,
+           int8_t iterandChildNum,
+           int8_t withClauseChildNum,
+           int loopBodyChildNum,
+           int numLoopBodyStmts,
+           bool usesDo)
+    : IndexableLoop(asttags::Coforall, std::move(children),
+                    indexChildNum,
+                    iterandChildNum,
+                    withClauseChildNum,
+                    loopBodyChildNum,
+                    numLoopBodyStmts,
+                    usesDo,
+                    /*isExpressionLevel*/ false) {
+    assert(isExpressionASTList(children_));
+  }
+
+  bool contentsMatchInner(const ASTNode* other) const override {
+    return indexableLoopContentsMatchInner(other->toIndexableLoop());
+  }
+
+  void markUniqueStringsInner(Context* context) const override {
+    indexableLoopMarkUniqueStringsInner(context);
+  }
+
+ public:
+  ~Coforall() override = default;
+
+  /**
+    Create and return a coforall loop. 
+  */
+  static owned<Coforall> build(Builder* builder, Location loc,
+                               owned<Decl> index,
+                               owned<Expression> iterand,
+                               owned<WithClause> withClause,
+                               ASTList stmts,
+                               bool usesDo);
+
+};
+
+
+} // end namespace uast
+} // end namespace chpl
+
+#endif

--- a/compiler/next/lib/frontend/Parser/ParserContext.h
+++ b/compiler/next/lib/frontend/Parser/ParserContext.h
@@ -194,20 +194,20 @@ struct ParserContext {
                                       WithClause* withClause,
                                       BlockOrDo blockOrDo);
 
-  CommentsAndStmt buildForeachLoopStmt(YYLTYPE locForall,
+  CommentsAndStmt buildForeachLoopStmt(YYLTYPE locForeach,
                                        YYLTYPE locIndex,
                                        Expression* indexExpr,
                                        Expression* iterandExpr,
                                        WithClause* withClause,
                                        BlockOrDo blockOrDo);
 
-  CommentsAndStmt buildForLoopStmt(YYLTYPE locForall,
+  CommentsAndStmt buildForLoopStmt(YYLTYPE locFor,
                                    YYLTYPE locIndex,
                                    Expression* indexExpr,
                                    Expression* iterandExpr,
                                    BlockOrDo blockOrDo);
 
-  CommentsAndStmt buildCoforallLoopStmt(YYLTYPE locForeach,
+  CommentsAndStmt buildCoforallLoopStmt(YYLTYPE locCoforall,
                                         YYLTYPE locIndex,
                                         Expression* indexExpr,
                                         Expression* iterandExpr,

--- a/compiler/next/lib/frontend/Parser/ParserContext.h
+++ b/compiler/next/lib/frontend/Parser/ParserContext.h
@@ -207,6 +207,13 @@ struct ParserContext {
                                    Expression* iterandExpr,
                                    BlockOrDo blockOrDo);
 
+  CommentsAndStmt buildCoforallLoopStmt(YYLTYPE locForeach,
+                                        YYLTYPE locIndex,
+                                        Expression* indexExpr,
+                                        Expression* iterandExpr,
+                                        WithClause* withClause,
+                                        BlockOrDo blockOrDo);
+
   // Do we really need these?
   /*
   int         captureTokens; // no, new AST meant to be more faithful to src;

--- a/compiler/next/lib/frontend/Parser/ParserContextImpl.h
+++ b/compiler/next/lib/frontend/Parser/ParserContextImpl.h
@@ -497,7 +497,7 @@ CommentsAndStmt ParserContext::buildForLoopStmt(YYLTYPE locFor,
   return { .comments=comments, .stmt=node.release() };
 }
 
-CommentsAndStmt ParserContext::buildCoforallLoopStmt(YYLTYPE locForeach,
+CommentsAndStmt ParserContext::buildCoforallLoopStmt(YYLTYPE locCoforall,
                                                      YYLTYPE locIndex,
                                                      Expression* indexExpr,
                                                      Expression* iterandExpr,
@@ -505,8 +505,8 @@ CommentsAndStmt ParserContext::buildCoforallLoopStmt(YYLTYPE locForeach,
                                                      BlockOrDo blockOrDo) {
   auto index = indexExpr ? buildLoopIndexDecl(locIndex, toOwned(indexExpr))
                          : nullptr;
-  auto comments = gatherCommentsFromList(blockOrDo.exprList, locForeach);
-  auto node = Coforall::build(builder, convertLocation(locForeach),
+  auto comments = gatherCommentsFromList(blockOrDo.exprList, locCoforall);
+  auto node = Coforall::build(builder, convertLocation(locCoforall),
                               std::move(index),
                               toOwned(iterandExpr),
                               toOwned(withClause),

--- a/compiler/next/lib/frontend/Parser/ParserContextImpl.h
+++ b/compiler/next/lib/frontend/Parser/ParserContextImpl.h
@@ -496,3 +496,21 @@ CommentsAndStmt ParserContext::buildForLoopStmt(YYLTYPE locFor,
                          /*isParam*/ false);
   return { .comments=comments, .stmt=node.release() };
 }
+
+CommentsAndStmt ParserContext::buildCoforallLoopStmt(YYLTYPE locForeach,
+                                                     YYLTYPE locIndex,
+                                                     Expression* indexExpr,
+                                                     Expression* iterandExpr,
+                                                     WithClause* withClause,
+                                                     BlockOrDo blockOrDo) {
+  auto index = indexExpr ? buildLoopIndexDecl(locIndex, toOwned(indexExpr))
+                         : nullptr;
+  auto comments = gatherCommentsFromList(blockOrDo.exprList, locForeach);
+  auto node = Coforall::build(builder, convertLocation(locForeach),
+                              std::move(index),
+                              toOwned(iterandExpr),
+                              toOwned(withClause),
+                              consumeList(blockOrDo.exprList),
+                              blockOrDo.usesDo);
+  return { .comments=comments, .stmt=node.release() };
+}

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -600,9 +600,9 @@
 %type <newManagement> new_maybe_decorated
 %type <exprList> opt_inherit simple_expr_ls expr_ls assoc_expr_ls tuple_expr_ls
 %type <maybeNamedActualList> opt_actual_ls actual_ls
-%type <exprList> opt_task_intent_ls task_intent_ls task_intent_clause
+%type <exprList> task_intent_ls
 %type <exprList> forall_intent_ls
-%type <withClause> forall_intent_clause
+%type <withClause> opt_task_intent_ls task_intent_clause forall_intent_clause
 
 %type <functionParts> fn_decl_stmt_start fn_decl_stmt_inner
 %type <exprList> opt_formal_ls req_formal_ls formal_ls formal_ls_inner
@@ -1332,17 +1332,37 @@ loop_stmt:
     $$ = { .comments=comments, .stmt=node.release() };
   }
 | TCOFORALL expr TIN expr opt_task_intent_ls do_stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
+  {
+    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
+    auto comments = context->gatherCommentsFromList($6.exprList, @1);
+    auto node = Coforall::build(BUILDER, LOC(@1), std::move(index),
+                                toOwned($4),
+                                toOwned($5),
+                                context->consumeList($6.exprList),
+                                $6.usesDo);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
 | TCOFORALL expr TIN zippered_iterator opt_task_intent_ls do_stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
+  {
+    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
+    auto comments = context->gatherCommentsFromList($6.exprList, @1);
+    auto node = Coforall::build(BUILDER, LOC(@1), std::move(index),
+                                toOwned($4),
+                                toOwned($5),
+                                context->consumeList($6.exprList),
+                                $6.usesDo);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
 | TCOFORALL expr opt_task_intent_ls do_stmt
-    {
-      $$ = TODOSTMT(@$);
-    }
+  {
+    auto comments = context->gatherCommentsFromList($4.exprList, @1);
+    auto node = Coforall::build(BUILDER, LOC(@1), /*index*/ nullptr,
+                                toOwned($2),
+                                /*TODO: withClause*/ nullptr,
+                                context->consumeList($4.exprList),
+                                $4.usesDo);
+    $$ = { .comments=comments, .stmt=node.release() };
+  }
 | TFOR expr TIN expr do_stmt
   {
     auto index = context->buildLoopIndexDecl(@2, toOwned($2));
@@ -2674,16 +2694,21 @@ stmt_level_expr:
 
 opt_task_intent_ls:
                                 { $$ = nullptr; }
-| task_intent_clause
+| task_intent_clause            { $$ = $1; }
 ;
 
 task_intent_clause:
-  TWITH TLP task_intent_ls TRP  { $$ = $3; }
+  TWITH TLP task_intent_ls TRP
+  {
+    auto exprs = context->consumeList($3);
+    auto node = WithClause::build(BUILDER, LOC(@$), std::move(exprs));
+    $$ = node.release();
+  }
 ;
 
 task_intent_ls:
-  intent_expr                                       { $$ = TODOLIST(@$); }
-| task_intent_ls TCOMMA intent_expr                 { $$ = TODOLIST(@$); }
+  intent_expr                         { $$ = context->makeList($1); }
+| task_intent_ls TCOMMA intent_expr   { $$ = context->appendList($1, $3); }
 ;
 
 forall_intent_clause:

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -1333,35 +1333,15 @@ loop_stmt:
   }
 | TCOFORALL expr TIN expr opt_task_intent_ls do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($6.exprList, @1);
-    auto node = Coforall::build(BUILDER, LOC(@1), std::move(index),
-                                toOwned($4),
-                                toOwned($5),
-                                context->consumeList($6.exprList),
-                                $6.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildCoforallLoopStmt(@1, @2, $2, $4, $5, $6);
   }
 | TCOFORALL expr TIN zippered_iterator opt_task_intent_ls do_stmt
   {
-    auto index = context->buildLoopIndexDecl(@2, toOwned($2));
-    auto comments = context->gatherCommentsFromList($6.exprList, @1);
-    auto node = Coforall::build(BUILDER, LOC(@1), std::move(index),
-                                toOwned($4),
-                                toOwned($5),
-                                context->consumeList($6.exprList),
-                                $6.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildCoforallLoopStmt(@1, @2, $2, $4, $5, $6);
   }
 | TCOFORALL expr opt_task_intent_ls do_stmt
   {
-    auto comments = context->gatherCommentsFromList($4.exprList, @1);
-    auto node = Coforall::build(BUILDER, LOC(@1), /*index*/ nullptr,
-                                toOwned($2),
-                                /*TODO: withClause*/ nullptr,
-                                context->consumeList($4.exprList),
-                                $4.usesDo);
-    $$ = { .comments=comments, .stmt=node.release() };
+    $$ = context->buildCoforallLoopStmt(@1, @1, nullptr, $2, $3, $4);
   }
 | TFOR expr TIN expr do_stmt
   {

--- a/compiler/next/lib/frontend/Parser/parser-dependencies.h
+++ b/compiler/next/lib/frontend/Parser/parser-dependencies.h
@@ -28,6 +28,7 @@
 #include "chpl/uast/Block.h"
 #include "chpl/uast/Builder.h"
 #include "chpl/uast/Call.h"
+#include "chpl/uast/Coforall.h"
 #include "chpl/uast/Comment.h"
 #include "chpl/uast/Dot.h"
 #include "chpl/uast/DoWhile.h"

--- a/compiler/next/lib/uast/CMakeLists.txt
+++ b/compiler/next/lib/uast/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(libchplcomp-obj
                Block.cpp
                Builder.cpp
                Call.cpp
+               Coforall.cpp
                Comment.cpp
                ControlFlow.cpp
                Decl.cpp

--- a/compiler/next/lib/uast/Coforall.cpp
+++ b/compiler/next/lib/uast/Coforall.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/uast/Coforall.h"
+
+#include "chpl/uast/Builder.h"
+
+namespace chpl {
+namespace uast {
+
+
+owned<Coforall> Coforall::build(Builder* builder, Location loc,
+                                owned<Decl> index,
+                                owned<Expression> iterand,
+                                owned<WithClause> withClause,
+                                ASTList stmts,
+                                bool usesDo) {
+  assert(iterand.get() != nullptr);
+
+  ASTList lst;
+  int8_t indexChildNum = -1;
+  int8_t iterandChildNum = -1;
+  int8_t withClauseChildNum = -1;
+
+  if (index.get() != nullptr) {
+    indexChildNum = lst.size();
+    lst.push_back(std::move(index));
+  }
+
+  if (iterand.get() != nullptr) {
+    iterandChildNum = lst.size();
+    lst.push_back(std::move(iterand));
+  }
+
+  if (withClause.get() != nullptr) {
+    withClauseChildNum = lst.size();
+    lst.push_back(std::move(withClause));
+  }
+
+  const int loopBodyChildNum = lst.size();
+  const int numLoopBodyStmts = stmts.size();
+
+  for (auto& stmt : stmts) {
+    lst.push_back(std::move(stmt));
+  }
+
+  Coforall* ret = new Coforall(std::move(lst), indexChildNum,
+                               iterandChildNum,
+                               withClauseChildNum,
+                               loopBodyChildNum,
+                               numLoopBodyStmts,
+                               usesDo);
+  builder->noteLocation(ret, loc);
+  return toOwned(ret);
+}
+
+
+} // namespace uast
+} // namespace chpl

--- a/compiler/next/lib/uast/Coforall.cpp
+++ b/compiler/next/lib/uast/Coforall.cpp
@@ -30,7 +30,7 @@ owned<Coforall> Coforall::build(Builder* builder, Location loc,
                                 owned<Expression> iterand,
                                 owned<WithClause> withClause,
                                 ASTList stmts,
-                                bool usesDo) {
+                                bool usesImplicitBlock) {
   assert(iterand.get() != nullptr);
 
   ASTList lst;
@@ -65,7 +65,7 @@ owned<Coforall> Coforall::build(Builder* builder, Location loc,
                                withClauseChildNum,
                                loopBodyChildNum,
                                numLoopBodyStmts,
-                               usesDo);
+                               usesImplicitBlock);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/compiler/next/test/frontend/CMakeLists.txt
+++ b/compiler/next/test/frontend/CMakeLists.txt
@@ -35,6 +35,7 @@
 comp_unit_test(testFrontendQueries)
 comp_unit_test(testInteractive)
 comp_unit_test(testParse)
+comp_unit_test(testParseCoforall)
 comp_unit_test(testParseEnums)
 comp_unit_test(testParseFor)
 comp_unit_test(testParseForall)

--- a/compiler/next/test/frontend/testParseCoforall.cpp
+++ b/compiler/next/test/frontend/testParseCoforall.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/uast/Block.h"
+#include "chpl/uast/Expression.h"
+#include "chpl/uast/Coforall.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/TaskVar.h"
+#include "chpl/uast/WithClause.h"
+#include "chpl/uast/Zip.h"
+#include "chpl/frontend/Parser.h"
+#include "chpl/queries/Context.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+#include <iostream>
+
+using namespace chpl;
+using namespace uast;
+using namespace frontend;
+
+static void test0(Parser* parser) {
+  auto parseResult = parser->parseString("test0.chpl",
+      "/* comment 1 */\n"
+      "coforall x in foo do\n"
+      "  /* comment 2 */\n"
+      "  foo();\n"
+      "/* comment 3 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isCoforall());
+  assert(mod->stmt(2)->isComment());
+  const Coforall* coforall = mod->stmt(1)->toCoforall();
+  assert(coforall != nullptr);
+  assert(coforall->index() != nullptr);
+  assert(coforall->index()->isVariable());
+  assert(coforall->iterand() != nullptr);
+  assert(coforall->iterand()->isIdentifier());
+  assert(coforall->withClause() == nullptr);
+  assert(coforall->numStmts() == 2);
+  assert(coforall->usesDo());
+  assert(!coforall->isExpressionLevel());
+  assert(coforall->stmt(0)->isComment());
+  assert(coforall->stmt(1)->isFnCall());
+}
+
+static void test1(Parser* parser) {
+  auto parseResult = parser->parseString("test1.chpl",
+      "/* comment 1 */\n"
+      "coforall x in foo with (ref thing) {\n"
+      "  /* comment 2 */\n"
+      "  foo();\n"
+      "  /* comment 3 */\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isCoforall());
+  assert(mod->stmt(2)->isComment());
+  const Coforall* coforall = mod->stmt(1)->toCoforall();
+  assert(coforall != nullptr);
+  assert(coforall->index() != nullptr);
+  assert(coforall->index()->isVariable());
+  assert(coforall->iterand() != nullptr);
+  assert(coforall->iterand()->isIdentifier());
+  const WithClause* withClause = coforall->withClause();
+  assert(withClause);
+  assert(withClause->numExprs() == 1);
+  const TaskVar* taskVar = withClause->expr(0)->toTaskVar();
+  assert(taskVar);
+  assert(!taskVar->typeExpression());
+  assert(!taskVar->initExpression());
+  assert(taskVar->intent() == TaskVar::REF);
+  assert(!coforall->usesDo());
+  assert(!coforall->isExpressionLevel());
+  assert(coforall->numStmts() == 3);
+  assert(coforall->stmt(0)->isComment());
+  assert(coforall->stmt(1)->isFnCall());
+  assert(coforall->stmt(2)->isComment());
+}
+
+static void test2(Parser* parser) {
+  auto parseResult = parser->parseString("test2.chpl",
+      "/* comment 1 */\n"
+      "coforall x in zip(a, b) {\n"
+      "  foo();\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isCoforall());
+  assert(mod->stmt(2)->isComment());
+  const Coforall* coforall = mod->stmt(1)->toCoforall();
+  assert(coforall != nullptr);
+  assert(coforall->index() != nullptr);
+  assert(coforall->index()->isVariable());
+  assert(coforall->iterand() != nullptr);
+  const Zip* zip = coforall->iterand()->toZip();
+  assert(zip);
+  assert(zip->numActuals() == 2);
+  assert(zip->actual(0)->isIdentifier());
+  assert(zip->actual(1)->isIdentifier());
+  assert(!coforall->usesDo());
+  assert(!coforall->isExpressionLevel());
+  assert(coforall->numStmts() == 1);
+  assert(coforall->stmt(0)->isFnCall());
+}
+
+static void test3(Parser* parser) {
+  auto parseResult = parser->parseString("test3.chpl",
+      "/* comment 1 */\n"
+      "coforall x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
+      "  writeln(thing1);\n"
+      "  thing2 = thing3;\n"
+      "}\n"
+      "/* comment 4 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isCoforall());
+  assert(mod->stmt(2)->isComment());
+  const Coforall* coforall = mod->stmt(1)->toCoforall();
+  assert(coforall != nullptr);
+  assert(coforall->index() != nullptr);
+  assert(coforall->index()->isVariable());
+  assert(coforall->iterand() != nullptr);
+  const Zip* zip = coforall->iterand()->toZip();
+  assert(zip);
+  assert(zip->numActuals() == 3);
+  assert(zip->actual(0)->isIdentifier());
+  assert(zip->actual(1)->isIdentifier());
+  assert(zip->actual(2)->isFnCall());
+  const WithClause* withClause = coforall->withClause();
+  assert(withClause);
+  assert(withClause->numExprs() == 2);
+  const TaskVar* taskVar0 = withClause->expr(0)->toTaskVar();
+  assert(taskVar0);
+  assert(!taskVar0->typeExpression());
+  assert(!taskVar0->initExpression());
+  assert(taskVar0->intent() == TaskVar::CONST_REF);
+  const TaskVar* taskVar1 = withClause->expr(1)->toTaskVar();
+  assert(taskVar1);
+  assert(!taskVar1->typeExpression());
+  assert(taskVar1->initExpression());
+  assert(taskVar1->initExpression()->isIdentifier());
+  assert(taskVar1->intent() == TaskVar::IN);
+  assert(!coforall->usesDo());
+  assert(!coforall->isExpressionLevel());
+  assert(coforall->numStmts() == 2);
+  assert(coforall->stmt(0)->isFnCall());
+  assert(coforall->stmt(1)->isOpCall());
+}
+
+static void test4(Parser* parser) {
+  auto parseResult = parser->parseString("test4.chpl",
+      "/* comment 1 */\n"
+      "coforall foo() do\n"
+      "  /* comment 2 */\n"
+      "  bar();\n"
+      "/* comment 3 */\n");
+  assert(parseResult.errors.size() == 0);
+  assert(parseResult.topLevelExpressions.size() == 1);
+  assert(parseResult.topLevelExpressions[0]->isModule());
+  auto mod = parseResult.topLevelExpressions[0]->toModule();
+  assert(mod->numStmts() == 3);
+  assert(mod->stmt(0)->isComment());
+  assert(mod->stmt(1)->isCoforall());
+  assert(mod->stmt(2)->isComment());
+  const Coforall* coforall = mod->stmt(1)->toCoforall();
+  assert(coforall != nullptr);
+  assert(coforall->index() == nullptr);
+  assert(coforall->iterand() != nullptr);
+  assert(coforall->iterand()->isFnCall());
+  assert(coforall->withClause() == nullptr);
+  assert(coforall->numStmts() == 2);
+  assert(coforall->usesDo());
+  assert(!coforall->isExpressionLevel());
+  assert(coforall->stmt(0)->isComment());
+  assert(coforall->stmt(1)->isFnCall());
+}
+
+int main() {
+  Context context;
+  Context* ctx = &context;
+
+  auto parser = Parser::build(ctx);
+  Parser* p = parser.get();
+
+  test0(p);
+  test1(p);
+  test2(p);
+  test3(p);
+  test4(p);
+
+  return 0;
+}

--- a/compiler/next/test/frontend/testParseCoforall.cpp
+++ b/compiler/next/test/frontend/testParseCoforall.cpp
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
   assert(coforall->iterand()->isIdentifier());
   assert(coforall->withClause() == nullptr);
   assert(coforall->numStmts() == 2);
-  assert(coforall->usesDo());
+  assert(coforall->usesImplicitBlock());
   assert(!coforall->isExpressionLevel());
   assert(coforall->stmt(0)->isComment());
   assert(coforall->stmt(1)->isFnCall());
@@ -100,7 +100,7 @@ static void test1(Parser* parser) {
   assert(!taskVar->typeExpression());
   assert(!taskVar->initExpression());
   assert(taskVar->intent() == TaskVar::REF);
-  assert(!coforall->usesDo());
+  assert(!coforall->usesImplicitBlock());
   assert(!coforall->isExpressionLevel());
   assert(coforall->numStmts() == 3);
   assert(coforall->stmt(0)->isComment());
@@ -133,7 +133,7 @@ static void test2(Parser* parser) {
   assert(zip->numActuals() == 2);
   assert(zip->actual(0)->isIdentifier());
   assert(zip->actual(1)->isIdentifier());
-  assert(!coforall->usesDo());
+  assert(!coforall->usesImplicitBlock());
   assert(!coforall->isExpressionLevel());
   assert(coforall->numStmts() == 1);
   assert(coforall->stmt(0)->isFnCall());
@@ -180,7 +180,7 @@ static void test3(Parser* parser) {
   assert(taskVar1->initExpression());
   assert(taskVar1->initExpression()->isIdentifier());
   assert(taskVar1->intent() == TaskVar::IN);
-  assert(!coforall->usesDo());
+  assert(!coforall->usesImplicitBlock());
   assert(!coforall->isExpressionLevel());
   assert(coforall->numStmts() == 2);
   assert(coforall->stmt(0)->isFnCall());
@@ -209,7 +209,7 @@ static void test4(Parser* parser) {
   assert(coforall->iterand()->isFnCall());
   assert(coforall->withClause() == nullptr);
   assert(coforall->numStmts() == 2);
-  assert(coforall->usesDo());
+  assert(coforall->usesImplicitBlock());
   assert(!coforall->isExpressionLevel());
   assert(coforall->stmt(0)->isComment());
   assert(coforall->stmt(1)->isFnCall());


### PR DESCRIPTION
next: Add Coforall AST node and parse coforalls (#17824)

This is for `compiler/next`.

Add the `Coforall` AST node and support for parsing coforalls.

Reviewed by @daviditen. Thanks!

TESTING:

- [x] All `compiler/next` tests pass

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>