### PR TITLE
Switch from size/codepoint check to isEmpty for memtracking strings

### DIFF
--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -88,7 +88,7 @@ module MemTracking
     ret_memThreshold = cMemThreshold;
 
     if (here.id != 0) {
-      if memLeaksByDesc.size != 0 {
+      if !memLeaksByDesc.isEmpty() {
         var local_memLeaksByDesc = memLeaksByDesc;
         // Intentionally leak the string to persist the underlying buffer
         local_memLeaksByDesc.isOwned = false;
@@ -97,7 +97,7 @@ module MemTracking
         ret_memLeaksByDesc = nil;
       }
 
-      if memLog.size != 0 {
+      if !memLog.isEmpty() {
         var local_memLog = memLog;
         // Intentionally leak the string to persist the underlying buffer
         local_memLog.isOwned = false;
@@ -106,7 +106,7 @@ module MemTracking
         ret_memLog = nil;
       }
 
-      if memLeaksLog.size != 0 {
+      if !memLeaksLog.isEmpty() {
         var local_memLeaksLog = memLeaksLog;
         // Intentionally leak the string to persist the underlying buffer
         local_memLeaksLog.isOwned = false;


### PR DESCRIPTION
The mem tracking code checks if some config strings are set before
trying to copy locally and pass c_strings to the runtime. Previously,
this was done with a `.size != 0` check, which will count codepoints.
Switch to just doing a `isEmpty()` check, which is faster.

I discovered this while looking for out-of-segment comm as part of
#18284. It turns out that because string consts are shallow copied the
internal `locale_id` is wrong, which led to `numCodespoints` doing an
on-statement and out-of-segment comm. I opened Cray/chapel-private#2472
to track this shallow copying of strings, but still thought it made
sense to use the quicker `isEmpty` check here anyways.