### PR TITLE
Skip ConcurrentMap tests if LLVM is not present

### DIFF
--- a/test/library/packages/ConcurrentMap.skipif
+++ b/test/library/packages/ConcurrentMap.skipif
@@ -1,0 +1,11 @@
+# AtomicObjects uses extern blocks
+CHPL_LLVM==none
+# AtomicObjects uses GCC inline assembly, so only test it on gcc/clang
+CHPL_TARGET_COMPILER==cray-prgenv-pgi
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-cray
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER==cray-prgenv-intel
+# AtomicObjects uses x86-64 instructions in the inline assembly
+CHPL_TARGET_ARCH != x86_64


### PR DESCRIPTION
Skip ConcurrentMap tests if LLVM is not present (#18766)

The ConcurrentMap package module relies on atomic instructions which
require LLVM extern blocks to implement. As ASAN testing does not
run with LLVM, skip these tests in such configs.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>