### PR TITLE
Ensure we give a better error message if llvm-config is not in path.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,8 +58,8 @@ jobs:
         fetch-depth: 100000
     - name: check annotations
       run: |
-        make test-venv
-        CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
+        CHPL_LLVM=none make test-venv
+        CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
 
   bad_rt_calls:
     runs-on: ubuntu-latest

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -142,7 +142,7 @@ def find_system_llvm_config():
     if command and version and not config_err:
         return found[0]
 
-    return ''
+    return 'none'
 
 
 @memoize

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -131,6 +131,12 @@ ENV_VALS = {}
 def compute_all_values():
     global ENV_VALS
 
+    # error checking that would be hard to do in the .get functions
+    # due to circular dependencies
+    chpl_arch.validate('host')
+    chpl_arch.validate('target')
+    chpl_llvm.validate_llvm_config()
+
     ENV_VALS['CHPL_HOME'] = chpl_home_utils.get_chpl_home()
     ENV_VALS['CHPL_HOST_PLATFORM'] = chpl_platform.get('host')
 
@@ -189,11 +195,6 @@ def compute_all_values():
     ENV_VALS['CHPL_SANITIZE'] = chpl_sanitizers.get()
     ENV_VALS['CHPL_SANITIZE_EXE'] = chpl_sanitizers.get('exe')
 
-    # error checking that would be hard to do in the .get functions
-    # due to circular dependencies
-    chpl_arch.validate('host')
-    chpl_arch.validate('target')
-    chpl_llvm.validate_llvm_config()
 
 """Compute '--internal' env var values and populate global dict, ENV_VALS"""
 def compute_internal_values():


### PR DESCRIPTION
Prior to this change, if you run `printchplenv` (or if you run make to build Chapel which in turn will call `printchplenv` for you) you would get the following error:

 `OSError: command not found:`

With this change we now print the following error message:

 `Exception: CHPL_LLVM=system but could not find an installed LLVM with one of the supported versions: 11`

I've run paratest to ensure this doesn't break anything, but I'd like someone familiar with printchplenv to let me know if they anticipate that there would be any issue with moving when we do these checks.

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>