### PR TITLE
Add a flag to c2chapel to use GNU parser from pycparserext

### DIFF
--- a/doc/rst/tools/c2chapel/c2chapel.rst
+++ b/doc/rst/tools/c2chapel/c2chapel.rst
@@ -39,8 +39,8 @@ version 0.1.0.
 Building
 --------
 
-``c2chapel`` is built on top of `pycparser <https://github.com/eliben/pycparser>`_.
-Building ``c2chapel`` will install pycparser into a local virtualenv, leaving
+``c2chapel`` is built on top of `pycparser <https://github.com/eliben/pycparser>`_ and `pycparserext <https://github.com/inducer/pycparserext>`_.
+Building ``c2chapel`` will install pycparser and pycparserext into a local virtualenv, leaving
 the user's python environment untouched. A symbolic link will be created in the
 appropriate directory under ``$CHPL_HOME/bin``.
 
@@ -85,7 +85,7 @@ Run ``c2chapel`` with the ``--help`` flag to show more options:
 .. code-block:: text
 
   usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
-                  [--no-comments] [-V]
+                  [--no-comments] [-V] [--gnu-extensions]
                   file [cppFlags [cppFlags ...]]
 
   Generate C bindings for Chapel
@@ -102,6 +102,7 @@ Run ``c2chapel`` with the ``--help`` flag to show more options:
     --no-fake-headers  do not use fake headers included with c2chapel
     --no-comments      instruct c2chapel to not generate comments
     -V, --version      show program's version number and exit
+    --gnu-extensions   allow GNU extensions in C99 files
 
 
 ``c2chapel`` by default uses the fake standard headers included with pycparser.
@@ -128,4 +129,5 @@ Contributors
 ------------
 | Ben Harshbarger [HPE]
 | Nikhil Padmanabhan [Yale University]
+| Ben McDonald [HPE]
 |

--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,2 +1,3 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
 pycparser==2.20
+pycparserext>=2013.1

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -41,6 +41,7 @@ import sys
 
 try:
     from pycparser import c_parser, c_ast, parse_file
+    from pycparserext import ext_c_parser
 except ImportError as e:
     sys.exit("Unable to import pycparser: " + str(e));
 
@@ -84,6 +85,11 @@ c2chapel["uintptr_t"]          = "c_uintptr"
 c2chapel["ptrdiff_t"]          = "c_ptrdiff"
 c2chapel["ssize_t"]            = "ssize_t"
 c2chapel["size_t"]             = "size_t"
+c2chapel["long double"]        = "c_longlong"
+c2chapel["signed short"]       = "c_short"
+c2chapel["signed int"]         = "c_int"
+c2chapel["signed long long"]   = "c_longlong"
+c2chapel["signed long"]        = "c_long"
 
 # Note: this mapping is defined by the compiler, not the SysCTypes file
 c2chapel["FILE"] = "_file"
@@ -116,7 +122,7 @@ chapelKeywords = set(["align","as","atomic","begin","break","by","class",
     "nil","noinit","on","only","otherwise","out","param","private","proc",
     "public","record","reduce","ref","require","return","scan","select",
     "serial","single","sparse","subdomain","sync","then","type","union","use",
-    "var","when","where","while","with","yield","zip"])
+    "var","when","where","while","with","yield","zip", "string", "bytes", "locale"])
 
 
 def getArgs():
@@ -136,6 +142,9 @@ def getArgs():
                         action="store_true")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + __version__)
     parser.add_argument("cppFlags", nargs="*", help="flags forwarded to the C preprocessor (invoked with cc -E)")
+    parser.add_argument("--gnu-extensions",
+                        help="allow GNU extensions in C99 files",
+                        action="store_true")
     return parser.parse_known_args()
 
 # s - string to print out.
@@ -153,7 +162,7 @@ def commentNode(node):
 
 def getDeclName(decl):
     inner = decl
-    if type(inner) == c_ast.TypeDecl:
+    if type(inner) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt):
         inner = inner.type
 
     name = ""
@@ -185,7 +194,7 @@ def computeArgName(decl):
 def isStructOrUnionType(ast):
     inner = ast
 
-    if type(inner) == c_ast.TypeDecl:
+    if type(inner) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt):
         inner = inner.type
 
     if type(inner) == c_ast.IdentifierType:
@@ -251,7 +260,7 @@ def computeArgs(pl):
 
 def isPointerTo(ty, text):
     if type(ty) == c_ast.PtrDecl:
-        if type(ty.type) == c_ast.TypeDecl:
+        if type(ty.type) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt):
             name = getDeclName(ty.type)
             if name == text:
                 return True
@@ -262,14 +271,14 @@ def toChapelType(ty):
         return "c_string"
     elif isPointerTo(ty, "void"):
         return "c_void_ptr"
-    elif type(ty) == c_ast.ArrayDecl:
+    elif type(ty) in (c_ast.ArrayDecl, ext_c_parser.ArrayDeclExt):
         return "c_ptr(" + toChapelType(ty.type) + ")"
     elif type(ty) == c_ast.PtrDecl:
-        if type(ty.type) == c_ast.FuncDecl:
+        if type(ty.type) in (c_ast.FuncDecl, ext_c_parser.FuncDeclExt):
             return "c_fn_ptr"
         else:
             return "c_ptr(" + toChapelType(ty.type) + ")"
-    elif type(ty) == c_ast.TypeDecl:
+    elif type(ty) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt):
         inner = ty.type
         name = ""
         try:
@@ -281,7 +290,7 @@ def toChapelType(ty):
             return c2chapel[name]
 
         return name
-    elif type(ty) == c_ast.FuncDecl:
+    elif type(ty) in (c_ast.FuncDecl, ext_c_parser.FuncDeclExt):
         return "c_fn_ptr"
     else:
         ty.show()
@@ -291,10 +300,10 @@ def toChapelType(ty):
 def getFunctionName(ty):
     if type(ty) == c_ast.PtrDecl:
         return getFunctionName(ty.type)
-    elif type(ty) == c_ast.FuncDecl:
+    elif type(ty) in (c_ast.FuncDecl, ext_c_parser.FuncDeclExt):
         return getFunctionName(ty.type)
     else:
-        if type(ty) != c_ast.TypeDecl:
+        if type(ty) not in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt):
             ty.show()
             raise c_parser.ParseError("Expecting TypeDecl...")
         return ty.declname
@@ -335,7 +344,7 @@ def getStructOrUnionDef(decl):
             return decl
         else:
             return None
-    elif type(decl) == c_ast.Decl or type(decl) == c_ast.TypeDecl or type(decl) == c_ast.PtrDecl:
+    elif type(decl) == c_ast.Decl or type(decl) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt) or type(decl) == c_ast.PtrDecl:
         return getStructOrUnionDef(decl.type)
     else:
         return None
@@ -374,6 +383,8 @@ def genStructOrUnion(structOrUnion, name=""):
         if innerStructOrUnion is not None:
             genStructOrUnion(innerStructOrUnion)
 
+        if type(decl) == c_ast.Pragma:
+            break
         fieldName = getDeclName(decl)
         if fieldName in chapelKeywords:
             members = ""
@@ -397,6 +408,9 @@ def genStructOrUnion(structOrUnion, name=""):
 
 def genVar(decl):
     name = decl.name
+    if name in chapelKeywords:
+        name = 'c2chapel_' + name
+    
     ty   = toChapelType(decl.type)
     print("extern var " + name + " : " + ty + ";")
     print()
@@ -446,11 +460,11 @@ class ChapelVisitor(c_ast.NodeVisitor):
         for c_name, c in node.children():
             if type(c) == c_ast.Struct or type(c) == c_ast.Union:
                 self.visit_StructOrUnion(c)
-            elif type(c) == c_ast.FuncDecl:
+            elif type(c) in (c_ast.FuncDecl, ext_c_parser.FuncDeclExt):
                 self.visit_FuncDecl(c)
             elif type(c) == c_ast.Enum:
                 genEnum(c)
-            elif type(c) == c_ast.TypeDecl or type(c) == c_ast.PtrDecl or type(c) == c_ast.ArrayDecl:
+            elif type(c) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt) or type(c) == c_ast.PtrDecl or type(c) in (c_ast.ArrayDecl, ext_c_parser.ArrayDeclExt):
                 genVar(node)
             else:
                 node.show()
@@ -460,15 +474,19 @@ class ChapelVisitor(c_ast.NodeVisitor):
 
 def genTypeAlias(node):
     alias = node.name
-    if type(node.type) == c_ast.PtrDecl or type(node.type) == c_ast.TypeDecl:
+    if type(node.type) == c_ast.PtrDecl or type(node.type) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt):
         typeName = toChapelType(node.type)
+        # let compiler handle void typedefs
+        if typeName == '':
+            print("extern type " + alias + ";")
+        else:
+            print("extern type " + alias + " = " + typeName + ";")
         foundTypes.add(alias);
-        print("extern type " + alias + " = " + typeName + ";")
         print()
 
 def isPointerToStruct(node):
     if type(node) == c_ast.PtrDecl:
-        if type(node.type) == c_ast.TypeDecl and type(node.type.type) == c_ast.Struct:
+        if type(node.type) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt) and type(node.type.type) == c_ast.Struct:
             return node.type.type
         else:
             return isPointerToStruct(node.type)
@@ -476,7 +494,7 @@ def isPointerToStruct(node):
 
 def isPointerToUnion(node):
     if type(node) == c_ast.PtrDecl:
-        if type(node.type) == c_ast.TypeDecl and type(node.type.type) == c_ast.Union:
+        if type(node.type) in (c_ast.TypeDecl, ext_c_parser.TypeDeclExt) and type(node.type.type) == c_ast.Union:
             return node.type.type
         else:
             return isPointerToUnion(node.type)
@@ -626,6 +644,7 @@ if __name__=="__main__":
     fname      = args.file
     noComments = args.no_comments
     DEBUG      = args.debug
+    useGnu     = args.gnu_extensions
 
     if not os.path.isfile(fname):
         sys.exit("No such file: '" + fname + "'")
@@ -637,7 +656,10 @@ if __name__=="__main__":
         ignores = findIgnores()
 
     try:
-        ast = parse_file(fname, use_cpp=True, cpp_path="cc", cpp_args=["-E"] + fakes + unknowns)
+        if useGnu:
+            ast = parse_file(fname, use_cpp=True, cpp_path="cc", cpp_args=["-E"] + fakes + unknowns, parser=ext_c_parser.GnuCParser())
+        else:
+            ast = parse_file(fname, use_cpp=True, cpp_path="cc", cpp_args=["-E"] + fakes + unknowns)
     except c_parser.ParseError as e:
         sys.exit("Unable to parse file: " + str(e))
 

--- a/tools/c2chapel/test/help.good
+++ b/tools/c2chapel/test/help.good
@@ -1,5 +1,5 @@
 usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
-                [--no-comments] [-V]
+                [--no-comments] [-V] [--gnu-extensions]
                 file [cppFlags [cppFlags ...]]
 
 Generate C bindings for Chapel
@@ -16,3 +16,4 @@ optional arguments:
   --no-fake-headers  do not use fake headers included with c2chapel
   --no-comments      instruct c2chapel to not generate comments
   -V, --version      show program's version number and exit
+  --gnu-extensions   allow GNU extensions in C99 files

--- a/tools/c2chapel/test/no-args.2.good
+++ b/tools/c2chapel/test/no-args.2.good
@@ -1,4 +1,4 @@
 usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
-                [--no-comments] [-V]
+                [--no-comments] [-V] [--gnu-extensions]
                 file [cppFlags [cppFlags ...]]
 c2chapel: error: the following arguments are required: file, cppFlags

--- a/tools/c2chapel/test/no-args.good
+++ b/tools/c2chapel/test/no-args.good
@@ -1,4 +1,4 @@
 usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
-                [--no-comments] [-V]
+                [--no-comments] [-V] [--gnu-extensions]
                 file [cppFlags [cppFlags ...]]
 c2chapel: error: too few arguments

--- a/tools/c2chapel/test/tester.sh
+++ b/tools/c2chapel/test/tester.sh
@@ -62,7 +62,7 @@ function helper() {
   rm $diffFile > /dev/null 2>&1
 }
 
-echo "Testing c2chapel...\n"
+echo "Testing c2chapel..."
 
 helper "No arguments" "" "no-args.good" "no-args.2.good"
 helper "--help" "--help" "help.good"
@@ -75,6 +75,17 @@ for f in *.h ; do
     otherArgs=`cat $title.execopts`
   fi
   helper "$title" "$f $otherArgs" "$title.chpl"
+done
+
+echo 'Testing using GNU parser... '
+
+for f in *.h ; do
+    title=`basename $f .h`
+    otherArgs="--gnu-extensions"
+    if [ -e $title.execopts ]; then
+        otherArgs=`cat $title.execopts`
+    fi
+    helper "$title" "$f $otherArgs" "$title.chpl"
 done
 
 helper ".c file" "justC.c" "justC.chpl"


### PR DESCRIPTION
This PR adds a `--gnu-extensions` flag to c2chapel to use the GNU parser instead of the 
default pycparser. This enables c2chapel to behave the same as before by default, 
but also allows you to handle GNUisms if necessary by using the new flag.

The following features are added to c2chapel:
- `--gnu-extensions` flag added to switch to GNU parser
  - enables handling of gnuisms
- void typedefs are now blank
  - Before, they were left with an `= ;`, which was causing an error
- New types that hadn't been seen before are now included
  - Old c2chapel (outdated?) code that generated Chapel types that don't exist fixed
- New reserved words that hadn't been seen yet are now included
  - And also work for general variables, where before it was only arguments to functions
- Testing added for the GNU parser

Related issue https://github.com/Cray/chapel-private/issues/2309
Longer term effort/motivated by: https://github.com/Cray/chapel-private/issues/2294
Discussion issue: https://github.com/chapel-lang/chapel/issues/18209