### PR TITLE
update mason test's .skipif check

### DIFF
--- a/test/mason/mason-help-scope/masonHelpScope.skipif
+++ b/test/mason/mason-help-scope/masonHelpScope.skipif
@@ -1,33 +1,11 @@
-#!/usr/bin/env python3
+#!/bin/bash
 
-"""
-mason help tests require mason to be built
-"""
+command -v $CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR/mason > /dev/null
+status=$?
 
-from __future__ import print_function
-import subprocess
-
-def mason_exists():
-    """Return True if mason exists on the command line,
-       otherwise return False.
-    """
-    # Ensure mason is available via command line
-    try:
-        p = subprocess.Popen(['mason', '--help'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except OSError as e:
-        return False
-
-    # Ensure we are using the right mason
-    stdout, stderr = p.communicate()
-    sentinel_string = "Chapel's package manager"
-
-    for line in stdout.decode().split('\n'):
-        if sentinel_string in line:
-            return True
-
-    return False
-
-# Skip if mason does not exist
-SKIP = not mason_exists()
-print(SKIP)
-
+if [ $status -eq  0 ];  then
+    echo "False"
+else
+    echo "True"
+fi
+exit 0

--- a/test/mason/mason-test-exit/exitCodeTest.skipif
+++ b/test/mason/mason-test-exit/exitCodeTest.skipif
@@ -1,16 +1,11 @@
 #!/bin/bash
 
-command -v mason > /dev/null
+command -v $CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR/mason > /dev/null
 status=$?
 
 if [ $status -eq  0 ];  then
     echo "False"
-    exit 0
 else
     echo "True"
-    exit 0
 fi
-
-
-
-
+exit 0


### PR DESCRIPTION
This PR modifies the `.skipif` check for certain mason tests that fail to run
due to a failure to locate the `mason` executable. 

Fix for https://github.com/Cray/chapel-private/issues/2541

Thanks to @ronawho for suggesting this fix.

TESTING:

- [x] `util/start_test test/mason` all tests pass

Reviewed by @ronawho, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>