### PR TITLE
Add a delete to new test using unmanaged

### DIFF
--- a/test/types/sync/ferguson/sync-unmanaged-nilable.chpl
+++ b/test/types/sync/ferguson/sync-unmanaged-nilable.chpl
@@ -6,4 +6,5 @@ proc main() {
   v.writeEF(x);
   var y = v.readFE();
   assert(y == x);
+  delete x;
 }


### PR DESCRIPTION
Follow-up to PR #17248.

Adds a delete so that the test does not leak memory.

Trivial and not reviewed.