### PR TITLE
Fix an error in 'make docs' exit code

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -63,7 +63,7 @@ docs: FORCE
 	@COMP_DOCS_ERROR=0 ; \
 	(cd ../compiler/next && $(MAKE) -f Makefile.help libchplcomp-docs) || \
 	 COMP_DOCS_ERROR=1 ; \
-	$(MAKE) html-release || $(MAKE) error_docs ; \
+	$(MAKE) html-release && \
 	if [ $$COMP_DOCS_ERROR -ne 0 -o ! -d $(COMPILER_INTERNALS_DOXYGEN) ] ; \
 	  then \
 	  echo ; \
@@ -195,10 +195,6 @@ clean-symlinks: FORCE
 
 clean-doxygen: FORCE
 	cd ../compiler/next && $(MAKE) -f Makefile.help clean-libchplcomp-docs
-
-error_docs: FORCE
-	@exit 1 # Note that 'make' will return exit code of 2, despite exit 1
-
 
 FORCE:
 


### PR DESCRIPTION
Follow up to PRs #6256 #18519 #18538

I noticed in PR #18619 an error in `make docs` was not reported to the GitHub CI. This PR is intended to fix that.

Adjusts the 'make docs' Makefile rule to exit with a nonzero exit code in the case that `make html-release` fails.

Reviewed by @Maxrimus - thanks!