### PR TITLE
Update 'updateGITLOG' to use 'main' rather than 'master' if it exists

### DIFF
--- a/util/devel/updateGITLOG
+++ b/util/devel/updateGITLOG
@@ -1,7 +1,17 @@
 #!/bin/bash
 
+# for backwards compatibility
+BRANCH=master
+
+# if 'main' exists, use that instead
+if [ `git branch | grep '  main$' | wc -l` == 1 ]; then
+    BRANCH=main
+fi
+
+echo "Getting log for branch $BRANCH"
+    
 #git fetch chapel-lang master
-git log master --first-parent -m --name-status --pretty=format:"-----------------------------------------------------------------------------%n%ncommit %h%nMerge: %p%nDate:   %ad%nAuthor: %an <%ae>%n%n%s%n%n%b%n" --reverse . | dos2unix > GITLOG
+git log $BRANCH --first-parent -m --name-status --pretty=format:"-----------------------------------------------------------------------------%n%ncommit %h%nMerge: %p%nDate:   %ad%nAuthor: %an <%ae>%n%n%s%n%n%b%n" --reverse . | dos2unix > GITLOG
 
 # TODO: Can I use tformat to put the %b after the list of files?  And a label
 # to search on to find it?


### PR DESCRIPTION
This updates my utility script that lists all merge commits in a
directory so that it uses the branch 'main' if it exists rather than
'master', as it traditionally has.
