### PR TITLE
Make CC include `configured-clang-sysroot-arguments` for CHPL_LLVM builds

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -27,18 +27,6 @@
 CXX = $(CHPL_MAKE_CXX) # normally clang++
 CC = $(CHPL_MAKE_CC)   # normally clang
 
-ifeq ($(CHPL_MAKE_COMPILER), llvm)
-  ifeq ($(CHPL_MAKE_LLVM), bundled)
-    # handle using the included clang compiler
-    ifndef CLANG_SYSROOT_ARGS
-      export CLANG_SYSROOT_ARGS=$(shell cat $(LLVM_CLANG_ARGUMENTS_FILE))
-    endif
-    CXX = $(CHPL_MAKE_CXX) $(CLANG_SYSROOT_ARGS)
-    CC = $(CHPL_MAKE_CC) $(CLANG_SYSROOT_ARGS)
-  endif
-endif
-
-
 RANLIB = ranlib
 
 

--- a/third-party/llvm/Makefile.share-bundled
+++ b/third-party/llvm/Makefile.share-bundled
@@ -1,6 +1,5 @@
 include $(THIRD_PARTY_DIR)/llvm/Makefile.share
 
-LLVM_CLANG_ARGUMENTS_FILE=${LLVM_INSTALL_DIR}/configured-clang-sysroot-arguments
 LLVM_CONFIG=$(LLVM_INSTALL_DIR)/bin/llvm-config
 export LLVM_CONFIG:=$(CHPL_MAKE_LLVM_CONFIG)
 TEST_LLVM_CONFIG:=$(shell test -x $(LLVM_CONFIG) && echo 1)

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -218,13 +218,11 @@ def get_llvm_clang(lang):
     else:
         return ''
     # tack on the contents of configured-clang-sysroot-arguments
-    llvminstall = get_chpl_third_party() + "/llvm/install/" + get_uniq_cfg_path_for(llvm_val)
-    fname = os.path.join(llvminstall, "configured-clang-sysroot-arguments")
+    fname = os.path.join(get_chpl_third_party(), "llvm", "install", get_uniq_cfg_path_for(llvm_val), "configured-clang-sysroot-arguments")
     if os.path.isfile(fname):
         with open(fname) as f:
             for line in f:
                 clang += " " + line.rstrip()
-#        sys.stdout.write(llvm_val + ": " + clang + "\n")
     return clang
 
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -6,6 +6,8 @@ import sys
 import chpl_bin_subdir, chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import get_chpl_third_party
 from utils import memoize, error, run_command, try_run_command, warning
+import chpl_make
+import utils
 
 # returns a tuple of supported major LLVM versions as strings
 def llvm_versions():
@@ -203,18 +205,61 @@ def get_llvm_clang_command_name(lang):
     else:
         return 'clang'
 
+def myrun(cmd, arg=None):
+
+    use_cmd = list(cmd)
+    if arg:
+        use_cmd += [arg]
+
+    # Run $use_cmd but filter out e.g. make[2]: lines
+    # (about which directory we are in)
+    ret = ""
+    output = utils.run_command(use_cmd)
+    lines = [line for line in output.splitlines(True)
+                  if not line.startswith("make")]
+    ret = ''.join(lines)
+
+    return ret
+
 # lang should be C or CXX
 @memoize
 def get_llvm_clang(lang):
     clang_name = get_llvm_clang_command_name(lang)
+    make = chpl_make.get()
+
+    orig_make = make
+    # Do not print directory changes.
+    make = [make, "--no-print-directory"]
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    chpl_home_dir = os.path.dirname(os.path.dirname(script_dir))
+    os.environ["CHPL_MAKE_HOME"] = chpl_home_dir
+    make_helper = make + ["-f", chpl_home_dir + "/runtime/etc/Makefile.include"]
 
     llvm_val = get()
     if llvm_val == 'system':
         bindir = get_system_llvm_config_bindir()
-        return os.path.join(bindir, clang_name)
+        clang = os.path.join(bindir, clang_name)
+        # llvminstall = myrun(make_helper, "printllvminstall")
+        # sys.stdout.write("llvminstall: " + llvmInstall + "\n")
+        # llvminstall = llvminstall.strip()
+        llvminstall = get_chpl_third_party() + "/llvm/install/" + get_uniq_cfg_path_for(llvm_val)
+        fname = os.path.join(llvminstall, "configured-clang-sysroot-arguments")
+#        sys.stdout.write("fname: " + fname + "\n")
+        if os.path.isfile(fname):
+            with open(fname) as f:
+                for line in f:
+                    clang += " " + line.rstrip()
+#        sys.stdout.write("system: " + clang + "\n")
+        return clang
     elif llvm_val == 'bundled':
         llvm_subdir = get_bundled_llvm_dir()
-        return os.path.join(llvm_subdir, 'bin', clang_name)
+        clang = os.path.join(llvm_subdir, 'bin', clang_name)
+        llvminstall = myrun(make_helper, "printllvminstall")
+        llvminstall = llvminstall.strip()
+        clang = os.path.join(llvminstall, "configured-clang-sysroot-arguments")
+        sys.stdout.write("bundled: " + clang + "\n")
+        return clang
     else:
         return ''
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -6,7 +6,6 @@ import sys
 import chpl_bin_subdir, chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import get_chpl_third_party
 from utils import memoize, error, run_command, try_run_command, warning
-import chpl_make
 
 # returns a tuple of supported major LLVM versions as strings
 def llvm_versions():


### PR DESCRIPTION
PR #17923 had the impact of making CC store a full path to `clang`, where previously, it had just used `clang`.  When using the homebrew version of `clang` on Mac systems, this had the impact of re-breaking Mac builds on Mojave systems—re-opening https://github.com/Cray/chapel-private/issues/2069. (or "on my Mojave system" at least; in that prior to this, my system `clang` seemed to be used when building the runtime and third-party directories, due to being earlier in the path, and it worked out of the box with no special flags).  Once the homebrew version was used for these directories, it started giving the `ld: unknown option: -platform_version` errors again due to the `./configure` steps in the third-party packages because the `-mlinker-version=450` flag wasn't being given to it in these contexts.

This PR fixes this by having the `chpl_llvm.py` script always associate the contents of `configured-clang-sysroot-arguments` with `clang` when setting the `CC` variable.  This causes all compilations using the homebrew version of `clang` to include `-mlinker-version=450` when appropriate / necessary on Mojave, using the previous logic that added that option into `configured-clang-sysroot-arguments` in #17851.  It removes some now redundant logic from the Makefiles which was doing this for some, but not all directories.

(This change also has the side effect of adding other options that are currently in `configured-clang-sysroot-arguments`—namely `-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk -resource-dir /Library/Developer/CommandLineTools/usr/lib/clang/10.0.1` to the CC command line because they were also in the file.  These do not seem to be strictly necessary, but also seem to do no harm apart from making the compiler's command line longer than necessary).

Resolves https://github.com/Cray/chapel-private/issues/2069