### PR TITLE
Heap allocate string literals

### DIFF
--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -79,6 +79,7 @@ FnSymbol *gChplSaveTaskError;
 FnSymbol *gChplForallError;
 FnSymbol *gAtomicFenceFn;
 FnSymbol *gChplAfterForallFence;
+FnSymbol *gChplCreateLiteralsBuffer;
 FnSymbol *gChplCreateStringWithLiteral;
 FnSymbol *gChplCreateBytesWithLiteral;
 FnSymbol *gChplBuildLocaleId;
@@ -487,6 +488,12 @@ static WellKnownFn sWellKnownFns[] = {
   {
     "chpl_after_forall_fence",
     &gChplAfterForallFence,
+    FLAG_UNKNOWN
+  },
+
+  {
+    "chpl_createLiteralsBuffer",
+    &gChplCreateLiteralsBuffer,
     FLAG_UNKNOWN
   },
 

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -91,6 +91,7 @@ extern FnSymbol *gChplSaveTaskError;
 extern FnSymbol *gChplForallError;
 extern FnSymbol *gAtomicFenceFn;
 extern FnSymbol *gChplAfterForallFence;
+extern FnSymbol *gChplCreateLiteralsBuffer;
 extern FnSymbol *gChplCreateStringWithLiteral;
 extern FnSymbol *gChplCreateBytesWithLiteral;
 extern FnSymbol *gChplBuildLocaleId;

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -364,6 +364,10 @@ static bool isDeadModule(ModuleSymbol* mod) {
   if (mod == ModuleSymbol::mainModule())
     return false;
 
+  // Ditto for the string literals module
+  if (mod == stringLiteralModule)
+    return false;
+
   // Ditto for an exported module
   if (mod->hasFlag(FLAG_EXPORT_INIT))
     return false;

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -775,11 +775,8 @@ void deadCodeElimination() {
   }
 
   // Emit string literals. This too could be its own pass but
-  // for now it is convenient to do it here because the dead string
-  // literals still refer to valid memory and just are not in the tree.
-  // (If it is moved elsewhere, the stringLiteralsHash and bytesLiteralsHash
-  //  maps would need to have their values cleared when a string literal
-  //  is deemed dead).
+  // for now it is convenient to do it here. It could happen any time
+  // after dead string literal elimination and code generation.
   createInitStringLiterals();
 }
 

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -293,27 +293,6 @@ static void cleanup(ModuleSymbol* module) {
       addIntentRefMaybeConst(arg);
     }
   }
-
-  if (module == stringLiteralModule && !fMinimalModules) {
-    // Fix calls to chpl_createStringWithLiteral to use resolved expression.
-    // For compiler performance reasons, we'd like to have new_StringSymbol
-    // emit calls to a resolved function; however new_StringSymbol might
-    // run before that function is parsed. So fix up any literals created
-    // during parsing here.
-    INT_ASSERT(gChplCreateStringWithLiteral != NULL);
-    const char* name = gChplCreateStringWithLiteral->name;
-
-    for_vector(BaseAST, ast, asts) {
-      if (CallExpr* call = toCallExpr(ast)) {
-        if (UnresolvedSymExpr* urse = toUnresolvedSymExpr(call->baseExpr)) {
-          if (urse->unresolved == name) {
-            SET_LINENO(urse);
-            urse->replace(new SymExpr(gChplCreateStringWithLiteral));
-          }
-        }
-      }
-    }
-  }
 }
 
 /************************************* | **************************************

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -402,12 +402,13 @@ static void removeAggTypeFieldInfo() {
 
 // Remove module level variables if they are not defined or used
 // With the exception of variables that are defined in the rootModule
+// or in the string literals module.
 static void removeUnusedModuleVariables() {
   forv_Vec(DefExpr, def, gDefExprs) {
     if (VarSymbol* var = toVarSymbol(def->sym)) {
       if (ModuleSymbol* module = toModuleSymbol(def->parentSymbol)) {
         if (var->isDefined() == false && var->isUsed() == false) {
-          if (module != rootModule) {
+          if (module != rootModule && module != stringLiteralModule) {
             def->remove();
           }
         }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -197,7 +197,6 @@ static void resolveDestructors();
 static AggregateType* buildRuntimeTypeInfo(FnSymbol* fn);
 static void insertReturnTemps();
 static void initializeClass(Expr* stmt, Symbol* sym);
-static void ensureAndResolveInitStringLiterals();
 static void handleRuntimeTypes();
 static void buildRuntimeTypeInitFns();
 static void buildRuntimeTypeInitFn(FnSymbol* fn, Type* runtimeType);
@@ -9392,10 +9391,6 @@ void resolve() {
 
   handleRuntimeTypes();
 
-  // Resolve the string literal constructors after everything else since new
-  // ones may be created during postFold
-  ensureAndResolveInitStringLiterals();
-
   if (fPrintCallGraph) {
     // This needs to go after resolution is complete, but before
     // pruneResolvedTree() removes unused functions (like the uninstantiated
@@ -10226,15 +10221,6 @@ initializeClass(Expr* stmt, Symbol* sym) {
       }
     }
   }
-}
-
-
-static void ensureAndResolveInitStringLiterals() {
-  if (!initStringLiterals) {
-    INT_ASSERT(fMinimalModules);
-    createInitStringLiterals();
-  }
-  resolveFunction(initStringLiterals);
 }
 
 

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -142,11 +142,21 @@ module Bytes {
   }
 
   pragma "no doc"
-  proc chpl_createBytesWithLiteral(x: c_string, length: int) {
+  proc chpl_createBytesWithLiteral(buffer: c_void_ptr,
+                                   offset: int,
+                                   x: c_string,
+                                   length: int) {
+    // copy the string to the combined buffer
+    var buf = buffer:c_ptr(uint(8));
+    buf = buf + offset;
+    c_memcpy(buf:c_void_ptr, x:c_void_ptr, length);
+    // add null byte
+    buf[length] = 0;
+
     // NOTE: This is a "wellknown" function used by the compiler to create
     // string literals. Inlining this creates some bloat in the AST, slowing the
     // compilation.
-    return createBytesWithBorrowedBuffer(x, length);
+    return createBytesWithBorrowedBuffer(buf: c_string, length);
   }
 
   /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -602,11 +602,27 @@ module String {
   }
 
   pragma "no doc"
-  proc chpl_createStringWithLiteral(x: c_string, length: int, numCodepoints: int) {
+  proc chpl_createLiteralsBuffer(size: int): c_void_ptr {
+    return c_malloc(uint(8), size):c_void_ptr;
+  }
+
+  pragma "no doc"
+  proc chpl_createStringWithLiteral(buffer: c_void_ptr,
+                                    offset: int,
+                                    x: c_string,
+                                    length: int,
+                                    numCodepoints: int) {
+    // copy the string to the combined buffer
+    var buf = buffer:c_ptr(uint(8));
+    buf = buf + offset;
+    c_memcpy(buf:c_void_ptr, x:c_void_ptr, length);
+    // add null byte
+    buf[length] = 0;
+
     // NOTE: This is a "wellknown" function used by the compiler to create
     // string literals. Inlining this creates some bloat in the AST, slowing the
     // compilation.
-    return chpl_createStringWithBorrowedBufferNV(x:c_ptr(uint(8)),
+    return chpl_createStringWithBorrowedBufferNV(buf,
                                                  length=length,
                                                  size=length+1,
                                                  numCodepoints=numCodepoints);

--- a/test/types/string/ferguson/strings-not-rodata.chpl
+++ b/test/types/string/ferguson/strings-not-rodata.chpl
@@ -1,0 +1,37 @@
+use CPtr;
+
+writeln("Printing before modification");
+
+writeln("Hello World!");
+writeln("Hello World!".c_str():string);
+
+writeln(b"Hello World!");
+writeln(b"Hello World!".c_str():string);
+
+// Now modify a string literal
+// this is not an OK thing for code to do in general
+// but we do it in this test to make sure that if strings end
+// up in the read-only data section again, issues #18284 and #18287
+// are suitably resolved in a different way.
+
+// Programs that modify string literals like this should expect
+// undefined behavior.
+writeln("Modifying");
+
+{
+  var s = "Hello World!";
+  var cptr = s.c_str():c_void_ptr:c_ptr(uint(8));
+  cptr[0] = 66; // 'B'
+  writeln("Hello World!");
+  writeln(s);
+  writeln(s.c_str():string);
+}
+
+{
+  var s = b"Hello World!";
+  var cptr = s.c_str():c_void_ptr:c_ptr(uint(8));
+  cptr[0] = 66; // 'B'
+  writeln(b"Hello World!");
+  writeln(s);
+  writeln(s.c_str():string);
+}

--- a/test/types/string/ferguson/strings-not-rodata.good
+++ b/test/types/string/ferguson/strings-not-rodata.good
@@ -1,0 +1,12 @@
+Printing before modification
+Hello World!
+Hello World!
+Hello World!
+Hello World!
+Modifying
+Bello World!
+Bello World!
+Bello World!
+Bello World!
+Bello World!
+Bello World!


### PR DESCRIPTION
For issues #18287 and #18284

This PR adjusts the compiler code that emits string literal initialization in two ways.

First, it adjusts the initialization for string literals to be emitted after dead string literals are removed. That simplifies the logic by removing the need to remove string literal initialization code in the event that the literal is unused. So, after this PR, until deadCodeElimination, string literals only exist as DefExprs for module-level variables in the ChapelStringLiterals module.

Second, it changes the initialization pattern for string literals to create a single heap allocation to store all string and bytes literals and then to copy the string literals from the read-only data section into this heap allocation. This avoids problems with communicating from the read-only data section for string literals.

For now, the single heap allocation storing the string and bytes literals is leaked. This leak is not reported by `--memLeaks`.

Testing:
- [x] multilocale tests pass on an Infiniband system with `CHPL_COMM=gasnet` and `CHPL_COMM_SEGMENT=everything` 
- [x] full local testing
- [x] full local gasnet testing

Reviewed by @e-kayrakli - thanks!

Future Work:
 - add serialize/deserialize for `bytes` and have the compiler check that module-scope `const`s are either POD or have serialize/deserialize implemented (see https://github.com/Cray/chapel-private/issues/2472 )
 - free the heap allocation storing the string literals in the module deinit
 - figure out how the corresponding functionality can work with separate compilation and/or dynamic loading of Chapel code