### PR TITLE
Generate `struct typename` for named structs in c2chapel

### DIFF
--- a/test/c2chapel/c2chapel-tester.good
+++ b/test/c2chapel/c2chapel-tester.good
@@ -2,6 +2,7 @@ Testing c2chapel...
 No arguments: OK
 --help: OK
 File not found: OK
+anonymousStruct: OK
 arrayDecl: OK
 chapelKeywords: OK
 chapelVarargs: OK
@@ -23,6 +24,7 @@ opaqueUnion: OK
 simpleRecords: OK
 sysCTypes: OK
 Testing using GNU parser... 
+anonymousStruct: OK
 arrayDecl: OK
 chapelKeywords: OK
 chapelVarargs: OK

--- a/tools/c2chapel/.gitignore
+++ b/tools/c2chapel/.gitignore
@@ -1,1 +1,2 @@
 /install
+test/*.py

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -374,7 +374,7 @@ def genStructOrUnion(structOrUnion, name="", isAnon=False):
     if isAnon:
         ret = "extern union " if isUnion else "extern record "
     else:
-        ret = "extern union " if isUnion else "extern \"struct " + name + "\" record "
+        ret = "extern \"union " + name + "\" union " if isUnion else "extern \"struct " + name + "\" record "
     ret += name + " {"
     foundTypes.add(name)
 

--- a/tools/c2chapel/test/anonymousStruct.chpl
+++ b/tools/c2chapel/test/anonymousStruct.chpl
@@ -1,7 +1,7 @@
 // Generated with c2chapel version 0.1.0
 
 // Header given to c2chapel:
-require "opaqueStruct.h";
+require "anonymousStruct.h";
 
 // Note: Generated with fake std headers
 
@@ -16,6 +16,7 @@ extern "struct foobar" record foobar {
 
 // ==== c2chapel typedefs ====
 
-// Opaque struct?
-extern record myOpaque {};
+extern record sports {
+  var a : c_int;
+}
 

--- a/tools/c2chapel/test/anonymousStruct.chpl
+++ b/tools/c2chapel/test/anonymousStruct.chpl
@@ -14,7 +14,15 @@ extern "struct foobar" record foobar {
   var c : c_int;
 }
 
+extern "union namedUnion" union namedUnion {
+  var a : c_int;
+}
+
 // ==== c2chapel typedefs ====
+
+extern union anonymousUnion {
+  var a : c_int;
+}
 
 extern record sports {
   var a : c_int;

--- a/tools/c2chapel/test/anonymousStruct.h
+++ b/tools/c2chapel/test/anonymousStruct.h
@@ -7,3 +7,11 @@ struct foobar {
 typedef struct {
   int a;
 } sports;
+
+union namedUnion {
+  int a;
+};
+
+typedef union {
+  int a;
+} anonymousUnion;

--- a/tools/c2chapel/test/anonymousStruct.h
+++ b/tools/c2chapel/test/anonymousStruct.h
@@ -1,0 +1,9 @@
+struct foobar {
+  int a;
+  int b;
+  int c;
+};
+
+typedef struct {
+  int a;
+} sports;

--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -20,7 +20,7 @@ extern proc sized(x : c_ptr(c_int), ref y : c_int) : void;
 
 extern proc sized(x : c_ptr(c_int), y : c_ptr(c_int)) : void;
 
-extern record foobar {
+extern "struct foobar" record foobar {
   var x : c_int;
   var y : c_ptr(c_int);
   var z : c_ptr(c_ptr(c_int));

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -27,7 +27,7 @@ extern const FAILED :c_int;
 
 extern proc test_file(e : test_error) : c_int;
 
-extern record test_status {
+extern "struct test_status" record test_status {
   var current_status : test_error;
 }
 

--- a/tools/c2chapel/test/fileGlobals.chpl
+++ b/tools/c2chapel/test/fileGlobals.chpl
@@ -14,7 +14,7 @@ extern var globalChar : c_char;
 
 extern var globalPointer : c_ptr(c_int);
 
-extern record mytype {
+extern "struct mytype" record mytype {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;

--- a/tools/c2chapel/test/gnuTest.chpl
+++ b/tools/c2chapel/test/gnuTest.chpl
@@ -9,7 +9,7 @@ use CPtr;
 use SysCTypes;
 use SysBasic;
 // Anonymous union or struct was encountered within and skipped.
-extern record _GValue {
+extern "struct _GValue" record _GValue {
   var g_type : GType;
 }
 

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -8,7 +8,7 @@ require "miscTypedef.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record simpleStruct {
+extern "struct simpleStruct" record simpleStruct {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;
@@ -24,7 +24,7 @@ extern proc tdPointer(a : c_ptr(fancyStruct), b : c_ptr(c_ptr(renamedStruct))) :
 
 
 
-extern record forwardStruct {
+extern "struct forwardStruct" record forwardStruct {
   var a : c_int;
   var b : c_int;
 }

--- a/tools/c2chapel/test/miscTypedefUnion.chpl
+++ b/tools/c2chapel/test/miscTypedefUnion.chpl
@@ -8,7 +8,7 @@ require "miscTypedefUnion.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern union simpleUnion {
+extern "union simpleUnion" union simpleUnion {
   var a : c_int;
   var b : c_char;
   var c : c_void_ptr;
@@ -24,7 +24,7 @@ extern proc tdPointer(a : c_ptr(fancyUnion), b : c_ptr(c_ptr(renamedUnion))) : v
 
 
 
-extern union forwardUnion {
+extern "union forwardUnion" union forwardUnion {
   var a : c_int;
   var b : c_int;
 }

--- a/tools/c2chapel/test/nestedStruct.chpl
+++ b/tools/c2chapel/test/nestedStruct.chpl
@@ -8,17 +8,17 @@ require "nestedStruct.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record first {
+extern "struct first" record first {
   var a : c_int;
   var b : c_string;
 }
 
-extern record second {
+extern "struct second" record second {
   var a : c_ptr(c_int);
   var b : c_ptr(c_int);
 }
 
-extern record Outer {
+extern "struct Outer" record Outer {
   var structField : first;
   var fieldPtr : c_ptr(second);
 }

--- a/tools/c2chapel/test/nestedUnion.chpl
+++ b/tools/c2chapel/test/nestedUnion.chpl
@@ -8,17 +8,17 @@ require "nestedUnion.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern union first {
+extern "union first" union first {
   var a : c_int;
   var b : c_string;
 }
 
-extern union second {
+extern "union second" union second {
   var a : c_ptr(c_int);
   var b : c_ptr(c_int);
 }
 
-extern union Outer {
+extern "union Outer" union Outer {
   var unionField : first;
   var fieldPtr : c_ptr(second);
 }

--- a/tools/c2chapel/test/opaqueUnion.chpl
+++ b/tools/c2chapel/test/opaqueUnion.chpl
@@ -8,7 +8,7 @@ require "opaqueUnion.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern union foobar {
+extern "union foobar" union foobar {
   var a : c_int;
   var b : c_int;
   var c : c_int;

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -8,20 +8,20 @@ require "simpleRecords.h";
 use CPtr;
 use SysCTypes;
 use SysBasic;
-extern record allInts {
+extern "struct allInts" record allInts {
   var a : c_int;
   var b : c_uint;
   var c : c_longlong;
 }
 
-extern record misc {
+extern "struct misc" record misc {
   var a : c_char;
   var b : c_string;
   var c : c_void_ptr;
   var d : c_ptr(c_int);
 }
 
-extern record composition {
+extern "struct composition" record composition {
   var m : misc;
   var i : c_ptr(allInts);
 }


### PR DESCRIPTION
All structs in c2chapel were previously treated as typedef'd structs, even when they weren't typedef'd, so this PR adds the ability to detect whether or not a struct is typedef'd and named, in that case, it adds the `"struct typename"` identifier in the `extern record` definition.

I had reverted the previous attempt at this a bit prematurely, thinking that the issue was coming from LLVM vs C backend differences, but it turns out I just didn't understand how you could refer to a non-typedef'd struct in C (thanks @mppf).

Reverted PR trying to do the same thing: https://github.com/chapel-lang/chapel/pull/18355