### PR TITLE
Squash all deprecation warnings in deprecated symbols, no matter how deeply

### DIFF
--- a/test/deprecated-keyword/deepDepInDep.chpl
+++ b/test/deprecated-keyword/deepDepInDep.chpl
@@ -1,0 +1,30 @@
+module Main {
+  deprecated "x is deprecated, use y instead" var x: int = 17;
+  var y: int = 16;
+
+  deprecated module Deep {
+    // To check that we squash deprecation warnings for deep uses
+    module Deeper {
+      proc foo() {
+        use Main;
+        writeln(x);
+      }
+
+      // Even deeper!
+      module Deepest {
+        proc bar() {
+          use Main;
+          writeln(x);
+        }
+      }
+    }
+  }
+
+  proc main() {
+    use this.Deep.Deeper;
+    use this.Deep.Deeper.Deepest;
+
+    foo();
+    bar();
+  }
+}

--- a/test/deprecated-keyword/deepDepInDep.good
+++ b/test/deprecated-keyword/deepDepInDep.good
@@ -1,0 +1,5 @@
+deepDepInDep.chpl:23: In function 'main':
+deepDepInDep.chpl:24: warning: Deep is deprecated
+deepDepInDep.chpl:25: warning: Deep is deprecated
+17
+17


### PR DESCRIPTION
We were squashing deprecation warnings that were defined directly in a
deprecated symbol, but would only check the immediate parent symbol.  This meant
that if a deprecated symbol had a use of another deprecated symbol in a much
deeper context, we'd still get those warnings.  This change makes it so that all
deprecated warnings in already deprecated symbols are squashed, no matter how
deeply nested.

Add a test locking in the new behavior.  We already have a test of a deprecated
symbol directly in another deprecated symbol, so this test covers a use in an
intervening symbol in an intervening module, and another module in the intervening
module, just to be certain.

Passed a full paratest with futures