### PR TITLE
Change c2chapel record generation idiom

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -370,7 +370,7 @@ def genStructOrUnion(structOrUnion, name=""):
         print()
         return
 
-    ret = "extern union " if isUnion else "extern record ";
+    ret = "extern union " if isUnion else "extern \"struct " + name + "\" record ";
     ret += name + " {"
     foundTypes.add(name)
 

--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -20,7 +20,7 @@ extern proc sized(x : c_ptr(c_int), ref y : c_int) : void;
 
 extern proc sized(x : c_ptr(c_int), y : c_ptr(c_int)) : void;
 
-extern record foobar {
+extern "struct foobar" record foobar {
   var x : c_int;
   var y : c_ptr(c_int);
   var z : c_ptr(c_ptr(c_int));

--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -17,7 +17,7 @@ extern proc foo2(lambda_arg : c_double) : c_int;
 // ==== c2chapel typedefs ====
 
 // Fields omitted because one or more of the identifiers is a Chapel keyword
-extern record bar {}
+extern "struct bar" record bar {}
 
 // Unable to generate struct 'record' because its name is a Chapel keyword
 

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -27,7 +27,7 @@ extern const FAILED :c_int;
 
 extern proc test_file(e : test_error) : c_int;
 
-extern record test_status {
+extern "struct test_status" record test_status {
   var current_status : test_error;
 }
 

--- a/tools/c2chapel/test/fileGlobals.chpl
+++ b/tools/c2chapel/test/fileGlobals.chpl
@@ -14,7 +14,7 @@ extern var globalChar : c_char;
 
 extern var globalPointer : c_ptr(c_int);
 
-extern record mytype {
+extern "struct mytype" record mytype {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;

--- a/tools/c2chapel/test/fnPointers.chpl
+++ b/tools/c2chapel/test/fnPointers.chpl
@@ -14,7 +14,7 @@ extern proc foo(a : myFunctionPointer, b : c_int) : c_int;
 
 // ==== c2chapel typedefs ====
 
-extern record io_methods {
+extern "struct io_methods" record io_methods {
   var close : c_fn_ptr;
   var open : c_fn_ptr;
 }

--- a/tools/c2chapel/test/gnuTest.chpl
+++ b/tools/c2chapel/test/gnuTest.chpl
@@ -9,7 +9,7 @@ use CPtr;
 use SysCTypes;
 use SysBasic;
 // Anonymous union or struct was encountered within and skipped.
-extern record _GValue {
+extern "struct _GValue" record _GValue {
   var g_type : GType;
 }
 

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -8,7 +8,7 @@ require "miscTypedef.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record simpleStruct {
+extern "struct simpleStruct" record simpleStruct {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;
@@ -24,14 +24,14 @@ extern proc tdPointer(a : c_ptr(fancyStruct), b : c_ptr(c_ptr(renamedStruct))) :
 
 
 
-extern record forwardStruct {
+extern "struct forwardStruct" record forwardStruct {
   var a : c_int;
   var b : c_int;
 }
 
 // ==== c2chapel typedefs ====
 
-extern record fancyStruct {
+extern "struct fancyStruct" record fancyStruct {
   var a : c_int;
   var b : c_int;
   var c : renamedStruct;

--- a/tools/c2chapel/test/nestedStruct.chpl
+++ b/tools/c2chapel/test/nestedStruct.chpl
@@ -8,17 +8,17 @@ require "nestedStruct.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record first {
+extern "struct first" record first {
   var a : c_int;
   var b : c_string;
 }
 
-extern record second {
+extern "struct second" record second {
   var a : c_ptr(c_int);
   var b : c_ptr(c_int);
 }
 
-extern record Outer {
+extern "struct Outer" record Outer {
   var structField : first;
   var fieldPtr : c_ptr(second);
 }

--- a/tools/c2chapel/test/opaqueStruct.chpl
+++ b/tools/c2chapel/test/opaqueStruct.chpl
@@ -8,7 +8,7 @@ require "opaqueStruct.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record foobar {
+extern "struct foobar" record foobar {
   var a : c_int;
   var b : c_int;
   var c : c_int;

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -8,20 +8,20 @@ require "simpleRecords.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record allInts {
+extern "struct allInts" record allInts {
   var a : c_int;
   var b : c_uint;
   var c : c_longlong;
 }
 
-extern record misc {
+extern "struct misc" record misc {
   var a : c_char;
   var b : c_string;
   var c : c_void_ptr;
   var d : c_ptr(c_int);
 }
 
-extern record composition {
+extern "struct composition" record composition {
   var m : misc;
   var i : c_ptr(allInts);
 }


### PR DESCRIPTION
While running Arrow/Parquet code in Chapel that was generated by c2chapel, it was noticed that it would only compile when using the LLVM backend and not with `CHPL_LLVM=none`. This was due to some structs in the Arrow headers being declared as `struct foo { ... }` instead of `typedef struct _foo { ... } foo`.

To fix this, this PR changes records generated by c2chapel to be of the form `extern "struct foo" record foo { ... }`, instead of just `extern record foo { ... }`.

Motivated by and more information: https://github.com/Cray/chapel-private/issues/2433