### PR TITLE
Next: fix incremental bug with deleted function 

### DIFF
--- a/compiler/next/include/chpl/queries/Context-detail.h
+++ b/compiler/next/include/chpl/queries/Context-detail.h
@@ -207,6 +207,7 @@ class QueryMapResult final : public QueryMapResultBase {
  public:
   std::tuple<ArgTs...> tupleOfArgs;
   mutable ResultType result;
+  mutable ResultType partialResult;
 
   // This constructor creates an entry with
   //  * lastChecked and lastChanged = -1

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -597,6 +597,15 @@ class Context {
 
   template<typename ResultType,
            typename... ArgTs>
+  const ResultType& queryEndCurrentResult(
+      const ResultType& (*queryFunction)(Context* context, ArgTs...),
+      querydetail::QueryMap<ResultType, ArgTs...>* queryMap,
+      const querydetail::QueryMapResult<ResultType, ArgTs...>* r,
+      const std::tuple<ArgTs...>& tupleOfArgs,
+      const char* traceQueryName);
+
+  template<typename ResultType,
+           typename... ArgTs>
   void querySetterUpdateResult(
       const ResultType& (*queryFunction)(Context* context, ArgTs...),
       const std::tuple<ArgTs...>& tupleOfArgs,

--- a/compiler/next/include/chpl/queries/query-impl.h
+++ b/compiler/next/include/chpl/queries/query-impl.h
@@ -264,7 +264,7 @@ const ResultType* Context::queryGetRunningQueryPartialResult(
   }
 
   // query is currently running so return the partial result
-  return &search2->result;
+  return &search2->partialResult;
 }
 
 template<typename ResultType,
@@ -331,6 +331,27 @@ Context::queryEnd(
 
   return ret->result;
 }
+
+template<typename ResultType,
+         typename... ArgTs>
+const ResultType&
+Context::queryEndCurrentResult(
+              const ResultType& (*queryFunction)(Context* context, ArgTs...),
+              QueryMap<ResultType, ArgTs...>* queryMap,
+              const QueryMapResult<ResultType, ArgTs...>* r,
+              const std::tuple<ArgTs...>& tupleOfArgs,
+              const char* traceQueryName) {
+
+  // swap the partial result to a variable
+  ResultType partialResultVar;
+  chpl::update<ResultType> updater;
+  updater(partialResultVar, r->partialResult);
+
+  return queryEnd(queryFunction, queryMap, r, tupleOfArgs,
+                  std::move(partialResultVar),
+                  traceQueryName);
+}
+
 
 template<typename ResultType,
          typename... ArgTs>
@@ -517,9 +538,10 @@ Context::querySetterUpdateResult(
 /**
   Get the current partial result for the current query
   (for use in recursive queries). The result is an lvalue that can be set.
+  Queries that use this need to end with return QUERY_END_CURRENT_RESULT()
  */
 #define QUERY_CURRENT_RESULT \
-  (BEGIN_QUERY_FOUND->result)
+  (BEGIN_QUERY_FOUND->partialResult)
 
 /**
   Write
@@ -542,6 +564,17 @@ Context::querySetterUpdateResult(
                                  BEGIN_QUERY_FUNC_NAME))
 
 
+/**
+  For a query working with QUERY_CURRENT_RESULT,
+  return the current result.
+ */
+#define QUERY_END_CURRENT_RESULT() \
+  /* must not use BEGIN_QUERY_SEARCH1 (iterator could be invalidated) */ \
+  (BEGIN_QUERY_CONTEXT->queryEndCurrentResult(BEGIN_QUERY_FUNCTION, \
+                                              BEGIN_QUERY_MAP, \
+                                              BEGIN_QUERY_FOUND, \
+                                              BEGIN_QUERY_ARGS, \
+                                              BEGIN_QUERY_FUNC_NAME))
 /**
   Use QUERY_STORE_RESULT to implement a setter for a non-input query.
   Arguments are:

--- a/compiler/next/lib/parsing/parsing-queries.cpp
+++ b/compiler/next/lib/parsing/parsing-queries.cpp
@@ -79,10 +79,7 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path) {
     uast::BuilderResult tmpResult = parser->parseString(pathc, textc);
     result.swap(tmpResult);
     // raise any errors encountered
-    // TODO: add something to BuilderResult to iterate over the errors
-    int nErrors = result.numErrors();
-    for (int i = 0; i < nErrors; i++) {
-      const ErrorMessage& e = result.error(i);
+    for (const ErrorMessage& e : result.errors()) {
       if (!e.isEmpty()) {
         // report the error and save it for this query
         context->error(e);

--- a/compiler/next/lib/queries/ErrorMessage.cpp
+++ b/compiler/next/lib/queries/ErrorMessage.cpp
@@ -36,7 +36,10 @@ static std::string vprint_to_string(const char* format, va_list vl) {
     buf = (char*) realloc(buf, size);
     got = vsnprintf(buf, size, format, vl);
     assert(got < size);
-    if (got >= size) return "<internal error in saving error>";
+    if (got >= size) {
+      free(buf);
+      return "<internal error in saving error>";
+    }
   }
   std::string ret(buf);
   free(buf);

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -495,7 +495,8 @@ struct Resolver {
 
           if (inferFromInit) {
             // Infer the param value from the initialization expr
-            if (initType.kind() == QualifiedType::PARAM) {
+            if (qtKind == QualifiedType::PARAM &&
+                initType.kind() == QualifiedType::PARAM) {
               paramPtr = initType.param();
             }
             // Infer the type from the initialization expr
@@ -645,10 +646,7 @@ resolveFields(Context* context, ID id, bool useGenericFormalDefaults) {
     assert(false && "case not handled");
   }
 
-  // take the value out of the partial result in order to return it
-  ResolutionResultByPostorderID result;
-  result.swap(partialResult);
-  return QUERY_END(result);
+  return QUERY_END_CURRENT_RESULT();
 }
 
 
@@ -667,10 +665,7 @@ const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
     assert(false && "case not handled");
   }
 
-  // take the value out of the partial result in order to return it
-  ResolutionResultByPostorderID result;
-  result.swap(partialResult);
-  return QUERY_END(result);
+  return QUERY_END_CURRENT_RESULT();
 }
 
 static

--- a/compiler/next/lib/resolution/scope-queries.cpp
+++ b/compiler/next/lib/resolution/scope-queries.cpp
@@ -788,10 +788,7 @@ const owned<ResolvedVisibilityScope>& resolveVisibilityStmtsQuery(
     }
   }
 
-  // take the value out of the partial result in order to return it
-  owned<ResolvedVisibilityScope> result;
-  result.swap(partialResult);
-  return QUERY_END(result);
+  return QUERY_END_CURRENT_RESULT();
 }
 
 const ResolvedVisibilityScope* resolveVisibilityStmts(Context* context,

--- a/compiler/next/test/queries/testRecursiveQuery.cpp
+++ b/compiler/next/test/queries/testRecursiveQuery.cpp
@@ -59,6 +59,7 @@ static const int& recursiveQuery(Context* context, int arg) {
     result = 0;
   }
 
+  // TODO: should this use QUERY_END_CURRENT_RESULT
   return QUERY_END(result);
 }
 

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -21,6 +21,7 @@
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/Comment.h"
+#include "chpl/uast/FnCall.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
@@ -160,9 +161,86 @@ static void test2() {
   }
 }
 
+static void test3() {
+  printf("test3\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::build(context, "input.chpl");
+
+  {
+    context->advanceToNextRevision(true);
+    std::string contents = "proc foo(arg: int) {\n"
+                           "  return arg;\n"
+                           "}\n"
+                           "var y = foo(1);";
+    setFileText(context, path, contents);
+    const ModuleVec& vec = parse(context, path);
+    for (const Module* mod : vec) {
+      ASTNode::dump(mod);
+    }
+    assert(vec.size() == 1);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    const Function* procfoo = m->stmt(0)->toFunction();
+    assert(procfoo && procfoo->name() == "foo");
+    const Variable* y = m->stmt(1)->toVariable();
+    assert(y);
+    const Expression* rhs = y->initExpression();
+    assert(rhs);
+    const FnCall* fnc = rhs->toFnCall();
+    assert(fnc);
+    const Identifier* foo = fnc->calledExpression()->toIdentifier();
+    assert(foo && foo->name() == "foo");
+
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    auto rrfoo = rr.byAst(foo);
+    assert(rrfoo.toId() == procfoo->id());
+
+    auto yt = rr.byAst(y).type().type();
+    assert(yt->isIntType());
+
+    context->collectGarbage();
+  }
+
+  {
+    context->advanceToNextRevision(true);
+    std::string contents = "var y = foo(1);";
+    setFileText(context, path, contents);
+    const ModuleVec& vec = parse(context, path);
+    for (const Module* mod : vec) {
+      ASTNode::dump(mod);
+    }
+
+    assert(vec.size() == 1);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    const Variable* y = m->stmt(0)->toVariable();
+    assert(y);
+    const Expression* rhs = y->initExpression();
+    assert(rhs);
+    const FnCall* fnc = rhs->toFnCall();
+    assert(fnc);
+    const Identifier* foo = fnc->calledExpression()->toIdentifier();
+    assert(foo && foo->name() == "foo");
+
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    auto rrfoo = rr.byAst(foo);
+    assert(rrfoo.toId().isEmpty());
+
+    auto rry = rr.byAst(y);
+    auto yt = rry.type().type();
+    assert(yt);
+    assert(yt->isErroneousType());
+
+    context->collectGarbage();
+  }
+}
+
 int main() {
   test1();
   test2();
+  test3();
 
   return 0;
 }


### PR DESCRIPTION
Adds a test showing that a deleted function is no longer returned as part of a resolution result.

The fix is thanks to mppf, with the underlying cause that a garbage value was being used for partial result even when a query needed to be recomputed.

Also included is:
1) Fixing a memory leak (malloc without free in one code path)
2) Completing a TODO for using an Iterable instead of for i

test-libchplcomp tests are passing