### PR TITLE
Add STREAM for GPU and make necessary adjustments for it

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -240,6 +240,8 @@ extern bool preserveInlinedLineNumbers;
 extern int breakOnID;
 extern int breakOnRemoveID;
 
+extern int fGPUBlockSize;
+
 extern char stopAfterPass[128];
 
 // code generation strings

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -106,6 +106,8 @@ const char* CHPL_LAUNCHER_SUBDIR = NULL;
 const char* CHPL_SYS_MODULES_SUBDIR = NULL;
 const char* CHPL_LLVM_UNIQ_CFG_PATH = NULL;
 
+const char* CHPL_GPU_BLOCK_SIZE = NULL;
+
 static char libraryFilename[FILENAME_MAX] = "";
 static char incFilename[FILENAME_MAX] = "";
 static bool fBaseline = false;
@@ -292,6 +294,8 @@ static
 bool fPrintChplSettings = false;
 
 bool fCompilerLibraryParser = false;
+
+int fGPUBlockSize = 0;
 
 chpl::Context* gContext = nullptr;
 
@@ -1149,6 +1153,7 @@ static ArgumentDescription arg_desc[] = {
  {"ignore-user-errors", ' ', NULL, "[Don't] attempt to ignore user errors", "N", &ignore_user_errors, "CHPL_IGNORE_USER_ERRORS", NULL},
  {"ignore-errors-for-pass", ' ', NULL, "[Don't] attempt to ignore errors until the end of the pass in which they occur", "N", &ignore_errors_for_pass, "CHPL_IGNORE_ERRORS_FOR_PASS", NULL},
  {"infer-const-refs", ' ', NULL, "Enable [disable] inferring const refs", "n", &fNoInferConstRefs, NULL, NULL},
+ {"gpu-block-size", ' ', "<block-size>", "Block size for GPU launches", "I", &fGPUBlockSize, "CHPL_GPU_BLOCK_SIZE", NULL},
  {"library", ' ', NULL, "Generate a Chapel library file", "F", &fLibraryCompile, NULL, NULL},
  {"library-dir", ' ', "<directory>", "Save generated library helper files in directory", "P", libDir, "CHPL_LIB_SAVE_DIR", verifySaveLibDir},
  {"library-header", ' ', "<filename>", "Name generated header file", "P", libmodeHeadername, NULL, setLibmode},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -106,8 +106,6 @@ const char* CHPL_LAUNCHER_SUBDIR = NULL;
 const char* CHPL_SYS_MODULES_SUBDIR = NULL;
 const char* CHPL_LLVM_UNIQ_CFG_PATH = NULL;
 
-const char* CHPL_GPU_BLOCK_SIZE = NULL;
-
 static char libraryFilename[FILENAME_MAX] = "";
 static char incFilename[FILENAME_MAX] = "";
 static bool fBaseline = false;

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -433,6 +433,11 @@ bool isDenormalizable(Symbol* sym,
                   ce->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                   ce->isPrimitive(PRIM_RETURN) ||
                   (ce->isPrimitive(PRIM_ARRAY_SHIFT_BASE_POINTER) && ce->get(1) == se) ||
+
+                  // We want to pass symbols to kernel launches for now. This
+                  // simplifies its codegen.
+                  ce->isPrimitive(PRIM_GPU_KERNEL_LAUNCH_FLAT) ||
+
                   isBadMove(ce) ||
                   isValPassedByRef(ce, se) ||
                   isFloatComparisonPrimitive(ce))) {

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -35,7 +35,7 @@ void chpl_gpu_launch_kernel(const char* name,
                             int grd_dim_x, int grd_dim_y, int grd_dim_z,
                             int blk_dim_x, int blk_dim_y, int blk_dim_z,
                             int nargs, ...);
-void chpl_gpu_launch_kernel_flat(const char* name, int grid_dim_x, int block_dim_x,
+void chpl_gpu_launch_kernel_flat(const char* name, int num_threads, int blk_dim,
                                  int nargs, ...);
 
 void* chpl_gpu_mem_alloc(size_t size, chpl_mem_descInt_t description,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -79,7 +79,7 @@ void chpl_gpu_init() {
   // 
   // CUDA_CALL(cuDevicePrimaryCtxRetain(&context, device));
   
-  CUDA_CALL(cuCtxCreate(&context, 0, device));
+  CUDA_CALL(cuCtxCreate(&context, CU_CTX_BLOCKING_SYNC, device));
 
   CUcontext cuda_context = NULL;
   cuCtxGetCurrent(&cuda_context);
@@ -281,8 +281,10 @@ void chpl_gpu_launch_kernel(const char* name,
   va_end(args);
 }
 
-void chpl_gpu_launch_kernel_flat(const char* name, int grd_dim, int blk_dim,
+void chpl_gpu_launch_kernel_flat(const char* name, int num_threads, int blk_dim,
                                  int nargs, ...) {
+  int grd_dim = (num_threads+blk_dim-1)/blk_dim;
+
   va_list args;
   va_start(args, nargs);
   chpl_gpu_launch_kernel_help(name,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -31,7 +31,7 @@
 #include <cuda_runtime.h>
 #include <assert.h>
 
-#define CHPL_GPU_DEBUG  // TODO: adjust Makefile for this
+// #define CHPL_GPU_DEBUG  // TODO: adjust Makefile for this
 
 static void CHPL_GPU_LOG(const char *str, ...) {
 #ifdef CHPL_GPU_DEBUG

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -31,7 +31,7 @@
 #include <cuda_runtime.h>
 #include <assert.h>
 
-// #define CHPL_GPU_DEBUG  // TODO: adjust Makefile for this
+#define CHPL_GPU_DEBUG  // TODO: adjust Makefile for this
 
 static void CHPL_GPU_LOG(const char *str, ...) {
 #ifdef CHPL_GPU_DEBUG
@@ -177,14 +177,6 @@ static void chpl_gpu_launch_kernel_help(const char* name,
                                         va_list args) {
   chpl_gpu_ensure_context();
 
-  int i;
-  void* function = chpl_gpu_getKernel("tmp/chpl__gpu.fatbin", name);
-  // TODO: this should use chpl_mem_alloc
-  void*** kernel_params = chpl_malloc(nargs*sizeof(void**));
-
-  assert(function);
-  assert(kernel_params);
-
   CHPL_GPU_LOG("Kernel launcher called.\
                \n\tKernel: %s\n\tGrid: %d,%d,%d\n\t\
                Block: %d,%d,%d\n\tNumArgs: %d\n",
@@ -192,6 +184,14 @@ static void chpl_gpu_launch_kernel_help(const char* name,
                grd_dim_x, grd_dim_y, grd_dim_z,
                blk_dim_x, blk_dim_y, blk_dim_z,
                nargs);
+
+  int i;
+  void* function = chpl_gpu_getKernel("tmp/chpl__gpu.fatbin", name);
+  // TODO: this should use chpl_mem_alloc
+  void*** kernel_params = chpl_malloc(nargs*sizeof(void**));
+
+  assert(function);
+  assert(kernel_params);
 
   CHPL_GPU_LOG("Creating kernel parameters\n");
 

--- a/test/gpu/native/streamPrototype/forallOverZipArray.chpl
+++ b/test/gpu/native/streamPrototype/forallOverZipArray.chpl
@@ -3,7 +3,6 @@ config const end = 10;
 
 on here.getChild(1) {
   var a, b: [start..end] int;
-  var value = 20;
 
   forall  (x,i) in zip(b, b.domain) do x = i+12;
 

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -144,7 +144,8 @@ proc verifyResults(A, B, C) {
   //
   // recompute the computation, destructively storing into B to save space
   //
-  forall (b, c) in zip(B, C) do
+  // Originally this was a forall, but I want the validation to be run on CPU.
+  for (b, c) in zip(B, C) do
     b += alpha *c;  
 
   if (printArrays) then writeln("A-hat is: ", B, "\n");  // and A-hat too

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -25,7 +25,7 @@ type elemType = real(64);
 // TODO : we use the vector size as the 1D block size. However, maximum block
 // size is a hardware requirement (1024 in our testbed, for example). We need to
 // pass the vector size and add a conditional in the GPU kernel to scale up.
-config const m = 100, /*computeProblemSize(numVectors, elemType),*/
+config const m = 1024, /*computeProblemSize(numVectors, elemType),*/
              alpha = 3.0;
 
 //

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -1,0 +1,213 @@
+//
+// Use standard modules for Block distributions, Timing routines, Type
+// utility functions.
+//
+use Time, Types /*, Random */;
+
+//
+// Use shared user module for computing HPCC problem sizes
+//
+use HPCCProblemSize;
+
+//
+// The number of vectors and element type of those vectors
+//
+const numVectors = 3;
+type elemType = real(64);
+
+//
+// Configuration constants to set the problem size (m) and the scalar
+// multiplier, alpha
+//
+
+// TODO : we need the dynamic scope checking, because there is a reduction in
+// `computeProblemSize`
+// TODO : we use the vector size as the 1D block size. However, maximum block
+// size is a hardware requirement (1024 in our testbed, for example). We need to
+// pass the vector size and add a conditional in the GPU kernel to scale up.
+config const m = 100, /*computeProblemSize(numVectors, elemType),*/
+             alpha = 3.0;
+
+//
+// Configuration constants to set the number of trials to run and the
+// amount of error to permit in the verification
+//
+config const numTrials = 10,
+             epsilon = 0.0;
+
+//
+// Configuration constants to indicate whether or not to use a
+// pseudo-random seed (based on the clock) or a fixed seed; and to
+// specify the fixed seed explicitly
+//
+/*
+config const useRandomSeed = true,
+             seed = if useRandomSeed then SeedGenerator.oddCurrentTime else 314159265;
+ */
+
+//
+// Configuration constants to control what's printed -- benchmark
+// parameters, input and output arrays, and/or statistics
+//
+config const printParams = true,
+             printArrays = false,
+             printStats = true;
+
+//
+// The program entry point
+//
+proc main() {
+  printConfiguration();   // print the problem size, number of trials, etc.
+
+  on here.getChild(1) {
+    //
+    // ProblemSpace describes the index set for the three vectors.  It
+    // is a 1D domain that is distributed according to a Block
+    // distribution.  In this case, the Block distribution is 1D
+    // distribution computed by blocking the bounding box 1..m across
+    // the set of locales.  The ProblemSpace domain also contains the
+    // indices 1..m.
+    //
+    const ProblemSpace = {1..m};
+
+    //
+    // A, B, and C are the three distributed vectors, declared to store
+    // a variable of type elemType for each index in ProblemSpace.
+    //
+    var A, B, C: [ProblemSpace] elemType;
+
+    initVectors(B, C);    // Initialize the input vectors, B and C
+
+    var execTime: [1..numTrials] real;                 // an array of timings
+
+    for trial in 1..numTrials {                        // loop over the trials
+      const startTime = getCurrentTime();              // capture the start time
+
+      //
+      // The main loop: Iterate over the vectors A, B, and C in a
+      // parallel, zippered manner storing the elements as a, b, and c.
+      // Compute the multiply-add on b and c, storing the result to a.
+      //
+      forall (a, b, c) in zip(A, B, C) do
+        a = b + alpha * c;
+
+      execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    }
+
+    const validAnswer = verifyResults(A, B, C);        // verify...
+    printResults(validAnswer, execTime);               // ...and print the results
+  }
+}
+
+//
+// Print the problem size and number of trials
+//
+proc printConfiguration() {
+  if (printParams) {
+    if (printStats) then printLocalesTasks();
+    printProblemSize(elemType, numVectors, m);
+    writeln("Number of trials = ", numTrials, "\n");
+  }
+}
+
+//
+// Initialize vectors B and C using a random stream of values and
+// optionally print them to the console
+//
+proc initVectors(B, C) {
+  /*
+
+  TODO: fillRandom has a `forall`. We either need dynamic check and this
+  function to be called outside of the `on gpu` statement, or we fix transitive
+  GPU kernel creation.
+
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+
+  randlist.fillRandom(B);
+  randlist.fillRandom(C);
+  */
+  forall b in B do b = 1;
+  forall c in C do c = 1;
+
+  if (printArrays) {
+    writeln("B is: ", B, "\n");
+    writeln("C is: ", C, "\n");
+  }
+}
+
+//
+// Verify that the computation is correct
+//
+proc verifyResults(A, B, C) {
+  if (printArrays) then writeln("A is:     ", A, "\n");  // optionally print A
+
+  //
+  // recompute the computation, destructively storing into B to save space
+  //
+  forall (b, c) in zip(B, C) do
+    b += alpha *c;  
+
+  if (printArrays) then writeln("A-hat is: ", B, "\n");  // and A-hat too
+
+  //
+  // Compute the infinity-norm by computing the maximum reduction of the
+  // absolute value of A's elements minus the new result computed in B.
+  // "[i in I]" represents an expression-level loop: "forall i in I"
+  //
+
+  /*
+  TODO: we can't do reductions on GPU right now. This forall also calls `abs`,
+  which we don't handle today.
+  const infNorm = max reduce [(a,b) in zip(A,B)] abs(a - b);
+  */
+
+  var infNorm = min(real);
+  for (a,b) in zip(A,B) {
+    /*
+    TODO: for some reason I can't call `abs` here, even though it is inside a
+    `for` loop.
+
+     const delta = abs(a-b);
+       
+    */
+
+    const delta = if a<b then b-a else a-b;
+    if delta > infNorm then
+      infNorm = delta;
+  }
+
+  return (infNorm <= epsilon);    // return whether the error is acceptable
+}
+
+//
+// Print out success/failure, the timings, and the GB/s value
+//
+proc printResults(successful, execTimes) {
+  writeln("Validation: ", if successful then "SUCCESS" else "FAILURE");
+  if (printStats) {
+    /*
+    TODO: these reductions somehow compile but don't generate the right result.
+     totalTime is always zero, but minTime is non zero ?
+
+    const totalTime = + reduce execTimes,
+          avgTime = totalTime / numTrials,
+          minTime = min reduce execTimes;
+    */
+
+    var totalTime = 0.0;
+    var minTime = max(real);
+    for t in execTimes {
+      totalTime += t;
+      minTime = min(minTime, t);
+    }
+    var avgTime = totalTime/numTrials;
+
+    writeln("Execution time:");
+    writeln("  tot = ", totalTime);
+    writeln("  avg = ", avgTime);
+    writeln("  min = ", minTime);
+
+    const GBPerSec = numVectors * numBytes(elemType) * (m / minTime) * 1e-9;
+    writeln("Performance (GB/s) = ", GBPerSec);
+  }
+}

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -22,9 +22,6 @@ type elemType = real(64);
 
 // TODO : we need the dynamic scope checking, because there is a reduction in
 // `computeProblemSize`
-// TODO : we use the vector size as the 1D block size. However, maximum block
-// size is a hardware requirement (1024 in our testbed, for example). We need to
-// pass the vector size and add a conditional in the GPU kernel to scale up.
 config const m = 1024, /*computeProblemSize(numVectors, elemType),*/
              alpha = 3.0;
 

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -59,17 +59,15 @@ proc main() {
   on here.getChild(1) {
     //
     // ProblemSpace describes the index set for the three vectors.  It
-    // is a 1D domain that is distributed according to a Block
-    // distribution.  In this case, the Block distribution is 1D
-    // distribution computed by blocking the bounding box 1..m across
-    // the set of locales.  The ProblemSpace domain also contains the
-    // indices 1..m.
+    // is a 1D domain that has indices 1 to m.
     //
     const ProblemSpace = {1..m};
 
     //
-    // A, B, and C are the three distributed vectors, declared to store
-    // a variable of type elemType for each index in ProblemSpace.
+    // A, B, and C are the three vectors, declared to store a variable of type
+    // elemType for each index in ProblemSpace. As they are local to the `on`
+    // statement that executes on GPU, the memory for these arrays will be
+    // allocated on GPU-accessible memory.
     //
     var A, B, C: [ProblemSpace] elemType;
 
@@ -85,6 +83,7 @@ proc main() {
       // parallel, zippered manner storing the elements as a, b, and c.
       // Compute the multiply-add on b and c, storing the result to a.
       //
+      // This forall loop will be offloaded onto the GPU.
       forall (a, b, c) in zip(A, B, C) do
         a = b + alpha * c;
 

--- a/test/gpu/native/streamPrototype/stream.compopts
+++ b/test/gpu/native/streamPrototype/stream.compopts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+nvccDir=$(which nvcc)
+nvccLib=${nvccDir%/bin/nvcc}/lib64
+
+echo "-M../../../release/examples/benchmarks/hpcc --no-checks --ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda --savec tmp"

--- a/test/gpu/native/streamPrototype/stream.execopts
+++ b/test/gpu/native/streamPrototype/stream.execopts
@@ -1,0 +1,1 @@
+--printStats=false

--- a/test/gpu/native/streamPrototype/stream.good
+++ b/test/gpu/native/streamPrototype/stream.good
@@ -6,4 +6,3 @@ Total memory required (GB) = 2.28882e-05
 Number of trials = 10
 
 Validation: SUCCESS
-warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors

--- a/test/gpu/native/streamPrototype/stream.good
+++ b/test/gpu/native/streamPrototype/stream.good
@@ -1,0 +1,9 @@
+warning: Unknown CUDA version. version.txt: 11.0.228. Assuming the latest supported version 10.1
+warning: Unknown CUDA version. version.txt: 11.0.228. Assuming the latest supported version 10.1
+Problem size = 1024 (2**10)
+Bytes per array = 8192
+Total memory required (GB) = 2.28882e-05
+Number of trials = 10
+
+Validation: SUCCESS
+warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -71,6 +71,7 @@ _chpl ()
 --gdb \
 --gen-ids \
 --gmp \
+--gpu-block-size \
 --hdr-search-path \
 --help \
 --help-env \


### PR DESCRIPTION
This PR adds a full Stream benchmark for GPU.

In order to achieve that it also makes the followign adjustments to the GPU
support:

- Adds proper grid size calculation based on loop "size" and block size.
  - This is currenlty done by passing an argument representing number of threads
    to the runtime's kernel launcher. From there, the runtime launcher does the
    computation.
  - So, this PR adjusts the runtime interface slightly, as well.
- Adds an early return check in the gpu kernel, in case the local thread index
  is out-of-bounds for the loop.
- Adds a `--gpu-block-size` compiler flag to control the block size of gpu
  kernels.
- Adjusts the denormalize pass to avoid replacing temps used for kernel launches
  with equivalent expressions. This is done to avoid making more significant
  adjustments in the kernel launch codegen.

While there:
- Moves the `Kernel launcher called` output earlier to catch fatal launch errors
  that are due to not being able to load a kernel from the fatbinary.
- Drop an unused variable from a test.

#### Test
- [x] test/gpu/native
- [x] standard
