### PR TITLE
Stop setting CHPL_LLVM=none for mpicc testing

### DIFF
--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -8,7 +8,6 @@ source $CWD/common.bash
 # Currently, only fifo supported for MPI module
 export CHPL_TASKS=fifo
 export CHPL_TARGET_COMPILER=mpi-gnu
-export CHPL_LLVM=none
 
 # setup mpich 3.3.1
 source /data/cf/chapel/setup_mpich331.bash


### PR DESCRIPTION
The common-mpicc.bash script sets CHPL_TARGET_COMPILER=mpi-gnu so will default
to using that compiler even if llvm is found.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>