### PR TITLE
Update the required gcc module version for EX module builds.

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -326,7 +326,7 @@ else
         list_loaded_modules
     fi
 
-    gen_version_gcc=10.2.0
+    gen_version_gcc=10.3.0
     #[TODO] gen_version_intel=16.0.3.210
     gen_version_cce=10.0.2
 

--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -328,7 +328,7 @@ else
 
     gen_version_gcc=10.3.0
     #[TODO] gen_version_intel=16.0.3.210
-    gen_version_cce=10.0.2
+    gen_version_cce=12.0.2
 
     target_cpu_module=craype-x86-rome
 


### PR DESCRIPTION
HPE Cray EX environments, both the container-ish build ones and the
actual systems themselves, seem to have bumped from gcc/10.2.0 to
gcc/10.3.0 recently.  They also seem to have bumped from cce/10.0.2
to cce/12.0.2. Follow those changes, for module builds.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>