### PR TITLE
Add test demonstrating use-after-free for throwing function within forall

### DIFF
--- a/test/errhandling/parallel/forall-calls-throwing-fn2.chpl
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.chpl
@@ -1,0 +1,18 @@
+use BlockDist;
+
+var A = newBlockArr({1..10}, real);
+
+proc throwingFunction() throws {
+  throw new owned Error("die!");
+}
+
+proc throwingCaller() throws {
+  forall a in A {
+    throwingFunction();
+  }
+}
+
+proc main() {
+  try { throwingCaller(); }
+  catch e { writeln("Caught an error!"); }
+}

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.future
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.future
@@ -1,0 +1,8 @@
+bug: use-after-free when calling throwing function within forall loop
+
+This test exhibits a behavior in which the invocation of a throwing
+function within a 'forall' loop over a distributed array results in a
+use-after-free error being detected by valgrind (and a segmentation
+fault without).
+
+#18773

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.good
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.good
@@ -1,0 +1,1 @@
+Caught an error!

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.skipif
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
This is a future illustrating #18773.
