### PR TITLE
compiler/next: implement class/record/union in convert-uast

### DIFF
--- a/compiler/next/include/chpl/uast/New.h
+++ b/compiler/next/include/chpl/uast/New.h
@@ -35,7 +35,8 @@ namespace uast {
     var foo = new bar(a = 1, 2);
   \endrst
 
-  Creates a call expression where the base expression is 'new bar'.
+  The initialization expression of foo is an FnCall where the base expression
+  is a New node (representing 'new bar').
 */
 class New : public Expression {
  public:


### PR DESCRIPTION
This PR adjusts convert-uast to handle classes, records, and unions.

Future work:
 * add conversion for Dot
 * test `--compiler-library-parser` somehow in nightly testing

Reviewed by @dlongnecke-cray - thanks!
