### PR TITLE
Add llvm handling for basic macros used by LAPACK tests

### DIFF
--- a/compiler/include/LayeredValueTable.h
+++ b/compiler/include/LayeredValueTable.h
@@ -40,6 +40,7 @@ namespace clang {
   class NamedDecl;
   class TypeDecl;
   class ValueDecl;
+  class MacroInfo;
 }
 
 #include "llvm/ADT/StringMap.h"
@@ -84,6 +85,8 @@ class LayeredValueTable
         VarSymbol* chplVar;
         // For macros
         const char* castChplVarTo;
+        const char* forwardToName;
+        const clang::MacroInfo* macro;
       } u;
       int8_t isLVPtr;
       bool isUnsigned;
@@ -102,6 +105,8 @@ class LayeredValueTable
         u.cValueDecl = NULL;
         u.chplVar = NULL;
         u.castChplVarTo = NULL;
+        u.forwardToName = NULL;
+        u.macro = NULL;
         isLVPtr = GEN_VAL;
         isUnsigned = false;
         addedToChapelAST = false;
@@ -127,6 +132,8 @@ class LayeredValueTable
     void addGlobalCDecl(llvm::StringRef name, clang::NamedDecl* cdecl, const char* castToType=NULL);
     void addGlobalVarSymbol(llvm::StringRef name, VarSymbol* var, const char* castToType=NULL);
     void addBlock(llvm::StringRef name, llvm::BasicBlock *block);
+    void addMacro(llvm::StringRef name, const clang::MacroInfo *macro);
+    void addForwardName(llvm::StringRef name, const char* forwardName);
     GenRet getValue(llvm::StringRef name);
     llvm::BasicBlock *getBlock(llvm::StringRef name);
     llvm::Type *getType(llvm::StringRef name, bool* isUnsigned=NULL);
@@ -135,7 +142,7 @@ class LayeredValueTable
         astlocT *astlocOut=NULL);
     bool isCArray(llvm::StringRef name);
     VarSymbol* getVarSymbol(llvm::StringRef name);
- 
+    const clang::MacroInfo* getMacro(llvm::StringRef name); 
     bool isAlreadyInChapelAST(llvm::StringRef name);
     bool markAddedToChapelAST(llvm::StringRef name);
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -389,6 +389,7 @@ static astlocT getClangDeclLocation(clang::Decl* d) {
 static const bool debugPrintMacros = false;
 
 static void handleMacroExpr(const MacroInfo* inMacro,
+                            const IdentifierInfo* origID,
                             MacroInfo::tokens_iterator start,
                             MacroInfo::tokens_iterator end,
                             VarSymbol*& varRet,
@@ -396,6 +397,85 @@ static void handleMacroExpr(const MacroInfo* inMacro,
                             ValueDecl*& cValueRet,
                             const char*& cCastToTypeRet);
 
+static void handleCallMacro(const IdentifierInfo* origID,
+                            const MacroInfo* inMacro,
+                            const MacroInfo* calledMacro) {
+  if (inMacro->getNumTokens() != 6)
+    return;
+  if (calledMacro->getNumParams() != 2)
+    return;
+  if (calledMacro->getNumTokens() != 3)
+    return;
+
+  // expect 'LAPACK_GLOBAL' '(' 'actual1' ',' 'actual2' ')'
+  Token actual1, actual2;
+  int count = 0;
+  for (MacroInfo::tokens_iterator tok = inMacro->tokens_begin();
+       tok != inMacro->tokens_end(); ++tok) {
+    count++;
+    if (count == 3)
+      actual1 = *tok;
+    if (count == 5)
+      actual2 = *tok;
+  }
+
+  IdentifierInfo* formal1;
+  IdentifierInfo* formal2;
+  count = 0;
+  for (MacroInfo::param_iterator param = calledMacro->param_begin();
+       param != calledMacro->param_end(); ++param) {
+    count++;
+    if (count == 1)
+      formal1 = *param;
+    if (count == 2)
+      formal2 = *param;
+  }
+
+  // expecting 'identifier' ## '_'
+  count = 0;
+  Token body1, body2, body3;
+  for (MacroInfo::tokens_iterator tok = calledMacro->tokens_begin();
+       tok != calledMacro->tokens_end(); ++tok) {
+    count++;
+    if (count == 1) {
+      if (tok->getKind() != tok::identifier)
+        return;
+      body1 = *tok;
+    }
+    if (count == 2) {
+      if (tok->getKind() != tok::hashhash)
+        return;
+      body2 = *tok;
+    }
+    if (count == 3) {
+      if (tok->getKind() != tok::identifier)
+        return;
+      body3 = *tok;
+    }
+  }
+
+  llvm::StringRef lhsName;
+  if (body1.getIdentifierInfo()->getName() == formal1->getName()) {
+    lhsName = actual1.getIdentifierInfo()->getName();
+  } else if (body1.getIdentifierInfo()->getName() == formal2->getName()) {
+    lhsName = actual2.getIdentifierInfo()->getName();
+  } else {
+    return;
+  }
+
+  std::string replacement = lhsName.str() +
+                            body3.getIdentifierInfo()->getName().str();
+
+  GenInfo* info = gGenInfo;
+  INT_ASSERT(info);
+
+  info->lvt->addForwardName(origID->getName(), replacement.c_str());
+
+  if (debugPrintMacros) {
+    printf("replacing: %s with %s\n", origID->getName().str().c_str(),
+                                      replacement.c_str());
+  }
+}
 
 // Adds a mapping from id->getName() to a variable or CDecl to info->lvt
 static
@@ -406,9 +486,10 @@ void handleMacro(const IdentifierInfo* id, const MacroInfo* macro)
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
 
+  std::string name = id->getName().str();
   const bool debugPrint = debugPrintMacros;
 
-  if (debugPrint) printf("Working on macro %s\n", id->getName().str().c_str());
+  if (debugPrint) printf("Working on macro %s\n", name.c_str());
 
   //Handling only simple string or integer defines
   if (macro->getNumParams() > 0)
@@ -416,7 +497,11 @@ void handleMacro(const IdentifierInfo* id, const MacroInfo* macro)
     if( debugPrint) {
       printf("the macro takes arguments\n");
     }
-    return; // TODO -- handle macro functions.
+    if (name == "LAPACK_GLOBAL") {
+      info->lvt->addMacro(name, macro);
+    } else {
+      return; // TODO -- handle macro functions.
+    }
   }
 
   VarSymbol* varRet = NULL;
@@ -424,7 +509,7 @@ void handleMacro(const IdentifierInfo* id, const MacroInfo* macro)
   ValueDecl* cValueRet = NULL;
   const char* cCastToTypeRet = NULL;
 
-  handleMacroExpr(macro,
+  handleMacroExpr(macro, id,
                   macro->tokens_begin(), macro->tokens_end(),
                   varRet, cTypeRet, cValueRet, cCastToTypeRet);
 
@@ -520,9 +605,11 @@ static bool findParenthesizedExpr(const MacroInfo* inMacro,
 
 // Returns a type/identifier/macro name or NULL if it was not handled
 static const char* handleTypeOrIdentifierExpr(const MacroInfo* inMacro,
+                                              const IdentifierInfo* origID,
                                               MacroInfo::tokens_iterator start,
                                               MacroInfo::tokens_iterator end,
                                               IdentifierInfo*& ii) {
+  GenInfo* info = gGenInfo;
   ii = NULL;
 
   // handle things like 'unsigned int'
@@ -578,14 +665,16 @@ static const char* handleTypeOrIdentifierExpr(const MacroInfo* inMacro,
     Token tok = *start; // the main token
     ++start;
 
-    // Give up if there are any tokens beyond the main token
-    if (start != end)
-      return NULL;
-
     if (tok.getKind() == tok::identifier) {
       IdentifierInfo* tokId = tok.getIdentifierInfo();
       ii = tokId;
-      return astr(tokId->getNameStart());
+      if (const clang::MacroInfo* macro =
+            info->lvt->getMacro(tokId->getName())) {
+        INT_ASSERT(origID != NULL);
+        handleCallMacro(origID, inMacro, macro);
+      } else {
+        return astr(tokId->getNameStart());
+      }
     }
   } else {
     // Give up if we didn't handle all the tokens in the above loop
@@ -738,7 +827,7 @@ static bool handleNumericCastExpr(const MacroInfo* inMacro,
 
     const char* castTo = NULL;
     clang::IdentifierInfo* ii = NULL;
-    castTo = handleTypeOrIdentifierExpr(inMacro, castStart, castEnd, ii);
+    castTo = handleTypeOrIdentifierExpr(inMacro, NULL, castStart, castEnd, ii);
     if (castTo == NULL)
       return false;
     start = castEnd;
@@ -750,7 +839,7 @@ static bool handleNumericCastExpr(const MacroInfo* inMacro,
     ValueDecl* tmpVal = NULL;
     const char* tmpCastToType = NULL;
 
-    handleMacroExpr(inMacro, castStart, castEnd,
+    handleMacroExpr(inMacro, NULL, castStart, castEnd,
                     tmpVar, tmpType, tmpVal, tmpCastToType);
 
     if (tmpType == NULL || tmpCastToType != NULL)
@@ -1018,6 +1107,7 @@ static bool handleNumericBinOpExpr(const MacroInfo* inMacro,
 }
 
 static void handleMacroExpr(const MacroInfo* inMacro,
+                            const IdentifierInfo* origID,
                             MacroInfo::tokens_iterator start,
                             MacroInfo::tokens_iterator end,
                             VarSymbol*& varRet,
@@ -1049,12 +1139,13 @@ static void handleMacroExpr(const MacroInfo* inMacro,
          cur != end;
          ++cur) {
       Token t = *cur;
-      printf("Found token type %i\n", t.getKind());
+      printf("Found token type %i name %s\n", t.getKind(), t.getName());
     }
   }
 
   clang::IdentifierInfo* ii = NULL;
-  const char* idName = handleTypeOrIdentifierExpr(inMacro, start, end, ii);
+  const char* idName = handleTypeOrIdentifierExpr(inMacro, origID,
+                                                  start, end, ii);
   if (idName != NULL) {
     if( debugPrint) {
       printf("id = %s\n", idName);
@@ -2707,8 +2798,25 @@ void LayeredValueTable::addBlock(StringRef name, llvm::BasicBlock *block) {
   (*blockLayer)[name] = store;
 }
 
+void LayeredValueTable::addMacro(StringRef name,
+                                 const clang::MacroInfo *macro) {
+  Storage store;
+  store.u.macro = macro;
+  (layers.back())[name] = store;
+}
+
+void LayeredValueTable::addForwardName(llvm::StringRef name, const char* forwardName) {
+  Storage store;
+  store.u.forwardToName = astr(forwardName);
+  (layers.back())[name] = store;
+}
+
 GenRet LayeredValueTable::getValue(StringRef name) {
   if(Storage *store = get(name)) {
+    if (store->u.forwardToName) {
+      store = get(store->u.forwardToName);
+    }
+
     if( store->u.value ) {
       INT_ASSERT(isa<Value>(store->u.value));
       GenRet ret;
@@ -2797,6 +2905,9 @@ void LayeredValueTable::getCDecl(StringRef name, TypeDecl** cTypeOut,
   if (cCastedToTypeOut) *cCastedToTypeOut = NULL;
 
   if(Storage *store = get(name)) {
+    if (store->u.forwardToName) {
+      store = get(store->u.forwardToName);
+    }
     if( store->u.cValueDecl ) {
       INT_ASSERT(isa<ValueDecl>(store->u.cValueDecl));
       // we have a clang value decl.
@@ -2834,6 +2945,16 @@ VarSymbol* LayeredValueTable::getVarSymbol(StringRef name) {
       // maybe immediate number or string, possibly variable reference.
       // These come from macros.
       return store->u.chplVar;
+    }
+  }
+  return NULL;
+}
+
+const clang::MacroInfo* LayeredValueTable::getMacro(StringRef name) {
+  if (Storage *store = get(name)) {
+    if (store->u.macro) {
+      INT_ASSERT(isa<clang::MacroInfo>(store->u.macro));
+      return store->u.macro;
     }
   }
   return NULL;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -665,6 +665,19 @@ static const char* handleTypeOrIdentifierExpr(const MacroInfo* inMacro,
     Token tok = *start; // the main token
     ++start;
 
+    if (start != end) {
+      /* return NULL unless it's a specific pattern we know how to handle */
+      bool canHandle = false;
+      if (tok.getKind() == tok::identifier) {
+        IdentifierInfo* tokId = tok.getIdentifierInfo();
+        if (const clang::MacroInfo* macro
+              = info->lvt->getMacro(tokId->getName()))
+          canHandle = true;
+      }
+      if (!canHandle)
+        return NULL;
+    }
+
     if (tok.getKind() == tok::identifier) {
       IdentifierInfo* tokId = tok.getIdentifierInfo();
       ii = tokId;


### PR DESCRIPTION
When we encounter the LAPACK_GLOBAL macro add it and its clang::MacroInfo to
the LayeredValueTable. Then when processing the macros that call LAPACK_GLOBAL,
look it up in the LVT and compute the call's result using the arguments at
the call site. Add the mapping from the outer macro's name to the call's
computed forwarding result to the LVT.

When looking up a name in the LVT, check if it has a forwarded name and if
it does use that instead.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>
