### PR TITLE
Increased PMI_MAX_KVS_ENTRIES default value.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -40,11 +40,12 @@ void chpl_comm_preLaunch(int32_t numLocales) {
   // during comm layer initialization.  At this point we cannot tell
   // whether we'll do so, but it won't hurt anything to set it anyway.
   //
-  // Based on limited experimentation, it looks like the actual value we
-  // need is ((numLocales * 5) + 3).  (numLocales * 7) is a ceiling.
-  //
+  // Based on limited experimentation, numLocales * 10 works with
+  // small-scale runs. The cray-pmi{,-lib} modules are likely to be
+  // loaded for large-scale runs in which case KVS isn't even used. 
+  
   {
-    int32_t newVal = numLocales * 7;
+    int32_t newVal = numLocales * 10;
 
     const char* evName = "PMI_MAX_KVS_ENTRIES";
     char* evStr;


### PR DESCRIPTION
Previously it was 7 * numLocales which was too few on "tab". 8 worked,
but increased it to 10 to give us a bit of breathing room.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>