### PR TITLE
Consider the deprecated keyword as an alternative to compilerWarning().

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -20,6 +20,11 @@ The deprecation message uses the following format:
 
     foo is deprecated - please use bar
 
+   For compile-time messaging you can use ``compilerWarning()`` to do
+   this, but when deprecating symbols the ``deprecated`` keyword often
+   works best.  Look in the test/deprecated and test/deprecated-keyword
+   directories for many examples.
+
 2. Update the deprecated feature documentation to state that it is deprecated
    and point to the preferred feature.
 

--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -22,8 +22,12 @@ The deprecation message uses the following format:
 
    For compile-time messaging you can use ``compilerWarning()`` to do
    this, but when deprecating symbols the ``deprecated`` keyword often
-   works best.  Look in the test/deprecated and test/deprecated-keyword
-   directories for many examples.
+   works better because it can be applied to any symbol in a uniform
+   way.  Look in the test/deprecated and test/deprecated-keyword
+   directories for many examples.  Note that the ``deprecated`` keyword
+   itself is likely to be replaced by different syntax in the future,
+   though this may not affect its use in practice since deprecations
+   typically only last for one release anyway.
 
 2. Update the deprecated feature documentation to state that it is deprecated
    and point to the preferred feature.


### PR DESCRIPTION
Update deprecation documentation for new, handy keyword!
