### PR TITLE
Fix build_configs after CHPL_TARGET_COMPILER=llvm change

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -135,7 +135,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 
-        compilers=gnu,cray
+        compilers=gnu,llvm,cray
         comms=none,ofi
         launchers=none,pals,slurm-srun
         substrates=none
@@ -390,18 +390,26 @@ else
 
     # ---
 
-    # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
-    # Instead, they drive module load commands in the setenv callback
+    # NOTE: build_configs uses different values for CHPL_TARGET_COMPILER.
+    # The below statements translate to the variable needed by the
+    # Makefiles and perform appropriate module load commands.
 
     case "$CHPL_TARGET_COMPILER" in
     ( gnu )
         load_prgenv_gnu
+        export CHPL_TARGET_COMPILER=cray-prgenv-gnu
+        ;;
+    ( llvm )
+        load_prgenv_gnu
+        export CHPL_TARGET_COMPILER=llvm
         ;;
     ( intel )
         load_prgenv_intel
+        export CHPL_TARGET_COMPILER=cray-prgenv-intel
         ;;
     ( cray )
         load_prgenv_cray
+        export CHPL_TARGET_COMPILER=cray-prgenv-cray
         ;;
     ( compiler )
         load_prgenv_gnu
@@ -418,11 +426,6 @@ else
         ;;
     esac
 
-    # Discard the artificial CHPL_TARGET_COMPILER value.
-    # Chapel make will select cray-prgenv-gnu, cray-prgenv-intel, or cray-prgenv-cray,
-    # based on which module (PrgEnv-gnu, PrgEnv-intel, or PrgEnv-cray) it finds in the environment
-
-    unset CHPL_TARGET_COMPILER
     load_target_cpu $target_cpu_module
 
     if [ "$CHPL_AUX_FILESYS" == lustre ]; then

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -346,8 +346,9 @@ else
 
     # ---
 
-    # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
-    # Instead, they drive module load commands in the setenv callback
+    # NOTE: build_configs uses different values for CHPL_TARGET_COMPILER.
+    # The below statements translate to the variable needed by the
+    # Makefiles and perform appropriate module load commands.
 
     case "$CHPL_TARGET_COMPILER" in
     ( compiler)
@@ -373,9 +374,15 @@ else
         ;;
     ( gnu )
         load_prgenv_gnu
+        export CHPL_TARGET_COMPILER=cray-prgenv-gnu
+        ;;
+    ( llvm )
+        load_prgenv_gnu
+        export CHPL_TARGET_COMPILER=llvm
         ;;
     ( intel )
         load_prgenv_intel
+        export CHPL_TARGET_COMPILER=cray-prgenv-intel
         ;;
     ( "" )
         : ok
@@ -386,11 +393,6 @@ else
         ;;
     esac
 
-    # Discard the artificial CHPL_TARGET_COMPILER value.
-    # Chapel make will select cray-prgenv-gnu or cray-prgenv-intel, based on
-    # the presence of module PrgEnv-gnu or PrgEnv-intel in the environment
-
-    unset CHPL_TARGET_COMPILER
     load_target_cpu $target_cpu_module
 
     # ---


### PR DESCRIPTION
This PR makes adjustments to `build_configs` to work with the changes
from PR #17800.  In particular, that PR changed `make` for LLVM
configurations to no longer build the runtime twice (once for LLVM and
once for the current C compiler). But the `build_configs` module build
was relying on this behavior.

* Set `CHPL_TARGET_COMPILER` always in the `build_configs` setenv scripts
* Build LLVM as the `CHPL_TARGET_COMPILER` separately
* do so for EX, x86, and arm builds

Note that setting `CHPL_TARGET_COMPILER` on a PrgEnv system used to 
result in an error but no longer does. I do not know when that changed
but it was at least not an error at the time of the last release (or at
least not an error to run printchplenv). Now it is necessary to set it in
order to request the C backend on such systems when the LLVM backend is
available.

- [x] checked that the following command functions as expected

```
util/buildRelease/test_rpm_module.bash  https://github.com/mppf/chapel fix-build-configs-17800
```

Reviewed by @gbtitus and @Maxrimus - thanks!