### PR TITLE
Update default chpl__hashtable, map, and set initialCapacity to 16

### DIFF
--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -235,8 +235,8 @@ module ChapelHashtable {
 
     const startingSize: int;
 
-    proc init(type keyType, type valType, resizeThreshold = 0.5,
-              initialCapacity = 32,
+    proc init(type keyType, type valType, resizeThreshold=0.5,
+              initialCapacity=16,
               in rehashHelpers: owned chpl__rehashHelpers? = nil) {
       this.keyType = keyType;
       this.valType = valType;

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -135,7 +135,7 @@ module Map {
       } else {
         this.resizeThreshold = resizeThreshold;
       }
-      table = new chpl__hashtable(keyType, valType, resizeThreshold,
+      table = new chpl__hashtable(keyType, valType, this.resizeThreshold,
                                   initialCapacity);
     }
 
@@ -153,7 +153,7 @@ module Map {
       } else {
         this.resizeThreshold = resizeThreshold;
       }
-      table = new chpl__hashtable(keyType, valType, resizeThreshold,
+      table = new chpl__hashtable(keyType, valType, this.resizeThreshold,
                                   initialCapacity);
     }
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -123,7 +123,7 @@ module Map {
                             attempting to resize.
     */
     proc init(type keyType, type valType, param parSafe=false,
-              resizeThreshold = 0.5, initialCapacity = 16) {
+              resizeThreshold=0.5, initialCapacity=16) {
       _checkKeyAndValType(keyType, valType);
       this.keyType = keyType;
       this.valType = valType;
@@ -137,7 +137,7 @@ module Map {
     }
 
     proc init(type keyType, type valType, param parSafe=false,
-              resizeThreshold = 0.5, initialCapacity = 16)
+              resizeThreshold=0.5, initialCapacity=16)
     where isNonNilableClass(valType) {
       _checkKeyAndValType(keyType, valType);
       this.keyType = keyType;

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -128,8 +128,8 @@ module Map {
       this.keyType = keyType;
       this.valType = valType;
       this.parSafe = parSafe;
-      if resizeThreshold <= 0 || resizeThreshold > 1 {
-        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+      if resizeThreshold <= 0 || resizeThreshold >= 1 {
+        warning("'resizeThreshold' must be between 0 and 1.",
                         " 'resizeThreshold' will be set to 0.5");
         this.resizeThreshold = 0.5;
       } else {
@@ -146,8 +146,8 @@ module Map {
       this.keyType = keyType;
       this.valType = valType;
       this.parSafe = parSafe;
-      if resizeThreshold <= 0 || resizeThreshold > 1 {
-        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+      if resizeThreshold <= 0 || resizeThreshold >= 1 {
+        warning("'resizeThreshold' must be between 0 and 1.",
                         " 'resizeThreshold' will be set to 0.5");
         this.resizeThreshold = 0.5;
       } else {

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -128,10 +128,13 @@ module Map {
       this.keyType = keyType;
       this.valType = valType;
       this.parSafe = parSafe;
-      if boundsChecking then
-        if resizeThreshold <= 0 || resizeThreshold >= 1 then
-          boundsCheckHalt("'resizeThreshold' must be between 0 and 1");
-      this.resizeThreshold = resizeThreshold;
+      if resizeThreshold <= 0 || resizeThreshold > 1 {
+        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+                        " 'resizeThreshold' will be set to 0.5");
+        this.resizeThreshold = 0.5;
+      } else {
+        this.resizeThreshold = resizeThreshold;
+      }
       table = new chpl__hashtable(keyType, valType, resizeThreshold,
                                   initialCapacity);
     }
@@ -143,10 +146,13 @@ module Map {
       this.keyType = keyType;
       this.valType = valType;
       this.parSafe = parSafe;
-      if boundsChecking then
-        if resizeThreshold <= 0 || resizeThreshold >= 1 then
-          boundsCheckHalt("'resizeThreshold' must be between 0 and 1");
-      this.resizeThreshold = resizeThreshold;
+      if resizeThreshold <= 0 || resizeThreshold > 1 {
+        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+                        " 'resizeThreshold' will be set to 0.5");
+        this.resizeThreshold = 0.5;
+      } else {
+        this.resizeThreshold = resizeThreshold;
+      }
       table = new chpl__hashtable(keyType, valType, resizeThreshold,
                                   initialCapacity);
     }

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -181,7 +181,7 @@ module Set {
       } else {
         this.resizeThreshold = resizeThreshold;
       }
-      this._htb = new chpl__hashtable(eltType, nothing, resizeThreshold,
+      this._htb = new chpl__hashtable(eltType, nothing, this.resizeThreshold,
                                       initialCapacity);
     }
 
@@ -213,7 +213,7 @@ module Set {
       } else {
         this.resizeThreshold = resizeThreshold;
       }
-      this._htb = new chpl__hashtable(eltType, nothing, resizeThreshold,
+      this._htb = new chpl__hashtable(eltType, nothing, this.resizeThreshold,
                                       initialCapacity);
       this.complete();
 

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -174,10 +174,13 @@ module Set {
       _checkElementType(eltType);
       this.eltType = eltType;
       this.parSafe = parSafe;
-      if boundsChecking then
-        if resizeThreshold <= 0 || resizeThreshold >= 1 then
-          boundsCheckHalt("'resizeThreshold' must be between 0 and 1");
-      this.resizeThreshold = resizeThreshold;
+      if resizeThreshold <= 0 || resizeThreshold > 1 {
+        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+                        " 'resizeThreshold' will be set to 0.5");
+        this.resizeThreshold = 0.5;
+      } else {
+        this.resizeThreshold = resizeThreshold;
+      }
       this._htb = new chpl__hashtable(eltType, nothing, resizeThreshold,
                                       initialCapacity);
     }
@@ -203,10 +206,13 @@ module Set {
 
       this.eltType = eltType;
       this.parSafe = parSafe;
-      if boundsChecking then
-        if resizeThreshold <= 0 || resizeThreshold >= 1 then
-          boundsCheckHalt("'resizeThreshold' must be between 0 and 1");
-      this.resizeThreshold = resizeThreshold;
+      if resizeThreshold <= 0 || resizeThreshold > 1 {
+        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+                        " 'resizeThreshold' will be set to 0.5");
+        this.resizeThreshold = 0.5;
+      } else {
+        this.resizeThreshold = resizeThreshold;
+      }
       this._htb = new chpl__hashtable(eltType, nothing, resizeThreshold,
                                       initialCapacity);
       this.complete();

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -170,7 +170,7 @@ module Set {
                             attempting to resize.
     */
     proc init(type eltType, param parSafe=false, resizeThreshold=0.5,
-              initialCapacity=32) {
+              initialCapacity=16) {
       _checkElementType(eltType);
       this.eltType = eltType;
       this.parSafe = parSafe;
@@ -197,7 +197,7 @@ module Set {
                             attempting to resize.
     */
     proc init(type eltType, iterable, param parSafe=false,
-              resizeThreshold=0.5, initialCapacity=32)
+              resizeThreshold=0.5, initialCapacity=16)
     where canResolveMethod(iterable, "these") lifetime this < iterable {
       _checkElementType(eltType); 
 

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -174,8 +174,8 @@ module Set {
       _checkElementType(eltType);
       this.eltType = eltType;
       this.parSafe = parSafe;
-      if resizeThreshold <= 0 || resizeThreshold > 1 {
-        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+      if resizeThreshold <= 0 || resizeThreshold >= 1 {
+        warning("'resizeThreshold' must be between 0 and 1.",
                         " 'resizeThreshold' will be set to 0.5");
         this.resizeThreshold = 0.5;
       } else {
@@ -206,8 +206,8 @@ module Set {
 
       this.eltType = eltType;
       this.parSafe = parSafe;
-      if resizeThreshold <= 0 || resizeThreshold > 1 {
-        compilerWarning("'resizeThreshold' must be between 0 and 1.",
+      if resizeThreshold <= 0 || resizeThreshold >= 1 {
+        warning("'resizeThreshold' must be between 0 and 1.",
                         " 'resizeThreshold' will be set to 0.5");
         this.resizeThreshold = 0.5;
       } else {

--- a/test/types/chplhashtable/resize-threshold-oob1.good
+++ b/test/types/chplhashtable/resize-threshold-oob1.good
@@ -1,1 +1,1 @@
-resize-threshold-oob1.chpl:3: error: halt reached - 'resizeThreshold' must be between 0 and 1
+resize-threshold-oob1.chpl:3: warning: 'resizeThreshold' must be between 0 and 1. 'resizeThreshold' will be set to 0.5

--- a/test/types/chplhashtable/resize-threshold-oob2.good
+++ b/test/types/chplhashtable/resize-threshold-oob2.good
@@ -1,1 +1,1 @@
-resize-threshold-oob2.chpl:3: error: halt reached - 'resizeThreshold' must be between 0 and 1
+resize-threshold-oob2.chpl:3: warning: 'resizeThreshold' must be between 0 and 1. 'resizeThreshold' will be set to 0.5


### PR DESCRIPTION
`chpl__hashtable` sets the default table size to be 32, but map currently sets it to 16. This PR updates the map default size to be 32 to be consistent with that decision. The difference in numbers there stems from our definition of "initial capacity" where initially, we were defining it as "initial size of table", but decided to make it actually mean the number of elements the table can hold, so the starting table size will be larger than the initial capacity. 

- [x] paratest