### PR TITLE
Fix an issue involving 32-bit floating point math in the LLVM backend

### DIFF
--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -177,7 +177,7 @@ PromotedPair convertValuesToLarger(
       return PromotedPair(value1,
                           irBuilder->CreateFPExt(value2, type1), true);
     } else {
-      return PromotedPair(irBuilder->CreateFPTrunc(value1, type2),
+      return PromotedPair(irBuilder->CreateFPExt(value1, type2),
                           value2, true);
     }
   }

--- a/test/types/real/issue15817.chpl
+++ b/test/types/real/issue15817.chpl
@@ -1,0 +1,27 @@
+use CPtr;
+
+// This code is dereved from issue github issue #15817.
+// At the time it was written it was failing to compile
+// with the LLVM backend with an error like:
+//
+// DestTy too big for FPTrunc
+//   %97 = fptrunc float %96 to double
+// internal error: LLVM function verification failed
+
+record R {
+  type T;
+  var beta: T;
+  proc kernel(x: c_ptr) {
+    var dist: T = 0:T;
+    dist += x[0]**this.beta;
+    return 0.5:T;
+  }
+}
+
+proc main() {
+  type t = real(32);
+  var A: [0..5] t;
+  var r = new R(t);
+
+  var tmp = r.kernel(c_ptrTo(A));
+}


### PR DESCRIPTION
Fix an issue that was leading to an internal error with the LLVM backend that
caused it to print "DestTy too big for FPTrunc" and fail a consistency check.

When code generating an operation where the lhs was real(32) and the rhs was
real(64) we were generating FPTrunc(lhs, rhs.type). We instead need
FPExt(lhs, rhs.type).

Added a test derived from the code in issue #15817 that reproduces the error
prior to this fix.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>