### PR TITLE
Llvm intrinsic attributes test

### DIFF
--- a/test/gpu/native/llvmIntrinsicAttributes/.gitignore
+++ b/test/gpu/native/llvmIntrinsicAttributes/.gitignore
@@ -1,0 +1,3 @@
+llvmIntrinsicAttributes.good
+llvmIntrinsicAttributes-cuda-nvptx64-nvidia-cuda-sm_60.ll
+llvmIntrinsicAttributes.ll

--- a/test/gpu/native/llvmIntrinsicAttributes/CLEANFILES
+++ b/test/gpu/native/llvmIntrinsicAttributes/CLEANFILES
@@ -1,0 +1,3 @@
+llvmIntrinsicAttributes.good
+llvmIntrinsicAttributes-cuda-nvptx64-nvidia-cuda-sm_60.ll
+llvmIntrinsicAttributes.ll

--- a/test/gpu/native/llvmIntrinsicAttributes/README
+++ b/test/gpu/native/llvmIntrinsicAttributes/README
@@ -1,0 +1,12 @@
+The purpose of this test is to demonstrate that the attributes that clang
+applies when the intrinsic llvm.nvvm.read.ptx.sreg.tid.x is used is the same
+attributes that will be applied when Chapel uses the intrinsic. 
+
+Why do we care?
+
+The assumption is the clang knows best what attributes should be placed on this
+intrinsic. Unfortunately I haven't figured out a way to construct the
+declaration to this intrinsic function by calling out to the Clang API, so I
+end up manually constructing the LLVM IR for it. For now everything matches as
+we expect\want, but if Clang updates to give more specific \ better attributes
+it would be nice to have this test fail to inform us.

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.chpl
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.chpl
@@ -1,0 +1,8 @@
+use CPtr;
+
+pragma "codegen for GPU"
+pragma "always resolve function"
+export proc sample_kernel(dst_ptr: c_ptr(real(64))) {
+  dst_ptr[0] = __primitive("gpu threadIdx x");
+}
+

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.compopts
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.compopts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+nvccDir=$(which nvcc)
+nvccLib=${nvccDir%/bin/nvcc}/lib64
+
+echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda --llvm-print-ir-stage full --llvm-print-ir sample_kernel"

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.cu
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.cu
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+__global__ void sample_kernel() {
+    int i = threadIdx.x;
+    printf("thread %d\n", i);
+}
+
+int main() {
+  sample_kernel<<<1,1>>>();
+}

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.precomp
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.precomp
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+clang -S -emit-llvm llvmIntrinsicAttributes.cu --cuda-gpu-arch=sm_60 -L/global/opt/nvidia/cuda-11.0/lib64/ -lcudart_static -pthread
+
+# We're expecting to see the following declaration for the intrinsic to get 
+# a thread ID from the CUDA kernel.  I'm locking down that this intrinsic has
+# id #2 as I use this id to later search for the attributes on the intrinsic.
+#
+# declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #2
+#
+# We generate a good file that includes the declaration line and the line for
+# the attributes on that declaration.
+
+CLANG_IR_DUMP_FILE="llvmIntrinsicAttributes-cuda-nvptx64-nvidia-cuda-sm_60.ll"
+grep "declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #2" $CLANG_IR_DUMP_FILE > llvmIntrinsicAttributes.good
+grep "attributes #2" $CLANG_IR_DUMP_FILE >> llvmIntrinsicAttributes.good

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.prediff
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+LINE1=`grep "declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #2" $2`
+LINE2=`grep "attributes #2" $2`
+echo $LINE1 > $2
+echo $LINE2 >> $2


### PR DESCRIPTION
Add llvmIntrinsicAttributes_test test.

The purpose of this test is to demonstrate that the attributes that clang applies when the intrinsic llvm.nvvm.read.ptx.sreg.tid.x is used is the same attributes that will be applied when Chapel uses the intrinsic. 

Why do we care?

The assumption is the clang knows best what attributes should be placed on this intrinsic. Unfortunately I haven't figured out a way to construct the declaration to this intrinsic function by calling out to the Clang API, so I end up manually constructing the LLVM IR for it. For now everything matches as we expect\want, but if Clang updates to give more specific \ better attributes it would be nice to have this test fail to inform us.

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>