### PR TITLE
add break-on-query-hash flag

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -272,6 +272,8 @@ extern bool fPrintAdditionalErrors;
 extern bool fCompilerLibraryParser;
 extern bool fDebugTrace;
 
+extern size_t fBreakOnQueryHash;
+
 namespace chpl {
   class Context;
 }

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -347,6 +347,7 @@ Flag types:
   + = increment
   T = toggle
   L = int64 (long)
+  U = unsigned long
   N = --no-... flag, --no version sets to false
   n = --no-... flag, --no version sets to true
 */
@@ -480,6 +481,9 @@ static void ApplyValue(const ArgumentState*       state,
 
         break;
       }
+      case 'U':
+        *((size_t*) location) = str2uint64(value);
+        break;
     }
   }
 
@@ -695,6 +699,10 @@ static void process_arg(const ArgumentState*       state,
             }
             strncpy((char*) desc->location, arg, maxlen);
           }
+          break;
+
+        case 'U':
+          *((size_t*) desc->location) = std::stoull(arg);
           break;
 
         default:

--- a/compiler/main/docsDriver.cpp
+++ b/compiler/main/docsDriver.cpp
@@ -67,6 +67,7 @@ Flag types:
   + = increment
   T = toggle
   L = int64 (long)
+  U = unsigned long
   N = --no-... flag, --no version sets to false
   n = --no-... flag, --no version sets to true
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -301,6 +301,7 @@ bool fPrintChplSettings = false;
 
 bool fCompilerLibraryParser = false;
 bool fDebugTrace = false;
+size_t fBreakOnQueryHash = 0;
 
 int fGPUBlockSize = 0;
 char fCUDAArch[16] = "sm_60";
@@ -949,6 +950,7 @@ Flag types:
   + = increment
   T = toggle
   L = int64 (long)
+  U = unsigned long
   N = --no-... flag, --no version sets to false
   n = --no-... flag, --no version sets to true
 
@@ -1200,6 +1202,8 @@ static ArgumentDescription arg_desc[] = {
 
  {"compiler-library-parser", ' ', NULL, "Enable [disable] using compiler library parser", "N", &fCompilerLibraryParser, "CHPL_COMPILER_LIBRARY_PARSER", NULL},
  {"debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using compiler library parser", "N", &fDebugTrace, "CHPL_DEBUG_TRACE", NULL},
+ {"break-on-query-hash", ' ' , NULL, "Break when query with given hash value is executed when using compiler library parser", "U", &fBreakOnQueryHash, "CHPL_BREAK_ON_QUERY_HASH", NULL},
+
 
  DRIVER_ARG_PRINT_CHPL_HOME,
  DRIVER_ARG_LAST
@@ -1787,13 +1791,15 @@ int main(int argc, char* argv[]) {
 
     process_args(&sArgState, argc, argv);
 
-    if (gContext != nullptr) {
-      gContext->setDebugTraceFlag(fDebugTrace);
-    }
-
     setupChplGlobals(argv[0]);
 
     postprocess_args();
+
+    if (gContext != nullptr) {
+      gContext->setDebugTraceFlag(fDebugTrace);
+      if (fBreakOnQueryHash != 0)
+        gContext->setBreakOnHash(fBreakOnQueryHash);
+    }
 
     initCompilerGlobals(); // must follow argument parsing
 

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -35,7 +35,6 @@
 #include <utility>
 #include <vector>
 
-
 namespace chpl {
 
 namespace uast {
@@ -468,6 +467,12 @@ class Context {
     in main gets created before the arguments to the compiler are parsed.
   */
   void setDebugTraceFlag(const bool enable);
+
+  /*
+    Set the hash value of a query and its arguments to break on. Needed because
+    context in main is created before arguments to the compiler are parsed.
+  */
+  void setBreakOnHash(const size_t hashVal);
 
   typedef enum {
     NOT_CHECKED_NOT_CHANGED = 0,

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -478,6 +478,11 @@ void Context::setDebugTraceFlag(bool enable)  {
   enableDebugTrace = enable;
 }
 
+void Context::setBreakOnHash(size_t hashVal) {
+  breakSet = true;
+  breakOnHash = hashVal;
+}
+
 void Context::collectGarbage() {
   // if there are no parent queries, collect some garbage
   assert(queryStack.size() == 0);

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -32,6 +32,7 @@ _chpl ()
 --break-on-codegen \
 --break-on-codegen-id \
 --break-on-id \
+--break-on-query-hash \
 --break-on-remove-id \
 --break-on-resolve-id \
 --cache-remote \


### PR DESCRIPTION
This PR adds a compile time flag `--break-on-query-hash` that lets
the developer specify a specific hash value to break on during compilation.

The scope of work is outline in cray/chapel-private/issues/2783

TESTING:

- [x] compiler breaks on hash value
- [x] hash value can be passed through CL arg
- [x] hash value can be set with env var
- [x] break only happens with debugger flag `--gdb` or `--lldb`
- [x] break only happens when using `--compiler-library-parser`
- [x] break works in conjunction with `--debug-trace` 

Reviewed by @dlongnecke-cray

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>