### PR TITLE
Remove trivial shouldReturnRvalueByConstRef() routine

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -792,8 +792,7 @@ class UserMapAssocArr: AbsBaseArr {
     return dsiAccess(i(0));
   }
 
-  proc dsiAccess(i: idxType) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  proc dsiAccess(i: idxType) const ref {
     const localeIndex = dom.dist.indexToLocaleIndex(i);
     const locArr = locArrs[localeIndex]!;
     if locArr.locale == here {
@@ -804,8 +803,7 @@ class UserMapAssocArr: AbsBaseArr {
     return locArr[i];
   }
 
-  proc dsiAccess(i: 1*idxType) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  proc dsiAccess(i: 1*idxType) const ref {
     return dsiAccess(i(0));
   }
 
@@ -822,8 +820,7 @@ class UserMapAssocArr: AbsBaseArr {
     return locArr[i];
   }
 
-  inline proc dsiLocalAccess(i) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  inline proc dsiLocalAccess(i) const ref {
     const localeIndex = dom.dist.indexToLocaleIndex(i);
     const locArr = locArrs[localeIndex]!;
     return locArr[i];
@@ -988,8 +985,7 @@ class LocUserMapAssocArr {
   where shouldReturnRvalueByValue(eltType) {
     return myElems(i);
   }
-  proc this(i: idxType) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  proc this(i: idxType) const ref {
     return myElems(i);
   }
 

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -514,8 +514,7 @@ class SparseBlockArr: BaseSparseArr {
     }
     return locArr[dom.dist.targetLocsIdx(i)]!.dsiAccess(i);
   }
-  proc dsiAccess(i: rank*idxType) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  proc dsiAccess(i: rank*idxType) const ref {
     local {
       if myLocArr != nil && myLocArr!.locDom.parentDom.contains(i) {
         return myLocArr!.dsiAccess(i);
@@ -533,7 +532,6 @@ class SparseBlockArr: BaseSparseArr {
   where shouldReturnRvalueByValue(eltType)
     return dsiAccess(i);
   proc dsiAccess(i: idxType...rank) const ref
-  where shouldReturnRvalueByConstRef(eltType)
     return dsiAccess(i);
 
 
@@ -595,8 +593,7 @@ class LocSparseBlockArr {
   where shouldReturnRvalueByValue(eltType) {
     return myElems[i];
   }
-  proc dsiAccess(i) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  proc dsiAccess(i) const ref {
     return myElems[i];
   }
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1251,8 +1251,7 @@ where shouldReturnRvalueByValue(eltType) {
   return do_dsiAccess(false, i);
 }
 // const ref version for types with copy-ctor
-inline proc StencilArr.dsiAccess(i: rank*idxType) const ref
-where shouldReturnRvalueByConstRef(eltType) {
+inline proc StencilArr.dsiAccess(i: rank*idxType) const ref {
   return do_dsiAccess(false, i);
 }
 
@@ -1266,7 +1265,6 @@ where shouldReturnRvalueByValue(eltType)
   return dsiAccess(i);
 // const ref version for types with copy-ctor
 inline proc StencilArr.dsiAccess(i: idxType...rank) const ref
-where shouldReturnRvalueByConstRef(eltType)
   return dsiAccess(i);
 
 inline proc StencilArr.dsiBoundsCheck(i: rank*idxType) {

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -627,8 +627,7 @@ module ArrayViewRankChange {
       return dsiAccess(i);
     }
 
-    inline proc dsiAccess(i: idxType ...rank) const ref
-      where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(i: idxType ...rank) const ref {
       return dsiAccess(i);
     }
 
@@ -651,8 +650,7 @@ module ArrayViewRankChange {
       }
     }
 
-    inline proc dsiAccess(i) const ref
-      where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(i) const ref {
       if shouldUseIndexCache() {
         const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
@@ -669,7 +667,6 @@ module ArrayViewRankChange {
       return arr.dsiLocalAccess(chpl_rankChangeConvertIdx(i, collapsedDim, idx));
 
     inline proc dsiLocalAccess(i) const ref
-      where shouldReturnRvalueByConstRef(eltType)
       return arr.dsiLocalAccess(chpl_rankChangeConvertIdx(i, collapsedDim, idx));
 
     inline proc dsiBoundsCheck(i) {

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -515,8 +515,7 @@ module ArrayViewReindex {
       return dsiAccess(i);
     }
 
-    inline proc dsiAccess(i: idxType ...rank) const ref
-      where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(i: idxType ...rank) const ref {
       return dsiAccess(i);
     }
 
@@ -539,8 +538,7 @@ module ArrayViewReindex {
       }
     }
 
-    inline proc dsiAccess(i) const ref
-      where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(i) const ref {
       if shouldUseIndexCache() {
         const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);
@@ -557,7 +555,6 @@ module ArrayViewReindex {
       return arr.dsiLocalAccess(chpl_reindexConvertIdx(i, privDom, downdom));
 
     inline proc dsiLocalAccess(i) const ref
-      where shouldReturnRvalueByConstRef(eltType)
       return arr.dsiLocalAccess(chpl_reindexConvertIdx(i, privDom, downdom));
 
     inline proc dsiBoundsCheck(i) {

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -239,8 +239,7 @@ module ArrayViewSlice {
       return dsiAccess(i);
     }
 
-    inline proc dsiAccess(i: idxType ...rank) const ref
-      where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(i: idxType ...rank) const ref {
       return dsiAccess(i);
     }
 
@@ -263,8 +262,7 @@ module ArrayViewSlice {
       }
     }
 
-    inline proc dsiAccess(i) const ref
-      where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(i) const ref {
       if shouldUseIndexCache() {
         const dataIdx = indexCache.getDataIndex(i);
         return indexCache.getDataElem(dataIdx);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2564,10 +2564,6 @@ module ChapelArray {
   }
 
   pragma "no doc"
-  proc shouldReturnRvalueByConstRef(type t) param {
-    return true;
-  }
-  pragma "no doc"
   proc shouldReturnRvalueByValue(type t) param {
     if !PODValAccess then return false;
     if isPODType(t) then return true;
@@ -2811,7 +2807,6 @@ module ChapelArray {
     pragma "no doc" // const ref version, for not-POD types
     pragma "alias scope from this"
     inline proc const this(i: rank*_value.dom.idxType) const ref
-    where shouldReturnRvalueByConstRef(_value.eltType)
     {
       const value = _value;
       if boundsChecking then
@@ -2839,7 +2834,6 @@ module ChapelArray {
     pragma "no doc" // const ref version, for not-POD types
     pragma "alias scope from this"
     inline proc const this(i: _value.dom.idxType ...rank) const ref
-    where shouldReturnRvalueByConstRef(_value.eltType)
       return this(i);
 
 
@@ -2880,7 +2874,6 @@ module ChapelArray {
     pragma "no doc" // const ref version, for not-POD types
     pragma "alias scope from this"
     inline proc const localAccess(i: rank*_value.dom.idxType) const ref
-    where shouldReturnRvalueByConstRef(_value.eltType)
     {
       const value = _value;
       if boundsChecking then
@@ -2910,7 +2903,6 @@ module ChapelArray {
     pragma "no doc" // const ref version, for not-POD types
     pragma "alias scope from this"
     inline proc const localAccess(i: _value.dom.idxType ...rank) const ref
-    where shouldReturnRvalueByConstRef(_value.eltType)
       return localAccess(i);
 
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -565,8 +565,7 @@ module DefaultAssociative {
     }
 
     // const ref version for strings, records with copy ctor
-    proc dsiAccess(idx : idxType) const ref
-    where shouldReturnRvalueByConstRef(eltType) {
+    proc dsiAccess(idx : idxType) const ref {
       // no lock needed
       var (found, slotNum) = dom.table.findFullSlot(idx);
       if found {
@@ -577,8 +576,7 @@ module DefaultAssociative {
       }
     }
 
-    proc dsiAccess(idx : 1*idxType) const ref
-    where shouldReturnRvalueByConstRef(eltType) {
+    proc dsiAccess(idx : 1*idxType) const ref {
       return dsiAccess(idx(0));
     }
 
@@ -590,7 +588,6 @@ module DefaultAssociative {
       return dsiAccess(i);
 
     inline proc dsiLocalAccess(i) const ref
-    where shouldReturnRvalueByConstRef(eltType)
       return dsiAccess(i);
 
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1327,7 +1327,7 @@ module DefaultRectangular {
       return dsiAccess(ind);
 
     inline proc dsiAccess(ind: idxType ...1) const ref
-    where rank == 1 && shouldReturnRvalueByConstRef(eltType)
+    where rank == 1
       return dsiAccess(ind);
 
     inline proc dsiAccess(ind : rank*idxType) ref {
@@ -1343,8 +1343,7 @@ module DefaultRectangular {
       return theData(dataInd);
     }
 
-    inline proc dsiAccess(ind : rank*idxType) const ref
-    where shouldReturnRvalueByConstRef(eltType) {
+    inline proc dsiAccess(ind : rank*idxType) const ref {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -483,8 +483,7 @@ module DefaultSparse {
         return irv;
     }
     // const ref version for types with copy ctors
-    proc dsiAccess(ind: rank*idxType) const ref
-    where shouldReturnRvalueByConstRef(eltType) {
+    proc dsiAccess(ind: rank*idxType) const ref {
       // make sure we're in the dense bounding box
       if boundsChecking then
         if !(dom.parentDom.contains(ind)) then

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -683,8 +683,7 @@ class CSArr: BaseSparseArrImpl {
       return irv;
   }
   // const ref version for types with copy ctors
-  proc dsiAccess(ind: rank*idxType) const ref
-  where shouldReturnRvalueByConstRef(eltType) {
+  proc dsiAccess(ind: rank*idxType) const ref {
     // make sure we're in the dense bounding box
     dom.boundsCheck(ind);
 

--- a/modules/packages/OrderedMap.chpl
+++ b/modules/packages/OrderedMap.chpl
@@ -285,7 +285,7 @@ module OrderedMap {
 
     pragma "no doc"
     proc const this(k: keyType) const ref
-    where shouldReturnRvalueByConstRef(valType) && !isNonNilableClass(valType) {
+    where !isNonNilableClass(valType) {
       _enter(); defer _leave();
 
       // Could halt

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -337,7 +337,7 @@ module Map {
 
     pragma "no doc"
     proc const this(k: keyType) const ref
-    where shouldReturnRvalueByConstRef(valType) && !isNonNilableClass(valType) {
+    where !isNonNilableClass(valType) {
       _warnForParSafeIndexing();
 
       _enter(); defer _leave();

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -1010,13 +1010,11 @@ inline proc AccumStencilArr.dsiAccess(i: rank*idxType) ref {
   return do_dsiAccess(true, i);
 }
 // value version for POD types
-inline proc AccumStencilArr.dsiAccess(i: rank*idxType)
-where shouldReturnRvalueByValue(eltType) {
+inline proc AccumStencilArr.dsiAccess(i: rank*idxType) {
   return do_dsiAccess(false, i);
 }
 // const ref version for types with copy-ctor
-inline proc AccumStencilArr.dsiAccess(i: rank*idxType) const ref
-where shouldReturnRvalueByConstRef(eltType) {
+inline proc AccumStencilArr.dsiAccess(i: rank*idxType) const ref {
   return do_dsiAccess(false, i);
 }
 


### PR DESCRIPTION
This routine was defined to always return 'param true', so just
removed it and all where clauses referring to it.  I happened
across this while helping others navigate ways of creating an
array implementation that returns classes instead of eltTypes
while exploring workarounds for issue #17999.