### PR TITLE
Use pclose rather than fclose

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -950,7 +950,7 @@ void readArgsFromCommand(std::string cmd, std::vector<std::string>& args) {
       // First argument is the clang install directory...
       args.push_back(arg);
     }
-    fclose(fd);
+    pclose(fd);
   }
 }
 


### PR DESCRIPTION
To address an error pointed out by GCC 11.2 - the popen function is documented to return something that needs to be closed with pclose rather than fclose.

Reviewed by @jhh67 - thanks!

- [x] full local testing