### PR TITLE
Ignore and warn for extern inline

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -72,7 +72,11 @@ static void inlineFunctionsImpl() {
     forv_Vec(FnSymbol, fn, gFnSymbols) {
       if (fn->hasFlag(FLAG_INLINE) == true &&
           inlinedSet.find(fn)      == inlinedSet.end()) {
-        inlineFunction(fn, inlinedSet);
+        if (fn->hasFlag(FLAG_EXTERN)) {
+          USR_WARN(fn, "inline keyword has no effect an 'extern proc'");
+        } else {
+          inlineFunction(fn, inlinedSet);
+        }
       }
     }
   }
@@ -350,6 +354,8 @@ static void inlineCleanup() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     if (fNoInline                 == false &&
         fn->hasFlag(FLAG_INLINE)  ==  true &&
+        fn->hasFlag(FLAG_EXTERN)  ==  false &&
+        fn->hasFlag(FLAG_EXPORT)  ==  false &&
         fn->hasFlag(FLAG_VIRTUAL) == false) {
       fn->defPoint->remove();
     } else {

--- a/test/extern/ferguson/extern-inline.chpl
+++ b/test/extern/ferguson/extern-inline.chpl
@@ -1,0 +1,9 @@
+// test from issue #18672
+
+use SysCTypes;
+
+extern "strlen"        proc f1(c_string): size_t;
+extern "strlen" inline proc f2(c_string): size_t;
+
+writeln(f1("what's the length of this?"));
+writeln(f2("and of this?"));

--- a/test/extern/ferguson/extern-inline.good
+++ b/test/extern/ferguson/extern-inline.good
@@ -1,0 +1,3 @@
+extern-inline.chpl:6: warning: inline keyword has no effect an 'extern proc'
+26
+12


### PR DESCRIPTION
Resolves #18672

Adjusts the compiler to ignore `inline` for `extern proc`s and to warn in that case.

Reviewed by @ronawho - thanks!

- [x] full local testing