### PR TITLE
Restore lost `:throws:` clause to the `compile` documentation in Regex module

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -462,6 +462,9 @@ type BadRegexpError = owned BadRegexError;
                    this flag can be set inside the regular expression with
                    ``(?U)``.
 
+   :throws BadRegexError: If the argument 'pattern' has syntactical errors.
+                          Refer to https://github.com/google/re2/blob/master/re2/re2.h
+                          for more details about error codes.
  */
 proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
              /*i*/ ignoreCase=false, /*m*/ multiLine=false, /*s*/ dotAll=false,


### PR DESCRIPTION
These changes were added in #17338 to the Regexp module but
were not transferred to the Regex module when the contents of
Regexp were deleted.  Restore it so that Piyush's work is preserved.

Double checked the built docs

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>