### PR TITLE
Fix issue 18103

### DIFF
--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -434,9 +434,9 @@ err_t sys_strerror_internal(err_t error, char** string_out, size_t extra_space)
     }
     buf = newbuf;
     got = sys_xsi_strerror_r(error, buf, buf_sz);
-    if( got == 0 ) break;
-    if( got == -1 && errno != ERANGE ) {
-      err_out = errno;
+    if (got == 0) break;
+    if (got != ERANGE) {
+      err_out = got;
       break;
     }
     buf_sz *= 2; // try again with a bigger buffer.
@@ -444,7 +444,7 @@ err_t sys_strerror_internal(err_t error, char** string_out, size_t extra_space)
 
   // maybe it's a EAI/gai error, which we add GAI_ERROR_OFFSET to.
 #ifdef HAS_GETADDRINFO
-  if( got == -1 && err_out == EINVAL ) {
+  if( got != 0 && err_out == EINVAL ) {
     const char* gai_str;
     int len;
     gai_str = gai_strerror(error - GAI_ERROR_OFFSET);

--- a/runtime/src/qio/sys_xsi_strerror_r.c
+++ b/runtime/src/qio/sys_xsi_strerror_r.c
@@ -45,12 +45,16 @@ int sys_xsi_strerror_r(int errnum, char* buf, size_t buflen);
 int sys_xsi_strerror_r(int errnum, char* buf, size_t buflen)
 {
 #ifdef HAS_STRERROR_R
-  return strerror_r(errnum, buf, buflen);
+  int rc = strerror_r(errnum, buf, buflen);
+  if (rc == -1) {
+    rc = errno;
+  }
+  return rc;
 #else
   char* msg = strerror(errnum);
   if( strlen(msg) + 1 < buflen ) {
-   strcpy(buf, msg);
-   return 0;
+    strcpy(buf, msg);
+    return 0;
   }
   return ERANGE;
 #endif

--- a/test/errhandling/ferguson/issue-18103.chpl
+++ b/test/errhandling/ferguson/issue-18103.chpl
@@ -1,0 +1,5 @@
+use SysError;
+
+var e = SystemError.fromSyserr(-1);
+
+writeln(e);

--- a/test/errhandling/ferguson/issue-18103.good
+++ b/test/errhandling/ferguson/issue-18103.good
@@ -1,0 +1,1 @@
+SystemError: Unknown error


### PR DESCRIPTION
Fixes #18103 by adjusting `sys_xsi_strerror_r` to return an error code, 
or 0, for both glibc behaviors of the XSI `strerror_r`.

Reviewed by @jhh67 - thanks!

- [x] full local testing