### PR TITLE
Update setuptools version for Arkouda install

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==5.4.1
 filelock==3.0.12
 argcomplete==1.12.3
+setuptools==60.0.2


### PR DESCRIPTION
The `setuptools` package has now caused some of our testing to fail 2 nights in a row for unrelated reasons. This PR hardcodes the version to one that we know works for our testing. This is not a good long-term solution, but will hopefully prevent any further occurrences of this over break.

We tested a run of `make docs` to make sure that it didn't break anything else, and it seemed to be good. Restarting the failing testing to make sure that it comes back clean.