### PR TITLE
Allow non-nil to nil in type arguments

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -552,7 +552,7 @@ static bool shouldAllowCoercionsType(Type* actualType, Type* formalType) {
 
     AggregateType* at = toAggregateType(canonicalActual);
 
-    if (canInstantiateOrCoerceDecorators(actualD, formalD, false, false)) {
+    if (canInstantiateOrCoerceDecorators(actualD, formalD, true, false)) {
       if (canonicalActual == canonicalFormal ||
           isDispatchParent(canonicalActual, canonicalFormal) ||
           (at && at->instantiatedFrom &&

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -900,10 +900,6 @@ bool canInstantiate(Type* actualType, Type* formalType) {
     return true;
   }
 
-  if (formalType == dtString && actualType == dtStringC) {
-    return true;
-  }
-
   if (formalType                                        == dtIteratorRecord &&
       actualType->symbol->hasFlag(FLAG_ITERATOR_RECORD) == true) {
     return true;

--- a/test/classes/nilability/non-nil-subtype2.chpl
+++ b/test/classes/nilability/non-nil-subtype2.chpl
@@ -1,0 +1,55 @@
+class Parent { }
+class Child : Parent { }
+
+writeln("borrowed - borrowed");
+writeln(isSubtype(borrowed Child, borrowed Parent));
+writeln(isSubtype(borrowed Child, borrowed Parent?));
+writeln(isSubtype(borrowed Child?, borrowed Parent));
+writeln(isSubtype(borrowed Child?, borrowed Parent?));
+
+writeln("owned - owned");
+writeln(isSubtype(owned Child, owned Parent));
+writeln(isSubtype(owned Child, owned Parent?));
+writeln(isSubtype(owned Child?, owned Parent));
+writeln(isSubtype(owned Child?, owned Parent?));
+
+writeln("borrowed - generic");
+writeln(isSubtype(borrowed Child, Parent));
+writeln(isSubtype(borrowed Child, Parent?));
+writeln(isSubtype(borrowed Child?, Parent));
+writeln(isSubtype(borrowed Child?, Parent?));
+
+writeln("owned - generic");
+writeln(isSubtype(owned Child, Parent));
+writeln(isSubtype(owned Child, Parent?));
+writeln(isSubtype(owned Child?, Parent));
+writeln(isSubtype(owned Child?, Parent?));
+
+proc toBorrowedParent(type t:Parent) { }
+proc toBorrowedParentQ(type t:Parent?) { }
+proc toOwnedParent(type t:Parent) { }
+proc toOwnedParentQ(type t:Parent?) { }
+proc toGenericParent(type t:Parent) { }
+proc toGenericParentQ(type t:Parent?) { }
+
+// these should all resolve
+// see also #13541
+toBorrowedParent(borrowed Child);
+toBorrowedParentQ(borrowed Child);
+toBorrowedParentQ(borrowed Child?);
+
+toOwnedParent(owned Child);
+toOwnedParentQ(owned Child);
+toOwnedParentQ(owned Child?);
+
+toBorrowedParent(owned Child);
+toBorrowedParentQ(owned Child);
+toBorrowedParentQ(owned Child?);
+
+toGenericParent(borrowed Child);
+toGenericParentQ(borrowed Child);
+toGenericParentQ(borrowed Child?);
+
+toGenericParent(owned Child);
+toGenericParentQ(owned Child);
+toGenericParentQ(owned Child?);

--- a/test/classes/nilability/non-nil-subtype2.good
+++ b/test/classes/nilability/non-nil-subtype2.good
@@ -1,0 +1,20 @@
+borrowed - borrowed
+true
+true
+false
+true
+owned - owned
+true
+true
+false
+true
+borrowed - generic
+true
+true
+false
+true
+owned - generic
+true
+true
+false
+true

--- a/test/functions/typeMethods/anymanaged.good
+++ b/test/functions/typeMethods/anymanaged.good
@@ -33,15 +33,15 @@ anymanaged.chpl:70: warning:  (borrowed C?).mB()  true
 anymanaged.chpl:71: warning: (unmanaged C ).mB()  true
 anymanaged.chpl:72: warning: (unmanaged C?).mB()  true
 anymanaged.chpl:74: warning: 
-anymanaged.chpl:76: warning:            C  .mBn()  false
+anymanaged.chpl:76: warning:            C  .mBn()  true
 anymanaged.chpl:77: warning:           (C?).mBn()  true
-anymanaged.chpl:78: warning:     (owned C ).mBn()  false
+anymanaged.chpl:78: warning:     (owned C ).mBn()  true
 anymanaged.chpl:79: warning:     (owned C?).mBn()  true
-anymanaged.chpl:80: warning:    (shared C ).mBn()  false
+anymanaged.chpl:80: warning:    (shared C ).mBn()  true
 anymanaged.chpl:81: warning:    (shared C?).mBn()  true
-anymanaged.chpl:82: warning:  (borrowed C ).mBn()  false
+anymanaged.chpl:82: warning:  (borrowed C ).mBn()  true
 anymanaged.chpl:83: warning:  (borrowed C?).mBn()  true
-anymanaged.chpl:84: warning: (unmanaged C ).mBn()  false
+anymanaged.chpl:84: warning: (unmanaged C ).mBn()  true
 anymanaged.chpl:85: warning: (unmanaged C?).mBn()  true
 anymanaged.chpl:87: warning: 
 anymanaged.chpl:89: warning:            C  .mo()  false
@@ -57,7 +57,7 @@ anymanaged.chpl:98: warning: (unmanaged C?).mo()  false
 anymanaged.chpl:100: warning: 
 anymanaged.chpl:102: warning:            C  .mon()  false
 anymanaged.chpl:103: warning:           (C?).mon()  false
-anymanaged.chpl:104: warning:     (owned C ).mon()  false
+anymanaged.chpl:104: warning:     (owned C ).mon()  true
 anymanaged.chpl:105: warning:     (owned C?).mon()  true
 anymanaged.chpl:106: warning:    (shared C ).mon()  false
 anymanaged.chpl:107: warning:    (shared C?).mon()  false
@@ -81,7 +81,7 @@ anymanaged.chpl:128: warning:            C  .msn()  false
 anymanaged.chpl:129: warning:           (C?).msn()  false
 anymanaged.chpl:130: warning:     (owned C ).msn()  false
 anymanaged.chpl:131: warning:     (owned C?).msn()  false
-anymanaged.chpl:132: warning:    (shared C ).msn()  false
+anymanaged.chpl:132: warning:    (shared C ).msn()  true
 anymanaged.chpl:133: warning:    (shared C?).msn()  true
 anymanaged.chpl:134: warning:  (borrowed C ).msn()  false
 anymanaged.chpl:135: warning:  (borrowed C?).msn()  false
@@ -99,15 +99,15 @@ anymanaged.chpl:148: warning:  (borrowed C?).mb()  false
 anymanaged.chpl:149: warning: (unmanaged C ).mb()  true
 anymanaged.chpl:150: warning: (unmanaged C?).mb()  false
 anymanaged.chpl:152: warning: 
-anymanaged.chpl:154: warning:            C  .mbn()  false
+anymanaged.chpl:154: warning:            C  .mbn()  true
 anymanaged.chpl:155: warning:           (C?).mbn()  true
-anymanaged.chpl:156: warning:     (owned C ).mbn()  false
+anymanaged.chpl:156: warning:     (owned C ).mbn()  true
 anymanaged.chpl:157: warning:     (owned C?).mbn()  true
-anymanaged.chpl:158: warning:    (shared C ).mbn()  false
+anymanaged.chpl:158: warning:    (shared C ).mbn()  true
 anymanaged.chpl:159: warning:    (shared C?).mbn()  true
-anymanaged.chpl:160: warning:  (borrowed C ).mbn()  false
+anymanaged.chpl:160: warning:  (borrowed C ).mbn()  true
 anymanaged.chpl:161: warning:  (borrowed C?).mbn()  true
-anymanaged.chpl:162: warning: (unmanaged C ).mbn()  false
+anymanaged.chpl:162: warning: (unmanaged C ).mbn()  true
 anymanaged.chpl:163: warning: (unmanaged C?).mbn()  true
 anymanaged.chpl:165: warning: 
 anymanaged.chpl:167: warning:            C  .mu()  false
@@ -129,7 +129,7 @@ anymanaged.chpl:184: warning:    (shared C ).mun()  false
 anymanaged.chpl:185: warning:    (shared C?).mun()  false
 anymanaged.chpl:186: warning:  (borrowed C ).mun()  false
 anymanaged.chpl:187: warning:  (borrowed C?).mun()  false
-anymanaged.chpl:188: warning: (unmanaged C ).mun()  false
+anymanaged.chpl:188: warning: (unmanaged C ).mun()  true
 anymanaged.chpl:189: warning: (unmanaged C?).mun()  true
 anymanaged.chpl:191: warning: 
 anymanaged.chpl:193: warning: ========= D =========
@@ -167,15 +167,15 @@ anymanaged.chpl:230: warning:  (borrowed D?).mB()  true
 anymanaged.chpl:231: warning: (unmanaged D ).mB()  true
 anymanaged.chpl:232: warning: (unmanaged D?).mB()  true
 anymanaged.chpl:234: warning: 
-anymanaged.chpl:236: warning:            D  .mBn()  false
+anymanaged.chpl:236: warning:            D  .mBn()  true
 anymanaged.chpl:237: warning:           (D?).mBn()  true
-anymanaged.chpl:238: warning:     (owned D ).mBn()  false
+anymanaged.chpl:238: warning:     (owned D ).mBn()  true
 anymanaged.chpl:239: warning:     (owned D?).mBn()  true
-anymanaged.chpl:240: warning:    (shared D ).mBn()  false
+anymanaged.chpl:240: warning:    (shared D ).mBn()  true
 anymanaged.chpl:241: warning:    (shared D?).mBn()  true
-anymanaged.chpl:242: warning:  (borrowed D ).mBn()  false
+anymanaged.chpl:242: warning:  (borrowed D ).mBn()  true
 anymanaged.chpl:243: warning:  (borrowed D?).mBn()  true
-anymanaged.chpl:244: warning: (unmanaged D ).mBn()  false
+anymanaged.chpl:244: warning: (unmanaged D ).mBn()  true
 anymanaged.chpl:245: warning: (unmanaged D?).mBn()  true
 anymanaged.chpl:247: warning: 
 anymanaged.chpl:249: warning:            D  .mo()  false
@@ -191,7 +191,7 @@ anymanaged.chpl:258: warning: (unmanaged D?).mo()  false
 anymanaged.chpl:260: warning: 
 anymanaged.chpl:262: warning:            D  .mon()  false
 anymanaged.chpl:263: warning:           (D?).mon()  false
-anymanaged.chpl:264: warning:     (owned D ).mon()  false
+anymanaged.chpl:264: warning:     (owned D ).mon()  true
 anymanaged.chpl:265: warning:     (owned D?).mon()  true
 anymanaged.chpl:266: warning:    (shared D ).mon()  false
 anymanaged.chpl:267: warning:    (shared D?).mon()  false
@@ -215,7 +215,7 @@ anymanaged.chpl:288: warning:            D  .msn()  false
 anymanaged.chpl:289: warning:           (D?).msn()  false
 anymanaged.chpl:290: warning:     (owned D ).msn()  false
 anymanaged.chpl:291: warning:     (owned D?).msn()  false
-anymanaged.chpl:292: warning:    (shared D ).msn()  false
+anymanaged.chpl:292: warning:    (shared D ).msn()  true
 anymanaged.chpl:293: warning:    (shared D?).msn()  true
 anymanaged.chpl:294: warning:  (borrowed D ).msn()  false
 anymanaged.chpl:295: warning:  (borrowed D?).msn()  false
@@ -233,15 +233,15 @@ anymanaged.chpl:308: warning:  (borrowed D?).mb()  false
 anymanaged.chpl:309: warning: (unmanaged D ).mb()  true
 anymanaged.chpl:310: warning: (unmanaged D?).mb()  false
 anymanaged.chpl:312: warning: 
-anymanaged.chpl:314: warning:            D  .mbn()  false
+anymanaged.chpl:314: warning:            D  .mbn()  true
 anymanaged.chpl:315: warning:           (D?).mbn()  true
-anymanaged.chpl:316: warning:     (owned D ).mbn()  false
+anymanaged.chpl:316: warning:     (owned D ).mbn()  true
 anymanaged.chpl:317: warning:     (owned D?).mbn()  true
-anymanaged.chpl:318: warning:    (shared D ).mbn()  false
+anymanaged.chpl:318: warning:    (shared D ).mbn()  true
 anymanaged.chpl:319: warning:    (shared D?).mbn()  true
-anymanaged.chpl:320: warning:  (borrowed D ).mbn()  false
+anymanaged.chpl:320: warning:  (borrowed D ).mbn()  true
 anymanaged.chpl:321: warning:  (borrowed D?).mbn()  true
-anymanaged.chpl:322: warning: (unmanaged D ).mbn()  false
+anymanaged.chpl:322: warning: (unmanaged D ).mbn()  true
 anymanaged.chpl:323: warning: (unmanaged D?).mbn()  true
 anymanaged.chpl:325: warning: 
 anymanaged.chpl:327: warning:            D  .mu()  false
@@ -263,7 +263,7 @@ anymanaged.chpl:344: warning:    (shared D ).mun()  false
 anymanaged.chpl:345: warning:    (shared D?).mun()  false
 anymanaged.chpl:346: warning:  (borrowed D ).mun()  false
 anymanaged.chpl:347: warning:  (borrowed D?).mun()  false
-anymanaged.chpl:348: warning: (unmanaged D ).mun()  false
+anymanaged.chpl:348: warning: (unmanaged D ).mun()  true
 anymanaged.chpl:349: warning: (unmanaged D?).mun()  true
 anymanaged.chpl:351: warning: 
 anymanaged.chpl:353: warning: ========= E =========


### PR DESCRIPTION
Per the discussion/decision in issue #14307 (and largely implemented in PR #15210), going from a non-nilable type to a nilable type counts as a subtype relationship. At the same time, a `type` argument that constrains its type (e.g. `proc f(type t: borrowed MyClass?)`) allows subtype conversions when passing the argument in per discussion/decision in issue #13541. As a result, `f(borrowed MyClass)` should resolve. However, in working on porting some of this logic over to compiler/next code in #18795, noticed that this case was not working.

Note that PR #15210, which allowed `C` to be a subtype of `C?`, did so by adjusting call sites of `canCoerceDecorators`, but did not also adjust the related call to `canInstantiateOrCoerceDecorators`. The current PR adjusts it. The `allowNonSubtypes` argument is now always `true` for these functions and could be removed. I did not take that on here as I am focusing on improving the situation in the reworked resolver in #18795.

Adds a new test that fails before this PR. Also updates the test introduced in #13158 which added some special logic for type methods for classes.

Additionally, this PR removes a line from `canInstantiate` that appears to be unused and does not make sense. (The line was saying we could instantiate a `string` formal with a `c_string` actual, but that doesn't make sense because `string` is not generic).

- [x] full local futures testing