### PR TITLE
Reduce vector allocations in compiler (pt 1)

### DIFF
--- a/compiler/AST/bb.cpp
+++ b/compiler/AST/bb.cpp
@@ -38,6 +38,7 @@ int                                          BasicBlock::nextID     = 0;
 BasicBlock*                                  BasicBlock::basicBlock = NULL;
 Map<LabelSymbol*, std::vector<BasicBlock*>*> BasicBlock::gotoMaps;
 Map<LabelSymbol*, BasicBlock*>               BasicBlock::labelMaps;
+std::vector<BaseAST *>                       BasicBlock::asts;
 
 BasicBlock::BasicBlock() {
   id = nextID++;
@@ -53,6 +54,9 @@ void BasicBlock::reset(FnSymbol* fn) {
   fn->basicBlocks = new std::vector<BasicBlock*>();
 
   nextID = 0;
+
+  asts.clear();
+  asts.shrink_to_fit();
 }
 
 void BasicBlock::clear(FnSymbol* fn) {
@@ -231,8 +235,8 @@ void BasicBlock::buildBasicBlocks(FnSymbol* fn, Expr* stmt, bool mark) {
 
   } else {
     DefExpr*              def = toDefExpr(stmt);
-    std::vector<BaseAST*> asts;
 
+    asts.clear();
     collect_asts(stmt, asts);
 
     for_vector(BaseAST, ast, asts) {

--- a/compiler/include/bb.h
+++ b/compiler/include/bb.h
@@ -21,6 +21,7 @@
 #ifndef _BB_H_
 #define _BB_H_
 
+class BaseAST;
 class BitVec;
 class Expr;
 class FnSymbol;
@@ -122,6 +123,8 @@ private:
   static bool        verifyBasicBlocks(FnSymbol* fn);
 
   static int         nextID;
+
+  static std::vector<BaseAST*> asts;
 
   //
   // Instance methods/variables

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -212,13 +212,8 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
   formalIdxToActual.clear();
   actualIdxToFormal.clear();
 
-  for (int i = 0; i < fn->numFormals(); i++) {
-    formalIdxToActual.push_back(NULL);
-  }
-
-  for (int i = 0; i < info.actuals.n; i++) {
-    actualIdxToFormal.push_back(NULL);
-  }
+  formalIdxToActual.resize(fn->numFormals(), nullptr);
+  actualIdxToFormal.resize(info.actuals.n, nullptr);
 
   // Match named actuals against formal names in the function signature.
   // Record successful matches.


### PR DESCRIPTION
These changes reduce allocations compiling hello world from 9717441 to 8231998 (15%) reduction and a 2% time improvement compiling arkouda.

I'm not in love with the class static but it is in line with the existing code. `buildBasicBlocks` is called 289502 times in compiling hello world and this saves us from having a caller pass it in and lets the size naturally fit (max size 576 w/ 99% of 7) to the workload. The max size does not present a high memory overhead if `reset` is not called (which it isn't currently).

The second change in `computeAlignment` does a one-time resize instead of repeated `push_back` as this will reallocate every time the size is grown.

Passed paratest

