### PR TITLE
Renaming list.indexOf to list.find

### DIFF
--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -1675,7 +1675,7 @@ module ArgumentParser {
         if arrElt.startsWith("-") && arrElt.find("=") > 0 {
           var elems = new list(arrElt.split("=", 1));
           // replace this opt=val with opt val
-          var idx = argsList.indexOf(arrElt);
+          var idx = argsList.find(arrElt);
           argsList.pop(idx);
           argsList.insert(idx, elems.toArray());
         }

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1320,7 +1320,7 @@ module List {
         return error;
 
       if boundsChecking {
-        const msg = " index for \"list.indexOf\" out of bounds: ";
+        const msg = " index for \"list.find\" out of bounds: ";
 
         if end >= 0 && !_withinBounds(end) then
           boundsCheckHalt("End" + msg + end:string);

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1278,11 +1278,27 @@ module List {
     }
 
     /*
-    .. warning::
+      Return a zero-based index into this list of the first item whose value
+      is equal to `x`. If no such element can be found this method returns
+      the value `-1`.
 
-    indexOf on lists is deprecated, use :proc:`find` instead.
+      .. warning::
+
+        indexOf on lists is deprecated, use :proc:`find` instead.
+
+      :arg x: An element to search for.
+      :type x: `eltType`
+
+      :arg start: The start index to start searching from.
+      :type start: `int`
+
+      :arg end: The end index to stop searching at. A value less than
+                `0` will search the entire list.
+      :type end: `int`
+
+      :return: The index of the element to search for, or `-1` on error.
+      :rtype: `int`
     */
-
     deprecated "indexOf on lists is deprecated, use :proc:`find` instead; please let us know if this is problematic for you."
     proc const indexOf(x: eltType, start: int=0, end: int=-1): int {
       return find(x, start, end);

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1278,6 +1278,17 @@ module List {
     }
 
     /*
+    .. warning::
+
+    indexOf on lists is deprecated, use :proc:`find` instead.
+    */
+
+    deprecated "indexOf on lists is deprecated, use :proc:`find` instead; please let us know if this is problematic for you."
+    proc const indexOf(x: eltType, start: int=0, end: int=-1): int {
+      return find(x, start, end);
+    }
+
+    /*
       Return a zero-based index into this list of the first item whose value
       is equal to `x`. If no such element can be found this method returns
       the value `-1`.
@@ -1302,8 +1313,7 @@ module List {
       :return: The index of the element to search for, or `-1` on error.
       :rtype: `int`
     */
-    proc const indexOf(x: eltType, start: int=0, end: int=-1): int {
-
+    proc const find(x: eltType, start: int=0, end: int=-1): int {
       param error = -1;
 
       if _size == 0 then

--- a/test/deprecated/listIndexOf.chpl
+++ b/test/deprecated/listIndexOf.chpl
@@ -1,0 +1,12 @@
+private use List;
+
+var lst : list(int);
+var idx = 0;
+config const testIters = 8;
+
+for i in 1..testIters do
+  lst.append(i);
+
+idx = lst.indexOf(3);
+assert(idx == 2);
+

--- a/test/deprecated/listIndexOf.good
+++ b/test/deprecated/listIndexOf.good
@@ -1,0 +1,2 @@
+listIndexOf.chpl:11: warning: indexOf on lists is deprecated, use find instead; please let us know if this is problematic for you.
+

--- a/test/deprecated/listIndexOf.good
+++ b/test/deprecated/listIndexOf.good
@@ -1,2 +1,1 @@
-listIndexOf.chpl:11: warning: indexOf on lists is deprecated, use find instead; please let us know if this is problematic for you.
-
+listIndexOf.chpl:10: warning: indexOf on lists is deprecated, use find instead; please let us know if this is problematic for you.

--- a/test/library/standard/List/indexOf/listIndexOf.chpl
+++ b/test/library/standard/List/indexOf/listIndexOf.chpl
@@ -7,7 +7,7 @@ var idx = 0;
 
 for i in 1..testIters {
   lst.append(i);
-  idx = lst.indexOf(i);
+  idx = lst.find(i);
   assert(idx == i-1);
 }
 
@@ -15,13 +15,13 @@ for i in 1..testIters do
   lst.append(i);
 
 // Value of `end` < 0 defaults to searching entire list.
-idx = lst.indexOf(testIters, testIters, -1);
+idx = lst.find(testIters, testIters, -1);
 
 assert(idx >= 0);
 
 lst.pop();
 
-idx = lst.indexOf(testIters, testIters);
+idx = lst.find(testIters, testIters);
 
 assert(idx < 0);
 

--- a/test/library/standard/List/indexOf/listIndexOfEmptyList.chpl
+++ b/test/library/standard/List/indexOf/listIndexOfEmptyList.chpl
@@ -4,5 +4,5 @@ config const testIters = 8;
 
 var lst: list(int);
 
-var idx = lst.indexOf(testIters);
+var idx = lst.find(testIters);
 assert(idx == -1);

--- a/test/library/standard/List/indexOf/listIndexOfHaltEnd.chpl
+++ b/test/library/standard/List/indexOf/listIndexOfHaltEnd.chpl
@@ -9,5 +9,5 @@ for i in 1..testIters do
 
 lst.pop();
 
-var idx = lst.indexOf(testIters, 1, testIters);
+var idx = lst.find(testIters, 1, testIters);
 

--- a/test/library/standard/List/indexOf/listIndexOfHaltEnd.good
+++ b/test/library/standard/List/indexOf/listIndexOfHaltEnd.good
@@ -1,1 +1,1 @@
-listIndexOfHaltEnd.chpl:12: error: halt reached - End index for "list.indexOf" out of bounds: 8
+listIndexOfHaltEnd.chpl:12: error: halt reached - End index for "list.find" out of bounds: 8

--- a/test/library/standard/List/indexOf/listIndexOfHaltStart.chpl
+++ b/test/library/standard/List/indexOf/listIndexOfHaltStart.chpl
@@ -7,5 +7,5 @@ var lst: list(int);
 for i in 1..testIters do
   lst.append(i);
 
-var idx = lst.indexOf(testIters, -1, testIters-1);
+var idx = lst.find(testIters, -1, testIters-1);
 

--- a/test/library/standard/List/indexOf/listIndexOfHaltStart.good
+++ b/test/library/standard/List/indexOf/listIndexOfHaltStart.good
@@ -1,1 +1,1 @@
-listIndexOfHaltStart.chpl:10: error: halt reached - Start index for "list.indexOf" out of bounds: -1
+listIndexOfHaltStart.chpl:10: error: halt reached - Start index for "list.find" out of bounds: -1

--- a/test/release/examples/primers/listOps.chpl
+++ b/test/release/examples/primers/listOps.chpl
@@ -204,7 +204,7 @@ writeln("List 1 after correction: ", lst1);
 
 /*
   If you need to get the specific index of a value contained in a list, you
-  can use the ``list.indexOf()`` operator.
+  can use the ``list.find()`` operator.
 
   .. warning::
 
@@ -213,12 +213,12 @@ writeln("List 1 after correction: ", lst1);
 */
 
 for x in lst2 {
-  const idx = lst1.indexOf(x);
+  const idx = lst1.find(x);
   assert(x == idx+1);
 }
 
 for x in lst3 {
-  const idx = lst1.indexOf(x);
+  const idx = lst1.find(x);
   assert(x == idx+1);
 }
 


### PR DESCRIPTION
This PR:

- Renames list.indexOf to list.find to match with string.find and bytes.find (motivated by issue #18099)
- Updates modules that use list.indexOf to use list.find
- Adds new tests to indicate that list.indexOf is deprecated
- Modifies existing tests that use list.indexOf to use list.find
- Updates documentation to warn that list.indexOf is deprecated