### PR TITLE
Update GitHub CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       run: sudo apt-get install $CHPL_APT_DEPS
     - name: make check
       run: |
-        ./util/buildRelease/smokeTest hello
+        ./util/buildRelease/smokeTest chpl
 
   make_doc:
     runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
       run: |
-        ./util/buildRelease/smokeTest quickstart mason hello
+        ./util/buildRelease/smokeTest quickstart mason chpl
 
   check_compiler_next_tests:
     runs-on: ubuntu-latest
@@ -75,6 +75,6 @@ jobs:
       run: |
         CHPL_LLVM=none make test-venv
         CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
-    - name: check misc
+    - name: smokeTest lint
       run: |
-        ./util/buildRelease/smokeTest misc
+        ./util/buildRelease/smokeTest lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,40 +7,22 @@ on:
 
 env:
   NIGHTLY_TEST_SETTINGS: true
-  # By default `smokeTest` will run `make check`, `make mason`, and `make
-  # docs`. We split those into 3 separate jobs to speed up CI times, so
-  # disable all options here, and selectively enable below
-  CHPL_SMOKE_SKIP_MAKE_CHECK: true
-  CHPL_SMOKE_SKIP_MAKE_MASON: true
-  CHPL_SMOKE_SKIP_DOC: true
   # store the dependencies in one place
   CHPL_APT_DEPS: gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-11-dev llvm-11 llvm-11-tools clang-11 libclang-11-dev libedit-dev
 
 jobs:
   make_check:
     runs-on: ubuntu-latest
-    env:
-      CHPL_SMOKE_SKIP_MAKE_CHECK: false
     steps:
     - uses: actions/checkout@v2
     - name: install deps
       run: sudo apt-get install $CHPL_APT_DEPS
     - name: make check
       run: |
-        ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest hello
 
   make_doc:
     runs-on: ubuntu-latest
-    env:
-      # To try to keep this config from running the longest,
-      # use a simpler configuration
-      CHPL_TASKS: fifo
-      CHPL_MEM: cstdlib
-      CHPL_GMP: none
-      CHPL_RE2: bundled
-      CHPL_LLVM: none
-      # check that the docs build
-      CHPL_SMOKE_SKIP_DOC: false
     steps:
     - uses: actions/checkout@v2
     - name: install deps
@@ -49,8 +31,9 @@ jobs:
       run: |
         make libchplcomp-docs
     - name: make check-chpldoc && make docs
+      # Uses a quickstart config to keep it from running too long
       run: |
-        ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest quickstart docs
     - name: upload docs
       uses: actions/upload-artifact@v2
       with:
@@ -59,29 +42,15 @@ jobs:
 
   make_mason:
     runs-on: ubuntu-latest
-    env:
-      # To try to keep this config from running the longest,
-      # use a simpler configuration
-      CHPL_TASKS: fifo
-      CHPL_MEM: cstdlib
-      CHPL_GMP: none
-      CHPL_RE2: bundled
-      CHPL_LLVM: none
-      # check that mason builds
-      CHPL_SMOKE_SKIP_MAKE_MASON: false
-      # run make check in this config too
-      # to get more coverage for quickstart and because it's
-      # not the slowest config
-      CHPL_SMOKE_SKIP_MAKE_CHECK: false
     steps:
     - uses: actions/checkout@v2
-      #    - name: install deps
-      #run: sudo apt-get install $CHPL_APT_DEPS
     - name: make mason
+      # Use a quickstart config to keep it from running to long
+      # While there, run a make check in that config for more coverage
       run: |
-        ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest quickstart mason hello
 
-  check_compiler_tests:
+  check_compiler_next_tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -106,3 +75,6 @@ jobs:
       run: |
         CHPL_LLVM=none make test-venv
         CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
+    - name: check misc
+      run: |
+        ./util/buildRelease/smokeTest misc

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,8 @@ env:
   CHPL_SMOKE_SKIP_MAKE_CHECK: true
   CHPL_SMOKE_SKIP_MAKE_MASON: true
   CHPL_SMOKE_SKIP_DOC: true
+  # store the dependencies in one place
+  CHPL_APT_DEPS: gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-11-dev llvm-11 llvm-11-tools clang-11 libclang-11-dev libedit-dev
 
 jobs:
   make_check:
@@ -21,19 +23,34 @@ jobs:
       CHPL_SMOKE_SKIP_MAKE_CHECK: false
     steps:
     - uses: actions/checkout@v2
+    - name: install deps
+      run: sudo apt-get install $CHPL_APT_DEPS
     - name: make check
       run: |
-        CHPL_LLVM=none ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest
 
   make_doc:
     runs-on: ubuntu-latest
     env:
+      # To try to keep this config from running the longest,
+      # use a simpler configuration
+      CHPL_TASKS: fifo
+      CHPL_MEM: cstdlib
+      CHPL_GMP: none
+      CHPL_RE2: bundled
+      CHPL_LLVM: none
+      # check that the docs build
       CHPL_SMOKE_SKIP_DOC: false
     steps:
     - uses: actions/checkout@v2
+    - name: install deps
+      run: sudo apt-get install cmake doxygen
+    - name: make libchplcomp-docs
+      run: |
+        make libchplcomp-docs
     - name: make check-chpldoc && make docs
       run: |
-        CHPL_LLVM=none ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest
     - name: upload docs
       uses: actions/upload-artifact@v2
       with:
@@ -43,30 +60,49 @@ jobs:
   make_mason:
     runs-on: ubuntu-latest
     env:
+      # To try to keep this config from running the longest,
+      # use a simpler configuration
+      CHPL_TASKS: fifo
+      CHPL_MEM: cstdlib
+      CHPL_GMP: none
+      CHPL_RE2: bundled
+      CHPL_LLVM: none
+      # check that mason builds
       CHPL_SMOKE_SKIP_MAKE_MASON: false
+      # run make check in this config too
+      # to get more coverage for quickstart and because it's
+      # not the slowest config
+      CHPL_SMOKE_SKIP_MAKE_CHECK: false
     steps:
     - uses: actions/checkout@v2
+      #    - name: install deps
+      #run: sudo apt-get install $CHPL_APT_DEPS
     - name: make mason
       run: |
-        CHPL_LLVM=none ./util/buildRelease/smokeTest
+        ./util/buildRelease/smokeTest
 
-  check_annotations:
+  check_compiler_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install deps
+      run: sudo apt-get install $CHPL_APT_DEPS
+    - name: make test-libchplcomp
+      run: |
+        make test-libchplcomp -j`util/buildRelease/chpl-make-cpu_count`
+
+  check_annotations_rt_calls:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 100000
-    - name: check annotations
-      run: |
-        CHPL_LLVM=none make test-venv
-        CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
-
-  bad_rt_calls:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
     - name: install deps
       run: sudo apt-get install cscope
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls
+    - name: check annotations
+      run: |
+        CHPL_LLVM=none make test-venv
+        CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -11,8 +11,8 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 MASON=0
 DOCS=0
-HELLO=0
-MISC=0
+CHPL=0
+LINT=0
 QUICKSTART=0
 TARGETS_SET=0
 
@@ -32,15 +32,15 @@ while [[ $# -gt 0 ]]; do
             TARGETS_SET=1
             shift
             ;;
-        hello)
+        chpl)
             # run make check
-            HELLO=1
+            CHPL=1
             TARGETS_SET=1
             shift
             ;;
-        misc)
+        lint)
             # run scripts to check various properties
-            MISC=1
+            LINT=1
             TARGETS_SET=1
             shift
             ;;
@@ -49,7 +49,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         *)
-            echo "Usage: smokeTest [mason] [docs] [hello] [misc] [quickstart]"
+            echo "Usage: smokeTest [mason] [docs] [chpl] [lint] [quickstart]"
             exit 1
             ;;
         esac
@@ -66,10 +66,12 @@ if [ $TARGETS_SET -eq 0 ]; then
         DOCS=1
     fi
     if [ "${CHPL_SMOKE_SKIP_MAKE_CHECK}" != "true" ] ; then
-        HELLO=1
+        CHPL=1
     fi
-    MISC=1
+    LINT=1
 fi
+
+echo "Running with MASON=$MASON DOCS=$DOCS CHPL=$CHPL LINT=$LINT QUICKSTART=$QUICKSTART"
 
 # Ensure CC is respected, since it is typically ignored by chplenv/.
 if [ -n "${CC}" ] ; then
@@ -100,8 +102,8 @@ fi
 # Add some space between env setup output and test output.
 echo ""
 
-# Check for tabs.
-if [ $MISC -eq 1 ]; then
+if [ $LINT -eq 1 ]; then
+    # Check for tabs.
     num_tabs=$($CHPL_HOME/util/devel/lookForTabs | wc -l)
     if (( $num_tabs > 0 )) ; then
         echo "Found tabs :-("
@@ -147,7 +149,7 @@ if [ $MISC -eq 1 ]; then
         exit 1
     fi
 
-# done with misc checks
+    # done with lint checks
 fi
 
 # Source common.bash, which sets up a bunch of environment variables that are
@@ -202,7 +204,7 @@ num_procs=$($CHPL_HOME/util/buildRelease/chpl-make-cpu_count)
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.
 export CHPL_CHECK_INSTALL_DIR=$CHPL_HOME
 
-if [ $HELLO -eq 1 ]; then
+if [ $CHPL -eq 1 ]; then
     # Compile chapel and make sure `make check` works.
     # Compile first with parallel execution, but call `make check` without it.
     make -j${num_procs} $chpl_make_args && \

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -9,6 +9,68 @@ set -e
 
 CWD=$(cd $(dirname $0) ; pwd)
 
+MASON=0
+DOCS=0
+HELLO=0
+MISC=0
+QUICKSTART=0
+TARGETS_SET=0
+
+# Set the above options according to the arguments passed
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        mason)
+            # run make mason
+            MASON=1
+            TARGETS_SET=1
+            shift
+            ;;
+        docs)
+            # run make docs
+            DOCS=1
+            TARGETS_SET=1
+            shift
+            ;;
+        hello)
+            # run make check
+            HELLO=1
+            TARGETS_SET=1
+            shift
+            ;;
+        misc)
+            # run scripts to check various properties
+            MISC=1
+            TARGETS_SET=1
+            shift
+            ;;
+        quickstart)
+            QUICKSTART=1
+            shift
+            ;;
+        *)
+            echo "Usage: smokeTest [mason] [docs] [hello] [misc] [quickstart]"
+            exit 1
+            ;;
+        esac
+done
+
+# if no targets are set, check mason, docs, and make check
+# but respect the environment variables
+# CHPL_SMOKE_SKIP_MAKE_MASON CHPL_SMOKE_SKIP_DOC CHPL_SMOKE_SKIP_MAKE_CHECK
+if [ $TARGETS_SET -eq 0 ]; then
+    if [ "${CHPL_SMOKE_SKIP_MAKE_MASON}" != "true" ] ; then
+        MASON=1
+    fi
+    if [ "${CHPL_SMOKE_SKIP_DOC}" != "true" ] ; then
+        DOCS=1
+    fi
+    if [ "${CHPL_SMOKE_SKIP_MAKE_CHECK}" != "true" ] ; then
+        HELLO=1
+    fi
+    MISC=1
+fi
+
 # Ensure CC is respected, since it is typically ignored by chplenv/.
 if [ -n "${CC}" ] ; then
     case $CC in
@@ -28,57 +90,64 @@ fi
 
 # Ensure environment is correctly configured to run chpl.
 export CHPL_HOME=$(cd "$CWD/../.." ; pwd)
-source $CHPL_HOME/util/setchplenv.bash
+
+if [ $QUICKSTART -eq 0 ]; then
+    source $CHPL_HOME/util/setchplenv.bash
+else
+    source $CHPL_HOME/util/quickstart/setchplenv.bash
+fi
 
 # Add some space between env setup output and test output.
 echo ""
 
-# Show me the environment!
-$CHPL_HOME/util/printchplenv --all --no-tidy
-echo ""
-
 # Check for tabs.
-num_tabs=$($CHPL_HOME/util/devel/lookForTabs | wc -l)
-if (( $num_tabs > 0 )) ; then
-    echo "Found tabs :-("
-    echo $($CHPL_HOME/util/devel/lookForTabs)
-    exit 1
-fi
+if [ $MISC -eq 1 ]; then
+    num_tabs=$($CHPL_HOME/util/devel/lookForTabs | wc -l)
+    if (( $num_tabs > 0 )) ; then
+        echo "Found tabs :-("
+        echo $($CHPL_HOME/util/devel/lookForTabs)
+        exit 1
+    fi
 
-# Need to clean up all of the trailing spaces before adding this
-# Check for trailing spaces
-#num_trailing_space_lines=$($CHPL_HOME/util/devel/lookForTrailingSpaces | wc -l)
-#if (( $num_trailing_space_lines > 0 )) ; then
-#    echo "Found $num_trailing_space_lines lines with trailing spaces :-("
-#    echo $($CHPL_HOME/util/devel/lookForTrailingSpaces)
-#    exit 1
-#fi
+    # Need to clean up all of the trailing spaces before adding this
+    # Check for trailing spaces
+    #num_trailing_space_lines=$($CHPL_HOME/util/devel/lookForTrailingSpaces | wc -l)
+    #if (( $num_trailing_space_lines > 0 )) ; then
+    #    echo "Found $num_trailing_space_lines lines with trailing spaces :-("
+    #    echo $($CHPL_HOME/util/devel/lookForTrailingSpaces)
+    #    exit 1
+    #fi
 
-# Check for standard C headers.
-standard_c_headers=$($CHPL_HOME/util/devel/grepstdchdrs || :)
-if [ -n "${standard_c_headers}" ] ; then
-    echo "Standard C headers found in the following file(s):"
-    echo "${standard_c_headers}"
-    echo "The above list was generated with \$CHPL_HOME/util/devel/grepstdchdrs."
-    exit 1
-fi
+    # Check for standard C headers.
+    standard_c_headers=$($CHPL_HOME/util/devel/grepstdchdrs || :)
+    if [ -n "${standard_c_headers}" ] ; then
+        echo "Standard C headers found in the following file(s):"
+        echo "${standard_c_headers}"
+        echo "The above list was generated with \$CHPL_HOME/util/devel/grepstdchdrs."
+        exit 1
+    fi
 
-# Ensure nightly does not have syntax errors.
-perl -c $CHPL_HOME/util/buildRelease/gen_release
-perl -c $CHPL_HOME/util/cron/nightly
-perl -c $CHPL_HOME/util/tokencount/tokctnightly
+    # Ensure nightly does not have syntax errors.
+    perl -c $CHPL_HOME/util/buildRelease/gen_release
+    perl -c $CHPL_HOME/util/cron/nightly
+    perl -c $CHPL_HOME/util/tokencount/tokctnightly
 
-# Check copyrights in source files.
-$CHPL_HOME/util/test/checkCopyrights.bash
 
-# Check that test script names match their registered config names (for consistency).
-config_name_errors=$(grep CHPL_NIGHTLY_TEST_CONFIG_NAME $CHPL_HOME/util/cron/test-*.ba{t,sh} | \
-    $CHPL_HOME/util/cron/verify_config_names.py)
-if [ -n "${config_name_errors}" ] ; then
-    echo ""
-    echo "Test script naming errors:"
-    echo "${config_name_errors}"
-    exit 1
+    # Check copyrights in source files.
+    $CHPL_HOME/util/test/checkCopyrights.bash
+
+    # Check that test script names match their registered config names
+    # (for consistency).
+    config_name_errors=$(grep CHPL_NIGHTLY_TEST_CONFIG_NAME $CHPL_HOME/util/cron/test-*.ba{t,sh} | \
+        $CHPL_HOME/util/cron/verify_config_names.py)
+    if [ -n "${config_name_errors}" ] ; then
+        echo ""
+        echo "Test script naming errors:"
+        echo "${config_name_errors}"
+        exit 1
+    fi
+
+# done with misc checks
 fi
 
 # Source common.bash, which sets up a bunch of environment variables that are
@@ -91,13 +160,23 @@ export CHPL_GMP=none
 # mason currently requires CHPL_COMM=none -- https://github.com/chapel-lang/chapel/issues/12626
 COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
 if [ "$COMM" != "none" ]; then
-  CHPL_SMOKE_SKIP_MAKE_MASON=${CHPL_SMOKE_SKIP_MAKE_MASON:-true}
+  MASON=0
 fi
 
-if [ "${CHPL_SMOKE_SKIP_MAKE_MASON}" == "true" ] ; then
-  export CHPL_RE2=none
+# adjust CHPL_RE2
+#  * if mason is used, unset it to be sure to try to build RE2
+#    (even in a quickstart configuration)
+#  * if mason is not used, set it to none to save build time
+if [ $MASON -eq 1 ]; then
+    unset CHPL_RE2
+else
+    export CHPL_RE2=none
 fi
 
+echo ""
+
+# Show me the environment!
+$CHPL_HOME/util/printchplenv --all --no-tidy
 echo ""
 
 # If NIGHTLY_TEST_SETTINGS is set, call make with DEBUG=0 WARNINGS=1 OPTIMIZE=1
@@ -123,21 +202,21 @@ num_procs=$($CHPL_HOME/util/buildRelease/chpl-make-cpu_count)
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.
 export CHPL_CHECK_INSTALL_DIR=$CHPL_HOME
 
-if [ "${CHPL_SMOKE_SKIP_MAKE_CHECK}" != "true" ] ; then
-    # Compile chapel and make sure `make check` works. Compile first with parallel
-    # execution, but call `make check` without it.
+if [ $HELLO -eq 1 ]; then
+    # Compile chapel and make sure `make check` works.
+    # Compile first with parallel execution, but call `make check` without it.
     make -j${num_procs} $chpl_make_args && \
         CHPL_CHECK_DEBUG=1 make $chpl_make_args check || exit 2
 fi
 
-if [ "${CHPL_SMOKE_SKIP_DOC}" != "true" ] ; then
+if [ $DOCS -eq 1 ]; then
     # Build chpldoc, make sure the chpldoc primer runs, and the docs build.
     make -j${num_procs} $chpl_make_args chpldoc && \
         make $chpl_make_args check-chpldoc && \
         make docs || exit 2
 fi
 
-if [ "${CHPL_SMOKE_SKIP_MAKE_MASON}" != "true" ] ; then
+if [ $MASON -eq 1 ]; then
     # Build Mason
     make -j${num_procs} $chpl_make_args && \
         make $chpl_make_args mason || exit 2

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -104,6 +104,7 @@ echo ""
 
 if [ $LINT -eq 1 ]; then
     # Check for tabs.
+    echo "Checking for tabs"
     num_tabs=$($CHPL_HOME/util/devel/lookForTabs | wc -l)
     if (( $num_tabs > 0 )) ; then
         echo "Found tabs :-("
@@ -121,6 +122,7 @@ if [ $LINT -eq 1 ]; then
     #fi
 
     # Check for standard C headers.
+    echo "Checking standard C headers"
     standard_c_headers=$($CHPL_HOME/util/devel/grepstdchdrs || :)
     if [ -n "${standard_c_headers}" ] ; then
         echo "Standard C headers found in the following file(s):"
@@ -130,16 +132,19 @@ if [ $LINT -eq 1 ]; then
     fi
 
     # Ensure nightly does not have syntax errors.
+    echo "Checking nightly scripts"
     perl -c $CHPL_HOME/util/buildRelease/gen_release
     perl -c $CHPL_HOME/util/cron/nightly
     perl -c $CHPL_HOME/util/tokencount/tokctnightly
 
 
     # Check copyrights in source files.
+    echo "Checking copyrights"
     $CHPL_HOME/util/test/checkCopyrights.bash
 
     # Check that test script names match their registered config names
     # (for consistency).
+    echo "Checking test script names"
     config_name_errors=$(grep CHPL_NIGHTLY_TEST_CONFIG_NAME $CHPL_HOME/util/cron/test-*.ba{t,sh} | \
         $CHPL_HOME/util/cron/verify_config_names.py)
     if [ -n "${config_name_errors}" ] ; then


### PR DESCRIPTION
* install dependencies (LLVM, doxygen, cmake)
* adjust the docs build to include the compiler internals
* run the C++ compiler library tests
* make the docs and mason builds use a simpler environment for speed
* stop setting `CHPL_LLVM=none` for the make check test
* merge `bad_rt_calls` and `check_annotations` into a single check
* adjusted smokeTest to optionally take arguments for what checks to do (`chpl` `mason` `docs` `lint` - and `quickstart` to request a quickstart config). This makes the CI scripts simpler.

Reviewed by @ronawho and @Maxrimus - thanks!
