### PR TITLE
Skip memory fragmentation test under ugni for now

### DIFF
--- a/test/runtime/configMatters/mem/fragmentation.skipif
+++ b/test/runtime/configMatters/mem/fragmentation.skipif
@@ -1,1 +1,2 @@
 CHPL_MEM != jemalloc
+CHPL_COMM == ugni


### PR DESCRIPTION
A bug on one of our systems is causing the test to sporadically fail, so
skip it until that is addressed.

For https://github.com/cray/chapel-private/issues/2223