### PR TITLE
compiler/next: Stop using public fields in scope-types

### DIFF
--- a/compiler/next/doc/doxygen-pitfalls.txt
+++ b/compiler/next/doc/doxygen-pitfalls.txt
@@ -21,6 +21,10 @@ An "in-class member initializer" for a field looks like:
 
 Doxygen can't seem to resolve these when the RHS is an enum.
 
+`base.rst` needs to include types that might be declared in the chpl
+namespace elsewhere. Examples of this are chp::owned, chpl::Iterable,
+and chpl::UniqueString.
+
 ---
 "WARNING: Invalid C++ declaration: Expected end of definition."
 ---

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -381,6 +381,9 @@ enum {
 
 using LookupConfig = unsigned int;
 
+/**
+ PoiScope is a point-of-instantiation scope
+ */
 // When resolving a traditional generic, we also need to consider
 // the point-of-instantiation scope as a place to find visible functions.
 // This type tracks such a scope.
@@ -394,13 +397,24 @@ using LookupConfig = unsigned int;
 // visible. Which is better?
 // If we want to make PoiScope not depend on the contents it might be nice
 // to make Scope itself not depend on the contents, too.
-struct PoiScope {
-  const Scope* inScope = nullptr;         // parent Scope for the Call
-  const PoiScope* inFnPoi = nullptr;      // what is the POI of this POI?
+class PoiScope {
+private:
+  const Scope* inScope_ = nullptr;         // parent Scope for the Call
+  const PoiScope* inFnPoi_ = nullptr;      // what is the POI of this POI?
+
+public:
+  PoiScope(const Scope *scope, const PoiScope *poiScope)
+      : inScope_(scope), inFnPoi_(poiScope) {}
+
+  /** return the parent scope for the call */
+  const Scope *inScope() const { return inScope_; }
+
+  /** return the POI of this POI */
+  const PoiScope *inFnPoi() const { return inFnPoi_; }
 
   bool operator==(const PoiScope& other) const {
-    return inScope == other.inScope &&
-           inFnPoi == other.inFnPoi;
+    return inScope_ == other.inScope_ &&
+           inFnPoi_ == other.inFnPoi_;
   }
   bool operator!=(const PoiScope& other) const {
     return !(*this == other);

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -257,7 +257,7 @@ class Scope {
  by a use/import clause.
 */
 class VisibilitySymbols {
-public:
+ public:
   /** The kind of import symbol */
   enum Kind {
     /** the named symbol itself only (one name in names) */
@@ -270,7 +270,7 @@ public:
     CONTENTS_EXCEPT,
   };
 
-private:
+ private:
   ID symbolId_;      // ID of the imported symbol, e.g. ID of a Module
   Kind kind_ = SYMBOL_ONLY;
   bool isPrivate_ = true;
@@ -280,7 +280,7 @@ private:
   //  pair.second is the name here
   std::vector<std::pair<UniqueString,UniqueString>> names_;
 
-public:
+ public:
   VisibilitySymbols() { }
   VisibilitySymbols(ID symbolId, Kind kind, bool isPrivate,
                     std::vector<std::pair<UniqueString,UniqueString>> names)
@@ -337,11 +337,11 @@ public:
 // are only available after that statement (and in that case this analysis
 // could fold into the logic about variable declarations).
 class ResolvedVisibilityScope {
-private:
+ private:
   const Scope* scope_;
   std::vector<VisibilitySymbols> visibilityClauses_;
 
-public:
+ public:
   using VisibilitySymbolsIterable = Iterable<decltype(visibilityClauses_)>;
 
   ResolvedVisibilityScope(const Scope* scope)
@@ -398,11 +398,11 @@ using LookupConfig = unsigned int;
 // If we want to make PoiScope not depend on the contents it might be nice
 // to make Scope itself not depend on the contents, too.
 class PoiScope {
-private:
+ private:
   const Scope* inScope_ = nullptr;         // parent Scope for the Call
   const PoiScope* inFnPoi_ = nullptr;      // what is the POI of this POI?
 
-public:
+ public:
   PoiScope(const Scope *scope, const PoiScope *poiScope)
       : inScope_(scope), inFnPoi_(poiScope) {}
 
@@ -425,18 +425,18 @@ public:
  InnermostMatch
  */
 class InnermostMatch {
-public:
+ public:
   typedef enum {
     ZERO = 0,
     ONE = 1,
     MANY = 2,
   } MatchesFound;
 
-private:
+ private:
   ID id_;
   MatchesFound found_ = ZERO;
 
-public:
+ public:
   InnermostMatch() { }
   InnermostMatch(ID id, MatchesFound found)
     : id_(id), found_(found)

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -325,20 +325,41 @@ public:
   }
 };
 
-// Stores the result of in-order resolution of use/import
-// statements. This would not be separate from resolving variables
+/**
+ Stores the result of in-order resolution of use/import
+ statements.
+*/
+// This would not be separate from resolving variables
 // if the language design was that symbols available due to use/import
 // are only available after that statement (and in that case this analysis
 // could fold into the logic about variable declarations).
-struct ResolvedVisibilityScope {
-  const Scope* scope;
-  std::vector<VisibilitySymbols> visibilityClauses;
+class ResolvedVisibilityScope {
+private:
+  const Scope* scope_;
+  std::vector<VisibilitySymbols> visibilityClauses_;
+
+public:
   ResolvedVisibilityScope(const Scope* scope)
-    : scope(scope)
+    : scope_(scope)
   { }
+
+  /** Return the scope */
+  const Scope *scope() const { return scope_; }
+
+  /** Return the visibility clauses */
+  const std::vector<VisibilitySymbols> &visibilityClauses() const {
+    return visibilityClauses_;
+  }
+
+  /** Add a visibility clause */
+  void addVisibilityClause(const VisibilitySymbols &clause) {
+    // TODO are we missing the whole point of emplace_back here (see callsites)
+    visibilityClauses_.push_back(clause);
+  }
+
   bool operator==(const ResolvedVisibilityScope& other) const {
-    return scope == other.scope &&
-           visibilityClauses == other.visibilityClauses;
+    return scope_ == other.scope_ &&
+           visibilityClauses_ == other.visibilityClauses_;
   }
   bool operator!=(const ResolvedVisibilityScope& other) const {
     return !(*this == other);

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -421,30 +421,43 @@ public:
   }
 };
 
-struct InnermostMatch {
+/**
+ InnermostMatch
+ */
+class InnermostMatch {
+public:
   typedef enum {
     ZERO = 0,
     ONE = 1,
     MANY = 2,
   } MatchesFound;
 
-  ID id;
-  MatchesFound found = ZERO;
+private:
+  ID id_;
+  MatchesFound found_ = ZERO;
 
+public:
   InnermostMatch() { }
   InnermostMatch(ID id, MatchesFound found)
-    : id(id), found(found)
+    : id_(id), found_(found)
   { }
+
+  /** Return the id */
+  ID id() const { return id_;}
+
+  /** Return the matches found */
+  MatchesFound found() const { return found_;}
+
   bool operator==(const InnermostMatch& other) const {
-    return id == other.id &&
-           found == other.found;
+    return id_ == other.id_ &&
+           found_ == other.found_;
   }
   bool operator!=(const InnermostMatch& other) const {
     return !(*this == other);
   }
   void swap(InnermostMatch& other) {
-    id.swap(other.id);
-    std::swap(found, other.found);
+    id_.swap(other.id_);
+    std::swap(found_, other.found_);
   }
 };
 

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -31,8 +31,6 @@
 namespace chpl {
 namespace resolution {
 
-using chpl::util::Iterable;
-
 class BorrowedIdsWithName;
 
 /**
@@ -342,7 +340,7 @@ class ResolvedVisibilityScope {
   std::vector<VisibilitySymbols> visibilityClauses_;
 
  public:
-  using VisibilitySymbolsIterable = Iterable<decltype(visibilityClauses_)>;
+  using VisibilitySymbolsIterable = Iterable<std::vector<VisibilitySymbols>>;
 
   ResolvedVisibilityScope(const Scope* scope)
     : scope_(scope)

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -23,12 +23,15 @@
 #include "chpl/types/Type.h"
 #include "chpl/uast/ASTNode.h"
 #include "chpl/util/memory.h"
+#include "chpl/util/iteration.h"
 
 #include <unordered_map>
 #include <utility>
 
 namespace chpl {
 namespace resolution {
+
+using chpl::util::Iterable;
 
 class BorrowedIdsWithName;
 
@@ -339,6 +342,8 @@ private:
   std::vector<VisibilitySymbols> visibilityClauses_;
 
 public:
+  using VisibilitySymbolsIterable = Iterable<decltype(visibilityClauses_)>;
+
   ResolvedVisibilityScope(const Scope* scope)
     : scope_(scope)
   { }
@@ -346,9 +351,9 @@ public:
   /** Return the scope */
   const Scope *scope() const { return scope_; }
 
-  /** Return the visibility clauses */
-  const std::vector<VisibilitySymbols> &visibilityClauses() const {
-    return visibilityClauses_;
+  /** Return an iterator over the visibility clauses */
+  VisibilitySymbolsIterable visibilityClauses() const {
+    return VisibilitySymbolsIterable(visibilityClauses_);
   }
 
   /** Add a visibility clause */

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -248,46 +248,80 @@ class Scope {
   }
 };
 
-// This class supports both use and import
-// It stores a normalized form of the symbols made available
-// by a use/import clause.
-struct VisibilitySymbols {
-  ID symbolId;       // ID of the imported symbol, e.g. ID of a Module
+/**
+ This class supports both `use` and `import`.
+ It stores a normalized form of the symbols made available
+ by a use/import clause.
+*/
+class VisibilitySymbols {
+public:
+  /** The kind of import symbol */
   enum Kind {
-    SYMBOL_ONLY,     // the named symbol itself only (one name in names)
-    ALL_CONTENTS,    // (and names is empty)
-    ONLY_CONTENTS,   // only the contents named in names
-    CONTENTS_EXCEPT, // except the contents named in names (no renaming)
+    /** the named symbol itself only (one name in names) */
+    SYMBOL_ONLY,
+    /** (and names is empty) */
+    ALL_CONTENTS,
+    /** only the contents named in names */
+    ONLY_CONTENTS,
+    /** except the contents named in names (no renaming) */
+    CONTENTS_EXCEPT,
   };
-  Kind kind = SYMBOL_ONLY;
-  bool isPrivate = true;
+
+private:
+  ID symbolId_;      // ID of the imported symbol, e.g. ID of a Module
+  Kind kind_ = SYMBOL_ONLY;
+  bool isPrivate_ = true;
 
   // the names/renames:
   //  pair.first is the name as declared
   //  pair.second is the name here
-  std::vector<std::pair<UniqueString,UniqueString>> names;
+  std::vector<std::pair<UniqueString,UniqueString>> names_;
 
+public:
   VisibilitySymbols() { }
   VisibilitySymbols(ID symbolId, Kind kind, bool isPrivate,
                     std::vector<std::pair<UniqueString,UniqueString>> names)
-    : symbolId(symbolId), kind(kind), isPrivate(isPrivate),
-      names(std::move(names))
+    : symbolId_(symbolId), kind_(kind), isPrivate_(isPrivate),
+      names_(std::move(names))
   { }
 
+  /** Return the ID of the imported symbol, e.g. ID of a Module */
+  const ID &symbolId() const { return symbolId_; }
 
-  bool operator==(const VisibilitySymbols& other) const {
-    return symbolId == other.symbolId &&
-           kind == other.kind &&
-           names == other.names;
+  /** Return the kind of the imported symbol */
+  Kind kind() const { return kind_; }
+
+  /** Return whether or not the imported symbol is private */
+  bool isPrivate() const { return isPrivate_; }
+
+  /** Lookup the declared name for a given name
+      Returns true if `name` is found in the list of renamed names and
+      stores the declared name in `declared`
+      Returns false if `name` is not found
+  */
+  bool lookupName(const UniqueString &name, UniqueString &declared) const {
+    for (const auto &p : names_) {
+      if (p.second == name) {
+        declared = p.first;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool operator==(const VisibilitySymbols &other) const {
+    return symbolId_ == other.symbolId_ &&
+           kind_ == other.kind_ &&
+           names_ == other.names_;
   }
   bool operator!=(const VisibilitySymbols& other) const {
     return !(*this == other);
   }
 
   void swap(VisibilitySymbols& other) {
-    symbolId.swap(other.symbolId);
-    std::swap(kind, other.kind);
-    names.swap(other.names);
+    symbolId_.swap(other.symbolId_);
+    std::swap(kind_, other.kind_);
+    names_.swap(other.names_);
   }
 };
 

--- a/compiler/next/include/chpl/util/iteration.h
+++ b/compiler/next/include/chpl/util/iteration.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UTIL_ITERATION_H
+#define CHPL_UTIL_ITERATION_H
+
+namespace chpl {
+namespace util {
+
+/**
+ Defines a read-only iterator over elements of T
+ */
+template <typename C> class Iterable {
+private:
+  using It = typename C::const_iterator;
+  It begin_;
+  It end_;
+
+public:
+  Iterable(const C &c) : begin_(c.cbegin()), end_(c.cend()) {}
+
+  It begin() const { return begin_; }
+  It end() const { return end_; }
+};
+
+} // namespace util
+} // namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/util/iteration.h
+++ b/compiler/next/include/chpl/util/iteration.h
@@ -21,25 +21,22 @@
 #define CHPL_UTIL_ITERATION_H
 
 namespace chpl {
-namespace util {
 
 /**
- Defines a read-only iterator over elements of T
+ Defines a read-only iterator over elements of a container type C
  */
 template <typename C> class Iterable {
  private:
-  using It = typename C::const_iterator;
-  It begin_;
-  It end_;
+  typename C::const_iterator begin_;
+  typename C::const_iterator end_;
 
  public:
   Iterable(const C &c) : begin_(c.cbegin()), end_(c.cend()) {}
 
-  It begin() const { return begin_; }
-  It end() const { return end_; }
+  typename C::const_iterator begin() const { return begin_; }
+  typename C::const_iterator end() const { return end_; }
 };
 
-} // namespace util
 } // namespace chpl
 
 #endif

--- a/compiler/next/include/chpl/util/iteration.h
+++ b/compiler/next/include/chpl/util/iteration.h
@@ -27,12 +27,12 @@ namespace util {
  Defines a read-only iterator over elements of T
  */
 template <typename C> class Iterable {
-private:
+ private:
   using It = typename C::const_iterator;
   It begin_;
   It end_;
 
-public:
+ public:
   Iterable(const C &c) : begin_(c.cbegin()), end_(c.cend()) {}
 
   It begin() const { return begin_; }

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -1402,7 +1402,7 @@ CallResolutionResult resolveFnCall(Context* context,
   // next, look for candidates using POI
   for (const PoiScope* curPoi = inPoiScope;
        curPoi != nullptr;
-       curPoi = curPoi->inFnPoi) {
+       curPoi = curPoi->inFnPoi()) {
 
     // stop if any candidate has been found.
     if (candidates.empty() == false) {
@@ -1410,7 +1410,7 @@ CallResolutionResult resolveFnCall(Context* context,
     }
 
     // compute the potential functions that it could resolve to
-    auto v = lookupCalledExpr(context, curPoi->inScope, call, visited);
+    auto v = lookupCalledExpr(context, curPoi->inScope(), call, visited);
 
     // filter without instantiating yet
     const auto& initialCandidates = filterCandidatesInitial(context, v, ci);

--- a/compiler/next/lib/resolution/scope-queries.cpp
+++ b/compiler/next/lib/resolution/scope-queries.cpp
@@ -255,24 +255,17 @@ static bool doLookupInImports(Context* context,
     // check to see if it's mentioned in names/renames
     for (const VisibilitySymbols& is: r->visibilityClauses) {
       UniqueString from = name;
-      bool named = false;
-      for (const auto& p : is.names) {
-        if (p.second == name) {
-          from = p.first;
-          named = true;
-          break;
-        }
-      }
-      if (named && is.kind == VisibilitySymbols::SYMBOL_ONLY) {
-        result.push_back(BorrowedIdsWithName(is.symbolId));
+      bool named = is.lookupName(name, from);
+      if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
+        result.push_back(BorrowedIdsWithName(is.symbolId()));
         return true;
-      } else if (named && is.kind == VisibilitySymbols::CONTENTS_EXCEPT) {
+      } else if (named && is.kind() == VisibilitySymbols::CONTENTS_EXCEPT) {
         // mentioned in an except clause, so don't return it
-      } else if (named || is.kind == VisibilitySymbols::ALL_CONTENTS) {
+      } else if (named || is.kind() == VisibilitySymbols::ALL_CONTENTS) {
         // find it in the contents
-        const Scope* symScope = scopeForId(context, is.symbolId);
+        const Scope* symScope = scopeForId(context, is.symbolId());
         // this symbol should be a module/enum etc which has a scope
-        assert(symScope->id() == is.symbolId);
+        assert(symScope->id() == is.symbolId());
 
         LookupConfig newConfig = LOOKUP_DECLS |
                                  LOOKUP_IMPORT_AND_USE;
@@ -571,9 +564,9 @@ bool doIsWholeScopeVisibleFromScope(Context* context,
       const ResolvedVisibilityScope* r = resolveVisibilityStmts(context, cur);
 
       for (const VisibilitySymbols& is: r->visibilityClauses) {
-        if (is.kind == VisibilitySymbols::ALL_CONTENTS) {
+        if (is.kind() == VisibilitySymbols::ALL_CONTENTS) {
           // find it in the contents
-          const Scope* usedScope = scopeForId(context, is.symbolId);
+          const Scope* usedScope = scopeForId(context, is.symbolId());
           // check it recursively
           bool found = doIsWholeScopeVisibleFromScope(context,
                                                       checkScope,

--- a/compiler/next/lib/resolution/scope-queries.cpp
+++ b/compiler/next/lib/resolution/scope-queries.cpp
@@ -253,7 +253,7 @@ static bool doLookupInImports(Context* context,
 
   if (r != nullptr) {
     // check to see if it's mentioned in names/renames
-    for (const VisibilitySymbols& is: r->visibilityClauses) {
+    for (const VisibilitySymbols& is: r->visibilityClauses()) {
       UniqueString from = name;
       bool named = is.lookupName(name, from);
       if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
@@ -563,7 +563,7 @@ bool doIsWholeScopeVisibleFromScope(Context* context,
     if (cur->containsUseImport()) {
       const ResolvedVisibilityScope* r = resolveVisibilityStmts(context, cur);
 
-      for (const VisibilitySymbols& is: r->visibilityClauses) {
+      for (const VisibilitySymbols& is: r->visibilityClauses()) {
         if (is.kind() == VisibilitySymbols::ALL_CONTENTS) {
           // find it in the contents
           const Scope* usedScope = scopeForId(context, is.symbolId());
@@ -665,7 +665,7 @@ struct ImportsResolver {
       ID id = vec[0].id(0); // id of the 'use'd module/enum
 
       // First, add the entry for the symbol itself
-      resolvedVisibilityScope->visibilityClauses.push_back(
+      resolvedVisibilityScope->addVisibilityClause(
           VisibilitySymbols(id, VisibilitySymbols::SYMBOL_ONLY,
                             isPrivate, convertOneName(n)));
 
@@ -685,7 +685,7 @@ struct ImportsResolver {
           assert(false && "Should not be possible");
           break;
       }
-      resolvedVisibilityScope->visibilityClauses.push_back(
+      resolvedVisibilityScope->addVisibilityClause(
           VisibilitySymbols(id, kind, isPrivate,
                             convertLimitations(clause)));
     }
@@ -739,12 +739,12 @@ struct ImportsResolver {
           if (expr->isIdentifier()) {
             kind = VisibilitySymbols::SYMBOL_ONLY;
             // Add an entry for the imported thing
-            resolvedVisibilityScope->visibilityClauses.push_back(
+            resolvedVisibilityScope->addVisibilityClause(
                 VisibilitySymbols(id, kind, isPrivate,
                                   convertOneName(n)));
           } else if (expr->isDot()) {
             kind = VisibilitySymbols::ONLY_CONTENTS;
-            resolvedVisibilityScope->visibilityClauses.push_back(
+            resolvedVisibilityScope->addVisibilityClause(
                 VisibilitySymbols(id, kind, isPrivate,
                                   convertOneName(n)));
           }
@@ -752,7 +752,7 @@ struct ImportsResolver {
         case VisibilityClause::BRACES:
           kind = VisibilitySymbols::ONLY_CONTENTS;
           // Add an entry for the imported things
-          resolvedVisibilityScope->visibilityClauses.push_back(
+          resolvedVisibilityScope->addVisibilityClause(
               VisibilitySymbols(id, kind, isPrivate,
                                 convertLimitations(clause)));
           break;

--- a/compiler/next/lib/resolution/scope-queries.cpp
+++ b/compiler/next/lib/resolution/scope-queries.cpp
@@ -830,9 +830,7 @@ const owned<PoiScope>& constructPoiScopeQuery(Context* context,
                                               const PoiScope* parentPoiScope) {
   QUERY_BEGIN(constructPoiScopeQuery, context, scope, parentPoiScope);
 
-  owned<PoiScope> result = toOwned(new PoiScope());
-  result->inScope = scope;
-  result->inFnPoi = parentPoiScope;
+  owned<PoiScope> result = toOwned(new PoiScope(scope, parentPoiScope));
 
   return QUERY_END(result);
 }
@@ -861,10 +859,10 @@ pointOfInstantiationScopeQuery(Context* context,
   // the call site itself. These can be collapsed away.
   for (usePoi = parentPoiScope;
        usePoi != nullptr;
-       usePoi = usePoi->inFnPoi) {
+       usePoi = usePoi->inFnPoi()) {
 
     bool collapse = isWholeScopeVisibleFromScope(context,
-                                                 usePoi->inScope,
+                                                 usePoi->inScope(),
                                                  scope);
     if (collapse == false) {
       break;

--- a/compiler/next/test/resolution/testScopeResolve.cpp
+++ b/compiler/next/test/resolution/testScopeResolve.cpp
@@ -64,8 +64,8 @@ static void test1() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // testing no matching variable declaration
@@ -96,8 +96,8 @@ static void test2() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == ID());
-  assert(match.found == InnermostMatch::ZERO);
+  assert(match.id() == ID());
+  assert(match.found() == InnermostMatch::ZERO);
 }
 
 // testing duplicate matching variable declarations
@@ -132,8 +132,8 @@ static void test3() {
   // design of findInnermostDecl is to return the
   // innermost and first if there is any ambiguity.
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x1->id());
-  assert(match.found == InnermostMatch::MANY);
+  assert(match.id() == x1->id());
+  assert(match.found() == InnermostMatch::MANY);
 }
 
 // testing a simple use statement
@@ -171,8 +171,8 @@ static void test4() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // testing a simple recursive use statement
@@ -211,8 +211,8 @@ static void test5() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // testing symbol from parent scope
@@ -248,8 +248,8 @@ static void test6() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // test scope resolution handles incremental changes OK
@@ -315,8 +315,8 @@ static void test7() {
     assert(mScope != oldMScope);
 
     const auto& match = findInnermostDecl(context, mScope, ident->name());
-    assert(match.found == InnermostMatch::ZERO);
-    assert(match.id == ID());
+    assert(match.found() == InnermostMatch::ZERO);
+    assert(match.id() == ID());
 
     oldM = m;
     oldMScope = mScope;
@@ -356,8 +356,8 @@ static void test7() {
     assert(mScope == oldMScope);
 
     const auto& match = findInnermostDecl(context, mScope, ident->name());
-    assert(match.found == InnermostMatch::ONE);
-    assert(match.id == x->id());
+    assert(match.found() == InnermostMatch::ONE);
+    assert(match.id() == x->id());
 
     oldM = m;
     oldMScope = mScope;
@@ -399,8 +399,8 @@ static void test7() {
     assert(mScope != oldMScope);
 
     const auto& match = findInnermostDecl(context, mScope, ident->name());
-    assert(match.found == InnermostMatch::ONE);
-    assert(match.id == x->id());
+    assert(match.found() == InnermostMatch::ONE);
+    assert(match.id() == x->id());
 
     oldM = m;
     oldMScope = mScope;
@@ -453,14 +453,14 @@ static void test8() {
 
   {
     const auto& match = findInnermostDecl(context, outerScope, xStr);
-    assert(match.id == outerX->id());
-    assert(match.found == InnermostMatch::ONE);
+    assert(match.id() == outerX->id());
+    assert(match.found() == InnermostMatch::ONE);
   }
 
   {
     const auto& match = findInnermostDecl(context, innerScope, xStr);
-    assert(match.id == innerX->id());
-    assert(match.found == InnermostMatch::ONE);
+    assert(match.id() == innerX->id());
+    assert(match.found() == InnermostMatch::ONE);
   }
 }
 
@@ -499,8 +499,8 @@ static void test9() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, nIdent->name());
-  assert(match.id == n->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == n->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // testing a dotted import statement
@@ -538,8 +538,8 @@ static void test10() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // testing a dotted import with braces
@@ -583,12 +583,12 @@ static void test11() {
   assert(scopeForIdent);
 
   const auto& mx = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(mx.id == x->id());
-  assert(mx.found == InnermostMatch::ONE);
+  assert(mx.id() == x->id());
+  assert(mx.found() == InnermostMatch::ONE);
 
   const auto& my = findInnermostDecl(context, scopeForIdent, yIdent->name());
-  assert(my.id == y->id());
-  assert(my.found == InnermostMatch::ONE);
+  assert(my.id() == y->id());
+  assert(my.found() == InnermostMatch::ONE);
 
 }
 
@@ -634,8 +634,8 @@ static void test12() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // testing use of a nested module
@@ -680,8 +680,8 @@ static void test13() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id == x->id());
-  assert(match.found == InnermostMatch::ONE);
+  assert(match.id() == x->id());
+  assert(match.found() == InnermostMatch::ONE);
 }
 
 // test import of an ambiguous function name
@@ -718,7 +718,7 @@ static void test14() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, fIdent->name());
-  assert(match.found == InnermostMatch::MANY);
+  assert(match.found() == InnermostMatch::MANY);
 }
 
 

--- a/doc/rst/meta/compiler-internals-doxygen/base.rst
+++ b/doc/rst/meta/compiler-internals-doxygen/base.rst
@@ -31,5 +31,8 @@ namespace. The entries may not be exhaustive.
    :members:
    :undoc-members:
 
-.. doxygentypedef:: chpl::owned
+.. doxygenclass:: chpl::Iterable
+   :members:
+   :undoc-members:
 
+.. doxygentypedef:: chpl::owned


### PR DESCRIPTION
* Makes public fields private behind getter methods where appropriate.
* Adds an `Iterable` template as a more opaque "thing to be iterated over"
* Adds doc comments to classes, getters, and enums