### PR TITLE
Fix regex allocationCounts prediff to disregard size

### DIFF
--- a/test/regex/allocationCounts.good
+++ b/test/regex/allocationCounts.good
@@ -1,15 +1,15 @@
 Search no capture
 
 Search with capture
-0: file.chpl:line: allocate 8B of string copy data at <address>
-0: file.chpl:line: allocate 8B of string copy data at <address>
-0: file.chpl:line: free at <address>
-0: file.chpl:line: allocate 8B of string copy data at <address>
-0: file.chpl:line: allocate 8B of string copy data at <address>
-0: file.chpl:line: free at <address>
-0: file.chpl:line: allocate 8B of string copy data at <address>
-0: file.chpl:line: allocate 8B of string copy data at <address>
-0: file.chpl:line: free at <address>
+0: <file>.chpl:line: allocate <N>B of string copy data at <address>
+0: <file>.chpl:line: allocate <N>B of string copy data at <address>
+0: <file>.chpl:line: free at <address>
+0: <file>.chpl:line: allocate <N>B of string copy data at <address>
+0: <file>.chpl:line: allocate <N>B of string copy data at <address>
+0: <file>.chpl:line: free at <address>
+0: <file>.chpl:line: allocate <N>B of string copy data at <address>
+0: <file>.chpl:line: allocate <N>B of string copy data at <address>
+0: <file>.chpl:line: free at <address>
 (aaa, bbbbb, ccccc)
 
 Iter Matches no capture

--- a/test/regex/allocationCounts.prediff
+++ b/test/regex/allocationCounts.prediff
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 testname=$1
 outfile=$2
-sed -E -e 's/[^ ]+.chpl:[[:digit:]]+/file.chpl:line/' -e 's/0x[a-fA-F0-9]+/<address>/' $outfile > $outfile.tmp
+sed -E \
+    -e '/of tasking layer unspecified/d' \
+    -e 's/[^ ]+.chpl:[[:digit:]]+/<file>.chpl:line/' \
+    -e 's/at 0x[a-fA-F0-9]+/at <address>/' \
+    -e 's/allocate [[:digit:]]+/allocate <N>/' \
+    $outfile > $outfile.tmp
 mv $outfile.tmp $outfile


### PR DESCRIPTION
This test is intended to count the number of allocations, but is not
sensitive to the size of allocations. Because the size of allocation
will change between jemalloc and cstdlib, we prediff the size out

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>