### PR TITLE
Add test showing that FormattedIO is no longer available by default

### DIFF
--- a/test/library/standard/IO/useFormattedIO.chpl
+++ b/test/library/standard/IO/useFormattedIO.chpl
@@ -1,0 +1,1 @@
+use FormattedIO;

--- a/test/library/standard/IO/useFormattedIO.good
+++ b/test/library/standard/IO/useFormattedIO.good
@@ -1,0 +1,1 @@
+useFormattedIO.chpl:1: error: Cannot find module or enum 'FormattedIO'


### PR DESCRIPTION
I'm adding the test from issue #18743, just to lock in the intended
behavior and make sure we don't backslide on this in the future.
My guess is that Lydia probably has added equivalent tests that
check for similar things in user code, but this was puzzling enough
(and the compile errors quickly enough) that it seemed beneficial
to add a test while I was looking at it.
