### PR TITLE
Report an error for a non-rectangular sparse domains

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -328,6 +328,10 @@ module ChapelDistribution {
       return false;
     }
 
+    proc isRectangular() param return false;
+    proc isAssociative() param return false;
+    proc isSparse()      param return false;
+
     proc type isDefaultRectangular() param return false;
     proc isDefaultRectangular() param return false;
 
@@ -365,6 +369,8 @@ module ChapelDistribution {
     param rank : int;
     type idxType;
     param stridable: bool;
+
+    override proc isRectangular() param return true;
 
     proc getBaseArrType() type {
       var tmp = new unmanaged BaseArrOverRectangularDom(rank=rank, idxType=idxType, stridable=stridable);
@@ -594,6 +600,8 @@ module ChapelDistribution {
 
     /*var nnz = 0; //: int;*/
 
+    override proc isSparse() param return true;
+
     proc getNNZ(): int {
       halt("nnz queried on base class");
     }
@@ -663,6 +671,8 @@ module ChapelDistribution {
 
 
   class BaseAssociativeDom : BaseDom {
+    override proc isAssociative() param return true;
+
     proc deinit() {
       // this is a bug workaround
     }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -62,9 +62,21 @@ module ChapelDomain {
     return new _domain(dist, idxType, parSafe);
   }
 
+  private proc isUltimatelyRectangularParent(parentDom: domain) param {
+    if parentDom.isRectangular() then
+      return true;
+    else if parentDom.isSparse() then
+      return isUltimatelyRectangularParent(parentDom._value.parentDom);
+    else
+      return false;
+  }
+
   pragma "runtime type init fn"
   proc chpl__buildSparseDomainRuntimeType(dist: _distribution,
                                           parentDom: domain) {
+    if ! isUltimatelyRectangularParent(parentDom) then
+      compilerError("sparse subdomains are currently supported only for rectangular domains");
+
     return new _domain(dist, parentDom);
   }
 
@@ -2018,7 +2030,7 @@ module ChapelDomain {
     /* Return true if this domain is a rectangular.
        Otherwise return false.  */
     proc isRectangular() param {
-      return isSubtype(_to_borrowed(_value.type), BaseRectangularDom);
+      return this._value.isRectangular();
     }
 
     /* Return true if ``d`` is an irregular domain; e.g. is not rectangular.
@@ -2029,15 +2041,14 @@ module ChapelDomain {
 
     /* Return true if ``d`` is an associative domain. Otherwise return false. */
     proc isAssociative() param {
-      return chpl_isAssociativeDomClass(_to_borrowed(this._value));
+      return this._value.isAssociative();
     }
 
     /* Return true if ``d`` is a sparse domain. Otherwise return false. */
     proc isSparse() param {
-      proc isSparseDomClass(dc: BaseSparseDom) param return true;
-      proc isSparseDomClass(dc) param return false;
-      return isSparseDomClass(this._value);
+      return this._value.isSparse();
     }
+
   }  // record _domain
 
 }

--- a/test/domains/compilerErrors/sparseSubdom-types.chpl
+++ b/test/domains/compilerErrors/sparseSubdom-types.chpl
@@ -1,0 +1,12 @@
+
+var RD: domain(1);
+type SRT = sparse subdomain(RD);
+var SRD: SRT;
+type SSRT = sparse subdomain(SRD);
+var SSRD: SSRT;
+
+var AD: domain(int);
+type SAT = sparse subdomain(AD);
+var SAD: SAT;
+type SSAT = sparse subdomain(SAD);
+var SSAD: SSAT;

--- a/test/domains/compilerErrors/sparseSubdom-types.good
+++ b/test/domains/compilerErrors/sparseSubdom-types.good
@@ -1,0 +1,1 @@
+sparseSubdom-types.chpl:9: error: sparse subdomains are currently supported only for rectangular domains

--- a/test/domains/compilerErrors/sparseSubdom-values.chpl
+++ b/test/domains/compilerErrors/sparseSubdom-values.chpl
@@ -1,0 +1,8 @@
+
+var RD: domain(1);
+var SRD: sparse subdomain(RD);
+var SSRD: sparse subdomain(SRD);
+
+var AD: domain(int);
+var SAD: sparse subdomain(AD);
+var SSAD: sparse subdomain(SAD);

--- a/test/domains/compilerErrors/sparseSubdom-values.good
+++ b/test/domains/compilerErrors/sparseSubdom-values.good
@@ -1,0 +1,1 @@
+sparseSubdom-values.chpl:7: error: sparse subdomains are currently supported only for rectangular domains

--- a/test/domains/methods/isXXX.chpl
+++ b/test/domains/methods/isXXX.chpl
@@ -1,0 +1,39 @@
+// These definitions are copied from
+//   test/domains/compilerErrors/notsupportedCommon.chpl
+
+var dfltRectangularBase = {1..3};
+var dfltAssociativeBase = {1, 2, 3};
+
+// Test a distributed domain.
+use BlockDist;
+var DistributedBase = dfltRectangularBase dmapped Block({1..3});
+
+// Simple subdomains.
+var dfltRectangularSubdomain: subdomain(dfltRectangularBase) = dfltRectangularBase;
+var dfltAssociativeSubdomain: subdomain(dfltAssociativeBase) = dfltAssociativeBase;
+var DistributedSubdomain:     subdomain(DistributedBase)     = DistributedBase;
+
+// Sparse subdomains.
+var dfltRectangularSparseSub: sparse subdomain(dfltRectangularBase);
+//var dfltAssociativeSparseSub: sparse subdomain(dfltAssociativeBase);
+var DistributedSparseSub:     sparse subdomain(DistributedBase);
+
+// Test isXXX methods on domain classes.
+proc testDom(dom, param name) {
+  compilerWarning(name,
+                  "  ", dom.isRectangular(): string,
+                  "  ", dom.isAssociative(): string,
+                  "  ", dom.isSparse(): string);
+}
+
+testDom(dfltRectangularBase,      "dfltRectangularBase");
+testDom(dfltAssociativeBase,      "dfltAssociativeBase");
+testDom(DistributedBase,          "DistributedBase");
+testDom(dfltRectangularSubdomain, "dfltRectangularSubdomain");
+testDom(dfltAssociativeSubdomain, "dfltAssociativeSubdomain");
+testDom(DistributedSubdomain,     "DistributedSubdomain");
+testDom(dfltRectangularSparseSub, "dfltRectangularSparseSub");
+//testDom(dfltAssociativeSparseSub, "dfltAssociativeSparseSub");
+testDom(DistributedSparseSub,      "DistributedSparseSub");
+
+compilerError("done");

--- a/test/domains/methods/isXXX.good
+++ b/test/domains/methods/isXXX.good
@@ -1,0 +1,9 @@
+isXXX.chpl:29: warning: dfltRectangularBase  true  false  false
+isXXX.chpl:30: warning: dfltAssociativeBase  false  true  false
+isXXX.chpl:31: warning: DistributedBase  true  false  false
+isXXX.chpl:32: warning: dfltRectangularSubdomain  true  false  false
+isXXX.chpl:33: warning: dfltAssociativeSubdomain  false  true  false
+isXXX.chpl:34: warning: DistributedSubdomain  true  false  false
+isXXX.chpl:35: warning: dfltRectangularSparseSub  false  false  true
+isXXX.chpl:37: warning: DistributedSparseSub  false  false  true
+isXXX.chpl:39: error: done


### PR DESCRIPTION
Currently sparse subdomains are implemented only for rectangular domains,
including sparse subdomains of (simple and sparse) subdomains with
a rectangular domain as the final transitive parent.

This PR makes it a compile-time error to create a sparse subdomain type
that does not fit the above category. This way users will not encounter
unhelpful error messages when invoking some functionality (such as bulkAdd()
currently) on a non-rectangular sparse domain.

While there, introduce isRectangular(), isAssociative(), and isSparse()
on DSI domain classes (BaseDom and subclasses), to replace
some less-elegant code.

Testing: default paratest; multilocale tests under gasnet