### PR TITLE
Add missing stringify template for some integral types

### DIFF
--- a/compiler/next/include/chpl/queries/stringify-functions.h
+++ b/compiler/next/include/chpl/queries/stringify-functions.h
@@ -219,7 +219,6 @@ void operator()(std::ostream &stringOut,
 }
 };
 
-
 template<> struct stringify<long int> {
 void operator()(std::ostream &stringOut,
                 StringifyKind stringKind,
@@ -302,7 +301,6 @@ void operator()(std::ostream &stringOut,
 }
 };
 
-
 template<typename... ArgTs> struct stringify<std::tuple<ArgTs...>> {
   void operator()(std::ostream &stringOut,
                   StringifyKind stringKind,
@@ -313,8 +311,7 @@ template<typename... ArgTs> struct stringify<std::tuple<ArgTs...>> {
                           std::index_sequence_for<ArgTs...>{});
   }
 };
-/// \
-
+/// \endcond
 
 } // end namespace chpl
 

--- a/compiler/next/include/chpl/queries/stringify-functions.h
+++ b/compiler/next/include/chpl/queries/stringify-functions.h
@@ -219,6 +219,13 @@ void operator()(std::ostream &stringOut,
 }
 };
 
+template<> struct stringify<unsigned int> {
+void operator()(std::ostream &stringOut,
+               StringifyKind stringKind,
+               const unsigned int val) const {
+ stringOut << std::to_string(val);
+}
+};
 template<> struct stringify<long int> {
 void operator()(std::ostream &stringOut,
                 StringifyKind stringKind,
@@ -227,18 +234,10 @@ void operator()(std::ostream &stringOut,
 }
 };
 
-template<> struct stringify<double> {
+template<> struct stringify<unsigned long int> {
 void operator()(std::ostream &stringOut,
                 StringifyKind stringKind,
-                const double val) const {
-  stringOut << std::to_string(val);
-}
-};
-
-template<> struct stringify<long unsigned int> {
-void operator()(std::ostream &stringOut,
-                StringifyKind stringKind,
-                const long unsigned int val) const {
+                const unsigned long int val) const {
   stringOut << std::to_string(val);
 }
 };
@@ -251,15 +250,60 @@ void operator()(std::ostream &stringOut,
 }
 };
 
-template<> struct stringify<unsigned long long> {
+template<> struct stringify<unsigned long long int> {
 void operator()(std::ostream &stringOut,
                 StringifyKind stringKind,
-                const unsigned long long val) const {
+                const unsigned long long int val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+template<> struct stringify<short int> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const short int val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+template<> struct stringify<unsigned short int> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const unsigned short int val) const {
   stringOut << std::to_string(val);
 }
 };
 
 // end integral types
+
+/*
+  Floating Point Types
+*/
+template<> struct stringify<double> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const double val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+template<> struct stringify<long double> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const long double val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+template<> struct stringify<float> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const float val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+// end floating-point types
 
 template<> struct stringify<bool> {
 void operator()(std::ostream &stringOut,

--- a/compiler/next/include/chpl/queries/stringify-functions.h
+++ b/compiler/next/include/chpl/queries/stringify-functions.h
@@ -207,6 +207,10 @@ void operator()(std::ostream &stringOut,
 };
 
 
+/*
+  Templates for integral types start here
+*/
+
 template<> struct stringify<int> {
 void operator()(std::ostream &stringOut,
                StringifyKind stringKind,
@@ -214,6 +218,7 @@ void operator()(std::ostream &stringOut,
  stringOut << std::to_string(val);
 }
 };
+
 
 template<> struct stringify<long int> {
 void operator()(std::ostream &stringOut,
@@ -255,6 +260,7 @@ void operator()(std::ostream &stringOut,
 }
 };
 
+// end integral types
 
 template<> struct stringify<bool> {
 void operator()(std::ostream &stringOut,

--- a/compiler/next/include/chpl/queries/stringify-functions.h
+++ b/compiler/next/include/chpl/queries/stringify-functions.h
@@ -239,6 +239,23 @@ void operator()(std::ostream &stringOut,
 }
 };
 
+template<> struct stringify<long long int> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const long long int val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+template<> struct stringify<unsigned long long> {
+void operator()(std::ostream &stringOut,
+                StringifyKind stringKind,
+                const unsigned long long val) const {
+  stringOut << std::to_string(val);
+}
+};
+
+
 template<> struct stringify<bool> {
 void operator()(std::ostream &stringOut,
                 StringifyKind stringKind,


### PR DESCRIPTION
This PR fixes a breaking smoke test that is caused by missing
`stringify` specializations for some integral types. It also adds
templates for all the base integral and floating-point types
listed here: https://en.cppreference.com/w/cpp/language/types

TESTING:

I compared the output of `printchplenv --all` to that from 
the failed smoke test.

After reproducing the failure on `chapel-ubu1604-32-01` with settings
taken from the smoke test, I have verified that the updated
code builds using `make DEBUG=0 WARNINGS=1 OPTIMIZE=1`.

Reviewed by @stonea, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>