### PR TITLE
compiler/next: remove unnecessary 'const' on value returns

### DIFF
--- a/compiler/next/include/chpl/uast/Formal.h
+++ b/compiler/next/include/chpl/uast/Formal.h
@@ -85,7 +85,7 @@ class Formal final : public VarLikeDecl {
    Returns the intent of the formal, e.g. in `proc f(const ref y: int)`,
    the formal `y` has intent `const ref`.
    */
-  const Intent intent() const { return this->intent_; }
+  Intent intent() const { return this->intent_; }
 
 };
 

--- a/compiler/next/include/chpl/uast/Module.h
+++ b/compiler/next/include/chpl/uast/Module.h
@@ -65,7 +65,7 @@ class Module final : public NamedDecl {
                              UniqueString name, Decl::Visibility vis,
                              Module::Kind kind, ASTList stmts);
 
-  const Kind kind() const { return this->kind_; }
+  Kind kind() const { return this->kind_; }
 
   ASTListIteratorPair<Expression> stmts() const {
     return ASTListIteratorPair<Expression>(children_.begin(), children_.end());

--- a/compiler/next/include/chpl/uast/TaskVar.h
+++ b/compiler/next/include/chpl/uast/TaskVar.h
@@ -89,7 +89,7 @@ class TaskVar final : public VarLikeDecl {
   /**
     Returns the intent of this task variable.
   */
-  const Intent intent() const { return this->intent_; }
+  Intent intent() const { return this->intent_; }
 
 };
 

--- a/compiler/next/include/chpl/uast/TupleDecl.h
+++ b/compiler/next/include/chpl/uast/TupleDecl.h
@@ -87,7 +87,7 @@ class TupleDecl final : public Decl {
   /**
     Returns the kind of the tuple (`var` / `const` / `param` etc).
    */
-  const Variable::Kind kind() const { return this->kind_; }
+  Variable::Kind kind() const { return this->kind_; }
 
   /**
     Return a way to iterate over the contained Decls

--- a/compiler/next/include/chpl/uast/Variable.h
+++ b/compiler/next/include/chpl/uast/Variable.h
@@ -83,7 +83,7 @@ class Variable final : public VarLikeDecl {
   /**
     Returns the kind of the variable (`var` / `const` / `param` etc).
    */
-  const Kind kind() const { return this->kind_; }
+  Kind kind() const { return this->kind_; }
 
 };
 


### PR DESCRIPTION
This PR addresses intel compiler warnings as described in issue #17861.

Trivial and not reviewed.