### PR TITLE
chplspell dictionary updates

### DIFF
--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -97,7 +97,8 @@ FILTEROUT="compiler/include/bison-chapel.h  \
            doc/rst/examples                 \
            modules/packages/HDF5.chpl       \
            modules/packages/LAPACK.chpl     \
-           modules/packages/NetCDF.chpl"
+           modules/packages/NetCDF.chpl     \
+           compiler/next"
 
 
 # Here endeth the configuration options.  The rest of the script

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -2595,6 +2595,8 @@ stylesheet
 
 FILEID: 3f2e197e-1d0a-11e6-a3a6-10ddb1d4c3d5
 fptr
+innerprec
+outerprec
 symi
 
 FILEID: 77ab2706-1d0a-11e6-a3a6-10ddb1d4c3d5
@@ -2729,6 +2731,7 @@ strconfig
 vfns
 
 FILEID: 98c778e4-1d83-11e6-a3a6-10ddb1d4c3d5
+doctmpdirname
 rfind
 
 FILEID: 9c85c382-1d83-11e6-a3a6-10ddb1d4c3d5
@@ -2950,6 +2953,7 @@ FILEID: 47cb0e3c-1f14-11e6-a3a6-10ddb1d4c3d5
 almt
 dptpl
 flwlen
+upcasting
 
 FILEID: c643ceac-1f14-11e6-a3a6-10ddb1d4c3d5
 chaoticmind
@@ -3165,6 +3169,7 @@ FILEID: 55301aa8-1f2e-11e6-a3a6-10ddb1d4c3d5
 abzoo
 azgx
 bbbb
+cwrx
 isopen
 takz
 xzob
@@ -3207,8 +3212,11 @@ bavail
 bfree
 blkcnt
 bsize
+getsockaddr
+hostlen
 mtim
 nlink
+numericport
 rdev
 takz
 
@@ -3233,8 +3241,15 @@ setstart
 
 FILEID: 74ec0768-2405-11e6-a3a6-10ddb1d4c3d5
 atim
+hostlen
+htonl
+htons
 mtim
 nlink
+numerichost
+numericport
+numericserv
+pton
 rdev
 winerr
 
@@ -3335,6 +3350,7 @@ chpldocumentation
 circularities
 desync
 eigvalsh
+geany
 gengraphs
 getcid
 globalvars
@@ -3346,6 +3362,7 @@ libmvec
 librt
 libtool
 lmod
+lstlisting
 memkind
 memleakslog
 nodbg
@@ -3359,6 +3376,7 @@ readwritethis
 schpl
 senable
 spack
+sserialize
 stdinredirect
 stripdirectories
 structors
@@ -3708,6 +3726,7 @@ vdebugstarted
 FILEID: 390fbcc4-4e3c-11e6-907f-843835579daa
 chplserversrc
 chpluserobj
+doctmpdirname
 incpath
 libmvec
 lmode
@@ -3730,6 +3749,7 @@ chapcs
 chplgmp
 coargsort
 dclass
+groupby
 kace
 linkedlist
 paircount
@@ -3849,6 +3869,8 @@ FILEID: c6d25ce8-a183-11e6-91b8-10ddb1d4c3d5
 atype
 bdce
 ccfbb
+rtemp
+rtemps
 urse
 uscore
 
@@ -4468,13 +4490,16 @@ rview
 FILEID: 40d00fe6-1a82-11e7-980e-10ddb1d4c3d5
 adim
 adom
+approxd
 arange
 aref
 athbf
 atype
+awad
 azero
 bdim
 bdom
+bpos
 brange
 bulu
 bzero
@@ -4486,21 +4511,26 @@ csrmatvec
 czero
 eigvals
 eigvalsh
+exactd
 extbf
 geev
 gelsd
 gemm
 gemv
 gesdd
+gesv
 gesvd
 getrf
 getri
 heev
+higham
 igma
 indptr
 ipiv
+issn
 itern
 jobz
+jpos
 lapacke
 lblas
 ldom
@@ -4510,12 +4540,18 @@ llapacke
 lrefblas
 matmat
 maxiter
+mohy
 nzcur
 nznew
+onenorm
+pade
 pdet
 pinv
 potrf
 rcond
+siam
+sincos
+sinm
 smmp
 superdiagonal
 superdiagonals
@@ -4544,9 +4580,11 @@ enumcomp
 rhsv
 
 FILEID: e95fef8a-2015-11e7-980e-10ddb1d4c3d5
+cformal
 cthis
 icts
 parg
+pformal
 pthis
 ptype
 
@@ -4619,6 +4657,7 @@ todelete
 FILEID: a4c82866-83ce-11e7-ad1f-10ddb1d4c3d5
 csat
 indx
+istms
 multipledestructor
 
 FILEID: 733029d2-8aba-11e7-b3f1-10ddb1d4c3d5
@@ -4748,9 +4787,11 @@ cfgav
 cfgfab
 cfgfabhints
 cfgfabsall
+chapcs
 cmpl
 cmpls
 cmplt
+cmpr
 commprogress
 comparand
 configmore
@@ -4771,6 +4812,7 @@ hmem
 lcpus
 libiberty
 librdmacm
+mcmm
 mrdesc
 mrkey
 ofichkerr
@@ -4971,6 +5013,7 @@ lessless
 maino
 mfile
 mpicxx
+outbin
 ploc
 ptxas
 qunused
@@ -5075,6 +5118,7 @@ ememory
 enofunc
 mtpull
 mtpush
+nofunc
 sdispatch
 serverside
 swrapper
@@ -5377,14 +5421,26 @@ FILEID: 7356b18e-62e2-11eb-a43d-6f93f4244f4b
 logln
 
 FILEID: 94331c44-62e2-11eb-a43d-6f93f4244f4b
+acopy
 arglist
+atgen
 atype
+constemp
 csat
+dups
+gtype
 idstring
+ifcs
 impls
 indx
+istms
+needto
+reresolved
 simplements
+smth
 symstring
+tdefs
+tsub
 
 FILEID: b89daf54-62e2-11eb-a43d-6f93f4244f4b
 lmod
@@ -5409,6 +5465,147 @@ xprev
 
 FILEID: 622c50fc-7b39-11eb-91c9-15da80cfac4b
 maxlargc
+
+FILEID: bfdd8b4e-f55f-11eb-bb15-35b7469d4b43
+doctmpdirname
+
+FILEID: ca2e1636-f55f-11eb-bb15-35b7469d4b43
+blockdim
+blockidx
+ctaid
+griddim
+inalloca
+irgen
+isget
+nctaid
+negbv
+ntid
+nvvm
+sreg
+threadidx
+
+FILEID: 65cc59e0-f560-11eb-bb15-35b7469d4b43
+allocas
+dtype
+inalloca
+isinstance
+ndarray
+optos
+origt
+simport
+strname
+
+FILEID: 9431bc08-f560-11eb-bb15-35b7469d4b43
+blockdim
+blockidx
+griddim
+threadidx
+
+FILEID: 9ae97fd6-f560-11eb-bb15-35b7469d4b43
+doctmpdirname
+
+FILEID: a4a99de4-f560-11eb-bb15-35b7469d4b43
+istms
+
+FILEID: a7eb801c-f560-11eb-bb15-35b7469d4b43
+oast
+
+FILEID: dbcaace6-f560-11eb-bb15-35b7469d4b43
+blockdim
+blockidx
+griddim
+threadidx
+
+FILEID: e1c3d7ee-f560-11eb-bb15-35b7469d4b43
+strcount
+
+FILEID: e818580e-f560-11eb-bb15-35b7469d4b43
+parenless
+
+FILEID: ec0917b4-f560-11eb-bb15-35b7469d4b43
+blockdim
+blockidx
+griddim
+threadidx
+
+FILEID: 2e841d3c-f561-11eb-bb15-35b7469d4b43
+doxygennamespace
+
+FILEID: 324bcc62-f561-11eb-bb15-35b7469d4b43
+cfun
+cfuns
+istms
+reqfn
+tinst
+
+FILEID: 69462c94-f561-11eb-bb15-35b7469d4b43
+cfun
+cfuns
+istms
+
+FILEID: 83e8f86a-f561-11eb-bb15-35b7469d4b43
+acceptconn
+addrlen
+addrstrlen
+getfd
+getfl
+getsockaddr
+hostlen
+inaddr
+loopback
+maxhost
+maxserv
+oobinline
+rcvtimeo
+reuseaddr
+secinfo
+setfd
+setfl
+sndtimeo
+
+FILEID: b6ed298e-f561-11eb-bb15-35b7469d4b43
+curnext
+getcid
+
+FILEID: ceac0ff8-f562-11eb-bb15-35b7469d4b43
+sdispatch
+
+FILEID: d0707fc2-f562-11eb-bb15-35b7469d4b43
+nofunc
+
+FILEID: 14aecce8-f563-11eb-bb15-35b7469d4b43
+ucontext
+udevice
+udeviceptr
+ufunction
+umodule
+
+FILEID: 2fe4a316-f563-11eb-bb15-35b7469d4b43
+abday
+abmon
+ampm
+ctloc
+daysperlyear
+dayspernyear
+hhmm
+llim
+nadt
+relyear
+rulim
+ulim
+zulu
+
+FILEID: 77a59142-f563-11eb-bb15-35b7469d4b43
+allgthr
+appnum
+
+FILEID: 7d741f12-f563-11eb-bb15-35b7469d4b43
+libinterop
+
+FILEID: 80a8005e-f563-11eb-bb15-35b7469d4b43
+betweenpasses
+pruneagain
+tutils
 
 NATURAL:
 aarch
@@ -5455,6 +5652,7 @@ allocs
 alnum
 altix
 alvis
+american
 amos
 amudprun
 analyses
@@ -5719,6 +5917,7 @@ chikara
 chiki
 childnum
 childstate
+chinmay
 chiuw
 chksum
 chmod
@@ -5875,6 +6074,7 @@ datetime
 datetimes
 david
 davis
+daysperweek
 daystr
 dbase
 dbgstat
@@ -5986,6 +6186,7 @@ divceilpos
 divexact
 divfloor
 divfloorpos
+divye
 dlang
 dlmalloc
 dlongnecke
@@ -6028,6 +6229,7 @@ dubois
 ducournau
 dumler
 duncan
+duvvuri
 dwords
 dygraphs
 dylan
@@ -6276,6 +6478,7 @@ fopen
 forall
 forallexpr
 foralls
+foreach
 forexpr
 forloop
 formatters
@@ -6349,6 +6552,7 @@ getpath
 getpeername
 getput
 getrlimit
+getsockaddr
 getsockname
 getsockopt
 getticks
@@ -6406,6 +6610,7 @@ guckin
 gujarati
 gunzip
 gups
+gupta
 gurmukhi
 hacky
 hadoop
@@ -6468,6 +6673,7 @@ hoser
 hostname
 hostnames
 hotpar
+hoursperday
 howard
 howto
 hpcc
@@ -6723,7 +6929,10 @@ khatri
 khmer
 khronos
 kieee
+killough
 kissinger
+klaus
+klein
 klib
 kludge
 kmeans
@@ -6966,6 +7175,7 @@ mferguson
 mgmt
 mhmerrill
 michael
+michelle
 microsoft
 milano
 miniapp
@@ -6974,6 +7184,7 @@ minlen
 minloc
 minmax
 minnesota
+minsperhour
 misassumption
 miscompiles
 misconfigured
@@ -7002,6 +7213,7 @@ monday
 mongolian
 monoid
 monomorphization
+monsperyear
 monte
 monthstr
 morecore
@@ -7046,6 +7258,7 @@ myaccountid
 myadjust
 myanmar
 mycolor
+mycroft
 myers
 myfield
 myflag
@@ -7082,6 +7295,7 @@ narratively
 narrays
 natively
 navarro
+nayyar
 nbigsubs
 nbits
 nbodies
@@ -7125,6 +7339,7 @@ nikhil
 nilability
 nilable
 nilables
+nilpotent
 nimit
 nist
 nixos
@@ -7200,6 +7415,7 @@ nsecs
 nset
 nsync
 nthreads
+nullptr
 numa
 numanode
 numberofcells
@@ -7339,6 +7555,7 @@ pidigits
 pids
 pipermail
 pittsburgh
+piyush
 pkgconf
 pkgs
 pktinfo
@@ -7374,6 +7591,7 @@ pozo
 prabhanjan
 pragmas
 prasad
+prashanth
 prasun
 preadv
 preallocated
@@ -7664,12 +7882,16 @@ seander
 seattle
 sebastien
 secretkey
+secsperday
+secsperhour
+secspermin
 sedgewick
 seekable
 seekamp
 seekdata
 seekfunction
 segfault
+segfaulted
 segfaulting
 segfaults
 segsize
@@ -7757,6 +7979,7 @@ sigxcpu
 sigxfsz
 silva
 simd
+simt
 singh
 singlecls
 singlevar
@@ -7861,6 +8084,7 @@ stridable
 strided
 stringify
 strncmp
+strout
 strptime
 strrchr
 strs
@@ -8057,6 +8281,8 @@ treap
 treiber
 tridiagonal
 trigraphs
+trinary
+trustable
 trybang
 tshimanga
 tsiombikas
@@ -8066,6 +8292,7 @@ tuesday
 tupled
 tuples
 tupling
+tursi
 twofish
 typdef
 typecheck
@@ -8079,6 +8306,7 @@ typesymbol
 tzakian
 tzinfo
 tzname
+uast
 ubin
 ubits
 ubuntu
@@ -8175,6 +8403,7 @@ usernames
 userpwd
 ushort
 usingchapel
+ustr
 utcfromtimestamp
 utcnow
 utctimetuple
@@ -8182,6 +8411,7 @@ utmp
 valgrind
 valgrindexe
 valgrinds
+vallen
 valloc
 vals
 varargs
@@ -8277,6 +8507,7 @@ writeinfo
 writeln
 writeout
 writerange
+writeups
 writev
 wroclaw
 wronly

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -39,6 +39,9 @@
   "d551f4f6-d1a9-11e8-954d-10ddb1d4c3d5": [
     "compiler/AST/LoopExpr.cpp"
   ],
+  "e1c3d7ee-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/AST/ParamForLoop.cpp"
+  ],
   "93ca6f88-fd34-11e9-98b5-10ddb1d4c3d5": [
     "compiler/AST/astutil.cpp"
   ],
@@ -63,6 +66,9 @@
   ],
   "e2d7df7c-1d0c-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/AST/iterator.cpp"
+  ],
+  "dbcaace6-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/AST/primitive.cpp"
   ],
   "0846cc78-1d0d-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/AST/stmt.cpp"
@@ -92,6 +98,12 @@
   "661b62ac-1d7e-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/backend/beautify.cpp"
   ],
+  "ca2e1636-f55f-11eb-bb15-35b7469d4b43": [
+    "compiler/codegen/cg-expr.cpp"
+  ],
+  "65cc59e0-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/codegen/cg-symbol.cpp"
+  ],
   "75f1ecaa-1d83-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/codegen/codegen.cpp"
   ],
@@ -103,6 +115,9 @@
   ],
   "d20c5afc-1d7e-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/ifa/num.cpp"
+  ],
+  "a4a99de4-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/include/ResolutionCandidate.h"
   ],
   "82c1d8e6-e581-11e8-954d-10ddb1d4c3d5": [
     "compiler/include/baseAST.h"
@@ -146,11 +161,17 @@
   "ed3f86d6-1d7f-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/include/parser.h"
   ],
+  "9431bc08-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/include/primitive_list.h"
+  ],
   "a8be55e8-7b38-11eb-91c9-15da80cfac4b": [
     "compiler/include/resolution.h"
   ],
   "7e01f6c6-4110-11e8-af7e-10ddb1d4c3d5": [
     "compiler/include/symbol.h"
+  ],
+  "9ae97fd6-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/include/tmpdirname.h"
   ],
   "f765ca54-d1a9-11e8-954d-10ddb1d4c3d5": [
     "compiler/llvm/clangUtil.cpp"
@@ -178,6 +199,9 @@
   "a52d3b2e-8644-11e8-ad82-10ddb1d4c3d5": [
     "compiler/main/docsDriver.cpp"
   ],
+  "a7eb801c-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/next/README"
+  ],
   "4171383e-1d81-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/optimizations/copyPropagation.cpp"
   ],
@@ -195,6 +219,9 @@
   ],
   "eb10d276-d1a9-11e8-954d-10ddb1d4c3d5": [
     "compiler/optimizations/noAliasSets.cpp"
+  ],
+  "ec0917b4-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/optimizations/optimizeOnClauses.cpp"
   ],
   "ee09a666-09c3-11eb-b2e8-10ddb1d4c3d5": [
     "compiler/optimizations/preNormalizeOptimizations.cpp"
@@ -222,6 +249,9 @@
   ],
   "732b6fa0-1d83-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/passes/cleanup.cpp"
+  ],
+  "e818580e-f560-11eb-bb15-35b7469d4b43": [
+    "compiler/passes/convert-uast.cpp"
   ],
   "98c778e4-1d83-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/passes/docs.cpp"
@@ -316,6 +346,9 @@
   "9627af8c-e581-11e8-954d-10ddb1d4c3d5": [
     "compiler/util/stringutil.cpp"
   ],
+  "bfdd8b4e-f55f-11eb-bb15-35b7469d4b43": [
+    "compiler/util/tmpdirname.cpp"
+  ],
   "97641a68-1e44-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/bestPractices/CompilerDebugging.rst"
   ],
@@ -392,6 +425,15 @@
   ],
   "d819ca0c-1e45-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/hdfs_and_chapel/intro.tex"
+  ],
+  "69462c94-f561-11eb-bb15-35b7469d4b43": [
+    "doc/rst/developer/implementation/Interfaces-new.md"
+  ],
+  "324bcc62-f561-11eb-bb15-35b7469d4b43": [
+    "doc/rst/developer/implementation/Interfaces.md"
+  ],
+  "80a8005e-f563-11eb-bb15-35b7469d4b43": [
+    "doc/rst/developer/implementation/compilerOverview/compiler.tex"
   ],
   "d667ed16-fd34-11e9-98b5-10ddb1d4c3d5": [
     "doc/rst/language/spec.rst"
@@ -485,6 +527,9 @@
   ],
   "cd28f34a-a1b9-11e7-a204-10ddb1d4c3d5": [
     "doc/rst/usingchapel/prereqs.rst"
+  ],
+  "2e841d3c-f561-11eb-bb15-35b7469d4b43": [
+    "doc/templates/compiler-internals-doxygen/index.rst"
   ],
   "d741a952-4110-11e8-af7e-10ddb1d4c3d5": [
     "man/chpl.rst"
@@ -684,6 +729,9 @@
   "c0254978-0c13-11e7-980e-10ddb1d4c3d5": [
     "modules/standard/DateTime.chpl"
   ],
+  "b6ed298e-f561-11eb-bb15-35b7469d4b43": [
+    "modules/standard/Errors.chpl"
+  ],
   "fbc85e3e-1f2e-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/FileSystem.chpl"
   ],
@@ -714,6 +762,9 @@
   "f8d11ee0-1f2f-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/Regex.chpl"
   ],
+  "83e8f86a-f561-11eb-bb15-35b7469d4b43": [
+    "modules/standard/Sys.chpl"
+  ],
   "d41572f2-1f2c-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/SysBasic.chpl"
   ],
@@ -722,6 +773,12 @@
   ],
   "e9347814-1f30-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/Types.chpl"
+  ],
+  "d0707fc2-f562-11eb-bb15-35b7469d4b43": [
+    "runtime/etc/src/mli/chpl-mli-common-runtime.c"
+  ],
+  "ceac0ff8-f562-11eb-bb15-35b7469d4b43": [
+    "runtime/etc/src/mli/chpl-mli-server-runtime.c"
   ],
   "7238a240-9317-11e9-a422-10ddb1d4c3d5": [
     "runtime/etc/src/mli/common_code.c"
@@ -762,8 +819,14 @@
   "0ebaef5a-2409-11e6-a3a6-10ddb1d4c3d5": [
     "runtime/src/chpl-cache.c"
   ],
+  "14aecce8-f563-11eb-bb15-35b7469d4b43": [
+    "runtime/src/chpl-gpu.c"
+  ],
   "9410539a-9317-11e9-a422-10ddb1d4c3d5": [
     "runtime/src/chpl-launcher-common.c"
+  ],
+  "2fe4a316-f563-11eb-bb15-35b7469d4b43": [
+    "runtime/src/chpl-strptime.c"
   ],
   "8d9c0040-2407-11e6-a3a6-10ddb1d4c3d5": [
     "runtime/src/chpl-timers.c"
@@ -783,6 +846,9 @@
   ],
   "91c58b86-d1c1-11e8-954d-10ddb1d4c3d5": [
     "runtime/src/comm/ofi/comm-ofi-oob-pmi.c"
+  ],
+  "77a59142-f563-11eb-bb15-35b7469d4b43": [
+    "runtime/src/comm/ofi/comm-ofi-oob-pmi2.c"
   ],
   "38c20924-fd35-11e9-98b5-10ddb1d4c3d5": [
     "runtime/src/comm/ofi/comm-ofi-oob-slurm-pmi2.c"
@@ -1030,6 +1096,9 @@
   ],
   "5d456562-31db-11e6-a3a6-10ddb1d4c3d5": [
     "test/release/examples/primers/domains.chpl"
+  ],
+  "7d741f12-f563-11eb-bb15-35b7469d4b43": [
+    "test/release/examples/primers/interopWithC.chpl"
   ],
   "9b2d18d4-31db-11e6-a3a6-10ddb1d4c3d5": [
     "test/release/examples/primers/learnChapelInYMinutes.chpl"


### PR DESCRIPTION
Update the chplspell dictionary files.

Also exclude compiler/next from chplspell  for now.  It's under heavy development, so contributing typo fixes is likely to just contribute unnecessary merge conflicts for the developers.