### PR TITLE
Source LLVM setup scripts from common-whitebox test script

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -55,7 +55,6 @@ case $COMP_TYPE in
         export CHPL_TARGET_PLATFORM=$platform
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        fi
         ;;
     HOST-TARGET)
         if [ $COMPILER == "llvm" ] ; then

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -6,7 +6,7 @@
 #
 # Variable   Values
 # ------------------------------------------------------
-# COMPILER    cray, intel, pgi, gnu
+# COMPILER    cray, intel, pgi, gnu, llvm
 # COMP_TYPE   TARGET, HOST-TARGET, HOST-TARGET-no-PrgEnv
 #
 # Optionally, the platform can be set with:
@@ -42,16 +42,30 @@ log_info "Short platform: ${short_platform}"
 # Setup vars that will help load the correct compiler module.
 case $COMP_TYPE in
     TARGET)
-        module_name=PrgEnv-${COMPILER}
+        if [ $COMPILER == "llvm" ] ; then
+            module_name=PrgEnv-gnu
+            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.${COMPILER}"
+        else
+            module_name=PrgEnv-${COMPILER}
+            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.prgenv-${COMPILER}"
+        fi
+
         chpl_host_value=""
 
         export CHPL_TARGET_PLATFORM=$platform
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.prgenv-${COMPILER}"
+        fi
         ;;
     HOST-TARGET)
-        module_name=PrgEnv-${COMPILER}
+        if [ $COMPILER == "llvm" ] ; then
+            module_name=PrgEnv-gnu
+            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.${COMPILER}"
+        else
+            module_name=PrgEnv-${COMPILER}
+            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.prgenv-${COMPILER}"
+        fi
+
         chpl_host_value=cray-prgenv-${COMPILER}
 
         export CHPL_HOST_PLATFORM=$platform
@@ -59,7 +73,6 @@ case $COMP_TYPE in
         log_info "Set CHPL_HOST_PLATFORM to: ${CHPL_HOST_PLATFORM}"
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.prgenv-${COMPILER}"
         ;;
     HOST-TARGET-no-PrgEnv)
         the_cc=${COMPILER}
@@ -114,6 +127,8 @@ case $COMPILER in
         # force disable gmp until there's more time to investigate this.
         export CHPL_GMP=none
         ;;
+    llvm)
+        ;;
     *)
         log_error "Unknown COMPILER value: ${COMPILER}. Exiting."
         exit 4
@@ -137,11 +152,6 @@ fi
 # Disable launchers, comm.
 export CHPL_LAUNCHER=none
 export CHPL_COMM=none
-
-# Disable llvm for now, since we're explicitly trying to test different C
-# backends
-export CHPL_LLVM=none
-
 
 # Set some vars that nightly cares about.
 export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -101,6 +101,16 @@ source $CHPL_INTERNAL_REPO/build/compiler_versions.bash
 # Then load the selected compiler
 load_target_compiler ${COMPILER}
 
+if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
+  if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+    source /data/cf/chapel/setup_system_llvm.bash
+  elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cray/css/users/chapelu/setup_system_llvm.bash
+  fi
+fi
+
+source $CWD/common-llvm-comp-path.bash
+
 # Do minor fixups
 case $COMPILER in
     cray|intel|gnu)


### PR DESCRIPTION
When I tested the scripts locally I had the LLVM setup done already in my
environment so I didn't notice that it wasn't set up in the script. Add it
to the script now.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>