### PR TITLE
Add nightly gcc 11.2 testing

### DIFF
--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with compiler gcc-11.2
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+source /data/cf/chapel/setup_gcc112.bash     # host-specific setup for target compiler
+
+gcc_version=$(gcc -dumpversion)
+if [ "$gcc_version" != "11.2.0" ]; then
+  echo "Wrong gcc version"
+  echo "Expected Version: 11.2.0 Actual Version: $gcc_version"
+  exit 2
+fi
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc112"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
We had a couple of warnings with gcc 11 that are fixed in #18178. Add
nightly testing to lock in the fix and catch any future issues.