### PR TITLE
compiler/next: avoid public fields in FileContents

### DIFF
--- a/compiler/next/include/chpl/parsing/FileContents.h
+++ b/compiler/next/include/chpl/parsing/FileContents.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_PARSING_FILE_CONTENTS_H
+#define CHPL_PARSING_FILE_CONTENTS_H
+
+#include "chpl/queries/ErrorMessage.h"
+#include "chpl/queries/update-functions.h"
+
+#include <string>
+
+namespace chpl {
+namespace parsing {
+
+
+/**
+ This class represents the result of reading a file.
+ */
+class FileContents {
+ private:
+  std::string text_;
+  ErrorMessage error_;
+
+ public:
+  /** Construct a FileContents containing empty text and no error */
+  FileContents()
+    : text_(), error_() { }
+  /** Construct a FileContents containing the passed text and no error */
+  FileContents(std::string text)
+    : text_(std::move(text)), error_() { }
+  /** Construct a FileContents containing the passed text and error */
+  FileContents(std::string text, ErrorMessage error)
+    : text_(std::move(text)), error_(std::move(error)) { }
+
+  /** Return a reference to the contents of this file */
+  const std::string& text() const { return text_; }
+
+  /** Return a reference to an error encountered when reading this file */
+  const ErrorMessage& error() const { return error_; }
+
+  bool operator==(const FileContents& other) const {
+    return text_ == other.text_ &&
+           error_ == other.error_;
+  }
+  bool operator!=(const FileContents& other) const {
+    return !(*this == other);
+  }
+  void swap(FileContents& other) {
+    text_.swap(other.text_);
+    error_.swap(other.error_);
+  }
+};
+
+
+} // end namespace parsing
+
+template<> struct update<parsing::FileContents> {
+  bool operator()(parsing::FileContents& keep,
+                  parsing::FileContents& addin) const {
+    return defaultUpdate(keep, addin);
+  }
+};
+
+} // end namespace chpl
+#endif

--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -20,6 +20,7 @@
 #ifndef CHPL_PARSING_PARSING_QUERIES_H
 #define CHPL_PARSING_PARSING_QUERIES_H
 
+#include "chpl/parsing/FileContents.h"
 #include "chpl/queries/Context.h"
 #include "chpl/queries/ID.h"
 #include "chpl/queries/Location.h"
@@ -34,99 +35,77 @@ namespace chpl {
 namespace parsing {
 
 
-  struct FileContents {
-    std::string text;
-    ErrorMessage error;
-    FileContents()
-      : text(), error() { }
-    FileContents(std::string text)
-      : text(std::move(text)), error() { }
-    FileContents(std::string text, ErrorMessage error)
-      : text(std::move(text)), error(std::move(error)) { }
+/**
+ This query returns the contents of a file as the string field in the
+ FileContents.
+ In case there is an error reading the file, the error is stored in the error
+ field of the FileContents.
+ */
+const FileContents& fileText(Context* context, UniqueString path);
 
-    bool operator==(const FileContents& other) const {
-      return text == other.text &&
-             error == other.error;
-    }
-    bool operator!=(const FileContents& other) const {
-      return !(*this == other);
-    }
-    void swap(FileContents& other) {
-      text.swap(other.text);
-      error.swap(other.error);
-    }
-  };
+/**
+ This function sets the FileContents that will be returned by the fileText
+ query above.
+ */
+void setFileText(Context* context, UniqueString path, FileContents result);
+/**
+ This function sets the string that will be returned by the fileText
+ query above. The FileContents stored will have an empty ErrorMessage field.
+ */
+void setFileText(Context* context, UniqueString path, std::string text);
 
-  /**
-   This query returns the contents of a file as the string field in the
-   FileContents.
-   In case there is an error reading the file, the error is stored in the error
-   field of the FileContents.
-   */
-  const FileContents& fileText(Context* context, UniqueString path);
-
-  /**
-   This function sets the FileContents that will be returned by the fileText
-   query above.
-   */
-  void setFileText(Context* context, UniqueString path, FileContents result);
-  /**
-   This function sets the string that will be returned by the fileText
-   query above. The FileContents stored will have an empty ErrorMessage field.
-   */
-  void setFileText(Context* context, UniqueString path, std::string text);
-
-  /**
-   This query reads a file (with the fileText query) and then parses it.
-   */
-  const uast::BuilderResult& parseFile(Context* context, UniqueString path);
+/**
+ This query reads a file (with the fileText query) and then parses it.
+ */
+const uast::BuilderResult& parseFile(Context* context, UniqueString path);
 
 
-  // These functions can't return the Location for a Comment
-  // because Comments don't have IDs. If Locations for Comments are needed,
-  // instead use the astToLocation field from the result of parseFile.
+// These functions can't return the Location for a Comment
+// because Comments don't have IDs. If Locations for Comments are needed,
+// instead use the astToLocation field from the result of parseFile.
 
-  /**
-   This query returns the Location where a particular ID appeared.
-   It cannot be used for Comments because Comments don't have IDs set.
-   If Locations for Comments are needed, use the locations field from
-   the result of parseFile.
-   */
-  const Location& locateId(Context* context, ID id);
-  /**
-   This function just runs locateId on ast->id(). Similarly to locateID,
-   it cannot be used to get a Location for a Comment.
-   */
-  const Location& locateAst(Context* context, const uast::ASTNode* ast);
+/**
+ This query returns the Location where a particular ID appeared.
+ It cannot be used for Comments because Comments don't have IDs set.
+ If Locations for Comments are needed, use the locations field from
+ the result of parseFile.
+ */
+const Location& locateId(Context* context, ID id);
+/**
+ This function just runs locateId on ast->id(). Similarly to locateID,
+ it cannot be used to get a Location for a Comment.
+ */
+const Location& locateAst(Context* context, const uast::ASTNode* ast);
 
-  using ModuleVec = std::vector<const uast::Module*>;
-  /**
-   This query returns a vector of parsed modules given a file path.
-   */
-  const ModuleVec& parse(Context* context, UniqueString path);
+using ModuleVec = std::vector<const uast::Module*>;
+/**
+ This query returns a vector of parsed modules given a file path.
+ */
+const ModuleVec& parse(Context* context, UniqueString path);
 
-  /**
-   This query parses a toplevel module by name. Returns nullptr
-   if no such toplevel module can be found.
-   */
-  const uast::Module* getToplevelModule(Context* context, UniqueString name);
+/**
+ This query parses a toplevel module by name. Returns nullptr
+ if no such toplevel module can be found.
+ */
+const uast::Module* getToplevelModule(Context* context, UniqueString name);
 
-  /**
-   Returns the uast node with the given ID.
-   */
-  const uast::ASTNode* idToAst(Context* context, ID id);
+/**
+ Returns the uast node with the given ID.
+ */
+const uast::ASTNode* idToAst(Context* context, ID id);
 
-  /**
-   Returns the tag for the node with the given ID.
-   */
-  uast::ASTTag idToTag(Context* context, ID id);
+/**
+ Returns the tag for the node with the given ID.
+ */
+uast::ASTTag idToTag(Context* context, ID id);
 
-  /**
-   Returns the parent ID given an ID
-   */
-  const ID& idToParentId(Context* context, ID id);
+/**
+ Returns the parent ID given an ID
+ */
+const ID& idToParentId(Context* context, ID id);
 
-  // TODO: make a wrapper for ID.parentSymbolId
+// TODO: make a wrapper for ID.parentSymbolId
+
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/next/include/chpl/uast/ASTTag.h
+++ b/compiler/next/include/chpl/uast/ASTTag.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UAST_ASTTAG_H
 #define CHPL_UAST_ASTTAG_H
 
+#include "chpl/queries/update-functions.h"
+
 namespace chpl {
 namespace uast {
 namespace asttags {
@@ -98,6 +100,14 @@ const char* tagToString(ASTTag tag);
 using chpl::uast::asttags::ASTTag;
 
 } // end namespace uast
+
+template<> struct update<uast::ASTTag> {
+  bool operator()(uast::ASTTag& keep,
+                  uast::ASTTag& addin) const {
+    return defaultUpdateBasic(keep, addin);
+  }
+};
+
 } // end namespace chpl
 
 #endif

--- a/compiler/next/include/chpl/uast/BuilderResult.h
+++ b/compiler/next/include/chpl/uast/BuilderResult.h
@@ -72,34 +72,34 @@ class BuilderResult final {
   static void updateFilePaths(Context* context, const BuilderResult& keep);
 
  public:
-  /* Construct an empty BuilderResult */
+  /** Construct an empty BuilderResult */
   BuilderResult();
-  /* Construct a BuilderResult that records a particular file path. */
+  /** Construct a BuilderResult that records a particular file path. */
   BuilderResult(UniqueString filePath);
 
-  /* Return the file path this result refers to */
+  /** Return the file path this result refers to */
   UniqueString filePath() const {
     return filePath_;
   }
 
-  /* return the number of top-level expressions */
+  /** return the number of top-level expressions */
   int numTopLevelExpressions() const {
     return topLevelExpressions_.size();
   }
 
-  /* return the i'th top-level expression */
+  /** return the i'th top-level expression */
   const ASTNode* topLevelExpression(int i) const {
     assert(0 <= i && (size_t) i < topLevelExpressions_.size());
     return topLevelExpressions_[i].get();
   }
 
-  /* iterate over the parsed top-level expressions */
+  /** iterate over the parsed top-level expressions */
   ASTListIteratorPair<ASTNode> topLevelExpressions() const {
     return ASTListIteratorPair<ASTNode>(topLevelExpressions_.begin(),
                                         topLevelExpressions_.end());
   }
 
-  /* If the top-level expressions contain only a single Module,
+  /** If the top-level expressions contain only a single Module,
      return it. Otherwise, return nullptr. */
   const Module* singleModule() {
     if (topLevelExpressions_.size() == 1) {
@@ -110,12 +110,12 @@ class BuilderResult final {
   }
 
 
-  /* return the number of errors */
+  /** return the number of errors */
   int numErrors() const {
     return errors_.size();
   }
 
-  /* return the i'th error */
+  /** return the i'th error */
   ErrorMessage error(int i) const {
     return errors_[i];
   }
@@ -123,14 +123,14 @@ class BuilderResult final {
   // TODO: add something to iterate over the errors e.g.
   // ErrorListIteratorPair errors() const
 
-  /* Find the ASTNode* corresponding to a particular ID, or return
-     nullptr if there is not one in this result. */
+  /** Find the ASTNode* corresponding to a particular ID, or return
+      nullptr if there is not one in this result. */
   const ASTNode* idToAst(ID id) const;
-  /* Find the Location for a particular ID.
-     Returns a location just to path if none is found. */
+  /** Find the Location for a particular ID.
+      Returns a location just to path if none is found. */
   Location idToLocation(ID id, UniqueString path) const;
-  /* Find the ID for a parent given an ID.
-     Returns the empty ID if none is found */
+  /** Find the ID for a parent given an ID.
+      Returns the empty ID if none is found */
   ID idToParentId(ID id) const;
 
   BuilderResult(BuilderResult&&) = default; // move-constructable

--- a/compiler/next/include/chpl/uast/BuilderResult.h
+++ b/compiler/next/include/chpl/uast/BuilderResult.h
@@ -116,7 +116,7 @@ class BuilderResult final {
   }
 
   /** return the i'th error */
-  ErrorMessage error(int i) const {
+  const ErrorMessage& error(int i) const {
     return errors_[i];
   }
 

--- a/compiler/next/test/parsing/testParsingQueries.cpp
+++ b/compiler/next/test/parsing/testParsingQueries.cpp
@@ -43,7 +43,7 @@ static void test0() {
   std::string contents = "/* this is a test */";
   setFileText(ctx, path, contents);
  
-  std::string gotContents = fileText(ctx, path).text;
+  std::string gotContents = fileText(ctx, path).text();
   assert(gotContents == contents);
 }
 


### PR DESCRIPTION
* move FileContents to its own file, avoid public fields in it
* move update functions for it to that file
* move update function for ASTTag to ASTTag.h
* Adjust BuilderResult to return errors by const ref
* improve doxygen comments for BuilderResult