### PR TITLE
install all of util/config and byte-compile python code before installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,14 @@ c2chapel: third-party-c2chapel-venv FORCE
 	cd tools/c2chapel && $(MAKE)
 	cd tools/c2chapel && $(MAKE) install
 
+compile-util-python: FORCE
+	@if $(CHPL_MAKE_PYTHON) -m compileall -h > /dev/null 2>&1 ; then \
+	  echo "Compiling Python scripts in util/" ; \
+	  $(CHPL_MAKE_PYTHON) -m compileall util/config -q ; \
+	  $(CHPL_MAKE_PYTHON) -m compileall util/chplenv -q ; \
+	else \
+	  echo "Not compiling Python scripts - missing compileall" ; \
+	fi
 
 third-party-fltk: FORCE
 	cd third-party/fltk && $(MAKE)

--- a/configure
+++ b/configure
@@ -147,6 +147,12 @@ fi
 ./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig
 mv configured-chplconfig chplconfig
 
+# Compile the Python scripts in util before installation.
+# We want to do this before installing, but not in the install script
+# because that might have elevated privileges. We don't need to do
+# it for typical use of a source release (since Python will handle it).
+make compile-util-python
+
 echo
 echo "  Currently selected Chapel configuration:"
 echo

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -166,7 +166,8 @@ myinstalldir () {
     exit -1
   fi
 
-  ( cd "$FROM" ; tar cf - . ) | ( cd "$TO" ; tar xf - )
+  ( cd "$FROM" ; tar --exclude='__pycache__' -cf - . ) | \
+    ( cd "$TO" ; tar xf - )
 
   if [ $? -ne 0 ]
   then
@@ -263,30 +264,8 @@ myinstallfile util/printchplenv       "$DEST_CHPL_HOME"/util/
 # copy util/chplenv
 myinstalldir  util/chplenv            "$DEST_CHPL_HOME"/util/chplenv/
 
-# copy util/config/compileline
-# (needed for LLVM builds)
-myinstallfile util/config/compileline "$DEST_CHPL_HOME"/util/config/
-
-# copy util/config/compileline.py
-# (needed for LLVM builds)
-myinstallfile util/config/compileline.py "$DEST_CHPL_HOME"/util/config/
-
-# copy util/config/find-python.py
-# (needed by setchplenv*, Makefiles, compileline, printchplenv wrappers)
-myinstallfile util/config/find-python.sh "$DEST_CHPL_HOME"/util/config/
-
-# copy util/config/run-in-venv.bash
-# (needed primarily by start_test)
-myinstallfile util/config/run-in-venv.bash "$DEST_CHPL_HOME"/util/config
-
-# copy util/config/fixpath.py
-# (needed by setchplenv*)
-myinstallfile util/config/fixpath.py  "$DEST_CHPL_HOME"/util/config/
-
-# copy util/config/replace-paths.py
-# (needed by --library --library-makefile compilations)
-myinstallfile util/config/replace-paths.py  "$DEST_CHPL_HOME"/util/config/
-
+# copy util/config/
+myinstalldir  util/config            "$DEST_CHPL_HOME"/util/config/
 
 if [ ! -z "$DEST_DIR" ]
 then

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -166,8 +166,12 @@ myinstalldir () {
     exit -1
   fi
 
-  ( cd "$FROM" ; tar --exclude='__pycache__' -cf - . ) | \
-    ( cd "$TO" ; tar xf - )
+  # If we wanted to exclude the built Python files, we would use e.g.
+  #   tar --exclude='__pycache__' -cf -
+  # However in this install script we probably want to make sure that
+  # these are compiled ahead-of-time (and not with elevated
+  # privileges so not in this script).
+  ( cd "$FROM" ; tar cf - . ) | ( cd "$TO" ; tar xf - )
 
   if [ $? -ne 0 ]
   then


### PR DESCRIPTION
Resolves #17856.

This PR takes two steps.

First, for #17856, it changes install.sh to install all of util/config
instead of particular files.

Second, this PR adjusts `configure` to compile the Python programs in
util/config and util/chplenv.

There are the `__pycache__` directories in util/config and I was
wondering if these should be installed. These directories store the
compiled byte-code for Python programs using Python 3.

My understanding is that once the Python files are installed, the
destination might not be writable anymore. So if we would like these
Python programs to have the benefit of compiled byte-code, we need to
make sure to compile them before or during installation. This is one of
the purposes of the Python package
[compileall](https://docs.python.org/3.9/library/compileall.html). We
could, in theory, run it during `install.sh` but that script is meant to
be run as root (when installing system-wide) and we don't want to run
Python code in that setting if we don't have to. Additionally, this step
isn't really necessary for people using Chapel from a source release. So,
I adjusted `configure` to run a new make rule with `make
compile-util-python` to do the byte compilation.

Note that in the context of a Debian package, the compiled byte code
should not be installed directly but should rather be generated as a
post-install action. But, since `configure` / `make install` doesn't have
a post-install action, we can't easily use that same strategy in other
settings. (A Debian package effort can just delete the compiled byte code
when creating the package and then recompile with a post-install action).

- [x] configure, make install, and compile and run Hello works on Mac OS
  X (with Python 3)
- [x] same steps on a SLES 12 system
- [x] observed non-fatal "missing compileall" error with python 2.7

Reviewed by @Maxrimus and @lydia-duncan - thanks!