### PR TITLE
Fix how we stub out GNU's __extension__ in c2chapel

### DIFF
--- a/tools/c2chapel/utils/custom.h
+++ b/tools/c2chapel/utils/custom.h
@@ -2,7 +2,7 @@
 #define _C2CHAPEL_CUSTOM_H_
 
 #define __attribute__(x)
-#define __extension__(x)
+#define __extension__
 
 /* Add your own definitions below! */
 


### PR DESCRIPTION
This reflects how the pycparser FAQ [says to stub out GNU's `__extension__`](https://github.com/eliben/pycparser/wiki/FAQ#what-do-i-do-about-__extension__)
and seems to work better when trying to parse glib header files like those
used by Apache Arrow.