### PR TITLE
Fix Arkouda release testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -38,7 +38,8 @@ function test_release() {
   git checkout 1.24.1
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
-  git checkout $currentSha -- $CHPL_HOME/util/test/
+  git checkout $currentSha -- $CHPL_HOME/util/test/perf/
+  git checkout $currentSha -- $CHPL_HOME/util/test/computePerfStats
   $CWD/nightly -cron ${nightly_args}
 }
 


### PR DESCRIPTION
#18466 changed Arkouda release testing to use the current development
util/test directory to include a newer computePerfStats, but that broke
some python imports from other directories that have changed. Switch to
only grabbing the newer computePerfStats to fix this.