### PR TITLE
Change a case of applying -eq to string arguments to == (fixes #17851)

### DIFF
--- a/util/config/gather-clang-sysroot-arguments
+++ b/util/config/gather-clang-sysroot-arguments
@@ -29,7 +29,7 @@ if [ $? -eq 0 ]; then
 fi
 
 TARGET_PLATFORM=`$CHPL_HOME/util/chplenv/chpl_platform.py --target`
-if [[ $TARGET_PLATFORM -eq "darwin" ]]; then
+if [[ $TARGET_PLATFORM == "darwin" ]]; then
     os_ver=`sw_vers -productVersion`
     if [[ "$os_ver" == 10.14.* ]]; then
         echo "-mlinker-version=450"


### PR DESCRIPTION
This adjusts an `-eq` vs. `==` error that I introduced in #17851, where I wanted to compare strings, so should've used the latter.  While this didn't cause problems in my/our testing, @mppf saw failures with SLES12 in which it got into a conditional that should've been `darwin`-specific.