### PR TITLE
Remove the .bad and .future for this now passing test

### DIFF
--- a/test/modules/vass/use-a-Reflection-function.bad
+++ b/test/modules/vass/use-a-Reflection-function.bad
@@ -1,1 +1,0 @@
-use-a-Reflection-function.chpl:6: error: 'use' of non-module/enum symbol numFields

--- a/test/modules/vass/use-a-Reflection-function.future
+++ b/test/modules/vass/use-a-Reflection-function.future
@@ -1,2 +1,0 @@
-incorrect error for some cases of 'use FN;'
-#14535


### PR DESCRIPTION
The test was failing before due to not respecting private uses and imports when
validating use and import statements.  #18622 fixed that issue, so remove the
.bad and .future file from this test.

Checking a fresh checkout of the test

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>