### PR TITLE
Use default timeouts of Cray CS testing

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -33,6 +33,3 @@ source $CWD/common-llvm-comp-path.bash
 
 # https://github.com/Cray/chapel-private/issues/1601
 export SLURM_CPU_FREQ_REQ=high
-
-# workaround for https://github.com/Cray/chapel-private/issues/1598
-export CHPL_TEST_TIMEOUT=2000

--- a/util/cron/test-perf.cray-cs-hdr.ofi.bash
+++ b/util/cron/test-perf.cray-cs-hdr.ofi.bash
@@ -15,10 +15,6 @@ source $CWD/common-cray-cs.bash y
 source $CWD/common-perf-cray-cs-hdr.bash
 source $CWD/common-ofi.bash
 
-# Stopgap: bump the timeout so all tests pass.  (empty-chpl-remote-taskspawn
-# and miniMD time out with the default limit of 300.)
-export CHPL_TEST_TIMEOUT=1800
-
 if [[ $($CHPL_HOME/util/chplenv/chpl_platform.py --target) != cray-cs ]] || \
    [[ "$CHPL_COMM_OFI_OOB" != pmi2 ]] || \
    [[ "$SLURM_MPI_TYPE" != pmi2 ]] ; then


### PR DESCRIPTION
We used a higher timeout when ofi perf testing was originally added because MiniMD and task spawning tests were slow. Looking at the most recent nightly logs MiniMD takes under 2 minutes and task spawning is under a minute. MiniMD is the longest executing test so I think it's safe to use the default 5 minute timeout now.

Also remove regular cray cs timeout, which was added when we were having problems after moving to an EDR machine that ended up being unstable.  We moved to a different HDR machine that has not had the same issues so the timeouts are not needed.