### PR TITLE
Improve rank mismatch errors in zipperings between ranges / default arrays

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2455,8 +2455,8 @@ operator :(r: range(?), type t: range(?)) {
       compilerError("iteration over a range with no first index");
 
     if followThis.size != 1 then
-      compilerError("rank mismatch in zippered iteration (leader is " +
-                    followThis.size:string + "D, but ranges are 1D)");
+      compilerError("rank mismatch in zippered iteration (can't zip a " +
+                    followThis.size:string + "D expression with a range, which is 1D)");
 
     if debugChapelRange then
       chpl_debug_writeln("In range follower code: Following ", followThis);

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2455,7 +2455,8 @@ operator :(r: range(?), type t: range(?)) {
       compilerError("iteration over a range with no first index");
 
     if followThis.size != 1 then
-      compilerError("iteration over a range with multi-dimensional iterator");
+      compilerError("rank mismatch in zippered iteration (leader is " +
+                    followThis.size:string + "D, but ranges are 1D)");
 
     if debugChapelRange then
       chpl_debug_writeln("In range follower code: Following ", followThis);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -490,9 +490,9 @@ module DefaultRectangular {
       where tag == iterKind.follower {
 
       if followThis.size != this.rank then
-        compilerError("rank mismatch in zippered iteration (leader is " +
-                      followThis.size:string + "D, but array is " +
-                      this.rank:string + "D)");
+        compilerError("rank mismatch in zippered iteration (can't zip a " +
+                      followThis.size:string + "D expression with a " +
+                      this.rank:string + "D domain)");
         
       proc anyStridable(rangeTuple, param i: int = 0) param
         return if i == rangeTuple.size-1 then rangeTuple(i).stridable
@@ -1174,6 +1174,11 @@ module DefaultRectangular {
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity)
       ref where tag == iterKind.follower {
+      if followThis.size != this.rank then
+        compilerError("rank mismatch in zippered iteration (can't zip a " +
+                      followThis.size:string + "D expression with a " +
+                      this.rank:string + "D array)");
+
       if debugDefaultDist {
         chpl_debug_writeln("*** In defRectArr simple-dd follower iterator: ",
                            followThis);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -489,6 +489,11 @@ module DefaultRectangular {
                offset=createTuple(rank, intIdxType, 0:intIdxType))
       where tag == iterKind.follower {
 
+      if followThis.size != this.rank then
+        compilerError("rank mismatch in zippered iteration (leader is " +
+                      followThis.size:string + "D, but array is " +
+                      this.rank:string + "D)");
+        
       proc anyStridable(rangeTuple, param i: int = 0) param
         return if i == rangeTuple.size-1 then rangeTuple(i).stridable
                else rangeTuple(i).stridable || anyStridable(rangeTuple, i+1);

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -430,7 +430,10 @@ module UnitTest {
                               "'\nand\n'"+stringify(array2) + "'\n";
 
       // Compare array types, size, and shape
-      if array1.type != array2.type {
+      if array1.rank != array2.rank {
+        const errorMsg = genericErrorMsg + "are not of same rank";
+        throw new owned AssertionError(errorMsg);
+      } else if array1.type != array2.type {
         const errorMsg = genericErrorMsg + "are not of same type";
         throw new owned AssertionError(errorMsg);
       } else if array1.size != array2.size {
@@ -439,14 +442,15 @@ module UnitTest {
       } else if array1.shape != array2.shape {
         const errorMsg = genericErrorMsg + "are not of same shape";
         throw new owned AssertionError(errorMsg);
-      }
+      } else {
 
-      // Compare array values
-      const arraysEqual = && reduce (array1 == array2);
-      if !arraysEqual {
-        const errorMsg = "assert failed -\n'" + stringify(array1) +
-                         "'\n!=\n'"+stringify(array2)+"'";
-        throw new owned AssertionError(errorMsg);
+        // Compare array values
+        const arraysEqual = && reduce (array1 == array2);
+        if !arraysEqual {
+          const errorMsg = "assert failed -\n'" + stringify(array1) +
+                           "'\n!=\n'"+stringify(array2)+"'";
+          throw new owned AssertionError(errorMsg);
+        }
       }
     }
 

--- a/test/library/packages/UnitTest/AssertEqual/AssertEqualTest.good
+++ b/test/library/packages/UnitTest/AssertEqual/AssertEqualTest.good
@@ -45,7 +45,7 @@ and
 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 0.0 0.0 0.0 0.0 0.0 0.0 0.0'
-are not of same type
+are not of same rank
 ================================================================================
 Error Caught in Equal High Array Diff Type
 AssertionError: assert failed -

--- a/test/parallel/forall/zip/zipRankMismatch-1Darr-2Darr.good
+++ b/test/parallel/forall/zip/zipRankMismatch-1Darr-2Darr.good
@@ -1,3 +1,3 @@
 zipRankMismatch.chpl:6: In function 'zipem':
-zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 1D, but array is 2D)
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (can't zip a 1D expression with a 2D array)
   zipRankMismatch.chpl:13: called as zipem(X: [domain(1,int(64),false)] real(64), Y: [domain(2,int(64),false)] real(64))

--- a/test/parallel/forall/zip/zipRankMismatch-1Darr-2Darr.good
+++ b/test/parallel/forall/zip/zipRankMismatch-1Darr-2Darr.good
@@ -1,0 +1,3 @@
+zipRankMismatch.chpl:6: In function 'zipem':
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 1D, but array is 2D)
+  zipRankMismatch.chpl:13: called as zipem(X: [domain(1,int(64),false)] real(64), Y: [domain(2,int(64),false)] real(64))

--- a/test/parallel/forall/zip/zipRankMismatch-1Ddom-2Ddom.good
+++ b/test/parallel/forall/zip/zipRankMismatch-1Ddom-2Ddom.good
@@ -1,0 +1,3 @@
+zipRankMismatch.chpl:6: In function 'zipem':
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 1D, but array is 2D)
+  zipRankMismatch.chpl:15: called as zipem(X: domain(1,int(64),false), Y: domain(2,int(64),false))

--- a/test/parallel/forall/zip/zipRankMismatch-1Ddom-2Ddom.good
+++ b/test/parallel/forall/zip/zipRankMismatch-1Ddom-2Ddom.good
@@ -1,3 +1,3 @@
 zipRankMismatch.chpl:6: In function 'zipem':
-zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 1D, but array is 2D)
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (can't zip a 1D expression with a 2D domain)
   zipRankMismatch.chpl:15: called as zipem(X: domain(1,int(64),false), Y: domain(2,int(64),false))

--- a/test/parallel/forall/zip/zipRankMismatch-2D-range.good
+++ b/test/parallel/forall/zip/zipRankMismatch-2D-range.good
@@ -1,3 +1,3 @@
 zipRankMismatch.chpl:6: In function 'zipem':
-zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 2D, but ranges are 1D)
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (can't zip a 2D expression with a range, which is 1D)
   zipRankMismatch.chpl:17: called as zipem(X: [domain(2,int(64),false)] real(64), Y: range(int(64),bounded,false))

--- a/test/parallel/forall/zip/zipRankMismatch-2D-range.good
+++ b/test/parallel/forall/zip/zipRankMismatch-2D-range.good
@@ -1,0 +1,3 @@
+zipRankMismatch.chpl:6: In function 'zipem':
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 2D, but ranges are 1D)
+  zipRankMismatch.chpl:17: called as zipem(X: [domain(2,int(64),false)] real(64), Y: range(int(64),bounded,false))

--- a/test/parallel/forall/zip/zipRankMismatch-2Darr-1Darr.good
+++ b/test/parallel/forall/zip/zipRankMismatch-2Darr-1Darr.good
@@ -1,0 +1,3 @@
+zipRankMismatch.chpl:6: In function 'zipem':
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 2D, but array is 1D)
+  zipRankMismatch.chpl:12: called as zipem(X: [domain(2,int(64),false)] real(64), Y: [domain(1,int(64),false)] real(64))

--- a/test/parallel/forall/zip/zipRankMismatch-2Darr-1Darr.good
+++ b/test/parallel/forall/zip/zipRankMismatch-2Darr-1Darr.good
@@ -1,3 +1,3 @@
 zipRankMismatch.chpl:6: In function 'zipem':
-zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 2D, but array is 1D)
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (can't zip a 2D expression with a 1D array)
   zipRankMismatch.chpl:12: called as zipem(X: [domain(2,int(64),false)] real(64), Y: [domain(1,int(64),false)] real(64))

--- a/test/parallel/forall/zip/zipRankMismatch-2Ddom-1Ddom.good
+++ b/test/parallel/forall/zip/zipRankMismatch-2Ddom-1Ddom.good
@@ -1,3 +1,3 @@
 zipRankMismatch.chpl:6: In function 'zipem':
-zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 2D, but array is 1D)
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (can't zip a 2D expression with a 1D domain)
   zipRankMismatch.chpl:14: called as zipem(X: domain(2,int(64),false), Y: domain(1,int(64),false))

--- a/test/parallel/forall/zip/zipRankMismatch-2Ddom-1Ddom.good
+++ b/test/parallel/forall/zip/zipRankMismatch-2Ddom-1Ddom.good
@@ -1,0 +1,3 @@
+zipRankMismatch.chpl:6: In function 'zipem':
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 2D, but array is 1D)
+  zipRankMismatch.chpl:14: called as zipem(X: domain(2,int(64),false), Y: domain(1,int(64),false))

--- a/test/parallel/forall/zip/zipRankMismatch-range-2D.good
+++ b/test/parallel/forall/zip/zipRankMismatch-range-2D.good
@@ -1,0 +1,3 @@
+zipRankMismatch.chpl:6: In function 'zipem':
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 1D, but array is 2D)
+  zipRankMismatch.chpl:16: called as zipem(X: range(int(64),bounded,false), Y: [domain(2,int(64),false)] real(64))

--- a/test/parallel/forall/zip/zipRankMismatch-range-2D.good
+++ b/test/parallel/forall/zip/zipRankMismatch-range-2D.good
@@ -1,3 +1,3 @@
 zipRankMismatch.chpl:6: In function 'zipem':
-zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (leader is 1D, but array is 2D)
+zipRankMismatch.chpl:7: error: rank mismatch in zippered iteration (can't zip a 1D expression with a 2D array)
   zipRankMismatch.chpl:16: called as zipem(X: range(int(64),bounded,false), Y: [domain(2,int(64),false)] real(64))

--- a/test/parallel/forall/zip/zipRankMismatch.chpl
+++ b/test/parallel/forall/zip/zipRankMismatch.chpl
@@ -1,0 +1,18 @@
+config param case = 1;
+
+var A: [1..10, 1..10] real;
+var X: [1..10] real;
+
+proc zipem(X,Y) {
+  forall (x,y) in zip(X, Y) do
+    writeln((x,y));
+}
+
+select case {
+  when 1 do zipem(A, X);
+  when 2 do zipem(X, A);
+  when 3 do zipem(A.domain, X.domain);
+  when 4 do zipem(X.domain, A.domain);
+  when 5 do zipem(1..10, A);
+  when 6 do zipem(A, 1..10);
+}

--- a/test/parallel/forall/zip/zipRankMismatch.compopts
+++ b/test/parallel/forall/zip/zipRankMismatch.compopts
@@ -1,0 +1,6 @@
+-scase=1 # zipRankMismatch-2Darr-1Darr.good
+-scase=2 # zipRankMismatch-1Darr-2Darr.good
+-scase=3 # zipRankMismatch-2Ddom-1Ddom.good
+-scase=4 # zipRankMismatch-1Ddom-2Ddom.good
+-scase=5 # zipRankMismatch-range-2D.good
+-scase=6 # zipRankMismatch-2D-range.good

--- a/test/users/ferguson/assoc_domain_zip_range.bad
+++ b/test/users/ferguson/assoc_domain_zip_range.bad
@@ -1,1 +1,1 @@
-assoc_domain_zip_range.chpl:11: error: iteration over a range with multi-dimensional iterator
+assoc_domain_zip_range.chpl:11: error: rank mismatch in zippered iteration (leader is 2D, but ranges are 1D)


### PR DESCRIPTION
In a post-post-meeting question this week, @stonea asked about zippering
things of different ranks.  A quick check showed that for common types,
we generated an error, but not a very clear one, related more to the underlying
implementations than anything a user should be seeing.  This improves that error
for ranges and default domains and arrays by doing a simple rank check in the
follower iterators.

TBD: Do we need to do additional work to support the same checks in distributed
domains and arrays, or will the fact that they are implemented in terms of local
domains and arrays cause this check to be inherited?  I'm not certain and need to
write some more tests for that case (in a separate effort).