### PR TITLE
Skip random choice tests under cygwin

### DIFF
--- a/test/library/standard/Random/RandomStreamInterface/choiceTestArray.skipif
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestArray.skipif
@@ -1,0 +1,3 @@
+# This creates many short lived tasks, which is slow under cygwin. See
+# https://github.com/Cray/chapel-private/issues/2473
+CHPL_TARGET_PLATFORM <= cygwin

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestDomain.skipif
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestDomain.skipif
@@ -1,0 +1,3 @@
+# This creates many short lived tasks, which is slow under cygwin. See
+# https://github.com/Cray/chapel-private/issues/2473
+CHPL_TARGET_PLATFORM <= cygwin

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestRange.skipif
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestRange.skipif
@@ -1,0 +1,3 @@
+# This creates many short lived tasks, which is slow under cygwin. See
+# https://github.com/Cray/chapel-private/issues/2473
+CHPL_TARGET_PLATFORM <= cygwin


### PR DESCRIPTION
These tests create many short lived tasks, which is slow under cygwin
especially after #18302. The short lived tasks come from promotion and
a `checkSorted` call in `_choiceProbabilities`, which is called in a
10,000 iteration trial loop several times.

We have decided to just skip these tests under cygwin since they're so
slow. Note that the tests did not get any slower under linux+fifo or
mac+fifo, so the issue seems cygwin specific. For more details see
Cray/chapel-private#2473.
