### PR TITLE
Use more recent cmake installs in common_llvm.bash

### DIFF
--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -48,7 +48,7 @@ if test "$CHPL_LLVM" = bundled; then
         source ${cmake_setup}
     else
         # This is the path to look for on CS systems we have
-        cmake_setup=/cray/css/users/chapelu/setup_cmake321.bash
+        cmake_setup=/cray/css/users/chapelu/setup_cmake_nightly.bash
         if [ -f "${cmake_setup}" ] ; then
             source ${cmake_setup}
         else


### PR DESCRIPTION
util/cron/common_llvm.bash was sourcing setup_cmake39.bash which sets up
cmake-3.9. Change it to use either setup_cmake_nightly.bash or
setup_cmake321.bash which both set up cmake-3.21.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>