### PR TITLE
Update setuptools version to 54.0.0

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==5.4.1
 filelock==3.0.12
 argcomplete==1.12.3
-setuptools==59.6.0
+setuptools==54.0.0


### PR DESCRIPTION
After merging https://github.com/chapel-lang/chapel/pull/18898, we had another failure specific to that version that slipped through my local testing because I was using the wrong version of Python3 to test the Arkouda build. I am now more confident that this version will work with all testing.

- [x] install Arkouda deps (Python 3.7.9)
- [x] makes docs (Python 3.7.9, Python 3.6.10)