### PR TITLE
Fix handling of non-zero exit status in mysystem()

### DIFF
--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -125,7 +125,7 @@ int mysystem(const std::vector<std::string> commandVec,
     if (status != 0 && !ignoreStatus) {
       USR_FATAL("%s", description);
     }
-  // uh-oh cases below
+  // handle the case when the child couldn't be forked
   } else if (childPid == -1) {
     USR_FATAL("fork() failed: %s", strerror(errno));
   }

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -119,11 +119,15 @@ int mysystem(const std::vector<std::string> commandVec,
   } else if (childPid > 0 ) {
     // in parent process
     waitpid(childPid, &status, 0);
+    // filter status down to key bits
+    status = WEXITSTATUS(status);
+    // generate an error if there was one and we weren't asked to ignore it
+    if (status != 0 && !ignoreStatus) {
+      USR_FATAL("%s", description);
+    }
   // uh-oh cases below
   } else if (childPid == -1) {
     USR_FATAL("fork() failed: %s", strerror(errno));
-  } else if (childPid != 0 && !ignoreStatus) {
-    USR_FATAL("%s", description);
   }
-  return WEXITSTATUS(status);
+  return status;
 }


### PR DESCRIPTION
This fixes an issue introduced in PR #18594 in which mysystem()
no longer generates a user error if the forked off process
returned a non-zero exit code.  An example impact of this is
that if 'make -f' failed, the compiler would generate a 0 exit
status and the test system would assume compilation succeeded
until it tried to run the resulting program, which wasn't there.
    
The fix is to have the parent process handle the non-zero exit
status prior to returning.

Resolves https://github.com/Cray/chapel-private/issues/2725
