### PR TITLE
Remove unnecessary check in param uint **

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -466,8 +466,6 @@ module ChapelBase {
     return __primitive("**", a, b);
   }
   operator **(param a: uint(?w), param b: uint(w)) param {
-    if a == 0 && b < 0 then
-      compilerError("0 cannot be raised to a negative power");
     return __primitive("**", a, b);
   }
 


### PR DESCRIPTION
Follow-up to #18172

Removes an unnecessary check since uints can't be negative.

Thanks to @cassella for pointing out the issue!

Trivial and not reviewed.

- [x] full local testing