### PR TITLE
Update docs to use operator =

### DIFF
--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -557,7 +557,7 @@ the signature:
 
 .. code-block:: chapel
 
-   proc =(ref lhs:R, rhs:R) : void where lhs.type == rhs.type;
+   operator =(ref lhs:R, rhs:R) : void where lhs.type == rhs.type;
 
 In it, the value of each field of the record on the right-hand side is
 assigned to the corresponding field of the record on the left-hand side.

--- a/doc/rst/technotes/initequals.rst
+++ b/doc/rst/technotes/initequals.rst
@@ -23,7 +23,7 @@ operator:
     var A : [D] int;
   }
 
-  proc =(ref lhs : IntList, rhs : []) {
+  operator =(ref lhs : IntList, rhs : []) {
     lhs.D = rhs.domain;
     lhs.A = rhs;
   }


### PR DESCRIPTION
I saw these two places in the docs that were still using `proc =`.
