### PR TITLE
Revert c2chapel record generation idiom change

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -370,7 +370,7 @@ def genStructOrUnion(structOrUnion, name=""):
         print()
         return
 
-    ret = "extern union " if isUnion else "extern \"struct " + name + "\" record ";
+    ret = "extern union " if isUnion else "extern record ";
     ret += name + " {"
     foundTypes.add(name)
 

--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -20,7 +20,7 @@ extern proc sized(x : c_ptr(c_int), ref y : c_int) : void;
 
 extern proc sized(x : c_ptr(c_int), y : c_ptr(c_int)) : void;
 
-extern "struct foobar" record foobar {
+extern record foobar {
   var x : c_int;
   var y : c_ptr(c_int);
   var z : c_ptr(c_ptr(c_int));

--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -17,7 +17,7 @@ extern proc foo2(lambda_arg : c_double) : c_int;
 // ==== c2chapel typedefs ====
 
 // Fields omitted because one or more of the identifiers is a Chapel keyword
-extern "struct bar" record bar {}
+extern record bar {}
 
 // Unable to generate struct 'record' because its name is a Chapel keyword
 

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -27,7 +27,7 @@ extern const FAILED :c_int;
 
 extern proc test_file(e : test_error) : c_int;
 
-extern "struct test_status" record test_status {
+extern record test_status {
   var current_status : test_error;
 }
 

--- a/tools/c2chapel/test/fileGlobals.chpl
+++ b/tools/c2chapel/test/fileGlobals.chpl
@@ -14,7 +14,7 @@ extern var globalChar : c_char;
 
 extern var globalPointer : c_ptr(c_int);
 
-extern "struct mytype" record mytype {
+extern record mytype {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;

--- a/tools/c2chapel/test/fnPointers.chpl
+++ b/tools/c2chapel/test/fnPointers.chpl
@@ -14,7 +14,7 @@ extern proc foo(a : myFunctionPointer, b : c_int) : c_int;
 
 // ==== c2chapel typedefs ====
 
-extern "struct io_methods" record io_methods {
+extern record io_methods {
   var close : c_fn_ptr;
   var open : c_fn_ptr;
 }

--- a/tools/c2chapel/test/gnuTest.chpl
+++ b/tools/c2chapel/test/gnuTest.chpl
@@ -9,7 +9,7 @@ use CPtr;
 use SysCTypes;
 use SysBasic;
 // Anonymous union or struct was encountered within and skipped.
-extern "struct _GValue" record _GValue {
+extern record _GValue {
   var g_type : GType;
 }
 

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -8,7 +8,7 @@ require "miscTypedef.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern "struct simpleStruct" record simpleStruct {
+extern record simpleStruct {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;
@@ -24,14 +24,14 @@ extern proc tdPointer(a : c_ptr(fancyStruct), b : c_ptr(c_ptr(renamedStruct))) :
 
 
 
-extern "struct forwardStruct" record forwardStruct {
+extern record forwardStruct {
   var a : c_int;
   var b : c_int;
 }
 
 // ==== c2chapel typedefs ====
 
-extern "struct fancyStruct" record fancyStruct {
+extern record fancyStruct {
   var a : c_int;
   var b : c_int;
   var c : renamedStruct;

--- a/tools/c2chapel/test/nestedStruct.chpl
+++ b/tools/c2chapel/test/nestedStruct.chpl
@@ -8,17 +8,17 @@ require "nestedStruct.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern "struct first" record first {
+extern record first {
   var a : c_int;
   var b : c_string;
 }
 
-extern "struct second" record second {
+extern record second {
   var a : c_ptr(c_int);
   var b : c_ptr(c_int);
 }
 
-extern "struct Outer" record Outer {
+extern record Outer {
   var structField : first;
   var fieldPtr : c_ptr(second);
 }

--- a/tools/c2chapel/test/opaqueStruct.chpl
+++ b/tools/c2chapel/test/opaqueStruct.chpl
@@ -8,7 +8,7 @@ require "opaqueStruct.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern "struct foobar" record foobar {
+extern record foobar {
   var a : c_int;
   var b : c_int;
   var c : c_int;

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -8,20 +8,20 @@ require "simpleRecords.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern "struct allInts" record allInts {
+extern record allInts {
   var a : c_int;
   var b : c_uint;
   var c : c_longlong;
 }
 
-extern "struct misc" record misc {
+extern record misc {
   var a : c_char;
   var b : c_string;
   var c : c_void_ptr;
   var d : c_ptr(c_int);
 }
 
-extern "struct composition" record composition {
+extern record composition {
   var m : misc;
   var i : c_ptr(allInts);
 }


### PR DESCRIPTION
The previous PR I filed to change the c2chapel record idiom fixed a very specific case that was seen in a few spots in the Arrow headers. I thought that adding the `"struct typeName"` to an extern record would work in all cases, but due to differences between the C backend and LLVM backends with C interoperability this was not the case, so I am reverting that change because the difficulties of supporting this seem to outweigh the benefits.

Reverted PR: https://github.com/chapel-lang/chapel/pull/18355