### PR TITLE
Fix CHPL_LLVM=system for Mac Mojave users using llvm@11 from homebrew

### DIFF
--- a/util/config/gather-clang-sysroot-arguments
+++ b/util/config/gather-clang-sysroot-arguments
@@ -28,4 +28,12 @@ if [ $? -eq 0 ]; then
   fi
 fi
 
+TARGET_PLATFORM=`$CHPL_HOME/util/chplenv/chpl_platform.py --target`
+if [[ $TARGET_PLATFORM -eq "darwin" ]]; then
+    os_ver=`sw_vers -productVersion`
+    if [[ "$os_ver" == 10.14.* ]]; then
+        echo "-mlinker-version=450"
+    fi
+fi
+
 #otherwise, no clang in path. do nothing.


### PR DESCRIPTION
When using llvm@11 from homebrew on Mac Mojave, and using the
version of clang/clang++ it provides with the system linker,
the error message:

```
ld: unknown option: -platform_version
```

was being produced, as has been noticed by several other projects
online.  A workaround for this is to tell clang to assume a specific
linker version via:

```
-mlinker-version=450
```

this PR does that by adding a check to `gather-clang-sysroot-arguments`
that checks the Mac OS version, and adds this option if it's 1.14.x,
permitting the build and compilations to pass.

Resolves https://github.com/Cray/chapel-private/issues/2069
