### PR TITLE
Fix docs for *Dim

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -26,12 +26,14 @@ config param debugUserMapAssoc = false;
 // Returns an integer index into targetLocales
 // b/c this matches best with the expected use and it is
 // easy to guarantee that the returned locale is in the target set.
+pragma "no doc"
 record AbstractMapper {
   proc this(const ref ind, const ref targetLocales: [?D] locale) : D.idxType {
     return 0;
   }
 }
 
+pragma "no doc"
 record DefaultMapper {
   proc this(ind, targetLocales: [?D] locale) : D.idxType {
     const hash = chpl__defaultHashWrapper(ind);

--- a/modules/dists/fixDistDocs.perl
+++ b/modules/dists/fixDistDocs.perl
@@ -63,19 +63,13 @@ sub process {
          my $usageFirstLine = <RST>;
          $usageFirstLine =~ /^\*\*Usage\*\*/ or die "Expected usage information, got $usageFirstLine";
          print MOD $usageFirstLine;
-         # the next five lines are anticipated to be a continuation of the
+         # the next eleven lines are anticipated to be a continuation of the
          # usage output.  We don't really need to validate that, that's what our
          # testing system is for.
-         my $usageNextLine = <RST>;
-         print MOD $usageNextLine;
-         $usageNextLine = <RST>;
-         print MOD $usageNextLine;
-         $usageNextLine = <RST>;
-         print MOD $usageNextLine;
-         $usageNextLine = <RST>;
-         print MOD $usageNextLine;
-         $usageNextLine = <RST>;
-         print MOD $usageNextLine;
+         for (1..11) {
+             my $usageNextLine = <RST>;
+             print MOD $usageNextLine;
+         }
          last;
       }
    }

--- a/modules/dists/fixDistDocs.perl
+++ b/modules/dists/fixDistDocs.perl
@@ -80,9 +80,9 @@ sub process {
       }
    }
 
-   # Skip everything until "class::", edit that line and print.
+   # Skip everything until "class::" or "record::", edit that line and print.
    while (<RST>) {
-      if (/^.. class::/) {
+      if (/^.. (class|record)::/) {
          s/ : Base.*//;
          print MOD;
          last;


### PR DESCRIPTION
Previously, the docs for BlockDim and friends were not showing up because they used a record instead of a class. This fixes the fix script to output them correctly.

The "no doc" to HashedDist is because it has earlier `record`s defined
that then cause the real docs to get dropped. A proper fix would be to
"no doc" all the things and eliminate the fixDistDocs.perl

Tested by building docs locally and verifying all docs in `modules/dists` are visible in the HTML docs.