### PR TITLE
Add newline between compile commands of the generated code

### DIFF
--- a/runtime/etc/Makefile.exe
+++ b/runtime/etc/Makefile.exe
@@ -24,17 +24,20 @@ include $(CHPL_MAKE_HOME)/runtime/etc/Makefile.include
 
 all: $(TMPBINNAME)
 
-blank :=
-define newline
+# We need to put a newline between the backend launches. Otherwise, the
+# `foreach` below will generate a huge one-liner that will be longer than some
+# systems could handle.
+BLANK :=
+define NEWLINE
 
-$(blank)
+$(BLANK)
 endef
 
 $(TMPBINNAME): $(CHPL_CL_OBJS) checkRtLibDir FORCE
 	$(TAGS_COMMAND)
 ifneq ($(SKIP_COMPILE_LINK),skip)
 	$(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) -c -o $(TMPBINNAME).o $(CHPL_RT_INC_DIR) $(CHPLSRC)
-	$(foreach srcFile, $(CHPLUSEROBJ),$(newline)$(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) -c -o $(srcFile) $(CHPL_RT_INC_DIR) $(srcFile).c ;)
+	$(foreach srcFile, $(CHPLUSEROBJ),$(NEWLINE)$(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) -c -o $(srcFile) $(CHPL_RT_INC_DIR) $(srcFile).c ;)
 	$(LD) $(CHPL_MAKE_BASE_LFLAGS) \
               $(COMP_GEN_USER_LDFLAGS) $(GEN_LFLAGS) $(COMP_GEN_LFLAGS) \
               -o $(TMPBINNAME) $(TMPBINNAME).o $(CHPLUSEROBJ) \

--- a/runtime/etc/Makefile.exe
+++ b/runtime/etc/Makefile.exe
@@ -24,11 +24,17 @@ include $(CHPL_MAKE_HOME)/runtime/etc/Makefile.include
 
 all: $(TMPBINNAME)
 
+blank :=
+define newline
+
+$(blank)
+endef
+
 $(TMPBINNAME): $(CHPL_CL_OBJS) checkRtLibDir FORCE
 	$(TAGS_COMMAND)
 ifneq ($(SKIP_COMPILE_LINK),skip)
 	$(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) -c -o $(TMPBINNAME).o $(CHPL_RT_INC_DIR) $(CHPLSRC)
-	$(foreach srcFile, $(CHPLUSEROBJ),$(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) -c -o $(srcFile) $(CHPL_RT_INC_DIR) $(srcFile).c ;)
+	$(foreach srcFile, $(CHPLUSEROBJ),$(newline)$(CC) $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) -c -o $(srcFile) $(CHPL_RT_INC_DIR) $(srcFile).c ;)
 	$(LD) $(CHPL_MAKE_BASE_LFLAGS) \
               $(COMP_GEN_USER_LDFLAGS) $(GEN_LFLAGS) $(COMP_GEN_LFLAGS) \
               -o $(TMPBINNAME) $(TMPBINNAME).o $(CHPLUSEROBJ) \


### PR DESCRIPTION
This PR adds newline between the compilation commands of the generated code.

Context: CHAMPS team tried to use `--incremental` to reduce the backend's memory
footprint. But they got errors from `exec` command because we were simply
running a huge one-liner to compile the generated code. Note that the
compilation of individual files were still separated, but only with `;`. So it
was still a single huge argument for execvp.

I am not fond of the solution but we couldn't think of any other quick alternative.

Test
- [x] linux64 --incremental in examples
- [x] linux64 --no-local --incremental in examples
- [x] linux64
 
