### PR TITLE
Fix spurious extern-record-union error

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1436,7 +1436,7 @@ void TypeSymbol::codegenMetadata() {
 
   bool treatAsUnion = isUnion(type) || this->hasFlag(FLAG_EXTERN_UNION);
 
-  if (treatAsUnion && !isUnion(type))
+  if (treatAsUnion && !isUnion(type) && isRecord(type))
     USR_FATAL(type->symbol,
               "C union type '%s' should be declared as "
               "'extern union' and not as 'extern record'", type->symbol->cname);


### PR DESCRIPTION
Follow-up to PR #17752.

Resolves a spurious error message with

    test/runtime/configMatters/interop/unordered-atomics.chpl

Reviewed by @lydia-duncan - thanks!

- [x] full local testing