### PR TITLE
Update compiler/next handling of Location

### DIFF
--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -72,8 +72,13 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path);
  */
 const Location& locateId(Context* context, ID id);
 /**
+ This query returns the Location where a particular CommentID appeared.
+ */
+const Location& locateCommentId(Context* context, CommentID id);
+/**
+/**
  This function just runs locateId on ast->id(). Similarly to locateID,
- it cannot be used to get a Location for a Comment.
+ it can be used to get a Location for a Comment.
  */
 const Location& locateAst(Context* context, const uast::ASTNode* ast);
 

--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -67,13 +67,12 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path);
 /**
  This query returns the Location where a particular ID appeared.
  It cannot be used for Comments because Comments don't have IDs set.
- If Locations for Comments are needed, use the locations field from
- the result of parseFile.
+ If Locations for Comments are needed, use uast::BuilderResult::commentToLocation
  */
 const Location& locateId(Context* context, ID id);
 /**
  This function just runs locateId on ast->id(). Similarly to locateID,
- it can be used to get a Location for a Comment.
+ it cannot be used to get a Location for a Comment.
  */
 const Location& locateAst(Context* context, const uast::ASTNode* ast);
 

--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -72,11 +72,6 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path);
  */
 const Location& locateId(Context* context, ID id);
 /**
- This query returns the Location where a particular CommentID appeared.
- */
-const Location& locateCommentId(Context* context, CommentID id);
-/**
-/**
  This function just runs locateId on ast->id(). Similarly to locateID,
  it can be used to get a Location for a Comment.
  */

--- a/compiler/next/include/chpl/queries/CommentID.h
+++ b/compiler/next/include/chpl/queries/CommentID.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_QUERIES_COMMENT_ID_H
+#define CHPL_QUERIES_COMMENT_ID_H
+
+#include "chpl/queries/UniqueString.h"
+#include "chpl/util/hash.h"
+
+
+namespace chpl {
+/**
+   This class represents a unique ID for a comment
+   It is separate from ID because it does not participate in the query system
+ */
+class CommentID {
+ private:
+  // Index of comment in a file
+  int index_ = -1;
+
+ public:
+  CommentID() = default;
+  CommentID(int index) : index_(index) {
+    assert(index >= 0);
+  }
+
+  /** Return the index of the comment id */
+  int index() const { return index_; }
+};
+
+} // end namespace chpl
+
+#endif

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -22,6 +22,7 @@
 
 #include "chpl/queries/Context-detail.h"
 #include "chpl/queries/ID.h"
+#include "chpl/queries/CommentID.h"
 #include "chpl/queries/UniqueString.h"
 #include "chpl/util/memory.h"
 #include "chpl/util/hash.h"
@@ -413,6 +414,11 @@ class Context {
     Return the file path for the file containing this ID.
    */
   UniqueString filePathForId(ID id);
+
+  /**
+    Return the file path for the file containing this ID.
+   */
+  UniqueString filePathForCommentId(CommentID id);
 
   /**
     Returns true if filePathForId is already populated for

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -416,11 +416,6 @@ class Context {
   UniqueString filePathForId(ID id);
 
   /**
-    Return the file path for the file containing this ID.
-   */
-  UniqueString filePathForCommentId(CommentID id);
-
-  /**
     Returns true if filePathForId is already populated for
     this ID.
    */

--- a/compiler/next/include/chpl/queries/ErrorMessage.h
+++ b/compiler/next/include/chpl/queries/ErrorMessage.h
@@ -40,7 +40,7 @@ class ErrorMessage final {
   int level_; // error? warning? performance hint?
   Location location_;
   std::string message_;
-  ID parent_;
+  ID id_;
 
   // sometimes an error message wants to point to a bunch of
   // related line numbers. That can go here.
@@ -50,11 +50,11 @@ class ErrorMessage final {
 
  public:
   ErrorMessage();
-  ErrorMessage(ID parent, Location location, std::string message);
-  ErrorMessage(ID parent, Location location, const char* message);
+  ErrorMessage(ID id, Location location, std::string message);
+  ErrorMessage(ID id, Location location, const char* message);
 
-  static ErrorMessage vbuild(ID parent, Location loc, const char* fmt, va_list vl);
-  static ErrorMessage build(ID parent, Location loc, const char* fmt, ...)
+  static ErrorMessage vbuild(ID id, Location loc, const char* fmt, va_list vl);
+  static ErrorMessage build(ID id, Location loc, const char* fmt, ...)
 #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.

--- a/compiler/next/include/chpl/queries/ErrorMessage.h
+++ b/compiler/next/include/chpl/queries/ErrorMessage.h
@@ -21,6 +21,7 @@
 #define CHPL_QUERIES_ERRORMESSAGE_H
 
 #include "chpl/queries/Location.h"
+#include "chpl/queries/ID.h"
 
 #include <cstdarg>
 #include <string>
@@ -39,6 +40,7 @@ class ErrorMessage final {
   int level_; // error? warning? performance hint?
   Location location_;
   std::string message_;
+  ID parent_;
 
   // sometimes an error message wants to point to a bunch of
   // related line numbers. That can go here.
@@ -48,15 +50,15 @@ class ErrorMessage final {
 
  public:
   ErrorMessage();
-  ErrorMessage(Location location, std::string message);
-  ErrorMessage(Location location, const char* message);
+  ErrorMessage(ID parent, Location location, std::string message);
+  ErrorMessage(ID parent, Location location, const char* message);
 
-  static ErrorMessage vbuild(Location loc, const char* fmt, va_list vl);
-  static ErrorMessage build(Location loc, const char* fmt, ...)
+  static ErrorMessage vbuild(ID parent, Location loc, const char* fmt, va_list vl);
+  static ErrorMessage build(ID parent, Location loc, const char* fmt, ...)
 #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
-    __attribute__ ((format (printf, 2, 3)))
+    __attribute__ ((format (printf, 3, 4)))
 #endif
   ;
 
@@ -88,6 +90,7 @@ class ErrorMessage final {
   void swap(ErrorMessage& other);
 
   void markUniqueStrings(Context* context) const;
+  void updateLocation(Context *context);
 };
 
 

--- a/compiler/next/include/chpl/uast/Builder.h
+++ b/compiler/next/include/chpl/uast/Builder.h
@@ -60,7 +60,8 @@ class Builder final {
   std::unordered_map<const ASTNode*, Location> notedLocations_;
 
   // the following maps are computed during assignIDs
-  std::unordered_map<const ASTNode*, Location> astToLocation_;
+  std::unordered_map<ID, Location> idToLocation_;
+  std::vector<Location> commentToLocation_;
   std::unordered_map<ID, const ASTNode*> idToAst_;
   std::unordered_map<ID, ID> idToParent_;
 
@@ -72,7 +73,8 @@ class Builder final {
   void createImplicitModuleIfNeeded();
   void assignIDs();
   void doAssignIDs(ASTNode* ast, UniqueString symbolPath, int& i,
-                   pathVecT& pathVec, declaredHereT& duplicates);
+                   int& commentIndex, pathVecT& pathVec,
+                   declaredHereT& duplicates);
 
  public:
   static owned<Builder> build(Context* context, const char* filepath);

--- a/compiler/next/include/chpl/uast/BuilderResult.h
+++ b/compiler/next/include/chpl/uast/BuilderResult.h
@@ -67,8 +67,11 @@ class BuilderResult final {
   // Given an ID, what is the parent ID?
   std::unordered_map<ID, ID> idToParentId_;
 
-  // Goes from ASTNode* to Location because Comments don't have AST IDs
-  std::unordered_map<const ASTNode*, Location> astToLocation_;
+  // Goes from ID to Location, applies to all AST nodes except Comment
+  std::unordered_map<ID, Location> idToLocation_;
+
+  // Goes from Comment ID to Location, applies to all AST nodes except Comment
+  std::vector<Location> commentIdToLocation_;
 
  private:
   static void updateFilePaths(Context* context, const BuilderResult& keep);
@@ -138,6 +141,12 @@ class BuilderResult final {
   /** Find the Location for a particular ID.
       Returns a location just to path if none is found. */
   Location idToLocation(ID id, UniqueString path) const;
+  /** Find the Location for a particular comment.
+      The Comment must have been from this BuilderResult, but this is not
+      checked.
+      An empty Location will be returned if the Comment couldn't be found
+  */
+  Location commentToLocation(const Comment *comment) const;
   /** Find the ID for a parent given an ID.
       Returns the empty ID if none is found */
   ID idToParentId(ID id) const;

--- a/compiler/next/include/chpl/uast/Comment.h
+++ b/compiler/next/include/chpl/uast/Comment.h
@@ -22,6 +22,7 @@
 
 #include "chpl/uast/Expression.h"
 #include "chpl/queries/Location.h"
+#include "chpl/queries/CommentID.h"
 
 #include <string>
 
@@ -40,9 +41,10 @@ class Builder;
 class Comment final : public Expression {
  private:
   std::string comment_;
+  CommentID commentId_;
 
   Comment(std::string s)
-   : Expression(asttags::Comment), comment_(std::move(s)) {
+    : Expression(asttags::Comment), comment_(std::move(s)) {
   }
 
   bool contentsMatchInner(const ASTNode* other) const override {
@@ -52,7 +54,7 @@ class Comment final : public Expression {
            lhs->comment_ == rhs->comment_ ;
   }
   void markUniqueStringsInner(Context* context) const override {
-    return expressionMarkUniqueStringsInner(context);
+    expressionMarkUniqueStringsInner(context);
   }
 
  public:
@@ -69,6 +71,19 @@ class Comment final : public Expression {
    characters (e.g. `//`) as a C++ string.
    */
   const std::string& str() const { return comment_; }
+
+  /**
+     Set the comment's ID
+   */
+  void setCommentId(int index) {
+    commentId_ = CommentID(index);
+  }
+
+  /**
+     Returns the id of this comment, which is unique in
+     its BuilderResult
+  */
+  CommentID commentId() const { return commentId_; }
 };
 
 /**

--- a/compiler/next/include/chpl/uast/Comment.h
+++ b/compiler/next/include/chpl/uast/Comment.h
@@ -39,6 +39,8 @@ class Builder;
   are at a statement level will be represented with this type.
  */
 class Comment final : public Expression {
+  friend Builder;
+
  private:
   std::string comment_;
   CommentID commentId_;
@@ -73,17 +75,19 @@ class Comment final : public Expression {
   const std::string& str() const { return comment_; }
 
   /**
+     Returns the id of this comment, which is unique in
+     its BuilderResult
+  */
+  CommentID commentId() const { return commentId_; }
+
+ protected:
+  /**
      Set the comment's ID
    */
   void setCommentId(int index) {
     commentId_ = CommentID(index);
   }
 
-  /**
-     Returns the id of this comment, which is unique in
-     its BuilderResult
-  */
-  CommentID commentId() const { return commentId_; }
 };
 
 /**

--- a/compiler/next/lib/parsing/Parser.cpp
+++ b/compiler/next/lib/parsing/Parser.cpp
@@ -71,7 +71,7 @@ static void updateParseResult(ParserContext* parserContext) {
   for (ParserError & parserError : parserContext->errors) {
     // Need to convert the error to a regular ErrorMessage
     Location loc = parserContext->convertLocation(parserError.location);
-    builder->addError(ErrorMessage(loc, parserError.message));
+    builder->addError(ErrorMessage(ID(), loc, parserError.message));
   }
 }
 

--- a/compiler/next/lib/parsing/parsing-queries.cpp
+++ b/compiler/next/lib/parsing/parsing-queries.cpp
@@ -111,6 +111,7 @@ const Location& locateId(Context* context, ID id) {
 
 // this is just a convenient wrapper around locating with the id
 const Location& locateAst(Context* context, const ASTNode* ast) {
+  assert(!ast->isComment() && "cant locate comment like this");
   return locateId(context, ast->id());
 }
 

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -587,13 +587,9 @@ void Context::updateForReuse(const QueryMapResultBase* resultEntry) {
   }
   resultEntry->lastChecked = this->currentRevisionNumber;
 
-  // Update any error locations if needed
+  // Update error locations if needed and re-report the error
   for (auto& err: resultEntry->errors) {
     err.updateLocation(this);
-  }
-
-  // Re-report any errors in the query
-  for (const auto& err: resultEntry->errors) {
     reportError(err);
   }
 }

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -470,10 +470,11 @@ void Context::error(ErrorMessage error) {
 }
 
 void Context::error(Location loc, const char* fmt, ...) {
+  ID id;
   ErrorMessage err;
   va_list vl;
   va_start(vl, fmt);
-  err = ErrorMessage::vbuild(loc, fmt, vl);
+  err = ErrorMessage::vbuild(id, loc, fmt, vl);
   va_end(vl);
   Context::error(err);
 }
@@ -483,7 +484,7 @@ void Context::error(ID id, const char* fmt, ...) {
   ErrorMessage err;
   va_list vl;
   va_start(vl, fmt);
-  err = ErrorMessage::vbuild(loc, fmt, vl);
+  err = ErrorMessage::vbuild(id, loc, fmt, vl);
   va_end(vl);
   Context::error(err);
 }
@@ -493,7 +494,7 @@ void Context::error(const uast::ASTNode* ast, const char* fmt, ...) {
   ErrorMessage err;
   va_list vl;
   va_start(vl, fmt);
-  err = ErrorMessage::vbuild(loc, fmt, vl);
+  err = ErrorMessage::vbuild(ast->id(), loc, fmt, vl);
   va_end(vl);
   Context::error(err);
 }
@@ -505,7 +506,7 @@ void Context::error(const resolution::TypedFnSignature* inFn,
   ErrorMessage err;
   va_list vl;
   va_start(vl, fmt);
-  err = ErrorMessage::vbuild(loc, fmt, vl);
+  err = ErrorMessage::vbuild(ast->id(), loc, fmt, vl);
   va_end(vl);
   Context::error(err);
   // TODO: add note about instantiation & POI stack
@@ -585,6 +586,11 @@ void Context::updateForReuse(const QueryMapResultBase* resultEntry) {
     }
   }
   resultEntry->lastChecked = this->currentRevisionNumber;
+
+  // Update any error locations if needed
+  for (auto& err: resultEntry->errors) {
+    err.updateLocation(this);
+  }
 
   // Re-report any errors in the query
   for (const auto& err: resultEntry->errors) {

--- a/compiler/next/lib/queries/ErrorMessage.cpp
+++ b/compiler/next/lib/queries/ErrorMessage.cpp
@@ -50,24 +50,24 @@ static std::string vprint_to_string(const char* format, va_list vl) {
 ErrorMessage::ErrorMessage()
   : level_(-1), location_(), message_() {
 }
-ErrorMessage::ErrorMessage(ID parent, Location location, std::string message)
-  : level_(0), location_(location), message_(message), parent_(parent) {
+ErrorMessage::ErrorMessage(ID id, Location location, std::string message)
+  : level_(0), location_(location), message_(message), id_(id) {
 }
-ErrorMessage::ErrorMessage(ID parent, Location location, const char* message)
-  : level_(0), location_(location), message_(message), parent_(parent) {
+ErrorMessage::ErrorMessage(ID id, Location location, const char* message)
+  : level_(0), location_(location), message_(message), id_(id) {
 }
 
-ErrorMessage ErrorMessage::vbuild(ID parent, Location loc, const char* fmt, va_list vl) {
+ErrorMessage ErrorMessage::vbuild(ID id, Location loc, const char* fmt, va_list vl) {
   std::string ret;
   ret = vprint_to_string(fmt, vl);
-  return ErrorMessage(parent, loc, ret);
+  return ErrorMessage(id, loc, ret);
 }
 
-ErrorMessage ErrorMessage::build(ID parent, Location loc, const char* fmt, ...) {
+ErrorMessage ErrorMessage::build(ID id, Location loc, const char* fmt, ...) {
   ErrorMessage ret;
   va_list vl;
   va_start(vl, fmt);
-  ret = ErrorMessage::vbuild(parent, loc, fmt, vl);
+  ret = ErrorMessage::vbuild(id, loc, fmt, vl);
   va_end(vl);
   return ret;
 }
@@ -88,8 +88,8 @@ void ErrorMessage::markUniqueStrings(Context* context) const {
 }
 
 void ErrorMessage::updateLocation(Context* context) {
-  if (!parent_.isEmpty()) {
-    location_ = parsing::locateId(context, parent_);
+  if (!id_.isEmpty()) {
+    location_ = parsing::locateId(context, id_);
   }
   for (auto& err : details_) {
     err.updateLocation(context);

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -403,12 +403,12 @@ struct Resolver {
         if (m.id(0) == decl->id() && m.numIds() > 1) {
           Location loc = parsing::locateId(context, decl->id());
           auto error =
-            ErrorMessage::build(loc, "'%s' has multiple definitions",
+            ErrorMessage::build(decl->id(), loc, "'%s' has multiple definitions",
                                 decl->name().c_str());
           for (const ID& id : m) {
             if (id != decl->id()) {
               Location curLoc = parsing::locateId(context, id);
-              error.addDetail(ErrorMessage::build(curLoc, "redefined here"));
+              error.addDetail(ErrorMessage::build(id, curLoc, "redefined here"));
             }
           }
           context->error(error);

--- a/compiler/next/lib/uast/Builder.cpp
+++ b/compiler/next/lib/uast/Builder.cpp
@@ -23,6 +23,7 @@
 #include "chpl/queries/ErrorMessage.h"
 #include "chpl/uast/Expression.h"
 #include "chpl/uast/Module.h"
+#include "chpl/uast/Comment.h"
 
 #include <cstring>
 #include <string>
@@ -79,7 +80,8 @@ BuilderResult Builder::result() {
   ret.topLevelExpressions_.swap(topLevelExpressions_);
   ret.errors_.swap(errors_);
   ret.idToAst_.swap(idToAst_);
-  ret.astToLocation_.swap(astToLocation_);
+  ret.idToLocation_.swap(idToLocation_);
+  ret.commentIdToLocation_.swap(commentToLocation_);
 
   return ret;
 }
@@ -128,12 +130,13 @@ void Builder::assignIDs() {
   pathVecT pathVec;
   declaredHereT duplicates;
   int i = 0;
+  int commentIndex = 0;
 
   for (auto const& ownedExpression: topLevelExpressions_) {
     ASTNode* ast = ownedExpression.get();
     if (ast->isModule() || ast->isComment()) {
       UniqueString emptyString;
-      doAssignIDs(ast, emptyString, i, pathVec, duplicates);
+      doAssignIDs(ast, emptyString, i, commentIndex, pathVec, duplicates);
     } else {
       assert(false && "topLevelExpressions should only be module decls or comments");
     }
@@ -170,26 +173,27 @@ void Builder::assignIDs() {
   M@0         x;
             }
 
-  Comments are not included in ID assignment.
-  That means that comments don't have IDs and as a result it's not
-  possible to go from a Comment to the file. We think this is acceptable
-  because a documentation tool processing Comments can work with the
-  parse result and make its own tables of these things.
+
+  Comments are assigned a separate incrementing ID, but they don't
+  store any information that lets them map back to their module or file.
+  We think this is acceptable because a documentation tool processing
+  Comments can work with the parse result and look up comments with
+  BuilderResult::commentToLocation
  */
 void Builder::doAssignIDs(ASTNode* ast, UniqueString symbolPath, int& i,
-                          pathVecT& pathVec, declaredHereT& duplicates) {
+                          int& commentIndex, pathVecT& pathVec,
+                          declaredHereT& duplicates) {
+  if (Comment* comment = ast->toComment()) {
+    comment->setCommentId(commentIndex);
+    commentIndex += 1;
 
-  // update locations_ for the visited ast
-  auto search = notedLocations_.find(ast);
-  if (search != notedLocations_.end()) {
-    assert(!search->second.isEmpty());
-    astToLocation_[search->first] = search->second;
-  } else {
-    assert(false && "Location for all ast should be set by noteLocation");
-  }
-
-  if (ast->isComment()) {
-    // comments don't have IDs
+    auto search = notedLocations_.find(ast);
+    if (search != notedLocations_.end()) {
+      assert(!search->second.isEmpty());
+      commentToLocation_.push_back(search->second);
+    } else {
+      assert(false && "Location for all ast should be set by noteLocation");
+    }
     return;
   }
 
@@ -238,7 +242,7 @@ void Builder::doAssignIDs(ASTNode* ast, UniqueString symbolPath, int& i,
     declaredHereT freshMap;
     for (auto & child : ast->children_) {
       ASTNode* ptr = child.get();
-      this->doAssignIDs(ptr, newSymbolPath, freshId, pathVec, freshMap);
+      this->doAssignIDs(ptr, newSymbolPath, freshId, commentIndex, pathVec, freshMap);
     }
 
     int numContainedIds = freshId;
@@ -258,7 +262,7 @@ void Builder::doAssignIDs(ASTNode* ast, UniqueString symbolPath, int& i,
     // visit the children now to get integer part of ids in postorder
     for (auto & child : ast->children_) {
       ASTNode* ptr = child.get();
-      this->doAssignIDs(ptr, symbolPath, i, pathVec, duplicates);
+      this->doAssignIDs(ptr, symbolPath, i, commentIndex, pathVec, duplicates);
     }
 
     int afterChildID = i;
@@ -270,6 +274,15 @@ void Builder::doAssignIDs(ASTNode* ast, UniqueString symbolPath, int& i,
 
   // update idToAst_ for the visited AST node
   idToAst_[ast->id()] = ast;
+
+  // update locations_ for the visited ast
+  auto search = notedLocations_.find(ast);
+  if (search != notedLocations_.end()) {
+    assert(!search->second.isEmpty());
+    idToLocation_[ast->id()] = search->second;
+  } else {
+    assert(false && "Location for all ast should be set by noteLocation");
+  }
 }
 
 ASTList Builder::flattenTopLevelBlocks(ASTList lst) {

--- a/compiler/next/lib/util/filesystem.cpp
+++ b/compiler/next/lib/util/filesystem.cpp
@@ -42,9 +42,8 @@ FILE* openfile(const char* path, const char* mode, ErrorMessage& errorOut) {
   FILE* fp = fopen(path, mode);
   if (fp == nullptr) {
     std::string strerr = my_strerror(errno);
-    auto emptyLocation = Location();
     // set errorOut. NULL will be returned.
-    errorOut = ErrorMessage::build(emptyLocation, "opening %s: %s",
+    errorOut = ErrorMessage::build(ID(), Location(), "opening %s: %s",
                                    path, strerr.c_str());
   }
 
@@ -55,8 +54,7 @@ bool closefile(FILE* fp, const char* path, ErrorMessage& errorOut) {
   int rc = fclose(fp);
   if (rc != 0) {
     std::string strerr = my_strerror(errno);
-    auto emptyLocation = Location();
-    errorOut = ErrorMessage::build(emptyLocation, "closing %s: %s",
+    errorOut = ErrorMessage::build(ID(), Location(), "closing %s: %s",
                                    path, strerr.c_str());
     return false;
   }
@@ -86,8 +84,7 @@ bool readfile(const char* path,
       strOut.append(buf, got);
     } else {
       if (ferror(fp)) {
-        auto emptyLocation = Location();
-        errorOut = ErrorMessage::build(emptyLocation, "reading %s", path);
+        errorOut = ErrorMessage::build(ID(), Location(), "reading %s", path);
         ErrorMessage ignored;
         closefile(fp, path, ignored);
         return false;

--- a/compiler/next/test/resolution/CMakeLists.txt
+++ b/compiler/next/test/resolution/CMakeLists.txt
@@ -33,6 +33,7 @@
 # limitations under the License.
 
 comp_unit_test(testCanPass)
+comp_unit_test(testLocation)
 comp_unit_test(testInteractive)
 comp_unit_test(testParams)
 comp_unit_test(testPoi)

--- a/compiler/next/test/resolution/testLocation.cpp
+++ b/compiler/next/test/resolution/testLocation.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/types/all-types.h"
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
+#include "chpl/uast/Comment.h"
+#include "chpl/uast/Module.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+
+using namespace chpl;
+using namespace parsing;
+using namespace resolution;
+using namespace uast;
+
+static const Module* oneModule(const ModuleVec& vec) {
+  assert(vec.size() == 1);
+  return vec[0];
+}
+
+// TODO maybe we want to support something like this
+std::vector<ErrorMessage> errors;
+static void collectErrors(const ErrorMessage& err) { errors.push_back(err); }
+
+static void printErrors() {
+  for (auto err: errors) {
+    printf("%s\n", err.message().c_str());
+  }
+}
+
+// Reparsing gets updated location information
+static void test1() {
+  printf("test1\n");
+  Context ctx;
+  Context* context = &ctx;
+  auto path = UniqueString::build(context, "input.chpl");
+
+  {
+    context->advanceToNextRevision(true);
+    std::string contents = "var x = 42; /* comment */";
+    setFileText(context, path, contents);
+    const uast::BuilderResult& p = parseFile(context, path);
+    const Module* m = oneModule(parse(context, path));
+    const Expression *e = m->stmt(0);
+    const Comment *c = m->stmt(1)->toComment();
+    assert(locateAst(context, e).firstLine() == 1);
+    assert(p.commentToLocation(c).firstLine() == 1);
+  }
+
+  {
+    context->advanceToNextRevision(true);
+    std::string contents = "\n\nvar x = 42; /* comment */";
+    setFileText(context, path, contents);
+    const uast::BuilderResult& p = parseFile(context, path);
+    const Module* m = oneModule(parse(context, path));
+    const Expression *e = m->stmt(0);
+    const Comment *c = m->stmt(1)->toComment();
+    assert(locateAst(context, e).firstLine() == 3);
+    assert(p.commentToLocation(c).firstLine() == 3);
+  }
+}
+
+// Error messages get updated location information
+static void test2() {
+  printf("test2\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  ctx.setErrorHandler(collectErrors);
+
+  auto path = UniqueString::build(context, "input.chpl");
+
+  {
+    errors.clear();
+    context->advanceToNextRevision(true);
+    std::string contents = "var x:int = 3.14;";
+    setFileText(context, path, contents);
+    const ModuleVec& vec = parse(context, path);
+    for (const Module* mod : vec) {
+      ASTNode::dump(mod);
+    }
+    const Module* m = oneModule(vec);
+    const Expression *e = m->stmt(0);
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    (void)rr; // use result
+
+    auto l = locateAst(context, e);
+    printf("e loc is line %d\n", l.firstLine());
+    assert(l.firstLine() == 1);
+
+    printErrors();
+    assert(errors.size() == 1);
+    assert(errors[0].location().firstLine() == 1);
+  }
+
+  {
+    errors.clear();
+    context->advanceToNextRevision(true);
+    std::string contents = "\n\nvar x:int = 3.14;";
+    setFileText(context, path, contents);
+    const ModuleVec& vec = parse(context, path);
+    for (const Module* mod : vec) {
+      ASTNode::dump(mod);
+    }
+    const Module* m = oneModule(vec);
+    const Expression *e = m->stmt(0);
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    (void)rr; // use result
+
+    auto l = locateAst(context, e);
+    printf("e loc is line %d\n", l.firstLine());
+    fflush(stdout);
+    assert(l.firstLine() == 3);
+
+    printErrors();
+    assert(errors.size() == 1);
+    printf("%d\n", errors[0].location().firstLine());
+    assert(errors[0].location().firstLine() == 3);
+  }
+}
+
+int main() {
+  test1();
+  test2();
+
+  return 0;
+}

--- a/doc/rst/meta/compiler-internals-doxygen/base.rst
+++ b/doc/rst/meta/compiler-internals-doxygen/base.rst
@@ -11,6 +11,10 @@ namespace. The entries may not be exhaustive.
 .. comment:
    See entries in '$CHPL_HOME/compiler/next/include/chpl/queries'
 
+.. doxygenclass:: chpl::CommentID
+   :members:
+   :undoc-members:
+
 .. doxygenclass:: chpl::Context
    :members:
    :undoc-members:


### PR DESCRIPTION
1) Add ID to ErrorMessage

ErrorMessage previously only stored a Location. We'd like to store an
ID so that if a query result is re-used after an AST has moved in a
file (but not changed), the ErrorMessage stored wants a way to get
updated with the current information.

The idea here is to use an explicit update function, passing in the
Context as that is necessary for getting the current location.

---

2) Add tests for compiler/next incremental locations

  a) Previously, errors could be reported with old line numbers. Add a
  test to verify an error message uses the new line number.

  b) Previously, locateAst would also return old line numbers. Add a
  test to verify that locating both AST and Comment nodes return the
  correct location

---

3) Add CommentID and map locations by ID and CommentID

This adds a CommentID used similar to ID, but we want to separate the
notion that comments don't participate in the result of queries.

CommentID is set on a Comment

BuilderResult now maps ID -> Location for all AST nodes except Comment
BuilderResult now maps CommentID -> Location for all Comment

The "map" of CommentID -> Location is really a vector, because the
numbering of Comment's is dense.

A CommentID does not store the module or file it came from, so the
caller should only look up the location for a Comment with the
BuilderResult it came from. This is a reasonable expectation for use
in chpldoc for example.

---

test-libchplcomp passes

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>