### PR TITLE
Move some method definitions into headers

### DIFF
--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -144,22 +144,6 @@ static void callExprHelper(CallExpr* call, BaseAST* arg) {
   }
 }
 
-bool CallExpr::isEmpty() const {
-  return primitive == NULL && baseExpr == NULL;
-}
-
-bool CallExpr::isPrimitive() const {
-  return primitive != NULL;
-}
-
-bool CallExpr::isPrimitive(PrimitiveTag primitiveTag) const {
-  return primitive && primitive->tag == primitiveTag;
-}
-
-bool CallExpr::isPrimitive(const char* primitiveName) const {
-  return primitive && !strcmp(primitive->name, primitiveName);
-}
-
 Expr* CallExpr::getFirstExpr() {
   Expr* retval = NULL;
 
@@ -425,15 +409,6 @@ bool CallExpr::isNamedAstr(const char* name) const {
   }
 
   return retval;
-}
-
-int CallExpr::numActuals() const {
-  return argList.length;
-}
-
-
-Expr* CallExpr::get(int index) const {
-  return argList.get(index);
 }
 
 

--- a/compiler/AST/alist.cpp
+++ b/compiler/AST/alist.cpp
@@ -25,61 +25,6 @@
 #include "stmt.h"
 #include "stringutil.h"
 
-AList::AList() :
-  head(NULL),
-  tail(NULL),
-  parent(NULL),
-  length(0)
-{ }
-
-
-Expr* AList::first(void) {
-  return head;
-}
-
-
-Expr* AList::last(void) {
-  return tail;
-}
-
-
-Expr* AList::only(void) {
-  if (!head)
-    INT_FATAL("only() called on empty list");
-
-  if (head == tail)
-    return first();
-  else
-    INT_FATAL("only() called on list with more than one element");
-
-  return NULL;
-}
-
-
-Expr* AList::get(int index) const {
-  if (index <=0) {
-    INT_FATAL("Indexing list must use positive integer");
-  }
-
-  int i = 0;
-
-  for_alist(node, *this) {
-    i++;
-
-    if (i == index) {
-      return node;
-    }
-  }
-
-  INT_FATAL("Indexing list out of bounds");
-
-  return NULL;
-}
-
-bool AList::empty() const {
-  return length == 0;
-}
-
 void AList::insertAtHead(Expr* new_ast) {
   if (new_ast->parentSymbol || new_ast->parentExpr)
     INT_FATAL(new_ast, "Argument is already in AST in AList::insertAtHead");

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -287,14 +287,6 @@ void Expr::verifyParent(const Expr* child) {
     INT_FATAL(this, "bad parent of a child node");
 }
 
-bool Expr::inTree() {
-  if (parentSymbol)
-    return true;
-  else
-    return false;
-}
-
-
 QualifiedType Expr::qualType() {
   INT_FATAL(this, "Illegal call to Expr::qualType()");
   return QualifiedType(NULL);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -232,53 +232,11 @@ bool Symbol::isRenameable() const {
   return true;
 }
 
-bool Symbol::isRef() {
-  QualifiedType q = qualType();
-  return (type != NULL) && (q.isRef() || type->symbol->hasFlag(FLAG_REF));
-}
-
-bool Symbol::isWideRef() {
-  QualifiedType q = qualType();
-  return (q.isWideRef() || type->symbol->hasFlag(FLAG_WIDE_REF));
-}
-
-bool Symbol::isRefOrWideRef() {
-  return isRef() || isWideRef();
-}
-
-
 // Returns the scope in which the given symbol is declared; NULL otherwise.
 BlockStmt* Symbol::getDeclarationScope() const {
   return (defPoint != NULL) ? defPoint->getScopeBlock() : NULL;
 }
 
-
-bool Symbol::hasFlag(Flag flag) const {
-  CHECK_FLAG(flag);
-  return flags[flag];
-}
-
-
-void Symbol::addFlag(Flag flag) {
-  CHECK_FLAG(flag);
-  flags.set(flag);
-}
-
-
-void Symbol::copyFlags(const Symbol* other) {
-  flags |= other->flags;
-  qual   = other->qual;
-}
-
-
-void Symbol::removeFlag(Flag flag) {
-  CHECK_FLAG(flag);
-  flags.reset(flag);
-}
-
-bool Symbol::hasEitherFlag(Flag aflag, Flag bflag) const {
-  return hasFlag(aflag) || hasFlag(bflag);
-}
 
 bool Symbol::isKnownToBeGeneric() {
   if (FnSymbol* fn = toFnSymbol(this))

--- a/compiler/include/CallExpr.h
+++ b/compiler/include/CallExpr.h
@@ -178,6 +178,30 @@ inline bool CallExpr::isResolved() const {
   return resolvedFunction() != NULL;
 }
 
+inline bool CallExpr::isEmpty() const {
+  return primitive == NULL && baseExpr == NULL;
+}
+
+inline bool CallExpr::isPrimitive() const {
+  return primitive != NULL;
+}
+
+inline bool CallExpr::isPrimitive(PrimitiveTag primitiveTag) const {
+  return primitive && primitive->tag == primitiveTag;
+}
+
+inline bool CallExpr::isPrimitive(const char* primitiveName) const {
+  return primitive && !strcmp(primitive->name, primitiveName);
+}
+
+inline int CallExpr::numActuals() const {
+  return argList.length;
+}
+
+inline Expr* CallExpr::get(int index) const {
+  return argList.get(index);
+}
+
 // TODO: rename these
 bool isInitOrReturn(CallExpr* call, SymExpr*& lhsSe, CallExpr*& initOrCtor);
 bool isRecordInitOrReturn(CallExpr* call, SymExpr*& lhsSe, CallExpr*& initOrCtor);

--- a/compiler/include/alist.h
+++ b/compiler/include/alist.h
@@ -188,4 +188,64 @@ class AList {
        field = _alist_prev,                                             \
          _alist_prev = (field && field->defPoint->prev) ? toDefExpr(field->defPoint->prev)->sym : NULL)
 
+inline AList::AList() :
+  head(NULL),
+  tail(NULL),
+  parent(NULL),
+  length(0)
+{ }
+
+
+inline Expr* AList::first(void) {
+  return head;
+}
+
+
+inline Expr* AList::last(void) {
+  return tail;
+}
+
+
+inline Expr* AList::only(void) {
+  if (!head)
+    INT_FATAL("only() called on empty list");
+
+  if (head == tail)
+    return first();
+  else
+    INT_FATAL("only() called on list with more than one element");
+
+  return NULL;
+}
+
+// Yikes! This header has to go here because we want ::get to be inlined
+// Since we access expr->next we need the full defintion of Expr
+// but since  Expr includes an AList by value inside of itself,
+// it needs the full definition of AList
+#include "expr-class-def.h"
+
+inline Expr* AList::get(int index) const {
+  if (index <=0) {
+    INT_FATAL("Indexing list must use positive integer");
+  }
+
+  int i = 0;
+
+  for_alist(node, *this) {
+    i++;
+
+    if (i == index) {
+      return node;
+    }
+  }
+
+  INT_FATAL("Indexing list out of bounds");
+
+  return NULL;
+}
+
+inline bool AList::empty() const {
+  return length == 0;
+}
+
 #endif

--- a/compiler/include/alist.h
+++ b/compiler/include/alist.h
@@ -218,10 +218,9 @@ inline Expr* AList::only(void) {
   return NULL;
 }
 
-// Yikes! This header has to go here because we want ::get to be inlined
-// Since we access expr->next we need the full defintion of Expr
-// but since  Expr includes an AList by value inside of itself,
-// it needs the full definition of AList
+// This header has to go here because we want AList::get to be inlined.
+// AList::get accesses expr->next, so it needs the full defintion of Expr.
+// Expr has methods with AList formals so needs the full definition of AList.
 #include "expr-class-def.h"
 
 inline Expr* AList::get(int index) const {

--- a/compiler/include/expr-class-def.h
+++ b/compiler/include/expr-class-def.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _EXPR_CLASS_DEF_H_
+#define _EXPR_CLASS_DEF_H_
+
+class Expr : public BaseAST {
+public:
+   Expr(AstTag astTag);
+  ~Expr() override = default;
+
+  // Interface for BaseAST
+          bool    inTree()                                        override;
+  virtual bool    isStmt()                                           const;
+          QualifiedType qualType()                                override;
+          void    verify()                                        override;
+
+  void verify(AstTag expectedTag); // ensure tag is as expected, then verify()
+  void verifyParent(const Expr* child); // verify proper child->parentExpr
+
+  // New interface
+  virtual Expr*   copy(SymbolMap* map = NULL, bool internal = false)   = 0;
+  virtual void    replaceChild(Expr* old_ast, Expr* new_ast)           = 0;
+
+  virtual Expr*   getFirstExpr()                                       = 0;
+  virtual Expr*   getNextExpr(Expr* expr);
+
+  virtual bool    isNoInitExpr()                                     const;
+
+  virtual void    prettyPrint(std::ostream* o);
+
+
+  bool            isRef();
+  bool            isWideRef();
+  bool            isRefOrWideRef();
+
+  /* Returns true if the given expression is contained by this one. */
+  bool            contains(const Expr* expr)                         const;
+
+  bool            isModuleDefinition();
+
+  void            insertBefore(Expr* new_ast);
+  void            insertAfter(Expr* new_ast);
+  void            replace(Expr* new_ast);
+
+  // Insert multiple ASTs in the order of the arguments.
+  // Todo: replace with a single varargs version.
+  void            insertAfter(Expr* e1, Expr* e2);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
+                              Expr* e5);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
+                              Expr* e5, Expr* e6);
+
+  void            insertBefore(AList exprs);
+  void            insertAfter(AList exprs);
+
+  void            insertBefore(const char* format, ...);
+  void            insertAfter(const char* format, ...);
+  void            replace(const char* format, ...);
+
+  Expr*           remove();
+
+  bool            isStmtExpr()                                       const;
+  Expr*           getStmtExpr();
+
+  BlockStmt*      getScopeBlock();
+
+  Symbol*         parentSymbol;
+  Expr*           parentExpr;
+
+  AList*          list;           // alist pointer
+  Expr*           prev;           // alist previous pointer
+  Expr*           next;           // alist next     pointer
+
+private:
+  virtual Expr*   copyInner(SymbolMap* map) = 0;
+};
+
+#endif

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -39,81 +39,7 @@ namespace llvm
 
 class PrimitiveOp;
 
-
-class Expr : public BaseAST {
-public:
-   Expr(AstTag astTag);
-  ~Expr() override = default;
-
-  // Interface for BaseAST
-          bool    inTree()                                        override;
-  virtual bool    isStmt()                                           const;
-          QualifiedType qualType()                                override;
-          void    verify()                                        override;
-
-  void verify(AstTag expectedTag); // ensure tag is as expected, then verify()
-  void verifyParent(const Expr* child); // verify proper child->parentExpr
-
-  // New interface
-  virtual Expr*   copy(SymbolMap* map = NULL, bool internal = false)   = 0;
-  virtual void    replaceChild(Expr* old_ast, Expr* new_ast)           = 0;
-
-  virtual Expr*   getFirstExpr()                                       = 0;
-  virtual Expr*   getNextExpr(Expr* expr);
-
-  virtual bool    isNoInitExpr()                                     const;
-
-  virtual void    prettyPrint(std::ostream* o);
-
-
-  bool            isRef();
-  bool            isWideRef();
-  bool            isRefOrWideRef();
-
-  /* Returns true if the given expression is contained by this one. */
-  bool            contains(const Expr* expr)                         const;
-
-  bool            isModuleDefinition();
-
-  void            insertBefore(Expr* new_ast);
-  void            insertAfter(Expr* new_ast);
-  void            replace(Expr* new_ast);
-
-  // Insert multiple ASTs in the order of the arguments.
-  // Todo: replace with a single varargs version.
-  void            insertAfter(Expr* e1, Expr* e2);
-  void            insertAfter(Expr* e1, Expr* e2, Expr* e3);
-  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4);
-  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
-                              Expr* e5);
-  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
-                              Expr* e5, Expr* e6);
-
-  void            insertBefore(AList exprs);
-  void            insertAfter(AList exprs);
-
-  void            insertBefore(const char* format, ...);
-  void            insertAfter(const char* format, ...);
-  void            replace(const char* format, ...);
-
-  Expr*           remove();
-
-  bool            isStmtExpr()                                       const;
-  Expr*           getStmtExpr();
-
-  BlockStmt*      getScopeBlock();
-
-  Symbol*         parentSymbol;
-  Expr*           parentExpr;
-
-  AList*          list;           // alist pointer
-  Expr*           prev;           // alist previous pointer
-  Expr*           next;           // alist next     pointer
-
-private:
-  virtual Expr*   copyInner(SymbolMap* map) = 0;
-};
-
+#include "expr-class-def.h"
 
 class DefExpr final : public Expr {
 public:
@@ -330,6 +256,9 @@ inline InterfaceSymbol* IfcConstraint::ifcSymbol() const {
   return toInterfaceSymbol(toSymExpr(interfaceExpr)->symbol());
 }
 
+inline bool Expr::inTree() {
+  return parentSymbol != nullptr;
+}
 
 // Determines whether a node is in the AST (vs. has been removed
 // from the AST). Used e.g. by cleanAst().

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -676,6 +676,45 @@ public:
   void  codegenDef()                                      override;
 };
 
+inline bool Symbol::hasFlag(Flag flag) const {
+  CHECK_FLAG(flag);
+  return flags[flag];
+}
+
+inline void Symbol::addFlag(Flag flag) {
+  CHECK_FLAG(flag);
+  flags.set(flag);
+}
+
+inline void Symbol::copyFlags(const Symbol* other) {
+  flags |= other->flags;
+  qual   = other->qual;
+}
+
+inline void Symbol::removeFlag(Flag flag) {
+  CHECK_FLAG(flag);
+  flags.reset(flag);
+}
+
+inline bool Symbol::hasEitherFlag(Flag aflag, Flag bflag) const {
+  return hasFlag(aflag) || hasFlag(bflag);
+}
+
+inline bool Symbol::isRef() {
+  QualifiedType q = qualType();
+  return (type != NULL) && (q.isRef() || type->symbol->hasFlag(FLAG_REF));
+}
+
+inline bool Symbol::isWideRef() {
+  QualifiedType q = qualType();
+  return (q.isWideRef() || type->symbol->hasFlag(FLAG_WIDE_REF));
+}
+
+inline bool Symbol::isRefOrWideRef() {
+  return isRef() || isWideRef();
+}
+
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *


### PR DESCRIPTION
Move some method definitions into headers

These small method definitions are being moved into their header files
so that they are eligible for inlining, which most of these almost
certainly will.

This was motivated by seeing these methods commonly show up in the top
20 of profiling reports:

  * Symbol::hasFlag
  * CallExpr::isPrimitive
  * Expr::inTree
  * AList::get
  * Symbol::isRef

I used a bit of loose judgement to move some related functions if they
felt sufficiently small and/or similar to one of the above. I also
chose to keep the method definitions outside the class as it makes a
better diff.

I had to move the class definition for Expr into expr-class-def.h so
that the alist.h header can implement the ::get method. Expr contains
an AList so it also needs to know the full layout. Without major
changes to header structure, this was my solution.

I verified most of these actually do get inlined and saw a 3-5%
reduction in compiling hello, cg-sparse-timecomp, and arkouda.

Passes paratest