### PR TITLE
Avoid memory leak in ArgumentParser

### DIFF
--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -445,8 +445,12 @@ module ArgumentParser {
       _positionals = new list(borrowed Positional);
       _subcommands = new list(string);
       this.complete();
-      // configure to allow consuming of -- if passed from runtime
-      try!{addOption(name="dummyDashHandler", opts=["--"], numArgs=0);}
+      try! {
+        // configure to allow consuming of -- if passed from runtime
+
+        // storing into variable to avoid memory leak due to compiler bug #18391
+        var tmp = addOption(name="dummyDashHandler", opts=["--"], numArgs=0);
+      }
     }
 
     proc _parsePositionals(arguments:[?argsD] string, endIdx:int) throws {


### PR DESCRIPTION
This is a workaround for issue #18391. It avoids a memory leak that we observed in nightly testing, e.g. with

```
test/library/packages/ArgumentParser/ArgumentParserExample.chpl
```

Reviewed by @arezaii - thanks!

- [x] full local testing