### PR TITLE
Rename division methods in BigInteger and their arguments

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4184,43 +4184,43 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  // this gets quotient, r gets remainder
-  proc bigint.divQR(ref       r:        bigint,
+  // this gets quotient, remain gets remainder
+  proc bigint.divQR(ref       remain:        bigint,
                     const ref numer:        bigint,
                     const ref denom:        bigint,
                     param     rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
-              r.localeId    == chpl_nodeID &&
+              remain.localeId    == chpl_nodeID &&
               numer.localeId    == chpl_nodeID &&
               denom.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
       }
 
     } else {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        var   r_ = r;
+        var   remain_ = remain;
         const numer_ = numer;
         const denom_ = denom;
 
         select rounding {
-          when round.up   do mpz_cdiv_qr(this.mpz, r_.mpz, numer_.mpz, denom_.mpz);
-          when round.down do mpz_fdiv_qr(this.mpz, r_.mpz, numer_.mpz, denom_.mpz);
-          when round.zero do mpz_tdiv_qr(this.mpz, r_.mpz, numer_.mpz, denom_.mpz);
+          when round.up   do mpz_cdiv_qr(this.mpz, remain_.mpz, numer_.mpz, denom_.mpz);
+          when round.down do mpz_fdiv_qr(this.mpz, remain_.mpz, numer_.mpz, denom_.mpz);
+          when round.zero do mpz_tdiv_qr(this.mpz, remain_.mpz, numer_.mpz, denom_.mpz);
         }
 
-        r = r_;
+        remain = remain_;
       }
     }
   }
@@ -4241,11 +4241,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.divQR(ref       r: bigint,
+  proc bigint.divQR(ref       remain: bigint,
                     const ref numer: bigint,
                               denom: integral,
                     param     rounding = round.zero) {
-    this.divQR(r, numer, new bigint(denom), rounding);
+    this.divQR(remain, numer, new bigint(denom), rounding);
   }
 
   deprecated

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4050,8 +4050,8 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       }
 
     } else if this.localeId == chpl_nodeID &&
-              numer.localeId    == chpl_nodeID &&
-              denom.localeId    == chpl_nodeID {
+              numer.localeId == chpl_nodeID &&
+              denom.localeId == chpl_nodeID {
       select rounding {
         when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  denom.mpz);
         when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  denom.mpz);
@@ -4123,8 +4123,8 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       }
 
     } else if this.localeId == chpl_nodeID &&
-              numer.localeId    == chpl_nodeID &&
-              denom.localeId    == chpl_nodeID {
+              numer.localeId == chpl_nodeID &&
+              denom.localeId == chpl_nodeID {
       select rounding {
         when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  denom.mpz);
         when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  denom.mpz);
@@ -4185,25 +4185,31 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   // this gets quotient, remain gets remainder
-  proc bigint.divQR(ref       remain:        bigint,
-                    const ref numer:        bigint,
-                    const ref denom:        bigint,
+  proc bigint.divQR(ref       remain: bigint,
+                    const ref numer: bigint,
+                    const ref denom: bigint,
                     param     rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
+        when round.up do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz,
+                                     denom.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, remain.mpz, numer.mpz,
+                                       denom.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, remain.mpz, numer.mpz,
+                                       denom.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
-              remain.localeId    == chpl_nodeID &&
-              numer.localeId    == chpl_nodeID &&
-              denom.localeId    == chpl_nodeID {
+              remain.localeId == chpl_nodeID &&
+              numer.localeId == chpl_nodeID &&
+              denom.localeId == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, remain.mpz, numer.mpz, denom.mpz);
+        when round.up do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz,
+                                     denom.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, remain.mpz, numer.mpz,
+                                       denom.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, remain.mpz, numer.mpz,
+                                       denom.mpz);
       }
 
     } else {
@@ -4215,9 +4221,12 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const denom_ = denom;
 
         select rounding {
-          when round.up   do mpz_cdiv_qr(this.mpz, remain_.mpz, numer_.mpz, denom_.mpz);
-          when round.down do mpz_fdiv_qr(this.mpz, remain_.mpz, numer_.mpz, denom_.mpz);
-          when round.zero do mpz_tdiv_qr(this.mpz, remain_.mpz, numer_.mpz, denom_.mpz);
+          when round.up do mpz_cdiv_qr(this.mpz, remain_.mpz, numer_.mpz,
+                                       denom_.mpz);
+          when round.down do mpz_fdiv_qr(this.mpz, remain_.mpz, numer_.mpz,
+                                         denom_.mpz);
+          when round.zero do mpz_tdiv_qr(this.mpz, remain_.mpz, numer_.mpz,
+                                         denom_.mpz);
         }
 
         remain = remain_;
@@ -4264,23 +4273,23 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   proc bigint.divQ2Exp(const ref numer: bigint,
-                                 b: integral,
+                                 exp: integral,
                        param     rounding = round.zero) {
-    const b_ = b.safeCast(mp_bitcnt_t);
+    const exp_ = exp.safeCast(mp_bitcnt_t);
 
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_q_2exp(this.mpz, numer.mpz, b_);
-        when round.down do mpz_fdiv_q_2exp(this.mpz, numer.mpz, b_);
-        when round.zero do mpz_tdiv_q_2exp(this.mpz, numer.mpz, b_);
+        when round.up   do mpz_cdiv_q_2exp(this.mpz, numer.mpz, exp_);
+        when round.down do mpz_fdiv_q_2exp(this.mpz, numer.mpz, exp_);
+        when round.zero do mpz_tdiv_q_2exp(this.mpz, numer.mpz, exp_);
       }
 
     } else if this.localeId == chpl_nodeID &&
-              numer.localeId    == chpl_nodeID {
+              numer.localeId == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_q_2exp(this.mpz, numer.mpz, b_);
-        when round.down do mpz_fdiv_q_2exp(this.mpz, numer.mpz, b_);
-        when round.zero do mpz_tdiv_q_2exp(this.mpz, numer.mpz, b_);
+        when round.up   do mpz_cdiv_q_2exp(this.mpz, numer.mpz, exp_);
+        when round.down do mpz_fdiv_q_2exp(this.mpz, numer.mpz, exp_);
+        when round.zero do mpz_tdiv_q_2exp(this.mpz, numer.mpz, exp_);
       }
 
     } else {
@@ -4290,9 +4299,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const numer_ = numer;
 
         select rounding {
-          when round.up   do mpz_cdiv_q_2exp(this.mpz, numer_.mpz, b_);
-          when round.down do mpz_fdiv_q_2exp(this.mpz, numer_.mpz, b_);
-          when round.zero do mpz_tdiv_q_2exp(this.mpz, numer_.mpz, b_);
+          when round.up   do mpz_cdiv_q_2exp(this.mpz, numer_.mpz, exp_);
+          when round.down do mpz_fdiv_q_2exp(this.mpz, numer_.mpz, exp_);
+          when round.zero do mpz_tdiv_q_2exp(this.mpz, numer_.mpz, exp_);
         }
       }
     }
@@ -4314,22 +4323,22 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   proc bigint.divR2Exp(const ref numer: bigint,
-                                 b: integral,
+                                 exp: integral,
                        param     rounding = round.zero) {
-    const b_ = b.safeCast(mp_bitcnt_t);
+    const exp_ = exp.safeCast(mp_bitcnt_t);
 
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_r_2exp(this.mpz, numer.mpz, b_);
-        when round.down do mpz_fdiv_r_2exp(this.mpz, numer.mpz, b_);
-        when round.zero do mpz_tdiv_r_2exp(this.mpz, numer.mpz, b_);
+        when round.up   do mpz_cdiv_r_2exp(this.mpz, numer.mpz, exp_);
+        when round.down do mpz_fdiv_r_2exp(this.mpz, numer.mpz, exp_);
+        when round.zero do mpz_tdiv_r_2exp(this.mpz, numer.mpz, exp_);
       }
 
     } else if this.localeId == chpl_nodeID && numer.localeId == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_r_2exp(this.mpz, numer.mpz, b_);
-        when round.down do mpz_fdiv_r_2exp(this.mpz, numer.mpz, b_);
-        when round.zero do mpz_tdiv_r_2exp(this.mpz, numer.mpz, b_);
+        when round.up   do mpz_cdiv_r_2exp(this.mpz, numer.mpz, exp_);
+        when round.down do mpz_fdiv_r_2exp(this.mpz, numer.mpz, exp_);
+        when round.zero do mpz_tdiv_r_2exp(this.mpz, numer.mpz, exp_);
       }
 
     } else {
@@ -4339,9 +4348,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
         const numer_ = numer;
 
         select rounding {
-          when round.up   do mpz_cdiv_r_2exp(this.mpz, numer_.mpz, b_);
-          when round.down do mpz_fdiv_r_2exp(this.mpz, numer_.mpz, b_);
-          when round.zero do mpz_tdiv_r_2exp(this.mpz, numer_.mpz, b_);
+          when round.up   do mpz_cdiv_r_2exp(this.mpz, numer_.mpz, exp_);
+          when round.down do mpz_fdiv_r_2exp(this.mpz, numer_.mpz, exp_);
+          when round.zero do mpz_tdiv_r_2exp(this.mpz, numer_.mpz, exp_);
         }
       }
     }

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4027,7 +4027,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   "bigint.div_q using Round is deprecated, use bigint.divQ with round instead"
   proc bigint.div_q(const ref n: bigint,
                     const ref d: bigint,
-                    param     rounding: Round) {
+                    param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divQ(n, d, round.up);
@@ -4078,7 +4078,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   "bigint.div_q using Round is deprecated, use bigint.divQ with round instead"
   proc bigint.div_q(const ref n: bigint,
                               d: integral,
-                    param     rounding: Round) {
+                    param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divQ(n, d, round.up);
@@ -4100,7 +4100,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   "bigint.div_r using Round is deprecated, use bigint.divR with round instead"
   proc bigint.div_r(const ref n: bigint,
                     const ref d: bigint,
-                    param     rounding: Round) {
+                    param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divR(n, d, round.up);
@@ -4151,7 +4151,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   "bigint.div_r using Round is deprecated, use bigint.divR with round instead"
   proc bigint.div_r(const ref n: bigint,
                               d: integral,
-                    param     rounding: Round) {
+                    param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divR(n, d, round.up);
@@ -4173,7 +4173,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   proc bigint.div_qr(ref       r:        bigint,
                      const ref n:        bigint,
                      const ref d:        bigint,
-                     param     rounding: Round) {
+                     param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divQR(r, n, d, round.up);
@@ -4239,7 +4239,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   proc bigint.div_qr(ref       r: bigint,
                      const ref n: bigint,
                                d: integral,
-                     param     rounding: Round) {
+                     param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divQR(r, n, d, round.up);
@@ -4261,7 +4261,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   "bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead"
   proc bigint.div_q_2exp(const ref n: bigint,
                                    b: integral,
-                         param     rounding: Round) {
+                         param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divQ2Exp(n, b, round.up);
@@ -4311,7 +4311,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   "bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead"
   proc bigint.div_r_2exp(const ref n: bigint,
                                    b: integral,
-                         param     rounding: Round) {
+                         param     rounding = Round.ZERO) {
     use Round;
     if (rounding == UP) {
       this.divR2Exp(n, b, round.up);

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4039,36 +4039,36 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   // 5.6 Division Functions
-  proc bigint.divQ(const ref n: bigint,
+  proc bigint.divQ(const ref numer: bigint,
                    const ref d: bigint,
                    param rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
-        when round.down do mpz_fdiv_q(this.mpz, n.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  d.mpz);
+        when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_q(this.mpz, numer.mpz,  d.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
-              n.localeId    == chpl_nodeID &&
+              numer.localeId    == chpl_nodeID &&
               d.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
-        when round.down do mpz_fdiv_q(this.mpz, n.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_q(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  d.mpz);
+        when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_q(this.mpz, numer.mpz,  d.mpz);
       }
 
     } else {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        const n_ = n;
+        const numer_ = numer;
         const d_ = d;
 
         select rounding {
-          when round.up   do mpz_cdiv_q(this.mpz, n_.mpz, d_.mpz);
-          when round.down do mpz_fdiv_q(this.mpz, n_.mpz, d_.mpz);
-          when round.zero do mpz_tdiv_q(this.mpz, n_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_q(this.mpz, numer_.mpz, d_.mpz);
+          when round.down do mpz_fdiv_q(this.mpz, numer_.mpz, d_.mpz);
+          when round.zero do mpz_tdiv_q(this.mpz, numer_.mpz, d_.mpz);
           }
       }
     }
@@ -4089,11 +4089,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.divQ(const ref n: bigint,
+  proc bigint.divQ(const ref numer: bigint,
                              d: integral,
                    param     rounding = round.zero) {
 
-    this.divQ(n, new bigint(d), rounding);
+    this.divQ(numer, new bigint(d), rounding);
   }
 
   deprecated
@@ -4112,36 +4112,36 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
   }
 
-  proc bigint.divR(const ref n: bigint,
+  proc bigint.divR(const ref numer: bigint,
                    const ref d: bigint,
                    param     rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
-        when round.down do mpz_fdiv_r(this.mpz, n.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  d.mpz);
+        when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_r(this.mpz, numer.mpz,  d.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
-              n.localeId    == chpl_nodeID &&
+              numer.localeId    == chpl_nodeID &&
               d.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
-        when round.down do mpz_fdiv_r(this.mpz, n.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_r(this.mpz, n.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  d.mpz);
+        when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  d.mpz);
+        when round.zero do mpz_tdiv_r(this.mpz, numer.mpz,  d.mpz);
       }
 
     } else {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        const n_ = n;
+        const numer_ = numer;
         const d_ = d;
 
         select rounding {
-          when round.up   do mpz_cdiv_r(this.mpz, n_.mpz, d_.mpz);
-          when round.down do mpz_fdiv_r(this.mpz, n_.mpz, d_.mpz);
-          when round.zero do mpz_tdiv_r(this.mpz, n_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_r(this.mpz, numer_.mpz, d_.mpz);
+          when round.down do mpz_fdiv_r(this.mpz, numer_.mpz, d_.mpz);
+          when round.zero do mpz_tdiv_r(this.mpz, numer_.mpz, d_.mpz);
         }
       }
     }
@@ -4162,10 +4162,10 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.divR(const ref n: bigint,
+  proc bigint.divR(const ref numer: bigint,
                              d: integral,
                    param     rounding = round.zero) {
-    this.divR(n, new bigint(d), rounding);
+    this.divR(numer, new bigint(d), rounding);
   }
 
   deprecated
@@ -4186,24 +4186,24 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
   // this gets quotient, r gets remainder
   proc bigint.divQR(ref       r:        bigint,
-                    const ref n:        bigint,
+                    const ref numer:        bigint,
                     const ref d:        bigint,
                     param     rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
               r.localeId    == chpl_nodeID &&
-              n.localeId    == chpl_nodeID &&
+              numer.localeId    == chpl_nodeID &&
               d.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
       }
 
     } else {
@@ -4211,13 +4211,13 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
       on __primitive("chpl_on_locale_num", thisLoc) {
         var   r_ = r;
-        const n_ = n;
+        const numer_ = numer;
         const d_ = d;
 
         select rounding {
-          when round.up   do mpz_cdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
-          when round.down do mpz_fdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
-          when round.zero do mpz_tdiv_qr(this.mpz, r_.mpz, n_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_qr(this.mpz, r_.mpz, numer_.mpz, d_.mpz);
+          when round.down do mpz_fdiv_qr(this.mpz, r_.mpz, numer_.mpz, d_.mpz);
+          when round.zero do mpz_tdiv_qr(this.mpz, r_.mpz, numer_.mpz, d_.mpz);
         }
 
         r = r_;
@@ -4242,10 +4242,10 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   proc bigint.divQR(ref       r: bigint,
-                    const ref n: bigint,
+                    const ref numer: bigint,
                               d: integral,
                     param     rounding = round.zero) {
-    this.divQR(r, n, new bigint(d), rounding);
+    this.divQR(r, numer, new bigint(d), rounding);
   }
 
   deprecated
@@ -4263,36 +4263,36 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.divQ2Exp(const ref n: bigint,
+  proc bigint.divQ2Exp(const ref numer: bigint,
                                  b: integral,
                        param     rounding = round.zero) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_q_2exp(this.mpz, n.mpz, b_);
-        when round.down do mpz_fdiv_q_2exp(this.mpz, n.mpz, b_);
-        when round.zero do mpz_tdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_q_2exp(this.mpz, numer.mpz, b_);
+        when round.down do mpz_fdiv_q_2exp(this.mpz, numer.mpz, b_);
+        when round.zero do mpz_tdiv_q_2exp(this.mpz, numer.mpz, b_);
       }
 
     } else if this.localeId == chpl_nodeID &&
-              n.localeId    == chpl_nodeID {
+              numer.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_q_2exp(this.mpz, n.mpz, b_);
-        when round.down do mpz_fdiv_q_2exp(this.mpz, n.mpz, b_);
-        when round.zero do mpz_tdiv_q_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_q_2exp(this.mpz, numer.mpz, b_);
+        when round.down do mpz_fdiv_q_2exp(this.mpz, numer.mpz, b_);
+        when round.zero do mpz_tdiv_q_2exp(this.mpz, numer.mpz, b_);
       }
 
     } else {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        const n_ = n;
+        const numer_ = numer;
 
         select rounding {
-          when round.up   do mpz_cdiv_q_2exp(this.mpz, n_.mpz, b_);
-          when round.down do mpz_fdiv_q_2exp(this.mpz, n_.mpz, b_);
-          when round.zero do mpz_tdiv_q_2exp(this.mpz, n_.mpz, b_);
+          when round.up   do mpz_cdiv_q_2exp(this.mpz, numer_.mpz, b_);
+          when round.down do mpz_fdiv_q_2exp(this.mpz, numer_.mpz, b_);
+          when round.zero do mpz_tdiv_q_2exp(this.mpz, numer_.mpz, b_);
         }
       }
     }
@@ -4313,35 +4313,35 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.divR2Exp(const ref n: bigint,
+  proc bigint.divR2Exp(const ref numer: bigint,
                                  b: integral,
                        param     rounding = round.zero) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_r_2exp(this.mpz, n.mpz, b_);
-        when round.down do mpz_fdiv_r_2exp(this.mpz, n.mpz, b_);
-        when round.zero do mpz_tdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_r_2exp(this.mpz, numer.mpz, b_);
+        when round.down do mpz_fdiv_r_2exp(this.mpz, numer.mpz, b_);
+        when round.zero do mpz_tdiv_r_2exp(this.mpz, numer.mpz, b_);
       }
 
-    } else if this.localeId == chpl_nodeID && n.localeId == chpl_nodeID {
+    } else if this.localeId == chpl_nodeID && numer.localeId == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_r_2exp(this.mpz, n.mpz, b_);
-        when round.down do mpz_fdiv_r_2exp(this.mpz, n.mpz, b_);
-        when round.zero do mpz_tdiv_r_2exp(this.mpz, n.mpz, b_);
+        when round.up   do mpz_cdiv_r_2exp(this.mpz, numer.mpz, b_);
+        when round.down do mpz_fdiv_r_2exp(this.mpz, numer.mpz, b_);
+        when round.zero do mpz_tdiv_r_2exp(this.mpz, numer.mpz, b_);
       }
 
     } else {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        const n_ = n;
+        const numer_ = numer;
 
         select rounding {
-          when round.up   do mpz_cdiv_r_2exp(this.mpz, n_.mpz, b_);
-          when round.down do mpz_fdiv_r_2exp(this.mpz, n_.mpz, b_);
-          when round.zero do mpz_tdiv_r_2exp(this.mpz, n_.mpz, b_);
+          when round.up   do mpz_cdiv_r_2exp(this.mpz, numer_.mpz, b_);
+          when round.down do mpz_fdiv_r_2exp(this.mpz, numer_.mpz, b_);
+          when round.zero do mpz_tdiv_r_2exp(this.mpz, numer_.mpz, b_);
         }
       }
     }

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4024,24 +4024,24 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   deprecated
-  "bigint.div_q using Round is deprecated, use bigint.div_q with round instead"
+  "bigint.div_q using Round is deprecated, use bigint.divQ with round instead"
   proc bigint.div_q(const ref n: bigint,
                     const ref d: bigint,
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_q(n, d, round.up);
+      this.divQ(n, d, round.up);
     } else if (rounding == ZERO) {
-      this.div_q(n, d, round.zero);
+      this.divQ(n, d, round.zero);
     } else {
-      this.div_q(n, d, round.down);
+      this.divQ(n, d, round.down);
     }
   }
 
   // 5.6 Division Functions
-  proc bigint.div_q(const ref n: bigint,
-                    const ref d: bigint,
-                    param rounding = round.zero) {
+  proc bigint.divQ(const ref n: bigint,
+                   const ref d: bigint,
+                   param rounding = round.zero) {
     if _local {
       select rounding {
         when round.up   do mpz_cdiv_q(this.mpz, n.mpz,  d.mpz);
@@ -4075,46 +4075,46 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   deprecated
-  "bigint.div_q using Round is deprecated, use bigint.div_q with round instead"
+  "bigint.div_q using Round is deprecated, use bigint.divQ with round instead"
   proc bigint.div_q(const ref n: bigint,
                               d: integral,
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_q(n, d, round.up);
+      this.divQ(n, d, round.up);
     } else if (rounding == ZERO) {
-      this.div_q(n, d, round.zero);
+      this.divQ(n, d, round.zero);
     } else {
-      this.div_q(n, d, round.down);
+      this.divQ(n, d, round.down);
     }
   }
 
-  proc bigint.div_q(const ref n: bigint,
-                              d: integral,
-                    param     rounding = round.zero) {
+  proc bigint.divQ(const ref n: bigint,
+                             d: integral,
+                   param     rounding = round.zero) {
 
-    this.div_q(n, new bigint(d), rounding);
+    this.divQ(n, new bigint(d), rounding);
   }
 
   deprecated
-  "bigint.div_r using Round is deprecated, use bigint.div_r with round instead"
+  "bigint.div_r using Round is deprecated, use bigint.divR with round instead"
   proc bigint.div_r(const ref n: bigint,
                     const ref d: bigint,
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_r(n, d, round.up);
+      this.divR(n, d, round.up);
     } else if (rounding == ZERO) {
-      this.div_r(n, d, round.zero);
+      this.divR(n, d, round.zero);
     } else {
-      this.div_r(n, d, round.down);
+      this.divR(n, d, round.down);
     }
 
   }
 
-  proc bigint.div_r(const ref n: bigint,
-                    const ref d: bigint,
-                    param     rounding = round.zero) {
+  proc bigint.divR(const ref n: bigint,
+                   const ref d: bigint,
+                   param     rounding = round.zero) {
     if _local {
       select rounding {
         when round.up   do mpz_cdiv_r(this.mpz, n.mpz,  d.mpz);
@@ -4148,47 +4148,47 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   deprecated
-  "bigint.div_r using Round is deprecated, use bigint.div_r with round instead"
+  "bigint.div_r using Round is deprecated, use bigint.divR with round instead"
   proc bigint.div_r(const ref n: bigint,
                               d: integral,
                     param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_r(n, d, round.up);
+      this.divR(n, d, round.up);
     } else if (rounding == ZERO) {
-      this.div_r(n, d, round.zero);
+      this.divR(n, d, round.zero);
     } else {
-      this.div_r(n, d, round.down);
+      this.divR(n, d, round.down);
     }
   }
 
-  proc bigint.div_r(const ref n: bigint,
-                              d: integral,
-                    param     rounding = round.zero) {
-    this.div_r(n, new bigint(d), rounding);
+  proc bigint.divR(const ref n: bigint,
+                             d: integral,
+                   param     rounding = round.zero) {
+    this.divR(n, new bigint(d), rounding);
   }
 
   deprecated
-  "bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead"
+  "bigint.div_qr using Round is deprecated, use bigint.divQR with round instead"
   proc bigint.div_qr(ref       r:        bigint,
                      const ref n:        bigint,
                      const ref d:        bigint,
                      param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_qr(r, n, d, round.up);
+      this.divQR(r, n, d, round.up);
     } else if (rounding == ZERO) {
-      this.div_qr(r, n, d, round.zero);
+      this.divQR(r, n, d, round.zero);
     } else {
-      this.div_qr(r, n, d, round.down);
+      this.divQR(r, n, d, round.down);
     }
   }
 
   // this gets quotient, r gets remainder
-  proc bigint.div_qr(ref       r:        bigint,
-                     const ref n:        bigint,
-                     const ref d:        bigint,
-                     param     rounding = round.zero) {
+  proc bigint.divQR(ref       r:        bigint,
+                    const ref n:        bigint,
+                    const ref d:        bigint,
+                    param     rounding = round.zero) {
     if _local {
       select rounding {
         when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, n.mpz, d.mpz);
@@ -4226,46 +4226,46 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   deprecated
-  "bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead"
+  "bigint.div_qr using Round is deprecated, use bigint.divQR with round instead"
   proc bigint.div_qr(ref       r: bigint,
                      const ref n: bigint,
                                d: integral,
                      param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_qr(r, n, d, round.up);
+      this.divQR(r, n, d, round.up);
     } else if (rounding == ZERO) {
-      this.div_qr(r, n, d, round.zero);
+      this.divQR(r, n, d, round.zero);
     } else {
-      this.div_qr(r, n, d, round.down);
+      this.divQR(r, n, d, round.down);
     }
   }
 
-  proc bigint.div_qr(ref       r: bigint,
-                     const ref n: bigint,
-                               d: integral,
-                     param     rounding = round.zero) {
-    this.div_qr(r, n, new bigint(d), rounding);
+  proc bigint.divQR(ref       r: bigint,
+                    const ref n: bigint,
+                              d: integral,
+                    param     rounding = round.zero) {
+    this.divQR(r, n, new bigint(d), rounding);
   }
 
   deprecated
-  "bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead"
+  "bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead"
   proc bigint.div_q_2exp(const ref n: bigint,
                                    b: integral,
                          param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_q_2exp(n, b, round.up);
+      this.divQ2Exp(n, b, round.up);
     } else if (rounding == ZERO) {
-      this.div_q_2exp(n, b, round.zero);
+      this.divQ2Exp(n, b, round.zero);
     } else {
-      this.div_q_2exp(n, b, round.down);
+      this.divQ2Exp(n, b, round.down);
     }
   }
 
-  proc bigint.div_q_2exp(const ref n: bigint,
-                                   b: integral,
-                         param     rounding = round.zero) {
+  proc bigint.divQ2Exp(const ref n: bigint,
+                                 b: integral,
+                       param     rounding = round.zero) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {
@@ -4299,23 +4299,23 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   deprecated
-  "bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead"
+  "bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead"
   proc bigint.div_r_2exp(const ref n: bigint,
                                    b: integral,
                          param     rounding: Round) {
     use Round;
     if (rounding == UP) {
-      this.div_r_2exp(n, b, round.up);
+      this.divR2Exp(n, b, round.up);
     } else if (rounding == ZERO) {
-      this.div_r_2exp(n, b, round.zero);
+      this.divR2Exp(n, b, round.zero);
     } else {
-      this.div_r_2exp(n, b, round.down);
+      this.divR2Exp(n, b, round.down);
     }
   }
 
-  proc bigint.div_r_2exp(const ref n: bigint,
-                                   b: integral,
-                         param     rounding = round.zero) {
+  proc bigint.divR2Exp(const ref n: bigint,
+                                 b: integral,
+                       param     rounding = round.zero) {
     const b_ = b.safeCast(mp_bitcnt_t);
 
     if _local {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4040,22 +4040,22 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
   // 5.6 Division Functions
   proc bigint.divQ(const ref numer: bigint,
-                   const ref d: bigint,
+                   const ref denom: bigint,
                    param rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  d.mpz);
-        when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_q(this.mpz, numer.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  denom.mpz);
+        when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  denom.mpz);
+        when round.zero do mpz_tdiv_q(this.mpz, numer.mpz,  denom.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
               numer.localeId    == chpl_nodeID &&
-              d.localeId    == chpl_nodeID {
+              denom.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  d.mpz);
-        when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_q(this.mpz, numer.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  denom.mpz);
+        when round.down do mpz_fdiv_q(this.mpz, numer.mpz,  denom.mpz);
+        when round.zero do mpz_tdiv_q(this.mpz, numer.mpz,  denom.mpz);
       }
 
     } else {
@@ -4063,12 +4063,12 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
       on __primitive("chpl_on_locale_num", thisLoc) {
         const numer_ = numer;
-        const d_ = d;
+        const denom_ = denom;
 
         select rounding {
-          when round.up   do mpz_cdiv_q(this.mpz, numer_.mpz, d_.mpz);
-          when round.down do mpz_fdiv_q(this.mpz, numer_.mpz, d_.mpz);
-          when round.zero do mpz_tdiv_q(this.mpz, numer_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_q(this.mpz, numer_.mpz, denom_.mpz);
+          when round.down do mpz_fdiv_q(this.mpz, numer_.mpz, denom_.mpz);
+          when round.zero do mpz_tdiv_q(this.mpz, numer_.mpz, denom_.mpz);
           }
       }
     }
@@ -4090,10 +4090,10 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   proc bigint.divQ(const ref numer: bigint,
-                             d: integral,
+                             denom: integral,
                    param     rounding = round.zero) {
 
-    this.divQ(numer, new bigint(d), rounding);
+    this.divQ(numer, new bigint(denom), rounding);
   }
 
   deprecated
@@ -4113,22 +4113,22 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   proc bigint.divR(const ref numer: bigint,
-                   const ref d: bigint,
+                   const ref denom: bigint,
                    param     rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  d.mpz);
-        when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_r(this.mpz, numer.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  denom.mpz);
+        when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  denom.mpz);
+        when round.zero do mpz_tdiv_r(this.mpz, numer.mpz,  denom.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
               numer.localeId    == chpl_nodeID &&
-              d.localeId    == chpl_nodeID {
+              denom.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  d.mpz);
-        when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  d.mpz);
-        when round.zero do mpz_tdiv_r(this.mpz, numer.mpz,  d.mpz);
+        when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  denom.mpz);
+        when round.down do mpz_fdiv_r(this.mpz, numer.mpz,  denom.mpz);
+        when round.zero do mpz_tdiv_r(this.mpz, numer.mpz,  denom.mpz);
       }
 
     } else {
@@ -4136,12 +4136,12 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
       on __primitive("chpl_on_locale_num", thisLoc) {
         const numer_ = numer;
-        const d_ = d;
+        const denom_ = denom;
 
         select rounding {
-          when round.up   do mpz_cdiv_r(this.mpz, numer_.mpz, d_.mpz);
-          when round.down do mpz_fdiv_r(this.mpz, numer_.mpz, d_.mpz);
-          when round.zero do mpz_tdiv_r(this.mpz, numer_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_r(this.mpz, numer_.mpz, denom_.mpz);
+          when round.down do mpz_fdiv_r(this.mpz, numer_.mpz, denom_.mpz);
+          when round.zero do mpz_tdiv_r(this.mpz, numer_.mpz, denom_.mpz);
         }
       }
     }
@@ -4163,9 +4163,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   }
 
   proc bigint.divR(const ref numer: bigint,
-                             d: integral,
+                             denom: integral,
                    param     rounding = round.zero) {
-    this.divR(numer, new bigint(d), rounding);
+    this.divR(numer, new bigint(denom), rounding);
   }
 
   deprecated
@@ -4187,23 +4187,23 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   // this gets quotient, r gets remainder
   proc bigint.divQR(ref       r:        bigint,
                     const ref numer:        bigint,
-                    const ref d:        bigint,
+                    const ref denom:        bigint,
                     param     rounding = round.zero) {
     if _local {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
       }
 
     } else if this.localeId == chpl_nodeID &&
               r.localeId    == chpl_nodeID &&
               numer.localeId    == chpl_nodeID &&
-              d.localeId    == chpl_nodeID {
+              denom.localeId    == chpl_nodeID {
       select rounding {
-        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
-        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
-        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, d.mpz);
+        when round.up   do mpz_cdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
+        when round.down do mpz_fdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
+        when round.zero do mpz_tdiv_qr(this.mpz, r.mpz, numer.mpz, denom.mpz);
       }
 
     } else {
@@ -4212,12 +4212,12 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       on __primitive("chpl_on_locale_num", thisLoc) {
         var   r_ = r;
         const numer_ = numer;
-        const d_ = d;
+        const denom_ = denom;
 
         select rounding {
-          when round.up   do mpz_cdiv_qr(this.mpz, r_.mpz, numer_.mpz, d_.mpz);
-          when round.down do mpz_fdiv_qr(this.mpz, r_.mpz, numer_.mpz, d_.mpz);
-          when round.zero do mpz_tdiv_qr(this.mpz, r_.mpz, numer_.mpz, d_.mpz);
+          when round.up   do mpz_cdiv_qr(this.mpz, r_.mpz, numer_.mpz, denom_.mpz);
+          when round.down do mpz_fdiv_qr(this.mpz, r_.mpz, numer_.mpz, denom_.mpz);
+          when round.zero do mpz_tdiv_qr(this.mpz, r_.mpz, numer_.mpz, denom_.mpz);
         }
 
         r = r_;
@@ -4243,9 +4243,9 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
   proc bigint.divQR(ref       r: bigint,
                     const ref numer: bigint,
-                              d: integral,
+                              denom: integral,
                     param     rounding = round.zero) {
-    this.divQR(r, numer, new bigint(d), rounding);
+    this.divQR(r, numer, new bigint(denom), rounding);
   }
 
   deprecated

--- a/test/deprecated/BigInteger/deprecateRound.chpl
+++ b/test/deprecated/BigInteger/deprecateRound.chpl
@@ -73,3 +73,18 @@ writeln(d, " ", b);
 d.div_q_2exp(c, 3, zero);
 b.div_r_2exp(c, 3, zero);
 writeln(d, " ", b);
+
+writeln();
+// Check default arguments, too
+d.div_q(c, a); // same as UP   for negative integers
+b.div_r(c, a); // same as DOWN for positive integers
+writeln(d, " ", b);
+
+c.neg(c);
+d.div_qr(b, c, a); // same as DOWN for positive integers
+writeln(d, " ", b);
+
+c.neg(c);
+d.div_q_2exp(c, 3);
+b.div_r_2exp(c, 3);
+writeln(d, " ", b);

--- a/test/deprecated/BigInteger/deprecateRound.good
+++ b/test/deprecated/BigInteger/deprecateRound.good
@@ -25,6 +25,11 @@ deprecateRound.chpl:69: warning: bigint.div_q_2exp using Round is deprecated, us
 deprecateRound.chpl:70: warning: bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead
 deprecateRound.chpl:73: warning: bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead
 deprecateRound.chpl:74: warning: bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead
+deprecateRound.chpl:79: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:80: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:84: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:88: warning: bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead
+deprecateRound.chpl:89: warning: bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead
 -3 -3
 -4 5
 -3 -3
@@ -41,4 +46,8 @@ deprecateRound.chpl:74: warning: bigint.div_r_2exp using Round is deprecated, us
 
 -3 -3
 -4 5
+-3 -3
+
+-3 -3
+3 3
 -3 -3

--- a/test/deprecated/BigInteger/deprecateRound.good
+++ b/test/deprecated/BigInteger/deprecateRound.good
@@ -1,30 +1,30 @@
 deprecateRound.chpl:3: warning: The enum Round is deprecated, please use the enum round instead
 deprecateRound.chpl:4: warning: The enum Round is deprecated, please use the enum round instead
 deprecateRound.chpl:5: warning: The enum Round is deprecated, please use the enum round instead
-deprecateRound.chpl:13: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
-deprecateRound.chpl:14: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
-deprecateRound.chpl:17: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
-deprecateRound.chpl:18: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
-deprecateRound.chpl:21: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
-deprecateRound.chpl:22: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
-deprecateRound.chpl:26: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
-deprecateRound.chpl:29: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
-deprecateRound.chpl:32: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
-deprecateRound.chpl:38: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
-deprecateRound.chpl:39: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
-deprecateRound.chpl:42: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
-deprecateRound.chpl:43: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
-deprecateRound.chpl:46: warning: bigint.div_q using Round is deprecated, use bigint.div_q with round instead
-deprecateRound.chpl:47: warning: bigint.div_r using Round is deprecated, use bigint.div_r with round instead
-deprecateRound.chpl:51: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
-deprecateRound.chpl:54: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
-deprecateRound.chpl:57: warning: bigint.div_qr using Round is deprecated, use bigint.div_qr with round instead
-deprecateRound.chpl:65: warning: bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead
-deprecateRound.chpl:66: warning: bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead
-deprecateRound.chpl:69: warning: bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead
-deprecateRound.chpl:70: warning: bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead
-deprecateRound.chpl:73: warning: bigint.div_q_2exp using Round is deprecated, use bigint.div_q_2xp with round instead
-deprecateRound.chpl:74: warning: bigint.div_r_2exp using Round is deprecated, use bigint.div_r_2xp with round instead
+deprecateRound.chpl:13: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:14: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:17: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:18: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:21: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:22: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:26: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:29: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:32: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:38: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:39: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:42: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:43: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:46: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+deprecateRound.chpl:47: warning: bigint.div_r using Round is deprecated, use bigint.divR with round instead
+deprecateRound.chpl:51: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:54: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:57: warning: bigint.div_qr using Round is deprecated, use bigint.divQR with round instead
+deprecateRound.chpl:65: warning: bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead
+deprecateRound.chpl:66: warning: bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead
+deprecateRound.chpl:69: warning: bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead
+deprecateRound.chpl:70: warning: bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead
+deprecateRound.chpl:73: warning: bigint.div_q_2exp using Round is deprecated, use bigint.divQ2Exp with round instead
+deprecateRound.chpl:74: warning: bigint.div_r_2exp using Round is deprecated, use bigint.divR2Exp with round instead
 -3 -3
 -4 5
 -3 -3

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_arithmetic.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_arithmetic.chpl
@@ -32,7 +32,7 @@ writeln(a);
 a.mul_2exp(c, 3);                    // a = -1600
 writeln(a);
 
-a.div_q_2exp(a, 3);                  //a =   -200
+a.divQ2Exp(a, 3);                    //a =   -200
 writeln(a);
 
 a.neg(b);                            // a =    -2

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_division.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_division.chpl
@@ -6,51 +6,51 @@ var b = new bigint( 10);
 var c = new bigint(-27);
 var d = new bigint();
 
-d.div_q(c, a, round.up);
-b.div_r(c, a, round.up);
+d.divQ(c, a, round.up);
+b.divR(c, a, round.up);
 writeln(d, " ", b);
 
-d.div_q(c, a, round.down);
-b.div_r(c, a, round.down);
+d.divQ(c, a, round.down);
+b.divR(c, a, round.down);
 writeln(d, " ", b);
 
-d.div_q(c, a, round.zero); // same as up   for negative integers
-b.div_r(c, a, round.zero); // same as down for positive integers
+d.divQ(c, a, round.zero); // same as up   for negative integers
+b.divR(c, a, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
-d.div_qr(b, c, a, round.up);
+d.divQR(b, c, a, round.up);
 writeln(d, " ", b);
 
-d.div_qr(b, c, a, round.down);
+d.divQR(b, c, a, round.down);
 writeln(d, " ", b);
 
-d.div_qr(b, c, a, round.zero); // same as down for positive integers
+d.divQR(b, c, a, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 writeln();
 
 c.neg(c);
-d.div_q(c, 8, round.up);
-b.div_r(c, 8, round.up);
+d.divQ(c, 8, round.up);
+b.divR(c, 8, round.up);
 writeln(d, " ", b);
 
-d.div_q(c, 8, round.down);
-b.div_r(c, 8, round.down);
+d.divQ(c, 8, round.down);
+b.divR(c, 8, round.down);
 writeln(d, " ", b);
 
-d.div_q(c, 8, round.zero); // same as down for positive integers
-b.div_r(c, 8, round.zero); // same as down for positive integers
+d.divQ(c, 8, round.zero); // same as down for positive integers
+b.divR(c, 8, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
-d.div_qr(b, c, 8, round.up);
+d.divQR(b, c, 8, round.up);
 writeln(d, " ", b);
 
-d.div_qr(b, c, 8, round.down);
+d.divQR(b, c, 8, round.down);
 writeln(d, " ", b);
 
-d.div_qr(b, c, 8, round.zero); // same as down for positive integers
+d.divQR(b, c, 8, round.zero); // same as down for positive integers
 writeln(d, " ", b);
 
 c.neg(c);
@@ -58,16 +58,16 @@ writeln();
 
 
 // q = (n / 2^d)
-d.div_q_2exp(c, 3, round.up);
-b.div_r_2exp(c, 3, round.up);
+d.divQ2Exp(c, 3, round.up);
+b.divR2Exp(c, 3, round.up);
 writeln(d, " ", b);
 
-d.div_q_2exp(c, 3, round.down);
-b.div_r_2exp(c, 3, round.down);
+d.divQ2Exp(c, 3, round.down);
+b.divR2Exp(c, 3, round.down);
 writeln(d, " ", b);
 
-d.div_q_2exp(c, 3, round.zero);
-b.div_r_2exp(c, 3, round.zero);
+d.divQ2Exp(c, 3, round.zero);
+b.divR2Exp(c, 3, round.zero);
 writeln(d, " ", b);
 
 writeln();

--- a/test/release/examples/benchmarks/shootout/pidigits-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/pidigits-fast.chpl
@@ -57,7 +57,7 @@ iter genDigits(numDigits) {
   proc extractDigit(nth) {
     tmp1.mul(numer, nth);
     tmp2.add(tmp1,accum);
-    tmp1.div_q(tmp2, denom);
+    tmp1.divQ(tmp2, denom);
 
     return tmp1: int;
   }

--- a/test/studies/shootout/pidigits/bradc/pidigits-blc.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-blc.chpl
@@ -22,7 +22,7 @@ for k in (1..) {
   den *= k1;
 
   if a >= num {
-    t.div_qr(u, 3*num + a, den);
+    t.divQR(u, 3*num + a, den);
     u += num;
     if den > u {
       ns = 10*ns + t:int;

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-BigInt.chpl
@@ -61,7 +61,7 @@ iter genDigits(numDigits) {
 
       // tmp1 = tmp1 / denom; tmp2 = tmp1 % denom
       // tmp1 gets quotient, tmp2 gets remainder
-      tmp1.div_qr(tmp2, tmp1, denom, round.down);
+      tmp1.divQR(tmp2, tmp1, denom, round.down);
 
       // Now, if:
       //   (numer * 3 + accum) % denom + numer == (numer * 4 + accum) + numer

--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.chpl
@@ -74,7 +74,7 @@ iter genDigits(numDigits) {
   proc extractDigit(nth: uint) {
     tmp1.mul(numer, nth);
     tmp2.add(tmp1, accum);
-    tmp1.div_q(tmp2, denom);
+    tmp1.divQ(tmp2, denom);
 
     return tmp1 : uint;
   }

--- a/test/studies/shootout/submitted/pidigits2-27.good
+++ b/test/studies/shootout/submitted/pidigits2-27.good
@@ -1,3 +1,6 @@
+pidigits2.chpl:30: In iterator 'genDigits':
+pidigits2.chpl:60: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+  pidigits2.chpl:18: called as genDigits(numDigits: int(64))
 3141592653	:10
 5897932384	:20
 6264338   	:27

--- a/test/studies/shootout/submitted/pidigits2.good
+++ b/test/studies/shootout/submitted/pidigits2.good
@@ -1,3 +1,6 @@
+pidigits2.chpl:30: In iterator 'genDigits':
+pidigits2.chpl:60: warning: bigint.div_q using Round is deprecated, use bigint.divQ with round instead
+  pidigits2.chpl:18: called as genDigits(numDigits: int(64))
 3141592653	:10
 5897932384	:20
 6264338327	:30


### PR DESCRIPTION
This change adjusts the replacement division methods in the BigInteger module
to use new names and new argument names, to unify them with the expected style
of the standard modules.  These changes include:

- stop using snake case, so `div_q` is now `divQ`, `div_q_2exp` is now `divQ2Exp`, etc.
- Any `n` arguments are now `numer` (short for numerator, as opposed to `num`
which could be confused with its use for things like `numFields`)
- Any `d` arguments are now `denom` (short for denominator)
- Any `r` arguments are now `remain` (short for remainder)
- Any `b` arguments are now `exp` (short for exponent, since these versions of the
functions divide by 2 raised to the power of this argument: previously 2^b, now 2^exp)

Adjusts the deprecation warning for the old versions that used `Round` to refer to the
new names.  Restore the default value for the `Round` arguments, now that we don't
have to worry about whether having a default value will cause resolution errors (and
to allow users that relied on the default values to see the deprecation warning rather
than just a resolution error)

Resolves Cray/chapel-private#2092

Updates the tests that call these methods to use the new names.  Updates the
deprecation test to expect the new deprecation warning message and add tracking
for the deprecation warnings when default values are used.

Full paratest with futures passed