### PR TITLE
next: Fix parser conflicts for bracket loops by reverting nonterminal

### DIFF
--- a/compiler/next/lib/frontend/Parser/ParserContext.h
+++ b/compiler/next/lib/frontend/Parser/ParserContext.h
@@ -96,6 +96,14 @@ struct ParserContext {
   YYLTYPE declStartLoc(YYLTYPE curLoc);
   void resetDeclState();
 
+  ErroneousExpression* raiseError(YYLTYPE location, const char* msg) {
+    // note the error for printing
+    yyerror(&location, this, msg);
+    Location ll = convertLocation(location);
+    // return an error sentinel
+    return ErroneousExpression::build(builder, ll).release();
+  }
+
   void noteComment(YYLTYPE loc, const char* data, long size);
   std::vector<ParserComment>* gatherComments(YYLTYPE location);
   void clearCommentsBefore(YYLTYPE loc);
@@ -182,8 +190,14 @@ struct ParserContext {
 
   CommentsAndStmt buildBracketLoopStmt(YYLTYPE locLeftBracket,
                                        YYLTYPE locIndex,
-                                       Expression* indexExpr,
+                                       ParserExprList* indexExprs,
                                        Expression* iterandExpr,
+                                       WithClause* withClause,
+                                       CommentsAndStmt stmt);
+
+  CommentsAndStmt buildBracketLoopStmt(YYLTYPE locLeftBracket,
+                                       YYLTYPE locIterExprs,
+                                       ParserExprList* iterExprs,
                                        WithClause* withClause,
                                        CommentsAndStmt stmt);
 

--- a/compiler/next/lib/frontend/Parser/ParserContextImpl.h
+++ b/compiler/next/lib/frontend/Parser/ParserContextImpl.h
@@ -426,7 +426,7 @@ ParserContext::buildBracketLoopStmt(YYLTYPE locLeftBracket,
                                     WithClause* withClause,
                                     CommentsAndStmt stmt) {
   // Should not be nullptr, use other overload instead.
-  assert(indexExprs);
+  assert(indexExprs && indexExprs->size() >= 1);
 
   const bool usesImplicitBlock = !(stmt.stmt->isBlock());
   auto exprLst = makeList(stmt);
@@ -462,6 +462,8 @@ CommentsAndStmt ParserContext::buildBracketLoopStmt(YYLTYPE locLeftBracket,
                                                     ParserExprList* iterExprs,
                                                     WithClause* withClause,
                                                     CommentsAndStmt stmt) {
+  assert(iterExprs && iterExprs->size() >= 1);
+
   const bool usesImplicitBlock = !(stmt.stmt->isBlock());
   auto exprLst = makeList(stmt);
   auto comments = gatherCommentsFromList(exprLst, locLeftBracket);

--- a/compiler/next/lib/frontend/Parser/chapel.ypp
+++ b/compiler/next/lib/frontend/Parser/chapel.ypp
@@ -1436,37 +1436,39 @@ loop_stmt:
   {
     $$ = context->buildForeachLoopStmt(@1, @1, nullptr, $2, $3, $4);
   }
-| TLSBR expr TIN expr TRSBR stmt
+| TLSBR expr_ls TIN expr TRSBR stmt
   {
     $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, nullptr, $6);
   }
-| TLSBR expr TIN expr forall_intent_clause TRSBR stmt
+| TLSBR expr_ls TIN expr forall_intent_clause TRSBR stmt
   {
     $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, $5, $7);
   }
-| TLSBR expr TIN zippered_iterator TRSBR stmt
+| TLSBR expr_ls TIN zippered_iterator TRSBR stmt
   {
     $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, nullptr, $6);
   }
-| TLSBR expr TIN zippered_iterator forall_intent_clause TRSBR stmt
+| TLSBR expr_ls TIN zippered_iterator forall_intent_clause TRSBR stmt
   {
     $$ = context->buildBracketLoopStmt(@1, @2, $2, $4, $5, $7);
   }
-| TLSBR expr TRSBR stmt
+| TLSBR expr_ls TRSBR stmt
   {
-    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, nullptr, $4);
+    $$ = context->buildBracketLoopStmt(@1, @2, $2, nullptr, $4);
   }
-| TLSBR expr forall_intent_clause TRSBR stmt
+| TLSBR expr_ls forall_intent_clause TRSBR stmt
   {
-    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, $3, $5);
+    $$ = context->buildBracketLoopStmt(@1, @2, $2, $3, $5);
   }
 | TLSBR zippered_iterator TRSBR stmt
   {
-    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, nullptr, $4);
+    auto iterExprs = context->makeList($2);
+    $$ = context->buildBracketLoopStmt(@1, @2, iterExprs, nullptr, $4);
   }
 | TLSBR zippered_iterator forall_intent_clause TRSBR stmt
   {
-    $$ = context->buildBracketLoopStmt(@1, @1, nullptr, $2, $3, $5);
+    auto iterExprs = context->makeList($2);
+    $$ = context->buildBracketLoopStmt(@1, @2, iterExprs, $3, $5);
   }
 ;
 


### PR DESCRIPTION
next: Fix parser conflicts for bracket loops by reverting nonterminal

This is for `compiler/next`.

In #17822 I adjusted several of the bracket loop statement productions
to use `expr` instead of `expr_ls`. This introduced shift/reduce
conflicts that I didn't notice (there were warnings for deprecation
statements that I ignored, due to be fixed by #17826).

Revert to using `expr_ls`. The helpers to build bracket loops become
a bit more complicated as a result.

Reviewed by @mppf. Thanks!

TESTING:

- [x] All `compiler/next` tests pass
- [x] Shift/reduce conflicts gone

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>