### PR TITLE
Extend bounded coforall optimization to zippered loops

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1210,7 +1210,7 @@ static BlockStmt* buildLoweredCoforall(Expr* indices,
   if (bounded) {
     if (!onBlock) { block->insertAtHead(new CallExpr("chpl_resetTaskSpawn", numTasks)); }
     block->insertAtHead(new CallExpr("_upEndCount", coforallCount, countRunningTasks, numTasks));
-    block->insertAtHead(new CallExpr(PRIM_MOVE, numTasks, new CallExpr("chpl_boundedCoforallSize", iterator)));
+    block->insertAtHead(new CallExpr(PRIM_MOVE, numTasks, new CallExpr("chpl_boundedCoforallSize", iterator, zippered ? gTrue : gFalse)));
     block->insertAtHead(new DefExpr(numTasks));
     block->insertAtTail(new DeferStmt(new CallExpr("_endCountFree", coforallCount)));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, countRunningTasks, numTasks));
@@ -1311,7 +1311,7 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
   isBounded->addFlag(FLAG_MAYBE_PARAM);
   coforallBlk->insertAtTail(new DefExpr(isBounded));
 
-  coforallBlk->insertAtTail(new CallExpr(PRIM_MOVE, isBounded, new CallExpr("chpl_supportsBoundedCoforall", tmpIter)));
+  coforallBlk->insertAtTail(new CallExpr(PRIM_MOVE, isBounded, new CallExpr("chpl_supportsBoundedCoforall", tmpIter, zippered ? gTrue : gFalse)));
 
   coforallBlk->insertAtTail(new CondStmt(new SymExpr(isBounded),
                                          vectorCoforallBlk,

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1210,7 +1210,7 @@ static BlockStmt* buildLoweredCoforall(Expr* indices,
   if (bounded) {
     if (!onBlock) { block->insertAtHead(new CallExpr("chpl_resetTaskSpawn", numTasks)); }
     block->insertAtHead(new CallExpr("_upEndCount", coforallCount, countRunningTasks, numTasks));
-    block->insertAtHead(new CallExpr(PRIM_MOVE, numTasks, new CallExpr("chpl_coforallSize", iterator)));
+    block->insertAtHead(new CallExpr(PRIM_MOVE, numTasks, new CallExpr("chpl_boundedCoforallSize", iterator)));
     block->insertAtHead(new DefExpr(numTasks));
     block->insertAtTail(new DeferStmt(new CallExpr("_endCountFree", coforallCount)));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, countRunningTasks, numTasks));
@@ -1242,10 +1242,10 @@ static void removeWrappingBlock(BlockStmt*& block) {
 // This effectively builds up:
 //
 //     var tmpIter = iterator;
-//     param bounded = isBoundedRange(tmpIter) || isDomain(tmpIter) || isArray(tmpIter);
+//     param isBounded = chpl_supportsBoundedCoforall(tmpIter);
 //     param useLocalEndCount, countRunningTasks = !bodyContainsOnStmt();
-//     if bounded {
-//       var numTasks = tmpIter.size;
+//     if isBounded {
+//       var numTasks = chpl_boundedCoforallSize(tmpIter);
 //       var _coforallCount = _endCountAlloc(useLocalEndCount);
 //       // only bump EndCount once, instead of once per task
 //       _upEndCount(_coforallCount, countRunningTasks, numTasks);
@@ -1307,15 +1307,13 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
   BlockStmt* vectorCoforallBlk = buildLoweredCoforall(indices, tmpIter, copyByrefVars(byref_vars), body->copy(), zippered, /*bounded=*/true);
   BlockStmt* nonVectorCoforallBlk = buildLoweredCoforall(indices, tmpIter, byref_vars, body, zippered, /*bounded=*/false);
 
-  VarSymbol* isRngDomArr = newTemp("isRngDomArr");
-  isRngDomArr->addFlag(FLAG_MAYBE_PARAM);
-  coforallBlk->insertAtTail(new DefExpr(isRngDomArr));
+  VarSymbol* isBounded = newTemp("isBounded");
+  isBounded->addFlag(FLAG_MAYBE_PARAM);
+  coforallBlk->insertAtTail(new DefExpr(isBounded));
 
-  coforallBlk->insertAtTail(new CallExpr(PRIM_MOVE, isRngDomArr,
-                            new CallExpr("||", new CallExpr("isBoundedRange", tmpIter),
-                            new CallExpr("||", new CallExpr("isDomain", tmpIter), new CallExpr("isArray", tmpIter)))));
+  coforallBlk->insertAtTail(new CallExpr(PRIM_MOVE, isBounded, new CallExpr("chpl_supportsBoundedCoforall", tmpIter)));
 
-  coforallBlk->insertAtTail(new CondStmt(new SymExpr(isRngDomArr),
+  coforallBlk->insertAtTail(new CondStmt(new SymExpr(isBounded),
                                          vectorCoforallBlk,
                                          nonVectorCoforallBlk));
   return coforallBlk;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -909,12 +909,14 @@ proc BlockDom.dsiBuildArray(type eltType, param initElts:bool) {
   var myLocArrTemp: unmanaged LocBlockArr(eltType, rank, idxType, stridable)?;
 
   // formerly in BlockArr.setup()
-  coforall localeIdx in dom.dist.targetLocDom with (ref myLocArrTemp) {
-    on dom.dist.targetLocales(localeIdx) {
+  coforall (loc, locDomsElt, locArrTempElt)
+           in zip(dom.dist.targetLocales, dom.locDoms, locArrTemp)
+           with (ref myLocArrTemp) {
+    on loc {
       const LBA = new unmanaged LocBlockArr(eltType, rank, idxType, stridable,
-                                            dom.getLocDom(localeIdx),
+                                            locDomsElt,
                                             initElts=initElts);
-      locArrTemp(localeIdx) = LBA;
+      locArrTempElt = LBA;
       if here.id == creationLocale then
         myLocArrTemp = LBA;
     }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2374,14 +2374,18 @@ module ChapelBase {
     return x;
   }
 
-
-  // This is a helper function that I injected to reduce the
-  // compiler's reliance on 'iterable.size' for coforall loops because
-  // we started generating warnings for the return type of
-  // '[range|domain|array].size' changing.
   //
-  proc chpl_coforallSize(iterable) {
-    if (isRange(iterable) || isDomain(iterable) || isArray(iterable)) then
+  // Support for bounded coforall task counting optimizations
+  //
+
+  proc chpl_supportsBoundedCoforall(iterable) param {
+    if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
+      return true;
+    return false;
+  }
+
+  proc chpl_boundedCoforallSize(iterable) {
+    if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
       return iterable.sizeAs(iterable.intIdxType);
     else
       return iterable.size;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2378,17 +2378,22 @@ module ChapelBase {
   // Support for bounded coforall task counting optimizations
   //
 
-  proc chpl_supportsBoundedCoforall(iterable) param {
-    if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
+  proc chpl_supportsBoundedCoforall(iterable, param zippered) param {
+    if zippered && isTuple(iterable) then
+      return chpl_supportsBoundedCoforall(iterable[0], zippered=false);
+    else if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
       return true;
-    return false;
+    else
+      return false;
   }
 
-  proc chpl_boundedCoforallSize(iterable) {
-    if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
+  proc chpl_boundedCoforallSize(iterable, param zippered) {
+    if zippered && isTuple(iterable) then
+      return chpl_boundedCoforallSize(iterable[0], zippered=false);
+    else if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
       return iterable.sizeAs(iterable.intIdxType);
     else
-      return iterable.size;
+      compilerError("Called chpl_boundedCoforallSize on an unsupported type");
   }
 
   /* The following chpl_field_*() overloads support compiler-generated

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2) (get = 9, put = 1) (get = 9, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 5, put = 1, execute_on = 2) (get = 5, put = 1) (get = 5, put = 1)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2) (get = 15, put = 1) (get = 15, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2) (get = 9, put = 1) (get = 9, put = 1)
 Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 20, put = 1, execute_on = 2) (get = 20, put = 1) (get = 20, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 12, put = 1, execute_on = 2) (get = 12, put = 1) (get = 12, put = 1)
 Dom4D
-(execute_on = 4, execute_on_nb = 6) (get = 25, put = 1, execute_on = 2) (get = 25, put = 1) (get = 25, put = 1)
-Dom2D32
 (execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2) (get = 15, put = 1) (get = 15, put = 1)
+Dom2D32
+(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2) (get = 9, put = 1) (get = 9, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.block.na-none.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 5, put = 1, execute_on = 2, execute_on_fast = 2) (get = 5, put = 1, execute_on_fast = 2) (get = 5, put = 1, execute_on_fast = 2)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2)
 Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 20, put = 1, execute_on = 2, execute_on_fast = 2) (get = 20, put = 1, execute_on_fast = 2) (get = 20, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 12, put = 1, execute_on = 2, execute_on_fast = 2) (get = 12, put = 1, execute_on_fast = 2) (get = 12, put = 1, execute_on_fast = 2)
 Dom4D
-(execute_on = 4, execute_on_nb = 6) (get = 25, put = 1, execute_on = 2, execute_on_fast = 2) (get = 25, put = 1, execute_on_fast = 2) (get = 25, put = 1, execute_on_fast = 2)
-Dom2D32
 (execute_on = 4, execute_on_nb = 6) (get = 15, put = 1, execute_on = 2, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2) (get = 15, put = 1, execute_on_fast = 2)
+Dom2D32
+(execute_on = 4, execute_on_nb = 6) (get = 9, put = 1, execute_on = 2, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2) (get = 9, put = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 27, put = 6, execute_on = 16, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 15, put = 6, execute_on = 16, execute_on_nb = 9) (get = 15, put = 3, execute_on = 11, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom2D
-(get = 45, put = 6, execute_on = 16, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 27, put = 6, execute_on = 16, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom3D
-(get = 60, put = 6, execute_on = 16, execute_on_nb = 9) (get = 60, put = 3, execute_on = 11, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_nb = 6)
+(get = 36, put = 6, execute_on = 16, execute_on_nb = 9) (get = 36, put = 3, execute_on = 11, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_nb = 6)
 Dom4D
-(get = 75, put = 6, execute_on = 16, execute_on_nb = 9) (get = 75, put = 3, execute_on = 11, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_nb = 6)
-Dom2D32
 (get = 45, put = 6, execute_on = 16, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_nb = 6)
+Dom2D32
+(get = 27, put = 6, execute_on = 16, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_nb = 6)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.block.na-none.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 27, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 15, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 15, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 15, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D
-(get = 45, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 27, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom3D
-(get = 60, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 60, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 60, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 36, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 36, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 36, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom4D
-(get = 75, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 75, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 75, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
-Dom2D32
 (get = 45, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 45, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 45, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+Dom2D32
+(get = 27, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 27, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 27, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)


### PR DESCRIPTION
#5018 and #6419 optimized bounded coforalls over ranges/domains/arrays
by reducing the number of times we manipulate the endCount. However, it
only did this for direct loops, and not zippered ones. The lack of this
optimization led to regressions from #17354, which changed some direct
coforalls to zippered ones. That PR reduced the amount of communication,
but the overhead from not triggering the bounded coforall optimization
outweighed that, so it was partially reverted in #17531.

This extends the bounded coforall optimization to trigger for zippered
loops and reverts #17531.

See also https://github.com/Cray/chapel-private/issues/1836
Resolves https://github.com/Cray/chapel-private/issues/1850
Resolves https://github.com/Cray/chapel-private/issues/1925