### PR TITLE
Add skipif to the directory tracking deprecated BigInteger symbols

### DIFF
--- a/test/deprecated/BigInteger.skipif
+++ b/test/deprecated/BigInteger.skipif
@@ -1,0 +1,2 @@
+# Tests in this directory assume we can use GMP
+CHPL_GMP == none


### PR DESCRIPTION
BigInteger relies on GMP, so no tests in that directory should run when GMP is
not available.

Verified a fresh checkout behaved correctly with and without CHPL_GMP