### PR TITLE
Stop throwing a non-GCC flag with GCC

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -245,7 +245,6 @@ WARN_CXXFLAGS += -Wno-class-memaccess
 endif
 
 ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -eq 8; echo "$$?"),0)
-WARN_CFLAGS += -Wno-class-memaccess
 RUNTIME_CFLAGS += -Wno-stringop-overflow
 SQUASH_WARN_GEN_CFLAGS += -Wno-array-bounds
 endif


### PR DESCRIPTION
I've made some changes in `Makefile.gnu` in https://github.com/chapel-lang/chapel/pull/18033.

But there, I've added a non-GCC flag to `WARN_CFLAGS`, that caused some smoketest failures. This PR addresses the issue.