### PR TITLE
Stop disabling libnuma for hwloc builds

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -29,12 +29,6 @@ ifdef CHPL_HWLOC_PREFIX
    CHPL_HWLOC_CFG_OPTIONS += --with-hwloc-symbol-prefix=$(CHPL_HWLOC_PREFIX)
 endif
 
-# Libnuma requires dynamic linking, so for the flat locale model where
-# we have no need for NUMA info, disable it so we can link statically.
-ifeq ($(CHPL_MAKE_LOCALE_MODEL),flat)
-CHPL_HWLOC_CFG_OPTIONS += --disable-libnuma
-endif
-
 ifeq ($(CHPL_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif


### PR DESCRIPTION
hwloc uses libnuma for the memory binding API so without libnuma hwloc
can't support operations like `hwloc_set_area_membind`. Some upcoming
improvements for #18286 and longer term Cray/chapel-private#1816 want to
use use the memory binding API, so I'm enabling autodetection of libnuma
here to see if there's any fallout from including it. We originally
disabled libnuma in #2921 to avoid some build failure on Crays, but this
was back when Cray machines defaulted to static linking and libnuma is
only available as a shared library. I suspect this won't cause any
issues now, but want to test it ahead of the PRs that will require it.