### PR TITLE
Replace uses of "chpl__autoDestroy" with astr_autoDestroy

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2145,6 +2145,7 @@ const char* astr_autoCopy = NULL;
 const char* astr_initCopy = NULL;
 const char* astr_coerceCopy = NULL;
 const char* astr_coerceMove = NULL;
+const char* astr_autoDestroy = NULL;
 
 void initAstrConsts() {
   astrSassign = astr("=");
@@ -2185,6 +2186,8 @@ void initAstrConsts() {
   astr_initCopy = astr("chpl__initCopy");
   astr_coerceCopy = astr("chpl__coerceCopy");
   astr_coerceMove = astr("chpl__coerceMove");
+
+  astr_autoDestroy = astr("chpl__autoDestroy");
 }
 
 bool isAstrOpName(const char* name) {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -792,6 +792,7 @@ extern const char* astr_initCopy;
 extern const char* astr_coerceCopy;
 extern const char* astr_coerceCopy;
 extern const char* astr_coerceMove;
+extern const char* astr_autoDestroy;
 
 bool isAstrOpName(const char* name);
 

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1824,7 +1824,7 @@ static void checkForErroneousInitCopies() {
             if (CallExpr* useCall = toCallExpr(se->parentExpr)) {
               // TODO: May have to expand this to cover more cases...
               if (!useCall->isPrimitive(PRIM_END_OF_STATEMENT) &&
-                  !useCall->isNamedAstr("chpl__autoDestroy")) {
+                  !useCall->isNamedAstr(astr_autoDestroy)) {
                 nextUse = se;
                 break;
               }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -60,6 +60,7 @@
 #include "splitInit.h"
 #include "stlUtil.h"
 #include "stringutil.h"
+#include "symbol.h"
 #include "TryStmt.h"
 #include "typeSpecifier.h"
 #include "view.h"
@@ -9899,7 +9900,7 @@ static void resolveAutoCopyEtc(AggregateType* at) {
 
   // resolve autoDestroy
   if (autoDestroyMap.get(at) == NULL) {
-    FnSymbol* fn = autoMemoryFunction(at, "chpl__autoDestroy");
+    FnSymbol* fn = autoMemoryFunction(at, astr_autoDestroy);
     // If --minimal-modules is used, `chpl_autoDestroy` won't be defined
     if (fn)
       fn->addFlag(FLAG_AUTO_DESTROY_FN);

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -268,7 +268,7 @@ void initTypeHelperNames() {
   typeHelperNames.insert(astrNew);
   typeHelperNames.insert(astr_initCopy);
   typeHelperNames.insert(astr_autoCopy);
-  typeHelperNames.insert(astr("chpl__autoDestroy"));
+  typeHelperNames.insert(astr_autoDestroy);
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
This finishes off a remaining case from PR #15239 in an attempt to
close issue #15011. I don't think this is particularly important, but
the string literal being passed to isNamedAstr was suspect and this
brings it in line with other uses.

Paratest pass

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>