### PR TITLE
Remove more order independence pragmas

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -528,9 +528,8 @@ class UserMapAssocDom: BaseAssociativeDom {
 
   proc dsiHasSingleLocalSubdomain() param return false;
 
-  pragma "order independent yielding loops"
   iter dsiLocalSubdomains(loc: locale) {
-    for (idx,l) in zip(dist.targetLocDom, dist.targetLocales) {
+    foreach (idx,l) in zip(dist.targetLocDom, dist.targetLocales) {
       if l == loc {
         yield locDoms[idx]!.myInds;
       }

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -330,14 +330,13 @@ module ChapelAutoAggregation {
 
       // Iterate through buffer elements, must be running on loc. data is passed
       // in to avoid communication.
-      pragma "order independent yielding loops"
       iter localIter(data: c_ptr(elemType), size: int) ref : elemType {
         if boundsChecking {
           assert(this.loc == here.id);
           assert(this.data == data);
           assert(data != c_nil);
         }
-        for i in 0..<size {
+        foreach i in 0..<size {
           yield data[i];
         }
       }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -168,7 +168,6 @@ module ChapelDistribution {
     proc deinit() {
     }
 
-    pragma "order independent yielding loops"
     iter _arrs: unmanaged BaseArr {
       var tmp = _arrs_head;
       while tmp != nil {

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -64,8 +64,6 @@ module DefaultSparse {
                                             initElts=initElts);
     }
 
-    // ?FromMMS: this doesn't appear to be an order independent yielding loop,
-    // why does it use foreach?
     iter dsiIndsIterSafeForRemoving() {
       foreach i in 0..#_nnz by -1 {
         yield _indices(i);

--- a/modules/packages/OrderedMap.chpl
+++ b/modules/packages/OrderedMap.chpl
@@ -381,9 +381,8 @@ module OrderedMap {
 
       :yields: A reference to one of the keys contained in this orderedMap.
     */
-    pragma "order independent yielding loops"
     iter keys() const ref {
-      for kv in _set {
+      foreach kv in _set {
           yield kv[0];
       }
     }
@@ -394,9 +393,8 @@ module OrderedMap {
       :yields: A tuple of references to one of the key-value pairs contained in
                this orderedMap.
     */
-    pragma "order independent yielding loops"
     iter items() const ref {
-      for kv in _set {
+      foreach kv in _set {
         yield (kv[0], kv[1]!.val);
       }
     }
@@ -406,9 +404,8 @@ module OrderedMap {
 
       :yields: A reference to one of the values contained in this orderedMap.
     */
-    pragma "order independent yielding loops"
     iter values() ref {
-      for kv in _set {
+      foreach kv in _set {
         yield kv[1]!.val;
       }
     }

--- a/modules/packages/UnrolledLinkedList.chpl
+++ b/modules/packages/UnrolledLinkedList.chpl
@@ -1108,11 +1108,10 @@ module UnrolledLinkedList {
 
       :yields: A reference to one of the elements contained in this unrolledLinkedList.
     */
-    pragma "order independent yielding loops"
     iter these() ref {
       var cur = _head;
       while cur != nil {
-        for i in 0..#cur!.size {
+        foreach i in 0..#cur!.size {
           yield cur!.data[i];
         }
         cur = cur!.next;

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -804,7 +804,6 @@ record regex {
      :arg maxsplit: if nonzero, the maximum number of splits to do
      :yields: each split portion, one at a time
    */
-  pragma "not order independent yielding loops"
   iter split(text: exprType, maxsplit: int = 0)
   {
     var matches:_ddata(qio_regex_string_piece_t);
@@ -876,7 +875,6 @@ record regex {
      :yields: tuples of :record:`regexMatch` objects, the 1st is always
               the match for the whole pattern and the rest are the capture groups.
    */
-  pragma "not order independent yielding loops"
   iter matches(text: exprType, param captures=0, maxmatches: int = max(int))
   {
     var matches:_ddata(qio_regex_string_piece_t);


### PR DESCRIPTION
This PR removes more uses of order independence pragmas and is a follow on to #18046 

Except for the case in ChapelDistribution, I think those pragmas were added relatively recently and I missed them in my initial `foreach` PR.

Test:
- [x] standard
- [x] gasnet
- [x] standard release/examples with `--fast` 