### PR TITLE
Fix a % format mismatch that clang 10 was complaining about for comm=ofi

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2414,7 +2414,7 @@ chpl_bool nextMemMapEntry(void** pAddr, size_t* pSize,
     int ch;
 
     int scn_cnt;
-    scn_cnt = fscanf(f, "%lx-%lx%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
+    scn_cnt = fscanf(f, "%"PRIu64"-%"PRIu64"%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
     if (scn_cnt == EOF) {
       break;
     } else if (scn_cnt != 3) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2414,7 +2414,7 @@ chpl_bool nextMemMapEntry(void** pAddr, size_t* pSize,
     int ch;
 
     int scn_cnt;
-    scn_cnt = fscanf(f, "%"SCNu64"-%"SCNu64"%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
+    scn_cnt = fscanf(f, "%" SCNu64 "-%" SCNu64 "%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
     if (scn_cnt == EOF) {
       break;
     } else if (scn_cnt != 3) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2414,7 +2414,7 @@ chpl_bool nextMemMapEntry(void** pAddr, size_t* pSize,
     int ch;
 
     int scn_cnt;
-    scn_cnt = fscanf(f, "%" SCNu64 "-%" SCNu64 "%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
+    scn_cnt = fscanf(f, "%" SCNx64 "-%" SCNx64 "%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
     if (scn_cnt == EOF) {
       break;
     } else if (scn_cnt != 3) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2414,7 +2414,7 @@ chpl_bool nextMemMapEntry(void** pAddr, size_t* pSize,
     int ch;
 
     int scn_cnt;
-    scn_cnt = fscanf(f, "%"PRIu64"-%"PRIu64"%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
+    scn_cnt = fscanf(f, "%"SCNu64"-%"SCNu64"%4s%*x%*x:%*x%*x", &lo_addr, &hi_addr, perms);
     if (scn_cnt == EOF) {
       break;
     } else if (scn_cnt != 3) {


### PR DESCRIPTION
Trying CHPL_COMM=ofi on my Mac with CHPL_DEVELOPER set, I was getting
a broken build due to a % format mismatch.  This resolves it by using the stdint.h
macros for fixed-size int formats.