### PR TITLE
Fix a compiler seg-fault from infinite recursion

### DIFF
--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -166,7 +166,6 @@ public:
   bool                        fieldIsGeneric(Symbol* field,
                                              bool &hasDefault);
 
-
   Type*                       cArrayElementType()                        const;
   int64_t                     cArrayLength()                             const;
 

--- a/test/classes/ferguson/recursive/issue-12612.chpl
+++ b/test/classes/ferguson/recursive/issue-12612.chpl
@@ -1,0 +1,14 @@
+record R {
+  param size: uint;
+
+  proc type t type
+    return uint(size);
+
+  type this_type = R(size); // Recursive? This line causes a segfault.
+
+  var x: this_type.t;
+}
+
+proc main() {
+  var r: R(64);
+}

--- a/test/classes/ferguson/recursive/issue-12612.good
+++ b/test/classes/ferguson/recursive/issue-12612.good
@@ -1,0 +1,2 @@
+issue-12612.chpl:7: error: this recursive type construction is not yet handled
+Note: This source location is a guess.

--- a/test/classes/ferguson/recursive/waiter-bug.chpl
+++ b/test/classes/ferguson/recursive/waiter-bug.chpl
@@ -1,0 +1,16 @@
+class Waiter {
+  type valueType;
+  var value:valueType;
+
+  var prev : unmanaged Waiter?;
+  var next : unmanaged Waiter?;
+
+  proc init(value) {
+    this.valueType = value.type;
+    this.value = value;
+  }
+}
+
+var x = new Waiter(1);
+
+

--- a/test/classes/ferguson/recursive/waiter-bug.good
+++ b/test/classes/ferguson/recursive/waiter-bug.good
@@ -1,0 +1,4 @@
+waiter-bug.chpl:8: In initializer:
+waiter-bug.chpl:8: error: Cannot default-initialize a variable with generic type
+waiter-bug.chpl:8: note: 'prev' has generic type 'unmanaged Waiter?'
+  waiter-bug.chpl:14: called as Waiter.init(value: int(64))


### PR DESCRIPTION
Adds as tests two programs:
 * the first program in #12612
 * a program that @Yudhishthira1406 ran into during development that was 
   causing a compiler crash

Then, adjusts the recursion handling for finding if a type is generic to
use a visited set rather than trying to mark the type, which was not
working in all cases.

Reviewed by @e-kayrakli - thanks!

- [x] full local testing