### PR TITLE
fix bug when using add or rm -h or -V

### DIFF
--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -37,7 +37,7 @@ proc masonModify(args: [] string) throws {
 
   var extFlag = parser.addFlag("external", defaultValue=false);
   var sysFlag = parser.addFlag("system", defaultValue=false);
-  var depArg = parser.addArgument("dep");
+  var depArg = parser.addArgument("dep", numArgs=0..1);
 
   try {
     parser.parseArgs(args);
@@ -51,6 +51,12 @@ proc masonModify(args: [] string) throws {
   if helpFlag.valueAsBool() {
     masonModifyHelp();
     exit(0);
+  }
+
+  if !depArg.hasValue() {
+    stderr.writeln("package name missing value");
+    masonModifyHelp();
+    exit(1);
   }
   var add = false;
   if args[0] == "add" then add = true;


### PR DESCRIPTION
This PR fixes a small bug in the `mason add` and `rm` commands, when using the
version or help flags, an error is also printed that a required positional 
argument is missing. 

Here we relax the constraints on the positional argument to allow 0 or 1 values
as opposed to always expecting a value. 

This bug should have been caught when masonHelpScope returned an invalid value,
but I discovered a couple of the tests in the mason subdirectory are not running
based on the evaluation of their `.skipif` files. It seems like the test environment 
isn't able to properly locate the `mason` executable and that causes the test
directory to be skipped. Tracking for this issue is setup in cray/chapel-private#2541


TESTING:

- [x] `make all`
- [x] `make mason`
- [x] `util/start_test test/mason`
- [x] `util/start_test test/mason/mason-help-scope/masonHelpScope.chpl`
- [x] `util/start_test test/mason/mason-test-exit/exitCodeTest.chpl`

Reviewed by @mppf

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>