### PR TITLE
Make ConcurrentMap tests into futures due to memory leaks

### DIFF
--- a/test/library/packages/ConcurrentMap/EXECOPTS
+++ b/test/library/packages/ConcurrentMap/EXECOPTS
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/packages/ConcurrentMap/PREDIFF
+++ b/test/library/packages/ConcurrentMap/PREDIFF
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -E "s/0x[0-9a-f]*/prediffed/" <$2 >$2.predifftmp
+grep prediffed $2.predifftmp | uniq -c >$2
+rm $2.predifftmp

--- a/test/library/packages/ConcurrentMap/PREDIFF
+++ b/test/library/packages/ConcurrentMap/PREDIFF
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sed -E "s/0x[0-9a-f]*/prediffed/" <$2 >$2.predifftmp
-grep prediffed $2.predifftmp | uniq -c >$2
-rm $2.predifftmp

--- a/test/library/packages/ConcurrentMap/testAddSet.future
+++ b/test/library/packages/ConcurrentMap/testAddSet.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/ConcurrentMap/testClear.future
+++ b/test/library/packages/ConcurrentMap/testClear.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/ConcurrentMap/testContains.future
+++ b/test/library/packages/ConcurrentMap/testContains.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/ConcurrentMap/testEquality.future
+++ b/test/library/packages/ConcurrentMap/testEquality.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/ConcurrentMap/testExtend.future
+++ b/test/library/packages/ConcurrentMap/testExtend.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory

--- a/test/library/packages/ConcurrentMap/testGetRemove.future
+++ b/test/library/packages/ConcurrentMap/testGetRemove.future
@@ -1,0 +1,1 @@
+bug: this test leaks memory


### PR DESCRIPTION
Make ConcurrentMap tests into futures due to memory leaks

Turn all the tests for the `ConcurrentMap` package into futures until
all the memory leaks in it and packages it depends on are fixed.

The `ConcurrentMap` tests rely on the `EpochManager` package, which
has known memory leak issues (see #17629).

There are no `.bad` files for these futures because the leaks exhibit
non-determinism.

Reviewed by @e-kayrakli. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>