### PR TITLE
update addrinfo constructs

### DIFF
--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -376,18 +376,18 @@ module Sys {
   */
   proc sys_sockaddr_t.family:c_int { return sys_getsockaddr_family(this); }
 
-  extern record sys_addrinfo_t {
+  extern "struct addrinfo" record sys_addrinfo_t {
     var ai_flags: c_int;
     var ai_family: c_int;
     var ai_socktype: c_int;
     var ai_protocol: c_int;
+    var ai_addrlen: socklen_t;
+    var ai_next: c_ptr(sys_addrinfo_t);
   }
-  extern type sys_addrinfo_ptr_t; // opaque
-
+  type sys_addrinfo_ptr_t = c_ptr(sys_addrinfo_t); // opaque
 
   proc sys_addrinfo_ptr_t.flags:c_int { return sys_getaddrinfo_flags(this); }
   proc sys_addrinfo_ptr_t.family:c_int { return sys_getaddrinfo_family(this); }
-  proc sys_addrinfo_ptr_t.socktype:c_int { return sys_getaddrinfo_socktype(this); }
   proc sys_addrinfo_ptr_t.socktype:c_int { return sys_getaddrinfo_socktype(this); }
   proc sys_addrinfo_ptr_t.addr:sys_sockaddr_t { return sys_getaddrinfo_addr(this); }
   // Not supported yet
@@ -437,7 +437,7 @@ module Sys {
   extern proc sys_accept(sockfd:fd_t, ref add_out:sys_sockaddr_t, ref fd_out:fd_t):err_t;
   extern proc sys_bind(sockfd:fd_t, ref addr:sys_sockaddr_t):err_t;
   extern proc sys_connect(sockfd:fd_t, ref addr:sys_sockaddr_t):err_t;
-  extern proc sys_getaddrinfo(node:c_string, service:c_string, ref hints:sys_addrinfo_t, ref res_out:sys_addrinfo_ptr_t):err_t;
+  extern proc getaddrinfo(node:c_string, service:c_string, ref hints:sys_addrinfo_t, ref res_out:sys_addrinfo_ptr_t):err_t;
   extern proc sys_getaddrinfo_flags(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getaddrinfo_family(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getaddrinfo_socktype(res:sys_addrinfo_ptr_t):c_int;

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -384,7 +384,7 @@ module Sys {
     var ai_addrlen: socklen_t;
     var ai_next: c_ptr(sys_addrinfo_t);
   }
-  type sys_addrinfo_ptr_t = c_ptr(sys_addrinfo_t); // opaque
+  type sys_addrinfo_ptr_t = c_ptr(sys_addrinfo_t);
 
   proc sys_addrinfo_ptr_t.flags:c_int { return sys_getaddrinfo_flags(this); }
   proc sys_addrinfo_ptr_t.family:c_int { return sys_getaddrinfo_family(this); }
@@ -442,6 +442,7 @@ module Sys {
   extern proc sys_getaddrinfo_family(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getaddrinfo_socktype(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getaddrinfo_protocol(res:sys_addrinfo_ptr_t):c_int;
+  extern proc sys_getaddrinfo_addrlen(res:sys_addrinfo_ptr_t):socklen_t;
   extern proc sys_getaddrinfo_addr(res:sys_addrinfo_ptr_t):sys_sockaddr_t;
   extern proc sys_getaddrinfo_next(res:sys_addrinfo_ptr_t):sys_addrinfo_ptr_t;
   extern proc sys_freeaddrinfo(res:sys_addrinfo_ptr_t);

--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -247,6 +247,7 @@ int sys_getaddrinfo_flags(sys_addrinfo_ptr_t a);
 int sys_getaddrinfo_family(sys_addrinfo_ptr_t a);
 int sys_getaddrinfo_socktype(sys_addrinfo_ptr_t a);
 int sys_getaddrinfo_protocol(sys_addrinfo_ptr_t a);
+socklen_t sys_getaddrinfo_addrlen(sys_addrinfo_ptr_t a);
 sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a);
 sys_addrinfo_ptr_t sys_getaddrinfo_next(sys_addrinfo_ptr_t a);
 

--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -250,7 +250,7 @@ int sys_getaddrinfo_protocol(sys_addrinfo_ptr_t a);
 sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a);
 sys_addrinfo_ptr_t sys_getaddrinfo_next(sys_addrinfo_ptr_t a);
 
-void sys_freeaddr_info(sys_addrinfo_ptr_t* p);
+void sys_freeaddrinfo(sys_addrinfo_ptr_t* p);
 
 
 err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags);

--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -251,7 +251,7 @@ socklen_t sys_getaddrinfo_addrlen(sys_addrinfo_ptr_t a);
 sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a);
 sys_addrinfo_ptr_t sys_getaddrinfo_next(sys_addrinfo_ptr_t a);
 
-void sys_freeaddrinfo(sys_addrinfo_ptr_t* p);
+void sys_freeaddrinfo(sys_addrinfo_ptr_t p);
 
 
 err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags);

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -1532,7 +1532,7 @@ sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a) {
 }
 sys_addrinfo_ptr_t sys_getaddrinfo_next(sys_addrinfo_ptr_t a) {return a->ai_next;}
 
-void sys_freeaddr_info(sys_addrinfo_ptr_t *p)
+void sys_freeaddrinfo(sys_addrinfo_ptr_t *p)
 {
   freeaddrinfo(*p);
   *p = NULL;

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -1533,10 +1533,9 @@ sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a) {
 }
 sys_addrinfo_ptr_t sys_getaddrinfo_next(sys_addrinfo_ptr_t a) {return a->ai_next;}
 
-void sys_freeaddrinfo(sys_addrinfo_ptr_t *p)
+void sys_freeaddrinfo(sys_addrinfo_ptr_t p)
 {
-  freeaddrinfo(*p);
-  *p = NULL;
+  freeaddrinfo(p);
 }
 
 err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags)

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -1524,6 +1524,7 @@ int sys_getaddrinfo_flags(sys_addrinfo_ptr_t a) {return a->ai_flags;}
 int sys_getaddrinfo_family(sys_addrinfo_ptr_t a) {return a->ai_family;}
 int sys_getaddrinfo_socktype(sys_addrinfo_ptr_t a) {return a->ai_socktype;}
 int sys_getaddrinfo_protocol(sys_addrinfo_ptr_t a) {return a->ai_protocol;}
+socklen_t sys_getaddrinfo_addrlen(sys_addrinfo_ptr_t a) {return a->ai_addrlen;}
 sys_sockaddr_t sys_getaddrinfo_addr(sys_addrinfo_ptr_t a) {
   sys_sockaddr_t ret;
   qio_memcpy(&ret.addr, a->ai_addr, a->ai_addrlen);


### PR DESCRIPTION
- extern proc for adding in `getaddrinfo`
- extern `addrinfo_t`
- add in new getter
- remove duplicate getters and rename functions

Signed-off-by: Lakshya Singh <lakshay.singh1108@gmail.com>