### PR TITLE
Fix mentions of internal shadow environment variables in --help-env output

### DIFF
--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -147,6 +147,9 @@ void usage(const ArgumentState* state,
           {
             const char* setting = get_envvar_setting(desc[i]);
 
+            if (*envvar == '_') {
+              envvar++;
+            }
             printf("%s", envvar);
 
             if (setting)


### PR DESCRIPTION
While answering a question for Andy, I learned/remembered that in PR #2919, shadow variables
for the standard CHPL_ environment variables were introduced, differentiated by a leading
underscore (e.g., `_CHPL_COMM` rather than `CHPL_COMM`).  I hadn't noticed before now,
but it seems that these internal variables are revealed in our `--help-env` output, where we
should put the user versions of the variables instead.  This PR adds a special case to `--help-env`
to drop leading underscores when present.
 
We didn't catch this earlier because we don't have a test for `--help-env`—the reason being
that maintaining the tests of `--help` have traditionally caused maintenance gripes, so I think
we shied away from adding another test for `--help-env`.  I still feel OK about that decision,
just noting it here for posterity.