### PR TITLE
Don't always add -O3 to flags when compiling with gasnet

### DIFF
--- a/util/chplenv/chpl_gasnet.py
+++ b/util/chplenv/chpl_gasnet.py
@@ -29,9 +29,10 @@ def get_gasnet_pc_file():
 def filter_compile_args(args):
     compiler = chpl_compiler.get('target')
     is_prgenv = compiler_utils.target_compiler_is_prgenv(bypass_llvm=True)
+
+    ret = [ ]
     if compiler == 'llvm' and is_prgenv:
         # filter out compile arguments not starting with -D or -I
-        ret = [ ]
         n = len(args)
         i = 0
         while i < n:
@@ -46,7 +47,19 @@ def filter_compile_args(args):
         return ret
     else:
         # otherwise, just return the args the way they were
-        return args
+        ret = args
+
+    # subsequently, filter away a few gasnet flags we don't want
+    # an alternative to this filtering would be to only grab
+    # certain flags from the gasnet .pc file
+    more_filtered = [ ]
+    for arg in ret:
+        if arg == '-O3' or arg == '-Winline':
+            pass # leave out this flag
+        else:
+            more_filtered.append(arg)
+
+    return more_filtered
 
 # returns 2-tuple of lists
 #  (compiler_bundled_args, compiler_system_args)


### PR DESCRIPTION
Follow-up to PR #18880.

The pkg-config .pc file we get gasnet flags from includes -O3 in the
flags, which caused a failure for the test

    test/expressions/bradc/uminusVsTimesPrec.chpl

(which is sensitive to optimization level and skipped with --fast).

As well as failures with CHPL_UNWIND testing.

Previously the Makefile based approach avoided the -O3 by getting
only particular kinds of flags. We could do that too with the pkg-config
parsing as well but for now, just filter out the flags we don't want
after we parse them.

Reviewed by @ben-albrecht - thanks!

- [x] test/runtime/stacktrace passes with CHPL_COMM=gasnet and CHPL_UNWIND=bundled
- [x] full local gasnet testing