### PR TITLE
Clean up two temporaries in resolution

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9835,6 +9835,9 @@ static bool resolveSerializeDeserialize(AggregateType* at) {
     retval = true;
   }
 
+  // remove the temporary used in resolving
+  tmp->defPoint->remove();
+
   return retval;
 }
 
@@ -9875,6 +9878,9 @@ static void resolveBroadcasters(AggregateType* at) {
 
   ser.broadcaster = broadcastFn;
   ser.destroyer   = destroyFn;
+
+  // remove the temporary used to resolve
+  tmp->defPoint->remove();
 }
 
 static FnSymbol* createMethodStub(AggregateType* at, const char* methodName,


### PR DESCRIPTION
These are just used to resolve serialize/deserialize/broadcast.
These temporaries would be dead-code-eliminated anyway.
Cleaning them up right away simplifies the AST logs.

- [x] full local testing
- [x] full gasnet testing

Reviewed by @vasslitvinov - thanks!