### PR TITLE
fix bug causing forall loop outside of GPUs to execute serially.

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6271,17 +6271,13 @@ void CallExpr::codegenInvokeTaskFun(const char* name) {
 
   // We would like to remove this conditional and always do the true branch,
   // but wanted to limit the impact of this near the release date.
-  if (localeUsesGPU()) {
-    GenRet outerLocale = codegenCallExpr("chpl_task_getRequestedSubloc");
-    args[0]    = outerLocale;
-  } else {
-    args[0]      = new_IntSymbol(-2 /* c_sublocid_any */, INT_SIZE_32);
-  }
-  args[1]      = new_IntSymbol(ftableMap[fn], INT_SIZE_64);
-  args[2]      = codegenCast("chpl_task_bundle_p", taskBundle);
-  args[3]      = bundleSize;
-  args[4]      = fn->linenum();
-  args[5]      = new_IntSymbol(gFilenameLookupCache[fn->fname()], INT_SIZE_32);
+  GenRet outerLocale = codegenCallExpr("chpl_task_getRequestedSubloc");
+  args[0] = outerLocale;
+  args[1] = new_IntSymbol(ftableMap[fn], INT_SIZE_64);
+  args[2] = codegenCast("chpl_task_bundle_p", taskBundle);
+  args[3] = bundleSize;
+  args[4] = fn->linenum();
+  args[5] = new_IntSymbol(gFilenameLookupCache[fn->fname()], INT_SIZE_32);
 
   genComment(fn->cname, true);
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -30,6 +30,11 @@ module ChapelLocale {
   import HaltWrappers;
   use SysCTypes, CPtr;
 
+  compilerAssert(!(!localeModelHasSublocales &&
+   localeModelPartitionsIterationOnSublocales),
+   "Locale model without sublocales can not have " +
+   "localeModelPartitionsIterationOnSublocales set to true.");
+
   //
   // Node and sublocale types and special sublocale values.
   //

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2329,7 +2329,7 @@ operator :(r: range(?), type t: range(?)) {
 
   pragma "no doc"
   iter range.these(param tag: iterKind) where tag == iterKind.standalone &&
-                                              !localeModelHasSublocales
+    !localeModelPartitionsIterationOnSublocales
   {
     if ! isBoundedRange(this) {
       compilerError("parallel iteration is not supported over unbounded ranges");
@@ -2384,7 +2384,7 @@ operator :(r: range(?), type t: range(?)) {
       chpl_debug_writeln("*** In range leader:"); // ", this);
     const numSublocs = here.getChildCount();
 
-    if localeModelHasSublocales && numSublocs != 0 {
+    if localeModelPartitionsIterationOnSublocales && numSublocs != 0 {
       const len = this.sizeAs(intIdxType);
       const tasksPerLocale = dataParTasksPerLocale;
       const ignoreRunning = dataParIgnoreRunningTasks;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -359,7 +359,7 @@ module DefaultRectangular {
 
       const numSublocs = here.getChildCount();
 
-      if localeModelHasSublocales && numSublocs != 0 {
+      if localeModelPartitionsIterationOnSublocales && numSublocs != 0 {
         var dptpl = if tasksPerLocale==0 then here.maxTaskPar
                     else tasksPerLocale;
         if !ignoreRunning {
@@ -1244,7 +1244,7 @@ module DefaultRectangular {
           chpl_debug_writeln("*** DR alloc ", eltType:string, " ", size);
         }
 
-        if !localeModelHasSublocales {
+        if !localeModelPartitionsIterationOnSublocales {
           data = _ddata_allocate_noinit(eltType, size, callPostAlloc);
         } else {
           data = _ddata_allocate_noinit(eltType, size,

--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -20,6 +20,7 @@
 module LocaleModelHelpAPU {
 
   param localeModelHasSublocales = true;
+  param localeModelPartitionsIterationOnSublocales = true;
 
   public use LocaleModelHelpSetup;
   public use LocaleModelHelpRuntime;

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -21,6 +21,7 @@
 module LocaleModelHelpFlat {
 
   param localeModelHasSublocales = false;
+  param localeModelPartitionsIterationOnSublocales = false;
 
   public use LocaleModelHelpSetup;
   public use LocaleModelHelpRuntime;

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -19,6 +19,7 @@
 module LocaleModelHelpGPU {
 
   param localeModelHasSublocales = true;
+  param localeModelPartitionsIterationOnSublocales = false;
 
   public use LocaleModelHelpSetup;
   public use LocaleModelHelpRuntime;

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -22,6 +22,7 @@ module LocaleModelHelpNUMA {
   use SysCTypes;
 
   param localeModelHasSublocales = true;
+  param localeModelPartitionsIterationOnSublocales = true;
 
   public use LocaleModelHelpSetup;
   public use LocaleModelHelpRuntime;

--- a/test/localeModels/numa/dataParallel/partitionRanges.chpl
+++ b/test/localeModels/numa/dataParallel/partitionRanges.chpl
@@ -1,0 +1,82 @@
+use IO.FormattedIO;
+
+var counter = 0;
+proc writelnCnt(const args ...?k) throws {
+  writelnFix((...args));
+  counter += 1;
+}
+
+proc writelnFix(const args ...?k) throws {
+  var s: string = "%3i ".format(counter);
+  try writeln(s, (...args));
+}
+
+
+proc getSubloc() {
+  if localeModelHasSublocales {
+    return chpl_getSubloc();
+  }
+  return 0;
+}
+
+if(here.getChildCount() != 2) {
+  writeln("----------------------------------------------------------------------------");
+  writeln("We expect to run this test using the NUMA locale model on a machine with two");
+  writeln("NUMA domains.");
+  writeln("----------------------------------------------------------------------------");
+  exit(1);
+}
+
+writelnCnt("NUM LOCALES: ", numLocales-1);
+writelnCnt("CHILD COUNT: ", here.getChildCount());
+writelnCnt("-------------");
+
+{
+  writelnCnt("Range iteration:");
+  var r1 = 1..4;
+  forall i in r1 {
+    writelnFix("  i = ", i, "\t", here, "\t", getSubloc());
+  }
+}
+
+{
+  writelnCnt("Default rectangular domain zippered iteration:");
+  var D : domain(2) = {1..2, 1..2};
+  forall i in zip(D, D) {
+    // TODO: For some reason if we use here (the constant) rather than "here"
+    // the string we get the following error: use of 'here' before encountering
+    // its definition, type unknown.  Looks like this is a bug that should be
+    // fixed.  Once this is resolved remove the double quotes.
+    // FIXME: See https://github.com/chapel-lang/chapel/issues/18778
+    writelnFix("  i = ", i, "\t", "here", "\t", getSubloc());
+  }
+}
+
+{
+  writelnCnt("Array view slice iteration:");
+  const A = [1, 2, 3, 4, 5, 6];
+  const D = {2..5};
+  forall i in A[D] {
+    writelnFix("  i = ", i, "\t", here, "\t", getSubloc());
+  }
+}
+
+{
+  writelnCnt("Array view reindex iteration:");
+  const A = [1, 2];
+  const D = {4..5};
+  forall i in A.reindex(D) {
+    writelnFix("  i = ", i, "\t", here, "\t", getSubloc());
+  }
+}
+
+{
+  writelnCnt("Array view rank change iteration:");
+  var A : [1..2, 1..2] int;
+  A[1, 1] = 1; A[1, 2] = 2; A[2, 1] = 3; A[2, 2] = 4;
+  const B = A[1, ..];
+  forall i in B {
+    writelnFix("  i = ", i, "\t", here, "\t", getSubloc());
+  }
+}
+

--- a/test/localeModels/numa/dataParallel/partitionRanges.good
+++ b/test/localeModels/numa/dataParallel/partitionRanges.good
@@ -1,0 +1,24 @@
+  0 NUM LOCALES: 0
+  1 CHILD COUNT: 2
+  2 -------------
+  3 Range iteration:
+  4   i = 1	LOCALE0.ND0	0
+  4   i = 2	LOCALE0.ND0	0
+  4   i = 3	LOCALE0.ND1	1
+  4   i = 4	LOCALE0.ND1	1
+  4 Default rectangular domain zippered iteration:
+  5   i = ((1, 1), (1, 1))	here	0
+  5   i = ((1, 2), (1, 2))	here	0
+  5   i = ((2, 1), (2, 1))	here	1
+  5   i = ((2, 2), (2, 2))	here	1
+  5 Array view slice iteration:
+  6   i = 3	LOCALE0.ND0	0
+  6   i = 4	LOCALE0.ND0	0
+  6   i = 5	LOCALE0.ND1	1
+  6   i = 6	LOCALE0.ND1	1
+  6 Array view reindex iteration:
+  7   i = 1	LOCALE0.ND0	0
+  7   i = 2	LOCALE0.ND1	1
+  7 Array view rank change iteration:
+  8   i = 1	LOCALE0.ND0	0
+  8   i = 2	LOCALE0.ND1	1

--- a/test/localeModels/numa/dataParallel/partitionRanges.prediff
+++ b/test/localeModels/numa/dataParallel/partitionRanges.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sort -o $1.exec.out.tmp $1.exec.out.tmp 

--- a/test/localeModels/numa/dataParallel/partitionRanges.skipif
+++ b/test/localeModels/numa/dataParallel/partitionRanges.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL != numa


### PR DESCRIPTION
This PR is for: https://github.com/Cray/chapel-private/issues/2412

Specifically I add new variable to locale models indicating whether they should partition iterations across sublocales. Have all subocales other than flat and GPU
set this to true.

To code reviewers:

* Let me know if you feel the name `localeModelPartitionsIterationsOnSublocales` is appropriate. It's wordy but I feel it's not something that frequently used and the self documenting nature outweighs the verbosity.
* Let me know if you think the compilerAssert I have in ChapelLocale is in the right place. It's there to serve as a sanity check for anyone who creates a new locale model.
* The changes in cg-expr.cpp will introduce new errors with the NUMA local model in paratests (not with the flat locale model however). We already have several tests that fail with NUMA, so for this PR I'm accepting this as acceptable fallout, but if we expect that the NUMA model is anything other than experimental it may be a good idea to fork a new Github issue. Let me know what you think.
* I do have a test I used locally to test this (I'll copy it into the comments). But I'm not sure if this is appropriate to add to our test suite as I don't think we want to lock down how many NUMA domains we have in our testing hardware.