### PR TITLE
Mason parse complete

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-new.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-new.chpl
@@ -1,11 +1,11 @@
-
-use MasonUtils;
-use MasonNew;
 use IO;
+use MasonNew;
+use MasonUtils;
+
 
 proc main() {
-  const args : [0..2] string;
-  args = ['mason','new', 'newTest'];
+  const args : [0..1] string;
+  args = ['new', 'newTest'];
 
   assert(isDir("newTest") == false);
 

--- a/test/mason/env/mason-env.chpl
+++ b/test/mason/env/mason-env.chpl
@@ -24,9 +24,9 @@ proc main() {
 
   setEnv("MASON_HOME", here.cwd());
 
-  const args = ["foo", "env"];
-  const debugArgs = ["foo", "env", "--debug"];
-  const helpArgs = ["foo", "env", "--help"];
+  const args = ["env"];
+  const debugArgs = ["env", "--debug"];
+  const helpArgs = ["env", "--help"];
 
   masonEnv(args);
   writeln("----------");
@@ -40,7 +40,7 @@ proc main() {
 	masonEnv(args);
   writeln("---------");
   unsetEnv("MASON_OFFLINE");
-	
+
   masonEnv(debugArgs);
   writeln("----------");
 

--- a/test/mason/env/mason-registry.chpl
+++ b/test/mason/env/mason-registry.chpl
@@ -1,5 +1,5 @@
 
-private use List;
+use List;
 use MasonEnv;
 use MasonSearch;
 use MasonUtils;
@@ -83,10 +83,10 @@ proc main() {
 
   buildFakeRegistry(altRegistry);
 
-  masonEnv(["foo", "env"]);
+  masonEnv(["env"]);
 
   var args1: list(string);
-  for x in ["foo", "search"] do args1.append(x);
+  for x in ["search"] do args1.append(x);
   masonSearch(args1);
 
   assert(isDir(altRegistry));

--- a/test/mason/init/masonInteractive.chpl
+++ b/test/mason/init/masonInteractive.chpl
@@ -1,9 +1,6 @@
-use MasonUtils;
-use FileSystem;
 use MasonNew;
-use Spawn;
 
 proc main() {
-  const args = ['mason','init'];
+  const args = ['init'];
   masonNew(args);
 }

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -1,11 +1,11 @@
-use MasonExample;
+//use MasonExample;
 use MasonBuild;
 use MasonRun;
 
 proc main() {
 
   // build the examples
-  masonBuild(["mason", "--build", "--example", "--force"]);
+  masonBuild(["mason", "build", "--example", "--force"]);
 
   // run each example
   // over 3 arguments runs all examples

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -1,4 +1,3 @@
-//use MasonExample;
 use MasonBuild;
 use MasonRun;
 

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -1,11 +1,11 @@
-use MasonExample;
+//use MasonExample;
 use MasonBuild;
 use MasonRun;
 
 proc main() {
 
   // build the examples
-  masonBuild(["mason", "--build", "--example", "--force"]);
+  masonBuild(["mason","build", "--example", "--force"]);
 
   // run each example
   // over 3 arguments runs all examples

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -1,4 +1,3 @@
-//use MasonExample;
 use MasonBuild;
 use MasonRun;
 

--- a/test/mason/mason-external/libtomlc99/mason-external.chpl
+++ b/test/mason/mason-external/libtomlc99/mason-external.chpl
@@ -16,11 +16,11 @@ proc main() {
   setupSpack();
 
   // Update compilers.yaml for this system
-  var compilerFindArgs = ["mason", "external", "compiler", "--find"];
+  var compilerFindArgs = ["external", "compiler", "--find"];
   masonExternal(compilerFindArgs);
 
   // Download and install libtomlc99
-  var args = ["mason", "external", "install", "libtomlc99@0.2019.06.24"];
+  var args = ["external", "install", "libtomlc99@0.2019.06.24"];
   masonExternal(args);
 
   // build library that uses libtomlc99

--- a/test/mason/mason-external/masonExternalRanges/mason-external-range.chpl
+++ b/test/mason/mason-external/masonExternalRanges/mason-external-range.chpl
@@ -5,15 +5,15 @@ use MasonInit;
 
 proc main() {
   // Sets up Spack
-  const setupArgs = ['mason','external','--setup'];
+  const setupArgs = ["external","--setup"];
   masonExternal(setupArgs);
   // Update compilers.yaml for this system
-  var compilerFindArgs = ["mason", "external", "compiler", "--find"];
+  var compilerFindArgs = ["external", "compiler", "--find"];
   masonExternal(compilerFindArgs);
   // Download and install libtomlc99
-  var installArgs: [0..3] string = ['mason', 'external', 'install', 'libtomlc99@0.2019.06.24'];
+  var installArgs: [0..3] string = ["install", "libtomlc99@0.2019.06.24"];
   installSpkg(installArgs);
   // Build library that uses libtomlc99
-  var buildArgs: [0..2] string = ['mason', 'build', '--force'];
+  var buildArgs: [0..2] string = ["mason", "build", "--force"];
   masonBuild(buildArgs);
 }

--- a/test/mason/mason-offline/publishOffline.chpl
+++ b/test/mason/mason-offline/publishOffline.chpl
@@ -1,12 +1,11 @@
-use MasonPublish;
-private use List;
 use FileSystem;
-	
-	
+use List;
+use MasonPublish;
+
+
 proc main() {
   var args: list(string);
-  args.append('mason');
   args.append('publish');
   here.chdir('offlinePackage');
   masonPublish(args);
-} 
+}

--- a/test/mason/mason-test-exit/exitCodeTest.chpl
+++ b/test/mason/mason-test-exit/exitCodeTest.chpl
@@ -11,5 +11,4 @@ proc checkExitStatus(cmd) {
   }
 }
 
-checkExitStatus(['mason', 'test']);
- 
+checkExitStatus(['mason','test']);

--- a/test/mason/mason-test/mason-test.chpl
+++ b/test/mason/mason-test/mason-test.chpl
@@ -1,9 +1,6 @@
 use MasonTest;
 
-
-
-
 proc main() {
-  const args = ["mason", "test"];
+  const args = ["test"];
   masonTest(args);
 }

--- a/test/mason/masonInit/MasonInitTest5.chpl
+++ b/test/mason/masonInit/MasonInitTest5.chpl
@@ -3,11 +3,11 @@ use MasonInit;
 use MasonUtils;
 use MasonNew;
 
-proc main(){  
+proc main(){
   mkdir("testSrc");
-  const initArgs = ['mason','init','testSrc'];
+  const initArgs = ['init','testSrc'];
   masonInit(initArgs);
-  
+
   remove('testSrc/src/testSrc.chpl');
   masonInit(initArgs);
 

--- a/test/mason/masonInit/masonInitModifyToml.chpl
+++ b/test/mason/masonInit/masonInitModifyToml.chpl
@@ -4,10 +4,10 @@ use MasonUtils;
 use MasonNew;
 
 proc main(){
-  const newArgs = ['mason','new','testSrc'];
+  const newArgs = ['new','testSrc'];
   masonNew(newArgs);
   runCommand('rm -rf testSrc/Mason.toml');
-  const initArgs = ['mason','init','testSrc'];
+  const initArgs = ['init','testSrc'];
   masonInit(initArgs);
   //check if src and src/testSrc.chpl was created
   if isFile("./testSrc/Mason.toml") {

--- a/test/mason/masonInit/masonInitModule.chpl
+++ b/test/mason/masonInit/masonInitModule.chpl
@@ -5,8 +5,8 @@ use MasonNew;
 
 proc main(){
   mkdir("project-testSrc");
-  const initArgs: [0..3] string;
-  initArgs = ['mason', 'init', 'project-testSrc', '--name=project'];
+  const initArgs: [0..2] string;
+  initArgs = ['init', 'project-testSrc', '--name=project'];
   masonInit(initArgs);
   //check if src and src/testSrc.chpl was created
   if isFile("./project-testSrc/src/project.chpl") {

--- a/test/mason/masonInit/masonInitPathTest.chpl
+++ b/test/mason/masonInit/masonInitPathTest.chpl
@@ -5,7 +5,7 @@ use MasonInit;
 use MasonUtils;
 
 proc main(){
-  const args = ['mason','init','testSrc'];
+  const args = ['init','testSrc'];
   mkdir("testSrc");
   masonInit(args);
   rmTree("testSrc");

--- a/test/mason/masonInit/masonInitTest.chpl
+++ b/test/mason/masonInit/masonInitTest.chpl
@@ -3,10 +3,10 @@ use MasonInit;
 use MasonUtils;
 
 proc main(){
-  const args = ['mason', 'init', '-d'];
+  const args = ['init', '-d'];
   masonInit(args);
 
-  //check if files have been created 
+  //check if files have been created
   const pwd = getEnv('PWD');
   if isDir(pwd + '/src'){
       writeln("Init is correctly done");

--- a/test/mason/masonInit/masonInitTest2.chpl
+++ b/test/mason/masonInit/masonInitTest2.chpl
@@ -4,10 +4,10 @@ use MasonUtils;
 use MasonNew;
 
 proc main(){
-  const newArgs = ['mason','new','testSrc'];
+  const newArgs = ['new','testSrc'];
   masonNew(newArgs);
   rmTree('testSrc/src');
-  const initArgs = ['mason', 'init','testSrc'];
+  const initArgs = ['init','testSrc'];
   masonInit(initArgs);
   //check if src and src/testSrc.chpl was created
   if isFile("./testSrc/src/testSrc.chpl") && isDir("./testSrc/src") {

--- a/test/mason/masonInit/masonInitTest3.chpl
+++ b/test/mason/masonInit/masonInitTest3.chpl
@@ -4,10 +4,10 @@ use MasonUtils;
 use MasonNew;
 
 proc main(){
-  const newArgs = ['mason','new','testSrc'];
+  const newArgs = ['new','testSrc'];
   masonNew(newArgs);
   rmTree('testSrc/.git');
-  const initArgs = ['mason','init','testSrc'];
+  const initArgs = ['init','testSrc'];
   masonInit(initArgs);
   //check if src and src/testSrc.chpl was created
   if isDir("./testSrc/.git") {

--- a/test/mason/masonInit/masonInitTest4.chpl
+++ b/test/mason/masonInit/masonInitTest4.chpl
@@ -4,11 +4,11 @@ use MasonUtils;
 use MasonNew;
 
 proc main(){
-  const newArgs = ['mason','new','testSrc'];
+  const newArgs = ['new','testSrc'];
   masonNew(newArgs);
-  
-  const initArgs = ['mason','init','testSrc'];
+
+  const initArgs = ['init','testSrc'];
   masonInit(initArgs);
 
-  rmTree('testSrc');  
+  rmTree('testSrc');
 }

--- a/test/mason/masonNewBadName.chpl
+++ b/test/mason/masonNewBadName.chpl
@@ -1,10 +1,8 @@
-use MasonUtils;
-use FileSystem;
 use MasonNew;
 
 config const name="";
 
 proc main() {
-  const args = ['mason','new', name];
+  const args = ['new', name];
   masonNew(args);
 }

--- a/test/mason/masonNewModule.chpl
+++ b/test/mason/masonNewModule.chpl
@@ -1,11 +1,10 @@
-use MasonUtils;
 use FileSystem;
 use MasonNew;
 
 
 proc main() {
-  const args : [0..4] string;
-  args = ['mason', 'new', 'project-testSrc', '--name', 'project'];
+  const args : [0..3] string;
+  args = ['new', 'project-testSrc', '--name', 'project'];
   masonNew(args);
   if isFile("./project-testSrc/src/project.chpl") {
     writeln("Project.chpl has been successfully created");

--- a/test/mason/masonNewTest.chpl
+++ b/test/mason/masonNewTest.chpl
@@ -1,10 +1,8 @@
-
-use MasonUtils;
 use FileSystem;
 use MasonNew;
 
 proc main() {
-  const args = ['mason', 'new', 'Test'];
+  const args = ['new', 'Test'];
   masonNew(args);
 
   // Confirm structure

--- a/test/mason/masonTestSome/mason-test-some.chpl
+++ b/test/mason/masonTestSome/mason-test-some.chpl
@@ -1,9 +1,7 @@
 use MasonTest;
 
 
-
-
 proc main() {
-  const args = ["mason", "test" , "test/test1.chpl", "test/testDir"];
+  const args = ["test" , "test/test1.chpl", "test/testDir"];
   masonTest(args);
 }

--- a/test/mason/masonTestSubString/mason-test-sub-string.chpl
+++ b/test/mason/masonTestSubString/mason-test-sub-string.chpl
@@ -1,6 +1,6 @@
 use MasonTest;
 
 proc main() {
-  const args = ["mason", "test" , "1", "3", "--no-update"];
+  const args = ["test" , "1", "3", "--no-update"];
   masonTest(args);
 }

--- a/test/mason/new/masonInteractive.chpl
+++ b/test/mason/new/masonInteractive.chpl
@@ -1,9 +1,6 @@
-use MasonUtils;
-use FileSystem;
 use MasonNew;
-use Spawn;
 
 proc main() {
-  const args = ['mason','new'];
+  const args = ['new'];
   masonNew(args);
 }

--- a/test/mason/publish/badDry.chpl
+++ b/test/mason/publish/badDry.chpl
@@ -1,12 +1,11 @@
-
+use MasonNew;
 use MasonPublish;
 use MasonUtils;
-use MasonNew;
 
 const dir = here.cwd();
 
 proc main() {
-  masonNew(['mason', 'new', 'publishCheck']);
+  masonNew(['new', 'publishCheck']);
   here.chdir(dir + '/publishCheck');
-  masonPublish(['mason', 'publish', '--dry-run', '../bad-registry']);
+  masonPublish(['publish', '--dry-run', '../bad-registry']);
 }

--- a/test/mason/publish/badRegTest.chpl
+++ b/test/mason/publish/badRegTest.chpl
@@ -1,12 +1,12 @@
 
+use MasonNew;
 use MasonPublish;
 use MasonUtils;
-use MasonNew;
 
 const dir = here.cwd();
 
 proc main() {
-  masonNew(['mason','new','publishCheck']);
+  masonNew(['new','publishCheck']);
   here.chdir(dir + '/publishCheck');
-  masonPublish(['mason', 'publish', '../bad-regsitry']);
+  masonPublish(['publish', '../bad-regsitry']);
 }

--- a/test/mason/publish/create-registry/create-registry.chpl
+++ b/test/mason/publish/create-registry/create-registry.chpl
@@ -1,7 +1,6 @@
 use MasonPublish;
-use FileSystem;
 
 proc main(){
-  masonPublish(['mason', 'publish', '--create-registry', 'registry']);
+  masonPublish(['publish', '--create-registry', 'registry']);
 }
 

--- a/test/mason/publish/publish.chpl
+++ b/test/mason/publish/publish.chpl
@@ -1,14 +1,14 @@
 
+use MasonNew;
 use MasonPublish;
 use MasonUtils;
-use MasonNew;
 
 
 const dir = here.cwd();
 
 proc main() throws {
   try! {
-    masonNew(['mason', 'new' , 'publishCheck']);
+    masonNew(['new' , 'publishCheck']);
     here.chdir(dir + '/publishCheck');
     publishPackage('dummy','dir', true);
     here.chdir(dir);

--- a/test/mason/publish/publishGitCheck.chpl
+++ b/test/mason/publish/publishGitCheck.chpl
@@ -1,12 +1,9 @@
 use FileSystem;
-use MasonPublish;
-use MasonUtils;
-use Spawn;
-use TOML;
 use MasonNew;
+use MasonPublish;
 
 proc main(){
-  masonNew(['mason', 'new', 'publishCheck']);
+  masonNew(['new', 'publishCheck']);
   var pwd = here.cwd();
   here.chdir(pwd + '/publishCheck');
   if doesGitOriginExist() == false {

--- a/test/mason/search/badFileName/mason-search.chpl
+++ b/test/mason/search/badFileName/mason-search.chpl
@@ -1,10 +1,8 @@
-private use List;
+use List;
 use MasonSearch;
-
-use FileSystem;
 
 proc main() {
   var args: list(string);
-  for x in ["foo", "search", "--no-update"] do args.append(x);
+  for x in ["search", "--no-update"] do args.append(x);
   masonSearch(args);
 }

--- a/test/mason/search/cacheTest/mason-search.chpl
+++ b/test/mason/search/cacheTest/mason-search.chpl
@@ -1,12 +1,9 @@
-use MasonSearch;
 use List;
-use FileSystem;
+use MasonSearch;
 
 proc main() {
   var args: list(string);
-  args.append("mason");
   args.append("search");
   args.append("--no-update");
   masonSearch(args);
 }
-

--- a/test/mason/search/mason-search.chpl
+++ b/test/mason/search/mason-search.chpl
@@ -1,20 +1,15 @@
-
-private use List;
+use List;
 use MasonSearch;
-
-use FileSystem;
 
 config const pattern = "";
 
 proc main() {
   var args: list(string);
-  args.append("foo");
   args.append("search");
   args.append("--no-update");
   for arg in pattern.split() {
     if arg != "" then args.append(arg);
   }
-
 
   masonSearch(args);
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -41,7 +41,6 @@ proc masonBuild(args: [] string) throws {
   var opt = false;
   var example = false;
   var skipUpdate = MASON_OFFLINE;
-
   if args.size > 2 {
 
     // strip off the first two indices
@@ -94,6 +93,7 @@ proc masonBuild(args: [] string) throws {
     if show then compopts.append("--show");
     if release then compopts.append("--release");
     if force then compopts.append("--force");
+    compopts.insert(0,"example");
     masonExample(compopts.toArray());
   }
   else {

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -93,7 +93,8 @@ proc masonBuild(args: [] string) throws {
     if show then compopts.append("--show");
     if release then compopts.append("--release");
     if force then compopts.append("--force");
-    compopts.insert(0,"example");
+    // add expected arguments for masonExample
+    compopts.insert(0,["example", "--example"]);
     masonExample(compopts.toArray());
   }
   else {

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -19,17 +19,33 @@
  */
 
 
-private use FileSystem;
-private use MasonHelp;
-private use IO;
-private use MasonUtils;
+use FileSystem;
+use IO;
+use MasonArgParse;
+use MasonHelp;
+use MasonUtils;
 
 proc masonDoc(args: [] string) throws {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  try {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonDocHelp();
+    exit(1);
+  }
+
+  if helpFlag.valueAsBool() {
+    masonDocHelp();
+    exit(0);
+  }
+
   try! {
-    if args.size > 2 {
-      masonDocHelp();
-      exit(0);
-    }
     const tomlName = 'Mason.toml';
     const cwd = here.cwd();
 

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-private use List;
+use List;
+use MasonArgParse;
 use MasonUtils;
 public use MasonHelp;
 const regUrl: string = "https://github.com/chapel-lang/mason-registry";
@@ -112,12 +113,32 @@ proc MASON_REGISTRY {
 }
 
 proc masonEnv(args) {
-  if hasOptions(args, "-h", "--help") {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+
+  // TODO: When automatic help is generated, make sure this isn't documented
+  var debugFlag = parser.addFlag("debug",
+                                opts=["--debug"],
+                                defaultValue=false,
+                                flagInversion=false);
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonEnvHelp();
+    exit(1);
+  }
+
+  if helpFlag.valueAsBool() {
     masonEnvHelp();
     exit(0);
   }
 
-  const debug = hasOptions(args, "--debug");
+  const debug = debugFlag.valueAsBool();
 
   proc printVar(name : string, in val : string) {
     if getEnv(name) != "" then

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -81,43 +81,7 @@ proc masonExample(args: [] string) {
   if exampleOpts.hasValue() {
     for ex in exampleOpts.values() do examples.append(ex);
   }
-  // for arg in args {
-  //   if arg == '--show' {
-  //     show = true;
-  //   }
-  //   else if arg == '--no-run' {
-  //     run = false;
-  //   }
-  //   else if arg == '--no-build' {
-  //     build = false;
-  //   }
-  //   else if arg == '--release' {
-  //     release = true;
-  //   }
-  //   else if arg == '--force' {
-  //     force = true;
-  //   }
-  //   else if arg == '--no-update' {
-  //     skipUpdate = true;
-  //   }
-  //   else if arg == '--update' {
-  //     skipUpdate = false;
-  //   }
-  //   else if arg.startsWith('--example=') {
-  //     var exampleProgram = arg.split("=");
-  //     examples.append(exampleProgram[1]);
-  //     continue;
-  //   }
-  //   else if arg == '--example' {
-  //     continue;
-  //   }
-  //   else if arg == '--build' {
-  //     continue;
-  //   }
-  //   else {
-  //     examples.append(arg);
-  //   }
-  // }
+
   updateLock(skipUpdate);
   runExamples(show, run, build, release, force, examples);
 }

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -67,6 +67,7 @@ proc masonExample(args: [] string) {
   }
   catch ex : ArgumentError {
     stderr.writeln(ex.message());
+    exit(1);
   }
   var show = showFlag.valueAsBool();
   var run = runFlag.valueAsBool();

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -78,10 +78,6 @@ proc masonExample(args: [] string) {
     skipUpdate = !updateFlag.valueAsBool();
   }
   var examples = new list(exampleOpts.values());
-  // if exampleOpts.hasValue() {
-  //   for ex in exampleOpts.values() do examples.append(ex);
-  // }
-
   updateLock(skipUpdate);
   runExamples(show, run, build, release, force, examples);
 }

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -77,10 +77,10 @@ proc masonExample(args: [] string) {
   if updateFlag.hasValue() {
     skipUpdate = !updateFlag.valueAsBool();
   }
-  var examples : list(string);
-  if exampleOpts.hasValue() {
-    for ex in exampleOpts.values() do examples.append(ex);
-  }
+  var examples = new list(exampleOpts.values());
+  // if exampleOpts.hasValue() {
+  //   for ex in exampleOpts.values() do examples.append(ex);
+  // }
 
   updateLock(skipUpdate);
   runExamples(show, run, build, release, force, examples);

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -61,7 +61,7 @@ proc masonExample(args: [] string) {
                                 flagInversion=true);
   var exampleOpts = parser.addOption(name="example",
                                      opts=["--example"],
-                                     numArgs=1..);
+                                     numArgs=0..);
   try! {
     parser.parseArgs(args);
   }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -43,7 +43,7 @@ proc masonExternal(args: [] string) {
   var subCmds = new map(string, shared Argument);
 
   // define all the supported subcommand strings here
-  var cmds = ["search","compiler","install","uninstall","info","find"];
+  var cmds = ["search", "compiler", "install", "uninstall", "info", "find"];
   for cmd in cmds {
     subCmds.add(cmd,parser.addSubCommand(cmd));
   }
@@ -440,16 +440,12 @@ private proc compiler(args: [?d] string) {
     masonCompilerHelp();
     exit(0);
   }
-  // there was a minor bug in the previous code where the default option of
-  // list was not being selected when no arguments were passed because
-  // the pattern given was list but the pattern to match was --list.
-  // Here we have slightly modified the behavior to match what appeared to be
-  // the intent of the original developers.
+
   if findFlag.valueAsBool() {
     findCompilers();
   } else if editFlag.valueAsBool() {
     editCompilers();
-  } else {
+  } else { // handle default when no flags passed or when --list passed
     listCompilers();
   }
 }
@@ -728,7 +724,7 @@ proc uninstallSpkg(args: [?d] string) throws {
   if pkgArg.hasValue() then {
     var pkgArr = pkgArg.values();
     pkgName = "".join(pkgArr);
-  }else {
+  } else {
     masonUninstallHelp();
     exit(1);
   }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -26,27 +26,65 @@ const minor = v[1];
 const spackBranch = 'releases/v' + '.'.join(major, minor);
 const spackDefaultPath = MASON_HOME + "/spack";
 
-private use List;
-private use Map;
-use MasonUtils;
 use FileSystem;
-use MasonHelp;
-use SpecParser;
+use List;
+use Map;
+use MasonArgParse;
 use MasonEnv;
+use MasonHelp;
+use MasonUtils;
 use Path;
+use SpecParser;
 use TOML;
 
 proc masonExternal(args: [] string) {
+  var parser = new argumentParser();
+
+  var subCmds = new map(string, shared Argument);
+
+  // define all the supported subcommand strings here
+  var cmds = ["search","compiler","install","uninstall","info","find"];
+  for cmd in cmds {
+    subCmds.add(cmd,parser.addSubCommand(cmd));
+  }
+
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+
+  var setupFlag = parser.addFlag(name="setup",
+                                 opts=["--setup"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var specFlag = parser.addFlag(name="spec",
+                                opts=["--spec"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var versionFlag = parser.addFlag(name="versionFlag",
+                                   opts=["-V","--version"],
+                                   flagInversion=false,
+                                   defaultValue=false);
+
   try! {
-    if args.size < 3 {
-      masonExternalHelp();
-      exit(0);
-    }
-    else if args[2] == "-h" || args[2] == "--help" {
-      masonExternalHelp();
-      exit(0);
-    }
-    else if args[2] == "--setup" {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonExternalHelp();
+    exit(1);
+  }
+
+  if helpFlag.valueAsBool() {
+    masonExternalHelp();
+    exit(0);
+  }
+
+  if versionFlag.valueAsBool() then printSpackVersion();
+  if specFlag.valueAsBool() then specHelp();
+
+  try! {
+    if setupFlag.valueAsBool() {
       // if MASON_OFFLINE is set, then cannot install spack
       if MASON_OFFLINE {
         throw new owned MasonError('Cannot setup Spack when MASON_OFFLINE is set to true');
@@ -88,16 +126,24 @@ proc masonExternal(args: [] string) {
       exit(0);
     }
     if spackInstalled() {
-      select (args[2]) {
-        when 'search' do searchSpkgs(args);
-        when 'compiler' do compiler(args);
-        when 'install' do installSpkg(args);
-        when 'uninstall' do uninstallSpkg(args);
-        when 'info' do spkgInfo(args);
-        when 'find' do findSpkg(args);
-        when '--spec' do specHelp();
-        when '-V' do printSpackVersion();
-        when '--version' do printSpackVersion();
+      var usedCmd:string;
+      var cmdList:list(string);
+      // identify which, if any, subcommand was used and collect its arguments
+      for (cmd, arg) in subCmds.items() {
+        if arg.hasValue() {
+          usedCmd = cmd;
+          cmdList = new list(arg.values());
+          break;
+        }
+      }
+      var cmdArgs = cmdList.toArray();
+      select (usedCmd) {
+        when "search" do searchSpkgs(cmdArgs);
+        when "compiler" do compiler(cmdArgs);
+        when "install" do installSpkg(cmdArgs);
+        when "uninstall" do uninstallSpkg(cmdArgs);
+        when "info" do spkgInfo(cmdArgs);
+        when "find" do findSpkg(cmdArgs);
         otherwise {
           writeln('error: no such subcommand');
           writeln('try mason external --help');
@@ -227,31 +273,44 @@ private proc listSpkgs() {
 
 /* Queries spack for package existence */
 private proc searchSpkgs(args: [?d] string) {
-  if args.size < 4 {
-    listSpkgs();
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var descFlag = parser.addFlag(name="description",
+                                opts=["-d","--desc"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var searchArg = parser.addArgument(name="searchString", numArgs=0..1);
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonExternalSearchHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonExternalSearchHelp();
     exit(0);
   }
-  else {
-    var command = "spack list";
-    var pkgName: string;
-    if args[3].find('-') != -1 {
-      for arg in args[3..] {
-        if arg.find('h') != -1 {
-          masonExternalSearchHelp();
-          exit(0);
-        }
-      }
-    }
-    if args[3] == "-d" || args[3] == "--desc" {
-      command = " ".join(command, "--search-description");
-      pkgName = args[4];
-    }
-    else {
-      pkgName = args[3];
-    }
-    command = " ".join(command, pkgName);
-    const status = runSpackCommand(command);
+
+  var command = "spack list";
+  var pkgName: string;
+  if !searchArg.hasValue() {
+    listSpkgs();
+    exit(0);
+  } else {
+    pkgName = searchArg.value();
   }
+
+  if descFlag.valueAsBool() {
+    command = " ".join(command, "--search-description");
+  }
+
+  command = " ".join(command, pkgName);
+  const status = runSpackCommand(command);
 }
 
 /* Lists all installed spack packages for user */
@@ -263,41 +322,69 @@ private proc listInstalled() {
 /* User facing function to show packages installed on
    system. Takes all spack arguments ex. -df <package> */
 private proc findSpkg(args: [?d] string) {
-  if args.size == 3 {
-    listInstalled();
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var findArgs = parser.addArgument(name="package",
+                                    numArgs=0..);
+
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonExternalFindHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonExternalFindHelp();
     exit(0);
   }
-  if args[3].find('-') != -1 {
-    for arg in args[3..] {
-      if arg == "-h" || arg == "--help" {
-        masonExternalFindHelp();
-        exit(0);
-      }
-    }
-  }
   var command = "spack find";
-  var packageWithArgs = " ".join(args[3..]);
+  var findArray = findArgs.values();
+  var packageWithArgs = " ".join(findArray);
   const status = runSpackCommand(" ".join(command, packageWithArgs));
 }
 
 /* Entry point into the various info subcommands */
 private proc spkgInfo(args: [?d] string) {
-  var option = "--help";
-  if args.size < 4 {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var archFlag = parser.addFlag(name="architecture",
+                                opts=["--arch"],
+                                defaultValue=false,
+                                flagInversion=false);
+  // TODO: Argument parser may need support for mutually exclusive, or
+  // required if other value, or not required if other value setups
+  // but doesn't have them yet. As a workaround, look for 0 or 1 args here
+  // to allow for processing arguments without a package arg
+  var packageArg = parser.addArgument(name="package", numArgs=0..1);
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
     masonExternalInfoHelp();
     exit(1);
   }
-  else {
-    option = args[3];
+  if helpFlag.valueAsBool() {
+    masonExternalInfoHelp();
+    exit(0);
   }
-  select option {
-      when "--arch" do printArch();
-      when "--help" do masonExternalInfoHelp();
-      when "-h" do masonExternalInfoHelp();
-      otherwise {
-        var status = runSpackCommand("spack info " + option);
-      }
-    }
+
+  if archFlag.valueAsBool() {
+    printArch();
+  } else if packageArg.hasValue() {
+    var status = runSpackCommand("spack info " + packageArg.value());
+  } else {
+    masonExternalInfoHelp();
+  }
+
 }
 
 /* Print system arch info */
@@ -324,16 +411,47 @@ proc spkgInstalled(spec: string) {
 
 /* Entry point into the various compiler functions */
 private proc compiler(args: [?d] string) {
-  var option = "list";
-  if args.size > 3 {
-    option = args[3];
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var listFlag = parser.addFlag(name="list",
+                                opts=["--list"],
+                                defaultValue=true,
+                                flagInversion=false);
+  var findFlag = parser.addFlag(name="find",
+                                opts=["--find"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var editFlag = parser.addFlag(name="edit",
+                                opts=["--edit"],
+                                defaultValue=false,
+                                flagInversion=false);
+  try! {
+    parser.parseArgs(args);
   }
-  select option {
-      when "--list" do listCompilers();
-      when "--find" do findCompilers();
-      when "--edit" do editCompilers();
-      otherwise do masonCompilerHelp();
-    }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonCompilerHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonCompilerHelp();
+    exit(0);
+  }
+  // there was a minor bug in the previous code where the default option of
+  // list was not being selected when no arguments were passed because
+  // the pattern given was list but the pattern to match was --list.
+  // Here we have slightly modified the behavior to match what appeared to be
+  // the intent of the original developers.
+  if findFlag.valueAsBool() {
+    findCompilers();
+  } else if editFlag.valueAsBool() {
+    editCompilers();
+  } else {
+    listCompilers();
+  }
 }
 
 /* Lists available compilers on system */
@@ -523,81 +641,107 @@ private proc resolveSpec(spec: string): string throws {
 
 /* Install an external package */
 proc installSpkg(args: [?d] string) throws {
-  if hasOptions(args, '-h', '--help') {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var specArg = parser.addArgument(name="SpackSpec", numArgs=0..);
+
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
     masonInstallHelp();
     exit(1);
   }
-
-  if MASON_OFFLINE && args.count('--update') == 0 {
-    writeln('Cannot install Spack packages when MASON_OFFLINE=true');
-    return;
-  }
-
-  if args.size < 4 {
+  if helpFlag.valueAsBool() {
     masonInstallHelp();
-    exit(1);
+    exit(0);
+  }
+  var command = "spack install";
+  var spec: string;
+
+  if specArg.hasValue() {
+    var specArr = specArg.values();
+    if MASON_OFFLINE && specArr.count("--update") == 0 {
+      writeln("Cannot install Spack packages when MASON_OFFLINE=true");
+      return;
+    }
+    spec = " ".join(specArr);
   }
   else {
-    var command = "spack install";
-    var spec: string;
-    if args[3] == "-h" || args[3] == "--help" {
-      masonInstallHelp();
-      exit(1);
-    }
-    else {
-      spec = " ".join(args[3..]);
-    }
+    masonInstallHelp();
+    exit(1);
+  }
 
-    const status = runSpackCommand(" ".join(command, spec));
-    if status != 0 {
-      throw new owned MasonError("Package could not be installed");
-    }
+  const status = runSpackCommand(" ".join(command, spec));
+  if status != 0 {
+    throw new owned MasonError("Package could not be installed");
   }
 }
 
 
 /* Uninstall an external package */
 proc uninstallSpkg(args: [?d] string) throws {
-  if args.size < 4 {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var forceFlag = parser.addFlag(name="force",
+                                opts=["--force"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var allFlag = parser.addFlag(name="all",
+                                opts=["--all"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var depFlag = parser.addFlag(name="dependents",
+                                opts=["--dependents"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var pkgArg = parser.addArgument(name="package", numArgs=0..);
+
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
     masonUninstallHelp();
     exit(1);
   }
-  else {
-    var pkgName: string;
-    var command = "spack uninstall -y";
-    var confirm: string;
-    var uninstallArgs = "";
-    if args[3] == "-h" || args[3] == "--help" {
-      masonUninstallHelp();
-      exit(1);
-    }
-    else if args[3].startsWith("-") > 0 {
-      for arg in args[3..] {
-        if arg.startsWith("-") {
-          uninstallArgs = " ".join(uninstallArgs, arg);
-        }
-        else {
-          pkgName = "".join(pkgName, arg);
-        }
-      }
-    }
-    else {
-      pkgName = "".join(args[3..]);
-    }
+  if helpFlag.valueAsBool() {
+    masonUninstallHelp();
+    exit(0);
+  }
 
-    writeln("Are you sure you want to uninstall " + pkgName +"? [y/n]");
-    read(confirm);
-    if confirm != "y" {
-      writeln("Aborting...");
-      exit(0);
-    }
+  var pkgName: string;
+  var command = "spack uninstall -y";
+  var confirm: string;
+  var uninstallArgs = "";
 
+  if forceFlag.valueAsBool() then uninstallArgs += "--force ";
+  if allFlag.valueAsBool() then uninstallArgs += "--all ";
+  if depFlag.valueAsBool() then uninstallArgs += "--dependents ";
+  if pkgArg.hasValue() then {
+    var pkgArr = pkgArg.values();
+    pkgName = "".join(pkgArr);
+  }else {
+    masonUninstallHelp();
+    exit(1);
+  }
 
-    const status = runSpackCommand(" ".join(command, uninstallArgs, pkgName));
-    if status != 0 {
-      throw new owned MasonError("Package could not be uninstalled");
-    }
+  writeln("Are you sure you want to uninstall " + pkgName +"? [y/n]");
+  read(confirm);
+  if confirm != "y" {
+    writeln("Aborting...");
+    exit(0);
+  }
+
+  const status = runSpackCommand(" ".join(command, uninstallArgs, pkgName));
+  if status != 0 {
+    throw new owned MasonError("Package could not be uninstalled");
   }
 }
-
-

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -392,7 +392,7 @@ proc masonSystemSearchHelp() {
   writeln("Search for packages on system found via pkg-config");
   writeln();
   writeln("Usage:");
-  writeln("    mason search [options]");
+  writeln("    mason system search [options]");
   writeln();
   writeln("Options:");
   writeln("    -h, --help                  Display this message");
@@ -405,7 +405,7 @@ proc masonSystemPcHelp() {
   writeln("Print a package's .pc file (pkg-config file)");
   writeln();
   writeln("Usage:");
-  writeln("    mason pc [options]");
+  writeln("    mason system pc [options]");
   writeln();
   writeln("Options:");
   writeln("    -h, --help                  Display this message");

--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -71,44 +71,9 @@ proc masonInit(args: [] string) throws {
     var dirName = '';
     var show = showFlag.valueAsBool();
     var packageName = '';
-    //var countArgs = args.domain.low + 2;
     var defaultBehavior = defaultFlag.valueAsBool();
     if nameOpt.hasValue() then packageName = nameOpt.value();
     if dirArg.hasValue() then dirName = dirArg.value();
-    // for arg in args[args.domain.low+2..] {
-    //   countArgs += 1;
-    //   select (arg) {
-    //     when '-h' {
-    //       masonInitHelp();
-    //       exit();
-    //     }
-    //     when '--help' {
-    //       masonInitHelp();
-    //       exit();
-    //     }
-    //     when '--show' {
-    //       show = true;
-    //     }
-    //     when '-d' {
-    //       defaultBehavior = true;
-    //     }
-    //     when '--default' {
-    //       defaultBehavior = true;
-    //     }
-    //     when '--name' {
-    //       packageName = args[countArgs];
-    //     }
-    //     otherwise {
-    //       if arg.startsWith('--name=') {
-    //         var res = arg.split("=");
-    //         packageName = res[1];
-    //       }
-    //       else {
-    //         if args[countArgs - 2] != "--name" then dirName = arg;
-    //       }
-    //     }
-      // }
-    //}
 
     if dirName == '' {
       if defaultBehavior {

--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -19,18 +19,18 @@
  */
 
 use FileSystem;
+use List;
+use MasonArgParse;
+use MasonBuild;
+use MasonEnv;
+use MasonExample;
+use MasonHelp;
+use MasonModify;
+use MasonNew;
+use MasonUtils;
 use Path;
 use Spawn;
 use TOML;
-private use List;
-
-use MasonEnv;
-use MasonNew;
-use MasonBuild;
-use MasonHelp;
-use MasonUtils;
-use MasonExample;
-use MasonModify;
 
 /*
 Initialises a library project in a project directory
@@ -38,46 +38,77 @@ Initialises a library project in a project directory
   or mason init (inside project directory)
 */
 proc masonInit(args: [] string) throws {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var showFlag = parser.addFlag(name="show",
+                                opts=["--show"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var defaultFlag = parser.addFlag(name="default",
+                                   opts=["-d","--default"],
+                                   defaultValue=false,
+                                   flagInversion=false);
+  var nameOpt = parser.addOption(name="legalname",
+                                 opts=["--name"]);
+  var dirArg = parser.addArgument(name="directory", numArgs=0..1);
+  try {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonInitHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonInitHelp();
+    exit(0);
+  }
+
   try! {
     var dirName = '';
-    var show = false;
+    var show = showFlag.valueAsBool();
     var packageName = '';
-    var countArgs = args.domain.low + 2;
-    var defaultBehavior = false;
-    for arg in args[args.domain.low+2..] {
-      countArgs += 1;
-      select (arg) {
-        when '-h' {
-          masonInitHelp();
-          exit();
-        }
-        when '--help' {
-          masonInitHelp();
-          exit();
-        }
-        when '--show' {
-          show = true;
-        }
-        when '-d' {
-          defaultBehavior = true;
-        }
-        when '--default' {
-          defaultBehavior = true;
-        }
-        when '--name' {
-          packageName = args[countArgs];
-        }
-        otherwise {
-          if arg.startsWith('--name=') {
-            var res = arg.split("=");
-            packageName = res[1];
-          }
-          else {
-            if args[countArgs - 2] != "--name" then dirName = arg;
-          }
-        }
-      }
-    }
+    //var countArgs = args.domain.low + 2;
+    var defaultBehavior = defaultFlag.valueAsBool();
+    if nameOpt.hasValue() then packageName = nameOpt.value();
+    if dirArg.hasValue() then dirName = dirArg.value();
+    // for arg in args[args.domain.low+2..] {
+    //   countArgs += 1;
+    //   select (arg) {
+    //     when '-h' {
+    //       masonInitHelp();
+    //       exit();
+    //     }
+    //     when '--help' {
+    //       masonInitHelp();
+    //       exit();
+    //     }
+    //     when '--show' {
+    //       show = true;
+    //     }
+    //     when '-d' {
+    //       defaultBehavior = true;
+    //     }
+    //     when '--default' {
+    //       defaultBehavior = true;
+    //     }
+    //     when '--name' {
+    //       packageName = args[countArgs];
+    //     }
+    //     otherwise {
+    //       if arg.startsWith('--name=') {
+    //         var res = arg.split("=");
+    //         packageName = res[1];
+    //       }
+    //       else {
+    //         if args[countArgs - 2] != "--name" then dirName = arg;
+    //       }
+    //     }
+      // }
+    //}
 
     if dirName == '' {
       if defaultBehavior {
@@ -101,21 +132,21 @@ proc masonInit(args: [] string) throws {
         var defaultPackageName, defaultVersion, defaultChplVersion, defaultLicense, moduleName: string;
         if isMasonTomlPresent then
           (defaultPackageName, defaultVersion, defaultChplVersion, defaultLicense) = readPartialManifest();
-        if isSrcPresent then 
+        if isSrcPresent then
           moduleName = readPartialSrc();
        // begin interactive session and get values input by user
-        var result = beginInteractiveSession(defaultPackageName, defaultVersion, 
+        var result = beginInteractiveSession(defaultPackageName, defaultVersion,
                                               defaultChplVersion, defaultLicense);
         const newPackageName = result[0],
               newVersion = result[1],
               newChplVersion = result[2],
               newLicense = result[3];
-        // validate Mason.toml file 
+        // validate Mason.toml file
         validateMasonFile('.', newPackageName, show);
         isMasonTomlPresent = true;
         // overwrite to update existing values in Mason.toml
-        overwriteTomlFileValues(isMasonTomlPresent, newPackageName, 
-          newVersion, newChplVersion, newLicense, defaultPackageName, defaultVersion, 
+        overwriteTomlFileValues(isMasonTomlPresent, newPackageName,
+          newVersion, newChplVersion, newLicense, defaultPackageName, defaultVersion,
           defaultChplVersion, defaultLicense);
         if newPackageName + '.chpl' != moduleName {
           if isFile('./src/' + moduleName) then rename('src/' + moduleName, 'src/' + newPackageName + '.chpl');
@@ -153,8 +184,8 @@ proc masonInit(args: [] string) throws {
 }
 
 // Overwrites values of existing Mason.toml file
-proc overwriteTomlFileValues(isMasonTomlPresent, newPackageName, newVersion, 
-    newChplVersion, newLicense, defaultPackageName, defaultVersion, 
+proc overwriteTomlFileValues(isMasonTomlPresent, newPackageName, newVersion,
+    newChplVersion, newLicense, defaultPackageName, defaultVersion,
     defaultChplVersion, defaultLicense) {
   const tomlPath = "./Mason.toml";
   const toParse = open(tomlPath, iomode.r);
@@ -165,7 +196,7 @@ proc overwriteTomlFileValues(isMasonTomlPresent, newPackageName, newVersion,
     if newVersion != defaultVersion then
       tomlFile["brick"]!.set("version", newVersion);
     if newChplVersion != defaultChplVersion then
-      tomlFile["brick"]!.set("chplVersion", newChplVersion); 
+      tomlFile["brick"]!.set("chplVersion", newChplVersion);
     if newLicense != defaultLicense then
       tomlFile["brick"]!.set("license", newLicense);
   }
@@ -189,7 +220,7 @@ proc readPartialManifest() {
     defaultVersion = tomlFile["brick"]!["version"]!.s;
   if tomlFile.pathExists("brick.chplVersion") then
     defaultChplVersion = tomlFile["brick"]!["chplVersion"]!.s;
-  if tomlFile.pathExists("brick.license") then 
+  if tomlFile.pathExists("brick.license") then
     defaultLicense = tomlFile["brick"]!["license"]!.s;
   return (defaultPackageName, defaultVersion, defaultChplVersion, defaultLicense);
 }

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -19,72 +19,74 @@
  */
 
 
-use Path;
-use IO;
-use Spawn;
-use MasonModify;
 use FileSystem;
-use MasonUtils;
-use MasonUpdate;
-use MasonHelp;
+use IO;
+use MasonArgParse;
 use MasonEnv;
+use MasonHelp;
+use MasonModify;
+use MasonUpdate;
+use MasonUtils;
+use Path;
+use Spawn;
+
 
 /*
   Creates a new library project at a given directory
   mason new <projectName/directoryName>
 */
 proc masonNew(args: [] string) throws {
-  var vcs = true;
-  var show = false;
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var showFlag = parser.addFlag(name="show",
+                                opts=["--show"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var vcsFlag = parser.addFlag(name="vcs",
+                               opts=["--no-vcs"],
+                               defaultValue=false,
+                               flagInversion=false);
+  var nameOpt = parser.addOption(name="legalname",
+                                 opts=["--name"]);
+  var dirArg = parser.addArgument(name="directory", numArgs=0..1);
+
+  try {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonNewHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonNewHelp();
+    exit(0);
+  }
+  var vcs = !vcsFlag.valueAsBool();
+  var show = showFlag.valueAsBool();
   var packageName = '';
   var dirName = '';
   var version = '';
   var chplVersion = '';
   var license = 'None';
+
   try! {
-    if args.size < 3 {
+    if args.size == 1 {
       var metadata = beginInteractiveSession('','','','');
       packageName = metadata[0];
       dirName = packageName;
       version = metadata[1];
       chplVersion = metadata[2];
       license = metadata[3];
-    }
-    else {
-      var countArgs = args.domain.low + 2;
-      for arg in args[args.domain.low+2..] {
-        countArgs += 1;
-        select (arg) {
-          when '-h' {
-            masonNewHelp();
-            exit();
-          }
-          when '--help' {
-            masonNewHelp();
-            exit();
-          }
-          when '--no-vcs' {
-            vcs = false;
-          }
-          when '--show' {
-            show = true;
-          }
-          when '--name' {
-              packageName = args[countArgs];
-          }
-          otherwise {
-            if arg.startsWith('--name=') {
-              var res = arg.split("=");
-              packageName = res[1];
-            }
-            else {
-              if args[countArgs - 2] != '--name' then
-              dirName = arg;
-              if packageName.size == 0 then
-              packageName = arg;
-            }
-          }
-        }
+    } else {
+      if dirArg.hasValue() then dirName = dirArg.value();
+      if nameOpt.hasValue() {
+        packageName = nameOpt.value();
+      } else {
+        packageName = dirName;
       }
     }
     if validatePackageName(dirName=packageName) {
@@ -104,7 +106,7 @@ proc masonNew(args: [] string) throws {
   Starts an interactive session to create a
   new library project.
 */
-proc beginInteractiveSession(defaultPackageName: string, defVer: string, 
+proc beginInteractiveSession(defaultPackageName: string, defVer: string,
             defChplVer: string, license: string) throws {
   writeln("""This is an interactive session to walk you through creating a library
 project using Mason. The following queries covers the common items required to
@@ -144,10 +146,10 @@ considered if no input is given.""");
         }
         if !isIllegalName {
           if isDir('./' + packageName) then
-            throw new owned MasonError("Bad package name. A package with the name '" 
+            throw new owned MasonError("Bad package name. A package with the name '"
                               + packageName + "' already exists.");
           if validatePackageName(packageName) then
-            gotCorrectPackageName = true; 
+            gotCorrectPackageName = true;
         }
       }
       if !gotCorrectPackageVersion {
@@ -283,7 +285,7 @@ proc InitProject(dirName, packageName, vcs, show,
     makeSrcDir(dirName);
     makeModule(dirName, fileName=packageName);
     makeTestDir(dirName);
-    makeExampleDir(dirName);  
+    makeExampleDir(dirName);
     writeln("Created new library project: " + dirName);
   }
   else {
@@ -321,7 +323,7 @@ license = "%s"
 }
 
 /* Creates the Mason.toml file */
-proc makeBasicToml(dirName: string, path: string, version: string, 
+proc makeBasicToml(dirName: string, path: string, version: string,
             chplVersion: string, license: string) {
   var defaultVersion: string = "0.1.0";
   var defaultChplVersion: string = getChapelVersionStr();

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -19,17 +19,18 @@
  */
 
 
-use MasonUtils;
-use Spawn;
 use FileSystem;
-use TOML;
-use MasonEnv;
-use MasonNew;
-use MasonModify;
-use Random;
-use MasonUpdate;
-private use List;
+use List;
+use MasonArgParse;
 use MasonBuild;
+use MasonEnv;
+use MasonModify;
+use MasonNew;
+use MasonUpdate;
+use MasonUtils;
+use Random;
+use Spawn;
+use TOML;
 
 /* Top Level procedure that gets called from mason.chpl that takes in arguments from command line.
    Returns the help output in '-h' or '--help' exits in the arguments.
@@ -43,62 +44,68 @@ proc masonPublish(args: [?d] string) {
 }
 
 proc masonPublish(ref args: list(string)) throws {
-  try! {
-    if hasOptions(args, "-h", "--help") {
-      masonPublishHelp();
-      exit(0);
-    }
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var dryFlag = parser.addFlag(name="dry-run",
+                               opts=["--dry-run"],
+                               defaultValue=false,
+                               flagInversion=false);
+  var createFlag = parser.addFlag(name="create-registry",
+                                  opts=["-c","--create-registry"],
+                                  defaultValue=false,
+                                  flagInversion=false);
+  var checkArg = parser.addFlag(name="check",
+                                 opts=["--check"],
+                                 defaultValue=false,
+                                 flagInversion=false);
+  var ciFlag = parser.addFlag(name="ci-check",
+                              opts=["--ci-check"],
+                              defaultValue=false,
+                              flagInversion=false);
+  var updateFlag = parser.addFlag(name="update",
+                                  opts=["--update"],
+                                  flagInversion=true);
+  var registryArg = parser.addArgument(name="registry",
+                                       numArgs=0..1);
 
-    var dry = hasOptions(args, "--dry-run");
-    var checkFlag = hasOptions(args, '--check');
-    var registryPath = '';
+  try {
+    parser.parseArgs(args.toArray());
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonPublishHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonPublishHelp();
+    exit(0);
+  }
+  try! {
+    var dry = dryFlag.valueAsBool();
+    var checkFlag = checkArg.valueAsBool();
+    var registryPath = "";
+    if registryArg.hasValue() then registryPath = registryArg.value();
     var username = getUsername();
     var isLocal = false;
-    var ci = hasOptions(args, '--ci-check');
-    var update = hasOptions(args, '--update');
-    var noUpdate = hasOptions(args, '--no-update');
+    var ci = ciFlag.valueAsBool();
+    var update = false;
+    var noUpdate = false;
     var skipUpdate = MASON_OFFLINE;
-    var createReg = hasOptions(args, '-c', '--create-registry');
-    if update {
-      skipUpdate = false;
+    if updateFlag.hasValue() {
+      update = updateFlag.valueAsBool();
+      noUpdate = !update;
+      skipUpdate = !update;
     }
-    if noUpdate {
-      skipUpdate = true;
-    }
+    var createReg = createFlag.valueAsBool();
 
     const badSyntaxMessage = 'Arguments does not follow "mason publish [options] <registry>" syntax';
-    if args.size > 5 {
-      throw new owned MasonError(badSyntaxMessage);
-    }
-
-    if args.size > 2 {
-      var potentialPath = args.pop();
-      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potentialPath != '--ci-check') {
-        registryPath = potentialPath;
-      }
-      args.append(potentialPath);
-    }
 
     if createReg {
-      var pathReg: string;
-      for i in 2..<args.size {
-        // Find positional arguments
-        if !args[i].startsWith('-') {
-          if pathReg == '' {
-            pathReg = args[i];
-          } else {
-           // Multiple positional arguments is an error
-            throw new owned MasonError("mason publish --create-registry expects only one path");
-          }
-        }
-      }
-      if pathReg == '' {
-        // No positional arguments is an error
-        throw new owned MasonError("mason publish --create-registry expects a path");
-      }
+      var pathReg = registryPath;
       try! {
-        if pathReg == 'publish' then throw new owned MasonError('Valid path required ' +
-            'with "mason publish --create-registry"');
         if !isDir(pathReg) then mkdir(pathReg);
         else throw new owned MasonError("Registry already exists at %s".format(pathReg));
         if !isDir(pathReg + '/Bricks') then mkdir(pathReg + '/Bricks');
@@ -122,8 +129,7 @@ proc masonPublish(ref args: list(string)) throws {
 
     if registryPath.isEmpty() {
       registryPath = MASON_HOME;
-    }
-    else {
+    } else {
       isLocal = isRegistryPathLocal(registryPath);
     }
 
@@ -133,7 +139,8 @@ proc masonPublish(ref args: list(string)) throws {
         check(username, registryPath, isLocal, ci);
       }
     }
-    if ((MASON_OFFLINE  && !update) || noUpdate == true) && !falseIfRemotePath() {
+
+    if ((MASON_OFFLINE  && !update) || noUpdate) && !falseIfRemotePath() {
       if !isLocal {
         throw new owned MasonError('You cannot publish to a remote repository when MASON_OFFLINE is set to true or "--no-update" is passed, override with --update');
       }
@@ -322,7 +329,7 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
     var reg = MASON_REGISTRY;
 
     if reg.size == 1 {
-      if reg[0] == ('mason-registry', regUrl) 
+      if reg[0] == ('mason-registry', regUrl)
         then writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
     }
 
@@ -524,7 +531,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     }
     else {
       writeln('   Packages with more than one modules cannot be published. (FAILED)');
-      moduleTest = false; 
+      moduleTest = false;
     }
     writeln(spacer);
   }
@@ -554,7 +561,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     }
     writeln(spacer);
   }
-  
+
   if package {
     writeln('Checking for tests:');
     if testCheck(projectCheckHome) {
@@ -582,7 +589,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     }
     writeln(spacer);
   }
-  
+
   if package {
     writeln('Checking for license:');
     var validLicenseCheck = checkLicense(projectCheckHome);
@@ -608,7 +615,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     }
     writeln(spacer);
   }
-  
+
   writeln(spacer);
   if package && !ci {
     writeln('Attempting to build package using following options:');
@@ -629,7 +636,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
   writeln('RESULTS');
   writeln(spacer);
 
-  if packageTest && remoteTest && moduleTest && testTest 
+  if packageTest && remoteTest && moduleTest && testTest
     && licenseTest && gitTagTest && masonFieldsTest {
     writeln('(PASSED) Your package is ready to publish');
   }
@@ -663,7 +670,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
   writeln(spacer);
 
   if ci {
-    if package && moduleCheck(projectCheckHome) && testCheck(projectCheckHome) 
+    if package && moduleCheck(projectCheckHome) && testCheck(projectCheckHome)
     && checkLicense(projectCheckHome)[0] && masonTomlFileCheck(projectCheckHome)[0]
     && gitTagVersionCheck(projectCheckHome)[0] {
       attemptToBuild();
@@ -741,7 +748,7 @@ private proc registryPathCheck(path : string, username : string, trueIfLocal : b
       const hasBricks = exists(path + '/Bricks/');
       if !isLocalGit {
         writeln('   Registry with path ' + path + ' is not a git repository. (FAILED)');
-        writeln("   Local registries must be git repositorys in order to publish");
+        writeln("   Local registries must be git repositories in order to publish");
         return false;
       }
       else if !hasBricks {
@@ -808,7 +815,7 @@ proc testCheck(projectHome: string) {
 /* Returns the mason env
  */
 private proc returnMasonEnv() {
-  const fakeArgs = ['mason', 'env'];
+  const fakeArgs = ['env'];
   masonEnv(fakeArgs);
 }
 
@@ -837,7 +844,7 @@ proc gitTagVersionCheck(projectHome: string) throws {
   return (false, allTags, version);
 }
 
-/* make sure directory created is same as that of package 
+/* make sure directory created is same as that of package
    name in manifest file */
 proc namespaceCollisionCheck(projectHome: string) throws {
   var directoryName = basename(projectHome);

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -199,6 +199,7 @@ private proc masonBuildRun(args: [?d] string) {
       if release then execopts.append("--release");
       if force then execopts.append("--force");
       if show then execopts.append("--show");
+      execopts.insert(0,"example");
       masonExample(execopts.toArray());
     }
     else {
@@ -210,7 +211,6 @@ private proc masonBuildRun(args: [?d] string) {
       if release then buildArgs.append("--release");
       if force then buildArgs.append("--force");
       if show then buildArgs.append("--show");
-
       masonBuild(buildArgs.toArray());
       runProjectBinary(show, release, execopts);
     }

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -199,7 +199,8 @@ private proc masonBuildRun(args: [?d] string) {
       if release then execopts.append("--release");
       if force then execopts.append("--force");
       if show then execopts.append("--show");
-      execopts.insert(0,"example");
+      // add expected arguments for masonExample
+      execopts.insert(0,["example", "--example"]);
       masonExample(execopts.toArray());
     }
     else {

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -18,16 +18,17 @@
  * limitations under the License.
  */
 
-private use List;
-use MasonHelp;
+use FileSystem;
+use IO;
+use List;
+use MasonArgParse;
 use MasonEnv;
+use MasonHelp;
 use MasonUpdate;
 use MasonUtils;
-use TOML;
-use Sort;
-use FileSystem;
 use Regex;
-use IO;
+use Sort;
+use TOML;
 
 //
 // TODO:
@@ -46,29 +47,51 @@ proc masonSearch(args: [?d] string) {
 }
 
 proc masonSearch(ref args: list(string)) {
-  if hasOptions(args, "-h", "--help") {
+  var parser = new argumentParser();
+
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  // TODO: Is the debug flag supposed to be documented in help or not?
+  var debugFlag = parser.addFlag("debug",
+                                opts=["--debug"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var showFlag = parser.addFlag(name="show",
+                                opts=["--show"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var updateFlag = parser.addFlag(name="update",
+                                  opts=["--update"],
+                                  flagInversion=true);
+  var queryArg = parser.addArgument(name="query",
+                                    numArgs=0..1,
+                                    defaultValue=".*");
+  try! {
+    parser.parseArgs(args.toArray());
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonSearchHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
     masonSearchHelp();
     exit(0);
   }
 
-  const show = hasOptions(args, "--show");
-  const debug = hasOptions(args, "--debug");
+  const show = showFlag.valueAsBool();
+  const debug = debugFlag.valueAsBool();
   var skipUpdate = MASON_OFFLINE;
-  if hasOptions(args, "--update") {
-    skipUpdate = false;
-  }
-
-  if hasOptions(args, "--no-update") {
-    skipUpdate = true;
+  if updateFlag.hasValue() {
+    skipUpdate = !updateFlag.valueAsBool();
   }
 
   updateRegistry(skipUpdate);
 
-  consumeArgs(args);
-
   // If no query is provided, list all packages in registry
-  const query = if args.size > 0 then args[args.size-1].toLower()
-                else ".*";
+  const query = queryArg.value().toLower();
   const pattern = compile(query, ignoreCase=true);
   var results: list(string);
   var packages: list(string);
@@ -180,7 +203,7 @@ proc touch(pathToReg: string) {
 proc getPackageScores(res: [] string) {
   use Map;
   const pathToReg = MASON_HOME + "/mason-registry/cache.toml";
-  var cacheExists: bool = false;
+  var cacheExists = false;
   if isFile(pathToReg) then cacheExists = true;
   if !cacheExists then touch(pathToReg);
   const parse = open(pathToReg, iomode.r);
@@ -255,20 +278,6 @@ proc findLatest(packageDir: string): VersionInfo {
   }
   return ret;
 }
-
-proc consumeArgs(ref args : list(string)) {
-  args.pop(0);
-  const sub = args[0];
-  assert(sub == "search");
-  args.pop(0);
-
-  const options = {"--no-update", "--debug", "--show"};
-
-  while args.size > 0 && options.contains(args[0]) {
-    args.pop(0);
-  }
-}
-
 
 /* Print a TOML file. Expects full path. */
 proc showToml(tomlFile : string) {

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -65,6 +65,8 @@ proc masonSearch(ref args: list(string)) {
   var updateFlag = parser.addFlag(name="update",
                                   opts=["--update"],
                                   flagInversion=true);
+
+  // If no query is provided, list all packages in registry
   var queryArg = parser.addArgument(name="query",
                                     numArgs=0..1,
                                     defaultValue=".*");
@@ -90,7 +92,6 @@ proc masonSearch(ref args: list(string)) {
 
   updateRegistry(skipUpdate);
 
-  // If no query is provided, list all packages in registry
   const query = queryArg.value().toLower();
   const pattern = compile(query, ignoreCase=true);
   var results: list(string);

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -60,10 +60,6 @@ proc masonSystem(args: [] string) {
         var searchArgs = searchCmd.values();
         pkgSearch(searchArgs);
       }
-      // else {
-      //   masonSystemHelp();
-      //   exit(0);
-      // }
     }
     else {
       masonSystemHelp();
@@ -187,15 +183,6 @@ proc printPkgPc(args) throws {
     masonSystemPcHelp();
     exit(1);
   }
-  // if args.size < 4 {
-  //   masonSystemPcHelp();
-  //   exit(0);
-  // }
-  // else if args[3] == "-h" || args[3] == "--help" {
-  //   masonSystemPcHelp();
-  //   exit(0);
-  // }
-  // else {
   try! {
     const pkgName = pkgNameArg.value();
     if pkgExists(pkgName) {

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -50,23 +50,22 @@ proc masonSystem(args: [] string) {
     exit(0);
   }
   try! {
-
-    if pkgConfigExists() {
-      if pcCmd.hasValue() {
-        var pcArgs = pcCmd.values();
-        printPkgPc(pcArgs);
-      }
-      else if searchCmd.hasValue() {
-        var searchArgs = searchCmd.values();
-        pkgSearch(searchArgs);
-      }
+    if pcCmd.hasValue() {
+      pkgConfigExists();
+      var pcArgs = pcCmd.values();
+      printPkgPc(pcArgs);
     }
-    else {
+    else if searchCmd.hasValue() {
+      pkgConfigExists();
+      var searchArgs = searchCmd.values();
+      pkgSearch(searchArgs);
+    }
+    else { // no valid sub-command given
       masonSystemHelp();
       exit(0);
     }
   }
-  catch e: MasonError {
+  catch e: MasonError { // likely pkg-config wasn't found on system
     stderr.writeln(e.message());
     exit(1);
   }

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -19,35 +19,51 @@
  */
 
 
-private use List;
-private use Map;
-use Path;
-use MasonUtils;
+use List;
+use Map;
+use MasonArgParse;
 use MasonHelp;
+use MasonUtils;
+use Path;
 use Regex;
 
 /* Entry point for mason system commands */
 proc masonSystem(args: [] string) {
+  var parser = new argumentParser();
+
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var pcCmd = parser.addSubCommand("pc");
+  var searchCmd = parser.addSubCommand("search");
   try! {
-    if args.size < 3 {
-      masonSystemHelp();
-      exit(0);
-    }
-    else if args[2] == "--help" || args[2] == "-h" {
-      masonSystemHelp();
-      exit(0);
-    }
-    else if pkgConfigExists() {
-      if args[2] == "pc" {
-        printPkgPc(args);
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonSystemHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonSystemHelp();
+    exit(0);
+  }
+  try! {
+
+    if pkgConfigExists() {
+      if pcCmd.hasValue() {
+        var pcArgs = pcCmd.values();
+        printPkgPc(pcArgs);
       }
-      else if args[2] == "search" {
-        pkgSearch(args);
+      else if searchCmd.hasValue() {
+        var searchArgs = searchCmd.values();
+        pkgSearch(searchArgs);
       }
-      else {
-        masonSystemHelp();
-        exit(0);
-      }
+      // else {
+      //   masonSystemHelp();
+      //   exit(0);
+      // }
     }
     else {
       masonSystemHelp();
@@ -72,40 +88,75 @@ proc pkgConfigExists() throws {
 
 /* Searches available system packages */
 proc pkgSearch(args) throws {
+  var parser = new argumentParser();
 
-  var desc = false;
-  var quiet = false;
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var quietFlag = parser.addFlag(name="no-show-desc",
+                                opts=["--no-show-desc"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var descFlag = parser.addFlag(name="desc",
+                                opts=["--desc"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var pkgNameArg = parser.addArgument(name="package", numArgs=0..1);
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonSystemSearchHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
+    masonSystemSearchHelp();
+    exit(0);
+  }
+
+  var desc = descFlag.valueAsBool();
+  var quiet = quietFlag.valueAsBool();
   var pkgName = "";
-  if args.size < 4 {
+  if pkgNameArg.hasValue() {
+    pkgName = pkgNameArg.value();
+  }
+  else {
     listAllPkgs();
     exit(0);
   }
-  else {
-    for arg in args[3..] {
-      if arg == '-h' || arg == '--help' {
-        masonSystemSearchHelp();
-        exit(0);
-      }
-      else if arg == "--desc" {
-        desc=true;
-      }
-      else if arg == "--no-show-desc" {
-        quiet = true;
-      }
-      else {
-        pkgName = arg;
-      }
-    }
-  }
-  if pkgName == "" {
-    throw new owned MasonError("Must include a package name");
-  }
+  // if args.size < 4 {
+  //   listAllPkgs();
+  //   exit(0);
+  // }
+  // else {
+  //   for arg in args[3..] {
+  //     if arg == '-h' || arg == '--help' {
+  //       masonSystemSearchHelp();
+  //       exit(0);
+  //     }
+  //     else if arg == "--desc" {
+  //       desc=true;
+  //     }
+  //     else if arg == "--no-show-desc" {
+  //       quiet = true;
+  //     }
+  //     else {
+  //       pkgName = arg;
+  //     }
+  //   }
+  // }
+  // if pkgName == "" {
+  //   throw new owned MasonError("Must include a package name");
+  // }
   const pattern = compile(pkgName, ignoreCase=true);
   const command = "pkg-config --list-all";
   const cmd = command.split();
   var sub = spawn(cmd, stdout=PIPE);
   sub.wait();
 
+  // TODO: Test if this ever worked
   for line in sub.stdout.lines() {
     const toSearch = line.partition(" ");
     if desc {
@@ -137,43 +188,64 @@ proc listAllPkgs() {
 
 /* Prints a pc for user debugging */
 proc printPkgPc(args) throws {
-  if args.size < 4 {
+  var parser = new argumentParser();
+  var helpFlag = parser.addFlag("help",
+                                opts=["-h","--help"],
+                                defaultValue=false,
+                                flagInversion=false);
+  var pkgNameArg = parser.addArgument(name="package", numArgs=0..1);
+  try! {
+    parser.parseArgs(args);
+  }
+  catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonSystemPcHelp();
+    exit(1);
+  }
+  if helpFlag.valueAsBool() {
     masonSystemPcHelp();
     exit(0);
   }
-  else if args[3] == "-h" || args[3] == "--help" {
+  if !pkgNameArg.hasValue() {
     masonSystemPcHelp();
-    exit(0);
+    exit(1);
   }
-  else {
-    try! {
-      const pkgName = args[3];
-      if pkgExists(pkgName) {
-        //
-        // Add a these call, since `string.join` has an iterator overload but
-        // not one for list.
-        //
-        var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir").these()).strip();
-        var pcFile = joinPath(pcDir, pkgName + ".pc");
-        var pc = open(pcFile, iomode.r);
-        writeln("\n------- " + pkgName + ".pc -------\n");
-        for line in pc.lines() {
-          write(line);
-        }
-        writeln("\n-------------------\n");
+  // if args.size < 4 {
+  //   masonSystemPcHelp();
+  //   exit(0);
+  // }
+  // else if args[3] == "-h" || args[3] == "--help" {
+  //   masonSystemPcHelp();
+  //   exit(0);
+  // }
+  // else {
+  try! {
+    const pkgName = pkgNameArg.value();
+    if pkgExists(pkgName) {
+      //
+      // Add a these call, since `string.join` has an iterator overload but
+      // not one for list.
+      //
+      var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir").these()).strip();
+      var pcFile = joinPath(pcDir, pkgName + ".pc");
+      var pc = open(pcFile, iomode.r);
+      writeln("\n------- " + pkgName + ".pc -------\n");
+      for line in pc.lines() {
+        write(line);
       }
-      else {
-        throw new owned MasonError("Mason could not find " + pkgName + " on your system");
-      }
+      writeln("\n-------------------\n");
     }
-    catch e: FileNotFoundError {
-      stderr.writeln("Package exists but Mason could not find it's .pc file");
-      exit(1);
+    else {
+      throw new owned MasonError("Mason could not find " + pkgName + " on your system");
     }
-    catch e: MasonError {
-      stderr.writeln(e.message());
-      exit(1);
-    }
+  }
+  catch e: FileNotFoundError {
+    stderr.writeln("Package exists but Mason could not find it's .pc file");
+    exit(1);
+  }
+  catch e: MasonError {
+    stderr.writeln(e.message());
+    exit(1);
   }
 }
 

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -126,30 +126,7 @@ proc pkgSearch(args) throws {
     listAllPkgs();
     exit(0);
   }
-  // if args.size < 4 {
-  //   listAllPkgs();
-  //   exit(0);
-  // }
-  // else {
-  //   for arg in args[3..] {
-  //     if arg == '-h' || arg == '--help' {
-  //       masonSystemSearchHelp();
-  //       exit(0);
-  //     }
-  //     else if arg == "--desc" {
-  //       desc=true;
-  //     }
-  //     else if arg == "--no-show-desc" {
-  //       quiet = true;
-  //     }
-  //     else {
-  //       pkgName = arg;
-  //     }
-  //   }
-  // }
-  // if pkgName == "" {
-  //   throw new owned MasonError("Must include a package name");
-  // }
+
   const pattern = compile(pkgName, ignoreCase=true);
   const command = "pkg-config --list-all";
   const cmd = command.split();

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -113,16 +113,26 @@ proc masonTest(args: [] string) throws {
   var searchSubStrings: list(string);
 
   if otherArgs.hasValue() {
+    var flagInArgs = false;
     for arg in otherArgs.values() {
       try! {
-        if isFile(arg) && arg.endsWith(".chpl") {
+        // try to get option values meant for compilation
+        if flagInArgs && !arg.startsWith('-') {
+          compopts.append(arg);
+          flagInArgs=false;
+        }
+        // assume this is an individual test file
+        else if isFile(arg) && arg.endsWith(".chpl") {
           files.append(arg);
         }
+        // assume this is a test directory
         else if isDir(arg) {
           dirs.append(arg);
         }
+        // assume a flag for compiler
         else if arg.startsWith('-') {
           compopts.append(arg);
+          flagInArgs=true;
         }
         else {
           searchSubStrings.append(arg);

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -161,7 +161,7 @@ proc SPACK_ROOT : string {
 }
 /*
 This fetches the mason-installed spack registry only.
-Users that define SPACK_ROOT to their own spack installation will use 
+Users that define SPACK_ROOT to their own spack installation will use
 the registry of their spack installation.
 */
 proc getSpackRegistry : string {
@@ -216,7 +216,7 @@ proc runSpackCommand(command) {
   return sub.exit_status;
 }
 
-
+// TODO: This is no longer used by mason, consider removing it
 proc hasOptions(args: list(string), const opts: string ...) {
   var ret = false;
 
@@ -231,7 +231,7 @@ proc hasOptions(args: list(string), const opts: string ...) {
   return ret;
 }
 
-
+// TODO: This is no longer used by mason, consider removing it
 proc hasOptions(args : [] string, const opts : string ...) {
   var ret = false;
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -216,36 +216,6 @@ proc runSpackCommand(command) {
   return sub.exit_status;
 }
 
-// TODO: This is no longer used by mason, consider removing it
-proc hasOptions(args: list(string), const opts: string ...) {
-  var ret = false;
-
-  for o in opts {
-    const found = args.count(o) != 0;
-    if found {
-      ret = true;
-      break;
-    }
-  }
-
-  return ret;
-}
-
-// TODO: This is no longer used by mason, consider removing it
-proc hasOptions(args : [] string, const opts : string ...) {
-  var ret = false;
-
-  for o in opts {
-    const (found, idx) = args.find(o);
-    if found {
-      ret = true;
-      break;
-    }
-  }
-
-  return ret;
-}
-
 
 record VersionInfo {
   var major = -1, minor = -1, bug = 0;

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -134,22 +134,22 @@ proc main(args: [] string) throws {
   // while add and rm are taking just the args from the subcommand onward
   try {
     select (usedCmd) {
-      when "new" do masonNew(args);
-      when "init" do masonInit(args);
       when "add" do masonModify(cmdArgs);
-      when "rm" do masonModify(cmdArgs);
       when "build" do masonBuild(args);
-      when "update" do masonUpdate(args);
-      when "run" do masonRun(args);
-      when "search" do masonSearch(args);
-      when "system" do masonSystem(args);
-      when "external" do masonExternal(args);
-      when "test" do masonTest(args);
-      when "env" do masonEnv(args);
-      when "doc" do masonDoc(args);
-      when "publish" do masonPublish(args);
       when "clean" do masonClean(args);
+      when "doc" do masonDoc(cmdArgs);
+      when "env" do masonEnv(cmdArgs);
+      when "external" do masonExternal(cmdArgs);
       when "help" do masonHelp();
+      when "init" do masonInit(cmdArgs);
+      when "new" do masonNew(cmdArgs);
+      when "publish" do masonPublish(cmdArgs);
+      when "rm" do masonModify(cmdArgs);
+      when "run" do masonRun(args);
+      when "search" do masonSearch(cmdArgs);
+      when "system" do masonSystem(cmdArgs);
+      when "test" do masonTest(args);
+      when "update" do masonUpdate(cmdArgs);
       when "version" do printVersion();
       otherwise {
         throw new owned MasonError("No such subcommand \ntry mason --help");

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -129,9 +129,8 @@ proc main(args: [] string) throws {
   }
   var cmdArgs = cmdList.toArray();
   // pass the arguments to the appropriate subcommand
-  // currently, only add and rm have the new argument parser implemented,
-  // so that is why other commands take the full, original, input args
-  // while add and rm are taking just the args from the subcommand onward
+  // TODO: once we can override the RT behavior of consuming '--', continue
+  //       work on masonBuild and masonRun
   try {
     select (usedCmd) {
       when "add" do masonModify(cmdArgs);

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -148,7 +148,7 @@ proc main(args: [] string) throws {
       when "run" do masonRun(args);
       when "search" do masonSearch(cmdArgs);
       when "system" do masonSystem(cmdArgs);
-      when "test" do masonTest(args);
+      when "test" do masonTest(cmdArgs);
       when "update" do masonUpdate(cmdArgs);
       when "version" do printVersion();
       otherwise {


### PR DESCRIPTION
This PR incorporates the argument parser into mason as its command line parser.

Scope of work defined in Cray/chapel-private#2454, this work satisfies
the main goals of that issue which are to:

1. Continue incorporating the argument parser into mason
2. Use the argument parser for subcommands 
   - doc
   - env
   - external
   - init
   - publish
   - new
   - search
   - system
   - test
   - update

This PR also incorporates ordering and removing the `private` keyword from 
the `use` statements in the modified source files.

Some test inputs were modified to stop passing the executable name `mason` as 
the first argument to the subcommand entry point.

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/`

Reviewed by @mppf

Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com