### PR TITLE
Fence the cache on calls to chpl_comm_barrier

### DIFF
--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -23,7 +23,7 @@
 
 #include "chpltypes.h"
 #include "chpl-atomics.h"
-#include "chpl-comm.h" // to get HAS_CHPL_CACHE_FNS via chpl-comm-task-decls.h
+#include "chpl-comm-task-decls.h"
 #include "chpl-env.h"
 #include "chpl-tasks.h"
 #include "error.h"
@@ -55,8 +55,7 @@ extern const int CHPL_CACHE_REMOTE;
 static inline
 void chpl_cache_warn_if_disabled(void)
 {
-  if (CHPL_CACHE_REMOTE && chpl_nodeID == 0 &&
-      !chpl_env_rt_get_bool("CACHE_QUIET", false)) {
+  if (CHPL_CACHE_REMOTE && !chpl_env_rt_get_bool("CACHE_QUIET", false)) {
     if (CHPL_ASAN) {
       chpl_warning("Disabling --cache-remote due to incompatibility with "
                    "AddressSanitizer (quiet with CHPL_RT_CACHE_QUIET=true)", 0, 0);

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -30,6 +30,7 @@
 #include "chpl-tasks.h"
 #include "chpl-comm-task-decls.h"
 #include "chpl-comm-locales.h"
+#include "chpl-mem-consistency.h"
 #include "chpl-mem-desc.h"
 
 #ifdef __cplusplus
@@ -403,7 +404,20 @@ void chpl_comm_broadcast_private(int id, size_t size);
 // resources and prevent making progress. This barrier must be available
 // for use in module code, so it cannot be tied up in the runtime
 //
-void chpl_comm_barrier(const char *msg);
+void chpl_comm_impl_barrier(const char *msg);
+static inline void chpl_comm_barrier(const char *msg) {
+
+#ifdef CHPL_COMM_DEBUG
+  chpl_msg(2, "%d: enter barrier for '%s'\n", chpl_nodeID, msg);
+#endif
+
+  if (chpl_numNodes == 1) {
+    return;
+  }
+
+  chpl_rmem_consist_fence(memory_order_seq_cst, 0, 0);
+  chpl_comm_impl_barrier(msg);
+}
 
 //
 // Do exit processing that has to occur before the tasking layer is

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -153,7 +153,7 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) { return NULL; }
 
 void chpl_comm_broadcast_private(int id, size_t size) { }
 
-void chpl_comm_barrier(const char *msg) { }
+void chpl_comm_impl_barrier(const char *msg) { }
 
 void chpl_comm_pre_task_exit(int all) { }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -7509,16 +7509,8 @@ void init_bar(void) {
 }
 
 
-void chpl_comm_barrier(const char *msg) {
+void chpl_comm_impl_barrier(const char *msg) {
   DBG_PRINTF(DBG_IFACE_SETUP, "%s('%s')", __func__, msg);
-
-#ifdef CHPL_COMM_DEBUG
-  chpl_msg(2, "%d: enter barrier for '%s'\n", chpl_nodeID, msg);
-#endif
-
-  if (chpl_numNodes == 1) {
-    return;
-  }
 
   DBG_PRINTF(DBG_BARRIER, "barrier '%s'", (msg == NULL) ? "" : msg);
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3915,16 +3915,9 @@ void chpl_comm_broadcast_private(int id, size_t size)
 }
 
 
-void chpl_comm_barrier(const char *msg)
+void chpl_comm_impl_barrier(const char *msg)
 {
   DBG_P_L(DBGF_IFACE, "IFACE chpl_comm_barrier(\"%s\")", msg);
-
-#ifdef CHPL_COMM_DEBUG
-  chpl_msg(2, "%d: enter barrier for '%s'\n", chpl_nodeID, msg);
-#endif
-
-  if (chpl_numNodes == 1)
-    return;
 
   //
   // If we can't communicate yet, just do a PMI barrier.

--- a/test/memory/gbt/test-memLog.skipif
+++ b/test/memory/gbt/test-memLog.skipif
@@ -1,4 +1,1 @@
 CHPL_COMM == none
-# Skip with LLVM backend until we resolve the #1677/#1681/#1682 weirdness
-# and can make verbose mem logging work predictably.
-CHPL_TARGET_COMPILER == llvm


### PR DESCRIPTION
`chpl_comm_barrier` is a full synchronization point so we need to fence
the cache when hitting it. We speculated this may be needed in
Cray/chapel-private#1406, but didn't think it was actually a problem
since the AllLocalesBarrier that uses this from module code will use
atomics before calling the comm barrier. However, we recently discovered
that this was causing stale values to be read from the cache during
start up in chpl_setMemFlags. That code has a GET when memlog is
non-empty, but the GET was using a stale cached value from earlier in
locale model init. This mem flag code is surrounded by barriers but
since we weren't fencing on barrier calls before we ran into problems.
Adjust the barrier to fence now to correct this issue.

Some barriers are now calling the cache before the cache_init is done.
This exposed bugs in the cache code to make pre-init operations no-ops
when using non-native thread-local-storage, so work around that here.

Resolves Cray/chapel-private#1406
Resolves Cray/chapel-private#2763
Resolves Cray/chapel-private#2768