### PR TITLE
Parser updates for primer compilation

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -975,6 +975,16 @@ compareSymbol(const void* v1, const void* v2) {
     return strcmp(m1->cname, m2->cname) < 0;
   }
 
+  // prefer to place externs earlier in the function list (vector)
+  // this was necessary because in the new parser the order in which
+  // extern and non-externs are identified does not match the old parser.
+  // this keeps things consistent between the old and new parser
+  if (s1->hasFlag(FLAG_EXTERN) != s2->hasFlag(FLAG_EXTERN)) {
+    if (s1->hasFlag(FLAG_EXTERN))
+      return 1;
+    return 0;
+  }
+
   if (s1->linenum() != s2->linenum())
     return s1->linenum() < s2->linenum();
 

--- a/compiler/include/optimizations.h
+++ b/compiler/include/optimizations.h
@@ -34,6 +34,7 @@
 #include "vec.h"
 
 #include "flags.h"
+#include "symbol.h"
 
 #include <set>
 #include <map>
@@ -86,6 +87,8 @@ void setDefinedConstForDomainSymbol(Symbol *domainSym, Expr *nextExpr,
                                     Symbol *isConst);
 void setDefinedConstForDefExprIfApplicable(DefExpr* defExpr,
                                            std::set<Flag>* flags);
+void setDefinedConstForDefExprIfApplicable(DefExpr* defExpr,
+                                           FlagSet* flags);
 void setDefinedConstForPrimSetMemberIfApplicable(CallExpr *call);
 void setDefinedConstForFieldsInInitializer(FnSymbol *fn);
 

--- a/compiler/next/include/chpl/queries/all-global-strings.h
+++ b/compiler/next/include/chpl/queries/all-global-strings.h
@@ -83,6 +83,11 @@ X(logicalAnd     , "&&")
 X(logicalOr      , "||")
 X(plus           , "+")
 X(times          , "*")
+X(compareEqual   , "==")
+X(greaterOrEqual , ">=" )
+X(greaterThan    , ">")
+X(lessThan       , "<")
+X(lessOrEqual    , "<=")
 
 /* A string too long is checked at compile time */
 /* X(somethingtoolong      , "somethingtoolongforthemacro") */

--- a/compiler/next/lib/parsing/bison-chpl-lib.cpp
+++ b/compiler/next/lib/parsing/bison-chpl-lib.cpp
@@ -9216,7 +9216,7 @@ yyreduce:
 
   case 433: /* lifetime_expr: TRETURN lifetime_ident  */
 #line 2498 "chpl.ypp"
-    { (yyval.expr) = TODOEXPR((yyloc)); }
+    { (yyval.expr) = Return::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[0].expr))).release(); }
 #line 9221 "bison-chpl-lib.cpp"
     break;
 

--- a/compiler/next/lib/parsing/chpl.ypp
+++ b/compiler/next/lib/parsing/chpl.ypp
@@ -2495,7 +2495,7 @@ lifetime_expr:
 | lifetime_ident TGREATEREQUAL lifetime_ident
     { $$ = context->buildBinOp(@$, $1, $2, $3); }
 | TRETURN lifetime_ident
-    { $$ = TODOEXPR(@$); }
+    { $$ = Return::build(BUILDER, LOC(@$), toOwned($2)).release(); } // TLIFETIME //build return uast node with lifetime_ident
 ;
 
 lifetime_ident:

--- a/compiler/next/lib/parsing/chpl.ypp
+++ b/compiler/next/lib/parsing/chpl.ypp
@@ -2495,7 +2495,7 @@ lifetime_expr:
 | lifetime_ident TGREATEREQUAL lifetime_ident
     { $$ = context->buildBinOp(@$, $1, $2, $3); }
 | TRETURN lifetime_ident
-    { $$ = Return::build(BUILDER, LOC(@$), toOwned($2)).release(); } // TLIFETIME //build return uast node with lifetime_ident
+    { $$ = Return::build(BUILDER, LOC(@$), toOwned($2)).release(); }
 ;
 
 lifetime_ident:

--- a/compiler/next/lib/parsing/flex-chpl-lib.cpp
+++ b/compiler/next/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex-chpl-lib.cpp"
+#line 2 "flex-chpl-lib.cpp"
 
-#line 3 "flex-chpl-lib.cpp"
+#line 4 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1079,10 +1079,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1082 "flex-chpl-lib.cpp"
+#line 1083 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1085 "flex-chpl-lib.cpp"
+#line 1086 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1372,7 +1372,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1375 "flex-chpl-lib.cpp"
+#line 1376 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2372,7 +2372,7 @@ YY_RULE_SETUP
 #line 328 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2375 "flex-chpl-lib.cpp"
+#line 2376 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/compiler/next/lib/parsing/flex-chpl-lib.h
+++ b/compiler/next/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 5 "flex-chpl-lib.h"
+#line 6 "flex-chpl-lib.h"
 
-#line 7 "flex-chpl-lib.h"
+#line 8 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 328 "chpl.lex"
 
 
-#line 733 "flex-chpl-lib.h"
+#line 734 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */

--- a/compiler/optimizations/propagateDomainConstness.cpp
+++ b/compiler/optimizations/propagateDomainConstness.cpp
@@ -56,6 +56,16 @@ void setDefinedConstForDefExprIfApplicable(DefExpr* defExpr,
   }
 }
 
+void setDefinedConstForDefExprIfApplicable(DefExpr* defExpr,
+                                           FlagSet* flags) {
+  if (defExpr->init != NULL) {
+    // check for the FLAG_CONST bit in the FlagSet
+    if (!flags->test(FLAG_CONST)) {
+      setDefinedConstForDefExprWithIfExprs(defExpr->init);
+    }
+  }
+}
+
 // Add code right after a PRIM_SET_MEMBER, if it is setting a const domain
 // member in an aggregate type
 void setDefinedConstForPrimSetMemberIfApplicable(CallExpr *call) {

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -595,8 +595,7 @@ static std::set<std::string> blockedInternalModules = {
   "ChapelArray",             // Prim call with named args.
   "ChapelDomain",            // Prim call with named args.
   "ChapelDistribution",      // Segfault somewhere...
-  "ChapelSyncvar",           // Lifetimes.
-  "MemConsistency"           // Redefinition of a function...
+  "MemConsistency"           // error: conflicting types for ‘chpl_rmem_consist_fence’
 };
 
 // TODO: Adjust me over time as more internal modules parse.

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -595,8 +595,8 @@ static std::set<std::string> blockedInternalModules = {
   "ChapelArray",             // Prim call with named args.
   "ChapelDomain",            // Prim call with named args.
   "ChapelDistribution",      // Segfault somewhere...
-  "ChapelSyncvar",         // Lifetimes.
-  "MemConsistency"         // Redefinition of a function...
+  "ChapelSyncvar",           // Lifetimes.
+  "MemConsistency"           // Redefinition of a function...
 };
 
 // TODO: Adjust me over time as more internal modules parse.

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -593,9 +593,7 @@ static void parseDependentModules(bool isInternal) {
 // Internal modules that are currently NOT able to be parsed by the new parser.
 static std::set<std::string> blockedInternalModules = {
   "ChapelArray",             // Prim call with named args.
-  "ChapelDomain",            // Prim call with named args.
-  "ChapelDistribution",      // Segfault somewhere...
-  "MemConsistency"           // error: conflicting types for ‘chpl_rmem_consist_fence’
+  "ChapelDomain"            // Prim call with named args.
 };
 
 // TODO: Adjust me over time as more internal modules parse.

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -590,70 +590,13 @@ static void parseDependentModules(bool isInternal) {
 *                                                                             *
 ************************************** | *************************************/
 
-// Internal modules that are currently able to be parsed by the new parser.
-static std::set<std::string> allowedInternalModules = {
-  "ArrayViewRankChange",
-  "ArrayViewReindex",
-  "ArrayViewSlice",
-  "Atomics",
-  "AtomicsCommon",
-  "ByteBufferHelpers",
-  "Bytes",
-  "BytesCasts",
-  "BytesStringCommon",
-  /*"ChapelArray",*/             // Prim call with named args.
-  "ChapelAutoAggregation",
-  "ChapelAutoLocalAccess",
-  "ChapelBase",
-  "ChapelComplex_forDocs",
-  "ChapelDebugPrint",
-  /*"ChapelDistribution",*/      // Segfault somewhere...
-  "ChapelHashing",
-  "ChapelHashtable",
-  "ChapelIOStringifyHelper",
-  "ChapelIteratorSupport",
-  /*"ChapelLocale",*/            //ChapelLocale.chpl:531 not implemented yet
-  "ChapelLocks",
-  "ChapelNumLocales",
-  "ChapelPrivatization",
-  "ChapelRange",
-  "ChapelReduce",
-  "ChapelSerializedBroadcast",
-  "ChapelStandard",
-  /*"ChapelSyncvar",*/           // Lifetimes.
-  "ChapelTaskData",
-  "ChapelTaskDataHelp",
-  "ChapelTaskID",
-  "ChapelThreads",
-  "ChapelTuple",
-  "ChapelUtil",
-  "CString",
-  "DefaultAssociative",
-  "DefaultRectangular",
-  "DefaultSparse",
-  "ExportWrappers",
-  "ExternalArray",
-  "ISO_Fortran_binding",
-  "LocaleModelHelpAPU",
-  "LocaleModelHelpFlat",
-  "LocaleModelHelpGPU",
-  "LocaleModelHelpMem",
-  "LocaleModelHelpNUMA",
-  "LocaleModelHelpRuntime",
-  "LocaleModelHelpSetup",
-  "LocalesArray",
-  "LocaleTree",
-  /*"MemConsistency",*/          // Redefinition of a function...
-  "MemTracking",
-  "NetworkAtomics",
-  "NetworkAtomicTypes",
-  "OwnedObject",
-  "PrintModuleInitOrder",
-  "SharedObject",
-  "startInitCommDiags",
-  "stopInitCommDiags",
-  "String",
-  "StringCasts"
+// Internal modules that are currently NOT able to be parsed by the new parser.
+static std::set<std::string> blockedInternalModules = {
+  "ChapelArray",             // Prim call with named args.
+  "ChapelDomain",            // Prim call with named args.
+  "ChapelDistribution",      // Segfault somewhere...
+  "ChapelSyncvar",         // Lifetimes.
+  "MemConsistency"         // Redefinition of a function...
 };
 
 // TODO: Adjust me over time as more internal modules parse.
@@ -675,13 +618,13 @@ static bool uASTCanParseMod(const char* modName, ModTag modTag) {
 
   switch (modTag) {
     case MOD_INTERNAL:
-      ret = allowedInternalModules.count(modName);
+      ret = blockedInternalModules.count(modName);
       break;
     default:
       break;
   }
 
-  return ret;
+  return !ret;
 }
 
 static bool uASTAttemptToParseMod(const char* modName,

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1596,8 +1596,12 @@ struct Converter {
       auto lhsIdent = opCall->actual(0)->toIdentifier();
       auto rhsIdent = opCall->actual(1)->toIdentifier();
       assert(lhsIdent && rhsIdent);
-      assert(opCall->op() == "=" || opCall->op() == "<" || opCall->op() == "<="
-             || opCall->op() == "==" || opCall->op() == ">" || opCall->op() == ">=");
+      assert(opCall->op() == USTR("=") ||
+             opCall->op() == USTR("<") ||
+             opCall->op() == USTR(">") ||
+             opCall->op() == USTR("==")||
+             opCall->op() == USTR("<=")||
+             opCall->op() == USTR(">="));
       Expr* lhs = convertLifetimeIdent(lhsIdent);
       Expr* rhs = convertLifetimeIdent(rhsIdent);
       return new CallExpr(opCall->op().c_str(), lhs, rhs);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1520,10 +1520,8 @@ struct Converter {
     } else if (node->expr()->isVariable()) {
         auto child = node->expr()->toVariable();
         return buildForwardingDeclStmt((BlockStmt*)visit(child));
-    } else if (node->expr()->isFnCall()) {
-      auto child = node->expr()->toFnCall();
-
-      return buildForwardingStmt(convertExprOrNull(child));
+    } else if (node->expr()->isIdentifier() || node->expr()->isFnCall()) {
+      return buildForwardingStmt(convertExprOrNull(node->expr()));
     }
 
     INT_FATAL("Failed to convert ForwardingDecl");

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -31,6 +31,7 @@
 #include "ForallStmt.h"
 #include "ForLoop.h"
 #include "IfExpr.h"
+#include "optimizations.h"
 #include "TryStmt.h"
 #include "WhileDoStmt.h"
 #include "build.h"
@@ -2100,6 +2101,11 @@ struct Converter {
         ret->init = commandLineInit;
       }
     }
+
+    // If the init expression of this variable is a domain and this
+    // variable is not const, propagate that information by setting
+    // 'definedConst' in the domain to false.
+    setDefinedConstForDefExprIfApplicable(ret, &ret->sym->flags);
 
     return ret;
   }


### PR DESCRIPTION
This PR implements multiple fixes that allow for the new
parser to be used when compiling our primers.

Changes/updates include:

- Sort the extern functions to higher precedence during codegen
- Implement production for return lifetimes
- Add AST conversion for lifetime clauses and identifiers
- Invert the list of internal modules to be parsed
   with the new parser from an allow to a block list

These changes have made it possible to parse all but two internal
modules and compile the primers with `--compiler-library-parser`

TESTING:

- [x] primer tests pass with or without `--compiler-library-parser`
- [x] paratest passes without `--compiler-library-parser`

Reviewed by @mppf, thanks!

Signed-off-by: arezaii ahmad.rezaii@hpe.com