### PR TITLE
Adjustments to `bigint.size` and `bigint.sizeinbase`

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -291,6 +291,7 @@ module BigInteger {
       }
     }
 
+    deprecated "bigint.size() is deprecated"
     proc size() : size_t {
       var ret: size_t;
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -318,7 +318,7 @@ module BigInteger {
       return sizeInBase(base).safeCast(uint);
     }
 
-    proc sizeInBase(base: int) : uint {
+    proc sizeInBase(base: int) : int {
       const base_ = base.safeCast(c_int);
       var   ret: size_t;
 
@@ -336,7 +336,7 @@ module BigInteger {
         }
       }
 
-      return ret;
+      return ret.safeCast(int);
     }
 
     proc numLimbs : uint {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -318,6 +318,20 @@ module BigInteger {
       return sizeInBase(base).safeCast(uint);
     }
 
+    /* Determine the size of ``this`` measured in number of digits in the given
+       ``base``.  The sign of ``this`` is ignored, only the absolute value is
+       used.
+
+       :arg base: The base in which to compute the number of digits used to
+                  represent ``this``.  Can be between 2 and 62.
+       :type base: ``int``
+
+       :returns: The size of ``this`` measured in number of digits in the given
+                 ``base``.  Will either be exact or 1 too big.  If ``base`` is
+                 a power of 2, will always be exact.  If ``this`` is 0, will
+                 always return 1.
+       :rtype: ``int``
+     */
     proc sizeInBase(base: int) : int {
       const base_ = base.safeCast(c_int);
       var   ret: size_t;

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -312,7 +312,13 @@ module BigInteger {
       return ret;
     }
 
+    deprecated
+    "bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead"
     proc sizeinbase(base: int) : uint {
+      return sizeInBase(base).safeCast(uint);
+    }
+
+    proc sizeInBase(base: int) : uint {
       const base_ = base.safeCast(c_int);
       var   ret: size_t;
 

--- a/test/deprecated/BigInteger/deprecateSize.chpl
+++ b/test/deprecated/BigInteger/deprecateSize.chpl
@@ -1,0 +1,10 @@
+use BigInteger;
+
+// Tests the size deprecation message
+var a = new bigint(-65533256);
+var b = new bigint(-639283632585);
+
+var c = a * b * a;
+writeln(a, " has ", a.size(), " limb(s)");
+writeln(b, " has ", b.size(), " limb(s)");
+writeln(c, " has ", c.size(), " limb(s)");

--- a/test/deprecated/BigInteger/deprecateSize.good
+++ b/test/deprecated/BigInteger/deprecateSize.good
@@ -1,0 +1,6 @@
+deprecateSize.chpl:8: warning: bigint.size() is deprecated
+deprecateSize.chpl:9: warning: bigint.size() is deprecated
+deprecateSize.chpl:10: warning: bigint.size() is deprecated
+-65533256 has 1 limb(s)
+-639283632585 has 1 limb(s)
+-2745472373880471808926250560 has 2 limb(s)

--- a/test/deprecated/BigInteger/deprecateSizeinbase.chpl
+++ b/test/deprecated/BigInteger/deprecateSizeinbase.chpl
@@ -1,0 +1,10 @@
+use BigInteger;
+
+// Tests the sizeinbase deprecation message
+var a = new bigint(-65536);
+var b = new bigint(129);
+
+writeln(a, " is ", a.sizeinbase(10), " digits in base 10");
+writeln(a, " is ", a.sizeinbase(2), " digits in base 2");
+writeln(b, " is ", b.sizeinbase(10), " digits in base 10");
+writeln(b, " is ", b.sizeinbase(2), " digits in base 2");

--- a/test/deprecated/BigInteger/deprecateSizeinbase.good
+++ b/test/deprecated/BigInteger/deprecateSizeinbase.good
@@ -1,0 +1,8 @@
+deprecateSizeinbase.chpl:7: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
+deprecateSizeinbase.chpl:8: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
+deprecateSizeinbase.chpl:9: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
+deprecateSizeinbase.chpl:10: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
+-65536 is 6 digits in base 10
+-65536 is 17 digits in base 2
+129 is 3 digits in base 10
+129 is 8 digits in base 2

--- a/test/library/standard/GMP/ferguson/gmp_dist_array.chpl
+++ b/test/library/standard/GMP/ferguson/gmp_dist_array.chpl
@@ -31,12 +31,12 @@ forall (a,b,c) in zip(A,B,C) {
 var sum = new bigint(0);
 
 for c in C {
-  writeln(c.sizeinbase(10));
+  writeln(c.sizeInBase(10));
 
   sum.add(sum, c);
 }
 
-writeln(sum.sizeinbase(10));
+writeln(sum.sizeInBase(10));
 
 var modulus = new bigint("10000000000000000000000000000000000000000");
 

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_misc.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_misc.chpl
@@ -28,10 +28,10 @@ else if a.even_p() then writeln("a is even");
 if b.odd_p() then writeln("b is odd");
 else if b.even_p() then writeln("b is even");
 
-writeln(a, " is ", a.sizeinbase(10), " digits in base 10");
-writeln(a, " is ", a.sizeinbase(2), " digits in base 2");
-writeln(b, " is ", b.sizeinbase(10), " digits in base 10");
-writeln(b, " is ", b.sizeinbase(2), " digits in base 2");
+writeln(a, " is ", a.sizeInBase(10), " digits in base 10");
+writeln(a, " is ", a.sizeInBase(2), " digits in base 2");
+writeln(b, " is ", b.sizeInBase(10), " digits in base 10");
+writeln(b, " is ", b.sizeInBase(2), " digits in base 2");
 
 a.set(35);
 b.set(9);


### PR DESCRIPTION
Following the proposal in #17693, makes a number of changes to these
methods on the `bigint` type:

- Deprecates `bigint.size()`
- Renames `bigint.sizeinbase()` to `bigint.sizeInBase()`
- Changes the return type of `bigint.sizeInBase()` to `int`
- Documents `bigint.sizeInBase()`, using the GMP project documentation as a guide
- Adds tests to track the deprecation messages
- Updates tests that referenced the old version of `bigint.sizeinbase()` to use the
new name.  `bigint.size()` was not previously tested so no tests required updates.

Resolves #17693 
Resolves Cray/chapel-private#2384

Passed a full paratest with futures.  Double checked the built documentation with
this change.