### PR TITLE
Add an error for zippered follower iterations over too-small ranges

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2484,12 +2484,14 @@ operator :(r: range(?), type t: range(?)) {
       const flwlen = myFollowThis.sizeAs(myFollowThis.intIdxType);
       if boundsChecking && this.hasLast() {
         // this check is for typechecking only
-        if isBoundedRange(this) {
-          if this.sizeAs(intIdxType) < flwlen then
-            HaltWrappers.boundsCheckHalt("zippered iteration over a range with too few indices");
-        } else
+        if !isBoundedRange(this) then
           assert(false, "hasFirst && hasLast do not imply isBoundedRange");
       }
+      if flwlen != 0 then
+        if boundsChecking then
+          if isBoundedRange(this) && myFollowThis.last >= this.sizeAs(uint) then
+            HaltWrappers.boundsCheckHalt("size mismatch in zippered iteration");
+
       if this.stridable || myFollowThis.stridable {
         var r: range(idxType, stridable=true);
 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2482,15 +2482,16 @@ operator :(r: range(?), type t: range(?)) {
        myFollowThis.hasLast()
     {
       const flwlen = myFollowThis.sizeAs(myFollowThis.intIdxType);
-      if boundsChecking && this.hasLast() {
-        // this check is for typechecking only
-        if !isBoundedRange(this) then
-          assert(false, "hasFirst && hasLast do not imply isBoundedRange");
-      }
-      if flwlen != 0 then
-        if boundsChecking then
+      if boundsChecking {
+        if this.hasLast() {
+          // this check is for typechecking only
+          if !isBoundedRange(this) then
+            assert(false, "hasFirst && hasLast do not imply isBoundedRange");
+        }
+        if flwlen != 0 then
           if isBoundedRange(this) && myFollowThis.last >= this.sizeAs(uint) then
             HaltWrappers.boundsCheckHalt("size mismatch in zippered iteration");
+      }
 
       if this.stridable || myFollowThis.stridable {
         var r: range(idxType, stridable=true);

--- a/test/parallel/forall/zip/zipRangeMismatch.chpl
+++ b/test/parallel/forall/zip/zipRangeMismatch.chpl
@@ -1,0 +1,7 @@
+var A: [1..4] real;
+
+forall (i,j) in zip(1..4, 1..3) do
+  A[i] = j;
+
+writeln(A);
+

--- a/test/parallel/forall/zip/zipRangeMismatch.good
+++ b/test/parallel/forall/zip/zipRangeMismatch.good
@@ -1,0 +1,1 @@
+zipRangeMismatch.chpl:3: error: halt reached - size mismatch in zippered iteration

--- a/test/parallel/forall/zip/zipRangeMismatch2.chpl
+++ b/test/parallel/forall/zip/zipRangeMismatch2.chpl
@@ -1,0 +1,7 @@
+var A: [1..4] real;
+
+forall (i,j) in zip(1..4, 1..3 by 2) do
+  A[i] = j;
+
+writeln(A);
+

--- a/test/parallel/forall/zip/zipRangeMismatch2.good
+++ b/test/parallel/forall/zip/zipRangeMismatch2.good
@@ -1,0 +1,1 @@
+zipRangeMismatch2.chpl:3: error: halt reached - size mismatch in zippered iteration


### PR DESCRIPTION
This adds an error for zippered forall loops in which the follower is a
range that does not have enough elements in it.  For example:

```chapel
forall (i,j) in zip(1..4, 1..3) do ...
```

This is a case that was already generating an error, but not a very
clear one, and represents a stepping stone toward generating similar
such errors for domains and arrays (which currently quietly pass
today, as I was learning last night).

This does not address the longstanding and much more complex to
fix case when the follower is larger than the leader.  I.e., my most dreaded
Chapel bug (TM):  https://github.com/chapel-lang/chapel/issues/11428

I found that there was a previous attempt to create a similar error that
currently isn't being testing, and doesn't seem sound to me (in that it
compared the length of what a specific follower was being asked to
yield to the total range length).  This new version checks that the
indices being iterated over are within the size bounds of the range to
avoid bad orderToIndex() calls (which were resulting in the old, less
useful error).