### PR TITLE
Adjust a .good for #18000

### DIFF
--- a/test/constrained-generics/hashtable/test-chpl-hashtable.good
+++ b/test/constrained-generics/hashtable/test-chpl-hashtable.good
@@ -3,13 +3,7 @@ key = 1 val = 10
 test1
 init= 1 1
 init= 10 10
-init= 1 1
-init= 10 10
 key = (x = 1, ptr = {xx = 1}) val = (x = 10, ptr = {xx = 10})
-deinit 10 10
-deinit 1 1
-deinit 10 10
-deinit 1 1
 deinit 10 10
 deinit 1 1
 test3


### PR DESCRIPTION
This PR makes an adjustment to the interface-constrained version of
`test-chpl-hashtable.good`. This should have been a part of #18000.

This adjustment makes the number of traced inits/deinits
equal to that for test-chpl-hashtable.chpl in test/types/chplhashtable.

Trivial, not reviewed.