### PR TITLE
Fix broken chpl builds when using make install

### DIFF
--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -303,13 +303,13 @@ cd ..
 for dir in $THIRD_PARTY_DIRS
 do
   #echo "Considering 3p dir $dir"
-  if [ -f third-party/"$dir"/Makefile.include ]
-  then
-    for f in third-party/"$dir"/Makefile*
-    do
+  for f in third-party/"$dir"/Makefile*
+  do
+    if [ -f "$f" ]
+    then
       myinstallfile "$f"  "$DEST_THIRD_PARTY"/"$dir"
-    done
-  fi
+    fi
+  done
   if [ -d third-party/"$dir"/install ]
   then
     myinstalldir "third-party/$dir/install" "$DEST_THIRD_PARTY/$dir/install/"


### PR DESCRIPTION
Fixes #18763

Recent changes to jemalloc renamed jemalloc/Makefile.include ->
jemalloc/Makefile.target.include -- This caused the install script to
not copy it over into the install prefix, resulting in a missing
Makefile.

The fix is to copy over any Makefile* in a third-party dir instead of
just Makefile.include . This copies over a few Makefiles not strictly
necessary, but should prevent similar errors in the future

Tested by doing a `make install` and then compiling hello world.