### PR TITLE
Issue an error when a DR domain/array is following a larger leader

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -502,7 +502,7 @@ module DefaultRectangular {
       var block: rank*range(idxType=intIdxType, stridable=stridable);
       if boundsChecking then
         for param i in 0..rank-1 do
-          if followThis(i).high >= ranges(i).size then
+          if followThis(i).high >= ranges(i).sizeAs(uint) then
             HaltWrappers.boundsCheckHalt("size mismatch in zippered iteration (dimension " + i:string + ")");
       if stridable {
         type strType = chpl__signedType(intIdxType);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -21,6 +21,8 @@
 // DefaultRectangular.chpl
 //
 module DefaultRectangular {
+  import HaltWrappers;
+
   config const dataParTasksPerLocale = 0;
   config const dataParIgnoreRunningTasks = false;
   config const dataParMinGranularity: int = 1;
@@ -498,6 +500,10 @@ module DefaultRectangular {
 
       param stridable = this.stridable || anyStridable(followThis);
       var block: rank*range(idxType=intIdxType, stridable=stridable);
+      if boundsChecking then
+        for param i in 0..rank-1 do
+          if followThis(i).high >= ranges(i).size then
+            HaltWrappers.boundsCheckHalt("size mismatch in zippered iteration (dimension " + i:string + ")");
       if stridable {
         type strType = chpl__signedType(intIdxType);
         for param i in 0..rank-1 {

--- a/test/parallel/forall/zip/zipArrMismatch.chpl
+++ b/test/parallel/forall/zip/zipArrMismatch.chpl
@@ -1,0 +1,7 @@
+var A: [1..4] real;
+var B: [1..3] real = [1.0, 2.0, 3.0];
+
+forall (a,b) in zip(A, B) do
+  a = b;
+
+writeln(A);

--- a/test/parallel/forall/zip/zipArrMismatch.good
+++ b/test/parallel/forall/zip/zipArrMismatch.good
@@ -1,0 +1,1 @@
+zipArrMismatch.chpl:4: error: halt reached - size mismatch in zippered iteration (dimension 0)

--- a/test/parallel/forall/zip/zipDomMismatch.chpl
+++ b/test/parallel/forall/zip/zipDomMismatch.chpl
@@ -1,0 +1,7 @@
+var A: [1..4] real;
+var B: [1..3] real;
+
+forall (i,j) in zip(A.domain, B.domain) do
+  A[i] = j;
+
+writeln(A);

--- a/test/parallel/forall/zip/zipDomMismatch.good
+++ b/test/parallel/forall/zip/zipDomMismatch.good
@@ -1,0 +1,1 @@
+zipDomMismatch.chpl:4: error: halt reached - size mismatch in zippered iteration (dimension 0)


### PR DESCRIPTION
Nikhil shared a case on chat this week where—to my surprise—we weren't
generating OOB errors for having a DR array get indexed out of bounds
when it was following a larger leader array.  This is something that
we used to catch, but no longer seem to.  Here, I'm adding a check to
the DR domain follower code to catch such cases and a new test to lock
the check in.

Note that this doesn't address the longstanding error in which a leader
iterator expression is smaller than its follower (i.e., my most dreaded
Chapel bug (TM):  https://github.com/chapel-lang/chapel/issues/11428).