### PR TITLE
Add a task yield microbenchmark

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -233,6 +233,7 @@ parallel/taskCompare/lydia/loopCompare.graph
 # suite: Task Spawning
 parallel/taskCompare/elliot/taskSpawn.graph
 parallel/taskCompare/elliot/serialTaskSpawn.graph
+parallel/taskCompare/elliot/taskYield.graph
 studies/hpcc/STREAMS/elliot/stream-task-placement.graph
 # suite: Barrier
 performance/comm/barrier/empty-chpl-barrier.graph

--- a/test/parallel/taskCompare/elliot/chpl-taskyield.chpl
+++ b/test/parallel/taskCompare/elliot/chpl-taskyield.chpl
@@ -1,0 +1,34 @@
+use Time;
+
+config const numTrials = 100;
+config const printTimings = false;
+
+config const baseNumTasks = here.maxTaskPar;
+
+
+proc main() {
+  taskYield(1);
+  taskYield(4);
+  taskYield(16);
+}
+
+proc taskYield(oversub) {
+  var t: Timer;
+
+  t.start();
+  var total: atomic int;
+  coforall 1..baseNumTasks*oversub {
+    var i: int;
+    for 1..numTrials {
+      i += 1;
+      chpl_task_yield();
+    }
+    total.add(i);
+  }
+  assert(total.read() == numTrials * baseNumTasks*oversub);
+  t.stop();
+
+  if printTimings {
+    writeln("Elapsed time ", oversub, ": ", t.elapsed());
+  }
+}

--- a/test/parallel/taskCompare/elliot/chpl-taskyield.perfkeys
+++ b/test/parallel/taskCompare/elliot/chpl-taskyield.perfkeys
@@ -1,0 +1,3 @@
+Elapsed time 1:
+Elapsed time 4:
+Elapsed time 16:

--- a/test/parallel/taskCompare/elliot/taskYield.graph
+++ b/test/parallel/taskCompare/elliot/taskYield.graph
@@ -1,0 +1,5 @@
+perfkeys: Elapsed time 1:, Elapsed time 4:, Elapsed time 16:
+graphkeys: 1 task per core, 4 tasks per core, 16 tasks per core
+repeat-files: chpl-taskyield.dat
+graphtitle: Task Yield Timings (500,000 yields/task)
+ylabel: Time (seconds)


### PR DESCRIPTION
This is meant to track how fast task yields are both when there's only
one task per core and when there's multiple tasks per core. This will
help us track any improvements to task yielding for things like fast
qthreads context switching for ARM or if yields with no other tasks
scheduled get optimized into no-ops or something.

Motivated by https://github.com/cray/chapel-private/issues/2920