### PR TITLE
Change subprocess.exit_status to subprocess.exitCode

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -213,7 +213,7 @@ module Spawn {
     var running:bool;
     /* The exit status from the subprocess, or possibly a value >= 256
        if there was en error when creating the subprocess */
-    var exit_status:int;
+    var exitCodeUNIQUE:int;
 
     // the channels
     // TODO -- these could be private to this module
@@ -259,6 +259,12 @@ module Spawn {
         try ioerror(spawn_error,
                     "encountered when launching subprocess");
       }
+    }
+
+    pragma "no doc"
+    proc exit_status ref {
+      compilerWarning("subprocess.exit_status is deprecated. Use subprocess.exitCodeUNIQUE instead.");
+      return exitCodeUNIQUE;
     }
 
     /*
@@ -523,11 +529,11 @@ module Spawn {
                              inputfd=stdin_fd,
                              outputfd=stdout_fd,
                              errorfd=stderr_fd,
-                             running=true, exit_status=256);
+                             running=true, exitCodeUNIQUE=256);
 
     if err {
       ret.running = false;
-      ret.exit_status = 257;
+      ret.exitCodeUNIQUE = 257;
       ret.spawn_error = err;
       return ret;
     }
@@ -686,7 +692,7 @@ module Spawn {
       err = qio_waitpid(pid, 0, done, exitcode);
       if done {
         this.running = false;
-        this.exit_status = exitcode;
+        this.exitCodeUNIQUE = exitcode;
       }
     }
     if err then try ioerror(err, "in subprocess.poll");
@@ -708,7 +714,7 @@ module Spawn {
   /*
     Wait for a child process to complete. After this function
     returns, :attr:`~subprocess.running` is `false` and
-    :attr:`~subprocess.exit_status` stores the exit code returned
+    :attr:`~subprocess.exitCodeUNIQUE` stores the exit code returned
     by the subprocess.
 
     If `buffer` is `true`, then this call will handle cases in which
@@ -772,7 +778,7 @@ module Spawn {
       wait_err = qio_waitpid(pid, 1, done, exitcode);
       if done {
         this.running = false;
-        this.exit_status = exitcode;
+        this.exitCodeUNIQUE = exitcode;
       }
 
       // If these channels are to stay open, use buffer=true or communicate.
@@ -827,7 +833,7 @@ module Spawn {
 
     Wait for a child process to complete. After this function
     returns, :attr:`~subprocess.running` is `false` and
-    :attr:`~subprocess.exit_status` stores the exit code returned
+    :attr:`~subprocess.exitCodeUNIQUE` stores the exit code returned
     by the subprocess.
 
     This function handles cases in which stdin, stdout, or stderr
@@ -868,7 +874,7 @@ module Spawn {
     err = qio_waitpid(pid, 1, done, exitcode);
     if done {
       this.running = false;
-      this.exit_status = exitcode;
+      this.exitCodeUNIQUE = exitcode;
     }
     if err then try ioerror(err, "in subprocess.communicate");
   }

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -213,7 +213,7 @@ module Spawn {
     var running:bool;
     /* The exit status from the subprocess, or possibly a value >= 256
        if there was en error when creating the subprocess */
-    var exitCodeUNIQUE:int;
+    var exitCode:int;
 
     // the channels
     // TODO -- these could be private to this module
@@ -263,8 +263,8 @@ module Spawn {
 
     pragma "no doc"
     proc exit_status ref {
-      compilerWarning("subprocess.exit_status is deprecated. Use subprocess.exitCodeUNIQUE instead.");
-      return exitCodeUNIQUE;
+      compilerWarning("subprocess.exit_status is deprecated. Use subprocess.exitCode instead.");
+      return exitCode;
     }
 
     /*
@@ -529,11 +529,11 @@ module Spawn {
                              inputfd=stdin_fd,
                              outputfd=stdout_fd,
                              errorfd=stderr_fd,
-                             running=true, exitCodeUNIQUE=256);
+                             running=true, exitCode=256);
 
     if err {
       ret.running = false;
-      ret.exitCodeUNIQUE = 257;
+      ret.exitCode = 257;
       ret.spawn_error = err;
       return ret;
     }
@@ -692,7 +692,7 @@ module Spawn {
       err = qio_waitpid(pid, 0, done, exitcode);
       if done {
         this.running = false;
-        this.exitCodeUNIQUE = exitcode;
+        this.exitCode = exitcode;
       }
     }
     if err then try ioerror(err, "in subprocess.poll");
@@ -714,7 +714,7 @@ module Spawn {
   /*
     Wait for a child process to complete. After this function
     returns, :attr:`~subprocess.running` is `false` and
-    :attr:`~subprocess.exitCodeUNIQUE` stores the exit code returned
+    :attr:`~subprocess.exitCode` stores the exit code returned
     by the subprocess.
 
     If `buffer` is `true`, then this call will handle cases in which
@@ -778,7 +778,7 @@ module Spawn {
       wait_err = qio_waitpid(pid, 1, done, exitcode);
       if done {
         this.running = false;
-        this.exitCodeUNIQUE = exitcode;
+        this.exitCode = exitcode;
       }
 
       // If these channels are to stay open, use buffer=true or communicate.
@@ -833,7 +833,7 @@ module Spawn {
 
     Wait for a child process to complete. After this function
     returns, :attr:`~subprocess.running` is `false` and
-    :attr:`~subprocess.exitCodeUNIQUE` stores the exit code returned
+    :attr:`~subprocess.exitCode` stores the exit code returned
     by the subprocess.
 
     This function handles cases in which stdin, stdout, or stderr
@@ -874,7 +874,7 @@ module Spawn {
     err = qio_waitpid(pid, 1, done, exitcode);
     if done {
       this.running = false;
-      this.exitCodeUNIQUE = exitcode;
+      this.exitCode = exitcode;
     }
     if err then try ioerror(err, "in subprocess.communicate");
   }

--- a/test/c2chapel/c2chapel-tester.chpl
+++ b/test/c2chapel/c2chapel-tester.chpl
@@ -4,7 +4,7 @@ var testdir = CHPL_HOME + "/tools/c2chapel/test/";
 var command = "cd %s; ./tester.sh".format(testdir);
 var sub = Spawn.spawnshell(command);
 sub.communicate();
-if sub.exitCodeUNIQUE==0 then
+if sub.exitCode==0 then
   writeln("OK");
 else
   writeln("Test Failure");

--- a/test/c2chapel/c2chapel-tester.chpl
+++ b/test/c2chapel/c2chapel-tester.chpl
@@ -4,7 +4,7 @@ var testdir = CHPL_HOME + "/tools/c2chapel/test/";
 var command = "cd %s; ./tester.sh".format(testdir);
 var sub = Spawn.spawnshell(command);
 sub.communicate();
-if sub.exit_status==0 then
+if sub.exitCodeUNIQUE==0 then
   writeln("OK");
 else
   writeln("Test Failure");

--- a/test/chplenv/autocomplete/autocomplete.chpl
+++ b/test/chplenv/autocomplete/autocomplete.chpl
@@ -23,7 +23,7 @@ for line in runScript.stdout.lines() {
 runScript.wait();
 diff.wait();
 
-if diff.exitCodeUNIQUE != 0 {
+if diff.exitCode != 0 {
   writeln();
   writeln("diff failed. You may need to run ", genScript,
           " to regenerate ", completeScript, ". Try:");

--- a/test/chplenv/autocomplete/autocomplete.chpl
+++ b/test/chplenv/autocomplete/autocomplete.chpl
@@ -23,7 +23,7 @@ for line in runScript.stdout.lines() {
 runScript.wait();
 diff.wait();
 
-if diff.exit_status != 0 {
+if diff.exitCodeUNIQUE != 0 {
   writeln();
   writeln("diff failed. You may need to run ", genScript,
           " to regenerate ", completeScript, ". Try:");

--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -5,7 +5,7 @@ proc mysystem(cmd: string): int {
   use Spawn;
   var sub = spawnshell(cmd);
   sub.wait();
-  return sub.exitCodeUNIQUE;
+  return sub.exitCode;
 }
 
 var binpath = CHPL_HOST_PLATFORM + "-" + CHPL_HOST_ARCH;

--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -5,7 +5,7 @@ proc mysystem(cmd: string): int {
   use Spawn;
   var sub = spawnshell(cmd);
   sub.wait();
-  return sub.exit_status;
+  return sub.exitCodeUNIQUE;
 }
 
 var binpath = CHPL_HOST_PLATFORM + "-" + CHPL_HOST_ARCH;

--- a/test/deprecated/subprocess-exit-status.chpl
+++ b/test/deprecated/subprocess-exit-status.chpl
@@ -1,0 +1,6 @@
+use Spawn;
+
+proc main {
+  var sub: subprocess(iokind.dynamic, false);
+  var stat = sub.exit_status;
+}

--- a/test/deprecated/subprocess-exit-status.good
+++ b/test/deprecated/subprocess-exit-status.good
@@ -1,2 +1,2 @@
 subprocess-exit-status.chpl:3: In function 'main':
-subprocess-exit-status.chpl:5: warning: subprocess.exit_status is deprecated. Use subprocess.exitCodeUNIQUE instead.
+subprocess-exit-status.chpl:5: warning: subprocess.exit_status is deprecated. Use subprocess.exitCode instead.

--- a/test/deprecated/subprocess-exit-status.good
+++ b/test/deprecated/subprocess-exit-status.good
@@ -1,0 +1,2 @@
+subprocess-exit-status.chpl:3: In function 'main':
+subprocess-exit-status.chpl:5: warning: subprocess.exit_status is deprecated. Use subprocess.exitCodeUNIQUE instead.

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
@@ -4,7 +4,7 @@ proc mysystem(cmd: string): int {
   use Spawn;
   var sub = spawnshell(cmd);
   sub.wait();
-  return sub.exit_status;
+  return sub.exitCodeUNIQUE;
 }
 
 var binpath = CHPL_HOST_PLATFORM + "-" + CHPL_HOST_ARCH;

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
@@ -4,7 +4,7 @@ proc mysystem(cmd: string): int {
   use Spawn;
   var sub = spawnshell(cmd);
   sub.wait();
-  return sub.exitCodeUNIQUE;
+  return sub.exitCode;
 }
 
 var binpath = CHPL_HOST_PLATFORM + "-" + CHPL_HOST_ARCH;

--- a/test/library/packages/Curl/RunServer.chpl
+++ b/test/library/packages/Curl/RunServer.chpl
@@ -14,7 +14,7 @@ proc startServer() {
                      stdin=CLOSE, stdout=PIPE, stderr=PIPE);
   check.communicate();
 
-  if check.exitCodeUNIQUE == 0 {
+  if check.exitCode == 0 {
     // Server already running, so nothing to do.
     return;
   }
@@ -33,7 +33,7 @@ proc startServer() {
                        stdin=CLOSE, stdout=PIPE, stderr=PIPE);
     check.communicate();
 
-    if check.exitCodeUNIQUE == 0 {
+    if check.exitCode == 0 {
       ok = true;
       break;
     }

--- a/test/library/packages/Curl/RunServer.chpl
+++ b/test/library/packages/Curl/RunServer.chpl
@@ -14,7 +14,7 @@ proc startServer() {
                      stdin=CLOSE, stdout=PIPE, stderr=PIPE);
   check.communicate();
 
-  if check.exit_status == 0 {
+  if check.exitCodeUNIQUE == 0 {
     // Server already running, so nothing to do.
     return;
   }
@@ -33,7 +33,7 @@ proc startServer() {
                        stdin=CLOSE, stdout=PIPE, stderr=PIPE);
     check.communicate();
 
-    if check.exit_status == 0 {
+    if check.exitCodeUNIQUE == 0 {
       ok = true;
       break;
     }

--- a/test/library/standard/Spawn/no-command.chpl
+++ b/test/library/standard/Spawn/no-command.chpl
@@ -4,11 +4,11 @@ var sub = spawn(["./junk"]);
 
 // Different systems report this kind of error
 // at different times. On Mac OS X, an error
-// will be thrown. On Linux, exitCodeUNIQUE != 0.
+// will be thrown. On Linux, exitCode != 0.
 try {
   sub.wait();
   assert(sub.running == false);
-  assert(sub.exitCodeUNIQUE != 0);
+  assert(sub.exitCode != 0);
 } catch {
   assert(sub.running == false);
 }

--- a/test/library/standard/Spawn/no-command.chpl
+++ b/test/library/standard/Spawn/no-command.chpl
@@ -4,11 +4,11 @@ var sub = spawn(["./junk"]);
 
 // Different systems report this kind of error
 // at different times. On Mac OS X, an error
-// will be thrown. On Linux, exit_status != 0.
+// will be thrown. On Linux, exitCodeUNIQUE != 0.
 try {
   sub.wait();
   assert(sub.running == false);
-  assert(sub.exit_status != 0);
+  assert(sub.exitCodeUNIQUE != 0);
 } catch {
   assert(sub.running == false);
 }

--- a/test/library/standard/Spawn/spawn-checkmutate.chpl
+++ b/test/library/standard/Spawn/spawn-checkmutate.chpl
@@ -3,13 +3,13 @@ use Spawn;
 {
   var comp = spawn(["gcc", "mutate-args.c", "-o", "mutate-args"]);
   comp.wait();
-  assert(comp.exit_status == 0);
+  assert(comp.exitCodeUNIQUE == 0);
 }
 
 {
   var runit = spawn(["./mutate-args", "a", "bc", "def"], ["test=test"]);
   runit.wait();
-  assert(runit.exit_status == 0);
+  assert(runit.exitCodeUNIQUE == 0);
 }
 
 unlink("mutate-args");

--- a/test/library/standard/Spawn/spawn-checkmutate.chpl
+++ b/test/library/standard/Spawn/spawn-checkmutate.chpl
@@ -3,13 +3,13 @@ use Spawn;
 {
   var comp = spawn(["gcc", "mutate-args.c", "-o", "mutate-args"]);
   comp.wait();
-  assert(comp.exitCodeUNIQUE == 0);
+  assert(comp.exitCode == 0);
 }
 
 {
   var runit = spawn(["./mutate-args", "a", "bc", "def"], ["test=test"]);
   runit.wait();
-  assert(runit.exitCodeUNIQUE == 0);
+  assert(runit.exitCode == 0);
 }
 
 unlink("mutate-args");

--- a/test/library/standard/Spawn/spawn-checkret.chpl
+++ b/test/library/standard/Spawn/spawn-checkret.chpl
@@ -3,13 +3,13 @@ use Spawn;
 {
   var comp = spawn(["gcc", "return-10.c", "-o", "return-10"]);
   comp.wait();
-  assert(comp.exitCodeUNIQUE == 0);
+  assert(comp.exitCode == 0);
 }
 
 {
   var runit = spawn(["./return-10"]);
   runit.wait();
-  assert(runit.exitCodeUNIQUE == 10);
+  assert(runit.exitCode == 10);
 }
 
 unlink("return-10");

--- a/test/library/standard/Spawn/spawn-checkret.chpl
+++ b/test/library/standard/Spawn/spawn-checkret.chpl
@@ -3,13 +3,13 @@ use Spawn;
 {
   var comp = spawn(["gcc", "return-10.c", "-o", "return-10"]);
   comp.wait();
-  assert(comp.exit_status == 0);
+  assert(comp.exitCodeUNIQUE == 0);
 }
 
 {
   var runit = spawn(["./return-10"]);
   runit.wait();
-  assert(runit.exit_status == 10);
+  assert(runit.exitCodeUNIQUE == 10);
 }
 
 unlink("return-10");

--- a/test/library/standard/Spawn/spawn-kill.chpl
+++ b/test/library/standard/Spawn/spawn-kill.chpl
@@ -6,4 +6,4 @@ sleep(1);
 sub.kill();
 while sub.running do
   sub.poll();
-assert(sub.exitCodeUNIQUE == -SIGKILL);
+assert(sub.exitCode == -SIGKILL);

--- a/test/library/standard/Spawn/spawn-kill.chpl
+++ b/test/library/standard/Spawn/spawn-kill.chpl
@@ -6,4 +6,4 @@ sleep(1);
 sub.kill();
 while sub.running do
   sub.poll();
-assert(sub.exit_status == -SIGKILL);
+assert(sub.exitCodeUNIQUE == -SIGKILL);

--- a/test/library/standard/Spawn/spawn-popen-input-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-error-long.chpl
@@ -21,7 +21,7 @@ while sub.stderr.read(x) {
 }
 
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-error-long.chpl
@@ -21,7 +21,7 @@ while sub.stderr.read(x) {
 }
 
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
@@ -3,7 +3,7 @@ use Spawn;
 {
   var comp = spawnshell("$CHPL_HOME/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`/chpl cat-stdout-stderr.chpl -o stdout-stderr");
   comp.wait();
-  assert(comp.exitCodeUNIQUE == 0);
+  assert(comp.exitCode == 0);
 }
 
 var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=PIPE);
@@ -34,7 +34,7 @@ while sub.stderr.read(x) {
 
 
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
@@ -3,7 +3,7 @@ use Spawn;
 {
   var comp = spawnshell("$CHPL_HOME/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`/chpl cat-stdout-stderr.chpl -o stdout-stderr");
   comp.wait();
-  assert(comp.exit_status == 0);
+  assert(comp.exitCodeUNIQUE == 0);
 }
 
 var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=PIPE);
@@ -34,7 +34,7 @@ while sub.stderr.read(x) {
 
 
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
@@ -3,7 +3,7 @@ use Spawn;
 {
   var comp = spawnshell("$CHPL_HOME/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`/chpl cat-stdout-stderr.chpl -o stdout-stderr");
   comp.wait();
-  assert(comp.exitCodeUNIQUE == 0);
+  assert(comp.exitCode == 0);
 }
 
 var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=PIPE);
@@ -24,7 +24,7 @@ while sub.stderr.readline(line) {
 }
 
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
@@ -3,7 +3,7 @@ use Spawn;
 {
   var comp = spawnshell("$CHPL_HOME/bin/`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`/chpl cat-stdout-stderr.chpl -o stdout-stderr");
   comp.wait();
-  assert(comp.exit_status == 0);
+  assert(comp.exitCodeUNIQUE == 0);
 }
 
 var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=PIPE);
@@ -24,7 +24,7 @@ while sub.stderr.readline(line) {
 }
 
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-long.chpl
@@ -19,7 +19,7 @@ while sub.stdout.read(x) {
 }
 
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-long.chpl
@@ -19,7 +19,7 @@ while sub.stdout.read(x) {
 }
 
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output.chpl
@@ -13,7 +13,7 @@ while sub.stdout.readline(line) {
 }
 
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input-output.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output.chpl
@@ -13,7 +13,7 @@ while sub.stdout.readline(line) {
 }
 
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input.chpl
@@ -6,7 +6,7 @@ sub.stdin.writeln("Hello");
 sub.stdin.writeln("World");
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-input.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input.chpl
@@ -6,7 +6,7 @@ sub.stdin.writeln("Hello");
 sub.stdin.writeln("World");
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-wait.chpl
+++ b/test/library/standard/Spawn/spawn-popen-wait.chpl
@@ -66,7 +66,7 @@ while sub.stdout.readline(line) {
 
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen-wait.chpl
+++ b/test/library/standard/Spawn/spawn-popen-wait.chpl
@@ -66,7 +66,7 @@ while sub.stdout.readline(line) {
 
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();
 

--- a/test/library/standard/Spawn/spawn-popen.chpl
+++ b/test/library/standard/Spawn/spawn-popen.chpl
@@ -9,6 +9,6 @@ while sub.stdout.readline(line) {
 
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();

--- a/test/library/standard/Spawn/spawn-popen.chpl
+++ b/test/library/standard/Spawn/spawn-popen.chpl
@@ -9,6 +9,6 @@ while sub.stdout.readline(line) {
 
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();

--- a/test/library/standard/Spawn/spawn-popen2.chpl
+++ b/test/library/standard/Spawn/spawn-popen2.chpl
@@ -11,6 +11,6 @@ sub.stdout.close();
 
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 sub.close();

--- a/test/library/standard/Spawn/spawn-popen2.chpl
+++ b/test/library/standard/Spawn/spawn-popen2.chpl
@@ -11,6 +11,6 @@ sub.stdout.close();
 
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 sub.close();

--- a/test/library/standard/Spawn/spawn-print-args-env.chpl
+++ b/test/library/standard/Spawn/spawn-print-args-env.chpl
@@ -3,20 +3,20 @@ use Spawn;
 {
   var comp = spawn(["gcc", "print-args-env.c", "-o", "print-args-env"]);
   comp.wait();
-  assert(comp.exit_status == 0);
+  assert(comp.exitCodeUNIQUE == 0);
 }
 
 {
   var runit = spawn(["./print-args-env", "a", "bc", "def"], ["test=test"]);
   runit.wait();
-  assert(runit.exit_status == 0);
+  assert(runit.exitCodeUNIQUE == 0);
 }
 
 config const printEnv = false;
 if printEnv {
   var runit = spawn(["./print-args-env"]);
   runit.wait();
-  assert(runit.exit_status == 0);
+  assert(runit.exitCodeUNIQUE == 0);
 }
 
 

--- a/test/library/standard/Spawn/spawn-print-args-env.chpl
+++ b/test/library/standard/Spawn/spawn-print-args-env.chpl
@@ -3,20 +3,20 @@ use Spawn;
 {
   var comp = spawn(["gcc", "print-args-env.c", "-o", "print-args-env"]);
   comp.wait();
-  assert(comp.exitCodeUNIQUE == 0);
+  assert(comp.exitCode == 0);
 }
 
 {
   var runit = spawn(["./print-args-env", "a", "bc", "def"], ["test=test"]);
   runit.wait();
-  assert(runit.exitCodeUNIQUE == 0);
+  assert(runit.exitCode == 0);
 }
 
 config const printEnv = false;
 if printEnv {
   var runit = spawn(["./print-args-env"]);
   runit.wait();
-  assert(runit.exitCodeUNIQUE == 0);
+  assert(runit.exitCode == 0);
 }
 
 

--- a/test/library/standard/Spawn/spawn-system-shell.chpl
+++ b/test/library/standard/Spawn/spawn-system-shell.chpl
@@ -3,6 +3,6 @@ use Spawn;
 var sub = spawnshell("echo moo");
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 

--- a/test/library/standard/Spawn/spawn-system-shell.chpl
+++ b/test/library/standard/Spawn/spawn-system-shell.chpl
@@ -3,6 +3,6 @@ use Spawn;
 var sub = spawnshell("echo moo");
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 

--- a/test/library/standard/Spawn/spawn-system.chpl
+++ b/test/library/standard/Spawn/spawn-system.chpl
@@ -3,6 +3,6 @@ use Spawn;
 var sub = spawn(["ls", "test.txt"]);
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 

--- a/test/library/standard/Spawn/spawn-system.chpl
+++ b/test/library/standard/Spawn/spawn-system.chpl
@@ -3,6 +3,6 @@ use Spawn;
 var sub = spawn(["ls", "test.txt"]);
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 

--- a/test/library/standard/Spawn/spawn-system2.chpl
+++ b/test/library/standard/Spawn/spawn-system2.chpl
@@ -3,6 +3,6 @@ use Spawn;
 var sub = spawn(["ls", "test.txt"]);
 sub.wait(buffer=false);
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);
 
 

--- a/test/library/standard/Spawn/spawn-system2.chpl
+++ b/test/library/standard/Spawn/spawn-system2.chpl
@@ -3,6 +3,6 @@ use Spawn;
 var sub = spawn(["ls", "test.txt"]);
 sub.wait(buffer=false);
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);
 
 

--- a/test/library/standard/Spawn/spawn-term.chpl
+++ b/test/library/standard/Spawn/spawn-term.chpl
@@ -6,4 +6,4 @@ sleep(1);
 sub.terminate();
 while sub.running do
   sub.poll();
-assert(sub.exit_status == -SIGTERM);
+assert(sub.exitCodeUNIQUE == -SIGTERM);

--- a/test/library/standard/Spawn/spawn-term.chpl
+++ b/test/library/standard/Spawn/spawn-term.chpl
@@ -6,4 +6,4 @@ sleep(1);
 sub.terminate();
 while sub.running do
   sub.poll();
-assert(sub.exitCodeUNIQUE == -SIGTERM);
+assert(sub.exitCode == -SIGTERM);

--- a/test/library/standard/Spawn/ugni/spawn-system.chpl
+++ b/test/library/standard/Spawn/ugni/spawn-system.chpl
@@ -11,4 +11,4 @@ if pipeStdout then stdoutArg=PIPE;
 var sub = spawn(["ls", "../test.txt"], stdout=stdoutArg);
 sub.wait();
 assert(sub.running == false);
-assert(sub.exitCodeUNIQUE == 0);
+assert(sub.exitCode == 0);

--- a/test/library/standard/Spawn/ugni/spawn-system.chpl
+++ b/test/library/standard/Spawn/ugni/spawn-system.chpl
@@ -11,4 +11,4 @@ if pipeStdout then stdoutArg=PIPE;
 var sub = spawn(["ls", "../test.txt"], stdout=stdoutArg);
 sub.wait();
 assert(sub.running == false);
-assert(sub.exit_status == 0);
+assert(sub.exitCodeUNIQUE == 0);

--- a/test/mason/mason-help-scope/masonHelpScope.chpl
+++ b/test/mason/mason-help-scope/masonHelpScope.chpl
@@ -6,7 +6,7 @@ proc checkCommand(cmd: string) {
   var splitCmd = cmd.split();
   var p = spawn(splitCmd,stdout=PIPE);
   p.wait();
-  if p.exit_status != 0 {
+  if p.exitCodeUNIQUE != 0 {
     writeln("Failed to run cmd: '%s'".format(cmd));
   }
 }

--- a/test/mason/mason-help-scope/masonHelpScope.chpl
+++ b/test/mason/mason-help-scope/masonHelpScope.chpl
@@ -6,7 +6,7 @@ proc checkCommand(cmd: string) {
   var splitCmd = cmd.split();
   var p = spawn(splitCmd,stdout=PIPE);
   p.wait();
-  if p.exitCodeUNIQUE != 0 {
+  if p.exitCode != 0 {
     writeln("Failed to run cmd: '%s'".format(cmd));
   }
 }

--- a/test/mason/mason-test-exit/exitCodeTest.chpl
+++ b/test/mason/mason-test-exit/exitCodeTest.chpl
@@ -6,7 +6,7 @@ use Spawn;
 proc checkExitStatus(cmd) {
   var p = spawn(cmd, stdout=PIPE);
   p.wait();
-  if p.exitCodeUNIQUE == 1 {
+  if p.exitCode == 1 {
     writeln("Got exit status 1 as expected");
   }
 }

--- a/test/mason/mason-test-exit/exitCodeTest.chpl
+++ b/test/mason/mason-test-exit/exitCodeTest.chpl
@@ -6,7 +6,7 @@ use Spawn;
 proc checkExitStatus(cmd) {
   var p = spawn(cmd, stdout=PIPE);
   p.wait();
-  if p.exit_status == 1 {
+  if p.exitCodeUNIQUE == 1 {
     writeln("Got exit status 1 as expected");
   }
 }

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
@@ -72,7 +72,7 @@ proc printSystemInfo() {
     var sub = spawn(["uname", cmd], stdout=PIPE);
     sub.wait();
 
-    if sub.exit_status == 0 {
+    if sub.exitCodeUNIQUE == 0 {
       var ret, buf : string;
       while sub.stdout.readline(buf) do ret += buf;
       return ret.strip();

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
@@ -72,7 +72,7 @@ proc printSystemInfo() {
     var sub = spawn(["uname", cmd], stdout=PIPE);
     sub.wait();
 
-    if sub.exitCodeUNIQUE == 0 {
+    if sub.exitCode == 0 {
       var ret, buf : string;
       while sub.stdout.readline(buf) do ret += buf;
       return ret.strip();

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -208,7 +208,7 @@ proc checkRegistryPath(registryPath : string, trueIfLocal : bool) throws {
       var command = ('git ls-remote ' + registryPath).split();
       var checkRemote = spawn(command, stdout=PIPE);
       checkRemote.wait();
-      if checkRemote.exitCodeUNIQUE == 0 then return true;
+      if checkRemote.exitCode == 0 then return true;
       else {
         throw new owned MasonError(registryPath + " is not a valid remote path");
         exit(0);
@@ -385,7 +385,7 @@ private proc usernameCheck(username: string) {
 private proc checkIfForkExists(username: string) {
   var getFork = ('git ls-remote https://github.com/' + username + '/mason-registry');
   var p = runWithProcess(getFork, false);
-  return p.exitCodeUNIQUE;
+  return p.exitCode;
 }
 
 /* Gets the GitHub username of the user, by parsing from the remote origin url.
@@ -719,7 +719,7 @@ private proc checkLicense(projectHome: string) throws {
 private proc attemptToBuild() throws {
   var sub = spawn(['mason','build','--force'], stdout=PIPE);
   sub.wait();
-  if sub.exitCodeUNIQUE == 1 {
+  if sub.exitCode == 1 {
   writeln('(FAILED) Please make sure your package builds');
   }
   else {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -208,7 +208,7 @@ proc checkRegistryPath(registryPath : string, trueIfLocal : bool) throws {
       var command = ('git ls-remote ' + registryPath).split();
       var checkRemote = spawn(command, stdout=PIPE);
       checkRemote.wait();
-      if checkRemote.exit_status == 0 then return true;
+      if checkRemote.exitCodeUNIQUE == 0 then return true;
       else {
         throw new owned MasonError(registryPath + " is not a valid remote path");
         exit(0);
@@ -385,7 +385,7 @@ private proc usernameCheck(username: string) {
 private proc checkIfForkExists(username: string) {
   var getFork = ('git ls-remote https://github.com/' + username + '/mason-registry');
   var p = runWithProcess(getFork, false);
-  return p.exit_status;
+  return p.exitCodeUNIQUE;
 }
 
 /* Gets the GitHub username of the user, by parsing from the remote origin url.
@@ -719,7 +719,7 @@ private proc checkLicense(projectHome: string) throws {
 private proc attemptToBuild() throws {
   var sub = spawn(['mason','build','--force'], stdout=PIPE);
   sub.wait();
-  if sub.exit_status == 1 {
+  if sub.exitCodeUNIQUE == 1 {
   writeln('(FAILED) Please make sure your package builds');
   }
   else {

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -682,7 +682,7 @@ proc runAndLog(executable, fileName, ref result, reqNumLocales: int = numLocales
     }
   }
   exec.wait();//wait till the subprocess is complete
-  exitCode = exec.exit_status;
+  exitCode = exec.exitCodeUNIQUE;
   if haltOccured then
     exitCode = runAndLog(executable, fileName, result, reqNumLocales, testsPassed,
               testNames, localesCountMap, failedTestNames, erroredTestNames, skippedTestNames, show);

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -682,7 +682,7 @@ proc runAndLog(executable, fileName, ref result, reqNumLocales: int = numLocales
     }
   }
   exec.wait();//wait till the subprocess is complete
-  exitCode = exec.exitCodeUNIQUE;
+  exitCode = exec.exitCode;
   if haltOccured then
     exitCode = runAndLog(executable, fileName, result, reqNumLocales, testsPassed,
               testNames, localesCountMap, failedTestNames, erroredTestNames, skippedTestNames, show);

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -131,7 +131,7 @@ proc runWithStatus(command, show=true): int {
       while sub.stderr.readline(line) do write(line);
     }
     sub.wait();
-    return sub.exitCodeUNIQUE;
+    return sub.exitCode;
   }
   catch {
     return -1;
@@ -213,7 +213,7 @@ proc runSpackCommand(command) {
     write(line);
   }
 
-  return sub.exitCodeUNIQUE;
+  return sub.exitCode;
 }
 
 
@@ -318,7 +318,7 @@ proc getChapelVersionInfo(): VersionInfo {
 
       var process = spawn(["chpl", "--version"], stdout=PIPE);
       process.wait();
-      if process.exitCodeUNIQUE != 0 {
+      if process.exitCode != 0 {
         throw new owned MasonError("Failed to run 'chpl --version'");
       }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -131,7 +131,7 @@ proc runWithStatus(command, show=true): int {
       while sub.stderr.readline(line) do write(line);
     }
     sub.wait();
-    return sub.exit_status;
+    return sub.exitCodeUNIQUE;
   }
   catch {
     return -1;
@@ -213,7 +213,7 @@ proc runSpackCommand(command) {
     write(line);
   }
 
-  return sub.exit_status;
+  return sub.exitCodeUNIQUE;
 }
 
 
@@ -318,7 +318,7 @@ proc getChapelVersionInfo(): VersionInfo {
 
       var process = spawn(["chpl", "--version"], stdout=PIPE);
       process.wait();
-      if process.exit_status != 0 {
+      if process.exitCodeUNIQUE != 0 {
         throw new owned MasonError("Failed to run 'chpl --version'");
       }
 


### PR DESCRIPTION
Change subprocess.exit_status to subprocess.exitCode

Added a deprecation warning for subprocess.exit_status. Added a deprecated
test for subprocess.exit_status.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>