### PR TITLE
Allow user-defined hash functions on user-defined records

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1596,16 +1596,20 @@ static void checkNotPod(AggregateType* at) {
 ************************************** | *************************************/
 
 static void buildRecordHashFunction(AggregateType *ct) {
-  if (functionExists("chpl__defaultHash", ct))
+  if (functionExists("hashThis", dtMethodToken, ct))
     return;
 
-  FnSymbol *fn = new FnSymbol("chpl__defaultHash");
+  FnSymbol *fn = new FnSymbol("hashThis");
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
-  ArgSymbol *arg = new ArgSymbol(INTENT_BLANK, "r", ct);
+  ArgSymbol *arg = new ArgSymbol(INTENT_BLANK, "this", ct);
+  arg->addFlag(FLAG_ARG_THIS);
   arg->addFlag(FLAG_MARKED_GENERIC);
+  fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
   fn->insertFormalAtTail(arg);
-
+  fn->_this = arg;
+  fn->setMethod(true);
+  
   if (ct->fields.length == 0) {
     fn->insertAtTail(new CallExpr(PRIM_RETURN, new_UIntSymbol(0)));
     fn->addFlag(FLAG_INLINE);
@@ -1621,11 +1625,11 @@ static void buildRecordHashFunction(AggregateType *ct) {
             field->hasFlag(FLAG_PARAM))) {
         CallExpr *field_access = new CallExpr(field->name, gMethodToken, arg);
         if (first) {
-          call = new CallExpr("chpl__defaultHash", field_access);
+          call = new CallExpr("hashThis", gMethodToken, field_access);
           first = false;
         } else {
           call = new CallExpr("chpl__defaultHashCombine",
-                              new CallExpr("chpl__defaultHash", field_access),
+                              new CallExpr("hashThis", gMethodToken, field_access),
                               call,
                               new_IntSymbol(i));
         }

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -441,13 +441,17 @@ getTupleArgAndType(FnSymbol* fn, ArgSymbol*& arg, AggregateType*& ct) {
   // Adjust any formals for blank-intent tuple behavior now
   resolveSignature(fn);
 
+  int methodToken = 0;
+  if (fn->getFormal(1)->type == dtMethodToken)
+    methodToken = 1;
+  
   if (fn->name == astr_initCopy || fn->name == astr_autoCopy) {
     INT_ASSERT(fn->numFormals() == 2); // expected of the original function
   }
   else {
-    INT_ASSERT(fn->numFormals() == 1); // expected of the original function
+    INT_ASSERT(fn->numFormals() - methodToken == 1); // expected of the original function
   }
-  arg = fn->getFormal(1);
+  arg = fn->getFormal(1 + methodToken);
   ct = toAggregateType(arg->type);
   if (isReferenceType(ct))
     ct = toAggregateType(ct->getValType());
@@ -466,11 +470,11 @@ instantiate_tuple_hash( FnSymbol* fn) {
   for (int i=0; i<ct->fields.length-1; i++) {
     CallExpr *field_access = new CallExpr( arg, new_IntSymbol(i));
     if (first) {
-      call =  new CallExpr( "chpl__defaultHash", field_access);
+      call =  new CallExpr( "hashThis", gMethodToken, field_access);
       first = false;
     } else {
       call = new CallExpr( "chpl__defaultHashCombine",
-                           new CallExpr( "chpl__defaultHash", field_access),
+                           new CallExpr( "hashThis", gMethodToken, field_access),
                            call,
                            new_IntSymbol(i) );
     }
@@ -1073,8 +1077,9 @@ fixupTupleFunctions(FnSymbol* fn,
     return true;
   }
 
-  if (strcmp(fn->name, "chpl__defaultHash") == 0 &&
-      fn->getFormal(1)->type->symbol->hasFlag(FLAG_TUPLE)) {
+  if (strcmp(fn->name, "hashThis") == 0 &&
+      fn->_this != nullptr &&
+      fn->_this->type->symbol->hasFlag(FLAG_TUPLE)) {
     instantiate_tuple_hash(newFn);
     return true;
   }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1191,8 +1191,8 @@ module Bytes {
   //
 
   pragma "no doc"
-  inline proc chpl__defaultHash(x : bytes): uint {
-    return getHash(x);
+  inline proc bytes.hashThis(): uint {
+    return getHash(this);
   }
 
 } // end of module Bytes

--- a/modules/internal/ChapelHashing.chpl
+++ b/modules/internal/ChapelHashing.chpl
@@ -20,13 +20,13 @@
 
 // ChapelHashing.chpl
 //
-// chpl__defaultHash and related functions
+// hashThis and related functions
 module ChapelHashing {
 
   use ChapelBase;
 
   proc chpl__defaultHashWrapper(x): int {
-    const hash = chpl__defaultHash(x);
+    const hash = x.hashThis();
     return (hash & max(int)): int;
   }
 
@@ -58,73 +58,73 @@ module ChapelHashing {
     return _gen_key(a ^ chpl_bitops_rotl_64(b, n));
   }
 
-  inline proc chpl__defaultHash(b: bool): uint {
-    if (b) then
+  inline proc bool.hashThis(): uint {
+    if (this) then
       return 0;
     else
       return 1;
   }
 
-  inline proc chpl__defaultHash(i: int(64)): uint {
-    return _gen_key(i);
+  inline proc int.hashThis(): uint {
+    return _gen_key(this);
   }
 
-  inline proc chpl__defaultHash(u: uint(64)): uint {
-    return _gen_key(u);
+  inline proc uint.hashThis(): uint {
+    return _gen_key(this);
   }
 
-  inline proc chpl__defaultHash(e) where isEnum(e) {
-    return _gen_key(chpl__enumToOrder(e));
+  inline proc enum.hashThis(): uint {
+    return _gen_key(chpl__enumToOrder(this));
   }
 
-  inline proc chpl__defaultHash(f: real): uint {
-    return _gen_key(__primitive( "real2int", f));
+  inline proc real.hashThis(): uint {
+    return _gen_key(__primitive( "real2int", this));
   }
 
-  inline proc chpl__defaultHash(c: complex): uint {
-    return _gen_key(__primitive("real2int", c.re) ^ __primitive("real2int", c.im));
+  inline proc complex.hashThis(): uint {
+    return _gen_key(__primitive("real2int", this.re) ^ __primitive("real2int", this.im));
   }
 
-  inline proc chpl__defaultHash(a: imag): uint {
-    return _gen_key(__primitive( "real2int", _i2r(a)));
+  inline proc imag.hashThis(): uint {
+    return _gen_key(__primitive( "real2int", _i2r(this)));
   }
 
-  inline proc chpl__defaultHash(u: chpl_taskID_t): uint {
-    return _gen_key(u:int(64));
+  inline proc chpl_taskID_t.hashThis(): uint {
+    return _gen_key(this:int);
   }
 
-  inline proc chpl__defaultHash(l : []): uint {
+  inline proc _array.hashThis(): uint {
     var hash : uint = 0;
     var i = 1;
-    for obj in l {
-      hash = chpl__defaultHashCombine(chpl__defaultHash(obj), hash, i);
+    for obj in this {
+      hash = chpl__defaultHashCombine(obj.hashThis(), hash, i);
       i += 1;
     }
     return hash;
   }
 
   // Nilable and non-nilable classes will coerce to this.
-  inline proc chpl__defaultHash(o: borrowed object?): uint {
-    return _gen_key(__primitive( "object2int", o));
+  inline proc (borrowed object?).hashThis(): uint {
+    return _gen_key(__primitive( "object2int", this));
   }
 
-  inline proc chpl__defaultHash(l: locale): uint {
-    return _gen_key(__primitive( "object2int", l._value));
+  inline proc locale.hashThis(): uint {
+    return _gen_key(__primitive( "object2int", this._value));
   }
 
   //
-  // Implementation of chpl__defaultHash for ranges, in case the 'keyType'
+  // Implementation of hashThis for ranges, in case the 'keyType'
   // contains a range in some way (e.g. tuple of ranges).
   //
-  inline proc chpl__defaultHash(r : range): uint {
+  inline proc range.hashThis(): uint {
     use Reflection;
     var ret : uint;
-    for param i in 1..numImplementationFields(r.type) {
-      if isParam(getImplementationField(r, i)) == false &&
-         isType(getImplementationField(r, i)) == false &&
-         isNothingType(getImplementationField(r, i).type) == false {
-        const ref field = getImplementationField(r, i);
-        const fieldHash = chpl__defaultHash(field);
+    for param i in 1..numImplementationFields(this.type) {
+      if isParam(getImplementationField(this, i)) == false &&
+         isType(getImplementationField(this, i)) == false &&
+         isNothingType(getImplementationField(this, i).type) == false {
+        const ref field = getImplementationField(this, i);
+        const fieldHash = field.hashThis();
         if i == 1 then
           ret = fieldHash;
         else
@@ -135,13 +135,13 @@ module ChapelHashing {
   }
 
   // Is 'idxType' legal to create a default associative domain with?
-  // Currently based on the availability of chpl__defaultHash().
+  // Currently based on the availability of hashThis().
   // Enumerated and sparse domains are handled separately.
   // Tuples and records also work, somehow.
   proc chpl__validDefaultAssocDomIdxType(type idxType) param return false;
 
   proc chpl__validDefaultAssocDomIdxType(type idxType) param where
-      // one check per an implementation of chpl__defaultHash() above
+      // one check per an implementation of hashThis() above
       isBoolType(idxType)     ||
       isIntType(idxType)      ||
       isUintType(idxType)    ||

--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -25,7 +25,7 @@
 //
 // chpl_TableEntry is the type for each hashtable slot
 // chpl__hashtable is the record implementing a hashtable
-// chpl__defaultHash is the default hash function for most types
+// hashThis is the default hash method for most types
 pragma "unsafe"
 module ChapelHashtable {
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2516,7 +2516,7 @@ module String {
   //
 
   pragma "no doc"
-  inline proc chpl__defaultHash(x : string): uint {
-    return getHash(x);
+  inline proc string.hashThis(): uint {
+    return getHash(this);
   }
 }

--- a/test/associative/ferguson/check-hashing-statistics.chpl
+++ b/test/associative/ferguson/check-hashing-statistics.chpl
@@ -55,7 +55,7 @@ proc doHash(x:int) {
   if useSHA {
     return sha256hash(x:uint);
   } else {
-    return chpl__defaultHash(x);
+    return x.hashThis();
   }
 }
 
@@ -167,7 +167,7 @@ proc runTest() {
     triples[shrink(j), shrink(k), shrink(l)] += 1;
   }
 
-  check("chpl__defaultHash of 1..N", counts0);
+  check("hashThis of 1..N", counts0);
 
   check("hash top " + topBits:string + " bits", topCounts,    true);
   check("hash bottom " + botBits:string + " bits", botCounts, true);

--- a/test/associative/waynew/record_hash.chpl
+++ b/test/associative/waynew/record_hash.chpl
@@ -17,12 +17,12 @@ var r6 = new R(1, 0, 1);
 writeln( r6);
 
 
-var h1 = chpl__defaultHash(r1);
-var h2 = chpl__defaultHash(r2);
-var h3 = chpl__defaultHash(r3);
-var h4 = chpl__defaultHash(r4);
-var h5 = chpl__defaultHash(r5);
-var h6 = chpl__defaultHash(r6);
+var h1 = r1.hashThis();
+var h2 = r2.hashThis();
+var h3 = r3.hashThis();
+var h4 = r4.hashThis();
+var h5 = r5.hashThis();
+var h6 = r6.hashThis();
 
 
 if (h1==h2 || h1==h3 || h1==h4 || h1==h5 || h1==h6 ||

--- a/test/constrained-generics/hashtable/test-chpl-hashtable.chpl
+++ b/test/constrained-generics/hashtable/test-chpl-hashtable.chpl
@@ -94,9 +94,9 @@ operator R.=(ref lhs:R, rhs:R) {
 operator R.==(const ref lhs: R, const ref rhs: R) {
   return lhs.x == rhs.x && lhs.ptr.xx == rhs.ptr.xx;
 }
-proc chpl__defaultHash(o: R) {
-  return chpl__defaultHashCombine(chpl__defaultHash(o.x),
-                                  chpl__defaultHash(o.ptr.xx),
+proc R.hashThis() {
+  return chpl__defaultHashCombine(this.x.hashThis(),
+                                  this.ptr.xx.hashThis(),
                                   1);
 }
 

--- a/test/library/standard/Set/setRecordEqualityOverload.chpl
+++ b/test/library/standard/Set/setRecordEqualityOverload.chpl
@@ -13,8 +13,8 @@ record r {
 // There isn't a public interface for this yet, but we need to override the
 // hash function for 'r' in order to avoid hashing on the address contained
 // in 'c', which will vary from instance to instance.
-proc chpl__defaultHash(x: r) {
-  return chpl__defaultHash(x.c.x);
+proc r.hashThis() {
+  return this.c.x.hashThis();
 }
 
 operator r.==(lhs: r, rhs: r) {

--- a/test/types/chplhashtable/test-chpl-hashtable.chpl
+++ b/test/types/chplhashtable/test-chpl-hashtable.chpl
@@ -86,9 +86,9 @@ operator R.=(ref lhs:R, rhs:R) {
 operator R.==(const ref lhs: R, const ref rhs: R) {
   return lhs.x == rhs.x && lhs.ptr.xx == rhs.ptr.xx;
 }
-proc chpl__defaultHash(o: R) {
-  return chpl__defaultHashCombine(chpl__defaultHash(o.x),
-                                  chpl__defaultHash(o.ptr.xx),
+proc R.hashThis() {
+  return chpl__defaultHashCombine(this.x.hashThis(),
+                                  this.ptr.xx.hashThis(),
                                   1);
 }
 


### PR DESCRIPTION
This PR renames `chpl__defaultHash()` to `hashThis()` (still deciding on name) and changes it to a method rather than a function. Users can create records that allow users to define `type.hashThis()` in their record, and that will get used by the internal hash table (e.g., map, associative arrays, etc.). 

- [x] standard paratest
- [ ] testing added

Motivated by https://github.com/cray/chapel-private/issues/2365
Discussion issue: https://github.com/chapel-lang/chapel/issues/18291