### PR TITLE
Make the channel <~> operators into operator methods

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3353,7 +3353,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
      :returns: ch
      :throws SystemError: When an IO error has occurred.
    */
-  inline operator <~>(const ref ch: channel, const x) const ref throws
+  inline operator channel.<~>(const ref ch: channel, const x) const ref throws
   where ch.writing {
     try ch.readwrite(x);
     return ch;
@@ -3361,7 +3361,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
 
   // documented in the writing version.
   pragma "no doc"
-  inline operator <~>(const ref ch: channel, ref x) const ref throws
+  inline operator channel.<~>(const ref ch: channel, ref x) const ref throws
   where !ch.writing {
     try ch.readwrite(x);
     return ch;
@@ -3382,7 +3382,8 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
      works without requiring an explicit temporary value to store
      the ioLiteral.
    */
-  inline operator <~>(const ref r: channel, lit:ioLiteral) const ref throws
+  inline operator channel.<~>(const ref r: channel,
+                              lit:ioLiteral) const ref throws
   where !r.writing {
     var litCopy = lit;
     try r.readIt(litCopy);
@@ -3399,7 +3400,8 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
      works without requiring an explicit temporary value to store
      the ioNewline.
    */
-  inline operator <~>(const ref r: channel, nl:ioNewline) const ref throws
+  inline operator channel.<~>(const ref r: channel,
+                              nl:ioNewline) const ref throws
   where !r.writing {
     var nlCopy = nl;
     try r.readIt(nlCopy);


### PR DESCRIPTION
The last time I tried this, the calls were getting flagged as ambiguous.
Michael hypothesized that there might be something wrong with operator methods
and where clauses.  Today, making this change seems to work - I think because I
fixed the general problem with where clauses getting ignored when one of the
argument actuals ends up being generic over in #18170.

Resolves #17538
Resolves Cray/chapel-private#2190

Passed a full paratest with futures

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>