### PR TITLE
ignore jetbrains IDE folder, cmake-build-debug folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags
 .vscode/
 .idea/
 cmake-build-debug/
+.cache/
 
 # Top level ignores.
 /BUILD_VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ tags
 *.DS_Store
 *.vagrant
 .vscode/
-
+.idea/
+cmake-build-debug/
 
 # Top level ignores.
 /BUILD_VERSION


### PR DESCRIPTION
This PR adds git ignore rules for folders introduced
by jetbrains IDEs, such as clion, and the `.cache` folder
that `clangd` creates.

TESTING: 

- [x] files and subdirectories created by clion are ignored

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>