### PR TITLE
bigint.remove() renamed to bigint.removeFactor()

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3163,17 +3163,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   proc bigint.remove(const ref a: bigint, const ref f: bigint) : uint {
     return this.removeFactor(a,f);
   }
-  /*
-    .. warning::
-
-       a and f are deprecated - please use x and fac respectively
-  */
-  pragma "last resort"
-  deprecated
-  "a and f are deprecated - please use x and fac respectively"
-  proc bigint.removeFactor(const ref a: bigint, const ref f: bigint) : uint {
-    return this.removeFactor(x=a,fac=f);
-  }
+  
   // This helper is intended for use only when the factor is 0
   // Division by 0 is undefined and it results in a
   // Floating point exception error.

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3163,30 +3163,54 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   proc bigint.remove(const ref a: bigint, const ref f: bigint) : uint {
     return this.removeFactor(a,f);
   }
+  /*
+    .. warning::
 
+       a and f are deprecated - please use x and fac respectively
+  */
+  pragma "last resort"
+  deprecated
+  "a and f are deprecated - please use x and fac respectively"
   proc bigint.removeFactor(const ref a: bigint, const ref f: bigint) : uint {
+    return this.removeFactor(x=a,fac=f);
+  }
+  // This helper is intended for use only when the factor is 0
+  // Division by 0 is undefined and it results in a
+  // Floating point exception error.
+  pragma "no doc"
+  proc bigint.removeFactorZeroHelper(const ref x: bigint, const ref fac: bigint) : uint {
+    this = 0;
+    return 0;
+  }
+
+  proc bigint.removeFactor(const ref x: bigint, const ref fac: bigint) : uint {
     var ret: c_ulong;
+    if(fac!=0){
+      if _local {
+        ret = mpz_remove(this.mpz, x.mpz, fac.mpz);
 
-    if _local {
-      ret = mpz_remove(this.mpz, a.mpz, f.mpz);
+      } else if this.localeId == chpl_nodeID &&
+              x.localeId    == chpl_nodeID &&
+              fac.localeId    == chpl_nodeID {
+          ret = mpz_remove(this.mpz, x.mpz, fac.mpz);
 
-    } else if this.localeId == chpl_nodeID &&
-              a.localeId    == chpl_nodeID &&
-              f.localeId    == chpl_nodeID {
-      ret = mpz_remove(this.mpz, a.mpz, f.mpz);
+      } else {
+        const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
-    } else {
-      const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
+        on __primitive("chpl_on_locale_num", thisLoc) {
+          var x_ = x;
+          var fac_ = fac;
 
-      on __primitive("chpl_on_locale_num", thisLoc) {
-        var a_ = a;
-        var f_ = f;
-
-        ret = mpz_remove(this.mpz, a_.mpz, f_.mpz);
+          ret = mpz_remove(this.mpz, x_.mpz, fac_.mpz);
+        }
       }
+
+      return ret.safeCast(uint);
+
+    }else{
+      return this.removeFactorZeroHelper(x,fac);
     }
 
-    return ret.safeCast(uint);
   }
 
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3153,7 +3153,18 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
 
   // remove
+    /*
+    .. warning::
+
+       bigint.remove is deprecated, use bigint.removeFactor instead
+  */
+  deprecated
+  "bigint.remove is deprecated, use bigint.removeFactor instead"
   proc bigint.remove(const ref a: bigint, const ref f: bigint) : uint {
+    return this.removeFactor(a,f);
+  }
+
+  proc bigint.removeFactor(const ref a: bigint, const ref f: bigint) : uint {
     var ret: c_ulong;
 
     if _local {

--- a/test/deprecated/BigInteger/deprecateRemove.chpl
+++ b/test/deprecated/BigInteger/deprecateRemove.chpl
@@ -2,14 +2,9 @@ use BigInteger;
 
 var a = new bigint( 32);
 var b = new bigint( 4);
-var x = new bigint( 7);
 var c = new bigint();
 var d = new bigint();
-var p = new bigint();
-var q = new bigint();
 
 d=c.remove(a, b);
-q=p.removeFactor(a=x,f=b);
 
 writeln("32 is ",c," times the factor ",b," raised to the power ",d);
-writeln("7 is ",p," times the factor ",b," raised to the power ",q);

--- a/test/deprecated/BigInteger/deprecateRemove.chpl
+++ b/test/deprecated/BigInteger/deprecateRemove.chpl
@@ -2,8 +2,14 @@ use BigInteger;
 
 var a = new bigint( 32);
 var b = new bigint( 4);
+var x = new bigint( 7);
 var c = new bigint();
 var d = new bigint();
+var p = new bigint();
+var q = new bigint();
 
 d=c.remove(a, b);
-writeln("32 is ",d," times the factor ",b," raised to the power ",c);
+q=p.removeFactor(a=x,f=b);
+
+writeln("32 is ",c," times the factor ",b," raised to the power ",d);
+writeln("7 is ",p," times the factor ",b," raised to the power ",q);

--- a/test/deprecated/BigInteger/deprecateRemove.chpl
+++ b/test/deprecated/BigInteger/deprecateRemove.chpl
@@ -1,0 +1,9 @@
+use BigInteger;
+
+var a = new bigint( 32);
+var b = new bigint( 4);
+var c = new bigint();
+var d = new bigint();
+
+d=c.remove(a, b);
+writeln("32 is ",d," times the factor ",b," raised to the power ",c);

--- a/test/deprecated/BigInteger/deprecateRemove.good
+++ b/test/deprecated/BigInteger/deprecateRemove.good
@@ -1,2 +1,4 @@
-deprecateRemove.chpl:8: warning: bigint.remove is deprecated, use bigint.removeFactor instead
+deprecateRemove.chpl:11: warning: bigint.remove is deprecated, use bigint.removeFactor instead
+deprecateRemove.chpl:12: warning: a and f are deprecated - please use x and fac respectively
 32 is 2 times the factor 4 raised to the power 2
+7 is 7 times the factor 4 raised to the power 0

--- a/test/deprecated/BigInteger/deprecateRemove.good
+++ b/test/deprecated/BigInteger/deprecateRemove.good
@@ -1,4 +1,2 @@
-deprecateRemove.chpl:11: warning: bigint.remove is deprecated, use bigint.removeFactor instead
-deprecateRemove.chpl:12: warning: a and f are deprecated - please use x and fac respectively
+deprecateRemove.chpl:8: warning: bigint.remove is deprecated, use bigint.removeFactor instead
 32 is 2 times the factor 4 raised to the power 2
-7 is 7 times the factor 4 raised to the power 0

--- a/test/deprecated/BigInteger/deprecateRemove.good
+++ b/test/deprecated/BigInteger/deprecateRemove.good
@@ -1,0 +1,2 @@
+deprecateRemove.chpl:8: warning: bigint.remove is deprecated, use bigint.removeFactor instead
+32 is 2 times the factor 4 raised to the power 2

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.chpl
@@ -108,7 +108,7 @@ writeln();
 
 c.set(36);
 b.set(2);
-a.remove(c, b);
+a.removeFactor(c, b);
 writeln(c, " without factors of ", b, " is ", a);
 
 writeln();

--- a/test/library/standard/GMP/removeFactorCheck.chpl
+++ b/test/library/standard/GMP/removeFactorCheck.chpl
@@ -1,0 +1,16 @@
+use BigInteger;
+
+var a = new bigint(2);
+var b = new bigint(-2);
+var z = new bigint(0);
+var c = new bigint();
+var d = new bigint();
+
+c=d.removeFactor(a, z); 
+writeln("0 as a factor of 2 is undefined, so returning ", c," & ",d);
+
+c=d.removeFactor(b, z);
+writeln("0 as a factor of -2 is undefined, so returning ", c," & ",d);
+
+c=d.removeFactor(z, z); 
+writeln("0 as a factor of 0 is undefined, so returning ", c," & ",d);

--- a/test/library/standard/GMP/removeFactorCheck.good
+++ b/test/library/standard/GMP/removeFactorCheck.good
@@ -1,0 +1,3 @@
+0 as a factor of 2 is undefined, so returning 0 & 0
+0 as a factor of -2 is undefined, so returning 0 & 0
+0 as a factor of 0 is undefined, so returning 0 & 0


### PR DESCRIPTION
This PR closes #17732

### Description
* Changed the function name
* Added the required Deprecation Warning test.