### PR TITLE
Simplify locale setup barrier

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -626,16 +626,21 @@ module ChapelLocale {
     // initialization (e.g., rootLocale).
     iter chpl_initOnLocales(param tag: iterKind)
       where tag==iterKind.standalone {
-      // Simple locales barrier, see implementation below for notes
-      var b: localesBarrier;
-      var flags: [1..#numLocales-1] unmanaged localesSignal?;
-      coforall locIdx in 0..#numLocales /*ref(b)*/ {
+      // Split into 2 coforalls to barrier after the yield. Ideally, we would
+      // just use a real barrier, but `chpl_comm_barrier` is in use and other
+      // custom barriers have been non-scalable in the past.
+      coforall locIdx in 0..#numLocales {
         on __primitive("chpl_on_locale_num",
                        chpl_buildLocaleID(locIdx:chpl_nodeID_t,
                                           c_sublocid_any)) {
           chpl_defaultDistInitPrivate();
           yield locIdx;
-          b.wait(locIdx, flags);
+        }
+      } // Relying on barrier at join, do NOT fuse these loops
+      coforall locIdx in 0..#numLocales  {
+        on __primitive("chpl_on_locale_num",
+                       chpl_buildLocaleID(locIdx:chpl_nodeID_t,
+                                          c_sublocid_any)) {
           chpl_rootLocaleInitPrivate(locIdx);
           chpl_defaultLocaleInitPrivate();
           chpl_singletonCurrentLocaleInitPrivate(locIdx);
@@ -657,70 +662,6 @@ module ChapelLocale {
       c_free(p);
     }
   }
-
-  //
-  // Simple locales barrier
-  //
-  // This sits outside of the abstract root locale definition above
-  // because the compiler cannot resolve the constructor (known issues
-  // with nested classes/records).  In addition, we cannot have the
-  // flags array in the record, because the initCopy function needs
-  // the dataPar* configs declared in ChapelDistribution.
-  //
-  // Each non-0 locale increments the count, and then waits on a
-  // *local* atomic.  This is done by creating an array of type
-  // class localesSignal, one per locale, and allocating each locale's
-  // copy before updating the count.  Locale 0 waits for the others to
-  // arrive and then set the signals to true.  We can't do anything
-  // too complicated this early on, so we are using a for loop to
-  // broadcast that we are done.
-  pragma "no doc"
-  class localesSignal {
-    var s: atomic bool;
-
-    // Override default initializer; this could go away when the
-    // compiler's default initializer creates a version that takes a
-    // bool rather than an 'atomic bool' (which generates a
-    // '--warn-unstable' warning otherwise)
-    proc init() {
-    }
-  }
-  pragma "no doc"
-  record localesBarrier {
-    proc wait(locIdx, flags) {
-      if locIdx==0 {
-        // locale 0 has nothing else to do, so check flags
-        while (true) {
-          // This fence ensures that writes to the count variables
-          // are available to this task. (Note that they aren't
-          // atomic if they're 128-bit writes though - so we
-          // have some risk of getting part of a wide pointer).
-          // Without this fence, there is a race condition on
-          // a weakly-ordered architecture.
-          atomicFence();
-          var count = 0;
-          for f in flags do
-            if f then count += 1;
-          if count==numLocales-1 then break;
-          // Give time to other tasks/threads/processes
-          // like we do in waitFor
-          chpl_task_yield();
-        }
-        // Let the others go
-        for f in flags do
-          f!.s.testAndSet();
-      } else {
-        var f = new unmanaged localesSignal();
-        // expose my flag to locale 0
-        flags[locIdx] = f;
-        // wait (locally) for locale 0 to set my flag
-        f.s.waitFor(true);
-        // clean up
-        delete f;
-      }
-    }
-  }
-
 
   // This function is called in the LocaleArray module to initialize
   // the rootLocale.  It sets up the origRootLocale and also includes

--- a/test/functions/operatorOverloads/operatorMethods/genericsInstantiationBad.good
+++ b/test/functions/operatorOverloads/operatorMethods/genericsInstantiationBad.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:N: note: is passed to formal 'a: nil
 genericsInstantiationBad.chpl:N: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:N: note:   ==(a: bool, b: bool)
 $CHPL_HOME/modules/internal/ChapelBase.chpl:N: note:   ==(a: borrowed object?, b: borrowed object?)
-note: and 87 other candidates, use --print-all-candidates to see them
+note: and 86 other candidates, use --print-all-candidates to see them

--- a/test/modules/sungeun/init/printInitCommCounts.good
+++ b/test/modules/sungeun/init/printInitCommCounts.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 13, put = 3, execute_on_fast = 6) (get = 13, put = 3, execute_on_fast = 6) (get = 13, put = 3, execute_on_fast = 6) (get = 13, put = 3, execute_on_fast = 6)
+(execute_on_fast = 4, execute_on_nb = 8) (get = 10, put = 1, execute_on_fast = 7) (get = 10, put = 1, execute_on_fast = 7) (get = 10, put = 1, execute_on_fast = 7) (get = 10, put = 1, execute_on_fast = 7)

--- a/test/modules/sungeun/init/printInitCommCounts.lm-numa.good
+++ b/test/modules/sungeun/init/printInitCommCounts.lm-numa.good
@@ -1,1 +1,0 @@
-(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 125, put = 3, execute_on_fast = 6) (get = 125, put = 3, execute_on_fast = 6) (get = 125, put = 3, execute_on_fast = 6) (get = 125, put = 3, execute_on_fast = 6)

--- a/test/visibility/except/operatorsExceptions/exceptGreaterThan.good
+++ b/test/visibility/except/operatorsExceptions/exceptGreaterThan.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptGreaterThan.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   >(a: enum, b: enum)
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   >(a: uint(64), b: int(64))
-note: and 64 other candidates, use --print-all-candidates to see them
+note: and 63 other candidates, use --print-all-candidates to see them

--- a/test/visibility/except/operatorsExceptions/exceptGreaterThanOrEqual.good
+++ b/test/visibility/except/operatorsExceptions/exceptGreaterThanOrEqual.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptGreaterThanOrEqual.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   >=(a: enum, b: enum)
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   >=(a: uint(64), b: int(64))
-note: and 64 other candidates, use --print-all-candidates to see them
+note: and 63 other candidates, use --print-all-candidates to see them

--- a/test/visibility/except/operatorsExceptions/exceptLessThan.good
+++ b/test/visibility/except/operatorsExceptions/exceptLessThan.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptLessThan.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   <(a: enum, b: enum)
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   <(a: uint(64), b: int(64))
-note: and 64 other candidates, use --print-all-candidates to see them
+note: and 63 other candidates, use --print-all-candidates to see them

--- a/test/visibility/except/operatorsExceptions/exceptLessThanOrEqual.good
+++ b/test/visibility/except/operatorsExceptions/exceptLessThanOrEqual.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptLessThanOrEqual.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   <=(a: enum, b: enum)
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   <=(a: uint(64), b: int(64))
-note: and 64 other candidates, use --print-all-candidates to see them
+note: and 63 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
We need to barrier while setting up locale data structures. Previously,
we were doing this with a custom barrier added in 340ce913d6. The
barrier was not highly optimized partially due to being called early in
startup when not all features are available, and we couldn't just use
`chpl_comm_barrier` since it's already in use. This barrier was also
racey because it PUT wide class pointers to locale 0 while locale 0 was
reading to see if the classes are non-nil. I don't know that this has
bitten us in the past, but it's wasn't ideal.

Instead of trying to free up `chpl_comm_barrier()` (which would be nice
but has not been easy) or trying to improve the existing barrier, just
change the callsite to use 2 coforall+ons and rely on the implicit
barrier at join. This adds an extra coforall+on, but that pattern is
already highly optimized since it's used all over. A comm barrier may
ultimately be a little more efficient, but this approach is much faster
at least on platforms that don't support network atomics. Here's 512
node XC timings for `helpSetupRootLocaleFlat()`:

| Config                 | Before | After |
| ---------------------- | -----: | ----: |
| --network-atomics=ugni | 0.09s  | 0.09s |
| --network-atomics=none | 4.13s  | 0.09s |

I'm actually quite surprised how slow the processor atomic version was
before. I suspect this is mostly due to the `testAndSet` used to release
remote nodes being serial and blocking (and creating a remote task since
it's fetching), but I'm still surprised by just how much overhead that
adds. We could have changed the `testAndSet` to a `write` since the
result isn't used or performed the updates in parallel, but I don't
expect any of those to be any faster. This new version seems plenty fast
and gets rid of some crufty and racey code.