### PR TITLE
Allow llvm whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -6,7 +6,7 @@
 #
 # Variable   Values
 # ------------------------------------------------------
-# COMPILER    cray, intel, pgi, gnu
+# COMPILER    cray, intel, pgi, gnu, llvm
 # COMP_TYPE   TARGET, HOST-TARGET, HOST-TARGET-no-PrgEnv
 #
 # Optionally, the platform can be set with:
@@ -42,16 +42,28 @@ log_info "Short platform: ${short_platform}"
 # Setup vars that will help load the correct compiler module.
 case $COMP_TYPE in
     TARGET)
-        module_name=PrgEnv-${COMPILER}
+        if [ $COMPILER == "llvm" ] ; then
+          module_name=PrgEnv-gnu
+          export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.${COMPILER}"
+        else
+          module_name=PrgEnv-${COMPILER}
+          export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.prgenv-${COMPILER}"
+        fi
         chpl_host_value=""
 
         export CHPL_TARGET_PLATFORM=$platform
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.prgenv-${COMPILER}"
         ;;
     HOST-TARGET)
-        module_name=PrgEnv-${COMPILER}
+        if [ $COMPILER == "llvm" ] ; then
+          module_name=PrgEnv-gnu
+          export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.${COMPILER}"
+        else
+          module_name=PrgEnv-${COMPILER}
+          export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.prgenv-${COMPILER}"
+        fi
+
         chpl_host_value=cray-prgenv-${COMPILER}
 
         export CHPL_HOST_PLATFORM=$platform
@@ -59,7 +71,6 @@ case $COMP_TYPE in
         log_info "Set CHPL_HOST_PLATFORM to: ${CHPL_HOST_PLATFORM}"
         log_info "Set CHPL_TARGET_PLATFORM to: ${CHPL_TARGET_PLATFORM}"
 
-        export CHPL_NIGHTLY_TEST_CONFIG_NAME="${short_platform}-wb.host.prgenv-${COMPILER}"
         ;;
     HOST-TARGET-no-PrgEnv)
         the_cc=${COMPILER}
@@ -89,6 +100,16 @@ source $CHPL_INTERNAL_REPO/build/compiler_versions.bash
 # Then load the selected compiler
 load_target_compiler ${COMPILER}
 
+if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
+  if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+    source /data/cf/chapel/setup_system_llvm.bash
+  elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cray/css/users/chapelu/setup_system_llvm.bash
+  fi
+fi
+
+source $CWD/common-llvm-comp-path.bash
+
 # Do minor fixups
 case $COMPILER in
     cray|intel|gnu)
@@ -104,14 +125,13 @@ case $COMPILER in
         # force disable gmp until there's more time to investigate this.
         export CHPL_GMP=none
         ;;
+    llvm)
+        ;;
     *)
         log_error "Unknown COMPILER value: ${COMPILER}. Exiting."
         exit 4
         ;;
 esac
-
-log_info "Unloading cray-mpich module"
-module unload cray-mpich
 
 log_info "Unloading atp module"
 module unload atp
@@ -127,11 +147,6 @@ fi
 # Disable launchers, comm.
 export CHPL_LAUNCHER=none
 export CHPL_COMM=none
-
-# Disable llvm for now, since we're explicitly trying to test different C
-# backends
-export CHPL_LLVM=none
-
 
 # Set some vars that nightly cares about.
 export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}


### PR DESCRIPTION
Update util/cron/common-whitebox.bash to allow COMPILER=llvm as an option.
Stop unloading the mpich module because not having it makes our scripts
that gather the prgenv arguments misbehave.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>