### PR TITLE
Change `map.getValue` to throw instead of halt and add a sentinel getValue overload

### DIFF
--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -126,15 +126,6 @@ module Errors {
     }
   }
 
-  class KeyNotFoundError : Error {
-    proc init() {}
-
-    proc init(k: string) {
-      var msg = "key '" + k + "' not found";
-      super.init(msg);
-    }
-  }
-
   // Used by the runtime to accumulate errors. This type
   // supports adding errors concurrently but need not support
   // iterating over the errors concurrently. Errors

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -126,6 +126,15 @@ module Errors {
     }
   }
 
+  class ElementNotFoundError : Error {
+    proc init() {}
+
+    proc init(k: string) {
+      var msg = "key '" + k + "' not found";
+      super.init(msg);
+    }
+  }
+
   // Used by the runtime to accumulate errors. This type
   // supports adding errors concurrently but need not support
   // iterating over the errors concurrently. Errors

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -126,7 +126,7 @@ module Errors {
     }
   }
 
-  class ElementNotFoundError : Error {
+  class KeyNotFoundError : Error {
     proc init() {}
 
     proc init(k: string) {

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -424,7 +424,7 @@ module Map {
 
     /* Get a copy of the element stored at position `k`.
      */
-    proc getValue(k: keyType) const {
+    proc getValue(k: keyType) const throws {
       if !isCopyableType(valType) then
         compilerError('cannot call `getValue()` for non-copyable ' +
                       'map value type: ' + valType:string);
@@ -432,7 +432,22 @@ module Map {
       _enter(); defer _leave();
       var (found, slot) = table.findFullSlot(k);
       if !found then
-        boundsCheckHalt("map index " + k:string + " out of bounds");
+        throw new ElementNotFoundError(k: string);
+      try! {
+        const result = table.table[slot].val: valType;
+        return result;
+      }
+    }
+
+    proc getValue(k: keyType, const sentinel: valType) const {
+      if !isCopyableType(valType) then
+        compilerError('cannot call `getValue()` for non-copyable ' +
+                      'map value type: ' + valType:string);
+
+      _enter(); defer _leave();
+      var (found, slot) = table.findFullSlot(k);
+      if !found then
+        return sentinel;
       try! {
         const result = table.table[slot].val: valType;
         return result;

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -432,7 +432,7 @@ module Map {
       _enter(); defer _leave();
       var (found, slot) = table.findFullSlot(k);
       if !found then
-        throw new ElementNotFoundError(k: string);
+        throw new KeyNotFoundError(k: string);
       try! {
         const result = table.table[slot].val: valType;
         return result;
@@ -728,7 +728,7 @@ module Map {
 
     lhs.clear();
     for key in rhs.keys() {
-      lhs.add(key, rhs.getValue(key));
+      lhs.add(key, try! rhs.getValue(key));
     }
   }
 
@@ -810,8 +810,8 @@ module Map {
                  b: map(keyType, valueType, ?)) {
     var newMap = new map(keyType, valueType, (a.parSafe || b.parSafe));
 
-    for k in a do newMap.add(k, a.getValue(k));
-    for k in b do newMap.add(k, b.getValue(k));
+    for k in a do newMap.add(k, try! a.getValue(k));
+    for k in b do newMap.add(k, try! b.getValue(k));
     return newMap;
   }
 
@@ -821,7 +821,7 @@ module Map {
   operator map.|=(ref a: map(?keyType, ?valueType, ?),
                   b: map(keyType, valueType, ?)) {
     // add keys/values from b to a if they weren't already in a
-    for k in b do a.add(k, b.getValue(k));
+    for k in b do a.add(k, try! b.getValue(k));
   }
 
   /* Returns a new map containing the keys that are in both a and b. */
@@ -831,7 +831,7 @@ module Map {
 
     for k in a.keys() do
       if b.contains(k) then
-        newMap.add(k, a.getValue(k));
+        newMap.add(k, try! a.getValue(k));
 
     return newMap;
   }
@@ -850,7 +850,7 @@ module Map {
 
     for ak in a.keys() {
       if !b.contains(ak) then
-        newMap.add(ak, a.getValue(ak));
+        newMap.add(ak, try! a.getValue(ak));
     }
 
     return newMap;
@@ -880,9 +880,9 @@ module Map {
     var newMap = new map(keyType, valueType, (a.parSafe || b.parSafe));
 
     for k in a.keys() do
-      if !b.contains(k) then newMap.add(k, a.getValue(k));
+      if !b.contains(k) then newMap.add(k, try! a.getValue(k));
     for k in b do
-      if !a.contains(k) then newMap.add(k, b.getValue(k));
+      if !a.contains(k) then newMap.add(k, try! b.getValue(k));
     return newMap;
   }
 
@@ -892,7 +892,7 @@ module Map {
                   b: map(keyType, valueType, ?)) {
     for k in b.keys() {
       if a.contains(k) then a.remove(k);
-      else a.add(k, b.getValue(k));
+      else a.add(k, try! b.getValue(k));
     }
   }
 }

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -828,8 +828,8 @@ module Map {
                  b: map(keyType, valueType, ?)) {
     var newMap = new map(keyType, valueType, (a.parSafe || b.parSafe));
 
-    try! for k in a do newMap.add(k, a.getValue(k));
-    try! for k in b do newMap.add(k, b.getValue(k));
+    try! { for k in a do newMap.add(k, a.getValue(k)); }
+    try! { for k in b do newMap.add(k, b.getValue(k)); }
     return newMap;
   }
 
@@ -839,7 +839,7 @@ module Map {
   operator map.|=(ref a: map(?keyType, ?valueType, ?),
                   b: map(keyType, valueType, ?)) {
     // add keys/values from b to a if they weren't already in a
-    try! for k in b do a.add(k, b.getValue(k));
+    try! { for k in b do a.add(k, b.getValue(k)); }
   }
 
   /* Returns a new map containing the keys that are in both a and b. */
@@ -847,9 +847,11 @@ module Map {
                  b: map(keyType, valueType, ?)) {
     var newMap = new map(keyType, valueType, (a.parSafe || b.parSafe));
 
-    try! for k in a.keys() do
-      if b.contains(k) then
-        newMap.add(k, a.getValue(k));
+    try! {
+      for k in a.keys() do
+        if b.contains(k) then
+          newMap.add(k, a.getValue(k));
+    }
 
     return newMap;
   }
@@ -899,10 +901,14 @@ module Map {
                  b: map(keyType, valueType, ?)) {
     var newMap = new map(keyType, valueType, (a.parSafe || b.parSafe));
 
-    try! for k in a.keys() do
-      if !b.contains(k) then newMap.add(k, a.getValue(k));
-    try! for k in b do
-      if !a.contains(k) then newMap.add(k, b.getValue(k));
+    try! {
+      for k in a.keys() do
+        if !b.contains(k) then newMap.add(k, a.getValue(k));
+    }
+    try! {
+      for k in b do
+        if !a.contains(k) then newMap.add(k, b.getValue(k));
+    }
     return newMap;
   }
 

--- a/test/library/standard/Map/mapErrors.chpl
+++ b/test/library/standard/Map/mapErrors.chpl
@@ -13,7 +13,7 @@ try {
   m.getValue(1);
 } catch e {
   caughtVal = 1;
-  writeln("caught error");
+  writeln(e: string);
 }
 
 sentinelVal = m.getValue(1, 1);

--- a/test/library/standard/Map/mapErrors.chpl
+++ b/test/library/standard/Map/mapErrors.chpl
@@ -1,0 +1,23 @@
+use Map;
+
+var m = new map(int, int);
+
+m[0] = 1;
+
+m.getValue(0);
+
+var caughtVal: int;
+var sentinelVal: int;
+
+try {
+  m.getValue(1);
+} catch e {
+  caughtVal = 1;
+  writeln("caught error");
+}
+
+sentinelVal = m.getValue(1, 1);
+
+writeln(caughtVal == sentinelVal);
+
+m.getValue(1);

--- a/test/library/standard/Map/mapErrors.good
+++ b/test/library/standard/Map/mapErrors.good
@@ -1,0 +1,5 @@
+caught error
+true
+uncaught ElementNotFoundError: key '1' not found
+  mapErrors.chpl:23: thrown here
+  mapErrors.chpl:23: uncaught here

--- a/test/library/standard/Map/mapErrors.good
+++ b/test/library/standard/Map/mapErrors.good
@@ -1,5 +1,5 @@
-caught error
+KeyNotFoundError: key '1' not found
 true
-uncaught ElementNotFoundError: key '1' not found
+uncaught KeyNotFoundError: key '1' not found
   mapErrors.chpl:23: thrown here
   mapErrors.chpl:23: uncaught here


### PR DESCRIPTION
Two users have requested the ability to have an overload of `map.getValue()` that will return a sentinel value in the case where the value is not found in the map. Through design discussion, we decided that we should instead throw rather than halt for `getValue()` and we should also have the sentinel overload, so this PR adds both of those methods.

- [x] map testing updated
- [x] paratest

Closes https://github.com/chapel-lang/chapel/issues/17498
Closes https://github.com/cray/chapel-private/issues/2774
Design discussion: https://github.com/chapel-lang/chapel/issues/18786