### PR TITLE
Incorporate ArgumentParser in mason run and mason build subcommands

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -35,7 +35,7 @@ Basic Usage
 Starting a New Package
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To initialize a new mason package, run ``mason new``. The same can also be done using ``mason init`` as follows: 
+To initialize a new mason package, run ``mason new``. The same can also be done using ``mason init`` as follows:
 
   .. code-block:: sh
 
@@ -53,19 +53,19 @@ A more advanced user may use the ``mason new [ options ] <project name>`` comman
 This creates a git repository by default, unless ``--no-vcs`` is included.
 
 Mason packages can also be initialized using the ``mason init [options] [directory path]``.
-To avoid the interactive session while initializing the project, run ``mason init -d | --default``. 
+To avoid the interactive session while initializing the project, run ``mason init -d | --default``.
 
 
-For example, for an existing directory named MyPackage, 
-    
+For example, for an existing directory named MyPackage,
+
   .. code-block:: sh
-    
-    mason init MyPackage 
 
-    # OR 
+    mason init MyPackage
+
+    # OR
 
     cd MyPackage
-    mason init -d  
+    mason init -d
 
 
 The package will have the following hierarchy::
@@ -91,10 +91,10 @@ additional functionality that comes with these folders later.
 Mason enforces that the main file be named after the package to enforce namespacing.
 ``MyPackage.chpl`` will be the first file listed in ``src/``.
 
-You can create a package in a directory that differs from the mason 
+You can create a package in a directory that differs from the mason
 package name with the `mason {new,init} --name` flag.
-This may be useful when creating a package in a directory that 
-is an illegal Mason package name, such as names with dashes. For example, 
+This may be useful when creating a package in a directory that
+is an illegal Mason package name, such as names with dashes. For example,
 
   .. code-block:: sh
 
@@ -224,16 +224,17 @@ For an example of forwarding arguments in a call to ``mason run``, a chapel prog
 mason might have a ``config const number`` that corresponds to a value used in ``MyPackage.chpl``.
 To try out different values at runtime, pass the values for ``number`` to ``mason run`` as follows::
 
-      mason run --number=100
-      mason run --number=1000
+      mason run -- --number=100
+      mason run -- --number=1000
 
 
 .. note::
 
-   For the case when a flag intended for the ``chpl`` compiler or executable is recognized by
-   ``mason build`` or ``mason run``, respectively, the flag can be thrown after ``--``
-   to override this conflict. For example, ``mason run -- -nl 4``. Instead of mason recognizing
-   this argument, this command will run the executable over 4 locales.
+   Previous releases allowed flags meant for the compiler or chapel program to be mixed with
+   those meant for ``mason build`` or ``mason run``, respectively. As of Chapel 1.25 and
+   mason 0.2.0, flags not intended for ``mason`` must follow a double dash ``--`` regardless
+   of if they conflict or not.
+
 
 
 Testing your Package

--- a/test/library/packages/ArgumentParser/ArgumentParserTests.chpl
+++ b/test/library/packages/ArgumentParser/ArgumentParserTests.chpl
@@ -3606,6 +3606,30 @@ proc testMixedNegativeIntegerArgsOptions(test: borrowed Test) throws {
   test.assertEqual(new list(myIntOpts.values()), new list(argList[4..5]));
 }
 
+// test for presence of option without values
+proc testOptionZeroValueDetection(test: borrowed Test) throws {
+  var argList = ["progName","--example"];
+  var parser = new argumentParser();
+  var myOption = parser.addOption(name="example",
+                                  opts=["--example"],
+                                  numArgs=0..);
+  var myOtherOption = parser.addOption(name="other",
+                                       opts=["--other"],
+                                       numArgs=0..);
+
+  //make sure no value currently exists
+  test.assertFalse(myOption.hasValue());
+  test.assertFalse(myOtherOption.hasValue());
+  //parse the options
+  parser.parseArgs(argList);
+  //make sure we found the option
+  test.assertTrue(myOption._present);
+  test.assertFalse(myOtherOption._present);
+  //ensure there is no value
+  test.assertFalse(myOption.hasValue());
+  test.assertFalse(myOtherOption.hasValue());
+  test.assertEqual(new list(myOption.values()), new list(string));
+}
 
 // TODO: SPLIT THIS INTO MULTIPLE FILES BY FEATURE
 

--- a/test/library/packages/ArgumentParser/ArgumentParserTests.good
+++ b/test/library/packages/ArgumentParser/ArgumentParserTests.good
@@ -538,6 +538,10 @@ testMixedNegativeIntegerArgsOptions()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
+testOptionZeroValueDetection()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
 Found some unrecognizable arguments: thirty
 Found some unrecognizable arguments: badArg1 --BadFlag
 Use '-' or '--' to indicate option/flag, or use positional arguments.

--- a/test/mason/build/noDeps.chpl
+++ b/test/mason/build/noDeps.chpl
@@ -6,6 +6,6 @@ use MasonBuild;
 proc main() {
   const package = '_noDeps';
   here.chdir(package);
-  const args = ["mason", "build"];
+  const args = ["build"];
   masonBuild(args);
 }

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -4,11 +4,11 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["mason", "build", "--example", "--force"]);
+  masonBuild(["build", "--example", "--force"]);
 
   // run each example
   // over 3 arguments runs all examples
-  var runArgs: [0..3] string = ["mason", "run", "--example", "--force"];
+  var runArgs: [0..2] string = ["run", "--example", "--force"];
   masonRun(runArgs);
 
 }

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -4,10 +4,10 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["mason","build", "--example", "--force"]);
+  masonBuild(["build", "--example", "--force"]);
 
   // run each example
   // over 3 arguments runs all examples
-  masonRun(["mason", "run", "--example", "--force", "--no-update"]);
+  masonRun(["run", "--example", "--force", "--no-update"]);
 
 }

--- a/test/mason/mason-external/libtomlc99/mason-external.chpl
+++ b/test/mason/mason-external/libtomlc99/mason-external.chpl
@@ -24,7 +24,7 @@ proc main() {
   masonExternal(args);
 
   // build library that uses libtomlc99
-  var buildArgs = ["mason", "build", "--force"];
+  var buildArgs = ["build", "--force"];
   masonBuild(buildArgs);
 
 }

--- a/test/mason/run/mason-run.chpl
+++ b/test/mason/run/mason-run.chpl
@@ -1,6 +1,6 @@
 use MasonRun;
 
 proc main() {
-  const args: [0..3] string = ["mason", "run", "--build", "--force"];
+  const args: [0..2] string = ["run", "--build", "--force"];
   masonRun(args);
 }

--- a/test/mason/subdir-commands/mason-run.chpl
+++ b/test/mason/subdir-commands/mason-run.chpl
@@ -1,6 +1,6 @@
 use MasonRun;
 
 proc main() {
-  const args: [0..3] string = ["mason", "run", "--build", "--force"];
+  const args: [0..2] string = ["run", "--build", "--force"];
   masonRun(args);
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -82,7 +82,7 @@ proc masonBuild(args: [] string) throws {
   }
 
   if example {
-    // compopts become test names. Build never runs examples
+    // compopts become example names. Build never runs examples
     for val in exampleOpts.values() do compopts.append(val);
     compopts.append("--no-run");
     if skipUpdate then compopts.append('--no-update');

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -19,12 +19,10 @@
  */
 
 
-private use List;
-private use Map;
-
-use TOML;
-use Spawn;
+use ArgumentParser;
 use FileSystem;
+use List;
+use Map;
 use MasonUtils;
 use MasonHelp;
 use MasonEnv;
@@ -32,61 +30,105 @@ use MasonUpdate;
 use MasonSystem;
 use MasonExternal;
 use MasonExample;
+use Spawn;
+use TOML;
 
 proc masonBuild(args: [] string) throws {
-  var show = false;
-  var release = false;
-  var force = false;
+  const NOEXAMPLES = "**NO EXAMPLES**";
+
+  var parser = new argumentParser();
+
+  var showFlag = parser.addFlag(name="show", defaultValue=false);
+  var releaseFlag = parser.addFlag(name="release", defaultValue=false);
+  var forceFlag = parser.addFlag(name="force", defaultValue=false);
+  var exampleOpts = parser.addOption(name="example",
+                                     numArgs=0..,
+                                     defaultValue=NOEXAMPLES);
+  var updateFlag = parser.addFlag(name="update", flagInversion=true);
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false);
+
+  var passArgs = parser.addPassThrough();
+
+  try {
+    parser.parseArgs(args);
+  } catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonBuildHelp();
+    exit(1);
+  }
+
+  if helpFlag.valueAsBool() {
+    masonBuildHelp();
+    exit(0);
+  }
+
+  var show = showFlag.valueAsBool();
+  var release = releaseFlag.valueAsBool();
+  var force = forceFlag.valueAsBool();
   var compopts: list(string);
-  var opt = false;
+  //var opt = false;
   var example = false;
   var skipUpdate = MASON_OFFLINE;
-  if args.size > 2 {
+  if (exampleOpts.hasValue() && exampleOpts.value() != NOEXAMPLES)
+      || !exampleOpts.hasValue() then example = true;
 
-    // strip off the first two indices
-    for i in args.domain#-(args.size-2) {
-      var arg = args[i];
-      if opt == true {
-        compopts.append(arg);
-      }
-      else if arg == '-h' || arg == '--help' {
-        masonBuildHelp();
-        exit(0);
-      }
-      else if arg == '--' {
-        if example then
-          throw new owned MasonError("Examples do not support `--` syntax");
-        opt = true;
-      }
-      else if arg == '--release' {
-        release = true;
-      }
-      else if arg == '--force' {
-        force = true;
-      }
-      else if arg == '--show' {
-        show = true;
-      }
-      else if arg.startsWith('--example=') {
-        example = true;
-        compopts.append(arg);
-      }
-      else if arg == '--example' {
-        example = true;
-      }
-      else if arg == '--update' {
-        skipUpdate = false;
-      }
-      else if arg == '--no-update' {
-        skipUpdate = true;
-      }
-      else {
-        compopts.append(arg);
-      }
-    }
+
+  if updateFlag.hasValue() {
+    if updateFlag.valueAsBool() then skipUpdate = false;
+    else skipUpdate = true;
   }
+
+
+  // if args.size > 2 {
+
+  //   // strip off the first two indices
+  //   for i in args.domain#-(args.size-2) {
+  //     var arg = args[i];
+  //     if opt == true {
+  //       compopts.append(arg);
+  //     }
+  //     else if arg == '-h' || arg == '--help' {
+  //       masonBuildHelp();
+  //       exit(0);
+  //     }
+  //     else if arg == '--' {
+  //       if example then
+  //         throw new owned MasonError("Examples do not support `--` syntax");
+  //       opt = true;
+  //     }
+  //     else if arg == '--release' {
+  //       release = true;
+  //     }
+  //     else if arg == '--force' {
+  //       force = true;
+  //     }
+  //     else if arg == '--show' {
+  //       show = true;
+  //     }
+  //     else if arg.startsWith('--example=') {
+  //       example = true;
+  //       compopts.append(arg);
+  //     }
+  //     else if arg == '--example' {
+  //       example = true;
+  //     }
+  //     else if arg == '--update' {
+  //       skipUpdate = false;
+  //     }
+  //     else if arg == '--no-update' {
+  //       skipUpdate = true;
+  //     }
+  //     else {
+  //       compopts.append(arg);
+  //     }
+  //   }
+  // }
+
   if example {
     // compopts become test names. Build never runs examples
+    for val in exampleOpts.values() do compopts.append(val);
     compopts.append("--no-run");
     if skipUpdate then compopts.append('--no-update');
                   else compopts.append('--update');
@@ -98,8 +140,11 @@ proc masonBuild(args: [] string) throws {
     masonExample(compopts.toArray());
   }
   else {
-    var argsList = new list(string);
-    for x in args do argsList.append(x);
+    if passArgs.hasValue() {
+      for val in passArgs.values() do compopts.append(val);
+    }
+    // var argsList = new list(string);
+    // for x in args do argsList.append(x);
     const configNames = updateLock(skipUpdate);
     const tomlName = configNames[0];
     const lockName = configNames[1];

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -68,7 +68,6 @@ proc masonBuild(args: [] string) throws {
   var release = releaseFlag.valueAsBool();
   var force = forceFlag.valueAsBool();
   var compopts: list(string);
-  //var opt = false;
   var example = false;
   var skipUpdate = MASON_OFFLINE;
   if (exampleOpts.hasValue() && exampleOpts.value() != NOEXAMPLES)
@@ -79,52 +78,6 @@ proc masonBuild(args: [] string) throws {
     if updateFlag.valueAsBool() then skipUpdate = false;
     else skipUpdate = true;
   }
-
-
-  // if args.size > 2 {
-
-  //   // strip off the first two indices
-  //   for i in args.domain#-(args.size-2) {
-  //     var arg = args[i];
-  //     if opt == true {
-  //       compopts.append(arg);
-  //     }
-  //     else if arg == '-h' || arg == '--help' {
-  //       masonBuildHelp();
-  //       exit(0);
-  //     }
-  //     else if arg == '--' {
-  //       if example then
-  //         throw new owned MasonError("Examples do not support `--` syntax");
-  //       opt = true;
-  //     }
-  //     else if arg == '--release' {
-  //       release = true;
-  //     }
-  //     else if arg == '--force' {
-  //       force = true;
-  //     }
-  //     else if arg == '--show' {
-  //       show = true;
-  //     }
-  //     else if arg.startsWith('--example=') {
-  //       example = true;
-  //       compopts.append(arg);
-  //     }
-  //     else if arg == '--example' {
-  //       example = true;
-  //     }
-  //     else if arg == '--update' {
-  //       skipUpdate = false;
-  //     }
-  //     else if arg == '--no-update' {
-  //       skipUpdate = true;
-  //     }
-  //     else {
-  //       compopts.append(arg);
-  //     }
-  //   }
-  // }
 
   if example {
     // compopts become test names. Build never runs examples
@@ -164,7 +117,6 @@ private proc checkChplVersion(lockFile : borrowed Toml) throws {
 
 proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: list(string),
                   tomlName="Mason.toml", lockName="Mason.lock") throws {
-
 
   try! {
 

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -27,9 +27,9 @@ use MasonHelp;
 use MasonUtils;
 use TOML;
 
-proc masonRun(args: [] string) throws {
+const NOEXAMPLES = "**NO EXAMPLES**";
 
-  const NOEXAMPLES = "**NO EXAMPLES**";
+proc masonRun(args: [] string) throws {
 
   var parser = new argumentParser();
   var showFlag = parser.addFlag(name="show", defaultValue=false);
@@ -145,77 +145,72 @@ proc runProjectBinary(show: bool, release: bool, execopts: list(string)) throws 
 /* Builds program before running. */
 private proc masonBuildRun(args: [?d] string) {
 
-// TODO: Implement Parser Here
+  var parser = new argumentParser();
+  var showFlag = parser.addFlag(name="show", defaultValue=false);
+  var releaseFlag = parser.addFlag(name="release", defaultValue=false);
+  var buildFlag = parser.addFlag(name="build", defaultValue=false);
+
+  // not actually flags for Run, but rather for build
+  var forceFlag = parser.addFlag(name="force", defaultValue=false);
+  var updateFlag = parser.addFlag(name="update", flagInversion=true);
+
+  var exampleOpts = parser.addOption(name="example",
+                                     numArgs=0..,
+                                     defaultValue=NOEXAMPLES);
+  var helpFlag = parser.addFlag(name="help",
+                                opts=["-h","--help"],
+                                defaultValue=false);
+
+  var passArgs = parser.addPassThrough();
+
+  try! {
+    parser.parseArgs(args);
+  } catch ex : ArgumentError {
+    stderr.writeln(ex.message());
+    masonRunHelp();
+    exit(1);
+  }
+
   try! {
     var example = false;
-    var show = false;
-    var release = false;
-    var force = false;
+    var show = showFlag.valueAsBool();
+    var release = releaseFlag.valueAsBool();
+    var force = forceFlag.valueAsBool();
     var exec = false;
     var buildExample = false;
     var skipUpdate = MASON_OFFLINE;
     var execopts: list(string);
     var exampleProgram='';
-    for arg in args[1..] {
-      if exec == true {
-        execopts.append(arg);
-      }
-      else if arg == "--" {
-        if example then
-          throw new owned MasonError("Examples do not support `--` syntax");
-        exec = true;
-      }
-      else if arg.startsWith("--example=") {
-        execopts.append(arg);
-        example = true;
-      }
-      else if arg == "--example" {
-        example = true;
-      }
-      else if arg == "--show" {
-        show = true;
-      }
-      else if arg == "--build" {
-        buildExample = true;
-      }
-      else if arg == "--force" {
-        force = true;
-      }
-      else if arg == "--release" {
-        release = true;
-      }
-      else if arg == '--no-update' {
-        skipUpdate = true;
-      }
-      else if arg == '--update' {
-        skipUpdate = false;
-      }
-      else {
-        // could be examples or execopts
-        execopts.append(arg);
-      }
+
+    if (exampleOpts.hasValue() && exampleOpts.value() != NOEXAMPLES)
+        || !exampleOpts.hasValue() then example = true;
+
+
+    if updateFlag.hasValue() {
+      if updateFlag.valueAsBool() then skipUpdate = false;
+      else skipUpdate = true;
     }
+
     if example {
+      // add expected arguments for masonExample
+      execopts.insert(0,["example", "--example"]);
+      for val in exampleOpts.values() do execopts.append(val);
       if !buildExample then execopts.append("--no-build");
       if release then execopts.append("--release");
       if force then execopts.append("--force");
       if show then execopts.append("--show");
-      // add expected arguments for masonExample
-      execopts.insert(0,["example", "--example"]);
-      //writeln("input to MasonExample " + execopts.toArray());
       masonExample(execopts.toArray());
     }
     else {
       var buildArgs: list(string);
-      //buildArgs.append("mason");
       buildArgs.append("build");
       if skipUpdate then buildArgs.append("--no-update");
                     else buildArgs.append("--update");
       if release then buildArgs.append("--release");
       if force then buildArgs.append("--force");
       if show then buildArgs.append("--show");
-      // writeln("input to masonBuild " + execopts.toArray());
       masonBuild(buildArgs.toArray());
+      for val in passArgs.values() do execopts.append(val);
       runProjectBinary(show, release, execopts);
     }
   }

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -65,7 +65,8 @@ proc masonRun(args: [] string) throws {
   var execopts = new list(passArgs.values());
 
 
-  if exampleOpts._present && args.size == 2 {
+  if exampleOpts._present && !exampleOpts.hasValue()
+    && args.size == 2 {
     // when mason run --example called
     printAvailableExamples();
     exit(0);

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -132,7 +132,7 @@ proc main(args: [] string) throws {
   try {
     select (usedCmd) {
       when "add" do masonModify(cmdArgs);
-      when "build" do masonBuild(args);
+      when "build" do masonBuild(cmdArgs);
       when "clean" do masonClean(args);
       when "doc" do masonDoc(cmdArgs);
       when "env" do masonEnv(cmdArgs);
@@ -142,7 +142,7 @@ proc main(args: [] string) throws {
       when "new" do masonNew(cmdArgs);
       when "publish" do masonPublish(cmdArgs);
       when "rm" do masonModify(cmdArgs);
-      when "run" do masonRun(args);
+      when "run" do masonRun(cmdArgs);
       when "search" do masonSearch(cmdArgs);
       when "system" do masonSystem(cmdArgs);
       when "test" do masonTest(cmdArgs);


### PR DESCRIPTION
This PR adds the ArgumentParser module to `mason run` and `mason build`
subcommands.

The scope of the work is described in cray/chapel-private#2502.

With this change, we will start properly recognizing the `--` to indicate 
arguments that follow should be directed to the runtime or compiler. 
If a user had previously setup a script that mixed the runtime/compiler 
arguments with the subcommand arguments, they will likely encounter
a runtime error going forward and will need to restructure their input.

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/`

Reviewed by @mppf, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>