### PR TITLE
next: Remove unused helper method for converting indexable loops

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -766,12 +766,6 @@ struct Converter {
         !node->stmt(0)->isConditional();
   }
 
-  // TODO: Use for BracketLoop/Forall...
-  BlockStmt* convertCommonIndexableLoop(const uast::IndexableLoop* node) {
-    INT_FATAL("TODO");
-    return nullptr;
-  }
-
   Expr* convertBracketLoopExpr(const uast::BracketLoop* node) {
     assert(node->isExpressionLevel());
     assert(node->numStmts() == 1);


### PR DESCRIPTION
next: Remove unused helper method for converting indexable loops

This is for `compiler/next`.

The Intel C++ compiler fails to compile `chpl` with `-Werror` due to
an unused function in `compiler/passes/convert-uast.cpp`. Remove
that function.

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>