### PR TITLE
Add docs for CHPL_RT_UNWIND

### DIFF
--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -386,6 +386,47 @@ runtime, to be more considerate in how they use node resources.
 
 
 ----------------
+Stack Traces
+----------------
+
+When compiled with unwind support (``CHPL_UNWIND=bundled`` or
+``CHPL_UNWIND=system``), Chapel can print a stacktrace when it halts due to an
+error. For example, when compiling and running the following program:
+
+   .. code-block:: chapel
+
+       // outofbounds.chpl
+       var A: [1..3] real;
+       A[5] = 1.0;
+
+   .. code-block:: sh
+
+        ./outofbounds
+
+   .. code-block:: sh
+
+        test/outofbounds.chpl:2: error: halt reached - array index out of bounds
+        note: index was 5 but array bounds are 1..3
+        Stacktrace
+
+        halt() at $CHPL_HOME/modules/standard/Errors.chpl:741
+        checkAccess() at $CHPL_HOME/modules/internal/ChapelArray.chpl:2675
+        chpl__init_outofbounds() at test/outofbounds.chpl:1
+
+The stacktrace will be printed. This behavior can also be disabled at runtime
+with the environment variable
+
+    .. code-block:: sh
+
+        export CHPL_RT_UNWIND=no
+
+Note that compiling programs with ``--fast`` effectively forces
+``CHPL_RT_UNWIND=no`` so that no stacktrace will be printed even if the Chapel
+compiler was built with unwind support. And in the above example, ``--fast``
+also omits the bounds check.
+
+
+----------------
 Launcher Support
 ----------------
 


### PR DESCRIPTION
The environment variable CHPL_RT_UNWIND was previously undocumented. This adds an explanation in the section "Using Chapel" > "Executing Chapel Programs"

Relates to #5320

