### PR TITLE
Add user-facing error when indexing into an enum type

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3194,7 +3194,7 @@ static Type* resolveTypeSpecifier(CallInfo& info) {
     }
   }
 
-  if (isPrimitiveType(tsType)) {
+  if (isPrimitiveType(tsType) || at == NULL) {
     USR_FATAL_CONT(info.call, "illegal type index expression '%s'", info.toString());
     USR_PRINT(info.call, "primitive type '%s' cannot be used in an index expression", tsType->symbol->name);
     USR_STOP();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3194,9 +3194,11 @@ static Type* resolveTypeSpecifier(CallInfo& info) {
     }
   }
 
-  if (isPrimitiveType(tsType) || at == NULL) {
+  if (at == NULL) {
     USR_FATAL_CONT(info.call, "illegal type index expression '%s'", info.toString());
-    USR_PRINT(info.call, "primitive type '%s' cannot be used in an index expression", tsType->symbol->name);
+    const char* typeclass = (isPrimitiveType(tsType) ? "primitive type" :
+                             (isEnumType(tsType) ? "enum type" : "type"));
+    USR_PRINT(info.call, "%s '%s' cannot be used in an index expression", typeclass, tsType->symbol->name);
     USR_STOP();
   } else if (at->symbol->hasFlag(FLAG_TUPLE)) {
     SymbolMap subs;

--- a/test/types/enum/indexEnumType.chpl
+++ b/test/types/enum/indexEnumType.chpl
@@ -1,0 +1,2 @@
+enum testEnum {a, b, c};
+testEnum[0];

--- a/test/types/enum/indexEnumType.good
+++ b/test/types/enum/indexEnumType.good
@@ -1,0 +1,2 @@
+indexEnumType.chpl:2: error: illegal type index expression 'testEnum[0]'
+indexEnumType.chpl:2: note: enum type 'testEnum' cannot be used in an index expression


### PR DESCRIPTION
This adds a user-facing error when a user indexes into an enum type, where before it
caused a segfault.  It also adds a test to lock the behavior in.

Resolves https://github.com/chapel-lang/chapel/issues/18674.

