### PR TITLE
Fix mason bug when using mason external -V or --spec

### DIFF
--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -72,8 +72,14 @@ proc masonExternal(args: [] string) {
     exit(0);
   }
 
-  if versionFlag.valueAsBool() then printSpackVersion();
-  if specFlag.valueAsBool() then specHelp();
+  if versionFlag.valueAsBool() {
+    printSpackVersion();
+    exit(0);
+  }
+  if specFlag.valueAsBool() {
+    specHelp();
+    exit(0);
+  }
 
   try! {
     if setupFlag.valueAsBool() {
@@ -143,7 +149,7 @@ proc masonExternal(args: [] string) {
         when "info" do spkgInfo(cmdArgs);
         when "find" do findSpkg(cmdArgs);
         otherwise {
-          writeln('error: no such subcommand');
+          writeln('error: no such subcommand %s'.format(usedCmd));
           writeln('try mason external --help');
           exit(1);
         }


### PR DESCRIPTION
This PR fixes a small bug where the `mason external -V` 
or `mason external --spec` commands generate an
invalid subcommand error after printing out their respective
messages.

TESTING:

- [x] can `make mason`
- [x] all tests pass when running `util/start_test test/mason`

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>