### PR TITLE
Add missing import for python3

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -141,6 +141,7 @@ import re
 import shlex
 import datetime
 import errno
+from functools import reduce
 
 # update path to allow 'import fixpath' below
 util_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'util')


### PR DESCRIPTION
python3 removed the global `reduce` function, which is used in `Fatal`

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>