### PR TITLE
Remove a comment from a SKIPIF line

### DIFF
--- a/test/llvm/abi/x86-64/SKIPIF
+++ b/test/llvm/abi/x86-64/SKIPIF
@@ -1,5 +1,5 @@
 CHPL_LLVM==none
-CHPL_LLVM==system # Our system llvm is version 11 and this test assumes 12
+CHPL_LLVM==system
 CHPL_LIB_PIC==pic
 CHPL_TARGET_ARCH!=x86_64
 COMPOPTS <= --baseline


### PR DESCRIPTION
The same-line comment was preventing the line from skipping the test.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>