### PR TITLE
Argparse doc note

### DIFF
--- a/doc/rst/technotes/main.rst
+++ b/doc/rst/technotes/main.rst
@@ -21,6 +21,7 @@ declared to return an integer in which case the value returned serves
 as the status value.
 
 
+.. _technote-mainWithArgs:
 
 Having main() accept command-line arguments
 ===========================================

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -32,9 +32,9 @@
 
     Chapel programs can make use of :ref:`configuration constants and variables <ug-configs>`.
     The ArgumentParser module can be used in place of, or in addition to,
-    configuration variables and constants. However, many programs may not need
-    the added complexity of the ArgumentParser, relying solely on the
-    functionality provided by configuration variables.
+    configuration variables and constants. In particular, it is common for Chapel
+    programs to rely solely upon configuration variables and for such programs
+    the ArgumentParser is not needed.
 
   .. note::
 

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -30,6 +30,14 @@
 
   .. note::
 
+    Chapel programs can make use of :ref:`configuration constants and variables <ug-configs>`.
+    The ArgumentParser module can be used in place of, or in addition to,
+    configuration variables and constants. However, many programs may not need
+    the added complexity of the ArgumentParser, relying solely on the
+    functionality provided by configuration variables.
+
+  .. note::
+
     This module is in the initial stages of development and should be expected
     to change in future releases.
 

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -22,6 +22,14 @@
 
   .. note::
 
+    You must declare your main method to take an array of string arguments in
+    order to get values from the command line.
+    See the Quickstart example below or the technote about
+    :ref:`getting arguments from main()<technote-mainWithArgs>`.
+
+
+  .. note::
+
     This module is in the initial stages of development and should be expected
     to change in future releases.
 

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -24,8 +24,8 @@
 
     You must declare your main method to take an array of string arguments in
     order to get values from the command line.
-    See the Quickstart example below or the technote about
-    :ref:`getting arguments from main()<technote-mainWithArgs>`.
+    See the :ref:`quickstart example<argumentParser-quickstart>` below or the
+    technote about :ref:`getting arguments from main()<technote-mainWithArgs>`.
 
 
   .. note::
@@ -99,6 +99,8 @@
     .. code-block:: shell
 
       $ myExecutable build --force otherProgram -- --flags --for --compiling otherProgram
+
+  .. _argumentParser-quickstart:
 
   Quickstart Example
   -------------------


### PR DESCRIPTION
This PR updates the ArgumentParser docs to include a note about setting up 
`main()` to take arguments. 

No code or logic changes.

TESTING:

I have verified that `make docs` completes successfully after these changes.

Reviewed by @mppf - Thanks!

Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com