### PR TITLE
Add file for capturing `git log` of '.' to GITLOG file in (my) personally preferred format

### DIFF
--- a/util/devel/updateGITLOG
+++ b/util/devel/updateGITLOG
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#git fetch chapel-lang master
+git log master --first-parent -m --name-status --pretty=format:"-----------------------------------------------------------------------------%n%ncommit %h%nMerge: %p%nDate:   %ad%nAuthor: %an <%ae>%n%n%s%n%n%b%n" --reverse . | dos2unix > GITLOG
+
+# TODO: Can I use tformat to put the %b after the list of files?  And a label
+# to search on to find it?


### PR DESCRIPTION
Those who've been with the project for awhile may recall `updateSVNLOG` which was a little script that dumped the SVN commits into a file for browsing.  When we switched to `git`, I was shamed by those more git-knowledgeable into not creating a similar `updateGITLOG` script because `git log` was so powerful and flexible that I'd never want for it again.  But the fact of the matter is that I created and have been using my own `updateGITLOG` script for years—even though I also use `git log` there are times when surfing through a text file of the merge commits seems most productive to me, and the options I use to generate it aren't succinct or memorable enough for me to learn not to use the script.

While using it in a demo today, I was asked "where does that live in the repo?" which made me realize that I'm not ashamed to be using it anymore, and am tired of copying it around from each repo or computer I use to the next.  So this PR proposes adding it to `util/devel/updateGITLOG`.

What does the output look like?  Something like this:

```
-----------------------------------------------------------------------------

commit 2f9ad2bf32
Merge:
Date:   2009-04-16 03:48:19 +0000
Author: Brad Chamberlain <bradcray@users.noreply.github.com>

adding trunk manually during sourceforge conversion

git-svn-id: http://svn.code.sf.net/p/chapel/code/trunk@1 3a8e244f-b0f2-452b-bcb\
a-4c88e055c3ca


-----------------------------------------------------------------------------

commit b5c0556bd5
Merge: 2f9ad2bf32
Date:   2004-01-20 18:47:13 +0000
Author: Brad Chamberlain <bradcray@users.noreply.github.com>

Initial hamble check-in of proposed Chapel tree.
```

[...1 million or so lines later...]

```
-----------------------------------------------------------------------------

commit 7e877bf8f9
Merge: 34cded4e9e 99372f0e4b
Date:   2021-05-25 17:13:55 -0700
Author: David Longnecker <47797485+dlongnecke-cray@users.noreply.github.com>

Merge pull request #17804 from dlongnecke-cray/next-add-while

next: Parse While and DoWhile loops

This is for `compiler/next`.

Add nodes for `While` and `DoWhile` loops, and wire up the parser
actions for them.

Reviewed by @lydia-duncan and @mppf. Thanks!

TESTING:

- [x] All `compiler/next` tests pass

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>

M       compiler/next/include/chpl/uast/Builder.h
A       compiler/next/include/chpl/uast/DoWhile.h
A       compiler/next/include/chpl/uast/While.h
M       compiler/next/lib/frontend/Parser/ParserContextImpl.h
M       compiler/next/lib/frontend/Parser/chapel.ypp
M       compiler/next/lib/frontend/Parser/parser-dependencies.h
M       compiler/next/lib/uast/Builder.cpp
M       compiler/next/lib/uast/CMakeLists.txt
A       compiler/next/lib/uast/DoWhile.cpp
A       compiler/next/lib/uast/While.cpp
M       compiler/next/test/frontend/CMakeLists.txt
A       compiler/next/test/frontend/testParseDoWhile.cpp
A       compiler/next/test/frontend/testParseWhile.cpp
```