### PR TITLE
Remove request too big prime capacity test

### DIFF
--- a/test/domains/johnk/capacityTooBig.chpl
+++ b/test/domains/johnk/capacityTooBig.chpl
@@ -1,3 +1,0 @@
-var D : domain(string);
-
-D.requestCapacity(864691128455135208);

--- a/test/domains/johnk/capacityTooBig.good
+++ b/test/domains/johnk/capacityTooBig.good
@@ -1,1 +1,0 @@
-capacityTooBig.chpl:3: error: Attempting to allocate > max(size_t) bytes of memory


### PR DESCRIPTION
This test requested a size that was larger than what was available in the `chpl__primes` table, and since we have now removed this table in #18427, this test no longer makes sense.