### PR TITLE
Add deprecation warnings when deprecated configs are set at compilation and execution

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -388,7 +388,7 @@ DefExpr* buildDeprecated(DefExpr* def, const char* msg) {
     // compilation line
     if (isUsedCmdLineConfig(sym->name)) {
       USR_WARN("%s", sym->getDeprecationMsg());
-      USR_PRINT("'%s' was set via a compilation flag", sym->name);
+      USR_PRINT("'%s' was set via a compiler flag", sym->name);
     }
   }
   return def;

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -388,6 +388,7 @@ DefExpr* buildDeprecated(DefExpr* def, const char* msg) {
     // compilation line
     if (isUsedCmdLineConfig(sym->name)) {
       USR_WARN("%s", sym->getDeprecationMsg());
+      USR_PRINT("'%s' was set via a compilation flag", sym->name);
     }
   }
   return def;

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -382,6 +382,14 @@ DefExpr* buildDeprecated(DefExpr* def, const char* msg) {
   Symbol* sym = def->sym;
   sym->addFlag(FLAG_DEPRECATED);
   sym->deprecationMsg = msg;
+
+  if (sym->hasFlag(FLAG_CONFIG)) {
+    // Trigger a warning now if the deprecated config has been set via the
+    // compilation line
+    if (isUsedCmdLineConfig(sym->name)) {
+      USR_WARN("%s", sym->getDeprecationMsg());
+    }
+  }
   return def;
 }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2027,7 +2027,7 @@ codegen_config() {
 
     forv_Vec(VarSymbol, var, gVarSymbols) {
       if (var->hasFlag(FLAG_CONFIG) && !var->isType()) {
-        std::vector<llvm::Value *> args (4);
+        std::vector<llvm::Value *> args (6);
         args[0] = info->irBuilder->CreateLoad(
             new_CStringSymbol(var->name)->codegen().val);
 
@@ -2054,6 +2054,9 @@ codegen_config() {
         }
 
         args[3] = info->irBuilder->getInt32(var->hasFlag(FLAG_PRIVATE));
+
+        args[4] = info->irBuilder->getInt32(var->hasFlag(FLAG_DEPRECATED));
+        args[5] = info->irBuilder->CreateLoad(new_CStringSymbol(var->getDeprecationMsg())->codegen().val);
 
         info->irBuilder->CreateCall(installConfigFunc, args);
       }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1983,7 +1983,10 @@ codegen_config() {
         } else {
           fprintf(outfile, "\", \"%s\"", var->getModule()->name);
         }
-        fprintf(outfile,", /* private = */ %d);\n", var->hasFlag(FLAG_PRIVATE));
+        fprintf(outfile,", /* private = */ %d", var->hasFlag(FLAG_PRIVATE));
+        fprintf(outfile,", /* deprecated = */ %d",
+                var->hasFlag(FLAG_DEPRECATED));
+        fprintf(outfile,", \"%s\");\n", var->getDeprecationMsg());
 
       }
     }

--- a/runtime/include/config.h
+++ b/runtime/include/config.h
@@ -34,7 +34,8 @@ void initSetValue(const char* varName, const char* value,
                   const char* moduleName, int32_t lineno, int32_t filename);
 const char* lookupSetValue(const char* varName, const char* moduleName);
 void installConfigVar(const char* varName, const char* value, 
-                      const char* moduleName, int isprivate);
+                      const char* moduleName, int private, int deprecated,
+                      const char* deprecationMsg);
 
 int handlePossibleConfigVar(int* argc, char* argv[], int argnum, 
                             int32_t lineno, int32_t filename);

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -41,6 +41,8 @@ typedef struct _configVarType { /* table entry */
   char* defaultValue;
   char* setValue;
   int private;
+  int deprecated;
+  const char* deprecationMsg;
 
   struct _configVarType* nextInBucket;
   struct _configVarType* nextInstalled;
@@ -296,6 +298,8 @@ void initSetValue(const char* varName, const char* value,
                                             "disambiguate using '<moduleName>.",
                                             varName, "'.");
     chpl_error(message, lineno, filename);
+  } else if (configVar->deprecated) {
+    chpl_warning(configVar->deprecationMsg, lineno, filename);
   }
   if (strcmp(varName, "numLocales") == 0) {
     parseNumLocales(value, lineno, filename);
@@ -323,7 +327,8 @@ const char* lookupSetValue(const char* varName, const char* moduleName) {
 
 
 void installConfigVar(const char* varName, const char* value,
-                      const char* moduleName, int private) {
+                      const char* moduleName, int private, int deprecated,
+                      const char* deprecationMsg) {
   unsigned hashValue;
   configVarType* configVar = (configVarType*)
     chpl_mem_allocMany(1, sizeof(configVarType), CHPL_RT_MD_CF_TABLE_DATA, 0, 0);
@@ -343,6 +348,8 @@ void installConfigVar(const char* varName, const char* value,
   configVar->defaultValue = chpl_glom_strings(1, value);
   configVar->setValue = NULL;
   configVar->private = private;
+  configVar->deprecated = deprecated;
+  configVar->deprecationMsg = deprecationMsg;
 }
 
 

--- a/test/deprecated-keyword/handleConfig.chpl
+++ b/test/deprecated-keyword/handleConfig.chpl
@@ -1,0 +1,7 @@
+// Handle when a config var is referenced via its flag
+deprecated "don't use x, use y" config var x: bool = false;
+config var y: bool = false;
+
+proc main() {
+  writeln(x);
+}

--- a/test/deprecated-keyword/handleConfig.execopts
+++ b/test/deprecated-keyword/handleConfig.execopts
@@ -1,0 +1,5 @@
+ # handleConfig.unset.good
+--y=true # handleConfig.unset.good
+--x=true # handleConfig.set.good
+--x=true --y=true # handleConfig.set.good
+--y=true --x=true # handleConfig.set2.good

--- a/test/deprecated-keyword/handleConfig.set.good
+++ b/test/deprecated-keyword/handleConfig.set.good
@@ -1,0 +1,4 @@
+handleConfig.chpl:5: In function 'main':
+handleConfig.chpl:6: warning: don't use x, use y
+true
+<command-line arg>:1: warning: don't use x, use y

--- a/test/deprecated-keyword/handleConfig.set2.good
+++ b/test/deprecated-keyword/handleConfig.set2.good
@@ -1,0 +1,4 @@
+handleConfig.chpl:5: In function 'main':
+handleConfig.chpl:6: warning: don't use x, use y
+true
+<command-line arg>:2: warning: don't use x, use y

--- a/test/deprecated-keyword/handleConfig.unset.good
+++ b/test/deprecated-keyword/handleConfig.unset.good
@@ -1,0 +1,3 @@
+handleConfig.chpl:5: In function 'main':
+handleConfig.chpl:6: warning: don't use x, use y
+false

--- a/test/deprecated-keyword/handleConfigNoMsg.chpl
+++ b/test/deprecated-keyword/handleConfigNoMsg.chpl
@@ -1,0 +1,7 @@
+// Handle when a config var is referenced via its flag
+deprecated config var x: bool = false;
+config var y: bool = false;
+
+proc main() {
+  writeln(x);
+}

--- a/test/deprecated-keyword/handleConfigNoMsg.execopts
+++ b/test/deprecated-keyword/handleConfigNoMsg.execopts
@@ -1,0 +1,5 @@
+ # handleConfigNoMsg.unset.good
+--y=true # handleConfigNoMsg.unset.good
+--x=true # handleConfigNoMsg.set.good
+--x=true --y=true # handleConfigNoMsg.set.good
+--y=true --x=true # handleConfigNoMsg.set2.good

--- a/test/deprecated-keyword/handleConfigNoMsg.set.good
+++ b/test/deprecated-keyword/handleConfigNoMsg.set.good
@@ -1,0 +1,4 @@
+handleConfigNoMsg.chpl:5: In function 'main':
+handleConfigNoMsg.chpl:6: warning: x is deprecated
+true
+<command-line arg>:1: warning: x is deprecated

--- a/test/deprecated-keyword/handleConfigNoMsg.set2.good
+++ b/test/deprecated-keyword/handleConfigNoMsg.set2.good
@@ -1,0 +1,4 @@
+handleConfigNoMsg.chpl:5: In function 'main':
+handleConfigNoMsg.chpl:6: warning: x is deprecated
+true
+<command-line arg>:2: warning: x is deprecated

--- a/test/deprecated-keyword/handleConfigNoMsg.unset.good
+++ b/test/deprecated-keyword/handleConfigNoMsg.unset.good
@@ -1,0 +1,3 @@
+handleConfigNoMsg.chpl:5: In function 'main':
+handleConfigNoMsg.chpl:6: warning: x is deprecated
+false

--- a/test/deprecated-keyword/handleConfigParam.chpl
+++ b/test/deprecated-keyword/handleConfigParam.chpl
@@ -1,0 +1,7 @@
+// Handle when a config param is referenced via its flag
+deprecated "don't use x, use y" config param x: bool = false;
+config param y: bool = false;
+
+proc main() {
+  writeln(x);
+}

--- a/test/deprecated-keyword/handleConfigParam.compopts
+++ b/test/deprecated-keyword/handleConfigParam.compopts
@@ -1,0 +1,5 @@
+ # handleConfigParam.unset.good
+-sy=true # handleConfigParam.unset.good
+-sx=true # handleConfigParam.set.good
+-sx=true -sy=true # handleConfigParam.set.good
+-sy=true -sx=true # handleConfigParam.set.good

--- a/test/deprecated-keyword/handleConfigParam.set.good
+++ b/test/deprecated-keyword/handleConfigParam.set.good
@@ -1,4 +1,5 @@
 warning: don't use x, use y
+note: 'x' was set via a compilation flag
 handleConfigParam.chpl:5: In function 'main':
 handleConfigParam.chpl:6: warning: don't use x, use y
 true

--- a/test/deprecated-keyword/handleConfigParam.set.good
+++ b/test/deprecated-keyword/handleConfigParam.set.good
@@ -1,5 +1,5 @@
 warning: don't use x, use y
-note: 'x' was set via a compilation flag
+note: 'x' was set via a compiler flag
 handleConfigParam.chpl:5: In function 'main':
 handleConfigParam.chpl:6: warning: don't use x, use y
 true

--- a/test/deprecated-keyword/handleConfigParam.set.good
+++ b/test/deprecated-keyword/handleConfigParam.set.good
@@ -1,0 +1,4 @@
+warning: don't use x, use y
+handleConfigParam.chpl:5: In function 'main':
+handleConfigParam.chpl:6: warning: don't use x, use y
+true

--- a/test/deprecated-keyword/handleConfigParam.unset.good
+++ b/test/deprecated-keyword/handleConfigParam.unset.good
@@ -1,0 +1,3 @@
+handleConfigParam.chpl:5: In function 'main':
+handleConfigParam.chpl:6: warning: don't use x, use y
+false

--- a/test/deprecated-keyword/handleConfigParamNoMsg.chpl
+++ b/test/deprecated-keyword/handleConfigParamNoMsg.chpl
@@ -1,0 +1,7 @@
+// Handle when a config param is referenced via its flag
+deprecated config param x: bool = false;
+config param y: bool = false;
+
+proc main() {
+  writeln(x);
+}

--- a/test/deprecated-keyword/handleConfigParamNoMsg.compopts
+++ b/test/deprecated-keyword/handleConfigParamNoMsg.compopts
@@ -1,0 +1,5 @@
+ # handleConfigParamNoMsg.unset.good
+-sy=true # handleConfigParamNoMsg.unset.good
+-sx=true # handleConfigParamNoMsg.set.good
+-sx=true -sy=true # handleConfigParamNoMsg.set.good
+-sy=true -sx=true # handleConfigParamNoMsg.set.good

--- a/test/deprecated-keyword/handleConfigParamNoMsg.set.good
+++ b/test/deprecated-keyword/handleConfigParamNoMsg.set.good
@@ -1,0 +1,5 @@
+warning: x is deprecated
+note: 'x' was set via a compilation flag
+handleConfigParamNoMsg.chpl:5: In function 'main':
+handleConfigParamNoMsg.chpl:6: warning: x is deprecated
+true

--- a/test/deprecated-keyword/handleConfigParamNoMsg.set.good
+++ b/test/deprecated-keyword/handleConfigParamNoMsg.set.good
@@ -1,5 +1,5 @@
 warning: x is deprecated
-note: 'x' was set via a compilation flag
+note: 'x' was set via a compiler flag
 handleConfigParamNoMsg.chpl:5: In function 'main':
 handleConfigParamNoMsg.chpl:6: warning: x is deprecated
 true

--- a/test/deprecated-keyword/handleConfigParamNoMsg.unset.good
+++ b/test/deprecated-keyword/handleConfigParamNoMsg.unset.good
@@ -1,0 +1,3 @@
+handleConfigParamNoMsg.chpl:5: In function 'main':
+handleConfigParamNoMsg.chpl:6: warning: x is deprecated
+false


### PR DESCRIPTION
Deprecated configs already have warnings generated when the config is used in
Chapel code, but special handling was needed to generate warning when the
config is set via compilation or execution arguments.  This change adds such
handling.

Resolves #17791 
Resolves Cray/chapel-private#2089

<details>
Since we check whether a config has been set at compilation time when we see
the config's declaration (and don't attach the deprecation information until later),
generate the compilation time warning when we would attach the deprecation flag
and message.

For the execution flags, pass deprecation information along at codegen so that the
runtime can detect if the config being set was deprecated and generate the
appropriate message if so.
</details>

Adds tests to cover the behavior of config params and the behavior of config
vars, both with and without an explicit message provided.  These tests pass in
various combinations of compilation options and execution options respectively.

Passed a full paratest with futures