### PR TITLE
Improve extern block LLVM warning

### DIFF
--- a/test/release/examples/primers/interopWithC.chpl
+++ b/test/release/examples/primers/interopWithC.chpl
@@ -345,7 +345,8 @@ module interopWithC {
 
 /*
    .. warning::
-      As of now, chapel must be used with LLVM to use the extern block syntax
+      As of now, chapel must be used with LLVM support to use the extern block syntax.
+      See :ref:`readme-llvm` on how to build chapel with LLVM support.
 
 */
 


### PR DESCRIPTION
Improve the warning block in the C interoperability primer to direct the reader to where they can learn about LLVM Support.