### PR TITLE
stop having 'notcompiler' make 'chpldoc'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ comprt: FORCE
 notcompiler: FORCE
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) always-build-test-venv
-	@$(MAKE) always-build-chpldoc
 	@$(MAKE) runtime
 	@$(MAKE) modules
 


### PR DESCRIPTION
Currently, 'notcompiler' attempts to build 'chpldoc' which seems
contradictory since 'chpldoc' requires building the compiler.
This removes that rule.
