### PR TITLE
Stop hiding printchplenv errors in the compiler

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -559,8 +559,8 @@ std::string runPrintChplEnv(const std::map<std::string, const char*>& varMap) {
   for (auto& ii : varMap)
     command += ii.first + "=" + ii.second + " ";
 
-  // Toss stderr away until printchplenv supports a '--suppresswarnings' flag
-  command += std::string(CHPL_HOME) + "/util/printchplenv --all --internal --no-tidy --simple 2> /dev/null";
+  command += "CHPLENV_SUPPRESS_WARNINGS=true ";
+  command += std::string(CHPL_HOME) + "/util/printchplenv --all --internal --no-tidy --simple";
 
   return runCommand(command);
 }
@@ -568,8 +568,8 @@ std::string runPrintChplEnv(const std::map<std::string, const char*>& varMap) {
 std::string getChplDepsApp() {
   // Runs `util/chplenv/chpl_home_utils.py --chpldeps` and removes the newline
 
-  std::string command = "CHPL_HOME=" + std::string(CHPL_HOME) + " python3 ";
-  command += std::string(CHPL_HOME) + "/util/chplenv/chpl_home_utils.py --chpldeps 2> /dev/null";
+  std::string command = "CHPLENV_SUPPRESS_WARNINGS=true CHPL_HOME=" + std::string(CHPL_HOME) + " python3 ";
+  command += std::string(CHPL_HOME) + "/util/chplenv/chpl_home_utils.py --chpldeps";
 
   std::string venvDir = runCommand(command);
   venvDir.erase(venvDir.find_last_not_of("\n\r")+1);
@@ -600,7 +600,7 @@ std::string runCommand(std::string& command) {
   }
 
   if (pclose(pipe)) {
-    USR_FATAL("%s did not run successfully", command.c_str());
+    USR_FATAL("'%s' did not run successfully", command.c_str());
   }
 
   return result;

--- a/test/chplenv/chplconfig/warnings/warnings.chpl
+++ b/test/chplenv/chplconfig/warnings/warnings.chpl
@@ -9,7 +9,7 @@
 
 
 writeln("\
-Syntax Error: $CHPL_CONFIG/chplconfig:line 8\
+Warning: Syntax Error: $CHPL_CONFIG/chplconfig:line 8\
               > CHPL_TASKS == fifo\
               Expected format is:\
               > CHPL_VAR = VALUE\

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -3,7 +3,7 @@ import optparse
 import sys
 
 import chpl_cpu, overrides
-from utils import error, memoize
+from utils import error, memoize, warning
 
 @memoize
 def get(flag='host'):
@@ -33,13 +33,9 @@ def validate(flag='host'):
     machine = chpl_cpu.get_default_machine(flag)
     if cpuarch:
         if cpuarch != machine:
-            sys.stderr.write('Warning: Cross compilation not yet supported. '
-                             'Inferred {0}={1} based upon {2}={3} '
-                             'but running on {4}.\n'.format(arch_flag,
-                                                            cpuarch,
-                                                            cpu_flag,
-                                                            cpu_val,
-                                                            machine))
+            warning('Cross compilation not yet supported. Inferred {0}={1} '
+                    'based upon {2}={3} but running on {4}.'.format(arch_flag,
+                        cpuarch, cpu_flag, cpu_val, machine))
 
 def _main():
     parser = optparse.OptionParser(usage="usage: %prog [--host|target]")

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -6,7 +6,7 @@ import sys
 from distutils.spawn import find_executable
 
 import chpl_platform, overrides
-from utils import error, memoize
+from utils import error, memoize, warning
 
 
 #
@@ -22,7 +22,7 @@ def validate(compiler_val):
         chpl_home = chpl_home_utils.get_chpl_home()
         comp_makefile = os.path.join(chpl_home, 'make', 'compiler', 'Makefile.{0}'.format(compiler_val))
         if not os.path.isfile(comp_makefile):
-            sys.stderr.write('Warning: Unknown compiler: "{0}"\n'.format(compiler_val))
+            warning('Unknown compiler: "{0}"'.format(compiler_val))
 
 
 
@@ -35,7 +35,7 @@ def get_prgenv_compiler():
             return "cray-prgenv-{0}".format(subcompiler.lower())
 
         else:
-            sys.stderr.write("Warning: Compiling on {0} without a PrgEnv loaded\n".format(platform_val))
+            warning("Compiling on {0} without a PrgEnv loaded".format(platform_val))
 
     return 'none'
 

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -4,11 +4,11 @@ import optparse
 import os
 import platform
 from string import punctuation
-from sys import stderr, stdout
+import sys
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
 from compiler_utils import CompVersion, target_compiler_is_prgenv, get_compiler_version
-from utils import memoize, run_command
+from utils import memoize, run_command, warning
 
 
 #
@@ -247,10 +247,8 @@ class argument_map(object):
 
         arg_value = cls._get(cpu, compiler, version)
         if not arg_value:
-            stderr.write('Warning: No valid option found: cpu="{0}" '
-                         'compiler="{1}" version="{2}"\n'.format(cpu,
-                                                                 compiler,
-                                                                 version))
+            warning('No valid option found: cpu="{0}" compiler="{1}" '
+                    'version="{2}"'.format(cpu, compiler, version))
         return arg_value or None
 
     @classmethod
@@ -285,7 +283,7 @@ class argument_map(object):
                     return 'unknown'
             return cls.clang.get(cpu, '')
         else:
-            stderr.write('Warning: Unknown compiler: "{0}"\n'.format(compiler))
+            warning('Unknown compiler: "{0}"'.format(compiler))
             return ''
 
 
@@ -518,21 +516,20 @@ def adjust_cpu_for_compiler(cpu, flag, get_lcd):
     if isprgenv:
         cray_cpu = os.environ.get('CRAY_CPU_TARGET', 'none')
         if cpu and (cpu != 'none' and cpu != 'unknown' and cpu != cray_cpu):
-            stderr.write("Warning: Setting the processor type through "
-                         "environment variables is not supported for "
-                         "cray-prgenv-*. Please use the appropriate craype-* "
-                         "module for your processor type.\n")
+            warning("Setting the processor type through environment variables "
+                    "is not supported for cray-prgenv-*. Please use the "
+                    "appropriate craype-* module for your processor type.")
         cpu = cray_cpu
         if cpu == 'none':
-            stderr.write("Warning: No craype-* processor type module was "
-                         "detected, please load the appropriate one if you want "
-                         "any specialization to occur.\n")
+            warning("No craype-* processor type module was detected, please "
+                    "load the appropriate one if you want any specialization "
+                    "to occur.")
         if get_lcd:
             cpu = get_module_lcd_cpu(platform_val, cpu)
             if cpu == 'none':
-                stderr.write("Warning: Could not detect the lowest common "
-                             "denominator processor type for this platform. "
-                             "You may be unable to use the Chapel compiler\n")
+                warning("Could not detect the lowest common denominator "
+                        "processor type for this platform. You may be unable "
+                        "to use the Chapel compiler")
         return cpu
     elif 'pgi' in compiler_val:
         return 'none'
@@ -612,13 +609,12 @@ def verify_cpu(cpu, flag):
             if not feature_sets.subset(cpu, detected_cpu):
                 warn = True
         except ValueError:
-            stderr.write("Warning: Unknown platform, could not find CPU information\n")
+            warning("Unknown platform, could not find CPU information")
 
         if warn:
-                stderr.write("Warning: The supplied processor type does "
-                             "not appear to be compatible with the host "
-                             "processor type. The resultant binary may "
-                             "not run on the current machine.\n")
+                warning("The supplied processor type does not appear to be "
+                        "compatible with the host processor type. The "
+                        "resultant binary may not run on the current machine.")
 
 # get_lcd has no effect on non cray systems and is intended to be used to get
 # the correct runtime and gen directory.
@@ -726,8 +722,8 @@ def _main():
                       options.get_lcd)
 
     if options.compflag:
-        stdout.write("{0}=".format(flag))
-    stdout.write("{0}\n".format(cpu))
+        sys.stdout.write("{0}=".format(flag))
+    sys.stdout.write("{0}\n".format(cpu))
 
 if __name__ == '__main__':
     _main()

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -4,7 +4,7 @@ import sys
 
 import chpl_compiler, chpl_platform, overrides, third_party_utils
 from chpl_home_utils import get_chpl_third_party
-from utils import memoize
+from utils import memoize, warning
 
 
 @memoize
@@ -27,8 +27,7 @@ def get():
         else:
             gmp_val = 'none'
     elif gmp_val == 'gmp':
-        sys.stderr.write("Warning: CHPL_GMP=gmp is deprecated. "
-                         "Use CHPL_GMP=bundled instead.\n")
+        warning("CHPL_GMP=gmp is deprecated. Use CHPL_GMP=bundled.")
         gmp_val = 'bundled'
 
     return gmp_val

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -2,7 +2,7 @@
 import sys
 
 import chpl_locale_model, chpl_tasks, overrides, third_party_utils
-from utils import error, memoize
+from utils import error, memoize, warning
 
 
 @memoize
@@ -15,8 +15,7 @@ def get():
         else:
             hwloc_val = 'none'
     elif hwloc_val == 'hwloc':
-        sys.stderr.write("Warning: CHPL_HWLOC=hwloc is deprecated. "
-                         "Use CHPL_HWLOC=bundled instead.\n");
+        warning("CHPL_HWLOC=hwloc is deprecated. Use CHPL_HWLOC=bundled.")
         hwloc_val = 'bundled'
 
     return hwloc_val

--- a/util/chplenv/chpl_jemalloc.py
+++ b/util/chplenv/chpl_jemalloc.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 import chpl_mem, overrides, third_party_utils
-from utils import error, memoize, run_command
+from utils import error, memoize, run_command, warning
 
 
 @memoize
@@ -23,8 +23,7 @@ def get():
       error("CHPL_JEMALLOC must be 'none' when CHPL_MEM is not jemalloc")
 
     if jemalloc_val == 'jemalloc':
-        sys.stderr.write("Warning: CHPL_JEMALLOC=jemalloc is deprecated. "
-                         "Use CHPL_JEMALLOC=bundled instead\n")
+        warning("CHPL_JEMALLOC=jemalloc is deprecated. Use CHPL_JEMALLOC=bundled.")
         jemalloc_val = 'bundled'
 
     return jemalloc_val

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -3,7 +3,7 @@ from distutils.spawn import find_executable
 import sys
 
 import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
-from utils import error, memoize
+from utils import error, memoize, warning
 
 def slurm_prefix(base_launcher, platform_val):
     """ If salloc is available and we're on a cray-cs, prefix with slurm-"""
@@ -46,9 +46,8 @@ def get():
                 #        has_aprun and has_slurm should look other places
                 #        (maybe the modules?) to decide.
                 #        (thomasvandoren, 2014-08-12)
-                sys.stderr.write(
-                    'Warning: Cannot detect launcher on this system. Please '
-                    'set CHPL_LAUNCHER in the environment.\n')
+                warning('Cannot detect launcher on this system. Please '
+                        'set CHPL_LAUNCHER in the environment.')
         elif comm_val == 'gasnet':
             if substrate_val == 'smp':
                 launcher_val = 'smp'

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -2,7 +2,7 @@
 import sys
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform, overrides, third_party_utils
-from utils import error, memoize, try_run_command
+from utils import error, memoize, try_run_command, warning
 
 
 @memoize
@@ -22,14 +22,13 @@ def get():
         if libfabric_val == 'none':
             error("CHPL_LIBFABRIC must not be 'none' when CHPL_COMM is ofi")
         if platform_val == 'hpe-cray-ex' and libfabric_val != 'system':
-            sys.stderr.write('Warning: CHPL_LIBFABRIC!=system is discouraged '
-                             'on HPE Cray EX\n')
+            warning('CHPL_LIBFABRIC!=system is discouraged on HPE Cray EX')
     else:
         libfabric_val = 'none'
 
     if libfabric_val == 'libfabric':
-        sys.stderr.write("Warning: CHPL_LIBFABRIC=libfabric is deprecated. "
-                         "Use CHPL_LIBFABRIC=bundled instead.\n")
+        warning("CHPL_LIBFABRIC=libfabric is deprecated. Use "
+                "CHPL_LIBFABRIC=bundled instead.")
         libfabric_val = 'bundled'
 
     return libfabric_val

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -5,7 +5,7 @@ import sys
 
 import chpl_bin_subdir, chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import get_chpl_third_party
-from utils import memoize, error, run_command, try_run_command
+from utils import memoize, error, run_command, try_run_command, warning
 
 # returns a tuple of supported major LLVM versions as strings
 def llvm_versions():
@@ -154,8 +154,7 @@ def get_llvm_config():
         llvm_subdir = get_bundled_llvm_dir()
         bundled_config = os.path.join(llvm_subdir, 'bin', 'llvm-config')
         if llvm_config != 'none' and llvm_config != bundled_config:
-            sys.stderr.write("Warning: CHPL_LLVM_CONFIG is ignored for "
-                             "CHPL_LLVM=bundled\n");
+            warning("CHPL_LLVM_CONFIG is ignored for CHPL_LLVM=bundled");
         llvm_config = bundled_config
 
     elif llvm_config == 'none' and llvm_val == 'system':
@@ -244,14 +243,13 @@ def get():
             llvm_val = 'none'
 
     if llvm_val == 'llvm':
-        sys.stderr.write("Warning: CHPL_LLVM=llvm is deprecated. "
-                         "Use CHPL_LLVM=bundled instead\n")
+        warning("CHPL_LLVM=llvm is deprecated. Use CHPL_LLVM=bundled instead")
         llvm_val = 'bundled'
 
     if not compatible_platform_for_llvm():
         if llvm_val != 'none' and llvm_val != 'unset':
-            sys.stderr.write("Warning: CHPL_LLVM={0} is not compatible "
-                             "with this platform".format(llvm_val))
+            warning("CHPL_LLVM={0} is not compatible with this "
+                    "platform".format(llvm_val))
 
     return llvm_val
 

--- a/util/chplenv/chpl_re2.py
+++ b/util/chplenv/chpl_re2.py
@@ -4,7 +4,7 @@ import sys
 
 import chpl_compiler, chpl_platform, overrides, third_party_utils
 from chpl_home_utils import get_chpl_third_party
-from utils import memoize
+from utils import memoize, warning
 
 
 @memoize
@@ -14,9 +14,8 @@ def get():
     if regexp:
         if not re2:
             re2 = 'bundled' if regexp == 're2' else 'none'
-        sys.stderr.write("Warning: CHPL_REGEXP is deprecated.\n"
-                         "Set CHPL_RE2 to 'bundled' or 'none'.\n"
-                         "Assuming CHPL_RE2={}.\n".format(re2))
+
+        warning("CHPL_REGEXP is deprecated. Use CHPL_RE2.")
     elif not re2:
         re2_header = os.path.join(get_chpl_third_party(), 're2',
                                   'install', get_uniq_cfg_path(),

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -2,7 +2,7 @@
 import sys
 
 import chpl_platform, overrides, third_party_utils
-from utils import error, memoize
+from utils import error, memoize, warning
 
 
 @memoize
@@ -13,8 +13,7 @@ def get():
     val = overrides.get('CHPL_UNWIND')
 
     if val == 'libunwind':
-        sys.stderr.write("Warning: CHPL_UNWIND=libunwind is deprecated. "
-                         "Use CHPL_UNWIND=bundled instead\n")
+        warning("CHPL_UNWIND=libunwind is deprecated. Use CHPL_UNWIND=bundled.")
         val = 'bundled'
 
     if linux:

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -6,7 +6,7 @@ Checks environment variables first, then chplconfig file for definitions
 import os
 import sys
 
-from utils import memoize
+from utils import memoize, warning
 
 # List of Chapel Environment Variables
 chplvars = [
@@ -118,8 +118,8 @@ class ChapelConfig(object):
             if name == 'CHPL_CONFIG':
                 self.warnings.append(
                 (
-                    'Warning: No chplconfig or .chplconfig file is found in '
-                    'the defined $CHPL_CONFIG\n'
+                    'No chplconfig or .chplconfig file is found in '
+                    'the defined $CHPL_CONFIG'
                 ))
         return False
 
@@ -157,7 +157,7 @@ class ChapelConfig(object):
                 'Syntax Error: {0}:line {1}\n'
                 '              > {2}\n'
                 '              Expected format is:\n'
-                '              > CHPL_VAR = VALUE\n'
+                '              > CHPL_VAR = VALUE'
             ).format(self.prettypath, linenum, line.strip('\n')))
             return True
 
@@ -165,8 +165,7 @@ class ChapelConfig(object):
         if var not in chplvars:
             self.warnings.append(
             (
-                'Warning: {0}:line {1}: '
-                '"{2}" is not an acceptable variable\n'
+                '{0}:line {1}: "{2}" is not an acceptable variable'
             ).format(self.prettypath, linenum, var))
             return True
 
@@ -174,8 +173,7 @@ class ChapelConfig(object):
         elif var in self.chplconfig.keys():
             self.warnings.append(
             (
-                'Warning: {0}:line {1}: '
-                'Duplicate entry of "{2}"\n'
+                '{0}:line {1}: Duplicate entry of "{2}"'
             ).format(self.prettypath, linenum, var))
 
         # If we reach here, this is a valid assignment, so don't skip
@@ -184,8 +182,8 @@ class ChapelConfig(object):
     def printwarnings(self):
         """ Print any warnings accumulated throughout constructor """
         sys.stderr.write('\n')
-        for warning in self.warnings:
-            sys.stderr.write(warning)
+        for msg in self.warnings:
+            warning(msg)
         sys.stderr.write('\n')
 
 

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -3,6 +3,12 @@ import os
 import subprocess
 import sys
 
+def warning(msg):
+    if not os.environ.get('CHPLENV_SUPPRESS_WARNINGS'):
+        sys.stderr.write('Warning: ')
+        sys.stderr.write(msg)
+        sys.stderr.write('\n')
+
 
 def error(msg, exception=Exception):
     """Exception raising wrapper that differentiates developer-mode output"""


### PR DESCRIPTION
printchplenv is run from the compiler and previously any fatal errors
weren't visible to users. We hid stderr to avoid getting warnings into
the compiler output, but this made fatal errors tricky to debug.

To resolve this add a way to suppress warnings, use that, and stop
redirecting stderr so users will see the fatal error messages.

For #18021