### PR TITLE
Use gcc 10 for Arkouda XC release testing

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -16,6 +16,8 @@ module list
 # setup for XC perf (ugni, gnu, 28-core broadwell)
 module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
+# avoid gcc 11 warnings fixed in https://github.com/chapel-lang/chapel/pull/18178
+module swap gcc gcc/10.3.0
 module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base


### PR DESCRIPTION
This system version was just upgraded to 11 and we get some warnings
from 11 that are turned into build failures with `WARNINGS=1`, which
throws `-Werror`. These warnings were fixed in #18178, but this is
testing against Chapel 1.24.1 so those changes aren't available. Just
pin to gcc 10 until this testing moves on to 1.25.0.