### PR TITLE
Fix easy array zip size mismatch

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -535,6 +535,12 @@ module DefaultRectangular {
       }
     }
 
+    proc dsiMember(ind: idxType) {
+      if (rank != 1) then
+        compilerError("Can't call dsiMember(ind: idxType) on a 1D array");
+      return dsiMember((ind,));
+    }
+
     proc dsiMember(ind: rank*idxType) {
       for param i in 0..rank-1 do
         if !ranges(i).contains(ind(i)) then
@@ -1171,8 +1177,12 @@ module DefaultRectangular {
       for i in dom.these(tag=iterKind.follower, followThis,
                          tasksPerLocale,
                          ignoreRunning,
-                         minIndicesPerTask) do
+                         minIndicesPerTask) {
+        if boundsChecking then
+          if !dsiBoundsCheck(i) then
+            halt("zippered iterations have non-equal lengths");
         yield dsiAccess(i);
+      }
     }
 
     proc computeFactoredOffs() {
@@ -1339,7 +1349,6 @@ module DefaultRectangular {
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
     }
-
 
     inline proc dsiBoundsCheck(i) {
       return dom.dsiMember(i);

--- a/test/parallel/forall/zip/zipArrMismatch.chpl
+++ b/test/parallel/forall/zip/zipArrMismatch.chpl
@@ -1,0 +1,7 @@
+var A3: [1..3] real;
+var A4: [1..4] real = [1.0, 2.0, 3.0, 4.0];
+
+forall (i,j) in zip(A4, A3) do
+  i += j;
+
+writeln(A4);

--- a/test/parallel/forall/zip/zipArrMismatch.good
+++ b/test/parallel/forall/zip/zipArrMismatch.good
@@ -1,0 +1,1 @@
+zipArrMismatch.chpl:4: error: halt reached - zippered iterations have non-equal lengths


### PR DESCRIPTION
Issue #11428 captures a longstanding issue in which we
zipper a smaller thing and a larger one:

```chapel
var A3: [1..3] real;
var A4: [1..4] real;

forall (i,j) in zip(A3, A4) do ..
```

which is a longstanding challenge in Chapel's current
leader-follower iterator design.  However, it seems
that at some point we started permitting the opposite
case through as well:

```chapel
forall (i,j) in zip(A4, A3) do ...
```

which doesn't really make any sense since A3 doesn't have
3 items to yield, so should give an OOB error at some
point when trying to do what the leader says.  Yet... it
doesn't.

This PR fixes that by putting a bounds check into the DR
follower iterator.