### PR TITLE
Add missing hyperlink now that .rst files are being rendered on the web

### DIFF
--- a/doc/rst/developer/bestPractices/GettingStarted.rst
+++ b/doc/rst/developer/bestPractices/GettingStarted.rst
@@ -69,6 +69,7 @@ with the project via the following steps:
   and/or performance standpoints.
 
 * Once you're ready to move from a user role into more of a developer
-  role, refer to ``ContributorInfo.rst`` in this directory, which has
-  a step by step introduction to contributing to the project.
+  role, refer to :ref:`best-practices-contributor-info` in this
+  directory, which has a step by step introduction to contributing to
+  the project.
 


### PR DESCRIPTION
While proofreading the CHANGES.md file for 1.25.1, Michelle noted that
there was a hyperlink missing in this file, which is due to the edit
in question having pre-dated any intention to render these docs on the
web.  Now that we are, the lack of a hyperlink seems problematic, so add
one.

[Note that I suspect there are other places in the developer best practices
where links are similarly missing, as I don't know that they received a great
deal of scrutiny before being added online, and that I didn't put any effort
into looking for other cases in putting this PR together].