### PR TITLE
Ensure we give a better error message if llvm-config is not in path.

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -163,11 +163,14 @@ def get_llvm_config():
     return llvm_config
 
 @memoize
-def validate_llvm_config():
+def validate_llvm_config(llvm_config=None):
     llvm_val = get()
-    llvm_config = get_llvm_config()
+    # We pass in llvm_config if has already been computed (so we don't
+    # end up in an infinite loop).
+    if llvm_config is None:
+      llvm_config = get_llvm_config()
     if llvm_val == 'system':
-        if llvm_config == 'none':
+        if not llvm_config or llvm_config == 'none':
             error("CHPL_LLVM=system but could not find an installed LLVM"
                   " with one of the supported versions: {0}".format(
                   llvm_versions_string()))
@@ -183,6 +186,7 @@ def validate_llvm_config():
 @memoize
 def get_system_llvm_config_bindir():
     llvm_config = get_llvm_config()
+    validate_llvm_config(llvm_config)
     bindir = run_command([llvm_config, '--bindir']).strip()
 
     if os.path.isdir(bindir):

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -170,7 +170,7 @@ def validate_llvm_config(llvm_config=None):
     if llvm_config is None:
       llvm_config = get_llvm_config()
     if llvm_val == 'system':
-        if not llvm_config or llvm_config == 'none':
+        if llvm_config == '' or llvm_config == 'none':
             error("CHPL_LLVM=system but could not find an installed LLVM"
                   " with one of the supported versions: {0}".format(
                   llvm_versions_string()))


### PR DESCRIPTION
This is basically a redo of: https://github.com/chapel-lang/chapel/pull/18179

Which I had to back out due to failing smoke tests in: https://github.com/chapel-lang/chapel/pull/18191

I can reproduce the bug that was encountered in the smoke test by unsetting `CHPL_LLVM` and running `printchplenv`. I find this a little confusing since the name of the smoke test configuration would seem to indicate that it sets `CHPL_LLVM=none` (see here: https://chapel-ci.us.cray.com/job/chapel-code-smoke-test/2157/extra_config=none,label_exp=chapvm/) and if I explicitly set `CHPL_LLVM` to none I am not able to reproduce the issue.

Nevertheless, I want to proceed under the assumption that this was the bug.

--

Given that this failed smoke tests before, let me take the time to write a little bit about what I think the bug\fix for the smoke test failure is.

Before any of my changes (in the old PR or this one). We have a piece of Python code that is supposed to error out if `CHPL_LLVM` is system and no actual system path can be found here:

```python
def validate_llvm_config():
    llvm_val = get()
    llvm_config = get_llvm_config()
    if llvm_val == 'system':
        if llvm_config == 'none':
            error("CHPL_LLVM=system but could not find an installed LLVM"
                  " with one of the supported versions: {0}".format(
                  llvm_versions_string()))
```

The original issue motivating this issue is that if we set `CHPL_LLVM=system` and we don't actually have LLVM installed we get a bad error message that doesn't hint as to what the actual issue is.

To resolve this, the original PR (as well as this one) ensures that the `validate_llvm_config` function gets called before any other code that needs to call out to `llvm-config` is evaluated.  The second issue (addressed by the old PM as well as this one) is that `llvm_config` as it is returned by the `get_llvm_config()` function returns an empty string if we can't find a valid llvm-config. 

To make the error check work, in the previous PR I modified find_system_llvm_config() return 'none' instead of this empty string. The problem is another function, `has_compatible_installed_llvm` uses the value like this:

```python
def has_compatible_installed_llvm():
    llvm_config = find_system_llvm_config()
    if llvm_config:
        return True
    else:
        return False
```

Apparently if on an empty string in Python will return false, so the fact that I had it return 'none' instead of the empty string would cause `has_compatible_installed_llvm` to have the wrong behavior.

In this new PR I don't modify `find_system_llvm_config()` to return "none" (I keep at as the empty string), but I do add a check for the empty string back in `validate_llvm_config`.