### PR TITLE
Update script to performance test LLVM 12

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -34,12 +34,12 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 GITHUB_USER=daviditen
 GITHUB_BRANCH=upgrade-llvm-12
 SHORT_NAME=llvm12
-START_DATE=10/04/21
+START_DATE=10/25/21
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
-perf_args="-performance-description $SHORT_NAME -performance-configs llvm:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
+perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args} -compopts -senablePostfixBangChecks


### PR DESCRIPTION
Update the chapcs performance playground script to test LLVM 12.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>