### PR TITLE
No doc one more array method that I forgot

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3434,6 +3434,7 @@ module ChapelArray {
       return _value.doiScan(op, this.domain);
     }
 
+    pragma "no doc"
     proc iteratorYieldsLocalElements() param {
       return _value.dsiIteratorYieldsLocalElements();
     }


### PR DESCRIPTION
I have added some `no doc`s in https://github.com/chapel-lang/chapel/pull/17902

But I forgot that there was an array version of `iteratorYieldsLocalElements`.
This PR adds `no doc` for that helper.
