### PR TITLE
Rename private arg to isprivate

### DIFF
--- a/runtime/include/config.h
+++ b/runtime/include/config.h
@@ -34,7 +34,7 @@ void initSetValue(const char* varName, const char* value,
                   const char* moduleName, int32_t lineno, int32_t filename);
 const char* lookupSetValue(const char* varName, const char* moduleName);
 void installConfigVar(const char* varName, const char* value, 
-                      const char* moduleName, int private, int deprecated,
+                      const char* moduleName, int isprivate, int deprecated,
                       const char* deprecationMsg);
 
 int handlePossibleConfigVar(int* argc, char* argv[], int argnum, 

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -327,7 +327,7 @@ const char* lookupSetValue(const char* varName, const char* moduleName) {
 
 
 void installConfigVar(const char* varName, const char* value,
-                      const char* moduleName, int private, int deprecated,
+                      const char* moduleName, int isprivate, int deprecated,
                       const char* deprecationMsg) {
   unsigned hashValue;
   configVarType* configVar = (configVarType*)
@@ -347,7 +347,7 @@ void installConfigVar(const char* varName, const char* value,
   configVar->moduleName = chpl_glom_strings(1, moduleName);
   configVar->defaultValue = chpl_glom_strings(1, value);
   configVar->setValue = NULL;
-  configVar->private = private;
+  configVar->private = isprivate;
   configVar->deprecated = deprecated;
   configVar->deprecationMsg = deprecationMsg;
 }


### PR DESCRIPTION
`private` is a keyword in C++ and in some GPU interop situations we build
the runtime with a C++ compiler. So just use isprivate as the name of
the argument.

PR #16847 previously renamed this argument from private but PR #17848
changed it back to private.

- [x] full local testing