### PR TITLE
Add warnings to docs of package modules that depend on AtomicObjects

### DIFF
--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -19,13 +19,12 @@
  */
 
 /*
-  .. note:: 
+  .. warning::
 
     This module has several platform restrictions in its current state:
 
       - It relies on Chapel ``extern`` code blocks and so requires that
-        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
-        Chapel compiler is built with LLVM enabled.
+        the Chapel compiler is built with LLVM enabled.
       - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
         the x86-64 instruction: CMPXCHG16B_.
       - The implementation relies on ``GCC`` style inline assembly, and so

--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -21,10 +21,16 @@
 /*
   .. note:: 
 
-    This package relies on Chapel ``extern`` code blocks and so requires that
-    ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` and that the Chapel compiler is
-    built with LLVM enabled. As well, currently only ``CHPL_TARGET_ARCH=x86_64``
-    is supported as we make use of the x86-64 instruction: CMPXCHG16B_.
+    This module has several platform restrictions in its current state:
+
+      - It relies on Chapel ``extern`` code blocks and so requires that
+        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
+        Chapel compiler is built with LLVM enabled.
+      - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
+        the x86-64 instruction: CMPXCHG16B_.
+      - The implementation relies on ``GCC`` style inline assembly, and so
+        is restricted to a ``CHPL_TARGET_COMPILER`` value of ``gnu``,
+        ``clang``, or ``llvm``.
 
     .. _CMPXCHG16B: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
     

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -21,9 +21,19 @@
 /*
   .. note::
 
-    This module relies on the :mod:`AtomicObjects` package, which currently
-    requires ``extern`` code block support. See the documentation of the
-    :mod:`AtomicObjects` package for more details.
+    This module relies on the :mod:`AtomicObjects` package module, which
+    has several platform restrictions in its current state:
+
+      - It relies on Chapel ``extern`` code blocks and so requires that
+        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
+        Chapel compiler is built with LLVM enabled.
+      - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
+        the x86-64 instruction: CMPXCHG16B_.
+      - The implementation relies on ``GCC`` style inline assembly, and so
+        is restricted to a ``CHPL_TARGET_COMPILER`` value of ``gnu``,
+        ``clang``, or ``llvm``.
+
+    .. _CMPXCHG16B: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
 
   This module provides a fast, scalable, fine-grained concurrent map. It was
   inspired by the Interlocked Hash Table [#]_. It allows large critical

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -19,6 +19,12 @@
  */
 
 /*
+  .. note::
+
+    This module relies on the :mod:`AtomicObjects` package, which currently
+    requires ``extern`` code block support. See the documentation of the
+    :mod:`AtomicObjects` package for more details.
+
   This module provides a fast, scalable, fine-grained concurrent map. It was
   inspired by the Interlocked Hash Table [#]_. It allows large critical
   sections that access a single table element, and can easily support multikey

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -19,14 +19,13 @@
  */
 
 /*
-  .. note::
+  .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which
     has several platform restrictions in its current state:
 
       - It relies on Chapel ``extern`` code blocks and so requires that
-        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
-        Chapel compiler is built with LLVM enabled.
+        the Chapel compiler is built with LLVM enabled.
       - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
         the x86-64 instruction: CMPXCHG16B_.
       - The implementation relies on ``GCC`` style inline assembly, and so

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -19,14 +19,13 @@
  */
 
 /*
-  .. note::
+  .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which
     has several platform restrictions in its current state:
 
       - It relies on Chapel ``extern`` code blocks and so requires that
-        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
-        Chapel compiler is built with LLVM enabled.
+        the Chapel compiler is built with LLVM enabled.
       - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
         the x86-64 instruction: CMPXCHG16B_.
       - The implementation relies on ``GCC`` style inline assembly, and so

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -19,6 +19,21 @@
  */
 
 /*
+  .. note::
+
+    This module relies on the :mod:`AtomicObjects` package module, which
+    has several platform restrictions in its current state:
+
+      - It relies on Chapel ``extern`` code blocks and so requires that
+        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
+        Chapel compiler is built with LLVM enabled.
+      - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
+        the x86-64 instruction: CMPXCHG16B_.
+      - The implementation relies on ``GCC`` style inline assembly, and so
+        is restricted to a ``CHPL_TARGET_COMPILER`` value of ``gnu``,
+        ``clang``, or ``llvm``.
+
+    .. _CMPXCHG16B: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
 
   Epoch-Based Memory Reclamation
   ------------------------------

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -19,14 +19,13 @@
  */
 
 /*
-  .. note::
+  .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which
     has several platform restrictions in its current state:
 
       - It relies on Chapel ``extern`` code blocks and so requires that
-        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
-        Chapel compiler is built with LLVM enabled.
+        the Chapel compiler is built with LLVM enabled.
       - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
         the x86-64 instruction: CMPXCHG16B_.
       - The implementation relies on ``GCC`` style inline assembly, and so

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -19,6 +19,22 @@
  */
 
 /*
+  .. note::
+
+    This module relies on the :mod:`AtomicObjects` package module, which
+    has several platform restrictions in its current state:
+
+      - It relies on Chapel ``extern`` code blocks and so requires that
+        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
+        Chapel compiler is built with LLVM enabled.
+      - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
+        the x86-64 instruction: CMPXCHG16B_.
+      - The implementation relies on ``GCC`` style inline assembly, and so
+        is restricted to a ``CHPL_TARGET_COMPILER`` value of ``gnu``,
+        ``clang``, or ``llvm``.
+
+    .. _CMPXCHG16B: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+
   An implementation of the Michael & Scott [#]_, a lock-free queue. Concurrent safe
   memory reclamation is handled by an internal :record:`EpochManager`. Usage of the
   queue can be seen below.

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -20,14 +20,13 @@
 
 
 /*
-  .. note::
+  .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which
     has several platform restrictions in its current state:
 
       - It relies on Chapel ``extern`` code blocks and so requires that
-        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
-        Chapel compiler is built with LLVM enabled.
+        the Chapel compiler is built with LLVM enabled.
       - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
         the x86-64 instruction: CMPXCHG16B_.
       - The implementation relies on ``GCC`` style inline assembly, and so

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -20,6 +20,22 @@
 
 
 /*
+  .. note::
+
+    This module relies on the :mod:`AtomicObjects` package module, which
+    has several platform restrictions in its current state:
+
+      - It relies on Chapel ``extern`` code blocks and so requires that
+        ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=system`` be set, and that the
+        Chapel compiler is built with LLVM enabled.
+      - Currently only ``CHPL_TARGET_ARCH=x86_64`` is supported as it uses
+        the x86-64 instruction: CMPXCHG16B_.
+      - The implementation relies on ``GCC`` style inline assembly, and so
+        is restricted to a ``CHPL_TARGET_COMPILER`` value of ``gnu``,
+        ``clang``, or ``llvm``.
+
+    .. _CMPXCHG16B: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+
   An implementation of the Treiber Stack [#]_, a lock-free stack. Concurrent safe
   memory reclamation is handled by an internal :record:`EpochManager`. Usage of the
   stack can be seen below.


### PR DESCRIPTION
Add warnings to docs of package modules that depend on AtomicObjects

The `AtomicObjects` module has several platform constraints in its
implementation (such as requiring `x86_64` or `GCC` style inline
assembly). Add a warning to the top of every package module that
depends on the `AtomicObjects` module, including the newly added
`ConcurrentMap` module.

Reviewed by @bradcray, @e-kayrakli. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>