### PR TITLE
Progress the receive endpoint while waiting for AM transmit events

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -6727,15 +6727,23 @@ void amCheckRxTxCmpls(chpl_bool* pHadRxEvent, chpl_bool* pHadTxEvent,
       }
     }
   } else {
-    //
+    
     // The provider can't do poll sets.  Consume transmit completions,
-    // and just assume that there may be some inbound operations which
-    // the main loop will handle.  Also, avoid CPU monopolization even
-    // if we had events, because we can't actually tell.
-    //
-    sched_yield();
-    if (pHadRxEvent != NULL) {
-      *pHadRxEvent = true;
+    // and progress the receive endpoint as required by some providers
+    // (e.g. EFA, which may exhange handshake messages in the background
+    // during a transmit and therefore requires progressing the receive
+    // checkpoint so that handshakes are received). Inbound operations
+    // will be handled by the main loop. Also, avoid CPU monopolization
+    // even if we had events, because we can't actually tell.
+    
+    sched_yield(); 
+    int rc = fi_cq_read(ofi_rxCQ, NULL, 0); 
+    if (rc == 0) { 
+      if (pHadRxEvent != NULL) {
+        *pHadRxEvent = true;
+      }
+    } else if (rc != -FI_EAGAIN) {
+      INTERNAL_ERROR_V("fi_cq_read failed: %s", fi_strerror(rc));
     }
     (*tcip->checkTxCmplsFn)(tcip);
     if (pHadTxEvent != NULL) {


### PR DESCRIPTION
When the AM handler is waiting for a transmit event it should also progress the receive endpoint.
Empirically this is necessary due to providers such as EFA that use the endpoints to exchange
messages in the background.

This resolves #17906 and cray/chapel-private#2484 and closes cray/chapel-private#2842.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>