### PR TITLE
Curl check-http-setopt test: add module for error handling

### DIFF
--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -1,6 +1,8 @@
 // This test verifies that Curl + QIO integration
 // allows Curl setopt calls before the transfer starts.
 
+module CheckHttpSetOpt {
+
 use RunServer;
 use URL;
 use Curl;
@@ -11,7 +13,7 @@ extern const CURLOPT_FILETIME: CURLoption;
 extern const CURLOPT_URL: CURLoption;
 extern const CURLINFO_FILETIME: CURLINFO;
 
-proc test1() {
+proc test1() throws {
   writeln("\ntest1\n");
   var f = "test.txt";
   var url = "http://" + host + ":" + port + "/" + f;
@@ -29,7 +31,7 @@ proc test1() {
 }
 
 
-proc test2() {
+proc test2() throws {
   writeln("\ntest2\n");
   var f = "test.txt";
   var url = "http://" + host + ":" + port + "/" + f;
@@ -54,7 +56,7 @@ proc test2() {
 }
 
 // Test a string-type option, CURLOPT_URL
-proc test3() {
+proc test3() throws {
   writeln("\ntest3\n");
   var f = "test.txt";
   var url = "http://" + host + ":" + port + "/" + f;
@@ -73,7 +75,7 @@ proc test3() {
 }
 
 // Test a bytes-type option, CURLOPT_URL
-proc test4() {
+proc test4() throws {
   writeln("\ntest4\n");
   var f = "test.txt";
   var url = "http://" + host + ":" + port + "/" + f;
@@ -91,9 +93,13 @@ proc test4() {
   stdout.flush();
 }
 
-startServer();
-test1();
-test2();
-test3();
-test4();
-stopServer();
+proc main() throws {
+  startServer();
+  defer stopServer();
+  test1();
+  test2();
+  test3();
+  test4();
+}
+
+}

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -3,103 +3,103 @@
 
 module CheckHttpSetOpt {
 
-use RunServer;
-use URL;
-use Curl;
-use DateTime;
+  use RunServer;
+  use URL;
+  use Curl;
+  use DateTime;
 
-extern const CURLOPT_VERBOSE: CURLoption;
-extern const CURLOPT_FILETIME: CURLoption;
-extern const CURLOPT_URL: CURLoption;
-extern const CURLINFO_FILETIME: CURLINFO;
+  extern const CURLOPT_VERBOSE: CURLoption;
+  extern const CURLOPT_FILETIME: CURLoption;
+  extern const CURLOPT_URL: CURLoption;
+  extern const CURLINFO_FILETIME: CURLINFO;
 
-proc test1() throws {
-  writeln("\ntest1\n");
-  var f = "test.txt";
-  var url = "http://" + host + ":" + port + "/" + f;
-  var urlreader = openUrlReader(url);
+  proc test1() throws {
+    writeln("\ntest1\n");
+    var f = "test.txt";
+    var url = "http://" + host + ":" + port + "/" + f;
+    var urlreader = openUrlReader(url);
 
-  setopt(urlreader, CURLOPT_VERBOSE, true);
+    setopt(urlreader, CURLOPT_VERBOSE, true);
 
-  var str: string;
-  while urlreader.readline(str) {
-    writeln(str);
+    var str: string;
+    while urlreader.readline(str) {
+      writeln(str);
+    }
+
+    stderr.flush();
+    stdout.flush();
   }
 
-  stderr.flush();
-  stdout.flush();
-}
 
+  proc test2() throws {
+    writeln("\ntest2\n");
+    var f = "test.txt";
+    var url = "http://" + host + ":" + port + "/" + f;
+    var urlreader = openUrlReader(url);
 
-proc test2() throws {
-  writeln("\ntest2\n");
-  var f = "test.txt";
-  var url = "http://" + host + ":" + port + "/" + f;
-  var urlreader = openUrlReader(url);
+    setopt(urlreader, (CURLOPT_VERBOSE, true),
+	              (CURLOPT_FILETIME, true));
 
-  setopt(urlreader, (CURLOPT_VERBOSE, true),
-                    (CURLOPT_FILETIME, true));
+    var str: string;
+    while urlreader.readline(str) {
+      writeln(str);
+    }
 
-  var str: string;
-  while urlreader.readline(str) {
-    writeln(str);
+    var time:c_long = 0;
+
+    curl_easy_getinfo(getCurlHandle(urlreader), CURLINFO_FILETIME,
+		      c_ptrTo(time));
+
+    writeln("Remote Time ", datetime.utcfromtimestamp(time));
+
+    stderr.flush();
+    stdout.flush();
   }
 
-  var time:c_long = 0;
+  // Test a string-type option, CURLOPT_URL
+  proc test3() throws {
+    writeln("\ntest3\n");
+    var f = "test.txt";
+    var url = "http://" + host + ":" + port + "/" + f;
+    var urlreader = openUrlReader(""); // set real url via setopt()
 
-  curl_easy_getinfo(getCurlHandle(urlreader), CURLINFO_FILETIME, c_ptrTo(time));
+    setopt(urlreader, CURLOPT_VERBOSE, true);
+    setopt(urlreader, CURLOPT_URL, url);
 
-  writeln("Remote Time ", datetime.utcfromtimestamp(time));
+    var str: string;
+    while urlreader.readline(str) {
+      writeln(str);
+    }
 
-  stderr.flush();
-  stdout.flush();
-}
-
-// Test a string-type option, CURLOPT_URL
-proc test3() throws {
-  writeln("\ntest3\n");
-  var f = "test.txt";
-  var url = "http://" + host + ":" + port + "/" + f;
-  var urlreader = openUrlReader(""); // set real url via setopt()
-
-  setopt(urlreader, CURLOPT_VERBOSE, true);
-  setopt(urlreader, CURLOPT_URL, url);
-
-  var str: string;
-  while urlreader.readline(str) {
-    writeln(str);
+    stderr.flush();
+    stdout.flush();
   }
 
-  stderr.flush();
-  stdout.flush();
-}
+  // Test a bytes-type option, CURLOPT_URL
+  proc test4() throws {
+    writeln("\ntest4\n");
+    var f = "test.txt";
+    var url = "http://" + host + ":" + port + "/" + f;
+    var urlreader = openUrlReader(""); // set real url via setopt()
 
-// Test a bytes-type option, CURLOPT_URL
-proc test4() throws {
-  writeln("\ntest4\n");
-  var f = "test.txt";
-  var url = "http://" + host + ":" + port + "/" + f;
-  var urlreader = openUrlReader(""); // set real url via setopt()
+    setopt(urlreader, CURLOPT_VERBOSE, true);
+    setopt(urlreader, CURLOPT_URL, url:bytes);
 
-  setopt(urlreader, CURLOPT_VERBOSE, true);
-  setopt(urlreader, CURLOPT_URL, url:bytes);
+    var str: string;
+    while urlreader.readline(str) {
+      writeln(str);
+    }
 
-  var str: string;
-  while urlreader.readline(str) {
-    writeln(str);
+    stderr.flush();
+    stdout.flush();
   }
 
-  stderr.flush();
-  stdout.flush();
-}
-
-proc main() throws {
-  startServer();
-  defer stopServer();
-  test1();
-  test2();
-  test3();
-  test4();
-}
-
+  proc main() throws {
+    startServer();
+    defer stopServer();
+    test1();
+    test2();
+    test3();
+    test4();
+  }
 }

--- a/test/library/packages/Curl/check-http.chpl
+++ b/test/library/packages/Curl/check-http.chpl
@@ -1,64 +1,63 @@
 module CheckHttp {
-use RunServer;
-use URL;
-use FileSystem;
-use IO;
-use SysCTypes;
+  use RunServer;
+  use URL;
+  use FileSystem;
+  use IO;
+  use SysCTypes;
 
-config const verbose = false;
-config const bufsz = 0;
+  config const verbose = false;
+  config const bufsz = 0;
 
-extern var qbytes_iobuf_size:size_t;
+  extern var qbytes_iobuf_size:size_t;
 
-if bufsz > 0 {
-  qbytes_iobuf_size = bufsz:size_t;
-}
+  if bufsz > 0 {
+    qbytes_iobuf_size = bufsz:size_t;
+  }
 
-proc runtest() throws {
+  proc runtest() throws {
 
-  writeln("checking served files match");
+    writeln("checking served files match");
 
-  /* for f in findfiles() but for #18218 */
-  var files = findfiles();
-  for f in files {
-    if f.endsWith(".txt") ||
-       f.endsWith(".htm") || f.endsWith(".html") ||
-       f.endsWith(".chpl") {
+    /* for f in findfiles() but for #18218 */
+    var files = findfiles();
+    for f in files {
+      if f.endsWith(".txt") ||
+        f.endsWith(".htm") || f.endsWith(".html") ||
+        f.endsWith(".chpl") {
 
-      if verbose then
-        writeln("Testing with file ", f);
+        if verbose then
+          writeln("Testing with file ", f);
 
-      var filereader = open(f, iomode.r).reader();
+        var filereader = open(f, iomode.r).reader();
 
-      var url = "http://" + host + ":" + port + "/" + f;
-      var urlreader = openUrlReader(url);
+        var url = "http://" + host + ":" + port + "/" + f;
+        var urlreader = openUrlReader(url);
 
-      var nlines = 0;
-      var str1: string;
-      var str2: string;
-      while true {
-        var got1 = filereader.readline(str1);
-        var got2 = urlreader.readline(str2);
-        if got1 == false && got2 == false then
-          break;
-        if got1 != got2 then
-          halt("file lengths don't match");
-        if str1 != str2 then
-          halt("file data doesn't match");
+        var nlines = 0;
+        var str1: string;
+        var str2: string;
+        while true {
+          var got1 = filereader.readline(str1);
+          var got2 = urlreader.readline(str2);
+          if got1 == false && got2 == false then
+            break;
+          if got1 != got2 then
+            halt("file lengths don't match");
+          if str1 != str2 then
+            halt("file data doesn't match");
 
-        nlines += 1;
+          nlines += 1;
+        }
+
+        if verbose then
+          writeln("Read ", nlines, " lines");
       }
-
-      if verbose then
-        writeln("Read ", nlines, " lines");
     }
   }
-}
 
-proc main() throws {
-  startServer();
-  defer stopServer();
-  runtest();
-}
-
+  proc main() throws {
+    startServer();
+    defer stopServer();
+    runtest();
+  }
 }

--- a/test/library/packages/Curl/check-http.chpl
+++ b/test/library/packages/Curl/check-http.chpl
@@ -1,3 +1,4 @@
+module CheckHttp {
 use RunServer;
 use URL;
 use FileSystem;
@@ -13,11 +14,13 @@ if bufsz > 0 {
   qbytes_iobuf_size = bufsz:size_t;
 }
 
-proc runtest() {
+proc runtest() throws {
 
   writeln("checking served files match");
 
-  for f in findfiles() {
+  /* for f in findfiles() but for #18218 */
+  var files = findfiles();
+  for f in files {
     if f.endsWith(".txt") ||
        f.endsWith(".htm") || f.endsWith(".html") ||
        f.endsWith(".chpl") {
@@ -52,6 +55,10 @@ proc runtest() {
   }
 }
 
-startServer();
-runtest();
-stopServer();
+proc main() throws {
+  startServer();
+  defer stopServer();
+  runtest();
+}
+
+}


### PR DESCRIPTION
Add a module around the test so that on Error we can kill
the http server.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>