### PR TITLE
Downgrade the version of docutils used in order to upgrade sphinx-rtd-theme

### DIFF
--- a/test/chpldoc/compflags/author/withoutAuthor/withoutAuthor.doc.good
+++ b/test/chpldoc/compflags/author/withoutAuthor/withoutAuthor.doc.good
@@ -1,1 +1,1 @@
-        &copy; Copyright n
+        &#169; Copyright n.

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,10 +1,9 @@
-# Many of these packages have newer versions that work on Python 3 only.
 Jinja2==3.0.1
 MarkupSafe==2.0.1
 Pygments==2.9.0
 Sphinx==4.0.2
-docutils==0.17.1
-sphinx-rtd-theme==0.5.0
+docutils==0.16.0
+sphinx-rtd-theme==0.5.2
 sphinxcontrib-chapeldomain==0.0.20
 babel==2.9.1
 breathe==4.30.0


### PR DESCRIPTION
The newer version of docutils introduced an issue with displaying bulleted
lists.  This is probably part of the reason the newer version of
sphinx-rtd-theme explicitly avoids using it.  Downgrade to the older version of
docutils so we can use the newer sphinx-rtd-theme instead.

Verified that building the online documentation with this change restored the
bullets.

Updates a chpldoc test of failing to provide an author because the default
author behavior has changed as a result of the upgrade.  The only visible
difference when looking at the HTML page in my browser is the addition of the
period.  Otherwise it "looks" the same, even though more is changed.

Passed a full paratest with futures