### PR TITLE
Update packages relied upon by chpldoc for Python 3.10 compatibility

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-from distutils.spawn import find_executable
+from shutil import which
 
 import os
 
 chplPath = os.path.join(os.environ['CHPL_HOME'], "bin", os.environ['CHPL_HOST_BIN_SUBDIR'])
 
-if find_executable("protoc") is not None and find_executable("protoc-gen-chpl", path=chplPath) is not None:
+if which("protoc") is not None and which("protoc-gen-chpl", path=chplPath) is not None:
     print(False)
 else:
     print(True)

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -6,4 +6,4 @@ docutils==0.16.0
 sphinx-rtd-theme==0.5.2
 sphinxcontrib-chapeldomain==0.0.20
 babel==2.9.1
-breathe==4.30.0
+breathe==4.31.0

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==3.0.1
 MarkupSafe==2.0.1
 Pygments==2.9.0
-Sphinx==4.0.2
+Sphinx==4.3.2
 docutils==0.16.0
 sphinx-rtd-theme==0.5.2
 sphinxcontrib-chapeldomain==0.0.20

--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -4,6 +4,6 @@ Pygments==2.9.0
 Sphinx==4.3.2
 docutils==0.16.0
 sphinx-rtd-theme==0.5.2
-sphinxcontrib-chapeldomain==0.0.20
+sphinxcontrib-chapeldomain==0.0.21
 babel==2.9.1
 breathe==4.31.0


### PR DESCRIPTION
Older versions of Sphinx were having problems with Python 3.10 as
pointed out by the homebrew developers.  This version of Sphinx
includes changes to fix that.

As a result of the Sphinx update, breathe and the Chapel Sphinx domain
also needed to be updated.

While here, I also noticed that a skipif in the protobuf test directory was not
Python 3.10 compatible, so I updated it to work in both 3.10 and 3.6

TODO:
- [x] include new Sphinx domain updates when new release is pushed
- [x] retest test/chpldoc with this change (with both Python 3.10 and nightly python)