### PR TITLE
Optimize allLocalesBarrier by reducing communication

### DIFF
--- a/modules/packages/AllLocalesBarriers.chpl
+++ b/modules/packages/AllLocalesBarriers.chpl
@@ -67,19 +67,11 @@
 module AllLocalesBarriers {
   use BlockDist, Barriers;
 
+  private const BarrierSpace = LocaleSpace dmapped Block(LocaleSpace);
+  private var globalBarrier = [b in BarrierSpace] new unmanaged aBarrier(1, reusable=true, procAtomics=true, hackIntoCommBarrier=true);
+
   pragma "no doc"
   class AllLocalesBarrier: BarrierBaseType {
-
-    const BarrierSpace = LocaleSpace dmapped Block(LocaleSpace);
-    var globalBarrier: [BarrierSpace] unmanaged aBarrier(reusable=true, procAtomics=true, hackIntoCommBarrier=true);
-
-    proc init(numTasksPerLocale: int) {
-      globalBarrier = [b in BarrierSpace] new unmanaged aBarrier(numTasksPerLocale, reusable=true, procAtomics=true, hackIntoCommBarrier=true);
-    }
-
-    proc deinit() {
-      [b in globalBarrier] delete b;
-    }
 
     override proc barrier() {
       globalBarrier.localAccess[here.id].barrier();
@@ -89,6 +81,5 @@ module AllLocalesBarriers {
       [b in globalBarrier] b.reset(numTasksPerLocale);
     }
   }
-
-  const allLocalesBarrier: AllLocalesBarrier = new AllLocalesBarrier(1);
+  const allLocalesBarrier: AllLocalesBarrier = new AllLocalesBarrier();
 }

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -259,7 +259,7 @@ module Barriers {
         if myc<=1 {
           if hackIntoCommBarrier {
             extern proc chpl_comm_barrier(msg: c_string);
-            chpl_comm_barrier("local barrier call".localize().c_str());
+            chpl_comm_barrier(c"local barrier call");
           }
           const alreadySet = done.testAndSet();
           if boundsChecking && alreadySet {

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
@@ -1,4 +1,5 @@
 use Barriers;
+use AllLocalesBarriers;
 use BlockDist;
 use CommDiagnostics;
 
@@ -10,7 +11,7 @@ proc printCommDiagnostics(diag) {
   }
 }
 
-proc remoteTestBasic(b: Barrier, numRemoteTasks) {
+proc remoteTestBasic(b, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
@@ -74,3 +75,6 @@ remoteTestBasic(sb, numRemoteTasks);
 sb.reset(numRemoteTasks);
 writeln("sync remote test split phase");
 remoteTestSplitPhase(sb, numRemoteTasks);
+
+writeln("allLocalesBarrier test basic");
+remoteTestBasic(allLocalesBarrier, numRemoteTasks);

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.comm-none.good
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.comm-none.good
@@ -6,3 +6,5 @@ sync remote test basic
 (<no communication>)
 sync remote test split phase
 (<no communication>)
+allLocalesBarrier test basic
+(<no communication>)

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.good
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.good
@@ -22,3 +22,9 @@ sync remote test split phase
 (get = 2, execute_on = 2)
 (get = 2, execute_on = 2)
 (get = 2, execute_on = 2)
+allLocalesBarrier test basic
+(execute_on_nb = 4)
+(<no communication>)
+(<no communication>)
+(<no communication>)
+(<no communication>)

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.na-none.good
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.na-none.good
@@ -22,3 +22,9 @@ sync remote test split phase
 (get = 2, execute_on = 2, execute_on_fast = 1)
 (get = 2, execute_on = 2, execute_on_fast = 1)
 (get = 2, execute_on = 2, execute_on_fast = 1)
+allLocalesBarrier test basic
+(execute_on_nb = 4)
+(execute_on_fast = 1)
+(execute_on_fast = 1)
+(execute_on_fast = 1)
+(execute_on_fast = 1)


### PR DESCRIPTION
The `allLocalesBarrier` was previously implemented using a distributed
field in a class. This was hitting the performance issue in #10160 where
any access of the distributed field was doing a GET of the class
instance first, which resulted in all remote tasks doing a GET from
locale 0. This really hurt performance, especially on InfiniBand systems
where communication injection is serialized.

This moves the distributed field out of the class into a global, which
for this case is fine since the allLocalesBarrier is a singleton global
anyways. This significantly improves the performance of the barrier by
eliminating needless communication. A comm test is added to lock in that
behavior too.

Comparing performance for performance/comm/barrier/empty-chpl-barrier
with 100,000 trials we significant improvements at small scale for
InfiniBand and non-trivial improvements for Aries. The following results
are on 16 nodes with 40 cores each:

| config | Aries | IB    |
| -----: | ----: | ----: |
| before | 3.6s  | 61.4s |
| after  | 2.8s  |  4.4s |

And on 512 nodes of a different Aries system with 36 cores per node:

| config | Aries   |
| -----: | ------: |
| before | 89.2s   |
| after  |  5.1s   |

So at small scale we see large benefits for InfiniBand and on Aries at
large scale we also see big improvements. There's 2 factors here, on IB
communication is serialized, which makes the impact more dramatic and
even on Aries which has fast concurrent comm the all-to-one behavior
becomes a bottleneck at scale.