### PR TITLE
Add skipif for mapOfArray test under baseline

### DIFF
--- a/test/library/standard/Map/mapOfArray.skipif
+++ b/test/library/standard/Map/mapOfArray.skipif
@@ -1,0 +1,4 @@
+# baseline causes this test to fail in the `_moveInit`
+# private proc in `chpl__hashtable`.
+
+COMPOPTS <= --baseline


### PR DESCRIPTION
The `test/library/standard/Map/mapOfArray.chpl` test fails under baseline with a nil dereference coming from the `_moveInit()` function and should be investigated further. I suspect that this is due to the `_ddata` not properly 0 initializing the array in this case since the value type is an array, but haven't dug into enough to know if this is the case.

Adding a `writeln(tableEntry);` in the `fillSlot()` function is a simple way to reproduce this error without baseline. 

See issue https://github.com/Cray/chapel-private/issues/2644