### PR TITLE
Fix problem building compiler on GCC 5

### DIFF
--- a/compiler/next/include/chpl/types/ClassTypeDecorator.h
+++ b/compiler/next/include/chpl/types/ClassTypeDecorator.h
@@ -196,7 +196,7 @@ class ClassTypeDecorator final {
     return !(*this == other);
   }
   size_t hash() const {
-    return chpl::hash(val_);
+    return chpl::hash((unsigned) val_);
   }
   void swap(ClassTypeDecorator other) {
     std::swap(this->val_, other.val_);


### PR DESCRIPTION
Follow up to PR #18700 to address a failure building chpl in linux32 testing.
GCC 5 does not have a `std::hash` function for enums,
so cast to unsigned.

Trivial and not reviewed.