### PR TITLE
Scale heap by number of locales on local node.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -263,6 +263,7 @@ void chpl_comm_ofi_oob_fini(void);
 void chpl_comm_ofi_oob_barrier(void);
 void chpl_comm_ofi_oob_allgather(const void*, void*, size_t);
 void chpl_comm_ofi_oob_bcast(void*, size_t);
+int  chpl_comm_ofi_oob_locales_on_node(void);
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
@@ -96,3 +96,26 @@ void chpl_comm_ofi_oob_bcast(void* buf, size_t size) {
   DBG_PRINTF(DBG_OOB, "OOB bcast: %zd", size);
   MPI_CHK(MPI_Bcast(buf, size, MPI_BYTE, 0, MPI_COMM_WORLD));
 }
+
+int chpl_comm_ofi_oob_locales_on_node(void) {
+  //
+  // The MPI_Comm_split_type() call splits the specified input communicator
+  // (MPI_COMM_WORLD) into one or more output communicators which, because of the
+  // MPI_COMM_TYPE_SHARED argument, each refer to the shared-memory regions of the
+  // job. Then it returns these communicators to all of the ranks, with all ranks in
+  // a given shared-memory region getting the same one. The ranks on a node can then
+  // communicate just among themselves using this resulting communicator. Note that
+  // MPI_Comm_split_type() is a collective call -- it must be called by all members
+  // of the to-be-split communicator (here, MPI_COMM_WORLD) cooperatively. It's like
+  // a barrier, in other words. For our use, we just need to know its size, i.e.,
+  // the number of MPI ranks (Chapel locales) on our node.
+  //
+  MPI_Comm nodeComm;
+  MPI_CHK(MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0,
+                              MPI_INFO_NULL, &nodeComm));
+  int nodeSize;
+  MPI_CHK(MPI_Comm_size(nodeComm, &nodeSize));
+  MPI_CHK(MPI_Comm_free(&nodeComm));
+  DBG_PRINTF(DBG_OOB, "OOB locales on node: %d", nodeSize);
+  return nodeSize;
+}

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
@@ -39,7 +39,6 @@
 
 #include "comm-ofi-internal.h"
 
-
 #define PMI2_SUCCESS 0
 #define PMI2_ID_NULL -1
 #define PMI2_MAX_VALLEN 1024
@@ -284,4 +283,9 @@ void decode_kvs(char* raw, const char* enc, size_t size) {
     raw[i] =   ((enc[2 * i + 0] - 'a') << (0 * 4))
              | ((enc[2 * i + 1] - 'a') << (1 * 4));
   }
+}
+
+int chpl_comm_ofi_oob_locales_on_node(void) {
+  // TODO: figure out how to implement this correctly
+  return 1;
 }

--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -100,3 +100,8 @@ void chpl_comm_ofi_oob_bcast(void* buf, size_t len) {
     INTERNAL_ERROR_V("multi-locale bcast not supported");
   }
 }
+
+int chpl_comm_ofi_oob_locales_on_node(void) {
+  // assume the answer is 1
+  return 1;
+}

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2887,13 +2887,27 @@ void init_fixedHeap(void) {
   }
 
   //
-  // We'll use a fixed heap.  If its size is not specified, default
-  // to 85% of physical memory.
+  // If we get this far we'll use a fixed heap.
+  // 
+  uint64_t total_memory = chpl_sys_physicalMemoryBytes();
+
+  //
+  // Don't use more than 85% of the total memory for heaps.
+  //
+  uint64_t max_heap_memory = (size_t) (0.85 * total_memory);
+
+  int num_locales_on_node = chpl_comm_ofi_oob_locales_on_node();
+  size_t max_heap_per_locale = (size_t) (max_heap_memory / num_locales_on_node);
+
+
+  //
+  // If the maximum heap size is not specified or it's greater than the maximum heap per
+  // locale, set it to the maximum heap per locale.
   //
   ssize_t size = envMaxHeapSize;
   CHK_TRUE(size != 0);
-  if (size < 0) {
-    size = (size_t) (0.85 * chpl_sys_physicalMemoryBytes());
+  if ((size < 0) || (size > max_heap_per_locale)) {
+    size = max_heap_per_locale;
   }
 
   //
@@ -2917,19 +2931,8 @@ void init_fixedHeap(void) {
   size = ALIGN_UP(size, page_size);
 
   //
-  // As a hedge against silliness, first reduce any request so that it's
-  // no larger than the physical memory.  As a beneficial side effect
-  // when the user request is ridiculously large, this also causes the
-  // reduce-by-5% loop below to run faster and produce a final size
-  // closer to the maximum available.
-  //
-  const size_t size_phys = ALIGN_DN(chpl_sys_physicalMemoryBytes(), page_size);
-  if (size > size_phys)
-    size = size_phys;
-
-  //
   // Work our way down from the starting size in (roughly) 5% steps
-  // until we can actually get that much from the system.
+  // until we can actually allocate a heap that size.
   //
   size_t decrement;
   if ((decrement = ALIGN_DN((size_t) (0.05 * size), page_size)) < page_size) {
@@ -2967,7 +2970,6 @@ void init_fixedHeap(void) {
                chpl_snprintf_KMG_z(buf, sizeof(buf), size), size);
   }
 #endif
-
   fixedHeapSize  = size;
   fixedHeapStart = start;
 }


### PR DESCRIPTION
init_fixedHeap now scales the computed heap size by the number of locales on the local node
to avoid running out of memory. The function chpl_comm_ofi_oob_locales_on_node is called
to determine the number of locales on the local node. This function is currently only implemented
for MPI, the PMI2 and socket implementations return 1.

This resolves issue #2284.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>