### PR TITLE
Remove `make third-party` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,6 @@ runtime: FORCE
 	@echo "Making the runtime..."
 	@cd runtime && $(MAKE)
 
-third-party: FORCE
-	@echo "Making the third-party libraries..."
-	@cd third-party && $(MAKE)
-
 third-party-try-opt: third-party-try-re2 third-party-try-gmp
 
 third-party-try-re2: FORCE


### PR DESCRIPTION
As discussed in #18929, `make third-party` isn't useful since it doesn't
build third-parties that are dependent on each other in the right order
and it tries to build all packages even if they aren't needed.

You could imagine wanting this target when building a matrix or
something to just build the third-party packages once ahead of
everything else, but that's not really how our build system works. We
might build jemalloc multiple times for the host and target, qthreads
with different schedulers depending on locale model, or gasnet for
different conduits/substrates. The way we do this for our own module
builds is to build the compiler once, and then for each target in our
matrix use `make notcompiler` to build runtime/third-party/whatever for
each aspect of the matrix. We rely on our build infrastructure to only
rebuild when the unique install paths change (i.e. gasnet has a unique
install path for different conduits/substrates, and qthreads for locale
models.) This ensures we don't needlessly rebuild the third-party
packages, just when the configuration may require different build steps.

All that to say, `make third-party` is no longer useful, so remove it.

Resolves #18929