### PR TITLE
Fix syntax error in common-whitebox.bash

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -55,7 +55,6 @@ case $COMP_TYPE in
         export CHPL_TARGET_PLATFORM=$platform
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        fi
         ;;
     HOST-TARGET)
         if [ $COMPILER == "llvm" ] ; then


### PR DESCRIPTION
An extra 'fi' got into this script without me noticing. Remove it.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>