### PR TITLE
Update error messages referring to array front\back to first\last

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -60,7 +60,10 @@ For example:
    This step is not necessary when using the ``deprecated`` keyword to
    generate the documentation.
 
-3. Add a deprecation test to ``test/deprecated/`` to:
+3. Search for error messages that refer to the deprecated feature.
+   If appropriate, update them to refer to the new feature.
+
+4. Add a deprecation test to ``test/deprecated/`` to:
 
   - confirm the deprecation warning works as intended
   - remind us to to remove the deprecated feature in the following release

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3440,7 +3440,7 @@ module ChapelArray {
      */
     proc last {
       if !this.isRectangular() || this.rank != 1 then
-        compilerError("last() is only supported on 1D rectangular arrays");
+        compilerError("last is only supported on 1D rectangular arrays");
 
       if boundsChecking && isEmpty() then
         halt("last called on an empty array");
@@ -3458,7 +3458,7 @@ module ChapelArray {
      */
     proc first {
       if !this.isRectangular() || this.rank != 1 then
-        compilerError("first() is only supported on 1D rectangular arrays");
+        compilerError("first is only supported on 1D rectangular arrays");
 
       if boundsChecking && isEmpty() then
         halt("first called on an empty array");

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3440,10 +3440,10 @@ module ChapelArray {
      */
     proc last {
       if !this.isRectangular() || this.rank != 1 then
-        compilerError("back() is only supported on 1D rectangular arrays");
+        compilerError("last() is only supported on 1D rectangular arrays");
 
       if boundsChecking && isEmpty() then
-        halt("back called on an empty array");
+        halt("last called on an empty array");
 
       return this(this.domain.high);
     }
@@ -3458,10 +3458,10 @@ module ChapelArray {
      */
     proc first {
       if !this.isRectangular() || this.rank != 1 then
-        compilerError("front() is only supported on 1D rectangular arrays");
+        compilerError("first() is only supported on 1D rectangular arrays");
 
       if boundsChecking && isEmpty() then
-        halt("front called on an empty array");
+        halt("first called on an empty array");
 
       return this(this.domain.low);
     }

--- a/test/arrays/diten/arrayBack2D.good
+++ b/test/arrays/diten/arrayBack2D.good
@@ -1,1 +1,1 @@
-arrayBack2D.chpl:3: error: back() is only supported on 1D rectangular arrays
+arrayBack2D.chpl:3: error: last() is only supported on 1D rectangular arrays

--- a/test/arrays/diten/arrayBack2D.good
+++ b/test/arrays/diten/arrayBack2D.good
@@ -1,1 +1,1 @@
-arrayBack2D.chpl:3: error: last() is only supported on 1D rectangular arrays
+arrayBack2D.chpl:3: error: last is only supported on 1D rectangular arrays

--- a/test/arrays/diten/arrayBackOOB.good
+++ b/test/arrays/diten/arrayBackOOB.good
@@ -1,1 +1,1 @@
-arrayBackOOB.chpl:3: error: halt reached - back called on an empty array
+arrayBackOOB.chpl:3: error: halt reached - last called on an empty array

--- a/test/arrays/diten/arrayFront2D.good
+++ b/test/arrays/diten/arrayFront2D.good
@@ -1,1 +1,1 @@
-arrayFront2D.chpl:3: error: first() is only supported on 1D rectangular arrays
+arrayFront2D.chpl:3: error: first is only supported on 1D rectangular arrays

--- a/test/arrays/diten/arrayFront2D.good
+++ b/test/arrays/diten/arrayFront2D.good
@@ -1,1 +1,1 @@
-arrayFront2D.chpl:3: error: front() is only supported on 1D rectangular arrays
+arrayFront2D.chpl:3: error: first() is only supported on 1D rectangular arrays

--- a/test/arrays/diten/arrayFrontOOB.good
+++ b/test/arrays/diten/arrayFrontOOB.good
@@ -1,1 +1,1 @@
-arrayFrontOOB.chpl:3: error: halt reached - front called on an empty array
+arrayFrontOOB.chpl:3: error: halt reached - first called on an empty array


### PR DESCRIPTION
@bradcray helpfully noticed that I forgot to update error message when I submitted this PR that renamed array's front\back methods to first\last: https://github.com/chapel-lang/chapel/pull/18256

This PR updates the error messages and associated tests.