### PR TITLE
Fix regex serialization with --no-remote-value-forwarding

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -638,7 +638,7 @@ record regex {
   proc _serialize() {
     var pattern: exprType;
     var options: qio_regex_options_t;
-    var _regexCopy = _regex;
+    const _regexCopy = _regex;
 
     on this.home {
       /* NOTE we can't reference `this` inside this on block because

--- a/test/regex/correctness.compopts
+++ b/test/regex/correctness.compopts
@@ -1,2 +1,4 @@
--st=string
--st=bytes
+-st=string --remote-value-forwarding
+-st=bytes --remote-value-forwarding
+-st=string --no-remote-value-forwarding
+-st=bytes --no-remote-value-forwarding


### PR DESCRIPTION
* Without `const`, the runtime thinks that `_regexCopy` is a remote
pointer even though we execute on this.home
* Adds test coverage