### PR TITLE
Update workflows to not set CHPL_LLVM=none

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make check
       run: |
-        CHPL_LLVM=none ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest
 
   make_doc:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make check-chpldoc && make docs
       run: |
-        CHPL_LLVM=none ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest
     - name: upload docs
       uses: actions/upload-artifact@v2
       with:
@@ -58,8 +58,8 @@ jobs:
         fetch-depth: 100000
     - name: check annotations
       run: |
-        CHPL_LLVM=none make test-venv
-        CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
+        make test-venv
+        CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
 
   bad_rt_calls:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ignore this PR.

This is not something I intend to actually submit (at least not for the moment). But I want to observe the github CI actions so I'm creating a pull request. I should be able to use  act (https://github.com/nektos/act) instead of doing things this way, but it doesn't seem to be reproducing things the way I expect.