### PR TITLE
Extend c2chapel to use GNU parser and add general c2chapel features

### DIFF
--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,2 +1,3 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
 pycparser==2.20
+pycparserext>=2013.1

--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -6,6 +6,7 @@ require "arrayDecl.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern var intArr : c_ptr(c_int);
 
 extern var stringList : c_ptr(c_string);

--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -6,11 +6,12 @@ require "chapelKeywords.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc foo(out_arg : c_int, ref_arg : c_char) : c_int;
 
 // Unable to generate function 'coforall' because its name is a Chapel keyword
 
-extern proc foo2(lambda_arg : c_double) : c_int;
+extern proc foo2(lambda_arg : real(64)) : c_int;
 
 // ==== c2chapel typedefs ====
 

--- a/tools/c2chapel/test/chapelVarargs.chpl
+++ b/tools/c2chapel/test/chapelVarargs.chpl
@@ -6,6 +6,7 @@ require "chapelVarargs.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc printf_wrapper(format : c_string, c__varargs ...) : void;
 
 // Overload for empty varargs

--- a/tools/c2chapel/test/cstrvoid.chpl
+++ b/tools/c2chapel/test/cstrvoid.chpl
@@ -6,6 +6,7 @@ require "cstrvoid.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc arg_c_string(str : c_string, n : c_int) : void;
 
 extern proc arg_c_void_ptr(ptr : c_void_ptr) : void;

--- a/tools/c2chapel/test/dashEye.chpl
+++ b/tools/c2chapel/test/dashEye.chpl
@@ -6,6 +6,7 @@ require "dashEye.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc otherFunction(ref arr : c_int) : void;
 
 extern proc otherFunction(arr : c_ptr(c_int)) : void;

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -6,6 +6,7 @@ require "enum.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 // Enum: anonymous
 extern const TEST_STATUS_PASSED :c_int;
 extern const TEST_STATUS_FAILED :c_int;

--- a/tools/c2chapel/test/enumVar.chpl
+++ b/tools/c2chapel/test/enumVar.chpl
@@ -6,6 +6,7 @@ require "enumVar.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 // Enum: E
 extern const UP :c_int;
 extern const DOWN :c_int;

--- a/tools/c2chapel/test/fileGlobals.chpl
+++ b/tools/c2chapel/test/fileGlobals.chpl
@@ -6,6 +6,7 @@ require "fileGlobals.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern var globalInt : c_int;
 
 extern var globalChar : c_char;

--- a/tools/c2chapel/test/fnPointers.chpl
+++ b/tools/c2chapel/test/fnPointers.chpl
@@ -6,16 +6,19 @@ require "fnPointers.h";
 // Note: Generated with fake std headers
 
 use CPtr;
-extern proc fnPointerArgs(callback : c_fn_ptr, msg : c_string) : c_int;
+use SysCTypes;
+extern proc fnPointerArgs(ref callback : c_fn_ptr, msg : c_string) : c_int;
+
+extern proc fnPointerArgs(callback : c_ptr(c_fn_ptr), msg : c_string) : c_int;
 
 extern proc foo(a : myFunctionPointer, b : c_int) : c_int;
 
 // ==== c2chapel typedefs ====
 
 extern record io_methods {
-  var close : c_fn_ptr;
-  var open : c_fn_ptr;
+  var close : c_ptr(c_fn_ptr);
+  var open : c_ptr(c_fn_ptr);
 }
 
-extern type myFunctionPointer = c_fn_ptr;
+extern type myFunctionPointer = c_ptr(c_fn_ptr);
 

--- a/tools/c2chapel/test/fnints.chpl
+++ b/tools/c2chapel/test/fnints.chpl
@@ -6,6 +6,7 @@ require "fnints.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc firstFunc(a : c_int, b : c_int, c : c_int) : void;
 
 extern proc secondFunc(a : c_int, ref b : c_int, ref c : c_ptr(c_int)) : void;

--- a/tools/c2chapel/test/gnuParserTest.chpl
+++ b/tools/c2chapel/test/gnuParserTest.chpl
@@ -1,0 +1,29 @@
+// Generated with c2chapel version 0.1.0
+
+// Header given to c2chapel:
+require "gnuParserTest.h";
+
+// Note: Generated with fake std headers
+
+use CPtr;
+use SysCTypes;
+extern var a : c_longlong;
+
+extern var b : c_short;
+
+extern var c : c_int;
+
+extern var d : c_longlong;
+
+extern var e : c_long;
+
+extern var c2chapel_string : c_int;
+
+extern var c2chapel_bytes : real(64);
+
+extern proc testFun(_data : c_int) : c_int;
+
+// ==== c2chapel typedefs ====
+
+extern type GMainContextPusher;
+

--- a/tools/c2chapel/test/gnuParserTest.h
+++ b/tools/c2chapel/test/gnuParserTest.h
@@ -1,0 +1,23 @@
+// test new types
+long double a;
+signed short b;
+signed int c;
+signed long long d;
+signed long e;
+
+// test variable named string and bytes
+int string;
+double bytes;
+
+// void typedef, previously an error
+typedef void GMainContextPusher;
+
+// GNU expression in return
+static inline
+int
+testFun(
+ int _data
+ )
+{
+ return (int)((_data << 8) | (_data >> 8));
+}

--- a/tools/c2chapel/test/intDefines.chpl
+++ b/tools/c2chapel/test/intDefines.chpl
@@ -6,6 +6,7 @@ require "intDefines.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 // #define'd integer literals:
 // Note: some of these may have been defined with an ifdef
 extern const FOO_OK : int;

--- a/tools/c2chapel/test/justC.chpl
+++ b/tools/c2chapel/test/justC.chpl
@@ -3,6 +3,7 @@
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc foobar(x : c_int) : c_int;
 
 extern proc main() : c_int;

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -6,6 +6,7 @@ require "miscTypedef.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern record simpleStruct {
   var a : c_int;
   var b : c_char;

--- a/tools/c2chapel/test/miscTypedefUnion.chpl
+++ b/tools/c2chapel/test/miscTypedefUnion.chpl
@@ -6,6 +6,7 @@ require "miscTypedefUnion.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern union simpleUnion {
   var a : c_int;
   var b : c_char;

--- a/tools/c2chapel/test/nestedStruct.chpl
+++ b/tools/c2chapel/test/nestedStruct.chpl
@@ -6,6 +6,7 @@ require "nestedStruct.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern record first {
   var a : c_int;
   var b : c_string;

--- a/tools/c2chapel/test/nestedUnion.chpl
+++ b/tools/c2chapel/test/nestedUnion.chpl
@@ -6,6 +6,7 @@ require "nestedUnion.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern union first {
   var a : c_int;
   var b : c_string;

--- a/tools/c2chapel/test/opaqueStruct.chpl
+++ b/tools/c2chapel/test/opaqueStruct.chpl
@@ -6,6 +6,7 @@ require "opaqueStruct.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern record foobar {
   var a : c_int;
   var b : c_int;

--- a/tools/c2chapel/test/opaqueUnion.chpl
+++ b/tools/c2chapel/test/opaqueUnion.chpl
@@ -6,6 +6,7 @@ require "opaqueUnion.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern union foobar {
   var a : c_int;
   var b : c_int;

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -6,6 +6,7 @@ require "simpleRecords.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern record allInts {
   var a : c_int;
   var b : c_uint;

--- a/tools/c2chapel/test/sysCTypes.chpl
+++ b/tools/c2chapel/test/sysCTypes.chpl
@@ -6,6 +6,7 @@ require "sysCTypes.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
 extern proc test_int(a : c_int, ref b : c_int) : c_int;
 
 extern proc test_int(a : c_int, b : c_ptr(c_int)) : c_int;


### PR DESCRIPTION
This PR extends c2chapel to use GNU parser instead of the default pycparser parser. This results in a bit slower parsing according to docs that I have read (although, I haven't actually tested this performance), but this doesn't seem to be a concern with c2chapel. 

This PR adds the following features to c2chapel:
- void typedefs are now blank
  - Before, they were left with an `= ;`, which was causing an error
- New types that hadn't been seen before are now included
  - Old c2chapel (outdated?) code that generated Chapel types that don't exist fixed
- New reserved words that hadn't been seen yet are now included
  - And also work for general variables, where before it was only arguments to functions
- New test added to test these features/old tests updated
- Handling of GNUisms
- `use SysCTypes;` added by default 
  - pretty much guaranteed you will need it to run the generated c2chapel code, even for most of the old tests that wouldn't build after being run through c2chapel

Resolves https://github.com/Cray/chapel-private/issues/2309
Longer term effort: https://github.com/Cray/chapel-private/issues/2294