### PR TITLE
Stop ignoring declared types when initializing expressions are tuples

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7110,7 +7110,8 @@ void resolveInitVar(CallExpr* call) {
              targetType->getValType()->symbol->hasFlag(FLAG_ARRAY) ||
              isDomainWithoutNew ||
              initCopySyncSingle ||
-             (targetType->getValType()->symbol->hasFlag(FLAG_TUPLE) && srcType->getValType()->symbol->hasFlag(FLAG_TUPLE)) ||
+             (targetType->getValType()->symbol->hasFlag(FLAG_TUPLE) &&
+              srcType->getValType()->symbol->hasFlag(FLAG_TUPLE)) ||
              initCopyIter) {
     // These cases require an initCopy to implement special initialization
     // semantics (e.g. reading a sync for variable initialization).

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7110,7 +7110,7 @@ void resolveInitVar(CallExpr* call) {
              targetType->getValType()->symbol->hasFlag(FLAG_ARRAY) ||
              isDomainWithoutNew ||
              initCopySyncSingle ||
-             srcType->getValType()->symbol->hasFlag(FLAG_TUPLE) ||
+             (targetType->getValType()->symbol->hasFlag(FLAG_TUPLE) && srcType->getValType()->symbol->hasFlag(FLAG_TUPLE)) ||
              initCopyIter) {
     // These cases require an initCopy to implement special initialization
     // semantics (e.g. reading a sync for variable initialization).

--- a/test/types/records/init/copy/copyInitFromTuple.chpl
+++ b/test/types/records/init/copy/copyInitFromTuple.chpl
@@ -19,9 +19,13 @@ record Foo {
 
 var bar: Foo = new Foo(10, "Hi");
 var baz: Foo = (11, "Bye");
+const tup = (12, "Wait!");
+var bab: Foo = tup;
 
 writeln(bar);
 writeln(baz);
+writeln(bab);
 
 writeln(isTuple(bar));
 writeln(isTuple(baz));
+writeln(isTuple(bab));

--- a/test/types/records/init/copy/copyInitFromTuple.chpl
+++ b/test/types/records/init/copy/copyInitFromTuple.chpl
@@ -1,0 +1,27 @@
+record Foo {
+    var x: int;
+    var y: string;
+
+    proc init(x: int, y: string){
+        this.x = x + 1;
+        this.y = y + "!";
+    }
+
+    proc init=(tup) where isTuple(tup){
+        this.init(tup(0), tup(1));
+    }
+
+    operator :(tup, type t: Foo) {
+        var f: Foo = tup;
+        return f;
+    }
+}
+
+var bar: Foo = new Foo(10, "Hi");
+var baz: Foo = (11, "Bye");
+
+writeln(bar);
+writeln(baz);
+
+writeln(isTuple(bar));
+writeln(isTuple(baz));

--- a/test/types/records/init/copy/copyInitFromTuple.good
+++ b/test/types/records/init/copy/copyInitFromTuple.good
@@ -1,4 +1,6 @@
 (x = 11, y = Hi!)
 (x = 12, y = Bye!)
+(x = 13, y = Wait!!)
+false
 false
 false

--- a/test/types/records/init/copy/copyInitFromTuple.good
+++ b/test/types/records/init/copy/copyInitFromTuple.good
@@ -1,0 +1,4 @@
+(x = 11, y = Hi!)
+(x = 12, y = Bye!)
+false
+false


### PR DESCRIPTION
This fixes a bug in our code base that Shreyas ran into, in which if a
variable's initializer is a tuple:

```chapel
var r: T = (t1, t2);
```

then the type of the variable 'T' is completely ignored and 'r' is
treated as a tuple, as though it had been declared:

```chapel
var r = (t1, t2);
```

The effect was that if `T` was a record with a copy initializer
accepting tuples, say, the type of `T` would be dropped on
the floor and the copy initializer never called.

It turns out that this was because when resolution found any
declaration initialized with a tuple, it rewrote the declaration
essentially as:

```chapel
var r = initCopy((t1, t2));
```
Here, I only make this initCopy() rule fire if both the rhs and
lhs are tuple types, which is presumably what was intended.

This is one of those classic fixes where part of me thinks
"Are there other things we should be checking for before
applying this rule to tuples?" (like "same size?" "same element
type?") and/or "Are there other types in this conditional that
are similarly causing declared types to be ignored?" but in
the interest of not getting too distracted from my main tasks,
I'm considering this an improvement that doesn't break anything
in our testing system and leaving those questions open for
another day.

Resolves #18219.