### PR TITLE
Fix: failing cron asan tests in next/primers

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -616,7 +616,9 @@ struct Converter {
         assert(ifVar->kind() == uast::Variable::CONST ||
                ifVar->kind() == uast::Variable::VAR);
         assert(ifVar->initExpression());
-        auto varNameStr = ifVar->name().c_str();
+        // astr() varNameStr so it doesn't go out of scope when passed to
+        // buildIfVar
+        auto varNameStr = astr(ifVar->name().c_str());
         auto initExpr = toExpr(convertAST(ifVar->initExpression()));
         bool isConst = ifVar->kind() == uast::Variable::CONST;
         cond = buildIfVar(varNameStr, initExpr, isConst);


### PR DESCRIPTION
This PR fixes an issue where testing with the
address sanitizer caused several next/primer
tests to fail.

We wrap a call to `c_str()` in `astr()` to prevent an 
instance of use-after-scope that happened when
visiting a `Conditional` node during the ast conversion
process.

TESTING:
all with `LLVM=none`

- [x] linux testing with address sanitizer
- [x] mac testing with address sanitizer
- [x] paratest

Reviewed by @dlongnecke-cray, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>