### PR TITLE
Remove a variable declaration to avoid an unused variable warning

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -670,8 +670,7 @@ static const char* handleTypeOrIdentifierExpr(const MacroInfo* inMacro,
       bool canHandle = false;
       if (tok.getKind() == tok::identifier) {
         IdentifierInfo* tokId = tok.getIdentifierInfo();
-        if (const clang::MacroInfo* macro
-              = info->lvt->getMacro(tokId->getName()))
+        if (info->lvt->getMacro(tokId->getName()))
           canHandle = true;
       }
       if (!canHandle)


### PR DESCRIPTION
I had a variable declared in a conditional that was otherwise unused.
Remove the declaration to avoid the warning.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>