### PR TITLE
IFC workaround for a compilation issue

### DIFF
--- a/test/constrained-generics/basic/set3/hashtable-table.bad
+++ b/test/constrained-generics/basic/set3/hashtable-table.bad
@@ -1,0 +1,8 @@
+hashtable-table.chpl:40: internal error: COD-CG--XPR-nnnn chpl version mmmm
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/constrained-generics/basic/set3/hashtable-table.chpl
+++ b/test/constrained-generics/basic/set3/hashtable-table.chpl
@@ -1,0 +1,47 @@
+// This is a small reproducer of a problem with --no-local compilations
+// of rev. fe4b408912 of these two files when compiled together:
+//   test/constrained-generics/hashtable/MyHashtable.chpl
+//   test/constrained-generics/hashtable/test-chpl-hashtable.chpl
+
+record my__hashtable {
+  var table: _ddata(int) = _ddata_allocate(int, 2, initElts=true);
+}
+
+interface chpl_Hashtable(HT) {
+  proc HT.table ref: tableType;
+
+  // represents '_ddata(int)'
+  type tableType;
+  proc tableType.this(idx: int) ref: int;
+
+  // to support updateTable()-like code
+  proc chpl__initCopy(arg: tableType, definedConst: bool): tableType;
+  operator =(ref lhs: tableType, rhs: tableType);
+}
+
+my__hashtable implements chpl_Hashtable;
+
+proc my__hashtable.tableType type return _ddata(int);
+
+// We need to support assignment to 'table'.
+proc chpl_Hashtable.updateTable() {
+  var oldTable = table;
+  table = oldTable;
+}
+
+// concrete function
+proc testConcrete(ref h: my__hashtable) {
+  ref entry = h.table[1];
+  writeln(entry);
+}
+
+// interface-generic function
+proc testIC(ref h: chpl_Hashtable) {
+  ref entry = h.table[1];
+  writeln(entry);
+}
+
+var h1 = new my__hashtable();
+h1.updateTable();
+testConcrete(h1);
+testIC(h1);

--- a/test/constrained-generics/basic/set3/hashtable-table.future
+++ b/test/constrained-generics/basic/set3/hashtable-table.future
@@ -1,0 +1,29 @@
+bug: compiler crashes when compiling this test with --no-local
+
+This is a small reproducer of a problem with --no-local compilations
+of rev. fe4b408912 of these two files when compiled together:
+  test/constrained-generics/hashtable/MyHashtable.chpl
+  test/constrained-generics/hashtable/test-chpl-hashtable.chpl
+
+where testConcrete() compiles fine while testIC() causes an assertion
+failure in the codegen pass.
+
+The PR that adds this test also adds a workaround in MyHashtable.chpl
+by adding an implicit ref-intent for the receiver argument or
+the method 'proc tableType.this(idx: int)'.
+
+Here is a possible set of steps taht cause the assertion failure:
+* the method 'HT.table' returns a ref to 'tableType'
+* it is passed to the method 'tableType.this()' by default intent
+* when early-resolving testIC(), which contains the above two,
+  the compiler treats 'tableType' as a record, so the default intent
+  is a [const] ref
+* when instantiating testIC() for my__hashtable, 'tableType' is _ddata,
+  for which is the default intent is by value
+* no further resolution happens upon this instantiation,
+  so the AST is likely left in an inconsistent state w.r.t.
+  by-ref vs. by-value argument passing
+
+This future poses the question of whether the compiler should be
+adjusted to compile this code properly or report an error like
+"cannot use the default intent on arguments of interface types".

--- a/test/constrained-generics/basic/set3/hashtable-table.good
+++ b/test/constrained-generics/basic/set3/hashtable-table.good
@@ -1,0 +1,1 @@
+<what is the desired output when compiling this code? see .future>

--- a/test/constrained-generics/basic/set3/hashtable-table.skipif
+++ b/test/constrained-generics/basic/set3/hashtable-table.skipif
@@ -1,0 +1,6 @@
+# This exposes a problem in --no-local/gasnet/etc. compilations.
+# So, test it only in the --no-local configuration.
+# Once the problem is resolved, remove this skipif.
+
+CHPL_COMM != none
+COMPOPTS  >= --no-local

--- a/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.bad
+++ b/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.bad
@@ -1,0 +1,4 @@
+invoke-icfun-on-AT-interface.chpl:17: In function 'ic':
+invoke-icfun-on-AT-interface.chpl:18: error: unresolved call 'ic2(AT)'
+invoke-icfun-on-AT-interface.chpl:21: note: this candidate did not match: ic2(z: ?R)
+invoke-icfun-on-AT-interface.chpl:21: note: because interface constraint(s) were not satisfied

--- a/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.chpl
+++ b/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.chpl
@@ -1,0 +1,22 @@
+// Check that a formal of an IC function whose type is an associated type
+// can be passed to another IC function when doing so is legal due to an
+// associated constraint.
+//
+// This test is simplified for --minimal-modules
+// Once this functionality is implemented, we should beef up this code.
+
+interface IFC {
+  type AT;
+  AT implements I2;
+}
+
+interface I2 {
+  proc writeln(arg: Self);
+}
+
+proc ic(x: ?Q, y: Q.AT) where Q implements IFC {
+  ic2(y);  // this call should be legal
+}
+
+proc ic2(z: ?R) where R implements I2 {
+}

--- a/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.compopts
+++ b/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.compopts
@@ -1,0 +1,4 @@
+# This example is simplified for --minimal-modules
+# Once this functionality is implemented, we should beef it up.
+
+--minimal-modules

--- a/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.future
+++ b/test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.future
@@ -1,0 +1,1 @@
+unimplemented feature: a case of invoking an IC function from another IC function

--- a/test/constrained-generics/hashtable/MyHashtable.chpl
+++ b/test/constrained-generics/hashtable/MyHashtable.chpl
@@ -395,7 +395,7 @@ interface chpl_Hashtable(HT) {
   type tableType;
   proc chpl__initCopy(arg: tableType, definedConst: bool): tableType;
   operator =(ref lhs: tableType, rhs: tableType);
-  proc tableType.this(idx: int) ref: tableEntryType;  
+  proc ref tableType.this(idx: int) ref: tableEntryType;  
 
   // replaces 'chpl_TableEntry(keyType, valType)'
   // todo: move into its own interface


### PR DESCRIPTION
This PR adds a workaround for a compilation issue introduced,
or at least exposed, by #18000. The fix is in:

     test/constrained-generics/hashtable/MyHashtable.chpl

The following future test records the issue itself,
see its future file for details:

    test/constrained-generics/basic/set3/hashtable-table.chpl

While there, add a future test for an unimplemented feature:

    test/constrained-generics/basic/set3/invoke-icfun-on-AT-interface.chpl

Not reviewed.