### PR TITLE
Fix failing futures from ChapelArray -> ChapelDomain separation.

### DIFF
--- a/test/classes/generic/typeOfGenericField-fromTypeVariable.bad
+++ b/test/classes/generic/typeOfGenericField-fromTypeVariable.bad
@@ -1,8 +1,8 @@
 typeOfGenericField-fromTypeVariable.chpl:12: error: unresolved call 'type [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64)._instance'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1048: note: this candidate did not match: _distribution._instance
+$CHPL_HOME/modules/internal/ChapelArray.chpl:825: note: this candidate did not match: _distribution._instance
 typeOfGenericField-fromTypeVariable.chpl:12: note: because method call receiver is a type
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1048: note: but is passed to non-type formal 'ref this: _distribution'
+$CHPL_HOME/modules/internal/ChapelArray.chpl:825: note: but is passed to non-type formal 'ref this: _distribution'
 typeOfGenericField-fromTypeVariable.chpl:12: note: other candidates are:
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1187: note:   _domain._instance
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2465: note:   []._instance
+$CHPL_HOME/modules/internal/ChapelArray.chpl:971: note:   []._instance
+$CHPL_HOME/modules/internal/ExternalArray.chpl:32: note:   chpl_opaque_array._instance
 note: and 2 other candidates, use --print-all-candidates to see them

--- a/test/distributions/ferguson/dist-assoc-bulkadd.bad
+++ b/test/distributions/ferguson/dist-assoc-bulkadd.bad
@@ -1,5 +1,5 @@
 dist-assoc-bulkadd.chpl:7: error: unresolved call 'UserMapAssocDom(true,real(64),DefaultMapper).bulkAdd([domain(1,int(64),false)] real(64))'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1671: note: this candidate did not match: ref _domain.bulkAdd(inds: [] _value.idxType, dataSorted = false, isUnique = false, preserveInds = true, addOn = nilLocale)
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1671: note: because where clause evaluated to false
+$CHPL_HOME/modules/internal/ChapelDomain.chpl:1313: note: this candidate did not match: ref _domain.bulkAdd(inds: [] _value.idxType, dataSorted = false, isUnique = false, preserveInds = true, addOn = nilLocale)
+$CHPL_HOME/modules/internal/ChapelDomain.chpl:1313: note: because where clause evaluated to false
 dist-assoc-bulkadd.chpl:7: note: other candidates are:
-$CHPL_HOME/modules/internal/ChapelArray.chpl:1760: note:   ref _domain.bulkAdd(inds: [] _value.rank*_value.idxType, dataSorted = false, isUnique = false, preserveInds = true, addOn = nilLocale)
+$CHPL_HOME/modules/internal/ChapelDomain.chpl:1402: note:   ref _domain.bulkAdd(inds: [] _value.rank*_value.idxType, dataSorted = false, isUnique = false, preserveInds = true, addOn = nilLocale)


### PR DESCRIPTION
Fix `.bad` files for failing futures caused by this PR, which separates `_domain` and associated functions out into their own file: https://github.com/chapel-lang/chapel/pull/18829.

To reviewers ---

* I don't think there's anything controversial in updating `test/distributions/ferguson/dist-assoc-bulkadd.bad`, just updating filenames and line numbers for code I moved
* For the most part the same is true for `test/classes/generic/typeOfGenericField-fromTypeVariable.bad`. One thing that looks odd to me is it looks like the error for:

`unresolved call 'type [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64)._instance'`

Gives as a candidate function:
`$CHPL_HOME/modules/internal/ExternalArray.chpl:32: note:   chpl_opaque_array._instance`

Instead of:

`$CHPL_HOME/modules/internal/ChapelArray.chpl:1187: note:   _domain._instance`

Kind of confusing since I didn't touch `ExternalArray.chpl` at all but I think maybe reordering the functions has impacted name resolution?

I'm tempted to say I should just update the .bad file and move on (especially since this is locking down .bad behavior), but if this raises a red flag for anyone let me know and I can dig deeper.

* I'm also confused why I didn't see these failures in paratests. I'm can see in my log file they didn't run but I don't know any reason why not. I don't see any `.skipif` file or any obvious reason it wouldn't run. Do you know if you need to pass some special flag to paratests or something to indicate to run futures?
