### PR TITLE
compiler/next linter

### DIFF
--- a/compiler/next/include/chpl/queries/ErrorMessage.h
+++ b/compiler/next/include/chpl/queries/ErrorMessage.h
@@ -79,9 +79,11 @@ class ErrorMessage final {
   const std::vector<ErrorMessage>& details() const { return details_; }
 
   inline bool operator==(const ErrorMessage& other) const {
-    return this->level_ == other.level_ &&
-           this->location_ == other.location_ &&
-           this->message_ == other.message_;
+    return level_ == other.level_ &&
+           location_ == other.location_ &&
+           message_ == other.message_ &&
+           details_ == other.details_ &&
+           id_ == other.id_;
   }
   inline bool operator!=(const ErrorMessage& other) const {
     return !(*this == other);

--- a/compiler/next/include/chpl/queries/ID.h
+++ b/compiler/next/include/chpl/queries/ID.h
@@ -130,6 +130,7 @@ class ID final {
   int compare(const ID& other) const;
 
   bool operator==(const ID& other) const {
+    (void)numChildIds_; // quiet nextLinter
     return symbolPath_ == other.symbolPath_ &&
           postOrderId_ == other.postOrderId_;
   }
@@ -156,6 +157,7 @@ class ID final {
   }
 
   size_t hash() const {
+    (void)numChildIds_; // quiet nextLinter
     std::hash<int> hasher;
     return hash_combine(symbolPath_.hash(), hasher(postOrderId_));
   }

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -253,7 +253,8 @@ class Scope {
            containsUseImport_ == other.containsUseImport_ &&
            containsFunctionDecls_ == other.containsFunctionDecls_ &&
            id_ == other.id_ &&
-           declared_ == other.declared_;
+           declared_ == other.declared_ &&
+           name_ == other.name_;
   }
   bool operator!=(const Scope& other) const {
     return !(*this == other);
@@ -346,7 +347,8 @@ class VisibilitySymbols {
   bool operator==(const VisibilitySymbols &other) const {
     return symbolId_ == other.symbolId_ &&
            kind_ == other.kind_ &&
-           names_ == other.names_;
+           names_ == other.names_ &&
+           isPrivate_ == other.isPrivate_;
   }
   bool operator!=(const VisibilitySymbols& other) const {
     return !(*this == other);
@@ -356,9 +358,11 @@ class VisibilitySymbols {
     symbolId_.swap(other.symbolId_);
     std::swap(kind_, other.kind_);
     names_.swap(other.names_);
+    std::swap(isPrivate_, isPrivate_);
   }
 
   void mark(Context* context) const {
+    symbolId_.mark(context);
     for (auto p : names_) {
       p.first.mark(context);
       p.second.mark(context);

--- a/compiler/next/include/chpl/types/Param.h
+++ b/compiler/next/include/chpl/types/Param.h
@@ -124,6 +124,7 @@ class Param {
   }
 
   bool operator==(const Param& other) const {
+    (void)tag_;  // quiet nextLinter
     return completeMatch(&other);
   }
   bool operator!=(const Param& other) const {

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -82,6 +82,7 @@ class Type {
   }
 
   bool operator==(const Type& other) const {
+    (void)tag_;  // quiet nextLinter
     return completeMatch(&other);
   }
   bool operator!=(const Type& other) const {

--- a/util/devel/nextLinter
+++ b/util/devel/nextLinter
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+
+import subprocess
+import json
+from pathlib import Path
+from collections import defaultdict
+from functools import partial, cache
+import sys
+import multiprocessing
+import itertools
+import re
+
+log = partial(print, file=sys.stderr)
+
+methods_of_interest = {'operator==', 'mark', 'update', 'swap', 'hash'}
+include_dirs = ('compiler/next/include', 'compiler/include')
+
+# These types are okay to not be mentioned in a mark function because they are primitives, enums, etc.
+mark_ignore_type = {
+    'bool',
+    'int',
+
+    'std::string',
+
+    'chpl::resolution::InnermostMatch::MatchesFound',
+    'chpl::resolution::TypedFnSignature::WhereClauseResult',
+    'chpl::resolution::VisibilitySymbols::Kind',
+
+    'chpl::types::paramtags::ParamTag',
+    'chpl::types::typetags::TypeTag',
+
+    'uast::Function::Kind',
+    'uast::asttags::ASTTag',
+    'uast::Function::ReturnIntent',
+}
+
+klass_ignore_set = {
+    'basic_istringstream',
+    'basic_ostringstream',
+    'basic_stringbuf',
+    'basic_stringstream',
+}
+
+
+def files_changed(to='main'):
+    def run(args):
+        return subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+
+    proc = run(['git', 'diff', to, '--name-only'])
+    return set(map(Path, proc.stdout.strip().split('\n')))
+
+# prefer clang++-12 and above
+@cache
+def get_clang():
+    def run(args):
+        return subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+
+    for version in ['-13', '-12', '']:
+        binary = f'clang++{version}'
+        try:
+            proc = run([binary, '--version'])
+        except FileNotFoundError:
+            continue
+        if proc.returncode == 0:
+            version_number = re.search(r'clang version ([^\s]+)', proc.stdout).group(1)
+            log(f'Using {binary}, {version_number} clang++-12 and above is required')
+            return binary
+
+    raise Exception('Could not find a suitable clang++ binary')
+
+def get_ast(filename, includes=include_dirs):
+    args = [get_clang()]
+    for inc in include_dirs:
+        args.append(f'-I{inc}')
+    args.extend(('-Xclang', '-ast-dump=json', '-fsyntax-only', str(filename)))
+
+    log(' '.join(args))
+    proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=True)
+    return json.loads(proc.stdout)
+
+def visit_tree(node, remembering=set(), kind_include=None, kind_exclude=None, ctx=()):
+    assert isinstance(node, dict)
+
+    kind = node.get('kind', 'nokind')
+    if kind in remembering:
+        ctx = ctx + (node,)
+
+    if kind_exclude is not None and kind in kind_exclude:
+        return
+    if kind_include is None:
+        yield node, ctx
+    else:
+        if kind in kind_include:
+            yield node, ctx
+
+    for x in node.get('inner', []):
+        yield from visit_tree(x, remembering, kind_include, kind_exclude, ctx)
+
+def class_defined_in_our_project(node):
+    return ('name' in node and
+            node.get('completeDefinition', False) and
+            ('includedFrom' not in node.get('loc', {}) or
+             node['loc']['includedFrom']['file'].startswith('compiler/next')
+             )
+            )
+
+def parse(filename):
+    ast = get_ast(filename)
+
+    # jsonfile = Path('/tmp') / filename.with_suffix('.json').name
+    # if not jsonfile.exists():
+    #     with open(jsonfile, 'w') as fh:
+    #         json.dump(ast, fh, indent=2)
+
+    methods = defaultdict(lambda: defaultdict(set))
+    fields = defaultdict(dict)
+
+    for node, ctx in visit_tree(ast, kind_include={'CXXMethodDecl'}, remembering={'CXXRecordDecl'}):
+        method_name = node['name']
+        if not ctx:
+            # log('WARN empty context')
+            continue
+        parent = ctx[-1]
+        if not class_defined_in_our_project(parent):
+            continue
+        class_name = parent['name']
+        # log(class_name, method_name)
+
+        for this, ctx in visit_tree(node, kind_include={'CXXThisExpr'}, remembering={'MemberExpr'}):
+            if not ctx:
+                # log('WARN empty context')
+                continue
+            member_expr = ctx[-1]
+            field_name = member_expr['name']
+            # log('  ', field_name)
+
+            methods[class_name][method_name].add(field_name)
+
+    for node, ctx in visit_tree(ast, kind_include={'FieldDecl'}, remembering={'CXXRecordDecl'}):
+        if not ctx:
+            # log('WARN empty context')
+            continue
+        parent = ctx[-1]
+        if not class_defined_in_our_project(parent):
+            continue
+        class_name = parent['name']
+        field_name = node.get('name')
+        if field_name is None:
+            continue
+        # log(parent['name'], node['name'])
+
+        fields[class_name][field_name] = node['type']['qualType']
+
+    return fields, methods
+
+def check_mark(fields, not_mentioned):
+    for k, typ in fields.items():
+        if typ in mark_ignore_type:
+            not_mentioned.discard(k)
+
+def check_file(filename):
+    fields, methods = parse(filename)
+
+    any_bad = False
+
+    errors = []
+
+    for klass in sorted(methods.keys()):
+        if klass.startswith('_') or klass in klass_ignore_set:
+            continue
+
+        log(klass)
+        log('  Fields:')
+        log('\n'.join(f'    {v:<20}:{k}' for k, v in sorted(fields[klass].items())))
+        log('\n  Methods')
+        for method_name in sorted(methods[klass].keys()):
+            if method_name not in methods_of_interest:
+                continue
+            mentioned = methods[klass][method_name]
+            not_mentioned = set(fields[klass].keys()) - mentioned
+            if method_name == 'mark':
+                check_mark(fields[klass], not_mentioned)
+            log('  ', method_name, ' '.join(sorted(mentioned)))
+            if not_mentioned:
+                any_bad = True
+                errors.append((klass, method_name, tuple(sorted('{}:{}'.format(k, fields[klass][k]) for k in not_mentioned))))
+        log()
+
+    return errors
+
+def check_file_wrapper(filename):
+    try:
+        return check_file(filename)
+    except subprocess.CalledProcessError as e:
+        return e
+
+def main(files, jobs=1):
+    acc = set()
+    failed = []
+    with multiprocessing.Pool(jobs) as pool:
+        for result in pool.imap_unordered(check_file_wrapper, files):
+            if isinstance(result, Exception):
+                failed.append(result)
+            else:
+                for r in result:
+                    acc.add(r)
+
+    return failed, sorted(acc)
+
+if __name__ == '__main__':
+    import argparse
+
+    lib_dir = Path('compiler/next/lib')
+    lib_dirs = ['queries', 'resolution']
+    default_files = list(itertools.chain.from_iterable(
+        (lib_dir / d).glob('*.cpp') for d in lib_dirs
+    ))
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('files', type=Path, nargs='*', help='Files to check', default=default_files)
+    parser.add_argument('--jobs', type=int, default=1)
+    parser.add_argument('--only-changed', action='store_true', default=False, help='Only run on files that are different than your `main` branch')
+    args = parser.parse_args()
+
+    if args.only_changed:
+        next_includes = Path('compiler/next/include')
+        changed_files = files_changed()
+        # Check the cpp files that have changed we would check by default
+        # And also include any header that changed in compiler/next/include
+        args.files = (set(args.files) & changed_files) | {x for x in changed_files if x.is_relative_to(next_includes)}
+
+        if args.files:
+            print('Running on files that are different from main:')
+            for f in args.files:
+                print('  ', f)
+        else:
+            print('No files to work on')
+            sys.exit(0)
+
+    failed, errors = main(args.files, jobs=args.jobs)
+
+    for f in failed:
+        log('WARN failed to process {}'.format(' '.join(f.cmd)))
+
+    if errors:
+        print('ERROR there are {} potentital missing uses'.format(len(errors)))
+        print('{:20} {:10}  {}'.format('class', 'method', 'fields missing'))
+
+        for klass, method, not_mentioned in errors:
+            s = ', '.join(not_mentioned)
+            print(f'{klass:20} {method:10}  {s}')
+
+    elif not failed:
+        print('No errors or failures found')
+
+    code = bool(failed) or bool(errors)
+    sys.exit(code)


### PR DESCRIPTION
This is a linter to help properly implementing some conventions in
compiler/next

It uses the JSON dump of the C++ AST

Currently it flags unused fields in operator==, mark, and hash.

It has an allow-list for unused fields of primitive type (int, enum,
etc) in mark.

It is rather slow (5-10s), consumes plenty of memory (~1G), and requires clang
12+ (I get weird segfaults with 11).

Generally, my thoughts are this is just useful enough to keep around, but not a
great fit to put in our CI yet.
