### PR TITLE
Add preliminary support for Slingshot network settings.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -79,6 +79,7 @@ extern "C" {
   m(TCIPS,                  "tx context alloc/free")                    \
   m(OOB,                    "out-of-band calls")                        \
   m(BARRIER,                "barriers")                                 \
+  m(SLINGSHOT,              "Slingshot")                                \
   m(TSTAMP,                 "timestamp output")
 
 //

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1978,6 +1978,25 @@ void heedSlingshotSettings(struct fi_info* info) {
   const char* evSvcIds = getenv("SLINGSHOT_SVC_IDS");
   const char* evTcs = getenv("SLINGSHOT_TCS");
   const char* evVnis = getenv("SLINGSHOT_VNIS");
+
+  DBG_PRINTF(DBG_SLINGSHOT,
+             "SLINGSHOT_DEVICES %s%s%s, "
+             "SVC_IDS %s%s%s, "
+             "TCS %s%s%s, "
+             "VNIS %s%s%s",
+             (evDevs == NULL) ? "" : "\"",
+             (evDevs == NULL) ? "not set" : evDevs,
+             (evDevs == NULL) ? "" : "\"",
+             (evSvcIds == NULL) ? "" : "\"",
+             (evSvcIds == NULL) ? "not set" : evSvcIds,
+             (evSvcIds == NULL) ? "" : "\"",
+             (evTcs == NULL) ? "" : "\"",
+             (evTcs == NULL) ? "not set" : evTcs,
+             (evTcs == NULL) ? "" : "\"",
+             (evVnis == NULL) ? "" : "\"",
+             (evVnis == NULL) ? "not set" : evVnis,
+             (evVnis == NULL) ? "" : "\"");
+
   CHK_TRUE((evDevs == NULL) == (evSvcIds == NULL)
            && (evSvcIds == NULL) == (evTcs == NULL)
            && (evTcs == NULL) == (evVnis == NULL)); // sanity
@@ -2009,9 +2028,7 @@ void heedSlingshotSettings(struct fi_info* info) {
     char* lasts;
     CHK_TRUE((tok = strtok_r(ev, ",", &lasts)) != NULL);
     CHK_TRUE(sscanf(tok, "%" SCNu32, &auth_key->svc_id) == 1);
-    DBG_PRINTF(DBG_CFG,
-               "Slingshot svc_id %" PRIu32 " (from SVC_IDS=%s)",
-               auth_key->svc_id, evSvcIds);
+    DBG_PRINTF(DBG_SLINGSHOT, "Slingshot svc_id %" PRIu32, auth_key->svc_id);
   }
 
   //
@@ -2032,9 +2049,7 @@ void heedSlingshotSettings(struct fi_info* info) {
     char* lasts2;
     CHK_TRUE((tok2 = strtok_r(ev2, ":", &lasts2)) != NULL);
     CHK_TRUE(sscanf(tok2, "%" SCNu16, &auth_key->vni) == 1);
-    DBG_PRINTF(DBG_CFG,
-               "Slingshot VNI %" PRIu16 " (from VNIS=%s)",
-               auth_key->vni, evVnis);
+    DBG_PRINTF(DBG_SLINGSHOT, "Slingshot VNI %" PRIu16, auth_key->vni);
   }
 
   info->domain_attr->auth_key = (void*) auth_key;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1885,7 +1885,8 @@ void init_ofiFabricDomain(void) {
   //
   OFI_CHK(fi_fabric(ofi_info->fabric_attr, &ofi_fabric, NULL));
 
-  if (strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex") == 0) {
+  if (strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex") == 0
+      && chpl_env_rt_get_bool("COMM_OFI_SLINGSHOT_CHECK_ENV", true)) {
     heedSlingshotSettings(ofi_info);
   }
 
@@ -1989,7 +1990,7 @@ void heedSlingshotSettings(struct fi_info* info) {
     uint16_t vni;
   };
   struct ss_auth_key* auth_key;
-  CHPL_CALLOC(auth_key, 1);
+  CHK_SYS_MALLOC(auth_key, 1);    // fi_freeinfo() will free this with free()
 
   //
   // Service ID.  If there are more than one, just take the first.

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2002,6 +2002,9 @@ void heedSlingshotSettings(struct fi_info* info) {
     char* lasts;
     CHK_TRUE((tok = strtok_r(ev, ",", &lasts)) != NULL);
     CHK_TRUE(sscanf(tok, "%" SCNu32, &auth_key->svc_id) == 1);
+    DBG_PRINTF(DBG_CFG,
+               "Slingshot svc_id %" PRIu32 " (from SVC_IDS=%s)",
+               auth_key->svc_id, evSvcIds);
   }
 
   //
@@ -2022,6 +2025,9 @@ void heedSlingshotSettings(struct fi_info* info) {
     char* lasts2;
     CHK_TRUE((tok2 = strtok_r(ev2, ":", &lasts2)) != NULL);
     CHK_TRUE(sscanf(tok2, "%" SCNu16, &auth_key->vni) == 1);
+    DBG_PRINTF(DBG_CFG,
+               "Slingshot VNI %" PRIu16 " (from VNIS=%s)",
+               auth_key->vni, evVnis);
   }
 
   info->domain_attr->auth_key = (void*) auth_key;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2018,7 +2018,10 @@ void heedSlingshotSettings(struct fi_info* info) {
   CHK_SYS_MALLOC(auth_key, 1);
 
   //
-  // Service ID.  If there are more than one, just take the first.
+  // Service ID.  If there are more than one, then we have access to
+  // more than one interface.  But we only support one anyway and our
+  // domain logic will have found the first of them, so just take the
+  // first service ID.
   //
   {
     char ev[strlen(evSvcIds) + 1];  // non-constant, for strtok()
@@ -2032,7 +2035,8 @@ void heedSlingshotSettings(struct fi_info* info) {
   }
 
   //
-  // VNI.  If there are more than one, just take the first.
+  // VNI.  Similarly to the service ID case, if there are more than one,
+  // just take the first.
   //
   {
     char ev[strlen(evVnis) + 1];  // non-constant, for strtok()

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1985,12 +1985,18 @@ void heedSlingshotSettings(struct fi_info* info) {
     return;
   }
 
+  //
+  // Libfabric allocates and frees struct fi_info structures and their
+  // substructures with the system allocator.  Therefore, that instead
+  // of the Chapel allocator for this auth_key since the pointer to it
+  // will be assigned into that struct.
+  //
   struct ss_auth_key {
     uint32_t svc_id;
     uint16_t vni;
   };
   struct ss_auth_key* auth_key;
-  CHK_SYS_MALLOC(auth_key, 1);    // fi_freeinfo() will free this with free()
+  CHK_SYS_MALLOC(auth_key, 1);
 
   //
   // Service ID.  If there are more than one, just take the first.


### PR DESCRIPTION
The HPE Cray EX networking support requires that applications provide
certain information produced by workload managers in order to use
the network resources allocated on their behalf.  Here, do that.

This resolves https://github.com/Cray/chapel-private/issues/2493 and
resolves https://github.com/Cray/chapel-private/issues/2740. At least,
it gives us the minimum we need, although there may be more to do in
the future.