### PR TITLE
Follow convention when specifying an executable skipif's shell.

### DIFF
--- a/test/parallel/reports/task-report-sanity.skipif
+++ b/test/parallel/reports/task-report-sanity.skipif
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 if [[ $CHPL_TARGET_PLATFORM =~ linux \
       && $CHPL_COMM == none \
       && $CHPL_TASKS == fifo ]] ; then


### PR DESCRIPTION
I specified /bin/sh as the shell for a new executable .skipif file, but
then used bash-specific syntax in its body.  That "worked" on a system
where /bin/sh was a symbolic link to bash, but broke on a another one
where it was not.  Here, specify bash as the shell, and do it in a more
conventional way.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>