### PR TITLE
Update the compiler to support LLVM-13

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2585,7 +2585,12 @@ void FnSymbol::codegenDef() {
               // consume the next LLVM argument
               llvm::Value* val = &*ai++;
               // store it into the addr
+#if HAVE_LLVM_VER >= 130
+              llvm::Value* eltPtr =
+                irBuilder->CreateStructGEP(storeAdr->getType(), storeAdr, i);
+#else
               llvm::Value* eltPtr = irBuilder->CreateStructGEP(storeAdr, i);
+#endif
               irBuilder->CreateStore(val, eltPtr);
             }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2099,8 +2099,14 @@ codegen_config() {
     forv_Vec(VarSymbol, var, gVarSymbols) {
       if (var->hasFlag(FLAG_CONFIG) && !var->isType()) {
         std::vector<llvm::Value *> args (6);
-        args[0] = info->irBuilder->CreateLoad(
-            new_CStringSymbol(var->name)->codegen().val);
+        {
+          GenRet gen = new_CStringSymbol(var->name)->codegen();
+#if HAVE_LLVM_VER >= 130
+          args[0] = info->irBuilder->CreateLoad(gen.val->getType(), gen.val);
+#else
+          args[0] = info->irBuilder->CreateLoad(gen.val);
+#endif
+        }
 
         Type* type = var->type;
         if (type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
@@ -2112,23 +2118,43 @@ codegen_config() {
         if (type->symbol->hasFlag(FLAG_WIDE_CLASS)) {
           type = type->getField("addr")->type;
         }
-        args[1] = info->irBuilder->CreateLoad(
-            new_CStringSymbol(type->symbol->name)->codegen().val);
+        {
+          GenRet gen = new_CStringSymbol(type->symbol->name)->codegen();
+#if HAVE_LLVM_VER >= 130
+          args[1] = info->irBuilder->CreateLoad(gen.val->getType(), gen.val);
+#else
+          args[1] = info->irBuilder->CreateLoad(gen.val);
+#endif
+        }
 
         if (var->getModule()->modTag == MOD_INTERNAL) {
-          args[2] = info->irBuilder->CreateLoad(
-              new_CStringSymbol("Built-in")->codegen().val);
+          GenRet gen = new_CStringSymbol("Built-in")->codegen();
+#if HAVE_LLVM_VER >= 130
+          args[2] = info->irBuilder->CreateLoad(gen.val->getType(), gen.val);
+#else
+          args[2] = info->irBuilder->CreateLoad(gen.val);
+#endif
         }
         else {
-          args[2] =info->irBuilder->CreateLoad(
-              new_CStringSymbol(var->getModule()->name)->codegen().val);
+          GenRet gen = new_CStringSymbol(var->getModule()->name)->codegen();
+#if HAVE_LLVM_VER >= 130
+          args[2] =info->irBuilder->CreateLoad(gen.val->getType(), gen.val);
+#else
+          args[2] =info->irBuilder->CreateLoad(gen.val);
+#endif
         }
 
         args[3] = info->irBuilder->getInt32(var->hasFlag(FLAG_PRIVATE));
 
         args[4] = info->irBuilder->getInt32(var->hasFlag(FLAG_DEPRECATED));
-        args[5] = info->irBuilder->CreateLoad(new_CStringSymbol(var->getDeprecationMsg())->codegen().val);
-
+        {
+          GenRet gen = new_CStringSymbol(var->getDeprecationMsg())->codegen();
+#if HAVE_LLVM_VER >= 130
+          args[5] = info->irBuilder->CreateLoad(gen.val->getType(), gen.val);
+#else
+          args[5] = info->irBuilder->CreateLoad(gen.val);
+#endif
+        }
         info->irBuilder->CreateCall(installConfigFunc, args);
       }
     }

--- a/compiler/include/llvmGlobalToWide.h
+++ b/compiler/include/llvmGlobalToWide.h
@@ -33,6 +33,7 @@ namespace llvm {
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/ValueHandle.h"
+#include <vector>
 
 /* The LLVM Global to Wide transformation allows the Chapel code generator
  * to emit multi-locale global pointer code that can be optimized by existing

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -813,7 +813,11 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
         Type* SrcTy = origSrcTy->getPointerElementType()->getPointerTo(0);
         Value* Src = irBuilder.CreatePointerCast(i8Src, SrcTy);
 
+#if HAVE_LLVM_VER >= 130
+        LoadInst* newLoad = irBuilder.CreateLoad(Src->getType(), Src);
+#else
         LoadInst* newLoad = irBuilder.CreateLoad(Src);
+#endif
 #if HAVE_LLVM_VER >= 100
         newLoad->setAlignment(oldLoad->getAlign());
 #else

--- a/compiler/llvm/llvmExtractIR.cpp
+++ b/compiler/llvm/llvmExtractIR.cpp
@@ -86,7 +86,11 @@ void extractAndPrintFunctionsLLVM(std::set<const GlobalValue*> *gvs) {
 
   std::error_code EC;
   // note: could output to a file if we replace "-" with a filename
+#if HAVE_LLVM_VER >= 120
+  ToolOutputFile Out("-", EC, sys::fs::OF_None);
+#else
   ToolOutputFile Out("-", EC, sys::fs::F_None);
+#endif
   if (EC) {    
     errs() << EC.message() << '\n';
     return;

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -521,7 +521,11 @@ llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
       llvm::Value* tmp_cur = irBuilder->CreatePointerCast(tmp_alloc, curPtrType);
       llvm::Value* tmp_new = irBuilder->CreatePointerCast(tmp_alloc, newPtrType);
       irBuilder->CreateStore(value, tmp_cur);
+#if HAVE_LLVM_VER >= 130
+      return irBuilder->CreateLoad(tmp_new->getType(), tmp_new);
+#else
       return irBuilder->CreateLoad(tmp_new);
+#endif
     }
   }
 


### PR DESCRIPTION
Update the compiler with changes required to work with LLVM-13. Maintain
backward compatibility with versions 12 and 11.

The widest change was changing calls to the CreateLoad method to take the
value's type as its the first argument.

There were also a handful of flags that changed availability when passing
options between Clang and LLVM, functions that were deprecated and other
small changes.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>