### PR TITLE
Update compiler code to work with LLVM-12

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2478,6 +2478,12 @@ GenRet codegenCallExprInner(GenRet function,
             INT_FATAL("inalloca arguments not yet implemented");
             break;
 
+#if HAVE_LLVM_VER >= 120
+          case clang::CodeGen::ABIArgInfo::Kind::IndirectAliased:
+            INT_FATAL("IndirectAliased not yet implemented");
+            break;
+#endif
+
           case clang::CodeGen::ABIArgInfo::Kind::Indirect:
           {
             // clang's CodeGenFunction::EmitCall contains many
@@ -3943,7 +3949,13 @@ DEFINE_PRIM(PRIM_RETURN) {
           }
           break;
         }
-
+#if HAVE_LLVM_VER >= 120
+        case clang::CodeGen::ABIArgInfo::Kind::IndirectAliased:
+        {
+          INT_FATAL("IndirectAliased not implemented yet");
+          break;
+        }
+#endif
         case clang::CodeGen::ABIArgInfo::Kind::Indirect:
         {
           auto ii = curFn->arg_begin();

--- a/compiler/codegen/cg-stmt.cpp
+++ b/compiler/codegen/cg-stmt.cpp
@@ -29,6 +29,7 @@
 #include "ImportStmt.h"
 #include "LayeredValueTable.h"
 #include "llvmDebug.h"
+#include "llvmVer.h"
 #include "misc.h"
 #include "passes.h"
 #include "stlUtil.h"

--- a/compiler/codegen/cg-stmt.cpp
+++ b/compiler/codegen/cg-stmt.cpp
@@ -66,8 +66,14 @@ void codegenStmt(Expr* stmt) {
         scope = info->irBuilder->getCurrentDebugLocation().getScope();
       }
 
+#if HAVE_LLVM_VER >= 120
+      info->irBuilder->SetCurrentDebugLocation(
+                  llvm::DILocation::get(scope->getContext(), stmt->linenum(),
+                                        /*col=*/ 0, scope, nullptr, false));
+#else
       info->irBuilder->SetCurrentDebugLocation(
                   llvm::DebugLoc::get(stmt->linenum(),0 /*col*/,scope));
+#endif
     }
 #endif
   }

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1801,6 +1801,13 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
     const clang::CodeGen::ABIArgInfo& returnInfo = CGI->getReturnInfo();
 
     switch (returnInfo.getKind()) {
+#if HAVE_LLVM_VER >= 120
+      case clang::CodeGen::ABIArgInfo::Kind::IndirectAliased:
+      {
+        INT_FATAL("IndirectAliased not handled yet");
+        break;
+      }
+#endif
       case clang::CodeGen::ABIArgInfo::Kind::Indirect:
       case clang::CodeGen::ABIArgInfo::Kind::Ignore:
       {
@@ -1923,6 +1930,14 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
         case clang::CodeGen::ABIArgInfo::Kind::Ignore:
         case clang::CodeGen::ABIArgInfo::Kind::InAlloca:
           break;
+
+#if HAVE_LLVM_VER >= 120
+        case clang::CodeGen::ABIArgInfo::Kind::IndirectAliased:
+        {
+          INT_FATAL("IndirectAliased not handled yet");
+          break;
+        }
+#endif
 
         case clang::CodeGen::ABIArgInfo::Kind::Indirect:
         {
@@ -2419,8 +2434,14 @@ void FnSymbol::codegenDef() {
 
     if(debug_info) {
       llvm::DISubprogram* dbgScope = debug_info->get_function(this);
+#if HAVE_LLVM_VER >= 120
+      info->irBuilder->SetCurrentDebugLocation(
+        llvm::DILocation::get(dbgScope->getContext(), linenum(), 0,
+                              dbgScope, nullptr, false));
+#else
       info->irBuilder->SetCurrentDebugLocation(
         llvm::DebugLoc::get(linenum(),0,dbgScope));
+#endif
       func->setSubprogram(dbgScope);
     }
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2572,7 +2572,13 @@ clang::FunctionDecl* getFunctionDeclClang(const char* name)
 llvm::Type* getTypeLLVM(const char* name)
 {
   GenInfo* info = gGenInfo;
+#if HAVE_LLVM_VER >= 120
+  llvm::MDNode* scope = info->irBuilder->getCurrentDebugLocation().getScope();
+  llvm::Type* t = llvm::StructType::getTypeByName(scope->getContext(), name);
+#else
   llvm::Type* t = info->module->getTypeByName(name);
+#endif
+
   if( t ) return t;
 
   t = info->lvt->getType(name);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2573,8 +2573,7 @@ llvm::Type* getTypeLLVM(const char* name)
 {
   GenInfo* info = gGenInfo;
 #if HAVE_LLVM_VER >= 120
-  llvm::MDNode* scope = info->irBuilder->getCurrentDebugLocation().getScope();
-  llvm::Type* t = llvm::StructType::getTypeByName(scope->getContext(), name);
+  llvm::Type* t = llvm::StructType::getTypeByName(info->llvmContext, name);
 #else
   llvm::Type* t = info->module->getTypeByName(name);
 #endif

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -650,10 +650,16 @@ llvm::DIVariable* debug_data::construct_variable(VarSymbol *varSym)
       true/*AlwaysPreserve, won't be removed when optimized*/
       ); //omit the  Flags and ArgNo
 
+#if HAVE_LLVM_VER >= 120
+    this->dibuilder.insertDeclare(varSym->codegen().val, localVariable,
+      this->dibuilder.createExpression(), llvm::DILocation::get(
+        scope->getContext(), line_number, 0, scope, nullptr, false),
+      gGenInfo->irBuilder->GetInsertBlock());
+#else
     this->dibuilder.insertDeclare(varSym->codegen().val, localVariable,
       this->dibuilder.createExpression(), llvm::DebugLoc::get(line_number, 0, scope),
       gGenInfo->irBuilder->GetInsertBlock());
-
+#endif
     return localVariable;
   }
   else {

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1218,7 +1218,12 @@ namespace {
         info->globalSpace = 100;
         info->wideSpace = 101;
         info->globalPtrBits = 128;
+#if HAVE_LLVM_VER >= 120
+        info->localeIdType = StructType::getTypeByName(M.getContext(),
+                                                       "struct.c_localeid_t");
+#else
         info->localeIdType = M.getTypeByName("struct.c_localeid_t");
+#endif
         if( ! info->localeIdType ) {
           StructType* t = StructType::create(M.getContext(), "struct.c_localeid_t");
           t->setBody(Type::getInt32Ty(M.getContext()),

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -351,8 +351,8 @@ int64_t arrayVecN(llvm::Type *t)
     if (llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(t)) {
       n = vt->getNumElements();
     } else {
-      assert(0 && "Scalable vector type not handled");
-      n = 0;
+      // Scalable vector type not handled here
+      return -1;
     }
 #else
     llvm::VectorType *vt = llvm::dyn_cast<llvm::VectorType>(t);

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -346,8 +346,18 @@ int64_t arrayVecN(llvm::Type *t)
     unsigned n = at->getNumElements();
     return n;
   } else if( t->isVectorTy() ) {
+#if HAVE_LLVM_VER >= 120
+    unsigned n;
+    if (llvm::FixedVectorType *vt = llvm::dyn_cast<llvm::FixedVectorType>(t)) {
+      n = vt->getNumElements();
+    } else {
+      assert(0 && "Scalable vector type not handled");
+      n = 0;
+    }
+#else
     llvm::VectorType *vt = llvm::dyn_cast<llvm::VectorType>(t);
     unsigned n = vt->getNumElements();
+#endif
     return n;
   } else {
     return -1;


### PR DESCRIPTION
Updating to LLVM-12 had some backward compatibility breaks that we hit. Update
the compiler so it will continue to work with both LLVM-11 and LLVM-12.

A new value in an enum required adding a new case to some switch statements.

A static method on DebugLoc became a static method on DILocation.

A static method on Module became a static method on StructType.

A method on VectorType got specialized into separate handling for
FixedVectorType and ScalableVectorType.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>