### PR TITLE
Revamp InfiniBand documentation

### DIFF
--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -4,140 +4,162 @@
 Using Chapel with InfiniBand
 ============================
 
-This document describes how to run Chapel across multiple machines in an
-InfiniBand cluster.  :ref:`readme-multilocale` describes general
-information about running Chapel in a multilocale configuration.
+This document describes how to run Chapel across multiple nodes of
+an InfiniBand cluster, including Cray CS and HPE Apollo systems.
+:ref:`readme-multilocale` describes general information about
+running Chapel in a multilocale configuration.
 
-Avoiding Slow Job Launch
-++++++++++++++++++++++++
+.. contents::
 
-We've observed very slow job launch on some systems with InfiniBand
-that were resolved by limiting the memory available for
-communication, for example with:
+--------------------------
+Configuring for InfiniBand
+--------------------------
+
+Due to the wide variety of InfiniBand clusters and potential for
+false-positives, Chapel does not currently auto-detect InfiniBand
+configurations or platforms that commonly use InfiniBand. To build
+Chapel with InfiniBand support, set:
 
 .. code-block:: bash
-
-   export GASNET_PHYSMEM_MAX=1G
-
-Note that setting ``GASNET_PHYSMEM_MAX`` will limit amount of memory
-available to Chapel programs if ``CHPL_GASNET_SEGMENT=fast``.
-
-It might be necessary to also set ``GASNET_PHYSMEM_NOPROBE=1`` -
-especially if you increase the size of ``GASNET_PHYSMEM_MAX``.
-
-It's probably a good idea to start with this variable set
-and to try removing it once everything else is working.
-
-Using Slurm for Job Launch
-++++++++++++++++++++++++++
-
-For clusters using Slurm, there are a few options:
-
-a. The current best option for InfiniBand+Slurm is
-   ``CHPL_LAUNCHER=slurm-gasnetrun_ibv``:
-
-   .. code-block:: bash
-
-     export CHPL_COMM=gasnet
-     export CHPL_COMM_SUBSTRATE=ibv
-
-     export CHPL_LAUNCHER=slurm-gasnetrun_ibv
-
-     # Rebuild the Chapel runtime for these settings
-     cd $CHPL_HOME
-     make
-
-     # Compile a sample program
-     chpl -o hello6-taskpar-dist examples/hello6-taskpar-dist.chpl
-
-   See :ref:`using-slurm` for other options available, such
-   as setting the time limit or selecting the type of node.
-   Some settings might be required by your Slurm configuration.
-   Setting these variables are typically necessary:
-
-   .. code-block:: bash
-
-      # Specify the Slurm partition to use
-      export CHPL_LAUNCHER_PARTITION=debug
-
-      # Run the sample program
-      ./hello6-taskpar-dist -nl 2
-
-#. An alternative is to use an ssh spawner and configure it to use the
-   nodes allocated by Slurm.
-
-   .. code-block:: bash
 
       export CHPL_COMM=gasnet
       export CHPL_COMM_SUBSTRATE=ibv
 
-      export CHPL_LAUNCHER=gasnetrun_ibv
-      
-      # Rebuild the Chapel runtime for these settings
-      cd $CHPL_HOME
-      make
+Alternatively, when running on a Cray CS or HPE Apollo system
+``CHPL_HOST_PLATFORM`` can instead be set, in which case the comm
+and substrate settings will be inferred.
 
-      # Compile a sample program
-      chpl -o hello6-taskpar-dist examples/hello6-taskpar-dist.chpl
-
-   Now, to run a program, reserve some nodes with `salloc` and then
-   within the resulting shell, configure the servers to SSH and run
-   the program:
-
-   .. code-block:: bash
-
-      # Reserve 2 nodes for an interactive run
-      salloc -N 2
-      # Then, within the salloc shell
-
-        # Specify that ssh should be used
-        export GASNET_IBV_SPAWNER=ssh
-        # Run the program on the 2 reserved nodes.
-        # gasnetrun_ibv will use the nodes Slurm allocated above.
-        ./hello6-taskpar-dist -nl 2
-
-   This technique is also possible when using `sbatch`. In that case,
-   make sure your `sbatch` script includes the line:
-
-   .. code-block:: bash
-
-      export GASNET_IBV_SPAWNER=ssh
-
-   See :ref:`ssh-launchers-with-slurm` for more information on these
-   techniques.
-
-#. A further alternative is to configure GASNet to use *mpirun* to launch your
-   program. *mpirun* might already be configured to work with Slurm. See
-   using-mpi-for-job-launch_.
-
-Using SSH for Job Launch
-++++++++++++++++++++++++
-
-To launch InfiniBand jobs with SSH, use the following
+For Cray CS:
 
 .. code-block:: bash
 
-   export CHPL_COMM=gasnet
-   export CHPL_COMM_SUBSTRATE=ibv
+      export CHPL_HOST_PLATFORM=cray-cs
 
-   export CHPL_LAUNCHER=gasnetrun_ibv
-  
-   # Rebuild the Chapel runtime for these settings
-   cd $CHPL_HOME
-   make
+For HPE Apollo:
 
-   # Compile a sample program
-   chpl -o hello6-taskpar-dist examples/hello6-taskpar-dist.chpl
+.. code-block:: bash
 
-   # Specify that ssh should be used
+      export CHPL_HOST_PLATFORM=hpe-apollo
+
+
+----------------------
+Configuring a Launcher
+----------------------
+
+A ``gasnetrun_ibv`` based launcher should be used to launch jobs and
+generally speaking native launchers like ``srun`` will not work.
+Most InfiniBand clusters use a workload manager or queueing system
+such a Slurm, LSF, or PBS. To select an appropriate Chapel launcher
+you can set ``CHPL_LAUNCHER`` to one of the following values:
+
+===================  ======================================
+Launcher Name        Description
+===================  ======================================
+gasnetrun_ibv         run jobs interactively on your system
+slurm-gasnetrun_ibv   queue jobs using Slurm (srun/sbatch)
+pbs-gasnetrun_ibv     queue jobs using PBS (qsub)
+lsf-gasnetrun_ibv     queue jobs using LSF (bsub)
+===================  ======================================
+
+``CHPL_LAUNCHER`` will typically default to ``gasnetrun_ibv`` unless
+``CHPL_HOST_PLATFORM`` is ``cray-cs`` or ``hpe-apollo`` and ``srun``
+is in your path, in which case it will default to
+``slurm-gasnetrun_ibv``
+
+By default Slurm, PBS, and LSF versions launch in an interactive
+mode. For batch submission with Slurm ``CHPL_LAUNCHER_USE_SBATCH``
+can be used as described in :ref:`using-slurm`. For other launchers
+and as an alternative for Slurm, users can write batch submission
+scripts and use ``gasnetrun_ibv`` to launch their jobs.
+
+
+---------------------------
+Setting Registration Limits
+---------------------------
+
+On most high performance networks, including InfiniBand, memory has
+to be registered with the network in order for Chapel to take
+advantage of fast one-sided communication. On InfiniBand networks
+there may be limits placed on how much memory can be registered so
+GASNet will probe at startup to detect this value. This probing can
+be slow, so GASNet will recommend setting ``GASNET_PHYSMEM_MAX`` to
+avoid probing every time. On nodes with homogeneous amounts of
+memory this message usually looks something like:
+
+.. code-block:: printoutput
+
+      WARNING: Beginning a potentially slow probe of max pinnable memory...
+      WARNING: Probe of max pinnable memory completed in 45s.
+      WARNING:   Probe of max pinnable memory has yielded '335 GB'.
+      WARNING:   If you have the same memory configuration on all nodes, then
+      WARNING:   to avoid this probe in the future either reconfigure using
+      WARNING:      --with-ibv-physmem-max='335 GB'
+      WARNING:   or run with environment variable
+      WARNING:      GASNET_PHYSMEM_MAX='335 GB'.
+
+Where setting ``GASNET_PHYSMEM_MAX='335 GB'`` will quiet the warning
+and skip the startup probe.  On nodes with non-homogeneous amounts
+of memory GASNet may recommend using a fraction of memory instead of
+an absolute value with something like
+``GASNET_PHYSMEM_MAX='0.667'``.
+
+Setting ``GASNET_PHYSMEM_MAX`` to a small value can limit
+communication performance so it is highly recommend to use the value
+GASNet suggests.
+
+
+.. _setting-ibv-spawner:
+
+-------------------
+Selecting a Spawner
+-------------------
+
+Under the covers ``gasnetrun_ibv`` based launchers must figure out
+how to spawn jobs and get them up and running on the compute nodes.
+GASNet's two primary means of doing this on InfiniBand clusters are
+``ssh`` and ``mpi``. GASNet will default to ``mpi`` if MPI support
+is detected at configure time, otherwise it will default to ``ssh``.
+Using ``mpi`` will likely incur a performance penalty because MPI
+will be running concurrently with GASNet. Running with ``ssh`` is
+recommended, but not all systems support ssh'ing to compute nodes so
+it is not always the default.
+
+
+Using SSH for Job Launch
+------------------------
+
+To launch InfiniBand jobs with SSH, use the following:
+
+.. code-block:: bash
+
+   # Specify ssh spawner
    export GASNET_IBV_SPAWNER=ssh
-   # Specify the nodes to run on
-   export GASNET_SSH_SERVERS="host1 host2 host3 ..."
 
-.. _using-mpi-for-job-launch:
+   # Specify the nodes to run on (only required when using plain
+   # gasnetrun_ibv outside a Slurm/PBS/LSF reservation)
+   export GASNET_SSH_SERVERS="nid00001 nid00002 nid00003 ..."
+
+If you receive an error message like:
+
+.. code-block:: printoutput
+
+      *** Failed to start processes on nid00001, possibly due to an inability to establish an ssh connection from login-node without interactive authentication.
+
+This indicates passwordless SSH is not set up. You can try copying
+existing SSH keys or generating new ones with the following:
+
+.. code-block:: bash
+
+      ssh-keygen -t rsa # use default location and empty passphrase
+      cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+
+If you see the same error message this may indicate ssh connections
+to compute nodes are not allowed, in which case using the MPI
+spawner may be your only option.
+
 
 Using MPI for Job Launch
-++++++++++++++++++++++++
+------------------------
 
 To launch InfiniBand jobs with *mpirun*, first make sure that *mpicc* is
 available and that MPI programs launch appropriately with *mpirun*. Then use
@@ -146,29 +168,43 @@ configuration output.
 
 .. code-block:: bash
 
-   export CHPL_COMM=gasnet
-   export CHPL_COMM_SUBSTRATE=ibv
-
-   export CHPL_LAUNCHER=gasnetrun_ibv
-  
-   # Rebuild the Chapel runtime for these settings
-   cd $CHPL_HOME
-   make
-
-   # Compile a sample program
-   chpl -o hello6-taskpar-dist examples/hello6-taskpar-dist.chpl
-
-   # Specify that ssh should be used
    export GASNET_IBV_SPAWNER=mpi
 
 
+-------------------
+Verifing Job Launch
+-------------------
 
+Once the above configuration has been done, checking that job
+launching is happening properly is recommended. The following Chapel
+program will print out the locale names and how much parallelism is
+available per locale. Ideally each locale is running on a unique
+node (not oversubscribed) and the amount of parallelism matches the
+number of physical cores on each node.
+
+.. code-block:: chapel
+
+      for loc in Locales do on loc do
+        writeln((here.name, here.maxTaskPar));
+
+An example run may look something like the following:
+
+.. code-block:: printoutput
+
+      (nid00001, 28)
+      (nid00002, 28)
+
+If nodes are oversubscribed or the amount of parallelism is far less
+than expected see :ref:`setting-ibv-spawner` and if that does not
+help consider opening a bug as described in :ref:`readme-bugs`.
+
+
+--------
 See Also
-++++++++
+--------
 
 For more information on these and other available GASNet options,
 including configuring to launch through MPI, please refer to
 GASNet's official `InfiniBand conduit documentation
 <https://gasnet.lbl.gov/dist/ibv-conduit/README>`_, which can also be found
 in ``$CHPL_HOME/third-party/gasnet/gasnet-src/ibv-conduit/README``.
-

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -106,6 +106,7 @@ CHPL_HOST_PLATFORM
         cray-cs      Cray CS\ |trade|
         cray-xc      Cray XC\ |trade|
         hpe-cray-ex  HPE Cray EX\ |trade|
+        hpe-apollo   HPE Apollo
         ===========  ==================================
 
    Platform-specific documentation is available for most of these platforms in


### PR DESCRIPTION
Our old InfiniBand documentation was pretty out of date and in some
cases wrong. We've had a lot more experience on InfiniBand systems
recently, so revamp the documentation to reflect the current state of
things. This also updates the IB docs to cover Cray CS and HPE Apollo
platforms.

Closes https://github.com/Cray/chapel-private/issues/1286