### PR TITLE
Adjust Makefile.gnu to account for different gcc/g++ versions

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -227,6 +227,11 @@ endif
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 7; echo "$$?"),0)
 WARN_CXXFLAGS += -Walloc-size-larger-than=18446744073709551615
 WARN_CXXFLAGS += -Wno-stringop-truncation
+endif
+
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -gt 7; echo "$$?"),0)
+WARN_CFLAGS += -Walloc-size-larger-than=18446744073709551615
+WARN_CFLAGS += -Wno-stringop-truncation
 SQUASH_WARN_GEN_CFLAGS += -Walloc-size-larger-than=18446744073709551615 -Wno-restrict
 endif
 
@@ -237,6 +242,10 @@ endif
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-class-memaccess
+endif
+
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -eq 8; echo "$$?"),0)
+WARN_CFLAGS += -Wno-class-memaccess
 RUNTIME_CFLAGS += -Wno-stringop-overflow
 SQUASH_WARN_GEN_CFLAGS += -Wno-array-bounds
 endif


### PR DESCRIPTION
This PR adjusts two checks in `Makefile.gnu` to account for different versions of gcc and g++.

Tested with versions 6 to 9, but not with different versions of gcc/g++.