### PR TITLE
Fix not supported yet for overrided param args with defaults

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -286,14 +286,7 @@ static void collectMethods(FnSymbol*               pfn,
           }
         }
         if (possibleSignatureMatch(pfn, cfn) == true) {
-          if (cfn->retTag == RET_PARAM ||
-              cfn->retTag == RET_TYPE) {
-            USR_FATAL_CONT(cfn,
-                           "param default arguments in overridden methods "
-                           "are not yet supported.");
-          } else {
-            methods.push_back(cfn);
-          }
+          methods.push_back(cfn);
         }
       }
     }
@@ -462,11 +455,18 @@ static void resolveOverride(FnSymbol* pfn, FnSymbol* cfn) {
     // corresponding ones exist for the child.
     int nUserFormals = getNumUserFormals(pfn);
     for (int i = 1; i <= nUserFormals; i++) {
-      ArgSymbol* pformal = getUserFormal(pfn, i);
-      ArgSymbol* cformal = getUserFormal(cfn, i);
-      FnSymbol* pDefFn = findExistingDefaultedActualFn(pfn, pformal);
+      ArgSymbol* pFormal = getUserFormal(pfn, i);
+      ArgSymbol* cFormal = getUserFormal(cfn, i);
+      FnSymbol* pDefFn = findExistingDefaultedActualFn(pfn, pFormal);
       if (pDefFn) {
-        getOrCreateDefaultedActualFn(cfn, cformal);
+        FnSymbol* cDefFn = getOrCreateDefaultedActualFn(cfn, cFormal);
+        if (cDefFn) {
+          if (pFormal->hasFlag(FLAG_INSTANTIATED_PARAM) &&
+              cFormal->hasFlag(FLAG_INSTANTIATED_PARAM)) {
+            USR_FATAL_CONT(cfn, "param default arguments in overridden methods"
+                                " are not yet supported.");
+          }
+        }
       }
     }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -466,6 +466,11 @@ static void resolveOverride(FnSymbol* pfn, FnSymbol* cfn) {
             USR_FATAL_CONT(cfn, "param default arguments in overridden methods"
                                 " are not yet supported.");
           }
+          if (pFormal->hasFlag(FLAG_TYPE_VARIABLE) &&
+              cFormal->hasFlag(FLAG_TYPE_VARIABLE)) {
+            USR_FATAL_CONT(cfn, "type default arguments in overridden methods"
+                                " are not yet supported.");
+          }
         }
       }
     }

--- a/test/functions/default-arguments/default-argument-class-override3b.bad
+++ b/test/functions/default-arguments/default-argument-class-override3b.bad
@@ -1,0 +1,2 @@
+default-argument-class-override3b.chpl:11: error: type default arguments in overridden methods are not yet supported.
+default-argument-class-override3b.chpl:11: error: type default arguments in overridden methods are not yet supported.

--- a/test/functions/default-arguments/default-argument-class-override3b.chpl
+++ b/test/functions/default-arguments/default-argument-class-override3b.chpl
@@ -1,0 +1,25 @@
+proc f() type { return int; }
+proc g() type { return real; }
+
+class Parent {
+  proc method(type arg = f()) {
+    writeln("in Parent.method arg=", arg:string);
+  }
+}
+
+class Child : Parent {
+  override proc method(type arg = g()) {
+    writeln("in Child.method arg=", arg:string);
+  }
+}
+
+proc main() {
+  var x:Parent = new Child();
+  x.method();
+
+  var y = new Child();
+  y.method();
+
+  var z = new Parent();
+  z.method();
+}

--- a/test/functions/default-arguments/default-argument-class-override3b.future
+++ b/test/functions/default-arguments/default-argument-class-override3b.future
@@ -1,0 +1,11 @@
+bug: dynamically dispatched methods with default type arguments wrong
+
+#15164
+
+This test demonstrates that when methods are dynamically dispatched
+and have type arguments with defaults, the compiler doesn't use the
+default from the method that was chosen dynamically, but the one based
+on the static type.  This is because we implement default arguments
+as methods currently, and can't dynamically dispatch type methods.
+Yet we have to statically invoke the default arguments in order to
+fulfill the `type` nature of the arguments.

--- a/test/functions/default-arguments/default-argument-class-override3b.good
+++ b/test/functions/default-arguments/default-argument-class-override3b.good
@@ -1,0 +1,3 @@
+in Child.method arg=real(64)
+in Child.method arg=real(64)
+in Parent.method arg=int(64)


### PR DESCRIPTION
This adjusts the error check from #18023 to work after the function is instantiated. It allows the future default-argument-class-override3a.chpl to once again match its .bad file after PR #18428 changed related code. In addition, it adds a new test that is a `type` variant of the above test and that would hit an internal error before #18428.

Reviewed by @e-kayrakli - thanks!

- [x] full local futures testing
- [x] `--verify` testing
- [x] gasnet testing