### PR TITLE
Change internal error to user error for bad import expression

### DIFF
--- a/compiler/AST/ImportStmt.cpp
+++ b/compiler/AST/ImportStmt.cpp
@@ -306,7 +306,9 @@ bool ImportStmt::checkValid(Expr* expr) const {
     }
 
   } else {
-    INT_FATAL(this, "Unexpected import stmt");
+    USR_FATAL_CONT(this, "Illegal expression in 'import' statement");
+    USR_PRINT(this, "only identifiers and 'dot' expressions are supported");
+    USR_STOP();
   }
 
   return retval;

--- a/test/statements/errors/importIllegalExpr.chpl
+++ b/test/statements/errors/importIllegalExpr.chpl
@@ -1,0 +1,20 @@
+module foo {
+
+config param p = true;
+
+module M {
+  public import (if p then super.a else super.b) as A;
+}
+
+module a {
+  var x = 7;
+}
+
+module b {
+  var x = 8;
+}
+
+import this.M;
+writeln(M.A.x);
+
+}

--- a/test/statements/errors/importIllegalExpr.good
+++ b/test/statements/errors/importIllegalExpr.good
@@ -1,0 +1,2 @@
+importIllegalExpr.chpl:6: error: Illegal expression in 'import' statement
+importIllegalExpr.chpl:6: note: only identifiers and 'dot' expressions are supported


### PR DESCRIPTION
This resolves an error pointed out by @cassella in which an `import`
statement with an unexpected expression caused an internal error
rather than a helpful user-facing one.  Changed to a user error and
added Paul's test to prevent backsliding.

Resolves #18718.