### PR TITLE
Remove migrate/strict flags from hwloc interleave call

### DIFF
--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -524,7 +524,8 @@ void chpl_topo_interleaveMemLocality(void* p, size_t size) {
     return;
   }
 
-  if (!topoSupport->membind->set_area_membind) {
+  if (!topoSupport->membind->set_area_membind ||
+      !topoSupport->membind->interleave_membind) {
     return;
   }
 
@@ -533,7 +534,7 @@ void chpl_topo_interleaveMemLocality(void* p, size_t size) {
   obj = hwloc_get_root_obj(topology);
   set = hwloc_bitmap_dup(obj->cpuset);
 
-  flags = HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT;
+  flags = 0;
   CHK_ERR_ERRNO(hwloc_set_area_membind(topology, p, size, set, HWLOC_MEMBIND_INTERLEAVE, flags) == 0);
 }
 


### PR DESCRIPTION
Follow on to #18350. We only want to interleave new pages when faulting
them in, we don't want to move existing pages. This shouldn't impact
gasnet-ibv-large, which is what the interleaving code was added for, but
it's also called for ibv-fast where we want it to be a no-op. It didn't
seem to cause any issues before, but I think this is still the right
change. There was no inherent reason to have the migrate/strict flags
before, they were just copied from `chpl_topo_setMemLocalityByPages`.

While here also update our check to ensure that interleave is supported.