### PR TITLE
Remove old chplenv logic about CHPL_COMM=ofi substrates

### DIFF
--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -21,12 +21,6 @@ def get():
                 substrate_val = 'ibv'
             else:
                 substrate_val = 'udp'
-        elif comm_val == 'ofi':
-            if platform_val == 'cray-xc':
-                substrate_val = 'sockets'
-                # substrate_val = 'gni'
-            else:
-                substrate_val = 'sockets'
         else:
             substrate_val = 'none'
     return substrate_val


### PR DESCRIPTION
Remove some old and unused chplenv code for inferring substrates for
ofi. Substrates (providers under ofi) are selected at execution time and
not baked into the build time path, so this code isn't needed.

It was added and used in the initial OFI commit (d1aa83ea9b), but the
runtime code that used it has long since been removed.