### PR TITLE
add CLEANFILE for mason test

### DIFF
--- a/test/mason/mason-help-tests/CLEANFILES
+++ b/test/mason/mason-help-tests/CLEANFILES
@@ -1,0 +1,1 @@
+mason_home/


### PR DESCRIPTION
This PR adds the `CLEANFILES` file to the `mason/mason-help-test`
directory to remove the `mason_home` subdirectory between runs.

Also includes `mason_home.notest` to skip evaluating it for tests.

TESTING:

- [x] `mason_home` replaced between test runs
- [x] `mason_home` skipped when evaluating folders for tests

Reviewed by @mppf 

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>