### PR TITLE
Don't use absolute paths in Socket includes

### DIFF
--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -63,8 +63,8 @@ module Socket {
 // which writes back to a sync variable passed on to it by the
 // caller. The caller then reads the sync variable to determine
 // event type and processes things further.
-require "/usr/local/include/event2/event.h";
-require "/usr/local/include/event2/thread.h";
+require "event2/event.h";
+require "event2/thread.h";
 require "-levent";
 require "-levent_pthreads";
 


### PR DESCRIPTION
We don't know where the event2/event.h header will be,
so don't use the absolute path. Just requiring "event2/event.h"
works though.

Trivial, but checked by @king-11 

- [x] test/library/packages/Socket/ passes on Ubuntu 21.10