### PR TITLE
Stop setting CHPL_LLVM=none in Linux32 testing

### DIFF
--- a/util/cron/test-linux32.bash
+++ b/util/cron/test-linux32.bash
@@ -6,8 +6,6 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_LLVM=none
-
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux32"
 
 $CWD/nightly -cron $(get_nightly_paratest_args)

--- a/util/cron/test-no-local.linux32.bash
+++ b/util/cron/test-no-local.linux32.bash
@@ -8,7 +8,4 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-local.linux32"
 
-# Linux32 doesn't currently support LLVM
-export CHPL_LLVM=none
-
 $CWD/nightly -cron -examples -no-local


### PR DESCRIPTION
It should now be inferred to be 'none' in these configurations and not error
out when not explicitly set.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>