### PR TITLE
Array module review  dim dims

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2983,6 +2983,25 @@ module ChapelArray {
       return _newArray(a);
     }
 
+    /*
+       Return a tuple of ranges describing the bounds of a rectangular domain.
+       For a sparse domain, return the bounds of the parent domain.
+     */
+    proc dims() return this.domain.dims();
+
+    /*
+       Return a range representing the boundary of this
+       domain in a particular dimension.
+     */
+    proc dim(d : int) {
+      return this.domain.dim(d);
+    }
+
+    pragma "no doc"
+    proc dim(param d : int) {
+      return this.domain.dim(d); 
+    }
+
     pragma "no doc"
     proc checkRankChange(args) {
       for param i in 0..args.size-1 do

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -17,6 +17,8 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
   writeln();
   // Test simple queries
   writeln("size is: ", X.size);
+  writeln("dims are: ", X.dims());
+  writeln("dim(0) is: ", X.dim(0));
 
   writeln("shape is: ", X.shape);
   writeln();
@@ -115,6 +117,9 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
 
   // Test simple queries
   writeln("size is: ", X.size);
+  writeln("dims are: ", X.dims());
+  writeln("dim(0) is: ", X.dim(0));
+  writeln("dim(1) is: ", X.dim(1));
 
   writeln("shape is: ", X.shape);
   writeln();

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:224: error: only sparse arrays have an IRV
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:229: error: only sparse arrays have an IRV
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:220: error: reverse() is only supported on dense 1D arrays
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:225: error: reverse() is only supported on dense 1D arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:229: error: sort() is currently only supported for 1D rectangular arrays
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:234: error: sort() is currently only supported for 1D rectangular arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D.good
+++ b/test/arrays/userAPI/arrayOps2D.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:

--- a/test/arrays/userAPI/blockOps2D.comm-none.good
+++ b/test/arrays/userAPI/blockOps2D.comm-none.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 100
+dims are: (1..10, 1..10)
+dim(0) is: 1..10
+dim(1) is: 1..10
 shape is: (10, 10)
 
 X is:
@@ -251,6 +254,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 49
+dims are: (2..8, 2..8)
+dim(0) is: 2..8
+dim(1) is: 2..8
 shape is: (7, 7)
 
 X is:

--- a/test/arrays/userAPI/blockOpsRankChange.comm-none.good
+++ b/test/arrays/userAPI/blockOpsRankChange.comm-none.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 49
+dims are: (1..7, 1..7)
+dim(0) is: 1..7
+dim(1) is: 1..7
 shape is: (7, 7)
 
 X is:

--- a/test/arrays/userAPI/blockOpsReindex.comm-none.good
+++ b/test/arrays/userAPI/blockOpsReindex.comm-none.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 100
+dims are: (0..9, 1..20 by 2)
+dim(0) is: 0..9
+dim(1) is: 1..20 by 2
 shape is: (10, 10)
 
 X is:

--- a/test/arrays/userAPI/callExternArrTest.good
+++ b/test/arrays/userAPI/callExternArrTest.good
@@ -5,6 +5,8 @@ idxType is: int(64)
 rank is: 1
 
 size is: 5
+dims are: (0..4)
+dim(0) is: 0..4
 shape is: (5)
 
 X is:

--- a/test/arrays/userAPI/enumArray.good
+++ b/test/arrays/userAPI/enumArray.good
@@ -5,6 +5,9 @@ idxType is: color
 rank is: 2
 
 size is: 25
+dims are: (red..blue, yellow..violet)
+dim(0) is: red..blue
+dim(1) is: yellow..violet
 shape is: (5, 5)
 
 X is:
@@ -127,6 +130,9 @@ idxType is: color
 rank is: 2
 
 size is: 16
+dims are: (red..violet by 2, red..violet by 2)
+dim(0) is: red..violet by 2
+dim(1) is: red..violet by 2
 shape is: (4, 4)
 
 X is:

--- a/test/arrays/userAPI/rankChangeOps3to2D.good
+++ b/test/arrays/userAPI/rankChangeOps3to2D.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:
@@ -109,6 +112,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:
@@ -213,6 +219,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:

--- a/test/arrays/userAPI/reindexOps2D.good
+++ b/test/arrays/userAPI/reindexOps2D.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 16
+dims are: (0..3, 2..9 by 2)
+dim(0) is: 0..3
+dim(1) is: 2..9 by 2
 shape is: (4, 4)
 
 X is:

--- a/test/arrays/userAPI/sliceOps2D.good
+++ b/test/arrays/userAPI/sliceOps2D.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:

--- a/test/arrays/userAPI/unsignedOps.good
+++ b/test/arrays/userAPI/unsignedOps.good
@@ -1,32 +1,32 @@
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:117: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:119: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
   or switch to the new '.sizeAs(type t: integral)' method)
-./arrayAPItest.chpl:119: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
+./arrayAPItest.chpl:124: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
 
   unsignedOps.chpl:6: called as testArrayAPI2D(lbl: string, X: [domain(2,uint(64),false)] real(64), sliceDom: domain(2,uint(64),false), reindexDom: domain(2,uint(64),true))
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:117: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:119: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
   or switch to the new '.sizeAs(type t: integral)' method)
-./arrayAPItest.chpl:119: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
+./arrayAPItest.chpl:124: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
 
   unsignedOps.chpl:12: called as testArrayAPI2D(lbl: string, X: [domain(2,uint(64),false)] real(64), sliceDom: domain(2,uint(64),false), reindexDom: domain(2,uint(64),true))
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:117: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:119: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
   or switch to the new '.sizeAs(type t: integral)' method)
-./arrayAPItest.chpl:119: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
+./arrayAPItest.chpl:124: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
 
   unsignedOps.chpl:18: called as testArrayAPI2D(lbl: string, X: [ArrayViewReindexDom(2,uint(64),true,int(64),unmanaged domain(2,uint(64),false),int(64),unmanaged ArrayViewReindexDist(unmanaged DefaultDist,unmanaged domain(2,uint(64),true),int(64),unmanaged domain(2,uint(64),false)))] real(64), sliceDom: domain(2,uint(64),true), reindexDom: domain(2,uint(64),true))
-./arrayAPItest.chpl:105: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:117: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
+./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:119: warning: '.size' queries for domains and arrays with 'idxType == uint(64)' are changing to return 'int' values rather than 'uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
   or switch to the new '.sizeAs(type t: integral)' method)
-./arrayAPItest.chpl:119: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
+./arrayAPItest.chpl:124: warning: '.shape' queries for domains and arrays with 'idxType = uint(64)' are changing to return '2int' values rather than '2*uint(64)'
   (to opt into the change now, re-compile with '-ssizeReturnsInt=true'
 
   unsignedOps.chpl:24: called as testArrayAPI2D(lbl: string, X: [ArrayViewRankChangeDom(2,uint(64),false,3*bool,3*uint(64),int(64),unmanaged ArrayViewRankChangeDist(unmanaged DefaultDist,3*bool,3*uint(64)))] real(64), sliceDom: domain(2,uint(64),false), reindexDom: domain(2,uint(64),true))
@@ -37,6 +37,9 @@ idxType is: uint(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:
@@ -141,6 +144,9 @@ idxType is: uint(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:
@@ -245,6 +251,9 @@ idxType is: uint(64)
 rank is: 2
 
 size is: 16
+dims are: (0..3, 2..9 by 2)
+dim(0) is: 0..3
+dim(1) is: 2..9 by 2
 shape is: (4, 4)
 
 X is:
@@ -349,6 +358,9 @@ idxType is: uint(64)
 rank is: 2
 
 size is: 16
+dims are: (1..4, 1..4)
+dim(0) is: 1..4
+dim(1) is: 1..4
 shape is: (4, 4)
 
 X is:


### PR DESCRIPTION
This PR is to satisfy this issue: https://github.com/chapel-lang/chapel/issues/18085

---

This is a followup item for the [Array module review](https://github.com/Cray/chapel-private/issues/2241).

The domain datatype has functions:

```
  proc dim(d: int)
  proc dims()
```

Given that the array type already has several functions that effectively forward to the underlying domain it makes sense to add these two in as well.

I've ensured that this PR passes paratests.