### PR TITLE
Fix warnings about initializing subobjects

### DIFF
--- a/compiler/next/include/chpl/queries/UniqueString-detail.h
+++ b/compiler/next/include/chpl/queries/UniqueString-detail.h
@@ -116,7 +116,7 @@ struct InlinedString {
   static inline InlinedString buildFromAligned(const char* s, size_t len) {
     // Store empty strings as nullptr
     if (s == nullptr || len == 0)
-      return { nullptr };
+      return {{ nullptr }};
 
     // Would the tag, null terminator, and data fit?
     if (len <= MAX_SIZE_INLINED) {
@@ -126,11 +126,11 @@ struct InlinedString {
       // (since null byte will come from the zeros in val)
       memcpy(dst, s, len);
       // create a struct with the value we created and return it
-      return { (const char*) val };
+      return {{ (const char*) val }};
     }
 
     assert(!alignmentIndicatesTag(s));
-    return { s };
+    return {{ s }};
   }
 
   static InlinedString buildUsingContextTable(Context* context,


### PR DESCRIPTION
Fixes: https://github.com/chapel-lang/chapel/issues/17860

That warning was turned off by default in `-Wall` and similar options in later versions of GCC and Clang, because it produces spurious warnings for `std::array`s.

See: https://bugs.llvm.org/show_bug.cgi?id=21629

Since we have an anonymous union as the only member of our struct, and since only the first member of a union is initialized, the warning is spurious in our context too.