### PR TITLE
Fix Arkouda XC release testing

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -9,7 +9,6 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda.release"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
-source $CWD/common-llvm-comp-path.bash
 export ARKOUDA_NUMLOCALES=16
 
 module list
@@ -17,12 +16,11 @@ module list
 # setup for XC perf (ugni, gnu, 28-core broadwell)
 module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
-# avoid gcc 11 warnings fixed in https://github.com/chapel-lang/chapel/pull/18178
-module swap gcc gcc/10.3.0
 module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp
+source $CWD/common-llvm-comp-path.bash
 
 module list
 


### PR DESCRIPTION
Follow on to #18621, correct where we set the compiler path and stop
loading an older gcc.
