### PR TITLE
Refresh QUICKSTART.rst and building.rst

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -4,15 +4,17 @@ Chapel Quickstart Instructions
 ==============================
 
 These instructions are designed to help users get started with a
-source distribution of Chapel as quickly as possible.  If you are
+single-locale (shared-memory) implementation of Chapel from the source
+distribution of the release as quickly as possible.  If you are
 interested in taking the time to understand Chapel's configuration
 options, build process, and installation more thoroughly, please refer
 to :ref:`readme-chplenv` and :ref:`readme-building` instead.
 
 These instructions first have you build a minimal, stripped-down
 version of Chapel to reduce build times and the potential for
-confusion.  Once you are interested in a full-featured version of
-Chapel, refer to :ref:`using-a-more-full-featured-chapel` below.
+third-party portability issues.  Once you are interested in a
+full-featured version of Chapel, refer to
+:ref:`using-a-more-full-featured-chapel` below.
 
 
 0) See :ref:`readme-prereqs` for information about system tools and
@@ -54,14 +56,14 @@ Chapel, refer to :ref:`using-a-more-full-featured-chapel` below.
          make
 
 
-3) Compile an example program:
+3) Compile an example program, which uses a ``forall`` loop to print messages:
 
    .. code-block:: bash
 
       chpl examples/hello3-datapar.chpl
 
 
-4) Run the resulting executable:
+4) Run the resulting executable, which will print 100 messages in parallel:
 
    .. code-block:: bash
 
@@ -69,7 +71,9 @@ Chapel, refer to :ref:`using-a-more-full-featured-chapel` below.
 
 
 5) Experiment with Chapel in this Quickstart mode to your heart's
-   content.  Once you are comfortable with Chapel and interested in
+   content.  If you'd like to use this Chapel build in additional
+   shell / terminal sessions, see :ref:`using-chapel-in-another-shell`
+   below.  Once you are comfortable with Chapel and interested in
    using a full-featured version in the preferred configuration, see
    the next section.
 
@@ -82,8 +86,8 @@ Using Chapel in its Preferred Configuration
 To use Chapel in its preferred, full-featured mode, you will need to
 rebuild Chapel from source in a different configuration:
 
-*  Open up a new shell to avoid inheriting the previous environment
-   settings.
+* Open up a new shell to avoid inheriting the previous environment
+  settings.
 
 * The Quickstart configuration described above sets ``CHPL_LLVM=none``
   for simplicity and to save time.  This causes the Chapel compiler to
@@ -96,35 +100,41 @@ rebuild Chapel from source in a different configuration:
     find it if it's in your path)
 
   - set ``CHPL_LLVM=bundled`` to have Chapel build and use the bundled
-    version of LLVM (note that this can take a *long* time)
+    version of LLVM (note that building the bundled version of LLVM
+    can take a *long* time)
 
   - set ``CHPL_LLVM=none`` to continue using the C back-end rather
     than LLVM
 
-*  Repeat steps 2-5 above, but in step 2, source ``util/setchplenv.bash``
-   instead of ``util/quickstart/setchplenv.bash``.
-   This will set up your environment to use Chapel in the preferred
-   configuration.  Note that building this configuration involves
-   compiling third-party packages, which will increase the overall
-   build time.
+* If you are interested in building Chapel to support multiple compute
+  nodes (locales), refer to :ref:`readme-multilocale` for other
+  settings to enable that.
+    
+* Repeat steps 2-5 above, but in step 2, source
+  ``util/setchplenv.bash`` instead of
+  ``util/quickstart/setchplenv.bash``.  This will set up your
+  environment to use Chapel in the preferred configuration.  Note that
+  building this configuration involves compiling third-party packages,
+  which will increase the overall build time.
 
-   .. code-block:: bash
+  .. code-block:: bash
 
-      # Set environment variables to preferred configuration
-      source util/setchplenv.bash
+     # Set environment variables to preferred configuration
+     source util/setchplenv.bash
 
-      # re-build Chapel
-      make
+     # re-build Chapel
+     make
 
-      # compile a sample program
-      chpl -examples/hello3-datapar.chpl
+     # compile a sample program
+     chpl -examples/hello3-datapar.chpl
 
-      # run the sample program
-      ./hello3-datapar
+     # run the sample program
+     ./hello3-datapar
 
-   If you run into any portability issues, please see
-   :ref:`readme-bugs`:
+  If you run into any portability issues, please see
+  :ref:`readme-bugs`:
 
+.. _using-chapel-in-another-shell:
 
 Using Chapel in a Different Shell / Session
 -------------------------------------------
@@ -168,8 +178,8 @@ the fish shell (fish)                ``. util/quickstart/setchplenv.fish``
 the Bourne shell (sh)                ``. util/quickstart/setchplenv.sh``
 ==================================== ==========================================
 
-For the full-featured builds using these shells, simply remove
-``quickstart/`` from the path.
+For the versions of the scripts that set the preferred environment for
+each of these shells, remove ``quickstart/`` from the paths above.
 
 
 What's next?

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -41,7 +41,7 @@ full-featured version of Chapel, refer to
          cd chapel-1.25.0
 
    c. Set up your environment for Chapel's Quickstart mode.
-      If you are using a shell other than bash,
+      If you are using a shell other than ``bash``,
       see :ref:`quickstart-with-other-shells` below.
 
       .. code-block:: bash
@@ -71,8 +71,8 @@ full-featured version of Chapel, refer to
 
 
 5) Experiment with Chapel in this Quickstart mode to your heart's
-   content.  If you'd like to use this Chapel build in additional
-   shell / terminal sessions, see :ref:`using-chapel-in-another-shell`
+   content.  If you'd like to use this build of Chapel in a different
+   shell / terminal session, see :ref:`using-chapel-in-another-shell`
    below.  Once you are comfortable with Chapel and interested in
    using a full-featured version in the preferred configuration, see
    the next section.
@@ -91,9 +91,9 @@ rebuild Chapel from source in a different configuration:
 
 * The Quickstart configuration described above sets ``CHPL_LLVM=none``
   for simplicity and to save time.  This causes the Chapel compiler to
-  use its C back-end, which is not the preferred option.  As of Chapel
+  use its C back-end, which is not the preferred option; as of Chapel
   1.25, LLVM is the default back-end, which needs to be available for
-  full functionality.  There are a few ways to use LLVM:
+  full functionality.  There are a few options for using LLVM:
 
   - ensure that you have a version of LLVM 11 installed on your system
     and set ``CHPL_LLVM=system`` (or leave it unset and Chapel should
@@ -126,18 +126,18 @@ rebuild Chapel from source in a different configuration:
      make
 
      # compile a sample program
-     chpl -examples/hello3-datapar.chpl
+     chpl examples/hello3-datapar.chpl
 
      # run the sample program
      ./hello3-datapar
 
   If you run into any portability issues, please see
-  :ref:`readme-bugs`:
+  :ref:`readme-bugs`.
 
 .. _using-chapel-in-another-shell:
 
-Using Chapel in a Different Shell / Session
--------------------------------------------
+Using Chapel in a Different Shell or Terminal
+---------------------------------------------
 
 Note that in both the Quickstart and preferred modes above, any
 environment settings made by ``setchplenv.bash`` will not persist
@@ -153,7 +153,8 @@ Using Chapel in Multi-Locale Mode
 
 All of the instructions above describe how to run Chapel programs in a
 single-locale (shared-memory) mode. To run using multiple locales
-(distributed memory), please refer to :ref:`readme-multilocale`.
+(multiple compute nodes with distributed memory), please refer to
+:ref:`readme-multilocale`.
 
 
 Notes on Performance
@@ -169,6 +170,10 @@ https://chapel-lang.org/perf-tips.html for valuable tips.
 Quickstart with Other Shells
 ----------------------------
 
+If you use a shell other than ``bash``, see the table below to
+identify the location of an appropriate Quickstart ``setchplenv``
+script.
+
 ==================================== ==========================================
 **If you use:**                       **then type:**
 ------------------------------------ ------------------------------------------
@@ -178,14 +183,14 @@ the fish shell (fish)                ``. util/quickstart/setchplenv.fish``
 the Bourne shell (sh)                ``. util/quickstart/setchplenv.sh``
 ==================================== ==========================================
 
-For the versions of the scripts that set the preferred environment for
-each of these shells, remove ``quickstart/`` from the paths above.
+Scripts that set the preferred environment for each of these shells
+can be found by removing ``quickstart/`` from the paths.
 
 
 What's next?
 ------------
 
-For more information about Chapel, refer to the following resources:
+For further information about Chapel, refer to the following resources:
 
 ============================ ==================================================
 Online documentation:        :ref:`chapel-lang.org/docs <chapel-documentation>`

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -3,35 +3,36 @@
 Chapel Quickstart Instructions
 ==============================
 
-These instructions are designed to help you get started with
-a source distribution of the latest Chapel release.
+These instructions are designed to help users get started with a
+source distribution of Chapel as quickly as possible.  If you are
+interested in taking the time to understand Chapel's configuration
+options, build process, and installation more thoroughly, please refer
+to :ref:`readme-chplenv` and :ref:`readme-building` instead.
 
-In the following instructions, note that building and using Chapel as
-described in steps 2-5 disables optional and advanced features in the
-interest of getting you a clean build as quickly as possible. Later
-sections explain how to re-build in the preferred configuration and how to
-enable more features, such as distributed memory execution.
+These instructions first have you build a minimal, stripped-down
+version of Chapel to reduce build times and the potential for
+confusion.  Once you are interested in a full-featured version of
+Chapel, refer to :ref:`using-a-more-full-featured-chapel` below.
 
 
-0) See :ref:`prereqs.rst <readme-prereqs>` for more information about system
-   tools and packages you may need to have installed to build and run Chapel.
+0) See :ref:`readme-prereqs` for information about system tools and
+   packages you should have available to build and run Chapel.
 
-1) If you don't already have Chapel 1.25, see
-   https://chapel-lang.org/download.html .
 
-2) If you are using a source release, build Chapel in a *quickstart*
-   configuration. The *quickstart* script used below is designed to help you
-   get started with Chapel. After that, you may want to switch to a more
-   full-featured configuration. See using-a-more-full-featured-chapel_ below.
+1) If you don't already have the Chapel 1.25 source release, see
+   https://chapel-lang.org/download.html.
 
-   a. Expand the source release if you haven't already:
+
+2) Build Chapel in its 'Quickstart' configuration:
+
+   a. Unpack the source release if you haven't already:
 
       .. code-block:: bash
 
          tar xzf chapel-1.25.0.tar.gz
 
-   b. Make sure that you are in the directory you just created by expanding the
-      source release, for example:
+   b. Make sure that you are in the directory that was created when
+      unpacking the source release, for example:
 
       .. code-block:: bash
 
@@ -39,39 +40,33 @@ enable more features, such as distributed memory execution.
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,
-      see quickstart-with-other-shells_ below.
+      see :ref:`quickstart-with-other-shells` below.
 
       .. code-block:: bash
 
          source util/quickstart/setchplenv.bash
 
-   d. Use GNU make to build Chapel.
-      On some systems, you will have to use gmake.
-      See :ref:`building.rst <readme-building>` for more information about
-      building Chapel.
+   d. Use GNU make to build Chapel.  On some systems, you may have to
+      use ``gmake`` if ``make`` is not a GNU version.
 
       .. code-block:: bash
 
          make
-
-   e. Optionally, check that your Chapel build is working correctly
-
-      .. code-block:: bash
-
-         make check
 
 
 3) Compile an example program:
 
    .. code-block:: bash
 
-      chpl -o hello examples/hello.chpl
+      chpl examples/hello3-datapar.chpl
+
 
 4) Run the resulting executable:
 
    .. code-block:: bash
 
-      ./hello
+      ./hello3-datapar
+
 
 5) Experiment with Chapel in this Quickstart mode to your heart's
    content.  Once you are comfortable with Chapel and interested in
@@ -81,33 +76,37 @@ enable more features, such as distributed memory execution.
 
 .. _using-a-more-full-featured-chapel:
 
-Using a More Full-Featured Chapel
----------------------------------
+Using Chapel in its Preferred Configuration
+-------------------------------------------
 
-To use Chapel in a more full-featured and preferred configuration,
-you will need to rebuild Chapel from source in a different configuration.
+To use Chapel in its preferred, full-featured mode, you will need to
+rebuild Chapel from source in a different configuration:
 
 *  Open up a new shell to avoid inheriting the previous environment
    settings.
 
-*  The quickstart configuration described above sets ``CHPL_LLVM=none``
-   but this is not the preferred configuration of Chapel. As of 1.25,
-   LLVM is the default compiler backend and it needs to be available
-   for full functionality. So make sure you have a compatible system LLVM
-   installed in a standard location or set the environment variable
-   ``CHPL_LLVM`` to ``bundled`` or ``none`` as described in
-   :ref:`chplenv.rst <readme-chplenv.CHPL_LLVM>`.  If desired, you must
-   explicitly opt-out of using it by setting
-   ``CHPL_LLVM=none``. The ``CHPL_LLVM=bundled`` build takes a long
-   time, so to avoid surprises you need to explicitly opt-in to using it.
+* The Quickstart configuration described above sets ``CHPL_LLVM=none``
+  for simplicity and to save time.  This causes the Chapel compiler to
+  use its C back-end, which is not the preferred option.  As of Chapel
+  1.25, LLVM is the default back-end, which needs to be available for
+  full functionality.  There are a few ways to use LLVM:
 
-*  Repeat steps 2-5 above, but in Step 2, source ``util/setchplenv.bash``
+  - ensure that you have a version of LLVM 11 installed on your system
+    and set ``CHPL_LLVM=system`` (or leave it unset and Chapel should
+    find it if it's in your path)
+
+  - set ``CHPL_LLVM=bundled`` to have Chapel build and use the bundled
+    version of LLVM (note that this can take a *long* time)
+
+  - set ``CHPL_LLVM=none`` to continue using the C back-end rather
+    than LLVM
+
+*  Repeat steps 2-5 above, but in step 2, source ``util/setchplenv.bash``
    instead of ``util/quickstart/setchplenv.bash``.
    This will set up your environment to use Chapel in the preferred
-   configuration.  Building this configuration involves compiling
-   third-party packages, which will increase the overall build time.
-   If you run into any portability issues, please let us know via
-   :ref:`bugs.rst <readme-bugs>`.
+   configuration.  Note that building this configuration involves
+   compiling third-party packages, which will increase the overall
+   build time.
 
    .. code-block:: bash
 
@@ -117,40 +116,42 @@ you will need to rebuild Chapel from source in a different configuration.
       # re-build Chapel
       make
 
-      # make check is available but optional
-      make check
-
       # compile a sample program
-      chpl -o hello examples/hello.chpl
+      chpl -examples/hello3-datapar.chpl
 
       # run the sample program
-      ./hello
+      ./hello3-datapar
 
-   Note that the environment settings from ``util/setchplenv.bash`` will not persist beyond this terminal session.
-   You can choose to source ``setchplenv.bash`` whenever you want to use relevant commands.
-   If you want these environment settings to persist for future terminal sessions,
-   copy the commands from the Recommended Settings in :ref:`chplenv.rst <readme-chplenv.recommended_settings>` into your ``~/.bashrc`` file.
-   You can also store Chapel configuration settings in a :ref:`chplconfig <readme-chplenv.chplconfig>` file instead of your ``~/.bashrc``.
+   If you run into any portability issues, please see
+   :ref:`readme-bugs`:
 
-   See :ref:`chplenv.rst <readme-chplenv>` for a complete description of
-   Chapel's configuration variables, what they mean, and how they
-   can be set.
+
+Using Chapel in a Different Shell / Session
+-------------------------------------------
+
+Note that in both the Quickstart and preferred modes above, any
+environment settings made by ``setchplenv.bash`` will not persist
+beyond your current shell / terminal session.  To use Chapel from a
+different shell or terminal, you will need to either re-``source`` the
+``setchplenv.bash`` script that you used when building Chapel or set
+up your environment to support additional shells automatically.  See
+:ref:`using-chapel-in-other-sessions` for details.
 
 
 Using Chapel in Multi-Locale Mode
 ---------------------------------
 
-All of the instructions above describe how to run Chapel programs
-in a single-locale (shared-memory) mode. To run using multiple
-locales (distributed memory), please refer to
-:ref:`multilocale.rst <readme-multilocale>`.
+All of the instructions above describe how to run Chapel programs in a
+single-locale (shared-memory) mode. To run using multiple locales
+(distributed memory), please refer to :ref:`readme-multilocale`.
 
-Performance
------------
 
-If you plan to do performance studies of Chapel programs, be sure to use the
-full-featured version from using-a-more-full-featured-chapel_ above and see
-https://chapel-lang.org/performance.html for performance tips.
+Notes on Performance
+--------------------
+
+If you plan to do performance studies of Chapel programs, be sure to
+use the full-featured version above and see
+https://chapel-lang.org/perf-tips.html for valuable tips.
 
 
 .. _quickstart-with-other-shells:
@@ -166,6 +167,9 @@ a csh-compatible shell (csh/tcsh)    ``source util/quickstart/setchplenv.csh``
 the fish shell (fish)                ``. util/quickstart/setchplenv.fish``
 the Bourne shell (sh)                ``. util/quickstart/setchplenv.sh``
 ==================================== ==========================================
+
+For the full-featured builds using these shells, simply remove
+``quickstart/`` from the path.
 
 
 What's next?

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -5,10 +5,10 @@ Chapel Quickstart Instructions
 
 These instructions are designed to help users get started with a
 single-locale (shared-memory) implementation of Chapel from the source
-distribution of the release as quickly as possible.  If you are
-interested in taking the time to understand Chapel's configuration
-options, build process, and installation more thoroughly, please refer
-to :ref:`readme-chplenv` and :ref:`readme-building` instead.
+distribution of the release as quickly as possible.  If you want to
+understand Chapel's configuration options, build process, and
+installation more thoroughly, please refer to :ref:`readme-chplenv`
+and :ref:`readme-building` instead.
 
 These instructions first have you build a minimal, stripped-down
 version of Chapel to reduce build times and the potential for
@@ -41,7 +41,7 @@ full-featured version of Chapel, refer to
          cd chapel-1.25.0
 
    c. Set up your environment for Chapel's Quickstart mode.
-      If you are using a shell other than ``bash``,
+      If you are using a shell other than ``bash`` or ``zsh``,
       see :ref:`quickstart-with-other-shells` below.
 
       .. code-block:: bash
@@ -101,7 +101,7 @@ rebuild Chapel from source in a different configuration:
 
   - set ``CHPL_LLVM=bundled`` to have Chapel build and use the bundled
     version of LLVM (note that building the bundled version of LLVM
-    can take a *long* time)
+    can take a long time)
 
   - set ``CHPL_LLVM=none`` to continue using the C back-end rather
     than LLVM
@@ -141,10 +141,11 @@ Using Chapel in a Different Shell or Terminal
 
 Note that in both the Quickstart and preferred modes above, any
 environment settings made by ``setchplenv.bash`` will not persist
-beyond your current shell / terminal session.  To use Chapel from a
-different shell or terminal, you will need to either re-``source`` the
-``setchplenv.bash`` script that you used when building Chapel or set
-up your environment to support additional shells automatically.  See
+beyond your current shell/terminal session.  One easy way to use
+Chapel from a different shell or terminal is to re-``source`` the
+``setchplenv.bash`` script that you used when building Chapel.
+However since this can quickly become annoying, other strategies are
+available including a ``./configure`` + ``make install`` option.  See
 :ref:`using-chapel-in-other-sessions` for details.
 
 
@@ -161,8 +162,9 @@ Notes on Performance
 --------------------
 
 If you plan to do performance studies of Chapel programs, be sure to
-use the full-featured version above and see
-https://chapel-lang.org/perf-tips.html for valuable tips.
+use the full-featured version above, to compile with ``--fast`` once
+your program is correct, and to refer to
+https://chapel-lang.org/perf-tips.html for other tips.
 
 
 .. _quickstart-with-other-shells:
@@ -170,9 +172,8 @@ https://chapel-lang.org/perf-tips.html for valuable tips.
 Quickstart with Other Shells
 ----------------------------
 
-If you use a shell other than ``bash``, see the table below to
-identify the location of an appropriate Quickstart ``setchplenv``
-script.
+Use the table below to identify the location of an appropriate
+Quickstart ``setchplenv`` script, based on the shell you use.
 
 ==================================== ==========================================
 **If you use:**                       **then type:**
@@ -183,8 +184,8 @@ the fish shell (fish)                ``. util/quickstart/setchplenv.fish``
 the Bourne shell (sh)                ``. util/quickstart/setchplenv.sh``
 ==================================== ==========================================
 
-Scripts that set the preferred environment for each of these shells
-can be found by removing ``quickstart/`` from the paths.
+Scripts that set the preferred environment for each shell can be
+located by removing ``quickstart/`` from the paths above.
 
 
 What's next?

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -89,10 +89,10 @@ Typically, this is accomplished in one of the following ways:
   appropriate ``setchplenv.*`` script.
 
 * by creating a ``chplconfig`` file to store your preferred ``$CHPL_``
-  settings (see :ref:`chplconfig <readme-chplenv.chplconfig>` for
-  further details on creating a chplconfig file).  Note, however, that
-  some other technique would still be required to ensure that ``chpl``
-  is in your path.
+  settings (see :ref:`readme-chplenv.chplconfig` for further details
+  on creating a chplconfig file).  Note, however, that some other
+  standard technique is still required to ensure that ``chpl`` is in
+  your path.
 
 * by installing Chapel to a specific location—perhaps one that is
   already in your path—using the instructions in the next section.
@@ -114,8 +114,8 @@ Chapel can be built and installed to a specific location as follows:
 
 Running ``./configure`` will save your current configuration of
 ``$CHPL_`` settings into a ``chplconfig`` file.  Running it with the
-``--prefix`` or ``chpl-home`` options permits you to specify where and
-how Chapel should be installed during the ``make install`` step.
+``--prefix`` or ``--chpl-home`` options permits you to specify where
+and how Chapel should be installed during the ``make install`` step.
 Specifically:
 
 * ``--prefix=/dir/for/install/`` causes the Chapel compiler,
@@ -127,7 +127,7 @@ Specifically:
 
   This technique is designed to install Chapel using a standard
   directory structure for the purposes of integrating it into a
-  standard location that is already be in your path, such as
+  standard location that is already in your path, such as
   ``/usr/local/`` or ``~/``.  Note that elevated privileges are likely
   to be required for any system-wide installation locations.
 
@@ -149,6 +149,13 @@ the current set of ``CHPL_`` environment variables defined by—and
 inferred for—your environment.  To build support for additional
 configurations, you will need to modify your ``CHPL_`` environment
 variables and re-make.
+
+Once you have built multiple configurations, you can switch between
+them either by setting your ``CHPL_`` environment variables to the
+same values as when the configuration was built, or using the ``chpl``
+compiler's command-line options that correspond to the environment
+variables (see the 'Compiler Configuration Options' section of the
+:ref:`man-chpl` man page for details).
 
 
 ----------------

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -108,7 +108,7 @@ Chapel can be built and installed to a specific location as follows:
 
 .. code-block:: bash
 
-  ./configure  # use ``./configure --help`` for specific options
+  ./configure  # use './configure --help' for specific options
   make
   make install
 

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -5,11 +5,10 @@ Building Chapel
 ===============
 
 To build the Chapel compiler, set up your environment as described in
-:ref:`chapelhome-quickstart` or :ref:`readme-chplenv`, cd to
-``$CHPL_HOME`` (the root directory of your unpacked Chapel release),
-and run GNU make.  This will build the compiler and runtime libraries
-for your current environment as indicated by running
-``$CHPL_HOME/util/printchplenv --all``.
+:ref:`readme-chplenv`, cd to ``$CHPL_HOME`` (the root directory of
+your unpacked Chapel release), and run GNU make.  This will build the
+compiler and runtime libraries for your current environment as
+indicated by running ``$CHPL_HOME/util/printchplenv --all``.
 
 On many systems, GNU make is available simply as ``make``. On others,
 it is called ``gmake``.  To check whether ``make`` refers to GNU make
@@ -98,6 +97,8 @@ Typically, this is accomplished in one of the following ways:
 * by installing Chapel to a specific location—perhaps one that is
   already in your path—using the instructions in the next section.
 
+
+.. _readme-installing:
 
 -----------------
 Installing Chapel
@@ -200,5 +201,4 @@ are described below. Set the value to 1 to enable the feature.
   ========  ================================================================
 
 
-.. _readme-installing:
 

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -94,8 +94,8 @@ Typically, this is accomplished in one of the following ways:
   standard technique is still required to ensure that ``chpl`` is in
   your path.
 
-* by installing Chapel to a specific location—perhaps one that is
-  already in your path—using the instructions in the next section.
+* by installing Chapel to a specific location that is in your path
+  using the instructions in the next section.
 
 
 .. _readme-installing:
@@ -193,9 +193,11 @@ Each target processes all subdirectories, then the current directory.
 Makefile Options
 ----------------
 
-The Chapel makefiles have a few options that enable or disable optimization,
-debugging support, profiling, and back-end C compiler warnings. The variables
-are described below. Set the value to 1 to enable the feature.
+The Chapel makefiles have a few options that enable or disable
+optimization, debugging support, profiling, and back-end C compiler
+warnings. The variables are described below. Set the value to 1 to
+enable the feature or 0 to disable it (e.g., ``make DEBUG=1 OPTIMIZE=1
+WARNINGS=0``).
 
   ========  ================================================================
   Option    Effect

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -5,19 +5,23 @@ Building Chapel
 ===============
 
 To build the Chapel compiler, set up your environment as described in
-:ref:`chapelhome-quickstart` (or :ref:`readme-chplenv` for more
-settings), cd to ``$CHPL_HOME``, and run GNU make.
+:ref:`chapelhome-quickstart` or :ref:`readme-chplenv`, cd to
+``$CHPL_HOME`` (the root directory of your unpacked Chapel release),
+and run GNU make.  This will build the compiler and runtime libraries
+for your current environment as indicated by running
+``$CHPL_HOME/util/printchplenv --all``.
 
-On many systems, GNU make is available simply as ``make``. On others, it is
-called ``gmake``. So, first check if ``make`` refers to GNU make:
+On many systems, GNU make is available simply as ``make``. On others,
+it is called ``gmake``.  To check whether ``make`` refers to GNU make
+on your system, run:
 
 .. code-block:: bash
 
-   # If the first line includes "GNU Make", you have GNU Make.
    make -v
 
-Further instructions will assume ``make`` refers to GNU Make. If that's not
-the case, you'll need to replace ``make`` with ``gmake``.
+If the first line includes "GNU Make", you have GNU Make.  The rest of
+these instructions will assume ``make`` refers to GNU Make. If that's
+not the case, you'll need to replace ``make`` with ``gmake``.
 
 Now build the Chapel compiler:
 
@@ -34,26 +38,17 @@ If everything works as intended, you ought to see:
 
 #. the compiler binary getting linked and stored as:
 
-     ``$CHPL_HOME/bin/$CHPL_HOST_PLATFORM/chpl``
+     ``$CHPL_HOME/bin/$CHPL_HOST_PLATFORM-$CHPL_HOST_ARCH/chpl``
 
 #. the runtime support libraries being compiled, archived, and stored
    in a configuration-specific subdirectory under:
 
-     ``$CHPL_HOME/lib/$CHPL_TARGET_PLATFORM.$CHPL_TARGET_COMPILER.../``
+     ``$CHPL_HOME/lib/$CHPL_TARGET_PLATFORM/.../``
 
-If you get an error or failure during the make process, first
-double-check that you have the required prerequisites (see
-:ref:`readme-prereqs`). If you do, please submit a bug report for the failure
-and any workaround that you come up with, through :ref:`readme-bugs`
-
-Note that each make command only builds the compiler and runtime for
-the current set of ``CHPL_`` environment variables defined by (and
-inferred for) your environment.  Thus, while the directory structure
-above supports the ability to have multiple versions of the compiler
-and runtime built simultaneously, only one version will be created for
-each make command.  To support additional host/target platforms,
-host/target compilers, or threading/communication layers, you will
-need to reset your environment variables and re-make.
+If you get an error or failure during the make process, double-check
+that you have the required prerequisites (see
+:ref:`readme-prereqs`). If you do, please submit a bug report for the
+failure through :ref:`readme-bugs`.
 
 After a successful build, you should be able to run the compiler and
 display its help message using:
@@ -62,36 +57,104 @@ display its help message using:
 
   chpl --help
 
-In which case, you will be ready to move on to compiling with the
-Chapel compiler (see :ref:`readme-compiling`).  The rest of this
-file gives more information about Chapel's Makefiles for advanced
+In which case, you are ready to move on to compiling with the Chapel
+compiler (see :ref:`readme-compiling`).  The next few sections provide
+more information about using Chapel across multiple sessions,
+installing Chapel, and supporting multiple Chapel configurations.
+Following that are sections describing Chapel's Makefiles for advanced
 users or developers of Chapel.
 
 
-----------------
-Platform Support
-----------------
+.. _using-chapel-in-other-sessions:
 
-Currently supported platforms include 32- and 64-bit Linux, Mac OS X,
-Cygwin (Windows), SunOS, a variety of current HPE and Cray platforms, and a
-few systems by other vendors.  Most UNIX-based environments ought to
-support Chapel (subject to the assumptions in :ref:`readme-prereqs`), but may
-not be supported "out-of-the-box" by our current Makefile structure.
-See the section below on platform-specific settings for more
-information on adding support for additional UNIX-compatible
-environments.
+------------------------------------------------------
+Using Chapel in a Different Shell / Terminal / Session
+------------------------------------------------------
 
-Note that a single Chapel installation can simultaneously support
-Chapel for multiple platforms and compiler options because all
-platform-specific binary files and executables are stored in
-subdirectories named by ``CHPL_`` environment variables.
+Once you have built Chapel, you can use it in other sessions (new
+shells or terminals) as long as:
+
+1. the ``chpl`` compiler is in your ``$PATH``
+
+#. your ``$CHPL_`` environment variables are set or inferred to values
+   that match a configuration you have already built
+
+Typically, this is accomplished in one of the following ways:
+
+* by manually re-sourcing the ``setchplenv.*`` file that you used
+  when building Chapel.
+
+* by editing your 'dot files' (e.g., ``.bashrc``, ``bash_profile``, or
+  whatever your shell uses to start up each session) to explicitly set
+  your path and ``$CHPL_`` settings as desired, or to source the
+  appropriate ``setchplenv.*`` script.
+
+* by creating a ``chplconfig`` file to store your preferred ``$CHPL_``
+  settings (see :ref:`chplconfig <readme-chplenv.chplconfig>` for
+  further details on creating a chplconfig file).  Note, however, that
+  some other technique would still be required to ensure that ``chpl``
+  is in your path.
+
+* by installing Chapel to a specific location—perhaps one that is
+  already in your path—using the instructions in the next section.
+
+
+-----------------
+Installing Chapel
+-----------------
+
+Chapel can be built and installed to a specific location as follows:
+
+.. code-block:: bash
+
+  ./configure  # use ``./configure --help`` for specific options
+  make
+  make install
+
+Running ``./configure`` will save your current configuration of
+``$CHPL_`` settings into a ``chplconfig`` file.  Running it with the
+``--prefix`` or ``chpl-home`` options permits you to specify where and
+how Chapel should be installed during the ``make install`` step.
+Specifically:
+
+* ``--prefix=/dir/for/install/`` causes the Chapel compiler,
+  libraries, and supporting code to be installed into the directories:
+
+  - ``/dir/for/install/bin``
+  - ``/dir/for/install/lib``
+  - ``/dir/for/install/share``
+
+  This technique is designed to install Chapel using a standard
+  directory structure for the purposes of integrating it into a
+  standard location that is already be in your path, such as
+  ``/usr/local/`` or ``~/``.  Note that elevated privileges are likely
+  to be required for any system-wide installation locations.
+
+* ``--chpl-home=/dir/for/install`` copies key files and directories
+  from the Chapel source tree into ``/dir/for/install``, preserving
+  Chapel's traditional directory structure.
+
+
+-----------------------------------------
+Switching Between Multiple Configurations
+-----------------------------------------
+
+A single installation of Chapel can simultaneously support multiple
+configuration options, such as target platforms or compilers, because
+all binary files and executables are stored in unique subdirectories
+as determined by the ``CHPL_`` environment variables.  However, note
+that each ``make`` command only builds the compiler and runtime for
+the current set of ``CHPL_`` environment variables defined by—and
+inferred for—your environment.  To build support for additional
+configurations, you will need to modify your ``CHPL_`` environment
+variables and re-make.
 
 
 ----------------
 Makefile Targets
 ----------------
 
-The Chapel sources are structured so that a GNU-compatible make
+The Chapel sources are structured so that a GNU-compatible ``make``
 utility can be used in any source directory to build the sources
 contained in that directory and its subdirectories.  All of these
 Makefiles support the following targets:
@@ -99,23 +162,23 @@ Makefiles support the following targets:
   +-----------+------------------------------------------------------+
   | Target    | Action                                               |
   +===========+======================================================+
-  | (nothing) | Build the appropriate output files e.g. objects,     |
+  | (nothing) | Build the appropriate targets — e.g., objects files, |
   | default   | libraries, executables                               |
   | all       |                                                      |
   +-----------+------------------------------------------------------+
-  | check     | verify basic functionality of chapel build           |
+  | check     | verify basic functionality of a Chapel build         |
   +-----------+------------------------------------------------------+
   | clean     | Remove the intermediate files for this configuration |
   +-----------+------------------------------------------------------+
   | cleanall  | Remove the intermediate files for all configurations |
   +-----------+------------------------------------------------------+
   | clobber   | Remove everything created by the Makefiles           |
-  |           | Note: make clobber will remove chplconfig            |
+  |           | as well as ``chplconfig``                            |
   +-----------+------------------------------------------------------+
-  | install   | Install chapel to a previously configured location   |
+  | install   | Install Chapel to a previously configured location   |
   +-----------+------------------------------------------------------+
 
-Each target processes all subdirectories then the current directory.
+Each target processes all subdirectories, then the current directory.
 
 
 ----------------
@@ -123,71 +186,19 @@ Makefile Options
 ----------------
 
 The Chapel makefiles have a few options that enable or disable optimization,
-debugging support, profiling, and backend C compiler warnings. The variables
+debugging support, profiling, and back-end C compiler warnings. The variables
 are described below. Set the value to 1 to enable the feature.
 
-  ========  =======================================================
+  ========  ================================================================
   Option    Effect
-  ========  =======================================================
-  DEBUG     Generate debug information (e.g. add -g to C compiler).
-  OPTIMIZE  Enable optimizations (e.g. add -O3 to C compiler).
-  PROFILE   Enable profiling support (e.g. add -pg to C compiler).
-  WARNINGS  Promote backend C compiler warnings to errors.
-  ASSERTS   Enables correctness assertions in the compiler and runtime.
-  ========  =======================================================
+  ========  ================================================================
+  DEBUG     Generate debug information (e.g., pass ``-g`` to the C compiler)
+  OPTIMIZE  Enable optimizations (e.g., pass ``-O3`` to the C compiler)
+  PROFILE   Enable profiling support (e.g., pass ``-pg`` to C compiler)
+  WARNINGS  Enable more warnings and treat them as errors
+  ASSERTS   Enables correctness assertions in the compiler and runtime
+  ========  ================================================================
 
-
-.. _platform-specific-settings:
-
---------------------------
-Platform-specific Settings
---------------------------
-
-The structure of Chapel's Makefiles is designed to factor any
-compiler-specific settings in
-``$CHPL_HOME/make/compiler/Makefile.<compiler>`` where ``<compiler>`` refers
-to ``$CHPL_HOST_COMPILER`` for the compiler sources and
-``$CHPL_TARGET_COMPILER`` for the runtime sources and generated code.
-Refer to :ref:`readme-chplenv` for more information about these variables and
-their default settings.
-
-In addition, any architecture-specific settings are defined in
-``$CHPL_HOME/make/platform/Makefile.<platform>``, where ``<platform>`` refers
-to ``$CHPL_HOST_PLATFORM`` for the compiler sources and
-``$CHPL_TARGET_PLATFORM`` for the runtime sources and generated code.
-Again, :ref:`readme-chplenv` details these variables and their default
-settings.
-
-If you try making the compiler and runtime for an unknown platform, it
-will assume that you want to use gcc/g++ to compile the code and that
-you require no platform-specific settings.  You can add support for a
-new build environment by creating ``Makefile.<compiler>`` and/or
-``Makefile.<platform>`` files and setting your environment variables to
-refer to those files.  If you do develop new build environment support
-that you would like to contribute back to the community, we encourage
-you to submit a pull request to the `Chapel GitHub repository`_.
 
 .. _readme-installing:
 
------------------
-Installing Chapel
------------------
-
-Chapel can be built and installed as follows:
-
-.. code-block:: bash
-
-  ./configure # adding appropriate options
-  make
-  make install # possibly with elevated privilege
-
-See ``./configure --help`` for more information on the options available.
-
-.. note::
-
- ``./configure`` will save the current configuration into a
- ``chplconfig`` file and can set the installation path that will be
- compiled in to the ``chpl`` binary.
-
-
-.. _Chapel GitHub repository: https://github.com/chapel-lang/chapel

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -114,10 +114,9 @@ CHPL_HOST_PLATFORM
    The Chapel Makefiles and sources are designed to work for any UNIX-compatible
    environment that supports a GNU-compatible make utility.  The list above
    represents the set of platforms that we have access to and can test easily.
-   We are interested in making our code framework portable to other platforms --
-   if you are using Chapel on a platform other than the ones listed above,
-   please refer to :ref:`platform-specific-settings` for ways to set up a
-   Makefile for this platform.
+   We are interested in making our code framework portable to other
+   platforms—if you are using Chapel on a platform other than the ones
+   listed above, please contact us for help with the effort.
 
 
 .. _readme-chplenv.CHPL_TARGET_PLATFORM:

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -686,6 +686,9 @@ CHPL_LLVM
        system         find a compatible LLVM in system libraries;
                       note: the LLVM must be a version supported by Chapel
        none           do not support llvm/clang-related features
+       unset          indicates that no reasonable default has been
+                      inferred, requiring the user to intentionally select
+                      another option
        ============== ======================================================
 
    If unset, ``CHPL_LLVM`` defaults to:
@@ -772,8 +775,8 @@ value selects that flag.
 
 .. _readme-chplenv.chplconfig:
 
-Chapel Configuration File
--------------------------
+Chapel Configuration Files
+--------------------------
 
 The Chapel configuration file is a file named either ``chplconfig`` or
 ``.chplconfig`` that can store overrides of the inferred environment variables


### PR DESCRIPTION
Motivated by user issue #18150, I took an editing pass over QUICKSTART.rst and building.rst to refresh them for the upcoming Chapel 1.25 release.  Specifically, my high-level goals were to:

* keep QUICKSTART as lean and mean as possible while having it refer users to other places to avoid common traps
* make sure that things were still as accurate as possible
* promote the `make install` content a bit higher and address the challenge of using Chapel across multiple shells more directly
* generally wordsmithed and smoothed things over

In more detail, In `building.rst`, I:

* removed the reference back to QUICKSTART.rst in this file, promoting chplenv.rst in its place, because I think quickstart should be all about "quick and dirty" with building.rst and chplenv.rst being more about "the complete story in plenty of detail"
* mentioned `printchplenv` in the opening paragraph for someone arriving in this file without going through `chplenv.rst` to understand what we mean by the Chapel environment
* moved the comment about interpreting the output of `make -v` into actual text in the document because if someone needs this level of hand-holding, they may not know what a bash comment is and may type it in
* fixed the updated path to `chpl`
* fixed the prefix of the path to the libraries (while leaving the details vague)
* moved the part about each `make` command only building the current configuration further down in the document
* made the part about "now you can compile" allude to the next few sections so that people wouldn't stop reading prematurely (while still knowing that they had a working compile)
* added a detailed section about using the built Chapel in other shells / terminals, because this is increasingly FAQ'd as we get more beginning users
* fleshed out the section of `./configure` + `make install` to be a bit more precise about how to use it.  I can never remember, and I feel as though those commands currently require more than an ideal amount of expertise.  I think we could go even further with hand-holding in these instructions, but I'm not quite clear I could do it justice (not really understanding the full behavior...), and hopefully this is a step in the right direction.
* took out the paragraph about supported platforms because... what is that doing here?  (and who wants to maintain it here)
* added a section about switching between multiple configurations / supporting them in a single place
* removed a big section about supporting a new compiler or platform by simply dropping in a Makefile.<whatever> because I don't think the world is that simple anymore (at least on the compiler side of things)
* tweaked some details and formatting and wordings in the Makefile-related sections

In QUICKSTART.rst, I:

* started the document off with a bit more of "What the goal here is", referring people to the "official / full-fledged" instructions if they'd prefer to do that and trying to make the quickstart vs. full-featured branch clearer earlier.  Overall, my hope is that most people will head into the quickstart instructions due to lack of patience, but that those patient enough to read these paragraphs may self select into the chplenv + building docs or perhaps jump directly to the preferred configuration if they don't want to waste time with a stripped-down version / are willing to deal with more detail.  This also allowed me to make subsequent bullets shorter and sweeter (where my guess is that 80% of readers will just jump to step 0 and start typing stuff... I know I would).
* changed from "expand" to "unpack" when talking about dealing with the .tar.gz
* generally switched from hyperlinks that refer to filenames and section names to those that spell out the section (with the assumption that it looks better in web form and that that's where most people see it)
* removed references to `make check` since it essentially builds and runs a program which is what the instructions are just about to suggest you do
* switched hello.chpl to hello3-datapar.chpl just because it's more interesting; may produce more of a "wow!" factor when run; may lead people to look at what hellos 1-3+ are, etc.
* removed the -o flag from the `chpl` command lines since we don't generate `a.out` anymore, so it seems redundant
* tried to make the section about LLVM in the preferred configuration a bit clearer by breaking the options out into bullets
* forked the part about using your build in other shells/terminals into its own section (for visibility given that it's FAQ'd) but then had it refer to the relevant section in building.rst to avoid duplication / keep this treatment short and sweet
* fixed the link about performance tips to point to the more specific page
* added a note for reassurance that we support the setchplenv scripts for the preferred mode for non-bash shells as well

Resolves #18150.
