### PR TITLE
Change zmq tests to use port 5556 instead of 5555

### DIFF
--- a/test/library/packages/ZMQ/hello.chpl
+++ b/test/library/packages/ZMQ/hello.chpl
@@ -44,13 +44,13 @@ proc Launcher(exec: string) {
 proc Master() {
   var context: Context;
   var socket = context.socket(ZMQ.PUSH);
-  socket.bind("tcp://*:5555");
+  socket.bind("tcp://*:5556");
   socket.send(to);
 }
 
 proc Worker() {
   var context: Context;
   var socket = context.socket(ZMQ.PULL);
-  socket.connect("tcp://localhost:5555");
+  socket.connect("tcp://localhost:5556");
   writeln("Hello, ", socket.recv(string));
 }

--- a/test/library/packages/ZMQ/interop-py/client.py
+++ b/test/library/packages/ZMQ/interop-py/client.py
@@ -3,7 +3,7 @@ import zmq
 
 context = zmq.Context()
 socket = context.socket(zmq.REQ)
-socket.connect("tcp://localhost:5555")
+socket.connect("tcp://localhost:5556")
 
 for request in range(10):
     message = "Hello %i from Python" % request

--- a/test/library/packages/ZMQ/interop-py/server.chpl
+++ b/test/library/packages/ZMQ/interop-py/server.chpl
@@ -17,7 +17,7 @@ use ZMQ;
 
 var context: Context;
 var socket = context.socket(ZMQ.REP);
-socket.bind("tcp://*:5555");
+socket.bind("tcp://*:5556");
 
 for i in 0..#10 {
   var msg = socket.recv(string);

--- a/test/library/packages/ZMQ/multilocale/hello-multilocale.chpl
+++ b/test/library/packages/ZMQ/multilocale/hello-multilocale.chpl
@@ -5,7 +5,7 @@ proc Master() {
   on Locales[(here.id+1) % numLocales] {
     var socket = context.socket(ZMQ.PUSH);
     on Locales[(here.id+1) % numLocales] {
-      socket.bind("tcp://*:5555");
+      socket.bind("tcp://*:5556");
       on Locales[(here.id+1) % numLocales] {
         writeln("Master socket lives on locale ", socket.classRef.home.id);
         var msg = "I'm locale %i".format(here.id);
@@ -20,7 +20,7 @@ proc Worker() {
   on Locales[(here.id+numLocales-1) % numLocales] {
     var socket = context.socket(ZMQ.PULL);
     on Locales[(here.id+numLocales-1) % numLocales] {
-      socket.connect("tcp://localhost:5555");
+      socket.connect("tcp://localhost:5556");
       on Locales[(here.id+numLocales-1) % numLocales] {
         writeln("Worker socket lives on locale ", socket.classRef.home.id);
         var msg = socket.recv(string);

--- a/test/library/packages/ZMQ/multilocale/req-rep.chpl
+++ b/test/library/packages/ZMQ/multilocale/req-rep.chpl
@@ -19,7 +19,7 @@ enum Baz {
 proc Master() {
   var context: Context;
   var socket = context.socket(ZMQ.REP);
-  socket.bind("tcp://*:5555");
+  socket.bind("tcp://*:5556");
 
   // Numeric Types
   {
@@ -56,7 +56,7 @@ proc Master() {
 proc Worker() {
   var context: Context;
   var socket = context.socket(ZMQ.REQ);
-  socket.connect("tcp://localhost:5555");
+  socket.connect("tcp://localhost:5556");
 
   // Numeric Types
   {

--- a/test/library/packages/ZMQ/pair.chpl
+++ b/test/library/packages/ZMQ/pair.chpl
@@ -58,7 +58,7 @@ proc Launcher(exec: string) {
 proc Master() {
   var context = new ZMQ.Context();
   var socket = context.socket(ZMQ.PAIR);
-  socket.bind("tcp://*:5555");
+  socket.bind("tcp://*:5556");
 
   // Numeric Types
   {
@@ -102,7 +102,7 @@ proc Master() {
 proc Worker() {
   var context = new ZMQ.Context();
   var socket = context.socket(ZMQ.PAIR);
-  socket.connect("tcp://localhost:5555");
+  socket.connect("tcp://localhost:5556");
 
   // Numeric Types
   {

--- a/test/library/packages/ZMQ/req-rep.chpl
+++ b/test/library/packages/ZMQ/req-rep.chpl
@@ -58,7 +58,7 @@ proc Launcher(exec: string) {
 proc Master() {
   var context = new ZMQ.Context();
   var socket = context.socket(ZMQ.REP);
-  socket.bind("tcp://*:5555");
+  socket.bind("tcp://*:5556");
 
   // Numeric Types
   {
@@ -95,7 +95,7 @@ proc Master() {
 proc Worker() {
   var context = new ZMQ.Context();
   var socket = context.socket(ZMQ.REQ);
-  socket.connect("tcp://localhost:5555");
+  socket.connect("tcp://localhost:5556");
 
   // Numeric Types
   {


### PR DESCRIPTION
5555 is the default port for Arkouda so that can
cause problems when somebody is also doing an Arkouda
experiment on the same system.

Reviewed by @ronawho - thanks!