### PR TITLE
remove extra closing paren to fix bug in two masontests

### DIFF
--- a/test/mason/MasonTestHelpers.chpl
+++ b/test/mason/MasonTestHelpers.chpl
@@ -2,12 +2,13 @@ use Spawn;
 
 proc checkExitStatus(cmd: [] string, exitStatus: int) {
   var p = spawn(cmd, stdout=PIPE);
+  var cmdString = " ".join(cmd);
   p.wait();
   if p.exitCode == exitStatus {
     writef("Got exit status %i as expected\n", exitStatus);
   } else {
-    writef("Error: %s returned %i when test expected %i\n", " ".join(cmd),
+    writef("Error: %s returned %i when test expected %i\n", cmdString,
                                                             p.exitCode,
-                                                            exitStatus));
+                                                            exitStatus);
   }
 }


### PR DESCRIPTION
This PR fixes a bug in MasonTestHelper that caused two mason tests to fail.

TESTING: 

- [x] masonExternalExitCodes passes
- [x] exitCodeTest passes

Reviewed by @mppf

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>