### PR TITLE
Update prereqs

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -26,27 +26,30 @@ for using Chapel:
     GCC 5 or newer is required for C++14 support. Note that C11 support,
     while not required, will enable faster atomic operations.
 
-  * Building GMP requires an M4 macro processor.
-
-  * If you wish to use chpldoc or Chapel's test system, Python 3.7 or
-    newer is required and the ``python3`` and ``pip3`` commands must be
-    available. The ``venv`` Python package must be available (note that
-    it is often included by default in a Python 3 installation).
-    Additionally, ``curl``, ``perl``, and ``python3-devel``
-    (or equivalent packages for your platform) are required.
-
-  * If you wish to use :ref:`readme-mason`, chapel's package manager,
-    ``git`` is required.
-
-    * The ``mason system`` subcommands additionally require ``pkg-config``.
-
   * The LLVM backend is now the default and it is easiest to use it with
     a system-wide installation of LLVM. Only LLVM 11 is currently
     supported. If a system-wide installation of LLVM 11 is not available,
     you can use the bundled LLVM or disable LLVM support (see
     :ref:`readme-chplenv.CHPL_LLVM`). Please note that building the
-    bundled LLVM requires cmake version 3.4.3 or later (and upcoming
-    versions will require 3.13.4);
+    bundled LLVM requires cmake version 3.13.4 or later.
+
+In addition, several optional components have additional requirements:
+
+  * Python 3.7 or newer is required if you want to use chpldoc, c2chapel,
+    or Chapel's test system. These additionally require ``python3-devel``
+    or equivalent package; ``python3`` and ``pip3`` commands; and the
+    ``venv`` Pyton package.
+
+  * ``cmake`` 3.13.4 or later is required to build the bundled LLVM or
+    to build the complete documentation
+
+  * ``doxygen`` is required to build the complete documentation
+
+  * ``m4`` is required for building the bundled GMP
+
+  * ``git`` is required for :ref:`readme-mason`, chapel's package manager
+
+  * ``pkg-config`` is required for the ``mason system`` subcommands
 
 
 .. _readme-prereqs-installation:


### PR DESCRIPTION
 * add a section for optional prereqs
 * focus on what is required and then the reason (easier to explain when
   multiple elements need the same thing)
 * note cmake & doxygen required for full docs build