### PR TITLE
Use SysCTypes and SysBasic by default in c2chapel

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -616,6 +616,10 @@ def preamble(args, fakes):
     # generate, but for now this is good enough
     print("use CPtr;")
 
+    # Needed for C types
+    print("use SysCTypes;")
+    print("use SysBasic;")
+
 # TODO: accept file from stdin?
 if __name__=="__main__":
     (args, unknowns)  = getArgs()

--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -6,6 +6,8 @@ require "arrayDecl.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern var intArr : c_ptr(c_int);
 
 extern var stringList : c_ptr(c_string);

--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -6,6 +6,8 @@ require "chapelKeywords.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc foo(out_arg : c_int, ref_arg : c_char) : c_int;
 
 // Unable to generate function 'coforall' because its name is a Chapel keyword

--- a/tools/c2chapel/test/chapelVarargs.chpl
+++ b/tools/c2chapel/test/chapelVarargs.chpl
@@ -6,6 +6,8 @@ require "chapelVarargs.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc printf_wrapper(format : c_string, c__varargs ...) : void;
 
 // Overload for empty varargs

--- a/tools/c2chapel/test/cstrvoid.chpl
+++ b/tools/c2chapel/test/cstrvoid.chpl
@@ -6,6 +6,8 @@ require "cstrvoid.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc arg_c_string(str : c_string, n : c_int) : void;
 
 extern proc arg_c_void_ptr(ptr : c_void_ptr) : void;

--- a/tools/c2chapel/test/dashEye.chpl
+++ b/tools/c2chapel/test/dashEye.chpl
@@ -6,6 +6,8 @@ require "dashEye.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc otherFunction(ref arr : c_int) : void;
 
 extern proc otherFunction(arr : c_ptr(c_int)) : void;

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -6,6 +6,8 @@ require "enum.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 // Enum: anonymous
 extern const TEST_STATUS_PASSED :c_int;
 extern const TEST_STATUS_FAILED :c_int;

--- a/tools/c2chapel/test/enumVar.chpl
+++ b/tools/c2chapel/test/enumVar.chpl
@@ -6,6 +6,8 @@ require "enumVar.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 // Enum: E
 extern const UP :c_int;
 extern const DOWN :c_int;

--- a/tools/c2chapel/test/fileGlobals.chpl
+++ b/tools/c2chapel/test/fileGlobals.chpl
@@ -6,6 +6,8 @@ require "fileGlobals.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern var globalInt : c_int;
 
 extern var globalChar : c_char;

--- a/tools/c2chapel/test/fnPointers.chpl
+++ b/tools/c2chapel/test/fnPointers.chpl
@@ -6,6 +6,8 @@ require "fnPointers.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc fnPointerArgs(callback : c_fn_ptr, msg : c_string) : c_int;
 
 extern proc foo(a : myFunctionPointer, b : c_int) : c_int;

--- a/tools/c2chapel/test/fnints.chpl
+++ b/tools/c2chapel/test/fnints.chpl
@@ -6,6 +6,8 @@ require "fnints.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc firstFunc(a : c_int, b : c_int, c : c_int) : void;
 
 extern proc secondFunc(a : c_int, ref b : c_int, ref c : c_ptr(c_int)) : void;

--- a/tools/c2chapel/test/intDefines.chpl
+++ b/tools/c2chapel/test/intDefines.chpl
@@ -6,6 +6,8 @@ require "intDefines.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 // #define'd integer literals:
 // Note: some of these may have been defined with an ifdef
 extern const FOO_OK : int;

--- a/tools/c2chapel/test/justC.chpl
+++ b/tools/c2chapel/test/justC.chpl
@@ -3,6 +3,8 @@
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc foobar(x : c_int) : c_int;
 
 extern proc main() : c_int;

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -6,6 +6,8 @@ require "miscTypedef.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern record simpleStruct {
   var a : c_int;
   var b : c_char;

--- a/tools/c2chapel/test/miscTypedefUnion.chpl
+++ b/tools/c2chapel/test/miscTypedefUnion.chpl
@@ -6,6 +6,8 @@ require "miscTypedefUnion.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern union simpleUnion {
   var a : c_int;
   var b : c_char;

--- a/tools/c2chapel/test/nestedStruct.chpl
+++ b/tools/c2chapel/test/nestedStruct.chpl
@@ -6,6 +6,8 @@ require "nestedStruct.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern record first {
   var a : c_int;
   var b : c_string;

--- a/tools/c2chapel/test/nestedUnion.chpl
+++ b/tools/c2chapel/test/nestedUnion.chpl
@@ -6,6 +6,8 @@ require "nestedUnion.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern union first {
   var a : c_int;
   var b : c_string;

--- a/tools/c2chapel/test/opaqueStruct.chpl
+++ b/tools/c2chapel/test/opaqueStruct.chpl
@@ -6,6 +6,8 @@ require "opaqueStruct.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern record foobar {
   var a : c_int;
   var b : c_int;

--- a/tools/c2chapel/test/opaqueUnion.chpl
+++ b/tools/c2chapel/test/opaqueUnion.chpl
@@ -6,6 +6,8 @@ require "opaqueUnion.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern union foobar {
   var a : c_int;
   var b : c_int;

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -6,6 +6,8 @@ require "simpleRecords.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern record allInts {
   var a : c_int;
   var b : c_uint;

--- a/tools/c2chapel/test/sysCTypes.chpl
+++ b/tools/c2chapel/test/sysCTypes.chpl
@@ -6,6 +6,8 @@ require "sysCTypes.h";
 // Note: Generated with fake std headers
 
 use CPtr;
+use SysCTypes;
+use SysBasic;
 extern proc test_int(a : c_int, ref b : c_int) : c_int;
 
 extern proc test_int(a : c_int, b : c_ptr(c_int)) : c_int;


### PR DESCRIPTION
Pretty much all c2chapel programs use SysCTypes and
SysBasic for all C types and C type aliases, but
it previously wasn't a default `use`, only CPtr was,
so this PR adds that to all c2chapel output and also
updates all existing tests to reflect that behavior.

Motivated by: https://github.com/Cray/chapel-private/issues/2294
Related to: https://github.com/Cray/chapel-private/issues/2363