### PR TITLE
Add chplvis build test

### DIFF
--- a/util/cron/test-chplvis.bash
+++ b/util/cron/test-chplvis.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Test we can successfully build chplvis
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="chplvis"
+
+make chplvis


### PR DESCRIPTION
Add chplvis nightly build

Partially addresses Cray/chapel-private#1994

Requires updating chapel-ci-config as well.