### PR TITLE
Implement chpl_comm_ofi_oob_locales_on_node for PMI2.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -254,6 +254,9 @@ extern int chpl_comm_ofi_abort_on_error;
     p = NULL;                                                           \
   } while (0)
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
 
 //
 // Out-of-band support

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
@@ -299,7 +299,7 @@ int chpl_comm_ofi_oob_locales_on_node(void) {
     // do an allgather of hostname hashes to determine the locales on the same node as us
     // assumes each hostname has a unique hash
 
-    char hostname[256];
+    char hostname[HOST_NAME_MAX+1];
     int rc = gethostname(hostname, sizeof(hostname));
     CHK_TRUE(rc == 0);
 


### PR DESCRIPTION
Determines the number of locales on the local node by calling PMI_Get_clique_size if it is
available, otherwise uses an allgather to collect the hash of the hostname for each locale
from which the number of locales on the local node can be determined.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>