### PR TITLE
Speed up and reduce memory footprint of computePerfStats

### DIFF
--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -48,23 +48,26 @@ def main():
 
 def find_keys(keys, date):
     found_everything = True
-    with open(data_file, "a") as file:
-        file.write("{0} ".format(date))
-        for key in keys:
-            sys.stdout.write("Looking for {0}...".format(key))
-            file.write("\t")
-            regex = r"(\s|\S)*" + re.escape(key) + r"\s*(\S*)"
-            # scan through output, looking for key
-            m = re.match(regex, test_output_raw, re.MULTILINE)
-            if m:
-                print("found it: {0}".format(m.group(2)))
-                file.write(m.group(2))
-            else:
-                file.write("-")
-                print("didn't find it")
-                found_everything = False
+    values = ["{0}".format(date)]
+    for key in keys:
+        regex = re.escape(key) + r"\s*(\S*)"
+        # scan through output, looking the key. prefer start of line or after
+        # whitespace matches for when keys are substrings of each other
+        m = re.search(r"^" + regex, test_output_raw, re.MULTILINE)
+        if not m:
+            m = re.search(r"\s+" + regex, test_output_raw)
+        if not m:
+            m = re.search(regex, test_output_raw)
+        if m:
+            print("Looking for {0}...found it: {1}".format(key, m.group(1)))
+            values.append(m.group(1))
+        else:
+            values.append("-")
+            print("Looking for {0}...didn't find it".format(key))
+            found_everything = False
         
-        file.write("\n")
+    with open(data_file, "a") as f:
+        f.write("{0}\n".format('\t'.join(values)))
 
     return found_everything
 


### PR DESCRIPTION
#18466 was intended to update computePerfStats to find the shortest regex
match. However, it didn't actually do this, and the new implementation
was memory intensive and causing OOMs on some machines. What we used to
do was just match for our regex line-by-line, which wasn't helpful when
we had some keys that were substrings of others. #18466 changed to match
on all the output, which helped match some substrings better but not all
and it made the regex match a slow memory hog for perf tests that have a
lot of output (like many of the shootout benchmarks.)

Update computePerfStats here to switch from `match` to a simpler
`search`. This is faster and uses much less memory, but it gets us back
to finding the first key even if there's a shorter match later. To
combat that, first search for keys at the beginning of a line or
preceded by whitespace. This will help cases like:

```
non-regex time:
other regex time:
regex time:
```

It's not perfect, but some code I attempted with finditer to gather the
shortest match was just way too slow (30+ minutes for revcomp2.chpl). I
think this current approach will cover any likely substrings, but longer
term we should add an error message if we detect an ambiguity.

This also improves what we do in case of error in computePerfStats.
Previously, we might partially write to the .dat file and stdout, which
would leave the .dat file malformed and would cause any error messages
on stdout to be offset, preventing our sentinel error message matching
from working. Update to only print complete lines and only write to the
.dat file once we have all the values to write.