### PR TITLE
Have Arkouda release testing use mains test dependencies

### DIFF
--- a/test/studies/arkouda/constraints.txt
+++ b/test/studies/arkouda/constraints.txt
@@ -1,1 +1,0 @@
-setuptools==54.0.0

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -64,7 +64,7 @@ fi
 export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
 # If Arkouda deps use any of our test deps, try to use the versions we want
 AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user --constraint ../constraints.txt; then
+if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user ; then
   log_fatal_error "installing arkouda"
 fi
 

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -48,6 +48,7 @@ function test_release() {
   git checkout $currentSha -- $CHPL_HOME/util/cron/
   git checkout $currentSha -- $CHPL_HOME/util/test/perf/
   git checkout $currentSha -- $CHPL_HOME/util/test/computePerfStats
+  git checkout $currentSha -- $CHPL_HOME/third-party/chpl-venv/test-requirements.txt
   $CWD/nightly -cron ${nightly_args}
 }
 


### PR DESCRIPTION
Alternative to #18903 and follow on to #16977, where we wanted arkouda to
use our current test-requirements. We still want to do that but we want
release testing to use any versions that get updated on main.