### PR TITLE
Update c2chapel test file

### DIFF
--- a/test/c2chapel/c2chapel-tester.good
+++ b/test/c2chapel/c2chapel-tester.good
@@ -1,7 +1,28 @@
-Testing c2chapel...\n
+Testing c2chapel...
 No arguments: OK
 --help: OK
 File not found: OK
+arrayDecl: OK
+chapelKeywords: OK
+chapelVarargs: OK
+cstrvoid: OK
+dashEye: OK
+enum: OK
+enumVar: OK
+fileGlobals: OK
+fnPointers: OK
+fnints: OK
+intDefines: OK
+invalidC: OK
+miscTypedef: OK
+miscTypedefUnion: OK
+nestedStruct: OK
+nestedUnion: OK
+opaqueStruct: OK
+opaqueUnion: OK
+simpleRecords: OK
+sysCTypes: OK
+Testing using GNU parser... 
 arrayDecl: OK
 chapelKeywords: OK
 chapelVarargs: OK

--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,3 +1,3 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
 pycparser==2.20
-pycparserext>=2013.1
+pycparserext


### PR DESCRIPTION
The c2chapel tests were failing because I was only running `make check` and not a `start_test test/c2chapel`. This PR adds the GNU testing changes to the .good file for `start_test` to account for the added GNU tests. Also, this removes the versioning for pycparserext.

Related PR: https://github.com/chapel-lang/chapel/pull/18189