### PR TITLE
Fix typos

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4721,7 +4721,7 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   for_actuals(actual, call) {
     if (i >= nNonKernelParamArgs) {
       args.push_back(codegenAddrOf(actual));
-      i++; // probably unneccesary
+      i++; // probably unnecessary
     }
     else {
       args.push_back(actual->codegen());

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1479,7 +1479,7 @@ static void checkLLVMCodeGen() {
   // LLVM does not currently work on 32-bit x86
   bool unsupportedLlvmConfiguration = (0 == strcmp(CHPL_TARGET_ARCH, "i686"));
   if (fLlvmCodegen && unsupportedLlvmConfiguration)
-    USR_FATAL("CHPL_TARGET_COMPLIER=llvm not yet supported for this architecture");
+    USR_FATAL("CHPL_TARGET_COMPILER=llvm not yet supported for this architecture");
 
   if (0 == strcmp(CHPL_LLVM, "none")) {
     if (fLlvmCodegen)

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -366,7 +366,7 @@ static void parseCommandLineFiles() {
       {
         // error message to print placeholders for fileName and maxLength
         const char *errorMessage = "%s, filename is longer than maximum allowed length of %d\n";
-        // throwr error will concatenated messages
+        // throw error with concatenated message
         USR_FATAL(errorMessage, baseName, maxFileName);
       }
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -693,7 +693,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
     // when we didn't, tests like release/examples/primers/associative.chpl
     // and reductions/bradc/manual/promote.chpl failed their '--verify'
     // test runs for reasons that seemed puzzling and related to the
-    // intracacies of the _toFollower() code path; and it seemed unlikely
+    // intricacies of the _toFollower() code path; and it seemed unlikely
     // that they would care about default arguments and inheritance.
     //
     bool classDefaultArgCase = (fn->_this &&

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -172,7 +172,7 @@ istr(int i) {
 //
 // returns a canonicalized substring that contains the first part of
 // 's' up to 'e'
-// note: e must be a pointer that points within in s
+// note: e must be a pointer that points within s
 //
 const char* asubstr(const char* s, const char* e) {
   char* ss = (char*)malloc(e-s+1);

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -48,7 +48,7 @@ Functions and Methods
 
 Function and method names should be camelCase.
 
-Generally speaking, it's desireable to use methods on a value (vs
+Generally speaking, it's desirable to use methods on a value (vs
 functions that aren't methods) when there is a clear type responsible for
 the operation.
 

--- a/doc/rst/developer/implementation/Interfaces.md
+++ b/doc/rst/developer/implementation/Interfaces.md
@@ -116,7 +116,7 @@ Basic Syntax
 ------------
 
 ```chpl
-proc ..... where IFC_CONSTRAINT...  // where-clause constains 1 or more
+proc ..... where IFC_CONSTRAINT...  // where-clause contains 1 or more
 { .... }                            // interface constraints &&-ed together
 
 IFC_CONSTRAINT ::= implements IFC_NAME(TYPE...)

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4157,7 +4157,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
      :type rounding: ``round``
 
      .. warning::
-        If the denominator is zero, the progam behavior is undefined.
+        If the denominator is zero, the program behavior is undefined.
   */
   proc bigint.divQ(const ref numer: bigint,
                              denom: integral,

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -1169,8 +1169,8 @@ module DateTime {
      deprecated. */
   pragma "no doc"
   proc type datetime.strptime(date_string: string, format: string = "%a %b %d %H:%M:%S %Y") {
-    compilerWarning("proc type datetype.strptime() is deprecated.\nPlease use proc datetime.strptime() instead.");
-    /* intialization to epoch time */
+    compilerWarning("proc type datetime.strptime() is deprecated.\nPlease use proc datetime.strptime() instead.");
+    /* initialization to epoch time */
     var dt: datetime = new datetime(1970, 1, 1);
     try! dt.strptime(date_string, format);
     return dt;

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -818,7 +818,7 @@ proc replaceExt(path: string, newExt: string): string throws {
     if  basename.isEmpty() {
       throw new owned IllegalArgumentError(path, "has an empty basename");
     }
-    // check is extension contains spearator.
+    // check if extension contains separator.
     else if newExt.find(pathSep) != -1 {
       throw new owned IllegalArgumentError(newExt, "extension can't contain path separators");
     }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1339,7 +1339,7 @@ chpl_bool canBindTxCtxs(struct fi_info* info) {
 
   //
   // Gather invariant info.  The simplistic first-time check here is
-  // sufficent because we only get called from single-threaded code
+  // sufficient because we only get called from single-threaded code
   // while examining provider candidates.
   //
   static chpl_bool haveInvariants = false;

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -1907,7 +1907,7 @@ err_t sys_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds,
   got_nset = select(nfds, &temp_readfds, &temp_writefds, &temp_exceptfds, &first_timeout);
   if (got_nset == -1) err_out = errno; // save error
 
-  // check for error/success else check if first_timeout subtraced all the timeout.
+  // check for error/success else check if first_timeout subtracted all the timeout.
   if(got_nset != 0 || (timeout != NULL && second_timeout.tv_sec == 0 && second_timeout.tv_usec == 0)){
     *nset = got_nset;
     return err_out;

--- a/test/deprecated/strptime.good
+++ b/test/deprecated/strptime.good
@@ -1,3 +1,3 @@
 strptime.chpl:3: In function 'test_microsecond':
-strptime.chpl:4: warning: proc type datetype.strptime() is deprecated.
+strptime.chpl:4: warning: proc type datetime.strptime() is deprecated.
 Please use proc datetime.strptime() instead.


### PR DESCRIPTION
Fix typos in

stringutil.cpp, cg-expr.cpp, main/driver.cpp, resolution/wrappers.cpp
comm-ofi.c, qio/sys.c
StandardModuleStyle.rst, Interfaces.md
BigInteger.chpl, Path.chpl,
DateTime.chpl and test/deprecated/strptime.good,
