### PR TITLE
On exit, close temp files before removing tmp dir

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2389,6 +2389,13 @@ static void codegenPartOne() {
   uniquify_names(cnames, types, functions, globals);
 }
 
+static fileinfo hdrfile    = { NULL, NULL, NULL };
+static fileinfo mainfile   = { NULL, NULL, NULL };
+static fileinfo defnfile   = { NULL, NULL, NULL };
+static fileinfo strconfig  = { NULL, NULL, NULL };
+static fileinfo modulefile = { NULL, NULL, NULL };
+
+
 // Do this for GPU and then do for CPU
 static void codegenPartTwo() {
 
@@ -2409,11 +2416,6 @@ static void codegenPartTwo() {
   }
 
   SET_LINENO(rootModule);
-
-  fileinfo hdrfile    = { NULL, NULL, NULL };
-  fileinfo mainfile   = { NULL, NULL, NULL };
-  fileinfo defnfile   = { NULL, NULL, NULL };
-  fileinfo strconfig  = { NULL, NULL, NULL };
 
   GenInfo* info     = gGenInfo;
 
@@ -2487,7 +2489,6 @@ static void codegenPartTwo() {
         const char* filename = NULL;
         filename = generateFileName(fileNameHashMap, filename, currentModule->name);
         if(currentModule->modTag == MOD_USER) {
-          fileinfo modulefile;
           openCFile(&modulefile, filename, "c");
           int modulePathLen = strlen(astr(modulefile.pathname));
           char path[FILENAME_MAX];
@@ -2544,7 +2545,6 @@ static void codegenPartTwo() {
       const char* filename = NULL;
       filename = generateFileName(fileNameHashMap, filename,currentModule->name);
 
-      fileinfo modulefile;
       openCFile(&modulefile, filename, "c");
       info->cfile = modulefile.fptr;
       if(fIncrementalCompilation && (currentModule->modTag == MOD_USER))
@@ -2794,4 +2794,13 @@ void nprint_view(GenRet& gen) {
   }
   printf("isUnsigned %i\n", (int) gen.isUnsigned);
   printf("}\n");
+}
+
+void closeCodegenFiles() {
+  // close the C files without trying to beautify
+  closeCFile(&hdrfile, false);
+  closeCFile(&mainfile, false);
+  closeCFile(&defnfile, false);
+  closeCFile(&strconfig, false);
+  closeCFile(&modulefile, false);
 }

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -181,4 +181,7 @@ void gatherTypesForCodegen(void);
 void registerPrimitiveCodegens();
 
 bool localeUsesGPU();
+
+void closeCodegenFiles();
+
 #endif //CODEGEN_H

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -316,7 +316,10 @@ FILE* openfile(const char* filename,
 
 
 void closefile(FILE* thefile) {
-  if (fclose(thefile) != 0) {
+  if (thefile == nullptr) return;
+
+  int rc = fclose(thefile);
+  if (rc != 0) {
     USR_FATAL("closing file: %s", strerror(errno));
   }
 }
@@ -329,6 +332,7 @@ void openfile(fileinfo* thefile, const char* mode) {
 
 void closefile(fileinfo* thefile) {
   closefile(thefile->fptr);
+  thefile->fptr = nullptr;
 }
 
 
@@ -343,7 +347,7 @@ void openCFile(fileinfo* fi, const char* name, const char* ext) {
 }
 
 void closeCFile(fileinfo* fi, bool beautifyIt) {
-  closefile(fi->fptr);
+  closefile(fi);
   //
   // We should beautify if (1) we were asked to and (2) either (a) we
   // were asked to save the C code or (b) we were asked to codegen cpp

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -23,6 +23,7 @@
 #include "astlocs.h"
 #include "baseAST.h"
 #include "chpl.h"
+#include "codegen.h"
 #include "driver.h"
 #include "expr.h"
 #include "files.h"
@@ -131,6 +132,7 @@ const char* cleanFilename(const BaseAST* ast) {
 
 
 static void cleanup_for_exit() {
+  closeCodegenFiles();
   deleteTmpDir();
   stopCatchingSignals();
 }


### PR DESCRIPTION
This PR is to fix a problem we have been seeing when TMPDIR is set to an
NFS location and the C backend is used but the LLVM support is included.
In that event we were seeing errors with
`extern/ferguson/c-array/c-array-too-big` which seems to fail in
`cleanup_for_exit` when ending compilation with a fatal error.
`cleanup_for_exit` calls `deleteTmpDir` which in turn calls `deleteDir`
which is implemented with LLVM's `remove_directories` when it is
available. The error does not seem to appear when we fork/exec `rm -rf`
using the non-LLVM implementation of `deleteDir`.

When the C backend is used, there are open `FILE*` files that are located
in the temp dir at the time the fatal error occurs during codegen. This
PR arranges to close these files. That allows the LLVM
`remove_directories` call to function correctly and also seems like a
improvement for other reasons.

Reviewed by @lydia-duncan - thanks!

- [x] full local testing