### PR TITLE
Fix missing word in error message, skip test on baseline

### DIFF
--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -73,7 +73,7 @@ static void inlineFunctionsImpl() {
       if (fn->hasFlag(FLAG_INLINE) == true &&
           inlinedSet.find(fn)      == inlinedSet.end()) {
         if (fn->hasFlag(FLAG_EXTERN)) {
-          USR_WARN(fn, "inline keyword has no effect an 'extern proc'");
+          USR_WARN(fn, "inline keyword has no effect on an 'extern proc'");
         } else {
           inlineFunction(fn, inlinedSet);
         }

--- a/test/extern/ferguson/extern-inline.good
+++ b/test/extern/ferguson/extern-inline.good
@@ -1,3 +1,3 @@
-extern-inline.chpl:6: warning: inline keyword has no effect an 'extern proc'
+extern-inline.chpl:6: warning: inline keyword has no effect on an 'extern proc'
 26
 12

--- a/test/extern/ferguson/extern-inline.skipif
+++ b/test/extern/ferguson/extern-inline.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
Follow-up to PR #18673.

Addresses a testing failure with `--baseline` and fixes a missing word in the error message.

Reviewed by @ronawho - thanks!