### PR TITLE
Add an error when trying to overload paren-ful vs. paren-less standalone functions in a scope

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -398,6 +398,26 @@ bool ResolveScope::extend(Symbol* newSym, bool isTopLevel) {
 
     // Do not complain if they are both functions
     if (oldFn != NULL && newFn != NULL) {
+      FnSymbol* parenLess = NULL;
+      FnSymbol* parenFull = NULL;
+      if (oldFn->hasFlag(FLAG_NO_PARENS) && oldFn->_this == NULL) {
+        parenLess = oldFn;
+      } else {
+        parenFull = oldFn;
+      }
+      if (newFn->hasFlag(FLAG_NO_PARENS) && newFn->_this == NULL) {
+        if (parenLess != NULL) {
+          USR_FATAL(newSym, "Can't overload paren-less function '%s'; previous definition at:\n  %s", name, oldSym->stringLoc());
+        } else {
+          parenLess = newFn;
+        }
+      } else {
+        parenFull = newFn;
+      }
+      if (parenLess) {
+        USR_FATAL(parenFull, "Can't overload function '%s' with and without parentheses\n  other version at: %s", name, parenLess->stringLoc());
+      }
+
       retval = true;
 
     // Methods currently leak their scope and can conflict with variables

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -398,23 +398,18 @@ bool ResolveScope::extend(Symbol* newSym, bool isTopLevel) {
 
     // Do not complain if they are both functions
     if (oldFn != NULL && newFn != NULL) {
-      FnSymbol* parenLess = NULL;
-      FnSymbol* parenFull = NULL;
-      if (oldFn->hasFlag(FLAG_NO_PARENS) && oldFn->_this == NULL) {
-        parenLess = oldFn;
-      } else {
-        parenFull = oldFn;
-      }
-      if (newFn->hasFlag(FLAG_NO_PARENS) && newFn->_this == NULL) {
-        if (parenLess != NULL) {
-          USR_FATAL(newSym, "Can't overload paren-less function '%s'; previous definition at:\n  %s", name, oldSym->stringLoc());
+      // give an error for paren-ful vs. paren-less overloads
+      if (oldFn->hasFlag(FLAG_NO_PARENS) != newFn->hasFlag(FLAG_NO_PARENS)
+          && oldFn->_this == newFn->_this) {
+        FnSymbol* parenLess = NULL;
+        FnSymbol* parenFull = NULL;
+        if (oldFn->hasFlag(FLAG_NO_PARENS)) {
+          parenLess = oldFn;
+          parenFull = newFn;
         } else {
           parenLess = newFn;
+          parenFull = oldFn;
         }
-      } else {
-        parenFull = newFn;
-      }
-      if (parenLess) {
         USR_FATAL(parenFull, "Can't overload function '%s' with and without parentheses\n  other version at: %s", name, parenLess->stringLoc());
       }
 

--- a/test/functions/resolution/errors/testParenFulVsLess.chpl
+++ b/test/functions/resolution/errors/testParenFulVsLess.chpl
@@ -1,0 +1,11 @@
+proc foo {
+  writeln("In paren-less foo");
+  return [1.0, 2.0];
+}
+
+proc foo(x: int) {
+  writeln("In paren-ful foo");
+  return x + 1;
+}
+
+writeln(foo(1));

--- a/test/functions/resolution/errors/testParenFulVsLess.good
+++ b/test/functions/resolution/errors/testParenFulVsLess.good
@@ -1,0 +1,2 @@
+testParenFulVsLess.chpl:6: error: Can't overload function 'foo' with and without parentheses
+  other version at: testParenFulVsLess.chpl:1

--- a/test/functions/resolution/errors/testParenFulVsLess2.chpl
+++ b/test/functions/resolution/errors/testParenFulVsLess2.chpl
@@ -1,0 +1,11 @@
+proc foo(x: int) {
+  writeln("In paren-ful foo");
+  return x + 1;
+}
+
+proc foo {
+  writeln("In paren-less foo");
+  return [1.0, 2.0];
+}
+
+writeln(foo(1));

--- a/test/functions/resolution/errors/testParenFulVsLess2.good
+++ b/test/functions/resolution/errors/testParenFulVsLess2.good
@@ -1,0 +1,2 @@
+testParenFulVsLess2.chpl:1: error: Can't overload function 'foo' with and without parentheses
+  other version at: testParenFulVsLess2.chpl:6


### PR DESCRIPTION
This adds an error when a standalone function is overloaded at the same scope:

```chapel
proc foo {
  return [1.1, 2.2];
}

proc foo(x: int) {
  return x + 1;
}
```

the reason being that it's ambiguous which should be called in a case like `foo(1)`.  I could've sworn that we'd implemented an ambiguity error for this case (and had decided to call it ambiguous) from the earliest days of the compiler, yet I haven't been able to find a historical version of the compiler that does complain about it, going back to 0.5 and several versions in-between with a quick search.

I wanted to simply make this an ambiguity at function resolution time, but unfortunately, in scopeResolve(), if we happen to find the paren-less version of `foo` first during `lookup()`, we start rewriting the code differently than when we find the paren-ful version first.  And my attempts to disable this early rewriting ran into all sorts of issues with the use of paren-less functions in the internal modules due to deferring decisions that we've traditionally been making (too) early (*).  

Due to those challenges, the approach I took here is similar to what we do today for overloading a function and a variable:  catch it in scope resolution.  This is not ideal, but should help head off some obvious abuses / points of confusion that people could hit today.

(* = That said, I worry a bit about the approach taken here because if the where clauses for the two functions are param bool opposites of one another, the code should be legal until resolution time.  For that reason, I proceeded with https://github.com/bradcray/chapel/tree/error-paren-ful-vs-less-fns-methods-too and would like to revisit disabling early handling in scopeResolve to see whether it's any better with these other changes.)