### PR TITLE
Fix use-after-free bug in regex chpl__serialize

### DIFF
--- a/runtime/include/qio/qio_regex.h
+++ b/runtime/include/qio/qio_regex.h
@@ -72,7 +72,7 @@ void qio_regex_release(qio_regex_t* regex);
 
 void qio_regex_get_options(const qio_regex_t* regex, qio_regex_options_t* options);
 
-void qio_regex_get_pattern(const qio_regex_t* regex, const char** pattern, int64_t* len_out);
+void qio_regex_borrow_pattern(const qio_regex_t* regex, const char** pattern, int64_t* len_out);
 
 int64_t qio_regex_get_ncaptures(const qio_regex_t* regex);
 qio_bool qio_regex_ok(const qio_regex_t* regex);

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -244,14 +244,11 @@ void qio_regex_get_options(const qio_regex_t* regex, qio_regex_options_t* option
   re2_options_to_qio_re_options(&opts, options);
 }
 
-void qio_regex_get_pattern(const qio_regex_t* regex, const char** pattern, int64_t* len_out)
+void qio_regex_borrow_pattern(const qio_regex_t* regex, const char** pattern, int64_t* len_out)
 {
   RE2* re2 = (RE2*) regex->regex;
   const std::string &s = re2->pattern();
-  char *copy = (char*) qio_malloc(s.length()+1);
-  memcpy(copy, s.data(), s.length());
-  copy[s.length()] = '\0';
-  *pattern = copy;
+  *pattern = s.c_str();
   *len_out = s.length();
 }
 

--- a/runtime/src/qio/regex/none/fail-regex.c
+++ b/runtime/src/qio/regex/none/fail-regex.c
@@ -55,7 +55,7 @@ void qio_regex_get_options(const qio_regex_t* regex, qio_regex_options_t* option
 {
 }
 
-void qio_regex_get_pattern(const qio_regex_t* regex, const char** pattern, int64_t* len_out)
+void qio_regex_borrow_pattern(const qio_regex_t* regex, const char** pattern, int64_t* len_out)
 {
 }
 


### PR DESCRIPTION
in _serialize, qio_regex_get_pattern returnas a copy of the pattern
string, which we then store a pointer to in the serialize helper. The
function returns and we free that buffer because it was an owned
buffer. _deserialize then tries to do a copy of the now-freed buffer
and we have a use-after-free.

The fix included switches to use a borrowed string gotten from the new
qio_regex_borrow_pattern. That buffer is valid as long as the regex is
alive, which is long enough for the matching _deserialize function to
work.

qio_regex_borrow_pattern could have been introduced in addition to
qio_regex_get_pattern, but the number of call sites is low and
create{String,Bytes}WithNewBuffer seems natural

* [x] locally tested asan+gasnet and asan+none on regex tests