### PR TITLE
fix compiler/next/lib/util/Makefile - mkdir first

### DIFF
--- a/compiler/next/lib/util/Makefile
+++ b/compiler/next/lib/util/Makefile
@@ -34,10 +34,10 @@ TARGETS = $(NEXT_UTIL_OBJS)
 
 include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
 
-$(NEXT_UTIL_OBJDIR)/my_aligned_alloc.o: my_aligned_alloc.c
+$(NEXT_UTIL_OBJDIR)/my_aligned_alloc.o: my_aligned_alloc.c $(OBJ_SUBDIR_MADE)
 	$(CC) -c $(COMP_CFLAGS) -DCOMPILER_SUBDIR=$(COMPILER_SUBDIR) -o $@ $<
 
-$(NEXT_UTIL_OBJDIR)/my_strerror_r.o: my_strerror_r.c
+$(NEXT_UTIL_OBJDIR)/my_strerror_r.o: my_strerror_r.c $(OBJ_SUBDIR_MADE)
 	$(CC) -c $(COMP_CFLAGS) -DCOMPILER_SUBDIR=$(COMPILER_SUBDIR) -o $@ $<
 
 FORCE:


### PR DESCRIPTION
We have been seeing sporadic parallel build failures where the 
destination directory doesn't exist yet for the two rules compiling C
files. To fix that, adjust these Makefile rules to depend on the rule
that creates the destination directory.

- [x] checked parallel build after removing the build directory works on 
  a few systems

Reviewed by @vasslitvinov - thanks!