### PR TITLE
Ensure we give a better error message if llvm-config is not in path (attempt 2).

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,8 +58,8 @@ jobs:
         fetch-depth: 100000
     - name: check annotations
       run: |
-        make test-venv
-        CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
+        CHPL_LLVM=none make test-venv
+        CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
 
   bad_rt_calls:
     runs-on: ubuntu-latest

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -142,7 +142,7 @@ def find_system_llvm_config():
     if command and version and not config_err:
         return found[0]
 
-    return ''
+    return 'none'
 
 
 @memoize
@@ -163,9 +163,12 @@ def get_llvm_config():
     return llvm_config
 
 @memoize
-def validate_llvm_config():
+def validate_llvm_config(llvm_config=None):
     llvm_val = get()
-    llvm_config = get_llvm_config()
+    # We pass in llvm_config if has already been computed (so we don't
+    # end up in an infinite loop).
+    if llvm_config is None:
+      llvm_config = get_llvm_config()
     if llvm_val == 'system':
         if llvm_config == 'none':
             error("CHPL_LLVM=system but could not find an installed LLVM"
@@ -183,6 +186,7 @@ def validate_llvm_config():
 @memoize
 def get_system_llvm_config_bindir():
     llvm_config = get_llvm_config()
+    validate_llvm_config(llvm_config)
     bindir = run_command([llvm_config, '--bindir']).strip()
 
     if os.path.isdir(bindir):


### PR DESCRIPTION
Ensure we give a better error message if llvm-config is not in path

This is my second attempt to fix this bug.  The first can be seen in this PR here:

https://github.com/chapel-lang/chapel/pull/18151

I tried this second approach since the first was failing a CI test (check annotations). Specifically it would produce my new error message complaining about CHPL_LLVM="system". Turns out this PR also fails that test. So I've updated CI.yml to set CHPL_LLVM=none.


--

Prior to this change, if you run printchplenv (or if you run make to build Chapel, in turn it will call printchplenv for you) you would get the following error:

OSError: command not found:

With this change we now print the following error message:

Exception: CHPL_LLVM=system but could not find an installed LLVM with one of the supported versions: 11

I've run paratest to ensure this doesn't break anything, but I'd like someone familiar with printchplenv to let me know if they anticipate that there would be any issue with moving when we do these checks.

