### PR TITLE
Avoid adding clang resource dir args to the link command when not using clang

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3923,9 +3923,13 @@ void makeBinaryLLVM(void) {
     if (s == "-isysroot")
       sawSysroot = true;
   }
-  // add arguments that we captured at compile time
-  options += " ";
-  options += get_clang_sysroot_args();
+
+  // only use clang sysroot args if we haven't overridden the linker
+  if (clangCXX != useLinkCXX) {
+    // add arguments that we captured at compile time
+    options += " ";
+    options += get_clang_sysroot_args();
+  }
 
   if(debugCCode) {
     options += " -g";


### PR DESCRIPTION
The MPI testing wants to use mpicc to link, but was unconditionally passing the
clang resource dir arguments to it. Only use that option when actually using
clang.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>