### PR TITLE
Empty regex matching

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -895,7 +895,7 @@ record regex {
 
     var nfound = 0;
     var cur = pos;
-    while nfound < maxmatches && cur < endpos {
+    while nfound < maxmatches && cur <= endpos {
       var got:bool;
       on this.home {
         got = qio_regex_match(_regex, text.localize().c_str(), textLength, cur:int, endpos:int, QIO_REGEX_ANCHOR_UNANCHORED, matches, nmatches);
@@ -907,7 +907,7 @@ record regex {
         ret[i] = new regexMatch(got, matches[i].offset:byteIndex, matches[i].len);
       }
       yield ret;
-      cur = matches[0].offset + matches[0].len;
+      cur = matches[0].offset + max(1, matches[0].len);
     }
     on this.home {
       _ddata_free(matches, nmatches);

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -296,9 +296,11 @@ qio_bool qio_regex_match(qio_regex_t* regex, const char* text, int64_t text_len,
       submatch[i].len = 0;
     } else {
       intptr_t diff = 0;
-      if( ! spPtr[i].empty() ) {
+      if( spPtr[i].empty() ) {
+        diff = startpos;
+      } else {
         diff = qio_ptr_diff((void*) spPtr[i].data(), (void*) textp.data());
-        assert( diff >= 0 && diff <= endpos );
+        assert( diff >= startpos && diff <= endpos );
       }
       submatch[i].offset = diff;
       submatch[i].len = spPtr[i].length();

--- a/test/regex/emptyregex.chpl
+++ b/test/regex/emptyregex.chpl
@@ -1,0 +1,32 @@
+use Regex;
+
+var r = compile("");
+var s = "one";
+assert(r.match(s).matched);
+assert(!r.fullMatch(s).matched);
+assert(r.search(s).matched);
+
+var matches = r.matches(s);
+assert(matches.size == (s.size + 1));
+writeln(matches.size);
+for (i, (match,)) in zip(matches.domain, matches) {
+  writeln("offset=", match.offset);
+  assert(i == match.offset);
+}
+
+writeln();
+
+for x in compile("a").split("babbbba") do
+  writef("%t\n", x);
+
+writeln();
+
+for x in compile("z").split("babbbba") do
+  writef("%t\n", x);
+
+writeln();
+for x in r.split(s) do
+  writef("%t\n", x);
+
+writeln();
+writeln(r.subn("A", "one"));

--- a/test/regex/emptyregex.good
+++ b/test/regex/emptyregex.good
@@ -1,0 +1,19 @@
+4
+offset=0
+offset=1
+offset=2
+offset=3
+
+"b"
+"bbbb"
+""
+
+"babbbba"
+
+""
+"o"
+"n"
+"e"
+""
+
+(AoAnAeA, 4)


### PR DESCRIPTION
This fixes user issue https://github.com/chapel-lang/chapel/issues/18639 where an empty regex ie `compile("")` was infinitely looping on `iter matches`.

I also found that split behaved in a similar infinite loop and I've fixed it as well.

 * [x] Paratest passed