### PR TITLE
Source a script to update to a newer cmake in util/cron/common.bash

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -21,6 +21,12 @@ if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
   fi
 fi
 
+if [ -f /data/cf/chapel/setup_cmake_nightly.bash ] ; then
+  source /data/cf/chapel/setup_cmake_nightly.bash
+elif [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
+  source /cray/css/users/chapelu/setup_cmake_nightly.bash
+fi
+
 log_info "gcc version: $(which gcc)"
 gcc --version
 


### PR DESCRIPTION
Make a newer cmake version available to our nightly testing systems. The newer
version is required for building LLVM-12.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>