### PR TITLE
Skipif this test for CHPL_TARGET_COMPILER=llvm

### DIFF
--- a/test/expressions/hilde/constOverflow.skipif
+++ b/test/expressions/hilde/constOverflow.skipif
@@ -1,4 +1,5 @@
 # This test only fails on PGI and Intel compilers.
 CHPL_TARGET_COMPILER<=gnu
 CHPL_TARGET_COMPILER<=clang
+CHPL_TARGET_COMPILER==llvm
 CHPL_TARGET_COMPILER==cray-prgenv-cray


### PR DESCRIPTION
Adjusts the skipif for expressions/hilde/constOverflow which is intended to check only Intel and PGI compilers.

Trivial and not reviewed.