### PR TITLE
Add positional arguments to argument parser

### DIFF
--- a/test/mason/mason-argparse/MasonArgParseExample.chpl
+++ b/test/mason/mason-argparse/MasonArgParseExample.chpl
@@ -33,7 +33,7 @@ module M {
                                    opts=["--flagOn"]);
 
       // add a positional argument that expects 1 value
-      var posArg = parser.addPositional(name="positionalArg");
+      var posArg = parser.addArgument(name="positionalArg");
 
       // add a subcommand that has its own parser (defined later)
       var subCmd1 = parser.addSubCommand(cmd="subCmd1");
@@ -77,9 +77,9 @@ module M {
                                    defaultValue=false);
 
       // add a positional argument to the subcommand that expects 0 or 1 values
-      var subPosArg = parser.addPositional(name="subItem",
-                                           numArgs=0..1,
-                                           defaultValue=none);
+      var subPosArg = parser.addArgument(name="subItem",
+                                         numArgs=0..1,
+                                         defaultValue=none);
 
       var rest = parser.parseArgs(args);
       writeln("args parsed in subcommand:");

--- a/test/mason/mason-argparse/MasonArgParseExample.chpl
+++ b/test/mason/mason-argparse/MasonArgParseExample.chpl
@@ -5,7 +5,7 @@ module M {
     proc main(args:[?argsD]string) throws {
       writeln("Config Var Values:");
       writeln(myConfigVar);
-      
+
       writeln("Arguments Received from CL:");
       // print the contents of args, skipping the executable name
       // as it can vary depending on the test environment
@@ -14,7 +14,7 @@ module M {
       }
       // create a parser for the main entry point
       var parser = new argumentParser();
-    
+
       // add a string option that accepts between 1 and 10 values
       var strArg = parser.addOption(name="strArg1",
                                     opts=["-o","--option"],
@@ -23,7 +23,7 @@ module M {
       var typArg = parser.addOption(name="strArg2",
                                     opts=["-t","--types"],
                                     numArgs=1..);
-      // add a string option that accepts exactly 1 value                                    
+      // add a string option that accepts exactly 1 value
       var confArg = parser.addOption(name="strArg3",
                                     opts=["--myConfigVar"],
                                     numArgs=1);
@@ -32,22 +32,27 @@ module M {
       var boolArg = parser.addFlag(name="boolArg1",
                                    opts=["--flagOn"]);
 
+      // add a positional argument that expects 1 value
+      var posArg = parser.addPositional(name="positionalArg");
+
       // add a subcommand that has its own parser (defined later)
       var subCmd1 = parser.addSubCommand(cmd="subCmd1");
 
       // parse the args and collect any remaining values in rest
       var rest = parser.parseArgs(args[1..]);
-      
+
       writeln("Values received from argparse:");
-      if strArg.hasValue() {         
+      if strArg.hasValue() {
         for val in strArg.values() do writeln(val);
-      }      
+      }
       for item in typArg.values() do writeln(item);
       for item in confArg.values() do writeln(item);
       if boolArg.hasValue() then writeln("boolArg: " + boolArg.value());
+      if posArg.hasValue() then writeln("positional value: " + posArg.value());
       if subCmd1.hasValue() {
         mySubCmd1(rest.toArray());
       }
+
 
     }
 
@@ -66,16 +71,23 @@ module M {
                                         opts=["-t","--cmdArg2"],
                                         numArgs=1);
       // add a flag that can be set with --subFlagOn or --no-subFlagOn
-      // with a default value of false                                  
+      // with a default value of false
       var boolArg = parser.addFlag(name="subBoolArg",
                                    opts=["-f","--subFlagOn"],
                                    defaultValue=false);
+
+      // add a positional argument to the subcommand that expects 0 or 1 values
+      var subPosArg = parser.addPositional(name="subItem",
+                                           numArgs=0..1,
+                                           defaultValue=none);
 
       var rest = parser.parseArgs(args);
       writeln("args parsed in subcommand:");
       for item in subCmdArg1.values() do writeln(item);
       for item in subCmdArg2.values() do writeln(item);
       writeln("subBoolFlag: " + boolArg.value());
+      if subPosArg.hasValue() then writeln("subcommand positional value: " +
+                                            subPosArg.value());
 
     }
 }

--- a/test/mason/mason-argparse/MasonArgParseExample.good
+++ b/test/mason/mason-argparse/MasonArgParseExample.good
@@ -12,12 +12,14 @@ Arguments Received from CL:
 9 time
 10 --myConfigVar=@10
 11 --flagOn
-12 subCmd1
-13 -c
-14 one
-15 -t
-16 two
-17 -f
+12 aValue
+13 subCmd1
+14 bValue
+15 -c
+16 one
+17 -t
+18 two
+19 -f
 Values received from argparse:
 w
 a
@@ -29,8 +31,10 @@ tea
 time
 @10
 boolArg: true
+positional value: aValue
 SubCommand1 was called
 args parsed in subcommand:
 one
 two
 subBoolFlag: true
+subcommand positional value: bValue

--- a/test/mason/mason-argparse/MasonArgParseExample.lastexecopts
+++ b/test/mason/mason-argparse/MasonArgParseExample.lastexecopts
@@ -1,1 +1,1 @@
---myConfigVar testVar -o w a y d t a? -- -t=tea time --myConfigVar=@10 --flagOn subCmd1 -c one -t two -f
+--myConfigVar testVar -o w a y d t a? -- -t=tea time --myConfigVar=@10 --flagOn aValue subCmd1 bValue -c one -t two -f

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1073,7 +1073,7 @@ proc testMultStringShortOptDefMultiVal(test: borrowed Test) throws {
                                    defaultValue=none);
   var myStrArg3 = parser.addOption(name="StringOpt3",
                                    opts=["-t","--stringVal3"],
-                                   defaultValue=new list(["1","2"]),
+                                   defaultValue=["1","2"],
                                    numArgs=1..2,
                                    required=false);
 
@@ -1100,7 +1100,7 @@ proc testMultStringShortOptDefMultiValNoVal(test: borrowed Test) throws {
   var parser = new argumentParser();
   var myStrArg1 = parser.addOption(name="StringOpt1",
                                    opts=["-n","--stringVal1"],
-                                   defaultValue=new list(["one","two"]),
+                                   defaultValue=["one","two"],
                                    numArgs=1..3,
                                    required=false);
   var myStrArg2 = parser.addOption(name="StringOpt2",
@@ -2279,6 +2279,279 @@ proc testMixPosBoolOptWithValuesFixed(test: borrowed Test) throws {
   test.assertTrue(myBoolArg.valueAsBool());
   test.assertEqual(posList, new list(argList[1..3]));
   test.assertEqual(optList, new list(argList[7..9]));
+}
+
+// a mix of positionals, bools, and options with fixed # values expected
+// and positional argument after the boolean flag
+proc testMixPosBoolOptWithValuesFixedPosAfterBool(test: borrowed Test) throws {
+  var argList = ["progName","-n","myStrOpt1","myStrOpt2","myStrOpt3",
+                 "-b","myFile1","subCmd1"];
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"]);
+  var myPosArg = parser.addPositional(name="FileNames");
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=3,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(myBoolArg.hasValue());
+  test.assertTrue(myPosArg.hasValue());
+  test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //ensure the value passed is correct
+  var optList = new list(myStrArg.values());
+  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertEqual(myPosArg.value(), argList[6]);
+  test.assertEqual(optList, new list(argList[2..4]));
+  test.assertEqual(subCmd1.value(),"subCmd1");
+}
+
+// a mix of positionals, bools, and options with fixed # values expected
+// and positional argument intermixed in the input
+proc testMixPosBoolOptWithValuesFixedPosInterMixed(test: borrowed Test) throws {
+  var argList = ["progName","p1","-n","myStrOpt1","myStrOpt2","myStrOpt3","p2",
+                 "-b","myFile1","subCmd1"];
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addPositional(name="pos0");
+  var myPosArg1 = parser.addPositional(name="pos1");
+  var myPosArg2 = parser.addPositional(name="FileName");
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=3,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg0.hasValue());
+  test.assertFalse(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(myBoolArg.hasValue());
+  test.assertTrue(myPosArg0.hasValue());
+  test.assertTrue(myPosArg1.hasValue());
+  test.assertTrue(myPosArg2.hasValue());
+  test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //ensure the value passed is correct
+  var optList = new list(myStrArg.values());
+  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertEqual(myPosArg0.value(), argList[1]);
+  test.assertEqual(myPosArg1.value(), argList[6]);
+  test.assertEqual(myPosArg2.value(), argList[8]);
+  test.assertEqual(optList, new list(argList[3..5]));
+  test.assertEqual(subCmd1.value(),"subCmd1");
+}
+
+// a mix of positionals, bools, and options with fixed # values expected
+// and positional argument intermixed in the input
+proc testMixPosBoolOptWithValuesPosInterMixedRange(test: borrowed Test) throws {
+  var argList = ["progName","p1","-n","myStrOpt1","myStrOpt2","myStrOpt3","p2",
+                 "-b","subCmd1"];
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addPositional(name="pos0");
+  var myPosArg1 = parser.addPositional(name="pos1");
+  var myPosArg2 = parser.addPositional(name="FileName",
+                                       numArgs=0..1,
+                                       defaultValue=none);
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=3,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg0.hasValue());
+  test.assertFalse(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(myBoolArg.hasValue());
+  test.assertTrue(myPosArg0.hasValue());
+  test.assertTrue(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //ensure the value passed is correct
+  var optList = new list(myStrArg.values());
+  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertEqual(myPosArg0.value(), argList[1]);
+  test.assertEqual(myPosArg1.value(), argList[6]);
+  test.assertEqual(optList, new list(argList[3..5]));
+  test.assertEqual(subCmd1.value(),"subCmd1");
+}
+
+// a mix of positionals, bools, and options with fixed # values expected
+// and positional argument intermixed in the input, with several values
+// expected for last positional argument
+proc testMixPosBoolOptPosInterMixedRangeWithVals(test: borrowed Test) throws {
+  var argList = ["progName","p1","-n","myStrOpt1","myStrOpt2","myStrOpt3","p2",
+                 "myFile0","-b","myFile1","myFile2","subCmd1"];
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addPositional(name="pos0");
+  var myPosArg1 = parser.addPositional(name="pos1");
+  var myPosArg2 = parser.addPositional(name="FileName",
+                                       numArgs=0..,
+                                       defaultValue=none);
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=3,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg0.hasValue());
+  test.assertFalse(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(myBoolArg.hasValue());
+  test.assertTrue(myPosArg0.hasValue());
+  test.assertTrue(myPosArg1.hasValue());
+  test.assertTrue(myPosArg2.hasValue());
+  test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //ensure the value passed is correct
+  var optList = new list(myStrArg.values());
+  var posList = new list(myPosArg2.values());
+  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertEqual(myPosArg0.value(), argList[1]);
+  test.assertEqual(myPosArg1.value(), argList[6]);
+  test.assertEqual(optList, new list(argList[3..5]));
+  test.assertEqual(posList, new list(["myFile0","myFile1","myFile2"]));
+  test.assertEqual(subCmd1.value(),"subCmd1");
+}
+
+// a mix of positionals, bools, and options some with fixed # values expected
+// and positional argument intermixed in the input, with several values
+// possible for last positional argument, but none provided
+proc testMixPosBoolOptPosInterMixedRangeDefVals(test: borrowed Test) throws {
+  var argList = ["progName","p1","-n","myStrOpt1","myStrOpt2","myStrOpt3","p2",
+                "-b","subCmd1"];
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addPositional(name="pos0");
+  var myPosArg1 = parser.addPositional(name="pos1");
+  var myPosArg2 = parser.addPositional(name="FileName",
+                                       numArgs=0..,
+                                       defaultValue=["1","2","3"]);
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=3,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg0.hasValue());
+  test.assertFalse(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(myBoolArg.hasValue());
+  test.assertTrue(myPosArg0.hasValue());
+  test.assertTrue(myPosArg1.hasValue());
+  test.assertTrue(myPosArg2.hasValue());
+  test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //ensure the value passed is correct
+  var optList = new list(myStrArg.values());
+  var posList = new list(myPosArg2.values());
+  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertEqual(myPosArg0.value(), argList[1]);
+  test.assertEqual(myPosArg1.value(), argList[6]);
+  test.assertEqual(posList, new list(["1","2","3"]));
+  test.assertEqual(optList, new list(argList[3..5]));
+  test.assertEqual(subCmd1.value(),"subCmd1");
+}
+
+// a mix of positionals, bools, and options with fixed # values expected
+// and positional argument intermixed in the input, with several values
+// expected for last positional argument
+proc testMixPosBoolOptPosInterMixedRangeNoVals(test: borrowed Test) throws {
+  var argList = ["progName","p1","-n","myStrOpt1","myStrOpt2","myStrOpt3","p2",
+                "-b","subCmd1"];
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addPositional(name="pos0");
+  var myPosArg1 = parser.addPositional(name="pos1");
+  var myPosArg2 = parser.addPositional(name="FileName",
+                                       numArgs=0..,
+                                       defaultValue=none);
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=3,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand(cmd="subCmd1");
+
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg0.hasValue());
+  test.assertFalse(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(myBoolArg.hasValue());
+  test.assertTrue(myPosArg0.hasValue());
+  test.assertTrue(myPosArg1.hasValue());
+  test.assertFalse(myPosArg2.hasValue());
+  test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //ensure the value passed is correct
+  var optList = new list(myStrArg.values());
+  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertEqual(myPosArg0.value(), argList[1]);
+  test.assertEqual(myPosArg1.value(), argList[6]);
+  test.assertEqual(optList, new list(argList[3..5]));
+  test.assertEqual(subCmd1.value(),"subCmd1");
 }
 
 // a mix of positionals, bools, and options with ranges of values and subcommand

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -60,6 +60,27 @@ proc testSingleStringShortOptEqualsExtra(test: borrowed Test) throws {
   test.assertTrue(false);
 }
 
+// test to catch undefined args entered at beginning of cmd string
+proc testBadArgsAtFront(test: borrowed Test) throws {
+  var argList = ["progName","badArg1","--BadFlag","-n=twenty"];
+  var parser = new argumentParser();
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=1);
+
+  //make sure no value currently exists
+  test.assertFalse(myStrArg.hasValue());
+  //parse the options
+  try {
+    parser.parseArgs(argList[1..]);
+  }catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
+}
+
 // a short string opt with range of value with = and OK # values supplied
 proc testMultiStringShortOptEqualsOK(test: borrowed Test) throws {
   var argList = ["progName","-n=twenty","thirty"];

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -2297,13 +2297,18 @@ proc testMixPosBoolOptWithValuesSubCommand(test: borrowed Test) throws {
                                   numArgs=1..10,
                                   required=false,
                                   defaultValue=none);
-
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
   //parse the options
   var rest = parser.parseArgs(argList[1..]);
   //make sure we now have a value
   test.assertTrue(myBoolArg.hasValue());
   test.assertTrue(myPosArg.hasValue());
   test.assertTrue(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
   //ensure the value passed is correct
   var posList = new list(myPosArg.values());
   var optList = new list(myStrArg.values());
@@ -2324,10 +2329,76 @@ proc testMixPosBoolOptWithValuesSubCommand(test: borrowed Test) throws {
   //ensure the value passed is correct
   var subCmdPosList = new list(subCmdPosArg.values());
   var subCmdOptList = new list(subCmdStrArg.values());
-  test.assertTrue(myBoolArg.valueAsBool());
+  test.assertFalse(subCmdBoolArg.valueAsBool());
   test.assertEqual(subCmdPosList, new list(["f1","f2"]));
   test.assertEqual(subCmdOptList, new list(["s1","s2","s3"]));
 }
+
+// a mix of positionals, bools, and options with ranges of values and subcommand
+// with optional positional, bools, and options.
+proc testMixPosBoolOptWithValuesSubCommandLight(test: borrowed Test) throws {
+  var argList = ["progName","subCmd1","-b=true","--stringVal", "s1","s2","s3"];
+
+  var parser = new argumentParser();
+
+  var myBoolArg = parser.addFlag(name="BoolFlag",
+                                opts=["-b","--boolVal"],
+                                numArgs=0..1,
+                                flagInversion=false,
+                                defaultValue=none);
+  var myPosArg = parser.addPositional(name="FileNames",
+                                      numArgs=0..);
+  var myStrArg = parser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=1..10,
+                                  required=false,
+                                  defaultValue=none);
+  var subCmd1 = parser.addSubCommand("subCmd1");
+  // setup the subcommand parser
+  var subParser = new argumentParser();
+  var subCmdBoolArg = subParser.addFlag(name="BoolFlag",
+                              opts=["-b","--boolVal"],
+                              numArgs=0..1,
+                              flagInversion=false,
+                              defaultValue=none);
+  var subCmdPosArg = subParser.addPositional(name="FileNames",
+                                      numArgs=0..,
+                                      defaultValue=(new list(["f1","f2"])));
+  var subCmdStrArg = subParser.addOption(name="StringOpt",
+                                  opts=["-n","--stringVal"],
+                                  numArgs=1..10,
+                                  required=false,
+                                  defaultValue=none);
+  //make sure no value currently exists
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertFalse(subCmd1.hasValue());
+  //parse the options
+  var rest = parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertFalse(myBoolArg.hasValue());
+  test.assertFalse(myPosArg.hasValue());
+  test.assertFalse(myStrArg.hasValue());
+  test.assertTrue(subCmd1.hasValue());
+  //make sure no sub-values currently exist
+  test.assertFalse(subCmdBoolArg.hasValue());
+  test.assertFalse(subCmdPosArg.hasValue());
+  test.assertFalse(subCmdStrArg.hasValue());
+  //parse the remaining args
+  subParser.parseArgs(rest.toArray());
+  //make sure we now have a value
+  test.assertTrue(subCmdBoolArg.hasValue());
+  test.assertTrue(subCmdPosArg.hasValue());
+  test.assertTrue(subCmdStrArg.hasValue());
+  //ensure the value passed is correct
+  var subCmdPosList = new list(subCmdPosArg.values());
+  var subCmdOptList = new list(subCmdStrArg.values());
+  test.assertTrue(subCmdBoolArg.valueAsBool());
+  test.assertEqual(subCmdPosList, new list(["f1","f2"]));
+  test.assertEqual(subCmdOptList, new list(["s1","s2","s3"]));
+}
+
 
 
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -1302,12 +1302,12 @@ proc testTryDuplicateNameOpt(test: borrowed Test) throws {
   var argList = ["progName","-n=twenty","thirty"];
   var parser = new argumentParser();
   var myStrArg1 = parser.addOption(name="StringOpt",
-                                opts=["-n","--strArg"],
-                                numArgs=1);
+                                   opts=["-n","--strArg"],
+                                   numArgs=1);
   try {
     var myStrArg2 = parser.addOption(name="StringOpt",
-                                    opts=["-p","--print"],
-                                    numArgs=1);
+                                     opts=["-p","--print"],
+                                     numArgs=1);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1321,12 +1321,12 @@ proc testTryDuplicateShortOpt(test: borrowed Test) throws {
   var argList = ["progName","-n=twenty","thirty"];
   var parser = new argumentParser();
   var myStrArg1 = parser.addOption(name="StringOpt",
-                                opts=["-n","--strArg"],
-                                numArgs=1);
+                                   opts=["-n","--strArg"],
+                                   numArgs=1);
   try {
     var myStrArg2 = parser.addOption(name="PrintOpt",
-                                    opts=["-n","--print"],
-                                    numArgs=1);
+                                     opts=["-n","--print"],
+                                     numArgs=1);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1340,12 +1340,12 @@ proc testTryDuplicateLongOpt(test: borrowed Test) throws {
   var argList = ["progName","-n=twenty","thirty"];
   var parser = new argumentParser();
   var myStrArg1 = parser.addOption(name="StringOpt",
-                                opts=["-n","--strArg"],
-                                numArgs=1);
+                                   opts=["-n","--strArg"],
+                                   numArgs=1);
   try {
     var myStrArg2 = parser.addOption(name="PrintOpt",
-                                    opts=["-p","--strArg"],
-                                    numArgs=1);
+                                     opts=["-p","--strArg"],
+                                     numArgs=1);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1617,8 +1617,8 @@ proc testFromArgParseExample(test: borrowed Test) throws {
                                 opts=["-t","--types"],
                                 numArgs=1..);
   var confArg = parser.addOption(name="strArg3",
-                                opts=["--myConfigVar"],
-                                numArgs=1);
+                                 opts=["--myConfigVar"],
+                                 numArgs=1);
 
   var subCmd1 = parser.addSubCommand(cmd="subCmd1");
   var remain = parser.parseArgs(argList[1..]);
@@ -1666,7 +1666,7 @@ proc testBoolFlag(test: borrowed Test) throws {
   var argList = ["progName","-n"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"]);
+                                 opts=["-n","--boolVal"]);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1682,7 +1682,7 @@ proc testBoolLongFlag(test: borrowed Test) throws {
   var argList = ["progName","--boolVal"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"]);
+                                 opts=["-n","--boolVal"]);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1698,8 +1698,8 @@ proc testBoolLongNoFlag(test: borrowed Test) throws {
   var argList = ["progName","--no-boolVal"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                defaultValue=true);
+                                 opts=["-n","--boolVal"],
+                                 defaultValue=true);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1726,8 +1726,8 @@ proc testSubCommandAndBoolLongFlag(test: borrowed Test) throws {
 
   var subParser = new argumentParser();
   var myBoolArg = subParser.addFlag(name="BoolFlag",
-                              opts=["-n","--boolVal"],
-                              defaultValue=true);
+                                    opts=["-n","--boolVal"],
+                                    defaultValue=true);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   subParser.parseArgs(remain.toArray());
@@ -1740,8 +1740,8 @@ proc testParentCommandSubCommandAndBoolLongFlag(test: borrowed Test) throws {
   var argList = ["progName","-n","twenty", "subCmd","--no-boolVal"];
   var parser = new argumentParser();
   var myStrArg1 = parser.addOption(name="StringOpt1",
-                                  opts=["-n","--stringVal1"],
-                                  numArgs=1..);
+                                   opts=["-n","--stringVal1"],
+                                   numArgs=1..);
   var mySubCmd1 = parser.addSubCommand(cmd="subCmd");
   //make sure no value currently exists
   test.assertFalse(mySubCmd1.hasValue());
@@ -1757,8 +1757,8 @@ proc testParentCommandSubCommandAndBoolLongFlag(test: borrowed Test) throws {
 
   var subParser = new argumentParser();
   var myBoolArg = subParser.addFlag(name="BoolFlag",
-                              opts=["-n","--boolVal"],
-                              defaultValue=true);
+                                    opts=["-n","--boolVal"],
+                                    defaultValue=true);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   subParser.parseArgs(remain.toArray());
@@ -1771,10 +1771,10 @@ proc testBoolEqFlag(test: borrowed Test) throws {
   var argList = ["progName","-n=true"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1790,10 +1790,10 @@ proc testBoolEqForceOneFlag(test: borrowed Test) throws {
   var argList = ["progName","-n=true"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1809,10 +1809,10 @@ proc testBoolForceOneFlag(test: borrowed Test) throws {
   var argList = ["progName","-n","true"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1829,10 +1829,10 @@ proc testBoolZeroToOneFlagNoVal(test: borrowed Test) throws {
   var argList = ["progName","-n"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1848,10 +1848,10 @@ proc testBoolForceOneFlagNoVal(test: borrowed Test) throws {
   var argList = ["progName","-n"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1870,10 +1870,10 @@ proc testBoolForceOneFlagExtraGiven(test: borrowed Test) throws {
   var argList = ["progName","-n","true","false"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1892,10 +1892,10 @@ proc testBoolRangeFlagExtraGiven(test: borrowed Test) throws {
   var argList = ["progName","-n","true","false"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=none);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -1915,10 +1915,10 @@ proc testTryMakeBadFlagRange(test: borrowed Test) throws {
   var parser = new argumentParser();
   try {
     var myNewArg = parser.addFlag(name="BoolOpt",
-                                    opts=["--name","-n"],
-                                    numArgs=0..2,
-                                    required=false,
-                                    defaultValue=none);
+                                  opts=["--name","-n"],
+                                  numArgs=0..2,
+                                  required=false,
+                                  defaultValue=none);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1933,10 +1933,10 @@ proc testTryMakeNonSenseFlag(test: borrowed Test) throws {
   var parser = new argumentParser();
   try {
     var myNewArg = parser.addFlag(name="BoolOpt",
-                                    opts=["--name","-n"],
-                                    flagInversion=false,
-                                    required=true,
-                                    defaultValue=true);
+                                  opts=["--name","-n"],
+                                  flagInversion=false,
+                                  required=true,
+                                  defaultValue=true);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1951,10 +1951,10 @@ proc testTryMakeNonSenseFlagRange(test: borrowed Test) throws {
   var parser = new argumentParser();
   try {
     var myNewArg = parser.addFlag(name="BoolOpt",
-                                    opts=["--name","-n"],
-                                    numArgs=0..1,
-                                    required=true,
-                                    defaultValue=true);
+                                  opts=["--name","-n"],
+                                  numArgs=0..1,
+                                  required=true,
+                                  defaultValue=true);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1969,10 +1969,10 @@ proc testTryMakeNonSenseFlagFixed(test: borrowed Test) throws {
   var parser = new argumentParser();
   try {
     var myNewArg = parser.addFlag(name="BoolOpt",
-                                    opts=["--name","-n"],
-                                    numArgs=1,
-                                    required=true,
-                                    defaultValue=true);
+                                  opts=["--name","-n"],
+                                  numArgs=1,
+                                  required=true,
+                                  defaultValue=true);
   }catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -1986,10 +1986,10 @@ proc testBoolZeroToOneFlagNoValDefaultTrue(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=true);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=true);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2005,10 +2005,10 @@ proc testBoolZeroToOneFlagNoValDefaultFalse(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=false);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=false);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2024,10 +2024,10 @@ proc testBoolOneFlagNoValDefaultTrue(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=true);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=true);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2062,10 +2062,10 @@ proc testBoolZeroFlagNoValDefaultTrue(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=true);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=true);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2081,10 +2081,10 @@ proc testBoolZeroFlagNoValDefaultFalse(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false,
-                                defaultValue=false);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false,
+                                 defaultValue=false);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2100,9 +2100,9 @@ proc testBoolMultipleEntryValues(test: borrowed Test) throws {
   var argList = ["progName","-n","true","-n=false"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2119,9 +2119,9 @@ proc testFlagBadBoolValue(test: borrowed Test) throws {
   var argList = ["progName","-n","tru"];
   var parser = new argumentParser();
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-n","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false);
+                                 opts=["-n","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2141,9 +2141,9 @@ proc testFlagBadBoolNumArgs(test: borrowed Test) throws {
   var parser = new argumentParser();
   try {
     var myBoolArg = parser.addFlag(name="BoolFlag",
-                                  opts=["-n","--boolVal"],
-                                  numArgs=2,
-                                  flagInversion=false);
+                                   opts=["-n","--boolVal"],
+                                   numArgs=2,
+                                   flagInversion=false);
     //make sure no value currently exists
   //test.assertFalse(myBoolArg.hasValue());
   //parse the options
@@ -2185,7 +2185,7 @@ proc unitTestStringToBool(test: borrowed Test) throws {
 proc testSinglePositionalArgument(test: borrowed Test) throws {
   var argList = ["progName","myFileName"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileName");
+  var myPosArg = parser.addArgument(name="FileName");
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2201,9 +2201,9 @@ proc testSinglePositionalArgument(test: borrowed Test) throws {
 proc testPositionalArgumentDefault(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileName",
-                                      defaultValue=".",
-                                      numArgs=0..1);
+  var myPosArg = parser.addArgument(name="FileName",
+                                    defaultValue=".",
+                                    numArgs=0..1);
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2219,9 +2219,9 @@ proc testPositionalArgumentDefault(test: borrowed Test) throws {
 proc testPositionalArgumentOptionalMissing(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileName",
-                                      defaultValue=none,
-                                      numArgs=0..1);
+  var myPosArg = parser.addArgument(name="FileName",
+                                    defaultValue=none,
+                                    numArgs=0..1);
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2234,8 +2234,8 @@ proc testPositionalArgumentOptionalMissing(test: borrowed Test) throws {
 proc testPositionalArgumentRangeOneOrMore(test: borrowed Test) throws {
   var argList = ["progName","file1","file2","file3","file4"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=1..);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=1..);
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2252,9 +2252,9 @@ proc testPositionalArgumentRangeOneOrMore(test: borrowed Test) throws {
 proc testPositionalArgumentTooManyVals(test: borrowed Test) throws {
   var argList = ["progName","file1","file2","file3","file4"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=1..2,
-                                      defaultValue=none);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=1..2,
+                                    defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2272,9 +2272,9 @@ proc testPositionalArgumentTooManyVals(test: borrowed Test) throws {
 proc testPositionalArgumentNotEnoughVals(test: borrowed Test) throws {
   var argList = ["progName","file1","file2","file3","file4"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=5..7,
-                                      defaultValue=none);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=5..7,
+                                    defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2292,8 +2292,8 @@ proc testPositionalArgumentNotEnoughVals(test: borrowed Test) throws {
 proc testPositionalArgumentNoVals(test: borrowed Test) throws {
   var argList = ["progName"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=1..);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=1..);
   //make sure no value currently exists
   test.assertFalse(myPosArg.hasValue());
   //parse the options
@@ -2311,10 +2311,10 @@ proc testPositionalArgumentNoVals(test: borrowed Test) throws {
 proc testPositionalArgumentRangeBeforePos(test: borrowed Test) throws {
   var argList = ["progName","file1","file2","file3","file4"];
   var parser = new argumentParser();
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=1..);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=1..);
   try {
-    var myPosArg = parser.addPositional(name="otherArg");
+    var myPosArg = parser.addArgument(name="otherArg");
   } catch ex: ArgumentError {
     test.assertTrue(true);
     stderr.writeln(ex.message());
@@ -2330,11 +2330,11 @@ proc testMixPosBoolOptWithValues(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false);
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=1..);
+                                 opts=["-b","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=1..);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=1..3,
@@ -2365,11 +2365,11 @@ proc testMixPosBoolOptWithValuesFixed(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"],
-                                numArgs=1,
-                                flagInversion=false);
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=3);
+                                 opts=["-b","--boolVal"],
+                                 numArgs=1,
+                                 flagInversion=false);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=3);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2401,8 +2401,8 @@ proc testMixPosBoolOptWithValuesFixedPosAfterBool(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"]);
-  var myPosArg = parser.addPositional(name="FileNames");
+                                 opts=["-b","--boolVal"]);
+  var myPosArg = parser.addArgument(name="FileNames");
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2438,10 +2438,10 @@ proc testMixPosBoolOptWithValuesFixedPosInterMixed(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"]);
-  var myPosArg0 = parser.addPositional(name="pos0");
-  var myPosArg1 = parser.addPositional(name="pos1");
-  var myPosArg2 = parser.addPositional(name="FileName");
+                                 opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addArgument(name="pos0");
+  var myPosArg1 = parser.addArgument(name="pos1");
+  var myPosArg2 = parser.addArgument(name="FileName");
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2483,12 +2483,12 @@ proc testMixPosBoolOptWithValuesPosInterMixedRange(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"]);
-  var myPosArg0 = parser.addPositional(name="pos0");
-  var myPosArg1 = parser.addPositional(name="pos1");
-  var myPosArg2 = parser.addPositional(name="FileName",
-                                       numArgs=0..1,
-                                       defaultValue=none);
+                                 opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addArgument(name="pos0");
+  var myPosArg1 = parser.addArgument(name="pos1");
+  var myPosArg2 = parser.addArgument(name="FileName",
+                                     numArgs=0..1,
+                                     defaultValue=none);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2530,12 +2530,12 @@ proc testMixPosBoolOptPosInterMixedRangeWithVals(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"]);
-  var myPosArg0 = parser.addPositional(name="pos0");
-  var myPosArg1 = parser.addPositional(name="pos1");
-  var myPosArg2 = parser.addPositional(name="FileName",
-                                       numArgs=0..,
-                                       defaultValue=none);
+                                 opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addArgument(name="pos0");
+  var myPosArg1 = parser.addArgument(name="pos1");
+  var myPosArg2 = parser.addArgument(name="FileName",
+                                     numArgs=0..,
+                                     defaultValue=none);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2579,12 +2579,12 @@ proc testMixPosBoolOptPosInterMixedRangeDefVals(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"]);
-  var myPosArg0 = parser.addPositional(name="pos0");
-  var myPosArg1 = parser.addPositional(name="pos1");
-  var myPosArg2 = parser.addPositional(name="FileName",
-                                       numArgs=0..,
-                                       defaultValue=["1","2","3"]);
+                                 opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addArgument(name="pos0");
+  var myPosArg1 = parser.addArgument(name="pos1");
+  var myPosArg2 = parser.addArgument(name="FileName",
+                                     numArgs=0..,
+                                     defaultValue=["1","2","3"]);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2628,12 +2628,12 @@ proc testMixPosBoolOptPosInterMixedRangeNoVals(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"]);
-  var myPosArg0 = parser.addPositional(name="pos0");
-  var myPosArg1 = parser.addPositional(name="pos1");
-  var myPosArg2 = parser.addPositional(name="FileName",
-                                       numArgs=0..,
-                                       defaultValue=none);
+                                 opts=["-b","--boolVal"]);
+  var myPosArg0 = parser.addArgument(name="pos0");
+  var myPosArg1 = parser.addArgument(name="pos1");
+  var myPosArg2 = parser.addArgument(name="FileName",
+                                     numArgs=0..,
+                                     defaultValue=none);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=3,
@@ -2676,12 +2676,12 @@ proc testMixPosBoolOptWithValuesSubCommand(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=none);
-  var myPosArg = parser.addPositional(name="FileNames",
-                                      numArgs=1..);
+                                 opts=["-b","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=none);
+  var myPosArg = parser.addArgument(name="FileNames",
+                                    numArgs=1..);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
                                   numArgs=1..10,
@@ -2691,18 +2691,18 @@ proc testMixPosBoolOptWithValuesSubCommand(test: borrowed Test) throws {
   // setup the subcommand parser
   var subParser = new argumentParser();
   var subCmdBoolArg = subParser.addFlag(name="BoolFlag",
-                              opts=["-b","--boolVal"],
-                              numArgs=0..1,
-                              flagInversion=false,
-                              defaultValue=none);
-  var subCmdPosArg = subParser.addPositional(name="FileNames",
-                                      numArgs=0..,
-                                      defaultValue=(new list(["f1","f2"])));
+                                        opts=["-b","--boolVal"],
+                                        numArgs=0..1,
+                                        flagInversion=false,
+                                        defaultValue=none);
+  var subCmdPosArg = subParser.addArgument(name="FileNames",
+                                           numArgs=0..,
+                                           defaultValue=(["f1","f2"]));
   var subCmdStrArg = subParser.addOption(name="StringOpt",
-                                  opts=["-n","--stringVal"],
-                                  numArgs=1..10,
-                                  required=false,
-                                  defaultValue=none);
+                                         opts=["-n","--stringVal"],
+                                         numArgs=1..10,
+                                         required=false,
+                                         defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   test.assertFalse(myPosArg.hasValue());
@@ -2748,11 +2748,11 @@ proc testMixPosBoolOptWithValuesSubCommandLight(test: borrowed Test) throws {
   var parser = new argumentParser();
 
   var myBoolArg = parser.addFlag(name="BoolFlag",
-                                opts=["-b","--boolVal"],
-                                numArgs=0..1,
-                                flagInversion=false,
-                                defaultValue=none);
-  var myPosArg = parser.addPositional(name="FileNames",
+                                 opts=["-b","--boolVal"],
+                                 numArgs=0..1,
+                                 flagInversion=false,
+                                 defaultValue=none);
+  var myPosArg = parser.addArgument(name="FileNames",
                                       numArgs=0..);
   var myStrArg = parser.addOption(name="StringOpt",
                                   opts=["-n","--stringVal"],
@@ -2763,18 +2763,18 @@ proc testMixPosBoolOptWithValuesSubCommandLight(test: borrowed Test) throws {
   // setup the subcommand parser
   var subParser = new argumentParser();
   var subCmdBoolArg = subParser.addFlag(name="BoolFlag",
-                              opts=["-b","--boolVal"],
-                              numArgs=0..1,
-                              flagInversion=false,
-                              defaultValue=none);
-  var subCmdPosArg = subParser.addPositional(name="FileNames",
-                                      numArgs=0..,
-                                      defaultValue=(new list(["f1","f2"])));
+                                        opts=["-b","--boolVal"],
+                                        numArgs=0..1,
+                                        flagInversion=false,
+                                        defaultValue=none);
+  var subCmdPosArg = subParser.addArgument(name="FileNames",
+                                           numArgs=0..,
+                                           defaultValue=(["f1","f2"]));
   var subCmdStrArg = subParser.addOption(name="StringOpt",
-                                  opts=["-n","--stringVal"],
-                                  numArgs=1..10,
-                                  required=false,
-                                  defaultValue=none);
+                                         opts=["-n","--stringVal"],
+                                         numArgs=1..10,
+                                         required=false,
+                                         defaultValue=none);
   //make sure no value currently exists
   test.assertFalse(myBoolArg.hasValue());
   test.assertFalse(myPosArg.hasValue());
@@ -2826,13 +2826,13 @@ proc testMockMasonNew(test: borrowed Test) throws {
   var extCmd = parser.addSubCommand("external");
   var pubCmd = parser.addSubCommand("publish");
   var helpFlag = parser.addFlag(name="help",
-                               opts=["-h","--help"],
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                               opts=["-V","--version"],
                                defaultValue=false,
                                flagInversion=false);
-  var verFlag = parser.addFlag(name="version",
-                              opts=["-V","--version"],
-                              defaultValue=false,
-                              flagInversion=false);
   // setup the subcommand parsers (normally done in each sub-module)
   var newParser = new argumentParser();
   var initParser = new argumentParser();
@@ -2860,12 +2860,12 @@ proc testMockMasonNew(test: borrowed Test) throws {
                                   flagInversion=false);
   var newLegalName = newParser.addOption(name="legalName",
                                     opts=["--name"]);
-  var newName = newParser.addPositional(name="name");
+  var newName = newParser.addArgument(name="name");
 
   var newHelpFlag = newParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   // setup arguments for subcommand 'add'
   var addExt = addParser.addFlag(name="external",
                                  opts=["--external"],
@@ -2875,12 +2875,12 @@ proc testMockMasonNew(test: borrowed Test) throws {
                                  opts=["--system"],
                                  defaultValue=false,
                                  flagInversion=false);
-  var addPkg = addParser.addPositional(name="package");
+  var addPkg = addParser.addArgument(name="package");
 
   var addHelpFlag = addParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   //make sure no value currently exists
   test.assertFalse(newCmd.hasValue());
   test.assertFalse(initCmd.hasValue());
@@ -2956,13 +2956,13 @@ proc testMockMasonNewDiffName(test: borrowed Test) throws {
   var extCmd = parser.addSubCommand("external");
   var pubCmd = parser.addSubCommand("publish");
   var helpFlag = parser.addFlag(name="help",
-                               opts=["-h","--help"],
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                               opts=["-V","--version"],
                                defaultValue=false,
                                flagInversion=false);
-  var verFlag = parser.addFlag(name="version",
-                              opts=["-V","--version"],
-                              defaultValue=false,
-                              flagInversion=false);
   // setup the subcommand parsers (normally done in each sub-module)
   var newParser = new argumentParser();
   var initParser = new argumentParser();
@@ -2990,12 +2990,12 @@ proc testMockMasonNewDiffName(test: borrowed Test) throws {
                                   flagInversion=false);
   var newLegalName = newParser.addOption(name="legalName",
                                     opts=["--name"]);
-  var newName = newParser.addPositional(name="name");
+  var newName = newParser.addArgument(name="name");
 
   var newHelpFlag = newParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   // setup arguments for subcommand 'add'
   var addExt = addParser.addFlag(name="external",
                                  opts=["--external"],
@@ -3005,12 +3005,12 @@ proc testMockMasonNewDiffName(test: borrowed Test) throws {
                                  opts=["--system"],
                                  defaultValue=false,
                                  flagInversion=false);
-  var addPkg = addParser.addPositional(name="package");
+  var addPkg = addParser.addArgument(name="package");
 
   var addHelpFlag = addParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   //make sure no value currently exists
   test.assertFalse(newCmd.hasValue());
   test.assertFalse(initCmd.hasValue());
@@ -3087,13 +3087,13 @@ proc testMockMasonNewTypical(test: borrowed Test) throws {
   var extCmd = parser.addSubCommand("external");
   var pubCmd = parser.addSubCommand("publish");
   var helpFlag = parser.addFlag(name="help",
-                               opts=["-h","--help"],
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                               opts=["-V","--version"],
                                defaultValue=false,
                                flagInversion=false);
-  var verFlag = parser.addFlag(name="version",
-                              opts=["-V","--version"],
-                              defaultValue=false,
-                              flagInversion=false);
   // setup the subcommand parsers (normally done in each sub-module)
   var newParser = new argumentParser();
   var initParser = new argumentParser();
@@ -3120,13 +3120,13 @@ proc testMockMasonNewTypical(test: borrowed Test) throws {
                                   defaultValue=false,
                                   flagInversion=false);
   var newLegalName = newParser.addOption(name="legalName",
-                                    opts=["--name"]);
-  var newName = newParser.addPositional(name="name");
+                                         opts=["--name"]);
+  var newName = newParser.addArgument(name="name");
 
   var newHelpFlag = newParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   // setup arguments for subcommand 'add'
   var addExt = addParser.addFlag(name="external",
                                  opts=["--external"],
@@ -3136,12 +3136,12 @@ proc testMockMasonNewTypical(test: borrowed Test) throws {
                                  opts=["--system"],
                                  defaultValue=false,
                                  flagInversion=false);
-  var addPkg = addParser.addPositional(name="package");
+  var addPkg = addParser.addArgument(name="package");
 
   var addHelpFlag = addParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   //make sure no value currently exists
   test.assertFalse(newCmd.hasValue());
   test.assertFalse(initCmd.hasValue());
@@ -3217,13 +3217,13 @@ proc testMockMasonAddExternal(test: borrowed Test) throws {
   var extCmd = parser.addSubCommand("external");
   var pubCmd = parser.addSubCommand("publish");
   var helpFlag = parser.addFlag(name="help",
-                               opts=["-h","--help"],
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                               opts=["-V","--version"],
                                defaultValue=false,
                                flagInversion=false);
-  var verFlag = parser.addFlag(name="version",
-                              opts=["-V","--version"],
-                              defaultValue=false,
-                              flagInversion=false);
   // setup the subcommand parsers (normally done in each sub-module)
   var newParser = new argumentParser();
   var initParser = new argumentParser();
@@ -3251,12 +3251,12 @@ proc testMockMasonAddExternal(test: borrowed Test) throws {
                                   flagInversion=false);
   var newLegalName = newParser.addOption(name="legalName",
                                     opts=["--name"]);
-  var newName = newParser.addPositional(name="name");
+  var newName = newParser.addArgument(name="name");
 
   var newHelpFlag = newParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   // setup arguments for subcommand 'add'
   var addExt = addParser.addFlag(name="external",
                                  opts=["--external"],
@@ -3266,12 +3266,12 @@ proc testMockMasonAddExternal(test: borrowed Test) throws {
                                  opts=["--system"],
                                  defaultValue=false,
                                  flagInversion=false);
-  var addPkg = addParser.addPositional(name="package");
+  var addPkg = addParser.addArgument(name="package");
 
   var addHelpFlag = addParser.addFlag(name="help",
-                               opts=["-h","--help"],
-                               defaultValue=false,
-                               flagInversion=false);
+                                      opts=["-h","--help"],
+                                      defaultValue=false,
+                                      flagInversion=false);
   //make sure no value currently exists
   test.assertFalse(newCmd.hasValue());
   test.assertFalse(initCmd.hasValue());

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -2215,6 +2215,21 @@ proc testPositionalArgumentDefault(test: borrowed Test) throws {
   test.assertEqual((new list(myPosArg.values())).size, 1);
 }
 
+// single positional argument test with no default value
+proc testPositionalArgumentOptionalMissing(test: borrowed Test) throws {
+  var argList = ["progName"];
+  var parser = new argumentParser();
+  var myPosArg = parser.addPositional(name="FileName",
+                                      defaultValue=none,
+                                      numArgs=0..1);
+  //make sure no value currently exists
+  test.assertFalse(myPosArg.hasValue());
+  //parse the options
+  parser.parseArgs(argList[1..]);
+  //make sure we still don't have a value
+  test.assertFalse(myPosArg.hasValue());
+}
+
 // multiple value positional argument test
 proc testPositionalArgumentRangeOneOrMore(test: borrowed Test) throws {
   var argList = ["progName","file1","file2","file3","file4"];
@@ -2231,6 +2246,65 @@ proc testPositionalArgumentRangeOneOrMore(test: borrowed Test) throws {
   var valList = new list(myPosArg.values());
   test.assertEqual(valList,new list(argList[1..]));
   test.assertEqual(valList.size, 4);
+}
+
+// too many values for positional argument
+proc testPositionalArgumentTooManyVals(test: borrowed Test) throws {
+  var argList = ["progName","file1","file2","file3","file4"];
+  var parser = new argumentParser();
+  var myPosArg = parser.addPositional(name="FileNames",
+                                      numArgs=1..2,
+                                      defaultValue=none);
+  //make sure no value currently exists
+  test.assertFalse(myPosArg.hasValue());
+  //parse the options
+  try {
+    parser.parseArgs(argList[1..]);
+  } catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
+}
+
+// not enough values for positional argument
+proc testPositionalArgumentNotEnoughVals(test: borrowed Test) throws {
+  var argList = ["progName","file1","file2","file3","file4"];
+  var parser = new argumentParser();
+  var myPosArg = parser.addPositional(name="FileNames",
+                                      numArgs=5..7,
+                                      defaultValue=none);
+  //make sure no value currently exists
+  test.assertFalse(myPosArg.hasValue());
+  //parse the options
+  try {
+    parser.parseArgs(argList[1..]);
+  } catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
+}
+
+// no values for positional argument
+proc testPositionalArgumentNoVals(test: borrowed Test) throws {
+  var argList = ["progName"];
+  var parser = new argumentParser();
+  var myPosArg = parser.addPositional(name="FileNames",
+                                      numArgs=1..);
+  //make sure no value currently exists
+  test.assertFalse(myPosArg.hasValue());
+  //parse the options
+  try {
+    parser.parseArgs(argList[1..]);
+  } catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
 }
 
 // multiple value positional arguments with range before other positional

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -2399,8 +2399,529 @@ proc testMixPosBoolOptWithValuesSubCommandLight(test: borrowed Test) throws {
   test.assertEqual(subCmdOptList, new list(["s1","s2","s3"]));
 }
 
+// mockup of a Mason interface testing "new" options
+proc testMockMasonNew(test: borrowed Test) throws {
+  var argList = ["mason","new","--no-vcs","myPackage"];
+
+  var parser = new argumentParser();
+  var newCmd = parser.addSubCommand("new");
+  var initCmd = parser.addSubCommand("init");
+  var addCmd = parser.addSubCommand("add");
+  var rmCmd = parser.addSubCommand("rm");
+  var upCmd = parser.addSubCommand("update");
+  var testCmd = parser.addSubCommand("test");
+  var buildCmd = parser.addSubCommand("build");
+  var runCmd = parser.addSubCommand("run");
+  var searchCmd = parser.addSubCommand("search");
+  var envCmd = parser.addSubCommand("env");
+  var cleanCmd = parser.addSubCommand("clean");
+  var docCmd = parser.addSubCommand("doc");
+  var sysCmd = parser.addSubCommand("system");
+  var extCmd = parser.addSubCommand("external");
+  var pubCmd = parser.addSubCommand("publish");
+  var helpFlag = parser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                              opts=["-V","--version"],
+                              defaultValue=false,
+                              flagInversion=false);
+  // setup the subcommand parsers (normally done in each sub-module)
+  var newParser = new argumentParser();
+  var initParser = new argumentParser();
+  var addParser = new argumentParser();
+  var rmParser = new argumentParser();
+  var upParser = new argumentParser();
+  var testParser = new argumentParser();
+  var buildParser = new argumentParser();
+  var runParser = new argumentParser();
+  var searchParser = new argumentParser();
+  var envParser = new argumentParser();
+  var cleanParser = new argumentParser();
+  var docParser = new argumentParser();
+  var sysParser = new argumentParser();
+  var extParser = new argumentParser();
+  var pubParser = new argumentParser();
+
+  // setup arguments for subcommand 'new'
+  var newVCS = newParser.addFlag(name="vcs",
+                                 opts=["--vcs"],
+                                 defaultValue=true);
+  var newShow = newParser.addFlag(name="show",
+                                  opts=["--show"],
+                                  defaultValue=false,
+                                  flagInversion=false);
+  var newLegalName = newParser.addOption(name="legalName",
+                                    opts=["--name"]);
+  var newName = newParser.addPositional(name="name");
+
+  var newHelpFlag = newParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  // setup arguments for subcommand 'add'
+  var addExt = addParser.addFlag(name="external",
+                                 opts=["--external"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addSys = addParser.addFlag(name="system",
+                                 opts=["--system"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addPkg = addParser.addPositional(name="package");
+
+  var addHelpFlag = addParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  //make sure no value currently exists
+  test.assertFalse(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertFalse(helpFlag.hasValue());
+  test.assertFalse(verFlag.hasValue());
+  //parse the options
+  var rest = parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertTrue(helpFlag.hasValue());
+  test.assertTrue(verFlag.hasValue());
+  test.assertFalse(helpFlag.valueAsBool());
+  test.assertFalse(verFlag.valueAsBool());
+  test.assertFalse(newLegalName.hasValue());
+  //parse the remaining args
+  newParser.parseArgs(rest.toArray());
+  //make sure we now have a value
+  test.assertTrue(newVCS.hasValue());
+  test.assertTrue(newName.hasValue());
+  test.assertTrue(newHelpFlag.hasValue());
+  test.assertFalse(newHelpFlag.valueAsBool());
+  //ensure the value passed is correct
+  test.assertFalse(newVCS.valueAsBool());
+  test.assertEqual(newName.value(), "myPackage");
+}
 
 
+// mockup of a Mason interface testing "new" options
+proc testMockMasonNewDiffName(test: borrowed Test) throws {
+  var argList = ["mason","new","--no-vcs","--name","notMyPackage","myPackage"];
+
+  var parser = new argumentParser();
+  var newCmd = parser.addSubCommand("new");
+  var initCmd = parser.addSubCommand("init");
+  var addCmd = parser.addSubCommand("add");
+  var rmCmd = parser.addSubCommand("rm");
+  var upCmd = parser.addSubCommand("update");
+  var testCmd = parser.addSubCommand("test");
+  var buildCmd = parser.addSubCommand("build");
+  var runCmd = parser.addSubCommand("run");
+  var searchCmd = parser.addSubCommand("search");
+  var envCmd = parser.addSubCommand("env");
+  var cleanCmd = parser.addSubCommand("clean");
+  var docCmd = parser.addSubCommand("doc");
+  var sysCmd = parser.addSubCommand("system");
+  var extCmd = parser.addSubCommand("external");
+  var pubCmd = parser.addSubCommand("publish");
+  var helpFlag = parser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                              opts=["-V","--version"],
+                              defaultValue=false,
+                              flagInversion=false);
+  // setup the subcommand parsers (normally done in each sub-module)
+  var newParser = new argumentParser();
+  var initParser = new argumentParser();
+  var addParser = new argumentParser();
+  var rmParser = new argumentParser();
+  var upParser = new argumentParser();
+  var testParser = new argumentParser();
+  var buildParser = new argumentParser();
+  var runParser = new argumentParser();
+  var searchParser = new argumentParser();
+  var envParser = new argumentParser();
+  var cleanParser = new argumentParser();
+  var docParser = new argumentParser();
+  var sysParser = new argumentParser();
+  var extParser = new argumentParser();
+  var pubParser = new argumentParser();
+
+  // setup arguments for subcommand 'new'
+  var newVCS = newParser.addFlag(name="vcs",
+                                 opts=["--vcs"],
+                                 defaultValue=true);
+  var newShow = newParser.addFlag(name="show",
+                                  opts=["--show"],
+                                  defaultValue=false,
+                                  flagInversion=false);
+  var newLegalName = newParser.addOption(name="legalName",
+                                    opts=["--name"]);
+  var newName = newParser.addPositional(name="name");
+
+  var newHelpFlag = newParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  // setup arguments for subcommand 'add'
+  var addExt = addParser.addFlag(name="external",
+                                 opts=["--external"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addSys = addParser.addFlag(name="system",
+                                 opts=["--system"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addPkg = addParser.addPositional(name="package");
+
+  var addHelpFlag = addParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  //make sure no value currently exists
+  test.assertFalse(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertFalse(helpFlag.hasValue());
+  test.assertFalse(verFlag.hasValue());
+  //parse the options
+  var rest = parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertTrue(helpFlag.hasValue());
+  test.assertTrue(verFlag.hasValue());
+  test.assertFalse(helpFlag.valueAsBool());
+  test.assertFalse(verFlag.valueAsBool());
+  test.assertFalse(newLegalName.hasValue());
+  //parse the remaining args
+  newParser.parseArgs(rest.toArray());
+  //make sure we now have a value
+  test.assertTrue(newVCS.hasValue());
+  test.assertTrue(newName.hasValue());
+  test.assertTrue(newLegalName.hasValue());
+  test.assertTrue(newHelpFlag.hasValue());
+  test.assertFalse(newHelpFlag.valueAsBool());
+  //ensure the value passed is correct
+  test.assertFalse(newVCS.valueAsBool());
+  test.assertEqual(newLegalName.value(),"notMyPackage");
+  test.assertEqual(newName.value(), "myPackage");
+}
+
+// mockup of a Mason interface testing "new" options
+proc testMockMasonNewTypical(test: borrowed Test) throws {
+  var argList = ["mason","new","myPackage"];
+
+  var parser = new argumentParser();
+  var newCmd = parser.addSubCommand("new");
+  var initCmd = parser.addSubCommand("init");
+  var addCmd = parser.addSubCommand("add");
+  var rmCmd = parser.addSubCommand("rm");
+  var upCmd = parser.addSubCommand("update");
+  var testCmd = parser.addSubCommand("test");
+  var buildCmd = parser.addSubCommand("build");
+  var runCmd = parser.addSubCommand("run");
+  var searchCmd = parser.addSubCommand("search");
+  var envCmd = parser.addSubCommand("env");
+  var cleanCmd = parser.addSubCommand("clean");
+  var docCmd = parser.addSubCommand("doc");
+  var sysCmd = parser.addSubCommand("system");
+  var extCmd = parser.addSubCommand("external");
+  var pubCmd = parser.addSubCommand("publish");
+  var helpFlag = parser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                              opts=["-V","--version"],
+                              defaultValue=false,
+                              flagInversion=false);
+  // setup the subcommand parsers (normally done in each sub-module)
+  var newParser = new argumentParser();
+  var initParser = new argumentParser();
+  var addParser = new argumentParser();
+  var rmParser = new argumentParser();
+  var upParser = new argumentParser();
+  var testParser = new argumentParser();
+  var buildParser = new argumentParser();
+  var runParser = new argumentParser();
+  var searchParser = new argumentParser();
+  var envParser = new argumentParser();
+  var cleanParser = new argumentParser();
+  var docParser = new argumentParser();
+  var sysParser = new argumentParser();
+  var extParser = new argumentParser();
+  var pubParser = new argumentParser();
+
+  // setup arguments for subcommand 'new'
+  var newVCS = newParser.addFlag(name="vcs",
+                                 opts=["--vcs"],
+                                 defaultValue=true);
+  var newShow = newParser.addFlag(name="show",
+                                  opts=["--show"],
+                                  defaultValue=false,
+                                  flagInversion=false);
+  var newLegalName = newParser.addOption(name="legalName",
+                                    opts=["--name"]);
+  var newName = newParser.addPositional(name="name");
+
+  var newHelpFlag = newParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  // setup arguments for subcommand 'add'
+  var addExt = addParser.addFlag(name="external",
+                                 opts=["--external"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addSys = addParser.addFlag(name="system",
+                                 opts=["--system"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addPkg = addParser.addPositional(name="package");
+
+  var addHelpFlag = addParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  //make sure no value currently exists
+  test.assertFalse(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertFalse(helpFlag.hasValue());
+  test.assertFalse(verFlag.hasValue());
+  //parse the options
+  var rest = parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertTrue(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertTrue(helpFlag.hasValue());
+  test.assertTrue(verFlag.hasValue());
+  test.assertFalse(helpFlag.valueAsBool());
+  test.assertFalse(verFlag.valueAsBool());
+  test.assertFalse(newLegalName.hasValue());
+  //parse the remaining args
+  newParser.parseArgs(rest.toArray());
+  //make sure we now have a value
+  test.assertTrue(newVCS.hasValue());
+  test.assertTrue(newName.hasValue());
+  test.assertFalse(newLegalName.hasValue());
+  test.assertTrue(newHelpFlag.hasValue());
+  test.assertFalse(newHelpFlag.valueAsBool());
+  //ensure the value passed is correct
+  test.assertTrue(newVCS.valueAsBool());
+  test.assertEqual(newName.value(), "myPackage");
+}
+
+// mockup of a Mason interface testing "add" options
+proc testMockMasonAddExternal(test: borrowed Test) throws {
+  var argList = ["mason","add","--external","externalPackage@0.2.3"];
+
+  var parser = new argumentParser();
+  var newCmd = parser.addSubCommand("new");
+  var initCmd = parser.addSubCommand("init");
+  var addCmd = parser.addSubCommand("add");
+  var rmCmd = parser.addSubCommand("rm");
+  var upCmd = parser.addSubCommand("update");
+  var testCmd = parser.addSubCommand("test");
+  var buildCmd = parser.addSubCommand("build");
+  var runCmd = parser.addSubCommand("run");
+  var searchCmd = parser.addSubCommand("search");
+  var envCmd = parser.addSubCommand("env");
+  var cleanCmd = parser.addSubCommand("clean");
+  var docCmd = parser.addSubCommand("doc");
+  var sysCmd = parser.addSubCommand("system");
+  var extCmd = parser.addSubCommand("external");
+  var pubCmd = parser.addSubCommand("publish");
+  var helpFlag = parser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  var verFlag = parser.addFlag(name="version",
+                              opts=["-V","--version"],
+                              defaultValue=false,
+                              flagInversion=false);
+  // setup the subcommand parsers (normally done in each sub-module)
+  var newParser = new argumentParser();
+  var initParser = new argumentParser();
+  var addParser = new argumentParser();
+  var rmParser = new argumentParser();
+  var upParser = new argumentParser();
+  var testParser = new argumentParser();
+  var buildParser = new argumentParser();
+  var runParser = new argumentParser();
+  var searchParser = new argumentParser();
+  var envParser = new argumentParser();
+  var cleanParser = new argumentParser();
+  var docParser = new argumentParser();
+  var sysParser = new argumentParser();
+  var extParser = new argumentParser();
+  var pubParser = new argumentParser();
+
+  // setup arguments for subcommand 'new'
+  var newVCS = newParser.addFlag(name="vcs",
+                                 opts=["--vcs"],
+                                 defaultValue=true);
+  var newShow = newParser.addFlag(name="show",
+                                  opts=["--show"],
+                                  defaultValue=false,
+                                  flagInversion=false);
+  var newLegalName = newParser.addOption(name="legalName",
+                                    opts=["--name"]);
+  var newName = newParser.addPositional(name="name");
+
+  var newHelpFlag = newParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  // setup arguments for subcommand 'add'
+  var addExt = addParser.addFlag(name="external",
+                                 opts=["--external"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addSys = addParser.addFlag(name="system",
+                                 opts=["--system"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var addPkg = addParser.addPositional(name="package");
+
+  var addHelpFlag = addParser.addFlag(name="help",
+                               opts=["-h","--help"],
+                               defaultValue=false,
+                               flagInversion=false);
+  //make sure no value currently exists
+  test.assertFalse(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertFalse(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertFalse(helpFlag.hasValue());
+  test.assertFalse(verFlag.hasValue());
+  //parse the options
+  var rest = parser.parseArgs(argList[1..]);
+  //make sure we now have a value
+  test.assertFalse(newCmd.hasValue());
+  test.assertFalse(initCmd.hasValue());
+  test.assertTrue(addCmd.hasValue());
+  test.assertFalse(rmCmd.hasValue());
+  test.assertFalse(upCmd.hasValue());
+  test.assertFalse(testCmd.hasValue());
+  test.assertFalse(buildCmd.hasValue());
+  test.assertFalse(runCmd.hasValue());
+  test.assertFalse(searchCmd.hasValue());
+  test.assertFalse(envCmd.hasValue());
+  test.assertFalse(cleanCmd.hasValue());
+  test.assertFalse(docCmd.hasValue());
+  test.assertFalse(sysCmd.hasValue());
+  test.assertFalse(extCmd.hasValue());
+  test.assertFalse(pubCmd.hasValue());
+  test.assertTrue(helpFlag.hasValue());
+  test.assertTrue(verFlag.hasValue());
+  test.assertFalse(helpFlag.valueAsBool());
+  test.assertFalse(verFlag.valueAsBool());
+  test.assertFalse(addPkg.hasValue());
+  test.assertFalse(addExt.hasValue());
+  test.assertFalse(addSys.hasValue());
+  //parse the remaining args
+  addParser.parseArgs(rest.toArray());
+  //make sure we now have a value
+  test.assertTrue(addExt.hasValue());
+  test.assertTrue(addPkg.hasValue());
+  test.assertTrue(addSys.hasValue());
+  test.assertTrue(addHelpFlag.hasValue());
+  test.assertFalse(addHelpFlag.valueAsBool());
+  //ensure the value passed is correct
+  test.assertFalse(addSys.valueAsBool());
+  test.assertTrue(addExt.valueAsBool());
+  test.assertEqual(addPkg.value(), "externalPackage@0.2.3");
+}
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 
 UnitTest.main();

--- a/test/mason/mason-argparse/MasonArgParseTests.chpl
+++ b/test/mason/mason-argparse/MasonArgParseTests.chpl
@@ -2135,6 +2135,28 @@ proc testFlagBadBoolValue(test: borrowed Test) throws {
   test.assertTrue(false);
 }
 
+// a short bool flag with too many values defined
+proc testFlagBadBoolNumArgs(test: borrowed Test) throws {
+  var argList = ["progName","-n"];
+  var parser = new argumentParser();
+  try {
+    var myBoolArg = parser.addFlag(name="BoolFlag",
+                                  opts=["-n","--boolVal"],
+                                  numArgs=2,
+                                  flagInversion=false);
+    //make sure no value currently exists
+  //test.assertFalse(myBoolArg.hasValue());
+  //parse the options
+
+   // parser.parseArgs(argList[1..]);
+  } catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
+}
+
 // check expected output from helper string to bool method
 proc unitTestStringToBool(test: borrowed Test) throws {
   var trueStrVals = ["true","1","yes"," true ", " yes ", " 1 "];
@@ -2209,6 +2231,22 @@ proc testPositionalArgumentRangeOneOrMore(test: borrowed Test) throws {
   var valList = new list(myPosArg.values());
   test.assertEqual(valList,new list(argList[1..]));
   test.assertEqual(valList.size, 4);
+}
+
+// multiple value positional arguments with range before other positional
+proc testPositionalArgumentRangeBeforePos(test: borrowed Test) throws {
+  var argList = ["progName","file1","file2","file3","file4"];
+  var parser = new argumentParser();
+  var myPosArg = parser.addPositional(name="FileNames",
+                                      numArgs=1..);
+  try {
+    var myPosArg = parser.addPositional(name="otherArg");
+  } catch ex: ArgumentError {
+    test.assertTrue(true);
+    stderr.writeln(ex.message());
+    return;
+  }
+  test.assertTrue(false);
 }
 
 // a mix of positionals, bools, and options

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -426,7 +426,23 @@ testMixPosBoolOptWithValuesSubCommandLight()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
-Found undefined values: thirty
+testMockMasonNew()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMockMasonNewDiffName()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMockMasonNewTypical()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMockMasonAddExternal()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+Found some unrecognizable arguments
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 StringOpt Too many values: expected 1..1 got 3
@@ -435,10 +451,10 @@ StringOpt has extra values
 StringOpt Required value missing
 Found some unrecognizable arguments
 StringOpt Not enough values: expected 1..2 got 0
-Found undefined values: two
-Found undefined values: -p thirty
+Found some unrecognizable arguments
+Found some unrecognizable arguments
 StringOpt Not enough values: expected 3..5 got 2
-Found undefined values: fifty
+Found some unrecognizable arguments
 StringOpt Not enough values: expected 1..3 got 0
 StringOpt Not enough values: expected 1..1 got 0
 StringOpt1 Not enough values: expected 1..1 got 0
@@ -446,7 +462,7 @@ StringOpt2 Not enough values: expected 1..1 got 0
 StringOpt3 Not enough values: expected 1..1 got 0
 StringOpt1 has extra values
 StringOpt2 has extra values
-Found undefined values: five
+Found some unrecognizable arguments
 StringOpt2 has extra values
 StringOpt2 Required value missing
 Only string and list of strings are supported as default values at this time
@@ -461,8 +477,8 @@ Found some unrecognizable arguments
 Found some unrecognizable arguments
 StringOpt1 has extra values
 BoolFlag Not enough values: expected 1..1 got 0
-Found undefined values: false
-Found undefined values: false
+Found some unrecognizable arguments
+Found some unrecognizable arguments
 Creating 'no' flag options prevents using value to set flag
 Setting up a required flag that defaults to true with no way for user to set false
 Creating 'no' flag options prevents using value to set flag

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -472,8 +472,8 @@ Flavour: OK
 ----------------------------------------------------------------------
 Found some unrecognizable arguments: thirty
 Found some unrecognizable arguments: badArg1 --BadFlag
-Use '-' or '--' to indicate options, or use positional arguments.
-Use '-' or '--' to indicate options, or use positional arguments.
+Use '-' or '--' to indicate option/flag, or use positional arguments.
+Use '-' or '--' to indicate option/flag, or use positional arguments.
 StringOpt Too many values: expected 1..1 got 3
 StringOpt Too many values: expected 1..3 got 6
 Found some unrecognizable arguments: fifty
@@ -499,8 +499,8 @@ Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
 Option name StringOpt is previously defined
-Option flag -n is previously defined
-Option flag --strArg is previously defined
+Option/flag -n is previously defined
+Option/flag --strArg is previously defined
 Found some unrecognizable arguments: subCommandNone
 Found some unrecognizable arguments: subCommandNone
 Found some unrecognizable arguments: -x

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -422,6 +422,10 @@ testMixPosBoolOptWithValuesSubCommand()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testMixPosBoolOptWithValuesSubCommandLight()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 Found undefined values: thirty
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -414,7 +414,23 @@ testPositionalArgumentDefault()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testPositionalArgumentOptionalMissing()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 testPositionalArgumentRangeOneOrMore()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testPositionalArgumentTooManyVals()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testPositionalArgumentNotEnoughVals()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testPositionalArgumentNoVals()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
@@ -522,4 +538,7 @@ Creating 'no' flag options prevents using value to set flag
 Creating 'no' flag options prevents using value to set flag
 Unrecognized value tru
 Maximum number of values for a flag is 1
+Found some unrecognizable arguments: file3 file4
+FileNames Not enough values: expected 5..7 got 4
+FileNames Required value missing
 Positional arguments that allow for range of values must be last relative to other positional arguments

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -398,6 +398,30 @@ unitTestStringToBool()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testSinglePositionalArgument()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testPositionalArgumentDefault()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testPositionalArgumentRangeOneOrMore()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptWithValues()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptWithValuesFixed()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptWithValuesSubCommand()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 Found undefined values: thirty
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
 Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
@@ -405,7 +429,7 @@ StringOpt Too many values: expected 1..1 got 3
 StringOpt Too many values: expected 1..3 got 6
 StringOpt has extra values
 StringOpt Required value missing
-unrecognized options/values encountered: -n twenty
+Found some unrecognizable arguments
 StringOpt Not enough values: expected 1..2 got 0
 Found undefined values: two
 Found undefined values: -p thirty
@@ -428,9 +452,9 @@ Only string and list of strings are supported as default values at this time
 Option name StringOpt is previously defined
 Option flag -n is previously defined
 Option flag --strArg is previously defined
-Found undefined values: subCommandNone
-Found undefined values: subCommandNone
-Found undefined values: -x
+Found some unrecognizable arguments
+Found some unrecognizable arguments
+Found some unrecognizable arguments
 StringOpt1 has extra values
 BoolFlag Not enough values: expected 1..1 got 0
 Found undefined values: false

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -442,19 +442,19 @@ testMockMasonAddExternal()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
-Found some unrecognizable arguments
-Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
-Use '-' or '--' to indicate opt flags. Positional arguments not yet supported
+Found some unrecognizable arguments: thirty
+Use '-' or '--' to indicate options, or use positional arguments.
+Use '-' or '--' to indicate options, or use positional arguments.
 StringOpt Too many values: expected 1..1 got 3
 StringOpt Too many values: expected 1..3 got 6
 StringOpt has extra values
 StringOpt Required value missing
-Found some unrecognizable arguments
+unrecognized options/values encountered: -n twenty
 StringOpt Not enough values: expected 1..2 got 0
-Found some unrecognizable arguments
-Found some unrecognizable arguments
+Found some unrecognizable arguments: two
+Found some unrecognizable arguments: -p thirty
 StringOpt Not enough values: expected 3..5 got 2
-Found some unrecognizable arguments
+Found some unrecognizable arguments: fifty
 StringOpt Not enough values: expected 1..3 got 0
 StringOpt Not enough values: expected 1..1 got 0
 StringOpt1 Not enough values: expected 1..1 got 0
@@ -462,7 +462,7 @@ StringOpt2 Not enough values: expected 1..1 got 0
 StringOpt3 Not enough values: expected 1..1 got 0
 StringOpt1 has extra values
 StringOpt2 has extra values
-Found some unrecognizable arguments
+Found some unrecognizable arguments: five
 StringOpt2 has extra values
 StringOpt2 Required value missing
 Only string and list of strings are supported as default values at this time
@@ -472,13 +472,13 @@ Only string and list of strings are supported as default values at this time
 Option name StringOpt is previously defined
 Option flag -n is previously defined
 Option flag --strArg is previously defined
-Found some unrecognizable arguments
-Found some unrecognizable arguments
-Found some unrecognizable arguments
+Found some unrecognizable arguments: subCommandNone
+Found some unrecognizable arguments: subCommandNone subCommand1
+Found some unrecognizable arguments: -x -n twenty
 StringOpt1 has extra values
 BoolFlag Not enough values: expected 1..1 got 0
-Found some unrecognizable arguments
-Found some unrecognizable arguments
+Found some unrecognizable arguments: false
+Found some unrecognizable arguments: false
 Creating 'no' flag options prevents using value to set flag
 Setting up a required flag that defaults to true with no way for user to set false
 Creating 'no' flag options prevents using value to set flag

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -422,6 +422,30 @@ testMixPosBoolOptWithValuesFixed()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testMixPosBoolOptWithValuesFixedPosAfterBool()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptWithValuesFixedPosInterMixed()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptWithValuesPosInterMixedRange()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptPosInterMixedRangeWithVals()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptPosInterMixedRangeDefVals()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixPosBoolOptPosInterMixedRangeNoVals()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 testMixPosBoolOptWithValuesSubCommand()
 Flavour: OK
 ======================================================================
@@ -452,7 +476,7 @@ Use '-' or '--' to indicate options, or use positional arguments.
 Use '-' or '--' to indicate options, or use positional arguments.
 StringOpt Too many values: expected 1..1 got 3
 StringOpt Too many values: expected 1..3 got 6
-StringOpt has extra values
+Found some unrecognizable arguments: fifty
 StringOpt Required value missing
 unrecognized options/values encountered: -n twenty
 StringOpt Not enough values: expected 1..2 got 0
@@ -465,10 +489,10 @@ StringOpt Not enough values: expected 1..1 got 0
 StringOpt1 Not enough values: expected 1..1 got 0
 StringOpt2 Not enough values: expected 1..1 got 0
 StringOpt3 Not enough values: expected 1..1 got 0
-StringOpt1 has extra values
-StringOpt2 has extra values
 Found some unrecognizable arguments: five
-StringOpt2 has extra values
+Found some unrecognizable arguments: five
+Found some unrecognizable arguments: five
+Found some unrecognizable arguments: five
 StringOpt2 Required value missing
 Only string and list of strings are supported as default values at this time
 Only string and list of strings are supported as default values at this time
@@ -480,7 +504,7 @@ Option flag --strArg is previously defined
 Found some unrecognizable arguments: subCommandNone
 Found some unrecognizable arguments: subCommandNone
 Found some unrecognizable arguments: -x
-StringOpt1 has extra values
+Found some unrecognizable arguments: -f
 BoolFlag Not enough values: expected 1..1 got 0
 Found some unrecognizable arguments: false
 Found some unrecognizable arguments: false

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -10,6 +10,10 @@ testSingleStringShortOptEqualsExtra()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testBadArgsAtFront()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 testMultiStringShortOptEqualsOK()
 Flavour: OK
 ======================================================================
@@ -443,6 +447,7 @@ Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
 Found some unrecognizable arguments: thirty
+Found some unrecognizable arguments: badArg1 --BadFlag
 Use '-' or '--' to indicate options, or use positional arguments.
 Use '-' or '--' to indicate options, or use positional arguments.
 StringOpt Too many values: expected 1..1 got 3
@@ -473,8 +478,8 @@ Option name StringOpt is previously defined
 Option flag -n is previously defined
 Option flag --strArg is previously defined
 Found some unrecognizable arguments: subCommandNone
-Found some unrecognizable arguments: subCommandNone subCommand1
-Found some unrecognizable arguments: -x -n twenty
+Found some unrecognizable arguments: subCommandNone
+Found some unrecognizable arguments: -x
 StringOpt1 has extra values
 BoolFlag Not enough values: expected 1..1 got 0
 Found some unrecognizable arguments: false

--- a/test/mason/mason-argparse/MasonArgParseTests.good
+++ b/test/mason/mason-argparse/MasonArgParseTests.good
@@ -398,6 +398,10 @@ testFlagBadBoolValue()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testFlagBadBoolNumArgs()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 unitTestStringToBool()
 Flavour: OK
 ======================================================================
@@ -411,6 +415,10 @@ Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
 testPositionalArgumentRangeOneOrMore()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testPositionalArgumentRangeBeforePos()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
@@ -513,3 +521,5 @@ Setting up a required flag that defaults to true with no way for user to set fal
 Creating 'no' flag options prevents using value to set flag
 Creating 'no' flag options prevents using value to set flag
 Unrecognized value tru
+Maximum number of values for a flag is 1
+Positional arguments that allow for range of values must be last relative to other positional arguments

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -22,23 +22,8 @@ module MasonArgParse {
   private use Map;
   private use IO;
   private use Sort;
-  private use Sys only sys_getenv;
 
-  config var OTFDebug=false;
-
-  const DEBUG = _checkDebug();
-
-  proc _checkDebug() : bool {
-    var envValue = "FALSE";
-    var rtn = false;
-
-   // if sys_getenv("ARGPARSE_DEBUG", envValue) == 1 ) {
-      if _convertStringToBool(envValue, rtn) {
-        return rtn || OTFDebug;
-      }
-   // }
-    return false;
-  }
+  private config var DEBUG=false;
 
   // TODO: Add pass-thru options following "-"
   // TODO: Add int opts
@@ -165,11 +150,11 @@ module MasonArgParse {
   }
 
   class Positional : Action {
-    // indicates if this flag is required to be entered by the user
+    // indicates if this argument is required to be entered by the user
     var _required:bool;
-    // default value to use when flag is not present
+    // default value to use when argument is not present
     var _defaultValue:list(string);
-    // number of acceptable values to be present after argument is indicated
+    // number of acceptable values to be present for this argument
     var _numArgs:range;
 
     proc init(name:string, defaultValue:?t=none, numArgs=1..1) {
@@ -233,10 +218,7 @@ module MasonArgParse {
       debugTrace("present="+present:string + " required="+_required:string);
       if !present && _required {
         return "Required value missing";
-      } else if valueCount > _numArgs.high {
-        return "Too many values: expected " + _numArgs:string +
-               " got " + valueCount:string;
-      } else if valueCount < _numArgs.low && present {
+      } else if valueCount < _numArgs.low {
         return "Not enough values: expected " + _numArgs:string +
                " got " + valueCount:string;
       } else {

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -728,7 +728,8 @@ module MasonArgParse {
       for arg in _positionals {
         if arg._numArgs.high >= 1 && arg._numArgs.low != arg._numArgs.high {
           throw new ArgumentError("Positional arguments that allow for range " +
-                                  "of values must be in the last position");
+                                  "of values must be last relative to other " +
+                                  "positional arguments");
         }
       }
 

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -138,7 +138,7 @@ module MasonArgParse {
     }
 
     // for subcommands, _match attempts to identify values at the index of the
-    // subcommadn at position startPos (inclusive) and through the
+    // subcommand at position startPos (inclusive) and through the
     // endPos (inclusive) parameter [startPos, endPos]
     override proc _match(args:[?argsD]string, startPos:int, myArg:Argument,
                          ref rest:list(string), endPos:int) throws {
@@ -418,6 +418,8 @@ module MasonArgParse {
     var _options: map(string, string);
     // store positional definitions
     var _positionals: list(borrowed Positional);
+    // store subcommand names
+    var _subcommands: list(string);
 
     proc _parsePositionals(arguments:[?argsD] string, endIdx:int) throws {
       var endPos = 0;
@@ -476,6 +478,8 @@ module MasonArgParse {
           // create an entry for this index and the argument name
           optionIndices.add(i, optName);
           argRslt._present = true;
+          // if subcommand found, stop processing more args
+          if _subcommands.contains(argElt) then break;
         }
       }
 
@@ -676,6 +680,7 @@ module MasonArgParse {
 
     proc addSubCommand(cmd:string) throws {
       var act = new owned SubCommand(cmd);
+      _subcommands.append(cmd);
       _options.add(cmd, cmd);
       return _addAction(act);
     }

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -27,10 +27,10 @@ module MasonArgParse {
 
   config var OTFDebug=false;
 
-  const DEBUG = false;//_checkDebug();
+  const DEBUG = _checkDebug();
 
   proc _checkDebug() : bool {
-    var envValue:string;
+    var envValue = "FALSE";
     var rtn = false;
 
    // if sys_getenv("ARGPARSE_DEBUG", envValue) == 1 ) {
@@ -41,7 +41,6 @@ module MasonArgParse {
     return false;
   }
 
-  // TODO: Add positional arguments
   // TODO: Add pass-thru options following "-" or "--"
   // TODO: Add int opts
   // TODO: Implement Help message and formatting

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -692,17 +692,17 @@ module MasonArgParse {
       return _addAction(act);
     }
 
-    proc addPositional(name:string, numArgs=1, defaultValue:?t=none) throws {
-      return addPositional(name, numArgs..numArgs, defaultValue);
+    proc addArgument(name:string, numArgs=1, defaultValue:?t=none) throws {
+      return addArgument(name, numArgs..numArgs, defaultValue);
     }
 
-    proc addPositional(name:string,
+    proc addArgument(name:string,
                        numArgs:range(boundedType=BoundedRangeType.boundedLow),
                        defaultValue:?t=none) throws {
-      return addPositional(name, numArgs.low..max(int), defaultValue);
+      return addArgument(name, numArgs.low..max(int), defaultValue);
     }
 
-    proc addPositional(name:string,
+    proc addArgument(name:string,
                        numArgs:range,
                        defaultValue:?t=none) throws {
       var act = new owned Positional(name, defaultValue, numArgs);

--- a/tools/mason/MasonArgParse.chpl
+++ b/tools/mason/MasonArgParse.chpl
@@ -440,7 +440,7 @@ module MasonArgParse {
       // check that we consumed everything we expected to
       if endPos < endIdx then{
         throw new ArgumentError("Found some unrecognizable arguments: " +
-                                " ".join(arguments[endPos..]));
+                                " ".join(arguments[endPos..<endIdx]));
       }
       return endPos;
     }
@@ -501,12 +501,6 @@ module MasonArgParse {
         firstFlagIdx = arrayOptionIndices[0][0];
       if firstFlagIdx > 0 then
         endPos = _parsePositionals(argsList.toArray(), firstFlagIdx);
-
-
-      // check for undefined argument provided at beginning of cmd string
-      if arrayOptionIndices.size > 0 && arrayOptionIndices[0][0] != endPos {
-          throw new ArgumentError("Found undefined values: " + argsList[0]);
-      }
 
       // try to match for each of the identified options
       for i in arrayOptionIndices.indices {


### PR DESCRIPTION
This PR adds positional arguments to the argument parser. 

Scope of work defined in Cray/chapel-private#2302, this work satisfies
the main goals of that issue which are to:

1. Allow the developer to add positional arguments to their CLI
2. Allow options, subcommands, flags, and positional arguments to be 
entered together
3. Identify positional arguments at the beginning, end, or intermixed within a 
command string

Relates to broader implementation task in Cray/chapel-private#2192

Tests added for flags and mixing positional arguments, subcommands, options, 
and flags.

Example updated to include flags.

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/mason-argparse`

Reviewed by @mppf 

Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com