### PR TITLE
compiler/next: Start parsing and converting internal modules

### DIFF
--- a/compiler/next/include/chpl/queries/ErrorMessage.h
+++ b/compiler/next/include/chpl/queries/ErrorMessage.h
@@ -21,6 +21,7 @@
 #define CHPL_QUERIES_ERRORMESSAGE_H
 
 #include "chpl/queries/Location.h"
+#include "chpl/util/iteration.h"
 
 #include <cstdarg>
 #include <string>

--- a/compiler/next/include/chpl/queries/ErrorMessage.h
+++ b/compiler/next/include/chpl/queries/ErrorMessage.h
@@ -21,7 +21,6 @@
 #define CHPL_QUERIES_ERRORMESSAGE_H
 
 #include "chpl/queries/Location.h"
-#include "chpl/util/iteration.h"
 
 #include <cstdarg>
 #include <string>

--- a/compiler/next/include/chpl/uast/Attributes.h
+++ b/compiler/next/include/chpl/uast/Attributes.h
@@ -87,11 +87,8 @@ class Attributes final : public Expression {
     return pragmas_.find(tag) != pragmas_.end();
   }
 
-  // TODO: How to hide/obfuscate this without adjusting nitpick_ignore?
-  using PragmaGroup = std::set<PragmaTag>;
-
   // An iterable over the pragmas of this.
-  using PragmaIterable = Iterable<PragmaGroup>;
+  using PragmaIterable = Iterable<std::set<PragmaTag>>;
 
   /**
     Iterate over the pragmas stored in this attributes.

--- a/compiler/next/include/chpl/uast/BuilderResult.h
+++ b/compiler/next/include/chpl/uast/BuilderResult.h
@@ -120,8 +120,15 @@ class BuilderResult final {
     return errors_[i];
   }
 
-  // TODO: add something to iterate over the errors e.g.
-  // ErrorListIteratorPair errors() const
+  using ErrorGroup = std::vector<ErrorMessage>;
+  using ErrorIterable = Iterable<ErrorGroup>;
+
+  /**
+    Iterate over the errors.
+  */
+  ErrorIterable errors() const {
+    return ErrorIterable(errors_);
+  }
 
   /** Find the ASTNode* corresponding to a particular ID, or return
       nullptr if there is not one in this result. */

--- a/compiler/next/include/chpl/uast/BuilderResult.h
+++ b/compiler/next/include/chpl/uast/BuilderResult.h
@@ -25,6 +25,7 @@
 #include "chpl/queries/mark-functions.h"
 #include "chpl/queries/update-functions.h"
 #include "chpl/uast/ASTNode.h"
+#include "chpl/util/iteration.h"
 
 #include <vector>
 #include <unordered_map>
@@ -120,8 +121,8 @@ class BuilderResult final {
     return errors_[i];
   }
 
-  using ErrorGroup = std::vector<ErrorMessage>;
-  using ErrorIterable = Iterable<ErrorGroup>;
+  // An iterable over the errors of this.
+  using ErrorIterable = Iterable<std::vector<ErrorMessage>>;
 
   /**
     Iterate over the errors.

--- a/compiler/next/include/chpl/uast/Module.h
+++ b/compiler/next/include/chpl/uast/Module.h
@@ -73,9 +73,12 @@ class Module final : public NamedDecl {
     namedDeclMarkUniqueStringsInner(context);
   }
 
+  int stmtChildNum() const {
+    return attributes() ? 1 : 0;
+  }
+
  public:
   ~Module() override = default;
-
 
   static owned<Module> build(Builder* builder, Location loc,
                              owned<Attributes> attributes,
@@ -84,17 +87,35 @@ class Module final : public NamedDecl {
                              Module::Kind kind,
                              ASTList stmts);
 
+  /**
+    Return the kind of this module (e.g. 'PROTOTYPE' or 'IMPLICIT');
+  */
   Kind kind() const { return this->kind_; }
 
+  /**
+    Iterate over the statements in this module.
+  */
   ASTListIteratorPair<Expression> stmts() const {
-    return ASTListIteratorPair<Expression>(children_.begin(), children_.end());
+    auto begin = numStmts()
+        ? children_.begin() + stmtChildNum()
+        : children_.end();
+    auto end = begin + numStmts();
+    return ASTListIteratorPair<Expression>(begin, end);
   }
 
+  /**
+    Return the number of statements in this module.
+  */
   int numStmts() const {
-    return this->numChildren();
+    return attributes() ? numChildren()-1 : numChildren();
   }
+
+  /**
+    Get the i'th statement in this module.
+  */
   const Expression* stmt(int i) const {
-    const ASTNode* ast = this->child(i);
+    assert(0 <= i && i < numStmts());
+    const ASTNode* ast = this->child(i + stmtChildNum());
     assert(ast->isExpression());
     return (Expression*) ast;
   }

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -45,10 +45,10 @@
 #define REPORT_AST_KIND_WHEN_PARSING_MODULE 0
 
 // Use to eagerly try compiling all internal modules to uAST.
-#define COMPILE_ALL_INTERNAL_MODULES_TO_UAST 0
+#define PARSE_ALL_INTERNAL_MODULES_TO_UAST 0
 
 // Use to eagerly try compiling all standard modules to uAST.
-#define COMPILE_ALL_STANDARD_MODULES_TO_UAST 0
+#define PARSE_ALL_STANDARD_MODULES_TO_UAST 0
 
 #if DUMP_WHEN_CONVERTING_UAST_TO_AST
 #include "view.h"
@@ -84,7 +84,6 @@ static void          parseCommandLineFiles();
 
 static void          parseDependentModules(bool isInternal);
 
-
 static ModuleSymbol* parseMod(const char* modName,
                               bool        isInternal);
 
@@ -104,7 +103,6 @@ static ModuleSymbol* uASTParseFile(const char* fileName,
                                    ModTag      modTag,
                                    bool        namedOnCommandLine,
                                    bool        include);
-
 
 static const char*   stdModNameToPath(const char* modName,
                                       bool*       isStandard);
@@ -586,11 +584,11 @@ static std::set<std::string> allowedInternalModules = {
 static bool uASTCanParseMod(const char* modName, ModTag modTag) {
   if (!fCompilerLibraryParser) return false;
 
-#if COMPILE_ALL_INTERNAL_MODULES_TO_UAST
+#if PARSE_ALL_INTERNAL_MODULES_TO_UAST
   if (modTag == MOD_INTERNAL) return true;
 #endif
 
-#if COMPILE_ALL_STANDARD_MODULES_TO_UAST
+#if PARSE_ALL_STANDARD_MODULES_TO_UAST
   if (modTag == MOD_STANDARD) return true;
 #endif
 
@@ -615,8 +613,6 @@ static bool uASTAttemptToParseMod(const char* modName,
                                   ModTag modTag,
                                   ModuleSymbol*& outModSym) {
   if (!uASTCanParseMod(modName, modTag)) return false;
-
-
 
   const bool namedOnCommandLine = false;
   const bool include = false;

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -909,7 +909,7 @@ static ModuleSymbol* uASTParseFile(const char* fileName,
       }
     }
 
-    USR_STOP();
+    USR_FATAL("%s", "One or more errors when parsing uAST");
   }
 
   ModuleSymbol* lastModSym = nullptr;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1668,6 +1668,10 @@ struct Converter {
                                     prototype,
                                     /* docs */ nullptr);
 
+    if (node->kind() == uast::Module::IMPLICIT) {
+      mod->addFlag(FLAG_IMPLICIT_MODULE);
+    }
+
     attachSymbolAttributes(node->attributes(), mod);
 
     return new DefExpr(mod);
@@ -2085,6 +2089,5 @@ ModuleSymbol* convertToplevelModule(chpl::Context* context,
   Converter c(context);
   DefExpr* def = c.visit(mod);
   ModuleSymbol* ret = toModuleSymbol(def->sym);
-  ModuleSymbol::addTopLevelModule(ret);
   return ret;
 }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1551,7 +1551,9 @@ struct Converter {
       fn->addFlag(FLAG_OVERRIDE);
     }
 
-    // TODO: add FLAG_NO_PARENS for parenless functions
+    if (node->isParenless()) {
+      fn->addFlag(FLAG_NO_PARENS);
+    }
 
     IntentTag thisTag = INTENT_BLANK;
     Expr* receiverType = nullptr;
@@ -1682,7 +1684,11 @@ struct Converter {
     chpl::UniqueString ustr = node->name();
     const char* name = ustr.c_str();
     const char* path = context->filePathForId(node->id()).c_str();
-    ModTag tag = MOD_USER; // TODO: distinguish internal/standard/etc
+
+    // TODO (dlongnecke): For now, the tag is overridden by the caller.
+    // See 'uASTAttemptToParseMod'. Eventually, it would be great if the
+    // new frontend could note if a module is standard/internal/user.
+    const ModTag tag = MOD_USER;
     bool priv = (node->visibility() == uast::Decl::PRIVATE);
     bool prototype = (node->kind() == uast::Module::PROTOTYPE ||
                       node->kind() == uast::Module::IMPLICIT);


### PR DESCRIPTION
This is for `compiler/next`.

Adjust the `uASTParseFile` function to mimic most of the logic in the
old `parseFile` function. Some things are different (for example, the
new `uAST` builder will handle building an implicit module for us),
but most behaviors should match.

Add a helper function `uASTAttemptToParseMod` which will try to parse
a module into `uAST` and convert it to `AST`. Right now only a subset
of internal modules can be parsed, based on an allow-list that is
baked into the source code. This list should be adjusted over time
as more internal modules can be successfully parsed.

Add comments to the `Module` `uAST` node and adjust its accessor
functions to account for the potential presence of an `Attributes`.

Add a `errors()` iterator to the `ErrorMessage` class.

Adjust iterables I've added to only use a single `using` statement
in order to follow convention.

Attach the `modTag` to the converted `AST` module in `uASTParseFile`.

Adjust converter for `uast::Function` to attach `FLAG_NO_PARENS`.

Add `#defines` which can be used as toggles to try parsing all
internal or standard modules into `uAST`. These may be useful for
further work on this effort.

Clean up calls to `attachSymbolAttributes()` in `convert-uast.cpp`
by making them take a `Decl` instead of an `Attributes` (only `Decl`
can have attributes, anyhow, and all `Decl` are converted into one
or more `Symbol` in the old `AST`).

Reviewed by @mppf. Thanks!

TESTING

- [x] All on `linux64` when `COMM=none` (to make sure `chpl` works)
- [x] All hellos with `--compiler-library-parser`
- [x] All primers with `--compiler-library-parser`