### PR TITLE
Update setuptools version requirement to 59.6.0

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==5.4.1
 filelock==3.0.12
 argcomplete==1.12.3
-setuptools==60.0.2
+setuptools==59.6.0


### PR DESCRIPTION
The requirement of 60.0.2 that I added in https://github.com/chapel-lang/chapel/pull/18895 is only available for Python 3.7 and some of our testing is still using Python 3.6, so they were not able to install that dependency.

I have tested that this works with the Arkouda install and that I am able to install 59.6.0 with Python 3.6.