### PR TITLE
Revert "Have Arkouda 16-node-cs-hdr nightly testing use --interleave-memory"

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.arkouda.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.bash
@@ -23,9 +23,5 @@ module list
 export GASNET_PHYSMEM_MAX="9/10"
 nightly_args="${nightly_args} -no-buildcheck"
 
-# Try out branch to use --interleave-memory
-export ARKOUDA_URL=https://github.com/ronawho/arkouda.git
-export ARKOUDA_BRANCH=interleave-memory
-
 test_nightly
 sync_graphs


### PR DESCRIPTION
This reverts commit a896354abc1b9214ced9db5d41a89a118cf3ec82.

This feature was automatically enabled upstream, so we don't need to
manually test it.