### PR TITLE
Change != to == in a conditional

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3925,7 +3925,7 @@ void makeBinaryLLVM(void) {
   }
 
   // only use clang sysroot args if we haven't overridden the linker
-  if (clangCXX != useLinkCXX) {
+  if (clangCXX == useLinkCXX) {
     // add arguments that we captured at compile time
     options += " ";
     options += get_clang_sysroot_args();


### PR DESCRIPTION
In PR #17827 which wanted to avoid adding -resource-dir to mpicxx I must
have mis-typed a character when switching machines between testing the
change and adding it to git. This reversed the meaning of the conditional
from what I intended.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>