### PR TITLE
Avoid chpldoc failures on our Ubuntu boxes

### DIFF
--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -24,7 +24,16 @@ def main():
     results.append( check_man_page(chpl, ['--no-devel']) )
 
     # Test chpldoc
-    results.append( check_man_page(chpldoc) )
+    # chpldoc requires Python version 3.6 or greater.  Don't check it otherwise
+    version_is_good = True
+    if sys.version_info[0] < 3:
+        version_is_good = False
+    else:
+        if sys.version_info[0] == 3 and sys.version_info[1] <= 5:
+            version_is_good = False
+
+    if version_is_good:
+        results.append( check_man_page(chpldoc) )
 
     # Exit clean if no errors.
     if not reduce(operator.and_, results):

--- a/test/mason/mason-doc/SKIPIF
+++ b/test/mason/mason-doc/SKIPIF
@@ -1,1 +1,20 @@
-../SKIPIF
+#!/usr/bin/env python3
+
+"""
+mason requires CHPL_COMM=none (local)
+"""
+
+from __future__ import print_function
+from os import environ
+import sys
+
+# chpldoc, which this test directory relies on, requires Python version 3.6 or
+# greater
+version_is_good = True
+if sys.version_info[0] < 3:
+    version_is_good = False
+else:
+    if sys.version_info[0] == 3 and sys.version_info[1] <= 5:
+        version_is_good = False
+
+print(environ['CHPL_COMM'] != 'none' or environ['CHPL_RE2'] == 'none' or environ['CHPL_LAUNCHER'] != 'none' or not version_is_good)

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -524,10 +524,12 @@ mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-o
 
 # if we are using python2, we cannot build the test-venv and/or chpldoc
 if ($python2 == 0) {
+  $pythonVersion = `python3 --version`;
+  $pythonVersionArr = split(/\./, $pythonVersion);
 
-  # linux32 currently cannot build chpldoc.  TODO: remove this when the linux32
-  # box is using a later version of Python than 3.5
-  if (!($ENV{'CHPL_NIGHTLY_TEST_CONFIG_NAME'} eq "linux32")) {
+  # chpldoc can't be built with Python 3.5  TODO: remove this when the Ubuntu
+  # boxes are using a later version of Python than 3.5
+  if ($pythonVersionArr[1] > 5) {
     # Build chpldoc. Do not fail the build if it does not succeed. Do not send
     # mail either.
     print "Making $make_vars_opt chpldoc\n";


### PR DESCRIPTION
Adjust nightly to check the Python version instead of if it's a linux32 config.
This is a better predicter of if we can appropriately build chpldoc, since it
seems like all the Ubuntu boxes use this older version

Skips the mason test if the Python version is 3.5 or earlier.  In the man page
test, skips checking the chpldoc portion under the same conditions.

I intend to remove all this code when we no longer have machines with Python
3.5, since it seems a little suspect to lock us into a Python version.

Verified that these operate correctly in scenarios where Python 3.5 is not used.