### PR TITLE
Fix bug with isConstAssignable and operator methods

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -352,7 +352,14 @@ static void setRecordAssignableFlags(AggregateType* at) {
           ts->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
       } else {
         // formals are lhs, rhs
-        ArgSymbol* rhs = assign->getFormal(2);
+        int rhsNum = 2;
+        if (assign->hasFlag(FLAG_OPERATOR) && assign->hasFlag(FLAG_METHOD)) {
+          // Sometimes operators are defined as operator methods, in which case
+          // there are an extra two arguments and we need to adjust where we
+          // look for the rhs
+          rhsNum += 2;
+        }
+        ArgSymbol* rhs = assign->getFormal(rhsNum);
         IntentTag intent = concreteIntentForArg(rhs);
         if (intent == INTENT_IN ||
             intent == INTENT_CONST_IN ||

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -700,35 +700,35 @@ module Atomics {
   // We need to explicitly define these for all types because the atomic
   // types are records and unless explicitly defined, it will resolve
   // to the normal record version of the function.  Sigh.
-  inline operator =(ref a:AtomicBool, const ref b:AtomicBool) {
+  inline operator AtomicBool.=(ref a:AtomicBool, const ref b:AtomicBool) {
     a.write(b.read());
   }
-  inline operator =(ref a:AtomicBool, b) {
+  inline operator AtomicBool.=(ref a:AtomicBool, b) {
     compilerError("Cannot directly assign atomic variables");
   }
-  inline operator =(ref a:AtomicT, const ref b:AtomicT) {
+  inline operator AtomicT.=(ref a:AtomicT, const ref b:AtomicT) {
     a.write(b.read());
   }
-  inline operator =(ref a:AtomicT, b) {
+  inline operator AtomicT.=(ref a:AtomicT, b) {
     compilerError("Cannot directly assign atomic variables");
   }
-  inline operator +(a:AtomicT, b) {
+  inline operator AtomicT.+(a:AtomicT, b) {
     compilerError("Cannot directly add atomic variables");
     return a;
   }
-  inline operator -(a:AtomicT, b) {
+  inline operator AtomicT.-(a:AtomicT, b) {
     compilerError("Cannot directly subtract atomic variables");
     return a;
   }
-  inline operator *(a:AtomicT, b) {
+  inline operator AtomicT.*(a:AtomicT, b) {
     compilerError("Cannot directly multiply atomic variables");
     return a;
   }
-  inline operator /(a:AtomicT, b) {
+  inline operator AtomicT./(a:AtomicT, b) {
     compilerError("Cannot directly divide atomic variables");
     return a;
   }
-  inline operator %(a:AtomicT, b) {
+  inline operator AtomicT.%(a:AtomicT, b) {
     compilerError("Cannot directly divide atomic variables");
     return a;
   }

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -340,35 +340,35 @@ module NetworkAtomics {
     return lhs;
   }
 
-  inline operator =(ref a:RAtomicBool, const b:RAtomicBool) {
+  inline operator RAtomicBool.=(ref a:RAtomicBool, const b:RAtomicBool) {
     a.write(b.read());
   }
-  inline operator =(ref a:RAtomicBool, b) {
+  inline operator RAtomicBool.=(ref a:RAtomicBool, b) {
     compilerError("Cannot directly assign atomic variables");
   }
-  inline operator =(ref a:RAtomicT, const b:RAtomicT) {
+  inline operator RAtomicT.=(ref a:RAtomicT, const b:RAtomicT) {
     a.write(b.read());
   }
-  inline operator =(ref a:RAtomicT, b) {
+  inline operator RAtomicT.=(ref a:RAtomicT, b) {
     compilerError("Cannot directly assign atomic variables");
   }
-  inline operator +(a:RAtomicT, b) {
+  inline operator RAtomicT.+(a:RAtomicT, b) {
     compilerError("Cannot directly add atomic variables");
     return a;
   }
-  inline operator -(a:RAtomicT, b) {
+  inline operator RAtomicT.-(a:RAtomicT, b) {
     compilerError("Cannot directly subtract atomic variables");
     return a;
   }
-  inline operator *(a:RAtomicT, b) {
+  inline operator RAtomicT.*(a:RAtomicT, b) {
     compilerError("Cannot directly multiply atomic variables");
     return a;
   }
-  inline operator /(a:RAtomicT, b) {
+  inline operator RAtomicT./(a:RAtomicT, b) {
     compilerError("Cannot directly divide atomic variables");
     return a;
   }
-  inline operator %(a:RAtomicT, b) {
+  inline operator RAtomicT.%(a:RAtomicT, b) {
     compilerError("Cannot directly divide atomic variables");
     return a;
   }

--- a/test/library/standard/Types/copyable-custom-records-op-method.chpl
+++ b/test/library/standard/Types/copyable-custom-records-op-method.chpl
@@ -1,0 +1,110 @@
+use Types;
+
+proc checkit(type t,
+             param expectCopyable,
+             param expectConstCopyable,
+             param expectAssignable,
+             param expectConstAssignable,
+             param expectDefaultInitable) {
+
+  if isCopyable(t) != expectCopyable then
+    compilerError("isCopyable " + t:string + " did not match");
+
+  if isConstCopyable(t) != expectConstCopyable then
+    compilerError("isConstCopyable " + t:string + " did not match");
+  
+  if isAssignable(t) != expectAssignable then
+    compilerError("isAssignable " + t:string + " did not match");
+
+  if isConstAssignable(t) != expectConstAssignable then
+    compilerError("isConstAssignable " + t:string + " did not match");
+
+  if isDefaultInitializable(t) != expectDefaultInitable then
+    compilerError("isDefaultInitializable " + t:string + " did not match");
+}
+
+proc checkit(e,
+             param expectCopyable,
+             param expectConstCopyable,
+             param expectAssignable,
+             param expectConstAssignable,
+             param expectDefaultInitable) {
+
+  if isCopyable(e) != expectCopyable then
+    compilerError("isCopyable " + e.type:string + " did not match");
+
+  if isConstCopyable(e) != expectConstCopyable then
+    compilerError("isConstCopyable " + e.type:string + " did not match");
+  
+  if isAssignable(e) != expectAssignable then
+    compilerError("isAssignable " + e.type:string + " did not match");
+
+  if isConstAssignable(e) != expectConstAssignable then
+    compilerError("isConstAssignable " + e.type:string + " did not match");
+
+  if isDefaultInitializable(e) != expectDefaultInitable then
+    compilerError("isDefaultInitializable " + e.type:string + " did not match");
+}
+
+
+proc checkNormal(type t, e) {
+  checkit(t, true, true, true, true, true);
+  if t != e.type then
+    compilerError("types do not match");
+  checkit(e, true, true, true, true, true);
+}
+proc checkNormalNoDefault(type t, e) {
+  checkit(t, true, true, true, true, false);
+  if t != e.type then
+    compilerError("types do not match");
+  checkit(e, true, true, true, true, false);
+}
+proc checkMutable(type t, e) {
+  checkit(t, true, false, true, false, true);
+  if t != e.type then
+    compilerError("types do not match");
+  checkit(e, true, false, true, false, true);
+}
+proc checkNo(type t, e) {
+  checkit(t, false, false, false, false, false);
+  if t != e.type then
+    compilerError("types do not match");
+  checkit(e, false, false, false, false, false);
+}
+
+class C { var x: int; }
+record CustomContainingNilableOwned {
+  var zq: owned C?;
+  proc init() {
+    this.zq = nil;
+  }
+  proc init=(other) {
+    this.zq = new owned C();
+  }
+}
+operator CustomContainingNilableOwned.=(ref lhs: CustomContainingNilableOwned,
+       const ref rhs: CustomContainingNilableOwned) {
+  lhs.zq = new owned C();
+}
+
+record CustomContainingNonNilableOwned {
+  var z: owned C;
+  proc init() {
+    this.z = new owned C();
+  }
+  proc init=(other) {
+    this.z = new owned C();
+  }
+}
+operator
+CustomContainingNonNilableOwned.=(ref lhs: CustomContainingNonNilableOwned,
+       const ref rhs: CustomContainingNonNilableOwned) {
+  lhs.z = new owned C();
+}
+
+proc main() {
+
+  checkNormal(CustomContainingNilableOwned, new CustomContainingNilableOwned());
+  checkNormal(CustomContainingNonNilableOwned,
+              new CustomContainingNonNilableOwned());
+}


### PR DESCRIPTION
Prior to this change, we were looking at the wrong argument of the assignment
operator when determining the assignment style of types with operator method
assignment functions.  Rectify that issue by adjusting the argument we check if
the assignment function is an operator method.

With this change, AtomicT can now use operator methods (there was a test that
was checking if it specifically was const assignable, and we were getting the
wrong answer because of this bug)

Adjust AtomicBool and AtomicT to use operator methods now that they can do so.
Made the Network Atomic types use operator methods, too

Resolves #17536 
Resolves Cray/chapel-private#2129

Add a copy of test/library/standard/Types/copyable-custom-records.chpl.  This
one uses operator methods instead of standalone operators, since that exhibited
different behavior (so it's worth tracking that both continue to work going
forward).

Full paratest and a ugni run of test/release/examples/benchmarks passed