### PR TITLE
Fix set add memory leaks by always moving element to value when the element is not serializable

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -274,15 +274,8 @@ module Set {
       var result = false;
 
       on this {
-
-        // TODO: The following variation gets lifetime errors in
-        // '.../Set/types/testNilableTuple.chpl':
-        //
-        // var moved = moveToValue(elem);
-        // var (isFullSlot, idx) = _htb.findAvailableSlot(moved);
-        //
-        var (isFullSlot, idx) = _htb.findAvailableSlot(elem);
         var moved = moveToValue(elem);
+        var (isFullSlot, idx) = _htb.findAvailableSlot(moved);
 
         if !isFullSlot {
           _htb.fillSlot(idx, moved, none);

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -282,9 +282,9 @@ module Set {
         // var (isFullSlot, idx) = _htb.findAvailableSlot(moved);
         //
         var (isFullSlot, idx) = _htb.findAvailableSlot(elem);
+        var moved = moveToValue(elem);
 
         if !isFullSlot {
-          var moved = moveToValue(elem);
           _htb.fillSlot(idx, moved, none);
           result = true;
         }


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/18842 a memory leak was uncovered in the Set module `add()` function. The underlying cause was that the element was being taken with an `in` intent and then never being moved to a value if the element already existed in the table, which seems to have been causing the value to not being cleaned up when it is a string in a record.