### PR TITLE
Skip test for clang to workaround missing omp.h

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
@@ -1,5 +1,6 @@
-# mppf: For some reason I havn't been able to understand yet,
-# nightly testing configurations that build LLVM have trouble
-# finding omp.h. I haven't been able to reproduce this myself.
+# mppf: nightly testing configurations using our own clang/llvm
+# build are having trouble finding omp.h.
+#
 # Skip this test under LLVM configurations as a workaround.
 CHPL_LLVM!=none
+CHPL_TARGET_COMPILER==clang


### PR DESCRIPTION
We were seeing failure to find omp.h when compiling empty-omp-taskspawn with the clang we built to support CHPL_LLVM=system. Since this is an issue with that clang build, this PR just skips the test in that configuration.