### PR TITLE
Fix comm count microbenchmarks

### DIFF
--- a/test/performance/ferguson/MYCOMPOPTS
+++ b/test/performance/ferguson/MYCOMPOPTS
@@ -28,20 +28,14 @@ def f(options, configname):
 # where the maximum is not passed.
 checkMaxAttained=' -scheckMaxAttained=true'
 
-if not do_llvm:
-  # C backend, no cache remote
-  f('--no-cache-remote ' + checkMaxAttained, 'c')
-  # C backend, cache remote
-  if do_cache:
-    f('--cache-remote', 'c-cache')
+
+# Test combinations of wide-opt and remote cache
+
+f('--no-llvm-wide-opt --no-cache-remote ' + checkMaxAttained, 'no-wideopt-no-cache')
+if do_cache:
+    f('--no-llvm-wide-opt --cache-remote', 'no-wideopt-cache')
 
 if do_llvm:
-  # LLVM backend, no cache remote
-  #f('--no-cache-remote', 'llvm')
-  # LLVM backend, cache remote
-  #f('--cache-remote', 'llvm-cache')
-  # LLVM backend, llvm wide opts, no cache remote
-  f('--llvm-wide-opt --no-cache-remote', 'llvm-wide-opt')
-  # LLVM backend, llvm wide opts, cache remote
+  f('--llvm-wide-opt --no-cache-remote', 'wideopt-no-cache')
   if do_cache:
-    f('--llvm-wide-opt --cache-remote', 'llvm-wide-opt-cache')
+    f('--llvm-wide-opt --cache-remote', 'wideopt-cache')

--- a/test/performance/ferguson/array-assign-get.graph
+++ b/test/performance/ferguson/array-assign-get.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: array-assign-get-c.dat, array-assign-get-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: array-assign-get-no-wideopt-no-cache.dat, array-assign-get-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: array-assign-get

--- a/test/performance/ferguson/remote-array-copy.graph
+++ b/test/performance/ferguson/remote-array-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, PUTs:, GETs:, PUTs:
-files: remote-array-copy-c.dat, remote-array-copy-c.dat, remote-array-copy-c-cache.dat, remote-array-copy-c-cache.dat
-graphkeys: c GETs, c PUTs, c-cache GETs, c-cache PUTs
+files: remote-array-copy-no-wideopt-no-cache.dat, remote-array-copy-no-wideopt-no-cache.dat, remote-array-copy-no-wideopt-cache.dat, remote-array-copy-no-wideopt-cache.dat
+graphkeys: no-cache GETs, no-cache PUTs, cache GETs, cache PUTs
 ylabel: Count
 graphtitle: remote-array-copy

--- a/test/performance/ferguson/remote-array-read-access.graph
+++ b/test/performance/ferguson/remote-array-read-access.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-array-read-access-c.dat, remote-array-read-access-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-array-read-access-no-wideopt-no-cache.dat, remote-array-read-access-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-array-read-access

--- a/test/performance/ferguson/remote-array-read.graph
+++ b/test/performance/ferguson/remote-array-read.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-array-read-c.dat, remote-array-read-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-array-read-no-wideopt-no-cache.dat, remote-array-read-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-array-read

--- a/test/performance/ferguson/remote-array-write-access.graph
+++ b/test/performance/ferguson/remote-array-write-access.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-array-write-access-c.dat, remote-array-write-access-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-array-write-access-no-wideopt-no-cache.dat, remote-array-write-access-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-array-write-access

--- a/test/performance/ferguson/remote-array-write.graph
+++ b/test/performance/ferguson/remote-array-write.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-array-write-c.dat, remote-array-write-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-array-write-no-wideopt-no-cache.dat, remote-array-write-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-array-write

--- a/test/performance/ferguson/remote-class-read.graph
+++ b/test/performance/ferguson/remote-class-read.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-class-read-c.dat, remote-class-read-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-class-read-no-wideopt-no-cache.dat, remote-class-read-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-class-read

--- a/test/performance/ferguson/remote-class-write.graph
+++ b/test/performance/ferguson/remote-class-write.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, PUTs:, GETs:, PUTs:
-files: remote-class-write-c.dat, remote-class-write-c.dat, remote-class-write-c-cache.dat, remote-class-write-c-cache.dat
-graphkeys: c GETs, c PUTs, c-cache GETs, c-cache PUTs
+files: remote-class-write-no-wideopt-no-cache.dat, remote-class-write-no-wideopt-no-cache.dat, remote-class-write-no-wideopt-cache.dat, remote-class-write-no-wideopt-cache.dat
+graphkeys: no-cache GETs, no-cache PUTs, cache GETs, cache PUTs
 ylabel: Count
 graphtitle: remote-class-write

--- a/test/performance/ferguson/remote-record-read-copy.graph
+++ b/test/performance/ferguson/remote-record-read-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-record-read-copy-c.dat, remote-record-read-copy-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-record-read-copy-no-wideopt-no-cache.dat, remote-record-read-copy-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-record-read-copy

--- a/test/performance/ferguson/remote-record-read-licm.graph
+++ b/test/performance/ferguson/remote-record-read-licm.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-record-read-licm-c.dat, remote-record-read-licm-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-record-read-licm-no-wideopt-no-cache.dat, remote-record-read-licm-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-record-read-licm

--- a/test/performance/ferguson/remote-record-read.graph
+++ b/test/performance/ferguson/remote-record-read.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-record-read-c.dat, remote-record-read-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-record-read-no-wideopt-no-cache.dat, remote-record-read-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-record-read

--- a/test/performance/ferguson/remote-record-write-copy.graph
+++ b/test/performance/ferguson/remote-record-write-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-record-write-copy-c.dat, remote-record-write-copy-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-record-write-copy-no-wideopt-no-cache.dat, remote-record-write-copy-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-record-write-copy

--- a/test/performance/ferguson/remote-record-write.graph
+++ b/test/performance/ferguson/remote-record-write.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-record-write-c.dat, remote-record-write-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-record-write-no-wideopt-no-cache.dat, remote-record-write-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-record-write

--- a/test/performance/ferguson/remote-tuple-read-copy.graph
+++ b/test/performance/ferguson/remote-tuple-read-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-tuple-read-copy-c.dat, remote-tuple-read-copy-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-tuple-read-copy-no-wideopt-no-cache.dat, remote-tuple-read-copy-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-tuple-read-copy

--- a/test/performance/ferguson/remote-tuple-read-small-copy.graph
+++ b/test/performance/ferguson/remote-tuple-read-small-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-tuple-read-small-copy-c.dat, remote-tuple-read-small-copy-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-tuple-read-small-copy-no-wideopt-no-cache.dat, remote-tuple-read-small-copy-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-tuple-read-small-copy

--- a/test/performance/ferguson/remote-tuple-read-small.graph
+++ b/test/performance/ferguson/remote-tuple-read-small.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-tuple-read-small-c.dat, remote-tuple-read-small-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-tuple-read-small-no-wideopt-no-cache.dat, remote-tuple-read-small-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-tuple-read-small

--- a/test/performance/ferguson/remote-tuple-read.graph
+++ b/test/performance/ferguson/remote-tuple-read.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-tuple-read-c.dat, remote-tuple-read-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-tuple-read-no-wideopt-no-cache.dat, remote-tuple-read-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-tuple-read

--- a/test/performance/ferguson/remote-tuple-write-copy.graph
+++ b/test/performance/ferguson/remote-tuple-write-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-tuple-write-copy-c.dat, remote-tuple-write-copy-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-tuple-write-copy-no-wideopt-no-cache.dat, remote-tuple-write-copy-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-tuple-write-copy

--- a/test/performance/ferguson/remote-tuple-write-small-copy.graph
+++ b/test/performance/ferguson/remote-tuple-write-small-copy.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-tuple-write-small-copy-c.dat, remote-tuple-write-small-copy-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-tuple-write-small-copy-no-wideopt-no-cache.dat, remote-tuple-write-small-copy-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-tuple-write-small-copy

--- a/test/performance/ferguson/remote-tuple-write-small.graph
+++ b/test/performance/ferguson/remote-tuple-write-small.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-tuple-write-small-c.dat, remote-tuple-write-small-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-tuple-write-small-no-wideopt-no-cache.dat, remote-tuple-write-small-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-tuple-write-small

--- a/test/performance/ferguson/remote-tuple-write.graph
+++ b/test/performance/ferguson/remote-tuple-write.graph
@@ -1,5 +1,5 @@
 perfkeys: PUTs:, PUTs:
-files: remote-tuple-write-c.dat, remote-tuple-write-c-cache.dat
-graphkeys: c PUTs, c-cache PUTs
+files: remote-tuple-write-no-wideopt-no-cache.dat, remote-tuple-write-no-wideopt-cache.dat
+graphkeys: no-cache PUTs, cache PUTs
 ylabel: Count
 graphtitle: remote-tuple-write

--- a/test/performance/ferguson/remote-two-array-read.graph
+++ b/test/performance/ferguson/remote-two-array-read.graph
@@ -1,5 +1,5 @@
 perfkeys: GETs:, GETs:
-files: remote-two-array-read-c.dat, remote-two-array-read-c-cache.dat
-graphkeys: c GETs, c-cache GETs
+files: remote-two-array-read-no-wideopt-no-cache.dat, remote-two-array-read-no-wideopt-cache.dat
+graphkeys: no-cache GETs, cache GETs
 ylabel: Count
 graphtitle: remote-two-array-read


### PR DESCRIPTION
Previously, these tests always ran the default backend (labelled as
C-backend) and if llvm was enabled it would run llvm variants as well.
With the switch to llvm as our default and changes made in #17800 we
stopped running the default config for these microbenchmarks and only
ran llvm-wideopt variants.

Fix that here and rename the configs to avoid mention of the backend
and be more explicit about cache vs. no-cache and wideopt vs. no-wideopt
to avoid this problem with future changes to our default config.

Resolves Cray/chapel-private#2409