### PR TITLE
Bring in an upstream syscall errno fix for qthreads

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -25,6 +25,11 @@ as follows:
 * We added a simple mechanism to reset the automatic task spawning
   order for better affinity between consecutive parallel loops.
 
-* We fixed a bug in the binders topology layer.
+* Pulled in an upstream fix for the binders topology layer.
+  https://github.com/Qthreads/qthreads/pull/82
 
-* Added --with-hwloc-symbol-prefix configuration option.
+* Pulled in an upstream --with-hwloc-symbol-prefix configuration option.
+  https://github.com/Qthreads/qthreads/pull/87
+
+* Pulled in an upstream for for errno with syscalls.
+  https://github.com/Qthreads/qthreads/pull/89

--- a/third-party/qthread/qthread-src/include/qt_blocking_structs.h
+++ b/third-party/qthread/qthread-src/include/qt_blocking_structs.h
@@ -42,6 +42,7 @@ typedef struct _qt_blocking_queue_node_s {
     syscall_t                         op;
     uintptr_t                         args[5];
     ssize_t                           ret;
+    int                               err;
 } qt_blocking_queue_node_t;
 
 typedef struct qthread_addrstat_s {

--- a/third-party/qthread/qthread-src/src/io.c
+++ b/third-party/qthread/qthread-src/src/io.c
@@ -357,6 +357,8 @@ int INTERNAL qt_process_blocking_call(void)
             break;
         }
     }
+    /* preserve errno in item */
+    item->err = errno;
     /* and now, re-queue */
     qt_threadqueue_enqueue(item->thread->rdata->shepherd_ptr->ready, item->thread);
     FREE_SYSCALLJOB(item);

--- a/third-party/qthread/qthread-src/src/syscalls/accept.c
+++ b/third-party/qthread/qthread-src/src/syscalls/accept.c
@@ -40,6 +40,7 @@ int qt_accept(int                       socket,
     me->thread_state     = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/connect.c
+++ b/third-party/qthread/qthread-src/src/syscalls/connect.c
@@ -40,6 +40,7 @@ int qt_connect(int                    socket,
     me->thread_state     = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/poll.c
+++ b/third-party/qthread/qthread-src/src/syscalls/poll.c
@@ -41,6 +41,7 @@ int qt_poll(struct pollfd fds[],
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/pread.c
+++ b/third-party/qthread/qthread-src/src/syscalls/pread.c
@@ -43,6 +43,7 @@ ssize_t qt_pread(int    filedes,
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/pwrite.c
+++ b/third-party/qthread/qthread-src/src/syscalls/pwrite.c
@@ -43,6 +43,7 @@ ssize_t qt_pwrite(int         filedes,
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/read.c
+++ b/third-party/qthread/qthread-src/src/syscalls/read.c
@@ -41,6 +41,7 @@ ssize_t qt_read(int    filedes,
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/select.c
+++ b/third-party/qthread/qthread-src/src/syscalls/select.c
@@ -47,6 +47,7 @@ int qt_select(int                      nfds,
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/system.c
+++ b/third-party/qthread/qthread-src/src/syscalls/system.c
@@ -36,6 +36,7 @@ int qt_system(const char *command)
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/wait4.c
+++ b/third-party/qthread/qthread-src/src/syscalls/wait4.c
@@ -50,6 +50,7 @@ pid_t qt_wait4(pid_t          pid,
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }

--- a/third-party/qthread/qthread-src/src/syscalls/write.c
+++ b/third-party/qthread/qthread-src/src/syscalls/write.c
@@ -41,6 +41,7 @@ ssize_t qt_write(int         filedes,
     me->thread_state        = QTHREAD_STATE_SYSCALL;
     qthread_back_to_master(me);
     ret = job->ret;
+    errno = job->err;
     FREE_SYSCALLJOB(job);
     return ret;
 }


### PR DESCRIPTION
Bring in Qthreads/qthreads#89 to ensure that errno is preserved for
system calls made through the qthreads syscall interface.