### PR TITLE
Add a constraints file to arkouda testing itself for now

### DIFF
--- a/test/studies/arkouda/constraints.txt
+++ b/test/studies/arkouda/constraints.txt
@@ -1,0 +1,1 @@
+setuptools==54.0.0

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -64,7 +64,7 @@ fi
 export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
 # If Arkouda deps use any of our test deps, try to use the versions we want
 AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user ; then
+if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user --constraint constraints.txt; then
   log_fatal_error "installing arkouda"
 fi
 

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -64,7 +64,7 @@ fi
 export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
 # If Arkouda deps use any of our test deps, try to use the versions we want
 AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user --constraint constraints.txt; then
+if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user --constraint ../constraints.txt; then
   log_fatal_error "installing arkouda"
 fi
 


### PR DESCRIPTION
This is a hotfix for not having previously pinned setuptools versions.  Release
arkouda testing will not otherwise respond to changes to version numbers.  We
should remove this hotfix in the future.

Adds a constraints file to the arkouda testing directory, and uses it when
installing python testing requirements to explicitly limit which version of
setuptools is used.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>