### PR TITLE
Fix problem in get_compiler_from_command

### DIFF
--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -238,8 +238,9 @@ def get_compiler_from_command(command):
     # the following adjustments are to handle a command like
     #    /path/to/gcc-10 --some-option
     # where we are looking for just the 'gcc' part.
-    basename = os.path.basename(command)
-    name = basename.split('-')[0]
+    first = command.split()[0]
+    basename = os.path.basename(first)
+    name = basename.split('-')[0].strip()
     for tup in COMPILERS:
         if name == tup[1] or name == tup[2]:
             return tup[0]


### PR DESCRIPTION
Follow-up to PR #18745 .

PR #18745 assumed that all calls to it would be passing in just one
command (since the arguments are frequently now stored in a list and so
call sites can just get the first list element). However that's not the
case in get_compiler_from_cc_cxx where this function is called with the
value of CC / CXX environment variables.

- [x] full local testing

Reviewed by @e-kayrakli - thanks!