### PR TITLE
Use 6 Xs in mktemp calls

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -47,7 +47,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_TMPDIR"})) {
 }
 $user = `whoami`;
 chomp($user);
-$tmpdir = tempdir("chapel-release.$user.deleteme.XXXXX", DIR => $basetmpdir, CLEANUP => 1);
+$tmpdir = tempdir("chapel-release.$user.deleteme.XXXXXX", DIR => $basetmpdir, CLEANUP => 1);
 $archive_dir = "$tmpdir/$reldir";
 SystemOrDie("rm -rf $tmpdir");
 SystemOrDie("mkdir -pv $archive_dir");

--- a/util/cron/test-release.bash
+++ b/util/cron/test-release.bash
@@ -5,7 +5,7 @@ source $CWD/common.bash
 
 # Create a tmpdir in the current workspace.
 WORKSPACE=${WORKSPACE:-$CWD/../..}
-export TMPDIR=$(mktemp -d $WORKSPACE/chapel-test-release.XXXXX)
+export TMPDIR=$(mktemp -d $WORKSPACE/chapel-test-release.XXXXXX)
 export CHPL_GEN_RELEASE_TMPDIR=$TMPDIR
 
 $CWD/../buildRelease/testRelease -cron

--- a/util/test/checkChplDoc
+++ b/util/test/checkChplDoc
@@ -108,7 +108,7 @@ if [ ! -d $chpl_dir ] ; then
     mkdir -p $chpl_dir || { log_error "Failed to create ${chpl_dir}." && exit 10 ; }
 fi
 
-TMP_TEST_DIR=$(mktemp -d ${chpl_dir}/chapel-test-XXXXX)
+TMP_TEST_DIR=$(mktemp -d ${chpl_dir}/chapel-test-XXXXXX)
 log_debug "TMP_TEST_DIR: ${TMP_TEST_DIR}"
 
 # Ensure the tmp dir is deleted when script exits.

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -103,9 +103,9 @@ fi
 ( cd "${CHPL_DIR}" ) || { log_error "failed cd $CHPL_DIR" ; exit 1 ; }
 
 # Tmp directory for compile output
-TMP_TEST_DIR="$(mktemp -d ${CHPL_DIR}/chapel-test-XXXXX)"
+TMP_TEST_DIR="$(mktemp -d ${CHPL_DIR}/chapel-test-XXXXXX)"
 if [ -z "${TMP_TEST_DIR}" ] ; then
-    log_error "failed mktemp -d ${CHPL_DIR}/chapel-test-XXXXX"
+    log_error "failed mktemp -d ${CHPL_DIR}/chapel-test-XXXXXX"
     exit 1
 fi
 log_info "Temporary test job directory: ${TMP_TEST_DIR}"


### PR DESCRIPTION
On Alpine Linux, make check does not work because the busybox
`mktemp -d` call requires six Xs at the end. Seems like six Xs
is reasonably good practice in any case, so this PR adjusts
a few mktemp calls to always use six Xs.

- [x] full local testing

Reviewed by @ronawho - thanks!