### PR TITLE
Make a Map method private to remove from docs

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -51,7 +51,7 @@ module Map {
     }
   }
 
-  proc _checkKeyAndValType(type K, type V) {
+  private proc _checkKeyAndValType(type K, type V) {
     if isGenericType(K) {
       compilerWarning('creating a map with key type ', K:string, 2);
       if isClassType(K) && !isGenericType(borrowed K) {


### PR DESCRIPTION
A map method `_checkKeyAndValType(type K, type V)` was showing up in documentation, but it was not intended to be user facing, so this PR makes it private to keep it out of the docs.