### PR TITLE
Migrate locales documentation to the spec

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -113,6 +113,7 @@ exclude_patterns = ['Makefile',
                     # These don't need to be processed separately
                     # since they are included in the spec with .. include::
                     'builtins/Atomics.rst',
+                    'builtins/ChapelLocale.rst',
                    ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -23,14 +23,15 @@ running on another locale.
 Locales
 -------
 
-A *locale* is a portion of the target parallel architecture that has
-processing and storage capabilities. Chapel implementations should
-typically define locales for a target architecture such that tasks
-running within a locale have roughly uniform access to values stored in
-the locale’s local memory and longer latencies for accessing the
-memories of other locales. As an example, a cluster of multicore nodes
-or SMPs would typically define each node to be a locale. In contrast a
-pure shared memory machine would be defined as a single locale.
+A *locale* is a Chapel abstraction for a piece of a target
+architecture that has processing and storage capabilities.
+Generally speaking, the tasks running within a locale have
+roughly uniform access to values stored in the locale's local
+memory and longer latencies for accessing the memories of other
+locales.  As examples, a single shared memory machine would be
+defined as a single locale, while in a system consisting of a
+group of network-connected multicore nodes or SMPs each node
+would be defined as a locale.
 
 .. _The_Locale_Type:
 
@@ -40,6 +41,8 @@ Locale Types
 The identifier ``locale`` is a type that abstracts a locale as described above.
 Both data and tasks can be associated with a value of locale type.
 
+The default value for a variable with ``locale`` type is ``Locales[0]``.
+
 .. _Locale_Methods:
 
 Locale Methods
@@ -47,57 +50,7 @@ Locale Methods
 
 The locale type supports the following methods:
 
-
-
-.. function:: proc locale.callStackSize: uint(64);
-
-   Returns the per-task call stack size used when creating tasks on the
-   locale in question. A value of 0 indicates that the call stack size is
-   determined by the system.
-
-
-
-.. function:: proc locale.id: int;
-
-   Returns a unique integer for each locale, from 0 to the number of
-   locales less one.
-
-
-
-.. function:: proc locale.maxTaskPar: int(32);
-
-   Returns an estimate of the maximum parallelism available for tasks on a
-   given locale.
-
-
-
-.. function:: proc locale.name: string;
-
-   Returns the name of the locale.
-
-
-
-.. function:: proc locale.numPUs(logical: bool = false, accessible: bool = true);
-
-   Returns the number of processing unit instances available on a given
-   locale. Basically these are the things that execute instructions. If
-   ``logical`` is ``false`` then the count reflects physical instances,
-   often referred to as *cores*. Otherwise it reflects logical instances,
-   such as hardware threads on multithreaded CPU architectures. If
-   ``accessible`` is ``true`` then the count includes only those processors
-   the OS has made available to the program. Otherwise it includes all
-   processors that seem to be present.
-
-
-
-.. code-block:: chapel
-
-   use Memory;
-   proc locale.physicalMemory(unit: MemUnits=MemUnits.Bytes, type retType=int(64)): retType;
-
-Returns the amount of physical memory available on a given locale in
-terms of the specified memory units (Bytes, KB, MB, or GB) using a value
-of the specified return type.
+.. include:: /builtins/ChapelLocale.rst
 
 .. _Predefined_Locales_Array:
 
@@ -108,7 +61,7 @@ Chapel provides a predefined environment that stores information about
 the locales used during program execution. This *execution environment*
 contains definitions for the array of locales on which the program is
 executing (``Locales``), a domain for that array (``LocaleSpace``), and
-the number of locales (``numLocales``). 
+the number of locales (``numLocales``).
 
 .. code-block:: chapel
 
@@ -279,6 +232,14 @@ Return statements may not be lexically enclosed in on statements. Yield
 statements may only be lexically enclosed in on statements in parallel
 iterators :ref:`Parallel_Iterators`.
 
+One common code idiom in Chapel is the following, which spreads parallel
+tasks across the network-connected locales upon which the program is running:
+
+  .. code-block:: chapel
+
+    coforall loc in Locales { on loc { ... } }
+
+
 .. _remote_variable_declarations:
 
 Remote Variable Declarations
@@ -295,3 +256,7 @@ keyword and braces. The syntax is given by:
 
    remote-variable-declaration-statement:
      'on' expression variable-declaration-statement
+
+.. note::
+
+  Support for this syntax is not yet implemented.

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -23,15 +23,13 @@ running on another locale.
 Locales
 -------
 
-A *locale* is a Chapel abstraction for a piece of a target
-architecture that has processing and storage capabilities.
-Generally speaking, the tasks running within a locale have
-roughly uniform access to values stored in the locale's local
-memory and longer latencies for accessing the memories of other
-locales.  As examples, a single shared memory machine would be
-defined as a single locale, while in a system consisting of a
-group of network-connected multicore nodes or SMPs each node
-would be defined as a locale.
+A *locale* is a Chapel abstraction for a piece of a target architecture
+that has processing and storage capabilities.  Generally speaking, the
+tasks running within a locale have roughly uniform access to values
+stored in the locale's local memory and longer latencies for accessing
+the memories of other locales.  As an example, a single shared memory
+machine would be defined as a single locale. In contrast, a cluster of
+network-connected multicore nodes would have a locale for each node.
 
 .. _The_Locale_Type:
 

--- a/doc/rst/meta/builtins/index.rst
+++ b/doc/rst/meta/builtins/index.rst
@@ -12,7 +12,6 @@ amenable to being documented using **chpldoc**:
 .. toctree::
    :maxdepth: 1
 
-   ChapelLocale
    OwnedObject
    Bytes
    ChapelRange

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -18,52 +18,10 @@
  * limitations under the License.
  */
 
+// NOTE: the docs below are intended to be included
+// in the relevant spec section
+
 /*
-  A *locale* is a Chapel abstraction for a piece of a target
-  architecture that has processing and storage capabilities.
-  Generally speaking, the tasks running within a locale have
-  roughly uniform access to values stored in the locale's local
-  memory and longer latencies for accessing the memories of other
-  locales.  As examples, a single shared memory machine would be
-  defined as a single locale, while in a system consisting of a
-  group of network-connected multicore nodes or SMPs each node
-  would be defined as a locale.
-
-  Chapel provides several predefined methods on locales, as well as
-  a few variables that describe the locales upon which a program is
-  running.
-
-  In addition to what is documented below, ``numLocales``, ``LocaleSpace``,
-  and ``Locales`` are available as global variables.
-
-  ``numLocales`` is the number of top-level (network connected) locales.
-
-  .. code-block:: chapel
-
-    config const numLocales: int;
-
-  ``LocaleSpace`` is the domain over which the global ``Locales`` array is
-  defined.
-
-  .. code-block:: chapel
-
-    const LocaleSpace = {0..numLocales-1};
-
-  The global ``Locales`` array contains an entry for each top-level locale.
-
-  .. code-block:: chapel
-
-    const Locales: [LocaleSpace] locale;
-
-
-  One common code idiom in Chapel is the following, which spreads parallel
-  tasks across the network-connected locales upon which the program is running:
-
-    .. code-block:: chapel
-
-      coforall loc in Locales { on loc { ... } }
-
-  The default value for a ``locale`` variable is ``Locales[0]``
 
  */
 module ChapelLocale {
@@ -211,6 +169,7 @@ module ChapelLocale {
     :return: current locale
     :rtype: locale
   */
+  pragma "no doc" // because the spec covers it in a different section
   inline proc here {
     return chpl_localeID_to_locale(here_id);
   }
@@ -240,7 +199,7 @@ module ChapelLocale {
   }
 
   /*
-    Get the integer identifier for this locale.
+    Get the unique integer identifier for this locale.
 
     :returns: locale number, in the range ``0..numLocales-1``
     :rtype: int

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -143,7 +143,7 @@ removeUsage $file
 ## ChapelLocale ##
 
 file="./ChapelLocale.rst"
-fixTitle "Locales" $file
+removeTitle $file
 replace "LocaleSpace = chpl__buildDomainExpr(0..numLocales-1)" \
         "LocaleSpace = {0..numLocales-1}" $file
 removeUsage $file


### PR DESCRIPTION
This PR migrates the Locales docs to the Locales spec section per #18027. 

It leaves as future work to migrate the other internal module docs.

Reviewed by @lydia-duncan - thanks!