### PR TITLE
In string methods, use localThis when it it is available

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -548,13 +548,13 @@ module String {
 
   private proc validateEncoding(buf, len): int throws {
     extern proc chpl_enc_validate_buf(buf, len, ref numCodepoints) : c_int;
-    
+
     var numCodepoints: int;
-    
+
     if chpl_enc_validate_buf(buf, len, numCodepoints) != 0 {
       throw new DecodeError();
     }
-    
+
     return numCodepoints;
   }
 
@@ -875,7 +875,7 @@ module String {
         }
       }
     }
-    
+
     proc chpl__serialize() {
       var data : chpl__inPlaceBuffer;
       if buffLen <= CHPL_SHORT_STRING_SIZE {
@@ -884,7 +884,7 @@ module String {
       return new __serializeHelper(buffLen, buff, buffSize, locale_id, data,
                                    cachedNumCodepoints);
     }
-    
+
     proc type chpl__deserialize(data) {
       if data.locale_id != chpl_nodeID {
         if data.buffLen <= CHPL_SHORT_STRING_SIZE {
@@ -981,7 +981,7 @@ module String {
         i = j;
       }
     }
-    
+
     inline proc substring(i: int) {
       compilerError("substring removed: use string[index]");
     }
@@ -1213,7 +1213,7 @@ module String {
                                                  buffLen=result.buffLen,
                                                  offset=0,
                                                  allowEsc=false);
-      
+
       var upCodepoint = codepoint_toUpper(cp);
       if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
         // Use the MacOS approach everywhere:  only change the case if
@@ -1224,7 +1224,7 @@ module String {
     }
 
   } // end record string
-                                        
+
   /*
     :returns: The number of codepoints in the string.
   */
@@ -1254,7 +1254,7 @@ module String {
     }
     return n;
   }
-  
+
   /*
      Gets a version of the :mod:`string <String>` that is on the currently
      executing locale.
@@ -1298,12 +1298,12 @@ module String {
   inline proc string.c_str(): c_string {
     return getCStr(this);
   }
-  
+
   /*
     Returns a :mod:`bytes <Bytes>` from the given :mod:`string <String>`. If the
     string contains some escaped non-UTF8 bytes, `policy` argument determines
     the action.
-        
+
     :arg policy: `encodePolicy.pass` directly copies the (potentially escaped)
                   data, `encodePolicy.unescape` recovers the escaped bytes
                   back.
@@ -2107,7 +2107,7 @@ module String {
                 lowercase counterpart.
 
       .. note::
-        
+
         The case change operation is not currently performed on characters whose
         cases take different number of bytes to represent in Unicode mapping.
     */
@@ -2131,7 +2131,7 @@ module String {
                 uppercase counterpart.
 
       .. note::
-        
+
         The case change operation is not currently performed on characters whose
         cases take different number of bytes to represent in Unicode mapping.
     */

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -947,9 +947,9 @@ module String {
     */
     iter _cpIndexLen(start = 0:byteIndex) {
       const localThis = this.localize();
-      var i = _findStartOfNextCodepointFromByte(this, start);
+      var i = _findStartOfNextCodepointFromByte(localThis, start);
       while i < localThis.buffLen {
-        yield _cpIndexLenHelpNoAdjustment(i);  // this increments i
+        yield localThis._cpIndexLenHelpNoAdjustment(i);  // this increments i
       }
     }
 
@@ -1423,7 +1423,7 @@ module String {
     const localThis = this.localize();
     var i = 0;
     while i < localThis.buffLen {
-      yield _cpIndexLenHelpNoAdjustment(i)[0];  // this increments i
+      yield localThis._cpIndexLenHelpNoAdjustment(i)[0];  // this increments i
     }
   }
 


### PR DESCRIPTION
In PR #18323, I noticed that `var localThis = this.localize()` was being called redundantly in several code paths and that made adjustments to avoid a redundant call.

However, it turns out that several method calls were made to `this` instead of `localThis` which caused failures with the tests `utf8_values.chpl` and `utf8_misc.chpl`.
    
This PR:
 * fixes the two failing cases to use the 'localThis' that was computed rather than 'this'.
 * adds checking for this class of error
 * adjusts a few other cases to use 'localThis' instead of 'this' when available

Reviewed by @e-kayrakli - thanks!

- [x] full local testing
- [x] gasnet testing
- [x] test/multilocale/strings passes with gasnet