### PR TITLE
Enable runtime GPU diagnostics with the existing --verbose flag

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -31,16 +31,14 @@
 #include <cuda_runtime.h>
 #include <assert.h>
 
-// #define CHPL_GPU_DEBUG  // TODO: adjust Makefile for this
-
 static void CHPL_GPU_LOG(const char *str, ...) {
-#ifdef CHPL_GPU_DEBUG
-  va_list args;
-  va_start(args, str);
-  vfprintf(stdout, str, args);
-  va_end(args);
-  fflush(stdout);
-#endif
+  if (verbosity >= 2) {
+    va_list args;
+    va_start(args, str);
+    vfprintf(stdout, str, args);
+    va_end(args);
+    fflush(stdout);
+  }
 }
 
 static void chpl_gpu_cuda_check(int err, const char* file, int line) {


### PR DESCRIPTION
Instead of using a macro at compile time, enable GPU diagnostics with the
existing flag '--verbose' or '-v'. This enables turning the GPU diagnostics
on and off with a flag at program launch time instead of needing to recompile
the runtime and user-program.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>