### PR TITLE
Emit user error when field not found in getCRecordMemberGEP

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2919,6 +2919,15 @@ int getCRecordMemberGEP(const char* typeName, const char* fieldName,
       break;
     }
   }
+
+  // TODO (dlongnecke): Try to move this to a spot before codegen? It would
+  // also be cool if we could point this to the point in the source code
+  // where the field is being accessed.
+  if (!field) {
+    auto fmt = "Definition of '%s.%s' not visible in external C code";
+    USR_FATAL(fmt, typeName, fieldName);
+  }
+
   INT_ASSERT(field);
 
   isCArrayField = field->getType()->isArrayType();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2921,7 +2921,7 @@ int getCRecordMemberGEP(const char* typeName, const char* fieldName,
   }
 
   // TODO (dlongnecke): Try to move this to a spot before codegen? It would
-  // also be cool if we could point this to the point in the source code
+  // also be cool if we could point this to the location in the source code
   // where the field is being accessed.
   if (!field) {
     auto fmt = "Definition of '%s.%s' not visible in external C code";

--- a/test/extern/records/OpaqueStruct.chpl
+++ b/test/extern/records/OpaqueStruct.chpl
@@ -1,0 +1,12 @@
+use SysCTypes;
+
+extern record Foo {
+  var value: c_int;
+}
+
+proc test() {
+  var foo: Foo;
+  writeln(foo);
+}
+test();
+

--- a/test/extern/records/OpaqueStruct.compopts
+++ b/test/extern/records/OpaqueStruct.compopts
@@ -1,0 +1,1 @@
+OpaqueStruct.h

--- a/test/extern/records/OpaqueStruct.good
+++ b/test/extern/records/OpaqueStruct.good
@@ -1,0 +1,1 @@
+error: Definition of 'Foo.value' not visible in external C code

--- a/test/extern/records/OpaqueStruct.h
+++ b/test/extern/records/OpaqueStruct.h
@@ -1,0 +1,6 @@
+#ifndef OPAQUE_STRUCT 
+#define OPAQUE_STRUCT 
+
+typedef struct Foo_ Foo;
+
+#endif

--- a/test/extern/records/OpaqueStruct.skipif
+++ b/test/extern/records/OpaqueStruct.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Emit user error when field not found in getCRecordMemberGEP

Resolves #18022.

Change an `INT_FATAL` within `getCRecordMemberGEP` to a user facing
fatal error. This error can fire when the field of an `extern record`
cannot be found in external C code.

Reviewed by @daviditen. Thanks!

TESTING:

  - [x] `ALL` on `linux64` when `COMM=none`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>