### PR TITLE
produce error when CHPL_LOCALE_MODEL=gpu and CHPL_COMM != none

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2693,6 +2693,11 @@ void codegen() {
       while (wait(&status) != pid) {
         // wait for child process
       }
+      // If there was an error in GPU code generation then the .fatbin file (containing
+      // the generated GPU code) was not created and we won't be able to continue.
+      if(status != 0) {
+        clean_exit(status);
+      }
     }
   }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1671,6 +1671,10 @@ static void postprocess_args() {
 // errors rather than doing what the user said (for which these
 // checks don't apply because we're not going to compile anything).
 //
+// NOTE: Before adding something here consider whether you should add it into
+// printchplenv.py instead. If placed there then you'll get the check
+// both at runtime (because we end up calling printchplenv) but also when
+// building the Chapel compiler itself.
 static void validateSettings() {
   checkNotLibraryAndMinimalModules();
 

--- a/test/gpu/native/environment/gasnet.chpl
+++ b/test/gpu/native/environment/gasnet.chpl
@@ -1,0 +1,2 @@
+// We don't actually have a program to compile. Just want to ensure that
+// if CHPL_LOCALE_MODEL == gpu and CHPL_COMM != none we error out.

--- a/test/gpu/native/environment/gasnet.compopts
+++ b/test/gpu/native/environment/gasnet.compopts
@@ -1,0 +1,1 @@
+--comm gasnet

--- a/test/gpu/native/environment/gasnet.good
+++ b/test/gpu/native/environment/gasnet.good
@@ -1,0 +1,2 @@
+Error: The prototype GPU support does not work when CHPL_COMM is not set to
+"none".

--- a/test/gpu/native/environment/gasnet.prediff
+++ b/test/gpu/native/environment/gasnet.prediff
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+testname=$1
+outfile=$2
+
+tmpfile=$outfile.prediff.tmp
+grep -e 'Error:' -e 'none' $outfile > $tmpfile
+mv $tmpfile $outfile

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -1,6 +1,7 @@
 import utils
 import os
 import chpl_locale_model
+from utils import error
 
 def get():
     if chpl_locale_model.get() == 'gpu':
@@ -21,3 +22,8 @@ def get_cuda_path():
         return chpl_cuda_path
     else:
         return ""
+
+def validate(chplLocaleModel, chplComm):
+    if chplLocaleModel == 'gpu' and chplComm != "none":
+        error("The prototype GPU support does not work when CHPL_COMM is not set to\n\"none\".");
+

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -44,6 +44,7 @@ from functools import partial
 import optparse
 import os
 from sys import stdout, path
+from utils import error
 
 from chplenv import *
 
@@ -210,6 +211,11 @@ def compute_all_values():
     chpl_arch.validate('target')
     chpl_llvm.validate_llvm_config()
     chpl_compiler.validate_compiler_settings()
+
+    if ENV_VALS['CHPL_LOCALE_MODEL'] == 'gpu' and \
+       ENV_VALS['CHPL_COMM'] != "none":
+        error("The prototype GPU support does not work when CHPL_COMM is not set to\n\"none\".");
+
 
 """Compute '--internal' env var values and populate global dict, ENV_VALS"""
 def compute_internal_values():

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -44,7 +44,6 @@ from functools import partial
 import optparse
 import os
 from sys import stdout, path
-from utils import error
 
 from chplenv import *
 
@@ -211,11 +210,7 @@ def compute_all_values():
     chpl_arch.validate('target')
     chpl_llvm.validate_llvm_config()
     chpl_compiler.validate_compiler_settings()
-
-    if ENV_VALS['CHPL_LOCALE_MODEL'] == 'gpu' and \
-       ENV_VALS['CHPL_COMM'] != "none":
-        error("The prototype GPU support does not work when CHPL_COMM is not set to\n\"none\".");
-
+    chpl_gpu.validate(ENV_VALS['CHPL_LOCALE_MODEL'], ENV_VALS['CHPL_COMM'])
 
 """Compute '--internal' env var values and populate global dict, ENV_VALS"""
 def compute_internal_values():


### PR DESCRIPTION
This is for: https://github.com/chapel-lang/chapel/issues/18858

As shown here: #18850 GPU code generation does not work if CHPL_COMM is something other than none.

As of the release if you do this you'll get a confusing error message about a missing fatbin file at runtime. Ultimately we'll want to support this combination but it seems worth producing a nice error message in the meantime.

This PR also modifies things so if the "GPU code generation process" that we fork off from the main process encounters an error we stop the main process once we join back (otherwise we'll always get an additional error about a missing `.fatbin` file when the GPU thread encounters an issue)