### PR TITLE
Default to fifo tasking layer on arm based macs

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 
-import chpl_compiler, chpl_platform, overrides
+import chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import using_chapel_module
 from compiler_utils import CompVersion, get_compiler_version
 from utils import memoize
@@ -13,10 +13,14 @@ def get():
     if not tasks_val:
         platform_val = chpl_platform.get('target')
         compiler_val = chpl_compiler.get('target')
+        arch_val = chpl_arch.get('target')
 
-        if (platform_val.startswith('cygwin') or
-                platform_val.startswith('netbsd') or
-                platform_val.startswith('freebsd')):
+        cygwin = platform_val.startswith('cygwin')
+        bsd = (platform_val.startswith('netbsd') or
+               platform_val.startswith('freebsd'))
+        mac_arm = platform_val.startswith('darwin') and arch_val == 'arm64'
+
+        if cygwin or bsd or mac_arm:
             tasks_val = 'fifo'
         else:
             tasks_val = 'qthreads'


### PR DESCRIPTION
Qthreads doesn't currently support arm based macs. Configure fails with
`error: What kind of a Mac is this?` while trying to figure out what
native assembly to use for context switching. We started looking at
using system `ucontext` in Qthreads/qthreads#90, but given how close our
release is we want to default to fifo since we know some users have had
success with that.

Resolves Cray/chapel-private#2424
Part of #17911