### PR TITLE
Adjust cache-remote to avoid unnecessary assertion failures

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1342,10 +1342,11 @@ void ain_evict(struct rdcache_s* cache,
     if (y==NULL)
       return;
 
-    assert(y->entryReservedByTask != task_local);
     // give up if locked
     if (give_up_if_locked && y->entryReservedByTask != NULL)
       return;
+
+    assert(y->entryReservedByTask != task_local);
 
     if (!try_reserve_entry(cache, task_local, y)) {
       // could not "lock" entry y so try again


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/2358

Avoid assertion failure in ain_evict if we give up

If give_up_if_locked is set, it should be just fine
for the entry to be reserved by the current task,
since we just return anyway.

Reviewed by @ronawho - thanks!