### PR TITLE
Add technote for manage and add 'manage' to keyword list in spec

### DIFF
--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -179,6 +179,7 @@ The following identifiers are reserved as keywords:
    lifetime
    local
    locale
+   manage
    module
    new
    nil

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -22,6 +22,7 @@ Base Language Features
    main() Functions <main>
    Module Search Paths <module_search>
    Operator Methods <operatorMethods>
+   The 'manage' Statement <manage>
 
 
 Initializers and Generic Programming

--- a/doc/rst/technotes/manage.rst
+++ b/doc/rst/technotes/manage.rst
@@ -24,7 +24,7 @@ block.
 The manager may optionally return a `resource`. If a developer wants
 to make use of the resource, they may capture it after the manager
 expression (the `myResource` declaration in the above example).
-The resource may be any type, and is the value returned by the
+The resource may be of any type, and is the value returned by the
 special method called ``enterThis()``.
 
 Any aggregate type may be used as a manager as long as it defines

--- a/doc/rst/technotes/manage.rst
+++ b/doc/rst/technotes/manage.rst
@@ -16,16 +16,19 @@ keyword to open the statement instead of ``with``:
     manage myManager() as myResource do
       myResource.doSomething();
 
-The manage statement accepts a `manager` (the `myManager` in the
-above example). The statement calls a special method on the manager
-which lets it perform actions before executing the managed block.
+The ``manage`` statement accepts a `manager` (the `myManager()` call
+in the above example). The statement calls a special method on the
+manager which lets it perform actions before executing the managed
+block.
 
 The manager may optionally return a `resource`. If a developer wants
 to make use of the resource, they may capture it after the manager
-expression (the `myResource` in the above example).
+expression (the `myResource` declaration in the above example).
+The resource may be any type, and is the value returned by the
+special method called ``enterThis()``.
 
 Any aggregate type may be used as a manager as long as it defines
-two special methods:
+two special methods called ``enterThis()`` and ``leaveThis()``:
 
 .. code-block:: chapel
 
@@ -50,11 +53,11 @@ two special methods:
      // Prints '8'
    }
 
-The ``enterThis()`` method is called on the manager before executing
+The ``enterThis()`` method is called on the manager before entering
 the managed block. The ``leaveThis()`` method is called on the
-manager before exiting the block. It accepts an ``owned Error?`` by
-``in`` intent in order to take ownership of it. The record author
-may decide to rethrow the error or suppress it.
+manager before leaving the block. It accepts a nillable
+``owned Error?`` by ``in`` intent in order to take ownership of it.
+The type author may decide to rethrow the error or suppress it.
 
 Status and Future Work
 ----------------------
@@ -66,8 +69,19 @@ to be formalized, such as:
   return intents, it is unclear what the disambiguation order used
   to select an overload should be.
 - It is uncertain whether or not the storage kind (e.g. ``var``) of
-  a resource should be allowed to be explicitly specified.
+  a resource should be allowed to be explicitly specified. For
+  example:
+
+  .. code-block:: chapel
+
+    manage foo as var bar do writeln(bar);
+
+  Should explicit declaration of the ``var`` storage kind for `bar`
+  be allowed?
+
 - It is unclear how the ``leaveThis()`` method of a manager should
   interact with errors beyond guaranteeing that ``leaveThis()``
   is called even if an error is thrown from within a managed block.
+- The names of the special methods ``enterThis()`` and ``leaveThis()``
+  are unstable and subject to change.
 

--- a/doc/rst/technotes/manage.rst
+++ b/doc/rst/technotes/manage.rst
@@ -1,0 +1,73 @@
+.. _readme-manage:
+
+======================
+The 'manage' statement
+======================
+
+The ``manage`` statement provides a mechanism for performing actions
+automatically at the beginning and end of a scope.
+
+The syntax of the ``manage`` statement is inspired by its Python
+counterpart. The main difference is the use of the ``manage``
+keyword to open the statement instead of ``with``:
+
+.. code-block:: chapel
+
+    manage myManager() as myResource do
+      myResource.doSomething();
+
+The manage statement accepts a `manager` (the `myManager` in the
+above example). The statement calls a special method on the manager
+which lets it perform actions before executing the managed block.
+
+The manager may optionally return a `resource`. If a developer wants
+to make use of the resource, they may capture it after the manager
+expression (the `myResource` in the above example).
+
+Any aggregate type may be used as a manager as long as it defines
+two special methods:
+
+.. code-block:: chapel
+
+   record myManager {
+     var x: int = 0;
+
+     proc enterThis() ref: int {
+       writeln('x is: ', x);
+       return x;
+     }
+
+     proc leaveThis(in err: owned Error?) {
+       if err then halt(err:string);
+       writeln('x is: ', x);
+     }
+   }
+
+   var m = new myManager();
+   manage m as myResource {
+     // Prints '0'
+     myResource = 8;
+     // Prints '8'
+   }
+
+The ``enterThis()`` method is called on the manager before executing
+the managed block. The ``leaveThis()`` method is called on the
+manager before exiting the block. It accepts an ``owned Error?`` by
+``in`` intent in order to take ownership of it. The record author
+may decide to rethrow the error or suppress it.
+
+Status and Future Work
+----------------------
+
+The behavior of several aspects of the ``manage`` statement have yet
+to be formalized, such as:
+
+- If multiple overloads of ``enterThis()`` exist that have different
+  return intents, it is unclear what the disambiguation order used
+  to select an overload should be.
+- It is uncertain whether or not the storage kind (e.g. ``var``) of
+  a resource should be allowed to be explicitly specified.
+- It is unclear how the ``leaveThis()`` method of a manager should
+  interact with errors beyond guaranteeing that ``leaveThis()``
+  is called even if an error is thrown from within a managed block.
+


### PR DESCRIPTION
Add technote about manage statement, add 'manage' keyword to spec

Write a technote about the `manage` statement that describes how it
works today, as well as its current status and open questions.

Add `manage` to the list of keywords in the "Lexical Structure"
section of the spec.

Reviewed by @arezaii and @lydia-duncan. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>