### PR TITLE
Enable parquet support for Arkouda testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -21,8 +21,12 @@ ARKOUDA_DEP_DIR=$CSS_DIR/arkouda-deps
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}
   export ARKOUDA_HDF5_PATH=${ARKOUDA_HDF5_PATH:-$ARKOUDA_DEP_DIR/hdf5-install}
+  export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}
   export PATH="$ARKOUDA_HDF5_PATH/bin:$PATH"
 fi
+
+# enable arrow/parquet support
+export ARKOUDA_SERVER_PARQUET_SUPPORT=true
 
 # Arkouda requires Python >= 3.7
 SETUP_PYTHON=$CSS_DIR/setup_python37.bash


### PR DESCRIPTION
Enable the opt-in parquet support for our nightly arkouda testing.

See https://github.com/Bears-R-Us/arkouda/pull/967 for more info.