### PR TITLE
Fix a prediff issue in a future

### DIFF
--- a/test/expressions/loop-expr/ifExprWithForallBug.bad
+++ b/test/expressions/loop-expr/ifExprWithForallBug.bad
@@ -1,4 +1,4 @@
-ifExprWithForallBug.chpl:6: internal error: RES-RES-ION
+ifExprWithForallBug.chpl:6: internal error: RES-RES-ION-nnnn chpl version mmmm
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/expressions/loop-expr/ifExprWithForallBug.prediff
+++ b/test/expressions/loop-expr/ifExprWithForallBug.prediff
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-sed -i .bak "s/\(.*RES-RES-ION\).*/\1/" $2
-rm $2.bak


### PR DESCRIPTION
This PR removes a prediff, because there was already a default
prediff for bad files that I wasn't aware of when I added the future.

Also updates the pertinent .bad file.
