### PR TITLE
Initialize CUDA context internally

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -301,7 +301,6 @@ void* chpl_gpu_mem_alloc(size_t size, chpl_mem_descInt_t description,
   CHPL_GPU_LOG("chpl_gpu_mem_alloc called. Size:%d file:%s line:%d\n", size,
                chpl_lookupFilename(filename), lineno);
 
-
   CUdeviceptr ptr;
   CUDA_CALL(cuMemAllocManaged(&ptr, size, CU_MEM_ATTACH_GLOBAL));
 

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
@@ -45,7 +45,6 @@ export proc add_nums(dst_ptr: c_ptr(real(64))){
 
 
 proc main() {
-chpl_gpu_init();
 
 var output: real(64);
 var deviceBuffer = getDeviceBufferPointer();

--- a/test/gpu/native/memory/basic.chpl
+++ b/test/gpu/native/memory/basic.chpl
@@ -1,18 +1,12 @@
 use SysCTypes, CPtr;
 
 
-extern proc chpl_gpu_init(): void;
 extern proc chpl_gpu_get_alloc_size(arg): size_t;
 extern proc chpl_gpu_copy_device_to_host(dst: c_void_ptr, src: c_void_ptr, n): void;
 extern proc chpl_gpu_copy_host_to_device(dst: c_void_ptr, src: c_void_ptr, n): void;
 extern proc chpl_gpu_is_device_ptr(ptr): bool;
 
 config const n = 3;
-
-// this doesn't work
-/*coforall 0..#here.maxTaskPar {*/
-  /*chpl_gpu_init();*/
-/*}*/
 
 var ptrHst = chpl_here_alloc(n, 0): c_ptr(c_uchar);
 
@@ -25,7 +19,6 @@ var expandedPtrHst = chpl_here_alloc(n*2, 0): c_ptr(c_uchar);
 
 var s: uint;
 on here.getChild(1) {
-  chpl_gpu_init();
 
   ////////////////////////////////////////////////////
 

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -114,8 +114,6 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
 }
 
 proc main() {
-  chpl_gpu_init();
-
   runExample(1,1,1, 1,1,1);
 
   runExample(1,1,1, 2,2,2);


### PR DESCRIPTION
Adds `chpl_gpu_ensure_context` to the GPU runtime support and calls it for every
other GPU runtime function. The end result is that the user code doesn't have to
call `chpl_gpu_init` explicitly.

The solution in this PR might be too big a hammer, and we can be more precise in
terms of what GPU support functions call this initializer or not. In the long
term, I prefer if we have a hook in the runtime where we can call this for every
pthread as we create them.

Test:
- [x] `test/gpu/native`
