### PR TITLE
Add performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1056,6 +1056,8 @@ knucleotide: &knucleotide-base
     - Optimize the method map.this(k) (#14065)
   07/29/20:
     - Optimize ASCII strings (#16092)
+  09/03/21:
+    - Two little string optimizations (#18323)
 knucleotide-submitted:
   <<: *knucleotide-base
 


### PR DESCRIPTION
Adds the annotation for string optimizations that improved the k-nucleotide
performance.

PR: https://github.com/chapel-lang/chapel/pull/18323
Plot: https://chapel-lang.org/perf/chapcs/?startdate=2021/08/19&enddate=2021/09/09&graphs=knucleotideshootoutbenchmark