### PR TITLE
fix bad ast tag in iterator test

### DIFF
--- a/compiler/next/test/frontend/testParseSync.cpp
+++ b/compiler/next/test/frontend/testParseSync.cpp
@@ -70,7 +70,7 @@ static void test0(Parser* parser) {
   {
     std::array<ASTTag, 2> stmtList = {
       asttags::Comment,
-      asttags::FnCall
+      asttags::Begin
     };
     auto i = 0;
     for (const auto stmt : sync->stmts()) {


### PR DESCRIPTION
fix needed to correct failing test for parsing Sync node.

change the asttag value from `FnCall` to `Begin` in statement iterator checks
for Sync node parsing `test0`

TESTING:

  - [x] All `compiler/next` tests pass
  - [x] Could build `chpl`

Reviewed by @dlongnecke-cray 

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>