### PR TITLE
Stop setting CHPL_LLVM=none for cray-cs-gpu-interop

### DIFF
--- a/util/cron/test-cray-cs-gpu-interop.bash
+++ b/util/cron/test-cray-cs-gpu-interop.bash
@@ -7,7 +7,6 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-interop"
 
-export CHPL_LLVM=none
 export CHPL_COMM_SUBSTRATE=ibv
 
 module load cudatoolkit


### PR DESCRIPTION
This configuration should be working with the system LLVM now, so stop using
CHPL_LLVM=none.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>