### PR TITLE
Add helpers that suggest using IO to do read() routines

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -798,6 +798,36 @@ module ChapelIO {
     try! {
       return stdout.writef(fmt);
     }
+      }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc read(x...) {
+    compilerError("read() is not available by default; consider adding 'use'/'import' IO");
+  }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc read(type t) {
+    compilerError("read() is not available by default; consider adding 'use'/'import' IO");
+  }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc readline() {
+    compilerError("readline() is not available by default; consider adding 'use'/'import' IO");
+  }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc readln(x...) {
+    compilerError("readln() is not available by default; consider adding 'use'/'import' IO");
+  }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc readln() {
+    compilerError("readln() is not available by default; consider adding 'use'/'import' IO");
   }
 
   pragma "no doc"


### PR DESCRIPTION
Every Advent of Code exercise I've written requires file input in the form of read, readf, readline, etc.
In almost every cases, I have typed the routine without `use IO;` and gotten not-so-clear error messages
with suggestions like "Maybe you want atomic.read?"  (no).  This PR proposes adding "last resort"
versions of the read routines to ChapelIO.chpl (which is automatically included) to result in better
error messages for consideration.