### PR TITLE
Update required python package versions for chpldoc and start_test

### DIFF
--- a/test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.bad
+++ b/test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.bad
@@ -1,4 +1,4 @@
-Running Sphinx v3.2.1
+Running Sphinx vN.N.N
 
 Warning, treated as error:
 html_static_path entry '_static' is placed inside outdir

--- a/test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.future
+++ b/test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.future
@@ -6,3 +6,5 @@ Because chpldoc uses 'docs' as a special directory, the --save-sphinx
 option doesn't work when 'docs' is supplied as a directory name,
 resulting in a confusing error message.  We should replace this with a
 better user-facing message.
+
+When this is done, we probably can remove the .prediff file on this test

--- a/test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.prediff
+++ b/test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.prediff
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Hide the Sphinx version in the .bad output so we don't have to keep updating
+# it.
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='s/Running Sphinx v[0-9]*.[0-9]*.[0-9]*/Running Sphinx vN.N.N/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+
+mv $tmptmp $tmpfile

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,7 +1,7 @@
 # Many of these packages have newer versions that work on Python 3 only.
 Jinja2==3.0.1
 MarkupSafe==2.0.1
-Pygments==2.7.1
+Pygments==2.9.0
 Sphinx==3.2.1
 docutils==0.16
 sphinx-rtd-theme==0.5.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -6,5 +6,5 @@ Sphinx==4.0.2
 docutils==0.17.1
 sphinx-rtd-theme==0.5.0
 sphinxcontrib-chapeldomain==0.0.20
-babel==2.8.0
+babel==2.9.1
 breathe==4.30.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,6 +1,6 @@
 # Many of these packages have newer versions that work on Python 3 only.
-Jinja2==2.11.2
-MarkupSafe==1.1.1
+Jinja2==3.0.1
+MarkupSafe==2.0.1
 Pygments==2.7.1
 Sphinx==3.2.1
 docutils==0.16

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -3,7 +3,7 @@ Jinja2==3.0.1
 MarkupSafe==2.0.1
 Pygments==2.9.0
 Sphinx==4.0.2
-docutils==0.16
+docutils==0.17.1
 sphinx-rtd-theme==0.5.0
 sphinxcontrib-chapeldomain==0.0.20
 babel==2.8.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -2,9 +2,9 @@
 Jinja2==3.0.1
 MarkupSafe==2.0.1
 Pygments==2.9.0
-Sphinx==3.2.1
+Sphinx==4.0.2
 docutils==0.16
 sphinx-rtd-theme==0.5.0
 sphinxcontrib-chapeldomain==0.0.20
 babel==2.8.0
-breathe==4.27
+breathe==4.30.0

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,3 @@
 PyYAML==5.4.1
 filelock==3.0.12
-argcomplete==1.12.1
+argcomplete==1.12.3


### PR DESCRIPTION
Now that we're into the next release cycle, it seemed like a healthy point to look
for newer versions of the Python packages we rely on for chpldoc and start_test.
Only one of the start_test packages had a newer version out, but every package
for chpldoc had a newer version available (except for the Chapel sphinx domain,
which we control).  One of these packages was incompatible when updated, so
stick with the older version for that one since that seems to work okay.  (If it's a
problem in nightly, I can swap them, but it seemed to be fine even with a
`make clobber`)

Updates:
- Jinja2 from 2.11.2 to 3.0.1
- MarkupSafe from 1.1.1 to 2.0.1 (which was required by Jinja2 after its update)
- Pygments from 2.7.1 to 2.9.0
- Sphinx from 3.2.1 to 4.0.2
- docutils from 0.16 to 0.17.1 (which prevented us from updating sphinx-rtd-theme)
- babel from 2.8.0 to 2.9.1
- breathe from 4.27 to 4.30.0 (the old version was relying on an older Sphinx)
- argcomplete from 1.12.1 to 1.12.3

Update chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.chpl to hide
the Sphinx version number so I don't have to keep updating the .bad file.

Passed a full paratest with futures