### PR TITLE
Fix a problem with CC=clang-11 e.g.

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -57,7 +57,7 @@ def get(flag='target'):
             elif compiler_val in ['allinea', 'cray-prgenv-allinea']:
                 atomics_val = 'cstdlib'
             elif compiler_val == 'clang':
-                if has_std_atomics(compiler_val):
+                if has_std_atomics():
                     atomics_val = 'cstdlib'
                 else:
                     atomics_val = 'intrinsics'

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -73,17 +73,17 @@ def strip_preprocessor_lines(lines):
 # Clang, and the Intel compiler, but probably not others.
 #
 @memoize
-def has_std_atomics(compiler_val):
+def has_std_atomics():
     try:
-        compiler_name = chpl_compiler.get_compiler_name_c(compiler_val)
-        if compiler_name == 'unknown-c-compiler':
+        compiler_command = chpl_compiler.get_compiler_command('target', 'c')
+        if compiler_command == '':
             return False
 
         version_key='version'
         atomics_key='atomics'
 
         cmd_input = '{0}=__STDC_VERSION__\n{1}=__STDC_NO_ATOMICS__'.format(version_key, atomics_key)
-        cmd = [compiler_name, '-E', '-x', 'c', '-']
+        cmd = [compiler_command, '-E', '-x', 'c', '-']
         output = run_command(cmd, cmd_input=cmd_input)
         output = strip_preprocessor_lines(output.splitlines())
 


### PR DESCRIPTION
On my system, `clang` is not available, but `clang-11` is. In doing some experiments with `clang-11` I compiled Chapel with `CHPL_TARGET_CC=clang-11` `CHPL_TARGET_CXX=clang++-11` `CHPL_TARGET_COMPILER=clang` and had `CHPL_DEVELOPER` unset. When I did that, I noticed an `Error: command not found: clang` coming from printchplenv.

The problem was code checking if cstdlib atomics can be used. This PR updates that code to use the specified C compiler command rather than the name of the compiler.

- [x] full local testing

Reviewed by @ronawho - thanks!
