### PR TITLE
Stop some chpldoc tests from leaving some tmp files around

### DIFF
--- a/test/chpldoc/compflags/folder/PREDIFF
+++ b/test/chpldoc/compflags/folder/PREDIFF
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-sed -i -e '/^Running Sphinx v/,/^HTML files are at:/d' $2
+sed -e '/^Running Sphinx v/,/^HTML files are at:/d' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/chpldoc/compflags/version/PREDIFF
+++ b/test/chpldoc/compflags/version/PREDIFF
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-sed -i -e '/^Running Sphinx v/,/URL_ROOT:/d;s/^ *//;/LANGUAGE:/,$d' $2
+sed -e '/^Running Sphinx v/,/URL_ROOT:/d;s/^ *//;/LANGUAGE:/,$d' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Using `-i` for the sed command in the PREDIFF for these chpldoc test folders was
causing us to leave behind some *.tmp-e files in those directories.  Stop using
`-i` so that these files are no longer generated.

It seems like these files were only left around on OSX, but the change does improve
the situation there and I noticed no negative effects on Linux

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>