### PR TITLE
Don't rename Errors module in sidebar

### DIFF
--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -17,7 +17,7 @@ default:
    :maxdepth: 1
 
    Chapel Environment Variables <standard/ChapelEnv>
-   Error Handling <standard/Errors>
+   Errors <standard/Errors>
    IO Support <standard/ChapelIO>
    Math <standard/Math>
    Types <standard/Types>


### PR DESCRIPTION
Follow-up to PR #18113

Since Errors is a reasonable name and one a user can use (e.g. `Errors.halt()`) we don't need to re-title this module in the sidebar anymore.

Change requested by @bradcray.
