### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2081,6 +2081,8 @@ compilerAndTestingStats: &compiler-perf-base
     - Change range.size to return int; add range.sizeAs (#17628)
   06/01/21:
     - Add explicit string casts for common/easy cases (#17855)
+  06/16/21:
+    - Translate uAST to old AST (#17919)
 
 allTotalTime:
   <<: *compiler-perf-base


### PR DESCRIPTION
Adds annotation for a small performance regression in the compilation.

PR: https://github.com/chapel-lang/chapel/pull/17919/
Plots: https://chapel-lang.org/perf/chapcs/?startdate=2021/06/03&enddate=2021/06/17&graphs=fftcompilationtimebypass,samplercompilationtimebypass,cgsparsecompilationtimebypass,compilationtime,jacobiastsize,jacobiemittedcodesize
