### PR TITLE
Address command quoting issue in printchplenv

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -43,7 +43,7 @@ def get(flag='target'):
             # For pgi or 32-bit platforms with an older gcc, we fall back to
             # locks
             if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu']:
-                version = get_compiler_version('gnu')
+                version = get_compiler_version(flag)
                 if version >= CompVersion('5.0'):
                     atomics_val = 'cstdlib'
                 elif version >= CompVersion('4.8'):

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -7,7 +7,7 @@ from string import punctuation
 import sys
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
-from compiler_utils import CompVersion, target_compiler_is_prgenv, get_compiler_version
+from compiler_utils import CompVersion, target_compiler_is_prgenv
 from utils import memoize, run_command, warning
 
 # This map has a key as a synonym and the value as the LLVM arch/cpu

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -319,6 +319,17 @@ def get_gcc_prefix():
 
     return gcc_prefix
 
+# The bundled LLVM does not currently know to look in a particular Mac OS X SDK
+# so we provide a -isysroot arg to indicate which is used.
+#
+# Potential alternatives to -isysroot here include:
+#  * using the environment variable SDKROOT
+#  * providing a cmake argument to adjust the clang build
+#  * using -mmacosx-version-min=11.2 e.g.
+#
+# Additionally the -resource-dir arg indicates where to find some clang
+# dependencies.
+#
 # Returns a [ ] list of args
 @memoize
 def get_sysroot_resource_dir_args():

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -325,8 +325,7 @@ def get_sysroot_resource_dir_args():
     args = [ ]
     target_platform = chpl_platform.get('target')
     llvm_val = get()
-    if (target_platform == "darwin" and
-        (llvm_val == "bundled" or llvm_val == "system")):
+    if (target_platform == "darwin" and llvm_val == "bundled"):
         # Add -isysroot and -resourcedir based upon what 'clang' uses
         cfile = os.path.join(get_chpl_home(),
                              "runtime", "include", "sys_basic.h")
@@ -365,9 +364,6 @@ def get_clang_additional_args():
             has_sysroot = True
 
     if has_sysroot:
-        # Add the equivalent of /usr/include and /usr/lib
-        comp_args.append('-I' + os.path.join(sysroot_arg, 'usr', 'include'))
-        link_args.append('-L' + os.path.join(sysroot_arg, 'usr', 'lib'))
         # Work around a bug in some versions of Clang that forget to
         # search /usr/local/include and /usr/local/lib
         # if there is a -isysroot argument.

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -225,7 +225,7 @@ def get_llvm_clang(lang):
         return ''
 
     # tack on arguments that control clang's function
-    result = [clang_name] + get_clang_basic_args()
+    result = [clang] + get_clang_basic_args()
     return result
 
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -165,17 +165,27 @@ def get_llvm_config():
     return llvm_config
 
 @memoize
-def validate_llvm_config(llvm_config=None):
+def validate_llvm_config():
     llvm_val = get()
-    # We pass in llvm_config if has already been computed (so we don't
-    # end up in an infinite loop).
-    if llvm_config is None:
-      llvm_config = get_llvm_config()
+    llvm_config = get_llvm_config()
+
     if llvm_val == 'system':
         if llvm_config == '' or llvm_config == 'none':
             error("CHPL_LLVM=system but could not find an installed LLVM"
                   " with one of the supported versions: {0}".format(
                   llvm_versions_string()))
+
+        else:
+            bindir = get_system_llvm_config_bindir()
+            if not (bindir and os.path.isdir(bindir)):
+                error("llvm-config command {0} provides missing bin dir {0}"
+                      .format(llvm_config, bindir))
+            clang_c = get_llvm_clang('c')[0]
+            clang_cxx = get_llvm_clang('c++')[0]
+            if not os.path.exists(clang_c):
+                error("Missing clang command at {0}".format(clang_c))
+            if not os.path.exists(clang_cxx):
+                error("Missing clang++ command at {0}".format(clang_cxx))
 
     if (llvm_val == 'system' or
         (llvm_val == 'bundled' and os.path.exists(llvm_config))):
@@ -187,15 +197,14 @@ def validate_llvm_config(llvm_config=None):
 
 @memoize
 def get_system_llvm_config_bindir():
-    llvm_config = get_llvm_config()
-    validate_llvm_config(llvm_config)
-    bindir = run_command([llvm_config, '--bindir']).strip()
+    llvm_config = find_system_llvm_config()
+    found_version, found_config_err = check_llvm_config(llvm_config)
 
-    if os.path.isdir(bindir):
-        pass
-    else:
-        error("llvm-config command {0} provides missing bin directory {0}"
-              .format(llvm_config, bindir))
+    bindir = None
+
+    if llvm_config and found_version and not found_config_err:
+        bindir = run_command([llvm_config, '--bindir']).strip()
+
     return bindir
 
 def get_llvm_clang_command_name(lang):
@@ -209,20 +218,32 @@ def get_llvm_clang_command_name(lang):
     else:
         return 'clang'
 
+def get_system_llvm_clang(lang):
+    clang_name = get_llvm_clang_command_name(lang)
+    bindir = get_system_llvm_config_bindir()
+    clang = ''
+    if bindir:
+        clang = os.path.join(bindir, clang_name)
+
+    return clang
+
 # lang should be C or CXX
+# returns [] list with the first element the clang command,
+# then necessary arguments
 @memoize
 def get_llvm_clang(lang):
-    clang_name = get_llvm_clang_command_name(lang)
 
+    clang = None
     llvm_val = get()
     if llvm_val == 'system':
-        bindir = get_system_llvm_config_bindir()
-        clang = os.path.join(bindir, clang_name)
+        clang = get_system_llvm_clang(lang)
     elif llvm_val == 'bundled':
+        clang_name = get_llvm_clang_command_name(lang)
         llvm_subdir = get_bundled_llvm_dir()
         clang = os.path.join(llvm_subdir, 'bin', clang_name)
-    else:
-        return ''
+
+    if not clang:
+        return ['']
 
     # tack on arguments that control clang's function
     result = [clang] + get_clang_basic_args()
@@ -231,10 +252,17 @@ def get_llvm_clang(lang):
 
 def has_compatible_installed_llvm():
     llvm_config = find_system_llvm_config()
+
     if llvm_config:
-        return True
-    else:
-        return False
+        clang_c_command = get_system_llvm_clang('c')
+        clang_cxx_command = get_system_llvm_clang('c++')
+
+        if (os.path.exists(clang_c_command) and
+            os.path.exists(clang_cxx_command)):
+            return True
+
+    # otherwise, something went wrong, so return False
+    return False
 
 @memoize
 def get():

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -225,13 +225,8 @@ def get_llvm_clang(lang):
         return ''
 
     # tack on arguments that control clang's function
-    clang_args = get_clang_basic_args()
-    if clang_args:
-        args = ' '.join(clang_args)
-        if args:
-            clang += ' ' + args
-
-    return clang
+    result = [clang_name] + get_clang_basic_args()
+    return result
 
 
 def has_compatible_installed_llvm():
@@ -316,7 +311,13 @@ def get_gcc_prefix():
                         if os.path.isdir(inc):
                             gcc_prefix = mydir
 
-    return gcc_prefix.strip()
+        gcc_prefix = gcc_prefix.strip()
+        if gcc_prefix == '/usr':
+            # clang will be able to figure this out so don't
+            # bother with the argument here.
+            gcc_prefix = ''
+
+    return gcc_prefix
 
 # Returns a [ ] list of args
 @memoize

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -3,7 +3,7 @@ import sys
 
 import chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import using_chapel_module
-from compiler_utils import CompVersion, get_compiler_version
+from compiler_utils import CompVersion
 from utils import memoize
 
 

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -142,8 +142,8 @@ def compute_all_values():
     host_compiler_c = chpl_compiler.get_compiler_command('host', 'c')
     host_compiler_cpp = chpl_compiler.get_compiler_command('host', 'c++')
     ENV_VALS['CHPL_HOST_COMPILER'] = host_compiler
-    ENV_VALS['  CHPL_HOST_CC'] = host_compiler_c
-    ENV_VALS['  CHPL_HOST_CXX'] = host_compiler_cpp
+    ENV_VALS['  CHPL_HOST_CC'] = " ".join(host_compiler_c)
+    ENV_VALS['  CHPL_HOST_CXX'] = " ".join(host_compiler_cpp)
 
     ENV_VALS['CHPL_HOST_ARCH'] = chpl_arch.get('host')
     ENV_VALS['CHPL_HOST_CPU'] = chpl_cpu.get('host').cpu
@@ -154,8 +154,8 @@ def compute_all_values():
     target_compiler_cpp = chpl_compiler.get_compiler_command('target', 'c++')
     target_compiler_prgenv = chpl_compiler.get_prgenv_compiler()
     ENV_VALS['CHPL_TARGET_COMPILER'] = target_compiler
-    ENV_VALS['  CHPL_TARGET_CC'] = target_compiler_c
-    ENV_VALS['  CHPL_TARGET_CXX'] = target_compiler_cpp
+    ENV_VALS['  CHPL_TARGET_CC'] = " ".join(target_compiler_c)
+    ENV_VALS['  CHPL_TARGET_CXX'] = " ".join(target_compiler_cpp)
     ENV_VALS['  CHPL_TARGET_COMPILER_PRGENV'] = target_compiler_prgenv
 
     ENV_VALS['CHPL_TARGET_ARCH'] = chpl_arch.get('target')
@@ -186,8 +186,10 @@ def compute_all_values():
     ENV_VALS['CHPL_RE2'] = chpl_re2.get()
     ENV_VALS['CHPL_LLVM'] = chpl_llvm.get()
     ENV_VALS['  CHPL_LLVM_CONFIG'] = chpl_llvm.get_llvm_config()
-    ENV_VALS['  CHPL_LLVM_CLANG_C'] = chpl_llvm.get_llvm_clang('c')
-    ENV_VALS['  CHPL_LLVM_CLANG_CXX'] = chpl_llvm.get_llvm_clang('c++')
+    llvm_clang_c = chpl_llvm.get_llvm_clang('c')
+    llvm_clang_cxx = chpl_llvm.get_llvm_clang('c++')
+    ENV_VALS['  CHPL_LLVM_CLANG_C'] = " ".join(llvm_clang_c)
+    ENV_VALS['  CHPL_LLVM_CLANG_CXX'] = " ".join(llvm_clang_cxx)
     ENV_VALS['  CHPL_LLVM_CLANG_COMPILE_ARGS'] = chpl_llvm.get_clang_compile_args()
     ENV_VALS['  CHPL_LLVM_CLANG_LINK_ARGS'] = chpl_llvm.get_clang_link_args()
     aux_filesys = chpl_aux_filesys.get()
@@ -223,7 +225,7 @@ def compute_internal_values():
 
     sys_modules_subdir = (chpl_platform.get('target') + "-" +
                           chpl_arch.get('target') + "-" +
-                          chpl_compiler.get_path_component('target'));
+                          chpl_compiler.get_path_component('target'))
     ENV_VALS['CHPL_SYS_MODULES_SUBDIR'] = sys_modules_subdir
 
     ENV_VALS['  CHPL_LLVM_UNIQ_CFG_PATH'] = chpl_llvm.get_uniq_cfg_path()


### PR DESCRIPTION
For #18741

This PR adjusts chpl_compiler.get_compiler_command and chpl_llvm.get_llvm_clang to return a Python list so that it is easier to construct the correctly quoted command to run when using these.

It also adjusts get_compiler_version to accept flag of host or target.

While there, avoid adding a gcc prefix argument for clang when the prefix is just the normal /usr.

It removes two workarounds I added in PR #18727 because reinstalling CommandLineTools fixed the problem for me and these workarounds weren't sufficient to get the third-party code compiling.

Future Work:
 * figure out how to resolve linker errors like `object file ... was built for newer macOS version (11.6) than being linked (11.0)` with CHPL_LLVM=bundled when linking `chpl` itself. So far these appear to be harmless.
 * Look into problems with Mojave with CHPL_LLVM=bundled (wasn't working for @e-kayrakli but so far we are not sure if that is a local issue)

Verified that `make check` passes on
- [x] Big Sur with CHPL_LLVM=system with Homebrew LLVM 11.1
- [x] Big Sur with CHPL_LLVM=bundled
- [x] Mojave with CHPL_LLVM=system with Homebrew LLVM 10.1
- [x] Catalina with CHPL_LLVM=system with Homebrew LLVM 10.1
- [x] Ubuntu builds with CHPL_LLVM=bundled, CHPL_TARGET_COMPILER=clang, custom GCC, and no clang in path
- [x] Ubuntu builds with CHPL_LLVM=system

And
- [x] full local testing