### PR TITLE
Add missing skipif for regex serialization comm count test

### DIFF
--- a/test/regex/serializationCommCounts.skipif
+++ b/test/regex/serializationCommCounts.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM==none


### PR DESCRIPTION
Test should be skipped when comm=none

Addresses testing failure from last run

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>