### PR TITLE
Add computation to calculate index to operate on in extracted GPU kernel

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -583,14 +583,14 @@ static void outlineGPUKernels() {
                   if (isIndexVariable(sym, loop)) {
                     if (indexSymbol == NULL) {
                       indexSymbol = sym;
-                      VarSymbol* fakeIndex = new VarSymbol("fakeIndex", sym->type);
+                      VarSymbol* flatIndex = new VarSymbol("flatIndex", sym->type);
 
-                      outlinedFunction->insertAtTail(new DefExpr(fakeIndex));
+                      outlinedFunction->insertAtTail(new DefExpr(flatIndex));
                       outlinedFunction->insertAtTail(new CallExpr(PRIM_MOVE,
-                                                                  fakeIndex,
+                                                                  flatIndex,
                                                                   generateIndexComputation()));
 
-                      copyMap.put(sym, fakeIndex);
+                      copyMap.put(sym, flatIndex);
                     }
                   }
                   else {

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -507,7 +507,7 @@ static  CallExpr* generateGPUCall(FnSymbol* kernel,
   return call;
 }
 
-static Expr* generateIndexComputation() {
+static CallExpr* generateIndexComputation() {
   // Generates Chapel AST corresponding to the following CUDA code:
   // blockIdx.x * blockDim.x + threadIdx.x
   CallExpr* call = new CallExpr(PRIM_ADD,


### PR DESCRIPTION
Add computation to calculate index to operate on in extracted GPU kernel.

Basically just add AST to do: fakeIndex = blockIdx.x * blockDim.x + threadIdx.x.

See corresponding issue: https://github.com/Cray/chapel-private/issues/2314