### PR TITLE
Add perf annotation for concurrent map

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1442,6 +1442,8 @@ memleaksfull:
     - Two fixes in OrderedMap (#17463)
   03/27/21:
     - CG Adjust in-intent handling to fix a memleak (#17480)
+  11/24/21:
+    - Add module ConcurrentMap (#16704)
 # End memleaksfull
 
 meteor:


### PR DESCRIPTION
Add an annotation for the memory leaks that resulted from the ConcurrentMap module being added.

https://chapel-lang.org/perf/chapcs/?startdate=2021/11/18&enddate=2021/12/02&graphs=memoryleaksforalltests,numberoftestswithleaks

PR: #16704 