### PR TITLE
Fix c2chapel test to use Subprocess instead of Spawn

### DIFF
--- a/test/c2chapel/c2chapel-tester.chpl
+++ b/test/c2chapel/c2chapel-tester.chpl
@@ -1,8 +1,8 @@
-import Spawn;
+import Subprocess;
 
 var testdir = CHPL_HOME + "/tools/c2chapel/test/";
 var command = "cd %s; ./tester.sh".format(testdir);
-var sub = Spawn.spawnshell(command);
+var sub = Subprocess.spawnshell(command);
 sub.communicate();
 if sub.exitCode==0 then
   writeln("OK");


### PR DESCRIPTION
This c2chapel test was using Spawn instead of Subprocess still. It only runs
if c2chapel is built, so I missed it in the first pass.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>