### PR TITLE
Adjust chpl-cache initialization logic

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -3566,12 +3566,32 @@ static struct rdcache_s* cache_create(void);
 CHPL_TLS_DECL(struct rdcache_s*,cache_remote_data);
 static pthread_key_t pthread_cache_info_key; // stores struct rdcache_s*
 
+// ideally we would just make is_inited an atomic but
+// the runtime atomics support can't handle static initialization
+// so we use a pthread mutex for now
+static pthread_mutex_t is_inited_mutex = PTHREAD_MUTEX_INITIALIZER;
+static unsigned char is_inited = 0; // protected by is_inited_mutex
+
+static
+unsigned char get_is_inited(void) {
+  unsigned char ret = 0;
+
+  pthread_mutex_lock(&is_inited_mutex);
+  ret = is_inited;
+  pthread_mutex_unlock(&is_inited_mutex);
+
+  return ret;
+}
+
+// returns NULL if the cache is not yet inited
 static
 struct rdcache_s* tls_cache_remote_data(void) {
   struct rdcache_s *cache = CHPL_TLS_GET(cache_remote_data);
-  if( ! cache && chpl_cache_enabled() ) {
+  if( !cache && chpl_cache_enabled() && get_is_inited()) {
     cache = cache_create();
     CHPL_TLS_SET(cache_remote_data, cache);
+    // set the pthread key so that the cache will be freed
+    // on thread exit
     pthread_setspecific(pthread_cache_info_key, cache);
   }
   return cache;
@@ -3589,25 +3609,26 @@ static
 void destroy_pthread_local_cache(void* arg)
 {
   struct rdcache_s* s = (struct rdcache_s*) arg;
-  cache_destroy(s);
+  if (s) cache_destroy(s);
 }
 
 static
 void chpl_cache_do_init(void)
 {
-  static int inited = 0;
-  if( ! inited ) {
+  pthread_mutex_lock(&is_inited_mutex);
+  if (!is_inited) {
     // We will need some thread-local storage.
     // We create two versions: cache_remote_data stores
     // our pointer to the struct rd_cache_s* and is what
     // we normally use, with __thread or CHPL_TLS_GET which is
     // faster.
     CHPL_TLS_INIT(cache_remote_data);
-    // The second key we never read but create so that we
+    // The second key we never read but we create it so that we
     // can free the cache when the thread exits.
     pthread_key_create(&pthread_cache_info_key, &destroy_pthread_local_cache);
-    inited = 1;
+    is_inited = 1;
   }
+  pthread_mutex_unlock(&is_inited_mutex);
 }
 
 // The implementation of functions in chpl-cache.h
@@ -3632,38 +3653,39 @@ void chpl_cache_exit(void)
 
 void chpl_cache_fence(int acquire, int release, int ln, int32_t fn)
 {
+  struct rdcache_s* cache = tls_cache_remote_data();
+  chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
+
+  // Do nothing if the cache is not yet inited
+  if (!cache) return;
+
   if( acquire == 0 && release == 0 ) return;
-  if( chpl_cache_enabled() ) {
-    struct rdcache_s* cache = tls_cache_remote_data();
-    chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
 
-    INFO_PRINT(("%i fence acquire %i release %i %s:%i\n", chpl_nodeID, acquire, release, fn, ln));
+  INFO_PRINT(("%i fence acquire %i release %i %s:%i\n", chpl_nodeID, acquire, release, fn, ln));
 
-    TRACE_FENCE_PRINT(("%d: task %d in chpl_cache_fence(acquire=%i,release=%i)"
-                       " on cache %p from %s:%d\n",
-                       chpl_nodeID, (int) chpl_task_getId(), acquire, release,
-                       cache, chpl_lookupFilename(fn), ln));
+  TRACE_FENCE_PRINT(("%d: task %d in chpl_cache_fence(acquire=%i,release=%i)"
+                     " on cache %p from %s:%d\n",
+                     chpl_nodeID, (int) chpl_task_getId(), acquire, release,
+                     cache, chpl_lookupFilename(fn), ln));
 
 #ifdef DUMP
-    DEBUG_PRINT(("%d: task %d before fence\n", chpl_nodeID, (int) chpl_task_getId()));
-    chpl_cache_print();
+  DEBUG_PRINT(("%d: task %d before fence\n", chpl_nodeID, (int) chpl_task_getId()));
+  chpl_cache_print();
 #endif
 
-    if( acquire ) {
-      task_local->last_acquire = cache->next_request_number;
-      cache->next_request_number++;
-    }
-
-    if( release ) {
-      cache_clean_dirty(cache, task_local);
-      wait_all(cache);
-    }
-#ifdef DUMP
-    DEBUG_PRINT(("%d: task %d after fence\n", chpl_nodeID, (int) chpl_task_getId()));
-    chpl_cache_print();
-#endif
+  if( acquire ) {
+    task_local->last_acquire = cache->next_request_number;
+    cache->next_request_number++;
   }
-  // Do nothing if cache is not enabled.
+
+  if( release ) {
+    cache_clean_dirty(cache, task_local);
+    wait_all(cache);
+  }
+#ifdef DUMP
+  DEBUG_PRINT(("%d: task %d after fence\n", chpl_nodeID, (int) chpl_task_getId()));
+  chpl_cache_print();
+#endif
 }
 
 void chpl_cache_invalidate(c_nodeid_t node, void* raddr, size_t size,
@@ -3672,6 +3694,8 @@ void chpl_cache_invalidate(c_nodeid_t node, void* raddr, size_t size,
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
 
+  // Do nothing if the cache is not yet inited
+  if (!cache) return;
 
   TRACE_PRINT(("%d: task %d in chpl_cache_invalidate %s:%d %d bytes at %d:%p\n",
                chpl_nodeID, (int)chpl_task_getId(),
@@ -3698,9 +3722,12 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   int all_hits;
 
-  if (size_merits_direct_comm(cache, size)) {
-    cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+  if (!cache || size_merits_direct_comm(cache, size)) {
+    if (cache)
+      cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+
     chpl_comm_put(addr, node, raddr, size, commID, ln, fn);
+
     if (EXTRA_YIELDS) {
       TRACE_YIELD_PRINT(("%d: task %d cache %p yielding for chpl_comm_put\n",
                          chpl_nodeID, (int) chpl_task_getId(), cache));
@@ -3739,14 +3766,16 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                          size_t size, int32_t commID, int ln, int32_t fn)
 {
-  //printf("get len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   int all_hits;
 
-  if (size_merits_direct_comm(cache, size)) {
-    cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+  if (!cache || size_merits_direct_comm(cache, size)) {
+    if (cache)
+      cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+
     chpl_comm_get(addr, node, raddr, size, commID, ln, fn);
+
     if (EXTRA_YIELDS) {
       TRACE_YIELD_PRINT(("%d: task %d cache %p yielding for chpl_comm_get\n",
                          chpl_nodeID, (int) chpl_task_getId(), cache));
@@ -3787,6 +3816,9 @@ void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
+
+  // Do nothing if the cache is not yet inited
+  if (!cache) return;
 
   TRACE_PRINT(("%d: in chpl_cache_comm_prefetch\n", chpl_nodeID));
 
@@ -3833,6 +3865,9 @@ void strd_invalidate(void *addr, void *dststr, c_nodeid_t node,
 
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
+
+  // Do nothing if the cache is not yet inited
+  if (!cache) return;
 
   struct cache_strd_callback_ctx ctx;
   ctx.cache = cache;
@@ -3928,8 +3963,12 @@ void chpl_cache_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
-  cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+
+  if (cache)
+    cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+
   chpl_comm_put_unordered(addr, node, raddr, size, commID, ln, fn);
+
   if (EXTRA_YIELDS) {
     TRACE_YIELD_PRINT(("%d: task %d cache %p yielding for put_unordered\n",
                       chpl_nodeID, (int) chpl_task_getId(), cache));
@@ -3946,8 +3985,12 @@ void chpl_cache_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
-  cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+
+  if (cache)
+    cache_invalidate(cache, task_local, node, (raddr_t)raddr, size);
+
   chpl_comm_get_unordered(addr, node, raddr, size, commID, ln, fn);
+
   if (EXTRA_YIELDS) {
     TRACE_YIELD_PRINT(("%d: task %d cache %p yielding for get_unordered\n",
                        chpl_nodeID, (int) chpl_task_getId(), cache));
@@ -3967,9 +4010,14 @@ void chpl_cache_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
-  cache_invalidate(cache, task_local, srcnode, (raddr_t)srcaddr, size);
-  cache_invalidate(cache, task_local, dstnode, (raddr_t)dstaddr, size);
+
+  if (cache) {
+    cache_invalidate(cache, task_local, srcnode, (raddr_t)srcaddr, size);
+    cache_invalidate(cache, task_local, dstnode, (raddr_t)dstaddr, size);
+  }
+
   chpl_comm_getput_unordered(dstnode, dstaddr, srcnode, srcaddr, size, commID, ln, fn);
+
   if (EXTRA_YIELDS) {
     TRACE_YIELD_PRINT(("%d: task %d cache %p yielding for getput_unordered\n",
                        chpl_nodeID, (int) chpl_task_getId(), cache));
@@ -3991,6 +4039,9 @@ void chpl_cache_print(void)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
+
+  if (!cache) return;
+
   printf("%d: cache dump last acquire %i\n", chpl_nodeID, (int) task_local->last_acquire);
   rdcache_print(cache);
 }
@@ -4002,6 +4053,8 @@ void chpl_cache_assert_released(void)
   struct dirty_entry_s* cur;
   cache_seqn_t sn;
   int index;
+
+  if (!cache) return;
 
   cur = cache->dirty_lru_head;
   if ( cur && cur->entry )
@@ -4019,6 +4072,8 @@ void chpl_cache_assert_released(void)
 // This is for debugging
 void chpl_cache_print_stats(void) {
   struct rdcache_s* cache = tls_cache_remote_data();
+  if (!cache) return;
+
   int n_used_slots = 0;
   int n_full_slots = 0;
   int n_bottom_entries = 0;
@@ -4078,6 +4133,9 @@ int chpl_cache_mock_get(c_nodeid_t node, uint64_t raddr, size_t size)
 
   if (!chpl_cache_enabled())
     chpl_internal_error("chpl_cache_mock_get called without --cache-remote");
+
+  if (!cache)
+    chpl_internal_error("chpl_cache_mock_get called without cache inited");
 
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   TRACE_PRINT(("%d: task %d in chpl_cache_mock_get from %d:%p\n",


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/2768

This PR adjusts chpl-cache.c to not allow the cache to be used until after `chpl_cache_init` is run. That prevents the cache from causing surprising behavior during runtime and program initialization.

To do so, it makes `tls_cache_remote_data` potentially return NULL if the cache was not yet inited. It was already the case that it could return NULL if the cache was not enabled at compile time.

Because we don't have C static initializers for atomics in the C runtime (issue #18801), this code uses a pthread mutex around the new global `is_inited` for the cache. When doing a cache operation, each thread will get the thread-local cache information and in that case it doesn't need to check the mutex at all. If the thread-local cache information is NULL then it needs to do allocation and setup and that is where the additional mutex is now present.

- [x] test/runtime/configMatters/comm/cache-remote/ passes with local UDP
- [x] full gasnet testing

Reviewed by @ronawho - thanks!