### PR TITLE
Disable cache-remote prefetching read-aheads under ugni

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -167,6 +167,12 @@ int chpl_comm_try_nb_some(chpl_comm_nb_handle_t* h, size_t nhandles);
 // this function always returns 0 since although any address is in the
 // segment, not all addresses are readable without causing a segmentation
 // violation on the remote locale.
+//
+// Note that this call is asking if a future GET will be safe, so in cases
+// where memory is registered dynamically or on-demand it's possible that
+// another task might deregister memory between this call and the GET so it
+// should also return 0 in such configurations.
+//
 int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len);
 
 //

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6142,11 +6142,10 @@ int chpl_comm_try_nb_some(chpl_comm_nb_handle_t* h, size_t nhandles)
 
 int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
 {
-  //
-  // We assume here that no object can span a boundary between mapped
-  // and unmapped memory, so we only have to check the start address.
-  //
-  return mreg_for_remote_addr(start, node) != NULL;
+  // This call asks if a future GET is safe, but we can't know that in the case
+  // of dynamic registration. We could support it for a static/fixed heap, but
+  // that's not a very common configuration.
+  return 0;
 }
 
 


### PR DESCRIPTION
The cache supports a read-ahead feature where it will GET an entire page
if it detects sequential access across multiple user GETs. It also
supports a more aggressive prefetching read-ahead that will prefetch
additional pages if it thinks they could be needed. This more aggressive
read-ahead relied on `chpl_comm_addr_gettable`, where the cache is
asking the comm layer if it's safe to GET this memory.

The implementation of `chpl_comm_addr_gettable` was broken under ugni
because it was only checking if the starting address was GETable, but it
did not check that the entire range was. So we could easily cross a page
boundary and start trying to do GETs from unregistered and potentially
unreadable memory. We could have fixed this by just checking that it was
safe to do a GET on every page, but in looking at this we realized that
with dynamic registration (the default under ugni) a concurrent task
could de-register memory between the GETable call and the GET, so to be
safe we just have `chpl_comm_addr_gettable` return false now. We could
do something smarter when a fixed heap is being used, but that's not a
common configuration and it's not one we test regularly so I didn't want
to introduce more differences.

Resolves https://github.com/Cray/chapel-private/issues/2358
Resolves https://github.com/cray/chapel-private/issues/2397