### PR TITLE
Generate user error if 'make' fails to build generated code

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2712,7 +2712,10 @@ void makeBinary(void) {
     const char* command = astr(astr(CHPL_MAKE, " "),
                                makeflags,
                                getIntermediateDirName(), "/Makefile");
-    mysystem(command, "compiling generated source");
+    int status = mysystem(command, "compiling generated source");
+    if (status != 0) {
+      INT_FATAL("Error compiling generated sources");
+    }
   }
 
   if (gCodegenGPU == false) {


### PR DESCRIPTION
I've recently been noticing that when the `make` command that the
compiler fires off to generate the binary fails, `chpl` doesn't return
a non-zero exit code, and therefore the test system tries to run the
binary, only to complain that it doesn't exist.  This PR makes such
failures to `make` into a user error, which in turn generates a non-zero
exit code.

At first I made this an internal error, but it seems as though
sometimes the fault could be ours, sometimes the user's (e.g., "I had
a require statement that named a file that didn't exist").  So I ended
up making it a user error since (a) they'll see the C compiler output
and will hopefully be able to tell in cases where it's their fault and
(b) internal errors are so inscrutible.

I was expecting to find that we used to exit with non-zero and that we'd
broken it at some point, but spot-checking a few releases, I'm not seeing
any sign of it as far back as 1.10.  So maybe we just assumed that users
would know that the C compile had failed due to its output and were
sloppy in not thinking about the exit code?

I haven't added any tests here because I haven't been able to come up with
a good way to add a portable test.  E.g., one idea was to add a test that
has `require "foo.h";` in it, which will break the C compilation if `foo.h`
doesn't exist, but how it will break the C compilation varies per compiler.
And that's going to be true for most C compilation-time errors.