### PR TITLE
Fix bundled LLVM builds

### DIFF
--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -96,6 +96,15 @@ endef
 # set all of the CHPL_MAKE_... configuration-based variables!
 $(eval $(CHPL_MAKE_SETTINGS))
 
+# check a few variables to give a make invocation with an
+# invalid configuration a better error.
+ifndef CHPL_MAKE_HOST_PLATFORM
+  $(error error running util/printchplenv -- please see error above)
+endif
+ifndef CHPL_MAKE_THIRD_PARTY_LINK_ARGS
+  $(error error running util/printchplenv -- please see error above)
+endif
+
 # Try this to debug issues with CHPL_MAKE_* variables
 # $(info $(CHPL_MAKE_CHPLENV_CACHE))
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -172,7 +172,8 @@ def validate_llvm_config():
                   " with one of the supported versions: {0}".format(
                   llvm_versions_string()))
 
-    if llvm_val == 'system' or llvm_val == 'bundled':
+    if (llvm_val == 'system' or
+        (llvm_val == 'bundled' and os.path.exists(llvm_config))):
         version, config_error = check_llvm_config(llvm_config)
         if config_error:
             error("Problem with llvm-config at {0} -- {1}"


### PR DESCRIPTION
Fixes `CHPL_LLVM=bundled` builds after PR #17923.

* Allows the configured `CHPL_LLVM_CONFIG` to not exist yet for 
  `CHPL_LLVM=bundled` without giving an error
* Improves the errors from `make` for a failed `printchplenv` to be less 
  confusing

Reviewed by @daviditen - thanks!

- [x] a `CHPL_LLVM=bundled` build now works and `make check` succeeds