### PR TITLE
Fix chplvis build

### DIFF
--- a/tools/chplvis/MenuManager.cxx
+++ b/tools/chplvis/MenuManager.cxx
@@ -19,12 +19,9 @@
  */
 
 #include "chplvis.h"
-#include <sstream>
+#include <string>
 #include <FL/Fl_File_Chooser.H>
 #include <FL/fl_ask.H>
-
-#define SSTR( x ) dynamic_cast< std::ostringstream & >( \
-                    ( std::ostringstream() << std::dec << x ) ).str()
 
 // Utility routine
 
@@ -315,7 +312,7 @@ void MenuManager::toggleUTags ()
 void MenuManager::makeLocaleMenu (void)
 {
   for (long ix = 0; ix < VisData.NumLocales(); ix++) {
-    std::string entryName = "Locale/" + SSTR(ix);
+    std::string entryName = "Locale/" + std::to_string(ix);
     MainMenuBar->add(entryName.c_str(), 0, cb_selectLocale, (void *)ix);
     popup->add(entryName.c_str(), 0, cb_selectLocale, (void *)ix);
   }
@@ -397,7 +394,7 @@ void MenuManager::makeTagsMenu(void)
       if (VisData.hasUniqueTags() || useUTags)
         menuName = "Tags/" + std::string(tagName);
       else
-        menuName = "Tags/tag " + SSTR(ix) + " (" + tagName + ")";
+        menuName = "Tags/tag " + std::to_string(ix) + " (" + tagName + ")";
       MainMenuBar->add(menuName.c_str(), 0, cb_selTag, (void *)ix, 0);
       popup->add(menuName.c_str(), 0, cb_selTag, (void *)ix, 0);
     }


### PR DESCRIPTION
This dynamic_cast succeeds in c++03 but not in c++11 or later. Removed
the macro altogether as it was only used in 2 callsites

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>