### PR TITLE
Fix a race in memory tracking initialization

### DIFF
--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -157,7 +157,7 @@ void chpl_setMemFlags(void) {
                                     &memLog,
                                     &memLeaksLog);
 
-  chpl_memTrack = (local_memTrack
+  local_memTrack = (local_memTrack
                    || memStats
                    || memLeaksByType
                    || (memLeaksByDesc && strcmp(memLeaksByDesc, ""))
@@ -179,10 +179,13 @@ void chpl_setMemFlags(void) {
     }
   }
 
-  if (chpl_memTrack) {
+  if (local_memTrack) {
     hashSizeIndex = 0;
     hashSize = hashSizes[hashSizeIndex];
     memTable = sys_calloc(hashSize, sizeof(memTableEntry*));
+    chpl_atomic_thread_fence(memory_order_release);
+    chpl_memTrack = local_memTrack;
+    chpl_atomic_thread_fence(memory_order_release);
   }
 }
 


### PR DESCRIPTION
Previously, we set `chpl_memTrack` before we initialized our memory
tracking table. We believed this wasn't an issue because we initialize
the memory tracking in between 2 barrier calls so we assumed nothing
else could be running concurrently. However, prior to #18309 the module
code that's used to initialize memory tracking had on-stmts and so we
did have other threads on locale 0 concurrently running and allocating
memory. That PR happened to work around the issue, but here we solve it
in a more principled manner by only setting `chpl_memTrack` after we
allocate the table and issue a memory fence.

Resolves Cray/chapel-private#1656