### PR TITLE
Respect CHPL_LAUNCHER_ACCOUNT without sbatch

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -302,6 +302,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       len += sprintf(iCom+len, "--partition=%s ", partition);
     if(exclude)
       len += sprintf(iCom+len, "--exclude=%s ", exclude);
+    if(projectString && strlen(projectString) > 0)
+      len += sprintf(iCom+len, "--account=%s ", projectString);
     if (constraint)
       len += sprintf(iCom+len, " -C %s", constraint);
     len += sprintf(iCom+len, " %s/%s/%s -n %d -N %d -c 0",


### PR DESCRIPTION
`CHPL_LAUNCHER_ACCOUNT` can be set to control the slurm account the job needs to
be submitted. But currently, for `gasnet` it only works if you also set
`CHPL_LAUNCHER_USE_SBATCH`, which causes less interactivity. This PR makes
`slurm-gasnetrun` launchers make use of `CHPL_LAUNCHER_ACCOUNT` with `salloc`
based launches, as well.
