### PR TITLE
no-doc some domain methods

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2338,14 +2338,17 @@ module ChapelArray {
       }
     }
 
+    pragma "no doc"
     proc supportsAutoLocalAccess() param {
       return _value.dsiSupportsAutoLocalAccess();
     }
 
+    pragma "no doc"
     proc iteratorYieldsLocalElements() param {
       return _value.dsiIteratorYieldsLocalElements();
     }
 
+    pragma "no doc"
     operator :(val: _domain, type t: string) {
       use Reflection;
       if canResolveMethod(val._value, "doiToString") {


### PR DESCRIPTION
This PR `no doc`s:

- supportsAutoLocalAccess
- iteratorYieldsLocalElements
- operator :(domain, string)
