### PR TITLE
Update mason version to v0.2.0 for release 1.25

### DIFF
--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -179,5 +179,5 @@ proc masonClean(args) {
 
 
 proc printVersion() {
-  writeln("mason 0.1.2");
+  writeln("mason 0.2.0");
 }


### PR DESCRIPTION
This PR updates the version of mason from `0.1.2` to `0.2.0` to reflect the 
refactoring that has been done to the command line parsing. While those changes
should not break the existing API, there is one significant change to the 
subcommands which eliminates the need to pass `mason` as the first entry in the
arguments array.

Additionally, once chapel-lang/chapel/pull/18409 is merged, argument checking 
for `run` and `build` will be more strict than it has been, and could cause 
some input strings to fail if they had mixed compiler/runtime arguments with 
the subcommand arguments instead of separating them with a `--`, which would 
be required after the merge.

TESTING:

After running `make cleanall` from `$CHPL_HOME`:

- [x] Can `make`
- [x] Can `make docs`
- [x] Can `make mason`
- [x] Can `make check`
- [x] Passing tests from `util/start_test test/mason/`

Reviewed by @mppf - Thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>