### PR TITLE
Remove error when building LLVM without PrgEnv-gnu loaded on XC

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -195,25 +195,11 @@ llvm: $(LLVM_CONFIGURED_HEADER_FILE) $(LLVM_HEADER_FILE) $(LLVM_SUPPORT_FILE) $(
 
 llvm-minimal: $(LLVM_CONFIGURED_HEADER_FILE) $(LLVM_HEADER_FILE) $(LLVM_SUPPORT_FILE) $(LLVM_CONFIG_FILE)
 
-# Just adding this error since this is the only configuration we test.
-check-prgenv-gnu: FORCE
-	@case "$(CHPL_MAKE_TARGET_COMPILER_PRGENV)" in \
-	  none) \
-	    ;; \
-	  cray-prgenv-gnu) \
-	    ;; \
-	  *) \
-	    echo "Error: make with CHPL_LLVM!=none requires PrgEnv-gnu" ; \
-	    echo "  e.g. module swap PrgEnv-cray PrgEnv-gnu" ; \
-	    echo "  or to just build the runtime, use 'make runtime'" ;\
-	    exit 1 ; \
-	esac
+llvm-clang: llvm
 
-llvm-clang: check-prgenv-gnu llvm
+bundled: llvm
 
-bundled: check-prgenv-gnu llvm
-
-system: check-prgenv-gnu $(LLVM_CLANG_CONFIG_FILE)
+system: $(LLVM_CLANG_CONFIG_FILE)
 
 system-minimal:
 


### PR DESCRIPTION
This PR removes an error that we generate if PrgEnv-gnu is loaded when
building the Chapel compiler with CHPL_LLVM!=none.

Michael added the error defensively while we were locking down LLVM
test failures and configurations because it represented a case that we
didn't test against nightly and that was causing some problems.
However, we believe that unifying the llvm setting with
CHPL_TARGET_COMPILER probably resolved those issues (and a quick test
on my part seems to confirm that).  Meanwhile the presence of the
error caused some churn for users who had configurations in which they
were trying to build with CHPL_LLVM=system and
CHPL_TARGET_COMPILER=PrgEnv-intel.

While we were able to advise those users about what they probably
wanted to do for that test configuration (set CHPL_LLVM=none so they
could focus on the intel build of the runtime), it also raised the
question "Do we really care what PrgEnv is loaded on an XC when doing
an LLVM-enabled build?"  Specifically, 'gcc' will be used as the host
compiler and 'clang' will be used as the target compiler, so the
choice of `PrgEnv-*` module shouldn't really be held against the user
since their choice won't be used in any way (we do swap in PrgEnv-gnu
in order to query some paths and such, but that doesn't really care which
PrgEnv was loaded to begin with.  And since we don't typically prevent choices
in the `CHPL_*` configuration that we don't test against until we're
aware of a problem with them, it makes sense to relax this defensive
error until such a time.