### PR TITLE
compiler/next: adding function resolution

### DIFF
--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -39,6 +39,11 @@ namespace uast {
   class ASTNode;
 }
 
+namespace resolution {
+  struct TypedFnSignature;
+}
+
+
 /**
 
 \rst
@@ -418,6 +423,23 @@ class Context {
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
     __attribute__ ((format (printf, 3, 4)))
+  #endif
+;
+  /**
+    Note an error for the currently running query.
+    This is a convenience overload.
+    This version takes in a TypedFnSignature and an AST node and a
+    printf-style format string.
+    The AST node is used to compute a Location by using a parsing::locateAst.
+    The TypedFnSignature is used to print out instantiation information.
+   */
+  void error(const resolution::TypedFnSignature* inFn,
+             const uast::ASTNode* ast,
+             const char* fmt, ...)
+  #ifndef DOXYGEN
+    // docs generator has trouble with the attribute applied to 'build'
+    // so the above ifndef works around the issue.
+    __attribute__ ((format (printf, 4, 5)))
   #endif
 ;
 

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -248,7 +248,8 @@ class Context {
       querydetail::QueryMap<ResultType, ArgTs...>* queryMap,
       const querydetail::QueryMapResult<ResultType, ArgTs...>* r,
       const std::tuple<ArgTs...>& tupleOfArgs,
-      ResultType result);
+      ResultType result,
+      bool forSetter);
 
   template<typename ResultType,
            typename... ArgTs>
@@ -256,7 +257,8 @@ class Context {
   updateResultForQueryMap(
       querydetail::QueryMap<ResultType, ArgTs...>* queryMap,
       const std::tuple<ArgTs...>& tupleOfArgs,
-      ResultType result);
+      ResultType result,
+      bool forSetter);
 
   template<typename ResultType,
            typename... ArgTs>
@@ -266,7 +268,8 @@ class Context {
        const std::tuple<ArgTs...>& tupleOfArgs,
        ResultType result,
        const char* traceQueryName,
-       bool isInputQuery);
+       bool isInputQuery,
+       bool forSetter);
 
   template<typename ResultType,
            typename... ArgTs>

--- a/compiler/next/include/chpl/queries/query-impl.h
+++ b/compiler/next/include/chpl/queries/query-impl.h
@@ -355,7 +355,7 @@ Context::updateResultForQueryMapR(QueryMap<ResultType, ArgTs...>* queryMap,
 
   // For setter queries, only run the combiner if the last
   // time the query was checked was an earlier revision.
-  // If the combiner is skipped, changed is left as false.
+  // If the combiner is skipped, 'changed' is left as false.
   if (forSetter == false || r->lastChecked != currentRevision) {
     chpl::update<ResultType> combiner;
     changed = combiner(r->result, result);

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -89,6 +89,11 @@ namespace resolution {
 
 
   /**
+    Resolves a concrete function using the above queries.
+    */
+  const ResolvedFunction* resolvedConcreteFunction(Context* context, ID id);
+
+  /**
     Compute the return/yield type for a function.
    */
   const types::QualifiedType& returnType(Context* context,

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -88,6 +88,13 @@ namespace resolution {
                                            const PoiScope* poiScope);
 
 
+  /**
+    Compute the return/yield type for a function.
+   */
+  const types::QualifiedType& returnType(Context* context,
+                                         const TypedFnSignature* sig,
+                                         const PoiScope* poiScope);
+
   /////// call resolution
 
   /**

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -32,7 +32,7 @@ namespace resolution {
   /**
     Resolve the contents of a Module
    */
-  const ResolutionResultByPostorderID& resolveModule(Context* context, ID id);
+  const ResolutionResultByPostorderID& resolvedModule(Context* context, ID id);
 
   /**
     Compute the type for a NamedDecl with a particular id.
@@ -93,6 +93,13 @@ namespace resolution {
     */
   const ResolvedFunction* resolvedConcreteFunction(Context* context, ID id);
 
+  /**
+    Returns the ResolvedFunction called by a particular
+    ResolvedExpression, if there was exactly one candidate.
+    This function does not handle return intent overloading.
+   */
+  const ResolvedFunction* resolvedOnlyCandidate(Context* context,
+                                                const ResolvedExpression& r);
   /**
     Compute the return/yield type for a function.
    */

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -62,12 +62,12 @@ namespace resolution {
     The pointer result is unique'd and safe to use as a query argument.
    */
   const TypedFnSignature*
-  typedSignatureInital(Context* context,
-                       const UntypedFnSignature* untypedSig);
+  typedSignatureInitial(Context* context,
+                        const UntypedFnSignature* untypedSig);
 
   /**
     Instantiate a TypedFnSignature from
-     * the result of typedSignatureInital,
+     * the result of typedSignatureInitial,
      * a CallInfo describing the types at the call site, and
      * a point-of-instantiation scope representing the POI scope of the call
 

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -26,6 +26,18 @@ namespace chpl {
 namespace resolution {
 
 
+  /**
+    Create an UntypedFnSignature for a Function, or return
+    nullptr if the passed ID is not a Function.
+   */
+  UntypedFnSignature* untypedSignature(Context* context, ID id);
+
+  /**
+    Compute the type for a NamedDecl with a particular id.
+    This is not used for local variables.
+   */
+  const KindParamType& typeForSymbol(Context* context, ID id);
+
   /*
   // Resolves the top-level declarations in a module
   const ResolvedSymbol&

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -115,12 +115,13 @@ namespace resolution {
     inScope/inPoiScope.
 
    */
-  std::vector<const TypedFnSignature*>
+  void
   filterCandidatesInstantiating(Context* context,
                                 std::vector<const TypedFnSignature*> lst,
                                 CallInfo call,
                                 const Scope* inScope,
-                                const PoiScope* inPoiScope);
+                                const PoiScope* inPoiScope,
+                                std::vector<const TypedFnSignature*>& result);
 
   /**
     Given the result of filterCandidatesInstantiating, run

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -32,7 +32,7 @@ namespace resolution {
   /**
     Resolve the contents of a Module
    */
-  const ResolutionResultByPostorderID& resolvedModule(Context* context, ID id);
+  const ResolutionResultByPostorderID& resolveModule(Context* context, ID id);
 
   /**
     Compute the type for a NamedDecl with a particular id.
@@ -83,23 +83,23 @@ namespace resolution {
     Checks the generic cache for potential for reuse. When reuse occurs,
     the ResolvedFunction might point to a different TypedFnSignature.
    */
-  const ResolvedFunction* resolvedFunction(Context* context,
-                                           const TypedFnSignature* sig,
-                                           const PoiScope* poiScope);
+  const ResolvedFunction* resolveFunction(Context* context,
+                                          const TypedFnSignature* sig,
+                                          const PoiScope* poiScope);
 
 
   /**
     Resolves a concrete function using the above queries.
     */
-  const ResolvedFunction* resolvedConcreteFunction(Context* context, ID id);
+  const ResolvedFunction* resolveConcreteFunction(Context* context, ID id);
 
   /**
     Returns the ResolvedFunction called by a particular
     ResolvedExpression, if there was exactly one candidate.
     This function does not handle return intent overloading.
    */
-  const ResolvedFunction* resolvedOnlyCandidate(Context* context,
-                                                const ResolvedExpression& r);
+  const ResolvedFunction* resolveOnlyCandidate(Context* context,
+                                               const ResolvedExpression& r);
   /**
     Compute the return/yield type for a function.
    */

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -110,12 +110,17 @@ namespace resolution {
     Further filter the result of filterCandidatesInitial down by doing
     instantiations. After this, all of the resulting TypedFnSignatures
     are actually candidates.
+
+    If instantiation occurs, gets/creates the new POI scope for
+    inScope/inPoiScope.
+
    */
   std::vector<const TypedFnSignature*>
   filterCandidatesInstantiating(Context* context,
                                 std::vector<const TypedFnSignature*> lst,
                                 CallInfo call,
-                                const PoiScope* poiScope);
+                                const Scope* inScope,
+                                const PoiScope* inPoiScope);
 
   /**
     Given the result of filterCandidatesInstantiating, run
@@ -137,8 +142,8 @@ namespace resolution {
   CallResolutionResult resolveCall(Context* context,
                                    const uast::Call* call,
                                    CallInfo ci,
-                                   const Scope* scope,
-                                   const PoiScope* poiScope);
+                                   const Scope* inScope,
+                                   const PoiScope* inPoiScope);
 
 
 } // end namespace resolution

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -63,7 +63,7 @@ namespace resolution {
    */
   const TypedFnSignature*
   typedSignatureInital(Context* context,
-                       const UntypedFnSignature* untypedSignature);
+                       const UntypedFnSignature* untypedSig);
 
   /**
     Instantiate a TypedFnSignature from
@@ -83,7 +83,7 @@ namespace resolution {
     Checks the generic cache for potential for reuse. When reuse occurs,
     the ResolvedFunction might point to a different TypedFnSignature.
    */
-  const ResolvedFunction& resolvedFunction(Context* context,
+  const ResolvedFunction* resolvedFunction(Context* context,
                                            const TypedFnSignature* sig,
                                            const PoiScope* poiScope);
 

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -145,7 +145,6 @@ namespace resolution {
                                    const Scope* inScope,
                                    const PoiScope* inPoiScope);
 
-
 } // end namespace resolution
 } // end namespace chpl
 #endif

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -33,10 +33,21 @@ namespace resolution {
   UntypedFnSignature* untypedSignature(Context* context, ID id);
 
   /**
+    Resolve the contents of a Symbol
+   */
+  const ResolutionResultByPostorderID& resolveSymbolContents(Context* context,
+                                                             ID id);
+
+  /**
     Compute the type for a NamedDecl with a particular id.
     This is not used for local variables.
    */
-  const KindParamType& typeForSymbol(Context* context, ID id);
+  const types::QualifiedType& typeForSymbol(Context* context, ID id);
+
+  /**
+    Compute the type for a Builtin type using just its name
+   */
+  const types::QualifiedType& typeForBuiltin(Context* context, UniqueString name);
 
   /*
   // Resolves the top-level declarations in a module

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -83,10 +83,9 @@ namespace resolution {
     Checks the generic cache for potential for reuse. When reuse occurs,
     the ResolvedFunction might point to a different TypedFnSignature.
    */
-  const ResolutionResultByPostorderID&
-  resolvedFunction(Context* context,
-                   const TypedFnSignature* sig,
-                   const PoiScope* poiScope);
+  const ResolvedFunction& resolvedFunction(Context* context,
+                                           const TypedFnSignature* sig,
+                                           const PoiScope* poiScope);
 
 
   /////// call resolution
@@ -125,13 +124,14 @@ namespace resolution {
   /**
     Given a CallInfo representing a call, a Scope representing the
     scope of that call, and a PoiScope representing the point-of-instantiation
-    scope of that call, find the most specific candidates.
+    scope of that call, find the most specific candidates as well
+    as the point-of-instantiation scopes that were used when resolving them.
    */
-  MostSpecificCandidates resolveCall(Context* context,
-                                     const uast::Call* call,
-                                     CallInfo ci,
-                                     const Scope* scope,
-                                     const PoiScope* poiScope);
+  CallResolutionResult resolveCall(Context* context,
+                                   const uast::Call* call,
+                                   CallInfo ci,
+                                   const Scope* scope,
+                                   const PoiScope* poiScope);
 
 
 } // end namespace resolution

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -21,40 +21,117 @@
 #define CHPL_RESOLUTION_RESOLUTION_QUERIES_H
 
 #include "chpl/resolution/resolution-types.h"
+#include "chpl/resolution/scope-types.h"
 
 namespace chpl {
 namespace resolution {
 
 
-  /**
-    Create an UntypedFnSignature for a Function, or return
-    nullptr if the passed ID is not a Function.
-   */
-  UntypedFnSignature* untypedSignature(Context* context, ID id);
+  ////// resolution basics
 
   /**
-    Resolve the contents of a Symbol
+    Resolve the contents of a Module
    */
-  const ResolutionResultByPostorderID& resolveSymbolContents(Context* context,
-                                                             ID id);
+  const ResolutionResultByPostorderID& resolveModule(Context* context, ID id);
 
   /**
     Compute the type for a NamedDecl with a particular id.
    */
-  const types::QualifiedType& typeForSymbol(Context* context, ID id);
+  const types::QualifiedType& typeForModuleLevelSymbol(Context* context, ID id);
 
   /**
     Compute the type for a Builtin type using just its name
    */
   const types::QualifiedType& typeForBuiltin(Context* context, UniqueString name);
 
-  /*
-  // Resolves the top-level declarations in a module
-  const ResolvedSymbol&
-  resolveModule(Context* context, const uast::Module* mod);
+  /////// function resolution
 
-  const ResolvedSymbolVec& resolveFile(Context* context, UniqueString path);
+  /**
+    Compute an UntypedFnSignature for a Function, or return
+    nullptr if the passed ID is not a Function.
+    The pointer result is unique'd and safe to use as a query argument.
    */
+  const UntypedFnSignature* untypedSignature(Context* context, ID id);
+
+
+  /**
+    Compute a TypedFnSignature from an UntypedFnSignature.
+    The TypedFnSignature will represent generic and potentially unknown
+    types if the function is generic.
+
+    The pointer result is unique'd and safe to use as a query argument.
+   */
+  const TypedFnSignature*
+  typedSignatureInital(Context* context,
+                       const UntypedFnSignature* untypedSignature);
+
+  /**
+    Instantiate a TypedFnSignature from
+     * the result of typedSignatureInital,
+     * a CallInfo describing the types at the call site, and
+     * a point-of-instantiation scope representing the POI scope of the call
+
+    Returns nullptr if the instantiation failed.
+   */
+  const TypedFnSignature* instantiateSignature(Context* context,
+                                               const TypedFnSignature* sig,
+                                               CallInfo call,
+                                               const PoiScope* poiScope);
+
+  /**
+    Compute a ResolvedFunction given a TypedFnSignature.
+    Checks the generic cache for potential for reuse. When reuse occurs,
+    the ResolvedFunction might point to a different TypedFnSignature.
+   */
+  const ResolutionResultByPostorderID&
+  resolvedFunction(Context* context,
+                   const TypedFnSignature* sig,
+                   const PoiScope* poiScope);
+
+
+  /////// call resolution
+
+  /**
+    Compute the (potentially generic) TypedFnSignatures of possibly applicable
+    candidate functions from a list of visible functions.
+   */
+  const std::vector<const TypedFnSignature*>&
+  filterCandidatesInitial(Context* context,
+                          std::vector<BorrowedIdsWithName> lst,
+                          CallInfo call);
+
+  /**
+    Further filter the result of filterCandidatesInitial down by doing
+    instantiations. After this, all of the resulting TypedFnSignatures
+    are actually candidates.
+   */
+  std::vector<const TypedFnSignature*>
+  filterCandidatesInstantiating(Context* context,
+                                std::vector<const TypedFnSignature*> lst,
+                                CallInfo call,
+                                const PoiScope* poiScope);
+
+  /**
+    Given the result of filterCandidatesInstantiating, run
+    overload resolution aka disambiguation
+    to determine the most specific functions.
+   */
+  const MostSpecificCandidates&
+  findMostSpecificCandidates(Context* context,
+                             std::vector<const TypedFnSignature*> lst,
+                             CallInfo call);
+
+
+  /**
+    Given a CallInfo representing a call, a Scope representing the
+    scope of that call, and a PoiScope representing the point-of-instantiation
+    scope of that call, find the most specific candidates.
+   */
+  MostSpecificCandidates resolveCall(Context* context,
+                                     const uast::Call* call,
+                                     CallInfo ci,
+                                     const Scope* scope,
+                                     const PoiScope* poiScope);
 
 
 } // end namespace resolution

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -40,7 +40,6 @@ namespace resolution {
 
   /**
     Compute the type for a NamedDecl with a particular id.
-    This is not used for local variables.
    */
   const types::QualifiedType& typeForSymbol(Context* context, ID id);
 

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -96,6 +96,8 @@ namespace resolution {
   /**
     Returns the ResolvedFunction called by a particular
     ResolvedExpression, if there was exactly one candidate.
+    Otherwise, it returns nullptr.
+
     This function does not handle return intent overloading.
    */
   const ResolvedFunction* resolveOnlyCandidate(Context* context,

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -234,10 +234,6 @@ struct TypedFnSignature {
   // function signature?
   const TypedFnSignature* parentFn = nullptr;
 
-  // If it's an instantiation, what are the point-of-instantiation scopes
-  // that were needed for resolving the signature?
-  PoiInfo poiInfo;
-
   // TODO: This could include a substitutions map, if we need it.
   // The formalTypes above might be enough, though.
 
@@ -247,8 +243,7 @@ struct TypedFnSignature {
            whereClauseResult == other.whereClauseResult &&
            needsInstantiation == other.needsInstantiation &&
            instantiatedFrom == other.instantiatedFrom &&
-           parentFn == other.parentFn &&
-           PoiInfo::updateEquals(poiInfo, other.poiInfo);
+           parentFn == other.parentFn;
   }
   bool operator!=(const TypedFnSignature& other) const {
     return !(*this == other);

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -140,32 +140,6 @@ struct CallInfo {
   }
 };
 
-// When resolving a traditional generic, we also need to consider
-// the point-of-instantiation scope as a place to find visible functions.
-// This type tracks such a scope.
-//
-// PoiScopes do not need to consider scopes that are visible from
-// the function declaration. These can be collapsed away.
-//
-// Performance: could have better reuse of PoiScope if it used the Scope ID
-// rather than changing if the contents do. But, the downside is that
-// further queries would be required to compute which functions are
-// visible. Which is better?
-// If we want to make PoiScope not depend on the contents it might be nice
-// to make Scope itself not depend on the contents, too.
-struct PoiScope {
-  const Scope* inScope = nullptr;         // parent Scope for the Call
-  const PoiScope* inFnPoi = nullptr;      // what is the POI of this POI?
-
-  bool operator==(const PoiScope& other) const {
-    return inScope == other.inScope &&
-           inFnPoi == other.inFnPoi;
-  }
-  bool operator!=(const PoiScope& other) const {
-    return !(*this == other);
-  }
-};
-
 
 struct PoiInfo {
   // For a not-yet-resolved instantiation

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -549,6 +549,15 @@ template<> struct update<resolution::ResolutionResultByPostorderID> {
   }
 };
 
+template<> struct update<owned<resolution::ResolvedFunction>> {
+  bool operator()(owned<resolution::ResolvedFunction>& keep,
+                  owned<resolution::ResolvedFunction>& addin) const {
+    // this function is just here to make debugging easier
+    return defaultUpdateOwned(keep, addin);
+  }
+};
+
+
 } // end namespace chpl
 
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -255,6 +255,10 @@ struct TypedFnSignature {
   }
 
   std::string toString() const;
+
+  const ID& functionId() const {
+    return untypedSignature->functionId;
+  }
 };
 
 class MostSpecificCandidates {
@@ -485,6 +489,17 @@ struct ResolvedFunction {
     std::swap(returnIntent, other.returnIntent);
     resolutionById.swap(other.resolutionById);
     poiInfo.swap(other.poiInfo);
+  }
+
+  const ResolvedExpression& byId(const ID& id) const {
+    return resolutionById.byId(id);
+  }
+  const ResolvedExpression& byAst(const uast::ASTNode* ast) const {
+    return resolutionById.byAst(ast);
+  }
+
+  const ID& functionId() const {
+    return signature->functionId();
   }
 };
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -296,6 +296,10 @@ class MostSpecificCandidates {
     return candidates[VALUE];
   }
 
+  /**
+    If there is exactly one candidate, return that candidate.
+    Otherwise, return nullptr.
+   */
   const TypedFnSignature* only() const {
     const TypedFnSignature* ret = nullptr;
     int nPresent = 0;
@@ -363,11 +367,11 @@ struct ResolvedExpression {
 
   // For a function call, what is the most specific candidate,
   // or when using return intent overloading, what are the most specific
-  // candidates.
+  // candidates?
   // The choice between these needs to happen
   // later than the main function resolution.
   MostSpecificCandidates mostSpecific;
-  // What point of instantiation scope is should be used when
+  // What point of instantiation scope should be used when
   // resolving functions in mostSpecific?
   const PoiScope* poiScope = nullptr;
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -368,6 +368,9 @@ using ResolutionResultByPostorderID = std::vector<ResolvedExpression>;
 struct ResolvedFunction {
   const TypedFnSignature* signature = nullptr;
 
+  uast::Function::ReturnIntent returnIntent =
+    uast::Function::DEFAULT_RETURN_INTENT;
+
   // this is the output of the resolution process
   ResolutionResultByPostorderID resolutionById;
 
@@ -376,6 +379,7 @@ struct ResolvedFunction {
 
   bool operator==(const ResolvedFunction& other) const {
     return signature == other.signature &&
+           returnIntent == other.returnIntent &&
            resolutionById == other.resolutionById &&
            PoiInfo::updateEquals(poiInfo, other.poiInfo);
   }
@@ -384,6 +388,7 @@ struct ResolvedFunction {
   }
   void swap(ResolvedFunction& other) {
     std::swap(signature, other.signature);
+    std::swap(returnIntent, other.returnIntent);
     resolutionById.swap(other.resolutionById);
     poiInfo.swap(other.poiInfo);
   }

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -259,7 +259,7 @@ struct MostSpecificCandidates {
   const TypedFnSignature* bestConstRef = nullptr;
   const TypedFnSignature* bestValue = nullptr;
 
-  const TypedFnSignature* only() {
+  const TypedFnSignature* only() const {
     const TypedFnSignature* ret = nullptr;
     int i = 0;
     if (bestRef != nullptr) {
@@ -353,6 +353,8 @@ struct ResolvedExpression {
     toId.swap(other.toId);
     mostSpecific.swap(other.mostSpecific);
   }
+
+  std::string toString() const;
 };
 
 // postorder ID (int) -> ResolvedExpression *within* a Function etc

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -356,8 +356,6 @@ struct CallResolutionResult {
 };
 
 struct ResolvedExpression {
-  // the ID that is resolved
-  ID id;
   // What is its type and param value?
   types::QualifiedType type;
   // For simple (non-function Identifier) cases,
@@ -370,23 +368,26 @@ struct ResolvedExpression {
   // The choice between these needs to happen
   // later than the main function resolution.
   MostSpecificCandidates mostSpecific;
+  // What point of instantiation scope is should be used when
+  // resolving functions in mostSpecific?
+  const PoiScope* poiScope = nullptr;
 
   ResolvedExpression() { }
 
   bool operator==(const ResolvedExpression& other) const {
-    return id == other.id &&
-           type == other.type &&
+    return type == other.type &&
            toId == other.toId &&
-           mostSpecific == other.mostSpecific;
+           mostSpecific == other.mostSpecific &&
+           poiScope == other.poiScope;
   }
   bool operator!=(const ResolvedExpression& other) const {
     return !(*this == other);
   }
   void swap(ResolvedExpression& other) {
-    id.swap(other.id);
     type.swap(other.type);
     toId.swap(other.toId);
     mostSpecific.swap(other.mostSpecific);
+    std::swap(poiScope, other.poiScope);
   }
 
   std::string toString() const;

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -280,6 +280,12 @@ struct MostSpecificCandidates {
     return ret;
   }
 
+  bool anyInstantiated() const {
+    return (bestRef && bestRef->instantiatedFrom) ||
+           (bestConstRef && bestConstRef->instantiatedFrom) ||
+           (bestValue && bestValue->instantiatedFrom);
+  }
+
   bool operator==(const MostSpecificCandidates& other) const {
     return bestRef == other.bestRef &&
            bestConstRef == other.bestConstRef &&

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -205,6 +205,8 @@ struct TypedFnSignature {
   bool operator!=(const TypedFnSignature& other) const {
     return !(*this == other);
   }
+
+  std::string toString() const;
 };
 
 struct MostSpecificCandidates {

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -259,21 +259,24 @@ struct TypedFnSignature {
 class MostSpecificCandidates {
  public:
   typedef enum {
+    // the slots in the candidates array for return intent
+    // overloading
     REF = 0,
-    CONST_REF = 1,
-    VALUE = 2,
-    N = 3,
+    CONST_REF,
+    VALUE,
+    // NUM_INTENTS is the size of the candidates array
+    NUM_INTENTS,
   } Intent;
 
  private:
-  const TypedFnSignature* candidates[N] = {nullptr};
+  const TypedFnSignature* candidates[NUM_INTENTS] = {nullptr};
 
  public:
   const TypedFnSignature* const* begin() const {
     return &candidates[0];
   }
   const TypedFnSignature* const* end() const {
-    return &candidates[N];
+    return &candidates[NUM_INTENTS];
   }
 
   void setBestRef(const TypedFnSignature* sig) {
@@ -303,7 +306,7 @@ class MostSpecificCandidates {
   const TypedFnSignature* only() const {
     const TypedFnSignature* ret = nullptr;
     int nPresent = 0;
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < NUM_INTENTS; i++) {
       const TypedFnSignature* sig = candidates[i];
       if (sig != nullptr) {
         ret = sig;
@@ -317,7 +320,7 @@ class MostSpecificCandidates {
   }
 
   bool operator==(const MostSpecificCandidates& other) const {
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < NUM_INTENTS; i++) {
       if (candidates[i] != other.candidates[i])
         return false;
     }
@@ -327,7 +330,7 @@ class MostSpecificCandidates {
     return !(*this == other);
   }
   void swap(MostSpecificCandidates& other) {
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < NUM_INTENTS; i++) {
       std::swap(candidates[i], other.candidates[i]);
     }
   }

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -63,7 +63,7 @@ struct UntypedFnSignature {
   }
 
   bool operator==(const UntypedFnSignature& other) const {
-    return functionId != other.functionId &&
+    return functionId == other.functionId &&
            name == other.name &&
            isMethod == other.isMethod &&
            kind == other.kind &&

--- a/compiler/next/include/chpl/resolution/scope-queries.h
+++ b/compiler/next/include/chpl/resolution/scope-queries.h
@@ -116,9 +116,9 @@ namespace resolution {
     scope and parent POI scope. Collapses away POI scopes that
     do not affect visible functions.
    */
-  const PoiScope* poiScope(Context* context,
-                           const Scope* scope,
-                           const PoiScope* parentPoiScope);
+  const PoiScope* pointOfInstantiationScope(Context* context,
+                                            const Scope* scope,
+                                            const PoiScope* parentPoiScope);
 
  // TODO: lookupInScope accepting visited set
   // for use in POI traversal

--- a/compiler/next/include/chpl/resolution/scope-queries.h
+++ b/compiler/next/include/chpl/resolution/scope-queries.h
@@ -120,9 +120,6 @@ namespace resolution {
                                             const Scope* scope,
                                             const PoiScope* parentPoiScope);
 
- // TODO: lookupInScope accepting visited set
-  // for use in POI traversal
-
   /**
     Given a name and a Scope, return the innermost and first ID
     for a definition of that name, and an indication of

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -232,7 +232,7 @@ using LookupConfig = unsigned int;
 // the function declaration. These can be collapsed away.
 //
 // Performance: could have better reuse of PoiScope if it used the Scope ID
-// rather than changing if the contents do. But, the downside is that
+// rather than changing if the Scope contents do. But, the downside is that
 // further queries would be required to compute which functions are
 // visible. Which is better?
 // If we want to make PoiScope not depend on the contents it might be nice

--- a/compiler/next/include/chpl/util/hash.h
+++ b/compiler/next/include/chpl/util/hash.h
@@ -106,6 +106,16 @@ inline size_t hashSet(const std::set<T>& key) {
   return ret;
 }
 
+// Hash function for pair
+template<typename T, typename U>
+inline size_t hashPair(const std::pair<T, U>& key) {
+  size_t ret = 0;
+  ret = hash_combine(ret, hash(key.first));
+  ret = hash_combine(ret, hash(key.second));
+  return ret;
+}
+
+
 
 } // end namespace chpl
 
@@ -123,6 +133,12 @@ template<typename T> struct hash<std::set<T>> {
     return chpl::hashSet(key);
   }
 };
+template<typename T, typename U> struct hash<std::pair<T,U>> {
+  size_t operator()(const std::pair<T,U>& key) const {
+    return chpl::hashPair(key);
+  }
+};
+
 
 
 } // end namespace std

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -284,7 +284,8 @@ void Context::setFilePathForModuleID(ID moduleID, UniqueString path) {
   updateResultForQuery(filePathForModuleIdSymbolPathQuery,
                        tupleOfArgs, path,
                        "filePathForModuleIdSymbolPathQuery",
-                       false);
+                       /* isInputQuery */ false,
+                       /* forSetter */ true);
 
   if (enableDebugTracing) {
     printf("SETTING FILE PATH FOR MODULE %s -> %s\n",

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -331,6 +331,20 @@ void Context::error(const uast::ASTNode* ast, const char* fmt, ...) {
   Context::error(err);
 }
 
+void Context::error(const resolution::TypedFnSignature* inFn,
+                    const uast::ASTNode* ast,
+                    const char* fmt, ...) {
+  Location loc = parsing::locateAst(this, ast);
+  ErrorMessage err;
+  va_list vl;
+  va_start(vl, fmt);
+  err = ErrorMessage::vbuild(loc, fmt, vl);
+  va_end(vl);
+  Context::error(err);
+  // TODO: add note about instantiation & POI stack
+}
+
+
 void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
 
   if (enableDebugTracing) {

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -789,8 +789,8 @@ static ID parentFunctionId(Context* context, ID functionId) {
 }
 
 const TypedFnSignature*
-typedSignatureInital(Context* context,
-                     const UntypedFnSignature* untypedSig) {
+typedSignatureInitial(Context* context,
+                      const UntypedFnSignature* untypedSig) {
 
   const ASTNode* ast = parsing::idToAst(context, untypedSig->functionId);
   const Function* fn = ast->toFunction();
@@ -805,7 +805,7 @@ typedSignatureInital(Context* context,
   ID parentFnId = parentFunctionId(context, fn->id());
   if (!parentFnId.isEmpty()) {
     parentFnUntyped = untypedSignature(context, parentFnId);
-    parentFnTyped = typedSignatureInital(context, parentFnUntyped);
+    parentFnTyped = typedSignatureInitial(context, parentFnUntyped);
   }
 
   ResolutionResultByPostorderID r;
@@ -1102,8 +1102,7 @@ doIsCandidateApplicableInitial(Context* context,
                                const ID& candidateId,
                                const CallInfo& call) {
 
-  printf("CHECKING APPLICABLE INITIAL %s\n",
-        candidateId.toString().c_str());
+  printf("CHECKING APPLICABLE INITIAL %s\n", candidateId.toString().c_str());
 
   auto uSig = untypedSignature(context, candidateId);
   // First, check that the untyped properties allow a match:
@@ -1121,7 +1120,7 @@ doIsCandidateApplicableInitial(Context* context,
   // TODO: check method-ness
   // TODO: reason failed
 
-  auto initialTypedSignature = typedSignatureInital(context, uSig);
+  auto initialTypedSignature = typedSignatureInitial(context, uSig);
   // Next, check that the types are compatible
   size_t formalIdx = 0;
   for (const FormalActual& entry : faMap.byFormalIdx) {

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -395,6 +395,9 @@ struct Resolver {
           if (qtKind == QualifiedType::TYPE &&
               initType.kind() != QualifiedType::TYPE) {
             context->error(initExpr, "Cannot initialize type with value");
+          } else if (qtKind != QualifiedType::TYPE &&
+                     initType.kind() == QualifiedType::TYPE) {
+            context->error(initExpr, "Cannot initialize value with type");
           } else if (qtKind == QualifiedType::PARAM &&
                      initType.kind() != QualifiedType::PARAM) {
             context->error(initExpr, "Cannot initialize param with non-param");

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -206,9 +206,6 @@ struct Resolver {
 
     poiInfo.poiScope = poiScope;
 
-    // include any pois required for the signature in the resulting PoiInfo
-    poiInfo.accumulate(typedFnSignature->poiInfo);
-
     byPostorder.setupForFunction(fn);
     enterScope(symbol);
 
@@ -638,11 +635,10 @@ typedSignatureQuery(Context* context,
                     TypedFnSignature::WhereClauseResult whereClauseResult,
                     bool needsInstantiation,
                     const TypedFnSignature* instantiatedFrom,
-                    const TypedFnSignature* parentFn,
-                    PoiInfo poiInfo) {
+                    const TypedFnSignature* parentFn) {
   QUERY_BEGIN(typedSignatureQuery, context,
               untypedSignature, formalTypes, whereClauseResult,
-              needsInstantiation, instantiatedFrom, parentFn, poiInfo);
+              needsInstantiation, instantiatedFrom, parentFn);
 
   auto result = toOwned(new TypedFnSignature());
   result->untypedSignature = untypedSignature;
@@ -651,7 +647,6 @@ typedSignatureQuery(Context* context,
   result->needsInstantiation = needsInstantiation;
   result->instantiatedFrom = instantiatedFrom;
   result->parentFn = parentFn;
-  result->poiInfo = std::move(poiInfo);
 
   return QUERY_END(result);
 }
@@ -767,8 +762,7 @@ typedSignatureInitial(Context* context,
                                            whereResult,
                                            needsInstantiation,
                                            /* instantiatedFrom */ nullptr,
-                                           /* parentFn */ parentFnTyped,
-                                           std::move(poiFnIdsUsed));
+                                           /* parentFn */ parentFnTyped);
   return result.get();
 }
 
@@ -819,8 +813,6 @@ const TypedFnSignature* instantiateSignature(Context* context,
   std::vector<types::QualifiedType> formalTypes = getFormalTypes(fn, r);
   bool needsInstantiation = anyFormalNeedsInstantiation(formalTypes);
   auto whereResult = whereClauseResult(context, fn, r, needsInstantiation);
-  PoiInfo poiInfo;
-  poiInfo.swap(visitor.poiInfo);
 
   const auto& result = typedSignatureQuery(context,
                                            untypedSignature,
@@ -828,8 +820,7 @@ const TypedFnSignature* instantiateSignature(Context* context,
                                            whereResult,
                                            needsInstantiation,
                                            /* instantiatedFrom */ sig,
-                                           /* parentFn */ parentFnTyped,
-                                           std::move(poiInfo));
+                                           /* parentFn */ parentFnTyped);
   return result.get();
 }
 

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -935,9 +935,6 @@ resolvedFunctionByInfoQuery(Context* context,
     // save the POI info in the resolution result
     resolved->poiInfo = resolvedPoiInfo;
 
-    if (resolvedPoiInfo.poiScopesUsed.size() != 0)
-      printf("BOBB\n");
-
     // Store the result in the query under the POIs used.
     // This should not update the value if there was already one
     // and they are the same.

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -1284,14 +1284,18 @@ findMostSpecificCandidates(Context* context,
   MostSpecificCandidates result;
 
   if (lst.size() > 1) {
+
     // TODO: find most specific -- pull over disambiguation code
     // TODO: handle return intent overloading
     // TODO: this is demo code
-    if (call.actuals.size() > 1 &&
-        call.actuals[1].type.type()->isIntType()) {
-      result.setBestRef(lst[0]);
+    if (call.actuals.size() > 1) {
+      if (call.actuals[1].type.type()->isIntType()) {
+        result.setBestRef(lst[0]);
+      } else {
+        result.setBestRef(lst[lst.size()-1]);
+      }
     } else {
-      result.setBestRef(lst[lst.size()-1]);
+      result.setBestRef(lst[0]);
     }
   }
   if (lst.size() == 1) {

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -537,8 +537,8 @@ struct Resolver {
   }
 };
 
-const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
-  QUERY_BEGIN(resolveModule, context, id);
+const ResolutionResultByPostorderID& resolvedModule(Context* context, ID id) {
+  QUERY_BEGIN(resolvedModule, context, id);
 
   ResolutionResultByPostorderID& partialResult = QUERY_CURRENT_RESULT;
 
@@ -564,14 +564,14 @@ const ResolutionResultByPostorderID& partiallyResolvedModule(Context* context,
 
   // check for a partial result from a running query
   const ResolutionResultByPostorderID* r =
-    QUERY_RUNNING_PARTIAL_RESULT(resolveModule, context, id);
+    QUERY_RUNNING_PARTIAL_RESULT(resolvedModule, context, id);
   // if there was a partial result, return it
   if (r != nullptr) {
     return *r;
   }
 
   // otherwise, run the query to compute the full result
-  return resolveModule(context, id);
+  return resolvedModule(context, id);
 }
 
 const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id) {
@@ -925,6 +925,17 @@ const ResolvedFunction* resolvedConcreteFunction(Context* context, ID id) {
 
   const ResolvedFunction* ret = resolvedFunction(context, sig, nullptr);
   return ret;
+}
+
+const ResolvedFunction* resolvedOnlyCandidate(Context* context,
+                                              const ResolvedExpression& r) {
+  const TypedFnSignature* sig = r.mostSpecific.only();
+  const PoiScope* poiScope = r.poiScope;
+
+  if (sig == nullptr)
+    return nullptr;
+
+  return resolvedFunction(context, sig, poiScope);
 }
 
 struct ReturnTypeInferer {

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -283,7 +283,7 @@ struct SymbolResolver {
   ResolvedExpression& resultForId(const ID& id) {
     auto postorder = id.postOrderId();
     assert(0 <= postorder);
-    if (postorder < byPostorder.size()) {
+    if ((size_t) postorder < byPostorder.size()) {
       // OK
     } else {
       byPostorder.resize(postorder+1);
@@ -320,7 +320,7 @@ struct SymbolResolver {
   ResolvedExpression& resultById(ID id) {
     int postorder = id.postOrderId();
     assert(0 <= postorder);
-    if (postorder < byPostorder.size()) {
+    if ((size_t) postorder < byPostorder.size()) {
       // OK
     } else {
       byPostorder.resize(postorder+1);
@@ -528,7 +528,7 @@ const QualifiedType& typeForSymbol(Context* context, ID id) {
     // Find the parent scope for the ID - i.e. where the id is declared
     ID parentId = parsing::idToParentId(context, id);
     auto& r = resolveSymbolContents(context, parentId);
-    assert(postOrderId < r.size());
+    assert((size_t) postOrderId < r.size());
     result = r[postOrderId].type;
   } else {
     assert(false && "TODO -- handle finding type for fn etc");

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -150,7 +150,7 @@ struct Resolver {
       symbol(mod),
       byPostorder(byPostorder) {
 
-    byPostorder.resizeForSymbol(mod);
+    byPostorder.setupForSymbol(mod);
     enterScope(symbol);
   }
 
@@ -164,7 +164,7 @@ struct Resolver {
       fnBody(fn->body()),
       byPostorder(byPostorder) {
 
-    byPostorder.resizeForSignature(fn);
+    byPostorder.setupForSignature(fn);
     enterScope(symbol);
   }
 
@@ -184,7 +184,7 @@ struct Resolver {
 
     poiInfo.poiScope = poiScope;
 
-    byPostorder.resizeForSignature(fn);
+    byPostorder.setupForSignature(fn);
     enterScope(symbol);
   }
 
@@ -209,7 +209,7 @@ struct Resolver {
     // include any pois required for the signature in the resulting PoiInfo
     poiInfo.accumulate(typedFnSignature->poiInfo);
 
-    byPostorder.resizeForSymbol(fn);
+    byPostorder.setupForFunction(fn);
     enterScope(symbol);
 
     // set the resolution results for the formals according to
@@ -550,7 +550,7 @@ const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
 
   auto ast = parsing::idToAst(context, id);
   if (const Module* mod = ast->toModule()) {
-    partialResult.resizeForSymbol(mod);
+    partialResult.setupForSymbol(mod);
 
     Resolver visitor(context, mod, partialResult);
     for (auto child: ast->children()) {
@@ -1281,13 +1281,13 @@ findMostSpecificCandidates(Context* context,
     // TODO: this is demo code
     if (call.actuals.size() > 1 &&
         call.actuals[1].type.type()->isIntType()) {
-      result.candidates[MostSpecificCandidates::REF] = lst[0];
+      result.setBestRef(lst[0]);
     } else {
-      result.candidates[MostSpecificCandidates::REF] = lst[lst.size()-1];
+      result.setBestRef(lst[lst.size()-1]);
     }
   }
   if (lst.size() == 1) {
-    result.candidates[MostSpecificCandidates::REF] = lst[0];
+    result.setBestRef(lst[0]);
   }
 
   return QUERY_END(result);

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -771,6 +771,14 @@ const TypedFnSignature* instantiateSignature(Context* context,
                                              CallInfo call,
                                              const PoiScope* poiScope) {
 
+  // Performance: Should this query use a similar approach to
+  // resolvedFunctionByInfoQuery, where the PoiInfo and visibility
+  // are consulted?
+  //
+  // It does not impact correctness, because typedSignatureQuery
+  // will arrange to construct a unique TypedFnSignature by
+  // its contents.
+
   assert(sig->needsInstantiation);
 
   const UntypedFnSignature* untypedSignature = sig->untypedSignature;
@@ -871,8 +879,9 @@ resolvedFunctionByInfoQuery(Context* context,
     resolved->poiInfo = resolvedPoiInfo;
 
     // Store the result in the query under the POIs used.
-    // This should not update the value if there was already one
-    // and they are the same.
+    // If there was already a value for this revision, this
+    // call will not update it. (If it did, that could lead to
+    // memory errors).
     QUERY_STORE_RESULT(resolvedFunctionByPoisQuery,
                        context,
                        resolved,

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -274,8 +274,7 @@ struct Resolver {
 
     auto vec = lookupInScope(context, scope, ident, config);
     if (vec.size() == 0) {
-      result.type = QualifiedType(QualifiedType::UNKNOWN,
-                                  ErroneousType::get(context));
+      result.type = QualifiedType(QualifiedType::UNKNOWN, nullptr);
     } else if (vec.size() > 1) {
       // can't establish the type. If this is in a function
       // call, we'll establish it later anyway.

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -174,5 +174,19 @@ std::string TypedFnSignature::toString() const {
 }
 
 
+void PoiInfo::accumulate(const PoiInfo& addPoiInfo) {
+  poiScopesUsed.insert(addPoiInfo.poiScopesUsed.begin(),
+                       addPoiInfo.poiScopesUsed.end());
+}
+
+// this is a resolved function
+// check is a not-yet-resolved function
+bool PoiInfo::canReuse(const PoiInfo& check) const {
+  assert(resolved && !check.resolved);
+
+  return false; // TODO -- consider function names etc -- see PR #16261
+}
+
+
 } // end namespace resolution
 } // end namespace chpl

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -18,9 +18,143 @@
  */
 
 #include "chpl/resolution/resolution-types.h"
+#include "chpl/uast/Formal.h"
 
 namespace chpl {
 namespace resolution {
+
+using namespace uast;
+
+bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
+                                       const TypedFnSignature* typed,
+                                       const CallInfo& call) {
+
+  // untyped must be provided but typed can be nullptr.
+  assert(untyped);
+
+  // create the mapping handling named and default arguments
+
+  // clear the current mapping
+  byFormalIdx.empty();
+  actualIdxToFormalIdx.empty();
+  mappingIsValid = false;
+  failingActualIdx = -1;
+
+  // allocate space in the arrays
+  byFormalIdx.resize(untyped->formals.size());
+  actualIdxToFormalIdx.resize(call.actuals.size());
+
+  // initialize the FormalActual parts from the Formals
+  size_t formalIdx = 0;
+  for (const Formal* formal : untyped->formals) {
+    FormalActual& entry = byFormalIdx[formalIdx];
+    entry.formal = formal;
+    if (typed) {
+      entry.formalType = typed->formalTypes[formalIdx];
+    }
+    entry.hasActual = false;
+    entry.actualIdx = -1;
+
+    formalIdx++;
+  }
+
+  // Match named actuals against formal names in the function signature.
+  // Record successful matches in actualIdxToFormalIdx.
+
+  size_t actualIdx = 0;
+  for (const CallInfoActual& actual : call.actuals) {
+    if (!actual.byName.isEmpty()) {
+      bool match = false;
+      int formalIdx = 0;
+      for (const Formal* formal : untyped->formals) {
+        if (actual.byName == formal->name()) {
+          match = true;
+          FormalActual& entry = byFormalIdx[formalIdx];
+          entry.hasActual = true;
+          entry.actualIdx = actualIdx;
+          entry.actualType = actual.type;
+          actualIdxToFormalIdx[actualIdx] = formalIdx;
+          break;
+        }
+        formalIdx++;
+      }
+
+      // Fail if no matching formal is found.
+      if (match == false) {
+        mappingIsValid = false;
+        failingActualIdx = actualIdx;
+        // TODO: track failure type for error messages
+        return false;
+      }
+    }
+    actualIdx++;
+  }
+
+  // Fill in unmatched formals in sequence with the remaining actuals.
+  // Record successful substitutions
+  formalIdx = 0;
+  actualIdx = 0;
+  for (const CallInfoActual& actual : call.actuals) {
+    if (actual.byName.isEmpty()) {
+      // Skip any formals already matched to named arguments
+      while (byFormalIdx[formalIdx].actualIdx >= 0) {
+        if (formalIdx + 1 >= byFormalIdx.size()) {
+          // too many actuals
+          mappingIsValid = false;
+          failingActualIdx = actualIdx;
+          return false;
+        }
+        formalIdx++;
+      }
+      assert(formalIdx < byFormalIdx.size());
+
+      // TODO: special handling for operators
+
+      FormalActual& entry = byFormalIdx[formalIdx];
+      entry.hasActual = true;
+      entry.actualIdx = actualIdx;
+      entry.actualType = actual.type;
+      actualIdxToFormalIdx[actualIdx] = formalIdx;
+    }
+    actualIdx++;
+  }
+
+  // Make sure that any remaining formals are matched by name
+  // or have a default value.
+  while (formalIdx < byFormalIdx.size()) {
+    if (byFormalIdx[formalIdx].actualIdx < 0 &&
+        untyped->formals[formalIdx]->initExpression() == nullptr) {
+      // formal was not provided and there is no default value
+      mappingIsValid = false;
+      failingFormalIdx = formalIdx;
+      return false;
+    }
+    formalIdx++;
+  }
+
+  return true;
+}
+
+FormalActualMap FormalActualMap::build(const UntypedFnSignature* sig,
+                                       const CallInfo& call) {
+
+  FormalActualMap ret;
+  bool ok = ret.computeAlignment(sig, nullptr, call);
+  if (!ok) {
+    ret.mappingIsValid = false;
+  }
+  return ret;
+}
+
+FormalActualMap FormalActualMap::build(const TypedFnSignature* sig,
+                                       const CallInfo& call) {
+  FormalActualMap ret;
+  bool ok = ret.computeAlignment(sig->untypedSignature, sig, call);
+  if (!ok) {
+    ret.mappingIsValid = false;
+  }
+  return ret;
+}
 
 
 } // end namespace resolution

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -17,13 +17,33 @@
  * limitations under the License.
  */
 
+#include "chpl/queries/update-functions.h"
 #include "chpl/resolution/resolution-types.h"
+#include "chpl/uast/Builder.h"
 #include "chpl/uast/Formal.h"
 
 namespace chpl {
 namespace resolution {
 
 using namespace uast;
+
+void ResolutionResultByPostorderID::resizeForSymbol(const ASTNode* ast) {
+  assert(Builder::astTagIndicatesNewIdScope(ast->tag()));
+  vec.resize(ast->id().numContainedChildren());
+}
+void ResolutionResultByPostorderID::resizeForSignature(const Function* func) {
+  int bodyPostorder = 0;
+  if (func && func->body())
+    bodyPostorder = func->body()->id().postOrderId();
+  assert(0 <= bodyPostorder);
+  vec.resize(bodyPostorder);
+}
+
+bool ResolutionResultByPostorderID::update(ResolutionResultByPostorderID& keep,
+                                           ResolutionResultByPostorderID& addin)
+{
+  return defaultUpdateVec(keep.vec, addin.vec);
+}
 
 bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
                                        const TypedFnSignature* typed,

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -175,8 +175,8 @@ std::string TypedFnSignature::toString() const {
 
 
 void PoiInfo::accumulate(const PoiInfo& addPoiInfo) {
-  poiScopesUsed.insert(addPoiInfo.poiScopesUsed.begin(),
-                       addPoiInfo.poiScopesUsed.end());
+  poiFnIdsUsed.insert(addPoiInfo.poiFnIdsUsed.begin(),
+                      addPoiInfo.poiFnIdsUsed.end());
 }
 
 // this is a resolved function
@@ -201,17 +201,17 @@ std::string ResolvedExpression::toString() const {
       ret += " calls ";
       ret += onlyFn->toString();
     } else {
-      if (mostSpecific.bestRef) {
+      if (auto sig = mostSpecific.bestRef()) {
         ret += " calls ref ";
-        ret += mostSpecific.bestRef->toString();
+        ret += sig->toString();
       }
-      if (mostSpecific.bestConstRef) {
+      if (auto sig = mostSpecific.bestConstRef()) {
         ret += " calls const ref ";
-        ret += mostSpecific.bestConstRef->toString();
+        ret += sig->toString();
       }
-      if (mostSpecific.bestValue) {
+      if (auto sig = mostSpecific.bestValue()) {
         ret += " calls value ";
-        ret += mostSpecific.bestValue->toString();
+        ret += sig->toString();
       }
     }
   }

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -27,16 +27,23 @@ namespace resolution {
 
 using namespace uast;
 
-void ResolutionResultByPostorderID::resizeForSymbol(const ASTNode* ast) {
+void ResolutionResultByPostorderID::setupForSymbol(const ASTNode* ast) {
   assert(Builder::astTagIndicatesNewIdScope(ast->tag()));
   vec.resize(ast->id().numContainedChildren());
+
+  symbolId = ast->id();
 }
-void ResolutionResultByPostorderID::resizeForSignature(const Function* func) {
+void ResolutionResultByPostorderID::setupForSignature(const Function* func) {
   int bodyPostorder = 0;
   if (func && func->body())
     bodyPostorder = func->body()->id().postOrderId();
   assert(0 <= bodyPostorder);
   vec.resize(bodyPostorder);
+
+  symbolId = func->id();
+}
+void ResolutionResultByPostorderID::setupForFunction(const Function* func) {
+  setupForSymbol(func);
 }
 
 bool ResolutionResultByPostorderID::update(ResolutionResultByPostorderID& keep,

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -159,16 +159,16 @@ FormalActualMap FormalActualMap::build(const TypedFnSignature* sig,
 
 std::string TypedFnSignature::toString() const {
   std::string ret = untypedSignature->functionId.toString();
-  ret += " ";
+  ret += "(";
   for (size_t i = 0; i < untypedSignature->formals.size(); i++) {
-    if (i != 0)
-      ret += ",";
-
-    ret += " ";
+    if (i != 0) {
+      ret += ", ";
+    }
     ret += untypedSignature->formals[i]->name().c_str();
     ret += " : ";
     ret += formalTypes[i].toString();
   }
+  ret += ")";
 
   return ret;
 }
@@ -191,6 +191,7 @@ std::string ResolvedExpression::toString() const {
   std::string ret;
   ret += " : ";
   ret += type.toString();
+  ret += " ; ";
   if (!toId.isEmpty()) {
     ret += " refers to ";
     ret += toId.toString();

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -187,6 +187,37 @@ bool PoiInfo::canReuse(const PoiInfo& check) const {
   return false; // TODO -- consider function names etc -- see PR #16261
 }
 
+std::string ResolvedExpression::toString() const {
+  std::string ret;
+  ret += " : ";
+  ret += type.toString();
+  if (!toId.isEmpty()) {
+    ret += " refers to ";
+    ret += toId.toString();
+  } else {
+    auto onlyFn = mostSpecific.only();
+    if (onlyFn) {
+      ret += " calls ";
+      ret += onlyFn->toString();
+    } else {
+      if (mostSpecific.bestRef) {
+        ret += " calls ref ";
+        ret += mostSpecific.bestRef->toString();
+      }
+      if (mostSpecific.bestConstRef) {
+        ret += " calls const ref ";
+        ret += mostSpecific.bestConstRef->toString();
+      }
+      if (mostSpecific.bestValue) {
+        ret += " calls value ";
+        ret += mostSpecific.bestValue->toString();
+      }
+    }
+  }
+
+  return ret;
+}
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -132,6 +132,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
     formalIdx++;
   }
 
+  mappingIsValid = true;
   return true;
 }
 
@@ -153,6 +154,22 @@ FormalActualMap FormalActualMap::build(const TypedFnSignature* sig,
   if (!ok) {
     ret.mappingIsValid = false;
   }
+  return ret;
+}
+
+std::string TypedFnSignature::toString() const {
+  std::string ret = untypedSignature->functionId.toString();
+  ret += " ";
+  for (size_t i = 0; i < untypedSignature->formals.size(); i++) {
+    if (i != 0)
+      ret += ",";
+
+    ret += " ";
+    ret += untypedSignature->formals[i]->name().c_str();
+    ret += " : ";
+    ret += formalTypes[i].toString();
+  }
+
   return ret;
 }
 

--- a/compiler/next/lib/resolution/scope-queries.cpp
+++ b/compiler/next/lib/resolution/scope-queries.cpp
@@ -819,11 +819,11 @@ const owned<PoiScope>& constructPoiScopeQuery(Context* context,
   return QUERY_END(result);
 }
 
-static
-const PoiScope* const& poiScopeQuery(Context* context,
-                                     const Scope* scope,
-                                     const PoiScope* parentPoiScope) {
-  QUERY_BEGIN(poiScopeQuery, context, scope, parentPoiScope);
+static const PoiScope* const&
+pointOfInstantiationScopeQuery(Context* context,
+                               const Scope* scope,
+                               const PoiScope* parentPoiScope) {
+  QUERY_BEGIN(pointOfInstantiationScopeQuery, context, scope, parentPoiScope);
 
   // figure out which POI scope to create.
   const Scope* useScope = nullptr;
@@ -860,10 +860,10 @@ const PoiScope* const& poiScopeQuery(Context* context,
   return QUERY_END(result);
 }
 
-const PoiScope* poiScope(Context* context,
-                         const Scope* scope,
-                         const PoiScope* parentPoiScope) {
-  return poiScopeQuery(context, scope, parentPoiScope);
+const PoiScope* pointOfInstantiationScope(Context* context,
+                                          const Scope* scope,
+                                          const PoiScope* parentPoiScope) {
+  return pointOfInstantiationScopeQuery(context, scope, parentPoiScope);
 }
 
 const InnermostMatch& findInnermostDecl(Context* context,

--- a/compiler/next/lib/types/QualifiedType.cpp
+++ b/compiler/next/lib/types/QualifiedType.cpp
@@ -53,7 +53,7 @@ std::string QualifiedType::toString() const {
   }
 
   if (kind_ == QualifiedType::PARAM) {
-    ret += " ";
+    ret += " = ";
     ret += std::to_string(param_);
   }
 

--- a/compiler/next/lib/uast/Builder.cpp
+++ b/compiler/next/lib/uast/Builder.cpp
@@ -155,12 +155,14 @@ void Builder::assignIDs() {
   that is just after the last element contained within.
 
   When printing IDs we use the notation of putting the symbolPath
-  part first and then '@' and then the postOrderId.
+  part first and then '@' and then the postOrderId. We leave out the
+  @ and postOrderId when the postOrderId is -1. That is the case
+  with AST nodes that create a new scope (Modules, Functions, Type decls).
 
   For example:
 
-  M@-1      module M {
-  M.Inner@3   module Inner {
+  M         module M {
+  M.Inner     module Inner {
   M.Inner@0     a;
   M.Inner@1     b;
   M.Inner@2     c;

--- a/compiler/next/test/resolution/CMakeLists.txt
+++ b/compiler/next/test/resolution/CMakeLists.txt
@@ -33,5 +33,6 @@
 # limitations under the License.
 
 comp_unit_test(testInteractive)
+comp_unit_test(testPoi)
 comp_unit_test(testResolve)
 comp_unit_test(testScopeResolve)

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -65,7 +65,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
       auto parentAst = idToAst(context, parentId);
       if (parentAst != nullptr) {
         if (parentAst->isModule()) {
-          const auto& byId = resolvedModule(context, parentAst->id());
+          const auto& byId = resolveModule(context, parentAst->id());
           return &byId.byAst(ast);
         } else if (parentAst->isFunction()) {
           auto untyped = untypedSignature(context, parentAst->id());
@@ -75,7 +75,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
           } else {
             auto typed = typedSignatureInitial(context, untyped);
             if (!typed->needsInstantiation) {
-              auto rFn = resolvedFunction(context, typed, nullptr);
+              auto rFn = resolveFunction(context, typed, nullptr);
               return &rFn->resolutionById.byAst(ast);
             }
           }
@@ -138,7 +138,7 @@ computeAndPrintStuff(Context* context,
   if (r != nullptr) {
     for (const TypedFnSignature* sig : r->mostSpecific) {
       if (sig != nullptr) {
-        auto fn = resolvedFunction(context, sig, r->poiScope);
+        auto fn = resolveFunction(context, sig, r->poiScope);
         calledFns.insert(fn);
       }
     }

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -65,7 +65,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
       auto parentAst = idToAst(context, parentId);
       if (parentAst != nullptr) {
         if (parentAst->isModule()) {
-          const auto& byId = resolveModule(context, parentAst->id());
+          const auto& byId = resolvedModule(context, parentAst->id());
           return &byId.byAst(ast);
         } else if (parentAst->isFunction()) {
           auto untyped = untypedSignature(context, parentAst->id());

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -65,7 +65,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
       if (parentAst != nullptr) {
         if (parentAst->isModule()) {
           const auto& byId = resolveModule(context, parentAst->id());
-          assert(0 <= postorder && postorder < byId.size());
+          assert(0 <= postorder && postorder < (int) byId.size());
           return &byId[postorder];
         } else if (parentAst->isFunction()) {
           auto untyped = untypedSignature(context, parentAst->id());
@@ -76,7 +76,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
           }
           if (!typed->needsInstantiation) {
             auto rFn = resolvedFunction(context, typed, typed->poiInfo.poiScope);
-            assert(0 <= postorder && postorder < rFn->resolutionById.size());
+            assert(0 <= postorder && postorder < (int)rFn->resolutionById.size());
             return &rFn->resolutionById[postorder];
           }
         }

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -90,7 +90,7 @@ static void computeAndPrintStuff(Context* context, const ASTNode* ast) {
   }
 
   // check the type
-  if (ast->isIdentifier() || ast->isNamedDecl()) {
+  if (!(ast->isLoop() || ast->isBlock())) {
     const auto& t = typeForSymbol(context, ast->id());
 
     printId(ast);

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -137,12 +137,11 @@ computeAndPrintStuff(Context* context,
   const ResolvedExpression* r = resolvedExpressionForAst(context, ast, inFn);
   int afterCount = context->numQueriesRunThisRevision();
   if (r != nullptr) {
-    if (r->mostSpecific.bestRef)
-      calledFns.insert(r->mostSpecific.bestRef);
-    if (r->mostSpecific.bestConstRef)
-      calledFns.insert(r->mostSpecific.bestConstRef);
-    if (r->mostSpecific.bestValue)
-      calledFns.insert(r->mostSpecific.bestValue);
+    for (const TypedFnSignature* candidate : r->mostSpecific) {
+      if (candidate != nullptr) {
+        calledFns.insert(candidate);
+      }
+    }
 
     printId(ast);
     printf("%-35s ", r->toString().c_str());

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -66,8 +66,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
       if (parentAst != nullptr) {
         if (parentAst->isModule()) {
           const auto& byId = resolveModule(context, parentAst->id());
-          assert(0 <= postorder && postorder < (int) byId.size());
-          return &byId[postorder];
+          return &byId.byAst(ast);
         } else if (parentAst->isFunction()) {
           auto untyped = untypedSignature(context, parentAst->id());
           auto typed = typedSignatureInitial(context, untyped);
@@ -77,8 +76,7 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
           }
           if (!typed->needsInstantiation) {
             auto rFn = resolvedFunction(context, typed, typed->poiInfo.poiScope);
-            assert(0 <= postorder && postorder < (int)rFn->resolutionById.size());
-            return &rFn->resolutionById[postorder];
+            return &rFn->resolutionById.byAst(ast);
           }
         }
       }

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -37,20 +37,21 @@ using namespace parsing;
 using namespace resolution;
 using namespace uast;
 
-static const char* nameForAst(const ASTNode* ast) {
+static UniqueString nameForAst(const ASTNode* ast) {
   if (auto ident = ast->toIdentifier()) {
-    return ident->name().c_str();
+    return ident->name();
   } else if (auto decl = ast->toNamedDecl()) {
-    return decl->name().c_str();
+    return decl->name();
   } else if (auto call = ast->toCall()) {
     return nameForAst(call->calledExpression());
   }
 
-  return "";
+  UniqueString empty;
+  return empty;
 }
 
 static void printId(const ASTNode* ast) {
-  printf("%-16s %-8s", ast->id().toString().c_str(), nameForAst(ast));
+  printf("%-16s %-8s", ast->id().toString().c_str(), nameForAst(ast).c_str());
 }
 
 static const ResolvedExpression*

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -91,13 +91,13 @@ static void computeAndPrintStuff(Context* context, const ASTNode* ast) {
 
   // check the type
   if (!(ast->isLoop() || ast->isBlock())) {
-    const auto& t = typeForSymbol(context, ast->id());
+    const auto& t = typeForModuleLevelSymbol(context, ast->id());
 
     printId(ast);
     printf(" has type:  ");
     printf("%-32s ", t.toString().c_str());
 
-    auto status = context->queryStatus(typeForSymbol,
+    auto status = context->queryStatus(typeForModuleLevelSymbol,
                                        std::make_tuple(ast->id()));
 
     if (status == Context::NOT_CHECKED_NOT_CHANGED) {

--- a/compiler/next/test/resolution/testPoi.cpp
+++ b/compiler/next/test/resolution/testPoi.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
+#include "chpl/resolution/scope-queries.h"
+#include "chpl/uast/Call.h"
+#include "chpl/uast/Comment.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/Variable.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+
+using namespace chpl;
+using namespace parsing;
+using namespace resolution;
+using namespace uast;
+
+// very simple test showing point-of-instantiation behavior
+static void test1() {
+  printf("test1\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::build(context, "input.chpl");
+  std::string contents = "module M {\n"
+                         "  proc generic(param p) {\n"
+                         "    helper();\n"
+                         "  }\n"
+                         "}\n"
+                         "module N {\n"
+                         "  use M;\n"
+                         "  proc helper() { }\n"
+                         "  generic(1);\n"
+                         "}\n";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parse(context, path);
+  assert(vec.size() == 2);
+  const Module* m = vec[0]->toModule();
+  assert(m);
+  assert(m->numStmts() == 1);
+  const Module* n = vec[1]->toModule();
+  assert(n);
+  assert(n->numStmts() == 3);
+  const Function* mGeneric = m->stmt(0)->toFunction();
+  assert(mGeneric);
+  const Call* helperCall = mGeneric->stmt(0)->toCall();
+  assert(helperCall);
+  const Function* nHelper = n->stmt(1)->toFunction();
+  assert(nHelper);
+  const Call* genericCall = n->stmt(2)->toCall();
+  assert(genericCall);
+
+  // resolve module N
+  const ResolutionResultByPostorderID& rr = resolveModule(context, n->id());
+
+  const TypedFnSignature* sig = rr.byAst(genericCall).mostSpecific.only();
+  assert(sig);
+  assert(sig->untypedSignature->functionId == mGeneric->id());
+
+  // get the resolved function
+  const ResolvedFunction* rfunc = resolvedFunction(context, sig,
+                                                   sig->poiInfo.poiScope);
+  assert(rfunc);
+  assert(rfunc->signature == sig);
+
+  const ResolvedExpression& re = rfunc->resolutionById.byAst(helperCall);
+  const TypedFnSignature* helpSig = re.mostSpecific.only();
+  assert(helpSig);
+  assert(helpSig->untypedSignature->functionId == nHelper->id());
+}
+
+// showing the challenging program from issue 18081
+/*static void test2() {
+  printf("test2\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::build(context, "input.chpl");
+  std::string contents = R""""(
+    module G {
+      proc foo(param arg:int, val:int) {
+        bar(arg);
+      }
+      proc foo(param arg:int, val:real) {
+        bar(arg);
+      }
+    }
+    module M1 {
+      use G;
+      proc bar(arg: int) { }
+      proc runM1() {
+        foo(1, 20);
+      }
+    }
+
+    module M2 {
+      use G;
+      proc bar(arg: int) { }
+      proc runM2() {
+        foo(1, 20.0);
+      }
+    }
+
+    module User {
+      use M1, M2;
+      proc main() {
+        runM1();
+        runM2();
+      }
+    }
+  )"""";
+
+
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parse(context, path);
+  assert(vec.size() == 4);
+  const Module* g = vec[0]->toModule();
+  assert(g);
+  assert(g->numStmts() == 2);
+  const Module* m1 = vec[1]->toModule();
+  assert(m1);
+  assert(m1->numStmts() == 3);
+  const Module* m2 = vec[2]->toModule();
+  assert(m2);
+  assert(m2->numStmts() == 3);
+  const Module* user = vec[3]->toModule();
+  assert(user);
+  assert(user->numStmts() == 2);
+
+  const Function* m1Bar = m1->stmt(1)->toFunction();
+  assert(m1Bar);
+  const Function* runM1 = m1->stmt(2)->toFunction();
+  assert(runM1);
+  const Function* m2Bar = m2->stmt(1)->toFunction();
+  assert(m2Bar);
+  const Function* runM2 = m2->stmt(2)->toFunction();
+  assert(runM2);
+
+  // resolve runM1
+  const ResolvedFunction* rRunM1 = resolvedConcreteFunction(runM1);
+  assert(rRunM1);
+  // resolve runM2
+  const ResolvedFunction* rRunM2 = resolvedConcreteFunction(runM2);
+  assert(rRunM2);
+
+  // find the resolved calls to foo
+  const in r
+
+  const TypedFnSignature* sig = rr.byAst(genericCall).mostSpecific.only();
+  assert(sig);
+  assert(sig->untypedSignature->functionId == mGeneric->id());
+
+  // get the resolved function
+  const ResolvedFunction* rfunc = resolvedFunction(context, sig,
+                                                   sig->poiInfo.poiScope);
+  assert(rfunc);
+  assert(rfunc->signature == sig);
+
+  const ResolvedExpression& re = rfunc->resolutionById.byAst(helperCall);
+  const TypedFnSignature* helpSig = re.mostSpecific.only();
+  assert(helpSig);
+  assert(helpSig->untypedSignature->functionId == nHelper->id());
+}
+*/
+
+
+int main() {
+  test1();
+
+  return 0;
+}

--- a/compiler/next/test/resolution/testPoi.cpp
+++ b/compiler/next/test/resolution/testPoi.cpp
@@ -38,7 +38,7 @@ using namespace parsing;
 using namespace resolution;
 using namespace uast;
 
-// very simple test showing point-of-instantiation behavior
+// test showing point-of-instantiation behavior
 static void test1() {
   printf("test1\n");
   Context ctx;
@@ -396,6 +396,10 @@ static void test3() {
     assert(h3);
     assert(h3->functionId() == mHelper3->id());
   }
+
+  // check that the generic function signatures are the same
+  assert(rNCallGF->signature == rMCallGF->signature);
+  assert(rMCallGF->signature == rMGenericCallGF->signature);
 }
 
 // check generic reuse from the same scope
@@ -574,8 +578,14 @@ static void test6() {
 
   auto rACallGeneric = resolvedOnlyCandidate(context, rA.byAst(aCall));
   assert(rACallGeneric);
+  assert(rACallGeneric->signature);
+  assert(rACallGeneric->signature->untypedSignature);
   auto rBCallGeneric = resolvedOnlyCandidate(context, rB.byAst(bCall));
   assert(rBCallGeneric);
+  assert(rBCallGeneric->signature->untypedSignature);
+
+  // check that these two have the same signature
+  assert(rACallGeneric->signature == rBCallGeneric->signature);
 
   // check that these two are the same instantiation.
   assert(rACallGeneric == rBCallGeneric);

--- a/compiler/next/test/resolution/testPoi.cpp
+++ b/compiler/next/test/resolution/testPoi.cpp
@@ -75,15 +75,15 @@ static void test1() {
   assert(genericCall);
 
   // resolve module N
-  const ResolutionResultByPostorderID& rr = resolvedModule(context, n->id());
+  const ResolutionResultByPostorderID& rr = resolveModule(context, n->id());
 
   // get the resolved function
   const ResolvedFunction* rfunc =
-    resolvedOnlyCandidate(context, rr.byAst(genericCall));
+    resolveOnlyCandidate(context, rr.byAst(genericCall));
   assert(rfunc);
 
   const ResolvedFunction* rhelp =
-    resolvedOnlyCandidate(context, rfunc->resolutionById.byAst(helperCall));
+    resolveOnlyCandidate(context, rfunc->resolutionById.byAst(helperCall));
   assert(rhelp);
   assert(rhelp->functionId() == nHelper->id());
 }
@@ -173,29 +173,29 @@ static void test2() {
 
   // resolve runM1
   const ResolvedFunction* rRunM1 =
-    resolvedConcreteFunction(context, runM1->id());
+    resolveConcreteFunction(context, runM1->id());
   assert(rRunM1);
   // resolve runM2
   const ResolvedFunction* rRunM2 =
-    resolvedConcreteFunction(context, runM2->id());
+    resolveConcreteFunction(context, runM2->id());
   assert(rRunM2);
 
   // find the resolved calls to foo in runM1 and runM2
   const ResolvedFunction* m1foo =
-    resolvedOnlyCandidate(context, rRunM1->byAst(runM1FooCall));
+    resolveOnlyCandidate(context, rRunM1->byAst(runM1FooCall));
   assert(m1foo);
   assert(m1foo->functionId() == fooA->id());
   const ResolvedFunction* m2foo =
-    resolvedOnlyCandidate(context, rRunM2->byAst(runM2FooCall));
+    resolveOnlyCandidate(context, rRunM2->byAst(runM2FooCall));
   assert(m2foo);
   assert(m2foo->functionId() == fooB->id());
 
   const ResolvedFunction* m1foobar =
-    resolvedOnlyCandidate(context, m1foo->byAst(fooABarCall));
+    resolveOnlyCandidate(context, m1foo->byAst(fooABarCall));
   assert(m1foobar);
   assert(m1foobar->functionId() == m1Bar->id());
   const ResolvedFunction* m2foobar =
-    resolvedOnlyCandidate(context, m2foo->byAst(fooBBarCall));
+    resolveOnlyCandidate(context, m2foo->byAst(fooBBarCall));
   assert(m2foobar);
   assert(m2foobar->functionId() == m2Bar->id());
 }
@@ -310,31 +310,31 @@ static void test3() {
   assert(mGenericCall);
 
   // resolve main
-  const ResolvedFunction* rMain = resolvedConcreteFunction(context, main->id());
+  const ResolvedFunction* rMain = resolveConcreteFunction(context, main->id());
   assert(rMain);
 
   // find the resolved calls in main to nCallFunc, mCallFunc, mGenericCallFunc
   const ResolvedFunction* rNCallFunc =
-    resolvedOnlyCandidate(context, rMain->byAst(nCall));
+    resolveOnlyCandidate(context, rMain->byAst(nCall));
   assert(rNCallFunc);
 
   const ResolvedFunction* rMCallFunc =
-    resolvedOnlyCandidate(context, rMain->byAst(mCall));
+    resolveOnlyCandidate(context, rMain->byAst(mCall));
   assert(rMCallFunc);
 
   const ResolvedFunction* rMGenericCallFunc =
-    resolvedOnlyCandidate(context, rMain->byAst(mGenericCall));
+    resolveOnlyCandidate(context, rMain->byAst(mGenericCall));
   assert(rMGenericCallFunc);
 
   // within each of those, find the call to genericfunc
   const ResolvedFunction* rNCallGF =
-    resolvedOnlyCandidate(context, rNCallFunc->byAst(nCallFuncGCall));
+    resolveOnlyCandidate(context, rNCallFunc->byAst(nCallFuncGCall));
   assert(rNCallGF);
   const ResolvedFunction* rMCallGF =
-    resolvedOnlyCandidate(context, rMCallFunc->byAst(mCallFuncGCall));
+    resolveOnlyCandidate(context, rMCallFunc->byAst(mCallFuncGCall));
   assert(rMCallGF);
   const ResolvedFunction* rMGenericCallGF =
-    resolvedOnlyCandidate(context, rMGenericCallFunc->byAst(mGenericCallFuncGCall));
+    resolveOnlyCandidate(context, rMGenericCallFunc->byAst(mGenericCallFuncGCall));
   assert(rMGenericCallGF);
 
   // now within each one of those, check the
@@ -343,11 +343,11 @@ static void test3() {
   // first, check in nCall
   {
     const ResolvedFunction* h1 =
-      resolvedOnlyCandidate(context, rNCallGF->byAst(helperCall1));
+      resolveOnlyCandidate(context, rNCallGF->byAst(helperCall1));
     const ResolvedFunction* h2 =
-      resolvedOnlyCandidate(context, rNCallGF->byAst(helperCall2));
+      resolveOnlyCandidate(context, rNCallGF->byAst(helperCall2));
     const ResolvedFunction* h3 =
-      resolvedOnlyCandidate(context, rNCallGF->byAst(helperCall3));
+      resolveOnlyCandidate(context, rNCallGF->byAst(helperCall3));
 
     assert(h1);
     assert(h1->functionId() == nHelper1->id());
@@ -362,11 +362,11 @@ static void test3() {
   // next, check in mCall
   {
     const ResolvedFunction* h1 =
-      resolvedOnlyCandidate(context, rMCallGF->byAst(helperCall1));
+      resolveOnlyCandidate(context, rMCallGF->byAst(helperCall1));
     const ResolvedFunction* h2 =
-      resolvedOnlyCandidate(context, rMCallGF->byAst(helperCall2));
+      resolveOnlyCandidate(context, rMCallGF->byAst(helperCall2));
     const ResolvedFunction* h3 =
-      resolvedOnlyCandidate(context, rMCallGF->byAst(helperCall3));
+      resolveOnlyCandidate(context, rMCallGF->byAst(helperCall3));
 
     assert(h1);
     assert(h1->functionId() == mHelper1->id());
@@ -381,11 +381,11 @@ static void test3() {
   // then, check in mGenericCall
   {
     const ResolvedFunction* h1 =
-      resolvedOnlyCandidate(context, rMGenericCallGF->byAst(helperCall1));
+      resolveOnlyCandidate(context, rMGenericCallGF->byAst(helperCall1));
     const ResolvedFunction* h2 =
-      resolvedOnlyCandidate(context, rMGenericCallGF->byAst(helperCall2));
+      resolveOnlyCandidate(context, rMGenericCallGF->byAst(helperCall2));
     const ResolvedFunction* h3 =
-      resolvedOnlyCandidate(context, rMGenericCallGF->byAst(helperCall3));
+      resolveOnlyCandidate(context, rMGenericCallGF->byAst(helperCall3));
 
     assert(h1);
     assert(h1->functionId() == mHelper1->id());
@@ -433,11 +433,11 @@ static void test4() {
   auto bCall = M->stmt(3)->toCall();
   assert(bCall);
 
-  const auto& rM = resolvedModule(context, M->id());
+  const auto& rM = resolveModule(context, M->id());
 
-  auto rAGeneric = resolvedOnlyCandidate(context, rM.byAst(aCall));
+  auto rAGeneric = resolveOnlyCandidate(context, rM.byAst(aCall));
   assert(rAGeneric);
-  auto rBGeneric = resolvedOnlyCandidate(context, rM.byAst(bCall));
+  auto rBGeneric = resolveOnlyCandidate(context, rM.byAst(bCall));
   assert(rBGeneric);
 
   // check that these two are the same instantiation.
@@ -497,13 +497,13 @@ static void test5() {
   auto bCall = B->stmt(2)->toCall();
   assert(bCall);
 
-  resolvedModule(context, Main->id());
-  const auto& rA = resolvedModule(context, A->id());
-  const auto& rB = resolvedModule(context, B->id());
+  resolveModule(context, Main->id());
+  const auto& rA = resolveModule(context, A->id());
+  const auto& rB = resolveModule(context, B->id());
 
-  auto rAGeneric = resolvedOnlyCandidate(context, rA.byAst(aCall));
+  auto rAGeneric = resolveOnlyCandidate(context, rA.byAst(aCall));
   assert(rAGeneric);
-  auto rBGeneric = resolvedOnlyCandidate(context, rB.byAst(bCall));
+  auto rBGeneric = resolveOnlyCandidate(context, rB.byAst(bCall));
   assert(rBGeneric);
 
   // check that these two are the same instantiation.
@@ -572,15 +572,15 @@ static void test6() {
   auto bCall = B->stmt(2)->toCall();
   assert(bCall);
 
-  resolvedModule(context, Main->id());
-  const auto& rA = resolvedModule(context, A->id());
-  const auto& rB = resolvedModule(context, B->id());
+  resolveModule(context, Main->id());
+  const auto& rA = resolveModule(context, A->id());
+  const auto& rB = resolveModule(context, B->id());
 
-  auto rACallGeneric = resolvedOnlyCandidate(context, rA.byAst(aCall));
+  auto rACallGeneric = resolveOnlyCandidate(context, rA.byAst(aCall));
   assert(rACallGeneric);
   assert(rACallGeneric->signature);
   assert(rACallGeneric->signature->untypedSignature);
-  auto rBCallGeneric = resolvedOnlyCandidate(context, rB.byAst(bCall));
+  auto rBCallGeneric = resolveOnlyCandidate(context, rB.byAst(bCall));
   assert(rBCallGeneric);
   assert(rBCallGeneric->signature->untypedSignature);
 

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -60,7 +60,7 @@ static void test1() {
     const Identifier* xIdent = m->stmt(1)->toIdentifier();
     assert(xIdent);
 
-    const ResolutionResultByPostorderID& rr = resolvedModule(context, m->id());
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
     assert(rr.byAst(x).type.type()->isIntType());
     assert(rr.byAst(xIdent).type.type()->isIntType());
@@ -87,7 +87,7 @@ static void test2() {
     assert(vec.size() == 1);
     const Module* m = vec[0]->toModule();
     assert(m);
-    resolvedModule(context, m->id());
+    resolveModule(context, m->id());
 
     context->collectGarbage();
   }
@@ -103,7 +103,7 @@ static void test2() {
     assert(vec.size() == 1);
     const Module* m = vec[0]->toModule();
     assert(m);
-    resolvedModule(context, m->id());
+    resolveModule(context, m->id());
 
     context->collectGarbage();
   }
@@ -123,7 +123,7 @@ static void test2() {
     const Variable* x = m->stmt(0)->toVariable();
     assert(x);
 
-    const ResolutionResultByPostorderID& rr = resolvedModule(context, m->id());
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
     assert(rr.byAst(x).type.type()->isIntType());
 
     context->collectGarbage();
@@ -148,7 +148,7 @@ static void test2() {
     const Identifier* xIdent = m->stmt(1)->toIdentifier();
     assert(xIdent);
 
-    const ResolutionResultByPostorderID& rr = resolvedModule(context, m->id());
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
     assert(rr.byAst(x).type.type()->isIntType());
     assert(rr.byAst(xIdent).type.type()->isIntType());

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -130,6 +130,8 @@ static void test2() {
   }
 
 
+  // Run it a few times to make sure there aren't errors related to
+  // collectGarbage being run across multiple revisions.
   for (int i = 0; i < 3; i++) {
     printf("part %i\n", 3+i);
     context->advanceToNextRevision(true);

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -60,7 +60,7 @@ static void test1() {
     const Identifier* xIdent = m->stmt(1)->toIdentifier();
     assert(xIdent);
 
-    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    const ResolutionResultByPostorderID& rr = resolvedModule(context, m->id());
 
     assert(rr.byAst(x).type.type()->isIntType());
     assert(rr.byAst(xIdent).type.type()->isIntType());
@@ -87,7 +87,7 @@ static void test2() {
     assert(vec.size() == 1);
     const Module* m = vec[0]->toModule();
     assert(m);
-    resolveModule(context, m->id());
+    resolvedModule(context, m->id());
 
     context->collectGarbage();
   }
@@ -103,7 +103,7 @@ static void test2() {
     assert(vec.size() == 1);
     const Module* m = vec[0]->toModule();
     assert(m);
-    resolveModule(context, m->id());
+    resolvedModule(context, m->id());
 
     context->collectGarbage();
   }
@@ -123,7 +123,7 @@ static void test2() {
     const Variable* x = m->stmt(0)->toVariable();
     assert(x);
 
-    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    const ResolutionResultByPostorderID& rr = resolvedModule(context, m->id());
     assert(rr.byAst(x).type.type()->isIntType());
 
     context->collectGarbage();
@@ -148,7 +148,7 @@ static void test2() {
     const Identifier* xIdent = m->stmt(1)->toIdentifier();
     assert(xIdent);
 
-    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    const ResolutionResultByPostorderID& rr = resolvedModule(context, m->id());
 
     assert(rr.byAst(x).type.type()->isIntType());
     assert(rr.byAst(xIdent).type.type()->isIntType());

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/Comment.h"
 #include "chpl/uast/Identifier.h"
@@ -36,7 +37,7 @@ using namespace parsing;
 using namespace resolution;
 using namespace uast;
 
-/*
+// test resolving a very simple module
 static void test1() {
   printf("test1\n");
   Context ctx;
@@ -45,29 +46,31 @@ static void test1() {
   {
     context->advanceToNextRevision(true);
     auto path = UniqueString::build(context, "input.chpl");
-    std::string contents = "var x;\n"
+    std::string contents = "var x: int;\n"
                            "x;";
     setFileText(context, path, contents);
 
-    auto& vec = resolveFile(context, path);
+    const ModuleVec& vec = parse(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0]->decl->toModule();
-    const auto& byId = vec[0]->resolutionById;
-    const Variable* varDecl = module->child(0)->toVariable();
-    const Identifier* identifier = module->child(1)->toIdentifier();
-    assert(varDecl);
-    assert(identifier);
-    assert(0 == varDecl->name().compare("x"));
-    assert(0 == identifier->name().compare("x"));
-    const ResolutionResult& rr = byId[identifier->id().postOrderId()];
-    assert(rr.expr != nullptr);
-    assert(rr.decl != nullptr);
-    assert(rr.decl == varDecl);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    assert(m->numStmts() == 2);
+    const Variable* x = m->stmt(0)->toVariable();
+    assert(x);
+    const Identifier* xIdent = m->stmt(1)->toIdentifier();
+    assert(xIdent);
+
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+    assert(rr.byAst(x).type.type()->isIntType());
+    assert(rr.byAst(xIdent).type.type()->isIntType());
+    assert(rr.byAst(xIdent).toId == x->id());
+
     context->collectGarbage();
   }
 }
 
-
+// test resolving a module in an incremental manner
 static void test2() {
   printf("test2\n");
   Context ctx;
@@ -79,11 +82,13 @@ static void test2() {
     auto path = UniqueString::build(context, "input.chpl");
     std::string contents = "";
     setFileText(context, path, contents);
-   
-    auto& vec = resolveFile(context, path);
+
+    const ModuleVec& vec = parse(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0]->decl->toModule();
-    ASTNode::dump(module, 2);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    resolveModule(context, m->id());
+
     context->collectGarbage();
   }
 
@@ -94,47 +99,68 @@ static void test2() {
     std::string contents = "var x;";
     setFileText(context, path, contents);
 
-    auto& vec = resolveFile(context, path);
+    const ModuleVec& vec = parse(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0]->decl->toModule();
-    ASTNode::dump(module, 2);
-    const Variable* varDecl = module->child(0)->toVariable();
-    assert(varDecl);
-    assert(0 == varDecl->name().compare("x"));
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    resolveModule(context, m->id());
+
     context->collectGarbage();
   }
+
+  {
+    printf("part 3\n");
+    context->advanceToNextRevision(true);
+    auto path = UniqueString::build(context, "input.chpl");
+    std::string contents = "var x: int;";
+    setFileText(context, path, contents);
+
+    const ModuleVec& vec = parse(context, path);
+    assert(vec.size() == 1);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+
+    const Variable* x = m->stmt(0)->toVariable();
+    assert(x);
+
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    assert(rr.byAst(x).type.type()->isIntType());
+
+    context->collectGarbage();
+  }
+
 
   for (int i = 0; i < 3; i++) {
     printf("part %i\n", 3+i);
     context->advanceToNextRevision(true);
     auto path = UniqueString::build(context, "input.chpl");
-    std::string contents = "var x;\n"
+    std::string contents = "var x: int;\n"
                            "x;";
     setFileText(context, path, contents);
 
-    auto& vec = resolveFile(context, path);
+    const ModuleVec& vec = parse(context, path);
     assert(vec.size() == 1);
-    const Module* module = vec[0]->decl->toModule();
-    ASTNode::dump(module, 2);
-    const auto& byId = vec[0]->resolutionById;
-    const Variable* varDecl = module->child(0)->toVariable();
-    const Identifier* identifier = module->child(1)->toIdentifier();
-    assert(varDecl);
-    assert(identifier);
-    assert(0 == varDecl->name().compare("x"));
-    assert(0 == identifier->name().compare("x"));
-    const ResolutionResult& rr = byId[identifier->id().postOrderId()];
-    assert(rr.expr != nullptr);
-    assert(rr.decl != nullptr);
-    assert(rr.decl == varDecl);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    assert(m->numStmts() == 2);
+    const Variable* x = m->stmt(0)->toVariable();
+    assert(x);
+    const Identifier* xIdent = m->stmt(1)->toIdentifier();
+    assert(xIdent);
+
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+    assert(rr.byAst(x).type.type()->isIntType());
+    assert(rr.byAst(xIdent).type.type()->isIntType());
+    assert(rr.byAst(xIdent).toId == x->id());
+
     context->collectGarbage();
   }
 }
-*/
 
 int main() {
-  //test1();
-  //test2();
+  test1();
+  test2();
 
   return 0;
 }


### PR DESCRIPTION
This PR adds function resolution to compiler/next.

Generally speaking, when there is an ordering constraint between
different operations (e.g. scope resolution to occur before type
resolution), there are two ways to handle it with the query framework:
 1. One query calls another query
 2. A query uses a data type that can only be produced by another
    operation that it depends upon The new resolution code uses approach
    (2) in several cases.

The main scope resolution functions and queries are declared in
scope-queries.h. These include an idea of a ResolvedVisibilityScope,
where what a use/import refers to is figured out. These are figured out
as-needed when lookupInScope and related functions are called.

The main (Function) resolution functions and queries are declared in
resolution-queries.h. These queries interact with the following types
declared in resolution-types.h:
   * QualifiedType - a Type as well as a Kind (think `var` / `const` /
     `in` etc) and Param values, if any
   * ResolvedExpression - combines QualifiedType along with information
     about which NamedDecl / Functions an expression refers to
   * ResolutionResultByPostorderID - stores a ResolvedExpression for
     every Expression contained in a symbol
   * UntypedFnSignature - stores only the function signature parts of a
     Function before any resolution is done - so it is mainly just a list
     of formals. This type exists so that, in incremental compilation, a
     choice of which function to call will not depend on the body of that
     function. (Where generally we have the property that changing
     something within an AST element will cause a new pointer to be made
     for it).
   * TypedFnSignature - stores a function signature along with some type
     information. A TypedFnSignature can represent a generic function
     with the generic types resolved. Or it can represent an
     instantiation of a generic function. Either way, this type is only
     talking about the function signature (formals and where clause) and
     does not consider anything about return type or body of the
     function.
   * ResolvedFunction - this type represents a fully resolved function
     including the function body. If it is a generic function, it must be
     an instantiation.

Function resolution proceeds in this general flow:
 * resolveModule is the normal entry point to drive the process
 * to resolve an expression to produce a ResolvedExpression:
    * if it is a Dot or Identifier, do scope resolution to figure out
      what it refers to
    * if it is a Call, perform call resolution, including finding
      candidates and instantiating
    * Either way, these details are handled in the implementation by the
      Resolver visitor

Call resolution is handled by resolveCall. It is relatively complex and
consists of several stages:
 * First, `lookupCalledExpr` gathers visible functions
 * Then, `filterCandidatesInitial` uses the list of visible functions to
   establish the list of possibly-generic functions (before
   instantiation) that are candidates. To do so, establish the initial
   type signatures for each candidate - that is, figure out what the
   possibly-generic types in the signature refer to without
   instantiating. Since this is done in the query framework, the result
   here is cached, so it will be reused if the same function is a
   candidate for another call.
 * Then, `filterCandidatesInstantiating` uses the list of
   possibly-generic candidates to produce a list of concrete or
   instantiated functions that are candidates. To do so, perform
   instantiation for any function signatures for candidates that are
   generic. 

The above steps are completed first in the scope of the Call and repeated
for each point-of-instantiation until candidates are found. (See
PRs #16158 and #16279 for a history of this behavior in the production
compiler).

Point-of-instantiation is tracked primarily by passing a PoiScope to the
Resolver visitor and to key functions such as resolveCall. However
instantiation caching uses two different strategies:
 * for TypedFnSignature, these are unique'd by their contents (e.g.
   formal types etc) since these are generally small
 * for ResolvedFunction, these are first checked according to PoiInfo
   (which in the future will follow the strategy in #16261 by having the
   hashtable hash-code based on the function signature but the == checks
   use the POI information). Once the function is resolved, we can be
   comprehensive about unique-ifying to ensure correct reuse of
   instantiations and we do that by storing the ResolvedFunctions in a
   map with a key including the signature and also `{set of (Call ID,
   resolution result ID) for calls that came from the Point of
   Instantiation}`. 

Besides adding function resolution, this PR makes the following
supporting changes:
 * Adjusted Context to include an `error` overload accepting a typed
   function signature.
 * Adjusted `QUERY_STORE_RESULT` to only store the first result if called
   multiple times within a single revision. That addresses a memory
   manegement error with one of the ResolvedFunction hashtables described
   above.
 * Added hash function for `std::pair`
 * renamed the query `poiScope` to `pointOfInstantiationScope` since the
   1st name collides with the obvious variable name
 * implement `PoiInfo::canReuse` similarly to PR #16261

Future Work:
 * adjust many of the new types to be better engineered e.g. with
   accessor methods and private fields.
 * make production-quality error messages
 * implement real logic for canPass etc
 * handle varargs functions
 * make sure we get a reasonable error for naming the same argument twice
   in a call
 * describe the flow of resolution (e.g. with the contents of this PR
   message) in a comment at the top of the resolver implementation

Reviewed by @stonea @lydia-duncan and @e-kayrakli - thanks!

- [x] full local testing