### PR TITLE
Have aligned bounds queries halt() if the range is not well-aligned

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -700,6 +700,9 @@ module ChapelRange {
 
   pragma "no doc"
   inline proc range.alignedLowAsInt {
+    if isAmbiguous() {
+      halt("Can't query the aligned bounds of an ambiguously aligned range");
+    }
     if !stridable then
       return _low;
     else
@@ -726,6 +729,9 @@ module ChapelRange {
 
   pragma "no doc"
   inline proc range.alignedHighAsInt {
+    if isAmbiguous() {
+      halt("Can't query the aligned bounds of an ambiguously aligned range");
+    }
     if ! stridable then
       return _high;
     else

--- a/test/types/range/strided/ambigAlignQueries-low.good
+++ b/test/types/range/strided/ambigAlignQueries-low.good
@@ -1,0 +1,1 @@
+ambigAlignQueries.chpl:6: error: halt reached - Can't query the aligned bounds of an ambiguously aligned range

--- a/test/types/range/strided/ambigAlignQueries.chpl
+++ b/test/types/range/strided/ambigAlignQueries.chpl
@@ -1,0 +1,6 @@
+config const case = 1;
+
+if case == 1 then
+  writeln((..10 by 2).alignedHigh);
+else
+  writeln((1.. by -2).alignedLow);

--- a/test/types/range/strided/ambigAlignQueries.execopts
+++ b/test/types/range/strided/ambigAlignQueries.execopts
@@ -1,0 +1,2 @@
+--case=1  # ambigAlignQueries.good
+--case=2  # ambigAlignQueries-low.good

--- a/test/types/range/strided/ambigAlignQueries.good
+++ b/test/types/range/strided/ambigAlignQueries.good
@@ -1,0 +1,1 @@
+ambigAlignQueries.chpl:4: error: halt reached - Can't query the aligned bounds of an ambiguously aligned range


### PR DESCRIPTION
Through a conversation in https://github.com/chapel-lang/chapel/issues/17123#issuecomment-908641401,
I realized that for bounds queries of ranges that are not
well-aligned, such as `..n by 2`, we do not currently report an error
where we should.  This adds an error for such cases and a test locking the
error in.
