### PR TITLE
Mark GPU kernels as `ExternalLinkage`

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2189,15 +2189,18 @@ void FnSymbol::codegenPrototype() {
       return;
     }
 
+    bool generatingGPUKernel = (gCodegenGPU && hasFlag(FLAG_GPU_CODEGEN));
+
     llvm::Function::LinkageTypes linkage = llvm::Function::InternalLinkage;
-    if (hasFlag(FLAG_EXPORT))
+    if (hasFlag(FLAG_EXPORT) || generatingGPUKernel) {
       linkage = llvm::Function::ExternalLinkage;
+    }
 
     // No other function with the same name exists.
     llvm::Function *func = llvm::Function::Create(fTy, linkage, cname,
                                                   info->module);
 
-    if (gCodegenGPU && hasFlag(FLAG_GPU_CODEGEN)) {
+    if (generatingGPUKernel) {
       func->setConvergent();
       func->setCallingConv(llvm::CallingConv::PTX_Kernel);
     }

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.skipif
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/gpu/native/streamPrototype/stream.compopts
+++ b/test/gpu/native/streamPrototype/stream.compopts
@@ -1,1 +1,2 @@
 -M../../../release/examples/benchmarks/hpcc --no-checks
+--fast -M../../../release/examples/benchmarks/hpcc --no-checks


### PR DESCRIPTION
Previously, GPU kernels were marked for internal linkage as with other
functions. This caused them to be eliminated with `--fast` because they aren't
called from inside the same binary that they are put in. This PR makes GPU
kernels similar to `export` functions by marking them as external linkage.

Thanks @mppf for pointing out the fix.

Test:
- [x] gpu/native with --fast
- [x] standard
