### PR TITLE
Add tests for issue #12242

### DIFF
--- a/test/functions/generic/genericChannelInInit1.chpl
+++ b/test/functions/generic/genericChannelInInit1.chpl
@@ -1,0 +1,19 @@
+module m {
+  use IO;
+
+  class C {
+
+   var nl: int;
+   var C_chnl: channel;
+
+   proc init() {
+     nl = 0;
+     nl = 0;
+   }
+ };
+
+ proc main() {
+   var b = new owned C();
+// writeln("HERE");
+ }
+}

--- a/test/functions/generic/genericChannelInInit1.good
+++ b/test/functions/generic/genericChannelInInit1.good
@@ -1,0 +1,5 @@
+genericChannelInInit1.chpl:9: In initializer:
+genericChannelInInit1.chpl:4: error: cannot default-initialize a variable with generic type
+genericChannelInInit1.chpl:4: note: 'this' has generic type 'borrowed C'
+genericChannelInInit1.chpl:4: note: cannot find initialization point to split-init this variable
+genericChannelInInit1.chpl:11: note: 'this' is used here before it is initialized

--- a/test/functions/generic/genericChannelInInit2.chpl
+++ b/test/functions/generic/genericChannelInInit2.chpl
@@ -1,0 +1,19 @@
+module m {
+  use IO;
+
+  class C {
+
+   var nl: int;
+   var C_chnl: channel;
+
+   proc init() {
+     nl = 0;
+     //nl = 0;
+   }
+ };
+
+ proc main() {
+   var b = new owned C();
+// writeln("HERE");
+ }
+}

--- a/test/functions/generic/genericChannelInInit2.good
+++ b/test/functions/generic/genericChannelInInit2.good
@@ -1,0 +1,3 @@
+genericChannelInInit2.chpl:9: In initializer:
+genericChannelInInit2.chpl:9: error: Cannot default-initialize a variable with generic type
+genericChannelInInit2.chpl:9: note: 'C_chnl' has generic type 'channel'


### PR DESCRIPTION
Add two tests for issue #12242 showing that we now have reasonable error
messages for this error case instead of an ICE.

The first issues errors about using 'this' before it is initialized. The second
comments out that use of 'this' and then has errors about default initializing
a generic channel.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>