### PR TITLE
Add an option to interleave large allocations for gasnet-ibv-large

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1147,6 +1147,7 @@ static void genConfigGlobalsAndAbout() {
 
   genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks, false);
   genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote, false);
+  genGlobalInt("CHPL_INTERLEAVE_MEM", fEnableMemInterleaving, false);
 
   for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
     if (env->first != "CHPL_HOME") {

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -54,6 +54,7 @@ extern bool fNoCastChecks;
 extern bool fNoDivZeroChecks;
 extern bool fMungeUserIdents;
 extern bool fEnableTaskTracking;
+extern bool fEnableMemInterleaving;
 extern bool fLLVMWideOpt;
 
 extern bool fAutoLocalAccess;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -162,6 +162,7 @@ bool fUserSetStackChecks = false;
 bool fNoCastChecks = false;
 bool fMungeUserIdents = true;
 bool fEnableTaskTracking = false;
+bool fEnableMemInterleaving = false;
 
 bool fAutoLocalAccess = true;
 bool fDynamicAutoLocalAccess = true;
@@ -1148,6 +1149,7 @@ static ArgumentDescription arg_desc[] = {
  {"overload-sets-checks", ' ', NULL, "Report potentially hijacked calls", "N", &fOverloadSetsChecks, NULL, NULL},
  {"compile-time-nil-checking", ' ', NULL, "Enable [disable] compile-time nil checking", "N", &fCompileTimeNilChecking, "CHPL_NO_COMPILE_TIME_NIL_CHECKS", NULL},
  {"infer-implements-decls", ' ', NULL, "Enable [disable] inference of implements-declarations", "N", &fInferImplementsStmts, "CHPL_INFER_IMPLEMENTS_DECLS", NULL},
+ {"interleave-memory", ' ', NULL, "Enable [disable] memory interleaving", "N", &fEnableMemInterleaving, "CHPL_INTERLEAVE_MEMORY", NULL},
  {"ignore-errors", ' ', NULL, "[Don't] attempt to ignore errors", "N", &ignore_errors, "CHPL_IGNORE_ERRORS", NULL},
  {"ignore-user-errors", ' ', NULL, "[Don't] attempt to ignore user errors", "N", &ignore_user_errors, "CHPL_IGNORE_USER_ERRORS", NULL},
  {"ignore-errors-for-pass", ' ', NULL, "[Don't] attempt to ignore errors until the end of the pass in which they occur", "N", &ignore_errors_for_pass, "CHPL_IGNORE_ERRORS_FOR_PASS", NULL},

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -66,6 +66,13 @@ void chpl_topo_setThreadLocality(c_sublocid_t);
 c_sublocid_t chpl_topo_getThreadLocality(void);
 
 //
+// Set the locality of a block of memory to interleave (round-robin) between
+// NUMA domains. This may only set the policy and does not necessarily fault
+// memory in
+//
+void chpl_topo_interleaveMemLocality (void*, size_t);
+
+//
 // set the locality of a block of memory, to a specific NUMA domain
 //
 // args:

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -76,6 +76,7 @@ extern const char* CHPL_RUNTIME_INCL;
 extern const char* CHPL_THIRD_PARTY;
 extern const int CHPL_STACK_CHECKS;
 extern const int CHPL_CACHE_REMOTE;
+extern const int CHPL_INTERLEAVE_MEM;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error
 // messages and logging. Defined in chpl_compilation_config.c (needed by launchers)

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -30,9 +30,15 @@
 #include "chpl-linefile-support.h"
 #include "chpl-mem.h"
 #include "chpl-mem-desc.h"
+#include "chpl-topo.h"
+#include "chplcgfns.h"
 #include "chplmemtrack.h"
 #include "chpltypes.h"
 #include "error.h"
+
+// The dedicated arena to use for large allocations (this is important to
+// minimize contention for large allocations)
+unsigned CHPL_JE_LG_ARENA;
 
 // Decide whether or not to try to use jemalloc's chunk hooks interface
 //   jemalloc < 4.0 didn't support chunk_hooks_t
@@ -118,6 +124,10 @@ static void* chunk_alloc(void *chunk, size_t size, size_t alignment, bool *zero,
 
     // now that cur_heap_offset is updated, we can unlock
     pthread_mutex_unlock(&heap.alloc_lock);
+
+    if (CHPL_INTERLEAVE_MEM && arena_ind == CHPL_JE_LG_ARENA) {
+      chpl_topo_interleaveMemLocality(cur_chunk_base, size);
+    }
   } else if (heap.type == DYNAMIC) {
     // jemalloc 4.5.0 man: "If chunk is not NULL, the returned pointer must be
     // chunk on success or NULL on error". This is used to grab new chunks in a
@@ -382,14 +392,11 @@ static void initializeSharedHeap(void) {
   useUpMemNotInHeap();
 }
 
-
-// The dedicated arena to use for large allocations (this is important to
-// minimize contention for large allocations)
-unsigned CHPL_JE_LG_ARENA;
-
 void chpl_mem_layerInit(void) {
   void* heap_base;
   size_t heap_size;
+
+  CHPL_JE_LG_ARENA = get_num_arenas()-1;
 
   chpl_comm_regMemHeapInfo(&heap_base, &heap_size);
   if (heap_base != NULL && heap_size == 0) {
@@ -423,7 +430,6 @@ void chpl_mem_layerInit(void) {
     }
     CHPL_JE_DALLOCX(p, MALLOCX_NO_FLAGS);
   }
-  CHPL_JE_LG_ARENA = get_num_arenas()-1;
 }
 
 

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -517,6 +517,27 @@ void alignAddrSize(void* p, size_t size, chpl_bool onlyInside,
 }
 
 
+void chpl_topo_interleaveMemLocality(void* p, size_t size) {
+  int flags;
+
+  if (!haveTopology) {
+    return;
+  }
+
+  if (!topoSupport->membind->set_area_membind) {
+    return;
+  }
+
+  hwloc_bitmap_t set;
+  hwloc_obj_t obj;
+  obj = hwloc_get_root_obj(topology);
+  set = hwloc_bitmap_dup(obj->cpuset);
+
+  flags = HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT;
+  CHK_ERR_ERRNO(hwloc_set_area_membind(topology, p, size, set, HWLOC_MEMBIND_INTERLEAVE, flags) == 0);
+}
+
+
 //
 // p must be page aligned and the page size must evenly divide size
 //

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -64,6 +64,7 @@ c_sublocid_t chpl_topo_getThreadLocality(void) {
   return c_sublocid_any;
 }
 
+void chpl_topo_interleaveMemLocality(void* p, size_t size) { }
 
 void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
                               c_sublocid_t subloc) { }

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -98,6 +98,7 @@ _chpl ()
 --inline-iterators \
 --inline-iterators-yield-limit \
 --instantiate-max \
+--interleave-memory \
 --interprocedural-alias-analysis \
 --launcher \
 --ldflags \
@@ -186,6 +187,7 @@ _chpl ()
 --no-infer-local-fields \
 --no-inline \
 --no-inline-iterators \
+--no-interleave-memory \
 --no-interprocedural-alias-analysis \
 --no-library-ml-debug \
 --no-lifetime-checking \


### PR DESCRIPTION
Add a compiler option `--interleave-memory` that will result in
interleaving large allocations under gasnet-ibv segment large. #18299
reduced memory fragmentation for configurations that use a fixed heap
but it hurt the NUMA affinity for configurations that use a fixed heap
but still rely on first-touch to set NUMA affinity (which I think is
just gasnet-ibv-large.) As a stopgap to reduce the performance impact
for that, this adds an option to interleave pages (round robin affinity
between NUMA domains.) This limits peak performance for NUMA sensitive
applications, but also significantly reduces the worst-case performance
impact. For traditional HPC applications that just allocate a few large
arrays the old first-touch behavior is better so make this feature
opt-in instead of enabling it by default.

Longer term I think we want to separately allocate large arrays and
completely return them to the system so we can get fresh NUMA affinity
(this is what we do for ugni). In the short-term this provides a way to
limit the performance impact from memory reuse that was caused by
reducing fragmentation for applications like Arkouda that do lots of
varying sized dynamic allocations.

Currently, this is a developer compiler flag. It's a developer option
since we view this as a short term workaround until we can do separate
allocations or something else, and it's a compiler flag so that it's
easier for applications to detect if the current chapel compiler/build
supports this option by inspecting the output of `chpl --devel --help`.

Note that we're only interleaving large allocations. Small allocations
(task tasks, aggregation buffers) still have first-touch semantics,
which should result in better NUMA affinity for these types of data
structures.

Performance results for Arkouda numeric operations (GiB/s):

| config            | argsort | 2-coarg | 2-groupby | gather | scatter | reduce  |
| ----------------- | ------: | ------: | --------: | -----: | ------: | ------: |
| original          | 10.86   | 8.93    | 5.67      | 124.93 | 150.27  | 3377.73 |
| fragmentation fix | 10.45   | 8.35    | 4.54      | 113.62 | 132.85  | 1978.72 |
| interleave alloc  | 10.02   | 8.83    | 5.56      | 124.54 | 128.07  | 2061.52 |

Part of #18286