### PR TITLE
Fix concurrent-alloc test for nodes with more than 127 cores

### DIFF
--- a/test/runtime/configMatters/mem/concurrent-alloc.chpl
+++ b/test/runtime/configMatters/mem/concurrent-alloc.chpl
@@ -4,7 +4,8 @@ config const size = 256 * 1024 * 1024;
 config const numTasks = max(here.maxTaskPar, max(int(8)));
 
 config const trials = 3;
-coforall taskid in 1..here.maxTaskPar {
+coforall i in 1..here.maxTaskPar {
+  var taskid = i % max(int(8));
   for 1..trials {
     var m = c_malloc(int(8), size);
     c_memset(m, taskid, size);


### PR DESCRIPTION
This test stores the taskid into int(8) arrays and that overflowed with
128-core systems. Adjust the test to do `taskid % max(int(8))`.