### PR TITLE
Bring in an upstream conftest fix for qthreads

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -28,8 +28,11 @@ as follows:
 * Pulled in an upstream fix for the binders topology layer.
   https://github.com/Qthreads/qthreads/pull/82
 
+* Pulled in an upstream fix for handling signals during configure.
+  https://github.com/Qthreads/qthreads/pull/84
+
 * Pulled in an upstream --with-hwloc-symbol-prefix configuration option.
   https://github.com/Qthreads/qthreads/pull/87
 
-* Pulled in an upstream for for errno with syscalls.
+* Pulled in an upstream fix for errno with syscalls.
   https://github.com/Qthreads/qthreads/pull/89

--- a/third-party/qthread/qthread-src/config/qthread_check_bitfield_order.m4
+++ b/third-party/qthread/qthread-src/config/qthread_check_bitfield_order.m4
@@ -15,6 +15,10 @@ AS_IF([test "x$with_forward_bitfields" = x],
                       [qthread_cv_bitfield_order],
                       [AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <assert.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+
 union foo {
     unsigned int w;
     struct bar {
@@ -24,6 +28,18 @@ union foo {
     } s;
 } fb;]],
 [[
+struct sigaction sa;
+void handler (int sig)
+{
+    exit(1);
+}
+
+memset (&sa, '\0', sizeof(sa));
+sa.sa_sigaction = (void (*)(int, siginfo_t *, void *)) &handler;
+sa.sa_flags = SA_SIGINFO;
+//Catch SIGABORT
+sigaction(SIGABRT, &sa, NULL); 
+
 fb.w = 0;
 fb.s.c = 1;
 assert(fb.w == 1);]])],

--- a/third-party/qthread/qthread-src/config/qthread_check_bitfield_order.m4
+++ b/third-party/qthread/qthread-src/config/qthread_check_bitfield_order.m4
@@ -16,6 +16,7 @@ AS_IF([test "x$with_forward_bitfields" = x],
                       [AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <assert.h>
 #include <signal.h>
+#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -29,13 +30,13 @@ union foo {
 } fb;]],
 [[
 struct sigaction sa;
-void handler (int sig)
+void handler (int sig, siginfo_t* s, void* v)
 {
-    exit(1);
+    _exit(1);
 }
 
 memset (&sa, '\0', sizeof(sa));
-sa.sa_sigaction = (void (*)(int, siginfo_t *, void *)) &handler;
+sa.sa_sigaction = &handler;
 sa.sa_flags = SA_SIGINFO;
 //Catch SIGABORT
 sigaction(SIGABRT, &sa, NULL); 

--- a/third-party/qthread/qthread-src/config/qthread_check_qsort.m4
+++ b/third-party/qthread/qthread-src/config/qthread_check_qsort.m4
@@ -16,16 +16,36 @@ AC_CHECK_FUNCS([qsort_r],
                                       [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <assert.h>
+#include <signal.h>
+#include <string.h>
+
+struct sigaction sa;
 
 int cmp(void *a, const void *b, const void*c)
 {
-assert(a == NULL);
-return *(int*)b - *(int*)c;
+  assert(a == NULL);
+  return *(int*)b - *(int*)c;
 }
+
+void handler(int sig)
+{
+    exit(1);
+}
+
+void handle()
+{
+    memset (&sa, '\0', sizeof(sa));
+    sa.sa_sigaction = (void (*)(int, siginfo_t *, void *)) &handler;
+    sa.sa_flags = SA_SIGINFO;
+    // Register handler for SIGSEGV 
+    sigaction(SIGSEGV, &sa, NULL); 
+}
+
 int main()
 {
     int array[5] = {7,3,5,2,8};
     int i;
+    handle();
     qsort_r(array,5,sizeof(int),NULL,cmp);
     for (i=0;i<4;i++) {
         assert(array[i] < array[i+1]);

--- a/third-party/qthread/qthread-src/config/qthread_check_qsort.m4
+++ b/third-party/qthread/qthread-src/config/qthread_check_qsort.m4
@@ -37,7 +37,7 @@ void handle()
     memset (&sa, '\0', sizeof(sa));
     sa.sa_sigaction = (void (*)(int, siginfo_t *, void *)) &handler;
     sa.sa_flags = SA_SIGINFO;
-    // Register handler for SIGSEGV 
+    // Catch SIGSEGV 
     sigaction(SIGSEGV, &sa, NULL); 
 }
 


### PR DESCRIPTION
Bring in Qthreads/qthreads#84 to resolve conftest errors on Ubuntu systems. This adds signal handling to some configure tests to avoid popups that some users have seen on Ubuntu desktop.

Resolves https://github.com/chapel-lang/chapel/pull/18116
Resolves https://github.com/Cray/chapel-private/issues/2351