### PR TITLE
fix(makefile): support python 3.10

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -24,34 +24,10 @@ OLD_PYTHON_ERROR="python3 version 3.5 or later is required to install chpldoc an
 #  (to allow for a different path to the system python3 in the future)
 $(CHPL_VENV_VIRTUALENV_DIR_OK):
 	@# First check the python version is OK
-	@case `$(PYTHON) --version` in \
-	  *"Python 3.0"*) \
-	    echo $(OLD_PYTHON_ERROR) ; \
-            exit 1 ; \
-	    ;; \
-	  *"Python 3.1"*) \
-	    echo $(OLD_PYTHON_ERROR) ; \
-            exit 1 ; \
-	    ;; \
-	  *"Python 3.2"*) \
-	    echo $(OLD_PYTHON_ERROR) ; \
-            exit 1 ; \
-	    ;; \
-	  *"Python 3.3"*) \
-	    echo $(OLD_PYTHON_ERROR) ; \
-            exit 1 ; \
-	    ;; \
-	  *"Python 3.4"*) \
-	    echo $(OLD_PYTHON_ERROR) ; \
-            exit 1 ; \
-	    ;; \
-	  *"Python 3"*) \
-	    ;; \
-	  *) \
-	    echo $(OLD_PYTHON_ERROR) ; \
-            exit 1 ; \
-	    ;; \
-	esac
+	@if $(PYTHON) -c 'import sys; sys.exit(int(sys.version_info[:2] >= (3, 5)))'; then \
+	  echo $(OLD_PYTHON_ERROR); \
+	  exit 1; \
+	fi
 
 	@# Now create the venv to use to get the dependencies
 	$(PYTHON) -m venv $(CHPL_VENV_VIRTUALENV_DIR)


### PR DESCRIPTION
This fixes a bug detecting the current Python version, noticed when building with Python 3.10 in https://github.com/Homebrew/homebrew-core/pull/90708

Before:

```console
$ make -C third-party/chpl-venv test-venv PYTHON=python3.10
python3 version 3.5 or later is required to install chpldoc and start_test dependencies. See https://www.python.org/
```

After:

```console
$ make -C third-party/chpl-venv test-venv PYTHON=python3.10
...
Successfully installed ...
```