### PR TITLE
Have savec directory implicitly set if CHPL_LOCALE_MODEL=gpu.

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4715,6 +4715,7 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   // Generates a call to the `chpl_gpu_launch_kernel*` runtime functions.
   //
   // The primitive's arguments are
+  //   - fatbinPath (path to file containing ptx code for the function)
   //   - function name (c_string immediate) or symbol (FnSymbol)
   //   - grid size (1 arg or 3 args)
   //   - block size (1 arg or 3 args)
@@ -4730,7 +4731,7 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   //    will be similar to 1.
 
   // number of arguments that are not kernel params
-  int nNonKernelParamArgs = is3d ? 7:3;
+  int nNonKernelParamArgs = is3d ? 8:4;
   int nKernelParamArgs = call->numActuals() - nNonKernelParamArgs;
 
   const char* fn = is3d ? "chpl_gpu_launch_kernel":"chpl_gpu_launch_kernel_flat";
@@ -4739,7 +4740,10 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   int curArg = 1;
   for_actuals(actual, call) {
     Symbol* actualSym = toSymExpr(actual)->symbol();
-    if (curArg == 1) {  // function name or symbol
+    if (curArg == 1) {  // fatbin path
+        args.push_back(actual->codegen());
+    }
+    else if (curArg == 2) {  // function name or symbol
       if (FnSymbol* fn = toFnSymbol(actualSym)) {
         args.push_back(new_CStringSymbol(fn->cname));
       }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -34,6 +34,7 @@
 #include "llvmUtil.h"
 #include "LayeredValueTable.h"
 #include "mli.h"
+#include "misc.h"
 #include "mysystem.h"
 #include "passes.h"
 #include "stlUtil.h"
@@ -2371,11 +2372,6 @@ Type* getNamedTypeDuringCodegen(const char* name) {
   return NULL;
 }
 
-
-// Return true if the current locale model needs GPU code generation
-bool localeUsesGPU() {
-  return 0 == strcmp(CHPL_LOCALE_MODEL, "gpu");
-}
 
 // Do this once for CPU and GPU
 static void codegenPartOne() {

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -180,8 +180,6 @@ void gatherTypesForCodegen(void);
 
 void registerPrimitiveCodegens();
 
-bool localeUsesGPU();
-
 void closeCodegenFiles();
 
 #endif //CODEGEN_H

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -88,6 +88,7 @@ class BaseAST;
 bool        forceWidePtrsForLocal();
 bool        requireWideReferences();
 bool        requireOutlinedOn();
+bool        localeUsesGPU();
 
 const char* cleanFilename(const BaseAST* ast);
 const char* cleanFilename(const char*    name);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1503,11 +1503,11 @@ static void setPrintCppLineno() {
 }
 
 static void setSaveCForGpuCodegen() {
-  bool isGpuCodegen = !strcmp(CHPL_LOCALE_MODEL, "gpu");
+  bool isGpuCodegen = localeUsesGPU();
   bool isSaveCDirEmpty = strlen(saveCDir) == 0;
 
   if(isGpuCodegen && isSaveCDirEmpty) {
-    int len = snprintf(saveCDir, FILENAME_MAX+1, ".%s_files", executableFilename);
+    int len = snprintf(saveCDir, FILENAME_MAX+1, "%s_gpu_files", executableFilename);
     if(len < 0 || len >= FILENAME_MAX+1) {
       USR_FATAL("Unable to produce name of savec directory for GPU code generation.");
     }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1502,6 +1502,18 @@ static void setPrintCppLineno() {
   if (developer && !userSetCppLineno) printCppLineno = false;
 }
 
+static void setSaveCForGpuCodegen() {
+  bool isGpuCodegen = !strcmp(CHPL_LOCALE_MODEL, "gpu");
+  bool isSaveCDirEmpty = strlen(saveCDir) == 0;
+
+  if(isGpuCodegen && isSaveCDirEmpty) {
+    int len = snprintf(saveCDir, FILENAME_MAX+1, ".%s_files", executableFilename);
+    if(len < 0 || len >= FILENAME_MAX+1) {
+      USR_FATAL("Unable to produce name of savec directory for GPU code generation.");
+    }
+  }
+}
+
 static void checkLLVMCodeGen() {
 #ifdef HAVE_LLVM
   // LLVM does not currently work on 32-bit x86
@@ -1628,6 +1640,8 @@ static void postprocess_args() {
   checkLibraryPythonAndLibmode();
 
   setPrintCppLineno();
+
+  setSaveCForGpuCodegen();
 }
 
 

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -40,6 +40,7 @@
 #include <queue>
 #include <set>
 #include <algorithm>
+#include <cstdio>
 
 typedef std::set<BasicBlock*> BasicBlockSet;
 
@@ -675,6 +676,12 @@ static void generateEarlyReturn(OutlineInfo& info) {
 
 static  CallExpr* generateGPUCall(OutlineInfo& info, VarSymbol* numThreads) { 
   CallExpr* call = new CallExpr(PRIM_GPU_KERNEL_LAUNCH_FLAT);
+
+  char fatbinPath[FILENAME_MAX+1];
+  int len = snprintf(fatbinPath, FILENAME_MAX+1, "%s/%s", saveCDir, "chpl__gpu.fatbin");
+  INT_ASSERT(len > 0 && len < FILENAME_MAX+1);
+
+  call->insertAtTail(new_CStringSymbol(fatbinPath));
   call->insertAtTail(info.fn);
 
   call->insertAtTail(numThreads);  // total number of GPU threads

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -859,7 +859,7 @@ void deadCodeElimination() {
 
   // For now, we are doing GPU outlining here. In the future, it should probably
   // be its own pass.
-  if (strcmp(CHPL_LOCALE_MODEL, "gpu") == 0) {
+  if (localeUsesGPU()) {
     outlineGPUKernels();
   }
 

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -677,11 +677,6 @@ static void generateEarlyReturn(OutlineInfo& info) {
 static  CallExpr* generateGPUCall(OutlineInfo& info, VarSymbol* numThreads) { 
   CallExpr* call = new CallExpr(PRIM_GPU_KERNEL_LAUNCH_FLAT);
 
-  char fatbinPath[FILENAME_MAX+1];
-  int len = snprintf(fatbinPath, FILENAME_MAX+1, "%s/%s", saveCDir, "chpl__gpu.fatbin");
-  INT_ASSERT(len > 0 && len < FILENAME_MAX+1);
-
-  call->insertAtTail(new_CStringSymbol(fatbinPath));
   call->insertAtTail(info.fn);
 
   call->insertAtTail(numThreads);  // total number of GPU threads

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -102,6 +102,11 @@ bool requireOutlinedOn() {
   return requireWideReferences();
 }
 
+// Return true if the current locale model needs GPU code generation
+bool localeUsesGPU() {
+  return 0 == strcmp(CHPL_LOCALE_MODEL, "gpu");
+}
+
 const char* cleanFilename(const char* name) {
   static int  chplHomeLen = strlen(CHPL_HOME);
   const char* retval      = NULL;

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -27,15 +27,16 @@ extern "C" {
 
 #ifdef HAS_GPU_LOCALE
 
-void  chpl_gpu_init(void);
+void chpl_gpu_init(void);
 bool chpl_gpu_has_context(void);
 bool chpl_gpu_running_on_gpu_locale(void);
 
-void chpl_gpu_launch_kernel(const char* name,
+void chpl_gpu_launch_kernel(const char* fatbinPath, const char* name,
                             int grd_dim_x, int grd_dim_y, int grd_dim_z,
                             int blk_dim_x, int blk_dim_y, int blk_dim_z,
                             int nargs, ...);
-void chpl_gpu_launch_kernel_flat(const char* name, int num_threads, int blk_dim,
+void chpl_gpu_launch_kernel_flat(const char* fatbinPath, const char* name,
+                                 int num_threads, int blk_dim,
                                  int nargs, ...);
 
 void* chpl_gpu_mem_alloc(size_t size, chpl_mem_descInt_t description,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -117,6 +117,7 @@ static void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName) 
     }
     fclose (f);
   } else {
+    printf("Attempt to open file: %s\n", fatbinFile);
     chpl_internal_error("Unable to open fatbin file.");
   }
 
@@ -192,7 +193,7 @@ static void chpl_gpu_launch_kernel_help(const char* fatbinPath,
                nargs);
 
   int i;
-  void* function = chpl_gpu_getKernel("tmp/chpl__gpu.fatbin", name);
+  void* function = chpl_gpu_getKernel(fatbinPath, name);
   // TODO: this should use chpl_mem_alloc
   void*** kernel_params = chpl_malloc(nargs*sizeof(void**));
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -116,6 +116,8 @@ static void* chpl_gpu_getKernel(const char* fatbinFile, const char* kernelName) 
       fread (buffer, 1, length, f);
     }
     fclose (f);
+  } else {
+    chpl_internal_error("Unable to open fatbin file.");
   }
 
   // Create module for object
@@ -166,7 +168,8 @@ bool chpl_gpu_running_on_gpu_locale() {
   return chpl_gpu_has_context() && chpl_task_getRequestedSubloc()>0;
 }
 
-static void chpl_gpu_launch_kernel_help(const char* name,
+static void chpl_gpu_launch_kernel_help(const char* fatbinPath,
+                                        const char* name,
                                         int grd_dim_x,
                                         int grd_dim_y,
                                         int grd_dim_z,
@@ -177,10 +180,13 @@ static void chpl_gpu_launch_kernel_help(const char* name,
                                         va_list args) {
   chpl_gpu_ensure_context();
 
-  CHPL_GPU_LOG("Kernel launcher called.\
-               \n\tKernel: %s\n\tGrid: %d,%d,%d\n\t\
-               Block: %d,%d,%d\n\tNumArgs: %d\n",
-               name,
+  CHPL_GPU_LOG("Kernel launcher called.\n"
+               "\tFatBinPath: %s\n"
+               "\tKernel: %s\n"
+               "\tGrid: %d,%d,%d\n"
+               "\tBlock: %d,%d,%d\n"
+               "\tNumArgs: %d\n",
+               fatbinPath, name,
                grd_dim_x, grd_dim_y, grd_dim_z,
                blk_dim_x, blk_dim_y, blk_dim_z,
                nargs);
@@ -268,26 +274,26 @@ void chpl_gpu_copy_host_to_device(void* dst, void* src, size_t n) {
   CUDA_CALL(cuMemcpyHtoD((CUdeviceptr)dst, src, n));
 }
 
-void chpl_gpu_launch_kernel(const char* name,
+void chpl_gpu_launch_kernel(const char* fatbinPath, const char* name,
                             int grd_dim_x, int grd_dim_y, int grd_dim_z,
                             int blk_dim_x, int blk_dim_y, int blk_dim_z,
                             int nargs, ...) {
   va_list args;
   va_start(args, nargs);
-  chpl_gpu_launch_kernel_help(name,
+  chpl_gpu_launch_kernel_help(fatbinPath, name,
                               grd_dim_x, grd_dim_y, grd_dim_z,
                               blk_dim_x, blk_dim_y, blk_dim_z,
                               nargs, args);
   va_end(args);
 }
 
-void chpl_gpu_launch_kernel_flat(const char* name, int num_threads, int blk_dim,
-                                 int nargs, ...) {
+void chpl_gpu_launch_kernel_flat(const char* fatbinPath, const char* name,
+                                 int num_threads, int blk_dim, int nargs, ...) {
   int grd_dim = (num_threads+blk_dim-1)/blk_dim;
 
   va_list args;
   va_start(args, nargs);
-  chpl_gpu_launch_kernel_help(name,
+  chpl_gpu_launch_kernel_help(fatbinPath, name,
                               grd_dim, 1, 1,
                               blk_dim, 1, 1,
                               nargs, args);

--- a/test/gpu/native/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums.chpl
@@ -2,7 +2,7 @@ extern {
   #include <cuda.h>
   #include <assert.h>
 
-  #define FATBIN_FILE ".gpuAddNums_files/chpl__gpu.fatbin"
+  #define FATBIN_FILE "gpuAddNums_gpu_files/chpl__gpu.fatbin"
 
   static void checkCudaErrors(CUresult err) {
     assert(err == CUDA_SUCCESS);

--- a/test/gpu/native/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums.chpl
@@ -2,7 +2,7 @@ extern {
   #include <cuda.h>
   #include <assert.h>
 
-  #define FATBIN_FILE "tmp/chpl__gpu.fatbin"
+  #define FATBIN_FILE ".gpuAddNums_files/chpl__gpu.fatbin"
 
   static void checkCudaErrors(CUresult err) {
     assert(err == CUDA_SUCCESS);

--- a/test/gpu/native/gpuAddNums/gpuAddNums.compopts
+++ b/test/gpu/native/gpuAddNums/gpuAddNums.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda"
+echo "--ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda"

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
@@ -50,7 +50,7 @@ var output: real(64);
 var deviceBuffer = getDeviceBufferPointer();
 
 // arguments are: fatbin path, function name, grid size, block size, arguments
-__primitive("gpu kernel launch flat", c".gpuAddNums_primitive_files/chpl__gpu.fatbin", c"add_nums", 1, 1, deviceBuffer);
+__primitive("gpu kernel launch flat", c"add_nums", 1, 1, deviceBuffer);
 output = getDataFromDevice(deviceBuffer);
 
 writeln(output);

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
@@ -49,8 +49,8 @@ proc main() {
 var output: real(64);
 var deviceBuffer = getDeviceBufferPointer();
 
-// arguments are: function name, grid size, block size, arguments
-__primitive("gpu kernel launch flat", c"add_nums", 1, 1, deviceBuffer);
+// arguments are: fatbin path, function name, grid size, block size, arguments
+__primitive("gpu kernel launch flat", c".gpuAddNums_primitive_files/chpl__gpu.fatbin", c"add_nums", 1, 1, deviceBuffer);
 output = getDataFromDevice(deviceBuffer);
 
 writeln(output);

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.compopts
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda"
+echo "--ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda"

--- a/test/gpu/native/jacobi/jacobi.compopts
+++ b/test/gpu/native/jacobi/jacobi.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--no-checks --ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda --savec tmp"
+echo "--no-checks --ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda"

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.compopts
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda --llvm-print-ir-stage full --llvm-print-ir sample_kernel"
+echo "--ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda --llvm-print-ir-stage full --llvm-print-ir sample_kernel"

--- a/test/gpu/native/memory/COMPOPTS
+++ b/test/gpu/native/memory/COMPOPTS
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda --savec tmp"
+echo "--ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda"

--- a/test/gpu/native/streamPrototype/COMPOPTS
+++ b/test/gpu/native/streamPrototype/COMPOPTS
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--no-checks --ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda --savec tmp"
+echo "--no-checks --ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda"

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -105,8 +105,7 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
   writeln("Block size: ", bdimX, " x ", bdimY, " x ", bdimZ);
 
   var deviceBuffer = getDeviceBufferPointer(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ);
-  __primitive("gpu kernel launch",
-              c".threadBlockAndGridPrimitives_files/chpl__gpu.fatbin", c"add_nums",
+  __primitive("gpu kernel launch", c"add_nums",
               gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ,
               deviceBuffer);
   getAndPrintDataFromDevice(deviceBuffer, gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ);

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -105,7 +105,8 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
   writeln("Block size: ", bdimX, " x ", bdimY, " x ", bdimZ);
 
   var deviceBuffer = getDeviceBufferPointer(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ);
-  __primitive("gpu kernel launch", c"add_nums",
+  __primitive("gpu kernel launch",
+              c".threadBlockAndGridPrimitives_files/chpl__gpu.fatbin", c"add_nums",
               gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ,
               deviceBuffer);
   getAndPrintDataFromDevice(deviceBuffer, gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ);

--- a/test/gpu/native/threadBlockAndGridPrimitives.compopts
+++ b/test/gpu/native/threadBlockAndGridPrimitives.compopts
@@ -3,4 +3,4 @@
 nvccDir=$(which nvcc)
 nvccLib=${nvccDir%/bin/nvcc}/lib64
 
-echo "--ccflags --cuda-gpu-arch=sm_60 --savec=tmp -L$nvccLib -lcuda"
+echo "--ccflags --cuda-gpu-arch=sm_60 -L$nvccLib -lcuda"


### PR DESCRIPTION
To satisfy this issue: https://github.com/Cray/chapel-private/issues/2445

For our current implementation of GPU code generation we require --savec tmp to be passed. In this issue I will make it so this no longer has to be explicitly specified (rather it will implicitly occur if CHPL_LOCALE_MODEL=gpu).

Also rather than using the name "tmp" for the saveC directory I compute it to be the .execName_files where execName is the executable name we Chapel is configured to produce.