### PR TITLE
    Add a user error for applying 'borrowed' to arrays

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -471,7 +471,7 @@ returnInfoToUnmanaged(CallExpr* call) {
 static QualifiedType
 returnInfoToBorrowed(CallExpr* call) {
   Expr* e = call->get(1);
-  if (LoopExpr* le = toLoopExpr(e)) {
+  if (toLoopExpr(e)) {
     USR_FATAL(call, "'borrowed' cannot be applied to types other than classes");
   }
   Type* t = call->get(1)->getValType();

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -470,6 +470,10 @@ returnInfoToUnmanaged(CallExpr* call) {
 
 static QualifiedType
 returnInfoToBorrowed(CallExpr* call) {
+  Expr* e = call->get(1);
+  if (LoopExpr* le = toLoopExpr(e)) {
+    USR_FATAL(call, "'borrowed' cannot be applied to types other than classes");
+  }
   Type* t = call->get(1)->getValType();
 
   ClassTypeDecoratorEnum decorator = ClassTypeDecorator::BORROWED;

--- a/test/classes/errors/borrowedArray.chpl
+++ b/test/classes/errors/borrowedArray.chpl
@@ -1,0 +1,20 @@
+record Chunk {
+  type eltType;
+  var D: domain(1);
+  var data: borrowed [D] eltType;
+
+  proc init(type eltType) {
+    this.eltType = eltType;
+  }
+
+  proc init(array: [?X] ?t) {
+    this.eltType = t;
+    this.D = X;
+    this.data = array;
+  }
+}
+
+proc main()
+{
+  var x = new Chunk([1, 2, 3]);
+}

--- a/test/classes/errors/borrowedArray.good
+++ b/test/classes/errors/borrowedArray.good
@@ -1,0 +1,1 @@
+borrowedArray.chpl:4: error: 'borrowed' cannot be applied to types other than classes


### PR DESCRIPTION
    This is motivated by issue #18717 and addresses it, but is not
    particularly satisfying.  Specifically, what I did was to jump into
    the most obvious place in the callchain that led to the error and
    spot-checked for the pattern that was causing the problem (namely
    applying 'borrowed' to an array type like '[D] int').  The reason
    that this is unsatisfying is that:

    * it doesn't make any attempt to prevent against applying other
      ownership types to arrays

    * it doesn't make any attempt to prevent against applying 'borrowed'
      to other non-class types

    The callstack leading to the error is:

    ```
      * frame #0: 0x000000010075aa04 chpl`gdbShouldBreakHere() at misc.cpp:72:1
        frame #1: 0x00000001000dbc89 chpl`Expr::qualType(this=0x00000001186b5370) at expr.cpp:299:3
        frame #2: 0x000000010008cdf6 chpl`BaseAST::typeInfo(this=0x00000001186b5370) at baseAST.cpp:405:28
        frame #3: 0x000000010008d1c5 chpl`BaseAST::getValType(this=0x00000001186b5370) at baseAST.cpp:444:16
        frame #4: 0x0000000100154852 chpl`returnInfoToBorrowed(call=0x00000001186b52e0) at primitive.cpp:473:27
    ```

    So this led to questions for me like:

    * Should you be able to call 'getValType' on an array type?  If so,
      what should it do?  If not, how do you prevent another internal
      error.  Would we need another 'hasValType' query that
      'returnInfoToBorrowed()' would call to handle the general issue?

    * Should you be able to call 'typeInfo()' on an array type?  (seems
      like it?)  But if so, then how to prevent it from calling into the
      general 'Expr::qualType()' overload.

    Anyway, a point solution seemed better than keeping the current
    internal error given that it was easy, so I'm filing this as a
    placeholder and for consideration, and/or to see whether others have
    different suggestions.

    Resolves #18717 (but not way satisfactorily)
