### PR TITLE
Curl: expose more of the curl_easy_ interface directly

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -118,6 +118,7 @@ module Curl {
   require "curl/curl.h";
   require "-lcurl";
 
+  config var debug = false;
 
   /* Returns the ``CURL`` handle connected to a channel opened with
      :proc:`URL.openUrlReader` or :proc:`URL.openUrlWriter`.

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -157,10 +157,6 @@ module Curl {
       throw SystemError.fromSyserr(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
     }
 
-    // Invalid argument type for option if the below conditionals
-    // don't handle it.
-    err = EINVAL;
-
     on ch.home {
       var plugin = ch.channelPlugin():CurlChannel?;
       if plugin == nil then
@@ -177,7 +173,9 @@ module Curl {
 
   // setopt on the curl_easy object, for sharing with easySetopt below.
   private proc setopt(curl: c_ptr(CURL), opt:c_int, arg) {
-      var err: syserr = ENOERR;
+      // Invalid argument type for option if the below conditionals
+      // don't handle it.
+      var err: syserr = EINVAL;
       // This reasoning is pulled from the libcurl source
       if (opt < CURLOPTTYPE_OBJECTPOINT) {
         // < OBJECTPOINT means CURLOPTTYPE_LONG; libcurl wants a "long" arg.

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -766,7 +766,7 @@ module Curl {
 
       var amt = realsize.safeCast(ssize_t);
 
-      //writeln("curl_write_received offset=", qio_channel_offset_unlocked(cc.qio_ch), " len=", amt);
+      //writeln("curl_write_received offset=", qio_channel_offset_unlocked(cc!.qio_ch), " len=", amt);
 
       // make sure the channel has room in the buffer for the data
       // copy the data to the channel's buffer

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -152,7 +152,7 @@ module Curl {
 
     var err:syserr = ENOERR;
 
-    if (arg.type == slist) && (slist.home != ch.home) {
+    if (arg.type == slist) && (arg.home != ch.home) {
       throw SystemError.fromSyserr(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
     }
 
@@ -402,6 +402,10 @@ module Curl {
   extern proc curl_multi_remove_handle(curlm:c_ptr(CURLM), curl:c_ptr(CURL)):CURLMcode;
   /* See https://curl.haxx.se/libcurl/c/curl_multi_cleanup.html */
   extern proc curl_multi_cleanup(curlm:c_ptr(CURLM)):CURLcode;
+
+  extern proc curl_slist_append(csl: c_ptr(curl_slist), char: c_string) : c_ptr(curl_slist);
+  extern proc curl_slist_free_all(csl: c_ptr(curl_slist));
+
 
   pragma "no doc"
   module CurlQioIntegration {


### PR DESCRIPTION
As a workaround / stopgap for #18260, expose the less Chapelrific more libcurltastic curl_easy_ API.  This allows a post to be done as:

```
    var curl = Curl.easyInit();
    Curl.easySetopt(curl, CURLOPT_URL, 'http://localhost:3000/posts');

    var args = new Curl.slist();
    args.append("Accept: application/json");
    args.append("Content-Type: application/json");

    Curl.easySetopt(curl, CURLOPT_HTTPHEADER, args);

    var jsonPayload = '{"foo": "from ChapelEasy"}';
    Curl.easySetopt(curl, CURLOPT_POSTFIELDS, jsonPayload);

    Curl.easySetopt(curl, CURLOPT_CUSTOMREQUEST, 'POST');

    writeln("calling perform");

    var ret = Curl.easyPerform(curl);

    writeln("perform returned ", ret);

    args.free();
    Curl.easyCleanup(curl);
```

Output may be suppressed with

```chapel
    use CPtr, SysCTypes;
    extern proc fopen(filename: c_string, mode: c_string): c_void_ptr;
    var devnull = fopen("/dev/null".c_str(), "w".c_str());
	  
    Curl.easySetopt(curl, CURLOPT_WRITEDATA, devnull);
```

~~I wasn't able to get my own `CURLOPT_WRITEFUNCTION` to be called, even though `Curl.chpl` is able to do so.~~   Oops, I'd been missing the cast to `c_void_ptr`.  The following works, but a bug fixed in the last commit was hiding the failure without the cast:

```chapel
Curl.easySetopt(curl, CURLOPT_WRITEFUNCTION, c_ptrTo(null_write_callback):c_void_ptr);
```


I was also able to use this to do a `PATCH` request.

The first and last (edit: last two) commits as of this writing are all that are needed; the others are for adding debugging.