### PR TITLE
Restore a linefeed at the end of `checkManPages`

### DIFF
--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -246,3 +246,4 @@ def _error(*args):
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
This linefeed was removed in #17741 and I'd meant to restore it.
I also needed a simple PR to test a change to our documentation
publishing that I just committed, so this is it.
