### PR TITLE
Array module review: replace front()\back() with  first\last

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3448,8 +3448,7 @@ module ChapelArray {
       return this(this.domain.high);
     }
 
-    /* This function is deprecated use .last instead */
-    deprecated "Array back() method is deprecated; use .last instead"
+    deprecated "Array back() method is deprecated; use :proc:`last` instead"
     proc back() {
       return this.last;
     }
@@ -3467,8 +3466,7 @@ module ChapelArray {
       return this(this.domain.low);
     }
 
-    /* This function is deprecated use .first instead */
-    deprecated "Array front() method is deprecated; use .front instead"
+    deprecated "Array front() method is deprecated; use :proc:`first` instead"
     proc front() {
       return this.first;
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3438,7 +3438,7 @@ module ChapelArray {
     /* Return the last element in the array. The array must be a
        rectangular 1-D array.
      */
-    proc back() {
+    proc last {
       if !isRectangularArr(this) || this.rank != 1 then
         compilerError("back() is only supported on 1D rectangular arrays");
 
@@ -3448,10 +3448,16 @@ module ChapelArray {
       return this(this.domain.high);
     }
 
+    /* This function is deprecated use .last instead */
+    deprecated "Array back() method is deprecated; use .last instead"
+    proc back() {
+      return this.last;
+    }
+    
     /* Return the first element in the array. The array must be a
        rectangular 1-D array.
      */
-    proc front() {
+    proc first {
       if !isRectangularArr(this) || this.rank != 1 then
         compilerError("front() is only supported on 1D rectangular arrays");
 
@@ -3459,6 +3465,12 @@ module ChapelArray {
         halt("front called on an empty array");
 
       return this(this.domain.low);
+    }
+
+    /* This function is deprecated use .first instead */
+    deprecated "Array front() method is deprecated; use .front instead"
+    proc front() {
+      return this.first;
     }
 
     /* Reverse the order of the values in the array. */

--- a/test/arrays/diten/arrayBack2D.chpl
+++ b/test/arrays/diten/arrayBack2D.chpl
@@ -1,3 +1,3 @@
 var A: [1..3, 1..3] int;
 
-writeln(A.back());
+writeln(A.last);

--- a/test/arrays/diten/arrayBackOOB.chpl
+++ b/test/arrays/diten/arrayBackOOB.chpl
@@ -1,3 +1,3 @@
 var A: [1..0] int;
 
-writeln(A.back());
+writeln(A.last);

--- a/test/arrays/diten/arrayFront2D.chpl
+++ b/test/arrays/diten/arrayFront2D.chpl
@@ -1,3 +1,3 @@
 var A: [1..3, 1..3] int;
 
-writeln(A.front());
+writeln(A.first);

--- a/test/arrays/diten/arrayFrontBack.chpl
+++ b/test/arrays/diten/arrayFrontBack.chpl
@@ -1,4 +1,4 @@
 var A: [1..10] int = 1..10;
 
-writeln(A.front());
-writeln(A.back());
+writeln(A.first);
+writeln(A.last);

--- a/test/arrays/diten/arrayFrontOOB.chpl
+++ b/test/arrays/diten/arrayFrontOOB.chpl
@@ -1,3 +1,3 @@
 var A: [1..0] int;
 
-writeln(A.front());
+writeln(A.first);

--- a/test/deprecated/arrays.chpl
+++ b/test/deprecated/arrays.chpl
@@ -1,0 +1,5 @@
+var A = [1,2,3,4];
+writeln(A.front());
+writeln(A.back());
+writeln(A.first);
+writeln(A.last);

--- a/test/deprecated/arrays.good
+++ b/test/deprecated/arrays.good
@@ -1,5 +1,5 @@
-arrays.chpl:2: warning: Array front() method is deprecated; use .front instead
-arrays.chpl:3: warning: Array back() method is deprecated; use .last instead
+arrays.chpl:2: warning: Array front() method is deprecated; use first instead
+arrays.chpl:3: warning: Array back() method is deprecated; use last instead
 1
 4
 1

--- a/test/deprecated/arrays.good
+++ b/test/deprecated/arrays.good
@@ -1,0 +1,6 @@
+arrays.chpl:2: warning: Array front() method is deprecated; use .front instead
+arrays.chpl:3: warning: Array back() method is deprecated; use .last instead
+1
+4
+1
+4


### PR DESCRIPTION
This PR is to satisfy this issue: https://github.com/chapel-lang/chapel/issues/18087

One item we had agreement on is that we should rename the array front and back methods to first and last. This provides consistency with domain which uses first and last to refer to the first and last indices.