### PR TITLE
Respect salloc/sbatch --cpus-per-task when launching with slurm-srun

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -108,12 +108,18 @@ static int getCoresPerLocale(int nomultithread) {
   char partition_arg[128];
   char* argv[7];
   char* numCoresString = getenv("CHPL_LAUNCHER_CORES_PER_LOCALE");
+  char* cpusPerTaskString = getenv("SLURM_CPUS_PER_TASK");
 
   if (numCoresString) {
     numCores = atoi(numCoresString);
     if (numCores > 0)
       return numCores;
     chpl_warning("CHPL_LAUNCHER_CORES_PER_LOCALE must be > 0.", 0, 0);
+  }
+
+  if (cpusPerTaskString) {
+    numCores = atoi(cpusPerTaskString);
+    return numCores;
   }
 
   argv[0] = (char *)  "sinfo";          // use sinfo to get num cpus


### PR DESCRIPTION
Respect salloc/sbatch --cpus-per-task when launching with slurm-srun

When we compute the value for `--cpus-per-task` check to see if we're
within an existing salloc/sbatch allocation that has already set the
value and use that instead of trying to compute our own and likely try
to use use too many cores.

This value can still be lowered with `CHPL_LAUNCHER_CORES_PER_LOCALE` if
a user wants to use only part of their allocation for a chapel program
keeping the rest for something else.