### PR TITLE
Remove new strptime future's .bad file

### DIFF
--- a/test/library/standard/DateTime/strptime.bad
+++ b/test/library/standard/DateTime/strptime.bad
@@ -1,2 +1,0 @@
-test_microsecond()
-strptime.chpl:7: error: halt reached - day is out of the valid range


### PR DESCRIPTION
It turns out that the error generated by this `.future` isn't as
deterministic as I'd hoped when filing it, so in this PR I'm removing
the `.bad` file.  Specifically, on GASNet testing, we saw a different
field (the month) being outside of the valid range.  My guess is that it's
an uninitialized memory issue due to the C interop situation and that
we can't rely on any particular failure mode.

Meanwhile, since it's an unimplemented feature future and named in the
relevant issue (#16922), the lack of a .bad doesn't seem like a liability.