### PR TITLE
Fix build errors introduced by PR #18055

### DIFF
--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #ifdef HAS_GPU_LOCALE
 
-void  chpl_gpu_init();
+void  chpl_gpu_init(void);
 void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName);
 
 #endif // HAS_GPU_LOCALE

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -20,6 +20,7 @@
 #include "sys_basic.h"
 #include "chplrt.h"
 #include "chpl-mem.h"
+#include "chpl-gpu.h"
 #include "error.h"
 
 #ifdef HAS_GPU_LOCALE


### PR DESCRIPTION
See: https://chapel.discourse.group/t/failure-cray-cs-correctness-test-cray-cs-gpu-native/6229
Caused by PR #18055 which added gpu functions to Chapel's runtime library.

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>