### PR TITLE
Revert PRs 17930 and 17926

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -55,6 +55,7 @@ case $COMP_TYPE in
         export CHPL_TARGET_PLATFORM=$platform
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
+        fi
         ;;
     HOST-TARGET)
         if [ $COMPILER == "llvm" ] ; then

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -6,7 +6,7 @@
 #
 # Variable   Values
 # ------------------------------------------------------
-# COMPILER    cray, intel, pgi, gnu, llvm
+# COMPILER    cray, intel, pgi, gnu
 # COMP_TYPE   TARGET, HOST-TARGET, HOST-TARGET-no-PrgEnv
 #
 # Optionally, the platform can be set with:
@@ -42,30 +42,16 @@ log_info "Short platform: ${short_platform}"
 # Setup vars that will help load the correct compiler module.
 case $COMP_TYPE in
     TARGET)
-        if [ $COMPILER == "llvm" ] ; then
-            module_name=PrgEnv-gnu
-            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.${COMPILER}"
-        else
-            module_name=PrgEnv-${COMPILER}
-            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.prgenv-${COMPILER}"
-        fi
-
+        module_name=PrgEnv-${COMPILER}
         chpl_host_value=""
 
         export CHPL_TARGET_PLATFORM=$platform
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        fi
+        export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.prgenv-${COMPILER}"
         ;;
     HOST-TARGET)
-        if [ $COMPILER == "llvm" ] ; then
-            module_name=PrgEnv-gnu
-            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.${COMPILER}"
-        else
-            module_name=PrgEnv-${COMPILER}
-            export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.prgenv-${COMPILER}"
-        fi
-
+        module_name=PrgEnv-${COMPILER}
         chpl_host_value=cray-prgenv-${COMPILER}
 
         export CHPL_HOST_PLATFORM=$platform
@@ -73,6 +59,7 @@ case $COMP_TYPE in
         log_info "Set CHPL_HOST_PLATFORM to: ${CHPL_HOST_PLATFORM}"
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
+        export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.prgenv-${COMPILER}"
         ;;
     HOST-TARGET-no-PrgEnv)
         the_cc=${COMPILER}
@@ -117,8 +104,6 @@ case $COMPILER in
         # force disable gmp until there's more time to investigate this.
         export CHPL_GMP=none
         ;;
-    llvm)
-        ;;
     *)
         log_error "Unknown COMPILER value: ${COMPILER}. Exiting."
         exit 4
@@ -142,6 +127,11 @@ fi
 # Disable launchers, comm.
 export CHPL_LAUNCHER=none
 export CHPL_COMM=none
+
+# Disable llvm for now, since we're explicitly trying to test different C
+# backends
+export CHPL_LLVM=none
+
 
 # Set some vars that nightly cares about.
 export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}


### PR DESCRIPTION
This reverts PRs #17926 and #17930 which have been breaking smoke testing all day.