### PR TITLE
Adjust codegenSizeofLLVM to use DataLayout

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -3064,6 +3064,25 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
   }
 }
 #ifdef HAVE_LLVM
+
+static
+llvm::Constant* codegenSizeofLLVM(llvm::Type* type)
+{
+  // This used to use llvm::ConstantExpr::getSizeOf(type);
+  // but that seems not to be constant folded.
+
+  GenInfo *info = gGenInfo;
+  const llvm::DataLayout& dl = info->module->getDataLayout();
+  llvm::LLVMContext& ctx = info->module->getContext();
+
+  INT_ASSERT(type->isSized());
+  llvm::TypeSize ret = dl.getTypeAllocSize(type);
+  auto intValue = ret.getKnownMinSize();
+  llvm::Type* sizeTy = dl.getIntPtrType(ctx);
+
+  return llvm::ConstantInt::get(sizeTy, intValue);
+}
+
 static
 GenRet codegenSizeof(llvm::Type* type)
 {

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -40,7 +40,6 @@ struct PromotedPair {
 };
 
 bool isArrayVecOrStruct(llvm::Type* t);
-llvm::Constant* codegenSizeofLLVM(llvm::Type* type);
 
 // 0 means undefined alignment
 llvm::AllocaInst* makeAlloca(llvm::Type* type, const char* name, llvm::Instruction* insertBefore, unsigned n=1, unsigned align=0);

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -32,11 +32,6 @@ bool isArrayVecOrStruct(llvm::Type* t)
   return t->isArrayTy() || t->isVectorTy() || t->isStructTy();
 }
 
-llvm::Constant* codegenSizeofLLVM(llvm::Type* type)
-{
-  return llvm::ConstantExpr::getSizeOf(type);
-}
-
 llvm::AllocaInst* makeAlloca(llvm::Type* type,
                              const char* name,
                              llvm::Instruction* insertBefore,


### PR DESCRIPTION
After PR #18542, we see valgrind errors / assert failures (if LLVM is built with asserts on) for these tests:

```
[Error matching program output for release/examples/benchmarks/hpcc/ra-atomics]
[Error matching program output for release/examples/benchmarks/hpcc/ra]
[Error matching program output for release/examples/benchmarks/hpcc/variants/ra-cleanloop]
```

The assertion error is coming from this line in SROA.cpp visitMemSetInst

```
  auto *C = cast<ConstantInt>(II.getLength());
```

Here, the way we were generating the sizeof for the memset instruction was making a constant expression but not a constant int, causing the failure.

This PR works around the problem by generating a constant int using DataLayout. That might be more straightforward for the optimizers anyway.

- [x] ra-atomics works with valgrind
- [x] ra.chpl works with valgrind
- [x] ra-cleanloop works with valgrind
- [x] full local testing

Reviewed by @daviditen - thanks!