### PR TITLE
Fix issue with variable init from return intent overloads

### DIFF
--- a/test/functions/ferguson/ref-pair/issue-18205.chpl
+++ b/test/functions/ferguson/ref-pair/issue-18205.chpl
@@ -1,0 +1,60 @@
+record rec { var x = 0; }
+
+var gRec = new rec();
+
+proc makeRec(): rec {
+  writeln('proc makeRec(): rec');
+  return new rec();
+}
+
+proc makeRec() ref: rec {
+  writeln('proc makeRec() ref: rec');
+  return gRec;
+}
+
+proc makeRec() const ref: rec {
+  writeln('proc makeRec() const ref: rec');
+  return gRec;
+}
+
+proc makeRecVal() : rec {
+  writeln('proc makeRecVal(): rec');
+  return new rec();
+}
+
+proc test() {
+  writeln('T1: store in var');
+  var x1 = makeRec();
+  writeln();
+
+  writeln('T1a: store in var');
+  var x1a = makeRecVal();
+  writeln();
+
+  writeln('T2: store in ref');
+  ref x2 = makeRec();
+  writeln();
+
+  writeln('T3: store in const ref');
+  const ref x3 = makeRec();
+  writeln();
+
+  writeln('T4: store in const');
+  const x4 = makeRec();
+  writeln();
+
+  writeln('T5: call without assignment');
+  makeRec();
+  writeln();
+
+  writeln('T6: split-init store in var');
+  var x6: rec;
+  x6 = makeRec();
+  writeln();
+
+  writeln('T7: assign');
+  var x7: rec; x7; // force default init
+  x7 = makeRec();
+  writeln();
+}
+test();

--- a/test/functions/ferguson/ref-pair/issue-18205.good
+++ b/test/functions/ferguson/ref-pair/issue-18205.good
@@ -1,0 +1,24 @@
+T1: store in var
+proc makeRec(): rec
+
+T1a: store in var
+proc makeRecVal(): rec
+
+T2: store in ref
+proc makeRec() ref: rec
+
+T3: store in const ref
+proc makeRec() const ref: rec
+
+T4: store in const
+proc makeRec(): rec
+
+T5: call without assignment
+proc makeRec(): rec
+
+T6: split-init store in var
+proc makeRec(): rec
+
+T7: assign
+proc makeRec() const ref: rec
+

--- a/test/statements/manage/ContextManagerSyntax.good
+++ b/test/statements/manage/ContextManagerSyntax.good
@@ -43,7 +43,7 @@ deinit (ptr = {x = 5})
 
 T6: resource is explicitly var
 default-init (ptr = {x = 7})
-proc man.enterThis() const ref: res
+proc man.enterThis(): res
 doing something with resource
 leaving
 deinit (ptr = {x = 7})
@@ -64,7 +64,7 @@ deinit (ptr = {x = 9})
 
 T9: resource is explicitly var
 default-init (ptr = {x = 10})
-proc man.enterThis() const ref: res
+proc man.enterThis(): res
 doing something with resource
 leaving
 deinit (ptr = {x = 10})
@@ -85,7 +85,7 @@ deinit (ptr = {x = 12})
 
 T12: nested managers, mixed resource storage types
 default-init (ptr = {x = 13})
-proc man.enterThis() const ref: res
+proc man.enterThis(): res
 default-init (ptr = {x = 14})
 proc man.enterThis() ref: res
 default-init (ptr = {x = 15})
@@ -104,7 +104,7 @@ T13: nested managers, mixed resource storage types
 default-init (ptr = {x = 16})
 default-init (ptr = {x = 17})
 default-init (ptr = {x = 18})
-proc man.enterThis() const ref: res
+proc man.enterThis(): res
 proc man.enterThis() ref: res
 proc man.enterThis() const ref: res
 doing something with resource
@@ -119,7 +119,7 @@ deinit (ptr = {x = 16})
 
 T14: same manager nested, mixed resource storage types
 default-init (ptr = {x = 19})
-proc man.enterThis() const ref: res
+proc man.enterThis(): res
 proc man.enterThis() ref: res
 proc man.enterThis() const ref: res
 doing something with resource

--- a/test/statements/manage/OverloadedReturnIntent.good
+++ b/test/statements/manage/OverloadedReturnIntent.good
@@ -1,8 +1,8 @@
 default-init (ptr = {x = 0})
 
 T1: store in var
-proc makeR() const ref: r
-(ptr = {x = 1}), init= from (ptr = {x = 0})
+proc makeR(): r
+default-init (ptr = {x = 1})
 deinit (ptr = {x = 1})
 
 T2: store in ref
@@ -12,8 +12,8 @@ T3: store in const ref
 proc makeR() const ref: r
 
 T4: store in const
-proc makeR() const ref: r
-(ptr = {x = 2}), init= from (ptr = {x = 0})
+proc makeR(): r
+default-init (ptr = {x = 2})
 deinit (ptr = {x = 2})
 
 T5: call without assignment


### PR DESCRIPTION
Fixes #18205 

Adjusts resolveInitVar to handle the combination of `PRIM_INIT_VAR` and a ContextCallExpr RHS directly. It's necessary to do it here to avoid adding an `init=` call for a ref RHS. If the `init=` call is added, we will be relying on copy elision to remove the copy, but copy elision runs in the callDestructors pass after the return intent overloading has been handled in cullOverReferences. So, handling it immediately here in resolveInitVar addresses that ordering issue.

Adds a test based on the example in issue #18205.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing