### PR TITLE
Add missing braces for compiler build error

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -301,7 +301,7 @@ static FnSymbol* functionExists(const char* name,
                                  Type* formalType1,
                                  functionExistsKind kind=FIND_EITHER)
 {
-  return functionExists<1>(name, {formalType1}, kind);
+  return functionExists<1>(name, {{formalType1}}, kind);
 }
 
 static FnSymbol* functionExists(const char* name,
@@ -309,7 +309,7 @@ static FnSymbol* functionExists(const char* name,
                                  Type* formalType2,
                                  functionExistsKind kind=FIND_EITHER)
 {
-  return functionExists<2>(name, {formalType1, formalType2}, kind);
+  return functionExists<2>(name, {{formalType1, formalType2}}, kind);
 }
 
 static FnSymbol* functionExists(const char* name,
@@ -318,7 +318,7 @@ static FnSymbol* functionExists(const char* name,
                                  Type* formalType3,
                                  functionExistsKind kind=FIND_EITHER)
 {
-  return functionExists<3>(name, {formalType1, formalType2, formalType3}, kind);
+  return functionExists<3>(name, {{formalType1, formalType2, formalType3}}, kind);
 }
 
 static FnSymbol* functionExists(const char* name,
@@ -327,7 +327,7 @@ static FnSymbol* functionExists(const char* name,
                                 Type* formalType3,
                                 Type* formalType4,
                                 functionExistsKind kind=FIND_EITHER) {
-  return functionExists<4>(name, {formalType1, formalType2, formalType3, formalType4}, kind);
+  return functionExists<4>(name, {{formalType1, formalType2, formalType3, formalType4}}, kind);
 }
 
 static void fixupAccessor(AggregateType* ct, Symbol *field,

--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -123,7 +123,7 @@ endif
 #
 # Flags for turning on warnings for C++/C code
 #
-WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations
+WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations -Wmissing-braces
 WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -164,7 +164,7 @@ GEN_CFLAGS += $(C_STD)
 # of Clang header files.
 #
 WARN_COMMONFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
-WARN_CXXFLAGS = $(WARN_COMMONFLAGS) -Wno-comment
+WARN_CXXFLAGS = $(WARN_COMMONFLAGS) -Wno-comment -Wmissing-braces
 WARN_CFLAGS = $(WARN_COMMONFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized


### PR DESCRIPTION
std::array needed another pair of braces when -Wmissing-braces was
on. When assigning with = you can drop the outermost one, but not here

Adds -Wmissing-braces to the compiler CXX flags so
we (I!) don't hit this in the future. Only added to gnu and clang as
those will be used in development (and these are warnings enabled with
CHPL_DEVELOPER)

Fixes a build error reported by the gasnet team. Thanks!

Note that it seems clang doesn't report this warning, but I've still
added it to Makefile.clang

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>