### PR TITLE
Use non-generic functions for some low-level array operations

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3540,7 +3540,7 @@ module ChapelArray {
   // _instance is a subclass of BaseArr.  LYDIA NOTE: moved this from
   // being a method on _array so that it could be called on unwrapped
   // _instance fields
-  inline proc _do_destroy_arr(_unowned: bool, _instance, deinitElts=true) {
+  inline proc _do_destroy_arr(_unowned: bool, _instance: BaseArr, deinitElts=true) {
     if ! _unowned {
       on _instance {
         param arrIsInList = !_instance.isSliceArrayView();
@@ -3583,7 +3583,7 @@ module ChapelArray {
     }
   }
   inline proc _do_destroy_array(array: _array, deinitElts=true) {
-    _do_destroy_arr(array._unowned, array._instance, deinitElts);
+    _do_destroy_arr(array._unowned, array._instance:BaseArr, deinitElts);
   }
 
   proc _deinitElementsIsParallel(type eltType) param {
@@ -5040,7 +5040,7 @@ module ChapelArray {
     // we might have already moved the elements out
     // and so should not try to deinit them.
     // We still need to free any array memory.
-    _do_destroy_arr(rhs._unowned, rhs._instance, deinitElts=!moveElts);
+    _do_destroy_arr(rhs._unowned, rhs._instance:BaseArr, deinitElts=!moveElts);
 
     lhs._value.dsiElementInitializationComplete();
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1752,10 +1752,16 @@ module ChapelBase {
     if (arg != nil) {
       arg!.deinit();
 
-      on arg do
-        chpl_here_free(__primitive("_wide_get_addr", arg));
+      var addr = __primitive("_wide_get_addr", arg):c_void_ptr;
+      delete_helper(addr, arg.locale);
     }
   }
+
+  inline proc delete_helper(addr: c_void_ptr, loc: locale) {
+    on loc do
+      chpl_here_free(addr);
+  }
+
 
   proc chpl__delete(arr: []) {
     forall a in arr do


### PR DESCRIPTION
This PR makes two small changes to slightly reduce the generated code size.

1. Make `_do_destroy_arr` accept a `BaseArr` argument, instead of a generic one. We only need fields of `BaseArr`, and generic instantiations are unnecessary.
2.  Create a nested helper for `chpl__delete` that frees a `c_void_ptr`. Prior to this, we were using the generic `arg` inside the freeing `on` statement. This caused the `on` function to be generic. Now, the `on` function is not generic and only takes `c_void_ptr`s thanks to the helper.