### PR TITLE
`bigint.probab_prime_p` renamed and return type changed

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2956,9 +2956,26 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
   // Number Theoretic Functions
 
+  /*
+    .. warning::
+
+       bigint.probab_prime_p is deprecated, use bigint.probablyPrime instead
+  */
+  deprecated
+  "bigint.probab_prime_p is deprecated, use bigint.probablyPrime instead"
+  proc bigint.probab_prime_p(reps: int) : int {
+    var ret = this.probablyPrime(reps):int;
+    return ret;
+  }
+ 
   // returns 2 if definitely prime, 0 if not prime, 1 if likely prime
   // reasonable number of reps is 15-50
-  proc bigint.probab_prime_p(reps: int) : int {
+  proc bigint.probablyPrime(reps: int) : enum {
+    enum checkPrime {
+      notPrime=0,
+      maybePrime,
+      isPrime
+    };
     var reps_ = reps.safeCast(c_int);
     var ret: c_int;
 
@@ -2970,8 +2987,13 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
       ret = mpz_probab_prime_p(t_.mpz, reps_);
     }
-
-    return ret.safeCast(int);
+    use checkPrime;
+    if ret==0 then
+      return notPrime;
+    else if ret==1 then
+      return maybePrime;
+    else
+      return isPrime;
   }
 
   proc bigint.nextprime(const ref a: bigint) {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2967,15 +2967,15 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     var ret = this.probablyPrime(reps):int;
     return ret;
   }
- 
+  
+  enum primeStatus {
+    notPrime=0,
+    maybePrime,
+    isPrime
+  };
   // returns 2 if definitely prime, 0 if not prime, 1 if likely prime
   // reasonable number of reps is 15-50
   proc bigint.probablyPrime(reps: int) : enum {
-    enum checkPrime {
-      notPrime=0,
-      maybePrime,
-      isPrime
-    };
     var reps_ = reps.safeCast(c_int);
     var ret: c_int;
 
@@ -2987,7 +2987,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
       ret = mpz_probab_prime_p(t_.mpz, reps_);
     }
-    use checkPrime;
+    use primeStatus;
     if ret==0 then
       return notPrime;
     else if ret==1 then

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2968,7 +2968,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     return ret;
   }
   
-  enum primeStatus {
+  enum primality {
     notPrime=0,
     maybePrime,
     isPrime
@@ -2987,7 +2987,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
 
       ret = mpz_probab_prime_p(t_.mpz, reps_);
     }
-    use primeStatus;
+    use primality;
     if ret==0 then
       return notPrime;
     else if ret==1 then

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2967,7 +2967,14 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
     var ret = this.probablyPrime(reps):int;
     return ret;
   }
-  
+
+  /* An enumeration of the different possibilitites of a number being prime, for use with e.g.
+     :proc:`~bigint.probablyPrime` to determine if a number is prime or not.
+
+     - ``primality.notPrime`` indicates that the number is not a prime.
+     - ``primality.maybePrime`` indicates that the number may or may not be a prime.
+     - ``primality.isPrime`` indicates that the number is a prime.
+   */
   enum primality {
     notPrime=0,
     maybePrime,
@@ -2975,7 +2982,7 @@ When ``n/d`` does not produce an integer, this method may produce incorrect resu
   };
   // returns 2 if definitely prime, 0 if not prime, 1 if likely prime
   // reasonable number of reps is 15-50
-  proc bigint.probablyPrime(reps: int) : enum {
+  proc bigint.probablyPrime(reps: int) : primality {
     var reps_ = reps.safeCast(c_int);
     var ret: c_int;
 

--- a/test/deprecated/BigInteger/deprecateProbabPrimeP.chpl
+++ b/test/deprecated/BigInteger/deprecateProbabPrimeP.chpl
@@ -1,0 +1,9 @@
+use BigInteger;
+
+var a = new bigint( 11);
+var b:int = 16;
+var c:int;
+
+c=a.probab_prime_p(b);
+
+writeln(a," is prime since return value is ",c);

--- a/test/deprecated/BigInteger/deprecateProbabPrimeP.good
+++ b/test/deprecated/BigInteger/deprecateProbabPrimeP.good
@@ -1,0 +1,2 @@
+deprecateProbabPrimeP.chpl:7: warning: bigint.probab_prime_p is deprecated, use bigint.probablyPrime instead
+11 is prime since return value is 2

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.chpl
@@ -16,21 +16,22 @@ var e   = new bigint(375);
 // Prime tester
 //
 
-var val = a.probab_prime_p(15);
+var val = a.probablyPrime(15);
 prime_parse(a, val);
 
-val = b.probab_prime_p(15);
+val = b.probablyPrime(15);
 prime_parse(b, val);
 
-val = c.probab_prime_p(50);
+val = c.probablyPrime(50);
 prime_parse(c, val);
 
 writeln();
 
 proc prime_parse(val, isProbPrime) {
-  if isProbPrime == 0 then
+  use primality;
+  if isProbPrime == notPrime then
     writeln(val, " not prime");
-  if isProbPrime == 1 || isProbPrime == 2 then
+  if isProbPrime == maybePrime || isProbPrime == isPrime then
     writeln(val, " prime or probably prime");
 }
 
@@ -95,7 +96,7 @@ writeln();
 // Inverse
 //
 c.set(23);
-val = a.invert(b, c);
+var val2 = a.invert(b, c);
 writeln("the inverse of ", b, " mod ", c, " is ", a);
 
 writeln();


### PR DESCRIPTION
This PR Resolves #17730 and #17706

### Description
* Changed the method name
* Change the return type of method
* Created the required Deprecation Warnings and tests.

### Method Changed:
 * `bigint.probab_prime_p()`



Signed-off-by: tiger-yash <tigeryashraj@gmail.com>