### PR TITLE
fix primer makefile to not build interopWithC helper makefile on 'make clean'

### DIFF
--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -38,6 +38,8 @@ TARGETS = \
 	varargs \
 	variables \
 
+CLEAN_TARGETS=$(TARGETS)
+
 #
 # Only make FFTW if FFTW_DIR is set or we can find the fftw library
 #
@@ -45,11 +47,13 @@ ifdef FFTW_DIR
 	TARGETS += FFTWlib
 	FFTW_OPTS = -I$(FFTW_DIR)/include -L$(FFTW_DIR)/lib
 endif
+CLEAN_TARGETS += FFTWlib
 
 ifdef CRAY_LIBSCI_PREFIX_DIR
 	TARGETS += LAPACKlib LinearAlgebralib
 	LAPACK_OPTS = -lgfortran -lsci_gnu
 endif
+CLEAN_TARGETS += LAPACKlib LinearAlgebralib
 
 #
 # Only make interopWithC if LLVM backend is set
@@ -58,16 +62,17 @@ CHPL_TARGET_COMPILER=$(shell $(CHPL_HOME)/util/chplenv/chpl_compiler.py --target
 ifeq ($(CHPL_TARGET_COMPILER),llvm)
 	TARGETS += interopWithC
 endif
-
+CLEAN_TARGETS += interopWithC
 
 REALS = $(TARGETS:%=%_real)
+CLEAN_REALS = $(CLEAN_TARGETS:%=%_real)
 
 default: all
 
 all: $(TARGETS)
 
 clean: FORCE
-	rm -rf $(TARGETS) $(REALS) lib/
+	rm -rf $(CLEAN_TARGETS) $(CLEAN_REALS) lib/
 
 %: %.chpl
 	+$(CHPL) -o $@ $<

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -63,6 +63,7 @@ ifeq ($(CHPL_TARGET_COMPILER),llvm)
 	TARGETS += interopWithC
 endif
 CLEAN_TARGETS += interopWithC
+CLEAN_TARGETS += cClient
 
 REALS = $(TARGETS:%=%_real)
 CLEAN_REALS = $(CLEAN_TARGETS:%=%_real)
@@ -89,5 +90,9 @@ INTEROP_DEPS = interopWithC.chpl cHelper.h cHelper.c fact.h fact.c
 interopWithC: $(INTEROP_DEPS)
 	+$(CHPL) $(INTEROP_DEPS) $(INTEROP_LIB_OPTS)
 	+$(CHPL) -o $@ $^
+	@echo "--------------------------------------------------------------"
+	@echo "Built interopWithC library. Run "make -f Makefile.cClient" to "
+	@echo "build a C client that uses this library."
+	@echo "--------------------------------------------------------------"
 
 FORCE:

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -52,11 +52,10 @@ ifdef CRAY_LIBSCI_PREFIX_DIR
 endif
 
 #
-# Only make interopWithC and cClient if LLVM backend is set
+# Only make interopWithC if LLVM backend is set
 #
 CHPL_TARGET_COMPILER=$(shell $(CHPL_HOME)/util/chplenv/chpl_compiler.py --target)
 ifeq ($(CHPL_TARGET_COMPILER),llvm)
-	TARGETS += cClient
 	TARGETS += interopWithC
 endif
 
@@ -79,13 +78,11 @@ FFTWlib: FFTWlib.chpl
 LAPACKlib: LAPACKlib.chpl
 	+$(CHPL) -o $@ $(LAPACK_OPTS) $<
 
-CCLIENT_OPTS = -Llib/ -linteropWithC `$CHPL_HOME/util/config/compileline --libraries`
 INTEROP_LIB_OPTS =  --library --library-makefile --savec ccode
 INTEROP_DEPS = interopWithC.chpl cHelper.h cHelper.c fact.h fact.c
 
 interopWithC: $(INTEROP_DEPS)
 	+$(CHPL) $(INTEROP_DEPS) $(INTEROP_LIB_OPTS)
 	+$(CHPL) -o $@ $^
-
 
 FORCE:

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -68,7 +68,7 @@ default: all
 all: $(TARGETS)
 
 clean: FORCE
-	rm -f $(TARGETS) $(REALS)
+	rm -rf $(TARGETS) $(REALS) lib/
 
 %: %.chpl
 	+$(CHPL) -o $@ $<
@@ -84,15 +84,8 @@ INTEROP_LIB_OPTS =  --library --library-makefile --savec ccode
 INTEROP_DEPS = interopWithC.chpl cHelper.h cHelper.c fact.h fact.c
 
 interopWithC: $(INTEROP_DEPS)
+	+$(CHPL) $(INTEROP_DEPS) $(INTEROP_LIB_OPTS)
 	+$(CHPL) -o $@ $^
 
-
-lib/Makefile.interopWithC:
-	+$(CHPL) $(INTEROP_DEPS) $(INTEROP_LIB_OPTS)
-
--include lib/Makefile.interopWithC
-
-cClient: cClient.test.c interopWithC.chpl
-	+$(CHPL_COMPILER) $(CHPL_CFLAGS) -o $@ $< $(CHPL_LDFLAGS)
 
 FORCE:

--- a/test/release/examples/primers/Makefile.cClient
+++ b/test/release/examples/primers/Makefile.cClient
@@ -1,3 +1,9 @@
+# This makefile is for building the cClient portion of the interopWithC primer.
+# The interopWithC target of the main makefile generates a library and helper
+# makefile (lib/Makefile.interopWithC), which defines variables that aid in
+# linking to the library. This Makefile you're viewing now (Makefile.cClient)
+# creates a C Client that links and uses the library.
+
 TARGETS = cClient
 
 default: all
@@ -7,12 +13,14 @@ all: $(TARGETS)
 clean: FORCE
 	rm -f $(TARGETS)
 
+# If not doing 'make clean', ensure that user built the helper Makefile
 ifneq ($(MAKECMDGOALS),clean)
   ifeq (,$(wildcard lib/Makefile.interopWithC))
     $(error Helper Makefile not found, run "make interopWithC" first)
   endif
 endif
 
+# Include helper makefile
 -include lib/Makefile.interopWithC
 
 cClient: cClient.test.c interopWithC.chpl

--- a/test/release/examples/primers/Makefile.cClient
+++ b/test/release/examples/primers/Makefile.cClient
@@ -1,0 +1,21 @@
+TARGETS = cClient
+
+default: all
+
+all: $(TARGETS)
+
+clean: FORCE
+	rm -f $(TARGETS)
+
+ifneq ($(MAKECMDGOALS),clean)
+  ifeq (,$(wildcard lib/Makefile.interopWithC))
+    $(error Helper Makefile not found, run "make interopWithC" first)
+  endif
+endif
+
+-include lib/Makefile.interopWithC
+
+cClient: cClient.test.c interopWithC.chpl
+	+$(CHPL_COMPILER) $(CHPL_CFLAGS) -o $@ $< $(CHPL_LDFLAGS)
+
+FORCE:

--- a/test/release/examples/primers/README
+++ b/test/release/examples/primers/README
@@ -45,3 +45,7 @@ demonstrate Chapel feature areas in detail.
 
      chplvis                     : A directory containing a primer on the chplvis tool
 
+To build these clients run make (optionally passing the name of the primer to
+build). The interopWithC primer builds a library that can be used by a C
+client, to build the C client part of this primer run:
+`make -f Makefile.cClient`.

--- a/test/release/examples/primers/interopWithC.chpl
+++ b/test/release/examples/primers/interopWithC.chpl
@@ -158,10 +158,15 @@ module interopWithC {
    but can be made simpler through the use of the ``--library-makefile`` flag
    as described in :ref:`readme-libraries-linking`.
    
-   An example of compiling a C program with a generated Chapel library using the
-   generated Makefile can be found in the `Makefile
-   <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile>`_
-   for the primers directory, to build this source file.
+   An example of compiling a C program with a generated Chapel library using
+  the generated Makefile can be found under the `interopWithC` target in the
+  `Makefile
+  <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile>`_
+  for the primers directory, to build this source file.  An example of using the
+  generated Makefile can be seen in `Makefile.cClient`
+  <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile.cClient>.
+  To build the C client, first run `make interopWithC` then run `make -f
+  Makefile.cClient`.
 */ 
 
 /*

--- a/test/release/examples/primers/interopWithC.chpl
+++ b/test/release/examples/primers/interopWithC.chpl
@@ -163,8 +163,8 @@ module interopWithC {
   `Makefile
   <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile>`_
   for the primers directory, to build this source file.  An example of using the
-  generated Makefile can be seen in `Makefile.cClient`
-  <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile.cClient>.
+  generated Makefile can be seen in `Makefile.cClient
+  <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile.cClient>`_.
   To build the C client, first run `make interopWithC` then run `make -f
   Makefile.cClient`.
 */ 


### PR DESCRIPTION
This is to fix the issue with `make clean` building the interop primer: https://github.com/chapel-lang/chapel/issues/18464

I detail the issue in this comment: https://github.com/chapel-lang/chapel/issues/18464#issuecomment-928148125 and the bottom half of this comment: https://github.com/chapel-lang/chapel/issues/18464#issuecomment-931801614

The punchline is the Makefile for primers included this line:

`-include lib/Makefile.interopWithC`

Which links to a "helper Makefile" that we generate for the interop primer. The (main primer) Makefile includes a target to build this helper Makefile and this target would be executed indiscriminately, even when doing `make clean`. In this PR I solve this problem by having the helper Makefile generated as part of the interopWithC target and separating the include line (and the target for the cClient) into a separate Makefile `Makefile.cClient`.

I detail this solution in the comment here: https://github.com/chapel-lang/chapel/issues/18464#issuecomment-943594240

I also update the primer to note the existence of these two files.