### PR TITLE
Sort TOML output 

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -921,9 +921,6 @@ used to recursively hold tables and respective values
     proc printValues(f: channel, v: borrowed Toml) throws {
       for key in v.A.keysToArray().sorted() {
         var value = v.A[key]!;
-
-      // for (key, val) in v.A.items() {
-      //   var value = val!;
         select value.tag {
           when fieldToml do continue; // Table
           when fieldBool {
@@ -977,8 +974,8 @@ used to recursively hold tables and respective values
     pragma "no doc"
     /* Send values from table to toString for writing  */
     proc printValuesJSON(f: channel, v: borrowed Toml, in indent=0) throws {
-      for ((key, val), i) in zip(v.A.items(), 1..v.A.size) {
-        var value = val!;
+      for (key, i) in zip(v.A.keysToArray().sorted(), 1..v.A.size) {
+        var value = v.A[key]!;
         select value.tag {
           when fieldToml do continue; // Table
           when fieldBool {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -919,8 +919,11 @@ used to recursively hold tables and respective values
     pragma "no doc"
     /* Send values from table to toString for writing  */
     proc printValues(f: channel, v: borrowed Toml) throws {
-      for (key, val) in v.A.items() {
-        var value = val!;
+      for key in v.A.keysToArray().sorted() {
+        var value = v.A[key]!;
+
+      // for (key, val) in v.A.items() {
+      //   var value = val!;
         select value.tag {
           when fieldToml do continue; // Table
           when fieldBool {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -127,6 +127,7 @@ module TomlParser {
   import IO.channel;
   private use TOML.TomlReader;
   import TOML.TomlError;
+  use Sort;
 
   /* Prints a line by line output of parsing process */
   config const debugTomlParser = false;
@@ -919,7 +920,9 @@ used to recursively hold tables and respective values
     pragma "no doc"
     /* Send values from table to toString for writing  */
     proc printValues(f: channel, v: borrowed Toml) throws {
-      for key in v.A.keysToArray().sorted() {
+      var keys = v.A.keysToArray();
+      sort(keys);
+      for key in keys {
         var value = v.A[key]!;
         select value.tag {
           when fieldToml do continue; // Table
@@ -974,7 +977,9 @@ used to recursively hold tables and respective values
     pragma "no doc"
     /* Send values from table to toString for writing  */
     proc printValuesJSON(f: channel, v: borrowed Toml, in indent=0) throws {
-      for (key, i) in zip(v.A.keysToArray().sorted(), 1..v.A.size) {
+      var keys = v.A.keysToArray();
+      sort(keys);
+      for (key, i) in zip(keys, 1..v.A.size) {
         var value = v.A[key]!;
         select value.tag {
           when fieldToml do continue; // Table

--- a/test/library/packages/TOML/test/UTomlTest.chpl
+++ b/test/library/packages/TOML/test/UTomlTest.chpl
@@ -5,7 +5,7 @@ config const f: string;
 proc main() {
   var tomlChannel = openreader(f);
   var tomlData = parseToml(tomlChannel);
-  writeln("Before Mutation: ", tomlData);
+  writeln("Before Mutation:", tomlData);
 
   // New Table
   var tblD: domain(string);
@@ -18,11 +18,11 @@ proc main() {
   var toAdd: bool = true;
   tomlData["A.B.C"]!.set("new-key-added", toAdd);
 
-  writeln("After Mutation: ", tomlData);
+  writeln("After Mutation:", tomlData);
 
   // test toString proc
   var strInt: string = tomlData["A.B"]!["number"]!.toString();
-  writeln("A.B.number = ",strInt); 
+  writeln("A.B.number = ",strInt);
 
   writeln(); //for spacing
 
@@ -30,7 +30,7 @@ proc main() {
   writeln("KV pairs in table A.C");
   writeln(tomlData["A.C"]);
 
- 
+
   // Test of the "copy constructor"
   // New Toml
   var tbl2D: domain(string);
@@ -43,7 +43,7 @@ proc main() {
   writeln("Should be the same as");
   writeln(tomlData2["A"]);
 
-  delete tomlData2;  
+  delete tomlData2;
   delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/test/UTomlTest.good
+++ b/test/library/packages/TOML/test/UTomlTest.good
@@ -1,65 +1,65 @@
-Before Mutation: 
+Before Mutation:
 [A]
 
 [A.B]
-name = "sam"
 job = "programmer"
+name = "sam"
 number = 7
 
 [A.C]
-name = "Ben"
 job = "programmer"
+name = "Ben"
 
 
-After Mutation: 
+After Mutation:
 [A]
 
 [A.B]
-name = "sam"
 job = "programmer"
+name = "sam"
 number = 7
 
 [A.B.C]
 new-key-added = true
 
 [A.C]
-name = "Ben"
 job = "programmer"
+name = "Ben"
 
 
 A.B.number = 7
 
 KV pairs in table A.C
-name = "Ben"
 job = "programmer"
+name = "Ben"
 
 
 
 [B]
-name = "sam"
 job = "programmer"
+name = "sam"
 number = 7
 
 [B.C]
 new-key-added = true
 
 [C]
-name = "Ben"
 job = "programmer"
+name = "Ben"
 
 
 Should be the same as
 
 [B]
-name = "sam"
 job = "programmer"
+name = "sam"
 number = 7
 
 [B.C]
 new-key-added = true
 
 [C]
-name = "Ben"
 job = "programmer"
+name = "Ben"
 
 

--- a/test/library/packages/TOML/test/actual.good
+++ b/test/library/packages/TOML/test/actual.good
@@ -4,15 +4,15 @@ default = ["use_std"]
 use_std = []
 
 [package]
-version = "0.2.28"
-name = "libc"
-description = " A library for types and bindings to native C functions often found in libc or other common platform libraries. "
 authors = ["The Rust Project Developers"]
-repository = "https://github.com/rust-lang/libc"
+description = " A library for types and bindings to native C functions often found in libc or other common platform libraries. "
 documentation = "http://doc.rust-lang.org/libc"
 homepage = "https://github.com/rust-lang/libc"
 license = "MIT/Apache-2.0"
+name = "libc"
 readme = "README.md"
+repository = "https://github.com/rust-lang/libc"
+version = "0.2.28"
 
 [workspace]
 members = ["libc-test", "libc-test/generate-files"]

--- a/test/library/packages/TOML/test/arrayCorner.good
+++ b/test/library/packages/TOML/test/arrayCorner.good
@@ -1,7 +1,7 @@
 outside = [true]
 
 [intable]
-outside = [false]
 int = [6]
+outside = [false]
 
 

--- a/test/library/packages/TOML/test/arrays.good
+++ b/test/library/packages/TOML/test/arrays.good
@@ -1,11 +1,11 @@
-single = [9]
-strings = ["a", "b", "c"]
-ints = [1, 2, 3]
-floats = [1.1, 2.1, 3.1]
-bool = [true]
 arrays = [["hello"], [1, 2, 3, 4, 5, 6, 7]]
+bool = [true]
 booleans = [true, false]
+floats = [1.1, 2.1, 3.1]
+ints = [1, 2, 3]
 mixed = [[1, 2], ["a", "b"], [1.1, 2.1]]
 real = [3.4]
+single = [9]
+strings = ["a", "b", "c"]
 
 

--- a/test/library/packages/TOML/test/example.good
+++ b/test/library/packages/TOML/test/example.good
@@ -5,14 +5,14 @@ data = [["gamma", "delta"], [1, 2]]
 hosts = ["alpha", "omega"]
 
 [database]
-server = "192.168.1.1"
+connection_max = 5000
 enabled = true
 ports = [8001, 8001, 8002]
-connection_max = 5000
+server = "192.168.1.1"
 
 [owner]
-name = "Tom Preston-Werner"
 dob = 1979-05-27T07:32:00
+name = "Tom Preston-Werner"
 
 [servers]
 
@@ -27,11 +27,11 @@ ip = "10.0.0.2"
 [servers.beta.zeta]
 
 [servers.beta.zeta.intable]
-supported = true
 still = "annoying"
+supported = true
 
 [table]
-this = "table"
 holds = "stuff"
+this = "table"
 
 

--- a/test/library/packages/TOML/test/mason-1.good
+++ b/test/library/packages/TOML/test/mason-1.good
@@ -1,8 +1,8 @@
 
 [brick]
-name = "MapReduce"
 chplVersion = "1.17.0"
 compopts = "--set configParam=2 -sverbose=true"
+name = "MapReduce"
 version = "0.1.0"
 
 [dependencies]

--- a/test/library/packages/TOML/test/subTable.good
+++ b/test/library/packages/TOML/test/subTable.good
@@ -2,12 +2,12 @@
 [A]
 
 [A.B]
-name = "sam"
 job = "programmer"
+name = "sam"
 number = 7
 
 [A.C]
-name = "Ben"
 job = "programmer"
+name = "Ben"
 
 

--- a/test/library/packages/TOML/test/subTable2.good
+++ b/test/library/packages/TOML/test/subTable2.good
@@ -2,8 +2,8 @@
 [servers]
 
 [servers.alpha]
-dc = "eqdc10"
 ap = 12
+dc = "eqdc10"
 
 [servers.alpha.right]
 please = "be"

--- a/test/mason/chplVersion/tomls/format/noBug.good
+++ b/test/mason/chplVersion/tomls/format/noBug.good
@@ -2,8 +2,8 @@ Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]
-name = "noBug"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "noBug"
 version = "0.1.0"
 
 

--- a/test/mason/chplVersion/tomls/format/unbounded.good
+++ b/test/mason/chplVersion/tomls/format/unbounded.good
@@ -2,8 +2,8 @@ Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]
-name = "unbounded"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "unbounded"
 version = "0.1.0"
 
 

--- a/test/mason/chplVersion/tomls/pass/ivrsChooses.good
+++ b/test/mason/chplVersion/tomls/pass/ivrsChooses.good
@@ -1,28 +1,28 @@
 ----- lock file -----
 
 [root]
-name = "ivrsChooses"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
 dependencies = ["usesBad 0.1.0 foo", "usesGood 0.1.0 foo"]
+name = "ivrsChooses"
 version = "0.1.0"
 
 [badThenGood]
-name = "badThenGood"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "badThenGood"
 source = "foo"
 version = "0.2.0"
 
 [usesBad]
-name = "usesBad"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
 dependencies = ["badThenGood 0.2.0 foo"]
+name = "usesBad"
 source = "foo"
 version = "0.1.0"
 
 [usesGood]
-name = "usesGood"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
 dependencies = ["badThenGood 0.2.0 foo"]
+name = "usesGood"
 source = "foo"
 version = "0.1.0"
 

--- a/test/mason/chplVersion/tomls/pass/simpleDep.good
+++ b/test/mason/chplVersion/tomls/pass/simpleDep.good
@@ -1,14 +1,14 @@
 ----- lock file -----
 
 [root]
-name = "simpleDep"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
 dependencies = ["simpleGoodDep 0.1.0 foo"]
+name = "simpleDep"
 version = "0.1.0"
 
 [simpleGoodDep]
-name = "simpleGoodDep"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "simpleGoodDep"
 source = "foo"
 version = "0.1.0"
 

--- a/test/mason/chplVersion/tomls/pass/simpleSolo.good
+++ b/test/mason/chplVersion/tomls/pass/simpleSolo.good
@@ -2,8 +2,8 @@ Skipping registry update since no dependency found in manifest file.
 ----- lock file -----
 
 [root]
-name = "simpleSolo"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "simpleSolo"
 version = "0.1.0"
 
 

--- a/test/mason/mason-modify/addWithDep.good
+++ b/test/mason/mason-modify/addWithDep.good
@@ -1,8 +1,8 @@
 Adding Mason dependency test version 1.2.3
 
 [brick]
-name = "Tester"
 author = "Sam Partee"
+name = "Tester"
 version = "0.1.0"
 
 [dependencies]

--- a/test/mason/mason-modify/rmWithDep.good
+++ b/test/mason/mason-modify/rmWithDep.good
@@ -1,8 +1,8 @@
 Removing Mason dependency test
 
 [brick]
-name = "Tester"
 author = "Sam Partee"
+name = "Tester"
 version = "0.1.0"
 
 [dependencies]

--- a/test/mason/noDep.good
+++ b/test/mason/noDep.good
@@ -1,8 +1,8 @@
 Skipping registry update since no dependency found in manifest file.
 
 [root]
-name = "Tester"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "Tester"
 version = "0.1.0"
 
 

--- a/test/mason/pkgconfig-tests/PRECOMP
+++ b/test/mason/pkgconfig-tests/PRECOMP
@@ -19,16 +19,16 @@ pkgincs="$(echo -e "${pkgincs}" | sed -e 's/[[:space:]]*$//')"
 echo Skipping registry update since no dependency found in manifest file. >$good
 echo>>$good
 echo [root]>>$good
-echo name = \"$pkg\">>$good
 echo chplVersion = \"$chplver..$chplver\">>$good
+echo name = \"$pkg\">>$good
 echo version = \"0.1.0\">>$good
 echo>>$good
 echo [system]>>$good
 echo>>$good
 echo [system.$pkg]>>$good
-echo name = \"$pkg\">>$good
-echo libs = \"$pkglibs\">>$good
 echo include = \"$pkgincs\">>$good
+echo libs = \"$pkglibs\">>$good
+echo name = \"$pkg\">>$good
 echo version = \"$pkgver\">>$good
 echo>>$good
 echo>>$good

--- a/test/mason/search/showCapsize.good
+++ b/test/mason/search/showCapsize.good
@@ -2,8 +2,8 @@ capsize (0.1.0)
 Displaying the latest version: capsize@0.1.0
 
 [brick]
-name = "capsize"
 chplVersion = "1.19.0"
+name = "capsize"
 source = "nil"
 version = "0.1.0"
 

--- a/test/mason/simple.good
+++ b/test/mason/simple.good
@@ -1,14 +1,14 @@
 
 [root]
-name = "Tester"
+author = "Sam Partee"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
 dependencies = ["_MasonTest1 0.2.0 https://github.com/Spartee/_MasonTest1"]
-author = "Sam Partee"
+name = "Tester"
 version = "0.1.0"
 
 [_MasonTest1]
-name = "_MasonTest1"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
+name = "_MasonTest1"
 source = "https://github.com/Spartee/_MasonTest1"
 version = "0.2.0"
 


### PR DESCRIPTION
This PR ensures that the output written from the TOML module
is consistently reproduced in an ordered manner. Previously,
the order in which keys would print out was subject to the 
whims of the hashtable implementation. After this change, all
TOML files will have their keys written in sorted order, using the 
default string comparator.

In conjunction with this change, several of the `.good` files in 
`test/mason` and `test/library/packages/TOML/test` needed 
updating to account for the new key order.

TESTING:

- [x] paratest
- [x] `util/start_test test/mason`

Reviewed by @ben-albrecht and @mppf, thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>