### PR TITLE
Make 'updateGITLOG' work when 'main' is the active branch

### DIFF
--- a/util/devel/updateGITLOG
+++ b/util/devel/updateGITLOG
@@ -4,7 +4,7 @@
 BRANCH=master
 
 # if 'main' exists, use that instead
-if [ `git branch | grep '  main$' | wc -l` == 1 ]; then
+if [ `git branch | grep ' main$' | wc -l` == 1 ]; then
     BRANCH=main
 fi
 


### PR DESCRIPTION
In my previous "fix", I forgot that when 'main' is the active branch
in a git repo, it's formatted differently in the 'git branch' output.
This fixes the script to deal with that.
