### PR TITLE
Fix bugs stemming from enums with duplicate values

### DIFF
--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -103,11 +103,7 @@ void EnumType::codegenDef() {
         //llvm::Constant *initConstant;
 
         VarSymbol* s;
-        if (constant->init) {
-          s = toVarSymbol(toSymExpr(constant->init)->symbol());
-        } else {
-          s = new_IntSymbol(order, INT_SIZE_64);
-        }
+        s = new_IntSymbol(order, INT_SIZE_64);
         INT_ASSERT(s);
         INT_ASSERT(s->immediate);
 

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -74,12 +74,12 @@ void EnumType::codegenDef() {
 
 
   if( outfile ) {
-    fprintf(outfile, "typedef int64_t ");
+    fprintf(outfile, "typedef int ");
     fprintf(outfile, "%s", symbol->codegen().c.c_str());
     fprintf(outfile, ";\n");
     int i = 0;
     for_enums(constant, this) {
-      fprintf(outfile, "const int64_t %s = %d;\n", constant->sym->codegen().c.c_str(), i);
+      fprintf(outfile, "#define %s %d\n", constant->sym->codegen().c.c_str(), i);
       i++;
     }
   } else {

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -74,21 +74,14 @@ void EnumType::codegenDef() {
 
 
   if( outfile ) {
-    fprintf(outfile, "typedef enum {");
-    bool first = true;
-    for_enums(constant, this) {
-      if (!first) {
-        fprintf(outfile, ", ");
-      }
-      fprintf(outfile, "%s", constant->sym->codegen().c.c_str());
-      if (constant->init) {
-        fprintf(outfile, " = %s", constant->init->codegen().c.c_str());
-      }
-      first = false;
-    }
-    fprintf(outfile, "} ");
+    fprintf(outfile, "typedef int64_t ");
     fprintf(outfile, "%s", symbol->codegen().c.c_str());
     fprintf(outfile, ";\n");
+    int i = 0;
+    for_enums(constant, this) {
+      fprintf(outfile, "const int64_t %s = %d;\n", constant->sym->codegen().c.c_str(), i);
+      i++;
+    }
   } else {
 #ifdef HAVE_LLVM
     // Make sure that we've computed all of the enum values..

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1257,9 +1257,7 @@ static void buildEnumIntegerCastFunctions(EnumType* et) {
           new CondStmt(new CallExpr(PRIM_WHEN,
                                     new CallExpr("+", lastInit->copy(),
                                                  new SymExpr(new_IntSymbol(count)))),
-                       new CallExpr(PRIM_RETURN,
-                                    new CallExpr(PRIM_CAST,
-                                                  et->symbol, from)));
+                       new CallExpr(PRIM_RETURN, new SymExpr(constant->sym)));
         whenstmts->insertAtTail(when);
       }
     }

--- a/test/types/enum/enumDupVal.chpl
+++ b/test/types/enum/enumDupVal.chpl
@@ -1,0 +1,6 @@
+enum color {red = 1, green = 2, blue = 1};
+
+writeln(color.blue);
+
+for c in color do
+  writeln(c);

--- a/test/types/enum/enumDupVal.good
+++ b/test/types/enum/enumDupVal.good
@@ -1,0 +1,4 @@
+blue
+Case 0: red
+Case 1: green
+Case 2: blue

--- a/test/types/enum/enumDupVal.good
+++ b/test/types/enum/enumDupVal.good
@@ -1,4 +1,4 @@
 blue
-Case 0: red
-Case 1: green
-Case 2: blue
+red
+green
+blue


### PR DESCRIPTION
While running some tests to check out an idea recently, I found that given an enum with
duplicate associated integer values:

```chapel
enum color {red=1, green=2, blue=1};
```

Strange things would happen, like:

```chapel
writeln(color.blue);
```

would print `red`.  This is one of those bugs that I probably knew about in the past and put
off as future work, but it surprised me all the same because I generally think of our enums
as working pretty well these days.

Although enums with duplicate values are currently marked as an unstable feature (#9786),
I'm skeptical that we should do away with them; and even if we ultimately do, they shouldn't
be this weird in the meantime.

The fix turns out to be to stop representing Chapel enums with C enums which is a change
that we have discussed wanting to make anyway (#10307).