### PR TITLE
Enable slice serialization by default

### DIFF
--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -27,7 +27,7 @@ module ArrayViewSlice {
   private use ChapelStandard;
 
   config param chpl_debugSerializeSlice = false,
-               chpl_serializeSlices = false;
+               chpl_serializeSlices = true;
 
   private proc buildIndexCacheHelper(arr, dom) {
     param isRankChangeReindex = arr.isRankChangeArrayView() ||


### PR DESCRIPTION
This slice enables slice serialization by default.

This has to go in after https://github.com/chapel-lang/chapel/pull/18881.

That PR does the necessary compiler and module work so switching this flag
does not cause performance degradation in cases where slices are used in 
promoted expressions.