### PR TITLE
compiler/next: scope resolution and uast improvements

### DIFF
--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -414,6 +414,26 @@ class Context {
   #endif
 ;
 
+  typedef enum {
+    NOT_CHECKED_NOT_CHANGED = 0,
+    REUSED = 1,
+    CHANGED = 2
+  } QueryStatus;
+
+  /**
+    Returns:
+      0 if the query was not checked or changed in this revision
+      1 if the query was checked but not changed in this revision
+      2 if the query was changed in this revision
+
+    This is intended only as a debugging aid.
+   */
+  template<typename ResultType,
+           typename... ArgTs>
+  QueryStatus queryStatus(
+         const ResultType& (*queryFunction)(Context* context, ArgTs...),
+         const std::tuple<ArgTs...>& tupleOfArgs);
+
   // the following functions are called by the macros defined in QueryImpl.h
   // and should not be called directly
 

--- a/compiler/next/include/chpl/uast/Begin.h
+++ b/compiler/next/include/chpl/uast/Begin.h
@@ -57,7 +57,18 @@ class Begin final : public SimpleBlockLike {
     assert(isExpressionASTList(children_));
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Begin* lhs = this;
+    const Begin* rhs = (const Begin*) other;
+
+    if (lhs->withClauseChildNum_ != rhs->withClauseChildNum_)
+      return false;
+
+    if (!lhs->simpleBlockLikeContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     simpleBlockLikeMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/BracketLoop.h
+++ b/compiler/next/include/chpl/uast/BracketLoop.h
@@ -48,7 +48,6 @@ class BracketLoop final : public IndexableLoop {
               int8_t withClauseChildNum,
               BlockStyle blockStyle,
               int loopBodyChildNum,
-              int numLoopBodyStmts,
               bool isExpressionLevel)
     : IndexableLoop(asttags::BracketLoop, std::move(children),
                     indexChildNum,
@@ -56,7 +55,6 @@ class BracketLoop final : public IndexableLoop {
                     withClauseChildNum,
                     blockStyle,
                     loopBodyChildNum,
-                    numLoopBodyStmts,
                     isExpressionLevel) {
     assert(isExpressionASTList(children_));
   }
@@ -80,7 +78,7 @@ class BracketLoop final : public IndexableLoop {
                                   owned<Expression> iterand,
                                   owned<WithClause> withClause,
                                   BlockStyle blockStyle,
-                                  ASTList stmts,
+                                  owned<Block> body,
                                   bool isExpressionLevel);
 
 

--- a/compiler/next/include/chpl/uast/Break.h
+++ b/compiler/next/include/chpl/uast/Break.h
@@ -48,7 +48,18 @@ class Break : public Expression {
     assert(numChildren() <= 1);
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Break* lhs = this;
+    const Break* rhs = other->toBreak();
+
+    if (lhs->targetChildNum_ != rhs->targetChildNum_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     expressionMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/Cobegin.h
+++ b/compiler/next/include/chpl/uast/Cobegin.h
@@ -56,7 +56,24 @@ class Cobegin final : public Expression {
     assert(isExpressionASTList(children_));
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Cobegin* lhs = this;
+    const Cobegin* rhs = (const Cobegin*) other;
+
+    if (lhs->withClauseChildNum_ != rhs->withClauseChildNum_)
+      return false;
+
+    if (lhs->bodyChildNum_ != rhs->bodyChildNum_)
+      return false;
+
+    if (lhs->numTaskBodies_ != rhs->numTaskBodies_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     expressionMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/Coforall.h
+++ b/compiler/next/include/chpl/uast/Coforall.h
@@ -49,15 +49,13 @@ class Coforall final : public IndexableLoop {
            int8_t iterandChildNum,
            int8_t withClauseChildNum,
            BlockStyle blockStyle,
-           int loopBodyChildNum,
-           int numLoopBodyStmts)
+           int loopBodyChildNum)
     : IndexableLoop(asttags::Coforall, std::move(children),
                     indexChildNum,
                     iterandChildNum,
                     withClauseChildNum,
                     blockStyle,
                     loopBodyChildNum,
-                    numLoopBodyStmts,
                     /*isExpressionLevel*/ false) {
     assert(isExpressionASTList(children_));
   }
@@ -81,7 +79,7 @@ class Coforall final : public IndexableLoop {
                                owned<Expression> iterand,
                                owned<WithClause> withClause,
                                BlockStyle blockStyle,
-                               ASTList stmts);
+                               owned<Block> body);
 
 
 };

--- a/compiler/next/include/chpl/uast/Comment.h
+++ b/compiler/next/include/chpl/uast/Comment.h
@@ -45,8 +45,15 @@ class Comment final : public Expression {
    : Expression(asttags::Comment), comment_(std::move(s)) {
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Comment* lhs = this;
+    const Comment* rhs = (const Comment*) other;
+    return lhs->expressionContentsMatchInner(rhs) &&
+           lhs->comment_ == rhs->comment_ ;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    return expressionMarkUniqueStringsInner(context);
+  }
 
  public:
   ~Comment() override = default;

--- a/compiler/next/include/chpl/uast/Conditional.h
+++ b/compiler/next/include/chpl/uast/Conditional.h
@@ -83,7 +83,36 @@ class Conditional final : public Expression {
     assert(((size_t)numKnownChildren) <= children_.size());
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Conditional* lhs = this;
+    const Conditional* rhs = other->toConditional();
+
+    if (lhs->thenBlockStyle_ != rhs->thenBlockStyle_)
+      return false;
+
+    if (lhs->thenBodyChildNum_ != rhs->thenBodyChildNum_)
+      return false;
+
+    if (lhs->numThenBodyStmts_ != rhs->numThenBodyStmts_)
+      return false;
+
+    if (lhs->elseBlockStyle_ != rhs->elseBlockStyle_)
+      return false;
+
+    if (lhs->elseBodyChildNum_ != rhs->elseBodyChildNum_)
+      return false;
+
+    if (lhs->numElseBodyStmts_ != rhs->numElseBodyStmts_)
+      return false;
+
+    if (lhs->isExpressionLevel_ != rhs->isExpressionLevel_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     expressionMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/Continue.h
+++ b/compiler/next/include/chpl/uast/Continue.h
@@ -47,7 +47,18 @@ class Continue : public Expression {
     assert(numChildren() <= 1);
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Continue* lhs = this;
+    const Continue* rhs = other->toContinue();
+
+    if (lhs->targetChildNum_ != rhs->targetChildNum_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     expressionMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/DoWhile.h
+++ b/compiler/next/include/chpl/uast/DoWhile.h
@@ -48,18 +48,27 @@ class DoWhile final : public Loop {
  private:
   DoWhile(ASTList children, BlockStyle blockStyle,
           int loopBodyChildNum,
-          int numLoopBodyStmts,
           int conditionChildNum)
     : Loop(asttags::DoWhile, std::move(children),
            blockStyle,
-           loopBodyChildNum,
-           numLoopBodyStmts),
+           loopBodyChildNum),
       conditionChildNum_(conditionChildNum) {
     assert(isExpressionASTList(children_));
     assert(condition());
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const DoWhile* lhs = this;
+    const DoWhile* rhs = (const DoWhile*) other;
+
+    if (lhs->conditionChildNum_ != rhs->conditionChildNum_)
+      return false;
+
+    if (!lhs->loopContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     loopMarkUniqueStringsInner(context);
@@ -75,7 +84,7 @@ class DoWhile final : public Loop {
   */
   static owned<DoWhile> build(Builder* builder, Location loc,
                               BlockStyle blockStyle,
-                              ASTList stmts,
+                              owned<Block> body,
                               owned<Expression> condition);
 
 

--- a/compiler/next/include/chpl/uast/Dot.h
+++ b/compiler/next/include/chpl/uast/Dot.h
@@ -55,8 +55,22 @@ class Dot final : public Call {
            /* hasCalledExpression */ true),
       fieldName_(fieldName) {
   }
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Dot* lhs = this;
+    const Dot* rhs = (const Dot*) other;
+
+    if (lhs->fieldName_ != rhs->fieldName_)
+      return false;
+
+    if (!lhs->callContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    callMarkUniqueStringsInner(context);
+    fieldName_.mark(context);
+  }
 
  public:
   ~Dot() override = default;

--- a/compiler/next/include/chpl/uast/Enum.h
+++ b/compiler/next/include/chpl/uast/Enum.h
@@ -50,8 +50,15 @@ class Enum final : public TypeDecl {
     assert(isEnumElementAndCommentList(children_));
   }
   static bool isEnumElementAndCommentList(const ASTList& list);
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Enum* lhs = this;
+    const Enum* rhs = (const Enum*) other;
+    return lhs->typeDeclContentsMatchInner(rhs);
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    typeDeclMarkUniqueStringsInner(context);
+  }
 
  public:
   ~Enum() override = default;

--- a/compiler/next/include/chpl/uast/EnumElement.h
+++ b/compiler/next/include/chpl/uast/EnumElement.h
@@ -48,8 +48,14 @@ class EnumElement final : public NamedDecl {
     assert(children_.size() == 0 || children_.size() == 1);
     assert(isExpressionASTList(children_));
   }
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const EnumElement* lhs = (const EnumElement*) this;
+    const EnumElement* rhs = (const EnumElement*) other;
+    return lhs->namedDeclContentsMatchInner(rhs);
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    namedDeclMarkUniqueStringsInner(context);
+  }
 
  public:
   ~EnumElement() override = default;

--- a/compiler/next/include/chpl/uast/ErroneousExpression.h
+++ b/compiler/next/include/chpl/uast/ErroneousExpression.h
@@ -35,8 +35,14 @@ class ErroneousExpression final : public Expression {
   ErroneousExpression()
     : Expression(asttags::ErroneousExpression) {
   }
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const ErroneousExpression* lhs = this;
+    const ErroneousExpression* rhs = (const ErroneousExpression*) other;
+    return lhs->expressionContentsMatchInner(rhs);
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    expressionMarkUniqueStringsInner(context);
+  }
 
  public:
   ~ErroneousExpression() = default;

--- a/compiler/next/include/chpl/uast/FnCall.h
+++ b/compiler/next/include/chpl/uast/FnCall.h
@@ -62,8 +62,31 @@ class FnCall : public Call {
       actualNames_(std::move(actualNames)),
       callUsedSquareBrackets_(callUsedSquareBrackets) {
   }
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const FnCall* lhs = this;
+    const FnCall* rhs = (const FnCall*) other;
+
+    if (!lhs->callContentsMatchInner(rhs))
+      return false;
+
+    if (lhs->callUsedSquareBrackets_ != rhs->callUsedSquareBrackets_ ||
+        lhs->actualNames_.size() != rhs->actualNames_.size())
+      return false;
+
+    int nActualNames = (int) lhs->actualNames_.size();
+    for (int i = 0; i < nActualNames; i++) {
+      if (lhs->actualNames_[i] != rhs->actualNames_[i])
+        return false;
+    }
+
+    return true;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    callMarkUniqueStringsInner(context);
+    for (const auto& str : actualNames_) {
+      str.mark(context);
+    }
+  }
 
  public:
   ~FnCall() override = default;

--- a/compiler/next/include/chpl/uast/For.h
+++ b/compiler/next/include/chpl/uast/For.h
@@ -48,7 +48,6 @@ class For final : public IndexableLoop {
       int8_t iterandChildNum,
       BlockStyle blockStyle,
       int loopBodyChildNum,
-      int numLoopBodyStmts,
       bool isExpressionLevel,
       bool isParam)
     : IndexableLoop(asttags::For, std::move(children),
@@ -57,7 +56,6 @@ class For final : public IndexableLoop {
                     /*withClauseChildNum*/ -1,
                     blockStyle,
                     loopBodyChildNum,
-                    numLoopBodyStmts,
                     isExpressionLevel),
       isParam_(isParam) {
 
@@ -65,7 +63,18 @@ class For final : public IndexableLoop {
     assert(withClause() == nullptr);
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const For* lhs = this;
+    const For* rhs = (const For*) other;
+
+    if (lhs->isParam_ != rhs->isParam_)
+      return false;
+
+    if (!lhs->indexableLoopContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     indexableLoopMarkUniqueStringsInner(context);
@@ -83,7 +92,7 @@ class For final : public IndexableLoop {
                           owned<Decl> index,
                           owned<Expression> iterand,
                           BlockStyle blockStyle,
-                          ASTList stmts,
+                          owned<Block> body,
                           bool isExpressionLevel,
                           bool isParam);
 

--- a/compiler/next/include/chpl/uast/Forall.h
+++ b/compiler/next/include/chpl/uast/Forall.h
@@ -51,7 +51,6 @@ class Forall final : public IndexableLoop {
          int8_t withClauseChildNum,
          BlockStyle blockStyle,
          int loopBodyChildNum,
-         int numLoopBodyStmts,
          bool isExpressionLevel)
     : IndexableLoop(asttags::Forall, std::move(children),
                     indexChildNum,
@@ -59,7 +58,6 @@ class Forall final : public IndexableLoop {
                     withClauseChildNum,
                     blockStyle,
                     loopBodyChildNum,
-                    numLoopBodyStmts,
                     isExpressionLevel) {
     assert(isExpressionASTList(children_));
   }
@@ -83,7 +81,7 @@ class Forall final : public IndexableLoop {
                              owned<Expression> iterand,
                              owned<WithClause> withClause,
                              BlockStyle blockStyle,
-                             ASTList stmts,
+                             owned<Block> body,
                              bool isExpressionLevel);
 
 };

--- a/compiler/next/include/chpl/uast/Foreach.h
+++ b/compiler/next/include/chpl/uast/Foreach.h
@@ -50,15 +50,13 @@ class Foreach final : public IndexableLoop {
           int8_t iterandChildNum,
           int8_t withClauseChildNum,
           BlockStyle blockStyle,
-          int loopBodyChildNum,
-          int numLoopBodyStmts)
+          int loopBodyChildNum)
     : IndexableLoop(asttags::Foreach, std::move(children),
                     indexChildNum,
                     iterandChildNum,
                     withClauseChildNum,
                     blockStyle,
                     loopBodyChildNum,
-                    numLoopBodyStmts,
                     /*isExpressionLevel*/ false) {
 
     assert(isExpressionASTList(children_));
@@ -83,7 +81,7 @@ class Foreach final : public IndexableLoop {
                               owned<Expression> iterand,
                               owned<WithClause> withClause,
                               BlockStyle blockStyle,
-                              ASTList stmts);
+                              owned<Block> body);
 
 
 };

--- a/compiler/next/include/chpl/uast/Formal.h
+++ b/compiler/next/include/chpl/uast/Formal.h
@@ -69,8 +69,15 @@ class Formal final : public VarLikeDecl {
                   initExpressionChildNum),
       intent_(intent) {}
 
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Formal* lhs = this;
+    const Formal* rhs = (const Formal*) other;
+    return lhs->varLikeDeclContentsMatchInner(rhs) &&
+           lhs->intent_ == rhs->intent_;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    varLikeDeclMarkUniqueStringsInner(context);
+  }
 
  public:
   ~Formal() override = default;

--- a/compiler/next/include/chpl/uast/Identifier.h
+++ b/compiler/next/include/chpl/uast/Identifier.h
@@ -50,8 +50,16 @@ class Identifier final : public Expression {
     assert(!name.isEmpty());
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Identifier* lhs = this;
+    const Identifier* rhs = (const Identifier*) other;
+    return lhs->expressionContentsMatchInner(rhs) &&
+           lhs->name_ == rhs->name_;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    expressionMarkUniqueStringsInner(context);
+    this->name_.mark(context);
+  }
 
  public:
   ~Identifier() override = default;

--- a/compiler/next/include/chpl/uast/IndexableLoop.h
+++ b/compiler/next/include/chpl/uast/IndexableLoop.h
@@ -40,11 +40,9 @@ class IndexableLoop : public Loop {
                 int8_t withClauseChildNum,
                 BlockStyle blockStyle,
                 int loopBodyChildNum,
-                int numLoopBodyStmts,
                 bool isExpressionLevel)
     : Loop(tag, std::move(children), blockStyle,
-           loopBodyChildNum,
-           numLoopBodyStmts),
+           loopBodyChildNum),
       indexChildNum_(indexChildNum),
       iterandChildNum_(iterandChildNum),
       withClauseChildNum_(withClauseChildNum),
@@ -54,7 +52,27 @@ class IndexableLoop : public Loop {
     assert(iterandChildNum >= 0);
   }
 
-  bool indexableLoopContentsMatchInner(const IndexableLoop* other) const;
+  bool indexableLoopContentsMatchInner(const IndexableLoop* other) const {
+    const IndexableLoop* lhs = this;
+    const IndexableLoop* rhs = other;
+
+    if (lhs->indexChildNum_ != rhs->indexChildNum_)
+      return false;
+
+    if (lhs->iterandChildNum_ != rhs->iterandChildNum_)
+      return false;
+
+    if (lhs->withClauseChildNum_ != rhs->withClauseChildNum_)
+      return false;
+
+    if (lhs->isExpressionLevel_ != rhs->isExpressionLevel_)
+      return false;
+
+    if (!lhs->loopContentsMatchInner(other))
+      return false;
+
+    return true;
+  }
 
   void indexableLoopMarkUniqueStringsInner(Context* context) const {
     loopMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/Label.h
+++ b/compiler/next/include/chpl/uast/Label.h
@@ -51,9 +51,24 @@ class Label final : public Expression {
     assert(numChildren() == 1);
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Label* lhs = this;
+    const Label* rhs = other->toLabel();
 
+    assert(lhs->loopChildNum_ == rhs->loopChildNum_);
+
+    if (lhs->name_ != rhs->name_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    name_.mark(context);
+    expressionMarkUniqueStringsInner(context);
+  }
   // This always exists and its position can never change.
   static const int8_t loopChildNum_ = 0;
 

--- a/compiler/next/include/chpl/uast/Local.h
+++ b/compiler/next/include/chpl/uast/Local.h
@@ -60,7 +60,18 @@ class Local final : public SimpleBlockLike {
     assert(isExpressionASTList(children_));
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Local* lhs = this;
+    const Local* rhs = (const Local*) other;
+
+    if (lhs->condChildNum_ != rhs->condChildNum_)
+      return false;
+
+    if (!lhs->simpleBlockLikeContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     simpleBlockLikeMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/Module.h
+++ b/compiler/next/include/chpl/uast/Module.h
@@ -54,8 +54,17 @@ class Module final : public NamedDecl {
 
     assert(isExpressionASTList(children_));
   }
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Module* lhs = this;
+    const Module* rhs = (const Module*) other;
+    return lhs->namedDeclContentsMatchInner(rhs) &&
+           lhs->kind_ == rhs->kind_;
+
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    namedDeclMarkUniqueStringsInner(context);
+  }
 
  public:
   ~Module() override = default;

--- a/compiler/next/include/chpl/uast/MultiDecl.h
+++ b/compiler/next/include/chpl/uast/MultiDecl.h
@@ -59,9 +59,16 @@ class MultiDecl final : public Decl {
     assert(isAcceptableMultiDecl());
   }
   bool isAcceptableMultiDecl();
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
 
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const MultiDecl* lhs = this;
+    const MultiDecl* rhs = (const MultiDecl*) other;
+    return lhs->declContentsMatchInner(rhs);
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    declMarkUniqueStringsInner(context);
+  }
+ 
  public:
   ~MultiDecl() override = default;
   static owned<MultiDecl> build(Builder* builder, Location loc,

--- a/compiler/next/include/chpl/uast/New.h
+++ b/compiler/next/include/chpl/uast/New.h
@@ -56,8 +56,23 @@ class New : public Expression {
   New(ASTList children, New::Management management)
     : Expression(asttags::New, std::move(children)),
       management_(management) {}
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const New* lhs = this;
+    const New* rhs = (const New*) other;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    if (lhs->management_ != rhs->management_)
+      return false;
+
+    return true;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    expressionMarkUniqueStringsInner(context);
+  }
+
   Management management_;
 
  public:

--- a/compiler/next/include/chpl/uast/OpCall.h
+++ b/compiler/next/include/chpl/uast/OpCall.h
@@ -45,8 +45,23 @@ class OpCall final : public Call {
            /* hasCalledExpression */ false),
       op_(op) {
   }
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const OpCall* lhs = this;
+    const OpCall* rhs = (const OpCall*) other;
+
+    if (lhs->op_ != rhs->op_)
+      return false;
+
+    if (!lhs->callContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    callMarkUniqueStringsInner(context);
+    op_.mark(context);
+  }
 
  public:
   ~OpCall() override = default;

--- a/compiler/next/include/chpl/uast/Return.h
+++ b/compiler/next/include/chpl/uast/Return.h
@@ -50,7 +50,18 @@ class Return final : public Expression {
     assert(valueChildNum_ <= 0);
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Return* lhs = this;
+    const Return* rhs = (const Return*) other;
+
+    if (lhs->valueChildNum_ != rhs->valueChildNum_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     expressionMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/Serial.h
+++ b/compiler/next/include/chpl/uast/Serial.h
@@ -60,7 +60,18 @@ class Serial final : public SimpleBlockLike {
     assert(isExpressionASTList(children_));
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Serial* lhs = this;
+    const Serial* rhs = (const Serial*) other;
+
+    if (lhs->condChildNum_ != rhs->condChildNum_)
+      return false;
+
+    if (!lhs->simpleBlockLikeContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     simpleBlockLikeMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/SimpleBlockLike.h
+++ b/compiler/next/include/chpl/uast/SimpleBlockLike.h
@@ -58,7 +58,24 @@ class SimpleBlockLike : public Expression {
     assert(isExpressionASTList(children_));
   }
 
-  bool simpleBlockLikeContentsMatchInner(const ASTNode* other) const;
+  bool simpleBlockLikeContentsMatchInner(const ASTNode* other) const {
+    const SimpleBlockLike* lhs = this;
+    const SimpleBlockLike* rhs = other->toSimpleBlockLike();
+
+    if (lhs->blockStyle_ != rhs->blockStyle_)
+      return false;
+
+    if (lhs->bodyChildNum_ != rhs->bodyChildNum_)
+      return false;
+
+    if (lhs->numBodyStmts_ != rhs->numBodyStmts_)
+      return false;
+
+    if (!lhs->expressionContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void simpleBlockLikeMarkUniqueStringsInner(Context* context) const {
     expressionMarkUniqueStringsInner(context);

--- a/compiler/next/include/chpl/uast/StringLikeLiteral.h
+++ b/compiler/next/include/chpl/uast/StringLikeLiteral.h
@@ -49,8 +49,16 @@ class StringLikeLiteral : public Literal {
       quotes_(quotes)
   { }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const StringLikeLiteral* lhs = this;
+    const StringLikeLiteral* rhs = (const StringLikeLiteral*) other;
+    return lhs->literalContentsMatchInner(rhs) &&
+           lhs->value_ == rhs->value_ &&
+           lhs->quotes_ == rhs->quotes_;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    literalMarkUniqueStringsInner(context);
+  }
 
  public:
   virtual ~StringLikeLiteral() = 0; // this is an abstract base class

--- a/compiler/next/include/chpl/uast/TaskVar.h
+++ b/compiler/next/include/chpl/uast/TaskVar.h
@@ -71,8 +71,19 @@ class TaskVar final : public VarLikeDecl {
                     initExpressionChildNum),
         intent_(intent) {}
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const TaskVar* lhs = this;
+    const TaskVar* rhs = (const TaskVar*) other;
 
+    if (lhs->intent_ != rhs->intent_)
+      return false;
+
+    if (!lhs->varLikeDeclContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
+ 
   void markUniqueStringsInner(Context* context) const override {
     varLikeDeclMarkUniqueStringsInner(context);
   }

--- a/compiler/next/include/chpl/uast/TupleDecl.h
+++ b/compiler/next/include/chpl/uast/TupleDecl.h
@@ -72,8 +72,19 @@ class TupleDecl final : public Decl {
     assert(assertAcceptableTupleDecl());
   }
   bool assertAcceptableTupleDecl();
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const TupleDecl* lhs = this;
+    const TupleDecl* rhs = (const TupleDecl*) other;
+    return lhs->declContentsMatchInner(rhs) &&
+           lhs->kind_ == rhs->kind_ &&
+           lhs->numElements_ == rhs->numElements_ &&
+           lhs->typeExpressionChildNum_ == rhs->typeExpressionChildNum_ &&
+           lhs->initExpressionChildNum_ == rhs->initExpressionChildNum_;
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    declMarkUniqueStringsInner(context);
+  }
 
  public:
   ~TupleDecl() override = default;

--- a/compiler/next/include/chpl/uast/Variable.h
+++ b/compiler/next/include/chpl/uast/Variable.h
@@ -76,8 +76,17 @@ class Variable final : public VarLikeDecl {
         isField_(isField) {
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
-  void markUniqueStringsInner(Context* context) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const Variable* lhs = this;
+    const Variable* rhs = (const Variable*) other;
+    return lhs->kind_ == rhs->kind_ &&
+           lhs->isConfig_ == rhs->isConfig_ &&
+           lhs->isField_ == rhs->isField_ &&
+           lhs->varLikeDeclContentsMatchInner(rhs);
+  }
+  void markUniqueStringsInner(Context* context) const override {
+    varLikeDeclMarkUniqueStringsInner(context);
+  }
 
   Kind kind_;
   bool isConfig_;

--- a/compiler/next/include/chpl/uast/While.h
+++ b/compiler/next/include/chpl/uast/While.h
@@ -48,17 +48,26 @@ class While final : public Loop {
  private:
   While(ASTList children, int8_t conditionChildNum,
         BlockStyle blockStyle,
-        int loopBodyChildNum,
-        int numLoopBodyStmts)
+        int loopBodyChildNum)
     : Loop(asttags::While, std::move(children), blockStyle,
-           loopBodyChildNum,
-           numLoopBodyStmts),
+           loopBodyChildNum),
       conditionChildNum_(conditionChildNum) {
     assert(isExpressionASTList(children_));
     assert(condition());
   }
 
-  bool contentsMatchInner(const ASTNode* other) const override;
+  bool contentsMatchInner(const ASTNode* other) const override {
+    const While* lhs = this;
+    const While* rhs = (const While*) other;
+
+    if (lhs->conditionChildNum_ != rhs->conditionChildNum_)
+      return false;
+
+    if (!lhs->loopContentsMatchInner(rhs))
+      return false;
+
+    return true;
+  }
 
   void markUniqueStringsInner(Context* context) const override {
     loopMarkUniqueStringsInner(context);
@@ -75,7 +84,7 @@ class While final : public Loop {
   static owned<While> build(Builder* builder, Location loc,
                             owned<Expression> condition,
                             BlockStyle blockStyle,
-                            ASTList stmts);
+                            owned<Block> stmts);
 
 
   /**

--- a/compiler/next/lib/parsing/ParserContext.h
+++ b/compiler/next/lib/parsing/ParserContext.h
@@ -241,7 +241,7 @@ struct ParserContext {
   CommentsAndStmt buildFunctionDecl(YYLTYPE location, FunctionParts& fp);
 
   // Build a loop index decl from a given expression. The expression is owned
-  // because it will be consumed. 
+  // because it will be consumed.
   owned<Decl> buildLoopIndexDecl(YYLTYPE location, owned<Expression> e);
 
   FnCall* wrapCalledExpressionInNew(YYLTYPE location,
@@ -292,7 +292,7 @@ struct ParserContext {
                          ParserExprList*& outExprLst,
                          BlockStyle& outBlockStyle,
                          YYLTYPE locStartKeyword,
-                         YYLTYPE locBodyAnchor, 
+                         YYLTYPE locBodyAnchor,
                          BlockOrDo consume);
 
   CommentsAndStmt buildBracketLoopStmt(YYLTYPE locLeftBracket,

--- a/compiler/next/lib/parsing/ParserContext.h
+++ b/compiler/next/lib/parsing/ParserContext.h
@@ -181,9 +181,9 @@ struct ParserContext {
   ParserExprList* appendList(ParserExprList* dst, CommentsAndStmt cs);
   ASTList consumeList(ParserExprList* lst);
 
- void consumeNamedActuals(MaybeNamedActualList* lst,
-                          ASTList& actualsOut,
-                          std::vector<UniqueString>& namesOut);
+  void consumeNamedActuals(MaybeNamedActualList* lst,
+                           ASTList& actualsOut,
+                           std::vector<UniqueString>& namesOut);
 
   std::vector<ParserComment>* gatherCommentsFromList(ParserExprList* lst,
                                                      YYLTYPE location);
@@ -251,6 +251,8 @@ struct ParserContext {
   BlockStyle determineBlockStyle(BlockOrDo blockOrDo);
 
   ASTList consumeAndFlattenTopLevelBlocks(ParserExprList* exprLst);
+
+  owned<Block> consumeToBlock(YYLTYPE blockLoc, ParserExprList* lst);
 
   // Lift up top level comments, clear expression level comments, prepare
   // the statement body, and determine the block style.

--- a/compiler/next/lib/parsing/ParserContextImpl.h
+++ b/compiler/next/lib/parsing/ParserContextImpl.h
@@ -427,7 +427,7 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
     auto scope = currentScope();
     if (currentScopeIsAggregate()) {
       if (fp.receiver == nullptr) {
-        auto loc = convertLocation(location); 
+        auto loc = convertLocation(location);
         auto ths = UniqueString::build(context(), "this");
         UniqueString cls = scope.name;
         fp.receiver = Formal::build(builder, loc,
@@ -507,7 +507,7 @@ FnCall* ParserContext::wrapCalledExpressionInNew(YYLTYPE location,
   return fnCall;
 }
 
-owned<Block> 
+owned<Block>
 ParserContext::consumeToBlock(YYLTYPE blockLoc, ParserExprList* lst) {
   // if it consists of only a block, return that block
   if (lst != nullptr && lst->size() == 1) {
@@ -622,14 +622,14 @@ ParserContext::buildBracketLoopStmt(YYLTYPE locLeftBracket,
   assert(indexExpr);
   auto index = buildLoopIndexDecl(locIndex, toOwned(indexExpr));
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(exprLst);
+  auto body = consumeToBlock(locBodyAnchor, exprLst);
 
   auto node = BracketLoop::build(builder, convertLocation(locLeftBracket),
                                  std::move(index),
                                  toOwned(iterandExpr),
                                  toOwned(withClause),
                                  blockStyle,
-                                 std::move(stmts),
+                                 std::move(body),
                                  /*isExpressionLevel*/ false);
 
   return { .comments=comments, .stmt=node.release() };
@@ -664,14 +664,14 @@ CommentsAndStmt ParserContext::buildBracketLoopStmt(YYLTYPE locLeftBracket,
 
   assert(iterandExpr);
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(exprLst);
+  auto body = consumeToBlock(locBodyAnchor, exprLst);
 
   auto node = BracketLoop::build(builder, convertLocation(locLeftBracket),
                                  /*index*/ nullptr,
                                  toOwned(iterandExpr),
                                  toOwned(withClause),
                                  blockStyle,
-                                 std::move(stmts),
+                                 std::move(body),
                                  /*isExpressionLevel*/ false);
 
   return { .comments=comments, .stmt=node.release() };
@@ -695,14 +695,14 @@ CommentsAndStmt ParserContext::buildForallLoopStmt(YYLTYPE locForall,
                     locBodyAnchor,
                     blockOrDo);
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(exprLst);
+  auto body = consumeToBlock(locBodyAnchor, exprLst);
 
   auto node = Forall::build(builder, convertLocation(locForall),
                             std::move(index),
                             toOwned(iterandExpr),
                             toOwned(withClause),
                             blockStyle,
-                            std::move(stmts),
+                            std::move(body),
                             /*isExpressionLevel*/ false);
 
   return { .comments=comments, .stmt=node.release() };
@@ -726,14 +726,14 @@ CommentsAndStmt ParserContext::buildForeachLoopStmt(YYLTYPE locForeach,
                     locBodyAnchor,
                     blockOrDo);
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(exprLst);
+  auto body = consumeToBlock(locBodyAnchor, exprLst);
 
   auto node = Foreach::build(builder, convertLocation(locForeach),
                              std::move(index),
                              toOwned(iterandExpr),
                              toOwned(withClause),
                              blockStyle,
-                             std::move(stmts));
+                             std::move(body));
 
   return { .comments=comments, .stmt=node.release() };
 }
@@ -755,13 +755,13 @@ CommentsAndStmt ParserContext::buildForLoopStmt(YYLTYPE locFor,
                     locBodyAnchor,
                     blockOrDo);
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(exprLst);
+  auto body = consumeToBlock(locBodyAnchor, exprLst);
 
   auto node = For::build(builder, convertLocation(locFor),
                          std::move(index),
                          toOwned(iterandExpr),
                          blockStyle,
-                         std::move(stmts),
+                         std::move(body),
                          /*isExpressionLevel*/ false,
                          /*isParam*/ false);
 
@@ -786,14 +786,14 @@ CommentsAndStmt ParserContext::buildCoforallLoopStmt(YYLTYPE locCoforall,
                     locBodyAnchor,
                     blockOrDo);
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(exprLst);
+  auto body = consumeToBlock(locBodyAnchor, exprLst);
 
   auto node = Coforall::build(builder, convertLocation(locCoforall),
                               std::move(index),
                               toOwned(iterandExpr),
                               toOwned(withClause),
                               blockStyle,
-                              std::move(stmts));
+                              std::move(body));
 
   return { .comments=comments, .stmt=node.release() };
 }

--- a/compiler/next/lib/parsing/ParserContextImpl.h
+++ b/compiler/next/lib/parsing/ParserContextImpl.h
@@ -439,6 +439,11 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
       }
     }
 
+    owned<Block> body;
+    if (fp.body != nullptr) {
+      body = consumeToBlock(location, fp.body);
+    }
+
     auto f = Function::build(builder, this->convertLocation(location),
                              fp.name, this->visibility,
                              fp.linkage, toOwned(fp.linkageNameExpr),
@@ -453,7 +458,7 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
                              toOwned(fp.returnType),
                              toOwned(fp.where),
                              this->consumeList(fp.lifetime),
-                             this->consumeList(fp.body));
+                             std::move(body));
     cs.stmt = f.release();
   } else {
     cs.stmt = fp.errorExpr;

--- a/compiler/next/lib/parsing/bison-chpl-lib.cpp
+++ b/compiler/next/lib/parsing/bison-chpl-lib.cpp
@@ -6652,7 +6652,7 @@ yyreduce:
                                false, locBodyAnchor, (yyvsp[0].commentsAndStmt));
     assert(blockStyle == BlockStyle::EXPLICIT);
     auto taskBodies = context->consumeAndFlattenTopLevelBlocks(exprLst);
-    auto node = Cobegin::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-1].withClause)), 
+    auto node = Cobegin::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-1].withClause)),
                                std::move(taskBodies));
     CommentsAndStmt ret = { .comments=comments, .stmt=node.release() };
     (yyval.commentsAndStmt) = context->finishStmt(ret);
@@ -7743,9 +7743,9 @@ yyreduce:
     if (blockStyle == BlockStyle::IMPLICIT) {
       exprLst = context->appendList(exprLst, context->gatherComments((yylsp[-2])));
     }
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock((yylsp[-4]), exprLst);
     auto node = DoWhile::build(BUILDER, LOC((yyloc)), blockStyle,
-                               std::move(stmts),
+                               std::move(body),
                                toOwned((yyvsp[-1].expr)));
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };
     (yyval.commentsAndStmt) = context->finishStmt(cs);
@@ -7760,10 +7760,10 @@ yyreduce:
     ParserExprList* exprLst;
     BlockStyle blockStyle;
     context->prepareStmtPieces(comments, exprLst, blockStyle, (yylsp[-2]), (yylsp[0]), (yyvsp[0].blockOrDo));
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock((yylsp[0]), exprLst);
     auto node = While::build(BUILDER, LOC((yylsp[-2])), toOwned((yyvsp[-1].expr)),
                              blockStyle,
-                             std::move(stmts));
+                             std::move(body));
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };
     (yyval.commentsAndStmt) = context->finishStmt(cs);
   }
@@ -7777,10 +7777,10 @@ yyreduce:
     ParserExprList* exprLst;
     BlockStyle blockStyle;
     context->prepareStmtPieces(comments, exprLst, blockStyle, (yylsp[-2]), (yylsp[0]), (yyvsp[0].blockOrDo));
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock((yylsp[0]), exprLst);
     auto node = While::build(BUILDER, LOC((yylsp[-2])), toOwned((yyvsp[-1].expr)),
                              blockStyle,
-                             std::move(stmts));
+                             std::move(body));
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };
     (yyval.commentsAndStmt) = context->finishStmt(cs);
   }
@@ -7852,11 +7852,11 @@ yyreduce:
     context->prepareStmtPieces(comments, exprLst, blockStyle, (yylsp[-5]), (yylsp[0]), (yyvsp[0].blockOrDo));
     Expression* ident = context->buildIdent((yylsp[-3]), (yyvsp[-3].uniqueStr));
     auto index = context->buildLoopIndexDecl((yylsp[-3]), toOwned(ident));
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock((yylsp[0]), exprLst);
     auto node = For::build(BUILDER, LOC((yylsp[-5])), std::move(index),
                            toOwned((yyvsp[-1].expr)),
                            blockStyle,
-                           std::move(stmts),
+                           std::move(body),
                            /*isExpressionLevel*/ false,
                            /*isParam*/ true);
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };

--- a/compiler/next/lib/parsing/chpl.ypp
+++ b/compiler/next/lib/parsing/chpl.ypp
@@ -754,7 +754,7 @@ stmt:
                                false, locBodyAnchor, $3);
     assert(blockStyle == BlockStyle::EXPLICIT);
     auto taskBodies = context->consumeAndFlattenTopLevelBlocks(exprLst);
-    auto node = Cobegin::build(BUILDER, LOC(@$), toOwned($2), 
+    auto node = Cobegin::build(BUILDER, LOC(@$), toOwned($2),
                                std::move(taskBodies));
     CommentsAndStmt ret = { .comments=comments, .stmt=node.release() };
     $$ = context->finishStmt(ret);
@@ -1510,9 +1510,9 @@ loop_stmt:
     if (blockStyle == BlockStyle::IMPLICIT) {
       exprLst = context->appendList(exprLst, context->gatherComments(@3));
     }
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock(@1, exprLst);
     auto node = DoWhile::build(BUILDER, LOC(@$), blockStyle,
-                               std::move(stmts),
+                               std::move(body),
                                toOwned($4));
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };
     $$ = context->finishStmt(cs);
@@ -1523,10 +1523,10 @@ loop_stmt:
     ParserExprList* exprLst;
     BlockStyle blockStyle;
     context->prepareStmtPieces(comments, exprLst, blockStyle, @1, @3, $3);
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock(@3, exprLst);
     auto node = While::build(BUILDER, LOC(@1), toOwned($2),
                              blockStyle,
-                             std::move(stmts));
+                             std::move(body));
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };
     $$ = context->finishStmt(cs);
   }
@@ -1536,10 +1536,10 @@ loop_stmt:
     ParserExprList* exprLst;
     BlockStyle blockStyle;
     context->prepareStmtPieces(comments, exprLst, blockStyle, @1, @3, $3);
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock(@3, exprLst);
     auto node = While::build(BUILDER, LOC(@1), toOwned($2),
                              blockStyle,
-                             std::move(stmts));
+                             std::move(body));
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };
     $$ = context->finishStmt(cs);
   }
@@ -1579,11 +1579,11 @@ loop_stmt:
     context->prepareStmtPieces(comments, exprLst, blockStyle, @1, @6, $6);
     Expression* ident = context->buildIdent(@3, $3);
     auto index = context->buildLoopIndexDecl(@3, toOwned(ident));
-    auto stmts = context->consumeAndFlattenTopLevelBlocks(exprLst);
+    auto body = context->consumeToBlock(@6, exprLst);
     auto node = For::build(BUILDER, LOC(@1), std::move(index),
                            toOwned($5),
                            blockStyle,
-                           std::move(stmts),
+                           std::move(body),
                            /*isExpressionLevel*/ false,
                            /*isParam*/ true);
     CommentsAndStmt cs = { .comments=comments, .stmt=node.release() };

--- a/compiler/next/lib/parsing/parsing-queries.cpp
+++ b/compiler/next/lib/parsing/parsing-queries.cpp
@@ -224,6 +224,7 @@ const ID& idToParentId(Context* context, ID id) {
   // Performance: Would it be better to have the parse query
   // set this query as an alternative to computing maps
   // in Builder::Result and then redundantly setting them here?
+  // Or, should we store parent ID as a field in ASTNode?
 
   QUERY_BEGIN(idToParentId, context, id);
 

--- a/compiler/next/lib/uast/Begin.cpp
+++ b/compiler/next/lib/uast/Begin.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Begin::contentsMatchInner(const ASTNode* other) const {
-  const Begin* lhs = this;
-  const Begin* rhs = (const Begin*) other;
-
-  if (lhs->withClauseChildNum_ != rhs->withClauseChildNum_)
-    return false;
-
-  if (!lhs->simpleBlockLikeContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Begin> Begin::build(Builder* builder,
                           Location loc,
                           owned<WithClause> withClause,

--- a/compiler/next/lib/uast/BracketLoop.cpp
+++ b/compiler/next/lib/uast/BracketLoop.cpp
@@ -30,10 +30,11 @@ owned<BracketLoop> BracketLoop::build(Builder* builder, Location loc,
                                       owned<Expression> iterand,
                                       owned<WithClause> withClause,
                                       BlockStyle blockStyle,
-                                      ASTList stmts,
+                                      owned<Block> body,
                                       bool isExpressionLevel) {
 
   assert(iterand.get() != nullptr);
+  assert(body.get() != nullptr);
 
   ASTList lst;
   int8_t indexChildNum = -1;
@@ -56,18 +57,13 @@ owned<BracketLoop> BracketLoop::build(Builder* builder, Location loc,
   }
 
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
-
-  for (auto& stmt : stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   BracketLoop* ret = new BracketLoop(std::move(lst), indexChildNum,
                                      iterandChildNum,
                                      withClauseChildNum,
                                      blockStyle,
                                      loopBodyChildNum,
-                                     numLoopBodyStmts,
                                      isExpressionLevel);
 
   builder->noteLocation(ret, loc);

--- a/compiler/next/lib/uast/Break.cpp
+++ b/compiler/next/lib/uast/Break.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Break::contentsMatchInner(const ASTNode* other) const {
-  const Break* lhs = this;
-  const Break* rhs = other->toBreak();
-
-  if (lhs->targetChildNum_ != rhs->targetChildNum_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Break> Break::build(Builder* builder, Location loc,
                           owned<Identifier> target) {
   ASTList lst;

--- a/compiler/next/lib/uast/Cobegin.cpp
+++ b/compiler/next/lib/uast/Cobegin.cpp
@@ -25,25 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Cobegin::contentsMatchInner(const ASTNode* other) const {
-  const Cobegin* lhs = this;
-  const Cobegin* rhs = (const Cobegin*) other;
-
-  if (lhs->withClauseChildNum_ != rhs->withClauseChildNum_)
-    return false;
-
-  if (lhs->bodyChildNum_ != rhs->bodyChildNum_)
-    return false;
-
-  if (lhs->numTaskBodies_ != rhs->numTaskBodies_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Cobegin> Cobegin::build(Builder* builder,
                               Location loc,
                               owned<WithClause> withClause,

--- a/compiler/next/lib/uast/Coforall.cpp
+++ b/compiler/next/lib/uast/Coforall.cpp
@@ -30,9 +30,10 @@ owned<Coforall> Coforall::build(Builder* builder, Location loc,
                                 owned<Expression> iterand,
                                 owned<WithClause> withClause,
                                 BlockStyle blockStyle,
-                                ASTList stmts) {
+                                owned<Block> body) {
 
   assert(iterand.get() != nullptr);
+  assert(body.get() != nullptr);
 
   ASTList lst;
   int8_t indexChildNum = -1;
@@ -55,18 +56,13 @@ owned<Coforall> Coforall::build(Builder* builder, Location loc,
   }
 
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
-
-  for (auto& stmt : stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   Coforall* ret = new Coforall(std::move(lst), indexChildNum,
                                iterandChildNum,
                                withClauseChildNum,
                                blockStyle,
-                               loopBodyChildNum,
-                               numLoopBodyStmts);
+                               loopBodyChildNum);
 
   builder->noteLocation(ret, loc);
   return toOwned(ret);

--- a/compiler/next/lib/uast/Comment.cpp
+++ b/compiler/next/lib/uast/Comment.cpp
@@ -25,17 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Comment::contentsMatchInner(const ASTNode* other) const {
-  const Comment* lhs = this;
-  const Comment* rhs = (const Comment*) other;
-  return lhs->expressionContentsMatchInner(rhs) &&
-         lhs->comment_ == rhs->comment_ ;
-}
-void Comment::markUniqueStringsInner(Context* context) const {
-  return expressionMarkUniqueStringsInner(context);
-}
-
-
 owned<Comment> Comment::build(Builder* builder, Location loc, std::string c) {
   Comment* ret = new Comment(std::move(c));
   builder->noteLocation(ret, loc);

--- a/compiler/next/lib/uast/Conditional.cpp
+++ b/compiler/next/lib/uast/Conditional.cpp
@@ -25,37 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Conditional::contentsMatchInner(const ASTNode* other) const {
-  const Conditional* lhs = this;
-  const Conditional* rhs = other->toConditional();
-
-  if (lhs->thenBlockStyle_ != rhs->thenBlockStyle_)
-    return false;
-
-  if (lhs->thenBodyChildNum_ != rhs->thenBodyChildNum_)
-    return false;
-
-  if (lhs->numThenBodyStmts_ != rhs->numThenBodyStmts_)
-    return false;
-
-  if (lhs->elseBlockStyle_ != rhs->elseBlockStyle_)
-    return false;
-
-  if (lhs->elseBodyChildNum_ != rhs->elseBodyChildNum_)
-    return false;
-
-  if (lhs->numElseBodyStmts_ != rhs->numElseBodyStmts_)
-    return false;
-
-  if (lhs->isExpressionLevel_ != rhs->isExpressionLevel_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Conditional> Conditional::build(Builder* builder, Location loc,
                                       owned<Expression> condition,
                                       BlockStyle thenBlockStyle,

--- a/compiler/next/lib/uast/Conditional.cpp
+++ b/compiler/next/lib/uast/Conditional.cpp
@@ -28,36 +28,24 @@ namespace uast {
 owned<Conditional> Conditional::build(Builder* builder, Location loc,
                                       owned<Expression> condition,
                                       BlockStyle thenBlockStyle,
-                                      ASTList thenStmts,
+                                      owned<Block> thenBlock,
                                       BlockStyle elseBlockStyle,
-                                      ASTList elseStmts,
+                                      owned<Block> elseBlock,
                                       bool isExpressionLevel) {
   assert(condition.get() != nullptr);
 
   ASTList lst;
 
   lst.push_back(std::move(condition));
+  lst.push_back(std::move(thenBlock));
 
-  const int8_t thenBodyChildNum = lst.size();
-  const int numThenBodyStmts = thenStmts.size();
-
-  for (auto& stmt : thenStmts) {
-    lst.push_back(std::move(stmt));
+  if (elseBlock.get() != nullptr) {
+    lst.push_back(std::move(elseBlock));
   }
 
-  const int elseBodyChildNum = lst.size();
-  const int numElseBodyStmts = elseStmts.size();
-
-  for (auto& stmt : elseStmts) {
-    lst.push_back(std::move(stmt));
-  }
-
-  Conditional* ret = new Conditional(std::move(lst), thenBlockStyle,
-                                     thenBodyChildNum,
-                                     numThenBodyStmts,
+  Conditional* ret = new Conditional(std::move(lst),
+                                     thenBlockStyle,
                                      elseBlockStyle,
-                                     elseBodyChildNum,
-                                     numElseBodyStmts,
                                      isExpressionLevel);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
@@ -66,29 +54,18 @@ owned<Conditional> Conditional::build(Builder* builder, Location loc,
 owned<Conditional> Conditional::build(Builder* builder, Location loc,
                                       owned<Expression> condition,
                                       BlockStyle thenBlockStyle,
-                                      ASTList thenStmts) {
+                                      owned<Block> thenBlock) {
   assert(condition.get() != nullptr);
   ASTList lst;
 
   lst.push_back(std::move(condition));
-
-  const int8_t thenBodyChildNum = lst.size();
-  const int numThenBodyStmts = thenStmts.size();
-
-  for (auto& stmt : thenStmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(thenBlock));
 
   const BlockStyle elseBlockStyle = BlockStyle::IMPLICIT;
-  const int elseBodyChildNum = -1;
-  const int numElseBodyStmts = 0; 
 
-  Conditional* ret = new Conditional(std::move(lst), thenBlockStyle,
-                                     thenBodyChildNum,
-                                     numThenBodyStmts,
+  Conditional* ret = new Conditional(std::move(lst),
+                                     thenBlockStyle,
                                      elseBlockStyle,
-                                     elseBodyChildNum,
-                                     numElseBodyStmts,
                                      /*isExpressionLevel*/ false);
   builder->noteLocation(ret, loc);
   return toOwned(ret);

--- a/compiler/next/lib/uast/Continue.cpp
+++ b/compiler/next/lib/uast/Continue.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Continue::contentsMatchInner(const ASTNode* other) const {
-  const Continue* lhs = this;
-  const Continue* rhs = other->toContinue();
-
-  if (lhs->targetChildNum_ != rhs->targetChildNum_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Continue> Continue::build(Builder* builder, Location loc,
                                 owned<Identifier> target) {
   ASTList lst;

--- a/compiler/next/lib/uast/DoWhile.cpp
+++ b/compiler/next/lib/uast/DoWhile.cpp
@@ -25,40 +25,24 @@ namespace chpl {
 namespace uast {
 
 
-bool DoWhile::contentsMatchInner(const ASTNode* other) const {
-  const DoWhile* lhs = this;
-  const DoWhile* rhs = (const DoWhile*) other;
-
-  if (lhs->conditionChildNum_ != rhs->conditionChildNum_)
-    return false;
-
-  if (!lhs->loopContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<DoWhile> DoWhile::build(Builder* builder, Location loc,
                               BlockStyle blockStyle,
-                              ASTList stmts,
+                              owned<Block> body,
                               owned<Expression> condition) {
 
   assert(condition.get() != nullptr);
+  assert(body.get() != nullptr);
 
   ASTList lst;
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
 
-  for (auto& stmt: stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   int conditionChildNum = lst.size();
   lst.push_back(std::move(condition));
 
   DoWhile* ret = new DoWhile(std::move(lst), blockStyle,
                              loopBodyChildNum,
-                             numLoopBodyStmts,
                              conditionChildNum);
 
   builder->noteLocation(ret, loc);

--- a/compiler/next/lib/uast/Dot.cpp
+++ b/compiler/next/lib/uast/Dot.cpp
@@ -24,24 +24,6 @@
 namespace chpl {
 namespace uast {
 
-bool Dot::contentsMatchInner(const ASTNode* other) const {
-  const Dot* lhs = this;
-  const Dot* rhs = (const Dot*) other;
-
-  if (lhs->fieldName_ != rhs->fieldName_)
-    return false;
-
-  if (!lhs->callContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-void Dot::markUniqueStringsInner(Context* context) const {
-
-  callMarkUniqueStringsInner(context);
-
-  fieldName_.mark(context);
-}
 
 owned<Dot> Dot::build(Builder* builder,
                       Location loc,

--- a/compiler/next/lib/uast/Enum.cpp
+++ b/compiler/next/lib/uast/Enum.cpp
@@ -35,14 +35,6 @@ bool Enum::isEnumElementAndCommentList(const ASTList& list) {
   }
   return true;
 }
-bool Enum::contentsMatchInner(const ASTNode* other) const {
-  const Enum* lhs = this;
-  const Enum* rhs = (const Enum*) other;
-  return lhs->typeDeclContentsMatchInner(rhs);
-}
-void Enum::markUniqueStringsInner(Context* context) const {
-  typeDeclMarkUniqueStringsInner(context);
-}
 
 owned<Enum> Enum::build(Builder* builder, Location loc,
                         UniqueString name, Decl::Visibility vis,

--- a/compiler/next/lib/uast/EnumElement.cpp
+++ b/compiler/next/lib/uast/EnumElement.cpp
@@ -25,15 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool EnumElement::contentsMatchInner(const ASTNode* other) const {
-  const EnumElement* lhs = this;
-  const EnumElement* rhs = (const EnumElement*) other;
-  return lhs->namedDeclContentsMatchInner(rhs);
-}
-void EnumElement::markUniqueStringsInner(Context* context) const {
-  namedDeclMarkUniqueStringsInner(context);
-}
-
 owned<EnumElement> EnumElement::build(Builder* builder, Location loc,
                                       UniqueString name,
                                       owned<Expression> initExpression) {

--- a/compiler/next/lib/uast/ErroneousExpression.cpp
+++ b/compiler/next/lib/uast/ErroneousExpression.cpp
@@ -25,15 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool ErroneousExpression::contentsMatchInner(const ASTNode* other) const {
-  const ErroneousExpression* lhs = this;
-  const ErroneousExpression* rhs = (const ErroneousExpression*) other;
-  return lhs->expressionContentsMatchInner(rhs);
-}
-void ErroneousExpression::markUniqueStringsInner(Context* context) const {
-  expressionMarkUniqueStringsInner(context);
-}
-
 owned<ErroneousExpression> ErroneousExpression::build(Builder* builder,
                                                       Location loc) {
   ErroneousExpression* ret = new ErroneousExpression();

--- a/compiler/next/lib/uast/FnCall.cpp
+++ b/compiler/next/lib/uast/FnCall.cpp
@@ -24,35 +24,8 @@
 namespace chpl {
 namespace uast {
 
-bool FnCall::contentsMatchInner(const ASTNode* other) const {
-  const FnCall* lhs = this;
-  const FnCall* rhs = (const FnCall*) other;
 
-  if (!lhs->callContentsMatchInner(rhs))
-    return false;
-
-  if (lhs->callUsedSquareBrackets_ != rhs->callUsedSquareBrackets_ ||
-      lhs->actualNames_.size() != rhs->actualNames_.size())
-    return false;
-
-  int nActualNames = (int) lhs->actualNames_.size();
-  for (int i = 0; i < nActualNames; i++) {
-    if (lhs->actualNames_[i] != rhs->actualNames_[i])
-      return false;
-  }
-
-  return true;
-}
-void FnCall::markUniqueStringsInner(Context* context) const {
-
-  callMarkUniqueStringsInner(context);
-
-  for (const auto& str : actualNames_) {
-    str.mark(context);
-  }
-}
-
-owned<FnCall> FnCall::build(Builder* builder,
+  owned<FnCall> FnCall::build(Builder* builder,
                             Location loc,
                             owned<Expression> calledExpression,
                             ASTList actuals,

--- a/compiler/next/lib/uast/For.cpp
+++ b/compiler/next/lib/uast/For.cpp
@@ -25,28 +25,16 @@ namespace chpl {
 namespace uast {
 
 
-bool For::contentsMatchInner(const ASTNode* other) const {
-  const For* lhs = this;
-  const For* rhs = (const For*) other;
-
-  if (lhs->isParam_ != rhs->isParam_)
-    return false;
-
-  if (!lhs->indexableLoopContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<For> For::build(Builder* builder,
                       Location loc,
                       owned<Decl> index,
                       owned<Expression> iterand,
                       BlockStyle blockStyle,
-                      ASTList stmts,
+                      owned<Block> body,
                       bool isExpressionLevel,
                       bool isParam) {
   assert(iterand.get() != nullptr);
+  assert(body.get() != nullptr);
   if (isParam) assert(!isExpressionLevel);
 
   ASTList lst;
@@ -64,17 +52,12 @@ owned<For> For::build(Builder* builder,
   }
 
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
-
-  for (auto& stmt : stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   For* ret = new For(std::move(lst), indexChildNum,
                      iterandChildNum,
                      blockStyle,
                      loopBodyChildNum,
-                     numLoopBodyStmts,
                      isExpressionLevel,
                      isParam);
   builder->noteLocation(ret, loc);

--- a/compiler/next/lib/uast/Forall.cpp
+++ b/compiler/next/lib/uast/Forall.cpp
@@ -30,9 +30,10 @@ owned<Forall> Forall::build(Builder* builder, Location loc,
                             owned<Expression> iterand,
                             owned<WithClause> withClause,
                             BlockStyle blockStyle,
-                            ASTList stmts,
+                            owned<Block> body,
                             bool isExpressionLevel) {
   assert(iterand.get() != nullptr);
+  assert(body.get() != nullptr);
 
   ASTList lst;
   int8_t indexChildNum = -1;
@@ -55,18 +56,13 @@ owned<Forall> Forall::build(Builder* builder, Location loc,
   }
 
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
-
-  for (auto& stmt : stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   Forall* ret = new Forall(std::move(lst), indexChildNum,
                            iterandChildNum,
                            withClauseChildNum,
                            blockStyle,
                            loopBodyChildNum,
-                           numLoopBodyStmts,
                            isExpressionLevel);
   builder->noteLocation(ret, loc);
   return toOwned(ret);

--- a/compiler/next/lib/uast/Foreach.cpp
+++ b/compiler/next/lib/uast/Foreach.cpp
@@ -31,9 +31,10 @@ owned<Foreach> Foreach::build(Builder* builder,
                               owned<Expression> iterand,
                               owned<WithClause> withClause,
                               BlockStyle blockStyle,
-                              ASTList stmts) {
+                              owned<Block> body) {
 
   assert(iterand.get() != nullptr);
+  assert(body.get() != nullptr);
 
   ASTList lst;
   int8_t indexChildNum = -1;
@@ -56,18 +57,13 @@ owned<Foreach> Foreach::build(Builder* builder,
   }
 
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
-
-  for (auto& stmt : stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   Foreach* ret = new Foreach(std::move(lst), indexChildNum,
-                           iterandChildNum,
-                           withClauseChildNum,
-                           blockStyle,
-                           loopBodyChildNum,
-                           numLoopBodyStmts);
+                             iterandChildNum,
+                             withClauseChildNum,
+                             blockStyle,
+                             loopBodyChildNum);
 
   builder->noteLocation(ret, loc);
   return toOwned(ret);

--- a/compiler/next/lib/uast/Formal.cpp
+++ b/compiler/next/lib/uast/Formal.cpp
@@ -25,17 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Formal::contentsMatchInner(const ASTNode* other) const {
-  const Formal* lhs = this;
-  const Formal* rhs = (const Formal*) other;
-  return lhs->varLikeDeclContentsMatchInner(rhs) &&
-         lhs->intent_ == rhs->intent_;
-}
-
-void Formal::markUniqueStringsInner(Context* context) const {
-  varLikeDeclMarkUniqueStringsInner(context);
-}
-
 owned<Formal>
 Formal::build(Builder* builder, Location loc,
               UniqueString name,

--- a/compiler/next/lib/uast/Identifier.cpp
+++ b/compiler/next/lib/uast/Identifier.cpp
@@ -25,17 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Identifier::contentsMatchInner(const ASTNode* other) const {
-  const Identifier* lhs = this;
-  const Identifier* rhs = (const Identifier*) other;
-  return lhs->expressionContentsMatchInner(rhs) &&
-         lhs->name_ == rhs->name_;
-}
-void Identifier::markUniqueStringsInner(Context* context) const {
-  expressionMarkUniqueStringsInner(context);
-  this->name_.mark(context);
-}
-
 owned<Identifier> Identifier::build(Builder* builder,
                                     Location loc, UniqueString name) {
   Identifier* ret = new Identifier(name);

--- a/compiler/next/lib/uast/IndexableLoop.cpp
+++ b/compiler/next/lib/uast/IndexableLoop.cpp
@@ -24,28 +24,6 @@
 namespace chpl {
 namespace uast {
 
-bool IndexableLoop::
-indexableLoopContentsMatchInner(const IndexableLoop* other) const {
-  const IndexableLoop* lhs = this;
-  const IndexableLoop* rhs = other;
-
-  if (lhs->indexChildNum_ != rhs->indexChildNum_)
-    return false;
-
-  if (lhs->iterandChildNum_ != rhs->iterandChildNum_)
-    return false;
-
-  if (lhs->withClauseChildNum_ != rhs->withClauseChildNum_)
-    return false;
-
-  if (lhs->isExpressionLevel_ != rhs->isExpressionLevel_)
-    return false;
-
-  if (!lhs->loopContentsMatchInner(other))
-    return false;
-
-  return true;
-}
 
 IndexableLoop::~IndexableLoop(){
 }

--- a/compiler/next/lib/uast/Label.cpp
+++ b/compiler/next/lib/uast/Label.cpp
@@ -24,25 +24,6 @@
 namespace chpl {
 namespace uast {
 
-bool Label::contentsMatchInner(const ASTNode* other) const {
-  const Label* lhs = this;
-  const Label* rhs = other->toLabel();
-
-  assert(lhs->loopChildNum_ == rhs->loopChildNum_);
-
-  if (lhs->name_ != rhs->name_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
-void Label::markUniqueStringsInner(Context* context) const {
-  name_.mark(context);
-  expressionMarkUniqueStringsInner(context);
-}
 
 owned<Label> Label::build(Builder* builder, Location loc, UniqueString name,
                           owned<Loop> loop) {

--- a/compiler/next/lib/uast/Local.cpp
+++ b/compiler/next/lib/uast/Local.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Local::contentsMatchInner(const ASTNode* other) const {
-  const Local* lhs = this;
-  const Local* rhs = (const Local*) other;
-
-  if (lhs->condChildNum_ != rhs->condChildNum_)
-    return false;
-
-  if (!lhs->simpleBlockLikeContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Local> Local::build(Builder* builder,
                           Location loc,
                           BlockStyle blockStyle,

--- a/compiler/next/lib/uast/Loop.cpp
+++ b/compiler/next/lib/uast/Loop.cpp
@@ -22,24 +22,6 @@
 namespace chpl {
 namespace uast {
 
-bool Loop::loopContentsMatchInner(const Loop* other) const {
-  const Loop* lhs = this;
-  const Loop* rhs = other;
-
-  if (lhs->loopBodyChildNum_ != rhs->loopBodyChildNum_)
-    return false;
-
-  if (lhs->numLoopBodyStmts_ != rhs->numLoopBodyStmts_)
-    return false;
-
-  if (lhs->blockStyle_ != rhs->blockStyle_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
 
 Loop::~Loop() {
 }

--- a/compiler/next/lib/uast/Module.cpp
+++ b/compiler/next/lib/uast/Module.cpp
@@ -25,16 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Module::contentsMatchInner(const ASTNode* other) const {
-  const Module* lhs = this;
-  const Module* rhs = (const Module*) other;
-  return lhs->namedDeclContentsMatchInner(rhs) &&
-         lhs->kind_ == rhs->kind_;
-}
-void Module::markUniqueStringsInner(Context* context) const {
-  namedDeclMarkUniqueStringsInner(context);
-}
-
 owned<Module>
 Module::build(Builder* builder, Location loc,
               UniqueString name, Decl::Visibility vis,

--- a/compiler/next/lib/uast/MultiDecl.cpp
+++ b/compiler/next/lib/uast/MultiDecl.cpp
@@ -35,15 +35,6 @@ bool MultiDecl::isAcceptableMultiDecl() {
   return true;
 }
 
-bool MultiDecl::contentsMatchInner(const ASTNode* other) const {
-  const MultiDecl* lhs = this;
-  const MultiDecl* rhs = (const MultiDecl*) other;
-  return lhs->declContentsMatchInner(rhs);
-}
-void MultiDecl::markUniqueStringsInner(Context* context) const {
-  declMarkUniqueStringsInner(context);
-}
-
 owned<MultiDecl> MultiDecl::build(Builder* builder,
                                   Location loc,
                                   Decl::Visibility vis,

--- a/compiler/next/lib/uast/New.cpp
+++ b/compiler/next/lib/uast/New.cpp
@@ -23,22 +23,6 @@
 namespace chpl {
 namespace uast {
 
-bool New::contentsMatchInner(const ASTNode* other) const {
-  const New* lhs = this;
-  const New* rhs = (const New*) other;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  if (lhs->management_ != rhs->management_)
-    return false;
-
-  return true;
-}
-
-void New::markUniqueStringsInner(Context* context) const {
-  return expressionMarkUniqueStringsInner(context);
-}
 
 owned<New> New::build(Builder* builder,
                       Location loc,

--- a/compiler/next/lib/uast/OpCall.cpp
+++ b/compiler/next/lib/uast/OpCall.cpp
@@ -24,24 +24,6 @@
 namespace chpl {
 namespace uast {
 
-bool OpCall::contentsMatchInner(const ASTNode* other) const {
-  const OpCall* lhs = this;
-  const OpCall* rhs = (const OpCall*) other;
-
-  if (lhs->op_ != rhs->op_)
-    return false;
-
-  if (!lhs->callContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-void OpCall::markUniqueStringsInner(Context* context) const {
-
-  callMarkUniqueStringsInner(context);
-
-  op_.mark(context);
-}
 
 owned<OpCall> OpCall::build(Builder* builder,
                             Location loc,

--- a/compiler/next/lib/uast/Return.cpp
+++ b/compiler/next/lib/uast/Return.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Return::contentsMatchInner(const ASTNode* other) const {
-  const Return* lhs = this;
-  const Return* rhs = (const Return*) other;
-
-  if (lhs->valueChildNum_ != rhs->valueChildNum_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Return> Return::build(Builder* builder, Location loc,
                             owned<Expression> value) {
   ASTList lst;

--- a/compiler/next/lib/uast/Serial.cpp
+++ b/compiler/next/lib/uast/Serial.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Serial::contentsMatchInner(const ASTNode* other) const {
-  const Serial* lhs = this;
-  const Serial* rhs = (const Serial*) other;
-
-  if (lhs->condChildNum_ != rhs->condChildNum_)
-    return false;
-
-  if (!lhs->simpleBlockLikeContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<Serial> Serial::build(Builder* builder,
                           Location loc,
                           BlockStyle blockStyle,

--- a/compiler/next/lib/uast/SimpleBlockLike.cpp
+++ b/compiler/next/lib/uast/SimpleBlockLike.cpp
@@ -25,28 +25,9 @@ namespace chpl {
 namespace uast {
 
 
-bool SimpleBlockLike::
-simpleBlockLikeContentsMatchInner(const ASTNode* other) const {
-  const SimpleBlockLike* lhs = this;
-  const SimpleBlockLike* rhs = other->toSimpleBlockLike();
-
-  if (lhs->blockStyle_ != rhs->blockStyle_)
-    return false;
-
-  if (lhs->bodyChildNum_ != rhs->bodyChildNum_)
-    return false;
-
-  if (lhs->numBodyStmts_ != rhs->numBodyStmts_)
-    return false;
-
-  if (!lhs->expressionContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 SimpleBlockLike::~SimpleBlockLike() {
 }
+
 
 } // namespace uast
 } // namespace chpl

--- a/compiler/next/lib/uast/StringLikeLiteral.cpp
+++ b/compiler/next/lib/uast/StringLikeLiteral.cpp
@@ -25,17 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool StringLikeLiteral::contentsMatchInner(const ASTNode* other) const {
-  const StringLikeLiteral* lhs = this;
-  const StringLikeLiteral* rhs = (const StringLikeLiteral*) other;
-  return lhs->literalContentsMatchInner(rhs) &&
-         lhs->value_ == rhs->value_ &&
-         lhs->quotes_ == rhs->quotes_;
-}
-void StringLikeLiteral::markUniqueStringsInner(Context* context) const {
-  literalMarkUniqueStringsInner(context);
-}
-
 StringLikeLiteral::~StringLikeLiteral() {
 }
 

--- a/compiler/next/lib/uast/TaskVar.cpp
+++ b/compiler/next/lib/uast/TaskVar.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool TaskVar::contentsMatchInner(const ASTNode* other) const {
-  const TaskVar* lhs = this;
-  const TaskVar* rhs = (const TaskVar*) other;
-
-  if (lhs->intent_ != rhs->intent_)
-    return false;
-
-  if (!lhs->varLikeDeclContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<TaskVar> TaskVar::build(Builder* builder, Location loc,
                               UniqueString name, 
                               TaskVar::Intent intent,

--- a/compiler/next/lib/uast/TupleDecl.cpp
+++ b/compiler/next/lib/uast/TupleDecl.cpp
@@ -46,19 +46,6 @@ bool TupleDecl::assertAcceptableTupleDecl() {
   return true;
 }
 
-bool TupleDecl::contentsMatchInner(const ASTNode* other) const {
-  const TupleDecl* lhs = this;
-  const TupleDecl* rhs = (const TupleDecl*) other;
-  return lhs->declContentsMatchInner(rhs) &&
-         lhs->kind_ == rhs->kind_ &&
-         lhs->numElements_ == rhs->numElements_ &&
-         lhs->typeExpressionChildNum_ == rhs->typeExpressionChildNum_ &&
-         lhs->initExpressionChildNum_ == rhs->initExpressionChildNum_;
-}
-void TupleDecl::markUniqueStringsInner(Context* context) const {
-  declMarkUniqueStringsInner(context);
-}
-
 owned<TupleDecl> TupleDecl::build(Builder* builder, Location loc,
                                   Decl::Visibility vis,
                                   Variable::Kind kind,

--- a/compiler/next/lib/uast/Variable.cpp
+++ b/compiler/next/lib/uast/Variable.cpp
@@ -25,19 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-bool Variable::contentsMatchInner(const ASTNode* other) const {
-  const Variable* lhs = this;
-  const Variable* rhs = (const Variable*) other;
-  return lhs->kind_ == rhs->kind_ &&
-         lhs->isConfig_ == rhs->isConfig_ &&
-         lhs->isField_ == rhs->isField_ &&
-         lhs->varLikeDeclContentsMatchInner(rhs);
-}
-
-void Variable::markUniqueStringsInner(Context* context) const {
-  varLikeDeclMarkUniqueStringsInner(context);
-}
-
 owned<Variable>
 Variable::build(Builder* builder, Location loc, UniqueString name,
                 Decl::Visibility vis,

--- a/compiler/next/lib/uast/While.cpp
+++ b/compiler/next/lib/uast/While.cpp
@@ -25,25 +25,13 @@ namespace chpl {
 namespace uast {
 
 
-bool While::contentsMatchInner(const ASTNode* other) const {
-  const While* lhs = this;
-  const While* rhs = (const While*) other;
-
-  if (lhs->conditionChildNum_ != rhs->conditionChildNum_)
-    return false;
-
-  if (!lhs->loopContentsMatchInner(rhs))
-    return false;
-
-  return true;
-}
-
 owned<While> While::build(Builder* builder, Location loc,
                       owned<Expression> condition,
                       BlockStyle blockStyle,
-                      ASTList stmts) {
+                      owned<Block> body) {
 
   assert(condition.get() != nullptr);
+  assert(body.get() != nullptr);
 
   ASTList lst;
   int8_t conditionChildNum = lst.size();
@@ -51,16 +39,12 @@ owned<While> While::build(Builder* builder, Location loc,
   lst.push_back(std::move(condition));
 
   const int loopBodyChildNum = lst.size();
-  const int numLoopBodyStmts = stmts.size();
 
-  for (auto& stmt: stmts) {
-    lst.push_back(std::move(stmt));
-  }
+  lst.push_back(std::move(body));
 
   While* ret = new While(std::move(lst), conditionChildNum,
                          blockStyle,
-                         loopBodyChildNum,
-                         numLoopBodyStmts);
+                         loopBodyChildNum);
 
   builder->noteLocation(ret, loc);
   return toOwned(ret);


### PR DESCRIPTION
This PR makes 3 improvements to the compiler/next code:
 * migrates contentsMatchInner definitions for uast nodes to header files 
   (the idea is that since they are closer to the field declarations,
   this is easier to maintain)
 * updates Loops, Function, and Conditional to store bodies in a separate 
   Block statement. The reason for this is to enable the scope resolution
   code to be able to create a map from ID to Scope. E.g., `for i in 
   1..10 { var x; }` has two different scopes, but before this PR the
   variable declarations for `i` and `x` are stored as direct children
   under the `For`. We need to have a parent AST element with a different
   ID for one of them to consider them as separate scopes.
 * updates testInteractive to print out whether or not a scope resolution
   query has changed in this revision (using a new method on Context).

Reviewed by @dlongnecke-cray - thanks!