### PR TITLE
Document that set operations will favor the LHS and add test to lock in that behavior

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -35,6 +35,13 @@
   setting the param formal 'parSafe` to true in any set constructor. When
   constructed from another set, the new set will inherit the parallel safety
   mode of its originating set.
+
+  When using set operators (e.g., `A | B`), if both sets contain elements that
+  are `==` equivalent, the element from the left hand side of the operation
+  will always be chosen for the resultant set. This may happen if the `==`
+  operator has been overloaded on the set element type, causing values of
+  the set type to be `==` equivalent, even when there may be differences
+  between the left hand side and right hand side elements.
 */
 module Set {
 

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -36,12 +36,13 @@
   constructed from another set, the new set will inherit the parallel safety
   mode of its originating set.
 
-  When using set operators (e.g., `A | B`), if both sets contain elements that
-  are `==` equivalent, the element from the left hand side of the operation
-  will always be chosen for the resultant set. This may happen if the `==`
+  When using set operators (e.g., ``A | B``), if both sets contain elements that
+  are ``==`` equivalent, the element from the first argument  of the operation
+  will always be chosen for the resultant set. This may happen if the ``==``
   operator has been overloaded on the set element type, causing values of
-  the set type to be `==` equivalent, even when there may be differences
-  between the left hand side and right hand side elements.
+  the set type to be ``==`` equivalent, even when there may be differences
+  between the elements of the first argument and the elements of the second
+  argument.
 */
 module Set {
 

--- a/test/library/standard/Set/setOperatorOrderTest.chpl
+++ b/test/library/standard/Set/setOperatorOrderTest.chpl
@@ -1,0 +1,39 @@
+use Set;
+
+record R {
+  var a: string;
+  
+  operator ==(a:R, b:R) {
+    return true;
+  }
+
+  // We need to ensure that objects of this type are
+  // not only `==` equivalent, but also hash to the
+  // same value, based on the internal hashtable
+  // implementation.
+  proc hash(): uint {
+    if a == "LHS" || a == "RHS" then
+      return 0;
+    else
+      return chpl__defaultHashWrapper(this): uint;
+  }
+}
+
+var s1 = new set(R);
+var s2 = new set(R);
+
+var a = new R("LHS");
+var b = new R("RHS");
+
+s1.add(a);
+s2.add(b);
+
+writeln(s1 | s2);
+writeln(s1 + s2);
+writeln(s1 - s2);
+writeln(s1 & s2);
+writeln(s1 ^ s2);
+writeln(s1 <= s2);
+writeln(s2 <= s1);
+writeln(s1 >= s2);
+writeln(s2 >= s1);

--- a/test/library/standard/Set/setOperatorOrderTest.chpl
+++ b/test/library/standard/Set/setOperatorOrderTest.chpl
@@ -15,7 +15,7 @@ record R {
     if a == "LHS" || a == "RHS" then
       return 0;
     else
-      return chpl__defaultHashWrapper(this): uint;
+      return chpl__defaultHashWrapper(a): uint;
   }
 }
 
@@ -24,9 +24,13 @@ var s2 = new set(R);
 
 var a = new R("LHS");
 var b = new R("RHS");
+var c = new R("LHS other");
+var d = new R("RHS other");
 
 s1.add(a);
 s2.add(b);
+s1.add(c);
+s2.add(d);
 
 writeln(s1 | s2);
 writeln(s1 + s2);

--- a/test/library/standard/Set/setOperatorOrderTest.good
+++ b/test/library/standard/Set/setOperatorOrderTest.good
@@ -1,0 +1,9 @@
+{(a = LHS)}
+{(a = LHS)}
+{}
+{(a = LHS)}
+{}
+true
+true
+true
+true

--- a/test/library/standard/Set/setOperatorOrderTest.good
+++ b/test/library/standard/Set/setOperatorOrderTest.good
@@ -1,9 +1,9 @@
+{(a = LHS), (a = RHS other), (a = LHS other)}
+{(a = LHS), (a = RHS other), (a = LHS other)}
+{(a = LHS other)}
 {(a = LHS)}
-{(a = LHS)}
-{}
-{(a = LHS)}
-{}
-true
-true
-true
-true
+{(a = RHS other), (a = LHS other)}
+false
+false
+false
+false

--- a/test/library/standard/Set/setOperatorOrderTest2.chpl
+++ b/test/library/standard/Set/setOperatorOrderTest2.chpl
@@ -12,10 +12,7 @@ record R {
   // same value, based on the internal hashtable
   // implementation.
   proc hash(): uint {
-    if a == "LHS" || a == "RHS" then
-      return 0;
-    else
-      return chpl__defaultHashWrapper(a): uint;
+    return 0;
   }
 }
 
@@ -25,17 +22,8 @@ var s2 = new set(R);
 var a = new R("LHS");
 var b = new R("RHS");
 
-// These elements are `==` equivalent, but will not be
-// stored in the same hash slot in the underlying table,
-// so the `_findSlot` function considers them as different
-// objects.
-var c = new R("LHS other");
-var d = new R("RHS other");
-
 s1.add(a);
 s2.add(b);
-s1.add(c);
-s2.add(d);
 
 writeln(s1 | s2);
 writeln(s1 + s2);

--- a/test/library/standard/Set/setOperatorOrderTest2.good
+++ b/test/library/standard/Set/setOperatorOrderTest2.good
@@ -1,0 +1,9 @@
+{(a = LHS)}
+{(a = LHS)}
+{}
+{(a = LHS)}
+{}
+true
+true
+true
+true


### PR DESCRIPTION
In the set module review and the resulting issues, it was decided that we should favor the LHS of a set operation for choosing which element is chosen for the resultant set. This could matter, for example, if the `==` operator has been overloaded to only compare a subset of the fields on the element type, so the two elements are considered `==` by the set, so only one of them can be contained in the resultant set, but they are not actually the same objects.

This PR adds documentation for that behavior and adds a test to ensure that remains the case in the future, so that we will not happen to stray from that behavior in the future, which would be a breaking change.

Closes https://github.com/chapel-lang/chapel/issues/18653 (design discussion)