### PR TITLE
Add foreach tech note

### DIFF
--- a/doc/rst/technotes/foreach.rst
+++ b/doc/rst/technotes/foreach.rst
@@ -6,10 +6,9 @@ The `foreach` Loop
 
 A ``foreach`` loop signifies that loop iterations are order-independent. This
 enables the compiler to vectorize the loop or to offload its execution to the
-GPU. In contrast, a ``for`` loop is order-dependent, and a ``forall`` loop can
-create parallel tasks and distribute iterations based on the iterator. The tasks
-created by ``forall`` can execute loop iterations in order-independent manner
-*if* the iterator uses ``foreach``.
+GPU. In contrast, a ``for`` loop is order-dependent; and a ``forall`` loop can
+create parallel tasks and distribute iterations based on the iterator, as well
+as being order-independent.
 
 The syntax of the ``foreach`` loop is similar to the other ``for``-like loops:
 

--- a/doc/rst/technotes/foreach.rst
+++ b/doc/rst/technotes/foreach.rst
@@ -5,9 +5,11 @@ The `foreach` Loop
 ====================
 
 A ``foreach`` loop signifies that loop iterations are order-independent. This
-enables the compiler to vectorize the loop. In contrast, a ``for`` loop is
-order-dependent, and a ``forall`` loop can create parallel tasks and distribute
-iterations based on the iterator.
+enables the compiler to vectorize the loop or to offload its execution to the
+GPU. In contrast, a ``for`` loop is order-dependent, and a ``forall`` loop can
+create parallel tasks and distribute iterations based on the iterator. The tasks
+created by ``forall`` can execute loop iterations in order-independent manner
+*if* the iterator uses ``foreach``.
 
 The syntax of the ``foreach`` loop is similar to the other ``for``-like loops:
 
@@ -36,3 +38,12 @@ The ``forall`` above will distribute the execution to all the locales and all
 the tasks within them. As the default parallel iterators for ``A.domain`` is
 implemented using ``foreach``, tasks executing parts of this loop will benefit
 from vectorization.
+
+Status and Future Work
+----------------------
+
+- The current implementation does not make full use of vectorization hinting.
+  We hope to expand the coverage especially to vectorize outer loops.
+
+- We intend to add ``with`` clauses to ``foreach`` loops to support
+  vector-lane-private variables.

--- a/doc/rst/technotes/foreach.rst
+++ b/doc/rst/technotes/foreach.rst
@@ -1,0 +1,38 @@
+.. _readme-foreach:
+
+====================
+The `foreach` Loop
+====================
+
+A ``foreach`` loop signifies that loop iterations are order-independent. This
+enables the compiler to vectorize the loop. In contrast, a ``for`` loop is
+order-dependent, and a ``forall`` loop can create parallel tasks and distribute
+iterations based on the iterator.
+
+The syntax of the ``foreach`` loop is similar to the other ``for``-like loops:
+
+.. code-block:: chapel
+
+    var A: [1..N] int;
+    foreach i in A.domain do
+      A[i] += 1;
+
+Vectorizability of a ``foreach`` loop will be determined transitively based on
+vectorizability of the iterator it runs over. All default range, domain and
+array iterators are vectorizable (i.e. implemented using ``foreach``).
+Therefore, the snippet above will be vectorized when run on a suitable
+architecture.
+
+Same transitivity applies to vectorizability of ``forall`` loops, as well.
+
+.. code-block:: chapel
+
+    var Dom = {1..N} dmapped Block({1..N});
+    var A: [Dom] int;
+    forall i in A.domain do
+      A[i] += 1;
+
+The ``forall`` above will distribute the execution to all the locales and all
+the tasks within them. As the default parallel iterators for ``A.domain`` is
+implemented using ``foreach``, tasks executing parts of this loop will benefit
+from vectorization.

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -47,6 +47,7 @@ Parallel Language Features
    Querying a Local Subdomain <subquery>
    Reduce Intents <reduceIntents>
    Runtime Support for Atomics <atomics>
+   The 'foreach' Loop <foreach>
    Prototyped Support for GPU-Targeted code <gpu>
 
 Interoperability


### PR DESCRIPTION
This PR adds a technote for the `foreach` loop added in #18046.

Under https://github.com/Cray/chapel-private/issues/2245 we were thinking
we can update the spec to include `foreach`, but we haven't made a lot of
improvements after the initial implementation that we wanted to. So, I'm adding
a tech note, instead.

`make docs` runs successfully and renders the doc nicely.