### PR TITLE
Two little string optimizations

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -471,7 +471,11 @@ module BytesStringCommon {
     if t == string {
       var numCodepoints = numChars;
       if numCodepoints == -1 {
-        numCodepoints = countNumCodepoints(buff, buffLen);
+        if x.isASCII() {
+          numCodepoints = buffLen;
+        } else {
+          numCodepoints = countNumCodepoints(buff, buffLen);
+        }
       }
       return chpl_createStringWithOwnedBufferNV(x=buff, length=buffLen,
           size=buffSize, numCodepoints=numCodepoints);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -919,18 +919,18 @@ module String {
     }
 
 
+    // assumes that 'this' is already localized
     proc _cpIndexLenHelpNoAdjustment(ref start: int) {
-      const localThis: string = this.localize();
       const i = start;
 
-      if localThis.isASCII() {
+      if this.isASCII() {
         start += 1;
         return (this.buff[i]:int(32), i:byteIndex, 1:int);
 
       }
       else {
-        const (decodeRet, cp, nBytes) = decodeHelp(buff=localThis.buff,
-                                                   buffLen=localThis.buffLen,
+        const (decodeRet, cp, nBytes) = decodeHelp(buff=this.buff,
+                                                   buffLen=this.buffLen,
                                                    offset=i,
                                                    allowEsc=true);
         start += nBytes;


### PR DESCRIPTION
This PR has two little string optimizations I came up with while working on #11158. This PR provides a modest speed improvement to knucleotide-strings.chpl by avoiding some redundant work within the `string` implementation.

Reviewed by @e-kayrakli - thanks!

- [x] full local testing

Future Work:
 * create a bytes-based variant of knucleotide-strings.chpl as a performance benchmark
 * improve the string implementation for the patterns used in knucleotide-strings.chpl 
    * improve substring operations by having them return some sort of "view" into the existing string. See #11222 (and to some degree #12670).
    * improve operations on short strings with a short-string optimization. See #11221.