### PR TITLE
Add a skipif for this test on linux32

### DIFF
--- a/test/deprecated/BigInteger/deprecateSize.skipif
+++ b/test/deprecated/BigInteger/deprecateSize.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM == linux32


### PR DESCRIPTION
It triggers a halt when creating one of the bigints to determine the size of,
but the test is testing a deprecation warning and it seems very unlikely the warning
would suddenly not trigger on linux32 but trigger for every other platform.
So skip and don't worry about fixing it in a more principled way.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>