### PR TITLE
Remove the specific module name requirement from GPU support

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -449,31 +449,6 @@ static void deadModuleElimination() {
   }
 }
 
-static bool shouldOutlineLoop(CForLoop *loop) {
-  // Obvious TODO :)
-  
-  const char* testModuleName = "GPUOutlineTest";
-  bool inTestModule = false;
-
-  Symbol* cur = loop->parentSymbol;
-
-  do {
-    if (ModuleSymbol* parentModule = toModuleSymbol(cur)) {
-      if (strcmp(parentModule->name, testModuleName) == 0) {
-        inTestModule = true;
-      }
-    }
-
-    if (cur->defPoint != NULL)
-      cur = cur->defPoint->parentSymbol;
-    else
-      cur = NULL;
-
-  } while (cur != NULL && !inTestModule);
-
-  return inTestModule && loop->isOrderIndependent();
-}
-
 static bool isDefinedInTheLoop(Symbol* sym, CForLoop* loop) {
   return LoopStmt::findEnclosingLoop(sym->defPoint) == loop;
 }
@@ -646,8 +621,7 @@ static void outlineGPUKernels() {
 
     for_vector(BaseAST, ast, asts) {
       if (CForLoop* loop = toCForLoop(ast)) {
-        if (shouldOutlineLoop(loop) &&
-            blockLooksLikeStreamForGPU(loop, /*allowFnCalls=*/false)) {
+        if (blockLooksLikeStreamForGPU(loop, /*allowFnCalls=*/false)) {
           SET_LINENO(loop);
           FnSymbol* outlinedFunction = new FnSymbol("chpl_gpu_kernel");
           outlinedFunction->addFlag(FLAG_RESOLVED);

--- a/test/gpu/native/streamPrototype/dr.chpl
+++ b/test/gpu/native/streamPrototype/dr.chpl
@@ -1,27 +1,21 @@
-// this module name is hard-coded in the compiler
-module GPUOutlineTest {
-  extern proc chpl_gpu_init(): void;
+extern proc chpl_gpu_init(): void;
 
-  config const n = 10;
+config const n = 10;
 
-  proc testMain() {
-    on here.getChild(1) {
-      chpl_gpu_init();
-      var a, b: [0..n] int;
-      var value = 20;
+on here.getChild(1) {
+  chpl_gpu_init();
+  var a, b: [0..n] int;
+  var value = 20;
 
-      // one array
-      forall  i in 0..n { a[i] += i+10;       } writeln(a);
-      forall  i in 0..n { a[i] += i+value;    } writeln(a);
-      foreach i in 0..n { a[i] += i+10;       } writeln(a);
-      foreach i in 0..n { a[i] += i+value;    } writeln(a);
+  // one array
+  forall  i in 0..n { a[i] += i+10;       } writeln(a);
+  forall  i in 0..n { a[i] += i+value;    } writeln(a);
+  foreach i in 0..n { a[i] += i+10;       } writeln(a);
+  foreach i in 0..n { a[i] += i+value;    } writeln(a);
 
-      // two arrays
-      forall  i in 0..n { b[i] += a[i]*10;    } writeln(b);
-      forall  i in 0..n { b[i] += a[i]*value; } writeln(b);
-      foreach i in 0..n { b[i] += a[i]*10;    } writeln(b);
-      foreach i in 0..n { b[i] += a[i]*value; } writeln(b);
-    }
-  }
-  testMain();
+  // two arrays
+  forall  i in 0..n { b[i] += a[i]*10;    } writeln(b);
+  forall  i in 0..n { b[i] += a[i]*value; } writeln(b);
+  foreach i in 0..n { b[i] += a[i]*10;    } writeln(b);
+  foreach i in 0..n { b[i] += a[i]*value; } writeln(b);
 }

--- a/test/gpu/native/streamPrototype/dr.chpl
+++ b/test/gpu/native/streamPrototype/dr.chpl
@@ -1,9 +1,6 @@
-extern proc chpl_gpu_init(): void;
-
 config const n = 10;
 
 on here.getChild(1) {
-  chpl_gpu_init();
   var a, b: [0..n] int;
   var value = 20;
 


### PR DESCRIPTION
Our initial prototype for outlining foralls included a limitation that the
module name should be `GPUOutlineTest`. After #18224 and #18232, we no longer
need that limitation. This PR removes that check from the compiler.

While there:
- Renames a compiler helper function
- Drops the explicit module from a relevant test.

Note that, we're still limited to user modules. I tried to remove that check,
too, but I bumped into https://github.com/Cray/chapel-private/issues/2416. So,
that's still a TODO.

Test:
- [x] gpu/native
