### PR TITLE
Add rivalq pidigits version to pidigits graph

### DIFF
--- a/test/studies/shootout/pidigits/pidigits.graph
+++ b/test/studies/shootout/pidigits/pidigits.graph
@@ -1,5 +1,5 @@
-perfkeys: real, real, real, real, real, real, real, real
-files: pidigits-blc.dat, pidigits-iter.dat, pidigits.dat, pidigits-ledrug.dat, pidigits-BigInt.dat, pidigits-ledrug-BigInt.dat, pidigits-fast.dat, pidigits-gmp.dat
-graphkeys: brad version, iterator version, release, Ledrug, early bigint version, early Ledrug with bigint, fast release version, GMP version
+perfkeys: real, real, real, real, real, real, real, real, real
+files: pidigits-blc.dat, pidigits-iter.dat, pidigits.dat, pidigits-ledrug.dat, pidigits-BigInt.dat, pidigits-ledrug-BigInt.dat, pidigits-fast.dat, pidigits-gmp.dat, pidigits-rivalq.dat
+graphkeys: brad version, iterator version, release, Ledrug, early bigint version, early Ledrug with bigint, fast release version, GMP version, rivalq version
 ylabel: Time (seconds)
 graphtitle: Pi digits variations


### PR DESCRIPTION
This adds the @rivalq version of pidigits added in #18482 to our performance graphs so that we can easily
compare and track the results over time.