### PR TITLE
Update, fix bug in string/bytes join methods

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -713,6 +713,9 @@ module Bytes {
     :returns: A :mod:`bytes <Bytes>`
   */
   inline proc bytes.join(const ref x) : bytes  {
+    // this overload serves as a catch-all for unsupported types.
+    // for the implementation of array and tuple overloads, see
+    // join() methods in the _bytes record.
     compilerError("bytes.join() accepts any number of bytes, homogenous "
                     + "tuple of bytes, or array of bytes as an argument");
   }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -370,7 +370,7 @@ module Bytes {
     }
 
     inline proc join(const ref x) where isTuple(x) {
-      if !isHomogeneousTuple(x) || !isBytes(x[1]) then
+      if !isHomogeneousTuple(x) || !isBytes(x[0]) then
         compilerError("join() on tuples only handles homogeneous tuples of bytes");
       return doJoin(this, x);
     }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -353,9 +353,6 @@ module Bytes {
       return this.byte(i:int);
     }
 
-
-
-
     inline proc param toByte() param : uint(8) {
       if this.numBytes != 1 then
         compilerError("bytes.toByte() only accepts single-byte bytes");
@@ -372,14 +369,16 @@ module Bytes {
       return doJoin(this, x);
     }
 
+    inline proc join(const ref x) where isTuple(x) {
+      if !isHomogeneousTuple(x) || !isBytes(x[1]) then
+        compilerError("join() on tuples only handles homogeneous tuples of bytes");
+      return doJoin(this, x);
+    }
+
     inline proc join(ir: _iteratorRecord): bytes {
       return doJoinIterator(this, ir);
     }
 
-    // TODO: we don't need this
-    // inline proc _join(const ref S) : bytes where isTuple(S) || isArray(S) {
-    //   return doJoin(this, S);
-    // }
   } // end of record bytes
 
   /*
@@ -677,405 +676,407 @@ module Bytes {
     for s in doSplitWSNoEnc(this, maxsplit) do yield s;
   }
 
-    /*
-      Returns a new :mod:`bytes <Bytes>`, which is the concatenation of all of
-      the :mod:`bytes <Bytes>` passed in with the contents of the method
-      receiver inserted between them.
+  /*
+    Returns a new :mod:`bytes <Bytes>`, which is the concatenation of all of
+    the :mod:`bytes <Bytes>` passed in with the contents of the method
+    receiver inserted between them.
 
-      .. code-block:: chapel
+    .. code-block:: chapel
 
-          var myBytes = b"|".join(b"a",b"10",b"d");
-          writeln(myBytes); // prints: "a|10|d"
+        var myBytes = b"|".join(b"a",b"10",b"d");
+        writeln(myBytes); // prints: "a|10|d"
 
-      :arg x: :mod:`bytes <Bytes>` values to be joined
+    :arg x: :mod:`bytes <Bytes>` values to be joined
 
-      :returns: A :mod:`bytes <Bytes>`
-    */
-    inline proc bytes.join(const ref x: bytes ...) : bytes {
-      return doJoin(this, x);
-    }
+    :returns: A :mod:`bytes <Bytes>`
+  */
+  inline proc bytes.join(const ref x: bytes ...) : bytes {
+    return doJoin(this, x);
+  }
 
-    /*
-      Returns a new :mod:`bytes <Bytes>`, which is the concatenation of all of
-      the :mod:`bytes <Bytes>` passed in with the contents of the method
-      receiver inserted between them.
+  /*
+    Returns a new :mod:`bytes <Bytes>`, which is the concatenation of all of
+    the :mod:`bytes <Bytes>` passed in with the contents of the method
+    receiver inserted between them.
 
-      .. code-block:: chapel
+    .. code-block:: chapel
 
-          var tup = (b"a",b"10",b"d");
-          var myBytes = b"|".join(tup);
-          writeln(myBytes); // prints: "a|10|d"
+        var tup = (b"a",b"10",b"d");
+        var myJoinedTuple = b"|".join(tup);
+        writeln(myJoinedTuple); // prints: "a|10|d"
 
-      :arg x: :mod:`bytes <Bytes>` values to be joined
-      :type x: tuple or array of :mod:`bytes <Bytes>`
+        var myJoinedArray = b"|".join([b"a",b"10",b"d"]);
+        writeln(myJoinedArray); // prints: "a|10|d"
 
-      :returns: A :mod:`bytes <Bytes>`
-    */
-    inline proc bytes.join(const ref x) : bytes where isTuple(x) {
-      if !isHomogeneousTuple(x) || !isBytes(x[1]) then
-        compilerError("join() on tuples only handles homogeneous tuples of bytes");
-      return doJoin(this, x);
-    }
+    :arg x: values to be joined
+    :type x: array or tuple of :mod:`bytes <Bytes>`
 
-    /*
-      Strips given set of leading and/or trailing characters.
+    :returns: A :mod:`bytes <Bytes>`
+  */
+  inline proc bytes.join(const ref x) : bytes  {
+    compilerError("bytes.join() accepts any number of bytes, homogenous "
+                    + "tuple of bytes, or array of bytes as an argument");
+  }
 
-      :arg chars: Characters to remove.  Defaults to `b" \\t\\r\\n"`.
+  /*
+    Strips given set of leading and/or trailing characters.
 
-      :arg leading: Indicates if leading occurrences should be removed.
+    :arg chars: Characters to remove.  Defaults to `b" \\t\\r\\n"`.
+
+    :arg leading: Indicates if leading occurrences should be removed.
+                  Defaults to `true`.
+
+    :arg trailing: Indicates if trailing occurrences should be removed.
                     Defaults to `true`.
 
-      :arg trailing: Indicates if trailing occurrences should be removed.
-                     Defaults to `true`.
+    :returns: A new :mod:`bytes <Bytes>` with `leading` and/or `trailing`
+              occurrences of characters in `chars` removed as appropriate.
+  */
+  proc bytes.strip(chars = b" \t\r\n", leading=true, trailing=true) : bytes {
+    return doStripNoEnc(this, chars, leading, trailing);
+  }
 
-      :returns: A new :mod:`bytes <Bytes>` with `leading` and/or `trailing`
-                occurrences of characters in `chars` removed as appropriate.
+  /*
+    Splits the :mod:`bytes <Bytes>` on a given separator
+
+    :arg sep: The separator
+
+    :returns: a `3*bytes` consisting of the section before `sep`,
+              `sep`, and the section after `sep`. If `sep` is not found, the
+              tuple will contain the whole :mod:`bytes <Bytes>`, and then two
+              empty :mod:`bytes <Bytes>`.
+  */
+  inline proc const bytes.partition(sep: bytes) : 3*bytes {
+    return doPartition(this, sep);
+  }
+
+  /* Remove indentation from each line of bytes.
+
+      This can be useful when applied to multi-line bytes that are indented
+      in the source code, but should not be indented in the output.
+
+      When ``columns == 0``, determine the level of indentation to remove from
+      all lines by finding the common leading whitespace across all non-empty
+      lines. Empty lines are lines containing only whitespace. Tabs and spaces
+      are the only whitespaces that are considered, but are not treated as
+      the same characters when determining common whitespace.
+
+      When ``columns > 0``, remove ``columns`` leading whitespace characters
+      from each line. Tabs are not considered whitespace when ``columns > 0``,
+      so only leading spaces are removed.
+
+      :arg columns: The number of columns of indentation to remove. Infer
+                    common leading whitespace if ``columns == 0``.
+
+      :arg ignoreFirst: When ``true``, ignore first line when determining the
+                        common leading whitespace, and make no changes to the
+                        first line.
+
+      :returns: A new :mod:`bytes <Bytes>` with indentation removed.
+
+      .. warning::
+
+        ``bytes.dedent`` is not considered stable and is subject to change in
+        future Chapel releases.
+  */
+  proc bytes.dedent(columns=0, ignoreFirst=true): bytes {
+    if chpl_warnUnstable then
+      compilerWarning("bytes.dedent is subject to change in the future.");
+    return doDedent(this, columns, ignoreFirst);
+  }
+
+  /*
+    Returns a UTF-8 string from the given :mod:`bytes <Bytes>`. If the data is
+    malformed for UTF-8, `policy` argument determines the action.
+
+    :arg policy: - `decodePolicy.strict` raises an error
+                  - `decodePolicy.replace` replaces the malformed character
+                    with UTF-8 replacement character
+                  - `decodePolicy.drop` drops the data silently
+                  - `decodePolicy.escape` escapes each illegal byte with
+                    private use codepoints
+
+    :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
+              argument and the :mod:`bytes <Bytes>` contains non-UTF-8 characters.
+
+    :returns: A UTF-8 string.
+  */
+  proc bytes.decode(policy=decodePolicy.strict) : string throws {
+    // NOTE: In the future this method could support more encodings.
+    var localThis: bytes = this.localize();
+    return decodeByteBuffer(localThis.buff, localThis.buffLen, policy);
+  }
+
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are uppercase
+    (A-Z) in ASCII.  Ignores uncased (not a letter) and extended ASCII
+    characters (decimal value larger than 127)
+
+    :returns: * `true`--there is at least one uppercase and no lowercase characters
+              * `false`--otherwise
     */
-    proc bytes.strip(chars = b" \t\r\n", leading=true, trailing=true) : bytes {
-      return doStripNoEnc(this, chars, leading, trailing);
+  proc bytes.isUpper() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !(byte_isUpper(b)) {
+          result = false;
+          break;
+        }
+      }
     }
+    return result;
+  }
 
-    /*
-      Splits the :mod:`bytes <Bytes>` on a given separator
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are lowercase
+    (a-z) in ASCII.  Ignores uncased (not a letter) and extended ASCII
+    characters (decimal value larger than 127)
 
-      :arg sep: The separator
-
-      :returns: a `3*bytes` consisting of the section before `sep`,
-                `sep`, and the section after `sep`. If `sep` is not found, the
-                tuple will contain the whole :mod:`bytes <Bytes>`, and then two
-                empty :mod:`bytes <Bytes>`.
+    :returns: * `true`--there is at least one lowercase and no uppercase characters
+              * `false`--otherwise
     */
-    inline proc const bytes.partition(sep: bytes) : 3*bytes {
-      return doPartition(this, sep);
+  proc bytes.isLower() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !(byte_isLower(b)) {
+          result = false;
+          break;
+        }
+      }
     }
+    return result;
 
-    /* Remove indentation from each line of bytes.
+  }
 
-       This can be useful when applied to multi-line bytes that are indented
-       in the source code, but should not be indented in the output.
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are whitespace
+    (' ', '\\t', '\\n', '\\v', '\\f', '\\r') in ASCII.
 
-       When ``columns == 0``, determine the level of indentation to remove from
-       all lines by finding the common leading whitespace across all non-empty
-       lines. Empty lines are lines containing only whitespace. Tabs and spaces
-       are the only whitespaces that are considered, but are not treated as
-       the same characters when determining common whitespace.
-
-       When ``columns > 0``, remove ``columns`` leading whitespace characters
-       from each line. Tabs are not considered whitespace when ``columns > 0``,
-       so only leading spaces are removed.
-
-       :arg columns: The number of columns of indentation to remove. Infer
-                     common leading whitespace if ``columns == 0``.
-
-       :arg ignoreFirst: When ``true``, ignore first line when determining the
-                         common leading whitespace, and make no changes to the
-                         first line.
-
-       :returns: A new :mod:`bytes <Bytes>` with indentation removed.
-
-       .. warning::
-
-          ``bytes.dedent`` is not considered stable and is subject to change in
-          future Chapel releases.
+    :returns: * `true`  -- when all the characters are whitespace.
+              * `false` -- otherwise
     */
-    proc bytes.dedent(columns=0, ignoreFirst=true): bytes {
-      if chpl_warnUnstable then
-        compilerWarning("bytes.dedent is subject to change in the future.");
-      return doDedent(this, columns, ignoreFirst);
+  proc bytes.isSpace() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !(byte_isWhitespace(b)) {
+          result = false;
+          break;
+        }
+      }
     }
+    return result;
+  }
 
-    /*
-      Returns a UTF-8 string from the given :mod:`bytes <Bytes>`. If the data is
-      malformed for UTF-8, `policy` argument determines the action.
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are alphabetic
+    (a-zA-Z) in ASCII.
 
-      :arg policy: - `decodePolicy.strict` raises an error
-                   - `decodePolicy.replace` replaces the malformed character
-                     with UTF-8 replacement character
-                   - `decodePolicy.drop` drops the data silently
-                   - `decodePolicy.escape` escapes each illegal byte with
-                     private use codepoints
-
-      :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
-               argument and the :mod:`bytes <Bytes>` contains non-UTF-8 characters.
-
-      :returns: A UTF-8 string.
+    :returns: * `true`  -- when the characters are alphabetic.
+              * `false` -- otherwise
     */
-    proc bytes.decode(policy=decodePolicy.strict) : string throws {
-      // NOTE: In the future this method could support more encodings.
-      var localThis: bytes = this.localize();
-      return decodeByteBuffer(localThis.buff, localThis.buffLen, policy);
-    }
+  proc bytes.isAlpha() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
 
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are uppercase
-     (A-Z) in ASCII.  Ignores uncased (not a letter) and extended ASCII
-     characters (decimal value larger than 127)
-
-      :returns: * `true`--there is at least one uppercase and no lowercase characters
-                * `false`--otherwise
-     */
-    proc bytes.isUpper() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !(byte_isUpper(b)) {
-            result = false;
-            break;
-          }
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !byte_isAlpha(b) {
+          result = false;
+          break;
         }
       }
-      return result;
     }
+    return result;
+  }
 
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are lowercase
-     (a-z) in ASCII.  Ignores uncased (not a letter) and extended ASCII
-     characters (decimal value larger than 127)
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are digits (0-9)
+    in ASCII.
 
-      :returns: * `true`--there is at least one lowercase and no uppercase characters
-                * `false`--otherwise
-     */
-    proc bytes.isLower() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !(byte_isLower(b)) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-
-    }
-
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are whitespace
-     (' ', '\\t', '\\n', '\\v', '\\f', '\\r') in ASCII.
-
-      :returns: * `true`  -- when all the characters are whitespace.
-                * `false` -- otherwise
-     */
-    proc bytes.isSpace() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !(byte_isWhitespace(b)) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-    }
-
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are alphabetic
-     (a-zA-Z) in ASCII.
-
-      :returns: * `true`  -- when the characters are alphabetic.
-                * `false` -- otherwise
-     */
-    proc bytes.isAlpha() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !byte_isAlpha(b) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-    }
-
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are digits (0-9)
-     in ASCII.
-
-      :returns: * `true`  -- when the characters are digits.
-                * `false` -- otherwise
-     */
-    proc bytes.isDigit() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !byte_isDigit(b) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-    }
-
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are alphanumeric
-     (a-zA-Z0-9) in ASCII.
-
-      :returns: * `true`  -- when the characters are alphanumeric.
-                * `false` -- otherwise
-     */
-    proc bytes.isAlnum() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !byte_isAlnum(b) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-
-    }
-
-    /*
-     Checks if all the characters in the :mod:`bytes <Bytes>` are printable in
-     ASCII.
-
-      :returns: * `true`  -- when the characters are printable.
-                * `false` -- otherwise
-     */
-    proc bytes.isPrintable() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for b in this.bytes() {
-          if !byte_isPrintable(b) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-
-    }
-
-    /*
-      Checks if all uppercase characters are preceded by uncased characters,
-      and if all lowercase characters are preceded by cased characters in ASCII.
-
-      :returns: * `true`  -- when the condition described above is met.
-                * `false` -- otherwise
-     */
-    proc bytes.isTitle() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        param UN = 0, UPPER = 1, LOWER = 2;
-        var last = UN;
-        for b in this.bytes() {
-          if byte_isLower(b) {
-            if last == UPPER || last == LOWER {
-              last = LOWER;
-            } else { // last == UN
-              result = false;
-              break;
-            }
-          }
-          else if byte_isUpper(b) {
-            if last == UN {
-              last = UPPER;
-            } else { // last == UPPER || last == LOWER
-              result = false;
-              break;
-            }
-          } else {
-            // Uncased elements
-            last = UN;
-          }
-        }
-      }
-      return result;
-    }
-
-    /*
-      Creates a new :mod:`bytes <Bytes>` with all applicable characters
-      converted to lowercase.
-
-      :returns: A new :mod:`bytes <Bytes>` with all uppercase characters (A-Z)
-                replaced with their lowercase counterpart in ASCII. Other
-                characters remain untouched.
+    :returns: * `true`  -- when the characters are digits.
+              * `false` -- otherwise
     */
-    proc bytes.toLower() : bytes {
-      var result: bytes = this;
-      if result.isEmpty() then return result;
-      for (i,b) in zip(0.., result.bytes()) {
-        result.buff[i] = byte_toLower(b); //check is done by byte_toLower
+  proc bytes.isDigit() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !byte_isDigit(b) {
+          result = false;
+          break;
+        }
       }
-      return result;
     }
+    return result;
+  }
 
-    /*
-      Creates a new :mod:`bytes <Bytes>` with all applicable characters
-      converted to uppercase.
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are alphanumeric
+    (a-zA-Z0-9) in ASCII.
 
-      :returns: A new :mod:`bytes <Bytes>` with all lowercase characters (a-z)
-                replaced with their uppercase counterpart in ASCII. Other
-                characters remain untouched.
+    :returns: * `true`  -- when the characters are alphanumeric.
+              * `false` -- otherwise
     */
-    proc bytes.toUpper() : bytes {
-      var result: bytes = this;
-      if result.isEmpty() then return result;
-      for (i,b) in zip(0.., result.bytes()) {
-        result.buff[i] = byte_toUpper(b); //check is done by byte_toUpper
+  proc bytes.isAlnum() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !byte_isAlnum(b) {
+          result = false;
+          break;
+        }
       }
-      return result;
     }
+    return result;
 
-    /*
-      Creates a new :mod:`bytes <Bytes>` with all applicable characters
-      converted to title capitalization.
+  }
 
-      :returns: A new :mod:`bytes <Bytes>` with all cased characters(a-zA-Z)
-                following an uncased character converted to uppercase, and all
-                cased characters following another cased character converted to
-                lowercase.
-     */
-    proc bytes.toTitle() : bytes {
-      var result: bytes = this;
-      if result.isEmpty() then return result;
+  /*
+    Checks if all the characters in the :mod:`bytes <Bytes>` are printable in
+    ASCII.
 
-      param UN = 0, LETTER = 1;
+    :returns: * `true`  -- when the characters are printable.
+              * `false` -- otherwise
+    */
+  proc bytes.isPrintable() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for b in this.bytes() {
+        if !byte_isPrintable(b) {
+          result = false;
+          break;
+        }
+      }
+    }
+    return result;
+
+  }
+
+  /*
+    Checks if all uppercase characters are preceded by uncased characters,
+    and if all lowercase characters are preceded by cased characters in ASCII.
+
+    :returns: * `true`  -- when the condition described above is met.
+              * `false` -- otherwise
+    */
+  proc bytes.isTitle() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      param UN = 0, UPPER = 1, LOWER = 2;
       var last = UN;
-      for (i,b) in zip(0.., result.bytes()) {
-        if byte_isAlpha(b) {
+      for b in this.bytes() {
+        if byte_isLower(b) {
+          if last == UPPER || last == LOWER {
+            last = LOWER;
+          } else { // last == UN
+            result = false;
+            break;
+          }
+        }
+        else if byte_isUpper(b) {
           if last == UN {
-            last = LETTER;
-            result.buff[i] = byte_toUpper(b);
-          } else { // last == LETTER
-            result.buff[i] = byte_toLower(b);
+            last = UPPER;
+          } else { // last == UPPER || last == LOWER
+            result = false;
+            break;
           }
         } else {
           // Uncased elements
           last = UN;
         }
       }
-      return result;
     }
+    return result;
+  }
+
+  /*
+    Creates a new :mod:`bytes <Bytes>` with all applicable characters
+    converted to lowercase.
+
+    :returns: A new :mod:`bytes <Bytes>` with all uppercase characters (A-Z)
+              replaced with their lowercase counterpart in ASCII. Other
+              characters remain untouched.
+  */
+  proc bytes.toLower() : bytes {
+    var result: bytes = this;
+    if result.isEmpty() then return result;
+    for (i,b) in zip(0.., result.bytes()) {
+      result.buff[i] = byte_toLower(b); //check is done by byte_toLower
+    }
+    return result;
+  }
+
+  /*
+    Creates a new :mod:`bytes <Bytes>` with all applicable characters
+    converted to uppercase.
+
+    :returns: A new :mod:`bytes <Bytes>` with all lowercase characters (a-z)
+              replaced with their uppercase counterpart in ASCII. Other
+              characters remain untouched.
+  */
+  proc bytes.toUpper() : bytes {
+    var result: bytes = this;
+    if result.isEmpty() then return result;
+    for (i,b) in zip(0.., result.bytes()) {
+      result.buff[i] = byte_toUpper(b); //check is done by byte_toUpper
+    }
+    return result;
+  }
+
+  /*
+    Creates a new :mod:`bytes <Bytes>` with all applicable characters
+    converted to title capitalization.
+
+    :returns: A new :mod:`bytes <Bytes>` with all cased characters(a-zA-Z)
+              following an uncased character converted to uppercase, and all
+              cased characters following another cased character converted to
+              lowercase.
+    */
+  proc bytes.toTitle() : bytes {
+    var result: bytes = this;
+    if result.isEmpty() then return result;
+
+    param UN = 0, LETTER = 1;
+    var last = UN;
+    for (i,b) in zip(0.., result.bytes()) {
+      if byte_isAlpha(b) {
+        if last == UN {
+          last = LETTER;
+          result.buff[i] = byte_toUpper(b);
+        } else { // last == LETTER
+          result.buff[i] = byte_toLower(b);
+        }
+      } else {
+        // Uncased elements
+        last = UN;
+      }
+    }
+    return result;
+  }
 
   pragma "no doc"
   inline operator :(x: string, type t: bytes) {

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -708,8 +708,7 @@ module Bytes {
         var myJoinedArray = b"|".join([b"a",b"10",b"d"]);
         writeln(myJoinedArray); // prints: "a|10|d"
 
-    :arg x: values to be joined
-    :type x: array or tuple of :mod:`bytes <Bytes>`
+    :arg x: An array or tuple of :mod:`bytes <Bytes>` values to be joined
 
     :returns: A :mod:`bytes <Bytes>`
   */

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -369,7 +369,7 @@ module Bytes {
     }
 
     inline proc join(const ref x: [] bytes) : bytes {
-      return _join(x);
+      return doJoin(this, x);
     }
 
     inline proc join(ir: _iteratorRecord): bytes {
@@ -377,9 +377,9 @@ module Bytes {
     }
 
     // TODO: we don't need this
-    inline proc _join(const ref S) : bytes where isTuple(S) || isArray(S) {
-      return doJoin(this, S);
-    }
+    // inline proc _join(const ref S) : bytes where isTuple(S) || isArray(S) {
+    //   return doJoin(this, S);
+    // }
   } // end of record bytes
 
   /*
@@ -692,7 +692,7 @@ module Bytes {
       :returns: A :mod:`bytes <Bytes>`
     */
     inline proc bytes.join(const ref x: bytes ...) : bytes {
-      return _join(x);
+      return doJoin(this, x);
     }
 
     /*
@@ -714,7 +714,7 @@ module Bytes {
     inline proc bytes.join(const ref x) : bytes where isTuple(x) {
       if !isHomogeneousTuple(x) || !isBytes(x[1]) then
         compilerError("join() on tuples only handles homogeneous tuples of bytes");
-      return _join(x);
+      return doJoin(this, x);
     }
 
     /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1797,6 +1797,9 @@ module String {
     :returns: A :mod:`string <String>`
   */
   inline proc string.join(const ref x) : string {
+    // this overload serves as a catch-all for unsupported types.
+    // for the implementation of array and tuple overloads, see
+    // join() methods in the _string record.
     compilerError("string.join() accepts any number of strings, homogenous "
                   + "tuple of strings, or array of strings as an argument");
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1199,7 +1199,7 @@ module String {
     }
 
     inline proc join(const ref x) where isTuple(x) {
-      if !isHomogeneousTuple(x) || !isString(x[1]) then
+      if !isHomogeneousTuple(x) || !isString(x[0]) then
         compilerError("join() on tuples only handles homogeneous tuples of strings");
       return doJoin(this, x);
     }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1792,8 +1792,7 @@ module String {
         var myJoinedArray = "|".join(["a","10","d"]);
         writeln(myJoinedArray); // prints: "a|10|d"
 
-    :arg x: values to be joined
-    :type x: array or tuple of :mod:`string <String>`
+    :arg x: An array or tuple of :mod:`string <String>` values to be joined
 
     :returns: A :mod:`string <String>`
   */

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1199,9 +1199,9 @@ module String {
     }
 
     // TODO: we don't need this
-    inline proc _join(const ref S) : string where isTuple(S) || isArray(S) {
-      return doJoin(this, S);
-    }
+    // inline proc _join(const ref S) : string where isTuple(S) || isArray(S) {
+    //   return doJoin(this, S);
+    // }
 
     /*
       :returns: A new string with the first character in uppercase (if it is a
@@ -1765,7 +1765,7 @@ module String {
         writeln(myString); // prints: "a|10|d"
    */
   inline proc string.join(const ref x: string ...) : string {
-    return _join(x);
+    return doJoin(this, x);
   }
 
   /*
@@ -1780,7 +1780,7 @@ module String {
   inline proc string.join(const ref x) : string where isTuple(x) {
     if !isHomogeneousTuple(x) || !isString(x[1]) then
       compilerError("join() on tuples only handles homogeneous tuples of strings");
-    return _join(x);
+    return doJoin(this, x);
   }
 
   /*
@@ -1792,7 +1792,7 @@ module String {
         writeln(myString); // prints: "a|10|d"
    */
   inline proc string.join(const ref x: [] string) : string {
-    return _join(x);
+    return doJoin(this, x);
   }
 
     /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1194,14 +1194,19 @@ module String {
       return ret;
     }
 
+    inline proc join(const ref x : [] string) : string {
+      return doJoin(this, x);
+    }
+
+    inline proc join(const ref x) where isTuple(x) {
+      if !isHomogeneousTuple(x) || !isString(x[1]) then
+        compilerError("join() on tuples only handles homogeneous tuples of strings");
+      return doJoin(this, x);
+    }
+
     inline proc join(ir: _iteratorRecord): string {
       return doJoinIterator(this, ir);
     }
-
-    // TODO: we don't need this
-    // inline proc _join(const ref S) : string where isTuple(S) || isArray(S) {
-    //   return doJoin(this, S);
-    // }
 
     /*
       :returns: A new string with the first character in uppercase (if it is a
@@ -1756,402 +1761,405 @@ module String {
   }
 
   /*
-    Returns a new string, which is the concatenation of all of the strings
-    passed in with the receiving string inserted between them.
+    Returns a new :mod:`string <String>`, which is the concatenation of all of
+    the :mod:`string <String>` passed in with the contents of the method
+    receiver inserted between them.
 
     .. code-block:: chapel
 
         var myString = "|".join("a","10","d");
         writeln(myString); // prints: "a|10|d"
-   */
+
+    :arg x: :mod:`string <String>` values to be joined
+
+    :returns: A :mod:`string <String>`
+  */
   inline proc string.join(const ref x: string ...) : string {
     return doJoin(this, x);
   }
 
   /*
-    Same as the varargs version, but with a homogeneous tuple of strings.
+    Returns a new :mod:`string <String>`, which is the concatenation of all of
+    the :mod:`string <String>` passed in with the contents of the method
+    receiver inserted between them.
 
     .. code-block:: chapel
 
         var tup = ("a","10","d");
-        var myString = "|".join(tup);
-        writeln(myString); // prints: "a|10|d"
-   */
-  inline proc string.join(const ref x) : string where isTuple(x) {
-    if !isHomogeneousTuple(x) || !isString(x[1]) then
-      compilerError("join() on tuples only handles homogeneous tuples of strings");
-    return doJoin(this, x);
+        var myJoinedTuple = "|".join(tup);
+        writeln(myJoinedTuple); // prints: "a|10|d"
+
+        var myJoinedArray = "|".join(["a","10","d"]);
+        writeln(myJoinedArray); // prints: "a|10|d"
+
+    :arg x: values to be joined
+    :type x: array or tuple of :mod:`string <String>`
+
+    :returns: A :mod:`string <String>`
+  */
+  inline proc string.join(const ref x) : string {
+    compilerError("string.join() accepts any number of strings, homogenous "
+                  + "tuple of strings, or array of strings as an argument");
+  }
+
+
+  /*
+    :arg chars: A string containing each character to remove.
+                Defaults to `" \\t\\r\\n"`.
+    :arg leading: Indicates if leading occurrences should be removed.
+                  Defaults to `true`.
+    :arg trailing: Indicates if trailing occurrences should be removed.
+                    Defaults to `true`.
+
+    :returns: A new string with `leading` and/or `trailing` occurrences of
+              characters in `chars` removed as appropriate.
+  */
+  proc string.strip(chars: string = " \t\r\n", leading=true,
+                    trailing=true) : string {
+    if this.isASCII() {
+      return doStripNoEnc(this, chars, leading, trailing);
+    } else {
+      if this.isEmpty() then return "";
+      if chars.isEmpty() then return this;
+
+      const localThis: string = this.localize();
+      const localChars: string = chars.localize();
+
+      var start: byteIndex = 0;
+      var end: byteIndex = localThis.buffLen-1;
+
+      if leading {
+        label outer for (thisChar, i, nBytes) in localThis._cpIndexLen() {
+          for removeChar in localChars.codepoints() {
+            if thisChar == removeChar {
+              start = i + nBytes;
+              continue outer;
+            }
+          }
+          break;
+        }
+      }
+
+      if trailing {
+        // Because we are working with codepoints whose starting byte index
+        // is not initially known, it is faster to work forward, assuming we
+        // are already past the end of the string, and then update the end
+        // point as we are proven wrong.
+        end = -1;
+        label outer for (thisChar, i, nBytes) in localThis._cpIndexLen(start) {
+          for removeChar in localChars.codepoints() {
+            if thisChar == removeChar {
+              continue outer;
+            }
+          }
+          // This was not a character to be removed, so update tentative end.
+          end = i + nBytes-1;
+        }
+      }
+
+      return localThis[start..end];
+    }
   }
 
   /*
-    Same as the varargs version, but with all the strings in an array.
-
-    .. code-block:: chapel
-
-        var myString = "|".join(["a","10","d"]);
-        writeln(myString); // prints: "a|10|d"
-   */
-  inline proc string.join(const ref x: [] string) : string {
-    return doJoin(this, x);
+    Splits the string on `sep` into a `3*string` consisting of the section
+    before `sep`, `sep`, and the section after `sep`. If `sep` is not found,
+    the tuple will contain the whole string, and then two empty strings.
+  */
+  inline proc const string.partition(sep: string) : 3*string {
+    return doPartition(this, sep);
   }
 
-    /*
-      :arg chars: A string containing each character to remove.
-                  Defaults to `" \\t\\r\\n"`.
-      :arg leading: Indicates if leading occurrences should be removed.
-                    Defaults to `true`.
-      :arg trailing: Indicates if trailing occurrences should be removed.
-                     Defaults to `true`.
 
-      :returns: A new string with `leading` and/or `trailing` occurrences of
-                characters in `chars` removed as appropriate.
+  /* Remove indentation from each line of string.
+
+      This can be useful when applied to multi-line strings that are indented
+      in the source code, but should not be indented in the output.
+
+      When ``columns == 0``, determine the level of indentation to remove from
+      all lines by finding the common leading whitespace across all non-empty
+      lines. Empty lines are lines containing only whitespace. Tabs and spaces
+      are the only whitespaces that are considered, but are not treated as
+      the same characters when determining common whitespace.
+
+      When ``columns > 0``, remove ``columns`` leading whitespace characters
+      from each line. Tabs are not considered whitespace when ``columns > 0``,
+      so only leading spaces are removed.
+
+      :arg columns: The number of columns of indentation to remove. Infer
+                    common leading whitespace if ``columns == 0``.
+
+      :arg ignoreFirst: When ``true``, ignore first line when determining the
+                        common leading whitespace, and make no changes to the
+                        first line.
+
+      :returns: A new `string` with indentation removed.
+
+      .. warning::
+
+        ``string.dedent`` is not considered stable and is subject to change in
+        future Chapel releases.
+  */
+  proc string.dedent(columns=0, ignoreFirst=true) : string {
+    if chpl_warnUnstable then
+      compilerWarning("string.dedent is subject to change in the future.");
+    return doDedent(this, columns, ignoreFirst);
+  }
+
+  /*
+    Checks if all the characters in the string are either uppercase (A-Z) or
+    uncased (not a letter).
+
+    :returns: * `true`  -- if the string contains at least one uppercase
+                            character and no lowercase characters, ignoring
+                            uncased characters.
+              * `false` -- otherwise
     */
-    proc string.strip(chars: string = " \t\r\n", leading=true,
-                      trailing=true) : string {
-      if this.isASCII() {
-        return doStripNoEnc(this, chars, leading, trailing);
-      } else {
-        if this.isEmpty() then return "";
-        if chars.isEmpty() then return this;
+  proc string.isUpper() : bool {
+    if this.isEmpty() then return false;
 
-        const localThis: string = this.localize();
-        const localChars: string = chars.localize();
-
-        var start: byteIndex = 0;
-        var end: byteIndex = localThis.buffLen-1;
-
-        if leading {
-          label outer for (thisChar, i, nBytes) in localThis._cpIndexLen() {
-            for removeChar in localChars.codepoints() {
-              if thisChar == removeChar {
-                start = i + nBytes;
-                continue outer;
-              }
-            }
-            break;
-          }
+    var result: bool;
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      var locale_result = false;
+      for cp in this.codepoints() {
+        if codepoint_isLower(cp) {
+          locale_result = false;
+          break;
+        } else if !locale_result && codepoint_isUpper(cp) {
+          locale_result = true;
         }
+      }
+      result = locale_result;
+    }
+    return result;
+  }
 
-        if trailing {
-          // Because we are working with codepoints whose starting byte index
-          // is not initially known, it is faster to work forward, assuming we
-          // are already past the end of the string, and then update the end
-          // point as we are proven wrong.
-          end = -1;
-          label outer for (thisChar, i, nBytes) in localThis._cpIndexLen(start) {
-            for removeChar in localChars.codepoints() {
-              if thisChar == removeChar {
-                continue outer;
-              }
-            }
-            // This was not a character to be removed, so update tentative end.
-            end = i + nBytes-1;
-          }
+  /*
+    Checks if all the characters in the string are either lowercase (a-z) or
+    uncased (not a letter).
+
+    :returns: * `true`  -- when there are no uppercase characters in the string.
+              * `false` -- otherwise
+    */
+  proc string.isLower() : bool {
+    if this.isEmpty() then return false;
+
+    var result: bool;
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      var locale_result = false;
+      for cp in this.codepoints() {
+        if codepoint_isUpper(cp) {
+          locale_result = false;
+          break;
+        } else if !locale_result && codepoint_isLower(cp) {
+          locale_result = true;
         }
+      }
+      result = locale_result;
+    }
+    return result;
+  }
 
-        return localThis[start..end];
+  /*
+    Checks if all the characters in the string are whitespace (' ', '\t',
+    '\n', '\v', '\f', '\r').
+
+    :returns: * `true`  -- when all the characters are whitespace.
+              * `false` -- otherwise
+    */
+  proc string.isSpace() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for cp in this.codepoints() {
+        if !(codepoint_isWhitespace(cp)) {
+          result = false;
+          break;
+        }
       }
     }
+    return result;
+  }
 
-    /*
-      Splits the string on `sep` into a `3*string` consisting of the section
-      before `sep`, `sep`, and the section after `sep`. If `sep` is not found,
-      the tuple will contain the whole string, and then two empty strings.
+  /*
+    Checks if all the characters in the string are alphabetic (a-zA-Z).
+
+    :returns: * `true`  -- when the characters are alphabetic.
+              * `false` -- otherwise
     */
-    inline proc const string.partition(sep: string) : 3*string {
-      return doPartition(this, sep);
+  proc string.isAlpha() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for cp in this.codepoints() {
+        if !codepoint_isAlpha(cp) {
+          result = false;
+          break;
+        }
+      }
     }
+    return result;
+  }
 
+  /*
+    Checks if all the characters in the string are digits (0-9).
 
-    /* Remove indentation from each line of string.
-
-       This can be useful when applied to multi-line strings that are indented
-       in the source code, but should not be indented in the output.
-
-       When ``columns == 0``, determine the level of indentation to remove from
-       all lines by finding the common leading whitespace across all non-empty
-       lines. Empty lines are lines containing only whitespace. Tabs and spaces
-       are the only whitespaces that are considered, but are not treated as
-       the same characters when determining common whitespace.
-
-       When ``columns > 0``, remove ``columns`` leading whitespace characters
-       from each line. Tabs are not considered whitespace when ``columns > 0``,
-       so only leading spaces are removed.
-
-       :arg columns: The number of columns of indentation to remove. Infer
-                     common leading whitespace if ``columns == 0``.
-
-       :arg ignoreFirst: When ``true``, ignore first line when determining the
-                         common leading whitespace, and make no changes to the
-                         first line.
-
-       :returns: A new `string` with indentation removed.
-
-       .. warning::
-
-          ``string.dedent`` is not considered stable and is subject to change in
-          future Chapel releases.
+    :returns: * `true`  -- when the characters are digits.
+              * `false` -- otherwise
     */
-    proc string.dedent(columns=0, ignoreFirst=true) : string {
-      if chpl_warnUnstable then
-        compilerWarning("string.dedent is subject to change in the future.");
-      return doDedent(this, columns, ignoreFirst);
-    }
+  proc string.isDigit() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
 
-    /*
-     Checks if all the characters in the string are either uppercase (A-Z) or
-     uncased (not a letter).
-
-      :returns: * `true`  -- if the string contains at least one uppercase
-                             character and no lowercase characters, ignoring
-                             uncased characters.
-                * `false` -- otherwise
-     */
-    proc string.isUpper() : bool {
-      if this.isEmpty() then return false;
-
-      var result: bool;
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        var locale_result = false;
-        for cp in this.codepoints() {
-          if codepoint_isLower(cp) {
-            locale_result = false;
-            break;
-          } else if !locale_result && codepoint_isUpper(cp) {
-            locale_result = true;
-          }
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for cp in this.codepoints() {
+        if !codepoint_isDigit(cp) {
+          result = false;
+          break;
         }
-        result = locale_result;
       }
-      return result;
     }
+    return result;
+  }
 
-    /*
-     Checks if all the characters in the string are either lowercase (a-z) or
-     uncased (not a letter).
+  /*
+    Checks if all the characters in the string are alphanumeric (a-zA-Z0-9).
 
-      :returns: * `true`  -- when there are no uppercase characters in the string.
-                * `false` -- otherwise
-     */
-    proc string.isLower() : bool {
-      if this.isEmpty() then return false;
+    :returns: * `true`  -- when the characters are alphanumeric.
+              * `false` -- otherwise
+    */
+  proc string.isAlnum() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
 
-      var result: bool;
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        var locale_result = false;
-        for cp in this.codepoints() {
-          if codepoint_isUpper(cp) {
-            locale_result = false;
-            break;
-          } else if !locale_result && codepoint_isLower(cp) {
-            locale_result = true;
-          }
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for cp in this.codepoints() {
+        if !(codepoint_isAlpha(cp) || codepoint_isDigit(cp)) {
+          result = false;
+          break;
         }
-        result = locale_result;
       }
-      return result;
     }
+    return result;
+  }
 
-    /*
-     Checks if all the characters in the string are whitespace (' ', '\t',
-     '\n', '\v', '\f', '\r').
+  /*
+    Checks if all the characters in the string are printable.
 
-      :returns: * `true`  -- when all the characters are whitespace.
-                * `false` -- otherwise
-     */
-    proc string.isSpace() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
+    :returns: * `true`  -- when the characters are printable.
+              * `false` -- otherwise
+    */
+  proc string.isPrintable() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
 
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for cp in this.codepoints() {
-          if !(codepoint_isWhitespace(cp)) {
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      for cp in this.codepoints() {
+        if !codepoint_isPrintable(cp) {
+          result = false;
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
+  /*
+    Checks if all uppercase characters are preceded by uncased characters,
+    and if all lowercase characters are preceded by cased characters.
+
+    :returns: * `true`  -- when the condition described above is met.
+              * `false` -- otherwise
+    */
+  proc string.isTitle() : bool {
+    if this.isEmpty() then return false;
+    var result: bool = true;
+
+    on __primitive("chpl_on_locale_num",
+                    chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+      param UN = 0, UPPER = 1, LOWER = 2;
+      var last = UN;
+      for cp in this.codepoints() {
+        if codepoint_isLower(cp) {
+          if last == UPPER || last == LOWER {
+            last = LOWER;
+          } else { // last == UN
             result = false;
             break;
           }
         }
-      }
-      return result;
-    }
-
-    /*
-     Checks if all the characters in the string are alphabetic (a-zA-Z).
-
-      :returns: * `true`  -- when the characters are alphabetic.
-                * `false` -- otherwise
-     */
-    proc string.isAlpha() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for cp in this.codepoints() {
-          if !codepoint_isAlpha(cp) {
+        else if codepoint_isUpper(cp) {
+          if last == UN {
+            last = UPPER;
+          } else { // last == UPPER || last == LOWER
             result = false;
             break;
           }
+        } else {
+          // Uncased elements
+          last = UN;
         }
       }
-      return result;
     }
+    return result;
+  }
 
-    /*
-     Checks if all the characters in the string are digits (0-9).
+  /*
+    :returns: A new string with all uppercase characters replaced with their
+              lowercase counterpart.
 
-      :returns: * `true`  -- when the characters are digits.
-                * `false` -- otherwise
-     */
-    proc string.isDigit() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
+    .. note::
 
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for cp in this.codepoints() {
-          if !codepoint_isDigit(cp) {
-            result = false;
-            break;
-          }
-        }
+      The case change operation is not currently performed on characters whose
+      cases take different number of bytes to represent in Unicode mapping.
+  */
+  proc string.toLower() : string {
+    var result: string = this;
+    if result.isEmpty() then return result;
+
+    for (cp, i, nBytes) in this._cpIndexLen() {
+      var lowCodepoint = codepoint_toLower(cp);
+      if lowCodepoint != cp && qio_nbytes_char(lowCodepoint) == nBytes {
+        // Use the MacOS approach everywhere:  only change the case if
+        // the result does not change the number of encoded bytes.
+        qio_encode_char_buf(result.buff + i, lowCodepoint);
       }
-      return result;
     }
+    return result;
+  }
 
-    /*
-     Checks if all the characters in the string are alphanumeric (a-zA-Z0-9).
+  /*
+    :returns: A new string with all lowercase characters replaced with their
+              uppercase counterpart.
 
-      :returns: * `true`  -- when the characters are alphanumeric.
-                * `false` -- otherwise
-     */
-    proc string.isAlnum() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
+    .. note::
 
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for cp in this.codepoints() {
-          if !(codepoint_isAlpha(cp) || codepoint_isDigit(cp)) {
-            result = false;
-            break;
-          }
-        }
+      The case change operation is not currently performed on characters whose
+      cases take different number of bytes to represent in Unicode mapping.
+  */
+  proc string.toUpper() : string {
+    var result: string = this;
+    if result.isEmpty() then return result;
+
+    for (cp, i, nBytes) in this._cpIndexLen() {
+      var upCodepoint = codepoint_toUpper(cp);
+      if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
+        // Use the MacOS approach everywhere:  only change the case if
+        // the result does not change the number of encoded bytes.
+        qio_encode_char_buf(result.buff + i, upCodepoint);
       }
-      return result;
     }
-
-    /*
-     Checks if all the characters in the string are printable.
-
-      :returns: * `true`  -- when the characters are printable.
-                * `false` -- otherwise
-     */
-    proc string.isPrintable() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        for cp in this.codepoints() {
-          if !codepoint_isPrintable(cp) {
-            result = false;
-            break;
-          }
-        }
-      }
-      return result;
-    }
-
-    /*
-      Checks if all uppercase characters are preceded by uncased characters,
-      and if all lowercase characters are preceded by cased characters.
-
-      :returns: * `true`  -- when the condition described above is met.
-                * `false` -- otherwise
-     */
-    proc string.isTitle() : bool {
-      if this.isEmpty() then return false;
-      var result: bool = true;
-
-      on __primitive("chpl_on_locale_num",
-                     chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
-        param UN = 0, UPPER = 1, LOWER = 2;
-        var last = UN;
-        for cp in this.codepoints() {
-          if codepoint_isLower(cp) {
-            if last == UPPER || last == LOWER {
-              last = LOWER;
-            } else { // last == UN
-              result = false;
-              break;
-            }
-          }
-          else if codepoint_isUpper(cp) {
-            if last == UN {
-              last = UPPER;
-            } else { // last == UPPER || last == LOWER
-              result = false;
-              break;
-            }
-          } else {
-            // Uncased elements
-            last = UN;
-          }
-        }
-      }
-      return result;
-    }
-
-    /*
-      :returns: A new string with all uppercase characters replaced with their
-                lowercase counterpart.
-
-      .. note::
-
-        The case change operation is not currently performed on characters whose
-        cases take different number of bytes to represent in Unicode mapping.
-    */
-    proc string.toLower() : string {
-      var result: string = this;
-      if result.isEmpty() then return result;
-
-      for (cp, i, nBytes) in this._cpIndexLen() {
-        var lowCodepoint = codepoint_toLower(cp);
-        if lowCodepoint != cp && qio_nbytes_char(lowCodepoint) == nBytes {
-          // Use the MacOS approach everywhere:  only change the case if
-          // the result does not change the number of encoded bytes.
-          qio_encode_char_buf(result.buff + i, lowCodepoint);
-        }
-      }
-      return result;
-    }
-
-    /*
-      :returns: A new string with all lowercase characters replaced with their
-                uppercase counterpart.
-
-      .. note::
-
-        The case change operation is not currently performed on characters whose
-        cases take different number of bytes to represent in Unicode mapping.
-    */
-    proc string.toUpper() : string {
-      var result: string = this;
-      if result.isEmpty() then return result;
-
-      for (cp, i, nBytes) in this._cpIndexLen() {
-        var upCodepoint = codepoint_toUpper(cp);
-        if upCodepoint != cp && qio_nbytes_char(upCodepoint) == nBytes {
-          // Use the MacOS approach everywhere:  only change the case if
-          // the result does not change the number of encoded bytes.
-          qio_encode_char_buf(result.buff + i, upCodepoint);
-        }
-      }
-      return result;
-    }
+    return result;
+  }
 
   /*
     :returns: A new string with all cased characters following an uncased

--- a/test/types/string/methods/simple-join.chpl
+++ b/test/types/string/methods/simple-join.chpl
@@ -1,0 +1,21 @@
+config type dataType = string;
+
+var sep = " ":dataType;
+var my = "my":dataType;
+var test = "test":dataType;
+var message = "message":dataType;
+
+var arr0 : [1..0] dataType;
+
+var tup3 = (my,test,message);
+var tup1 = (my,);
+var arr3 = [my,test,message];
+var arr1 = [my];
+
+writeln(sep.join(tup3));              // test 3 tuple
+writeln(sep.join(tup1));              // test 1 tuple
+writeln(sep.join(arr3));              // test 3 element array
+writeln(sep.join(arr1));              // test 1 element array
+writeln(sep.join(arr0));              // test empty array
+writeln(sep.join(my,test,message));   // test varargs
+writeln(sep.join(my));                // test single arg

--- a/test/types/string/methods/simple-join.compopts
+++ b/test/types/string/methods/simple-join.compopts
@@ -1,0 +1,2 @@
+-sdataType=bytes
+-sdataType=string

--- a/test/types/string/methods/simple-join.good
+++ b/test/types/string/methods/simple-join.good
@@ -1,0 +1,7 @@
+my test message
+my
+my test message
+my
+
+my test message
+my


### PR DESCRIPTION
This PR follows up on a `TODO` in the `string` and `bytes` modules to remove 
an unnecessary `_join` method. During this effort, a small bug was identified
in both methods that appears to be left over from the switch from 1 based to 
0 based indexing. The bug would only appear if a user attempted to join a
single item tuple. New tests have been added for single item tuples. 

The documentation has been updated to combine the join method that accepts 
both tuples and arrays, eliminating the need for separate section for both 
overloads. 

Additionally, the error message given by the compiler when
attempting to `join` an invalid type has been updated to be more specific
than a general inability to resolve. 

Further details can be found in cray/chapel-private/issues/2420

Indentation has been updated to align the secondary methods to the 
same indentation level.

TESTING:

After this change, I have verified:

- [x] make all
- [x] make docs
- [x] make mason
- [x] full paratest
- [x] visual inspection of docs for `bytes` and `strings`

Reviewed by @e-kayrakli 

Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com