### PR TITLE
Remove unused variable

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -853,13 +853,6 @@ static void checkNumArgsErrors(AggregateType* at, CallExpr* call, const char* ca
     USR_STOP();
   }
 
-  unsigned int numWithoutDefaults = 0;
-  for_vector(Symbol, sym, genericFields) {
-    if (sym->defPoint->init == NULL) {
-      numWithoutDefaults += 1;
-    }
-  }
-
   unsigned int numArgs = call->numActuals();
   if (numArgs > genericFields.size()) {
     USR_FATAL_CONT(call, "invalid type specifier '%s'", callString);


### PR DESCRIPTION
Paul Hargrove reported that clang++ from LLVM 13 started warning about this variable being
unused, which is pretty cool.  It's not that it's not referenced, and it's not that it's unused,
it's that it's only incremented, but never read after that.