### PR TITLE
In comm=ofi, register data segment, heap, and stack in addition to fixed heap.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -70,6 +70,7 @@ extern "C" {
   m(ACK,                    "tx acknowledgements")                      \
   m(ORDER,                  "ops done only for ordering")               \
   m(HEAP,                   "layer-provided fixed heap")                \
+  m(MEMMAP,                 "process memory map")                       \
   m(MR,                     "mem reg: regions")                         \
   m(MR_DESC,                "mem reg: local region descs")              \
   m(MR_KEY,                 "mem reg: remote region keys")              \
@@ -129,6 +130,13 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 
 #define DBG_VAL(pV, typ) chpl_comm_ofi_dbg_val(pV, typ)
 
+#define DBG_CATFILE(mask, fname, match)                                 \
+  do {                                                                  \
+    if (DBG_TEST_MASK(mask)) {                                          \
+      dbg_catfile(fname, match);                                        \
+    }                                                                   \
+  } while (0)
+
 #else // CHPL_COMM_DEBUG
 
 #define DBG_INIT()
@@ -136,6 +144,7 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 #define DBG_TEST_MASK(mask) 0
 #define DBG_PRINTF(mask, fmt, ...) do { } while (0)
 #define DBG_PRINTF_NODE0(mask, fmt, ...) do { } while (0)
+#define DBG_CATFILE(mask, fname, match) do { } while (0)
 
 #endif // CHPL_COMM_DEBUG
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2307,7 +2307,7 @@ void init_ofiForMem(void) {
                i, memTab[i].addr, memTab[i].size, bufAcc);
     OFI_CHK(fi_mr_reg(ofi_domain,
                       memTab[i].addr, memTab[i].size,
-                      bufAcc, (prov_key ? 0 : i), 0, 0, &ofiMrTab[i], NULL));
+                      bufAcc, 0, (prov_key ? 0 : i), 0, &ofiMrTab[i], NULL));
     memTab[i].desc = fi_mr_desc(ofiMrTab[i]);
     memTab[i].key  = fi_mr_key(ofiMrTab[i]);
     CHK_TRUE(prov_key || memTab[i].key == i);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2665,10 +2665,10 @@ chpl_bool get_next_rw_memory_range(uint64_t* addr, uint64_t* len,
         ;
 
       for (p_idx = 0; ch != EOF && ch != '\n'; ch = fgetc(f)) {
-        if (p_idx < pathname_size)
+        if (p_idx < pathname_size - 1)
           pathname[p_idx++] = ch;
       }
-      pathname[p_idx++] = '\0';
+      pathname[p_idx] = '\0';
     }
 
     *addr = lo_addr;


### PR DESCRIPTION
In the ofi comm layer when we have a fixed heap, also register the
static data segment as well as the existing pages of the process's
original heap and stack.  This allows communicating directly to and
from these regions via RMA instead of having to use AM-mediated PUTs
and GETs.

This can provide a significant performance benefit in some cases.  In a
highly artificial setup for an unrelated investigation on an HPE Cray EX
system, with 4 Chapel locales per compute node and a total of 64 locales
(thus 16 nodes), this reduced the time needed for module initialization
from roughly 160s to roughly 1s, apparently as a result of allowing the
use of RMA instead of AM-mediated PUTs for broadcasting all the config
constants from locale 0 to the other locales.  (However, note that by
itself this change cannot have caused the whole 160x benefit, because we
certainly cannot do RMA writes 160x faster than we can do AMs.  So, much
of the apparent improvement was probably due to reducing the contention
that setup was designed to study in the first place.)

Much of what's here was adapted from the same functionality in the ugni
comm layer.

While here I also did some cleanup in the memory table and registration
code, which was pretty old and in particular had not been exercised with
more than one registered region in a very long time.  I also fixed a minor
bug we'd never run into, in the ugni comm layer.