### PR TITLE
Curl.setopt(): handle string- and bytes-typed option arguments

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -187,7 +187,7 @@ module Curl {
         } else if arg.type == slist {
           var tmp:c_void_ptr = arg.list:c_void_ptr;
           err = qio_int_to_err(curl_easy_setopt_ptr(curl, opt:CURLoption, tmp));
-        } else if arg.type == string {
+        } else if arg.type == string || arg.type == bytes {
           var tmp = arg.localize().c_str():c_void_ptr;
           err = qio_int_to_err(curl_easy_setopt_ptr(curl, opt:CURLoption, tmp));
         }
@@ -200,8 +200,8 @@ module Curl {
       }
     }
 
-    if err then try ioerror(err, "in Curl.setopt(" + opt:string + "), " +
-                            arg:string + ": " + arg.type:string + ")");
+    if err then try ioerror(err, "in Curl.setopt(" + opt:string + ", arg: " +
+                            arg.type:string + ")");
     return true;
   }
 

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -72,9 +72,28 @@ proc test3() {
   stdout.flush();
 }
 
+// Test a bytes-type option, CURLOPT_URL
+proc test4() {
+  writeln("\ntest3\n");
+  var f = "test.txt";
+  var url = "http://" + host + ":" + port + "/" + f;
+  var urlreader = openUrlReader(""); // set real url via setopt()
+
+  setopt(urlreader, CURLOPT_VERBOSE, true);
+  setopt(urlreader, CURLOPT_URL, url:bytes);
+
+  var str: string;
+  while urlreader.readline(str) {
+    writeln(str);
+  }
+
+  stderr.flush();
+  stdout.flush();
+}
 
 startServer();
 test1();
 test2();
 test3();
+test4();
 stopServer();

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -74,7 +74,7 @@ proc test3() {
 
 // Test a bytes-type option, CURLOPT_URL
 proc test4() {
-  writeln("\ntest3\n");
+  writeln("\ntest4\n");
   var f = "test.txt";
   var url = "http://" + host + ":" + port + "/" + f;
   var urlreader = openUrlReader(""); // set real url via setopt()

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -8,6 +8,7 @@ use DateTime;
 
 extern const CURLOPT_VERBOSE: CURLoption;
 extern const CURLOPT_FILETIME: CURLoption;
+extern const CURLOPT_URL: CURLoption;
 extern const CURLINFO_FILETIME: CURLINFO;
 
 proc test1() {
@@ -52,7 +53,28 @@ proc test2() {
   stdout.flush();
 }
 
+// Test a string-type option, CURLOPT_URL
+proc test3() {
+  writeln("\ntest3\n");
+  var f = "test.txt";
+  var url = "http://" + host + ":" + port + "/" + f;
+  var urlreader = openUrlReader(""); // set real url via setopt()
+
+  setopt(urlreader, CURLOPT_VERBOSE, true);
+  setopt(urlreader, CURLOPT_URL, url);
+
+  var str: string;
+  while urlreader.readline(str) {
+    writeln(str);
+  }
+
+  stderr.flush();
+  stdout.flush();
+}
+
+
 startServer();
 test1();
 test2();
+test3();
 stopServer();

--- a/test/library/packages/Curl/check-http-setopt.good
+++ b/test/library/packages/Curl/check-http-setopt.good
@@ -2,3 +2,5 @@
 < HTTP/1.0 200 OK
 > GET /test.txt HTTP/1.1
 < HTTP/1.0 200 OK
+> GET /test.txt HTTP/1.1
+< HTTP/1.0 200 OK

--- a/test/library/packages/Curl/check-http-setopt.good
+++ b/test/library/packages/Curl/check-http-setopt.good
@@ -4,3 +4,5 @@
 < HTTP/1.0 200 OK
 > GET /test.txt HTTP/1.1
 < HTTP/1.0 200 OK
+> GET /test.txt HTTP/1.1
+< HTTP/1.0 200 OK


### PR DESCRIPTION
Also make the Error for unhandled cases report the option number and
the type of the passed argument.

Add a few comments.

Add a case to the check-http-setopt test of a string-typed option arg
and a bytes-typed option arg.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>