### PR TITLE
skip exit code test if mason not found, add output for failed cmd

### DIFF
--- a/test/mason/MasonTestHelpers.chpl
+++ b/test/mason/MasonTestHelpers.chpl
@@ -4,10 +4,10 @@ proc checkExitStatus(cmd: [] string, exitStatus: int) {
   var p = spawn(cmd, stdout=PIPE);
   p.wait();
   if p.exitCode == exitStatus {
-    writeln("Got exit status %i as expected".format(exitStatus));
+    writef("Got exit status %i as expected\n", exitStatus);
   } else {
-    writeln("Error: %s returned %i when test expected %i".format(" ".join(cmd),
-                                                                 p.exitCode,
-                                                                 exitStatus));
+    writef("Error: %s returned %i when test expected %i\n", " ".join(cmd),
+                                                            p.exitCode,
+                                                            exitStatus));
   }
 }

--- a/test/mason/mason-external/masonExternalRanges/masonExternalExitCodes.skipif
+++ b/test/mason/mason-external/masonExternalRanges/masonExternalExitCodes.skipif
@@ -1,11 +1,1 @@
-#!/bin/bash
-
-command -v $CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR/mason > /dev/null
-status=$?
-
-if [ $status -eq  0 ];  then
-    echo "False"
-else
-    echo "True"
-fi
-exit 0
+../../masonBinaryFound

--- a/test/mason/mason-help-scope/masonHelpScope.skipif
+++ b/test/mason/mason-help-scope/masonHelpScope.skipif
@@ -1,11 +1,1 @@
-#!/bin/bash
-
-command -v $CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR/mason > /dev/null
-status=$?
-
-if [ $status -eq  0 ];  then
-    echo "False"
-else
-    echo "True"
-fi
-exit 0
+../masonBinaryFound

--- a/test/mason/mason-test-exit/exitCodeTest.skipif
+++ b/test/mason/mason-test-exit/exitCodeTest.skipif
@@ -1,11 +1,1 @@
-#!/bin/bash
-
-command -v $CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR/mason > /dev/null
-status=$?
-
-if [ $status -eq  0 ];  then
-    echo "False"
-else
-    echo "True"
-fi
-exit 0
+../masonBinaryFound

--- a/test/mason/masonBinaryFound
+++ b/test/mason/masonBinaryFound
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+command -v $CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR/mason > /dev/null
+status=$?
+
+if [ $status -eq  0 ];  then
+    echo "False"
+else
+    echo "True"
+fi
+exit 0


### PR DESCRIPTION
This PR addresses the exit code tests for mason when the mason executable is 
not located. This test has caused several nightly tests to fail when the mason
executable was not built during testing.

Additionally, the exit code validation helper is updated to print a message 
when it fails.

TESTING: 

- [x] util/start_test test/mason passes all tests when mason present
- [x] test/mason/mason-external/masonExternalExitCodes skipped if mason missing
- [x] failure message printed when exit code not as expected

Reviewed by @mppf, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>