### PR TITLE
Improve lookForBadRTCalls error message.

### DIFF
--- a/util/devel/look_for_calls.py
+++ b/util/devel/look_for_calls.py
@@ -122,18 +122,35 @@ def check_for_calls(functions, search_dir, exclude_paths=None, rel_paths=True):
 
         found_calls = False
         for func in functions:
-            out = cscope_find_calls(func, cscope_database_name)
-            if out:
-                found_calls = True
-                log_error('found call to "{0}"'.format(func))
-                sys.stdout.write(out.replace(rel_dir, '') + '\n')
+          # If func is a tuple consider the first element to be the function
+          # we're searching for and the second an alternative to suggest
+          # to the user.
+          alternative = None
+          if isinstance(func, tuple):
+            alternative = func[1]
+            func = func[0]
+            
+          out = cscope_find_calls(func, cscope_database_name)
+          if out:
+              found_calls = True
+              msg = 'found call to "{0}"'.format(func)
+              if alternative is not None:
+                msg += ' consider using "{0}" instead'.format(alternative)
+              log_error(msg)
+              sys.stdout.write(out.replace(rel_dir, '') + '\n')
 
         return found_calls
 
 
 def get_alloc_funcs():
     """Return a list of the possible C alloc/dealloc routines"""
-    std = ['malloc', 'calloc', 'realloc', 'free']
+    # If list element is a tuple then consider the second element to
+    # be an alternative for the first. If the list element is a
+    # not a tuple then their is no known alternative.
+    std = [('malloc', 'chpl_malloc'),
+           ('calloc', 'chpl_calloc'),
+           ('realloc', 'chpl_realloc'),
+           ('free', 'chpl_free')]
     align = ['aligned_alloc', 'posix_memalign', 'memalign']
     page_align = ['valloc', 'pvalloc']
     string = ['strdup', 'strndup', 'asprintf', 'vasprintf']

--- a/util/devel/look_for_calls.py
+++ b/util/devel/look_for_calls.py
@@ -127,14 +127,13 @@ def check_for_calls(functions, search_dir, exclude_paths=None, rel_paths=True):
           # to the user.
           alternative = None
           if isinstance(func, tuple):
-            alternative = func[1]
-            func = func[0]
+            func, alternative = func
             
           out = cscope_find_calls(func, cscope_database_name)
           if out:
               found_calls = True
               msg = 'found call to "{0}"'.format(func)
-              if alternative is not None:
+              if alternative:
                 msg += ' consider using "{0}" instead'.format(alternative)
               log_error(msg)
               sys.stdout.write(out.replace(rel_dir, '') + '\n')
@@ -147,10 +146,10 @@ def get_alloc_funcs():
     # If list element is a tuple then consider the second element to
     # be an alternative for the first. If the list element is a
     # not a tuple then their is no known alternative.
-    std = [('malloc', 'chpl_malloc'),
-           ('calloc', 'chpl_calloc'),
-           ('realloc', 'chpl_realloc'),
-           ('free', 'chpl_free')]
+    std = [('malloc', 'chpl_mem_alloc'),
+           ('calloc', 'chpl_mem_calloc'),
+           ('realloc', 'chpl_mem_realloc'),
+           ('free', 'chpl_mem_free')]
     align = ['aligned_alloc', 'posix_memalign', 'memalign']
     page_align = ['valloc', 'pvalloc']
     string = ['strdup', 'strndup', 'asprintf', 'vasprintf']


### PR DESCRIPTION
Specifically by suggesting alternatives when lookForBadRTCalls finds memory
allocation functions like malloc or free.

So now instead of getting a message like this:

`Error: found call to "malloc"`

We should get:

`Error: found call to "malloc" consider using "chpl_mem_alloc" instead`