### PR TITLE
Add a future for an override hijack case

### DIFF
--- a/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.bad
+++ b/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.bad
@@ -1,0 +1,2 @@
+in Other's D.method
+in Other's D.method

--- a/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.chpl
+++ b/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.chpl
@@ -1,0 +1,20 @@
+module Library {
+  class C {
+    proc method() { writeln("in Library's C.method"); }
+  }
+  class D: C { }
+  class E: C { }
+  var myD = new D();
+  myD.method();
+}
+module Other {
+  use Library;
+  // shouldn't be allowed because
+  // it would change myD.method() in Library
+  override proc D.method() { writeln("in Other's D.method"); }
+
+  proc main() {
+    var d: C = new D();
+    d.method();
+  }
+}

--- a/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.future
+++ b/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.future
@@ -1,0 +1,2 @@
+design: hijacking with new override
+#16854

--- a/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.good
+++ b/test/functions/ferguson/hijacking/tertiary-class-method-override-bad.good
@@ -1,0 +1,2 @@
+some sort of compilation error
+line 14: can't make D.method virtually dispatched with only a tertiary method

--- a/test/functions/ferguson/hijacking/tertiary-class-methods-override-ok.chpl
+++ b/test/functions/ferguson/hijacking/tertiary-class-methods-override-ok.chpl
@@ -1,0 +1,23 @@
+module Library {
+  class C {
+    proc method() { }
+  }
+  class D: C { }
+  class E: C { }
+  var myD = new D();
+  myD.method();
+}
+module OKOther {
+  use Library;
+  // these methods are not defined on C/D in Library
+  // and so they can't affect code in there
+  proc C.otherOperation() { writeln("in C.otherOperation"); }
+  override proc D.otherOperation() { writeln("in D.otherOperation"); }
+
+  proc main() {
+    var d: C = new D();
+    var e: C = new E();
+    d.otherOperation();
+    e.otherOperation();
+  }
+}

--- a/test/functions/ferguson/hijacking/tertiary-class-methods-override-ok.good
+++ b/test/functions/ferguson/hijacking/tertiary-class-methods-override-ok.good
@@ -1,0 +1,2 @@
+in D.otherOperation
+in C.otherOperation


### PR DESCRIPTION
This PR adds a test that I think should keep working (because tertiary overrides with new method names make the visitor pattern easy) and a future case that is problematic (and arguably a case of hijacking).

See issue #16854 which discusses whether some tertiary overrides should be errors.

Test change only - not reviewed.