### PR TITLE
Disable nil checking for a few sync/single routines

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -489,6 +489,7 @@ module ChapelSyncvar {
       }
     }
 
+    pragma "unsafe"
     proc readFE() {
       pragma "no init"
       pragma "no auto destroy"
@@ -513,6 +514,7 @@ module ChapelSyncvar {
       return ret;
     }
 
+    pragma "unsafe"
     proc const readFF() {
       if !isConstCopyableType(valType) ||
          !isConstAssignableType(valType) {
@@ -1030,6 +1032,7 @@ module ChapelSyncvar {
       }
     }
 
+    pragma "unsafe"
     proc readFF() {
       if !isConstCopyableType(valType) ||
          !isConstAssignableType(valType) {

--- a/test/types/sync/ferguson/sync-borrowed-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-borrowed-nonnil.chpl
@@ -3,6 +3,8 @@ class C { var x: int; }
 proc main() {
   var x = new C(1);
   var v: sync borrowed C = x.borrow();
+  var a = v.readFF();
+  assert(a == x.borrow());
   var y = v.readFE();
   assert(y == x.borrow());
 }

--- a/test/types/sync/ferguson/sync-unmanaged-nonnil.chpl
+++ b/test/types/sync/ferguson/sync-unmanaged-nonnil.chpl
@@ -5,6 +5,8 @@ proc main() {
 
   var x: unmanaged C = new unmanaged C(1);
   var v: sync unmanaged C = x;
+  var a = v.readFF();
+  assert(a == x);
   var y = v.readFE();
   assert(y == x);
   delete x;


### PR DESCRIPTION
Follow-up to PR #18379.

The pattern of a "no init" variable set within an on statement by _moveSet seems to trip up the nil checker when compiling with `CHPL_COMM!=none`. This PR takes the simple approach of using `pragma "unsafe"` to disable the nil checker on the functions in the sync/single implementation that use this pattern. It also adds `readFF` calls to two tests to increase coverage of the problematic case. 

Trivial and not reviewed.

- [x] full local testing
