### PR TITLE
Add initial support for HPE Apollo platforms

### DIFF
--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -16,8 +16,8 @@ def get():
         # Use ofi on hpe-cray-ex
         elif platform_val == 'hpe-cray-ex':
             comm_val = 'ofi'
-        # Use gasnet on cray-cs
-        elif platform_val.startswith('cray-'):
+        # Use gasnet on cray-cs and hpe-apollo
+        elif platform_val in ('cray-cs', 'hpe-apollo'):
             comm_val = 'gasnet'
         else:
             comm_val = 'none'

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -15,7 +15,7 @@ def get():
         if comm_val == 'gasnet':
             if platform_val == 'cray-xc':
                 substrate_val = 'aries'
-            elif platform_val == 'cray-cs':
+            elif platform_val in ('cray-cs', 'hpe-apollo'):
                 substrate_val = 'ibv'
             elif platform_val == 'pwr6':
                 substrate_val = 'ibv'

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -6,8 +6,8 @@ import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
 from utils import error, memoize, warning
 
 def slurm_prefix(base_launcher, platform_val):
-    """ If salloc is available and we're on a cray-cs, prefix with slurm-"""
-    if platform_val == 'cray-cs' and find_executable('salloc'):
+    """ If salloc is available and we're on a cray-cs/hpe-apollo, prefix with slurm-"""
+    if platform_val in ('cray-cs', 'hpe-apollo') and find_executable('salloc'):
         return 'slurm-{}'.format(base_launcher)
     return base_launcher
 
@@ -60,7 +60,7 @@ def get():
             elif substrate_val == 'ofi':
                 launcher_val = slurm_prefix('gasnetrun_ofi', platform_val)
         else:
-            if platform_val == 'cray-cs' and find_executable('srun'):
+            if platform_val in ('cray-cs', 'hpe-apollo') and find_executable('srun'):
                 launcher_val = 'slurm-srun'
             else:
                 launcher_val = 'none'


### PR DESCRIPTION
Add chplenv support for HPE Apollo (`CHPL_*_PLATFORM=hpe-apollo`). Like
for Cray CS, we default to gasnet-ibv and will use slurm launchers if
they are available. Also like Cray CS, there does not appear to be a way
to automatically detect Apollo, so users are required to set the
platform manually.

Part of Cray/chapel-private#1810