### PR TITLE
Fix test that previously expected fatbin file to be output.

### DIFF
--- a/test/gpu/native/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums.chpl
@@ -38,24 +38,6 @@ extern {
       checkCudaErrors(cuCtxCreate(&context, CU_CTX_BLOCKING_SYNC, device), 5);
     }
 
-    /*char * buffer = 0;
-    long length;
-    FILE * f = fopen (FATBIN_FILE, "rb");
-
-    if (f)
-    {
-      fseek (f, 0, SEEK_END);
-      length = ftell (f);
-      fseek (f, 0, SEEK_SET);
-      buffer = (char* )malloc (length);
-      if (buffer)
-      {
-        fread (buffer, 1, length, f);
-      }
-      fclose (f);
-    }*/
-
-
     checkCudaErrors(cuModuleLoadData(&cudaModule, chpl_gpuBinary), 6);
 
     checkCudaErrors(cuModuleGetFunction(&function, cudaModule, "add_nums"), 7);

--- a/test/gpu/native/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums.chpl
@@ -14,6 +14,8 @@ extern {
     }
   }
 
+  extern char* chpl_gpuBinary;
+
   static double launchKernel(){
     CUdevice    device;
     CUmodule    cudaModule;
@@ -36,7 +38,7 @@ extern {
       checkCudaErrors(cuCtxCreate(&context, CU_CTX_BLOCKING_SYNC, device), 5);
     }
 
-    char * buffer = 0;
+    /*char * buffer = 0;
     long length;
     FILE * f = fopen (FATBIN_FILE, "rb");
 
@@ -51,10 +53,10 @@ extern {
         fread (buffer, 1, length, f);
       }
       fclose (f);
-    }
+    }*/
 
 
-    checkCudaErrors(cuModuleLoadData(&cudaModule, buffer), 6);
+    checkCudaErrors(cuModuleLoadData(&cudaModule, chpl_gpuBinary), 6);
 
     checkCudaErrors(cuModuleGetFunction(&function, cudaModule, "add_nums"), 7);
 


### PR DESCRIPTION
Fixing the gpuAddNums test failure in Jenkins noted here:

https://chapel-ci.us.cray.com/job/cray-cs-correctness-test-cray-cs-gpu-native/246/testReport/(root)/gpu_native_gpuAddNums/gpuAddNums/

Introduced by this PR:

https://github.com/chapel-lang/chapel/pull/18628

I missed this failure in failure in paratests since we don't run the GPU tests and missed it on my manual run of those tests in Osprey as the fatbin file was left around from a previous testrun and I didn't clean up the environment between runs.