### PR TITLE
Issue error if mkdtemp fails

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -173,11 +173,19 @@ const char* makeTempDir(const char* dirPrefix) {
   removeSpacesBackslashesFromString(myuserid);
 
   const char* tmpDir = astr(tmpdirprefix, myuserid, tmpdirsuffix);
-  const char* dirRes = mkdtemp((char*) tmpDir);
+  char* tmpDirMut = strdup(tmpDir);
+  char* dirRes = mkdtemp(tmpDirMut);
+
+  if (dirRes == NULL) {
+    USR_FATAL("unable to create temporary directory at %s\n", tmpDir);
+  }
 
   free(myuserid); myuserid = NULL;
 
-  return dirRes;
+  const char* ret = astr(dirRes);
+  free(tmpDirMut);
+
+  return ret;
 }
 
 void ensureTmpDirExists() {


### PR DESCRIPTION
Issue error if mkdtemp fails

Previously, if mkdtemp failed to create the directory requested, it
returns NULL which got propagated up, resulting in a segfault when it
tried to be used.

This change checks the return value and issues a fatal error instead.

Also dup'ing the return value of astr because we shouldn't be
modifying it.

Thanks to mppf for the suggestion on using a second astr

Closes Cray/chapel-private#2816

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>