### PR TITLE
Improve behavior when a CHPL_LLVM=none build is used when CHPL_LLVM!=none

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -295,6 +295,8 @@ bool fCompilerLibraryParser = false;
 
 chpl::Context* gContext = nullptr;
 
+static bool setChplLLVM = false;
+
 /* Note -- LLVM provides a way to get the path to the executable...
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
@@ -515,8 +517,11 @@ static void setupChplHome(const char* argv0) {
 //
 static void setupChplLLVM(void) {
   // set CHPL_LLVM to 'none' if it isn't already set
-  if (setenv("CHPL_LLVM", "none", 0) != 0) {
-    INT_FATAL("Problem setting CHPL_LLVM");
+  if (getenv("CHPL_LLVM") == NULL) {
+    if (setenv("CHPL_LLVM", "none", 0) != 0) {
+      INT_FATAL("Problem setting CHPL_LLVM");
+    }
+    setChplLLVM = true;
   }
 }
 #endif
@@ -1254,6 +1259,10 @@ static void printStuff(const char* argv0) {
       USR_FATAL("CHPL_HOME path name is too long");
     }
     int status = mysystem(buf, "running printchplenv", false);
+    if (setChplLLVM) {
+      printf("---\n");
+      printf("* Note: CHPL_LLVM was set by 'chpl' since it was built without LLVM support.\n");
+    }
     clean_exit(status);
   }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1488,7 +1488,9 @@ static void checkLLVMCodeGen() {
 #else
   // compiler wasn't built with LLVM, so if LLVM is enabled, error
   if (fLlvmCodegen)
-    USR_FATAL("This compiler was built without LLVM support");
+    USR_FATAL("You have requested a 'CHPL_LLVM=%s' compilation, but this copy of\n"
+              "       'chpl' was built without LLVM support.  Either set 'CHPL_LLVM=none'\n"
+              "       or re-build your compiler with LLVM enabled.", CHPL_LLVM);
 #endif
 }
 


### PR DESCRIPTION
When using a compiler built with `CHPL_LLVM=none` in an environment
that has `CHPL_LLVM` set or inferred to `system` or `bundled`, the
traditional error message has been short, but not particularly clear.
I keep hitting this error and find the current message difficult
to understand, particularly putting myself in the shoes of someone
who, say, built Chapel with the quickstart build and then is trying to
use it from a new shell that may not set CHPL_LLVM=none.  Or
someone piggy-backing off of someone else's installation that was
built without LLVM.

This PR improves things by:

* setting `CHPL_LLVM=none` in the compiler's environment in the event
  that it is unset and the compiler was built without LLVM support; this
  happens early in compilation so that when printchplenv is invoked, an
  appropriate back-end compiler will be selected.  I also added a note
  to `--print-chpl-settings` to indicate that this setting had been made
  by the compiler (and why).
* improving the existing error message so that if someone has explicitly
  requested the llvm back-end through `--target-compiler`, `CHPL_TARGET_COMPILER`,
  or `CHPL_LLVM` with a compiler that was built without LLVM, they get
  a better message than they used to.
* reordering how we do things early in the compiler so that things like `--help`
  are handled before we print errors like this one.  That way, someone running
  `chpl --help` won't immediately get an error about how they can't compile
  when they weren't actually trying to.

Resolves #18073.
Resolves #18197.