### PR TITLE
Fix clang++ 12 build by removing temporary char* variable

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1510,10 +1510,10 @@ static void setGPUFlags() {
 
   if(isGpuCodegen) {
     if (isSaveCDirEmpty) {
-      const char *gpuDir = strlen(executableFilename) != 0 ? 
-            executableFilename:std::to_string(getpid()).c_str();
-
-      int len = snprintf(saveCDir, FILENAME_MAX+1, "%s_gpu_files", gpuDir);
+      int len = snprintf(saveCDir, FILENAME_MAX+1, "%s_gpu_files",
+                         (strlen(executableFilename) != 0 ? 
+                          executableFilename :
+                          std::to_string(getpid()).c_str()));
       if(len < 0 || len >= FILENAME_MAX+1) {
         USR_FATAL("Unable to produce name of savec directory for GPU code generation.");
       }


### PR DESCRIPTION
@dlongnecke-cray  and @arezaii reported on Slack that PR #18329 (they think)
broke the compilation of driver.cpp, though this seems to be specific to
newer versions of clang++ (at least, it didn't show up with my default
version).  The error was:

```
driver.cpp:1514:32: error: object backing the pointer will be destroyed at the end of the
      full-expression [-Werror,-Wdangling-gsl]
            executableFilename:std::to_string(getpid()).c_str();
```

This PR fixes the issue by eliminating the temporary variable and
inserting the expression directly into the sprintf() that uses it.  Not
as pretty, but it does the trick.
