### PR TITLE
C Interoperability Primer Fixes

### DIFF
--- a/doc/rst/meta/primers/index.rst
+++ b/doc/rst/meta/primers/index.rst
@@ -66,13 +66,13 @@ Data Parallelism
    Replicated Distribution <replicated>
    Forall Loops <forallLoops>
 
-Chapel As A Library
+Interoperability
 -------------------
 
 .. toctree::
    :maxdepth: 1
 
-   C interoperability <interopWithC>
+   Chapel<->C interoperability <interopWithC>
 
 Library Utilities
 -----------------

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -51,6 +51,16 @@ ifdef CRAY_LIBSCI_PREFIX_DIR
 	LAPACK_OPTS = -lgfortran -lsci_gnu
 endif
 
+#
+# Only make interopWithC and cClient if LLVM backend is set
+#
+CHPL_TARGET_COMPILER=$(shell $(CHPL_HOME)/util/chplenv/chpl_compiler.py --target)
+ifeq ($(CHPL_TARGET_COMPILER),llvm)
+	TARGETS += cClient
+	TARGETS += interopWithC
+endif
+
+
 REALS = $(TARGETS:%=%_real)
 
 default: all
@@ -68,5 +78,21 @@ FFTWlib: FFTWlib.chpl
 
 LAPACKlib: LAPACKlib.chpl
 	+$(CHPL) -o $@ $(LAPACK_OPTS) $<
+
+CCLIENT_OPTS = -Llib/ -linteropWithC `$CHPL_HOME/util/config/compileline --libraries`
+INTEROP_LIB_OPTS =  --library --library-makefile --savec ccode
+INTEROP_DEPS = interopWithC.chpl cHelper.h cHelper.c fact.h fact.c
+
+interopWithC: $(INTEROP_DEPS)
+	+$(CHPL) -o $@ $^
+
+
+lib/Makefile.interopWithC:
+	+$(CHPL) $(INTEROP_DEPS) $(INTEROP_LIB_OPTS)
+
+-include lib/Makefile.interopWithC
+
+cClient: cClient.test.c interopWithC.chpl
+	+$(CHPL_COMPILER) $(CHPL_CFLAGS) -o $@ $< $(CHPL_LDFLAGS)
 
 FORCE:

--- a/test/release/examples/primers/README
+++ b/test/release/examples/primers/README
@@ -17,6 +17,7 @@ demonstrate Chapel feature areas in detail.
      fileIO.chpl                 : File I/O example using arrays
      forallLoops.chpl            : Forall loops - data parallel constructs
      genericClasses.chpl         : Defining and using generic classes
+     interopWithC.chpl           : Using Chapel code in C and vice versa
      iterators.chpl              : Iterator examples
      LAPACKlib.chpl              : the LAPACK standard library
      LinearAlgebralib.chpl       : LinearAlgebra module
@@ -43,3 +44,4 @@ demonstrate Chapel feature areas in detail.
      variables.chpl              : Variables, constants, and parameters
 
      chplvis                     : A directory containing a primer on the chplvis tool
+


### PR DESCRIPTION
This fixes the following issues caused/missed in  #18030 

- Updating the README in `test/release/examples/primers` to reference `interopWithC.chpl`
- Add Makefile targets for `interopWithChapel` and `cClient`
- Rename category for the Chapel<->C Interoperability Primer according to [this comment](https://github.com/chapel-lang/chapel/pull/18030#issuecomment-875170966) by @bradcray 