### PR TITLE
Avoid Passing Array View to C_BLAS

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -894,7 +894,13 @@ private proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType, trans=false)
              else {Adom.dim(0)};
 
   var Y: [Ydom] eltType;
-  BLAS.gemv(A, X, Y, 1:eltType, 0:eltType, opA=op);
+  
+  if chpl__isArrayView(X) {
+    var temp = X;
+    BLAS.gemv(A, temp, Y, 1:eltType, 0:eltType, opA=op);
+  } else {
+    BLAS.gemv(A, X, Y, 1:eltType, 0:eltType, opA=op);
+  }
   return Y;
 }
 


### PR DESCRIPTION
We were passing an `ArrayView` to the `C_BLAS` function which meant that even though it seemed like we were giving it a column, it was actually still taking the first row of the Array.
This was causing problems with matrix multiplication calculations as reported in #18118 

A quick workaround was to make a deep copy of the `ArrayView` so that the pointer we pass to C has the right elements in the expected order.

Resolves #18118 