### PR TITLE
Link to user-defined-reduction class example from spec

### DIFF
--- a/doc/rst/language/spec/user-defined-reductions-and-scans.rst
+++ b/doc/rst/language/spec/user-defined-reductions-and-scans.rst
@@ -7,10 +7,19 @@ User-Defined Reductions and Scans
 
 User-defined reductions and scans are supported via class definitions
 where the class implements a structural interface. The definition of
-this structural interface is forthcoming. The following paper sketched
-out such an interface:
+this structural interface is forthcoming as it is not yet stable.
 
-   S. J. Deitz, D. Callahan, B. L. Chamberlain, and L. Snyder.
-   **Global-view abstractions for user-defined reductions and scans**.
-   In *Proceedings of the Eleventh ACM SIGPLAN Symposium on Principles
-   and Practice of Parallel Programming*, 2006.
+.. note::
+
+   While the user-defined reduction class interface is not yet described
+   here in the language specification, the currently implemented
+   interface is described in the
+   :ref:`Reduce Intents Technote <readme-reduceIntents-interface>`.
+
+   Additionally, the following paper describes an early version of the
+   interface:
+
+     S. J. Deitz, D. Callahan, B. L. Chamberlain, and L. Snyder.
+     **Global-view abstractions for user-defined reductions and scans**.
+     In *Proceedings of the Eleventh ACM SIGPLAN Symposium on Principles
+     and Practice of Parallel Programming*, 2006.

--- a/doc/rst/technotes/reduceIntents.rst
+++ b/doc/rst/technotes/reduceIntents.rst
@@ -72,6 +72,8 @@ For a user-defined reduction, there is a task-private instance
 of the reduction class for each task created for the forall
 or coforall loop. Here is an example of such a class:
 
+.. _readme-reduceIntents-interface:
+
  .. code-block:: chapel
 
   /* Implements + reduction over numeric data. */

--- a/doc/rst/technotes/reduceIntents.rst
+++ b/doc/rst/technotes/reduceIntents.rst
@@ -68,11 +68,17 @@ Set ``x`` in the loop -- counts the number of tasks:
   }
   writeln("The number of tasks is: ", x);
 
-For a user-defined reduction, there is a task-private instance
-of the reduction class for each task created for the forall
-or coforall loop. Here is an example of such a class:
+For a user-defined reduction, there is a task-private instance of the
+reduction class for each task created for the forall or coforall loop.
+The below section shows how to define and use a user-defined reduction.
 
 .. _readme-reduceIntents-interface:
+
+------------------------------
+User-Defined Reduction Example
+------------------------------
+
+Here is an example that defines and uses a user-defined reduction.
 
  .. code-block:: chapel
 


### PR DESCRIPTION
I recently noticed that the "user-defined reductions and scans" section in the spec does not describe the reduction interface but the Reduce Intents technote does. Since the spec section is more likely to be found by searching, this PR adjusts the spec section to include a link to the technote.

Reviewed by @lydia-duncan - thanks!