### PR TITLE
Back out smoke-test failing change due to attempted fix of printchple…

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -142,7 +142,7 @@ def find_system_llvm_config():
     if command and version and not config_err:
         return found[0]
 
-    return 'none'
+    return ''
 
 
 @memoize
@@ -163,12 +163,9 @@ def get_llvm_config():
     return llvm_config
 
 @memoize
-def validate_llvm_config(llvm_config=None):
+def validate_llvm_config():
     llvm_val = get()
-    # We pass in llvm_config if has already been computed (so we don't
-    # end up in an infinite loop).
-    if llvm_config is None:
-      llvm_config = get_llvm_config()
+    llvm_config = get_llvm_config()
     if llvm_val == 'system':
         if llvm_config == 'none':
             error("CHPL_LLVM=system but could not find an installed LLVM"
@@ -186,7 +183,6 @@ def validate_llvm_config(llvm_config=None):
 @memoize
 def get_system_llvm_config_bindir():
     llvm_config = get_llvm_config()
-    validate_llvm_config(llvm_config)
     bindir = run_command([llvm_config, '--bindir']).strip()
 
     if os.path.isdir(bindir):


### PR DESCRIPTION
Back out smoke-test failing change due to attempted fix of printchplenv bug when chpl is configured to use system llvm but system llvm is not in path.

Original (backed out fix) from: https://github.com/chapel-lang/chapel/pull/18179

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>