### PR TITLE
compiler/next: add enableDebugTracing for tracing and fix docs build

### DIFF
--- a/compiler/next/doc/CMakeLists.txt
+++ b/compiler/next/doc/CMakeLists.txt
@@ -29,6 +29,11 @@ if(DOXYGEN_FOUND)
      "rst=\\verbatim embed:rst"
      "endrst=\\endverbatim")
   set(DOXYGEN_EXTRACT_PRIVATE NO)
+
+  # Enable the below line to request inherited members appear
+  # as if they are not inherited.
+  # set(DOXYGEN_INLINE_INHERITED_MEMB YES)
+
   # when Doxygen runs, define DOXYGEN in the preprocessor
   set(DOXYGEN_PREDEFINED "DOXYGEN")
   # exclude combine functions that the docs system has trouble with

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -190,6 +190,7 @@ class Context {
 
 
   querydetail::RevisionNumber currentRevisionNumber = 1;
+  bool enableDebugTracing = false;
 
   static void defaultReportError(const ErrorMessage& err);
   void (*reportError)(const ErrorMessage& err) = defaultReportError;

--- a/compiler/next/include/chpl/uast/ASTClassesList.h
+++ b/compiler/next/include/chpl/uast/ASTClassesList.h
@@ -152,3 +152,5 @@ AST_END_SUBCLASSES(Expression)
 
 
 /// \endcond
+
+// this comment seems to be necessary for doxygen xml output to be well-formed

--- a/doc/templates/compiler-internals-doxygen/index.rst
+++ b/doc/templates/compiler-internals-doxygen/index.rst
@@ -6,3 +6,11 @@ Compiler Internals
 .. doxygennamespace:: chpl
    :members:
    :undoc-members:
+
+.. comment
+
+  Future work --
+    * list each class separately (so it can have its own page)
+    * indicate which members (including inherited members) should
+      be documented (to provide the user-facing API and hiding
+      inheritance for implementation reasons)

--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -32,3 +32,4 @@ cpp:identifier size_t
 cpp:identifier detail
 cpp:identifier detail::PODUniqueString
 cpp:identifier ASTList::const_iterator::difference_type
+cpp:identifier uint64_t


### PR DESCRIPTION
This PR takes two steps:
 * adds enableDebugTracing to control query tracing output
 * makes minor adjustments to fix the compiler/next docs build

- [x] full local testing

Reviewed by @dlongnecke-cray - thanks!