### PR TITLE
compiler/next: canInstantiate and getInstantiationType

### DIFF
--- a/compiler/next/include/chpl/resolution/can-pass.h
+++ b/compiler/next/include/chpl/resolution/can-pass.h
@@ -99,8 +99,8 @@ class CanPassResult {
   static CanPassResult canPassClassTypes(const types::ClassType* actualCt,
                                          const types::ClassType* formalCt);
 
-  static bool isSubtype(const types::Type* actualT,
-                        const types::Type* formalT);
+  static CanPassResult canPassSubtype(const types::Type* actualT,
+                                      const types::Type* formalT);
 
   static CanPassResult canConvert(const types::QualifiedType& actualType,
                                   const types::QualifiedType& formalType);

--- a/compiler/next/include/chpl/resolution/can-pass.h
+++ b/compiler/next/include/chpl/resolution/can-pass.h
@@ -105,6 +105,12 @@ class CanPassResult {
   static CanPassResult canConvert(const types::QualifiedType& actualType,
                                   const types::QualifiedType& formalType);
 
+  static bool canInstantiateBuiltin(const types::Type* actualT,
+                                    const types::Type* formalT);
+
+  static CanPassResult canInstantiate(const types::QualifiedType& actualType,
+                                      const types::QualifiedType& formalType);
+
  public:
   CanPassResult() { }
   ~CanPassResult() = default;
@@ -133,6 +139,10 @@ class CanPassResult {
 /**
   Given an argument with QualifiedType actualType,
   can that argument be passed to a formal with QualifiedType formalType?
+
+  Note that a result with passes() and instantiates() indicates
+  that the compiler should try instantiating. Once instantiation occurs,
+  the compiler may figure out that the argument cannot be passed.
  */
 static inline
 CanPassResult canPass(const types::QualifiedType& actualType,

--- a/compiler/next/include/chpl/resolution/resolution-queries.h
+++ b/compiler/next/include/chpl/resolution/resolution-queries.h
@@ -63,8 +63,9 @@ typedSignatureInitial(Context* context,
   case in many uses of a type name but not the case when calling a type
   constructor or when inheriting.
  */
-const types::Type* typeForTypeDecl(Context* context, const uast::TypeDecl* d,
-                                   bool useGenericFormalDefaults);
+const types::Type* initialTypeForTypeDecl(Context* context,
+                                          const uast::TypeDecl* d,
+                                          bool useGenericFormalDefaults);
 
 /**
   Compute an initial TypedFnSignature for a type constructor for a

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -460,8 +460,14 @@ class TypedFnSignature {
   /**
     Is this TypedFnSignature representing an instantiation?  If so, returns the
     generic TypedFnSignature that was instantiated.  Otherwise, returns nullptr.
+
+    This function always returns the signature for the fully generic
+    function and never a partial instantiation. That is, the result
+    will either be nullptr or result->instantiatedFrom() will be nullptr.
    */
   const TypedFnSignature* instantiatedFrom() const {
+    assert(instantiatedFrom_ == nullptr ||
+           instantiatedFrom_->instantiatedFrom_ == nullptr);
     return instantiatedFrom_;
   }
 

--- a/compiler/next/include/chpl/types/BasicClassType.h
+++ b/compiler/next/include/chpl/types/BasicClassType.h
@@ -36,8 +36,10 @@ class BasicClassType final : public CompositeType {
 
   BasicClassType(ID id, UniqueString name,
                  const BasicClassType* parentType,
-                 std::vector<CompositeType::FieldDetail> fields)
-    : CompositeType(typetags::BasicClassType, id, name, std::move(fields)),
+                 std::vector<CompositeType::FieldDetail> fields,
+                 const BasicClassType* instantiatedFrom)
+    : CompositeType(typetags::BasicClassType, id, name, std::move(fields),
+                    instantiatedFrom),
       parentType_(parentType)
   {
     // all classes should have a parent type, except for object
@@ -61,14 +63,16 @@ class BasicClassType final : public CompositeType {
   static const owned<BasicClassType>&
   getBasicClassType(Context* context, ID id, UniqueString name,
                     const BasicClassType* parentType,
-                    std::vector<CompositeType::FieldDetail> fields);
+                    std::vector<CompositeType::FieldDetail> fields,
+                    const BasicClassType* instantiatedFrom);
  public:
   ~BasicClassType() = default;
 
   static const BasicClassType*
   get(Context* context, ID id, UniqueString name,
       const BasicClassType* parentType,
-      std::vector<CompositeType::FieldDetail> fields);
+      std::vector<CompositeType::FieldDetail> fields,
+      const BasicClassType* instantiatedFrom);
 
   static const BasicClassType* getObjectType(Context* context);
 
@@ -86,7 +90,19 @@ class BasicClassType final : public CompositeType {
       parent class type. That is, some chain of
          this->parentClassType()->parentClassType()->... = parentType
    */
- bool isTransitiveChildOf(const BasicClassType* parentType) const;
+  bool isTransitiveChildOf(const BasicClassType* parentType) const;
+
+  /** If this type represents an instantiated type,
+      returns the type it was instantiated from.
+
+      This is just instantiatedFromCompositeType() with the
+      result cast to BasicClassType.
+   */
+  const BasicClassType* instantiatedFrom() const {
+    const CompositeType* ret = instantiatedFromCompositeType();
+    assert(ret == nullptr || ret->tag() == typetags::BasicClassType);
+    return (const BasicClassType*) ret;
+  }
 
 };
 

--- a/compiler/next/include/chpl/types/BasicClassType.h
+++ b/compiler/next/include/chpl/types/BasicClassType.h
@@ -87,10 +87,16 @@ class BasicClassType final : public CompositeType {
   }
 
   /** Returns true if this class type is a subclass of the passed
-      parent class type. That is, some chain of
-         this->parentClassType()->parentClassType()->... = parentType
+      parent class type or an instantiaton of a passed generic
+      class type or a combination of the two.
+
+      The argument 'convert' is set to true if passing required
+      using a parent type and 'instantiates' is set to true if
+      it requires instantiation.
    */
-  bool isTransitiveChildOf(const BasicClassType* parentType) const;
+  bool isSubtypeOf(const BasicClassType* parentType,
+                   bool& converts,
+                   bool& instantiates) const;
 
   /** If this type represents an instantiated type,
       returns the type it was instantiated from.

--- a/compiler/next/include/chpl/types/CompositeType.h
+++ b/compiler/next/include/chpl/types/CompositeType.h
@@ -175,6 +175,11 @@ class CompositeType : public Type {
            instantiatedFrom_->instantiatedFrom_ == nullptr);
     return instantiatedFrom_;
   }
+
+  bool isInstantiationOf(const CompositeType* genericType) const {
+    auto from = instantiatedFromCompositeType();
+    return (from != nullptr && from == genericType);
+  }
 };
 
 

--- a/compiler/next/include/chpl/types/CompositeType.h
+++ b/compiler/next/include/chpl/types/CompositeType.h
@@ -70,6 +70,11 @@ class CompositeType : public Type {
   ID id_;
   UniqueString name_;
   std::vector<FieldDetail> fields_;
+
+  // Is this CompositeType representing an instantiation?
+  // If so, what is the generic CompositeType that was instantiated?
+  const CompositeType* instantiatedFrom_ = nullptr;
+
   bool isGeneric_ = false;
   bool allGenericFieldsHaveDefaultValues_ = false;
 
@@ -77,8 +82,13 @@ class CompositeType : public Type {
 
   CompositeType(typetags::TypeTag tag,
                 ID id, UniqueString name,
-                std::vector<FieldDetail> fields)
-    : Type(tag), id_(id), name_(name), fields_(std::move(fields)) {
+                std::vector<FieldDetail> fields,
+                const CompositeType* instantiatedFrom)
+    : Type(tag), id_(id), name_(name), fields_(std::move(fields)),
+      instantiatedFrom_(instantiatedFrom) {
+
+    // check instantiated only from same type of object
+    assert(instantiatedFrom_ == nullptr || instantiatedFrom_->tag() == tag);
 
     if (tag != typetags::BasicClassType)
       computeSummaryInformation();
@@ -88,8 +98,11 @@ class CompositeType : public Type {
 
   bool compositeTypeContentsMatchInner(const CompositeType* other) const {
     return id_ == other->id_ &&
+           name_ == other->name_ &&
            fields_ == other->fields_ &&
-           isGeneric_ == other->isGeneric_;
+           instantiatedFrom_ == other->instantiatedFrom_ &&
+           isGeneric_ == other->isGeneric_ &&
+           allGenericFieldsHaveDefaultValues_ == other->allGenericFieldsHaveDefaultValues_;
   }
 
   void compositeTypeMarkUniqueStringsInner(Context* context) const {
@@ -146,6 +159,21 @@ class CompositeType : public Type {
   const QualifiedType& fieldType(int i) const {
     assert(0 <= i && (size_t) i < fields_.size());
     return fields_[i].type;
+  }
+
+  /** If this type represents an instantiated type,
+      returns the type it was instantiated from.
+
+      This function always returns the fully generic type and never
+      a partial instantiation. That is, the result
+      will either be nullptr or result->instantiatedFrom() will
+      be nullptr.
+   */
+  const CompositeType* instantiatedFromCompositeType() const {
+    // at present, only expecting a single level of instantiated-from.
+    assert(instantiatedFrom_ == nullptr ||
+           instantiatedFrom_->instantiatedFrom_ == nullptr);
+    return instantiatedFrom_;
   }
 };
 

--- a/compiler/next/include/chpl/types/RecordType.h
+++ b/compiler/next/include/chpl/types/RecordType.h
@@ -33,8 +33,10 @@ namespace types {
 class RecordType final : public CompositeType {
  private:
   RecordType(ID id, UniqueString name,
-             std::vector<CompositeType::FieldDetail> fields)
-    : CompositeType(typetags::RecordType, id, name, std::move(fields))
+             std::vector<CompositeType::FieldDetail> fields,
+             const RecordType* instantiatedFrom)
+    : CompositeType(typetags::RecordType, id, name, std::move(fields),
+                    instantiatedFrom)
   { }
 
   bool contentsMatchInner(const Type* other) const override {
@@ -47,13 +49,28 @@ class RecordType final : public CompositeType {
 
   static const owned<RecordType>&
   getRecordType(Context* context, ID id, UniqueString name,
-                std::vector<CompositeType::FieldDetail> fields);
+                std::vector<CompositeType::FieldDetail> fields,
+                const RecordType* instantiatedFrom);
 
  public:
   ~RecordType() = default;
 
   static const RecordType* get(Context* context, ID id, UniqueString name,
-                               std::vector<CompositeType::FieldDetail> fields); 
+                               std::vector<CompositeType::FieldDetail> fields,
+                               const RecordType* instantiatedFrom);
+
+  /** If this type represents an instantiated type,
+      returns the type it was instantiated from.
+
+      This is just instantiatedFromCompositeType() with the
+      result cast to RecordType.
+   */
+  const RecordType* instantiatedFrom() const {
+    const CompositeType* ret = instantiatedFromCompositeType();
+    assert(ret == nullptr || ret->tag() == typetags::RecordType);
+    return (const RecordType*) ret;
+  }
+
 };
 
 

--- a/compiler/next/include/chpl/types/RecordType.h
+++ b/compiler/next/include/chpl/types/RecordType.h
@@ -73,8 +73,18 @@ class RecordType final : public CompositeType {
 
 };
 
-
 } // end namespace uast
+
+  /// \cond DO_NOT_DOCUMENT
+template<> struct stringify<chpl::types::RecordType> {
+  void operator()(std::ostream &stringOut,
+                  StringifyKind stringKind,
+                  const chpl::types::RecordType& stringMe) const {
+    stringOut << stringMe.toString();
+  }
+};
+  /// \endcond DO_NOT_DOCUMENT
+
 } // end namespace chpl
 
 #endif

--- a/compiler/next/include/chpl/types/TupleType.h
+++ b/compiler/next/include/chpl/types/TupleType.h
@@ -32,8 +32,10 @@ namespace types {
 class TupleType final : public CompositeType {
  private:
   TupleType(ID id, UniqueString name,
-            std::vector<CompositeType::FieldDetail> fields)
-    : CompositeType(typetags::TupleType, id, name, std::move(fields))
+            std::vector<CompositeType::FieldDetail> fields,
+            const TupleType* instantiatedFrom)
+    : CompositeType(typetags::TupleType, id, name, std::move(fields),
+                    instantiatedFrom)
   { }
 
   bool contentsMatchInner(const Type* other) const override {
@@ -46,14 +48,28 @@ class TupleType final : public CompositeType {
 
   static const owned<TupleType>&
   getTupleType(Context* context, ID id, UniqueString name,
-               std::vector<CompositeType::FieldDetail> fields);
+               std::vector<CompositeType::FieldDetail> fields,
+               const TupleType* instantiatedFrom);
 
  public:
   ~TupleType() = default;
 
   static const TupleType*
   get(Context* context, ID id, UniqueString name,
-      std::vector<CompositeType::FieldDetail> fields);
+      std::vector<CompositeType::FieldDetail> fields,
+      const TupleType* instantiatedFrom);
+
+  /** If this type represents an instantiated type,
+      returns the type it was instantiated from.
+
+      This is just instantiatedFromCompositeType() with the
+      result cast to TupleType.
+   */
+  const TupleType* instantiatedFrom() const {
+    const CompositeType* ret = instantiatedFromCompositeType();
+    assert(ret == nullptr || ret->tag() == typetags::TupleType);
+    return (const TupleType*) ret;
+  }
 };
 
 

--- a/compiler/next/include/chpl/types/TupleType.h
+++ b/compiler/next/include/chpl/types/TupleType.h
@@ -74,6 +74,18 @@ class TupleType final : public CompositeType {
 
 
 } // end namespace uast
+
+/// \cond DO_NOT_DOCUMENT
+template<> struct stringify<chpl::types::TupleType> {
+  void operator()(std::ostream &stringOut,
+                  StringifyKind stringKind,
+                  const chpl::types::TupleType& stringMe) const {
+    stringOut << stringMe.toString();
+  }
+};
+  /// \endcond DO_NOT_DOCUMENT
+
+
 } // end namespace chpl
 
 #endif

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -152,12 +152,18 @@ class Type {
   }
 
   /** returns true for a type that is a kind of pointer */
-  bool isAnyPtrType() const {
+  bool isPtrType() const {
     return isClassType() || isCFnPtrType() || isCVoidPtrType();
   }
 
   /** returns true for a pointer type that can store nil */
-  bool isAnyNilablePtrType() const;
+  bool isNilablePtrType() const;
+
+  /** Returns true for a type that is a user-defined record.
+      The compiler treats some internal types as records
+      but the language design does not insist that they are.
+   */
+  bool isUserRecordType() const;
 
   /** If 'this' is a CompositeType, return it.
       If 'this' is a ClassType, return the basicClassType.

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -128,6 +128,12 @@ class Type {
   #undef TYPE_IS
 
   // Additional helper functions
+  // Don't name these queries 'isAny...'.
+  // Why? Consider an example.
+  // AnyNumericType is a builtin type called 'numeric' in the source code.
+  // So, isAnyNumericType checks if the type is that builtin type 'numeric'.
+  // In contrast, isNumericType checks to see if the type is one of the
+  // numeric types.
 
   /** returns true if it's string, bytes, or c_string type */
   bool isStringLikeType() const {

--- a/compiler/next/include/chpl/types/TypeClassesList.h
+++ b/compiler/next/include/chpl/types/TypeClassesList.h
@@ -49,6 +49,14 @@ TYPE_NODE(StringType)
 TYPE_NODE(UnknownType)
 TYPE_NODE(VoidType)
 
+// TODO:
+// migrate BytesType / StringType to something backed by the modules
+// (if the modules are parsed) and also do the same for array, domain,
+// distribution.
+//
+// c_ptr
+// c_array
+
 TYPE_BEGIN_SUBCLASSES(BuiltinType)
   // concrete builtin types
   BUILTIN_TYPE_NODE(CFileType, "_cfile")
@@ -61,9 +69,9 @@ TYPE_BEGIN_SUBCLASSES(BuiltinType)
   // generic builtin types. AnyBoolType must be the first of these
   // (or else adjust BuiltinType::isGeneric and this comment)
   BUILTIN_TYPE_NODE(AnyBoolType, "chpl_anybool")
+  BUILTIN_TYPE_NODE(AnyBorrowedNilableType, "_borrowedNilable")
   BUILTIN_TYPE_NODE(AnyBorrowedNonNilableType, "_borrowedNonNilable")
   BUILTIN_TYPE_NODE(AnyBorrowedType, "borrowed")
-  BUILTIN_TYPE_NODE(AnyClassType, "class")
   BUILTIN_TYPE_NODE(AnyComplexType, "chpl_anycomplex")
   BUILTIN_TYPE_NODE(AnyEnumType, "enum")
   BUILTIN_TYPE_NODE(AnyImagType, "chpl_anyimag")
@@ -71,8 +79,9 @@ TYPE_BEGIN_SUBCLASSES(BuiltinType)
   BUILTIN_TYPE_NODE(AnyIntegralType, "integral")
   BUILTIN_TYPE_NODE(AnyIteratorClassType, "_iteratorClass")
   BUILTIN_TYPE_NODE(AnyIteratorRecordType, "_iteratorRecord")
-  BUILTIN_TYPE_NODE(AnyMaganementAnyNilableType, "_anyManagementAnyNilable")
+  BUILTIN_TYPE_NODE(AnyManagementAnyNilableType, "_anyManagementAnyNilable")
   BUILTIN_TYPE_NODE(AnyManagementNilableType, "_anyManagementNilable")
+  BUILTIN_TYPE_NODE(AnyManagementNonNilableType, "class")
   BUILTIN_TYPE_NODE(AnyNumericType, "numeric")
   BUILTIN_TYPE_NODE(AnyOwnedType, "owned")
   BUILTIN_TYPE_NODE(AnyPodType, "chpl_anyPOD")

--- a/compiler/next/include/chpl/types/UnionType.h
+++ b/compiler/next/include/chpl/types/UnionType.h
@@ -76,6 +76,17 @@ class UnionType final : public CompositeType {
 
 
 } // end namespace uast
+
+/// \cond DO_NOT_DOCUMENT
+template<> struct stringify<chpl::types::UnionType> {
+  void operator()(std::ostream &stringOut,
+                  StringifyKind stringKind,
+                  const chpl::types::UnionType& stringMe) const {
+    stringOut << stringMe.toString();
+  }
+};
+  /// \endcond DO_NOT_DOCUMENT
+
 } // end namespace chpl
 
 #endif

--- a/compiler/next/include/chpl/types/UnionType.h
+++ b/compiler/next/include/chpl/types/UnionType.h
@@ -33,8 +33,10 @@ namespace types {
 class UnionType final : public CompositeType {
  private:
   UnionType(ID id, UniqueString name,
-            std::vector<CompositeType::FieldDetail> fields)
-    : CompositeType(typetags::UnionType, id, name, std::move(fields))
+            std::vector<CompositeType::FieldDetail> fields,
+            const UnionType* instantiatedFrom)
+    : CompositeType(typetags::UnionType, id, name, std::move(fields),
+                    instantiatedFrom)
   { }
 
   bool contentsMatchInner(const Type* other) const override {
@@ -47,13 +49,29 @@ class UnionType final : public CompositeType {
 
   static const owned<UnionType>&
   getUnionType(Context* context, ID id, UniqueString name,
-               std::vector<CompositeType::FieldDetail> fields);
+               std::vector<CompositeType::FieldDetail> fields,
+               const UnionType* instantiatedFrom);
 
  public:
   ~UnionType() = default;
 
   static const UnionType* get(Context* context, ID id, UniqueString name,
-                              std::vector<CompositeType::FieldDetail> fields);
+                              std::vector<CompositeType::FieldDetail> fields,
+                              const UnionType* instantiatedFrom);
+
+  /** If this type represents an instantiated type,
+      returns the type it was instantiated from.
+
+      This is just instantiatedFromCompositeType() with the
+      result cast to UnionType.
+   */
+  const UnionType* instantiatedFrom() const {
+    const CompositeType* ret = instantiatedFromCompositeType();
+    assert(ret == nullptr || ret->tag() == typetags::UnionType);
+    return (const UnionType*) ret;
+  }
+
+
 };
 
 

--- a/compiler/next/lib/resolution/can-pass.cpp
+++ b/compiler/next/lib/resolution/can-pass.cpp
@@ -823,7 +823,7 @@ CanPassResult CanPassResult::canPass(const QualifiedType& actualQT,
       case QualifiedType::CONST_REF:
       case QualifiedType::TYPE:
         {
-          auto got = canPassSubtype(formalT, actualT);
+          auto got = canPassSubtype(actualT, formalT);
           if (got.passes()) {
             return got;
           }

--- a/compiler/next/lib/resolution/can-pass.cpp
+++ b/compiler/next/lib/resolution/can-pass.cpp
@@ -492,6 +492,9 @@ CanPassResult CanPassResult::canPassClassTypes(const ClassType* actualCt,
 }
 
 
+// TODO -- rename to something about clasess and return CanPassresult
+// so we can check instantiations
+
 // The compiler considers many patterns of "subtyping" as things that require
 // implicit conversions (they often require implicit conversions in the
 // generated C).  However not all implicit conversions are created equal.
@@ -693,7 +696,9 @@ CanPassResult CanPassResult::canInstantiate(const QualifiedType& actualQT,
   }
 
   // check for instantiating records
-  TODO;
+  //TODO;
+
+  return fail();
 }
 
 CanPassResult CanPassResult::canPass(const QualifiedType& actualQT,

--- a/compiler/next/lib/resolution/can-pass.cpp
+++ b/compiler/next/lib/resolution/can-pass.cpp
@@ -769,6 +769,13 @@ CanPassResult CanPassResult::canPass(const QualifiedType& actualQT,
   }
 
   if (actualT == formalT) {
+    if (formalQT.kind() == QualifiedType::PARAM &&
+        formalQT.param() == nullptr) {
+      // if the formal parameter value is unknown, we need to instantiate
+      return instantiate();
+    }
+
+    // otherwise we can pass as-is
     return passAsIs();
   }
 
@@ -824,6 +831,19 @@ CanPassResult CanPassResult::canPass(const QualifiedType& actualQT,
         }
 
       case QualifiedType::PARAM:
+        {
+          auto got = canConvert(actualQT, formalQT);
+          if (got.passes()) {
+            // if the formal parameter value is unknown, we need
+            // to instantiate as well.
+            if (formalQT.param() == nullptr) {
+              got.instantiates_ = true;
+            }
+            return got;
+          }
+          break;
+        }
+
       case QualifiedType::IN:
       case QualifiedType::CONST_IN:
       case QualifiedType::INOUT:

--- a/compiler/next/lib/resolution/resolution-queries.cpp
+++ b/compiler/next/lib/resolution/resolution-queries.cpp
@@ -925,8 +925,14 @@ initialTypeForTypeDeclQuery(Context* context,
       if (auto cls = ad->toClass()) {
         if (auto parentClassExpr = cls->parentClass()) {
           QualifiedType qt = r.byAst(parentClassExpr).type();
-          if (qt.isType() && qt.hasTypePtr() && qt.type()->isClassType()) {
-            parentType = qt.type()->toClassType()->basicClassType();
+          if (auto t = qt.type()) {
+            if (auto bct = t->toBasicClassType())
+              parentType = bct;
+            else if (auto ct = t->toClassType())
+              parentType = ct->basicClassType();
+          }
+          if (qt.isType() && parentType != nullptr) {
+            // OK
           } else {
             context->error(declId, "invalid parent class");
             parentType = BasicClassType::getObjectType(context);
@@ -1514,8 +1520,13 @@ const QualifiedType& returnType(Context* context,
           parentClassExpr->traverse(visitor);
           QualifiedType qt = r.byAst(parentClassExpr).type();
           assert(qt.hasTypePtr() && qt.isType());
-          assert(qt.type()->toBasicClassType());
-          parentType = qt.type()->toBasicClassType();
+          if (auto t = qt.type()) {
+            if (auto bct = t->toBasicClassType())
+              parentType = bct;
+            else if (auto ct = t->toClassType())
+              parentType = ct->basicClassType();
+          }
+          assert(parentType);
         } else {
           parentType = BasicClassType::getObjectType(context);
         }

--- a/compiler/next/lib/types/BasicClassType.cpp
+++ b/compiler/next/lib/types/BasicClassType.cpp
@@ -79,7 +79,6 @@ bool BasicClassType::isSubtypeOf(const BasicClassType* parentType,
     // check if t is parentType indicating use of subclass
     if (t == parentType) {
       if (t != this) converts = true;
-      instantiates = false;
       return true;
     }
 

--- a/compiler/next/lib/types/BasicClassType.cpp
+++ b/compiler/next/lib/types/BasicClassType.cpp
@@ -29,11 +29,14 @@ const owned<BasicClassType>&
 BasicClassType::getBasicClassType(
     Context* context, ID id, UniqueString name,
     const BasicClassType* parentType,
-    std::vector<CompositeType::FieldDetail> fields) {
-  QUERY_BEGIN(getBasicClassType, context, id, name, parentType, fields);
+    std::vector<CompositeType::FieldDetail> fields,
+    const BasicClassType* instantiatedFrom) {
+  QUERY_BEGIN(getBasicClassType, context, id, name, parentType, fields,
+              instantiatedFrom);
 
   auto result = toOwned(new BasicClassType(id, name,
-                                           parentType, std::move(fields)));
+                                           parentType, std::move(fields),
+                                           instantiatedFrom));
 
   return QUERY_END(result);
 }
@@ -41,12 +44,14 @@ BasicClassType::getBasicClassType(
 const BasicClassType*
 BasicClassType::get(Context* context, ID id, UniqueString name,
                     const BasicClassType* parentType,
-                    std::vector<CompositeType::FieldDetail> fields) {
+                    std::vector<CompositeType::FieldDetail> fields,
+                    const BasicClassType* instantiatedFrom) {
   // getObjectType should be used to construct object
   // everything else should have a parent type.
   assert(parentType != nullptr);
   return getBasicClassType(context, id, name,
-                           parentType, std::move(fields)).get();
+                           parentType, std::move(fields),
+                           instantiatedFrom).get();
 }
 
 const BasicClassType*
@@ -56,7 +61,9 @@ BasicClassType::getObjectType(Context* context) {
   std::vector<CompositeType::FieldDetail> emptyFields;
 
   return getBasicClassType(context, emptyId, name,
-                           nullptr, std::move(emptyFields)).get();
+                           /* parentType */ nullptr,
+                           std::move(emptyFields),
+                           /* instantiatedFrom */ nullptr).get();
 }
 
 bool

--- a/compiler/next/lib/types/BasicClassType.cpp
+++ b/compiler/next/lib/types/BasicClassType.cpp
@@ -66,16 +66,29 @@ BasicClassType::getObjectType(Context* context) {
                            /* instantiatedFrom */ nullptr).get();
 }
 
-bool
-BasicClassType::isTransitiveChildOf(const BasicClassType* parentType) const {
+bool BasicClassType::isSubtypeOf(const BasicClassType* parentType,
+                                 bool& converts,
+                                 bool& instantiates) const {
+
+  assert(parentType != nullptr); // code below assumes this
+
   for (const BasicClassType* t = this;
-       t != nullptr;
+       t != nullptr; // note: ObjectType has no parent
        t = t->parentClassType()) {
 
-    if (t == parentType)
+    // check if t is parentType indicating use of subclass
+    if (t == parentType) {
+      if (t != this) converts = true;
+      instantiates = false;
       return true;
-    if (t->isObjectType())
-      break;
+    }
+
+    // check also if t is an instantiation of parentType
+    if (t->instantiatedFrom() == parentType) {
+      if (t != this) converts = true;
+      instantiates = true;
+      return true;
+    }
   }
 
   return false;

--- a/compiler/next/lib/types/RecordType.cpp
+++ b/compiler/next/lib/types/RecordType.cpp
@@ -27,18 +27,22 @@ namespace types {
 
 const owned<RecordType>&
 RecordType::getRecordType(Context* context, ID id, UniqueString name,
-                          std::vector<CompositeType::FieldDetail> fields) {
-  QUERY_BEGIN(getRecordType, context, id, name, fields);
+                          std::vector<CompositeType::FieldDetail> fields,
+                          const RecordType* instantiatedFrom) {
+  QUERY_BEGIN(getRecordType, context, id, name, fields, instantiatedFrom);
 
-  auto result = toOwned(new RecordType(id, name, std::move(fields)));
+  auto result = toOwned(new RecordType(id, name, std::move(fields),
+                                       instantiatedFrom));
 
   return QUERY_END(result);
 }
 
 const RecordType*
 RecordType::get(Context* context, ID id, UniqueString name,
-                std::vector<CompositeType::FieldDetail> fields) {
-  return getRecordType(context, id, name, std::move(fields)).get();
+                std::vector<CompositeType::FieldDetail> fields,
+                const RecordType* instantiatedFrom) {
+  return getRecordType(context, id, name, std::move(fields),
+                       instantiatedFrom).get();
 }
 
 

--- a/compiler/next/lib/types/TupleType.cpp
+++ b/compiler/next/lib/types/TupleType.cpp
@@ -27,18 +27,22 @@ namespace types {
 
 const owned<TupleType>&
 TupleType::getTupleType(Context* context, ID id, UniqueString name,
-                        std::vector<CompositeType::FieldDetail> fields) {
-  QUERY_BEGIN(getTupleType, context, id, name, fields);
+                        std::vector<CompositeType::FieldDetail> fields,
+                        const TupleType* instantiatedFrom) {
+  QUERY_BEGIN(getTupleType, context, id, name, fields, instantiatedFrom);
 
-  auto result = toOwned(new TupleType(id, name, std::move(fields)));
+  auto result = toOwned(new TupleType(id, name, std::move(fields),
+                                      instantiatedFrom));
 
   return QUERY_END(result);
 }
 
 const TupleType*
 TupleType::get(Context* context, ID id, UniqueString name,
-               std::vector<CompositeType::FieldDetail> fields) {
-  return getTupleType(context, id, name, std::move(fields)).get();
+               std::vector<CompositeType::FieldDetail> fields,
+               const TupleType* instantiatedFrom) {
+  return getTupleType(context, id, name, std::move(fields),
+                      instantiatedFrom).get();
 }
 
 

--- a/compiler/next/lib/types/Type.cpp
+++ b/compiler/next/lib/types/Type.cpp
@@ -152,8 +152,8 @@ std::string Type::toString() const {
   return ret;
 }
 
-bool Type::isAnyNilablePtrType() const {
-  if (isAnyPtrType()) {
+bool Type::isNilablePtrType() const {
+  if (isPtrType()) {
 
     if (auto ct = toClassType()) {
       if (!ct->decorator().isNilable())
@@ -166,13 +166,13 @@ bool Type::isAnyNilablePtrType() const {
   return false;
 }
 
-bool Type::isAnyUserRecordType() const {
+bool Type::isUserRecordType() const {
   if (!isRecordType())
     return false;
 
-  // TODO: may need to add exceptions in here
-  // if there are any types implemented as records but where that
-  // isn't the user's view
+  // TODO: add exceptions in here
+  // for types implemented as records but where that
+  // isn't the user's view -- e.g.
   //  * string, bytes, distribution, domain, array, range
   //    tuple, sync, single, atomic, managed pointer
 

--- a/compiler/next/lib/types/Type.cpp
+++ b/compiler/next/lib/types/Type.cpp
@@ -166,6 +166,20 @@ bool Type::isAnyNilablePtrType() const {
   return false;
 }
 
+bool Type::isAnyUserRecordType() const {
+  if (!isRecordType())
+    return false;
+
+  // TODO: may need to add exceptions in here
+  // if there are any types implemented as records but where that
+  // isn't the user's view
+  //  * string, bytes, distribution, domain, array, range
+  //    tuple, sync, single, atomic, managed pointer
+
+  return true;
+}
+
+
 const CompositeType* Type::getCompositeType() const {
   if (auto at = toCompositeType())
     return at;

--- a/compiler/next/lib/types/UnionType.cpp
+++ b/compiler/next/lib/types/UnionType.cpp
@@ -27,18 +27,22 @@ namespace types {
 
 const owned<UnionType>&
 UnionType::getUnionType(Context* context, ID id, UniqueString name,
-                        std::vector<CompositeType::FieldDetail> fields) {
-  QUERY_BEGIN(getUnionType, context, id, name, fields);
+                        std::vector<CompositeType::FieldDetail> fields,
+                        const UnionType* instantiatedFrom) {
+  QUERY_BEGIN(getUnionType, context, id, name, fields, instantiatedFrom);
 
-  auto result = toOwned(new UnionType(id, name, std::move(fields)));
+  auto result = toOwned(new UnionType(id, name, std::move(fields),
+                                      instantiatedFrom));
 
   return QUERY_END(result);
 }
 
 const UnionType*
 UnionType::get(Context* context, ID id, UniqueString name,
-               std::vector<CompositeType::FieldDetail> fields) {
-  return getUnionType(context, id, name, std::move(fields)).get();
+               std::vector<CompositeType::FieldDetail> fields,
+               const UnionType* instantiatedFrom) {
+  return getUnionType(context, id, name, std::move(fields),
+                      instantiatedFrom).get();
 }
 
 

--- a/compiler/next/test/resolution/testCanPass.cpp
+++ b/compiler/next/test/resolution/testCanPass.cpp
@@ -393,9 +393,11 @@ static void test7() {
   auto childName = UniqueString::build(context, "Child");
   auto basicObj = BasicClassType::getObjectType(context);
   auto basicParent = BasicClassType::get(context, emptyId, parentName,
-                                         basicObj, emptyFields);
+                                         basicObj, emptyFields,
+                                         /* instantiatedFrom */ nullptr);
   auto basicChild = BasicClassType::get(context, emptyId, childName,
-                                        basicParent, emptyFields);
+                                        basicParent, emptyFields,
+                                        /* instantiatedFrom */ nullptr);
 
   auto borrowed = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
   auto borrowedQ = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NILABLE);

--- a/compiler/next/test/resolution/testResolve.cpp
+++ b/compiler/next/test/resolution/testResolve.cpp
@@ -237,10 +237,51 @@ static void test3() {
   }
 }
 
+// this test combines several ideas and is a more challenging
+// case for instantiation, conversions, and type construction
+static void test4() {
+  printf("test4\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::build(context, "input.chpl");
+  std::string contents = R""""(
+                           module M {
+                             class Parent { }
+                             class C : Parent { type t; var x: t; }
+
+                             proc f(arg: Parent) { }
+                             var x: owned C(int);
+                             f(x);
+                          }
+                        )"""";
+
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parse(context, path);
+  assert(vec.size() == 1);
+  const Module* m = vec[0]->toModule();
+  assert(m);
+  assert(m->numStmts() == 5);
+  const Call* call = m->stmt(4)->toCall();
+  assert(call);
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+  const ResolvedExpression& re = rr.byAst(call);
+
+  assert(re.type().type()->isVoidType());
+
+  const TypedFnSignature* fn = re.mostSpecific().only();
+  assert(fn != nullptr);
+  assert(fn->untyped()->name() == "f");
+}
+
+
 int main() {
   test1();
   test2();
   test3();
+  test4();
 
   return 0;
 }

--- a/compiler/next/test/resolution/testTypeConstruction.cpp
+++ b/compiler/next/test/resolution/testTypeConstruction.cpp
@@ -252,6 +252,15 @@ static void test5() {
   assert(rt->fieldHasDefaultValue(0) == false);
   assert(rt->fieldType(0).kind() == QualifiedType::TYPE);
   assert(rt->fieldType(0).type() == IntType::get(context, 0));
+
+  auto initialRt = rt->instantiatedFrom();
+  assert(initialRt);
+  assert(initialRt->instantiatedFrom() == nullptr);
+  assert(initialRt->numFields() == 1);
+  assert(initialRt->fieldName(0) == "t");
+  assert(initialRt->fieldHasDefaultValue(0) == false);
+  assert(initialRt->fieldType(0).kind() == QualifiedType::TYPE);
+  assert(initialRt->fieldType(0).type()->isAnyType());
 }
 
 static void test6() {


### PR DESCRIPTION
This PR continues the effort of filling in canInstantiate and getInstantiationType logic for the compiler/next prototype resolver.

In particular it:
 * in can-pass.h / can-pass.cpp:
    * moves isSubtype to include canPassSubtype since some subtype conversions also instantiate so we'd like to be able to track that
    * adds canInstantiateBuiltin and canInstantiate helpers to handle some of the cases
    * adds checks for subtype for class conversions
    * fixes param formals with unknown value as needing instantiation
    * adds logic in canPass to handle the variety of intents (e.g. `out`, `inout`) and to consider generic formals
 * in types/
    * adds instantiatedFrom to CompositeType and children
    * adds isSubtypeOf and instantatedFrom helpers in BasicClassType
    * adds instantiatedFromCompositeType and isInstantiationOf helpers to CompositeType
    * renames isAnyPtrType to isPtrType, isAnyNilablePtrType to isNilablePtrType to reduce confusions with typed named things like AnyType.
    * adds isUserRecordType
    * adds a few builtin types that were overlooked so far
 * in resolution-queries.h / resolution-queries.cpp:
    * renames typeForTypeDecl to initialTypeForTypeDecl to reflect that the final type might be a result of instantiation and to better match the initial / instantiated terminology for functions
    * resolves parent class types
    * adds an implementation of getInstantiationType
    * uses canPass result including instantiation to decide when to add a substitution for a formal
    * handle more cases in the resolveIntent implementation
    
Future work: Look into recursive type declarations & better factor the repeated calls to the struct Resolver.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing