### PR TITLE
Fix `memThreshold` memory tracking optimization

### DIFF
--- a/runtime/include/chpl-mem-array.h
+++ b/runtime/include/chpl-mem-array.h
@@ -200,9 +200,9 @@ void chpl_mem_array_free(void* p,
   // comm layer says it didn't come from there, free it in the memory
   // layer.
   //
-  chpl_memhook_free_pre(p, lineno, filename);
-
   const size_t size = nmemb * eltSize;
+  chpl_memhook_free_pre(p, size, lineno, filename);
+
   if (chpl_mem_size_justifies_comm_alloc(size)
       && chpl_comm_regMemFree(p, size)) {
     return;

--- a/runtime/include/chpl-mem-hook.h
+++ b/runtime/include/chpl-mem-hook.h
@@ -95,12 +95,12 @@ void chpl_memhook_malloc_post(void* memAlloc,
 
 
 static inline
-void chpl_memhook_free_pre(void* memAlloc,
+void chpl_memhook_free_pre(void* memAlloc, size_t approximateSize,
                            int32_t lineno, int32_t filename) {
   if (CHPL_MEMHOOKS_ACTIVE) {
     // call this one just to check heap is initialized.
     chpl_memhook_check_pre(0, 0, 0, lineno, filename);
-    chpl_track_free(memAlloc, lineno, filename);
+    chpl_track_free(memAlloc, approximateSize, lineno, filename);
   }
 }
 

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -121,7 +121,7 @@ void* chpl_mem_realloc(void* memAlloc, size_t size,
   chpl_memhook_realloc_pre(memAlloc, size, description,
                            lineno, filename);
   if (size == 0) {
-    chpl_memhook_free_pre(memAlloc, lineno, filename);
+    chpl_memhook_free_pre(memAlloc, 0, lineno, filename);
     chpl_free(memAlloc);
     return NULL;
   }
@@ -148,7 +148,10 @@ void* chpl_mem_memalign(size_t boundary, size_t size,
 
 static inline
 void chpl_mem_free(void* memAlloc, int32_t lineno, int32_t filename) {
-  chpl_memhook_free_pre(memAlloc, lineno, filename);
+  // Use the real size of an allocation as the approximate size for memory
+  // tracking so it can avoid grabbing a lock for allocations below a threshold
+  size_t approximateSize = CHPL_MEMHOOKS_ACTIVE ? chpl_real_alloc_size(memAlloc) : 0;
+  chpl_memhook_free_pre(memAlloc, approximateSize, lineno, filename);
   chpl_free(memAlloc);
 }
 

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -62,7 +62,8 @@ void chpl_stopVerboseMemHere(void);
 void chpl_track_malloc(void* memAlloc, size_t number, size_t size,
                        chpl_mem_descInt_t description,
                        int32_t lineno, int32_t filename);
-void chpl_track_free(void* memAlloc, int32_t lineno, int32_t filename);
+void chpl_track_free(void* memAlloc, size_t approximateSize, int32_t lineno,
+                     int32_t filename);
 void chpl_track_realloc_pre(void* memAlloc, size_t size,
                          chpl_mem_descInt_t description,
                          int32_t lineno, int32_t filename);


### PR DESCRIPTION
#18465 optimized memory leak tracking to avoid taking a lock when the real
allocation size is below `memThreshold`, but there were a few bugs in
the initial implementation.

For cases where the memory layer doesn't support `chpl_real_alloc_size`
(`CHPL_MEM=cstdlib`) we weren't handling the unknown size sentinel so we
weren't ever running the free hook, which made it look like we were
leaking all memory. Fix that to run the hook if the "real size" is 0
(the unknown sentinel.)

This was also broken under configurations that separately allocate
arrays (like `CHPL_COMM=ugni`). For those configs we were taking a comm
layer allocation and trying to ask jemalloc for the size of it, but this
results in mixed allocator calls, which is undefined behavior. Fix that
by making the higher level interface compute the size and passing it in
instead of computing it below the level where we know what allocator
memory came from.