### PR TITLE
include cstdarg for va_list declaration

### DIFF
--- a/compiler/next/include/chpl/queries/ErrorMessage.h
+++ b/compiler/next/include/chpl/queries/ErrorMessage.h
@@ -22,6 +22,7 @@
 
 #include "chpl/queries/Location.h"
 
+#include <cstdarg>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Hi,
While building the compiler I hit an error where va_list was not declared. I'm not sure why this is not a problem for anyone else as the code clearly uses va_list but there is no stdarg include.

Anyways, with this diff the chapel compiler builds successfully on OpenBSD 7.0 amd64 with clang.

Kyle