### PR TITLE
Add an error if a non-operator function is declared with the operator keyword

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2187,6 +2187,7 @@ bool isAstrOpName(const char* name) {
       strcmp(name, "|=") == 0 || strcmp(name, "^=") == 0 ||
       strcmp(name, ">>=") == 0 || strcmp(name, "<<=") == 0 ||
       strcmp(name, "#") == 0 || strcmp(name, "chpl_by") == 0 ||
+      strcmp(name, "by") == 0 || strcmp(name, "align") == 0 ||
       strcmp(name, "chpl_align") == 0 || name == astrScolon) {
     return true;
   } else {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2186,8 +2186,8 @@ bool isAstrOpName(const char* name) {
       strcmp(name, "**=") == 0 || strcmp(name, "&=") == 0 ||
       strcmp(name, "|=") == 0 || strcmp(name, "^=") == 0 ||
       strcmp(name, ">>=") == 0 || strcmp(name, "<<=") == 0 ||
-      strcmp(name, "#") == 0 || strcmp(name, "by") == 0 ||
-      strcmp(name, "align") == 0 || name == astrScolon) {
+      strcmp(name, "#") == 0 || strcmp(name, "chpl_by") == 0 ||
+      strcmp(name, "chpl_align") == 0 || name == astrScolon) {
     return true;
   } else {
     return false;

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -454,6 +454,10 @@ static void checkOperator(FnSymbol* fn) {
                "Operators declared without the operator keyword are deprecated");
       fn->addFlag(FLAG_OPERATOR);
     }
+  } else if (fn->hasFlag(FLAG_OPERATOR)) {
+    if (!isAstrOpName(fn->name)) {
+      USR_FATAL_CONT(fn, "'%s' is not a legal operator name", fn->name);
+    }
   }
 }
 

--- a/test/functions/diten/overloadBy.chpl
+++ b/test/functions/diten/overloadBy.chpl
@@ -1,4 +1,4 @@
-proc by(a, b) where !isSubtype(a.type,range) {
+operator by(a, b) where !isSubtype(a.type,range) {
   return a * b;
 }
 

--- a/test/functions/operatorOverloads/errors/namedOperator.bad
+++ b/test/functions/operatorOverloads/errors/namedOperator.bad
@@ -1,1 +1,0 @@
-In operator foo()

--- a/test/functions/operatorOverloads/errors/namedOperator.future
+++ b/test/functions/operatorOverloads/errors/namedOperator.future
@@ -1,3 +1,0 @@
-bug: arbitrary operator names are permitted (and resolvable when standalone)
-
-#17853

--- a/test/functions/operatorOverloads/errors/namedOperator.good
+++ b/test/functions/operatorOverloads/errors/namedOperator.good
@@ -1,1 +1,1 @@
-namedOperator.chpl:1:error: 'foo' is not a legal operator name
+namedOperator.chpl:1: error: 'foo' is not a legal operator name

--- a/test/functions/operatorOverloads/errors/namedOperator2.bad
+++ b/test/functions/operatorOverloads/errors/namedOperator2.bad
@@ -1,4 +1,0 @@
-namedOperator2.chpl:9: error: unresolved call 'R.foo()'
-namedOperator2.chpl:2: note: this candidate did not match: R.foo()
-namedOperator2.chpl:9: note: because call includes 0 arguments
-namedOperator2.chpl:2: note: but function can only accept 0 arguments

--- a/test/functions/operatorOverloads/errors/namedOperator2.future
+++ b/test/functions/operatorOverloads/errors/namedOperator2.future
@@ -1,3 +1,0 @@
-bug: arbitrary operator names are permitted (and generate confusing errors for methods)
-
-#17853

--- a/test/functions/operatorOverloads/errors/namedOperator2.good
+++ b/test/functions/operatorOverloads/errors/namedOperator2.good
@@ -1,1 +1,1 @@
-namedOperator2.chpl:2:error: 'foo' is not a legal operator name
+namedOperator2.chpl:2: error: 'foo' is not a legal operator name


### PR DESCRIPTION
We don't support defining arbitrary operators yet, so error if someone tries to
declare one until we do.

Resolves #17853 

With this new error, discovered that sometimes we overload the by operator with
the name `chpl_by` and the align operator with `chpl_align` so add those variations
to the list of potential operator names to check.

Update a test to use the operator keyword that had missed it, and update the
expected error message when using the `operator` keyword with an unexpected
operator name so that the appropriate spacing was used.  Now that those futures
pass, remove the .bad and .future files from them.

Passed a full paratest with futures