### PR TITLE
Fix good file for deprecated set test

### DIFF
--- a/test/deprecated/Set/setIsIntersecting.good
+++ b/test/deprecated/Set/setIsIntersecting.good
@@ -1,20 +1,20 @@
 setIsIntersecting.chpl:14: In function 'doTest':
-setIsIntersecting.chpl:18: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:19: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:26: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:27: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:34: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:35: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:41: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:42: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
+setIsIntersecting.chpl:18: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:19: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:26: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:27: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:34: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:35: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:41: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:42: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
   setIsIntersecting.chpl:45: called as doTest(type eltType = int(64))
 setIsIntersecting.chpl:14: In function 'doTest':
-setIsIntersecting.chpl:18: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:19: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:26: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:27: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:34: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:35: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:41: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
-setIsIntersecting.chpl:42: warning: Set isIntersecting() method is deprecated; use the negation of !isDisjoint instead
+setIsIntersecting.chpl:18: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:19: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:26: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:27: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:34: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:35: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:41: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
+setIsIntersecting.chpl:42: warning: Set isIntersecting() method is deprecated; use !isDisjoint instead
   setIsIntersecting.chpl:46: called as doTest(type eltType = testRecord)


### PR DESCRIPTION
After making a last minute change to the deprecation message, I forgot to update the good file for the new set deprecation test, so this updates that to reflect the new message.