### PR TITLE
Make complete support for c_fn_ptr's automatically available

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2413,4 +2413,18 @@ module ChapelBase {
   inline proc chpl_field_gt(a, b) where !isArrayType(a.type) {
     return a > b;
   }
+
+  // c_fn_ptr stuff
+  pragma "no doc"
+  inline operator c_fn_ptr.=(ref a:c_fn_ptr, b:c_fn_ptr) {
+    __primitive("=", a, b);
+  }
+  pragma "no doc"
+  proc c_fn_ptr.this() {
+    compilerError("Can't call a C function pointer within Chapel");
+  }
+  pragma "no doc"
+  proc c_fn_ptr.this(args...) {
+    compilerError("Can't call a C function pointer within Chapel");
+  }
 }

--- a/modules/standard/CPtr.chpl
+++ b/modules/standard/CPtr.chpl
@@ -363,12 +363,6 @@ module CPtr {
   inline operator :(x:c_ptr, type t:uint(64)) where c_uintptr != int(64)
     return __primitive("cast", t, x);
 
-  pragma "no doc"
-  inline operator c_fn_ptr.=(ref a:c_fn_ptr, b:c_fn_ptr) {
-    __primitive("=", a, b);
-  }
-
-
 
   pragma "no doc"
   inline operator c_ptr.==(a: c_ptr, b: c_ptr) where a.eltType == b.eltType {
@@ -467,14 +461,6 @@ module CPtr {
   pragma "no doc"
   inline proc c_ptrTo(x: c_fn_ptr) {
     return x;
-  }
-  pragma "no doc"
-  proc c_fn_ptr.this() {
-    compilerError("Can't call a C function pointer within Chapel");
-  }
-  pragma "no doc"
-  proc c_fn_ptr.this(args...) {
-    compilerError("Can't call a C function pointer within Chapel");
   }
 
   // Offset the CHPL_RT_MD constant in order to preserve the value through

--- a/test/extern/fnPtrs/cantCallCFnPtr.chpl
+++ b/test/extern/fnPtrs/cantCallCFnPtr.chpl
@@ -1,0 +1,5 @@
+var x: c_fn_ptr;
+x();
+x(1);
+x(x);
+

--- a/test/extern/fnPtrs/cantCallCFnPtr.compopts
+++ b/test/extern/fnPtrs/cantCallCFnPtr.compopts
@@ -1,0 +1,1 @@
+--ignore-errors-for-pass

--- a/test/extern/fnPtrs/cantCallCFnPtr.good
+++ b/test/extern/fnPtrs/cantCallCFnPtr.good
@@ -1,0 +1,3 @@
+cantCallCFnPtr.chpl:2: error: Can't call a C function pointer within Chapel
+cantCallCFnPtr.chpl:3: error: Can't call a C function pointer within Chapel
+cantCallCFnPtr.chpl:4: error: Can't call a C function pointer within Chapel


### PR DESCRIPTION
Currently, 'c_fn_ptr' is a type that's injected by the compiler and
therefore always available to Chapel programmers, unlike other C
interop types.  This is unfortunate, but more than I can currently
fix, so I filed issue #17994 against it instead.

When experimenting with 'c_fn_ptr' in response to a user query, I
noticed that the functions which prevent calls to it are defined in
CPtr.chpl, which means that they aren't automatically available.
Here, I've moved those functions—and any others specific to c_fn_ptr—
into ChapelBase.chpl to reflect that they are built-in / always
available.  Like so many things, this is essentially treating
ChapelBase as a kitchen sink (sorry).
