### PR TITLE
Fix compiler's representation of paren-less functions that simply return

### DIFF
--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -408,7 +408,7 @@ static int processToken(yyscan_t scanner, int t) {
       captureString.push_back(' ');
     }
 
-    if (t != TLCBR) {
+    if (t != TLCBR && t != TRETURN) {
       captureString.append(yyget_text(scanner));
     }
 

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -3449,7 +3449,7 @@ static int processToken(yyscan_t scanner, int t) {
       captureString.push_back(' ');
     }
 
-    if (t != TLCBR) {
+    if (t != TLCBR && t != TRETURN) {
       captureString.append(yyget_text(scanner));
     }
 

--- a/test/parsing/vass/parenthesis-less-function-string.bad
+++ b/test/parsing/vass/parenthesis-less-function-string.bad
@@ -1,4 +1,0 @@
-parenthesis-less-function-string.chpl:2: error: unresolved call 'real(64).x'
-parenthesis-less-function-string.chpl:1: note: this candidate did not match: int.xreturn
-parenthesis-less-function-string.chpl:2: note: because method call receiver with type 'real(64)'
-parenthesis-less-function-string.chpl:1: note: is passed to formal 'this: int(64)'

--- a/test/parsing/vass/parenthesis-less-function-string.future
+++ b/test/parsing/vass/parenthesis-less-function-string.future
@@ -1,5 +1,0 @@
-bug: the header string for a parenthesis-less function is incorrect
-
-... in the case where the body of the function is not enclosed in { }.
-Seems like the parser unputs "return" when parsing the function header
-but does not remove "return" from the header string it is accumulating.

--- a/test/trivial/diten/shortMethodError.bad
+++ b/test/trivial/diten/shortMethodError.bad
@@ -1,4 +1,0 @@
-shortMethodError.chpl:10: error: unresolved call 'owned D.shortMethod'
-shortMethodError.chpl:2: note: this candidate did not match: C.shortMethodreturn
-shortMethodError.chpl:10: note: because method call receiver with type 'owned D'
-shortMethodError.chpl:1: note: is passed to formal 'this: borrowed C'

--- a/test/trivial/diten/shortMethodError.future
+++ b/test/trivial/diten/shortMethodError.future
@@ -1,5 +1,0 @@
-error message: Error message from resolution includes token after function name 
-for parenthesis-less function with no braces around body
-
-The method C.shortMethod gets called C.shortMethodreturn in the unresolved call
-error message.


### PR DESCRIPTION
When the parser+lexer is gobbling up text to store as the user's
function header, it has not been handling this case properly:

```chapel
proc parenLessFn return expr;
```

because it's been triggering off of the presence of curly brackets as
the signal to stop gobbling code into the function's string.

This change makes a simple change to the lexer to also stop if it sees
a return statement (the one statement that we support for functions
without curly brackets at present) and retires two futures.

TODO:
- [x] check in generated parser files once this passes review