### PR TITLE
Remove deprecated environment settings

### DIFF
--- a/test/deprecated/environmentBundled.chpl
+++ b/test/deprecated/environmentBundled.chpl
@@ -1,4 +1,0 @@
-// This is a reminder to remove deprecation warnings for environment
-// variables that use 'bundled' to mean the included third-party libraries
-// CHPL_GMP, CHPL_HWLOC, CHPL_JEMALLOC, CHPL_LIBFABRIC, CHPL_LLVM, CHPL_UNWIND
-

--- a/test/deprecated/environmentBundled.notest
+++ b/test/deprecated/environmentBundled.notest
@@ -1,1 +1,0 @@
-This is just a reminder, not an actual test

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -26,9 +26,6 @@ def get():
             gmp_val = 'system'
         else:
             gmp_val = 'none'
-    elif gmp_val == 'gmp':
-        warning("CHPL_GMP=gmp is deprecated. Use CHPL_GMP=bundled.")
-        gmp_val = 'bundled'
 
     return gmp_val
 

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -14,9 +14,6 @@ def get():
             hwloc_val = 'bundled'
         else:
             hwloc_val = 'none'
-    elif hwloc_val == 'hwloc':
-        warning("CHPL_HWLOC=hwloc is deprecated. Use CHPL_HWLOC=bundled.")
-        hwloc_val = 'bundled'
 
     return hwloc_val
 

--- a/util/chplenv/chpl_jemalloc.py
+++ b/util/chplenv/chpl_jemalloc.py
@@ -22,10 +22,6 @@ def get():
     if mem_val != 'jemalloc' and jemalloc_val != 'none':
       error("CHPL_JEMALLOC must be 'none' when CHPL_MEM is not jemalloc")
 
-    if jemalloc_val == 'jemalloc':
-        warning("CHPL_JEMALLOC=jemalloc is deprecated. Use CHPL_JEMALLOC=bundled.")
-        jemalloc_val = 'bundled'
-
     return jemalloc_val
 
 

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -26,11 +26,6 @@ def get():
     else:
         libfabric_val = 'none'
 
-    if libfabric_val == 'libfabric':
-        warning("CHPL_LIBFABRIC=libfabric is deprecated. Use "
-                "CHPL_LIBFABRIC=bundled instead.")
-        libfabric_val = 'bundled'
-
     return libfabric_val
 
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -254,10 +254,6 @@ def get():
             # for one reason or another. So default to CHPL_LLVM=none.
             llvm_val = 'none'
 
-    if llvm_val == 'llvm':
-        warning("CHPL_LLVM=llvm is deprecated. Use CHPL_LLVM=bundled instead")
-        llvm_val = 'bundled'
-
     if not compatible_platform_for_llvm():
         if llvm_val != 'none' and llvm_val != 'unset':
             warning("CHPL_LLVM={0} is not compatible with this "

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -12,10 +12,6 @@ def get():
     osx = platform_val.startswith('darwin')
     val = overrides.get('CHPL_UNWIND')
 
-    if val == 'libunwind':
-        warning("CHPL_UNWIND=libunwind is deprecated. Use CHPL_UNWIND=bundled.")
-        val = 'bundled'
-
     if linux:
         if val == 'bundled':
             return 'bundled'


### PR DESCRIPTION
Remove CHPL_GMP=gmp, CHPL_HWLOC=hwloc, CHPL_JEMALLOC=jemalloc,
CHPL_LIBFABRIC=libfabric, CHPL_LLVM=llvm and CHPL_UNWIND=unwind. These have
been deprecated for a release and should use CHPL_*=bundled instead.

Remove the test/deprecated test reminding us of this.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>