### PR TITLE
Improve LLVM configuration on Mac OS X

### DIFF
--- a/third-party/llvm/Makefile.include-system
+++ b/third-party/llvm/Makefile.include-system
@@ -1,9 +1,13 @@
 include $(THIRD_PARTY_DIR)/llvm/Makefile.share-system
 
-# Always link dynamically when using a system LLVM.
+# Decide whether to try to link statically or dynamically.
 # Future work: consider using 'llvm-config --shared-mode'
 # to make this choice.
+ifeq ($(CHPL_MAKE_PLATFORM),darwin)
+CHPL_LLVM_DYNAMIC := 0
+else
 CHPL_LLVM_DYNAMIC := 1
+endif
 
 ifndef LLVM_LLVM_LIBS
   export LLVM_LLVM_LIBS=$(shell $(LLVM_CONFIG) --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets coverage coroutines lto)

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -354,11 +354,19 @@ def get_clang_additional_args():
     link_args = [ ]
     basic_args = get_clang_basic_args()
     has_sysroot = False
+    sysroot_arg = ""
     for arg in basic_args:
+        # if we set has_sysroot on last iteration, get the arg
+        if has_sysroot:
+            sysroot_arg = arg
+            break
         if arg == '-isysroot':
             has_sysroot = True
 
     if has_sysroot:
+        # Add the equivalent of /usr/include and /usr/lib
+        comp_args.append('-I' + os.path.join(sysroot_arg, 'usr', 'include'))
+        link_args.append('-L' + os.path.join(sysroot_arg, 'usr', 'lib'))
         # Work around a bug in some versions of Clang that forget to
         # search /usr/local/include and /usr/local/lib
         # if there is a -isysroot argument.

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -324,7 +324,8 @@ def get_sysroot_resource_dir_args():
     args = [ ]
     target_platform = chpl_platform.get('target')
     llvm_val = get()
-    if target_platform == "darwin" and llvm_val == "bundled":
+    if (target_platform == "darwin" and
+        (llvm_val == "bundled" or llvm_val == "system")):
         # Add -isysroot and -resourcedir based upon what 'clang' uses
         cfile = os.path.join(get_chpl_home(),
                              "runtime", "include", "sys_basic.h")


### PR DESCRIPTION
Follow-up to PR #18606

*  Add isysroot argument even for system llvm
   * This appears to be necessary on Mac OS X 11.6.1 with Homebrew llvm
     version 11.1.0.

* Link clang statically for Mac OS X with system LLVM
   * note that we were already linking statically with the LLVM binaries,
     but previously were linking clang dynamically 
   * intended to resolve problems building mason
     (https://github.com/Cray/chapel-private/issues/2702)
   
* Add -I and -L paths according to sysroot
  * The `-L` path at least seems to be necessary on Mac OS 11.6 and
    newer. See https://developer.apple.com/forums/thread/666700 for some
    background in this area. Even though the `-isysroot` path covers it,
    the linking call does not seem to use it.

- [x] homebrew system LLVM 11.1 functions on Big Sur
- [x] homebrew system LLVM 11.1 functions on Catalina
- [x] homebrew system LLVM functions on Mojave
- [x] bundled LLVM functions on Big Sur and Catalina
- [x] full local testing

Reviewed by @ronawho - thanks!