### PR TITLE
Remove trademark symbol from HPE Cray EX docs

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -6,8 +6,7 @@ Using Chapel on Cray Systems
 
 The following information is assembled to help Chapel users get up and running
 on HPE Cray\ |reg| systems including the Cray XC\ |trade| and
-HPE Cray EX\ |trade|
-series systems.
+HPE Cray EX series systems.
 
 .. contents::
 

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -105,7 +105,7 @@ CHPL_HOST_PLATFORM
         sunos        SunOS platforms
         cray-cs      Cray CS\ |trade|
         cray-xc      Cray XC\ |trade|
-        hpe-cray-ex  HPE Cray EX\ |trade|
+        hpe-cray-ex  HPE Cray EX
         hpe-apollo   HPE Apollo
         ===========  ==================================
 


### PR DESCRIPTION
Generally speaking, HPE does use or require trademark acknowledgement
symbols for their product lines so remove them from the HPE Cray EX
docs.