### PR TITLE
Add throws documentation to 3 subprocess methods

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -748,10 +748,8 @@ module Spawn {
 
     :throws BlockingIOError: when there weren't sufficient resources to perform
                              one of the required actions
-
-    TODO: errors from subprocess.communicate()
-
     :throws InterruptedError: when the call was interrupted in some way.
+    :throws BrokenPipeError: when a pipe for the subprocess closed early.
     :throws SystemError: when invalid values were passed to the subprocess's
                          stdin, or something else went wrong when
                          shutting down the subprocess.
@@ -881,6 +879,14 @@ module Spawn {
     input to the child process and buffering up the output
     of the child process as necessary while waiting for
     it to terminate.
+
+    :throws BlockingIOError: when there weren't sufficient resources to perform
+                             one of the required actions
+    :throws InterruptedError: when the call was interrupted in some way.
+    :throws BrokenPipeError: when a pipe for the subprocess closed early.
+    :throws SystemError: when something went wrong when shutting down the
+                         subprocess
+
    */
   proc subprocess.communicate() throws {
     try _throw_on_launch_error();


### PR DESCRIPTION
`subprocess.poll`, `subprocess.wait` and `subprocess.communicate` all
are declared as throwing functions, but didn't provide documentation of
what errors they throw.  Providing such documentation is useful for users
so that they know what to catch to recover from potential issues.

Some of the `SystemError` subclasses that can be thrown by these
methods would only occur if we'd done something wrong in setting the
subprocess up in some way, meaning that it isn't reasonable to expect
the user to be able to recover from them.  I've not gone into detail on
those errors in the documentation output (and to some extent wonder
if we should be throwing them), but I do call the list of them out in some
cases.  Others are errors that the user could respond to by restarting the
subprocess in some way or making the call again, and these I have called
out in more detail.

Makes progress on #12162, but does not complete it (as it took a while to
track down the errors for these methods)

The documentation built with these changes as expected and looked good.