### PR TITLE
Update argument names of set methods to use element instead of x

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -282,8 +282,7 @@ module Set {
     pragma "last resort"
     deprecated "The argument name `x` has been deprecated for function `add`, please use `element` instead"
     proc ref add(in x: eltType) lifetime this < x {
-      _enter(); defer _leave();
-      _addElem(x);
+      add(element=x);
     }
 
     /*
@@ -308,14 +307,7 @@ module Set {
     pragma "last resort"
     deprecated "The argument name `x` has been deprecated for function `contains, please use `element` instead"
     proc const contains(const ref x: eltType): bool {
-      var result = false;
-
-      on this {
-        _enter(); defer _leave();
-        result = _contains(x);
-      }
-
-      return result;
+      return contains(element=x);
     }
     
     /*
@@ -409,24 +401,7 @@ module Set {
     pragma "last resort"
     deprecated "The argument name `x` has been deprecated for function `remove`, please use `element` instead"
     proc ref remove(const ref x: eltType): bool {
-      var result = false;
-
-      on this {
-        _enter(); defer _leave();
-
-        var (hasFoundSlot, idx) = _htb.findFullSlot(x);
-
-        if hasFoundSlot {
-          var key: eltType;
-          var val: nothing;
-
-          _htb.clearSlot(idx, key, val);
-          _htb.maybeShrinkAfterRemove();
-          result = true;
-        }
-      }
-
-      return result;
+      return remove(element=x);
     }
 
     /*

--- a/test/deprecated/Set/setArgumentNames.chpl
+++ b/test/deprecated/Set/setArgumentNames.chpl
@@ -1,0 +1,14 @@
+use Set;
+
+var a: set(int);
+
+var val = 1;
+
+a.add(x=val);
+a.contains(x=val);
+a.remove(x=val);
+writeln(a);
+
+a.add(val);
+a.contains(val);
+a.remove(val);

--- a/test/deprecated/Set/setArgumentNames.good
+++ b/test/deprecated/Set/setArgumentNames.good
@@ -1,0 +1,4 @@
+setArgumentNames.chpl:7: warning: The argument name `x` has been deprecated for function `add`, please use `element` instead
+setArgumentNames.chpl:8: warning: The argument name `x` has been deprecated for function `contains, please use `element` instead
+setArgumentNames.chpl:9: warning: The argument name `x` has been deprecated for function `remove`, please use `element` instead
+{}


### PR DESCRIPTION
In the set module review, it was decided that we would prefer the name of `element` for argument names in set methods, where previously the argument names were just `x`. This PR deprecates the old methods and adds new ones with the new argument names, so anyone calling the methods with the `x` argument by name will get the deprecation message. Methods changed: `add()`, `contains()`, `remove()`.

- [x] paratest

Closes https://github.com/chapel-lang/chapel/issues/18651