### PR TITLE
add debug-trace flag for use with compiler-library-parser

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -270,6 +270,7 @@ extern std::string llvmFlags;
 extern bool fPrintAdditionalErrors;
 
 extern bool fCompilerLibraryParser;
+extern bool fDebugTrace;
 
 namespace chpl {
   class Context;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1787,6 +1787,10 @@ int main(int argc, char* argv[]) {
 
     process_args(&sArgState, argc, argv);
 
+    if (gContext != nullptr) {
+      gContext->setDebugTraceFlag(fDebugTrace);
+    }
+
     setupChplGlobals(argv[0]);
 
     postprocess_args();

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -300,6 +300,7 @@ static
 bool fPrintChplSettings = false;
 
 bool fCompilerLibraryParser = false;
+bool fDebugTrace = false;
 
 int fGPUBlockSize = 0;
 char fCUDAArch[16] = "sm_60";
@@ -1198,6 +1199,7 @@ static ArgumentDescription arg_desc[] = {
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},
 
  {"compiler-library-parser", ' ', NULL, "Enable [disable] using compiler library parser", "N", &fCompilerLibraryParser, "CHPL_COMPILER_LIBRARY_PARSER", NULL},
+ {"debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using compiler library parser", "N", &fDebugTrace, "CHPL_DEBUG_TRACE", NULL},
 
  DRIVER_ARG_PRINT_CHPL_HOME,
  DRIVER_ARG_LAST

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -35,6 +35,8 @@
 #include <utility>
 #include <vector>
 
+extern bool fDebugTrace;
+
 namespace chpl {
 
 namespace uast {
@@ -96,7 +98,6 @@ class Context {
 
   querydetail::RevisionNumber currentRevisionNumber = 1;
   bool checkStringsAlreadyMarked = false;
-  bool enableDebugTracing = false;
   bool breakSet = false;
   size_t breakOnHash = 0;
   int numQueriesRunThisRevision_ = 0;

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -35,7 +35,6 @@
 #include <utility>
 #include <vector>
 
-extern bool fDebugTrace;
 
 namespace chpl {
 
@@ -98,6 +97,7 @@ class Context {
 
   querydetail::RevisionNumber currentRevisionNumber = 1;
   bool checkStringsAlreadyMarked = false;
+  bool enableDebugTrace = false;
   bool breakSet = false;
   size_t breakOnHash = 0;
   int numQueriesRunThisRevision_ = 0;
@@ -462,6 +462,12 @@ class Context {
     __attribute__ ((format (printf, 4, 5)))
   #endif
   ;
+
+  /*
+    Sets the enableDebugTrace flag. This was needed because the context
+    in main gets created before the arguments to the compiler are parsed.
+  */
+  void setDebugTraceFlag(const bool enable);
 
   typedef enum {
     NOT_CHECKED_NOT_CHANGED = 0,

--- a/compiler/next/include/chpl/queries/query-impl.h
+++ b/compiler/next/include/chpl/queries/query-impl.h
@@ -120,10 +120,10 @@ template<typename... ArgTs>
 void Context::queryBeginTrace(const char* traceQueryName,
                               const std::tuple<ArgTs...>& tupleOfArg) {
 
-  if (breakSet || fDebugTrace) {
+  if (breakSet || enableDebugTrace) {
     auto args = queryArgsToStrings(tupleOfArg);
     size_t queryAndArgsHash = hash_combine(hash(traceQueryName), hash(args));
-    if (fDebugTrace) {
+    if (enableDebugTrace) {
       printf("QUERY BEGIN     %s (", traceQueryName);
       queryArgsPrint(tupleOfArg);
       printf(")\n");
@@ -193,7 +193,7 @@ Context::getResult(QueryMap<ResultType, ArgTs...>* queryMap,
   auto savedElement = &(*pair.first); // pointer to element in map (added/not)
   bool newElementWasAdded = pair.second;
 
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     if (newElementWasAdded)
       printf("Added new result %p %s\n", savedElement, queryMap->queryName);
     else
@@ -225,7 +225,7 @@ Context::queryUseSaved(
   const void* queryFuncV = (const void*) queryFunction;
   bool useSaved = queryCanUseSavedResultAndPushIfNot(queryFuncV, r);
 
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     if (useSaved) {
       printf("QUERY END       %s (...) REUSING BASED ON DEPS %p\n",
              traceQueryName, r);
@@ -326,7 +326,7 @@ Context::queryEnd(
     this->updateResultForQueryMapR(queryMap, r, tupleOfArgs,
                                    std::move(result), /* forSetter */ false);
 
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     bool changed = ret->lastChanged == this->currentRevisionNumber;
     printf("QUERY END       %s (", traceQueryName);
     queryArgsPrint(tupleOfArgs);

--- a/compiler/next/include/chpl/queries/query-impl.h
+++ b/compiler/next/include/chpl/queries/query-impl.h
@@ -120,10 +120,10 @@ template<typename... ArgTs>
 void Context::queryBeginTrace(const char* traceQueryName,
                               const std::tuple<ArgTs...>& tupleOfArg) {
 
-  if (breakSet || enableDebugTracing) {
+  if (breakSet || fDebugTrace) {
     auto args = queryArgsToStrings(tupleOfArg);
     size_t queryAndArgsHash = hash_combine(hash(traceQueryName), hash(args));
-    if (enableDebugTracing) {
+    if (fDebugTrace) {
       printf("QUERY BEGIN     %s (", traceQueryName);
       queryArgsPrint(tupleOfArg);
       printf(")\n");
@@ -193,7 +193,7 @@ Context::getResult(QueryMap<ResultType, ArgTs...>* queryMap,
   auto savedElement = &(*pair.first); // pointer to element in map (added/not)
   bool newElementWasAdded = pair.second;
 
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     if (newElementWasAdded)
       printf("Added new result %p %s\n", savedElement, queryMap->queryName);
     else
@@ -225,7 +225,7 @@ Context::queryUseSaved(
   const void* queryFuncV = (const void*) queryFunction;
   bool useSaved = queryCanUseSavedResultAndPushIfNot(queryFuncV, r);
 
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     if (useSaved) {
       printf("QUERY END       %s (...) REUSING BASED ON DEPS %p\n",
              traceQueryName, r);
@@ -326,7 +326,7 @@ Context::queryEnd(
     this->updateResultForQueryMapR(queryMap, r, tupleOfArgs,
                                    std::move(result), /* forSetter */ false);
 
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     bool changed = ret->lastChanged == this->currentRevisionNumber;
     printf("QUERY END       %s (", traceQueryName);
     queryArgsPrint(tupleOfArgs);

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -467,7 +467,7 @@ void Context::advanceToNextRevision(bool prepareToGC) {
     this->lastPrepareToGCRevisionNumber = this->currentRevisionNumber;
     gcCounter++;
   }
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     printf("CURRENT REVISION NUMBER IS NOW %i %s\n",
            (int) this->currentRevisionNumber,
            prepareToGC?"PREPARING GC":"");
@@ -478,7 +478,7 @@ void Context::collectGarbage() {
   // if there are no parent queries, collect some garbage
   assert(queryStack.size() == 0);
 
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     printf("COLLECTING GARBAGE\n");
   }
 
@@ -509,12 +509,12 @@ void Context::collectGarbage() {
       // buf[1] is the doNotCollectMark
       if (buf[1] || buf[0] == gcMark) {
         newTable.insert(e);
-        if (enableDebugTracing) {
+        if (fDebugTrace) {
           printf("COPYING OVER UNIQUESTRING %s\n", key);
         }
       } else {
         toFree.push_back(allocation);
-        if (enableDebugTracing) {
+        if (fDebugTrace) {
           printf("WILL FREE UNIQUESTRING %s\n", key);
         }
       }
@@ -524,7 +524,7 @@ void Context::collectGarbage() {
     }
     uniqueStringsTable.swap(newTable);
 
-    if (enableDebugTracing) {
+    if (fDebugTrace) {
       size_t nUniqueStringsAfter = uniqueStringsTable.size();
       printf("COLLECTED %i UniqueStrings\n",
              (int)(nUniqueStringsBefore-nUniqueStringsAfter));
@@ -542,7 +542,7 @@ void Context::setFilePathForModuleID(ID moduleID, UniqueString path) {
                        /* isInputQuery */ false,
                        /* forSetter */ true);
 
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     printf("SETTING FILE PATH FOR MODULE %s -> %s\n",
            moduleIdSymbolPath.c_str(), path.c_str());
   }
@@ -604,7 +604,7 @@ void Context::error(const resolution::TypedFnSignature* inFn,
 
 void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
 
-  if (enableDebugTracing) {
+  if (fDebugTrace) {
     printf("RECOMPUTING IF NEEDED FOR %p %s\n", resultEntry,
            resultEntry->parentQueryMap->queryName);
   }
@@ -647,14 +647,14 @@ void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
   if (useSaved == false) {
     resultEntry->recompute(this);
     assert(resultEntry->lastChecked == this->currentRevisionNumber);
-    if (enableDebugTracing) {
+    if (fDebugTrace) {
       printf("DONE RECOMPUTING IF NEEDED -- RECOMPUTED FOR %s\n",
              resultEntry->parentQueryMap->queryName);
     }
     return;
   } else {
     updateForReuse(resultEntry);
-    if (enableDebugTracing) {
+    if (fDebugTrace) {
       printf("DONE RECOMPUTING IF NEEDED -- REUSED FOR %s\n",
              resultEntry->parentQueryMap->queryName);
     }

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -467,18 +467,22 @@ void Context::advanceToNextRevision(bool prepareToGC) {
     this->lastPrepareToGCRevisionNumber = this->currentRevisionNumber;
     gcCounter++;
   }
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     printf("CURRENT REVISION NUMBER IS NOW %i %s\n",
            (int) this->currentRevisionNumber,
            prepareToGC?"PREPARING GC":"");
   }
 }
 
+void Context::setDebugTraceFlag(bool enable)  {
+  enableDebugTrace = enable;
+}
+
 void Context::collectGarbage() {
   // if there are no parent queries, collect some garbage
   assert(queryStack.size() == 0);
 
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     printf("COLLECTING GARBAGE\n");
   }
 
@@ -509,12 +513,12 @@ void Context::collectGarbage() {
       // buf[1] is the doNotCollectMark
       if (buf[1] || buf[0] == gcMark) {
         newTable.insert(e);
-        if (fDebugTrace) {
+        if (enableDebugTrace) {
           printf("COPYING OVER UNIQUESTRING %s\n", key);
         }
       } else {
         toFree.push_back(allocation);
-        if (fDebugTrace) {
+        if (enableDebugTrace) {
           printf("WILL FREE UNIQUESTRING %s\n", key);
         }
       }
@@ -524,7 +528,7 @@ void Context::collectGarbage() {
     }
     uniqueStringsTable.swap(newTable);
 
-    if (fDebugTrace) {
+    if (enableDebugTrace) {
       size_t nUniqueStringsAfter = uniqueStringsTable.size();
       printf("COLLECTED %i UniqueStrings\n",
              (int)(nUniqueStringsBefore-nUniqueStringsAfter));
@@ -542,7 +546,7 @@ void Context::setFilePathForModuleID(ID moduleID, UniqueString path) {
                        /* isInputQuery */ false,
                        /* forSetter */ true);
 
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     printf("SETTING FILE PATH FOR MODULE %s -> %s\n",
            moduleIdSymbolPath.c_str(), path.c_str());
   }
@@ -604,7 +608,7 @@ void Context::error(const resolution::TypedFnSignature* inFn,
 
 void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
 
-  if (fDebugTrace) {
+  if (enableDebugTrace) {
     printf("RECOMPUTING IF NEEDED FOR %p %s\n", resultEntry,
            resultEntry->parentQueryMap->queryName);
   }
@@ -647,14 +651,14 @@ void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
   if (useSaved == false) {
     resultEntry->recompute(this);
     assert(resultEntry->lastChecked == this->currentRevisionNumber);
-    if (fDebugTrace) {
+    if (enableDebugTrace) {
       printf("DONE RECOMPUTING IF NEEDED -- RECOMPUTED FOR %s\n",
              resultEntry->parentQueryMap->queryName);
     }
     return;
   } else {
     updateForReuse(resultEntry);
-    if (fDebugTrace) {
+    if (enableDebugTrace) {
       printf("DONE RECOMPUTING IF NEEDED -- REUSED FOR %s\n",
              resultEntry->parentQueryMap->queryName);
     }

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -52,6 +52,7 @@ _chpl ()
 --dead-code-elimination \
 --debug \
 --debug-short-loc \
+--debug-trace \
 --default-dist \
 --denormalize \
 --devel \
@@ -163,6 +164,7 @@ _chpl ()
 --no-dead-code-elimination \
 --no-debug \
 --no-debug-short-loc \
+--no-debug-trace \
 --no-denormalize \
 --no-devel \
 --no-div-by-zero-checks \


### PR DESCRIPTION
This PR adds a compiler flag `--debug-trace` to be used 
in conjunction with `--compiler-library-parser` to emit
debug output from the new parser. 

Passing the `--debug-trace` flag to the compiler arguments
has no effect on output unless `--compiler-library-parser` is present.

TESTING:

- [x] using `--compiler-library-parser` with `--debug-trace` emits debug info
- [x] compiling with `--debug-trace` doesn't affect output
- [x] paratest

Reviewed by @mppf, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>