### PR TITLE
Missing import of os package

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import glob
+import os
 
 import chpl_comm, chpl_comm_debug, chpl_launcher, chpl_platform
 import overrides, third_party_utils


### PR DESCRIPTION
This caused "printchplenv --internal" to fail if CHPL_COMM=ofi, CHPL_LAUNCHER=mpirun4ofi,
and MPI_DIR was set.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>