### PR TITLE
Add additional protection against non-param indexing into heterogeneous tuples

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -327,7 +327,10 @@ returnInfoGetMember(CallExpr* call) {
 static QualifiedType
 returnInfoGetTupleMember(CallExpr* call) {
   AggregateType* ct = toAggregateType(call->get(1)->getValType());
-  INT_ASSERT(ct && ct->symbol->hasFlag(FLAG_STAR_TUPLE));
+  INT_ASSERT(ct);
+  if (!ct->symbol->hasFlag(FLAG_STAR_TUPLE)) {
+    USR_FATAL(call, "invalid access of non-homogeneous tuple by runtime value");
+  }
   return ct->getField("x0")->qualType();
 }
 

--- a/test/types/tuple/errors/indexHetTuple.chpl
+++ b/test/types/tuple/errors/indexHetTuple.chpl
@@ -1,0 +1,37 @@
+use Sort;
+
+import Reflection.canResolveMethod;
+record ContrivedComparator {
+  const dc = new DefaultComparator();
+  proc keyPart(a, i: int) {
+    // Fall back to DefaultComparator implementation where possible
+    if canResolveMethod(dc, "keyPart", a, 0) {
+      return dc.keyPart(a, i);
+    } else if isTuple(a) {
+      // DefaultComparator does not handle non-homogeneous tuples
+      return tupleKeyPart(a, i);
+    } else {
+      compilerError("No keyPart method for eltType ", a.type:string);
+    }
+  }
+
+  proc tupleKeyPart(x, i:int) {
+    // This is the same as DefaultComparator.keyPart() for homogeneous tuple
+    const tup = dc.keyPart(x(i), 1);
+    const part = tup(1);
+//    const (_, part) = dc.keyPart(x(i), 1);
+    if i >= x.size {
+      return (-1, 0:part.type);
+    } else {
+      return (0, part);
+    }
+  }
+}
+
+const myDefaultComparator = new ContrivedComparator();
+
+var A: [0..#10] (real, int) = for i in 0..#10 do ((10-i):real, i);
+// Using the twoArrayRadixSort generates internal error
+TwoArrayRadixSort.twoArrayRadixSort(A, comparator=myDefaultComparator);
+// Using the regular sort instead does not
+sort(A);

--- a/test/types/tuple/errors/indexHetTuple.good
+++ b/test/types/tuple/errors/indexHetTuple.good
@@ -1,0 +1,5 @@
+$CHPL_HOME/modules/internal/ChapelTuple.chpl:212: In method 'this':
+$CHPL_HOME/modules/internal/ChapelTuple.chpl:220: error: invalid access of non-homogeneous tuple by runtime value
+  $CHPL_HOME/modules/packages/Sort.chpl:1733: called as ((real(64),int(64))).this(i: int(64)) from function 'msbRadixSortParamLastStartBit'
+  $CHPL_HOME/modules/packages/Sort.chpl:3143: called as msbRadixSortParamLastStartBit(Data: [domain(1,int(64),false)] (real(64),int(64)), comparator: ContrivedComparator) from function 'twoArrayRadixSort'
+  indexHetTuple.chpl:35: called as twoArrayRadixSort(Data: [domain(1,int(64),false)] (real(64),int(64)), comparator: ContrivedComparator)

--- a/test/types/tuple/errors/indexHetTuple.good
+++ b/test/types/tuple/errors/indexHetTuple.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/internal/ChapelTuple.chpl:212: In method 'this':
-$CHPL_HOME/modules/internal/ChapelTuple.chpl:220: error: invalid access of non-homogeneous tuple by runtime value
+$CHPL_HOME/modules/internal/ChapelTuple.chpl:218: error: invalid access of non-homogeneous tuple by runtime value
   $CHPL_HOME/modules/packages/Sort.chpl:1733: called as ((real(64),int(64))).this(i: int(64)) from function 'msbRadixSortParamLastStartBit'
   $CHPL_HOME/modules/packages/Sort.chpl:3143: called as msbRadixSortParamLastStartBit(Data: [domain(1,int(64),false)] (real(64),int(64)), comparator: ContrivedComparator) from function 'twoArrayRadixSort'
   indexHetTuple.chpl:35: called as twoArrayRadixSort(Data: [domain(1,int(64),false)] (real(64),int(64)), comparator: ContrivedComparator)


### PR DESCRIPTION
The test added here resulted in an internal rather than user-facing
error, I _believe_ due to the fact that it was following a speculative
resolution path to determine the type of an expression and
squashing user errors along the way which would have flagged this
expression as being illegal.  Here, I took the simple approach of
replicating the normal module-level user-facing error message in place
of the assert that the tuple was homogeneous which was being tripped
prior to this change.

Resolves #18775.