### PR TITLE
Add some additional task count runs to these tests

### DIFF
--- a/test/library/packages/Itertools/cycle/check_indexable.execopts
+++ b/test/library/packages/Itertools/cycle/check_indexable.execopts
@@ -1,0 +1,5 @@
+                           # check_indexable.good
+--dataParTasksPerLocale=1
+--dataParTasksPerLocale=8
+--dataParTasksPerLocale=4
+--dataParTasksPerLocale=3

--- a/test/library/packages/Itertools/cycle/check_non_indexable.execopts
+++ b/test/library/packages/Itertools/cycle/check_non_indexable.execopts
@@ -1,0 +1,5 @@
+                           # check_non_indexable.good
+--dataParTasksPerLocale=1
+--dataParTasksPerLocale=8
+--dataParTasksPerLocale=4
+--dataParTasksPerLocale=3


### PR DESCRIPTION
In issue #15554, @cassella noted that the cyclic() iterator in
Itertools was more dependent on task count than intended.  This
runs some of its tests for varying task counts to ensure that
the fix in PR #17157 sticks.
