### PR TITLE
Fix some bugs with operator methods during function resolution

### DIFF
--- a/compiler/passes/splitInit.cpp
+++ b/compiler/passes/splitInit.cpp
@@ -205,9 +205,15 @@ static found_init_t doFindInitPoints(Symbol* sym,
     // x = ...
     if (CallExpr* call = toCallExpr(cur)) {
       if (call->isNamedAstr(astrSassign)) {
-        if (SymExpr* se = toSymExpr(call->get(1))) {
+        int lhsNum = 1;
+        int rhsNum = 2;
+        if (call->get(1)->typeInfo() == dtMethodToken) {
+          lhsNum += 2;
+          rhsNum += 2;
+        }
+        if (SymExpr* se = toSymExpr(call->get(lhsNum))) {
           if (se->symbol() == sym) {
-            if (findSymExprFor(call->get(2), sym) == NULL) {
+            if (findSymExprFor(call->get(rhsNum), sym) == NULL) {
               // careful with e.g.
               //  x = x + 1;  or y = 1:y.type;
               initAssigns.push_back(call);

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -180,7 +180,12 @@ static Expr* postFoldNormal(CallExpr* call) {
   }
 
   if (call->isNamedAstr(astrSassign) == true) {
-    if (SymExpr* lhs = toSymExpr(call->get(1))) {
+    int lhsNum = 1;
+    if (fn->hasFlag(FLAG_METHOD)) {
+      // Handle operator methods
+      lhsNum += 2;
+    }
+    if (SymExpr* lhs = toSymExpr(call->get(lhsNum))) {
       if (lhs->symbol()->hasFlag(FLAG_MAYBE_PARAM) == true ||
           lhs->symbol()->isParameter()             == true) {
         if (paramMap.get(lhs->symbol())) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1237,7 +1237,11 @@ bool SplitInitVisitor::enterCallExpr(CallExpr* call) {
       // Change the '=' calls found into PRIM_INIT_VAR_SPLIT_INIT
       for_vector(CallExpr, assign, initAssigns) {
         SET_LINENO(assign);
-        Expr* rhs = assign->get(2)->remove();
+        int rhsNum = 2;
+        if (assign->get(1)->typeInfo() == dtMethodToken) {
+          rhsNum += 2;
+        }
+        Expr* rhs = assign->get(rhsNum)->remove();
         CallExpr* init = NULL;
         if (type)
           init = new CallExpr(PRIM_INIT_VAR_SPLIT_INIT, sym, rhs, type);

--- a/test/types/chplhashtable/test-chpl-hashtable.chpl
+++ b/test/types/chplhashtable/test-chpl-hashtable.chpl
@@ -78,7 +78,7 @@ record R {
     return "(" + this.x:string + " " + this.ptr.xx:string + ")";
   }
 }
-operator =(ref lhs:R, rhs:R) {
+operator R.=(ref lhs:R, rhs:R) {
   if printInitDeinit then writeln("lhs", lhs.toString(), " = rhs", rhs.toString());
   lhs.x = rhs.x;
   lhs.ptr = new shared C(rhs.ptr.xx);

--- a/test/types/records/intents/out-intent.chpl
+++ b/test/types/records/intents/out-intent.chpl
@@ -35,7 +35,7 @@ record R {
     return this;
   }
 }
-operator =(ref lhs:R, rhs:R) {
+operator R.=(ref lhs:R, rhs:R) {
   writeln("lhs", lhs.toString(), " = rhs", rhs.toString());
   lhs.x = rhs.x;
   lhs.ptr = new shared C(rhs.ptr.xx);

--- a/test/types/records/split-init/inner-fn.chpl
+++ b/test/types/records/split-init/inner-fn.chpl
@@ -12,7 +12,7 @@ record R {
     this.field = other.field;
   }
 }
-operator =(ref lhs: R, rhs: R) {
+operator R.=(ref lhs: R, rhs: R) {
   writeln(lhs, " = ", rhs);
   lhs.field = rhs.field;
 }

--- a/test/types/records/split-init/split-init-global1.chpl
+++ b/test/types/records/split-init/split-init-global1.chpl
@@ -12,7 +12,7 @@ record R {
     this.field = other.field;
   }
 }
-operator =(ref lhs: R, rhs: R) {
+operator R.=(ref lhs: R, rhs: R) {
   writeln(lhs, " = ", rhs);
   lhs.field = rhs.field;
 }

--- a/test/types/records/split-init/split-init-out-on.chpl
+++ b/test/types/records/split-init/split-init-out-on.chpl
@@ -15,7 +15,7 @@ record R {
     writeln("init= ", other.x);
   }
 }
-operator =(ref lhs:R, rhs:R) {
+operator R.=(ref lhs:R, rhs:R) {
   writeln("= ", lhs.x, " ", rhs.x);
   lhs.x = rhs.x;
 }


### PR DESCRIPTION
Turns out, we weren't adjusting for when the assignment call could be a operator
method, so were missing important handling that replaced split-init out
argument assignments with PRIM_MOVE.  This meant we had extra calls to
the assignment operator when the operator was defined as a method.

Resolves #17429 
Resolves Cray/chapel-private#1947

This was the case that motivated this investigation.  Other issues fixed include:

- Checks for assigning nil to records were not adjusting for the possibility of
the assignment operator being an operator method (though I'm not entirely
convinced this case would trigger, as the assignment function I was looking at
didn't trigger the "is a record" portion because it's a ref argument even though
the type it is a ref to is a record).
- Also, postFold double checking that a param is assigned multiple times was not
appropriately adjusting for operator method calls.

With the first bug fixed, five tests can now be updated to use operator methods
instead of standalone operator functions.

Passed a full paratest with futures