### PR TITLE
Deprecate bigint.powm in favor of bigint.powMod and document the latter

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2503,10 +2503,35 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
 
 
-  // Exponentiation Functions
+  deprecated
+  "bigint.powm is deprecated, use bigint.powMod instead"
   proc bigint.powm(const ref base: bigint,
                    const ref exp:  bigint,
                    const ref mod:  bigint) {
+    this.powMod(base, exp, mod);
+  }
+
+  deprecated
+  "bigint.powm is deprecated, use bigint.powMod instead"
+  proc bigint.powm(const ref base: bigint,
+                             exp:  int,
+                   const ref mod:  bigint) {
+    this.powMod(base, exp, mod);
+  }
+
+  deprecated
+  "bigint.powm is deprecated, use bigint.powMod instead"
+  proc bigint.powm(const ref base: bigint,
+                             exp:  uint,
+                   const ref mod:  bigint) {
+    this.powMod(base, exp, mod);
+  }
+
+
+  // Exponentiation Functions
+  // Note: Documentation on `exp: uint` version
+  proc bigint.powMod(const ref base: bigint, const ref exp:  bigint,
+                     const ref mod:  bigint) {
     if _local {
       mpz_powm(this.mpz, base.mpz, exp.mpz, mod.mpz);
 
@@ -2529,9 +2554,8 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.powm(const ref base: bigint,
-                             exp:  int,
-                   const ref mod:  bigint) {
+  // Note: Documentation on `exp: uint` version
+  proc bigint.powMod(const ref base: bigint, exp: int, const ref mod: bigint) {
     if exp >= 0 {
       const exp_ = exp.safeCast(c_ulong);
 
@@ -2581,9 +2605,25 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.powm(const ref base: bigint,
-                             exp:  uint,
-                   const ref mod:  bigint) {
+  /* Set ``this`` to the result of (``base`` raised to ``exp``) modulo ``mod``.
+
+     :arg base: The value to be raised to the power of ``exp`` before performin
+                a modulo operation on.
+     :type base: ``bigint``
+
+     :arg exp: The exponent to raise ``base`` to the power of prior to the
+               modulo operation.  Can be negative if the inverse (1/``base``)
+               modulo ``mod`` exists.
+     :type exp: ``bigint``, ``int``, or ``uint``
+
+     :arg mod: The divisor for the modulo operation.
+     :type mod: ``bigint``
+
+     .. warning::
+        The program behavior is undefined if ``exp`` is negative and the inverse
+        (1/``base``) modulo ``mod`` does not exist.
+   */
+  proc bigint.powMod(const ref base: bigint, exp: uint, const ref mod: bigint) {
     const exp_ = exp.safeCast(c_ulong);
 
     if _local {

--- a/test/deprecated/BigInteger/deprecatePowm.chpl
+++ b/test/deprecated/BigInteger/deprecatePowm.chpl
@@ -1,0 +1,16 @@
+use BigInteger;
+
+// Tests the power functions
+
+// powers
+var a = new bigint( 2);
+var b = new bigint( 4);
+var c = new bigint(10);
+var d = new bigint();
+
+a.powm(a, b, c);          // a = a^b mod c
+writeln("2^4 mod 10 = ", a);
+
+a.set(2);
+a.powm(a, 3, c);          // a = a^3 mod c
+writeln("2^3 mod 10 = ", a);

--- a/test/deprecated/BigInteger/deprecatePowm.good
+++ b/test/deprecated/BigInteger/deprecatePowm.good
@@ -1,0 +1,4 @@
+deprecatePowm.chpl:11: warning: bigint.powm is deprecated, use bigint.powMod instead
+deprecatePowm.chpl:15: warning: bigint.powm is deprecated, use bigint.powMod instead
+2^4 mod 10 = 6
+2^3 mod 10 = 8

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_powers_roots.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_powers_roots.chpl
@@ -8,11 +8,11 @@ var b = new bigint( 4);
 var c = new bigint(10);
 var d = new bigint();
 
-a.powm(a, b, c);          // a = a^b mod c
+a.powMod(a, b, c);          // a = a^b mod c
 writeln("2^4 mod 10 = ", a);
 
 a.set(2);
-a.powm(a, 3, c);          // a = a^3 mod c
+a.powMod(a, 3, c);          // a = a^3 mod c
 writeln("2^3 mod 10 = ", a);
 
 a.set(2);


### PR DESCRIPTION
Resolves #17729

We decided to rename `bigint.powm` to `bigint.powMod` for clarity.  Deprecate
the three overloads of `powm` in favor of new `powMod` overloads.  While there,
add documentation for the `powMod` methods based on the GMP original
documentation for `mpz_powm`.

The GMP powers test needed an update to use the new method name.  Copy the
original code into a new test to lock in the deprecation message.

Passed a full paratest with futures