### PR TITLE
compiler/next: add Types class hierarchy

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -42,6 +42,7 @@ SUBDIRS = \
 	next/lib/parsing \
 	next/lib/queries \
 	next/lib/resolution \
+	next/lib/types \
 	next/lib/uast \
 	next/lib/util \
 	optimizations \
@@ -84,6 +85,7 @@ include main/Makefile.include
 include next/lib/parsing/Makefile.include
 include next/lib/queries/Makefile.include
 include next/lib/resolution/Makefile.include
+include next/lib/types/Makefile.include
 include next/lib/uast/Makefile.include
 include next/lib/util/Makefile.include
 include optimizations/Makefile.include
@@ -111,6 +113,7 @@ CHPL_OBJS = \
 	$(NEXT_PARSING_OBJS) \
 	$(NEXT_QUERIES_OBJS) \
 	$(NEXT_RESOLUTION_OBJS) \
+	$(NEXT_TYPES_OBJS) \
 	$(NEXT_UAST_OBJS) \
 	$(NEXT_UTIL_OBJS) \
 

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -26,53 +26,17 @@
 namespace chpl {
 namespace resolution {
 
-  struct ResolutionResult {
-    // the expr that is resolved
-    const uast::Expression* exp;
-    // in simple cases, this is set
-    const uast::NamedDecl* decl;
-    // TODO:
-    //  return-intent overloading
-    //  generic instantiation
-    //  establish concrete intents
-    //  establish copy-init vs move
-    ResolutionResult() : exp(nullptr), decl(nullptr) { }
-  };
-
-  // postorder ID (int) -> ResolutionResult
-  using ResolutionResultByPostorderID = std::vector<ResolutionResult>;
 
   // Resolves the top-level declarations in a module
-  const ResolutionResultByPostorderID&
+  const ResolvedSymbol&
   resolveModule(Context* context, const uast::Module* mod);
 
-  struct ResolvedModule {
-    const uast::Module* module;
-    const ResolutionResultByPostorderID* resolution;
-    ResolvedModule(const uast::Module* module,
-                   const ResolutionResultByPostorderID* resolution)
-      : module(module), resolution(resolution) {
-    }
-    static bool update(ResolvedModule& keep, ResolvedModule& addin);
-  };
-  using ResolvedModuleVec = std::vector<ResolvedModule>;
+  const ResolvedSymbolVec& resolveFile(Context* context, UniqueString path);
 
-  const ResolvedModuleVec& resolveFile(Context* context, UniqueString path);
-
-  struct DefinedTopLevelNames {
-    // the module
-    const uast::Module* module;
-    // these are in program order
-    std::vector<UniqueString> topLevelNames;
-    DefinedTopLevelNames(const uast::Module* module,
-                         std::vector<UniqueString> topLevelNames)
-      : module(module), topLevelNames(std::move(topLevelNames)) {
-    }
-  };
-  using DefinedTopLevelNamesVec = std::vector<DefinedTopLevelNames>;
-
+  /*
   const DefinedTopLevelNamesVec& moduleLevelDeclNames(Context* context,
                                                       UniqueString path);
+   */
 
 
 } // end namespace resolution

--- a/compiler/next/include/chpl/types/BuiltinType.h
+++ b/compiler/next/include/chpl/types/BuiltinType.h
@@ -58,7 +58,8 @@ class BuiltinType : public Type {
   bool contentsMatchInner(const Type* other) const override {
     const BuiltinType* lhs = this;
     const BuiltinType* rhs = (const BuiltinType*) other;
-    return lhs->kind_ == rhs->kind_;
+    return lhs->kind_ == rhs->kind_ &&
+           lhs->bitwidth_ == rhs->bitwidth_;
   }
 
   void markUniqueStringsInner(Context* context) const override {

--- a/compiler/next/include/chpl/types/BuiltinType.h
+++ b/compiler/next/include/chpl/types/BuiltinType.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_TYPES_BUILTINTYPE_H
+#define CHPL_TYPES_BUILTINTYPE_H
+
+#include "chpl/types/Type.h"
+
+namespace chpl {
+namespace types {
+
+
+/**
+  This class represents a builtin type, e.g. `int`.
+
+ */
+class BuiltinType : public Type {
+ public:
+  enum Kind {
+    // concrete builtin types
+    BOOL,
+    COMPLEX,
+    IMAG,
+    INT,
+    REAL,
+    UINT,
+
+    // generic builtin types
+    // (note: isGeneric relies on NUMERIC being the first)
+    NUMERIC,
+  };
+
+ private:
+  Kind kind_;
+  int bitwidth_;
+
+  BuiltinType(Kind kind, int bitwidth)
+    : Type(typetags::BuiltinType), kind_(kind), bitwidth_(bitwidth) {
+    canonicalizeBitWidth();
+  }
+
+  bool contentsMatchInner(const Type* other) const override {
+    const BuiltinType* lhs = this;
+    const BuiltinType* rhs = (const BuiltinType*) other;
+    return lhs->kind_ == rhs->kind_;
+  }
+
+  void markUniqueStringsInner(Context* context) const override {
+  }
+
+  bool isGeneric() override {
+    return kind_ >= NUMERIC;
+  }
+
+  void canonicalizeBitWidth();
+
+ public:
+  ~BuiltinType() = default;
+
+  static owned<BuiltinType> build(Kind kind, int bitwidth);
+
+  /**
+    Returns the kind indicating which BuiltinType it is.
+   */
+  Kind kind() const {
+    return kind_;
+  }
+
+  /**
+   Returns the bit width selected for numeric types.
+   Returns 8 for the default sized bool.
+   */
+  int bitwidth() const {
+    if (isDefaultBool()) return 8;
+    return bitwidth_;
+  }
+
+  /**
+   Returns `true` if this is the type `bool` which is distinct from
+   `bool(8)`.
+   */
+  bool isDefaultBool() const {
+    return kind_ == BOOL && bitwidth_ == 0;
+  }
+
+  /**
+    Returns a C string for the name of this BuiltinType.
+   */
+  const char* c_str() const;
+};
+
+
+} // end namespace uast
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/types/ErroneousType.h
+++ b/compiler/next/include/chpl/types/ErroneousType.h
@@ -17,34 +17,39 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#ifndef CHPL_TYPES_ERRONEOUSTYPE_H
+#define CHPL_TYPES_ERRONEOUSTYPE_H
+
+#include "chpl/types/Type.h"
 
 namespace chpl {
-namespace uast {
+namespace types {
 
 
-// forward declare the various AST types
-// using macros and ASTClassesList.h
-/// \cond DO_NOT_DOCUMENT
-#define AST_DECL(NAME) class NAME;
-#define AST_NODE(NAME) AST_DECL(NAME)
-#define AST_LEAF(NAME) AST_DECL(NAME)
-#define AST_BEGIN_SUBCLASSES(NAME) AST_DECL(NAME)
-#define AST_END_SUBCLASSES(NAME)
-/// \endcond
-// Apply the above macros to ASTClassesList.h
-#include "chpl/uast/ASTClassesList.h"
-// clear the macros
-#undef AST_NODE
-#undef AST_LEAF
-#undef AST_BEGIN_SUBCLASSES
-#undef AST_END_SUBCLASSES
-#undef AST_DECL
+/**
+  This class represents an erroneous type - that is, a type used as an error
+  sentinel type. Errors with this type should be ignored.
+ */
+class ErroneousType : public Type {
+ private:
+  ErroneousType() : Type(typetags::ErroneousType) { }
 
-// forward declare other classes
-class ASTNode;
-class Builder;
+  bool contentsMatchInner(const Type* other) const override {
+    return true;
+  }
+
+  void markUniqueStringsInner(Context* context) const override {
+  }
+
+  bool isGeneric() override {
+    return false;
+  }
+
+ public:
+  ~ErroneousType() = default;
+
+  static owned<ErroneousType> build();
+};
 
 
 } // end namespace uast

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_TYPES_TYPE_H
+#define CHPL_TYPES_TYPE_H
+
+#include "chpl/queries/Context.h"
+#include "chpl/types/TypeClasses.h"
+#include "chpl/types/TypeTag.h"
+
+namespace chpl {
+namespace types {
+
+
+/**
+  This is the base class for classes that represent a type.
+
+  Functions like someType->isRecord() / someAst->toRecord() are available and
+  generated for all Typnode subclasses.
+
+ */
+class Type {
+ private:
+  TypeTag tag_;
+
+ protected:
+  /**
+    This function needs to be defined by subclasses.
+    It should check only those fields defined in subclasses
+    (it should not check the Type fields such as tag_).
+    It can assume that other has the same type as the receiver.
+   */
+  virtual bool contentsMatchInner(const Type* other) const = 0;
+
+  /**
+   This function needs to be defined by subclasses.
+   It should call the 'mark' method on any UniqueStrings
+   stored as fields. It need not worry about the children nodes
+   or the UniqueStrings stored in the ID.
+   */
+  virtual void markUniqueStringsInner(Context* context) const = 0;
+
+ public:
+  /**
+   This function needs to be defined by subclasses.
+   It returns 'true` if the type represents a generic type.
+   */
+  virtual bool isGeneric() = 0;
+
+ protected:
+  Type(TypeTag tag)
+    : tag_(tag) {
+  }
+
+ public:
+  virtual ~Type() = 0; // this is an abstract base class
+
+  /**
+    Returns the tag indicating which Type subclass this is.
+   */
+  TypeTag tag() const {
+    return tag_;
+  }
+
+  bool completeMatch(const Type* other) const;
+
+  // keep is some old Type
+  // addin is some new Type we wish to combine with it
+  //
+  // on exit, keep stores the Type we need to keep, and anything
+  // not kept is stored in 'addin'.
+  // the function returns 'true' if anything changed in 'keep'.
+  static bool updateType(owned<Type>& keep, owned<Type>& addin);
+
+  static void markType(Context* context, const Type* keep);
+
+  static void dump(const Type* type, int leadingSpaces=0);
+
+  // define is__ methods for the various Type subclasses
+  // using macros and TypeClassesList.h
+  /// \cond DO_NOT_DOCUMENT
+  #define TYPE_IS(NAME) \
+    bool is##NAME() const { \
+      return typetags::is##NAME(this->tag_); \
+    }
+  #define TYPE_NODE(NAME) TYPE_IS(NAME)
+  #define TYPE_BEGIN_SUBCLASSES(NAME) TYPE_IS(NAME)
+  #define TYPE_END_SUBCLASSES(NAME)
+  /// \endcond
+  // Apply the above macros to TypeClassesList.h
+  #include "chpl/types/TypeClassesList.h"
+  // clear the macros
+  #undef TYPE_NODE
+  #undef TYPE_BEGIN_SUBCLASSES
+  #undef TYPE_END_SUBCLASSES
+  #undef TYPE_IS
+
+  // define to__ methods for the various Type subclasses
+  // using macros and TypeClassesList.h
+  // Note: these offer equivalent functionality to C++ dynamic_cast<DstType*>
+  /// \cond DO_NOT_DOCUMENT
+  #define TYPE_TO(NAME) \
+    const NAME * to##NAME() const { \
+      return this->is##NAME() ? (const NAME *)this : nullptr; \
+    } \
+    NAME * to##NAME() { \
+      return this->is##NAME() ? (NAME *)this : nullptr; \
+    }
+  #define TYPE_NODE(NAME) TYPE_TO(NAME)
+  #define TYPE_BEGIN_SUBCLASSES(NAME) TYPE_TO(NAME)
+  #define TYPE_END_SUBCLASSES(NAME)
+  /// \endcond
+  // Apply the above macros to TypeClassesList.h
+  #include "chpl/types/TypeClassesList.h"
+  // clear the macros
+  #undef TYPE_NODE
+  #undef TYPE_BEGIN_SUBCLASSES
+  #undef TYPE_END_SUBCLASSES
+  #undef TYPE_TO
+};
+
+
+} // end namespace uast
+} // end namespace chpl
+
+// TODO: is there a reasonable way to define std::less on Type*?
+// Comparing pointers would lead to some nondeterministic ordering.
+
+#endif

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -32,7 +32,7 @@ namespace types {
   This is the base class for classes that represent a type.
 
   Functions like someType->isRecord() / someAst->toRecord() are available and
-  generated for all Typnode subclasses.
+  generated for all Type subclasses.
 
  */
 class Type {
@@ -80,10 +80,10 @@ class Type {
 
   bool completeMatch(const Type* other) const;
 
-  // keep is some old Type
-  // addin is some new Type we wish to combine with it
+  // 'keep' is some old Type
+  // 'addin' is some new Type we wish to combine with it
   //
-  // on exit, keep stores the Type we need to keep, and anything
+  // on exit, 'keep' stores the Type we need to keep, and anything
   // not kept is stored in 'addin'.
   // the function returns 'true' if anything changed in 'keep'.
   static bool updateType(owned<Type>& keep, owned<Type>& addin);

--- a/compiler/next/include/chpl/types/TypeClasses.h
+++ b/compiler/next/include/chpl/types/TypeClasses.h
@@ -17,34 +17,33 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#ifndef CHPL_TYPES_TYPECLASSES_H
+#define CHPL_TYPES_TYPECLASSES_H
 
 namespace chpl {
-namespace uast {
+namespace types {
 
 
-// forward declare the various AST types
-// using macros and ASTClassesList.h
+// forward declare the various Type subclasses
+// using macros and TypeClassesList.h
 /// \cond DO_NOT_DOCUMENT
-#define AST_DECL(NAME) class NAME;
-#define AST_NODE(NAME) AST_DECL(NAME)
-#define AST_LEAF(NAME) AST_DECL(NAME)
-#define AST_BEGIN_SUBCLASSES(NAME) AST_DECL(NAME)
-#define AST_END_SUBCLASSES(NAME)
+#define TYPE_DECL(NAME) class NAME;
+#define TYPE_NODE(NAME) TYPE_DECL(NAME)
+#define TYPE_LEAF(NAME) TYPE_DECL(NAME)
+#define TYPE_BEGIN_SUBCLASSES(NAME) TYPE_DECL(NAME)
+#define TYPE_END_SUBCLASSES(NAME)
 /// \endcond
-// Apply the above macros to ASTClassesList.h
-#include "chpl/uast/ASTClassesList.h"
+// Apply the above macros to TypeClassesList.h
+#include "chpl/types/TypeClassesList.h"
 // clear the macros
-#undef AST_NODE
-#undef AST_LEAF
-#undef AST_BEGIN_SUBCLASSES
-#undef AST_END_SUBCLASSES
-#undef AST_DECL
+#undef TYPE_NODE
+#undef TYPE_LEAF
+#undef TYPE_BEGIN_SUBCLASSES
+#undef TYPE_END_SUBCLASSES
+#undef TYPE_DECL
 
 // forward declare other classes
-class ASTNode;
-class Builder;
+class TypeNode;
 
 
 } // end namespace uast

--- a/compiler/next/include/chpl/types/TypeClassesList.h
+++ b/compiler/next/include/chpl/types/TypeClassesList.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file lists the ASTType subclasses to help with macros generating code
+// for each
+//
+// Each line consists of one of
+//   TYPE_NODE(NAME)
+//   TYPE_BEGIN_SUBCLASSES(NAME)
+//   TYPE_END_SUBCLASSES(NAME)
+//
+// TYPE_NODE is for an ASTType subclass
+// TYPE_BEGIN_SUBCLASSES/TYPE_END_SUBCLASSES mark subclasses of abstract classes
+
+// These Type nodes are documented in their respective header files
+// and only listed here.
+
+// This file should store the Type nodes in groups according to the
+// class hierarchy and otherwise be in sorted order.
+
+// the following comment disables doxygen for these
+/// \cond DO_NOT_DOCUMENT
+
+TYPE_NODE(BuiltinType)
+TYPE_NODE(ErroneousType)
+TYPE_NODE(UnknownType)
+
+TYPE_BEGIN_SUBCLASSES(DeclaredType)
+  TYPE_NODE(EnumType)
+  TYPE_NODE(OpaqueType)
+  TYPE_NODE(FunctionType)
+  TYPE_NODE(TupleType)
+
+  TYPE_BEGIN_SUBCLASSES(AggregateType)
+    TYPE_NODE(ClassType) // has field for management / generic management
+    TYPE_NODE(RecordType)
+    TYPE_NODE(UnionType)
+  TYPE_END_SUBCLASSES(AggregateType)
+
+TYPE_END_SUBCLASSES(DeclaredType)
+
+
+/// \endcond
+
+// this comment seems to be necessary for doxygen xml output to be well-formed

--- a/compiler/next/include/chpl/types/TypeTag.h
+++ b/compiler/next/include/chpl/types/TypeTag.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_TYPE_TYPETAG_H
+#define CHPL_TYPE_TYPETAG_H
+
+namespace chpl {
+namespace types {
+namespace typetags {
+
+
+/**
+
+  This enum is used to identify which ASTType subclass a node is.
+ */
+enum TypeTag {
+  // define the enum for all of the non-virtual Type nodes
+  // using macros and TypeClassesList.h
+  /// \cond DO_NOT_DOCUMENT
+  #define TYPE_NODE(NAME) NAME ,
+  #define TYPE_BEGIN_SUBCLASSES(NAME) START_##NAME ,
+  #define TYPE_END_SUBCLASSES(NAME) END_##NAME ,
+  /// \endcond
+  // Apply the above macros to TypeClassesList.h
+  #include "chpl/types/TypeClassesList.h"
+  // clear the macros
+  #undef TYPE_NODE
+  #undef TYPE_BEGIN_SUBCLASSES
+  #undef TYPE_END_SUBCLASSES
+  NUM_TYPE_TAGS
+};
+
+// define is___ for regular nodes
+// (not yet for abstract parent classes)
+/// \cond DO_NOT_DOCUMENT
+#define IS_TYPE(NAME) \
+  static inline bool is##NAME(TypeTag tag) { \
+    return tag == NAME; \
+  }
+#define TYPE_NODE(NAME) IS_TYPE(NAME)
+#define TYPE_BEGIN_SUBCLASSES(NAME)
+#define TYPE_END_SUBCLASSES(NAME)
+/// \endcond
+// Apply the above macros to TypeClassesList.h
+#include "chpl/types/TypeClassesList.h"
+// clear the macros
+#undef TYPE_NODE
+#undef TYPE_BEGIN_SUBCLASSES
+#undef TYPE_END_SUBCLASSES
+#undef IS_TYPE
+
+// define is___ for abstract parent classes
+/// \cond DO_NOT_DOCUMENT
+#define IS_BASE_CLASS_TYPE(NAME) \
+  static inline bool is##NAME(TypeTag tag) { \
+    return START_##NAME < tag && tag < END_##NAME; \
+  }
+#define TYPE_NODE(NAME)
+#define TYPE_BEGIN_SUBCLASSES(NAME) IS_BASE_CLASS_TYPE(NAME)
+#define TYPE_END_SUBCLASSES(NAME)
+/// \endcond
+// Apply the above macros to TYPEClassesList.h
+#include "chpl/types/TypeClassesList.h"
+// clear the macros
+#undef TYPE_NODE
+#undef TYPE_BEGIN_SUBCLASSES
+#undef TYPE_END_SUBCLASSES
+#undef IS_BASE_CLASS_TYPE
+
+const char* tagToString(TypeTag tag);
+
+
+} // end namespace typetags
+
+// Enable ASTTag to be used as chpl::types::TypeTag
+using chpl::types::typetags::TypeTag;
+
+} // end namespace types
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/types/UnknownType.h
+++ b/compiler/next/include/chpl/types/UnknownType.h
@@ -17,34 +17,39 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#ifndef CHPL_TYPES_UNKNOWNTYPE_H
+#define CHPL_TYPES_UNKNOWNTYPE_H
+
+#include "chpl/types/Type.h"
 
 namespace chpl {
-namespace uast {
+namespace types {
 
 
-// forward declare the various AST types
-// using macros and ASTClassesList.h
-/// \cond DO_NOT_DOCUMENT
-#define AST_DECL(NAME) class NAME;
-#define AST_NODE(NAME) AST_DECL(NAME)
-#define AST_LEAF(NAME) AST_DECL(NAME)
-#define AST_BEGIN_SUBCLASSES(NAME) AST_DECL(NAME)
-#define AST_END_SUBCLASSES(NAME)
-/// \endcond
-// Apply the above macros to ASTClassesList.h
-#include "chpl/uast/ASTClassesList.h"
-// clear the macros
-#undef AST_NODE
-#undef AST_LEAF
-#undef AST_BEGIN_SUBCLASSES
-#undef AST_END_SUBCLASSES
-#undef AST_DECL
+/**
+  This class represents an unknown type which can be used to represent a case
+  where the type is not established because it is generic.
+ */
+class UnknownType : public Type {
+ private:
+  UnknownType() : Type(typetags::UnknownType) { }
 
-// forward declare other classes
-class ASTNode;
-class Builder;
+  bool contentsMatchInner(const Type* other) const override {
+    return true;
+  }
+
+  void markUniqueStringsInner(Context* context) const override {
+  }
+
+  bool isGeneric() override {
+    return false;
+  }
+
+ public:
+  ~UnknownType() = default;
+
+  static owned<UnknownType> build();
+};
 
 
 } // end namespace uast

--- a/compiler/next/include/chpl/types/UnknownType.h
+++ b/compiler/next/include/chpl/types/UnknownType.h
@@ -42,7 +42,7 @@ class UnknownType : public Type {
   }
 
   bool isGeneric() override {
-    return false;
+    return true;
   }
 
  public:

--- a/compiler/next/include/chpl/uast/ASTNode.h
+++ b/compiler/next/include/chpl/uast/ASTNode.h
@@ -139,10 +139,10 @@ class ASTNode {
   bool shallowMatch(const ASTNode* other) const;
   bool completeMatch(const ASTNode* other) const;
 
-  // keep is some old AST
-  // addin is some new AST we wish to combine with it
+  // 'keep' is some old AST
+  // 'addin' is some new AST we wish to combine with it
   //
-  // on exit, keep stores the AST we need to keep, and anything
+  // on exit, 'keep' stores the AST we need to keep, and anything
   // not kept is stored in 'addin'.
   // the function returns 'true' if anything changed in 'keep'.
   static bool updateAST(owned<ASTNode>& keep, owned<ASTNode>& addin);

--- a/compiler/next/include/chpl/uast/all-uast.h
+++ b/compiler/next/include/chpl/uast/all-uast.h
@@ -58,6 +58,7 @@
 #include "chpl/uast/New.h"
 #include "chpl/uast/On.h"
 #include "chpl/uast/OpCall.h"
+//#include "chpl/uast/PrimCall.h"
 #include "chpl/uast/RealLiteral.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Return.h"

--- a/compiler/next/lib/CMakeLists.txt
+++ b/compiler/next/lib/CMakeLists.txt
@@ -35,6 +35,7 @@ target_include_directories(libchplcomp-obj PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(parsing)
 add_subdirectory(queries)
 add_subdirectory(resolution)
+add_subdirectory(types)
 add_subdirectory(uast)
 add_subdirectory(util)
 

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -23,56 +23,5 @@ namespace chpl {
 namespace resolution {
 
 
-using namespace uast;
-
-UniqueString Type::name(Context* context) {
-  switch (tag()) {
-    case FROM_DECL:
-      assert(typeDecl());
-      return typeDecl()->name();
-    case INT8:
-      return UniqueString::build(context, "int(8)");
-    case INT16:
-      return UniqueString::build(context, "int(16)");
-    case INT32:
-      return UniqueString::build(context, "int(32)");
-    case INT64:
-      return UniqueString::build(context, "int(64)");
-    case UINT8:
-      return UniqueString::build(context, "uint(8)");
-    case UINT16:
-      return UniqueString::build(context, "uint(16)");
-    case UINT32:
-      return UniqueString::build(context, "uint(32)");
-    case UINT64:
-      return UniqueString::build(context, "uint(64)");
-    case BOOL:
-      return UniqueString::build(context, "bool");
-    case BOOL8:
-      return UniqueString::build(context, "bool(8)");
-    case BOOL16:
-      return UniqueString::build(context, "bool(16)");
-    case BOOL32:
-      return UniqueString::build(context, "bool(32)");
-    case BOOL64:
-      return UniqueString::build(context, "bool(64)");
-    case REAL32:
-      return UniqueString::build(context, "real(32)");
-    case REAL64:
-      return UniqueString::build(context, "real(64)");
-    case IMAG32:
-      return UniqueString::build(context, "imag(32)");
-    case IMAG64:
-      return UniqueString::build(context, "imag(64)");
-    case COMPLEX64:
-      return UniqueString::build(context, "complex(64)");
-    case COMPLEX128:
-      return UniqueString::build(context, "complex(128)");
-  }
-  assert(false && "case not handled");
-  return UniqueString::build(context, "<unknown>");
-}
-
-
 } // end namespace resolution
 } // end namespace chpl

--- a/compiler/next/lib/types/BuiltinType.cpp
+++ b/compiler/next/lib/types/BuiltinType.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/types/BuiltinType.h"
+
+namespace chpl {
+namespace types {
+
+
+void BuiltinType::canonicalizeBitWidth() {
+  switch (kind()) {
+    case BOOL:
+    case INT:
+    case UINT:
+      if (bitwidth_ == 0) {
+        if (kind() == BOOL) {
+          // OK, 'bool' is separate type from other bool(num),
+          // represent that with bit width 0.
+        } else {
+          bitwidth_ = 64; // e.g. `int` means `int(64)`.
+        }
+      } else {
+        assert(bitwidth_ == 8 || bitwidth_ == 16 ||
+               bitwidth_ == 32 || bitwidth_ == 64);
+      }
+      break;
+
+    case IMAG:
+    case REAL:
+      if (bitwidth_ == 0) {
+        bitwidth_ = 64;
+      } else {
+        assert(bitwidth_ == 32 || bitwidth_ == 64);
+      }
+      break;
+
+    case COMPLEX:
+      if (bitwidth_ == 0) {
+        bitwidth_ = 128;
+      } else {
+        assert(bitwidth_ == 64 || bitwidth_ == 128);
+      }
+      break;
+
+    default:
+      // always use 0 bitwidth
+      bitwidth_ = 0;
+  }
+}
+
+const char* BuiltinType::c_str() const {
+  switch (kind_) {
+    case INT:
+      switch (bitwidth_) {
+        case 8:
+          return "int(8)";
+        case 16:
+          return "int(16)";
+        case 32:
+          return "int(32)";
+        case 64:
+          return "int(64)";
+        default:
+          assert(false && "int bit width case not handled");
+          return "int(<unknown>)";
+      }
+    case UINT:
+      switch (bitwidth_) {
+        case 8:
+          return "uint(8)";
+        case 16:
+          return "uint(16)";
+        case 32:
+          return "uint(32)";
+        case 64:
+          return "uint(64)";
+        default:
+          assert(false && "uint bit width case not handled");
+          return "uint(<unknown>)";
+      }
+    case BOOL:
+      switch (bitwidth_) {
+        case 0:
+          return "bool";
+        case 8:
+          return "bool(8)";
+        case 16:
+          return "bool(16)";
+        case 32:
+          return "bool(32)";
+        case 64:
+          return "bool(64)";
+        default:
+          assert(false && "bool bit width case not handled");
+          return "bool(<unknown>)";
+      }
+    case REAL:
+      switch (bitwidth_) {
+        case 32:
+          return "real(32)";
+        case 64:
+            return "real(64)";
+        default:
+          assert(false && "real bit width case not handled");
+          return "real(<unknown>)";
+      }
+    case IMAG:
+      switch (bitwidth_) {
+        case 32:
+          return "imag(32)";
+        case 64:
+            return "imag(64)";
+        default:
+          assert(false && "imag bit width case not handled");
+          return "imag(<unknown>)";
+      }
+    case COMPLEX:
+      switch (bitwidth_) {
+        case 64:
+          return "complex(64)";
+        case 128:
+          return "complex(128)";
+        default:
+          assert(false && "complex bit width case not handled");
+          return "complex(<unknown>)";
+      }
+
+    case NUMERIC:
+      return "numeric";
+  }
+
+  assert(false && "case not handled");
+  return "<unknown>";
+}
+
+owned<BuiltinType> BuiltinType::build(BuiltinType::Kind kind, int bitwidth) {
+  return toOwned(new BuiltinType(kind, bitwidth));
+}
+
+
+} // end namespace types
+} // end namespace chpl

--- a/compiler/next/lib/types/CMakeLists.txt
+++ b/compiler/next/lib/types/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+target_sources(libchplcomp-obj
+               PRIVATE
+
+               BuiltinType.cpp
+               ErroneousType.cpp
+               Type.cpp
+               TypeTag.cpp
+               UnknownType.cpp
+
+              )

--- a/compiler/next/lib/types/ErroneousType.cpp
+++ b/compiler/next/lib/types/ErroneousType.cpp
@@ -17,37 +17,16 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#include "chpl/types/ErroneousType.h"
 
 namespace chpl {
-namespace uast {
+namespace types {
 
 
-// forward declare the various AST types
-// using macros and ASTClassesList.h
-/// \cond DO_NOT_DOCUMENT
-#define AST_DECL(NAME) class NAME;
-#define AST_NODE(NAME) AST_DECL(NAME)
-#define AST_LEAF(NAME) AST_DECL(NAME)
-#define AST_BEGIN_SUBCLASSES(NAME) AST_DECL(NAME)
-#define AST_END_SUBCLASSES(NAME)
-/// \endcond
-// Apply the above macros to ASTClassesList.h
-#include "chpl/uast/ASTClassesList.h"
-// clear the macros
-#undef AST_NODE
-#undef AST_LEAF
-#undef AST_BEGIN_SUBCLASSES
-#undef AST_END_SUBCLASSES
-#undef AST_DECL
-
-// forward declare other classes
-class ASTNode;
-class Builder;
+owned<ErroneousType> ErroneousType::build() {
+  return toOwned(new ErroneousType());
+}
 
 
-} // end namespace uast
+} // end namespace types
 } // end namespace chpl
-
-#endif

--- a/compiler/next/lib/types/Makefile
+++ b/compiler/next/lib/types/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/../../../..
+endif
+
+COMPILER_ROOT = ../../..
+COMPILER_SUBDIR = next/lib/types
+
+#
+# standard header
+#
+include $(COMPILER_ROOT)/make/Makefile.compiler.head
+
+include Makefile.include
+
+TARGETS = $(NEXT_TYPES_OBJS)
+
+include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
+
+FORCE:
+
+#
+# standard footer
+#
+include $(COMPILER_ROOT)/make/Makefile.compiler.foot

--- a/compiler/next/lib/types/Makefile.include
+++ b/compiler/next/lib/types/Makefile.include
@@ -1,0 +1,34 @@
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NEXT_TYPES_OBJDIR = $(COMPILER_BUILD)/next/lib/types
+
+ALL_SRCS += next/lib/types/*.cpp
+
+NEXT_TYPES_SRCS =                                 \
+  BuiltinType.cpp \
+  ErroneousType.cpp \
+  Type.cpp \
+  TypeTag.cpp \
+  UnknownType.cpp \
+
+
+SRCS = $(NEXT_TYPES_SRCS)
+
+NEXT_TYPES_OBJS = \
+	$(NEXT_TYPES_SRCS:%.cpp=$(NEXT_TYPES_OBJDIR)/%.$(OBJ_SUFFIX))

--- a/compiler/next/lib/types/Type.cpp
+++ b/compiler/next/lib/types/Type.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/types/Type.h"
+
+namespace chpl {
+namespace types {
+
+
+Type::~Type() {
+}
+
+bool Type::completeMatch(const Type* other) const {
+  const Type* lhs = this;
+  const Type* rhs = other;
+  if (lhs->tag() != rhs->tag())
+    return false;
+  if (!lhs->contentsMatchInner(rhs))
+    return false;
+
+  return true;
+}
+
+bool Type::updateType(owned<Type>& keep, owned<Type>& addin) {
+  if (keep->completeMatch(addin.get())) {
+    // no changes are necessary
+    return false;
+  } else {
+    // swap the AST
+    keep.swap(addin);
+    return true;
+  }
+}
+
+void Type::markType(Context* context, const Type* keep) {
+  if (keep == nullptr) return;
+  // run markUniqueStrings on the node
+  keep->markUniqueStringsInner(context);
+}
+
+void Type::dump(const Type* type, int leadingSpaces) {
+  for (int i = 0; i < leadingSpaces; i++) {
+    printf("  ");
+  }
+
+  printf("type %s \n", typetags::tagToString(type->tag()));
+}
+
+
+} // end namespace types
+} // end namespace chpl

--- a/compiler/next/lib/types/TypeTag.cpp
+++ b/compiler/next/lib/types/TypeTag.cpp
@@ -17,37 +17,37 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#include "chpl/types/TypeTag.h"
 
 namespace chpl {
-namespace uast {
+namespace types {
+namespace typetags {
 
 
-// forward declare the various AST types
-// using macros and ASTClassesList.h
-/// \cond DO_NOT_DOCUMENT
-#define AST_DECL(NAME) class NAME;
-#define AST_NODE(NAME) AST_DECL(NAME)
-#define AST_LEAF(NAME) AST_DECL(NAME)
-#define AST_BEGIN_SUBCLASSES(NAME) AST_DECL(NAME)
-#define AST_END_SUBCLASSES(NAME)
-/// \endcond
-// Apply the above macros to ASTClassesList.h
-#include "chpl/uast/ASTClassesList.h"
+static const char* tagToStringTable[NUM_TYPE_TAGS] = {
+// define tag to string conversion
+#define NAMESTR(NAME) \
+  #NAME,
+#define TYPE_NODE(NAME) NAMESTR(NAME)
+#define TYPE_BEGIN_SUBCLASSES(NAME) NAMESTR(START_##NAME)
+#define TYPE_END_SUBCLASSES(NAME) NAMESTR(END_##NAME)
+// Apply the above macros to TypeClassesList.h
+#include "chpl/types/TypeClassesList.h"
 // clear the macros
-#undef AST_NODE
-#undef AST_LEAF
-#undef AST_BEGIN_SUBCLASSES
-#undef AST_END_SUBCLASSES
-#undef AST_DECL
+#undef TYPE_NODE
+#undef TYPE_BEGIN_SUBCLASSES
+#undef TYPE_END_SUBCLASSES
+#undef NAMESTR
+};
 
-// forward declare other classes
-class ASTNode;
-class Builder;
+const char* tagToString(TypeTag tag) {
+  if (0 <= tag && tag < NUM_TYPE_TAGS)
+    return tagToStringTable[tag];
+  else
+    return "<unknown-tag>";
+}
 
 
-} // end namespace uast
+} // end namespace typetags
+} // end namespace types
 } // end namespace chpl
-
-#endif

--- a/compiler/next/lib/types/UnknownType.cpp
+++ b/compiler/next/lib/types/UnknownType.cpp
@@ -17,37 +17,16 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#include "chpl/types/UnknownType.h"
 
 namespace chpl {
-namespace uast {
+namespace types {
 
 
-// forward declare the various AST types
-// using macros and ASTClassesList.h
-/// \cond DO_NOT_DOCUMENT
-#define AST_DECL(NAME) class NAME;
-#define AST_NODE(NAME) AST_DECL(NAME)
-#define AST_LEAF(NAME) AST_DECL(NAME)
-#define AST_BEGIN_SUBCLASSES(NAME) AST_DECL(NAME)
-#define AST_END_SUBCLASSES(NAME)
-/// \endcond
-// Apply the above macros to ASTClassesList.h
-#include "chpl/uast/ASTClassesList.h"
-// clear the macros
-#undef AST_NODE
-#undef AST_LEAF
-#undef AST_BEGIN_SUBCLASSES
-#undef AST_END_SUBCLASSES
-#undef AST_DECL
-
-// forward declare other classes
-class ASTNode;
-class Builder;
+owned<UnknownType> UnknownType::build() {
+  return toOwned(new UnknownType());
+}
 
 
-} // end namespace uast
+} // end namespace types
 } // end namespace chpl
-
-#endif

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -71,19 +71,19 @@ int main(int argc, char** argv) {
         }
       }*/
 
-      const ResolvedModuleVec& rmods = resolveFile(ctx, filepath);
+      const ResolvedSymbolVec& rmods = resolveFile(ctx, filepath);
       for (const auto& elt : rmods) {
-        const Module* module = elt.module;
+        const Module* module = elt->decl->toModule();
 
         printf("Module %s:\n", module->name().c_str());
         ASTNode::dump(module);
         printf("\n");
 
-        const ResolutionResultByPostorderID& resolution = *elt.resolution;
+        const ResolutionResultByPostorderID& resolution = elt->resolutionById;
         for (const auto& rr : resolution) {
-          if (rr.exp != nullptr && rr.decl != nullptr) {
+          if (rr.expr != nullptr && rr.decl != nullptr) {
             printf("Resolved:\n");
-            ASTNode::dump(rr.exp, 2);
+            ASTNode::dump(rr.expr, 2);
             printf("to:\n");
             ASTNode::dump(rr.decl, 2);
             printf("\n");

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -49,17 +49,16 @@ static void test1() {
 
     auto& vec = resolveFile(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0].module;
-    const auto* byId = vec[0].resolution; 
+    const Module* module = vec[0]->decl->toModule();
+    const auto& byId = vec[0]->resolutionById;
     const Variable* varDecl = module->child(0)->toVariable();
     const Identifier* identifier = module->child(1)->toIdentifier();
     assert(varDecl);
     assert(identifier);
     assert(0 == varDecl->name().compare("x"));
     assert(0 == identifier->name().compare("x"));
-    assert(byId);
-    const ResolutionResult& rr = (*byId)[identifier->id().postOrderId()];
-    assert(rr.exp != nullptr);
+    const ResolutionResult& rr = byId[identifier->id().postOrderId()];
+    assert(rr.expr != nullptr);
     assert(rr.decl != nullptr);
     assert(rr.decl == varDecl);
     context->collectGarbage();
@@ -81,7 +80,7 @@ static void test2() {
    
     auto& vec = resolveFile(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0].module;
+    const Module* module = vec[0]->decl->toModule();
     ASTNode::dump(module, 2);
     context->collectGarbage();
   }
@@ -95,7 +94,7 @@ static void test2() {
 
     auto& vec = resolveFile(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0].module;
+    const Module* module = vec[0]->decl->toModule();
     ASTNode::dump(module, 2);
     const Variable* varDecl = module->child(0)->toVariable();
     assert(varDecl);
@@ -113,18 +112,17 @@ static void test2() {
 
     auto& vec = resolveFile(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0].module;
+    const Module* module = vec[0]->decl->toModule();
     ASTNode::dump(module, 2);
-    const auto* byId = vec[0].resolution; 
+    const auto& byId = vec[0]->resolutionById;
     const Variable* varDecl = module->child(0)->toVariable();
     const Identifier* identifier = module->child(1)->toIdentifier();
     assert(varDecl);
     assert(identifier);
     assert(0 == varDecl->name().compare("x"));
     assert(0 == identifier->name().compare("x"));
-    assert(byId);
-    const ResolutionResult& rr = (*byId)[identifier->id().postOrderId()];
-    assert(rr.exp != nullptr);
+    const ResolutionResult& rr = byId[identifier->id().postOrderId()];
+    assert(rr.expr != nullptr);
     assert(rr.decl != nullptr);
     assert(rr.decl == varDecl);
     context->collectGarbage();


### PR DESCRIPTION
Since the resolver will need to be able to establish the types of 
everything, it has to be able to represent types. Chapel types include 
some built-in types that are relatively complex, especially for class
types (e.g. owned/shared/unmanaged/borrowed/generic management). So this
PR introduces a hierarchy of classes similar to the uast hierarchy for
types. It takes some initial steps to get the resolver using these but
these are all prototype changes and a follow-on PR will go further with
resolving.

Reviewed by @lydia-duncan and @dlongnecke-cray - thanks!

- [x] `make test-libchplcomp` passes