### PR TITLE
Fix problem with ofi after PR #18880

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -67,7 +67,7 @@ def get_compile_args():
     if libfabric_val == 'system' or libfabric_val == 'bundled':
         flags = [ ]
         launcher_val = chpl_launcher.get()
-        ofi_oob_val = overrides.get_environ('CHPL_RT_COMM_OFI_OOB')
+        ofi_oob_val = overrides.get_environ('CHPL_COMM_OFI_OOB')
         if 'mpi' in launcher_val or ( ofi_oob_val and 'mpi' in ofi_oob_val ):
             mpi_dir_val = overrides.get_environ('MPI_DIR')
             if mpi_dir_val:
@@ -116,7 +116,7 @@ def get_link_args():
     if libfabric_val == 'system' or libfabric_val == 'bundled':
         libs = [ ]
         launcher_val = chpl_launcher.get()
-        ofi_oob_val = overrides.get_environ('CHPL_RT_COMM_OFI_OOB')
+        ofi_oob_val = overrides.get_environ('CHPL_COMM_OFI_OOB')
         if 'mpi' in launcher_val or ( ofi_oob_val and 'mpi' in ofi_oob_val ):
             mpi_dir_val = overrides.get_environ('MPI_DIR')
             if mpi_dir_val:


### PR DESCRIPTION
Follow-up to PR #18880 to fix a problem with ofi testing.

Even before PR #18880, we had
 * `CHPL_COMM_OFI_OOB` used in Makefiles and set by testing
 * `CHPL_RT_COMM_OFI_OOB` that was used in printchplenv before that PR and which I used after
 
PR #18880 added to the printchplenv logic and used it during `chpl` invocations but that caused a problem because `CHPL_COMM_OFI_OOB` is set in testing (and `CHPL_RT_COMM_OFI_OOB` is not).

This PR just changes the uses of `CHPL_RT_COMM_OFI_OOB`  in printchplenv to `CHPL_COMM_OFI_OOB` because it's used for computing `-I` and `-L` flags and these don't happen at runtime.

Reviewed by @jhh67 - thanks!