### PR TITLE
Document isNothingValue()

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -238,7 +238,7 @@ proc isNumericValue(e)   param  return isNumericType(e.type);
 proc isPrimitiveValue(e) param  return isPrimitiveType(e.type);
 /* Returns `true` if the argument is a `enum` value. */
 proc isEnumValue(e)      param  return isEnumType(e.type);
-pragma "no doc"
+/* Returns `true` if the argument is a `nothing` value (i.e., `none`) */
 proc isNothingValue(e)   param return isNothingType(e.type);
 //Defined elsewhere:
 // isTupleValue


### PR DESCRIPTION
I think this one got overlooked in the recent effort to document
is*Value() routines due to the timing of the PR merges involved.
