### PR TITLE
Skip building the docs in linux32 testing

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -524,10 +524,15 @@ mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-o
 
 # if we are using python2, we cannot build the test-venv and/or chpldoc
 if ($python2 == 0) {
-  # Build chpldoc. Do not fail the build if it does not succeed. Do not send
-  # mail either.
-  print "Making $make_vars_opt chpldoc\n";
-  mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", 0, 0);
+
+  # linux32 currently cannot build chpldoc.  TODO: remove this when the linux32
+  # box is using a later version of Python than 3.5
+  if (!($ENV{'CHPL_NIGHTLY_TEST_CONFIG_NAME'} eq "linux32")) {
+    # Build chpldoc. Do not fail the build if it does not succeed. Do not send
+    # mail either.
+    print "Making $make_vars_opt chpldoc\n";
+    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", 0, 0);
+  }
 
   # Build test virtualenv. Fail if the build does not succeed as virtualenv is
   # needed for start_test. Send mail on failure


### PR DESCRIPTION
This skips building chpldoc and running documentation checks on linux32.  The
machine we are running linux32 testing on has a version of Python 3 that is too
old for some of the newer Python packages we want to rely on for chpldoc.  Turn
testing there off until we've updated our linux32 machine

I did a debug run of util/cron/test-linux32.bash and it didn't try to build chpldoc
so I think this works

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>