### PR TITLE
Fix problem with CHPL_LIB_PIC after PR #18880

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2372,6 +2372,11 @@ void runClang(const char* just_parse_filename) {
   }
 
 
+  // add -fPIC if CHPL_LIB_PIC indicates we should
+  if (strcmp(CHPL_LIB_PIC, "pic") == 0) {
+    clangCCArgs.push_back("-fPIC");
+  }
+
   // after arguments provided in CC/CXX
   // add include paths to anything builtin or in CHPL_HOME
   {

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -24,6 +24,9 @@ MAKE_COMP_GEN_CFLAGS =
 
 # These Make ifdefs are used for printcompileline and printcflags
 # in order to correctly set COMP_GEN_CFLAGS.
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
+  MAKE_COMP_GEN_CFLAGS += $(SHARED_LIB_CFLAGS)
+endif
 ifeq ($(COMP_GEN_WARN), 1)
   MAKE_COMP_GEN_CFLAGS += $(WARN_GEN_CFLAGS)
 endif

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -114,7 +114,7 @@ HWLOC_INCLUDE=$(RUNTIME_ROOT)/make/Makefile.runtime.hwloc-$(CHPL_MAKE_HWLOC)
 
 # For use with library-mode. Position independent code is required by shared
 # objects that want to bring in our static runtime/third-party libraries
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 RUNTIME_DEFS += $(SHARED_LIB_CFLAGS)
 endif
 


### PR DESCRIPTION
This PR fixes a problem with CHPL_LIB_PIC after PR #18880
 * updates clangUtil.cpp to pass `-fPIC` if `CHPL_LIB_PIC` is set
 * include `-fPIC` in MAKE_COMP_GEN_CFLAGS / COMP_GEN_CFLAGS for C backend
 * use CHPL_MAKE_LIB_PIC in Makefiles since this is the variable computed by printchplenv
 
- [x] test/interop/python//boolFunctions.chpl  passes with C backend
- [x] test/interop/python//boolFunctions.chpl  passes with LLVM backend
- [x] full local testing

Reviewed by @ben-albrecht - thanks!