### PR TITLE
Fix two warnings from GCC 11

### DIFF
--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -62,8 +62,8 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
   // create the mapping handling named and default arguments
 
   // clear the current mapping
-  byFormalIdx.empty();
-  actualIdxToFormalIdx.empty();
+  byFormalIdx.clear();
+  actualIdxToFormalIdx.clear();
   mappingIsValid = false;
   failingActualIdx = -1;
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -589,8 +589,10 @@ static VarSymbol* generateReadTupleField(Symbol* fromSym, Symbol* fromField,
   CallExpr* setReadF = new CallExpr(PRIM_MOVE, readF, get);
   if (insertBefore)
     insertBefore->insertBefore(setReadF);
-  else
+  else if (insertAtTail)
     insertAtTail->insertAtTail(setReadF);
+  else
+    INT_FATAL("bad arguments to generateReadTupleField");
 
   resolveCall(setReadF);
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -565,8 +565,10 @@ static VarSymbol* generateReadTupleField(Symbol* fromSym, Symbol* fromField,
     DefExpr* def = new DefExpr(readF);
     if (insertBefore)
       insertBefore->insertBefore(def);
-    else
+    else if (insertAtTail)
       insertAtTail->insertAtTail(def);
+    else
+      INT_FATAL("bad arguments to generateReadTupleField");
     get = new CallExpr(PRIM_GET_MEMBER_VALUE, fromSym, fromName);
   } else {
     // Otherwise, use PRIM_GET_MEMBER
@@ -576,8 +578,10 @@ static VarSymbol* generateReadTupleField(Symbol* fromSym, Symbol* fromField,
     DefExpr* def = new DefExpr(readF);
     if (insertBefore)
       insertBefore->insertBefore(def);
-    else
+    else if (insertAtTail)
       insertAtTail->insertAtTail(def);
+    else
+      INT_FATAL("bad arguments to generateReadTupleField");
 
     get   = new CallExpr(PRIM_GET_MEMBER, fromSym, fromName);
   }


### PR DESCRIPTION
This PR resolves two compilation warnings from GCC 11
 * one is from accidentally calling `empty` instead of `clear`
 * another is a warning about `this` being null in an inlined call which 
   is addressed with an additional check

- [x] full local testing

Reviewed by @ronawho - thanks!