### PR TITLE
Methods renamed and return type changed to boolean

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2894,7 +2894,18 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     }
   }
 
-  proc bigint.perfect_power_p() : int {
+  /*
+    .. warning::
+
+       bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead
+  */
+  deprecated
+  "bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead"
+  proc bigint.perfect_power_p() : bool {
+    return this.isPerfectPower();
+  }
+
+  proc bigint.isPerfectPower () : bool {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2906,10 +2917,24 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_perfect_power_p(t_.mpz);
     }
 
-    return ret.safeCast(int);
+    if ret.safeCast(int) then 
+      return true;
+    else 
+      return false;
   }
 
-  proc bigint.perfect_square_p() : int {
+  /*
+    .. warning::
+
+       bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead
+  */
+  deprecated
+  "bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead"
+  proc bigint.perfect_square_p() : bool {
+    return this.isPerfectSquare();
+  }
+
+  proc bigint.isPerfectSquare() : bool {
     var ret: c_int;
 
     if _local || this.localeId == chpl_nodeID {
@@ -2921,9 +2946,11 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_perfect_square_p(t_.mpz);
     }
 
-    return ret.safeCast(int);
+    if ret.safeCast(int) then 
+      return true;
+    else 
+      return false;
   }
-
 
 
 
@@ -3595,7 +3622,18 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     return ret.safeCast(int);
   }
 
-  proc bigint.even_p() : int {
+  /*
+    .. warning::
+
+       bigint.even_p is deprecated, use bigint.isEven instead
+  */
+  deprecated
+  "bigint.even_p is deprecated, use bigint.isEven instead"
+  proc bigint.even_p() : bool {
+    return this.isEven();
+  }
+
+  proc bigint.isEven() : bool {
     var ret: c_int;
 
     if _local {
@@ -3610,10 +3648,24 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_even_p(t_.mpz);
     }
 
-    return ret.safeCast(int);
+    if ret.safeCast(int) then 
+      return true;
+    else 
+      return false;
   }
 
-  proc bigint.odd_p() : int {
+  /*
+    .. warning::
+
+       bigint.odd_p is deprecated, use bigint.isOdd instead
+  */
+  deprecated
+  "bigint.odd_p is deprecated, use bigint.isOdd instead"
+  proc bigint.odd_p() : bool {
+    return this.isOdd();
+  }
+
+  proc bigint.isOdd() : bool {
     var ret: c_int;
 
     if _local {
@@ -3628,7 +3680,10 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_odd_p(t_.mpz);
     }
 
-    return ret.safeCast(int);
+    if ret.safeCast(int) then 
+      return true;
+    else 
+      return false;
   }
 
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2901,7 +2901,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   */
   deprecated
   "bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead"
-  proc bigint.perfect_power_p() : bool {
+  proc bigint.perfect_power_p() : int {
     return this.isPerfectPower();
   }
 
@@ -2917,7 +2917,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_perfect_power_p(t_.mpz);
     }
 
-    if ret.safeCast(int) then 
+    if ret then 
       return true;
     else 
       return false;
@@ -2930,7 +2930,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   */
   deprecated
   "bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead"
-  proc bigint.perfect_square_p() : bool {
+  proc bigint.perfect_square_p() : int {
     return this.isPerfectSquare();
   }
 
@@ -2946,7 +2946,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_perfect_square_p(t_.mpz);
     }
 
-    if ret.safeCast(int) then 
+    if ret then 
       return true;
     else 
       return false;
@@ -3629,7 +3629,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   */
   deprecated
   "bigint.even_p is deprecated, use bigint.isEven instead"
-  proc bigint.even_p() : bool {
+  proc bigint.even_p() : int {
     return this.isEven();
   }
 
@@ -3648,7 +3648,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_even_p(t_.mpz);
     }
 
-    if ret.safeCast(int) then 
+    if ret then 
       return true;
     else 
       return false;
@@ -3661,7 +3661,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   */
   deprecated
   "bigint.odd_p is deprecated, use bigint.isOdd instead"
-  proc bigint.odd_p() : bool {
+  proc bigint.odd_p() : int {
     return this.isOdd();
   }
 
@@ -3680,7 +3680,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
       ret = mpz_odd_p(t_.mpz);
     }
 
-    if ret.safeCast(int) then 
+    if ret then 
       return true;
     else 
       return false;

--- a/test/deprecated/BigInteger/deprecateEvenP.chpl
+++ b/test/deprecated/BigInteger/deprecateEvenP.chpl
@@ -1,7 +1,7 @@
 use BigInteger;
 
 var a=new bigint(6);
-var c:bool;
+var c:int;
 
 c=a.even_p();
 writeln(a," is Even, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecateEvenP.chpl
+++ b/test/deprecated/BigInteger/deprecateEvenP.chpl
@@ -1,0 +1,7 @@
+use BigInteger;
+
+var a=new bigint(6);
+var c:bool;
+
+c=a.even_p();
+writeln(a," is Even, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecateEvenP.good
+++ b/test/deprecated/BigInteger/deprecateEvenP.good
@@ -1,0 +1,2 @@
+deprecateEvenP.chpl:6: warning: bigint.even_p is deprecated, use bigint.isEven instead
+6 is Even, as true was returned

--- a/test/deprecated/BigInteger/deprecateEvenP.good
+++ b/test/deprecated/BigInteger/deprecateEvenP.good
@@ -1,2 +1,2 @@
 deprecateEvenP.chpl:6: warning: bigint.even_p is deprecated, use bigint.isEven instead
-6 is Even, as true was returned
+6 is Even, as 1 was returned

--- a/test/deprecated/BigInteger/deprecateOddP.chpl
+++ b/test/deprecated/BigInteger/deprecateOddP.chpl
@@ -1,0 +1,7 @@
+use BigInteger;
+
+var a=new bigint(5);
+var c:bool;
+
+c=a.odd_p();
+writeln(a," is Odd, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecateOddP.chpl
+++ b/test/deprecated/BigInteger/deprecateOddP.chpl
@@ -1,7 +1,7 @@
 use BigInteger;
 
 var a=new bigint(5);
-var c:bool;
+var c:int;
 
 c=a.odd_p();
 writeln(a," is Odd, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecateOddP.good
+++ b/test/deprecated/BigInteger/deprecateOddP.good
@@ -1,0 +1,2 @@
+deprecateOddP.chpl:6: warning: bigint.odd_p is deprecated, use bigint.isOdd instead
+5 is Odd, as true was returned

--- a/test/deprecated/BigInteger/deprecateOddP.good
+++ b/test/deprecated/BigInteger/deprecateOddP.good
@@ -1,2 +1,2 @@
 deprecateOddP.chpl:6: warning: bigint.odd_p is deprecated, use bigint.isOdd instead
-5 is Odd, as true was returned
+5 is Odd, as 1 was returned

--- a/test/deprecated/BigInteger/deprecatePerfectPowerP.chpl
+++ b/test/deprecated/BigInteger/deprecatePerfectPowerP.chpl
@@ -1,7 +1,7 @@
 use BigInteger;
 
 var a=new bigint(8);
-var c:bool;
+var c:int;
 
 c=a.perfect_power_p();
 writeln(a," is a perfect power, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecatePerfectPowerP.chpl
+++ b/test/deprecated/BigInteger/deprecatePerfectPowerP.chpl
@@ -1,0 +1,7 @@
+use BigInteger;
+
+var a=new bigint(8);
+var c:bool;
+
+c=a.perfect_power_p();
+writeln(a," is a perfect power, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecatePerfectPowerP.good
+++ b/test/deprecated/BigInteger/deprecatePerfectPowerP.good
@@ -1,0 +1,2 @@
+deprecatePerfectPowerP.chpl:6: warning: bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead
+8 is a perfect power, as true was returned

--- a/test/deprecated/BigInteger/deprecatePerfectPowerP.good
+++ b/test/deprecated/BigInteger/deprecatePerfectPowerP.good
@@ -1,2 +1,2 @@
 deprecatePerfectPowerP.chpl:6: warning: bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead
-8 is a perfect power, as true was returned
+8 is a perfect power, as 1 was returned

--- a/test/deprecated/BigInteger/deprecatePerfectSquareP.chpl
+++ b/test/deprecated/BigInteger/deprecatePerfectSquareP.chpl
@@ -1,7 +1,7 @@
 use BigInteger;
 
 var a=new bigint(4);
-var c:bool;
+var c:int;
 
 c=a.perfect_square_p();
 writeln(a," is a perfect square, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecatePerfectSquareP.chpl
+++ b/test/deprecated/BigInteger/deprecatePerfectSquareP.chpl
@@ -1,0 +1,7 @@
+use BigInteger;
+
+var a=new bigint(4);
+var c:bool;
+
+c=a.perfect_square_p();
+writeln(a," is a perfect square, as ",c," was returned");

--- a/test/deprecated/BigInteger/deprecatePerfectSquareP.good
+++ b/test/deprecated/BigInteger/deprecatePerfectSquareP.good
@@ -1,0 +1,2 @@
+deprecatePerfectSquareP.chpl:6: warning: bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead
+4 is a perfect square, as true was returned

--- a/test/deprecated/BigInteger/deprecatePerfectSquareP.good
+++ b/test/deprecated/BigInteger/deprecatePerfectSquareP.good
@@ -1,2 +1,2 @@
 deprecatePerfectSquareP.chpl:6: warning: bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead
-4 is a perfect square, as true was returned
+4 is a perfect square, as 1 was returned

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_misc.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_misc.chpl
@@ -22,11 +22,11 @@ writeln(a, parse_fit(a.fits_sshort_p()), " in a signed short integer");
 writeln(b, parse_fit(b.fits_sshort_p()), " in a signed short integer");
 writeln();
 
-if a.odd_p() then writeln("a is odd");
-else if a.even_p() then writeln("a is even");
+if a.isOdd() then writeln("a is odd");
+else if a.isEven() then writeln("a is even");
 
-if b.odd_p() then writeln("b is odd");
-else if b.even_p() then writeln("b is even");
+if b.isOdd() then writeln("b is odd");
+else if b.isEven() then writeln("b is even");
 
 writeln(a, " is ", a.sizeInBase(10), " digits in base 10");
 writeln(a, " is ", a.sizeInBase(2), " digits in base 2");

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_powers_roots.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_powers_roots.chpl
@@ -39,14 +39,14 @@ writeln("sqrt ", b, " = ", d, " remainder ", a);
 
 c.set(81);
 
-var d2 = c.perfect_power_p();
+var d2 = c.isPerfectPower();
 writeln(d2);
 
-d2 = b.perfect_power_p();
+d2 = b.isPerfectPower();
 writeln(d2);
 
-d2 = c.perfect_square_p();
+d2 = c.isPerfectSquare();
 writeln(d2);
 
-d2 = b.perfect_square_p();
+d2 = b.isPerfectSquare();
 writeln(d2);

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_powers_roots.good
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_powers_roots.good
@@ -6,7 +6,7 @@
 3, remainder 10
 sqrt 17 = 4
 sqrt 17 = 4 remainder 1
-1
-0
-1
-0
+true
+false
+true
+false


### PR DESCRIPTION
This PR Partly Resolves #17701 

### Description
* Changed the method names
* Updated the required Deprecation Warnings and tests.

### Methods changed:
 * `bigint.perfect_power_p()`
 * `bigint.perfect_square_p()`
 * `bigint.even_p()`
 * `bigint.odd_p()`

<br>
Note: Rest of the Methods Changed in PR #18784