### PR TITLE
Remove the .future for library/packages/BLAS/test_blas1.chpl

### DIFF
--- a/test/library/packages/BLAS/test_blas1.future
+++ b/test/library/packages/BLAS/test_blas1.future
@@ -1,5 +1,0 @@
-bug
-#17898
-
-chpl: /lus/scratch/killough/chapel/third-party/llvm/llvm-src/lib/IR/Instructions.cpp:2873: static llvm::CastInst* llvm::CastInst::Create(llvm::Instruction::CastOps, llvm::Value*, llvm::Type*, const llvm::Twine&, llvm::Instruction*): Assertion `castIsValid(op, S, Ty) && "Invalid cast!"' failed.
-timedexec: target program died with signal 6, with coredump


### PR DESCRIPTION
This test is no longer failing in the way described in #17898, though it
was still failing with a different LLVM issue with the same symptom as
#15817. The fix for #15817 (PR #18229) also fixed it here.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>