### PR TITLE
Remove unnecessary enum enumeration helpers

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -51,7 +51,6 @@ static void buildUnionAssignmentFunction(AggregateType* ct);
 
 static void buildEnumIntegerCastFunctions(EnumType* et);
 static void buildEnumFirstFunction(EnumType* et);
-static void buildEnumEnumerateFunction(EnumType* et);
 static void buildEnumSizeFunction(EnumType* et);
 static void buildEnumOrderFunctions(EnumType* et);
 static void buildEnumStringOrBytesCastFunctions(EnumType* type,
@@ -1112,7 +1111,6 @@ void buildEnumFunctions(EnumType* et) {
   buildEnumStringOrBytesCastFunctions(et, dtString);
 
   buildEnumIntegerCastFunctions(et);
-  buildEnumEnumerateFunction(et);
   buildEnumFirstFunction(et);
   buildEnumSizeFunction(et);
   buildEnumOrderFunctions(et);
@@ -1187,30 +1185,6 @@ static void buildEnumFirstFunction(EnumType* et) {
   // they are automatically inserted
   baseModule->block->insertAtTail(fnDef);
   reset_ast_loc(fnDef, et->symbol);
-
-  normalize(fn);
-  fn->tagIfGeneric();
-}
-
-static void buildEnumEnumerateFunction(EnumType* et) {
-  // Build a function that returns a tuple of the enum's values
-  // Each enum type has its own chpl_enum_enumerate function.
-  FnSymbol* fn = new FnSymbol("chpl_enum_enumerate");
-  fn->addFlag(FLAG_COMPILER_GENERATED);
-  fn->addFlag(FLAG_LAST_RESORT);
-  ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", et);
-  arg->addFlag(FLAG_TYPE_VARIABLE);
-  fn->insertFormalAtTail(arg);
-
-  baseModule->block->insertAtTail(new DefExpr(fn));
-
-  // Generate the tuple of enum values for the given enum type
-  CallExpr* call = new CallExpr("_build_tuple");
-  for_enums(constant, et) {
-    call->insertAtTail(constant->sym);
-  }
-
-  fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
 
   normalize(fn);
   fn->tagIfGeneric();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2849,7 +2849,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
   } else if isEnumType(t) {
     var err:syserr = ENOERR;
     var st = qio_channel_style_element(_channel_internal, QIO_STYLE_ELEMENT_AGGREGATE);
-    for i in chpl_enumerate(t) {
+    for i in t {
       { // try to read e.g. red for colorenum.red
         var str = i:string;
         if st == QIO_AGGREGATE_FORMAT_JSON then str = '"'+str+'"';

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -761,15 +761,9 @@ proc max(type t) where isComplexType(t) {
 }
 
 pragma "no doc"
-iter chpl_enumerate(type t: enum) {
-  const enumTuple = chpl_enum_enumerate(t);
-  foreach i in 0..enumTuple.size-1 do
-    yield enumTuple(i);
-}
-pragma "no doc"
 iter type enum.these(){
-  for i in chpl_enumerate(this) do
-    yield i;
+  foreach i in 0..<this.size do
+    yield chpl__orderToEnum(i, this);
 }
 
 pragma "no doc"

--- a/test/release/examples/benchmarks/lcals/LCALSChecksums.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSChecksums.chpl
@@ -83,10 +83,10 @@ module LCALSChecksums {
     var suite_run_info = getLoopSuiteRunInfo();
     for variant in run_variants.domain {
       const varStr = (variant:string).toLower();
-      for loopKernel in chpl_enumerate(LoopKernelID) {
+      for loopKernel in LoopKernelID {
         const kerStr = (loopKernel:string).toLower();
         var stat = suite_run_info.getLoopStats(variant)[loopKernel].borrow();
-        for length in chpl_enumerate(LoopLength) {
+        for length in LoopLength {
           const lenStr = (length:string).toLower();
           if run_loop[loopKernel] && stat.loop_is_run && stat.loop_run_count[length] > 0 {
             if run_loop_length[length] {


### PR DESCRIPTION
While debugging some enum functionality, I was realizing that the
implementation of our ways of iterating over enums had become fairly
complete overkill (and/or maybe always were?).  This removes those
capabilities, which may reduce compile times and/or execution times
somewhat for programs using enums (or maybe just programs containing
iterations over enums?)
