### PR TITLE
refactor mysystem for require statement fix

### DIFF
--- a/compiler/include/mysystem.h
+++ b/compiler/include/mysystem.h
@@ -2,15 +2,15 @@
  * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,10 +21,18 @@
 #ifndef _mysystem_H_
 #define _mysystem_H_
 
+#include <string>
+#include <vector>
+
 extern bool printSystemCommands;
 
-int mysystem(const char* command, 
-             const char* description, 
+int mysystem(const std::vector<std::string> commandVec,
+             const char* description,
+             bool        ignorestatus = false,
+             bool        quiet = false);
+
+int mysystem(const char* command,
+             const char* description,
              bool        ignorestatus = false,
              bool        quiet = false);
 

--- a/compiler/include/mysystem.h
+++ b/compiler/include/mysystem.h
@@ -26,6 +26,11 @@
 
 extern bool printSystemCommands;
 
+int myshell(const char* command,
+             const char* description,
+             bool        ignoreStatus = false,
+             bool        quiet = false);
+
 int mysystem(const std::vector<std::string> commandVec,
              const char* description,
              bool        ignorestatus = false,

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4077,11 +4077,11 @@ void makeBinaryLLVM(void) {
 
       outputASMfile.close();
 
-      if (mysystem("which ptxas > /dev/null 2>&1", "Check to see if ptxas command can be found", true)) {
+      if (myshell("which ptxas > /dev/null 2>&1", "Check to see if ptxas command can be found", true)) {
         USR_FATAL("Command 'ptxas' not found\n");
       }
 
-      if (mysystem("which fatbinary > /dev/null 2>&1", "Check to see if fatbinary command can be found", true)) {
+      if (myshell("which fatbinary > /dev/null 2>&1", "Check to see if fatbinary command can be found", true)) {
         USR_FATAL("Command 'fatbinary' not found\n");
       }
 

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -2,15 +2,15 @@
  * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -117,9 +117,9 @@ void docs(void) {
 }
 
 bool isNotSubmodule(ModuleSymbol *mod) {
-  return (mod->defPoint == NULL || 
+  return (mod->defPoint == NULL ||
           mod->defPoint->parentSymbol == NULL ||
-          mod->defPoint->parentSymbol->name == NULL || 
+          mod->defPoint->parentSymbol->name == NULL ||
           strcmp("chpl__Program", mod->defPoint->parentSymbol->name) == 0 ||
           strcmp("_root", mod->defPoint->parentSymbol->name) == 0);
 }
@@ -145,10 +145,10 @@ void printClass(std::ofstream *file, AggregateType *cl, unsigned int tabs) {
     }
 
     // If alphabetical option passed, alphabetizes the output
-    if (fDocsAlphabetize) 
-      qsort(cl->methods.v, cl->methods.n, sizeof(cl->methods.v[0]), 
+    if (fDocsAlphabetize)
+      qsort(cl->methods.v, cl->methods.n, sizeof(cl->methods.v[0]),
         compareNames);
-    
+
     forv_Vec(FnSymbol, fn, cl->methods){
       // We only want to print methods defined within the class under the
       // class header
@@ -165,7 +165,7 @@ bool devOnlyFunction(FnSymbol *fn) {
   return (fn->hasFlag(FLAG_MODULE_INIT) || fn->isPrimaryMethod());
 }
 
-// Returns true if the provide module is one of the internal or standard 
+// Returns true if the provide module is one of the internal or standard
 // modules. It is our opinion that these should only automatically be printed
 // out if the user is in developer mode.
 bool devOnlyModule(ModuleSymbol *mod) {
@@ -193,7 +193,7 @@ void printModule(std::ofstream *file, ModuleSymbol *mod, unsigned int tabs, std:
     // If alphabetical option passed, fDocsAlphabetizes the output
     if (fDocsAlphabetize)
       qsort(&fns[0], fns.size(), sizeof(FnSymbol*), compareNames);
-  
+
     for_vector(FnSymbol, fn, fns) {
       // TODO: Add flag to compiler to turn on doc dev only output
 
@@ -215,7 +215,7 @@ void printModule(std::ofstream *file, ModuleSymbol *mod, unsigned int tabs, std:
     std::vector<ModuleSymbol*> mods = mod->getTopLevelModules();
     if (fDocsAlphabetize)
       qsort(&mods[0], mods.size(), sizeof(ModuleSymbol*), compareNames);
-  
+
     for_vector(ModuleSymbol, subMod, mods) {
       // TODO: Add flag to compiler to turn on doc dev only output
       if (!devOnlyModule(subMod)) {
@@ -272,7 +272,7 @@ static bool existsAndDir(const char* dirpath) {
 }
 
 
-/* 
+/*
  * Create new sphinx project at given location and return path where .rst files
  * should be placed.
  */
@@ -395,7 +395,7 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir) {
   if( printSystemCommands ) {
     printf("%s\n", cmd);
   }
-  mysystem(cmd, "building html output from chpldoc sphinx project");
+  myshell(cmd, "building html output from chpldoc sphinx project");
   printf("HTML files are at: %s\n", outputDir.c_str());
 }
 

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -286,7 +286,7 @@ std::string generateSphinxProject(std::string dirpath) {
   if( printSystemCommands ) {
     printf("%s\n", cmd);
   }
-  mysystem(cmd, "copying chpldoc sphinx template");
+  myshell(cmd, "copying chpldoc sphinx template");
 
   const char * moddir = astr(sphinxDir, "/source/modules");
   return std::string(moddir);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -543,7 +543,7 @@ const char* createDebuggerFile(const char* debugger, int argc, char* argv[]) {
 
   fprintf(dbgfile, "\n");
   closefile(dbgfile);
-  mysystem(astr("cat ", CHPL_HOME, "/compiler/etc/", debugger, ".commands >> ",
+  myshell(astr("cat ", CHPL_HOME, "/compiler/etc/", debugger, ".commands >> ",
                 dbgfilename),
            astr("appending ", debugger, " commands"),
            false);

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -34,6 +34,36 @@
 
 bool printSystemCommands = false;
 
+int myshell(const char* command,
+             const char* description,
+             bool        ignoreStatus,
+             bool        quiet) {
+
+  int status = 0;
+
+  if (printSystemCommands && !quiet) {
+    printf("\n# %s\n", description);
+    printf("%s\n", command);
+    fflush(stdout);
+    fflush(stderr);
+  }
+
+  // Treat a '#' at the start of a line as a comment
+  if (command[0] == '#')
+    return 0;
+
+  status = system(command);
+
+  if (status == -1) {
+    USR_FATAL("system() fork failed: %s", strerror(errno));
+
+  } else if (status != 0 && ignoreStatus == false) {
+    USR_FATAL("%s", description);
+  }
+
+  return status;
+}
+
 int mysystem(const char* command,
              const char* description,
              bool        ignoreStatus,
@@ -71,7 +101,6 @@ int mysystem(const std::vector<std::string> commandVec,
   if (printSystemCommands && !quiet) {
     printf("\n# %s\n", description);
     printf("%s\n", commandStr.c_str());
-    printf("%s", execArgs[0]);
     fflush(stdout);
     fflush(stderr);
   }
@@ -79,8 +108,6 @@ int mysystem(const std::vector<std::string> commandVec,
   // Treat a '#' at the start of a line as a comment
   if (commandStr.c_str()[0] == '#')
     return 0;
-
-
 
   pid_t childPid;
 
@@ -100,16 +127,3 @@ int mysystem(const std::vector<std::string> commandVec,
   }
   return WEXITSTATUS(status);
 }
-  //status = exec(execArgs.data());
-
-  //status = system(commandStr.c_str());
-
-  // if (status == -1) {
-  //   USR_FATAL("system() fork failed: %s", strerror(errno));
-
-  // } else if (status != 0 && ignoreStatus == false) {
-  //   USR_FATAL("%s", description);
-  // }
-
-  // return status;
-// }

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -2,15 +2,15 @@
  * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,38 +22,94 @@
 
 #include "misc.h"
 
+#include "stringutil.h"
+
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 bool printSystemCommands = false;
 
-int mysystem(const char* command, 
+int mysystem(const char* command,
              const char* description,
              bool        ignoreStatus,
              bool        quiet) {
+  std::vector<std::string> commandVec;
+  std::string commandStr = command;
+  splitStringWhitespace(commandStr, commandVec);
+  return mysystem(commandVec, description, ignoreStatus, quiet);
+}
+
+
+int mysystem(const std::vector<std::string> commandVec,
+             const char* description,
+             bool        ignoreStatus,
+             bool        quiet) {
+
+  // if an empty command passed, do nothing
+  if (commandVec.empty()) {
+    return 0;
+  }
+
+  // Join the elements of commandVec into a single space separated string
+  std::string commandStr = commandVec.front();
+  for (unsigned int i = 1; i < commandVec.size(); i++) {
+    commandStr += " " + commandVec.at(i);
+  }
+
   int status = 0;
+  std::vector<const char*> execArgs;
+  for (unsigned int i = 0; i < commandVec.size(); ++i)
+      execArgs.push_back(commandVec[i].c_str());
+  execArgs.push_back(NULL);
+  execArgs.shrink_to_fit();
 
   if (printSystemCommands && !quiet) {
     printf("\n# %s\n", description);
-    printf("%s\n", command);
+    printf("%s\n", commandStr.c_str());
+    printf("%s", execArgs[0]);
     fflush(stdout);
     fflush(stderr);
   }
 
   // Treat a '#' at the start of a line as a comment
-  if (command[0] == '#')
+  if (commandStr.c_str()[0] == '#')
     return 0;
 
-  status = system(command);
 
-  if (status == -1) {
-    USR_FATAL("system() fork failed: %s", strerror(errno));
 
-  } else if (status != 0 && ignoreStatus == false) {
+  pid_t childPid;
+
+  childPid = fork();
+
+  if (childPid == 0) {
+    // in child process
+    execvp(execArgs[0], const_cast<char* const *> (execArgs.data()));
+  } else if (childPid > 0 ) {
+    // in parent process
+    waitpid(childPid, &status, 0);
+  // uh-oh cases below
+  } else if (childPid == -1) {
+    USR_FATAL("fork() failed: %s", strerror(errno));
+  } else if (childPid != 0 && !ignoreStatus) {
     USR_FATAL("%s", description);
   }
-
-  return status;
+  return WEXITSTATUS(status);
 }
+  //status = exec(execArgs.data());
+
+  //status = system(commandStr.c_str());
+
+  // if (status == -1) {
+  //   USR_FATAL("system() fork failed: %s", strerror(errno));
+
+  // } else if (status != 0 && ignoreStatus == false) {
+  //   USR_FATAL("%s", description);
+  // }
+
+  // return status;
+// }


### PR DESCRIPTION
This PR attempts to correct the behavior where arbitrary shell commands added
with a `require` statement will be executed at compile time. The issue is
described with a reproducer example here: 
https://github.com/Cray/chapel-private/issues/2262.

This change prevents this behavior only with LLVM backends. The C backend 
generates a line in the `Makefile` that is then executed through the shell.

TESTING:

- [x] Full `paratest` passes (13,208 tests)
- [x] with bundled and system LLVM, reproducer code fails to compile
- [x] reproducer code compiles and exhibits original behavior with C backend


Signed-off-by: Ahmad Rezaii ahmad.rezaii@hpe.com