### PR TITLE
remove open issues for string and bytes in types docs

### DIFF
--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -66,7 +66,7 @@ The concrete primitive types are: ``void``, ``nothing``, ``bool``,
 In addition, there are several generic primitive types that are
 described in :ref:`Built_in_Generic_types`.
 
-The primitive types are summarized by the following syntax: 
+The primitive types are summarized by the following syntax:
 
 .. code-block:: syntax
 
@@ -223,10 +223,6 @@ Strings are a primitive type designated by the symbol ``string``
 comprised of Unicode characters in UTF-8 encoding. Their length is
 unbounded.
 
-   *Open issue*.
-
-   There is an expectation of future support for fixed-length strings.
-
 .. _The_Bytes_Type:
 
 The Bytes Type
@@ -235,10 +231,6 @@ The Bytes Type
 Bytes is a primitive type designated by the symbol ``bytes`` comprised
 of arbitrary bytes. Bytes are immutable in-place and their length is
 unbounded.
-
-   *Open issue*.
-
-   There is an expectation of future support for mutable bytes.
 
 .. _Enumerated_Types:
 
@@ -295,14 +287,14 @@ concrete or semi-concrete
 
    *Example (enum-statesmen.chpl)*.
 
-   The code 
+   The code
 
    .. code-block:: chapel
 
       enum statesman { Aristotle, Roosevelt, Churchill, Kissinger }
 
    defines an abstract enumerated type with four constants. The function
-   
+
 
    .. code-block:: chapel
 
@@ -318,16 +310,16 @@ concrete or semi-concrete
              { write("No one will ever win the battle of the sexes; ");
                writeln("there's too much fraternizing with the enemy."); }
         }
-      } 
+      }
 
-   
+
 
    .. BLOCK-test-chapelnoprint
 
       for s in statesman do
         quote(s:statesman);
 
-   
+
 
    .. BLOCK-test-chapeloutput
 


### PR DESCRIPTION
This PR removes text describing open issues for string and bytes, 
as identified in cray/chapel-private/issues/2421.

TESTING:

After removing text:

- [x] can `make docs`
- [x] Visual inspection of `doc/html/language/spec/types.html`

Reviewed by @e-kayrakli, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>