### PR TITLE
If PE links with -dynamic, that also means dynamic linking.

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4005,17 +4005,21 @@ void makeBinaryLLVM(void) {
     if (fLinkStyle == LS_DEFAULT) {
       // check for indication that the PrgEnv defaults to dynamic linking
       bool defaultDynamic = false;
-      for(size_t i = 0; i < gatheredArgs.size(); i++)
-        if (gatheredArgs[i].find("-Wl,-Bdynamic") != std::string::npos)
+      for(size_t i = 0; i < gatheredArgs.size(); i++) {
+        if (gatheredArgs[i] == "-Wl,-Bdynamic"   // when PE links with gcc
+            || gatheredArgs[i] == "-dynamic") {  // when PE links with clang
           defaultDynamic = true;
+        }
+      }
 
       // Older Cray PrgEnv defaults to static linking.  If we are asking for
       // the default link type, and we don't find an explicit dynamic
       // flag in the gathered PrgEnv arguments, then force static linking
       // because LLVM's default (dynamic) is different from the PrgEnv
       // default (static).
-      if (defaultDynamic == false)
+      if (defaultDynamic == false) {
         fLinkStyle = LS_STATIC;
+      }
     }
 
     // Replace -lchpl_lib_token with the runtime arguments

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -117,6 +117,9 @@ do
   elif [[ $arg == -l* && $LINK == 1 ]]
   then
     echo $arg
+  elif [[ $arg == -dynamic && $LINK == 1 ]]
+  then
+    echo $arg
   fi
 done
 


### PR DESCRIPTION
In the PE command line driver's linking arguments, we have only been
recognizing '-Wl,-Bdynamic' as indicating that it will do dynamic
linking, because that's what the driver throws when it uses gcc to
link with.  But when it uses clang to link with, it instead throws
'-dynamic'.  Here, add recognition for that as well.  This fixes a
problem first seen with quite-new PrgEnv installs on an HPE Cray EX
lookalike system at a customer site.

While here, I also added curly braces in the immediate area of my
change around some single-statement code blocks that lacked them,
since that's our convention.

This resolves https://github.com/Cray/chapel-private/issues/2550.