### PR TITLE
Set CHPL_TARGET_COMPILER for clang testing

### DIFF
--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
 export CHPL_HOST_COMPILER=clang
-export CHPL_LLVM=none
+export CHPL_TARGET_COMPILER=clang
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang"
 

--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -8,7 +8,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 source $CWD/common-perf.bash
 
 export CHPL_HOST_COMPILER=clang
-export CHPL_LLVM=none
+export CHPL_TARGET_COMPILER=clang
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.clang"
 


### PR DESCRIPTION
Set CHPL_TARGET_COMPILER=clang for clang testing. Stop setting CHPL_LLVM=none.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>