### PR TITLE
In comm=ofi, use just one receive endpoint per locale instead of two.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -120,8 +120,8 @@ static struct fid_wait* ofi_amhWaitSet; // wait set for AM handler
 // spread the progress load across all the threads when we're doing
 // manual progress.
 //
-static struct fid_ep* ofi_rxEp;         // AM req receive endpoint
-static struct fid_cq* ofi_rxCQ;         // AM req receive endpoint CQ
+static struct fid_ep* ofi_rxEp;         // receive endpoint
+static struct fid_cq* ofi_rxCQ;         // receive endpoint CQ
 
 static struct fid_av* ofi_av;           // address vector
 static fi_addr_t* ofi_rxAddrs;          // table of remote endpoint addresses

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -122,17 +122,11 @@ static struct fid_wait* ofi_amhWaitSet; // wait set for AM handler
 //
 static struct fid_ep* ofi_rxEp;         // AM req receive endpoint
 static struct fid_cq* ofi_rxCQ;         // AM req receive endpoint CQ
-static struct fid_ep* ofi_rxEpRma;      // RMA/AMO target endpoint
-static struct fid_cq* ofi_rxCQRma;      // RMA/AMO target endpoint CQ
-static struct fid_cntr* ofi_rxCntrRma;  // RMA/AMO target endpoint counter
-static struct fid* ofi_rxCmplFidRma;    // rxCQRma or rxCntrRma fid
-static void (*checkRxRmaCmplsFn)(void); // fn: check for RMA/AMO EP completions
 
 static struct fid_av* ofi_av;           // address vector
 static fi_addr_t* ofi_rxAddrs;          // table of remote endpoint addresses
 
-#define rxMsgAddr(tcip, n) (ofi_rxAddrs[2 * (n)])
-#define rxRmaAddr(tcip, n) (ofi_rxAddrs[2 * (n) + 1])
+#define rxAddr(n) (ofi_rxAddrs[n])
 
 //
 // Transmit support.
@@ -285,8 +279,6 @@ static void do_remote_get_buff(void*, c_nodeid_t, void*, size_t);
 static void do_remote_amo_nf_buff(void*, c_nodeid_t, void*, size_t,
                                   enum fi_op, enum fi_datatype);
 static void amEnsureProgress(struct perTxCtxInfo_t*);
-static void checkRxRmaCmplsCQ(void);
-static void checkRxRmaCmplsCntr(void);
 static void checkTxCmplsCQ(struct perTxCtxInfo_t*);
 static void checkTxCmplsCntr(struct perTxCtxInfo_t*);
 static size_t readCQ(struct fid_cq*, void*, size_t);
@@ -2106,29 +2098,12 @@ void init_ofiEp(void) {
   OFI_CHK(fi_ep_bind(ofi_rxEp, &ofi_rxCQ->fid, FI_TRANSMIT | FI_RECV));
   OFI_CHK(fi_enable(ofi_rxEp));
 
-  OFI_CHK(fi_endpoint(ofi_domain, ofi_info, &ofi_rxEpRma, NULL));
-  OFI_CHK(fi_ep_bind(ofi_rxEpRma, &ofi_av->fid, 0));
-  if (true /*ofi_info->domain_attr->cntr_cnt == 0*/) { // disable tx counters
-    OFI_CHK(fi_cq_open(ofi_domain, &cqAttr, &ofi_rxCQRma,
-                       &checkRxRmaCmplsFn));
-    ofi_rxCmplFidRma = &ofi_rxCQRma->fid;
-    checkRxRmaCmplsFn = checkRxRmaCmplsCQ;
-  } else {
-    OFI_CHK(fi_cntr_open(ofi_domain, &cntrAttr, &ofi_rxCntrRma,
-                         &checkRxRmaCmplsFn));
-    ofi_rxCmplFidRma = &ofi_rxCntrRma->fid;
-    checkRxRmaCmplsFn = checkRxRmaCmplsCntr;
-  }
-  OFI_CHK(fi_ep_bind(ofi_rxEpRma, ofi_rxCmplFidRma, FI_TRANSMIT | FI_RECV));
-  OFI_CHK(fi_enable(ofi_rxEpRma));
-
   //
   // If we're using poll and wait sets, put all the progress-related
   // CQs and/or counters in the poll set.
   //
   if (ofi_amhPollSet != NULL) {
     OFI_CHK(fi_poll_add(ofi_amhPollSet, &ofi_rxCQ->fid, 0));
-    OFI_CHK(fi_poll_add(ofi_amhPollSet, ofi_rxCmplFidRma, 0));
     OFI_CHK(fi_poll_add(ofi_amhPollSet, tciTab[tciTabLen - 1].txCmplFid, 0));
     pollSetSize = 3;
   }
@@ -2189,11 +2164,7 @@ void init_ofiExchangeAvInfo(void) {
     // Sanity-check our same-address-length assumption.
     //
     size_t len = 0;
-    size_t lenRma = 0;
-
     OFI_CHK_1(fi_getname(&ofi_rxEp->fid, NULL, &len), -FI_ETOOSMALL);
-    OFI_CHK_1(fi_getname(&ofi_rxEpRma->fid, NULL, &lenRma), -FI_ETOOSMALL);
-    CHK_TRUE(len == lenRma);
 
     size_t* lens;
     CHPL_CALLOC(lens, chpl_numNodes);
@@ -2210,26 +2181,19 @@ void init_ofiExchangeAvInfo(void) {
   size_t my_addr_len = 0;
 
   OFI_CHK_1(fi_getname(&ofi_rxEp->fid, NULL, &my_addr_len), -FI_ETOOSMALL);
-  CHPL_CALLOC_SZ(my_addr, 2 * my_addr_len, 1);
+  CHPL_CALLOC_SZ(my_addr, my_addr_len, 1);
   OFI_CHK(fi_getname(&ofi_rxEp->fid, my_addr, &my_addr_len));
-  OFI_CHK(fi_getname(&ofi_rxEpRma->fid, my_addr + my_addr_len, &my_addr_len));
-  CHPL_CALLOC_SZ(addrs, chpl_numNodes, 2 * my_addr_len);
+  CHPL_CALLOC_SZ(addrs, chpl_numNodes, my_addr_len);
   if (DBG_TEST_MASK(DBG_CFG_AV)) {
     char nameBuf[128];
     size_t nameLen;
     nameLen = sizeof(nameBuf);
-    char nameBuf2[128];
-    size_t nameLen2;
-    nameLen2 = sizeof(nameBuf2);
     (void) fi_av_straddr(ofi_av, my_addr, nameBuf, &nameLen);
-    (void) fi_av_straddr(ofi_av, my_addr + my_addr_len, nameBuf2, &nameLen2);
-    DBG_PRINTF(DBG_CFG_AV, "my_addrs: %.*s%s, %.*s%s",
+    DBG_PRINTF(DBG_CFG_AV, "my_addrs: %.*s%s",
                (int) nameLen, nameBuf,
-               (nameLen <= sizeof(nameBuf)) ? "" : "[...]",
-               (int) nameLen2, nameBuf2,
-               (nameLen2 <= sizeof(nameBuf2)) ? "" : "[...]");
+               (nameLen <= sizeof(nameBuf)) ? "" : "[...]");
   }
-  chpl_comm_ofi_oob_allgather(my_addr, addrs, 2 * my_addr_len);
+  chpl_comm_ofi_oob_allgather(my_addr, addrs, my_addr_len);
 
   //
   // Insert the addresses into the address vector and build up a vector
@@ -2241,9 +2205,10 @@ void init_ofiExchangeAvInfo(void) {
   // Only when the provider cannot support scalable EPs and we have
   // multiple actual endpoints are the AVs individualized to those.
   //
-  CHPL_CALLOC(ofi_rxAddrs, 2 * chpl_numNodes);
-  CHK_TRUE(fi_av_insert(ofi_av, addrs, 2 * chpl_numNodes, ofi_rxAddrs, 0, NULL)
-           == 2 * chpl_numNodes);
+  size_t numAddrs = chpl_numNodes;
+  CHPL_CALLOC(ofi_rxAddrs, numAddrs);
+  CHK_TRUE(fi_av_insert(ofi_av, addrs, numAddrs, ofi_rxAddrs, 0, NULL)
+           == numAddrs);
 
   CHPL_FREE(my_addr);
   CHPL_FREE(addrs);
@@ -2326,7 +2291,7 @@ void init_ofiForMem(void) {
     CHK_TRUE(prov_key || memTab[i].key == i);
     DBG_PRINTF(DBG_MR, "[%d]     key %#" PRIx64, i, memTab[i].key);
     if ((ofi_info->domain_attr->mr_mode & FI_MR_ENDPOINT) != 0) {
-      OFI_CHK(fi_mr_bind(ofiMrTab[i], &ofi_rxEpRma->fid, 0));
+      OFI_CHK(fi_mr_bind(ofiMrTab[i], &ofi_rxEp->fid, 0));
       OFI_CHK(fi_mr_enable(ofiMrTab[i]));
     }
   }
@@ -2761,14 +2726,11 @@ void fini_ofi(void) {
 
   if (ofi_amhPollSet != NULL) {
     OFI_CHK(fi_poll_del(ofi_amhPollSet, tciTab[tciTabLen - 1].txCmplFid, 0));
-    OFI_CHK(fi_poll_del(ofi_amhPollSet, ofi_rxCmplFidRma, 0));
     OFI_CHK(fi_poll_del(ofi_amhPollSet, &ofi_rxCQ->fid, 0));
   }
 
   OFI_CHK(fi_close(&ofi_rxEp->fid));
   OFI_CHK(fi_close(&ofi_rxCQ->fid));
-  OFI_CHK(fi_close(&ofi_rxEpRma->fid));
-  OFI_CHK(fi_close(ofi_rxCmplFidRma));
 
   for (int i = 0; i < tciTabLen; i++) {
     OFI_CHK(fi_close(&tciTab[i].txCtx->fid));
@@ -3954,7 +3916,7 @@ ssize_t wrap_fi_send(c_nodeid_t node,
   }
   OFI_RIDE_OUT_EAGAIN(tcip,
                       fi_send(tcip->txCtx, req, reqSize, mrDesc,
-                              rxMsgAddr(tcip, node), ctx));
+                              rxAddr(node), ctx));
   tcip->numTxnsOut++;
   tcip->numTxnsSent++;
   return FI_SUCCESS;
@@ -3973,7 +3935,7 @@ ssize_t wrap_fi_inject(c_nodeid_t node,
   // TODO: How quickly/often does local resource throttling happen?
   OFI_RIDE_OUT_EAGAIN(tcip,
                       fi_inject(tcip->txCtx, req, reqSize,
-                                rxMsgAddr(tcip, node)));
+                                rxAddr(node)));
   tcip->numTxnsSent++;
   return FI_SUCCESS;
 }
@@ -3989,7 +3951,7 @@ ssize_t wrap_fi_sendmsg(c_nodeid_t node,
   const struct fi_msg msg = { .msg_iov = &msg_iov,
                               .desc = mrDesc,
                               .iov_count = 1,
-                              .addr = rxMsgAddr(tcip, node),
+                              .addr = rxAddr(node),
                               .context = ctx };
   if (DBG_TEST_MASK(DBG_AM | DBG_AM_SEND)
       || (req->b.op == am_opAMO && DBG_TEST_MASK(DBG_AMO))) {
@@ -4185,16 +4147,14 @@ void amHandler(void* argNil) {
       //
       // Process the CQs/counters that had events.  We really only have
       // to take any explicit actions for inbound AM messages and our
-      // transmit endpoint.  For the RMA endpoint we just need to ensure
-      // progress, and the poll call itself did that.
+      // transmit endpoint.  For RMA we just need to ensure progress,
+      // and the poll call itself did that.
       //
       for (int i = 0; i < ret; i++) {
         if (contexts[i] == &ofi_rxCQ) {
           processRxAmReq(tcip);
         } else if (contexts[i] == &tcip->checkTxCmplsFn) {
           (*tcip->checkTxCmplsFn)(tcip);
-        } else if (contexts[i] == &checkRxRmaCmplsFn) {
-          // no action
         } else {
           INTERNAL_ERROR_V("unexpected context %p from fi_poll()",
                            contexts[i]);
@@ -4206,7 +4166,6 @@ void amHandler(void* argNil) {
       //
       processRxAmReq(tcip);
       (*tcip->checkTxCmplsFn)(tcip);
-      (*checkRxRmaCmplsFn)();
 
       sched_yield();
     }
@@ -5285,7 +5244,7 @@ ssize_t wrap_fi_write(const void* addr, void* mrDesc,
              (int) node, mrRaddr, addr, size, ctx);
   OFI_RIDE_OUT_EAGAIN(tcip,
                       fi_write(tcip->txCtx, addr, size,
-                               mrDesc, rxRmaAddr(tcip, node),
+                               mrDesc, rxAddr(node),
                                mrRaddr, mrKey, ctx));
   tcip->numTxnsOut++;
   tcip->numTxnsSent++;
@@ -5305,7 +5264,7 @@ ssize_t wrap_fi_inject_write(const void* addr,
   // TODO: How quickly/often does local resource throttling happen?
   OFI_RIDE_OUT_EAGAIN(tcip,
                       fi_inject_write(tcip->txCtx, addr, size,
-                                      rxRmaAddr(tcip, node),
+                                      rxAddr(node),
                                       mrRaddr, mrKey));
   tcip->numTxnsSent++;
   return FI_SUCCESS;
@@ -5329,7 +5288,7 @@ ssize_t wrap_fi_writemsg(const void* addr, void* mrDesc,
                           { .msg_iov = &msg_iov,
                             .desc = mrDesc,
                             .iov_count = 1,
-                            .addr = rxRmaAddr(tcip, node),
+                            .addr = rxAddr(node),
                             .rma_iov = &rma_iov,
                             .rma_iov_count = 1,
                             .context = ctx };
@@ -5681,7 +5640,7 @@ ssize_t wrap_fi_read(void* addr, void* mrDesc,
              addr, (int) node, mrRaddr, size, ctx);
   OFI_RIDE_OUT_EAGAIN(tcip,
                       fi_read(tcip->txCtx, addr, size,
-                              mrDesc, rxRmaAddr(tcip, node),
+                              mrDesc, rxAddr(node),
                               mrRaddr, mrKey, ctx));
   tcip->numTxnsOut++;
   tcip->numTxnsSent++;
@@ -5706,7 +5665,7 @@ ssize_t wrap_fi_readmsg(void* addr, void* mrDesc,
                           { .msg_iov = &msg_iov,
                             .desc = mrDesc,
                             .iov_count = 1,
-                            .addr = rxRmaAddr(tcip, node),
+                            .addr = rxAddr(node),
                             .rma_iov = &rma_iov,
                             .rma_iov_count = 1,
                             .context = ctx };
@@ -5767,7 +5726,7 @@ void ofi_get_V(int v_len, void** addr_v, void** local_mr_v,
                             { .msg_iov = &msg_iov,
                               .desc = &local_mr_v[vi],
                               .iov_count = 1,
-                              .addr = rxRmaAddr(tcip, locale_v[vi]),
+                              .addr = rxAddr(locale_v[vi]),
                               .rma_iov = &rma_iov,
                               .rma_iov_count = 1,
                               .context = txnTrkEncodeId(__LINE__),
@@ -5905,7 +5864,7 @@ chpl_comm_nb_handle_t ofi_amo(c_nodeid_t node, uint64_t object, uint64_t mrKey,
   struct amoBundle_t ab = { .m = { .msg_iov = &ab.iovOpnd,
                                    .desc = &ab.mrDescOpnd,
                                    .iov_count = 1,
-                                   .addr = rxRmaAddr(tcip, node),
+                                   .addr = rxAddr(node),
                                    .rma_iov = &ab.iovObj,
                                    .rma_iov_count = 1,
                                    .datatype = ofiType,
@@ -6240,7 +6199,7 @@ void ofi_amo_nf_V(int v_len, uint64_t* opnd_v, void* local_mr,
     struct amoBundle_t ab = { .m = { .msg_iov = &ab.iovOpnd,
                                      .desc = &local_mr,
                                      .iov_count = 1,
-                                     .addr = rxRmaAddr(tcip, locale_v[vi]),
+                                     .addr = rxAddr(locale_v[vi]),
                                      .rma_iov = &ab.iovObj,
                                      .rma_iov_count = 1,
                                      .datatype = type_v[vi],
@@ -6288,16 +6247,14 @@ void amEnsureProgress(struct perTxCtxInfo_t* tcip) {
     // Process the CQs/counters that had events.  We really only have
     // to take any explicit actions for our transmit endpoint.  If we
     // have inbound AM messages we want to handle those in the main
-    // poll loop.  And for the RMA endpoint we just need to ensure
-    // progress, which the poll call itself will have done.
+    // poll loop.  And for RMA we just need to ensure progress, which
+    // the poll call itself will have done.
     //
     for (int i = 0; i < ret; i++) {
       if (contexts[i] == &ofi_rxCQ) {
         // no action
       } else if (contexts[i] == &tcip->checkTxCmplsFn) {
         (*tcip->checkTxCmplsFn)(tcip);
-      } else if (contexts[i] == &checkRxRmaCmplsFn) {
-        // no action
       } else {
         INTERNAL_ERROR_V("unexpected context %p from fi_poll()",
                          contexts[i]);
@@ -6308,21 +6265,7 @@ void amEnsureProgress(struct perTxCtxInfo_t* tcip) {
     // The provider can't do poll sets.
     //
     (*tcip->checkTxCmplsFn)(tcip);
-    (*checkRxRmaCmplsFn)();
   }
-}
-
-
-static
-void checkRxRmaCmplsCQ(void) {
-  struct fi_cq_data_entry cqe;
-  (void) readCQ(ofi_rxCQRma, &cqe, 1);
-}
-
-
-static
-void checkRxRmaCmplsCntr(void) {
-  (void) fi_cntr_read(ofi_rxCntrRma);
 }
 
 


### PR DESCRIPTION
The ofi comm layer has long had two receive endpoints for each locale:
one for messaging (Active Messages, i.e. on-stmts) and one for RMA and
atomics.  We originally did this for load spreading.  We discovered
quite a while ago that such load spreading was unnecessary and in fact
that having two endpoints made things more complicated no matter whether
progress was automatic or manual, but the code was working and there
were more pressing things to deal with, so we left things as they were.
Here, drop back to just one receive endpoint per locale for all kinds of
traffic.

While here I also removed support for completion counters (vs.  queues)
for the receive endpoints.  For received AMs we need CQ events in order
to tell where the messages landed, and for received RMA and atomics we
don't make use of target-side events at all, so a receive CQ is the only
thing that makes sense.

This closes https://github.com/Cray/chapel-private/issues/2159.