### PR TITLE
Bugfix for argument parser handling of negative numbers

### DIFF
--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -481,7 +481,7 @@ module ArgumentParser {
       var next = pos+1;
       debugTrace("starting at pos: " + pos:string);
       debugTrace("searching from: " + pos:string + " to " + endPos:string);
-      while matched < high && next <= endPos && !args[next].startsWith("-")
+      while matched < high && next <= endPos
       {
         pos=next;
         next+=1;

--- a/test/library/packages/ArgumentParser/ArgumentParserTests.good
+++ b/test/library/packages/ArgumentParser/ArgumentParserTests.good
@@ -298,7 +298,7 @@ testFromArgParseExample()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
-testOptRangeInterruptBadFlag()
+testOptRangeMixedWithLeadingDash()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
@@ -526,6 +526,18 @@ testRangeConverter()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testSimpleNegativeIntegerArguments()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testSimpleNegativeIntegerOptions()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+testMixedNegativeIntegerArgsOptions()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 Found some unrecognizable arguments: thirty
 Found some unrecognizable arguments: badArg1 --BadFlag
 Use '-' or '--' to indicate option/flag, or use positional arguments.
@@ -560,7 +572,6 @@ Option/flag --strArg is previously defined
 Found some unrecognizable arguments: subCommandNone
 Found some unrecognizable arguments: subCommandNone
 Found some unrecognizable arguments: -x
-Found some unrecognizable arguments: -f
 BoolFlag Not enough values: expected 1..1 got 0
 Found some unrecognizable arguments: false
 Found some unrecognizable arguments: false


### PR DESCRIPTION
This PR updates the argument parser to handle negative numbers as values in options.

Previously, the `_match` method for `Options` was looking for a leading dash `-` as an exit
condition. This change removes that check and will now consume values with leading
dashes. 

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/`
- [x] Passing tests from `util/start_test test/library/packages/ArgumentParser/` 

Reviewed by @mppf - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>