### PR TITLE
Remove expensive string check

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1247,11 +1247,6 @@ module String {
   */
   inline proc const string.numCodepoints {
     const n = this.cachedNumCodepoints;
-    if boundsChecking {
-      if n != countNumCodepoints(this) {
-        halt("Encountered corrupt string metadata");
-      }
-    }
     return n;
   }
 


### PR DESCRIPTION
This PR removes an expensive string check.

This check makes `isASCII` and `numCodepoints` both O(n) which is counterintuitive. It has caused timeouts for readcsv.chpl as well as knucleotide-strings.chpl.

Additionally, it is never reached in tests. While this check was important during development of UTF-8 string codepoint caching, at this point it is basically a memory checksum. I don't think we need that to be on by default.

- [ ] full local testing