### PR TITLE
Avoid an assert in chpl-cache.c during runtime init

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -3610,7 +3610,11 @@ static
 chpl_cache_taskPrvData_t* task_private_cache_data(void)
 {
   chpl_task_infoRuntime_t* infoRuntime = chpl_task_getInfoRuntime();
-  assert(infoRuntime);
+
+  // propagate NULL to caller if we run in to it
+  if (infoRuntime == NULL)
+    return NULL;
+
   return &infoRuntime->comm_data.cache_data;
 }
 


### PR DESCRIPTION
Follow-up to PRs #18800 and #18802.

This PR removes an assert that I observed us hitting when working with local gasnet configurations.

Reviewed by @ronawho - thanks!

- [x] full gasnet testing