### PR TITLE
fix quickstart builds

### DIFF
--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -101,9 +101,6 @@ $(eval $(CHPL_MAKE_SETTINGS))
 ifndef CHPL_MAKE_HOST_PLATFORM
   $(error error running util/printchplenv -- please see error above)
 endif
-ifndef CHPL_MAKE_THIRD_PARTY_LINK_ARGS
-  $(error error running util/printchplenv -- please see error above)
-endif
 
 # Try this to debug issues with CHPL_MAKE_* variables
 # $(info $(CHPL_MAKE_CHPLENV_CACHE))


### PR DESCRIPTION
Following #17979 which added too much checking since
`CHPL_MAKE_THIRD_PARTY_LINK_ARGS` isn't always defined
to be something other than the empty string
(e.g. it was failing for quickstart config)

Reviewed by @ronawho - thanks!

- [x] quickstart build works and make check succeeds on a mac