### PR TITLE
Allow enum reads prefixed with type name

### DIFF
--- a/test/io/ferguson/enum-with-prefix.chpl
+++ b/test/io/ferguson/enum-with-prefix.chpl
@@ -1,0 +1,57 @@
+use IO;
+
+enum myenum {red, green, blue}
+use myenum;
+
+writeln("WRITELN OF ENUM VALS");
+writeln(myenum.red);
+writeln(myenum.green);
+writeln(myenum.blue);
+writeln();
+
+writeln("JSON WRITE OF ENUM VALS");
+writef("%jt\n", myenum.red);
+writef("%jt\n", myenum.green);
+writef("%jt\n", myenum.blue);
+writeln();
+
+proc reade(s: string) : myenum {
+  var f = openmem();
+  f.writer().write(s);
+    
+  var reader = f.reader();
+
+  var e: myenum = myenum.red;
+  reader.read(e);
+  return e;
+}
+
+proc readj(s: string) : myenum {
+  var f = openmem();
+  f.writer().write(s);
+    
+  var reader = f.reader();
+
+  var e: myenum = myenum.red;
+  reader.readf("%jt", e);
+  return e;
+}
+
+
+writeln("READING ENUM VALS WITH READ");
+writeln('reading red -> ', reade('red'));
+writeln('reading green -> ', reade('green'));
+writeln('reading blue -> ', reade('blue'));
+writeln('reading myenum.red -> ', reade('myenum.red'));
+writeln('reading myenum.green -> ', reade('myenum.green'));
+writeln('reading myenum.blue -> ', reade('myenum.blue'));
+writeln();
+
+writeln("READING ENUM VALS WITH JSON READ");
+writeln('reading "red" -> ', readj('"red"'));
+writeln('reading "green" -> ', readj('"green"'));
+writeln('reading "blue" -> ', readj('"blue"'));
+writeln('reading "myenum.red" -> ', readj('"myenum.red"'));
+writeln('reading "myenum.green" -> ', readj('"myenum.green"'));
+writeln('reading "myenum.blue" -> ', readj('"myenum.blue"'));
+writeln();

--- a/test/io/ferguson/enum-with-prefix.good
+++ b/test/io/ferguson/enum-with-prefix.good
@@ -1,0 +1,26 @@
+WRITELN OF ENUM VALS
+red
+green
+blue
+
+JSON WRITE OF ENUM VALS
+"red"
+"green"
+"blue"
+
+READING ENUM VALS WITH READ
+reading red -> red
+reading green -> green
+reading blue -> blue
+reading myenum.red -> red
+reading myenum.green -> green
+reading myenum.blue -> blue
+
+READING ENUM VALS WITH JSON READ
+reading "red" -> red
+reading "green" -> green
+reading "blue" -> blue
+reading "myenum.red" -> red
+reading "myenum.green" -> green
+reading "myenum.blue" -> blue
+


### PR DESCRIPTION
Issue #18335 is requesting that reading an enum support things like `enumtype.valname`. This is already supported for casts from string to enum since PR #3225.

This PR adds such support by adjusting the enum read code to look for `enumtype` `.` `valname` instead of just `valname`.

- [x] full local testing

Reviewed by @dlongnecke-cray - thanks!