### PR TITLE
Remove trademark from Cray platform docs

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -4,10 +4,9 @@
 Using Chapel on Cray Systems
 ============================
 
-The following information is assembled to help Chapel users get up and running
-on HPE Cray\ |reg| systems including the Cray XC\ |trade| and
-HPE Cray EX\ |trade|
-series systems.
+The following information is assembled to help Chapel users get up
+and running on HPE Cray systems including the Cray XC and HPE Cray
+EX series systems.
 
 .. contents::
 
@@ -666,6 +665,3 @@ Known Constraints and Bugs
   above and/or the discussion of ``GASNET_MAX_SEGSIZE`` here::
 
      $CHPL_HOME/third-party/gasnet/gasnet-src/README
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN
-.. |trade|  unicode:: U+02122 .. TRADE MARK SIGN

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -87,8 +87,8 @@ CHPL_HOST_PLATFORM
         export CHPL_HOST_PLATFORM=`$CHPL_HOME/util/chplenv/chpl_platform.py`
 
    For other platforms that appear very similar to a UNIX workstation from the
-   shell prompt (e.g., a Cray CS\ |trade|), the value may need to be set
-   explicitly.  The strings for our currently-supported host platforms are as
+   shell prompt (e.g., a Cray CS, the value may need to be set explicitly.  The
+   strings for our currently-supported host platforms are as
    follows:
 
         ===========  ==================================
@@ -103,9 +103,10 @@ CHPL_HOST_PLATFORM
         netbsd64     64-bit NetBSD platforms
         pwr6         IBM Power6 SMP cluster
         sunos        SunOS platforms
-        cray-cs      Cray CS\ |trade|
-        cray-xc      Cray XC\ |trade|
-        hpe-cray-ex  HPE Cray EX\ |trade|
+        cray-cs      Cray CS
+        cray-xc      Cray XC
+        hpe-cray-ex  HPE Cray EX
+        hpe-apollo   HPE Apollo
         ===========  ==================================
 
    Platform-specific documentation is available for most of these platforms in
@@ -902,6 +903,3 @@ Variable precedence goes in the following order:
 2. Environment variables: ``CHPL_ENV=value``
 3. Chapel configuration file: ``~/.chplconfig``
 4. Inferred environment variables: ``printchplenv``
-
-
-.. |trade|  unicode:: U+02122 .. TRADE MARK SIGN


### PR DESCRIPTION
Historically, Cray required trademark and registered symbols, but HPE
does not. Based on internal docs and not seeing any symbols in
https://www.hpe.com/lamerica/en/what-is/cray-cs-series.html or
https://www.hpe.com/lamerica/en/what-is/cray-xc-series.html I think we
can remove the trademarks from Cray CS and XC too.