### PR TITLE
Do not run SSCA2 benchmark when CHPL_LOCALE_MODEL=numa

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.suppressif
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.suppressif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
This PR addresses the following test failure:

  https://chapel.discourse.group/t/cron-perf-chapcs-numa/8631/2

Which was introduced after merging this PR:

  https://github.com/chapel-lang/chapel/pull/18791

Specifically we're getting a failure on the SSCA2 performance benchmark when `CHPL_LOCALE_MODEL=numa`, but the failure doesn't look performance related.  Rather we're missing some of the output we see in the .good file and we see the presence of this error message:

`SSCA2_Modules/SSCA2_kernels.chpl:255: error: halt reached - internal error: dsiReallocate() can only be called from an array's home locale`

I'm not sure exactly what `dsiReallocate()` is used for of why the changes in pr #8631 would cause it to get triggered, but perhaps it doesn't play well with the NUMA locale model.  Given that the NUMA work is still in the experimental stage I think its fine to suppress this test for the time being and spawn a new Github issue with the intent that if\when there's a time we're serious about improving support for the NUMA locale model we can come back and investigate this.

To reviewers ---
* If you happen to know what `dsiReallocate()` is used for let me know. I'll spend the next half an hour or so investigating this just incase there's a quick fix but I'm not hopeful.
* Do you feel suppressing the test (when `CHPL_LOCALE_MODEL=numa`) is acceptable? This PR is introducing technical debt but I'm of the opinion that pulling back  https://github.com/chapel-lang/chapel/pull/18791 would be worse. I don't think my opinion here is controversial but I feel I should double check.
* If I do merge this PR my next step will be to create a new Github issue to investigate the root cause. My intention isn't to look at this anytime soon but I feel it's important that there's something in the system documenting it.