### PR TITLE
Fix typos

### DIFF
--- a/doc/rst/developer/bestPractices/buildingdocs.rst
+++ b/doc/rst/developer/bestPractices/buildingdocs.rst
@@ -75,7 +75,7 @@ Files that live in a repository
 ===============================
 Some of the documentation files are not converted into html files.  Instead
 they are raw html files in the chapel-www repository (currently only accessible
-by core developers) or raw .rst files that live in the public Github respository.
+by core developers) or raw .rst files that live in the public Github repository.
 
 Examples include:
  - https://chapel-lang.org/contributing.html

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1932,7 +1932,7 @@ struct fi_info* getBaseProviderHints(chpl_bool* pTxAttrsForced) {
                                  | FI_MR_PROV_KEY // TODO: avoid pkey bcast?
                                  | FI_MR_ENDPOINT);
 
-  // Set FI_MR_ALLOCATED if there is more than one node and the maximimum
+  // Set FI_MR_ALLOCATED if there is more than one node and the maximum
   // heap size was specified and the CHPL_RT_OVERSUBSCRIBED environment
   // variable was not set, otherwise we risk running out of memory when
   // the heap is allocated. If CHPL_RT_OVERSUBSCRIBED is set then we may


### PR DESCRIPTION
Fix typos in buildingdocs.rst and comm-ofi.c