### PR TITLE
re-order evaluation in scopeResolve, fixes some parse bugs

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -584,18 +584,18 @@ static std::set<std::string> allowedInternalModules = {
   "Bytes",
   "BytesCasts",
   "BytesStringCommon",
-  /*"ChapelArray",*/                  // Prim call with named args.
+  /*"ChapelArray",*/             // Prim call with named args.
   "ChapelAutoAggregation",
   "ChapelAutoLocalAccess",
   "ChapelBase",
   "ChapelComplex_forDocs",
   "ChapelDebugPrint",
-  /*"ChapelDistribution",*/           // Segfault somewhere...
+  /*"ChapelDistribution",*/      // Segfault somewhere...
   "ChapelHashing",
-  /*"ChapelHashtable",*/              // Problem: 'chpl__hashtable.init'
+  "ChapelHashtable",
   "ChapelIOStringifyHelper",
   "ChapelIteratorSupport",
-  /*"ChapelLocale",*/                 // Return lifetime?
+  /*"ChapelLocale",*/            //ChapelLocale.chpl:531 not implemented yet
   "ChapelLocks",
   "ChapelNumLocales",
   "ChapelPrivatization",
@@ -603,9 +603,9 @@ static std::set<std::string> allowedInternalModules = {
   "ChapelReduce",
   "ChapelSerializedBroadcast",
   "ChapelStandard",
-  /*"ChapelSyncvar",*/                // Lifetimes.
+  /*"ChapelSyncvar",*/           // Lifetimes.
   "ChapelTaskData",
-  /*"ChapelTaskDataHelp",*/           // Argument incompatible.
+  "ChapelTaskDataHelp",
   "ChapelTaskID",
   "ChapelThreads",
   "ChapelTuple",
@@ -626,13 +626,13 @@ static std::set<std::string> allowedInternalModules = {
   "LocaleModelHelpSetup",
   "LocalesArray",
   "LocaleTree",
-  /*"MemConsistency",*/               // Redefinition of a function...
+  /*"MemConsistency",*/          // Redefinition of a function...
   "MemTracking",
   "NetworkAtomics",
   "NetworkAtomicTypes",
-  /*"OwnedObject",*/                  // Compiler crash.
+  "OwnedObject",
   "PrintModuleInitOrder",
-  /*"SharedObject",*/                 // Compiler crash.
+  "SharedObject",
   "startInitCommDiags",
   "stopInitCommDiags",
   "String",

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1859,7 +1859,7 @@ static void lookup(const char*           name,
           lookup(name, context, standardModule->block, visited, symbols,
                  renameLocs, storeRenames, reexportPts);
           if (symbols.size() == 0) {
-            
+
             lookup(name, context, theProgram->block, visited, symbols,
                    renameLocs, storeRenames, reexportPts);
           }
@@ -2637,18 +2637,19 @@ static ModuleSymbol* definesModuleSymbol(Expr* expr) {
 // Find 'unmanaged SomeClass' and 'borrowed SomeClass' and replace these
 // with the compiler's simpler representation (canonical type or unmanaged type)
 void resolveUnmanagedBorrows(CallExpr* call) {
-  if (isClassDecoratorPrimitive(call)) {
 
-    // Give up now if the actual is missing.
-    if (call->numActuals() < 1)
-      return;
+  // Give up now if the actual is missing.
+  if (call->numActuals() < 1)
+    return;
 
-    // Make sure to handle nested calls appropriately
-    if (CallExpr* sub = toCallExpr(call->get(1))) {
-      if (isClassDecoratorPrimitive(sub)) {
-        resolveUnmanagedBorrows(sub);
-      }
+  // Make sure to handle nested calls appropriately
+  if (CallExpr* sub = toCallExpr(call->get(1))) {
+    if (isClassDecoratorPrimitive(sub)) {
+      resolveUnmanagedBorrows(sub);
     }
+  }
+
+  if (isClassDecoratorPrimitive(call)) {
 
     SymExpr* typeSymbolSe = NULL;
     if (SymExpr* se = toSymExpr(call->get(1))) {
@@ -2910,7 +2911,7 @@ static bool readNamedArgument(CallExpr* call, const char* name,
   bool ret = defaultValue;
   expectedNames.push_back((std::string)name);
 
-  for (int i = 1; i<= call->numActuals(); i++) { 
+  for (int i = 1; i<= call->numActuals(); i++) {
     NamedExpr* ne = toNamedExpr(call->get(i));
     if (ne && !strcmp(ne->name, name)) {
       SymExpr* se = toSymExpr(ne->actual);
@@ -3016,7 +3017,7 @@ static void processGetVisibleSymbols() {
             continue;
 
           printf("  %s:%d: %s\n", sym->defPoint->fname(),
-                 sym->defPoint->linenum(), sym->name); 
+                 sym->defPoint->linenum(), sym->name);
         }
 
         delete visibleMap[it->c_str()];


### PR DESCRIPTION
This PR fixes a small bug in the compiler's scope resolution pass
which caused some internal modules to fail to compile when using
the `--compiler-library-parser` flag to build various primers.

Initially, this started as an investigation into why parsing 
`ChapelHashtable.chpl` would fail to compile after converting 
the uast.  It is a happy coincidence that this change also fixed 
issues with parsing `ChapelTaskDataHelp`, `OwnedObject`, 
and `SharedObject`.

TESTING:
- [x] full paratest
- [x] `chpl` primer tests pass with `--compiler-library-parser`

Reviewed by @mppf

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>