### PR TITLE
Adjust make docs to try to build compiler docs

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -22,7 +22,7 @@ develall:
 	@$(MAKE) always-build-man
 	@$(MAKE) always-build-chplspell-venv
 
-docs: chpldoc man-chpl man-chpldoc try-libchplcomp-docs
+docs: chpldoc man-chpl man-chpldoc
 	cd doc && $(MAKE) docs
 
 checkdocs: FORCE
@@ -60,9 +60,6 @@ always-build-chplspell-venv: FORCE
 
 test: spectests FORCE
 	cd examples && start_test
-
-try-libchplcomp-docs: FORCE
-	-@cd compiler/next && $(MAKE) -f Makefile.help libchplcomp-docs
 
 libchplcomp-docs: FORCE
 	@cd compiler/next && $(MAKE) -f Makefile.help libchplcomp-docs

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -22,7 +22,7 @@ develall:
 	@$(MAKE) always-build-man
 	@$(MAKE) always-build-chplspell-venv
 
-docs: chpldoc man-chpl man-chpldoc
+docs: chpldoc man-chpl man-chpldoc try-libchplcomp-docs
 	cd doc && $(MAKE) docs
 
 checkdocs: FORCE
@@ -60,6 +60,9 @@ always-build-chplspell-venv: FORCE
 
 test: spectests FORCE
 	cd examples && start_test
+
+try-libchplcomp-docs: FORCE
+	-@cd compiler/next && $(MAKE) -f Makefile.help libchplcomp-docs
 
 libchplcomp-docs: FORCE
 	@cd compiler/next && $(MAKE) -f Makefile.help libchplcomp-docs

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -64,6 +64,9 @@ test: spectests FORCE
 libchplcomp-docs: FORCE
 	@cd compiler/next && $(MAKE) -f Makefile.help libchplcomp-docs
 
+clobber-libchplcomp: FORCE
+	@cd compiler/next && $(MAKE) -f Makefile.help clobber-libchplcomp
+
 test-libchplcomp: FORCE
 	@cd compiler/next && $(MAKE) -f Makefile.help test-libchplcomp
 

--- a/compiler/next/Makefile.help
+++ b/compiler/next/Makefile.help
@@ -71,6 +71,9 @@ libchplcomp-docs: $(LIBCOMPILER_BUILD_DIR) FORCE
 	  $(COPY_IF_DIFFERENT) $(LIBCOMPILER_BUILD_DIR)/doc/doxygen $(CHPL_MAKE_HOME)/build/doc/doxygen ; \
 	fi
 
+clean-libchplcomp-docs: FORCE
+	rm -rf $(CHPL_MAKE_HOME)/build/doc/doxygen
+
 test-libchplcomp: $(LIBCOMPILER_BUILD_DIR) FORCE
 	@echo "Making and running the tests..."
 	@if [ -f $(LIBCOMPILER_BUILD_DIR)/Makefile ]; then \

--- a/compiler/next/Makefile.help
+++ b/compiler/next/Makefile.help
@@ -74,7 +74,7 @@ libchplcomp-docs: $(LIBCOMPILER_BUILD_DIR) FORCE
 clean-libchplcomp-docs: FORCE
 	rm -rf $(CHPL_MAKE_HOME)/build/doc/doxygen
 
-clobber-libchplcomp: FORCE
+clobber-libchplcomp: clean-libchplcomp-docs FORCE
 	rm -rf $(LIBCOMPILER_BUILD_DIR)
 
 test-libchplcomp: $(LIBCOMPILER_BUILD_DIR) FORCE

--- a/compiler/next/Makefile.help
+++ b/compiler/next/Makefile.help
@@ -74,6 +74,9 @@ libchplcomp-docs: $(LIBCOMPILER_BUILD_DIR) FORCE
 clean-libchplcomp-docs: FORCE
 	rm -rf $(CHPL_MAKE_HOME)/build/doc/doxygen
 
+clobber-libchplcomp: FORCE
+	rm -rf $(LIBCOMPILER_BUILD_DIR)
+
 test-libchplcomp: $(LIBCOMPILER_BUILD_DIR) FORCE
 	@echo "Making and running the tests..."
 	@if [ -f $(LIBCOMPILER_BUILD_DIR)/Makefile ]; then \

--- a/compiler/next/doc/CMakeLists.txt
+++ b/compiler/next/doc/CMakeLists.txt
@@ -42,6 +42,6 @@ if(DOXYGEN_FOUND)
 
 else(DOXYGEN_FOUND)
   add_custom_target(api-docs
-                    COMMAND echo "not running doxygen because it is missing"
-                    COMMENT "using dummy api-docs because doxygen is missing")
+                    COMMAND echo "doxygen missing" && exit 1
+                    COMMENT "could not find doxygen -- is it installed?")
 endif(DOXYGEN_FOUND)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -68,7 +68,7 @@ docs: FORCE
 	  then \
 	  echo ; \
 	  echo " This docs build does not include compiler library API docs" ; \
-	  echo " Please try 'make libchplcomp-docs' to see the error" ; \
+	  echo " Try 'make clobber-libchplcomp && make libchplcomp-docs'" ; \
 	fi
 
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -60,8 +60,12 @@ help-source:
 
 
 docs: FORCE
-	@$(MAKE) html-release || $(MAKE) error_docs
-	@if [ ! -d $(COMPILER_INTERNALS_DOXYGEN) ]; then \
+	@COMP_DOCS_ERROR=0 ; \
+	(cd ../compiler/next && \
+	 ($(MAKE) -f Makefile.help libchplcomp-docs || COMP_DOCS_ERROR=1)) ; \
+	$(MAKE) html-release || $(MAKE) error_docs ; \
+	if [ $$COMP_DOCS_ERROR -ne 0 -o ! -d $(COMPILER_INTERNALS_DOXYGEN) ] ; \
+	  then \
 	  echo "This docs build does not include compiler library API docs" ; \
 	  echo "Please try 'make libchplcomp-docs' to see the error" ; \
 	fi

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -66,8 +66,9 @@ docs: FORCE
 	$(MAKE) html-release || $(MAKE) error_docs ; \
 	if [ $$COMP_DOCS_ERROR -ne 0 -o ! -d $(COMPILER_INTERNALS_DOXYGEN) ] ; \
 	  then \
-	  echo "This docs build does not include compiler library API docs" ; \
-	  echo "Please try 'make libchplcomp-docs' to see the error" ; \
+	  echo ; \
+	  echo " This docs build does not include compiler library API docs" ; \
+	  echo " Please try 'make libchplcomp-docs' to see the error" ; \
 	fi
 
 
@@ -150,11 +151,11 @@ prunedocs: FORCE
 	fi
 
 
-clean: clean-source clean-build clean-build-dir FORCE
+clean: clean-source clean-build clean-build-dir clean-doxygen FORCE
 
-cleanall: clean-source clean-build clean-build-dir FORCE
+cleanall: clean-source clean-build clean-build-dir clean-doxygen FORCE
 
-clobber: clean-source clean-build clean-build-dir FORCE
+clobber: clean-source clean-build clean-build-dir clean-doxygen FORCE
 
 clean-source: clean-module-docs clean-primers clean-examples clean-symlinks clean-collect-syntax clean-compiler-internals FORCE
 
@@ -191,6 +192,9 @@ clean-symlinks: FORCE
 	@echo
 	@echo "Removing all symbolic links"
 	find $(SOURCEDIR) -type l -delete
+
+clean-doxygen: FORCE
+	cd ../compiler/next && $(MAKE) -f Makefile.help clean-libchplcomp-docs
 
 error_docs: FORCE
 	@exit 1 # Note that 'make' will return exit code of 2, despite exit 1

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -61,6 +61,10 @@ help-source:
 
 docs: FORCE
 	@$(MAKE) html-release || $(MAKE) error_docs
+	@if [ ! -d $(COMPILER_INTERNALS_DOXYGEN) ]; then \
+	  echo "This docs build does not include compiler library API docs" ; \
+	  echo "Please try 'make libchplcomp-docs' to see the error" ; \
+	fi
 
 
 man-chapel: FORCE


### PR DESCRIPTION
This PR adjusts `make docs` so that it attempts to build the compiler library documentation. This documentation has additional requirements (cmake, doxygen) beyond the other documentation. However, we would like for `make docs` to build all of the documentation.

If the attempt to build the compiler library documentation fails but the docs build was otherwise successful, a note is printed at the end of the `make docs` output.

To get a complete docs build, one should install a recent enough doxygen and cmake.

For https://github.com/Cray/chapel-private/issues/2565

Reviewed by @lydia-duncan and @Maxrimus - thanks!

- [x] full local testing