### PR TITLE
Update failing tests.

### DIFF
--- a/test/arrays/userAPI/blockOps2D.good
+++ b/test/arrays/userAPI/blockOps2D.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 100
+dims are: (1..10, 1..10)
+dim(0) is: 1..10
+dim(1) is: 1..10
 shape is: (10, 10)
 
 X is:
@@ -252,6 +255,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 49
+dims are: (2..8, 2..8)
+dim(0) is: 2..8
+dim(1) is: 2..8
 shape is: (7, 7)
 
 X is:

--- a/test/arrays/userAPI/blockOpsRankChange.good
+++ b/test/arrays/userAPI/blockOpsRankChange.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 49
+dims are: (1..7, 1..7)
+dim(0) is: 1..7
+dim(1) is: 1..7
 shape is: (7, 7)
 
 X is:

--- a/test/arrays/userAPI/blockOpsReindex.good
+++ b/test/arrays/userAPI/blockOpsReindex.good
@@ -5,6 +5,9 @@ idxType is: int(64)
 rank is: 2
 
 size is: 100
+dims are: (0..9, 1..20 by 2)
+dim(0) is: 0..9
+dim(1) is: 1..20 by 2
 shape is: (10, 10)
 
 X is:


### PR DESCRIPTION
Specifically the gasnet version of blockOps tests now that we report the result
of dims and dim for arrays.

See: https://chapel.discourse.group/t/cron-gasnet-llvm/6760/1

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>