### PR TITLE
Add ifndef's around GNU_SOURCE #defines

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -21,7 +21,9 @@
 // This #define needs to be before the other #includes
 // since it affects included files
 #ifdef __linux__
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #endif
 
 #include "chplrt.h"

--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -18,7 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 // needed for dlfcn.h on linux
 
 #include "chplrt.h"


### PR DESCRIPTION
I bumped into issues building Chapel because of redefined `_GNU_SOURCE`s.
This PR prevents that by adding `ifndef`s.

The issue likely started with https://github.com/chapel-lang/chapel/pull/18880.