### PR TITLE
Add future to track the bug reported in #18257

### DIFF
--- a/test/visibility/private/moduleSymbols/importPrivateSubmodule.bad
+++ b/test/visibility/private/moduleSymbols/importPrivateSubmodule.bad
@@ -1,0 +1,2 @@
+importPrivateSubmodule.chpl:11: In function 'main':
+importPrivateSubmodule.chpl:15: error: Symbol 'do_my_impl' undeclared in module 'Details'

--- a/test/visibility/private/moduleSymbols/importPrivateSubmodule.chpl
+++ b/test/visibility/private/moduleSymbols/importPrivateSubmodule.chpl
@@ -1,0 +1,23 @@
+module ExternalLib1 {
+  private module Details {}
+}
+
+// My library's implementation details.
+module Details {
+  proc do_my_impl() { writeln("whatev"); }
+}
+
+module SomeOtherFile {
+  proc main() {
+    {
+      use ExternalLib1;
+      import Details;       // Should find the public module
+      Details.do_my_impl(); // bug: compile-error
+    }
+    {
+      import ExternalLib1;
+      import Details;       // Resolves fine
+      Details.do_my_impl();
+    }
+  }
+}

--- a/test/visibility/private/moduleSymbols/importPrivateSubmodule.future
+++ b/test/visibility/private/moduleSymbols/importPrivateSubmodule.future
@@ -1,0 +1,2 @@
+bug: private submodule able to be imported from outside parent's scope
+#18257

--- a/test/visibility/private/moduleSymbols/importPrivateSubmodule.good
+++ b/test/visibility/private/moduleSymbols/importPrivateSubmodule.good
@@ -1,0 +1,2 @@
+whatev
+whatev


### PR DESCRIPTION
This test demonstrates that a private submodule is accidentally able to be
imported outside of the scope where the module is defined, if the parent module
is used.  This is not intended behavior.

Based on code written by Bryant in #18257

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>