### PR TITLE
Halve memory leaks in compiler

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2672,7 +2672,7 @@ GenInfo::GenInfo()
              functionCNameAstrToSymbol()
 #ifdef HAVE_LLVM
              ,
-             lvt(NULL), module(NULL), irBuilder(NULL), mdBuilder(NULL),
+             lvt(nullptr), module(NULL), irBuilder(NULL), mdBuilder(NULL),
              loopStack(), currentStackVariables(),
              currentFunctionABI(NULL),
              llvmContext(),

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2667,24 +2667,24 @@ void makeBinary(void) {
 }
 
 GenInfo::GenInfo()
-         :   cfile(NULL), cLocalDecls(), cStatements(),
-             lineno(-1), filename(NULL),
+         :   cfile(nullptr), cLocalDecls(), cStatements(),
+             lineno(-1), filename(nullptr),
              functionCNameAstrToSymbol()
 #ifdef HAVE_LLVM
              ,
-             lvt(nullptr), module(NULL), irBuilder(NULL), mdBuilder(NULL),
+             lvt(nullptr), module(nullptr), irBuilder(nullptr), mdBuilder(nullptr),
              loopStack(), currentStackVariables(),
-             currentFunctionABI(NULL),
+             currentFunctionABI(nullptr),
              llvmContext(),
-             tbaaRootNode(NULL),
-             tbaaUnionsNode(NULL),
-             noAliasDomain(NULL),
+             tbaaRootNode(nullptr),
+             tbaaUnionsNode(nullptr),
+             noAliasDomain(nullptr),
              noAliasScopes(),
              noAliasScopeLists(),
              noAliasLists(),
              globalToWideInfo(),
-             FPM_postgen(NULL),
-             clangInfo(NULL)
+             FPM_postgen(nullptr),
+             clangInfo(nullptr)
 #endif
 {
 }

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -22,6 +22,7 @@
 #define CODEGEN_H
 
 #include "baseAST.h"
+#include "LayeredValueTable.h"
 
 #include <list>
 #include <map>
@@ -50,7 +51,6 @@ namespace clang {
 #include "llvm/Target/TargetMachine.h"
 
 struct ClangInfo;
-class LayeredValueTable;
 #include "llvmGlobalToWide.h"
 
 #endif
@@ -103,7 +103,7 @@ struct GenInfo {
 
 #ifdef HAVE_LLVM
   // stores parsed C stuff for extern blocks
-  LayeredValueTable *lvt;
+  std::unique_ptr<LayeredValueTable> lvt;
 
   // Once we get to code generation....
   llvm::Module *module;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -265,7 +265,7 @@ static
 void addMinMax(const char* prefix, int nbits, bool isSigned)
 {
   GenInfo* info = gGenInfo;
-  LayeredValueTable *lvt = info->lvt;
+  LayeredValueTable *lvt = info->lvt.get();
 
   astlocT prevloc = currentAstLoc;
 
@@ -1223,7 +1223,7 @@ void readMacrosClang(void) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-  LayeredValueTable *lvt = info->lvt;
+  LayeredValueTable *lvt = info->lvt.get();
 
   SET_LINENO(rootModule);
 
@@ -2388,7 +2388,7 @@ void runClang(const char* just_parse_filename) {
     INT_ASSERT(gGenInfo != NULL);
   }
 
-  gGenInfo->lvt = new LayeredValueTable();
+  gGenInfo->lvt = std::make_unique<LayeredValueTable>();
 
 
   ClangInfo* clangInfo = NULL;

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -225,6 +225,7 @@ const char* Context::uniqueCStringConcatLen(const char* s1, size_t len1,
     const char* ret = search->str;
     // update the GC mark
     this->markUniqueCString(ret);
+    free(buf);
     return ret;
   }
 

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1695,10 +1695,10 @@ static void addToDeinitOrderTree(DeinitOrderNode* dst, DeinitOrderNode* src) {
 
   // create new nodes for any sub-nodes if they are not present already.
   if (src->nestedOrder != NULL && dst->nestedOrder == NULL) {
-    dst->nestedOrder = new DeinitOrderNode();
+    dst->nestedOrder = new DeinitOrderNode(); // TODO this LEAK is unaccounted for
   }
   if (src->elseOrder != NULL && dst->elseOrder == NULL) {
-    dst->elseOrder = new DeinitOrderNode();
+    dst->elseOrder = new DeinitOrderNode(); // TODO this LEAK is unaccounted for
   }
 
   // copy the sub-nodes, recursively
@@ -1749,6 +1749,7 @@ void DeinitOrderVisitor::exitScope(Expr* block) {
     nextDeinitOrderNode(orderStack.back(), NULL);
   } else {
     INT_ASSERT(block->parentExpr == NULL);
+    delete last;  // Frees the node allocated in enterScope when orderStack is empty
   }
 }
 

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -1024,5 +1024,10 @@ void clean_exit(int status) {
   delete gContext;
   gContext = nullptr;
 
+  if (gGenInfo) {
+    delete gGenInfo;
+    gGenInfo = nullptr;
+  }
+
   exit(status);
 }


### PR DESCRIPTION
Found these while looking for allocation hotspots. Not critical but worth fixing while I was there.

Before: `total memory leaked: 12.95M`
After: `total memory leaked: 6.14M`