### PR TITLE
Disable jemalloc merge/split hooks under ugni

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -402,7 +402,6 @@ void chpl_mem_layerInit(void) {
   size_t heap_size;
 
   interleave_mem = chpl_env_rt_get_bool("INTERLEAVE_MEMORY", CHPL_INTERLEAVE_MEM);
-  merge_split_chunks = chpl_env_rt_get_bool("MERGE_SPLIT_CHUNKS", true);
   CHPL_JE_LG_ARENA = get_num_arenas()-1;
 
   chpl_comm_regMemHeapInfo(&heap_base, &heap_size);
@@ -419,6 +418,7 @@ void chpl_mem_layerInit(void) {
   //   memory allocation routines, the allocator initializes its internals"
   if (heap_base != NULL) {
     heap.type = FIXED;
+    merge_split_chunks = chpl_env_rt_get_bool("MERGE_SPLIT_CHUNKS", true);
     heap.base = heap_base;
     heap.size = heap_size;
     heap.cur_offset = 0;
@@ -428,6 +428,7 @@ void chpl_mem_layerInit(void) {
     initializeSharedHeap();
   } else if (chpl_comm_regMemAllocThreshold() < SIZE_MAX) {
     heap.type = DYNAMIC;
+    merge_split_chunks = chpl_env_rt_get_bool("MERGE_SPLIT_CHUNKS", false);
     initializeSharedHeap();
   } else {
     void* p;


### PR DESCRIPTION
We've been seeing sporadic errors under ugni that we've bisected to
18299, which enabled jemalloc merge/split hooks to reduce fragmentation
for configurations that use a fixed heap. It also enabled merge/split
for configs that use a dynamically extended heap, which today is just
ugni. For some reason this seems to be causing sporadic failures when
doing large BTE initiated GETs, so until we figure out the root cause
just disable merge/split for this config. This doesn't really impact
fragmentation since large arrays are separately allocated.

I view this as a short-term workaround for an upcoming point release,
but expect to spend more time investigating the root cause soon.

Part of https://github.com/Cray/chapel-private/issues/2678