### PR TITLE
Add filter for GASNet timer calibration errors

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -673,6 +673,14 @@ def filter_errors(output_in, pre_exec_output, execgoodfile, execlog):
             extra_msg = '(memory leak) '
             break
 
+    # detect cases of 'GASNet timer calibration on %s detected non-linear
+    # timer behavior:' messages which we can't do much about
+    err_strings = ['GASNet timer calibration on']
+    for s in err_strings:
+        if (re.search(s, output, re.IGNORECASE) != None):
+            extra_msg = '(private issue #480) '
+            break
+
     return extra_msg
 
 


### PR DESCRIPTION
With some infrequent regularity, we get errors of the form:

  GASNet timer calibration on %s detected non-linear timer behavior:

Which we've always turned a blind eye to, assuming it's not our fault.
Checking with the GASNet team today, they confirmed that it's mostly
reasonable to ignore these, so we're adding an automatic check for it
(or really, for the 'GASNet timer calibration on' part of it)
referring to issue https://github.com/Cray/chapel-private/issues/480 where we've been tracking it.  My regular
expression expertise isn't good enough to bother with trying to match
any %s that might appear, and this prefix only appears in this one
place in GASNet's sources, so it seems like a safe bet.

Capturing some of the discussion from the GASNet team:

> Ignoring this is safe.
> It indicates that a very rare event occurred during timer calibration and GASNet recovered.
> That is unless this is followed by a later fatal error.

I decided to ignore the "followed by a fatal error" clause because our
filtering doesn't really make that easy (or my Python isn't good
enough to make it easy), because I'm not aware that we've ever seen
it followed by a fatal error, and because it happens so rarely...

That said, the GASNet team has proposed that they could add an option
to squash these warnings, and if they were to do so, I think we'd
want to use that instead and remove this filter so that if there were
any subsequent fatal errors, we'd see them again.
