### PR TITLE
Include limits header file in an LLVM source file

### DIFF
--- a/third-party/llvm/llvm-src/utils/benchmark/src/benchmark_register.h
+++ b/third-party/llvm/llvm-src/utils/benchmark/src/benchmark_register.h
@@ -1,6 +1,7 @@
 #ifndef BENCHMARK_REGISTER_H
 #define BENCHMARK_REGISTER_H
 
+#include <limits>
 #include <vector>
 
 #include "check.h"


### PR DESCRIPTION
To address issue #18105 include the limits header in an LLVM source file.
I verified that the bundled LLVM still builds correctly.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>