### PR TITLE
Default CHPL_LLVM to 'none' for linux32 platforms

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -72,7 +72,7 @@ def get():
         elif (compatible_platform_for_llvm_default()):
             if has_compatible_installed_llvm():
                 llvm_val = 'system'
-        elif (chpl_platform.get('target' == 'linux32')):
+        else:
             llvm_val = 'none'
 
     if llvm_val == 'llvm':

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -72,6 +72,8 @@ def get():
         elif (compatible_platform_for_llvm_default()):
             if has_compatible_installed_llvm():
                 llvm_val = 'system'
+        elif (chpl_platform.get('target' == 'linux32')):
+            llvm_val = 'none'
 
     if llvm_val == 'llvm':
         sys.stderr.write("Warning: CHPL_LLVM=llvm is deprecated. "


### PR DESCRIPTION
We don't expect linux32 to work with llvm in the near term, so make the default
for CHPL_LLVM=none there.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>