### PR TITLE
Add `lambda` keyword in highlight files

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -88,6 +88,7 @@ not the type face."
          "const" "config"
          "except" "export" "extern"
          "import" "inline" "iter"
+         "lambda"
          "module"
          "only" "operator" "override"
          "param" "private" "proc" "public"
@@ -141,7 +142,7 @@ will be handled."
   ;; Default to `c-class-decl-kwds' and `c-brace-list-decl-kwds'
   ;; (since e.g. "Foo" is the identifier being defined in "class Foo
   ;; {...}").
-  chpl '("const" "iter" "module" "operator" "param" "proc" "type" "var"))
+  chpl '("const" "iter" "lambda" "module" "operator" "param" "proc" "type" "var"))
 
 (c-lang-defconst c-ref-list-kwds
   "Keywords that may be followed by a comma separated list of

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -216,7 +216,7 @@ if version >= 508 || !exists("did_c_syn_inits")
   HiLink cOctalError		cError
   HiLink cParenError		cError
   HiLink cErrInParen		cError
-" Hack: avoid range errors of the form [1..M) .. allows other bracket errors 
+" Hack: avoid range errors of the form [1..M) .. allows other bracket errors
 "  HiLink cErrInBracket		cError
   HiLink cCommentError		cError
   HiLink cCommentStartError	cError
@@ -271,7 +271,7 @@ syn keyword chplType            owned shared borrowed unmanaged
 syn keyword chplType            nothing void
 syn keyword chplOperator	on reduce scan by align
 syn keyword chplStructure	class record union enum
-syn keyword chplStructure	proc iter cobegin begin local sync let select where operator
+syn keyword chplStructure	proc iter cobegin begin local sync let select where operator lambda
 syn keyword chplStructure	pragma inline with private public forwarding
 syn keyword chplStructure	prototype override lifetime
 syn keyword chplBoolean		true false


### PR DESCRIPTION
Adds the `lambda` keyword to Emacs and Vim highlight files, where it was missing.