### PR TITLE
Fix c2chapel None concatenation bug and add GNU test

### DIFF
--- a/test/c2chapel/c2chapel-tester.good
+++ b/test/c2chapel/c2chapel-tester.good
@@ -33,6 +33,7 @@ enumVar: OK
 fileGlobals: OK
 fnPointers: OK
 fnints: OK
+gnuTest: OK
 intDefines: OK
 invalidC: OK
 miscTypedef: OK

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -272,7 +272,11 @@ def toChapelType(ty):
     elif isPointerTo(ty, "void"):
         return "c_void_ptr"
     elif type(ty) in (c_ast.ArrayDecl, ext_c_parser.ArrayDeclExt):
-        return "c_ptr(" + toChapelType(ty.type) + ")"
+        eltType = toChapelType(ty.type)
+        if eltType is not None:
+            return "c_ptr(" + eltType + ")"
+        else:
+            return None
     elif type(ty) == c_ast.PtrDecl:
         if type(ty.type) in (c_ast.FuncDecl, ext_c_parser.FuncDeclExt):
             return "c_fn_ptr"

--- a/tools/c2chapel/test/gnuTest.chpl
+++ b/tools/c2chapel/test/gnuTest.chpl
@@ -1,0 +1,29 @@
+// Generated with c2chapel version 0.1.0
+
+// Header given to c2chapel:
+require "gnuTest.h";
+
+// Note: Generated with fake std headers
+
+use CPtr;
+use SysCTypes;
+use SysBasic;
+// Anonymous union or struct was encountered within and skipped.
+extern record _GValue {
+  var g_type : GType;
+}
+
+// ==== c2chapel typedefs ====
+
+extern type GType = gsize;
+
+extern type GValue = _GValue;
+
+extern type gdouble = c_double;
+
+extern type gint64 = c_longlong;
+
+extern type gsize = c_ulong;
+
+extern type guint64 = c_ulonglong;
+

--- a/tools/c2chapel/test/gnuTest.h
+++ b/tools/c2chapel/test/gnuTest.h
@@ -1,0 +1,17 @@
+typedef struct _GValue GValue;
+
+__extension__ typedef unsigned long long guint64;
+__extension__ typedef signed long long gint64;
+typedef double gdouble;
+typedef unsigned long gsize;
+typedef gsize GType;
+
+
+struct _GValue
+{
+  GType g_type;
+
+  union {
+    gdouble v_double;
+  } data[2];
+};

--- a/tools/c2chapel/test/tester.sh
+++ b/tools/c2chapel/test/tester.sh
@@ -74,7 +74,9 @@ for f in *.h ; do
   if [ -e $title.execopts ]; then
     otherArgs=`cat $title.execopts`
   fi
-  helper "$title" "$f $otherArgs" "$title.chpl"
+  if [[ $title != "gnu"* ]]; then
+      helper "$title" "$f $otherArgs" "$title.chpl"
+  fi
 done
 
 echo 'Testing using GNU parser... '


### PR DESCRIPTION
Due to not rerunning the Arrow headers through c2chapel after implementing the review feedback, a bug slipped by that was happening with a union in an anonymous struct, where c2chapel was getting a `NoneType` as the type of the struct, which was then trying to concatenate as a string in the output, which was causing an error. This PR fixes that bug and adds a gnu specific test to check for the issue.

Now the Arrow headers will run through c2chapel with no errors.

Resolves: https://github.com/Cray/chapel-private/issues/2363
Follow up of: https://github.com/chapel-lang/chapel/pull/18189