### PR TITLE
compiler/next: Turn Context debug tracing off

### DIFF
--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -96,7 +96,7 @@ class Context {
 
   querydetail::RevisionNumber currentRevisionNumber = 1;
   bool checkStringsAlreadyMarked = false;
-  bool enableDebugTracing = true;
+  bool enableDebugTracing = false;
   bool breakSet = false;
   size_t breakOnHash = 0;
   int numQueriesRunThisRevision_ = 0;


### PR DESCRIPTION
Accidentally enabled it in PR #18839

Trivial and not reviewed.