### PR TITLE
Update deprecation best practices for auto-generated deprecation message

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -44,6 +44,11 @@ For example:
 
     Foo module long description.
 
+.. note::
+
+   This step is not necessary when using the ``deprecated`` keyword, though
+   it can be useful in cases where the documentation could explicitly link to
+   the new symbol to use instead.
 
 3. Add a deprecation test to ``test/deprecated/`` to:
 


### PR DESCRIPTION
Now that the `deprecated` keyword will trigger an automatic message in the
documentation of a deprecated symbol if there wasn't a mention of deprecation
already, note that step 2 of this document is not necessary in that case.

Double checked that the built version of the docs looked good

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>