### PR TITLE
Allow comm=ofi debugging output to go to stderr.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -7562,8 +7562,12 @@ void chpl_comm_ofi_dbg_init(void) {
   }
 
   if ((ev = chpl_env_rt_get("COMM_OFI_DEBUG_FNAME", NULL)) == NULL) {
+    chpl_comm_ofi_dbg_file = stderr;
+  } else if (!strcmp(ev, "STDOUT")) {
     chpl_comm_ofi_dbg_file = stdout;
-  } else {
+  } else if (!strcmp(ev, "STDERR")) {
+    chpl_comm_ofi_dbg_file = stderr;
+  } else {  
     char fname[strlen(ev) + 6 + 1];
     int fnameLen;
     fnameLen = snprintf(fname, sizeof(fname), "%s.%d", ev, (int) chpl_nodeID);


### PR DESCRIPTION
Some platforms that use slurm buffer stdout so that the debugging output from comm=ofi
can be lost in a crash. By default the debugging output now goes to stderr. This can be changed
via the CHPL_RT_COMM_OFI_DEBUG_FNAME variable. Setting it to STDOUT causes the output to go to
stdout, and setting it to STDERR causes the output to go to stderr. If it's set to any other
value it is used as the prefix for output files, one per locale (this is the existing behavior).

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>