### PR TITLE
Adjust LLVM pass configuration to better match clang

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -68,6 +68,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 #if HAVE_LLVM_VER >= 90
@@ -1735,6 +1736,166 @@ void setupClang(GenInfo* info, std::string mainFile)
   }
 }
 
+
+// copied from clang's BackendUtil.cpp
+static Optional<llvm::CodeModel::Model>
+getCodeModel(const CodeGenOptions &CodeGenOpts) {
+  unsigned CodeModel = llvm::StringSwitch<unsigned>(CodeGenOpts.CodeModel)
+                           .Case("tiny", llvm::CodeModel::Tiny)
+                           .Case("small", llvm::CodeModel::Small)
+                           .Case("kernel", llvm::CodeModel::Kernel)
+                           .Case("medium", llvm::CodeModel::Medium)
+                           .Case("large", llvm::CodeModel::Large)
+                           .Case("default", ~1u)
+                           .Default(~0u);
+  assert(CodeModel != ~0u && "invalid code model!");
+  if (CodeModel == ~1u)
+    return None;
+  return static_cast<llvm::CodeModel::Model>(CodeModel);
+}
+
+// this function is substantially similar to clang's
+// initTargetOptions from BackendUtil.cpp
+static llvm::TargetOptions getTargetOptions(
+    const clang::CodeGenOptions& CodeGenOpts,
+    const clang::TargetOptions& TargetOpts) {
+
+  llvm::TargetOptions Options;
+
+  // Chapel is always multithreaded
+  Options.ThreadModel = llvm::ThreadModel::POSIX;
+
+  // Set float ABI type.
+  assert((CodeGenOpts.FloatABI == "soft" || CodeGenOpts.FloatABI == "softfp" ||
+          CodeGenOpts.FloatABI == "hard" || CodeGenOpts.FloatABI.empty()) &&
+         "Invalid Floating Point ABI!");
+  Options.FloatABIType =
+      llvm::StringSwitch<llvm::FloatABI::ABIType>(CodeGenOpts.FloatABI)
+          .Case("soft", llvm::FloatABI::Soft)
+          .Case("softfp", llvm::FloatABI::Soft)
+          .Case("hard", llvm::FloatABI::Hard)
+          .Default(llvm::FloatABI::Default);
+
+
+  // Set the floating point optimization level
+  // see also code setting FastMathFlags
+  // This uses ffloatOpt rather than using clang's LangOpts.
+  if (ffloatOpt == 1) {
+    // --no-ieee-float
+    // Allow unsafe fast floating point optimization
+    Options.UnsafeFPMath = 1; // e.g. FSIN instruction
+    Options.NoInfsFPMath = 1;
+    Options.NoNaNsFPMath = 1;
+    Options.NoTrappingFPMath = 1;
+    Options.NoSignedZerosFPMath = 1;
+    Options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+  } else if (ffloatOpt == 0) {
+    // Target default floating point optimization
+    Options.AllowFPOpFusion = llvm::FPOpFusion::Standard;
+  } else if (ffloatOpt == -1) {
+    // --ieee-float
+    // Should this set targetOptions.HonorSignDependentRoundingFPMathOption ?
+    // Allow fused multiply-adds
+    Options.AllowFPOpFusion = llvm::FPOpFusion::Standard;
+  }
+
+#if HAVE_LLVM_VER >= 120
+  Options.BinutilsVersion =
+      llvm::TargetMachine::parseBinutilsVersion(CodeGenOpts.BinutilsVersion);
+#endif
+
+  Options.UseInitArray = CodeGenOpts.UseInitArray;
+  Options.DisableIntegratedAS = CodeGenOpts.DisableIntegratedAS;
+  Options.CompressDebugSections = CodeGenOpts.getCompressDebugSections();
+  Options.RelaxELFRelocations = CodeGenOpts.RelaxELFRelocations;
+
+  // Set EABI version.
+  Options.EABIVersion = TargetOpts.EABIVersion;
+
+  Options.ExceptionModel = llvm::ExceptionHandling::None;
+
+  //Options.NoInfsFPMath = LangOpts.NoHonorInfs; -- set above
+  //Options.NoNaNsFPMath = LangOpts.NoHonorNaNs; -- set above
+  Options.NoZerosInBSS = CodeGenOpts.NoZeroInitializedInBSS;
+  //Options.UnsafeFPMath = LangOpts.UnsafeFPMath; -- set above
+#if HAVE_LLVM_VER <= 110
+  Options.StackAlignmentOverride = CodeGenOpts.StackAlignment;
+#endif
+
+  Options.BBSections =
+    llvm::StringSwitch<llvm::BasicBlockSection>(CodeGenOpts.BBSections)
+        .Case("all", llvm::BasicBlockSection::All)
+        .Case("labels", llvm::BasicBlockSection::Labels)
+        .StartsWith("list=", llvm::BasicBlockSection::List)
+        .Case("none", llvm::BasicBlockSection::None)
+        .Default(llvm::BasicBlockSection::None);
+
+  if (Options.BBSections == llvm::BasicBlockSection::List) {
+    INT_FATAL("this clang configuration not supported");
+  }
+
+#if HAVE_LLVM_VER >= 120
+  Options.EnableMachineFunctionSplitter = CodeGenOpts.SplitMachineFunctions;
+#endif
+
+  Options.FunctionSections = CodeGenOpts.FunctionSections;
+  Options.DataSections = CodeGenOpts.DataSections;
+#if HAVE_LLVM_VER >= 120
+  Options.IgnoreXCOFFVisibility = LangOpts.IgnoreXCOFFVisibility;
+#endif
+  Options.UniqueSectionNames = CodeGenOpts.UniqueSectionNames;
+  Options.UniqueBasicBlockSectionNames =
+      CodeGenOpts.UniqueBasicBlockSectionNames;
+  Options.TLSSize = CodeGenOpts.TLSSize;
+  Options.EmulatedTLS = CodeGenOpts.EmulatedTLS;
+  Options.ExplicitEmulatedTLS = CodeGenOpts.ExplicitEmulatedTLS;
+  Options.DebuggerTuning = CodeGenOpts.getDebuggerTuning();
+  Options.EmitStackSizeSection = CodeGenOpts.StackSizeSection;
+#if HAVE_LLVM_VER >= 120
+  Options.StackUsageOutput = CodeGenOpts.StackUsageOutput;
+#endif
+  Options.EmitAddrsig = CodeGenOpts.Addrsig;
+  Options.ForceDwarfFrameSection = CodeGenOpts.ForceDwarfFrameSection;
+  Options.EmitCallSiteInfo = CodeGenOpts.EmitCallSiteInfo;
+#if HAVE_LLVM_VER >= 120
+  Options.EnableAIXExtendedAltivecABI = CodeGenOpts.EnableAIXExtendedAltivecABI;
+  Options.PseudoProbeForProfiling = CodeGenOpts.PseudoProbeForProfiling;
+  Options.ValueTrackingVariableLocations =
+      CodeGenOpts.ValueTrackingVariableLocations;
+#endif
+  Options.XRayOmitFunctionIndex = CodeGenOpts.XRayOmitFunctionIndex;
+#if HAVE_LLVM_VER >= 120
+  Options.LoopAlignment = CodeGenOpts.LoopAlignment;
+#endif
+
+  Options.MCOptions.SplitDwarfFile = CodeGenOpts.SplitDwarfFile;
+  Options.MCOptions.MCRelaxAll = CodeGenOpts.RelaxAll;
+  Options.MCOptions.MCSaveTempLabels = CodeGenOpts.SaveTempLabels;
+  Options.MCOptions.MCUseDwarfDirectory = !CodeGenOpts.NoDwarfDirectoryAsm;
+  Options.MCOptions.MCNoExecStack = CodeGenOpts.NoExecStack;
+  Options.MCOptions.MCIncrementalLinkerCompatible =
+      CodeGenOpts.IncrementalLinkerCompatible;
+  Options.MCOptions.MCFatalWarnings = CodeGenOpts.FatalWarnings;
+  Options.MCOptions.MCNoWarn = CodeGenOpts.NoWarn;
+  Options.MCOptions.AsmVerbose = CodeGenOpts.AsmVerbose;
+#if HAVE_LLVM_VER >= 120
+  Options.MCOptions.Dwarf64 = CodeGenOpts.Dwarf64;
+#endif
+  Options.MCOptions.PreserveAsmComments = CodeGenOpts.PreserveAsmComments;
+  Options.MCOptions.ABIName = TargetOpts.ABI;
+
+  // consider setting Options.MCOptions.IASSearchPaths
+  // if .include directives with integrated assembler are needed
+
+  Options.MCOptions.Argv0 = CodeGenOpts.Argv0;
+  Options.MCOptions.CommandLineArgs = CodeGenOpts.CommandLineArgs;
+#if HAVE_LLVM_VER >= 120
+  Options.DebugStrictDwarf = CodeGenOpts.DebugStrictDwarf;
+#endif
+
+  return Options;
+}
+
 static void setupModule()
 {
   GenInfo* info = gGenInfo;
@@ -1770,6 +1931,7 @@ static void setupModule()
 
 
   const clang::TargetOptions & ClangOpts = clangInfo->Clang->getTargetOpts();
+  const clang::CodeGenOptions& ClangCodeGenOpts = clangInfo->codegenOptions;
 
   std::string cpu = ClangOpts.CPU;
   std::vector<std::string> clangFeatures = ClangOpts.Features;
@@ -1786,32 +1948,10 @@ static void setupModule()
   }
 
   // Set up the TargetOptions
-  llvm::TargetOptions targetOptions;
-  targetOptions.ThreadModel = llvm::ThreadModel::POSIX;
-
-  // Set the floating point optimization level
-  // see also code setting FastMathFlags
-  if (ffloatOpt == 1) {
-    // --no-ieee-float
-    // Allow unsafe fast floating point optimization
-    targetOptions.UnsafeFPMath = 1; // e.g. FSIN instruction
-    targetOptions.NoInfsFPMath = 1;
-    targetOptions.NoNaNsFPMath = 1;
-    targetOptions.NoTrappingFPMath = 1;
-    targetOptions.NoSignedZerosFPMath = 1;
-    targetOptions.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-  } else if (ffloatOpt == 0) {
-    // Target default floating point optimization
-    targetOptions.AllowFPOpFusion = llvm::FPOpFusion::Standard;
-  } else if (ffloatOpt == -1) {
-    // --ieee-float
-    // Should this set targetOptions.HonorSignDependentRoundingFPMathOption ?
-    // Allow fused multiply-adds
-    targetOptions.AllowFPOpFusion = llvm::FPOpFusion::Standard;
-  }
+  llvm::TargetOptions Options = getTargetOptions(ClangCodeGenOpts, ClangOpts);
 
   if (!fFastFlag)
-    targetOptions.EnableFastISel = 1;
+    Options.EnableFastISel = 1;
   else {
     // things to consider:
     // EnableIPRA  -- InterProcedural Register Allocation (IPRA).
@@ -1819,13 +1959,15 @@ static void setupModule()
   }
 
   llvm::Reloc::Model relocModel = llvm::Reloc::Model::Static;
+  // a reasonable alternative would be
+  // llvm::Reloc::Model RM = CodeGenOpts.RelocationModel;
 
   if (strcmp(CHPL_LIB_PIC, "pic") == 0) {
     relocModel = llvm::Reloc::Model::PIC_;
   }
 
   // Choose the code model
-  llvm::Optional<CodeModel::Model> codeModel = None;
+  llvm::Optional<CodeModel::Model> codeModel = getCodeModel(ClangCodeGenOpts);
 
   llvm::CodeGenOpt::Level optLevel =
     fFastFlag ? llvm::CodeGenOpt::Aggressive : llvm::CodeGenOpt::None;
@@ -1834,7 +1976,7 @@ static void setupModule()
   info->targetMachine = Target->createTargetMachine(Triple.str(),
                                                     cpu,
                                                     featuresString,
-                                                    targetOptions,
+                                                    Options,
                                                     relocModel,
                                                     codeModel,
                                                     optLevel);
@@ -1936,43 +2078,53 @@ static void registerRVPasses(const llvm::PassManagerBuilder &Builder,
 }
 #endif
 
+// This has code based on clang's EmitAssemblyHelper::CreatePasses
+// in BackendUtil.cpp.
 static
 void configurePMBuilder(PassManagerBuilder &PMBuilder, bool forFunctionPasses, int optLevel=-1) {
   ClangInfo* clangInfo = gGenInfo->clangInfo;
   INT_ASSERT(clangInfo);
-  clang::CodeGenOptions &opts = clangInfo->codegenOptions;
+  clang::CodeGenOptions &CodeGenOpts = clangInfo->codegenOptions;
 
   if (optLevel < 0)
-    optLevel = opts.OptimizationLevel;
+    optLevel = CodeGenOpts.OptimizationLevel;
 
   if( fFastFlag ) {
     // TODO -- remove this assert
-    INT_ASSERT(opts.OptimizationLevel >= 2);
+    INT_ASSERT(CodeGenOpts.OptimizationLevel >= 2);
   }
 
-  if (optLevel >= 1)
-    PMBuilder.Inliner = createFunctionInliningPass(optLevel,
-                                                   opts.OptimizeSize,
-                                                   /*DisableInlineHotCallsite*/
-                                                   false
-                                                  );
+  if (optLevel <= 1) {
+      bool InsertLifetimeIntrinsics = (CodeGenOpts.OptimizationLevel != 0 &&
+                                       !CodeGenOpts.DisableLifetimeMarkers);
+      // TODO: insert lifetime intrinics if Coroutines are used
+    PMBuilder.Inliner = createAlwaysInlinerLegacyPass(InsertLifetimeIntrinsics);
+  } else {
+    PMBuilder.Inliner = createFunctionInliningPass(
+        CodeGenOpts.OptimizationLevel, CodeGenOpts.OptimizeSize,
+        (!CodeGenOpts.SampleProfileFile.empty() &&
+         CodeGenOpts.PrepareForThinLTO));
+  }
 
   PMBuilder.OptLevel = optLevel;
-  PMBuilder.SizeLevel = opts.OptimizeSize;
-  PMBuilder.SLPVectorize = opts.VectorizeSLP;
-  PMBuilder.LoopVectorize = opts.VectorizeLoop;
+  PMBuilder.SizeLevel = CodeGenOpts.OptimizeSize;
+  PMBuilder.SLPVectorize = CodeGenOpts.VectorizeSLP;
+  PMBuilder.LoopVectorize = CodeGenOpts.VectorizeLoop;
+  PMBuilder.CallGraphProfile = !CodeGenOpts.DisableIntegratedAS;
 
-  PMBuilder.DisableUnrollLoops = !opts.UnrollLoops;
-  PMBuilder.MergeFunctions = opts.MergeFunctions;
+  PMBuilder.DisableUnrollLoops = !CodeGenOpts.UnrollLoops;
+  PMBuilder.LoopsInterleaved = CodeGenOpts.UnrollLoops;
+  PMBuilder.MergeFunctions = CodeGenOpts.MergeFunctions;
 #if HAVE_LLVM_VER > 60
-  PMBuilder.PrepareForThinLTO = opts.PrepareForThinLTO;
+  PMBuilder.PrepareForThinLTO = CodeGenOpts.PrepareForThinLTO;
 #else
-  PMBuilder.PrepareForThinLTO = opts.EmitSummaryIndex;
+  PMBuilder.PrepareForThinLTO = CodeGenOpts.EmitSummaryIndex;
 #endif
+  PMBuilder.PrepareForLTO = CodeGenOpts.PrepareForLTO;
+  PMBuilder.RerollLoops = CodeGenOpts.RerollLoops;
 
-  PMBuilder.PrepareForLTO = opts.PrepareForLTO;
-  PMBuilder.RerollLoops = opts.RerollLoops;
-
+  if (gGenInfo->targetMachine)
+    gGenInfo->targetMachine->adjustPassManager(PMBuilder);
 
   // Enable Region Vectorizer aka Outer Loop Vectorizer
 #ifdef HAVE_LLVM_RV


### PR DESCRIPTION
In looking at some LLVM performance details it occurred to me to compare how we set up the LLVM optimizations and how clang does it. This PR updates our code to better match clang. (Where if we discover cases we should be doing something different we certainly can). So far I have not noticed any performance impact from this change. However I would expect that this PR allows for more clang command line options (from `--ccflags` arguments) to work correctly.

- [x] full local testing
- [x] full local --fast testing
- [x] perf playground -- https://chapel-lang.org/perf/chapcs/llvm-config-clang  -- no significant performance change

Reviewed by @daviditen - thanks!