### PR TITLE
Only warn if CHPL_MEM and CHPL_TARGET_MEM disagree

### DIFF
--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -18,7 +18,7 @@ def get(flag='host'):
             mem_val = 'cstdlib'
         elif chpl_target_mem:
             mem_val = chpl_target_mem
-            if chpl_mem:
+            if chpl_mem and chpl_target_mem != chpl_mem:
                 warning("CHPL_MEM and CHPL_TARGET_MEM are both set, "
                         "taking value from CHPL_TARGET_MEM")
         elif chpl_mem:


### PR DESCRIPTION
This silences the warning that was causing a failed test in
test/compflags/link/sungeun/static_dynamic.skipif because sub_test.py
runSkipIf calls util/test/testEnv which takes the output from
printchplenv --all --internal --simple --no-tidy and sets them in the
environment. Because CHPL_MEM and CHPL_TARGET_MEM both get set by this
script, we were triggering the warning (which anything on stderr will
cause the skipif to fail).

I still think having the warning is a good thing and I think it's
reasonable to only warn when there is a mismatch.

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>