### PR TITLE
Fix computePerfStats to find shortest regex

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -38,7 +38,7 @@ function test_release() {
   git checkout 1.24.1
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
-  git checkout $currentSha -- $CHPL_HOME/util/test/perf/
+  git checkout $currentSha -- $CHPL_HOME/util/test/
   $CWD/nightly -cron ${nightly_args}
 }
 

--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -53,18 +53,13 @@ def find_keys(keys, date):
         for key in keys:
             sys.stdout.write("Looking for {0}...".format(key))
             file.write("\t")
-            found = False
             regex = r"(\s|\S)*" + re.escape(key) + r"\s*(\S*)"
             # scan through output, looking for key
-            for line in test_output:
-                m = re.match(regex, line)
-                if m and not found:
-                    print("found it: {0}".format(m.group(2)))
-                    file.write(m.group(2))
-                    found = True
-                    break
-
-            if not found:
+            m = re.match(regex, test_output_raw, re.MULTILINE)
+            if m:
+                print("found it: {0}".format(m.group(2)))
+                file.write(m.group(2))
+            else:
                 file.write("-")
                 print("didn't find it")
                 found_everything = False


### PR DESCRIPTION
Previously, computePerfStats would search for performance keys
line-by-line. This caused us to find the wrong value if a key was a
substring of another one, but the longer key occurred first.

For example, if you had `non-regex time:` and `regex time:` keys, we
would find the `non-regex time:` value both times because `regex time:`
is in `non-regex time:`. Correct this by switching from searching line
at a time to a multiline regex, which will find the shortest match.

This was first noticed in some Arkouda benchmarks.