### PR TITLE
Test framework: update environment for skipif evaluation

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -367,6 +367,7 @@ def summarize():
     passing_futures_marker = "{0}.*{1}".format(future_marker, success_marker)
     success_marker = "^" + success_marker
     skip_stdin_redirect_marker = r"^\[Skipping test with .stdin input"
+    skip_skipif_marker = r"^\[Skipping test based on .skipif"
 
     # setup counts and blank strings to hold summaries
     global failures # for exit codes later
@@ -377,6 +378,7 @@ def summarize():
     passing_suppressions = 0
     passing_futures = 0
     skip_stdin_redirects = 0
+    skip_skipif = 0
     failure_summary = ""
     suppression_summary = ""
     future_summary = ""
@@ -405,6 +407,8 @@ def summarize():
                 passing_futures += 1
             elif re.search(skip_stdin_redirect_marker, line, flags=re.M):
                 skip_stdin_redirects += 1
+            elif re.search(skip_skipif_marker, line, flags=re.M):
+                skip_skipif +=1
 
     # compile summary
     summary += failure_summary
@@ -415,6 +419,10 @@ def summarize():
     if skip_stdin_redirects > 0:
         logger.write("[Skipped {0} tests with .stdin input]"
                 .format(skip_stdin_redirects))
+
+    if skip_skipif > 0:
+        logger.write("[Skipped {0} tests based on evaluation of .skipif file]"
+                .format(skip_skipif))
 
     summary += ("[Summary: #Successes = {0} | #Failures = {1} | #Futures = {2} "
             "| #Warnings = {3} ]\n"

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -545,9 +545,12 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
 # Use testEnv to process skipif files, it works for executable and
 # non-executable versions
 def runSkipIf(skipifName):
+    # build the test environment from the globalExecenv (which read EXECENV already)
     testenv = {}
     for var, val in [env.split('=', 1) for env in globalExecenv]:
         testenv[var.strip()] = val.strip()
+    # pass the test environment to the subprocess so .skipif is evaluated
+    # with settings from EXECENV
     p = py3_compat.Popen([utildir+'/test/testEnv', './'+skipifName],
                          env=dict(list(os.environ.items()) + list(testenv.items())),
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -482,7 +482,7 @@ def GetTimer(f):
     lines = ReadFileWithComments(f)
     if len(lines) != 1:
         sys.stdout.write('[Error "%s" must contain exactly one non-comment line '
-            'with the name of the timer located in %s to use. Using default ' 
+            'with the name of the timer located in %s to use. Using default '
             'timer %s.]\n' %(f, timersdir, defaultTimer))
         timer = defaultTimer
     else:
@@ -499,9 +499,9 @@ def GetTimer(f):
 # options are one of the below configuration specific parameters that are
 # checked for. E.G the current comm layer. commExecNums are the optional
 # compopt and execopt number to enable different .good files for different
-# compopts/execopts with explicitly specifying name. 
+# compopts/execopts with explicitly specifying name.
 def FindGoodFile(basename, commExecNums=['']):
-    
+
     goodfile = ''
     for commExecNum in commExecNums:
         # Try the machine specific .good
@@ -545,7 +545,12 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
 # Use testEnv to process skipif files, it works for executable and
 # non-executable versions
 def runSkipIf(skipifName):
-    p = py3_compat.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    testenv = {}
+    for var, val in [env.split('=', 1) for env in globalExecenv]:
+        testenv[var.strip()] = val.strip()
+    p = py3_compat.Popen([utildir+'/test/testEnv', './'+skipifName],
+                         env=dict(list(os.environ.items()) + list(testenv.items())),
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     status = p.returncode
 
@@ -1021,9 +1026,9 @@ if os.getenv('CHPL_TEST_COMP_PERF')!=None:
     if os.getenv('CHPL_TEST_COMP_PERF_DIR')!=None:
         compperfdir=os.getenv('CHPL_TEST_COMP_PERF_DIR')
     else:
-        compperfdir=chpl_home+'/test/compperfdat/' 
+        compperfdir=chpl_home+'/test/compperfdat/'
 
-    # The env var CHPL_PRINT_PASSES_FILE will cause the 
+    # The env var CHPL_PRINT_PASSES_FILE will cause the
     # compiler to save the pass timings to specified file.
     if os.getenv('CHPL_PRINT_PASSES_FILE')!=None:
         printpassesfile=os.getenv('CHPL_PRINT_PASSES_FILE')
@@ -1766,8 +1771,8 @@ for testname in testsrc:
             # .good file can be of the form testname.<configuration>.good or
             # explicitname.<configuration>.good. It's not currently setup to
             # handle testname.<configuration>.<compoptsnum>.good, but that
-            # would be easy to add. 
-            basename = test_filename 
+            # would be easy to add.
+            basename = test_filename
             if len(clist) != 0:
                 explicitcompgoodfile = clist[0].split('#')[1].strip()
                 basename = explicitcompgoodfile.replace('.good', '')
@@ -1872,11 +1877,11 @@ for testname in testsrc:
         #
         sys.stdout.write('[Success compiling %s/%s]\n'%(localdir, test_filename))
 
-        # Note that compiler performance only times successful compilations. 
-        # Tests that are designed to fail before compilation is complete will 
-        # not get timed, so the total time compiling might be off slightly.   
+        # Note that compiler performance only times successful compilations.
+        # Tests that are designed to fail before compilation is complete will
+        # not get timed, so the total time compiling might be off slightly.
         if compperftest and not is_c_or_cpp_test:
-            # make the compiler performance directories if they don't exist 
+            # make the compiler performance directories if they don't exist
             timePasses = True
             if not os.path.isdir(compperfdir) and not os.path.isfile(compperfdir):
                 py3_compat.makedirs(compperfdir, exist_ok=True)
@@ -1890,8 +1895,8 @@ for testname in testsrc:
                 sys.stdout.write('[Error creating compiler performance temp dat file test directory %s]\n'%(tempDatFilesDir))
                 timePasses = False
 
-            # so long as we have to the directories 
-            if timePasses: 
+            # so long as we have to the directories
+            if timePasses:
                 # We need to name the files differently for each compiler
                 # option. 0 is the default compoptsnum if there are no options
                 # listed so we don't need to clutter the names with that
@@ -1924,7 +1929,7 @@ for testname in testsrc:
                         if os.path.isfile(datFile):
                             os.unlink(datFile)
 
-            #delete the timing file     
+            #delete the timing file
             cleanup(printpassesfile)
 
 
@@ -2276,19 +2281,19 @@ for testname in testsrc:
                         sys.stdout.write(p.communicate()[0])
 
                     if not perftest:
-                        # find the good file 
+                        # find the good file
 
                         basename = test_filename
                         commExecNum = ['']
 
                         # if there were multiple compopts/execopts find the
-                        # .good file that corresponds to that run 
+                        # .good file that corresponds to that run
                         if not onlyone:
                             commExecNum.insert(0,'.'+str(compoptsnum)+'-'+str(execoptsnum))
 
                         # if the .good file was explicitly specified, look for
                         # that version instead of the multiple
-                        # compopts/execopts or just the base .good file 
+                        # compopts/execopts or just the base .good file
                         if explicitexecgoodfile != None:
                             basename  = explicitexecgoodfile.replace('.good', '')
                             commExecNum = ['']


### PR DESCRIPTION
This PR changes the test framework to utilize the environment setup as defined
in `EXECENV` when evaluating any `.skipif` files in a directory. Additionally, 
if a test is skipped based on the evaluation of its `.skipif` file, there will
be a line added to the test output indicating how many tests were skipped.

Prior to this change, the `.skipif` file was evaluated without any of the 
information contained in the `EXECENV` file, which caused two different tests
in the `mason` suite to be skipped.

See https://github.com/Cray/chapel-private/issues/2541 for info on where this 
cropped up.

TESTING:

- [x] paratest on chapcs11 passes 13195 tests
- [x] skipping a test based on evaluation of `.skipif` indicated before summary
- [x] mason tests that previously skipped now run

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>