### PR TITLE
Add subcommands to argument parser

### DIFF
--- a/test/mason/mason-argparse/MasonArgParseExample.chpl
+++ b/test/mason/mason-argparse/MasonArgParseExample.chpl
@@ -2,37 +2,61 @@ module M {
     private use MasonArgParse;
     config var myConfigVar:string;
 
-    proc main(args:[?argsD]string) throws{
-        writeln("Config Var Values:");
-        writeln(myConfigVar);
-        
-        writeln("Arguments Received from CL:");
-        // print the contents of args, skipping the executable name
-        // as it can vary depending on the test environment
-        for i in 1..argsD.high {
-            writeln(i:string + " " + args[i]);
-        }
-
-
-        var parser = new argumentParser();
+    proc main(args:[?argsD]string) throws {
+      writeln("Config Var Values:");
+      writeln(myConfigVar);
       
-        var strArg = parser.addOption(name="strArg1",
-                                      opts=["-o","--option"],
-                                      numArgs=1..10);
-        var typArg = parser.addOption(name="strArg2",
-                                      opts=["-t","--types"],
-                                      numArgs=1..);
-        var confArg = parser.addOption(name="strArg3",
-                                      opts=["--myConfigVar"],
-                                      numArgs=1);                                               
-        parser.parseArgs(args[1..]);
-        
-        writeln("Values received from argparse:");
-        if strArg.hasValue() {         
-          for val in strArg.values() do writeln(val);
-        }      
-        for item in typArg.values() do writeln(item);
-        for item in confArg.values() do writeln(item);
+      writeln("Arguments Received from CL:");
+      // print the contents of args, skipping the executable name
+      // as it can vary depending on the test environment
+      for i in 1..argsD.high {
+          writeln(i:string + " " + args[i]);
+      }
+
+      var parser = new argumentParser();
+    
+      var strArg = parser.addOption(name="strArg1",
+                                    opts=["-o","--option"],
+                                    numArgs=1..10);
+      var typArg = parser.addOption(name="strArg2",
+                                    opts=["-t","--types"],
+                                    numArgs=1..);
+      var confArg = parser.addOption(name="strArg3",
+                                    opts=["--myConfigVar"],
+                                    numArgs=1);
+
+      var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+      var rest = parser.parseArgs(args[1..]);
+      
+      writeln("Values received from argparse:");
+      if strArg.hasValue() {         
+        for val in strArg.values() do writeln(val);
+      }      
+      for item in typArg.values() do writeln(item);
+      for item in confArg.values() do writeln(item);
+      if subCmd1.hasValue() {
+        mySubCmd1(rest.toArray());
+      }
+
+    }
+
+    proc mySubCmd1(args:[?argsD]string) throws {
+      writeln("SubCommand1 was called");
+      var parser = new argumentParser();
+
+      var subCmdArg1 = parser.addOption(name="subCmdArg1",
+                                        opts=["-c","--cmdArg1"],
+                                        numArgs=1);
+
+      var subCmdArg2 = parser.addOption(name="subCmdArg2",
+                                        opts=["-t","--cmdArg2"],
+                                        numArgs=1);
+
+      var rest = parser.parseArgs(args);
+      writeln("args parsed in subcommand:");
+      for item in subCmdArg1.values() do writeln(item);
+      for item in subCmdArg2.values() do writeln(item);
 
     }
 }

--- a/test/mason/mason-argparse/MasonArgParseExample.good
+++ b/test/mason/mason-argparse/MasonArgParseExample.good
@@ -11,6 +11,11 @@ Arguments Received from CL:
 8 -t=tea
 9 time
 10 --myConfigVar=@10
+11 subCmd1
+12 -c
+13 one
+14 -t
+15 two
 Values received from argparse:
 w
 a
@@ -21,3 +26,7 @@ a?
 tea
 time
 @10
+SubCommand1 was called
+args parsed in subcommand:
+one
+two

--- a/test/mason/mason-argparse/MasonArgParseExample.lastexecopts
+++ b/test/mason/mason-argparse/MasonArgParseExample.lastexecopts
@@ -1,1 +1,1 @@
---myConfigVar testVar -o w a y d t a? -- -t=tea time --myConfigVar=@10
+--myConfigVar testVar -o w a y d t a? -- -t=tea time --myConfigVar=@10 subCmd1 -c one -t two

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1611,6 +1611,34 @@ proc testFromArgParseExample(test: borrowed Test) throws {
   test.assertEqual(new list(argList[12..]),remain);
 }
   
+// short option interrupted with bad flag value
+proc testOptRangeInterruptBadFlag(test: borrowed Test) throws {
+  var argList = ["progName","-n","twenty","-f","-p","thirty","-t","two"];
+  var parser = new argumentParser();
+  var myStrArg1 = parser.addOption(name="StringOpt1",
+                                   opts=["-n","--stringVal1"],            
+                                   numArgs=1..);
+  var myStrArg2 = parser.addOption(name="StringOpt2",
+                                   opts=["-p","--stringVal2"],            
+                                   numArgs=1);
+  var myStrArg3 = parser.addOption(name="StringOpt3",
+                                   opts=["-t","--stringVal3"],            
+                                   numArgs=1);
+
+  //make sure no value currently exists
+  test.assertFalse(myStrArg1.hasValue());
+  test.assertFalse(myStrArg2.hasValue());
+  test.assertFalse(myStrArg3.hasValue());
+  //parse the options
+  try {
+    parser.parseArgs(argList[1..]);
+  }catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
+}
 
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1509,6 +1509,77 @@ proc testRangeStringShortOptRepeatedAllowableCount(test: borrowed Test) throws {
                    new list(["twenty","thirty","forty"]));
 }
 
+// add a subcommand with sub options, and options before
+proc testOptionsWithSubCommandSubOptions(test: borrowed Test) throws {
+  var argList = ["progName","-x","four","subCommand1","-n","20"];
+  var parser = new argumentParser();
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-x","--stringVal"],            
+                                  numArgs=1);
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertTrue(myStrArg.hasValue());
+  test.assertEqual(myStrArg.value(), "four");
+  test.assertEqual(remain.size,2);
+  test.assertTrue(mySubCmd1.hasValue());
+  test.assertEqual(new list(argList[4..]),remain);
+}
+
+// add a subcommand with sub options, and options before
+proc testOptionsRangeWithSubCommandSubOptions(test: borrowed Test) throws {
+  var argList = ["progName","-x","four","subCommand1","-n","20"];
+  var parser = new argumentParser();
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-x","--stringVal"],            
+                                  numArgs=1..2,
+                                  required=false,
+                                  defaultValue=none);
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertTrue(myStrArg.hasValue());
+  test.assertEqual(myStrArg.value(), "four");
+  test.assertEqual(remain.size,2);
+  test.assertTrue(mySubCmd1.hasValue());
+  test.assertEqual(new list(argList[4..]),remain);
+}
+
+// add a subcommand with sub options, and options before with same flags
+proc testOptionsRangeWithSubCommandSameSubOptions(test: borrowed Test) throws {
+  var argList = ["progName","-n","four","subCommand1","-n","20","-x","30"];
+  var parser = new argumentParser();
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],            
+                                  numArgs=1..2,
+                                  required=false,
+                                  defaultValue=none);
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertTrue(myStrArg.hasValue());
+  test.assertEqual(myStrArg.value(), "four");
+  test.assertEqual(remain.size,4);
+  test.assertTrue(mySubCmd1.hasValue());
+  test.assertEqual(new list(argList[4..]),remain);
+}
+
+// add a subcommand with sub options, and options before with same flags
+// when main command has low bound range
+proc testOptsRangeWithSubCommandSameSubOptionsLow(test: borrowed Test) throws {
+  var argList = ["progName","-n","four","subCommand1","-n","20","-x","30"];
+  var parser = new argumentParser();
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],            
+                                  numArgs=1..,
+                                  required=false,
+                                  defaultValue=none);
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertTrue(myStrArg.hasValue());
+  test.assertEqual(myStrArg.value(), "four");
+  test.assertEqual(remain.size,4);
+  test.assertTrue(mySubCmd1.hasValue());
+  test.assertEqual(new list(argList[4..]),remain);
+}
+
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 
 UnitTest.main();

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1580,6 +1580,38 @@ proc testOptsRangeWithSubCommandSameSubOptionsLow(test: borrowed Test) throws {
   test.assertEqual(new list(argList[4..]),remain);
 }
 
+
+// add a subcommand with sub options, and options before with same flags
+// when main command has low bound range
+proc testFromArgParseExample(test: borrowed Test) throws {
+  var argList = ["progName","-o","w","a","y","d","t","a?","-t=tea","time",
+                 "--myConfigVar=@10","subCmd1","-c","one","-t","two"];
+  var parser = new argumentParser();
+  var strArg = parser.addOption(name="strArg1",
+                                opts=["-o","--option"],
+                                numArgs=1..10,
+                                required=false,
+                                defaultValue=none);
+  var typArg = parser.addOption(name="strArg2",
+                                opts=["-t","--types"],
+                                numArgs=1..);
+  var confArg = parser.addOption(name="strArg3",
+                                opts=["--myConfigVar"],
+                                numArgs=1);
+
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertTrue(strArg.hasValue());
+  test.assertEqual(new list(strArg.values()), 
+                   new list(["w","a","y","d","t","a?"]));
+  test.assertEqual(new list(typArg.values()), new list(["tea","time"]));
+  test.assertEqual(confArg.value(),"@10");
+  test.assertEqual(remain.size,4);
+  test.assertTrue(subCmd1.hasValue());
+  test.assertEqual(new list(argList[12..]),remain);
+}
+  
+
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 
 UnitTest.main();

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1332,7 +1332,7 @@ proc testAddSubCommand(test: borrowed Test) throws {
   var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
   var remain = parser.parseArgs(argList[1..]);
   test.assertEqual(remain.size,0);
-  test.assertTrue(mySubCmd1._present);
+  test.assertTrue(mySubCmd1.hasValue());
 }
 
 // use an option and then a subcommand
@@ -1341,11 +1341,11 @@ proc testOptionPlusSubCommand(test: borrowed Test) throws {
   var parser = new argumentParser();
   var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
   var myStrArg1 = parser.addOption(name="StringOpt",
-                              opts=["-n","--strArg"],            
-                              numArgs=1);
+                                   opts=["-n","--strArg"],            
+                                   numArgs=1);
   var remain = parser.parseArgs(argList[1..]);
 //  test.assertEqual(pos,1);
-  test.assertTrue(mySubCmd1._present);
+  test.assertTrue(mySubCmd1.hasValue());
   test.assertEqual(remain.size, 0);
   test.assertTrue(myStrArg1.hasValue());
   test.assertEqual(myStrArg1.value(), "20");
@@ -1359,8 +1359,61 @@ proc testAddSubCommandSubOptions(test: borrowed Test) throws {
   var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
   var remain = parser.parseArgs(argList[1..]);
   test.assertEqual(remain.size,2);
-  test.assertTrue(mySubCmd1._present);
+  test.assertTrue(mySubCmd1.hasValue());
   test.assertEqual(new list(argList[2..]),remain);
+}
+
+// add a subcommand and argument, but don't use subcommand
+proc testAddArgAndSubCommandOnlyArgUsed(test: borrowed Test) throws {
+  var argList = ["progName","-n","20"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var myStrArg1 = parser.addOption(name="StringOpt",
+                                   opts=["-n","--strArg"],            
+                                   numArgs=1);
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertEqual(remain.size,0);
+  test.assertFalse(mySubCmd1.hasValue());
+  test.assertTrue(myStrArg1.hasValue());
+  test.assertEqual(myStrArg1.value(),"20");
+}
+
+// add a subcommand and argument, but don't use either
+proc testAddArgAndSubCommandNoUseEither(test: borrowed Test) throws {
+  var argList = ["progName"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var myStrArg1 = parser.addOption(name="StringOpt",
+                                   opts=["-n","--strArg"],            
+                                   numArgs=1);
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertEqual(remain.size,0);
+  test.assertFalse(mySubCmd1.hasValue());
+  test.assertFalse(myStrArg1.hasValue());  
+}
+
+// add two subcommands and use first
+proc testAddTwoSubCommandUseFirst(test: borrowed Test) throws {
+  var argList = ["progName","subCommand1"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var mySubCmd2 = parser.addSubCommand(cmd="subCommand2");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertEqual(remain.size,0);
+  test.assertTrue(mySubCmd1.hasValue());
+  test.assertFalse(mySubCmd2.hasValue());
+}
+
+// add two subcommands and use second
+proc testAddTwoSubCommandUseSecond(test: borrowed Test) throws {
+  var argList = ["progName","subCommand2"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var mySubCmd2 = parser.addSubCommand(cmd="subCommand2");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertEqual(remain.size,0);
+  test.assertFalse(mySubCmd1.hasValue());
+  test.assertTrue(mySubCmd2.hasValue());
 }
 
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1325,6 +1325,44 @@ proc testTryDuplicateLongOpt(test: borrowed Test) throws {
   test.assertTrue(false);  
 }
 
+// add a subcommand
+proc testAddSubCommand(test: borrowed Test) throws {
+  var argList = ["progName","subCommand1"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertEqual(remain.size,0);
+  test.assertTrue(mySubCmd1._present);
+}
+
+// use an option and then a subcommand
+proc testOptionPlusSubCommand(test: borrowed Test) throws {
+  var argList = ["progName","-n","20","subCommand1"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var myStrArg1 = parser.addOption(name="StringOpt",
+                              opts=["-n","--strArg"],            
+                              numArgs=1);
+  var remain = parser.parseArgs(argList[1..]);
+//  test.assertEqual(pos,1);
+  test.assertTrue(mySubCmd1._present);
+  test.assertEqual(remain.size, 0);
+  test.assertTrue(myStrArg1.hasValue());
+  test.assertEqual(myStrArg1.value(), "20");
+}
+
+
+// add a subcommand with sub options
+proc testAddSubCommandSubOptions(test: borrowed Test) throws {
+  var argList = ["progName","subCommand1","-n","20"];
+  var parser = new argumentParser();
+  var mySubCmd1 = parser.addSubCommand(cmd="subCommand1");
+  var remain = parser.parseArgs(argList[1..]);
+  test.assertEqual(remain.size,2);
+  test.assertTrue(mySubCmd1._present);
+  test.assertEqual(new list(argList[2..]),remain);
+}
+
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 
 UnitTest.main();

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1314,7 +1314,7 @@ proc testTryDuplicateShortOpt(test: borrowed Test) throws {
   test.assertTrue(false);  
 }
 
-// attempt to define a short option twice
+// attempt to define a long option twice
 proc testTryDuplicateLongOpt(test: borrowed Test) throws {
   var argList = ["progName","-n=twenty","thirty"];
   var parser = new argumentParser();

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -274,6 +274,30 @@ testRangeStringShortOptRepeatedAllowableCount()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testOptionsWithSubCommandSubOptions()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testOptionsRangeWithSubCommandSubOptions()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testOptionsRangeWithSubCommandSameSubOptions()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testOptsRangeWithSubCommandSameSubOptionsLow()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testFromArgParseExample()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testOptRangeInterruptBadFlag()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 Found undefined values: thirty
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
@@ -307,3 +331,4 @@ Option flag --strArg is previously defined
 Found undefined values: subCommandNone
 Found undefined values: subCommandNone
 Found undefined values: -x
+StringOpt1 has extra values

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -226,26 +226,77 @@ testTryDuplicateLongOpt()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
--n\--stringVal has extra values
+testAddSubCommand()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testOptionPlusSubCommand()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddSubCommandSubOptions()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddArgAndSubCommandOnlyArgUsed()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddArgAndSubCommandNoUseEither()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddTwoSubCommandUseFirst()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddTwoSubCommandUseSecond()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddTwoSubCommandUseNone()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddTwoSubCommandUseUndefined()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testAddTwoSubCommandUseUndefinedWithGood()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testStringShortOptVarBadVarNoVal()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testRangeStringShortOptRepeatedAllowableCount()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+Found undefined values: thirty
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
--n\--stringVal not enough values
+StringOpt Too many values: expected 1..1 got 3
+StringOpt Too many values: expected 1..3 got 6
+StringOpt has extra values
+StringOpt Required value missing
 unrecognized options/values encountered: -n twenty
--n\--stringVal not enough values
--n\--stringVal has extra values
--n\--stringVal has extra values
--n\--stringVal not enough values
--n\--stringVal has extra values
--n\--stringVal not enough values
--n\--stringVal not enough values
--n\--stringVal1 not enough values
--p\--stringVal2 not enough values
--t\--stringVal3 not enough values
--n\--stringVal1 has extra values
--p\--stringVal2 has extra values
--t\--stringVal3 has extra values
--p\--stringVal2 has extra values
--p\--stringVal2 not enough values
+StringOpt Not enough values: expected 1..2 got 0
+Found undefined values: two
+Found undefined values: -p thirty
+StringOpt Not enough values: expected 3..5 got 2
+Found undefined values: fifty
+StringOpt Not enough values: expected 1..3 got 0
+StringOpt Not enough values: expected 1..1 got 0
+StringOpt1 Not enough values: expected 1..1 got 0
+StringOpt2 Not enough values: expected 1..1 got 0
+StringOpt3 Not enough values: expected 1..1 got 0
+StringOpt1 has extra values
+StringOpt2 has extra values
+Found undefined values: five
+StringOpt2 has extra values
+StringOpt2 Required value missing
 Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
@@ -253,3 +304,6 @@ Only string and list of strings are supported as default values at this time
 Option name StringOpt is previously defined
 Option flag -n is previously defined
 Option flag --strArg is previously defined
+Found undefined values: subCommandNone
+Found undefined values: subCommandNone
+Found undefined values: -x

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -98,13 +98,12 @@ module MasonArgParse {
 
   }
 
-  // stores a subcommand name
+  // stores a subcommand definition
   class SubCommand : Action {
     
     proc init(cmd:string) {
       super.init();
       this._name=cmd;
-      this.complete();     
     }
 
     override proc _match(args:[?argsD]string, startPos:int, myArg:Argument,
@@ -112,7 +111,7 @@ module MasonArgParse {
       var pos = startPos;
       var next = pos + 1;
       debugTrace("starting at pos: " + pos:string);
-      while pos <= argsD.high 
+      while pos <= endPos 
       {      
         if args[pos] == this._name {
           myArg._values.append(args[pos]);
@@ -128,7 +127,7 @@ module MasonArgParse {
 
   }
 
-  // stores the definition of an option
+  // stores an option definition
   class Option : Action {    
     // number of option flags that can indicate this argument
     var _numOpts:int;
@@ -155,7 +154,6 @@ module MasonArgParse {
       // make sure that if we make an argument required no default set
       assert(!(_required && _defaultValue.size > 0), 
               "Required options do not support default values");
-      this.complete();
     }
 
     override proc _isRequired() {

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -105,12 +105,17 @@ module MasonArgParse {
       super.init();
       this._name=cmd;
     }
-
+    
+    // for subcommands, _match attempts to identify values at the index of the 
+    // subcommadn at position startPos (inclusive) and through the 
+    // endPos (inclusive) parameter [startPos, endPos]
     override proc _match(args:[?argsD]string, startPos:int, myArg:Argument,
-                         ref rest:list(string), endPos:int) throws {
+                         ref rest:list(string), endPos:int) throws {                           
       var pos = startPos;
       var next = pos + 1;
       debugTrace("starting at pos: " + pos:string);
+      debugTrace("Searching positions from: " + pos:string + " to " 
+                 + endPos:string);
       while pos <= endPos 
       {
         if args[pos] == this._name {
@@ -171,6 +176,9 @@ module MasonArgParse {
     // maybe pass a list to fill by reference and have the argparser populate
     // the argument instead?
     // also need a bool by ref to indicate presence of arg or not
+    // for option values, _match attempts to identify values after the option
+    // at position startPos (exclusive) and through the endPos (inclusive)
+    // parameter (startPos, endPos]
     override proc _match(args:[?argsD]string, startPos:int, myArg:Argument, 
                          ref rest:list(string), endPos:int) throws {
       var high = _numArgs.high;
@@ -225,6 +233,9 @@ module MasonArgParse {
       var rest = new list(string);
       var endPos = 0;
 
+      // as noted in the comments on PR#18141, breaking up the arguments
+      // when they contain = disconnects the resulting array's indices from 
+      // the original.
       for i in argsD {
         const arrElt = arguments[i];
         // look for = sign after opt, split into two elements

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -53,16 +53,16 @@ module MasonArgParse {
     //indicates if an argument was entered on the command line
     var _present: bool=false;
     // hold the values of the argument from the command line
-    var _values: list(string);     
+    var _values: list(string);
     
-    proc value(){     
+    proc value(){
       return this._values.first();
     }
 
     iter values(){
       for val in _values {
         yield val;
-      }      
+      }
     }
 
     proc hasValue(){
@@ -93,7 +93,7 @@ module MasonArgParse {
     }
 
     proc _validate(present:bool, valueCount:int):string {
-        return "";      
+        return "";
     }
 
   }
@@ -107,12 +107,12 @@ module MasonArgParse {
     }
 
     override proc _match(args:[?argsD]string, startPos:int, myArg:Argument,
-                         ref rest:list(string), endPos:int) throws {      
+                         ref rest:list(string), endPos:int) throws {
       var pos = startPos;
       var next = pos + 1;
       debugTrace("starting at pos: " + pos:string);
       while pos <= endPos 
-      {      
+      {
         if args[pos] == this._name {
           myArg._values.append(args[pos]);
           debugTrace("matched cmd: " + args[pos] + " at pos: " + pos:string);
@@ -120,15 +120,15 @@ module MasonArgParse {
           return next;
         }
         pos = next;
-        next+=1;  
+        next+=1;
       }
-      return pos;                  
+      return pos;
     }
 
   }
 
   // stores an option definition
-  class Option : Action {    
+  class Option : Action {
     // number of option flags that can indicate this argument
     var _numOpts:int;
     // value of option flag(s) that can indicate this argument
@@ -141,18 +141,18 @@ module MasonArgParse {
     var _defaultValue:list(string);
 
 
-    proc init(name:string, numOpts:int, opts:[?argsD] string, numArgs:range, 
+    proc init(name:string, numOpts:int, opts:[?argsD] string, numArgs:range,
               required=false, defaultValue=new list(string)) {
-      super.init();      
+      super.init();
       _name=name;
       _numOpts=numOpts;
       _opts=opts;
       _numArgs=numArgs;
       _required=required;
-      _defaultValue=defaultValue;  
+      _defaultValue=defaultValue;
       
       // make sure that if we make an argument required no default set
-      assert(!(_required && _defaultValue.size > 0), 
+      assert(!(_required && _defaultValue.size > 0),
               "Required options do not support default values");
     }
 
@@ -163,7 +163,7 @@ module MasonArgParse {
     override proc _getDefaultValue() {
       return _defaultValue;
     }
-    
+
     override proc _hasDefault():bool {
       return !_defaultValue.isEmpty();
     }
@@ -181,13 +181,13 @@ module MasonArgParse {
       var next = pos+1;
       debugTrace("starting at pos: " + pos:string);
       debugTrace("searching from: " + pos:string + " to " + endPos:string);
-      while matched < high && next <= endPos && !args[next].startsWith("-") 
+      while matched < high && next <= endPos && !args[next].startsWith("-")
       {
         pos=next;
         next+=1;
         matched+=1; 
-        myArg._values.append(args[pos]);  
-        debugTrace("matched val: " + args[pos] + " at pos: " + pos:string);     
+        myArg._values.append(args[pos]);
+        debugTrace("matched val: " + args[pos] + " at pos: " + pos:string);
       }
       return next;
     }
@@ -238,7 +238,7 @@ module MasonArgParse {
       }
 
       for i in argsList.indices {
-        const argElt = argsList[i];        
+        const argElt = argsList[i];
         if _options.contains(argElt) {
           var optName = _options.getValue(argElt);
           var argRslt = _result.getValue(optName);
@@ -248,7 +248,7 @@ module MasonArgParse {
           argRslt._present = true;
         }
       }
-      
+
       // get this as an array so we can sort it, because maps are order-less
       // TODO: Can we eliminate this extra logic by using an OrderedMap type?
       var arrayoptionIndices = optionIndices.toArray();
@@ -256,7 +256,7 @@ module MasonArgParse {
 
       // check for undefined argument provided
       if arrayoptionIndices.size > 0 && arrayoptionIndices[0][0] != 0 {
-          throw new ArgumentError("Found undefined values: " + argsList[0]);                                  
+          throw new ArgumentError("Found undefined values: " + argsList[0]);
       }
 
       // try to match for each of the identified options
@@ -292,7 +292,7 @@ module MasonArgParse {
         }
 
         // make sure we don't overrun the array,
-        // then check that we don't have extra values        
+        // then check that we don't have extra values
         if k < arrayoptionIndices.size {
           if endPos != arrayoptionIndices[k][0] {
             debugTrace("Rest.size= " + rest.size:string);
@@ -350,7 +350,7 @@ module MasonArgParse {
       }
     }
 
-    proc _addAction(in action : Action) throws { 
+    proc _addAction(in action : Action) throws {
 
       // ensure option names are unique
       if _actions.contains(action._name) {
@@ -368,7 +368,7 @@ module MasonArgParse {
       return arg;
     }
 
-    proc addSubCommand(cmd:string) throws {       
+    proc addSubCommand(cmd:string) throws {
       var act = new owned SubCommand(cmd);
       _options.add(cmd, cmd);
       return _addAction(act);
@@ -392,7 +392,7 @@ module MasonArgParse {
                    opts:[?optsD]string,
                    numArgs:range(boundedType=BoundedRangeType.boundedLow),
                    required=false,
-                   defaultValue:?t=none) throws {                   
+                   defaultValue:?t=none) throws {
       return addOption(name=name,
                        opts=opts,
                        numArgs=numArgs.low..max(int),
@@ -405,7 +405,7 @@ module MasonArgParse {
                    opts:[?optsD]string,
                    numArgs:range,
                    required=false,
-                   defaultValue:?t=none) throws {      
+                   defaultValue:?t=none) throws {
       for i in optsD {
         if !opts[i].startsWith("-") {
           throw new ArgumentError("Use '-' or '--' to indicate opt flags. " +

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -118,7 +118,6 @@ module MasonArgParse {
       {      
         if args[pos] == this._name {
           myArg._values.append(args[pos]);
-          //myArg._present=true;
           debugTrace("matched val: " + args[pos] + " at pos: " + pos:string);
           rest.extend(args[next..]);
           return next;
@@ -191,18 +190,10 @@ module MasonArgParse {
       {
         pos=next;
         next+=1;
-        matched+=1;
-        //if high > myArg._values.size {
-        myArg._values.append(args[pos]);
-        //} else {
-        //   throw new ArgumentError("\\".join(_opts) + " too many values");
-        // }
-        //myArg._present=true;
+        matched+=1; 
+        myArg._values.append(args[pos]);  
         debugTrace("matched val: " + args[pos] + " at pos: " + pos:string);     
       }
-      // if matched < this._numArgs.low {
-      //   throw new ArgumentError("\\".join(_opts) + " not enough values");
-      // }
       return next;
     }
 
@@ -210,9 +201,11 @@ module MasonArgParse {
         if !present && _required {
         return "Required value missing";
       } else if valueCount > _numArgs.high {
-        return "Too many values";
+        return "Too many values: expected " + _numArgs:string + 
+               " got " + valueCount:string;
       } else if valueCount < _numArgs.low && present {
-        return "Not enough values";
+        return "Not enough values: expected " + _numArgs:string + 
+               " got " + valueCount:string;
       } else {
         return "";
       }
@@ -295,9 +288,6 @@ module MasonArgParse {
             throw new ArgumentError("\\".join(act._name) + " has extra values");
           }       
         } 
-        // else if endPos < argsList.size && endPos + rest.size < argsList.size {
-        //   throw new ArgumentError("\\".join(act._name) + " has extra values");
-        // }
       }
       // make sure all options defined got values if needed
       _checkSatisfiedOptions();

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -23,7 +23,7 @@ module MasonArgParse {
   private use IO;
   private use Sort;
 
-  const DEBUG=false;
+  const DEBUG=true;
   // TODO: Add bool flags
   // TODO: Add positional arguments
   // TODO: Add pass-thru options following "-" or "--"

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -23,7 +23,7 @@ module MasonArgParse {
   private use IO;
   private use Sort;
 
-  const DEBUG=true;
+  const DEBUG=false;
   // TODO: Add bool flags
   // TODO: Add positional arguments
   // TODO: Add pass-thru options following "-" or "--"
@@ -238,14 +238,16 @@ module MasonArgParse {
           argsList.insert(idx, elems.toArray());
         }
       }
-      
+
       for i in argsList.indices {
-        const argElt = argsList[i];
+        const argElt = argsList[i];        
         if _options.contains(argElt) {
+          var optName = _options.getValue(argElt);
+          var argRslt = _result.getValue(optName);
           debugTrace("found option " + argElt);
           // create an entry for this index and the argument name
-          optionIndices.add(i, _options.getValue(argElt));
-          _result.getValue(_options.getValue(argElt))._present = true;          
+          optionIndices.add(i, optName);
+          argRslt._present = true;
         }
       }
       
@@ -282,11 +284,21 @@ module MasonArgParse {
                  + arrayoptionIndices.size:string);
         debugTrace("argsList.size = " + argsList.size:string);
         debugTrace("argsD.high = " + argsD.high:string);
+        //check if we consumed the rest of the arguments
+        if rest.size + endPos == argsList.size {
+          // stop processing more arguments, let subcommand eat the rest
+          // needed when a subcommand defines same flag as parent command
+          // or else the parent command will try to match on the subcommand arg
+          debugTrace("Subcommand " + act._name +" consumes rest of arguments");
+          break;
+        }
+
         // make sure we don't overrun the array,
-        // then check that we don't have extra values
+        // then check that we don't have extra values        
         if k < arrayoptionIndices.size {
           if endPos != arrayoptionIndices[k][0] {
-            debugTrace("endpos != arrayoptionIndices[k][0] :"+endPos:string+" "
+            debugTrace("Rest.size= " + rest.size:string);
+            debugTrace("endpos != arrayoptionIndices[k][0] :"+endPos:string+"!="
                      + arrayoptionIndices[k][0]:string);
             debugTrace("arrayoptionIndices " + arrayoptionIndices:string);
             throw new ArgumentError("\\".join(act._name) + " has extra values");


### PR DESCRIPTION
This PR adds subcommands to the argument parser. 

Scope of work defined in Cray/chapel-private#2298, this work satisfies
the main goals of that issue which are to:

1. Allow the developer to add subcommands to their CLI
2. Allow options and subcommands entered together

Relates to broader implementation task in Cray/chapel-private#2192

Tests added for subcommands and mixing subcommands with options.

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/mason-argparse`

Reviewed by @mppf

Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com