### PR TITLE
Next cleanups public fields pt 3

### DIFF
--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -763,43 +763,66 @@ class ResolutionResultByPostorderID {
 /**
   This type represents a resolved function.
 */
-struct ResolvedFunction {
-  const TypedFnSignature* signature = nullptr;
+class ResolvedFunction {
+ private:
+  const TypedFnSignature *signature_ = nullptr;
 
-  uast::Function::ReturnIntent returnIntent =
-    uast::Function::DEFAULT_RETURN_INTENT;
+  uast::Function::ReturnIntent returnIntent_ =
+      uast::Function::DEFAULT_RETURN_INTENT;
 
   // this is the output of the resolution process
-  ResolutionResultByPostorderID resolutionById;
+  ResolutionResultByPostorderID resolutionById_;
 
   // the set of point-of-instantiation scopes used by the instantiation
-  PoiInfo poiInfo;
+  PoiInfo poiInfo_;
 
-  bool operator==(const ResolvedFunction& other) const {
-    return signature == other.signature &&
-           returnIntent == other.returnIntent &&
-           resolutionById == other.resolutionById &&
-           PoiInfo::updateEquals(poiInfo, other.poiInfo);
+ public:
+  ResolvedFunction(const TypedFnSignature *signature,
+                   uast::Function::ReturnIntent returnIntent,
+                   ResolutionResultByPostorderID resolutionById,
+                   PoiInfo poiInfo)
+      : signature_(signature), returnIntent_(returnIntent),
+        resolutionById_(resolutionById), poiInfo_(poiInfo) {}
+
+  /** The type signature */
+  const TypedFnSignature *signature() const { return signature_; }
+
+  /** the return intent */
+  uast::Function::ReturnIntent returnIntent() const { return returnIntent_; }
+
+  /** this is the output of the resolution process */
+  const ResolutionResultByPostorderID &resolutionById() const {
+    return resolutionById_;
+  }
+
+  /** the set of point-of-instantiations used by the instantiation */
+  const PoiInfo &poiInfo() const { return poiInfo_; }
+
+  bool operator==(const ResolvedFunction &other) const {
+    return signature_ == other.signature_ &&
+           returnIntent_ == other.returnIntent_ &&
+           resolutionById_ == other.resolutionById_ &&
+           PoiInfo::updateEquals(poiInfo_, other.poiInfo_);
   }
   bool operator!=(const ResolvedFunction& other) const {
     return !(*this == other);
   }
   void swap(ResolvedFunction& other) {
-    std::swap(signature, other.signature);
-    std::swap(returnIntent, other.returnIntent);
-    resolutionById.swap(other.resolutionById);
-    poiInfo.swap(other.poiInfo);
+    std::swap(signature_, other.signature_);
+    std::swap(returnIntent_, other.returnIntent_);
+    resolutionById_.swap(other.resolutionById_);
+    poiInfo_.swap(other.poiInfo_);
   }
 
   const ResolvedExpression& byId(const ID& id) const {
-    return resolutionById.byId(id);
+    return resolutionById_.byId(id);
   }
   const ResolvedExpression& byAst(const uast::ASTNode* ast) const {
-    return resolutionById.byAst(ast);
+    return resolutionById_.byAst(ast);
   }
 
   const ID& id() const {
-    return signature->id();
+    return signature_->id();
   }
 };
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -625,39 +625,71 @@ class CallResolutionResult {
 /**
   This type represents a resolved expression.
 */
-struct ResolvedExpression {
+class ResolvedExpression {
+ private:
   // What is its type and param value?
-  types::QualifiedType type;
+  types::QualifiedType type_;
   // For simple (non-function Identifier) cases,
   // the ID of a NamedDecl it refers to
-  ID toId;
+  ID toId_;
 
   // For a function call, what is the most specific candidate,
   // or when using return intent overloading, what are the most specific
   // candidates?
   // The choice between these needs to happen
   // later than the main function resolution.
-  MostSpecificCandidates mostSpecific;
+  MostSpecificCandidates mostSpecific_;
   // What point of instantiation scope should be used when
   // resolving functions in mostSpecific?
-  const PoiScope* poiScope = nullptr;
+  const PoiScope *poiScope_ = nullptr;
 
+ public:
   ResolvedExpression() { }
 
+  /** get the type and param value */
+  const types::QualifiedType &type() const { return type_; }
+
+  /** for simple (non-function Identifier) cases, the ID of a NamedDecl it
+   * refers to */
+  ID toId() const { return toId_; }
+
+  /** For a function call, what is the most specific candidate, or when using
+   * return intent overloading, what are the most specific candidates? The
+   * choice between these needs to happen later than the main function
+   * resolution.
+   */
+  const MostSpecificCandidates &mostSpecific() const { return mostSpecific_; }
+
+  const PoiScope *poiScope() const { return poiScope_; }
+
+  /** set the toId */
+  void setToId(ID toId) { toId_ = toId; }
+
+  /** set the type */
+  void setType(const types::QualifiedType &type) { type_ = type; }
+
+  /** set the most specific */
+  void setMostSpecific(const MostSpecificCandidates &mostSpecific) {
+    mostSpecific_ = mostSpecific;
+  }
+
+  /** set the point-of-instantiation scope */
+  void setPoiScope(const PoiScope *poiScope) { poiScope_ = poiScope; }
+
   bool operator==(const ResolvedExpression& other) const {
-    return type == other.type &&
-           toId == other.toId &&
-           mostSpecific == other.mostSpecific &&
-           poiScope == other.poiScope;
+    return type_ == other.type_ &&
+           toId_ == other.toId_ &&
+           mostSpecific_ == other.mostSpecific_ &&
+           poiScope_ == other.poiScope_;
   }
   bool operator!=(const ResolvedExpression& other) const {
     return !(*this == other);
   }
   void swap(ResolvedExpression& other) {
-    type.swap(other.type);
-    toId.swap(other.toId);
-    mostSpecific.swap(other.mostSpecific);
-    std::swap(poiScope, other.poiScope);
+    type_.swap(other.type_);
+    toId_.swap(other.toId_);
+    mostSpecific_.swap(other.mostSpecific_);
+    std::swap(poiScope_, other.poiScope_);
   }
 
   std::string toString() const;

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -20,6 +20,7 @@
 #ifndef CHPL_RESOLUTION_RESOLUTION_TYPES_H
 #define CHPL_RESOLUTION_RESOLUTION_TYPES_H
 
+#include "chpl/queries/UniqueString.h"
 #include "chpl/resolution/scope-types.h"
 #include "chpl/types/QualifiedType.h"
 #include "chpl/types/Type.h"
@@ -213,23 +214,56 @@ class CallInfoActual {
   }
 };
 
-struct CallInfo {
-  UniqueString name;                   // the name of the called thing
-  bool isMethod = false;               // in that case, actuals[0] is receiver
-  bool hasQuestionArg = false;         // includes ? arg for type constructor
-  std::vector<CallInfoActual> actuals; // types/params/names of actuals
+/** CallInfo */
+class CallInfo {
+ private:
+  UniqueString name_;                   // the name of the called thing
+  bool isMethod_ = false;               // in that case, actuals[0] is receiver
+  bool hasQuestionArg_ = false;         // includes ? arg for type constructor
+  std::vector<CallInfoActual> actuals_; // types/params/names of actuals
+
+ public:
+  using CallInfoActualIterable = Iterable<std::vector<CallInfoActual>>;
+
+  CallInfo(UniqueString name, bool hasQuestionArg,
+           std::vector<CallInfoActual> actuals)
+      : name_(name), hasQuestionArg_(hasQuestionArg),
+        actuals_(std::move(actuals)) {}
+
+  /** return the name of the called thing */
+  UniqueString name() const { return name_; }
+
+  /** check if the call is a method call */
+  bool isMethod() const { return isMethod_; }
+
+  /** check if the call includes ? arg for type constructor */
+  bool hasQuestionArg() const { return hasQuestionArg_; }
+
+  /** return the actuals */
+  CallInfoActualIterable actuals() const {
+    return CallInfoActualIterable(actuals_);
+  }
+
+  /** return the i'th actual */
+  const CallInfoActual& actuals(size_t i) const {
+    assert(i < actuals_.size());
+    return actuals_[i];
+  }
+
+  /** return the number of actuals */
+  size_t numActuals() const { return actuals_.size(); }
 
   bool operator==(const CallInfo& other) const {
-    return name == other.name &&
-           isMethod == other.isMethod &&
-           hasQuestionArg == other.hasQuestionArg &&
-           actuals == other.actuals;
+    return name_ == other.name_ &&
+           isMethod_ == other.isMethod_ &&
+           hasQuestionArg_ == other.hasQuestionArg_ &&
+           actuals_ == other.actuals_;
   }
   bool operator!=(const CallInfo& other) const {
     return !(*this == other);
   }
   size_t hash() const {
-    return chpl::hash(name, isMethod, hasQuestionArg, actuals);
+    return chpl::hash(name_, isMethod_, hasQuestionArg_, actuals_);
   }
 };
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -573,40 +573,52 @@ class MostSpecificCandidates {
   }
 };
 
-struct CallResolutionResult {
+/** CallResolutionResult */
+class CallResolutionResult {
+ private:
   // what are the candidates for return-intent overloading?
-  MostSpecificCandidates mostSpecific;
+  MostSpecificCandidates mostSpecific_;
   // what is the type of the call expression?
-  types::QualifiedType exprType;
+  types::QualifiedType exprType_;
   // if any of the candidates were instantiated, what point-of-instantiation
   // scopes were used when resolving their signature or body?
-  PoiInfo poiInfo;
+  PoiInfo poiInfo_;
 
+ public:
   // for simple cases where mostSpecific and poiInfo are irrelevant
   CallResolutionResult(types::QualifiedType exprType)
-    : exprType(std::move(exprType)) {
+    : exprType_(std::move(exprType)) {
   }
 
   CallResolutionResult(MostSpecificCandidates mostSpecific,
                        types::QualifiedType exprType,
                        PoiInfo poiInfo)
-    : mostSpecific(std::move(mostSpecific)),
-      exprType(std::move(exprType)),
-      poiInfo(std::move(poiInfo)) {
+    : mostSpecific_(std::move(mostSpecific)),
+      exprType_(std::move(exprType)),
+      poiInfo_(std::move(poiInfo)) {
   }
 
+  /** get the most specific candidates for return-intent overloading */
+  const MostSpecificCandidates &mostSpecific() const { return mostSpecific_; }
+
+  /** type of the call expression */
+  const types::QualifiedType &exprType() const { return exprType_; }
+
+  /** point-of-instantiation scopes used when resolving signature or body */
+  const PoiInfo &poiInfo() const { return poiInfo_; }
+
   bool operator==(const CallResolutionResult& other) const {
-    return mostSpecific == other.mostSpecific &&
-           exprType == other.exprType &&
-           PoiInfo::updateEquals(poiInfo, other.poiInfo);
+    return mostSpecific_ == other.mostSpecific_ &&
+           exprType_ == other.exprType_ &&
+           PoiInfo::updateEquals(poiInfo_, other.poiInfo_);
   }
   bool operator!=(const CallResolutionResult& other) const {
     return !(*this == other);
   }
   void swap(CallResolutionResult& other) {
-    mostSpecific.swap(other.mostSpecific);
-    exprType.swap(other.exprType);
-    poiInfo.swap(other.poiInfo);
+    mostSpecific_.swap(other.mostSpecific_);
+    exprType_.swap(other.exprType_);
+    poiInfo_.swap(other.poiInfo_);
   }
 };
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -306,10 +306,10 @@ class PoiInfo {
   }
 
   /** return the poiScope */
-  const PoiScope *poiScope() const { return poiScope_; }
+  const PoiScope* poiScope() const { return poiScope_; }
 
   /** set the poiScope */
-  void setPoiScope(const PoiScope *poiScope) { poiScope_ = poiScope; }
+  void setPoiScope(const PoiScope* poiScope) { poiScope_ = poiScope; }
 
   /** set resolved */
   void setResolved(bool resolved) { resolved_ = resolved; }
@@ -599,13 +599,13 @@ class CallResolutionResult {
   }
 
   /** get the most specific candidates for return-intent overloading */
-  const MostSpecificCandidates &mostSpecific() const { return mostSpecific_; }
+  const MostSpecificCandidates& mostSpecific() const { return mostSpecific_; }
 
   /** type of the call expression */
-  const types::QualifiedType &exprType() const { return exprType_; }
+  const types::QualifiedType& exprType() const { return exprType_; }
 
   /** point-of-instantiation scopes used when resolving signature or body */
-  const PoiInfo &poiInfo() const { return poiInfo_; }
+  const PoiInfo& poiInfo() const { return poiInfo_; }
 
   bool operator==(const CallResolutionResult& other) const {
     return mostSpecific_ == other.mostSpecific_ &&
@@ -646,8 +646,8 @@ class ResolvedExpression {
  public:
   ResolvedExpression() { }
 
-  /** get the type and param value */
-  const types::QualifiedType &type() const { return type_; }
+  /** get the qualified type */
+  const types::QualifiedType& type() const { return type_; }
 
   /** for simple (non-function Identifier) cases, the ID of a NamedDecl it
    * refers to */
@@ -658,23 +658,23 @@ class ResolvedExpression {
    * choice between these needs to happen later than the main function
    * resolution.
    */
-  const MostSpecificCandidates &mostSpecific() const { return mostSpecific_; }
+  const MostSpecificCandidates& mostSpecific() const { return mostSpecific_; }
 
-  const PoiScope *poiScope() const { return poiScope_; }
+  const PoiScope* poiScope() const { return poiScope_; }
 
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }
 
   /** set the type */
-  void setType(const types::QualifiedType &type) { type_ = type; }
+  void setType(const types::QualifiedType& type) { type_ = type; }
 
   /** set the most specific */
-  void setMostSpecific(const MostSpecificCandidates &mostSpecific) {
+  void setMostSpecific(const MostSpecificCandidates& mostSpecific) {
     mostSpecific_ = mostSpecific;
   }
 
   /** set the point-of-instantiation scope */
-  void setPoiScope(const PoiScope *poiScope) { poiScope_ = poiScope; }
+  void setPoiScope(const PoiScope* poiScope) { poiScope_ = poiScope; }
 
   bool operator==(const ResolvedExpression& other) const {
     return type_ == other.type_ &&
@@ -765,7 +765,7 @@ class ResolutionResultByPostorderID {
 */
 class ResolvedFunction {
  private:
-  const TypedFnSignature *signature_ = nullptr;
+  const TypedFnSignature* signature_ = nullptr;
 
   uast::Function::ReturnIntent returnIntent_ =
       uast::Function::DEFAULT_RETURN_INTENT;
@@ -785,20 +785,20 @@ class ResolvedFunction {
         resolutionById_(resolutionById), poiInfo_(poiInfo) {}
 
   /** The type signature */
-  const TypedFnSignature *signature() const { return signature_; }
+  const TypedFnSignature* signature() const { return signature_; }
 
   /** the return intent */
   uast::Function::ReturnIntent returnIntent() const { return returnIntent_; }
 
   /** this is the output of the resolution process */
-  const ResolutionResultByPostorderID &resolutionById() const {
+  const ResolutionResultByPostorderID& resolutionById() const {
     return resolutionById_;
   }
 
   /** the set of point-of-instantiations used by the instantiation */
-  const PoiInfo &poiInfo() const { return poiInfo_; }
+  const PoiInfo& poiInfo() const { return poiInfo_; }
 
-  bool operator==(const ResolvedFunction &other) const {
+  bool operator==(const ResolvedFunction& other) const {
     return signature_ == other.signature_ &&
            returnIntent_ == other.returnIntent_ &&
            resolutionById_ == other.resolutionById_ &&
@@ -848,10 +848,10 @@ class FormalActualMap {
 
   using FormalActualIterable = Iterable<std::vector<FormalActual>>;
 
-  FormalActualMap(const UntypedFnSignature *sig, const CallInfo &call) {
+  FormalActualMap(const UntypedFnSignature* sig, const CallInfo& call) {
     mappingIsValid_ = computeAlignment(sig, nullptr, call);
   }
-  FormalActualMap(const TypedFnSignature *sig, const CallInfo &call) {
+  FormalActualMap(const TypedFnSignature* sig, const CallInfo& call) {
     mappingIsValid_ = computeAlignment(sig->untyped(), sig, call);
   }
 
@@ -864,8 +864,8 @@ class FormalActualMap {
   }
 
  private:
-  bool computeAlignment(const UntypedFnSignature *untyped,
-                        const TypedFnSignature *typed, const CallInfo &call);
+  bool computeAlignment(const UntypedFnSignature* untyped,
+                        const TypedFnSignature* typed, const CallInfo& call);
 };
 
 } // end namespace resolution

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -826,6 +826,7 @@ class ResolvedFunction {
   }
 };
 
+/** FormalActual holds information on a function formal and its binding (if any) */
 struct FormalActual {
   const uast::Decl* formal = nullptr;
   types::QualifiedType formalType;
@@ -834,24 +835,38 @@ struct FormalActual {
   types::QualifiedType actualType;
 };
 
-struct FormalActualMap {
-  std::vector<FormalActual> byFormalIdx;
-  std::vector<int> actualIdxToFormalIdx;
-  bool mappingIsValid = false;
-  int failingActualIdx = -1;
-  int failingFormalIdx = -1;
+/** FormalActualMap maps formals to actuals */
+class FormalActualMap {
+ private:
+  std::vector<FormalActual> byFormalIdx_;
+  std::vector<int> actualIdxToFormalIdx_;
+  bool mappingIsValid_ = false;
+  int failingActualIdx_ = -1;
+  int failingFormalIdx_ = -1;
 
-  bool computeAlignment(const UntypedFnSignature* untyped,
-                        const TypedFnSignature* typed,
-                        const CallInfo& call);
+ public:
 
-  static FormalActualMap build(const UntypedFnSignature* untyped,
-                               const CallInfo& call);
-  static FormalActualMap build(const TypedFnSignature* typed,
-                               const CallInfo& call);
+  using FormalActualIterable = Iterable<std::vector<FormalActual>>;
+
+  FormalActualMap(const UntypedFnSignature *sig, const CallInfo &call) {
+    mappingIsValid_ = computeAlignment(sig, nullptr, call);
+  }
+  FormalActualMap(const TypedFnSignature *sig, const CallInfo &call) {
+    mappingIsValid_ = computeAlignment(sig->untyped(), sig, call);
+  }
+
+  /** check if mapping is valid */
+  bool isValid() const { return mappingIsValid_; }
+
+  /** get the FormalActual's */
+  FormalActualIterable byFormalIdx() const {
+    return FormalActualIterable(byFormalIdx_);
+  }
+
+ private:
+  bool computeAlignment(const UntypedFnSignature *untyped,
+                        const TypedFnSignature *typed, const CallInfo &call);
 };
-
-
 
 } // end namespace resolution
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -184,19 +184,32 @@ class UntypedFnSignature {
 
 using SubstitutionsMap = std::unordered_map<const uast::Decl*, types::QualifiedType>;
 
-struct CallInfoActual {
-  types::QualifiedType type;
-  UniqueString byName;
+/** CallInfoActual */
+class CallInfoActual {
+ private:
+  types::QualifiedType type_;
+  UniqueString byName_;
 
-  bool operator==(const CallInfoActual& other) const {
-    return type == other.type &&
-           byName == other.byName;
+ public:
+  CallInfoActual(types::QualifiedType type, UniqueString byName)
+      : type_(type), byName_(byName) {}
+
+  /** return the qualified type */
+  const types::QualifiedType& type() const { return type_; }
+
+  /** return the name, if any, that the argument was passed with.
+      Ex: in f(number=3), byName() would be "number"
+   */
+  UniqueString byName() const { return byName_; }
+
+  bool operator==(const CallInfoActual &other) const {
+    return type_ == other.type_ && byName_ == other.byName_;
   }
   bool operator!=(const CallInfoActual& other) const {
     return !(*this == other);
   }
   size_t hash() const {
-    return chpl::hash(type, byName);
+    return chpl::hash(type_, byName_);
   }
 };
 

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -596,9 +596,9 @@ struct Resolver {
 
     // save the most specific candidates in the resolution result for the id
     ResolvedExpression& r = byPostorder.byAst(call);
-    r.mostSpecific = c.mostSpecific;
-    r.poiScope = c.poiInfo.poiScope();
-    r.type = c.exprType;
+    r.mostSpecific = c.mostSpecific();
+    r.poiScope = c.poiInfo().poiScope();
+    r.type = c.exprType();
 
     if (r.type.type() == nullptr) {
       context->error(call, "Cannot establish type for call expression");
@@ -606,7 +606,7 @@ struct Resolver {
     }
 
     // gather the poi scopes used when resolving the call
-    poiInfo.accumulate(c.poiInfo);
+    poiInfo.accumulate(c.poiInfo());
   }
 
   bool enter(const ASTNode* ast) {

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -1040,14 +1040,14 @@ const TypedFnSignature* instantiateSignature(Context* context,
     // Set parentFnTyped somehow.
   }
 
-  auto faMap = FormalActualMap::build(sig, call);
-  if (!faMap.mappingIsValid) {
+  auto faMap = FormalActualMap(sig, call);
+  if (!faMap.isValid()) {
     return nullptr;
   }
 
   // compute the substitutions
   SubstitutionsMap substitutions;
-  for (const FormalActual& entry : faMap.byFormalIdx) {
+  for (const FormalActual& entry : faMap.byFormalIdx()) {
     // note: entry.actualType can have type()==nullptr and UNKNOWN.
     // in that case, resolver code should treat it as a hint to
     // use the default value. Unless the call used a ? argument.
@@ -1494,8 +1494,8 @@ doIsCandidateApplicableInitial(Context* context,
   //  * method-ness
   //  * ref-ness
 
-  auto faMap = FormalActualMap::build(uSig, call);
-  if (!faMap.mappingIsValid) {
+  auto faMap = FormalActualMap(uSig, call);
+  if (!faMap.isValid()) {
     return nullptr;
   }
 
@@ -1505,7 +1505,7 @@ doIsCandidateApplicableInitial(Context* context,
   auto initialTypedSignature = typedSignatureInitial(context, uSig);
   // Next, check that the types are compatible
   int formalIdx = 0;
-  for (const FormalActual& entry : faMap.byFormalIdx) {
+  for (const FormalActual& entry : faMap.byFormalIdx()) {
     const auto& actualType = entry.actualType;
     const auto& formalType = initialTypedSignature->formalType(formalIdx);
     bool ok = canPassInitial(actualType, formalType);

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -137,7 +137,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
 
   // allocate space in the arrays
   byFormalIdx.resize(untyped->numFormals());
-  actualIdxToFormalIdx.resize(call.actuals.size());
+  actualIdxToFormalIdx.resize(call.numActuals());
 
   // initialize the FormalActual parts from the Formals
   int formalIdx = 0;
@@ -160,7 +160,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
   // Record successful matches in actualIdxToFormalIdx.
 
   int actualIdx = 0;
-  for (const CallInfoActual& actual : call.actuals) {
+  for (const CallInfoActual& actual : call.actuals()) {
     if (!actual.byName().isEmpty()) {
       bool match = false;
       for (int i = 0; i < numFormals; i++) {
@@ -192,7 +192,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
   // Record successful substitutions
   formalIdx = 0;
   actualIdx = 0;
-  for (const CallInfoActual& actual : call.actuals) {
+  for (const CallInfoActual& actual : call.actuals()) {
     if (formalIdx >= (int) byFormalIdx.size()) {
       // too many actuals
       mappingIsValid = false;

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -301,26 +301,26 @@ bool PoiInfo::canReuse(const PoiInfo& check) const {
 std::string ResolvedExpression::toString() const {
   std::string ret;
   ret += " : ";
-  ret += type.toString();
+  ret += type_.toString();
   ret += " ; ";
-  if (!toId.isEmpty()) {
+  if (!toId_.isEmpty()) {
     ret += " refers to ";
-    ret += toId.toString();
+    ret += toId_.toString();
   } else {
-    auto onlyFn = mostSpecific.only();
+    auto onlyFn = mostSpecific_.only();
     if (onlyFn) {
       ret += " calls ";
       ret += onlyFn->toString();
     } else {
-      if (auto sig = mostSpecific.bestRef()) {
+      if (auto sig = mostSpecific_.bestRef()) {
         ret += " calls ref ";
         ret += sig->toString();
       }
-      if (auto sig = mostSpecific.bestConstRef()) {
+      if (auto sig = mostSpecific_.bestConstRef()) {
         ret += " calls const ref ";
         ret += sig->toString();
       }
-      if (auto sig = mostSpecific.bestValue()) {
+      if (auto sig = mostSpecific_.bestValue()) {
         ret += " calls value ";
         ret += sig->toString();
       }

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -286,14 +286,14 @@ std::string TypedFnSignature::toString() const {
 
 
 void PoiInfo::accumulate(const PoiInfo& addPoiInfo) {
-  poiFnIdsUsed.insert(addPoiInfo.poiFnIdsUsed.begin(),
-                      addPoiInfo.poiFnIdsUsed.end());
+  poiFnIdsUsed_.insert(addPoiInfo.poiFnIdsUsed_.begin(),
+                      addPoiInfo.poiFnIdsUsed_.end());
 }
 
 // this is a resolved function
 // check is a not-yet-resolved function
 bool PoiInfo::canReuse(const PoiInfo& check) const {
-  assert(resolved && !check.resolved);
+  assert(resolved_ && !check.resolved_);
 
   return false; // TODO -- consider function names etc -- see PR #16261
 }

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -161,15 +161,15 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
 
   int actualIdx = 0;
   for (const CallInfoActual& actual : call.actuals) {
-    if (!actual.byName.isEmpty()) {
+    if (!actual.byName().isEmpty()) {
       bool match = false;
       for (int i = 0; i < numFormals; i++) {
-        if (actual.byName == untyped->formalName(i)) {
+        if (actual.byName() == untyped->formalName(i)) {
           match = true;
           FormalActual& entry = byFormalIdx[i];
           entry.hasActual = true;
           entry.actualIdx = actualIdx;
-          entry.actualType = actual.type;
+          entry.actualType = actual.type();
           actualIdxToFormalIdx[actualIdx] = formalIdx;
           break;
         }
@@ -200,7 +200,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
       return false;
     }
 
-    if (actual.byName.isEmpty()) {
+    if (actual.byName().isEmpty()) {
       // Skip any formals already matched to named arguments
       while (byFormalIdx[formalIdx].actualIdx >= 0) {
         if (formalIdx + 1 >= (int) byFormalIdx.size()) {
@@ -218,7 +218,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
       FormalActual& entry = byFormalIdx[formalIdx];
       entry.hasActual = true;
       entry.actualIdx = actualIdx;
-      entry.actualType = actual.type;
+      entry.actualType = actual.type();
       actualIdxToFormalIdx[actualIdx] = formalIdx;
     }
     actualIdx++;

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -73,13 +73,13 @@ resolvedExpressionForAst(Context* context, const ASTNode* ast,
         } else if (auto parentFn = parentAst->toFunction()) {
           auto untyped = UntypedFnSignature::get(context, parentFn);
           // use inFn if it matches
-          if (inFn && inFn->signature->untyped() == untyped) {
-            return &inFn->resolutionById.byAst(ast);
+          if (inFn && inFn->signature()->untyped() == untyped) {
+            return &inFn->resolutionById().byAst(ast);
           } else {
             auto typed = typedSignatureInitial(context, untyped);
             if (!typed->needsInstantiation()) {
               auto rFn = resolveFunction(context, typed, nullptr);
-              return &rFn->resolutionById.byAst(ast);
+              return &rFn->resolutionById().byAst(ast);
             }
           }
         }
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
       size_t startCount = calledFns.size();
 
       for (auto calledFn : iterCalledFns) {
-        const TypedFnSignature* sig = calledFn->signature;
+        const TypedFnSignature* sig = calledFn->signature();
         if (sig->instantiatedFrom() != nullptr) {
           calledFns.insert(calledFn);
           auto pair = printed.insert(calledFn);

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -139,10 +139,10 @@ computeAndPrintStuff(Context* context,
   const ResolvedExpression* r = resolvedExpressionForAst(context, ast, inFn);
   int afterCount = context->numQueriesRunThisRevision();
   if (r != nullptr) {
-    for (const TypedFnSignature* sig : r->mostSpecific) {
+    for (const TypedFnSignature* sig : r->mostSpecific()) {
       if (sig != nullptr) {
         if (sig->untyped()->idIsFunction()) {
-          auto fn = resolveFunction(context, sig, r->poiScope);
+          auto fn = resolveFunction(context, sig, r->poiScope());
           calledFns.insert(fn);
         }
       }

--- a/compiler/next/test/resolution/testParams.cpp
+++ b/compiler/next/test/resolution/testParams.cpp
@@ -55,7 +55,7 @@ static QualifiedType getTypeForFirstStmt(Context* context,
 
   const auto& resolvedExpr = rr.byAst(stmt);
 
-  return resolvedExpr.type;
+  return resolvedExpr.type();
 }
 
 static void test1() {

--- a/compiler/next/test/resolution/testPoi.cpp
+++ b/compiler/next/test/resolution/testPoi.cpp
@@ -86,10 +86,10 @@ static void test1() {
     resolveOnlyCandidate(context, rr.byAst(genericCall));
   assert(rfunc);
   assert(rfunc->id() == mGeneric->id());
-  assert(rfunc->signature->instantiatedFrom() != nullptr);
+  assert(rfunc->signature()->instantiatedFrom() != nullptr);
 
   const ResolvedFunction* rhelp =
-    resolveOnlyCandidate(context, rfunc->resolutionById.byAst(helperCall));
+    resolveOnlyCandidate(context, rfunc->resolutionById().byAst(helperCall));
   assert(rhelp);
   assert(rhelp->id() == nHelper->id());
 }
@@ -148,9 +148,9 @@ static void test1n() {
     resolveOnlyCandidate(context, rr.byAst(genericCall));
   assert(rfunc);
   assert(rfunc->id() == mGeneric->id());
-  assert(rfunc->signature->instantiatedFrom() != nullptr);
+  assert(rfunc->signature()->instantiatedFrom() != nullptr);
 
-  const ResolvedExpression& rhelp = rfunc->resolutionById.byAst(helperCall);
+  const ResolvedExpression& rhelp = rfunc->resolutionById().byAst(helperCall);
   for (auto candidate : rhelp.mostSpecific()) {
     assert(candidate == nullptr);
   }
@@ -514,8 +514,8 @@ static void test3() {
   }
 
   // check that the generic function signatures are the same
-  assert(rNCallGF->signature == rMCallGF->signature);
-  assert(rMCallGF->signature == rMGenericCallGF->signature);
+  assert(rNCallGF->signature() == rMCallGF->signature());
+  assert(rMCallGF->signature() == rMGenericCallGF->signature());
 }
 
 // check generic reuse from the same scope
@@ -694,14 +694,14 @@ static void test6() {
 
   auto rACallGeneric = resolveOnlyCandidate(context, rA.byAst(aCall));
   assert(rACallGeneric);
-  assert(rACallGeneric->signature);
-  assert(rACallGeneric->signature->untyped());
+  assert(rACallGeneric->signature());
+  assert(rACallGeneric->signature()->untyped());
   auto rBCallGeneric = resolveOnlyCandidate(context, rB.byAst(bCall));
   assert(rBCallGeneric);
-  assert(rBCallGeneric->signature->untyped());
+  assert(rBCallGeneric->signature()->untyped());
 
   // check that these two have the same signature
-  assert(rACallGeneric->signature == rBCallGeneric->signature);
+  assert(rACallGeneric->signature() == rBCallGeneric->signature());
 
   // check that these two are the same instantiation.
   assert(rACallGeneric == rBCallGeneric);

--- a/compiler/next/test/resolution/testPoi.cpp
+++ b/compiler/next/test/resolution/testPoi.cpp
@@ -151,7 +151,7 @@ static void test1n() {
   assert(rfunc->signature->instantiatedFrom() != nullptr);
 
   const ResolvedExpression& rhelp = rfunc->resolutionById.byAst(helperCall);
-  for (auto candidate : rhelp.mostSpecific) {
+  for (auto candidate : rhelp.mostSpecific()) {
     assert(candidate == nullptr);
   }
 }

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -62,9 +62,9 @@ static void test1() {
 
     const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-    assert(rr.byAst(x).type.type()->isIntType());
-    assert(rr.byAst(xIdent).type.type()->isIntType());
-    assert(rr.byAst(xIdent).toId == x->id());
+    assert(rr.byAst(x).type().type()->isIntType());
+    assert(rr.byAst(xIdent).type().type()->isIntType());
+    assert(rr.byAst(xIdent).toId() == x->id());
 
     context->collectGarbage();
   }
@@ -124,7 +124,7 @@ static void test2() {
     assert(x);
 
     const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-    assert(rr.byAst(x).type.type()->isIntType());
+    assert(rr.byAst(x).type().type()->isIntType());
 
     context->collectGarbage();
   }
@@ -152,9 +152,9 @@ static void test2() {
 
     const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-    assert(rr.byAst(x).type.type()->isIntType());
-    assert(rr.byAst(xIdent).type.type()->isIntType());
-    assert(rr.byAst(xIdent).toId == x->id());
+    assert(rr.byAst(x).type().type()->isIntType());
+    assert(rr.byAst(xIdent).type().type()->isIntType());
+    assert(rr.byAst(xIdent).toId() == x->id());
 
     context->collectGarbage();
   }

--- a/compiler/next/test/resolution/testTypeConstruction.cpp
+++ b/compiler/next/test/resolution/testTypeConstruction.cpp
@@ -94,19 +94,19 @@ static void test1() {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-  assert(rr.byAst(i).type.type()   == IntType::get(context, 0));
-  assert(rr.byAst(i8).type.type()  == IntType::get(context, 8));
-  assert(rr.byAst(i16).type.type() == IntType::get(context, 16));
-  assert(rr.byAst(i32).type.type() == IntType::get(context, 32));
-  assert(rr.byAst(i64).type.type() == IntType::get(context, 64));
-  assert(rr.byAst(iq).type.type()  == AnyIntType::get(context));
+  assert(rr.byAst(i).type().type()   == IntType::get(context, 0));
+  assert(rr.byAst(i8).type().type()  == IntType::get(context, 8));
+  assert(rr.byAst(i16).type().type() == IntType::get(context, 16));
+  assert(rr.byAst(i32).type().type() == IntType::get(context, 32));
+  assert(rr.byAst(i64).type().type() == IntType::get(context, 64));
+  assert(rr.byAst(iq).type().type()  == AnyIntType::get(context));
 
-  assert(rr.byAst(u).type.type()   == UintType::get(context, 0));
-  assert(rr.byAst(u8).type.type()  == UintType::get(context, 8));
-  assert(rr.byAst(u16).type.type() == UintType::get(context, 16));
-  assert(rr.byAst(u32).type.type() == UintType::get(context, 32));
-  assert(rr.byAst(u64).type.type() == UintType::get(context, 64));
-  assert(rr.byAst(uq).type.type()  == AnyUintType::get(context));
+  assert(rr.byAst(u).type().type()   == UintType::get(context, 0));
+  assert(rr.byAst(u8).type().type()  == UintType::get(context, 8));
+  assert(rr.byAst(u16).type().type() == UintType::get(context, 16));
+  assert(rr.byAst(u32).type().type() == UintType::get(context, 32));
+  assert(rr.byAst(u64).type().type() == UintType::get(context, 64));
+  assert(rr.byAst(uq).type().type()  == AnyUintType::get(context));
 }
 
 static void test2() {
@@ -136,12 +136,12 @@ static void test2() {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-  assert(rr.byAst(b).type.type()   == BoolType::get(context, 0));
-  assert(rr.byAst(b8).type.type()  == BoolType::get(context, 8));
-  assert(rr.byAst(b16).type.type() == BoolType::get(context, 16));
-  assert(rr.byAst(b32).type.type() == BoolType::get(context, 32));
-  assert(rr.byAst(b64).type.type() == BoolType::get(context, 64));
-  assert(rr.byAst(bq).type.type()  == AnyBoolType::get(context));
+  assert(rr.byAst(b).type().type()   == BoolType::get(context, 0));
+  assert(rr.byAst(b8).type().type()  == BoolType::get(context, 8));
+  assert(rr.byAst(b16).type().type() == BoolType::get(context, 16));
+  assert(rr.byAst(b32).type().type() == BoolType::get(context, 32));
+  assert(rr.byAst(b64).type().type() == BoolType::get(context, 64));
+  assert(rr.byAst(bq).type().type()  == AnyBoolType::get(context));
 }
 
 static void test3() {
@@ -189,18 +189,18 @@ static void test3() {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-  assert(rr.byAst(r).type.type()    == RealType::get(context, 0));
-  assert(rr.byAst(r32).type.type()  == RealType::get(context, 32));
-  assert(rr.byAst(r64).type.type()  == RealType::get(context, 64));
-  assert(rr.byAst(rq).type.type()   == AnyRealType::get(context));
-  assert(rr.byAst(i).type.type()    == ImagType::get(context, 0));
-  assert(rr.byAst(i32).type.type()  == ImagType::get(context, 32));
-  assert(rr.byAst(i64).type.type()  == ImagType::get(context, 64));
-  assert(rr.byAst(iq).type.type()   == AnyImagType::get(context));
-  assert(rr.byAst(c).type.type()    == ComplexType::get(context, 0));
-  assert(rr.byAst(c64).type.type()  == ComplexType::get(context, 64));
-  assert(rr.byAst(c128).type.type() == ComplexType::get(context, 128));
-  assert(rr.byAst(cq).type.type()   == AnyComplexType::get(context));
+  assert(rr.byAst(r).type().type()    == RealType::get(context, 0));
+  assert(rr.byAst(r32).type().type()  == RealType::get(context, 32));
+  assert(rr.byAst(r64).type().type()  == RealType::get(context, 64));
+  assert(rr.byAst(rq).type().type()   == AnyRealType::get(context));
+  assert(rr.byAst(i).type().type()    == ImagType::get(context, 0));
+  assert(rr.byAst(i32).type().type()  == ImagType::get(context, 32));
+  assert(rr.byAst(i64).type().type()  == ImagType::get(context, 64));
+  assert(rr.byAst(iq).type().type()   == AnyImagType::get(context));
+  assert(rr.byAst(c).type().type()    == ComplexType::get(context, 0));
+  assert(rr.byAst(c64).type().type()  == ComplexType::get(context, 64));
+  assert(rr.byAst(c128).type().type() == ComplexType::get(context, 128));
+  assert(rr.byAst(cq).type().type()   == AnyComplexType::get(context));
 }
 
 // assumes 2nd statement is a variable declaration for x.
@@ -217,7 +217,7 @@ static const Type* parseTypeOfX(Context* context,
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-  auto qt = rr.byAst(x).type;
+  auto qt = rr.byAst(x).type();
   assert(qt.kind() == QualifiedType::VALUE);
   assert(qt.type());
 
@@ -885,10 +885,10 @@ static void testTypeAndFnSameName() {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-  const Type* xt = rr.byAst(x).type.type();
+  const Type* xt = rr.byAst(x).type().type();
   assert(xt);
   assert(xt == IntType::get(context, 0));
-  const Type* yt = rr.byAst(y).type.type();
+  const Type* yt = rr.byAst(y).type().type();
   assert(yt);
   auto yrt = yt->toRecordType();
   assert(yrt);


### PR DESCRIPTION
Continues effort in #18702 to use fewer public fields and finishes out resolution-types.h

See commits for some commentary on specific conversions.

Of note are:

1) PoiInfo and ResolutionResult needed setters for some fields to maintain their uses at call sites. This might hint we could reconsider how they are used, but I view this as future work
2) FormalActualMap went from a ::build to a regular constructor

Tested against test-libchplcomp
