### PR TITLE
Fix regex/allocationCounts test with --fast, --baseline, and --memLeaks

### DIFF
--- a/test/regex/allocationCounts.prediff
+++ b/test/regex/allocationCounts.prediff
@@ -3,6 +3,7 @@ testname=$1
 outfile=$2
 sed -E \
     -e '/of tasking layer unspecified/d' \
+    -e 's/free [[:digit:]]+.+at/free at/' \
     -e 's/[^ ]+.chpl:[[:digit:]]+/<file>.chpl:line/' \
     -e 's/at 0x[a-fA-F0-9]+/at <address>/' \
     -e 's/allocate [[:digit:]]+/allocate <N>/' \

--- a/test/regex/allocationCounts.skipif
+++ b/test/regex/allocationCounts.skipif
@@ -1,0 +1,2 @@
+COMPOPTS <= --baseline
+COMPOPTS <= --fast


### PR DESCRIPTION
test/regex/allocationCounts is meant to capture how much we allocate in typical scenarios.

However, we see variability depending on compile options, --fast and --baseline, and exec options like --memLeaks.

These fix the failing tests in the respective testing configurations (correctness-test-{fast,baseline,memleaks}