### PR TITLE
Add int: c_void_ptr casts

### DIFF
--- a/modules/standard/CPtr.chpl
+++ b/modules/standard/CPtr.chpl
@@ -337,17 +337,12 @@ module CPtr {
     return __primitive("cast", t, x);
   }
 
+  // casts from c pointer to c_intptr / c_uintptr
   pragma "no doc"
   inline operator :(x:c_void_ptr, type t:c_intptr)
     return __primitive("cast", t, x);
   pragma "no doc"
   inline operator :(x:c_void_ptr, type t:c_uintptr)
-    return __primitive("cast", t, x);
-  pragma "no doc"
-  inline operator :(x:c_void_ptr, type t:int(64)) where c_uintptr != int(64)
-    return __primitive("cast", t, x);
-  pragma "no doc"
-  inline operator :(x:c_void_ptr, type t:uint(64)) where c_uintptr != uint(64)
     return __primitive("cast", t, x);
 
   pragma "no doc"
@@ -356,11 +351,39 @@ module CPtr {
   pragma "no doc"
   inline operator :(x:c_ptr, type t:c_uintptr)
     return __primitive("cast", t, x);
+
+
+  // casts from c pointer to int / uint
+  // note that these are only used if c_intptr != int / c_uintptr != uint
   pragma "no doc"
-  inline operator :(x:c_ptr, type t:int(64)) where c_intptr != int(64)
+  inline operator :(x:c_void_ptr, type t:int) where c_uintptr != int
     return __primitive("cast", t, x);
   pragma "no doc"
-  inline operator :(x:c_ptr, type t:uint(64)) where c_uintptr != int(64)
+  inline operator :(x:c_void_ptr, type t:uint) where c_uintptr != uint
+    return __primitive("cast", t, x);
+
+  pragma "no doc"
+  inline operator :(x:c_ptr, type t:int) where c_intptr != int
+    return __primitive("cast", t, x);
+  pragma "no doc"
+  inline operator :(x:c_ptr, type t:uint) where c_uintptr != uint
+    return __primitive("cast", t, x);
+
+  // casts from c_intptr / c_uintptr to c_void_ptr
+  pragma "no doc"
+  inline operator :(x:c_intptr, type t:c_void_ptr)
+    return __primitive("cast", t, x);
+  pragma "no doc"
+  inline operator :(x:c_uintptr, type t:c_void_ptr)
+    return __primitive("cast", t, x);
+
+  // casts from int / uint to c_void_ptr
+  // note that these are only used if c_intptr != int / c_uintptr != uint
+  pragma "no doc"
+  inline operator :(x:int, type t:c_void_ptr) where c_intptr != int
+    return __primitive("cast", t, x);
+  pragma "no doc"
+  inline operator :(x:uint, type t:c_void_ptr) where c_uintptr != uint
     return __primitive("cast", t, x);
 
 

--- a/test/extern/ferguson/int-to-ptr.chpl
+++ b/test/extern/ferguson/int-to-ptr.chpl
@@ -1,16 +1,49 @@
 use SysCTypes;
 use CPtr;
 
-var a: c_void_ptr = (-1): c_void_ptr;
-var b: c_void_ptr = (-1): int : c_void_ptr;
-var c: c_void_ptr = (-1): uint : c_void_ptr;
-var d: c_void_ptr = (-1): c_intptr : c_void_ptr;
-var e: c_void_ptr = (-1): c_uintptr : c_void_ptr;
+config const debug = false;
 
-assert(a == b);
-assert(b == c);
-assert(c == d);
-assert(d == e);
+proc testType(type t, param val) {
+  if debug then
+    writef("testing %s with 0x%xu\n", t:string, val);
 
-var x = a: c_intptr;
-assert(x == -1);
+  param x: t = val;
+  var y: t = x;
+  var a: c_void_ptr = x: c_void_ptr;
+  var b: c_void_ptr = val: t : c_void_ptr;
+  var c: c_void_ptr = x: c_intptr : c_void_ptr;
+  var d: c_void_ptr = x: c_uintptr : c_void_ptr;
+
+
+  assert(a == b);
+  assert(b == c);
+  assert(c == d);
+
+  if debug then
+    writeln(a);
+
+  var back = a: c_uintptr : t;
+
+  if debug then
+    writef("0x%xu\n", back);
+
+  assert(back == y);
+}
+
+proc testWidth(param w) {
+  testType(int(w), -1);
+  testType(int(w), 1);
+  testType(uint(w), 1);
+  testType(uint(w), 1:uint(w) << (w-1));
+}
+
+testWidth(64);
+testWidth(32);
+testWidth(16);
+testWidth(8);
+
+// also check c_intptr / c_uintptr for good measure.
+// normally these are aliases for int/uint
+// but we check them again in case that's not the case.
+testType(c_intptr, -1);
+testType(c_uintptr, 1);

--- a/test/extern/ferguson/int-to-ptr.chpl
+++ b/test/extern/ferguson/int-to-ptr.chpl
@@ -1,0 +1,16 @@
+use SysCTypes;
+use CPtr;
+
+var a: c_void_ptr = (-1): c_void_ptr;
+var b: c_void_ptr = (-1): int : c_void_ptr;
+var c: c_void_ptr = (-1): uint : c_void_ptr;
+var d: c_void_ptr = (-1): c_intptr : c_void_ptr;
+var e: c_void_ptr = (-1): c_uintptr : c_void_ptr;
+
+assert(a == b);
+assert(b == c);
+assert(c == d);
+assert(d == e);
+
+var x = a: c_intptr;
+assert(x == -1);

--- a/test/extern/ferguson/int-to-ptr.chpl
+++ b/test/extern/ferguson/int-to-ptr.chpl
@@ -4,6 +4,7 @@ use CPtr;
 config const debug = false;
 
 proc testType(type t, param val) {
+
   if debug then
     writef("testing %s with 0x%xu\n", t:string, val);
 
@@ -22,12 +23,18 @@ proc testType(type t, param val) {
   if debug then
     writeln(a);
 
-  var back = a: c_uintptr : t;
-
-  if debug then
-    writef("0x%xu\n", back);
-
-  assert(back == y);
+  if isIntType(t) {
+    var back = a: c_intptr : t;
+    if debug then
+      writef("0x%xu\n", back);
+    assert(back == y);
+  }
+  if isUintType(t)  && (c_sizeof(t) == c_sizeof(c_void_ptr) || val == 1)  {
+    var back = a: c_uintptr : t;
+    if debug then
+      writef("0x%xu\n", back);
+    assert(back == y);
+  }
 }
 
 proc testWidth(param w) {


### PR DESCRIPTION
This PR adds int: c_void_ptr casts.

This is motivated by a feature request from @LouisJenkinsCS who was trying to use `mmap` from Chapel and so to have some equivalent to `MAP_FAILED = (void *) -1`. 

This PR also tidies up some ptr -> int casts.

Reviewed by @bradcray - thanks!

- [x] full local testing
- [x] check test on a 32-bit system