### PR TITLE
Use Subprocess instead of Spawn in HDF5 test

### DIFF
--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -15,7 +15,7 @@ module HDF5Preprocessors {
     const script: string;
 
     override proc preprocess(A: []) {
-      use FileSystem, Path, Spawn;
+      use FileSystem, Path, Subprocess;
 
       try! {
         // opentmp() doesn't seem to give me a file I can get the name of :(


### PR DESCRIPTION
The HDF5Preprocess.chpl file was still using Spawn instead of Subprocess. Fix
that.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>