### PR TITLE
Remove deprecated environment settings from usingchapel/chplenv doc

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -514,7 +514,6 @@ CHPL_GMP
                 (#include gmp.h, -lgmp)
        none     do not build GMP support into the Chapel runtime
        bundled  use the GMP distribution bundled with Chapel in third-party
-       gmp      deprecated - use bundled instead
        =======  ============================================================
 
    If unset, Chapel will attempt to build GMP using
@@ -549,7 +548,6 @@ CHPL_HWLOC
        ======== ==============================================================
        none     do not build hwloc support into the Chapel runtime
        bundled  use the hwloc distribution bundled with Chapel in third-party
-       hwloc    deprecated - use bundled instead
        ======== ==============================================================
 
    If unset, ``CHPL_HWLOC`` defaults to ``bundled`` if
@@ -583,7 +581,6 @@ CHPL_HWLOC
           ======== ==============================================================
           none     do not build or use jemalloc
           bundled  use the jemalloc distribution bundled with Chapel in third-party
-          jemalloc deprecated - use bundled instead
           ======== ==============================================================
 
       If unset, ``CHPL_JEMALLOC`` defaults to ``bundled`` if
@@ -613,7 +610,6 @@ CHPL_HWLOC
           ========= ==============================================================
           none      do not build or use libfabric
           bundled   use the libfabric distribution bundled with Chapel in third-party
-          libfabric deprecated - use bundled instead
           ========= ==============================================================
 
       If unset, ``CHPL_LIBFABRIC`` defaults to ``bundled`` if
@@ -688,7 +684,6 @@ CHPL_LLVM
        Value          Description
        ============== ======================================================
        bundled        use the llvm/clang distribution in third-party
-       llvm           deprecated - use bundled instead
        system         find a compatible LLVM in system libraries;
                       note: the LLVM must be a version supported by Chapel
        none           do not support llvm/clang-related features
@@ -700,10 +695,10 @@ CHPL_LLVM
      * ``bundled`` if you've already built the bundled llvm in
        `third-party/llvm`
      *  ``system`` if a compatible system-wide installation of LLVM is detected
+     * ``unset`` otherwise
 
-   If none of the above cases apply then you will need to either add a
-   system-wide installation of LLVM or set ``CHPL_LLVM`` to ``bundled``
-   or ``none``.
+   If CHPL_LLVM is ``unset`` you will need to either add a system-wide
+   installation of LLVM or set ``CHPL_LLVM`` to ``bundled`` or ``none``.
 
    See :ref:`readme-prereqs` for more information about currently
    supported LLVM versions.
@@ -725,7 +720,6 @@ CHPL_UNWIND
        Value     Description
        ========= =======================================================
        bundled   use the libunwind bundled with Chapel in third-party
-       libunwind deprecated - use bundled instead
        system    assume libunwind is already installed on the system
        none      don't use an unwind library, disabling stack tracing
        ========= =======================================================


### PR DESCRIPTION
Remove mentions of settings of the form CHPL_LLVM=llvm that were replaced
with CHPL_LLVM=bundled from the chplenv document.

Add a mention of defaulting to CHPL_LLVM=unset if none of the other cases
apply.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>