### PR TITLE
Adjust the intro paragraph for prereqs.rst

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -4,16 +4,8 @@
 Chapel Prerequisites
 ====================
 
-If you have a standard UNIX environment, a C/C++ compiler, some basic
-scripting languages, a GNU-compatible make, and awk installed you should
-have no problems getting started with Chapel.
-
-
-Prerequisites
--------------
-
-In slightly more detail, the following are prerequisites and assumptions
-about your environment for using Chapel:
+The following are prerequisites and assumptions about your environment
+for using Chapel:
 
   * You are using an environment that supports standard UNIX commands
     such as: ``cd, mkdir, rm, echo``

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -4,8 +4,8 @@
 Chapel Prerequisites
 ====================
 
-Chapel is designed to be portable to a variety of systems and depends on
-tools that are common on UNIX systems.
+Chapel is designed to be portable to a variety of systems and only
+requires tools that are common on UNIX systems.
 
 The following are prerequisites and assumptions about your environment
 for using Chapel:

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -4,6 +4,9 @@
 Chapel Prerequisites
 ====================
 
+Chapel is designed to be portable to a variety of systems and depends on
+tools that are common on UNIX systems.
+
 The following are prerequisites and assumptions about your environment
 for using Chapel:
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -5,7 +5,7 @@ Chapel Prerequisites
 ====================
 
 Chapel is designed to be portable to a variety of systems and only
-requires tools that are common on UNIX systems.
+requires software that is common on UNIX systems.
 
 The following are prerequisites and assumptions about your environment
 for using Chapel:


### PR DESCRIPTION
It was no longer accurate at least because now we require
C++14 (and other stuff, depending on the configuration, e.g. Python 3.7).

Reviewed by @tzinsky @bradcray @lydia-duncan - thanks!