### PR TITLE
Take 2: Fix problem building compiler on GCC 5

### DIFF
--- a/compiler/next/include/chpl/types/ClassTypeDecorator.h
+++ b/compiler/next/include/chpl/types/ClassTypeDecorator.h
@@ -196,7 +196,7 @@ class ClassTypeDecorator final {
     return !(*this == other);
   }
   size_t hash() const {
-    return chpl::hash((unsigned) val_);
+    return (unsigned) val_;
   }
   void swap(ClassTypeDecorator other) {
     std::swap(this->val_, other.val_);

--- a/compiler/next/include/chpl/types/QualifiedType.h
+++ b/compiler/next/include/chpl/types/QualifiedType.h
@@ -109,7 +109,7 @@ class QualifiedType final {
     std::swap(this->param_, other.param_);
   }
   size_t hash() const {
-    size_t h1 = chpl::hash((unsigned) kind_);
+    size_t h1 = (size_t) kind_;
     size_t h2 = chpl::hash(type_);
     size_t h3 = chpl::hash(param_);
 

--- a/compiler/next/include/chpl/uast/Function.h
+++ b/compiler/next/include/chpl/uast/Function.h
@@ -379,4 +379,12 @@ class Function final : public NamedDecl {
 } // end namespace uast
 } // end namespace chpl
 
+namespace std {
+  template<> struct hash<chpl::uast::Function::Kind> {
+    inline size_t operator()(const chpl::uast::Function::Kind& key) const {
+      return (size_t) key;
+    }
+  };
+} // end namespace std
+
 #endif


### PR DESCRIPTION
Take-2 follow up to PR #18700 to address a failure building chpl in linux32 testing.
GCC 5 does not have a `std::hash` function for enums, so cast to unsigned.

This PR focuses on using the enum value as the hash to keep it simple.

Trivial and not reviewed.