### PR TITLE
Add missing COMPOPTS file to always test these with --bounds-checks

### DIFF
--- a/test/parallel/forall/zip/COMPOPTS
+++ b/test/parallel/forall/zip/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks


### PR DESCRIPTION
My new tests only generate errors when bounds checking is on, so
are failing in our '--fast' configuration testing.

(How old will I need to be before I learn to do this proactively?)
