### PR TITLE
Fix deprecation failure with `--baseline`

### DIFF
--- a/test/deprecated/BigInteger/deprecateDivisible2expP.chpl
+++ b/test/deprecated/BigInteger/deprecateDivisible2expP.chpl
@@ -1,7 +1,7 @@
 use BigInteger;
 
 var a = new bigint(20);
-var b:integral;
+var b:int;
 b=2;
 
 var c:int=a.divisible_2exp_p(b=b);


### PR DESCRIPTION
I had missed that one of the variables in the test was declared as `integral`
(a generic type) rather than `int`.  This caused problems when compiling with
`--baseline` and isn't essential to the functionality of the test, so fix it.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>