### PR TITLE
Create GPU runtime library functions

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -130,7 +130,7 @@ static void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3, Gen
 
 static GenRet codegenZero();
 static GenRet codegenZero32();
-static GenRet codegenString(const char* val);
+static GenRet codegenCString(const char* val);
 static GenRet codegen_prim_get_real(GenRet, Type*, bool real);
 
 static int codegen_tmp = 1;
@@ -2946,7 +2946,7 @@ GenRet codegenZero32()
   return new_IntSymbol(0, INT_SIZE_32)->codegen();
 }
 
-static GenRet codegenString(const char* val) {
+static GenRet codegenCString(const char* val) {
   return new_CStringSymbol(val)->codegen();
 }
 
@@ -4711,7 +4711,7 @@ DEFINE_PRIM(PRIM_GPU_KERNEL_LAUNCH) {
       INT_ASSERT(actual->typeInfo() == dtStringC);
       
       std::vector<GenRet> argsToGetKernelCall;
-      argsToGetKernelCall.push_back(codegenString("tmp/chpl__gpu.fatbin"));
+      argsToGetKernelCall.push_back(codegenCString("tmp/chpl__gpu.fatbin"));
       argsToGetKernelCall.push_back(actual->codegen());
       
       ret = codegenCallExprWithArgs("chpl_gpu_getKernel", argsToGetKernelCall);

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _CHPL_GPU_H_
+#define _CHPL_GPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAS_GPU_LOCALE
+
+void  chpl_gpu_init();
+void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName);
+
+#endif // HAS_GPU_LOCALE
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/include/stdchpl.h
+++ b/runtime/include/stdchpl.h
@@ -50,6 +50,7 @@
 #include "chpl-external-array.h"
 #include "chpl-file-utils.h"
 #include <chplfp.h>
+#include "chpl-gpu.h"
 #include "chplglob.h"
 #include "chplio.h"
 #include "chplmath.h"

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -128,10 +128,11 @@ RUNTIME_DEFS += $(SHARED_LIB_CFLAGS)
 endif
 
 # If compiling for GPU locale add CUDA runtime headers to include path
-ifeq ($(CHPL_LOCALE_MODEL),gpu)
+ifeq ($(CHPL_MAKE_LOCALE_MODEL),gpu)
 RUNTIME_INCLS += -I/usr/local/cuda/include
 RUNTIME_DEFS += -DHAS_GPU_LOCALE
 endif
 
 RUNTIME_CFLAGS += $(RUNTIME_DEFS)
 RUNTIME_CXXFLAGS += $(RUNTIME_DEFS) $(CXXFLAGS)
+

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -127,7 +127,11 @@ ifeq ($(CHPL_LIB_PIC),pic)
 RUNTIME_DEFS += $(SHARED_LIB_CFLAGS)
 endif
 
+# If compiling for GPU locale add CUDA runtime headers to include path
+ifeq ($(CHPL_LOCALE_MODEL),gpu)
+RUNTIME_INCLS += -I/usr/local/cuda/include
+RUNTIME_DEFS += -DHAS_GPU_LOCALE
+endif
+
 RUNTIME_CFLAGS += $(RUNTIME_DEFS)
 RUNTIME_CXXFLAGS += $(RUNTIME_DEFS) $(CXXFLAGS)
-
-

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -41,6 +41,7 @@ COMMON_NOGEN_SRCS = \
 	chpl-external-array.c \
 	chpl-file-utils.c \
 	chpl-format.c \
+	chpl-gpu.c \
 	chplio.c \
 	chpl-mem.c \
 	chpl-mem-desc.c \

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -17,14 +17,8 @@
  * limitations under the License.
  */
 
-// This #define needs to be before the other #includes
-// since it affects included files
-#ifdef __linux__
-#define _GNU_SOURCE
-#endif
-
+#include "sys_basic.h"
 #include "chplrt.h"
-#include "chplsys.h"
 
 #ifdef HAS_GPU_LOCALE
 
@@ -32,8 +26,11 @@
 #include <cuda_runtime.h>
 #include <assert.h>
 
+#define 
 static void checkCudaErrors(CUresult err) {
-  assert(err == CUDA_SUCCESS);
+  if(err != CUDA_SUCCESS) {
+    chpl_internal_error("Encountered error calling CUDA function");
+  }
 }
 
 void chpl_gpu_init() {
@@ -42,11 +39,11 @@ void chpl_gpu_init() {
   int         devCount;
 
   // CUDA initialization
-  cuInit(0);
+  checkCudaErrors(cuInit(0));
 
-  cuDeviceGetCount(&devCount);
+  checkCudaErrors(cuDeviceGetCount(&devCount));
 
-  cuDeviceGet(&device, 0);
+  checkCudaErrors(cuDeviceGet(&device, 0));
 
   // Create driver context
   checkCudaErrors(cuCtxCreate(&context, 0, device));
@@ -75,10 +72,10 @@ void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName) {
   }
 
   // Create module for object
-  cuModuleLoadData(&cudaModule, buffer);
+  checkCudaErrors(cuModuleLoadData(&cudaModule, buffer));
 
   // Get kernel function
-  cuModuleGetFunction(&function, cudaModule, kernelName);
+  checkCudaErrors(cuModuleGetFunction(&function, cudaModule, kernelName));
 
   return (void*)function;
 }

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -19,6 +19,8 @@
 
 #include "sys_basic.h"
 #include "chplrt.h"
+#include "chpl-mem.h"
+#include "error.h"
 
 #ifdef HAS_GPU_LOCALE
 
@@ -26,7 +28,6 @@
 #include <cuda_runtime.h>
 #include <assert.h>
 
-#define 
 static void checkCudaErrors(CUresult err) {
   if(err != CUDA_SUCCESS) {
     chpl_internal_error("Encountered error calling CUDA function");
@@ -63,7 +64,7 @@ void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName) {
     fseek (f, 0, SEEK_END);
     length = ftell (f);
     fseek (f, 0, SEEK_SET);
-    buffer = (char* )malloc (length);
+    buffer = (char* )chpl_malloc (length);
     if (buffer)
     {
       fread (buffer, 1, length, f);

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.  * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This #define needs to be before the other #includes
+// since it affects included files
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+
+#include "chplrt.h"
+#include "chplsys.h"
+
+#ifdef HAS_GPU_LOCALE
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <assert.h>
+
+static void checkCudaErrors(CUresult err) {
+  assert(err == CUDA_SUCCESS);
+}
+
+void chpl_gpu_init() {
+  CUdevice    device;
+  CUcontext   context;
+  int         devCount;
+
+  // CUDA initialization
+  cuInit(0);
+
+  cuDeviceGetCount(&devCount);
+
+  cuDeviceGet(&device, 0);
+
+  // Create driver context
+  checkCudaErrors(cuCtxCreate(&context, 0, device));
+}
+
+void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName) {
+  CUmodule    cudaModule;
+  CUfunction  function;
+
+  //read in fatbin and store in buffer
+  char * buffer = 0;
+  long length;
+  FILE * f = fopen (fatbinFile, "rb");
+
+  if (f)
+  {
+    fseek (f, 0, SEEK_END);
+    length = ftell (f);
+    fseek (f, 0, SEEK_SET);
+    buffer = (char* )malloc (length);
+    if (buffer)
+    {
+      fread (buffer, 1, length, f);
+    }
+    fclose (f);
+  }
+
+  // Create module for object
+  cuModuleLoadData(&cudaModule, buffer);
+
+  // Get kernel function
+  cuModuleGetFunction(&function, cudaModule, kernelName);
+
+  return (void*)function;
+}
+
+#endif // HAS_GPU_LOCALE
+

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
@@ -4,63 +4,11 @@ extern {
   #include <stdlib.h>
   #include <assert.h>
 
-  #define FATBIN_FILE "tmp/chpl__gpu.fatbin"
-
   static void checkCudaErrors(CUresult err) {
     assert(err == CUDA_SUCCESS);
   }
 
-  static void initializeCuda(){
-    CUdevice    device;
-    CUcontext   context;
-    int         devCount;
-
-    // CUDA initialization
-    cuInit(0);
-
-    cuDeviceGetCount(&devCount);
-
-    cuDeviceGet(&device, 0);
-
-    // Create driver context
-    checkCudaErrors(cuCtxCreate(&context, 0, device));
-  }
-
-  static void* createFunction(){
-    CUmodule    cudaModule;
-    CUfunction  function;
-
-    //read in fatbin and store in buffer
-    char * buffer = 0;
-    long length;
-    FILE * f = fopen (FATBIN_FILE, "rb");
-
-    if (f)
-    {
-      fseek (f, 0, SEEK_END);
-      length = ftell (f);
-      fseek (f, 0, SEEK_SET);
-      buffer = (char* )malloc (length);
-      if (buffer)
-      {
-        fread (buffer, 1, length, f);
-      }
-      fclose (f);
-    }
-
-
-    // Create module for object
-    cuModuleLoadData(&cudaModule, buffer);
-
-
-    // Get kernel function
-    cuModuleGetFunction(&function, cudaModule, "add_nums");
-
-    return (void*)function;
-  }
-
   static CUdeviceptr getDeviceBufferPointer(){
-
     double X;
     CUdeviceptr devBufferX;
 
@@ -72,7 +20,6 @@ extern {
     checkCudaErrors(cuMemcpyHtoD(devBufferX, &X, sizeof(double)));
 
     return devBufferX;
-
   }
 
   static void **getKernelParams(CUdeviceptr *devBufferX){
@@ -98,16 +45,15 @@ export proc add_nums(dst_ptr: c_ptr(real(64))){
 
 
 proc main() {
+chpl_gpu_init();
+
 var output: real(64);
-initializeCuda();
-var funcPtr: c_void_ptr = createFunction();
 var deviceBuffer = getDeviceBufferPointer();
 var ptr: c_ptr(uint(64)) = c_ptrTo(deviceBuffer);
 var kernelParams = getKernelParams(ptr);
- __primitive("gpu kernel launch", funcPtr, 1, 1, 1, 1, 1, 1, 0, 0, kernelParams, 0);
+__primitive("gpu kernel launch", c"add_nums", 1, 1, 1, 1, 1, 1, 0, 0, kernelParams, 0);
 output = getDataFromDevice(deviceBuffer);
 
 writeln(output);
-
 }
 

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.compopts
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda"
+echo "--ccflags --cuda-gpu-arch=sm_60 --ccflags -DHAS_GPU_LOCALE --savec=tmp -L$nvccLib -lcuda"

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.compopts
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 --ccflags -DHAS_GPU_LOCALE --savec=tmp -L$nvccLib -lcuda"
+echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda"


### PR DESCRIPTION
Added functions to Chapel runtime library to setup CUDA and return a function pointer to a kernel (`chpl_gpu_getKernel()`). Also updated gpu kernel launch primitive to take in the name of the kernel rather than the function pointer and use `chpl_gpu_getKernel()` to get the function pointer when we rewrite the call to `cuLaunchKernel().`

To understand the motivation for this change see the simplifications to `gpuAddNums_primitive.chpl`.

Previously we had the following (where createFunction() was defined in some extern block)

```chpl
   var funcPtr: c_void_ptr = createFunction();
 __primitive("gpu kernel launch", funcPtr, 1, 1, 1, 1, 1, 1, 0, 0, kernelParams, 0);
```

And now we have this (where the code that was previously in createFunction has been generalized and moved to the runtime lib):

```chpl
__primitive("gpu kernel launch", c"add_nums", 1, 1, 1, 1, 1, 1, 0, 0, kernelParams, 0);
```


To reviewers:

I'm a little unsatisfied with the changes I've made to the runtime library make file. I need to have the include path to CUDA and right now I just check if CHPL_LOCALE_MODEL is set to GPU and if so add -I/usr/local/cuda/include.  I'm open to suggestions on how this could be engineered in a more general solution.

I guess we have other third-party libraries that we either include bundled with Chapel or give the user environmental variables to specify their install path right?  Should we follow this same pattern for CUDA?