### PR TITLE
Mason external bugfix

### DIFF
--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -19,7 +19,7 @@
  */
 
 /* Version as of Chapel 1.25 - to be updated each release */
-const spackVersion = new VersionInfo('0.16.3');
+const spackVersion = new VersionInfo('0.15.4');
 const major = spackVersion.major:string;
 const minor = spackVersion.minor:string;
 const spackBranch = 'releases/v' + '.'.join(major, minor);

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -268,8 +268,13 @@ private proc printSpackVersion() {
 /* Returns spack version */
 proc getSpackVersion : VersionInfo {
   const command = "spack --version";
-  const version = getSpackResult(command,true).strip();
-  return new VersionInfo(version);
+  const tmpVersion = getSpackResult(command,true).strip();
+  // on systems with their own spack, spack --version can provide
+  // a version string like x.x.x-xxxx-hash
+  // partitioning the string allows us to separate the major.minor.bug
+  // from the remaining values
+  const version = tmpVersion.partition("-");
+  return new VersionInfo(version[0]);
 }
 
 /* Lists available spack packages */


### PR DESCRIPTION
This is a hotfix to correct a failing test that breaks nightly testing.

This PR lowers the spack version that mason uses, from the latest 0.16.3
to the last patch prior to the 0.16 release, 0.15.4.

It also adds a small correction when getting the version info
from `spack --version`, where some locally installed versions
may report additional information beyond major.minor.patch.

TESTING: 

- [x] `test/mason/mason-external` tests pass
- [x] can `make mason`
- [x] `mason external --setup` updates spack to v0.15.4

Reviewed by @dlongnecke-cray, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>