### PR TITLE
Tighten check-no-dash-o test

### DIFF
--- a/test/compflags/ferguson/check-no-dash-o.prediff
+++ b/test/compflags/ferguson/check-no-dash-o.prediff
@@ -5,5 +5,5 @@ LOG=$2
 # PREDIFF: Script to execute before diff'ing output (arguments: <test
 #    executable>, <log>, <compiler executable>)
 
-cat $LOG | awk '/-O/{ print "-O found" } /hello/{ print $0 }' > $LOG.tmp
+cat $LOG | awk '/ -O/{ print "-O found: "; print } /hello/{ print $0 }' > $LOG.tmp
 mv $LOG.tmp $LOG


### PR DESCRIPTION
This PR improves a test added in #18985 to check for accidental `-O` in compiler or linker flags.

We saw this test fail in one nightly testing configuration. I think we were lucky enough to get a temporary directory for the source code files of something like `/tmp/chpl-user.deleteme-OigbDV`. Anyway this PR adjusts the prediff to look for `" -O"` (including the space) and to print out the whole line that matched in case this comes up again.

Test change only - not reviewed.