### PR TITLE
Fix .bad mismatch for different source file in internal error

### DIFF
--- a/test/functions/iterators/bradc/captureEmpty.bad
+++ b/test/functions/iterators/bradc/captureEmpty.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelTuple.chpl:nnnn: internal error: AST-FNS-BOL-nnnn chpl version mmmm
+internal error: RES-CLE-UPS-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 


### PR DESCRIPTION
Test change only - not reviewed. Follow-up to #18601.