### PR TITLE
Add futures showing that the compiler permits any operator name today

### DIFF
--- a/test/functions/operatorOverloads/errors/namedOperator.bad
+++ b/test/functions/operatorOverloads/errors/namedOperator.bad
@@ -1,0 +1,1 @@
+In operator foo()

--- a/test/functions/operatorOverloads/errors/namedOperator.chpl
+++ b/test/functions/operatorOverloads/errors/namedOperator.chpl
@@ -1,0 +1,5 @@
+operator foo() {
+  writeln("In operator foo()");
+}
+
+foo();

--- a/test/functions/operatorOverloads/errors/namedOperator.future
+++ b/test/functions/operatorOverloads/errors/namedOperator.future
@@ -1,0 +1,3 @@
+bug: arbitrary operator names are permitted (and resolvable when standalone)
+
+#17853

--- a/test/functions/operatorOverloads/errors/namedOperator.good
+++ b/test/functions/operatorOverloads/errors/namedOperator.good
@@ -1,0 +1,1 @@
+namedOperator.chpl:1:error: 'foo' is not a legal operator name

--- a/test/functions/operatorOverloads/errors/namedOperator2.bad
+++ b/test/functions/operatorOverloads/errors/namedOperator2.bad
@@ -1,0 +1,4 @@
+namedOperator2.chpl:9: error: unresolved call 'R.foo()'
+namedOperator2.chpl:2: note: this candidate did not match: R.foo()
+namedOperator2.chpl:9: note: because call includes 0 arguments
+namedOperator2.chpl:2: note: but function can only accept 0 arguments

--- a/test/functions/operatorOverloads/errors/namedOperator2.chpl
+++ b/test/functions/operatorOverloads/errors/namedOperator2.chpl
@@ -1,0 +1,9 @@
+record R {
+  operator foo() {
+    writeln("In operator foo()");
+  }
+}
+
+var myR: R;
+
+myR.foo();

--- a/test/functions/operatorOverloads/errors/namedOperator2.future
+++ b/test/functions/operatorOverloads/errors/namedOperator2.future
@@ -1,0 +1,3 @@
+bug: arbitrary operator names are permitted (and generate confusing errors for methods)
+
+#17853

--- a/test/functions/operatorOverloads/errors/namedOperator2.good
+++ b/test/functions/operatorOverloads/errors/namedOperator2.good
@@ -1,0 +1,1 @@
+namedOperator2.chpl:2:error: 'foo' is not a legal operator name


### PR DESCRIPTION
These futures are in support of issue #17853.