### PR TITLE
Recursive iterator futures for #18218 and #18236

### DIFF
--- a/test/functions/iterators/recursive/recursive-iter-findfilesfailure.bad
+++ b/test/functions/iterators/recursive/recursive-iter-findfilesfailure.bad
@@ -1,0 +1,8 @@
+recursive-iter-findfilesfailure.chpl:5: internal error: RES-LOW-ORS-nnnn chpl version mmmm
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/iterators/recursive/recursive-iter-findfilesfailure.chpl
+++ b/test/functions/iterators/recursive/recursive-iter-findfilesfailure.chpl
@@ -1,0 +1,53 @@
+use FileSystem;
+use IO;
+
+proc main() throws {
+  for f in myfindfiles() {
+    var filereader = open(f, iomode.r).reader();
+  }
+}
+
+/*
+ * Copies of findfiles() and walkdirs() from FileSystem so that this
+ * test covers this particular recursive iterator setup, no matter
+ * what happens to the iterators in the standard module.
+ *
+ * "use FileSystem" above to call listdir().
+ */
+iter myfindfiles(startdir: string = ".", recursive: bool = false,
+               hidden: bool = false): string {
+  if (recursive) then
+    foreach subdir in mywalkdirs(startdir, hidden=hidden) do
+      foreach file in listdir(subdir, hidden=hidden, dirs=false, files=true, listlinks=true) do
+        yield subdir+"/"+file;
+  else
+    foreach file in listdir(startdir, hidden=hidden, dirs=false, files=true, listlinks=false) do
+      yield startdir+"/"+file;
+}
+
+
+iter mywalkdirs(path: string = ".", topdown: bool = true, depth: int = max(int),
+              hidden: bool = false, followlinks: bool = false,
+              sort: bool = false): string {
+
+  if (topdown) then
+    yield path;
+
+  if (depth) {
+    var subdirs = listdir(path, hidden=hidden, files=false, listlinks=followlinks);
+    if (sort) {
+      use Sort /* only sort */;
+      sort(subdirs);
+    }
+
+    for subdir in subdirs {
+      const fullpath = path + "/" + subdir;
+      for subdir in mywalkdirs(fullpath, topdown, depth-1, hidden,
+                             followlinks, sort) do
+        yield subdir;
+    }
+  }
+
+  if (!topdown) then
+    yield path;
+}

--- a/test/functions/iterators/recursive/recursive-iter-findfilesfailure.future
+++ b/test/functions/iterators/recursive/recursive-iter-findfilesfailure.future
@@ -1,0 +1,4 @@
+bug: internal error when loop over findfiles calls a throwing function
+#18218
+
+findfiles() isn't recursive, but does call walkdirs() which is.

--- a/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.bad
+++ b/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.bad
@@ -1,0 +1,8 @@
+recursive-iter-yield-recursive-iter.chpl:3: internal error: UTI-MIS-nnnn chpl version mmmm
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.chpl
+++ b/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.chpl
@@ -1,0 +1,9 @@
+iter recursivator(n: int): int {
+  for i in 0..#n {
+    yield recursivator(i)+1;
+  }
+  yield 0;
+}
+
+for i in recursivator(2) {
+}

--- a/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.future
+++ b/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.future
@@ -1,0 +1,5 @@
+bug: segfault yielding promotion of "call" to recursive iterator
+#18236
+
+I don't know that the .good file is a good error message, but it matches
+the non-recursive case.

--- a/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.good
+++ b/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.good
@@ -1,0 +1,1 @@
+recursive-iter-loop-throwing-function.chpl:3: error: cannot initialize yield value of type 'int(64)' from a '_ir_chpl_promo1_+'


### PR DESCRIPTION
Add futures for two recursive iterator issues:

#18236: compiler segfault on suspect recursive iterator
#18218, internal error, loop over findfiles() calls throwing function


For the second, I was unable to reproduce this error writing my own
recursive iterator in place of findfiles().

I was concerned that a change to these iterators in the FileSystem
module might inadvertantly change the behavior of this test.  So I
added snapshots of findfiles and walkdirs() to the test for it to
call.
