### PR TITLE
Migrate Atomic module docs to the relevant spec section

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -109,6 +109,10 @@ exclude_patterns = ['Makefile',
                     'developer/implementation',
                     'util',
                     'meta',
+
+                    # These don't need to be processed separately
+                    # since they are included in the spec with .. include::
+                    'builtins/Atomics.rst',
                    ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/doc/rst/language/spec/README
+++ b/doc/rst/language/spec/README
@@ -1,4 +1,4 @@
-Here is the RST section title heirachy
+Here is the RST section title hierarchy
 
 |||||||||||||||||||||||||||||
 Chapel Language Specification

--- a/doc/rst/language/spec/README
+++ b/doc/rst/language/spec/README
@@ -1,3 +1,22 @@
+Here is the RST section title heirachy
+
+|||||||||||||||||||||||||||||
+Chapel Language Specification
+|||||||||||||||||||||||||||||
+
+=======
+Chapter
+=======
+
+Section
+-------
+
+Subsection
+~~~~~~~~~~
+
+Subsubsection
+^^^^^^^^^^^^^
+
 [The following was developed back when spec was written in Latex / .tex
 however the principles still hold for the rst-formatted spec.]
 

--- a/doc/rst/language/spec/acknowledgements.rst
+++ b/doc/rst/language/spec/acknowledgements.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Acknowledgments:
 
+===============
 Acknowledgments
 ===============
 

--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Arrays:
 
+======
 Arrays
 ======
 

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Classes:
 
+=======
 Classes
 =======
 

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Conversions:
 
+===========
 Conversions
 ===========
 

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Data_Parallelism:
 
+================
 Data Parallelism
 ================
 

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Domain_Maps:
 
+===========
 Domain Maps
 ===========
 

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Domains:
 
+=======
 Domains
 =======
 

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Error_Handling:
 
+==============
 Error Handling
 ==============
 

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Expressions:
 
+===========
 Expressions
 ===========
 

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Generics:
 
+========
 Generics
 ========
 

--- a/doc/rst/language/spec/index.rst
+++ b/doc/rst/language/spec/index.rst
@@ -1,5 +1,6 @@
 .. _chapel-spec:
 
+|||||||||||||||||||||||||||||
 Chapel Language Specification
 |||||||||||||||||||||||||||||
 

--- a/doc/rst/language/spec/input-and-output.rst
+++ b/doc/rst/language/spec/input-and-output.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Input_and_Output:
 
+================
 Input and Output
 ================
 

--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Interoperability:
 
+================
 Interoperability
 ================
 

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Iterators:
 
+=========
 Iterators
 =========
 

--- a/doc/rst/language/spec/language-overview.rst
+++ b/doc/rst/language/spec/language-overview.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Language_Overview:
 
+=================
 Language Overview
 =================
 

--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Lexical_Structure:
 
+=================
 Lexical Structure
 =================
 

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Locales_Chapter:
 
+=======
 Locales
 =======
 

--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Memory_Consistency_Model:
 
+========================
 Memory Consistency Model
 ========================
 

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Methods:
 
+=======
 Methods
 =======
 

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Modules:
 
+=======
 Modules
 =======
 

--- a/doc/rst/language/spec/notation.rst
+++ b/doc/rst/language/spec/notation.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Notation:
 
+========
 Notation
 ========
 

--- a/doc/rst/language/spec/organization.rst
+++ b/doc/rst/language/spec/organization.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Organization:
 
+============
 Organization
 ============
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Procedures:
 
+==========
 Procedures
 ==========
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Ranges:
 
+======
 Ranges
 ======
 

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Records:
 
+=======
 Records
 =======
 

--- a/doc/rst/language/spec/scope.rst
+++ b/doc/rst/language/spec/scope.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Scope:
 
+=====
 Scope
 =====
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Statements:
 
+==========
 Statements
 ==========
 

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -401,184 +401,22 @@ otherwise. This method is non-blocking and the state of the sync or
 single variable is unchanged when this method completes.
 
 .. _Atomic_Variables:
+.. _Functions_on_Atomic_Variables:
 
 Atomic Variables
 ----------------
 
-Atomic variables are variables that support atomic operations. Chapel
-currently supports atomic operations for bools, all supported sizes of
-signed and unsigned integers, as well as all supported sizes of reals.
-
-   *Rationale*.
-
-   The choice of supported atomic variable types as well as the atomic
-   operations was strongly influenced by the C11 standard.
-
-Atomic is a type qualifier that precedes the variable’s type in the
-declaration. Atomic operations are supported for bools, and all sizes of
-ints, uints, and reals.
-
-An atomic variable is specified with an atomic type given by the
-following syntax:
-
-
+``atomic`` is a type qualifier that precedes the variable’s type in the
+declaration.  An atomic variable is specified with an atomic type given
+by the following syntax:
 
 .. code-block:: syntax
 
    atomic-type:
      'atomic' type-expression
 
-.. _Functions_on_Atomic_Variables:
 
-Predefined Atomic Methods
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following methods are defined for variables of atomic type. Note
-that not all operations are supported for all atomic types. The
-supported types are listed for each method.
-
-Most of the predefined atomic methods accept an optional argument named
-``order`` of type memoryOrder. The ``order`` argument is used to specify
-the ordering constraints of atomic operations. The supported memoryOrder
-values are:
-
--  memoryOrder.relaxed
-
--  memoryOrder.acquire
-
--  memoryOrder.release
-
--  memoryOrder.acqRel
-
--  memoryOrder.seqCst
-
-See also :ref:`Chapter-Memory_Consistency_Model` and in particular
-:ref:`non_sc_atomics` for more information on the meaning of these memory
-orders.
-
-Unless specified, the default for the memoryOrder parameter is
-memoryOrder.seqCst.
-
-   *Implementors’ note*.
-
-   Not all architectures or implementations may support all memoryOrder
-   values. In these cases, the implementation should default to a more
-   conservative ordering than specified.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).read(param order:memoryOrder = memoryOrder.seqCst): T
-
-Reads and returns the stored value. Defined for all atomic types.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).write(v: T, param order:memoryOrder = memoryOrder.seqCst)
-
-Stores ``v`` as the new value. Defined for all atomic types.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).exchange(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-
-Stores ``v`` as the new value and returns the original value. Defined
-for all atomic types.
-
-   .. code-block:: chapel
-
-      proc (atomic T).compareExchange(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
-      proc (atomic T).compareExchange(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
-      proc (atomic T).compareExchangeWeak(ref e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
-      proc (atomic T).compareExchangeWeak(ref e: T, v: T, param failure:memoryOrder, param success:memoryOrder): bool
-
-Stores ``v`` as the new value, if and only if the original value is
-equal to ``e``. Returns ``true`` if ``v`` was stored, otherwise
-returns ``false`` and updates ``e`` to the old value.  The weak
-version is allowed to spuriously fail, but when using
-``compareExchange`` in a loop anyways, it can can offer better
-performance on some platforms. Defined for all atomic types.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).compareAndSwap(e: T, v: T, param order:memoryOrder = memoryOrder.seqCst): bool
-
-Stores ``v`` as the new value, if and only if the original value is
-equal to ``e``. Returns ``true`` if ``v`` was stored, ``false``
-otherwise. Defined for all atomic types.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).add(v: T, param order:memoryOrder = memoryOrder.seqCst)
-      proc (atomic T).sub(v: T, param order:memoryOrder = memoryOrder.seqCst)
-      proc (atomic T).or(v: T, param order:memoryOrder = memoryOrder.seqCst)
-      proc (atomic T).and(v: T, param order:memoryOrder = memoryOrder.seqCst)
-      proc (atomic T).xor(v: T, param order:memoryOrder = memoryOrder.seqCst)
-
-Applies the appropriate operator (``+``, ``-``, ``|``, ``&``, ``^``) to
-the original value and ``v`` and stores the result. All of the methods
-are defined for integral atomic types. Only add and sub (``+``, ``-``)
-are defined for ``real`` atomic types. None of the methods are defined
-for the ``bool`` atomic type.
-
-   .. note::
-   
-      *Future*.
-
-      In the future we may overload certain operations such as ``+=`` to call
-      the above methods automatically for atomic variables.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).fetchAdd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-      proc (atomic T).fetchSub(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-      proc (atomic T).fetchOr(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-      proc (atomic T).fetchAnd(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-      proc (atomic T).fetchXor(v: T, param order:memoryOrder = memoryOrder.seqCst): T
-
-Applies the appropriate operator (``+``, ``-``, ``|``, ``&``, ``^``) to
-the original value and ``v``, stores the result, and returns the original
-value. All of the methods are defined for integral atomic types. Only add
-and sub (``+``, ``-``) are defined for ``real`` atomic types. None of the
-methods are defined for the ``bool`` atomic type.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic bool).testAndSet(param order:memoryOrder = memoryOrder.seqCst): bool
-
-Stores ``true`` as the new value and returns the old value. Equivalent
-to ``exchange(true)``. Only defined for the ``bool`` atomic type.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic bool).clear(param order:memoryOrder = memoryOrder.seqCst)
-
-Stores ``false`` as the new value. Equivalent to ``write(false)``. Only
-defined for the ``bool`` atomic type.
-
-
-
-   .. code-block:: chapel
-
-      proc (atomic T).waitFor(v: T)
-
-Waits until the stored value is equal to ``v``. The implementation may
-yield the running task while waiting. Defined for all atomic types.
+.. include:: /builtins/Atomics.rst
 
 .. _Cobegin:
 

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Task_Parallelism_and_Synchronization:
 
+====================================
 Task Parallelism and Synchronization
 ====================================
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Tuples:
 
+======
 Tuples
 ======
 

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Types:
 
+=====
 Types
 =====
 

--- a/doc/rst/language/spec/unions.rst
+++ b/doc/rst/language/spec/unions.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Unions:
 
+======
 Unions
 ======
 

--- a/doc/rst/language/spec/user-defined-reductions-and-scans.rst
+++ b/doc/rst/language/spec/user-defined-reductions-and-scans.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-User_Defined_Reductions_and_Scans:
 
+=================================
 User-Defined Reductions and Scans
 =================================
 

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -2,6 +2,7 @@
 
 .. _Chapter-Variables:
 
+=========
 Variables
 =========
 

--- a/doc/rst/meta/builtins/index.rst
+++ b/doc/rst/meta/builtins/index.rst
@@ -11,9 +11,17 @@ amenable to being documented using **chpldoc**:
 
 .. toctree::
    :maxdepth: 1
-   :glob:
 
-   **
+   ChapelLocale
+   OwnedObject
+   Bytes
+   ChapelRange
+   SharedObject
+   ChapelArray
+   ChapelSyncvar
+   String
+   ChapelComplex_forDocs
+   ChapelTuple
 
 
 Index

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -65,20 +65,62 @@
    generated for records containing atomic fields.
 */
 
+// Note -- the next docs comment is intended to be included
+// directly in the appropriate language spec section.
+
 /*
-   Atomic variables are variables that support atomic operations. Chapel
-   currently supports atomic operations for bools, all supported sizes of
-   signed and unsigned integers, as well as all supported sizes of reals.
 
-   Most atomic methods accept an optional argument named ``order`` of type
-   ``memoryOrder``. The ``order`` argument is used to specify the ordering
-   constraints of atomic operations. The supported values are:
+For example, the following code declares an atomic variable ``x`` that
+stores an ``int``:
 
-     * memoryOrder.relaxed
-     * memoryOrder.acquire
-     * memoryOrder.release
-     * memoryOrder.acqRel
-     * memoryOrder.seqCst
+.. code-block:: chapel
+
+      var x: atomic int;
+
+Such an atomic variable that is declared without an initialization expression
+will store the default value of the contained type (i.e. ``0`` or ``false``).
+
+Atomic variables can also be declared with an initial value:
+
+.. code-block:: chapel
+
+      var y: atomic int = 1;
+
+
+Chapel currently supports atomic operations for bools, all supported sizes of
+signed and unsigned integers, as well as all supported sizes of reals.  Note
+that not all operations are supported for all atomic types. The supported types
+are listed for each operation.
+
+  *Rationale*.
+
+  The choice of supported atomic variable types as well as the atomic
+  operations was strongly influenced by the C11 standard.
+
+Most atomic methods accept an optional argument named ``order`` of type
+``memoryOrder``. The ``order`` argument is used to specify the ordering
+constraints of atomic operations. The supported memoryOrder values are:
+
+ * memoryOrder.relaxed
+ * memoryOrder.acquire
+ * memoryOrder.release
+ * memoryOrder.acqRel
+ * memoryOrder.seqCst
+
+
+See also :ref:`Chapter-Memory_Consistency_Model` and in particular
+:ref:`non_sc_atomics` for more information on the meaning of these memory
+orders.
+
+Unless specified, the default for the memoryOrder parameter is
+memoryOrder.seqCst.
+
+   *Implementors’ note*.
+
+   Not all architectures or implementations may support all memoryOrder
+   values. In these cases, the implementation should default to a more
+   conservative ordering than specified.
+
 */
 pragma "atomic module"
 module Atomics {
@@ -281,6 +323,10 @@ module Atomics {
        Similar to :proc:`compareExchange`, except that this function may
        return `false` even if the original value was equal to `expected`. This
        may happen if the value could not be updated atomically.
+
+       This weak version is allowed to spuriously fail, but when
+       is used compareExchange in a loop anyways, it can can offer better
+       performance on some platforms.
     */
     inline proc compareExchangeWeak(ref expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchangeWeak(expected, desired, order, readableOrder(order));
@@ -471,6 +517,11 @@ module Atomics {
        Similar to :proc:`compareExchange`, except that this function may
        return `false` even if the original value was equal to `expected`. This
        may happen if the value could not be updated atomically.
+
+       This weak version is allowed to spuriously fail, but when
+       is used compareExchange in a loop anyways, it can can offer better
+       performance on some platforms.
+
     */
     inline proc compareExchangeWeak(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchangeWeak(expected, desired, order, readableOrder(order));
@@ -700,34 +751,44 @@ module Atomics {
   // We need to explicitly define these for all types because the atomic
   // types are records and unless explicitly defined, it will resolve
   // to the normal record version of the function.  Sigh.
+
+  /* Equivalent to ``a.write(b.read())`` */
   inline operator AtomicBool.=(ref a:AtomicBool, const ref b:AtomicBool) {
     a.write(b.read());
   }
+  pragma "no doc"
   inline operator AtomicBool.=(ref a:AtomicBool, b) {
     compilerError("Cannot directly assign atomic variables");
   }
+  /* Equivalent to ``a.write(b.read())`` */
   inline operator AtomicT.=(ref a:AtomicT, const ref b:AtomicT) {
     a.write(b.read());
   }
+  pragma "no doc"
   inline operator AtomicT.=(ref a:AtomicT, b) {
     compilerError("Cannot directly assign atomic variables");
   }
+  pragma "no doc"
   inline operator AtomicT.+(a:AtomicT, b) {
     compilerError("Cannot directly add atomic variables");
     return a;
   }
+  pragma "no doc"
   inline operator AtomicT.-(a:AtomicT, b) {
     compilerError("Cannot directly subtract atomic variables");
     return a;
   }
+  pragma "no doc"
   inline operator AtomicT.*(a:AtomicT, b) {
     compilerError("Cannot directly multiply atomic variables");
     return a;
   }
+  pragma "no doc"
   inline operator AtomicT./(a:AtomicT, b) {
     compilerError("Cannot directly divide atomic variables");
     return a;
   }
+  pragma "no doc"
   inline operator AtomicT.%(a:AtomicT, b) {
     compilerError("Cannot directly divide atomic variables");
     return a;

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -325,7 +325,7 @@ module Atomics {
        may happen if the value could not be updated atomically.
 
        This weak version is allowed to spuriously fail, but when
-       is used compareExchange in a loop anyways, it can can offer better
+       compareExchange is already in a loop, it can offer better
        performance on some platforms.
     */
     inline proc compareExchangeWeak(ref expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
@@ -519,9 +519,8 @@ module Atomics {
        may happen if the value could not be updated atomically.
 
        This weak version is allowed to spuriously fail, but when
-       is used compareExchange in a loop anyways, it can can offer better
+       compareExchange is already in a loop, it can offer better
        performance on some platforms.
-
     */
     inline proc compareExchangeWeak(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchangeWeak(expected, desired, order, readableOrder(order));

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -188,7 +188,7 @@ removePrefixFunctions $file
 replace "record:: AtomicBool" "type:: atomic \(bool\)" $file
 replace "record:: AtomicT"    "type:: atomic \(T\)" $file
 
-fixTitle "Atomics" $file
+removeTitle $file
 removeUsage $file
 
 ## End Atomics ##

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -68,6 +68,21 @@ function fixTitle() {
   perl -0777 -i -pe "s/$base\n=+\n/$1\n$header\n/g" $2
 }
 
+# removes the title entirely (for internal module docs embedded in the spec)
+function removeTitle() {
+  if [ $# -ne 1 ] || [ ! -f $1 ]; then
+    echo "Bad call to removeTitle."
+    exit 1
+  fi
+  local base="$(basename $1 .rst)"
+
+  # Replace the section header so the internal modules don't show up like this:
+  # Module: ChapelFoo
+  local titleLen=${#1}
+  perl -0777 -i -pe "s/$base\n=+\n//g" $1
+}
+
+
 # Remove unwanted functions:
 #  - remove all procs/iters that start with chpl_ (they're internal)
 #  - remove all procs/iters that don't start with letters (to remove operator


### PR DESCRIPTION
This PR migrates the Atomics docs to the task parallelism and synchronization spec section per #18027. 

It leaves as future work to migrate the other internal module docs.

Reviewed by @lydia-duncan - thanks!