### PR TITLE
Adjust two .bad files after PR #17600

### DIFF
--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.bad
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.bad
@@ -1,4 +1,4 @@
-varargsHetTuple.chpl:16: internal error: COD-EXP-5628 chpl version 1.22.0.0ce16d314b
+varargsHetTuple.chpl:16: internal error: COD-CG--XPR-5628 chpl version 1.22.0.0ce16d314b
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/types/tuple/these/iterHetTupleArg.bad
+++ b/test/types/tuple/these/iterHetTupleArg.bad
@@ -1,4 +1,4 @@
-iterHetTupleArg.chpl:14: internal error: COD-EXP-5708 chpl version 1.24.0 pre-release (a721b8db24)
+iterHetTupleArg.chpl:14: internal error: COD-CG--XPR-5708 chpl version 1.24.0 pre-release (a721b8db24)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),


### PR DESCRIPTION
Follow-up to PR #17600 to adjust two .bad files to reflect the new source file names.

Trivial and not reviewed.