### PR TITLE
File Descriptor Getter for `file`

### DIFF
--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -397,8 +397,8 @@ module Sys {
   extern proc sys_init_sys_sockaddr_t(ref addr:sys_sockaddr_t);
   extern proc sys_getsockaddr_family(ref addr: sys_sockaddr_t):c_int;
   extern proc sys_set_sys_sockaddr_t(ref addr: sys_sockaddr_t, host: c_string, port: c_uint, family: c_int):c_int;
-  extern proc sys_set_sys_sockaddr_in_t(ref addr: sys_sockaddr_t, host:sys_in_addr_t, port:c_uint):c_int;
-  extern proc sys_set_sys_sockaddr_in6_t(ref addr: sys_sockaddr_t, host:sys_in6_addr_t, port:c_uint):c_int;
+  extern proc sys_set_sys_sockaddr_in_t(ref addr: sys_sockaddr_t, host:sys_in_addr_t, port:c_uint);
+  extern proc sys_set_sys_sockaddr_in6_t(ref addr: sys_sockaddr_t, host:sys_in6_addr_t, port:c_uint);
   extern proc sys_host_sys_sockaddr_t(ref addr: sys_sockaddr_t, host: c_ptr(c_char), hostlen: socklen_t, ref length: c_int) : c_int;
   extern proc sys_port_sys_sockaddr_t(ref addr: sys_sockaddr_t, ref port: c_uint) : c_int;
   extern proc sys_strerror(error:err_t, ref string_out:c_string):err_t;

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -452,6 +452,7 @@ qioerr qio_file_open_access_usr(qio_file_t** file_out, const char* pathname,
                                void* fs_info);
 
 qioerr qio_get_fs_type(qio_file_t* fl, int* out);
+qioerr qio_get_fd(qio_file_t* fl, int* out);
 qioerr qio_get_chunk(qio_file_t* fl, int64_t* len_out);
 qioerr qio_locales_for_region(qio_file_t* fl, off_t start, off_t end, const char*** locale_names_out, int64_t* num_locs_out);
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -2,15 +2,15 @@
  * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -316,7 +316,7 @@ char* qio_hints_to_string(qio_hint_t hint)
     }
   }
   if( !ok ) strcat(buf, "unknown_type");
- 
+
   if( method == QIO_METHOD_DEFAULT ) {
     strcat(buf, " default"); ok = 1;
   } else {
@@ -365,8 +365,8 @@ typedef struct qio_file_s {
   // and indicate how the file is backed.
   // We could potentially also support a "virtual file"
   // that handled pread/pwrite by calling some routine,
-  // but mostly 
-  // An (arguably) better solution is to put 
+  // but mostly
+  // An (arguably) better solution is to put
   FILE* fp; // set if this file wraps a FILE*
   fd_t fd; // -1 if not set
   int use_fp; // we only default to FREADFWRITE if this and fp are set.
@@ -391,7 +391,7 @@ typedef struct qio_file_s {
   //  but the mapping is fixed for the lifetime of
   //  the file. That's so that no locking is necessary
   //  on the file object itself).
-  
+
   // When writing files with buffered-mmap, we will mmap
   // the file in chunks. As a result, we might need to extend
   // the file to a size larger than the amount of data written
@@ -443,11 +443,11 @@ qioerr qio_file_open_mem(qio_file_t** file_out, qbuffer_t* buf, const qio_style_
 
 qioerr qio_file_open_tmp(qio_file_t** file_out, qio_hint_t iohints, const qio_style_t* style);
 
-qioerr qio_file_init_plugin(qio_file_t** file_out, void* file_info, 
+qioerr qio_file_init_plugin(qio_file_t** file_out, void* file_info,
                             int fdflags, const qio_style_t* style);
 
-qioerr qio_file_open_access_usr(qio_file_t** file_out, const char* pathname, 
-                               const char* access, qio_hint_t iohints, 
+qioerr qio_file_open_access_usr(qio_file_t** file_out, const char* pathname,
+                               const char* access, qio_hint_t iohints,
                                const qio_style_t* style,
                                void* fs_info);
 
@@ -511,7 +511,7 @@ void qio_file_get_style(qio_file_t* f, qio_style_t* style)
 }
 
 static inline
-bool qio_file_isopen(qio_file_t* f) 
+bool qio_file_isopen(qio_file_t* f)
 {
   return !(f->closed);
 }
@@ -654,7 +654,7 @@ typedef struct qio_channel_s {
    * and then move right_mark_start forward
    * (that is in qio_buffered_read)
    *
-   * When writing, we 'require' then write to 
+   * When writing, we 'require' then write to
    * right_mark_start to (potentially) end_iter(heavy->buf)
    * and then move right_mark_start forward
    * (that is in qio_buffered_write)
@@ -686,7 +686,7 @@ typedef struct qio_channel_s {
    * |             | aka available           | aka allocated          |
    *             mark_stack[0]              av_end
    *             "av_start"
-   *                  mark_stack[mark_next-1] 
+   *                  mark_stack[mark_next-1]
    *                  "right_mark_start"
    * the available section is ready for user read/write.
    * Space to the right of av_end is allocated but not yet read from disk
@@ -980,7 +980,7 @@ int64_t qio_channel_str_style(qio_channel_t* ch)
 }
 
 int64_t qio_channel_style_element(qio_channel_t* ch, int64_t element);
- 
+
 static inline
 qioerr qio_channel_write(const int threadsafe, qio_channel_t* restrict ch, const void* restrict ptr, ssize_t len, ssize_t* restrict amt_written )
 {
@@ -1126,7 +1126,7 @@ int64_t qio_channel_nbytes_allocated_unlocked(qio_channel_t* ch);
 // from right_mark_start (aka current offset) to av_end.
 int64_t qio_channel_nbytes_available_unlocked(qio_channel_t* ch);
 // returns the number of bytes ready for write-behind, that is,
-// the number of bytes from the start of the buffer to the av_start 
+// the number of bytes from the start of the buffer to the av_start
 int64_t qio_channel_nbytes_write_behind_unlocked(qio_channel_t* ch);
 
 // Returns a pointer,length for the next contiguous sequence in the
@@ -1244,7 +1244,7 @@ int64_t qio_channel_offset_unlocked(qio_channel_t* ch)
   return bytes_in_bits + ch->mark_stack[ch->mark_cur]; // _right_mark_start(ch);
 }
 
-/* 
+/*
  * Returns the end position of the channel.
  *  - If the channel is unbounded and we have not
  *    yet encountered an EOF when reading, returns MAX_INT64
@@ -1378,7 +1378,7 @@ qioerr qio_channel_revert(const int threadsafe, qio_channel_t* ch)
       return err;
     }
   }
-  
+
   qio_channel_revert_unlocked(ch);
 
   if( threadsafe ) {
@@ -1406,7 +1406,7 @@ qioerr qio_channel_commit(const int threadsafe, qio_channel_t* ch)
       return err;
     }
   }
-  
+
   qio_channel_commit_unlocked(ch);
 
   if( threadsafe ) {
@@ -1437,7 +1437,7 @@ qioerr qio_channel_write_bits(const int threadsafe, qio_channel_t* restrict ch, 
     // v must not have any extra bits set.
     QIO_RETURN_CONSTANT_ERROR(EINVAL, "no more bits");
   }
-  
+
   if( threadsafe ) {
     err = qio_lock(&ch->lock);
     if( err ) {
@@ -1571,7 +1571,7 @@ qioerr qio_channel_read_bits(const int threadsafe, qio_channel_t* restrict ch, u
         part_two_bits = qio_bitbuffer_unbe(part_two_bits); // host endian now.
         // now we need tmp_live top bits from tmp_bits
         // and the rest from part_two_bits.
-        
+
         // value we have now in bottom bits.
         value = qio_bitbuffer_topn(tmp_bits, tmp_live);
 

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -4439,4 +4439,3 @@ qioerr qio_locales_for_region(qio_file_t* fl, off_t start, off_t end, const char
     QIO_RETURN_CONSTANT_ERROR(ENOSYS, "Unable to get locale for specified region of file");
   }
 }
-

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -4388,6 +4388,18 @@ qioerr qio_get_fs_type(qio_file_t* fl, int* out)
   return 0;
 }
 
+qioerr qio_get_fd(qio_file_t* fl, int* out)
+{
+  if(fl != NULL && fl->fd != -1)
+    *out = fl->fd;
+  else {
+    *out = -1;
+    QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd");
+  }
+
+  return 0;
+}
+
 
 qioerr qio_get_chunk(qio_file_t* fl, int64_t* len_out)
 {


### PR DESCRIPTION
- feat: qio_get_fd function added
- useful for getting file descriptor primary use case in functions like setsocketopt and fcntl to change the file flags by making a system call
- fix different return types on `set_sys_sockaddr_in_t` and `set_sys_sockaddr_in6_t` in runtime and Sys.chpl

