### PR TITLE
Adjust this test to use operator methods

### DIFF
--- a/test/library/standard/Set/setCommTest.chpl
+++ b/test/library/standard/Set/setCommTest.chpl
@@ -20,7 +20,7 @@ record r {
   proc deinit() { if doPrint then writeln('deinit'); }
 }
 
-operator =(ref lhs: r, rhs: r) { writeln('assign'); }
+operator r.=(ref lhs: r, rhs: r) { writeln('assign'); }
 
 // Test migrating to N>=12 locales then adding to a set on Locale 0.
 // N>=12 is the number of distributed set.add() calls before a


### PR DESCRIPTION
I'd accidentally run it in a mode it wasn't supposed to run in when I tried to
use operator methods earlier, having missed that there was a skipif for
CHPL_COMM==none.  Running with gasnet, the change works fine.

Resolves #17834 

Checked a fresh checkout

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>