### PR TITLE
Document recommended adjustment to operator methods for inheritance

### DIFF
--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -68,6 +68,27 @@ does not match the type for any other argument.
 Operator methods can be defined on concrete types, generic types, or particular
 instantiations of generic types.
 
+Operator Methods and Classes
+----------------------------
+
+When an operator method is defined on a class, there are some known issues that
+impact its use in an inheritance situation.  For this reason it is recommended
+that class arguments to operator methods are declared as ``borrowed``, e.g.
+
+.. code-block:: chapel
+
+   class Parent {
+     var parentField: int;
+
+     operator <(lhs: borrowed Parent, rhs: borrowed Parent) {
+       return lhs.x < rhs.x;
+     }
+   }
+
+   class Child: Parent {
+     var childField: bool;
+   }
+
 Calling Operator Methods
 ------------------------
 

--- a/doc/rst/technotes/operatorMethods.rst
+++ b/doc/rst/technotes/operatorMethods.rst
@@ -71,9 +71,9 @@ instantiations of generic types.
 Operator Methods and Classes
 ----------------------------
 
-When an operator method is defined on a class, there are some known issues that
-impact its use in an inheritance situation.  For this reason it is recommended
-that class arguments to operator methods are declared as ``borrowed``, e.g.
+Operators that are defined on classes that are inherited from can run into known
+issues. To avoid these issues, define the class arguments to operator methods
+with ``borrowed``, e.g.:
 
 .. code-block:: chapel
 

--- a/test/functions/operatorOverloads/operatorMethods/inheritance-works.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/inheritance-works.chpl
@@ -1,0 +1,19 @@
+class Parent {
+  var x: int;
+
+  operator <(lhs: borrowed Parent, rhs: borrowed Parent) {
+    return lhs.x < rhs.x;
+  }
+}
+
+class Child: Parent {
+  var y: bool;
+}
+
+var c1 = new Parent(2);
+var c2 = new Child(3, false);
+writeln(c1 < c2);
+writeln(c2 < c1);
+var c3 = new Child(4, true);
+writeln(c2 < c3);
+writeln(c3 < c2);

--- a/test/functions/operatorOverloads/operatorMethods/inheritance-works.good
+++ b/test/functions/operatorOverloads/operatorMethods/inheritance-works.good
@@ -1,0 +1,4 @@
+true
+false
+true
+false


### PR DESCRIPTION
For now, we recommend declaring class arguments to operator methods as
`borrowed` to work around an issue with inheritance and owned.  Document that
recommendation.

Also, add a test that ensures this pattern works.

Resolves Cray/chapel-private#2180

Checked that the result of `make docs` looked good and that the test passed a
fresh checkout.