### PR TITLE
Spec improvements about extern record initialization, default init

### DIFF
--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -590,6 +590,25 @@ is changed when passing arguments to a C function using
 the ``ref`` intent. The C code implementing that function must
 dereference the argument to extract its value.
 
+.. _Interop_Variable_Initialization:
+
+Variable Initialization
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When default initializing a variable of extern type, the compiler will
+arrange to fill its memory with zero bytes. However, an
+``extern record`` can define a ``proc init()`` in order to define how
+it should be default initialized. See also :ref:`Record_Initialization`
+and :ref:`Variable_Lifetimes`.
+
+.. note::
+
+  Future versions may allow an ``extern record`` to include
+  ``proc init=`` and ``proc deinit`` but these cannot yet be counted on.
+  One challenge in this area is that C code working with the same type
+  will not call the copy or deinit function.
+
+
 .. [4]
    In UNIX-like programming environments, ``nm`` and ``grep`` can be
    used to find the mangled name of a given function within an object

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -193,10 +193,13 @@ for details on when a record becomes dead.
 Record Initialization
 ~~~~~~~~~~~~~~~~~~~~~
 
-A variable of a record type declared without an initialization
-expression is initialized through a call to the record’s default
-initializer, passing no arguments. The default initializer for a record
-is defined in the same way as the default initializer for a class
+When default initializing a record (see :ref:`Variable_Lifetimes`), an
+``init`` method on the record will be called. For a concrete record,
+``init`` wil be called with no arguments. For an instantiated generic
+record, the ``type`` and ``param`` arguments are passed by name.
+
+The compiler-generated default initializer for a record is defined in the
+same way as the default initializer for a class
 (:ref:`The_Compiler_Generated_Initializer`).
 
 To create a record as an expression, i.e. without binding it to a


### PR DESCRIPTION
This PR includes docs follow-ups to #18542 to describe in the language spec what default initializing a variable of extern type will do.

Additionally, it resolves a problem I noticed in the spec where it said than `init()` will be called for default initialization even though that is not true for generic records.

It said:

> A variable of a record type declared without an initialization expression is initialized through a call to the record’s default initializer, passing no arguments.

However this is not currently true and has not been true for some time.
As described in

  https://chapel-lang.org/docs/technotes/initTypeAlias.html#default-initialization-for-instantiated-generic-types

the compiler will pass by name the type and param components.

Reviewed by @lydia-duncan - thanks!