### PR TITLE
Prevent an infinite recursion in compiler/next

### DIFF
--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -480,7 +480,9 @@ class PoiScope {
     ss << "PoiScope ";
     inScope()->stringify(ss,stringKind);
     ss << " ";
-    inFnPoi()->stringify(ss, stringKind);
+    if (inFnPoi() != this) {
+      inFnPoi()->stringify(ss, stringKind);
+    }
   }
 };
 


### PR DESCRIPTION
This prevents a potential infinite recursion introduced by https://github.com/chapel-lang/chapel/pull/18877.

The compiler complains about it on darwin with CHPL_DEVELOPER.