### PR TITLE
Restore CHPL_REGEXP to ChapelEnv module, but mark it as deprecated

### DIFF
--- a/modules/standard/ChapelEnv.chpl
+++ b/modules/standard/ChapelEnv.chpl
@@ -139,6 +139,10 @@ module ChapelEnv {
   param CHPL_JEMALLOC:string;
   CHPL_JEMALLOC = __primitive("get compiler variable", "CHPL_JEMALLOC");
 
+  pragma "no doc"
+  deprecated "CHPL_REGEXP is deprecated, please use CHPL_RE2 instead"
+  param CHPL_REGEXP:string = __primitive("get compiler variable", "CHPL_RE2");
+
   /* See :ref:`readme-chplenv.CHPL_RE2` for more information. */
   param CHPL_RE2:string;
   CHPL_RE2 = __primitive("get compiler variable", "CHPL_RE2");

--- a/test/deprecated/ChapelEnv-CHPL_REGEXP.chpl
+++ b/test/deprecated/ChapelEnv-CHPL_REGEXP.chpl
@@ -1,0 +1,3 @@
+use ChapelEnv;
+
+writeln(CHPL_REGEXP);

--- a/test/deprecated/ChapelEnv-CHPL_REGEXP.good
+++ b/test/deprecated/ChapelEnv-CHPL_REGEXP.good
@@ -1,0 +1,2 @@
+ChapelEnv-CHPL_REGEXP.chpl:3: warning: CHPL_REGEXP is deprecated, please use CHPL_RE2 instead
+bundled

--- a/test/deprecated/ChapelEnv-CHPL_REGEXP.skipif
+++ b/test/deprecated/ChapelEnv-CHPL_REGEXP.skipif
@@ -1,0 +1,1 @@
+CHPL_RE2 != bundled


### PR DESCRIPTION
Also:
- don't add it to the documentation
- set it to CHPL_RE2 instead of restoring the compiler variable it used to
correspond to
- don't use split initialization because that triggered the deprecation warning

Add a deprecation test to lock in the deprecation message - note that this
uses a different environment variable than the other regex tests in that
directory

Passed a full paratest with futures and CHPL_RE2 = bundled.  Double checked
that the skipif fired appropriately when CHPL_RE2 = none