### PR TITLE
next: Break up compiler/next docs into one page per namespace

### DIFF
--- a/doc/templates/compiler-internals-doxygen/base.rst
+++ b/doc/templates/compiler-internals-doxygen/base.rst
@@ -1,6 +1,6 @@
 .. default-domain:: cpp
 
-.. _Chapter-Base:
+.. _Chapter-next-chpl:
 
 Base
 ====

--- a/doc/templates/compiler-internals-doxygen/base.rst
+++ b/doc/templates/compiler-internals-doxygen/base.rst
@@ -1,0 +1,35 @@
+.. default-domain:: cpp
+
+.. _Chapter-Base:
+
+Base
+====
+
+This section contains a selection of the definitions declared in the `chpl`
+namespace. The entries may not be exhaustive.
+
+.. comment:
+   See entries in '$CHPL_HOME/compiler/next/include/chpl/queries'
+
+.. doxygenclass:: chpl::Context
+   :members:
+   :undoc-members:
+
+.. doxygenclass:: chpl::ErrorMessage
+   :members:
+   :undoc-members:
+
+.. doxygenclass:: chpl::ID
+   :members:
+   :undoc-members:
+
+.. doxygenclass:: chpl::Location
+   :members:
+   :undoc-members:
+
+.. doxygenclass:: chpl::UniqueString
+   :members:
+   :undoc-members:
+
+.. doxygentypedef:: chpl::owned
+

--- a/doc/templates/compiler-internals-doxygen/index.rst
+++ b/doc/templates/compiler-internals-doxygen/index.rst
@@ -1,16 +1,28 @@
 .. _compiler-internals-index:
 
 Compiler Internals
-==================
+||||||||||||||||||
 
-.. doxygennamespace:: chpl
-   :members:
-   :undoc-members:
+This section documents the various functions and types of the
+new compiler.
+
+.. toctree::
+   :caption: Symbols by Namespace
+   :maxdepth: 2
+
+   parsing
+   resolution
+   types
+   uast
+   base
 
 .. comment
 
-  Future work --
-    * list each class separately (so it can have its own page)
-    * indicate which members (including inherited members) should
+  Tuning/Future --
+    * TODO: Add a table of contents just for C++ symbols?
+    * Do we want a finer granularity then one section per namespace?
+    * How to handle displaying one class per file for "base"? This
+      section represents the base 'chpl' namespace.
+    * Indicate which members (including inherited members) should
       be documented (to provide the user-facing API and hiding
-      inheritance for implementation reasons)
+      inheritance for implementation reasons).

--- a/doc/templates/compiler-internals-doxygen/parsing.rst
+++ b/doc/templates/compiler-internals-doxygen/parsing.rst
@@ -1,0 +1,13 @@
+.. default-domain:: cpp
+
+.. _Chapter-Parsing:
+
+Parsing
+=======
+
+This section contains definitions declared in the `chpl::parsing`
+namespace.
+
+.. doxygennamespace:: chpl::parsing
+   :members:
+   :undoc-members:

--- a/doc/templates/compiler-internals-doxygen/parsing.rst
+++ b/doc/templates/compiler-internals-doxygen/parsing.rst
@@ -1,6 +1,6 @@
 .. default-domain:: cpp
 
-.. _Chapter-Parsing:
+.. _Chapter-next-chpl-parsing:
 
 Parsing
 =======

--- a/doc/templates/compiler-internals-doxygen/resolution.rst
+++ b/doc/templates/compiler-internals-doxygen/resolution.rst
@@ -1,6 +1,6 @@
 .. default-domain:: cpp
 
-.. _Chapter-Resolution:
+.. _Chapter-next-chpl-resolution:
 
 Resolution
 ==========

--- a/doc/templates/compiler-internals-doxygen/resolution.rst
+++ b/doc/templates/compiler-internals-doxygen/resolution.rst
@@ -1,0 +1,13 @@
+.. default-domain:: cpp
+
+.. _Chapter-Resolution:
+
+Resolution
+==========
+
+This section contains definitions declared in the `chpl::resolution`
+namespace.
+
+.. doxygennamespace:: chpl::resolution
+   :members:
+   :undoc-members:

--- a/doc/templates/compiler-internals-doxygen/types.rst
+++ b/doc/templates/compiler-internals-doxygen/types.rst
@@ -1,0 +1,13 @@
+.. default-domain:: cpp
+
+.. _Chapter-Types:
+
+Types
+=====
+
+This section contains definitions declared in the `chpl::types`
+namespace.
+
+.. doxygennamespace:: chpl::types
+   :members:
+   :undoc-members:

--- a/doc/templates/compiler-internals-doxygen/types.rst
+++ b/doc/templates/compiler-internals-doxygen/types.rst
@@ -1,6 +1,6 @@
 .. default-domain:: cpp
 
-.. _Chapter-Types:
+.. _Chapter-next-chpl-types:
 
 Types
 =====

--- a/doc/templates/compiler-internals-doxygen/uast.rst
+++ b/doc/templates/compiler-internals-doxygen/uast.rst
@@ -1,6 +1,6 @@
 .. default-domain:: cpp
 
-.. _Chapter-uAST:
+.. _Chapter-next-chpl-uast:
 
 Untyped AST (uAST)
 ==================

--- a/doc/templates/compiler-internals-doxygen/uast.rst
+++ b/doc/templates/compiler-internals-doxygen/uast.rst
@@ -1,0 +1,13 @@
+.. default-domain:: cpp
+
+.. _Chapter-uAST:
+
+Untyped AST (uAST)
+==================
+
+This section contains definitions declared in the `chpl::uast`
+namespace.
+
+.. doxygennamespace:: chpl::uast
+   :members:
+   :undoc-members:

--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -49,3 +49,5 @@ cpp:identifier ZERO
 cpp:identifier SYMBOL_ONLY
 cpp:identifier uast::asttags::NUM_AST_TAGS
 cpp:identifier uast::Function::DEFAULT_RETURN_INTENT
+# Common symbols used as template typenames.
+cpp:identifier T


### PR DESCRIPTION
next: Break up compiler/next docs into one page per namespace

This is for `compiler/next`.

Add a subpage per namespace to the `compiler-internals` section of
the documentation. For the `base` section, which covers symbols in
the `chpl` namespace, add important types by hand. Documentation
for symbols in nested namespaces is generated automatically by
Doxygen.

FUTURE WORK

  - Get all classes to show up in the outline / sidebar
  - Generate an index containing only C++ symbols
  - Automatically generate types in `chpl` namespace
  - Expand macros before generating docs

Reviewed by @mppf. Thanks!

TESTING

  - [x] Can build `chpl`
  - [x] Can build docs on Mac
  - [x] Can build docs on Linux
  - [x] Share rendered docs with reviewer

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>