### PR TITLE
In comm=ofi, register uninitialized static data along with initialized.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3702,7 +3702,7 @@ void amRequestCommon(c_nodeid_t node,
   //
   // If blocking, make sure target can RMA PUT the indicator to us.
   //
-  amDone_t amDone;
+  amDone_t amDone = 0;
   amDone_t* pAmDone = NULL;
   if (ppAmDone != NULL) {
     pAmDone = mrLocalizeTargetRemote(&amDone, sizeof(*pAmDone),

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2377,15 +2377,26 @@ void findMoreMemoryRegions(void) {
       }
     }
 
-    if (!seen
-        && ((pnLen > 0 && strcmp(path, progName) == 0)
-            || strcmp(path, "[heap]") == 0
-            || strcmp(path, "[stack]") == 0)) {
-      DBG_PRINTF(DBG_MR, "record mem map region: %p %#zx \"%s\"",
-                 addr, size, path);
-      memTab[memTabCount].addr = addr;
-      memTab[memTabCount].size = size;
-      memTabCount++;
+    if (!seen) {
+      //
+      // Matching the initialized data, heap, and stack is easy (first
+      // three tests). The uninitialized .bss part of the static data
+      // is assumed to have an empty path and directly follow something
+      // we've already registered, namely the initialized data.
+      //
+      if ((pnLen > 0 && strcmp(path, progName) == 0)
+          || strcmp(path, "[heap]") == 0
+          || strcmp(path, "[stack]") == 0
+          || (path[0] == '\0'
+              && memTabCount > 0
+              && (char*) addr == ((char*) memTab[memTabCount - 1].addr
+                                  + memTab[memTabCount - 1].size))) {
+        DBG_PRINTF(DBG_MR, "record mem map region: %p %#zx \"%s\"",
+                   addr, size, path);
+        memTab[memTabCount].addr = addr;
+        memTab[memTabCount].size = size;
+        memTabCount++;
+      }
     }
   }
 }


### PR DESCRIPTION
In the ofi comm layer when not using scalable memory registration,
while our intent has been to register the whole static data segment
along with any fixed heap, we've actually only been registering the
initialized part of it, i.e. the .data and related sections. We've
been skipping the uninitialized .bss section, the implicitly zeroed
part of static data. Here, add the latter.

Surprisingly, this seems to make the comm layer barrier performance
worse. We had expected it would make it better, because the barrier
works off of a static, implicitly zeroed data structure and has been
doing AM-mediated remote PUTs instead of direct RMA. Nevertheless, the
empty-chpl-barrier test case seems to run about twice as long with
this change present. However, on a positive note, this does seem to
help the hangs we've been seeing in that test. In 20 runs of 50,000
trials each I didn't seen any hangs at all. We suspect there is more
to do with respect to that problem, but this is a promising result in
the meantime.

This resolves https://github.com/Cray/chapel-private/issues/2405.