### PR TITLE
Unique option strings and names in argument parser

### DIFF
--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1268,6 +1268,63 @@ proc testEmptyListDefaultVal(test: borrowed Test) throws {
   test.assertEqual(new list(myStrArg.values()),new list(string));
 }
 
+// attempt to define a name twice
+proc testTryDuplicateNameOpt(test: borrowed Test) throws {
+  var argList = ["progName","-n=twenty","thirty"];
+  var parser = new argumentParser();
+  var myStrArg1 = parser.addOption(name="StringOpt",
+                                opts=["-n","--strArg"],            
+                                numArgs=1);
+  try {
+    var myStrArg2 = parser.addOption(name="StringOpt",
+                                    opts=["-p","--print"],            
+                                    numArgs=1);
+  }catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);  
+}
+
+// attempt to define a short option twice
+proc testTryDuplicateShortOpt(test: borrowed Test) throws {
+  var argList = ["progName","-n=twenty","thirty"];
+  var parser = new argumentParser();
+  var myStrArg1 = parser.addOption(name="StringOpt",
+                                opts=["-n","--strArg"],            
+                                numArgs=1);
+  try {
+    var myStrArg2 = parser.addOption(name="PrintOpt",
+                                    opts=["-n","--print"],            
+                                    numArgs=1);
+  }catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);  
+}
+
+// attempt to define a short option twice
+proc testTryDuplicateLongOpt(test: borrowed Test) throws {
+  var argList = ["progName","-n=twenty","thirty"];
+  var parser = new argumentParser();
+  var myStrArg1 = parser.addOption(name="StringOpt",
+                                opts=["-n","--strArg"],            
+                                numArgs=1);
+  try {
+    var myStrArg2 = parser.addOption(name="PrintOpt",
+                                    opts=["-p","--strArg"],            
+                                    numArgs=1);
+  }catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);  
+}
+
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 
 UnitTest.main();

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -214,6 +214,18 @@ testEmptyListDefaultVal()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testTryDuplicateNameOpt()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testTryDuplicateShortOpt()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testTryDuplicateLongOpt()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 -n\--stringVal has extra values
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
@@ -238,3 +250,6 @@ Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
+Option name StringOpt is previously defined
+Option flag -n is previously defined
+Option flag --strArg is previously defined

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -24,9 +24,7 @@ module MasonArgParse {
   private use Sort;
 
   const DEBUG=false;
-  // TODO: Verify no duplicate names, flags defined by dev
-  // TODO: Make sure we don't shadow Chapel flags
-  // TODO: Make sure we don't shadow config vars  
+  // TODO: Add sub-commands
   // TODO: Implement Help message and formatting
   // TODO: Add bool flags
   // TODO: Add int opts

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -275,8 +275,20 @@ module MasonArgParse {
           throw new ArgumentError("Use '-' or '--' to indicate opt flags. " +
                                   "Positional arguments not yet supported");
         }
+
+        // ensure we don't redefine an existing option flag
+        if _options.contains(opts[i]) {
+          throw new ArgumentError("Option flag " + opts[i] + " is previously " +
+                                  "defined");
+        }
       }
 
+      // ensure option names are unique
+      if _actions.contains(name) {
+        throw new ArgumentError("Option name " + name + 
+                                " is previously defined");
+      }     
+      
       var myDefault = new list(string);
 
       if isStringType(t) {


### PR DESCRIPTION
This PR adds checking to mason argument parsing to ensure that no
option flags or names are accidentally redefined by the developer.

Scope of work defined in Cray/chapel-private#2323, this work satisfies
the main goals of that issue which are to:

1. Prevent developer from defining the same option string more than once
2. Prevent developer from defining the same option name more than once

Relates to broader implementation task in Cray/chapel-private#2192

Tests added for required arguments and optional default values.

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/mason-argparse`

Reviewed by @mppf. 

Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com