### PR TITLE
Add deprecated OrderedMap and OrderedSet modules

### DIFF
--- a/modules/packages/OrderedMap.chpl
+++ b/modules/packages/OrderedMap.chpl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+deprecated "The OrderedMap module and the orderedMap type are deprecated in favor of SortedMap and sortedMap."
+module OrderedMap {
+  public use SortedMap;
+
+  type orderedMap = sortedMap;
+}

--- a/modules/packages/OrderedSet.chpl
+++ b/modules/packages/OrderedSet.chpl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+deprecated "The OrderedSet module and the orderedSet type are deprecated in favor of SortedSet and sortedMap."
+module OrderedSet {
+  public use SortedSet;
+
+  type orderedSet = sortedSet;
+}

--- a/test/deprecated/oMap.chpl
+++ b/test/deprecated/oMap.chpl
@@ -1,0 +1,7 @@
+use OrderedMap;
+
+var omap = new orderedMap(int, int);
+
+omap[5] = 10;
+
+writeln(omap);

--- a/test/deprecated/oMap.good
+++ b/test/deprecated/oMap.good
@@ -1,0 +1,2 @@
+oMap.chpl:1: warning: The OrderedMap module and the orderedMap type are deprecated in favor of SortedMap and sortedMap.
+{5: 10}

--- a/test/deprecated/oSet.chpl
+++ b/test/deprecated/oSet.chpl
@@ -1,0 +1,8 @@
+use OrderedSet;
+
+var oset = new orderedSet(int);
+
+oset.add(5);
+oset.add(5);
+
+writeln(oset.size);

--- a/test/deprecated/oSet.good
+++ b/test/deprecated/oSet.good
@@ -1,0 +1,2 @@
+oSet.chpl:1: warning: The OrderedSet module and the orderedSet type are deprecated in favor of SortedSet and sortedMap.
+1


### PR DESCRIPTION
I renamed orderedSet/Map as sortedSet/Map in
https://github.com/chapel-lang/chapel/pull/18689. However, I forgot to
do proper deprecation for the old symbols. This PR does that by

- adding deprecated modules
- adding basic deprecation warning tests