### PR TITLE
Clean up uses of `pthread_once()` in the runtime.

### DIFF
--- a/runtime/src/chpl-tasks.c
+++ b/runtime/src/chpl-tasks.c
@@ -215,20 +215,17 @@ size_t chpl_task_getDefaultCallStackSize(void)
 // Support for task reporting on ^C.
 //
 static pthread_once_t taskReportOnce = PTHREAD_ONCE_INIT;
-static chpl_bool taskReportIsSet = false;
 static chpl_bool taskReport;
 
 static void init_taskReport(void);
 
 chpl_bool chpl_task_doTaskReport(void) {
-  if (!taskReportIsSet
-      && pthread_once(&taskReportOnce, init_taskReport) != 0) {
+  if (pthread_once(&taskReportOnce, init_taskReport) != 0) {
     chpl_internal_error("pthread_once(&taskReportOnce) failed");
   }
   return taskReport;
 }
 
 static void init_taskReport(void) {
-  taskReportIsSet = true;
   taskReport = chpl_env_rt_get_bool("ENABLE_TASK_REPORTING", false);
 }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -25,6 +25,7 @@
 #include "chplrt.h"
 #include "chpl-env-gen.h"
 
+#include "chpl-atomics.h"
 #include "chpl-comm.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"

--- a/runtime/src/comm/ugni/comm-ugni-heap-pages.c
+++ b/runtime/src/comm/ugni/comm-ugni-heap-pages.c
@@ -83,8 +83,7 @@ void set_hps(void)
 
 
 size_t chpl_comm_ugni_getHeapPageSize(void) {
-  if (hps == 0
-      && pthread_once(&hps_once, set_hps) != 0) {
+  if (pthread_once(&hps_once, set_hps) != 0) {
     chpl_internal_error("pthread_once(&hps_once) failed");
   }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -518,12 +518,10 @@ static gni_nic_device_t nic_type;
 // and from other areas by bouncing them through buffers in registered
 // memory.
 //
-static int registered_heap_info_set;
 static pthread_once_t registered_heap_once_flag = PTHREAD_ONCE_INIT;
 static size_t registered_heap_size;
 static void*  registered_heap_start;
 
-static int hugepage_info_set;
 static pthread_once_t hugepage_once_flag = PTHREAD_ONCE_INIT;
 static size_t hugepage_size;
 
@@ -2981,8 +2979,7 @@ void chpl_comm_rollcall(void)
 static
 void ensure_registered_heap_info_set(void)
 {
-  if (!registered_heap_info_set
-      && pthread_once(&registered_heap_once_flag, make_registered_heap) != 0) {
+  if (pthread_once(&registered_heap_once_flag, make_registered_heap) != 0) {
     CHPL_INTERNAL_ERROR("pthread_once(&registered_heap_once_flag) failed");
   }
 }
@@ -2999,8 +2996,6 @@ void make_registered_heap(void)
       || (size_from_env = chpl_comm_getenvMaxHeapSize()) <= 0) {
     registered_heap_size  = 0;
     registered_heap_start = NULL;
-    registered_heap_info_set = 1;
-    chpl_atomic_thread_fence(memory_order_release);
     return;
   }
 
@@ -3099,16 +3094,13 @@ void make_registered_heap(void)
 
   registered_heap_size  = size;
   registered_heap_start = start;
-  registered_heap_info_set = 1;
-  chpl_atomic_thread_fence(memory_order_release);
 }
 
 
 static inline
 size_t get_hugepage_size(void)
 {
-  if (!hugepage_info_set
-      && pthread_once(&hugepage_once_flag, set_hugepage_info) != 0) {
+  if (pthread_once(&hugepage_once_flag, set_hugepage_info) != 0) {
     CHPL_INTERNAL_ERROR("pthread_once(&hugepage_once_flag) failed");
   }
 
@@ -3138,9 +3130,6 @@ void set_hugepage_info(void)
       install_SIGBUS_handler();
     }
   }
-
-  hugepage_info_set = 1;
-  chpl_atomic_thread_fence(memory_order_release);
 
   DBG_P_L(DBGF_HUGEPAGES,
           "setting hugepage info: use hugepages %s, sz %#zx",


### PR DESCRIPTION
We use `pthread_once()` in a number of places in the runtime.  In some
cases we've been guarding it with a boolean so as to avoid calling it
when we could tell we had already done so.  But in at least one of those
cases we mis-coded the guard, setting it and then assigning the set-once
value, in that order, rather than assigning the set-once value, then
doing a fence, then setting the guard.  In addition, examining at least
the glibc `nptl` version of `pthread_once()` that we use on Linux systems
shows that it effectively does the same thing, using fast-path control
flow to avoid any locking when the called-once function is known to have
completed already.  It seems likely that other implementations would do
similarly.  Therefore here, remove all our guards on `pthread_once()`
calls.