### PR TITLE
Improve time-to-completion estimation better in arrayTransfer test.

### DIFF
--- a/test/performance/comm/low-level/arrayTransfer.chpl
+++ b/test/performance/comm/low-level/arrayTransfer.chpl
@@ -67,8 +67,9 @@ proc main() {
 
     while true {
       if nops == nopsAtCheck {
-        if t.elapsed() >= runSecs then break;
-        nopsAtCheck = (nops * (0.75 * runSecs / t.elapsed())):int;
+        const tElapsed = t.elapsed();
+        if tElapsed >= runSecs then break;
+        nopsAtCheck += (0.99 * nops * (runSecs / tElapsed - 1)):int;
         if nopsAtCheck - nops < minOpsPerTimerCheck then
           nopsAtCheck = nops + minOpsPerTimerCheck;
       }


### PR DESCRIPTION
The `arrayTransfer` test inherited poor time-to-completion estimation
logic from the `many-to-one` test.  The latter was fixed in #17676.  Here,
fix the former similarly.  I added some temporary instrumentation and
depending on circumstances saw as many as 100x fewer completion checks
in the course of a run.

This resolves https://github.com/Cray/chapel-private/issues/989.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>