### PR TITLE
Fix indexing bug in system libfabric chplenv

### DIFF
--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -112,7 +112,7 @@ def get_link_args():
                 if pcl.startswith('-L'):
                     libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
 
-        args(1).extend(libs)
+        args[1].extend(libs)
 
     if libfabric_val == 'system' or libfabric_val == 'bundled':
         libs = [ ]


### PR DESCRIPTION
The old code was trying to index into a tuple with `()` instead of `[]`,
which doesn't work in python (but does in chapel) so update to use `[]`.
Follow on to #18880.