### PR TITLE
Deprecate the BigInteger enum `Round` in favor of a new enum `round`

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -171,10 +171,17 @@ module BigInteger {
   use SysError;
   use SysBasic;
 
+  deprecated "The enum Round is deprecated, please use the enum round instead"
   enum Round {
     DOWN = -1,
     ZERO =  0,
     UP   =  1
+  }
+
+  enum round {
+    down = -1,
+    zero = 0,
+    up = 1
   }
 
   pragma "ignore noinit"
@@ -4016,24 +4023,39 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
+  deprecated
+  "bigint.div_q using Round is deprecated, use bigint.div_q with round instead"
+  proc bigint.div_q(const ref n: bigint,
+                    const ref d: bigint,
+                    param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_q(n, d, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_q(n, d, round.zero);
+    } else {
+      bigint.div_q(n, d, round.down);
+    }
+  }
+
   // 5.6 Division Functions
   proc bigint.div_q(const ref n: bigint,
                     const ref d: bigint,
-                    param     rounding = Round.ZERO) {
+                    param rounding = round.zero) {
     if _local {
       select rounding {
-        when Round.UP   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
-        when Round.DOWN do mpz_fdiv_q(this.mpz, n.mpz,  d.mpz);
-        when Round.ZERO do mpz_tdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.down do mpz_fdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_q(this.mpz, n.mpz,  d.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
               n.localeId    == chpl_nodeID &&
               d.localeId    == chpl_nodeID {
       select rounding {
-        when Round.UP   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
-        when Round.DOWN do mpz_fdiv_q(this.mpz, n.mpz,  d.mpz);
-        when Round.ZERO do mpz_tdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.down do mpz_fdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_q(this.mpz, n.mpz,  d.mpz);
       }
 
     } else {
@@ -4044,38 +4066,69 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const d_ = d;
 
         select rounding {
-          when Round.UP   do mpz_cdiv_q(this.mpz, n_.mpz, d_.mpz);
-          when Round.DOWN do mpz_fdiv_q(this.mpz, n_.mpz, d_.mpz);
-          when Round.ZERO do mpz_tdiv_q(this.mpz, n_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_q(this.mpz, n_.mpz, d_.mpz);
+          when round.down do mpz_fdiv_q(this.mpz, n_.mpz, d_.mpz);
+          when round.zero do mpz_tdiv_q(this.mpz, n_.mpz, d_.mpz);
           }
       }
     }
   }
 
+  deprecated
+  "bigint.div_q using Round is deprecated, use bigint.div_q with round instead"
   proc bigint.div_q(const ref n: bigint,
                               d: integral,
-                    param     rounding = Round.ZERO) {
+                    param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_q(n, d, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_q(n, d, round.zero);
+    } else {
+      bigint.div_q(n, d, round.down);
+    }
+  }
+
+  proc bigint.div_q(const ref n: bigint,
+                              d: integral,
+                    param     rounding = round.zero) {
 
     this.div_q(n, new bigint(d), rounding);
   }
 
+  deprecated
+  "bigint.div_r using Round is deprecated, use bigint.div_r with round instead"
   proc bigint.div_r(const ref n: bigint,
                     const ref d: bigint,
-                    param     rounding = Round.ZERO) {
+                    param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_r(n, d, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_r(n, d, round.zero);
+    } else {
+      bigint.div_r(n, d, round.down);
+    }
+
+  }
+
+  proc bigint.div_r(const ref n: bigint,
+                    const ref d: bigint,
+                    param     rounding = round.zero) {
     if _local {
       select rounding {
-        when Round.UP   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
-        when Round.DOWN do mpz_fdiv_r(this.mpz, n.mpz,  d.mpz);
-        when Round.ZERO do mpz_tdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.down do mpz_fdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_r(this.mpz, n.mpz,  d.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
               n.localeId    == chpl_nodeID &&
               d.localeId    == chpl_nodeID {
       select rounding {
-        when Round.UP   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
-        when Round.DOWN do mpz_fdiv_r(this.mpz, n.mpz,  d.mpz);
-        when Round.ZERO do mpz_tdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.down do mpz_fdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_r(this.mpz, n.mpz,  d.mpz);
       }
 
     } else {
@@ -4086,30 +4139,61 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const d_ = d;
 
         select rounding {
-          when Round.UP   do mpz_cdiv_r(this.mpz, n_.mpz, d_.mpz);
-          when Round.DOWN do mpz_fdiv_r(this.mpz, n_.mpz, d_.mpz);
-          when Round.ZERO do mpz_tdiv_r(this.mpz, n_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_r(this.mpz, n_.mpz, d_.mpz);
+          when round.down do mpz_fdiv_r(this.mpz, n_.mpz, d_.mpz);
+          when round.zero do mpz_tdiv_r(this.mpz, n_.mpz, d_.mpz);
         }
       }
     }
   }
 
+  deprecated
+  "bigint.div_r using Round is deprecated, use bigint.div_r with round instead"
   proc bigint.div_r(const ref n: bigint,
                               d: integral,
-                    param     rounding = Round.ZERO) {
+                    param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_r(n, d, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_r(n, d, round.zero);
+    } else {
+      bigint.div_r(n, d, round.down);
+    }
+  }
+
+  proc bigint.div_r(const ref n: bigint,
+                              d: integral,
+                    param     rounding = round.zero) {
     this.div_r(n, new bigint(d), rounding);
+  }
+
+  deprecated
+  "bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead"
+  proc bigint.div_qr(ref       r:        bigint,
+                     const ref n:        bigint,
+                     const ref d:        bigint,
+                     param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_qr(r, n, d, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_qr(r, n, d, round.zero);
+    } else {
+      bigint.div_qr(r, n, d, round.down);
+    }
   }
 
   // this gets quotient, r gets remainder
   proc bigint.div_qr(ref       r:        bigint,
                      const ref n:        bigint,
                      const ref d:        bigint,
-                     param     rounding = Round.ZERO) {
+                     param     rounding = round.zero) {
     if _local {
       select rounding {
-        when Round.UP   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when Round.DOWN do mpz_fdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when Round.ZERO do mpz_tdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
@@ -4117,9 +4201,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
               n.localeId    == chpl_nodeID &&
               d.localeId    == chpl_nodeID {
       select rounding {
-        when Round.UP   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when Round.DOWN do mpz_fdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when Round.ZERO do mpz_tdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
       }
 
     } else {
@@ -4131,9 +4215,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const d_ = d;
 
         select rounding {
-          when Round.UP   do mpz_cdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
-          when Round.DOWN do mpz_fdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
-          when Round.ZERO do mpz_tdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
+          when round.down do mpz_fdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
+          when round.zero do mpz_tdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
         }
 
         r = r_;
@@ -4141,31 +4225,62 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
+  deprecated
+  "bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead"
   proc bigint.div_qr(ref       r: bigint,
                      const ref n: bigint,
                                d: integral,
-                     param     rounding = Round.ZERO) {
+                     param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_qr(r, n, d, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_qr(r, n, d, round.zero);
+    } else {
+      bigint.div_qr(r, n, d, round.down);
+    }
+  }
+
+  proc bigint.div_qr(ref       r: bigint,
+                     const ref n: bigint,
+                               d: integral,
+                     param     rounding = round.zero) {
     this.div_qr(r, n, new bigint(d), rounding);
+  }
+
+  deprecated
+  "bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead"
+  proc bigint.div_q_2exp(const ref n: bigint,
+                                   b: integral,
+                         param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_q_2exp(n, b, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_q_2exp(n, b, round.zero);
+    } else {
+      bigint.div_q_2exp(n, b, round.down);
+    }
   }
 
   proc bigint.div_q_2exp(const ref n: bigint,
                                    b: integral,
-                         param     rounding = Round.ZERO) {
+                         param     rounding = round.zero) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {
       select rounding {
-        when Round.UP   do mpz_cdiv_q_2exp(this.mpz, n.mpz, b_);
-        when Round.DOWN do mpz_fdiv_q_2exp(this.mpz, n.mpz, b_);
-        when Round.ZERO do mpz_tdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.down do mpz_fdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.zero do mpz_tdiv_q_2exp(this.mpz, n.mpz, b_);
       }
 
     } else if this.localeId == chpl_nodeID &&
               n.localeId    == chpl_nodeID {
       select rounding {
-        when Round.UP   do mpz_cdiv_q_2exp(this.mpz, n.mpz, b_);
-        when Round.DOWN do mpz_fdiv_q_2exp(this.mpz, n.mpz, b_);
-        when Round.ZERO do mpz_tdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.down do mpz_fdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.zero do mpz_tdiv_q_2exp(this.mpz, n.mpz, b_);
       }
 
     } else {
@@ -4175,31 +4290,46 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const n_ = n;
 
         select rounding {
-          when Round.UP   do mpz_cdiv_q_2exp(this.mpz, n_.mpz, b_);
-          when Round.DOWN do mpz_fdiv_q_2exp(this.mpz, n_.mpz, b_);
-          when Round.ZERO do mpz_tdiv_q_2exp(this.mpz, n_.mpz, b_);
+          when round.up   do mpz_cdiv_q_2exp(this.mpz, n_.mpz, b_);
+          when round.down do mpz_fdiv_q_2exp(this.mpz, n_.mpz, b_);
+          when round.zero do mpz_tdiv_q_2exp(this.mpz, n_.mpz, b_);
         }
       }
     }
   }
 
+  deprecated
+  "bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead"
   proc bigint.div_r_2exp(const ref n: bigint,
                                    b: integral,
-                         param     rounding = Round.ZERO) {
+                         param     rounding: Round) {
+    use Round;
+    if (rounding == UP) {
+      bigint.div_r_2exp(n, b, round.up);
+    } else if (rounding == ZERO) {
+      bigint.div_r_2exp(n, b, round.zero);
+    } else {
+      bigint.div_r_2exp(n, b, round.down);
+    }
+  }
+
+  proc bigint.div_r_2exp(const ref n: bigint,
+                                   b: integral,
+                         param     rounding = round.zero) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {
       select rounding {
-        when Round.UP   do mpz_cdiv_r_2exp(this.mpz, n.mpz, b_);
-        when Round.DOWN do mpz_fdiv_r_2exp(this.mpz, n.mpz, b_);
-        when Round.ZERO do mpz_tdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.down do mpz_fdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.zero do mpz_tdiv_r_2exp(this.mpz, n.mpz, b_);
       }
 
     } else if this.localeId == chpl_nodeID && n.localeId == chpl_nodeID {
       select rounding {
-        when Round.UP   do mpz_cdiv_r_2exp(this.mpz, n.mpz, b_);
-        when Round.DOWN do mpz_fdiv_r_2exp(this.mpz, n.mpz, b_);
-        when Round.ZERO do mpz_tdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.down do mpz_fdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.zero do mpz_tdiv_r_2exp(this.mpz, n.mpz, b_);
       }
 
     } else {
@@ -4209,9 +4339,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const n_ = n;
 
         select rounding {
-          when Round.UP   do mpz_cdiv_r_2exp(this.mpz, n_.mpz, b_);
-          when Round.DOWN do mpz_fdiv_r_2exp(this.mpz, n_.mpz, b_);
-          when Round.ZERO do mpz_tdiv_r_2exp(this.mpz, n_.mpz, b_);
+          when round.up   do mpz_cdiv_r_2exp(this.mpz, n_.mpz, b_);
+          when round.down do mpz_fdiv_r_2exp(this.mpz, n_.mpz, b_);
+          when round.zero do mpz_tdiv_r_2exp(this.mpz, n_.mpz, b_);
         }
       }
     }

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4030,11 +4030,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_q(n, d, round.up);
+      this.div_q(n, d, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_q(n, d, round.zero);
+      this.div_q(n, d, round.zero);
     } else {
-      bigint.div_q(n, d, round.down);
+      this.div_q(n, d, round.down);
     }
   }
 
@@ -4081,11 +4081,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_q(n, d, round.up);
+      this.div_q(n, d, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_q(n, d, round.zero);
+      this.div_q(n, d, round.zero);
     } else {
-      bigint.div_q(n, d, round.down);
+      this.div_q(n, d, round.down);
     }
   }
 
@@ -4103,11 +4103,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_r(n, d, round.up);
+      this.div_r(n, d, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_r(n, d, round.zero);
+      this.div_r(n, d, round.zero);
     } else {
-      bigint.div_r(n, d, round.down);
+      this.div_r(n, d, round.down);
     }
 
   }
@@ -4154,11 +4154,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_r(n, d, round.up);
+      this.div_r(n, d, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_r(n, d, round.zero);
+      this.div_r(n, d, round.zero);
     } else {
-      bigint.div_r(n, d, round.down);
+      this.div_r(n, d, round.down);
     }
   }
 
@@ -4176,11 +4176,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                      param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_qr(r, n, d, round.up);
+      this.div_qr(r, n, d, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_qr(r, n, d, round.zero);
+      this.div_qr(r, n, d, round.zero);
     } else {
-      bigint.div_qr(r, n, d, round.down);
+      this.div_qr(r, n, d, round.down);
     }
   }
 
@@ -4233,11 +4233,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                      param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_qr(r, n, d, round.up);
+      this.div_qr(r, n, d, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_qr(r, n, d, round.zero);
+      this.div_qr(r, n, d, round.zero);
     } else {
-      bigint.div_qr(r, n, d, round.down);
+      this.div_qr(r, n, d, round.down);
     }
   }
 
@@ -4255,11 +4255,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                          param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_q_2exp(n, b, round.up);
+      this.div_q_2exp(n, b, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_q_2exp(n, b, round.zero);
+      this.div_q_2exp(n, b, round.zero);
     } else {
-      bigint.div_q_2exp(n, b, round.down);
+      this.div_q_2exp(n, b, round.down);
     }
   }
 
@@ -4305,11 +4305,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
                          param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      bigint.div_r_2exp(n, b, round.up);
+      this.div_r_2exp(n, b, round.up);
     } else if (rounding == ZERO) {
-      bigint.div_r_2exp(n, b, round.zero);
+      this.div_r_2exp(n, b, round.zero);
     } else {
-      bigint.div_r_2exp(n, b, round.down);
+      this.div_r_2exp(n, b, round.down);
     }
   }
 

--- a/test/deprecated/BigInteger/deprecateRound.chpl
+++ b/test/deprecated/BigInteger/deprecateRound.chpl
@@ -1,0 +1,75 @@
+use BigInteger;
+
+param down = Round.DOWN; // Should trigger the warning
+param zero = Round.ZERO; // Should trigger the warning
+param up = Round.UP;     // Should trigger the warning
+
+// Every non-writeln function call after this point should trigger the warning
+var a = new bigint(  8);
+var b = new bigint( 10);
+var c = new bigint(-27);
+var d = new bigint();
+
+d.div_q(c, a, up);
+b.div_r(c, a, up);
+writeln(d, " ", b);
+
+d.div_q(c, a, down);
+b.div_r(c, a, down);
+writeln(d, " ", b);
+
+d.div_q(c, a, zero); // same as UP   for negative integers
+b.div_r(c, a, zero); // same as DOWN for positive integers
+writeln(d, " ", b);
+
+c.neg(c);
+d.div_qr(b, c, a, up);
+writeln(d, " ", b);
+
+d.div_qr(b, c, a, down);
+writeln(d, " ", b);
+
+d.div_qr(b, c, a, zero); // same as DOWN for positive integers
+writeln(d, " ", b);
+
+writeln();
+
+c.neg(c);
+d.div_q(c, 8, up);
+b.div_r(c, 8, up);
+writeln(d, " ", b);
+
+d.div_q(c, 8, down);
+b.div_r(c, 8, down);
+writeln(d, " ", b);
+
+d.div_q(c, 8, zero); // same as DOWN for positive integers
+b.div_r(c, 8, zero); // same as DOWN for positive integers
+writeln(d, " ", b);
+
+c.neg(c);
+d.div_qr(b, c, 8, up);
+writeln(d, " ", b);
+
+d.div_qr(b, c, 8, down);
+writeln(d, " ", b);
+
+d.div_qr(b, c, 8, zero); // same as DOWN for positive integers
+writeln(d, " ", b);
+
+c.neg(c);
+writeln();
+
+
+// q = (n / 2^d)
+d.div_q_2exp(c, 3, up);
+b.div_r_2exp(c, 3, up);
+writeln(d, " ", b);
+
+d.div_q_2exp(c, 3, down);
+b.div_r_2exp(c, 3, down);
+writeln(d, " ", b);
+
+d.div_q_2exp(c, 3, zero);
+b.div_r_2exp(c, 3, zero);
+writeln(d, " ", b);

--- a/test/deprecated/BigInteger/deprecateRound.good
+++ b/test/deprecated/BigInteger/deprecateRound.good
@@ -1,0 +1,44 @@
+deprecateRound.chpl:3: warning: The enum Round is deprecated, please use the enum round instead
+deprecateRound.chpl:4: warning: The enum Round is deprecated, please use the enum round instead
+deprecateRound.chpl:5: warning: The enum Round is deprecated, please use the enum round instead
+deprecateRound.chpl:13: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
+deprecateRound.chpl:14: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
+deprecateRound.chpl:17: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
+deprecateRound.chpl:18: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
+deprecateRound.chpl:21: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
+deprecateRound.chpl:22: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
+deprecateRound.chpl:26: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
+deprecateRound.chpl:29: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
+deprecateRound.chpl:32: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
+deprecateRound.chpl:38: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
+deprecateRound.chpl:39: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
+deprecateRound.chpl:42: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
+deprecateRound.chpl:43: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
+deprecateRound.chpl:46: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
+deprecateRound.chpl:47: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
+deprecateRound.chpl:51: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
+deprecateRound.chpl:54: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
+deprecateRound.chpl:57: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
+deprecateRound.chpl:65: warning: bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead
+deprecateRound.chpl:66: warning: bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead
+deprecateRound.chpl:69: warning: bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead
+deprecateRound.chpl:70: warning: bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead
+deprecateRound.chpl:73: warning: bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead
+deprecateRound.chpl:74: warning: bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead
+-3 -3
+-4 5
+-3 -3
+4 -5
+3 3
+3 3
+
+-3 -3
+-4 5
+-3 -3
+4 -5
+3 3
+3 3
+
+-3 -3
+-4 5
+-3 -3

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_division.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_division.chpl
@@ -6,51 +6,51 @@ var b = new bigint( 10);
 var c = new bigint(-27);
 var d = new bigint();
 
-d.div_q(c, a, Round.UP);
-b.div_r(c, a, Round.UP);
+d.div_q(c, a, round.up);
+b.div_r(c, a, round.up);
 writeln(d, " ", b);
 
-d.div_q(c, a, Round.DOWN);
-b.div_r(c, a, Round.DOWN);
+d.div_q(c, a, round.down);
+b.div_r(c, a, round.down);
 writeln(d, " ", b);
 
-d.div_q(c, a, Round.ZERO); // same as UP   for negative integers
-b.div_r(c, a, Round.ZERO); // same as DOWN for positive integers
+d.div_q(c, a, round.zero); // same as up   for negative integers
+b.div_r(c, a, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
-d.div_qr(b, c, a, Round.UP);
+d.div_qr(b, c, a, round.up);
 writeln(d, " ", b);
 
-d.div_qr(b, c, a, Round.DOWN);
+d.div_qr(b, c, a, round.down);
 writeln(d, " ", b);
 
-d.div_qr(b, c, a, Round.ZERO); // same as DOWN for positive integers
+d.div_qr(b, c, a, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 writeln();
 
 c.neg(c);
-d.div_q(c, 8, Round.UP);
-b.div_r(c, 8, Round.UP);
+d.div_q(c, 8, round.up);
+b.div_r(c, 8, round.up);
 writeln(d, " ", b);
 
-d.div_q(c, 8, Round.DOWN);
-b.div_r(c, 8, Round.DOWN);
+d.div_q(c, 8, round.down);
+b.div_r(c, 8, round.down);
 writeln(d, " ", b);
 
-d.div_q(c, 8, Round.ZERO); // same as DOWN for positive integers
-b.div_r(c, 8, Round.ZERO); // same as DOWN for positive integers
+d.div_q(c, 8, round.zero); // same as down for positive integers
+b.div_r(c, 8, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
-d.div_qr(b, c, 8, Round.UP);
+d.div_qr(b, c, 8, round.up);
 writeln(d, " ", b);
 
-d.div_qr(b, c, 8, Round.DOWN);
+d.div_qr(b, c, 8, round.down);
 writeln(d, " ", b);
 
-d.div_qr(b, c, 8, Round.ZERO); // same as DOWN for positive integers
+d.div_qr(b, c, 8, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
@@ -58,16 +58,16 @@ writeln();
 
 
 // q = (n / 2^d)
-d.div_q_2exp(c, 3, Round.UP);
-b.div_r_2exp(c, 3, Round.UP);
+d.div_q_2exp(c, 3, round.up);
+b.div_r_2exp(c, 3, round.up);
 writeln(d, " ", b);
 
-d.div_q_2exp(c, 3, Round.DOWN);
-b.div_r_2exp(c, 3, Round.DOWN);
+d.div_q_2exp(c, 3, round.down);
+b.div_r_2exp(c, 3, round.down);
 writeln(d, " ", b);
 
-d.div_q_2exp(c, 3, Round.ZERO);
-b.div_r_2exp(c, 3, Round.ZERO);
+d.div_q_2exp(c, 3, round.zero);
+b.div_r_2exp(c, 3, round.zero);
 writeln(d, " ", b);
 
 writeln();

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
@@ -61,7 +61,7 @@ iter genDigits(numDigits) {
 
       // tmp1 = tmp1 / denom; tmp2 = tmp1 % denom
       // tmp1 gets quotient, tmp2 gets remainder
-      tmp1.div_qr(tmp2, tmp1, denom, Round.DOWN);
+      tmp1.div_qr(tmp2, tmp1, denom, round.down);
 
       // Now, if:
       //   (numer * 3 + accum) % denom + numer == (numer * 4 + accum) + numer


### PR DESCRIPTION
This new enum also uses all lowercase for the constants instead of all caps.

This meant deprecating the functions that took `Round` as an argument in favor
of new versions that take `round`.  This impacted:
- two versions of div_q
- two versions of div_r
- two versions of div_qr
- div_q_2exp
- div_r_2exp

When deprecating, replace the default argument value with just a type
declaration to avoid potential conflicts when relying on the default value (such
calls will naturally switch to using the new type)

Resolves #17723 

Replace uses of `Round` enum and its constants in tests with new `round` enum.

Adds a test of the deprecation warning for all these symbols

Passed a full paratest with futures