### PR TITLE
Allow Homebrew LLVM as the default on Darwin systems

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -55,8 +55,7 @@ def has_compatible_installed_llvm():
     got = run_command([find_llvm_config, preferred_vers])
     got = got.strip()
     platform = chpl_platform.get('target')
-    # We have a problem with homebrew installed system llvm
-    if platform != "darwin" and got and got != "missing-llvm-config":
+    if got and got != "missing-llvm-config":
         return True
     else:
         return False


### PR DESCRIPTION
The util/chplenv/chpl_llvm.py script was checking for darwin platform and
disallowing a default of CHPL_LLVM=system in that case. Remove the check so
that if a good Homebrew LLVM is installed we will default to using it.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>