### PR TITLE
Better memleaks skipifs

### DIFF
--- a/test/compflags/bradc/minimalModules/SKIPIF
+++ b/test/compflags/bradc/minimalModules/SKIPIF
@@ -1,8 +1,6 @@
+# Several configurations aren't working with minimal modules...
 COMPOPTS <= --baseline
 CHPL_COMM != none
-COMPOPTS  <= --no-local
+COMPOPTS <= --no-local
 CHPL_LOCALE_MODEL != flat
-#
-# when doing memory testing, the configs used are not available, so skip
-#
-EXECOPTS <= memLeaksLog
+EXECOPTS <= memLeaks

--- a/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
+++ b/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
@@ -3,4 +3,4 @@ COMPOPTS <= --baseline
 CHPL_COMM != none
 COMPOPTS <= --no-local
 CHPL_LOCALE_MODEL != flat
-EXECOPTS <= memLeaksLog
+EXECOPTS <= memLeaks


### PR DESCRIPTION
Change a couple of skipif files to react to execopts
containing `memLeaks` whereas they previously required `memLeaksLog`.
The modified skipfs will continue reacting to execopts with `memLeaksLog`,
by virtue of its including `memLeaks` as a substring. We could include
both `EXECOPTS <= memLeaksLog` and `EXECOPTS <= memLeaks`
lines for documentation clarity, however this is not needed for functionality.

My motivation is to avoid failures in the tests guarded by these skipifs
when I run paratest `-memleaks`.

While there, simplified and reorganized test/compflags/bradc/minimalModules/SKIPIF
so it matches test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
