### PR TITLE
Fix an issue where this test wasn't completely looking in the right place

### DIFF
--- a/test/chpldoc/nodoc/noDocPlease.doc.catfiles
+++ b/test/chpldoc/nodoc/noDocPlease.doc.catfiles
@@ -1,2 +1,3 @@
 docs/source/modules/Foo.rst
+docs/source/modules/Foo/invisible.rst
 docs/source/modules/toBeIgnored.rst

--- a/test/chpldoc/nodoc/noDocPlease.doc.good
+++ b/test/chpldoc/nodoc/noDocPlease.doc.good
@@ -25,4 +25,5 @@ or
 
    .. attribute:: var showMe: bool
 
+cat: docs/source/modules/Foo/invisible.rst: No such file or directory
 cat: docs/source/modules/toBeIgnored.rst: No such file or directory


### PR DESCRIPTION
While adding "no doc" tests when the symbol is deprecated, I noticed that this
test of "no doc" failed to go looking for a nested module file - thankfully it
doesn't hide a bug today, but if we accidentally changed it so that nested
modules experienced a bug that top-level modules did not, this test as written
previously would not have noticed.  Update the .catfiles and the .good output
so that it will notice in the future.

Passed a fresh checkout

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>