### PR TITLE
Drop unnecessary calls to `c_str` in compiler

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2279,7 +2279,7 @@ void runClang(const char* just_parse_filename) {
     clangOtherArgs.push_back("cuda");
 
     std::string cudaGPUArch = std::string("--cuda-gpu-arch=") + fCUDAArch;
-    clangOtherArgs.push_back(cudaGPUArch.c_str());
+    clangOtherArgs.push_back(cudaGPUArch);
   }
 
   // Always include sys_basic because it might change the
@@ -2314,7 +2314,7 @@ void runClang(const char* just_parse_filename) {
       fprintf(fp, "%s", ifdefStrEnd);
       closefile(fp);
       clangOtherArgs.push_back("-include");
-      clangOtherArgs.push_back(genHeaderFilename.c_str());
+      clangOtherArgs.push_back(genHeaderFilename);
     }
 
     // Running clang to compile all runtime and extern blocks


### PR DESCRIPTION
Removes calls to `c_str()` as noted by @mppf in:

https://github.com/chapel-lang/chapel/commit/7f6ff127a0f6c82416571435207e330650798dd0#r56915386