### PR TITLE
Deprecate/rename some regex formals, fix a bug

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -946,36 +946,44 @@ record regex {
      :yields: tuples of :record:`regexMatch` objects, the 1st is always
               the match for the whole pattern and the rest are the capture groups.
    */
-  iter matches(text: exprType, param captures=0, maxmatches: int = max(int))
+  iter matches(text: exprType, param numCaptures=0, maxMatches: int = max(int))
   {
     var regexCopy:regex(exprType);
     if home != here then regexCopy = this;
     const localRegex = if home != here then regexCopy._regex else _regex;
-    param nmatches = 1 + captures;
-    var matches: c_array(qio_regex_string_piece_t, nmatches);
+    param nMatches = 1 + numCaptures;
+    var matches: c_array(qio_regex_string_piece_t, nMatches);
     var pos:byteIndex;
-    var endpos:byteIndex;
+    var endPos:byteIndex;
     var textLength:int;
     var localText = text.localize();
 
     pos = 0;
     textLength = localText.numBytes;
-    endpos = pos + textLength;
+    endPos = pos + textLength;
 
-    var nfound = 0;
+    var nFound = 0;
     var cur = pos;
-    while nfound < maxmatches && cur <= endpos {
+    while nFound < maxMatches && cur <= endPos {
       var got = qio_regex_match(localRegex, localText.c_str(), textLength,
-                                cur:int, endpos:int, QIO_REGEX_ANCHOR_UNANCHORED,
-                                matches[0], nmatches);
+                                cur:int, endPos:int, QIO_REGEX_ANCHOR_UNANCHORED,
+                                matches[0], nMatches);
       if !got then break;
-      param nret = captures+1;
-      var ret:nret*regexMatch;
-      for i in 0..captures {
+      var ret:nMatches*regexMatch;
+      for i in 0..numCaptures {
         ret[i] = new regexMatch(got, matches[i].offset:byteIndex, matches[i].len);
       }
       yield ret;
       cur = matches[0].offset + max(1, matches[0].len);
+    }
+  }
+
+  pragma "last resort"
+  deprecated "regex.matches arguments 'captures' and 'maxmatches' are deprecated. Use 'numCaptures' and/or 'maxMatches instead."
+  iter matches(text: exprType, param captures=0, maxmatches: int = max(int))
+  {
+    for m in matches(text, numCaptures=captures, maxMatches=maxmatches) {
+      yield m;
     }
   }
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -975,6 +975,7 @@ record regex {
       }
       yield ret;
       cur = matches[0].offset + max(1, matches[0].len);
+      nFound += 1;
     }
   }
 

--- a/test/deprecated/regexMatchesArgs.chpl
+++ b/test/deprecated/regexMatchesArgs.chpl
@@ -1,0 +1,9 @@
+import Regex;
+
+var text = "foo 123 bar 345";
+
+var r = Regex.compile("\\d+");
+
+for m in r.matches(text, captures=0, maxmatches=1) {
+  writeln(m);
+}

--- a/test/deprecated/regexMatchesArgs.good
+++ b/test/deprecated/regexMatchesArgs.good
@@ -1,3 +1,2 @@
 regexMatchesArgs.chpl:7: warning: regex.matches arguments 'captures' and 'maxmatches' are deprecated. Use 'numCaptures' and/or 'maxMatches instead.
 ((matched = true, offset = 4, size = 3))
-((matched = true, offset = 12, size = 3))

--- a/test/deprecated/regexMatchesArgs.good
+++ b/test/deprecated/regexMatchesArgs.good
@@ -1,0 +1,3 @@
+regexMatchesArgs.chpl:7: warning: regex.matches arguments 'captures' and 'maxmatches' are deprecated. Use 'numCaptures' and/or 'maxMatches instead.
+((matched = true, offset = 4, size = 3))
+((matched = true, offset = 12, size = 3))

--- a/test/regex/allocationCounts.chpl
+++ b/test/regex/allocationCounts.chpl
@@ -40,7 +40,7 @@ var r = compile("(a+)(b+)(c+)":t);
 {
   writeln("Iter Matches with capture");
   startVerboseMem();
-  for (m, a, b, c) in r.matches("abcaabbcc":t, captures=3) {
+  for (m, a, b, c) in r.matches("abcaabbcc":t, numCaptures=3) {
     assert(m.matched);
   }
   stopVerboseMem();

--- a/test/regex/localFastPath.chpl
+++ b/test/regex/localFastPath.chpl
@@ -63,7 +63,7 @@ proc matchesL() {
   var s = "abaabaaab":t;
   var r = compile("(a+)(b)":t);
   writeln("matchesL");
-  for match in r.matches(s, captures=2) do
+  for match in r.matches(s, numCaptures=2) do
     writeln(match);
   writeln();
 }
@@ -74,7 +74,7 @@ proc matchesR(param rvf=true) {
   on locales1 {
     if !rvf then preventRvf(r);
     writef("matchesR(rvf=%t)\n", rvf);
-    for match in r.matches(s, captures=2) do
+    for match in r.matches(s, numCaptures=2) do
       writeln(match);
     writeln();
   }

--- a/test/regex/maxMatches.chpl
+++ b/test/regex/maxMatches.chpl
@@ -1,0 +1,9 @@
+import Regex;
+
+var text = "foo 123 bar 345";
+
+var r = Regex.compile("\\d+");
+
+for m in r.matches(text, maxMatches=1) {
+  writeln(m);
+}

--- a/test/regex/maxMatches.good
+++ b/test/regex/maxMatches.good
@@ -1,0 +1,1 @@
+((matched = true, offset = 4, size = 3))


### PR DESCRIPTION
This PR:

- deprecates `captures` and `maxmatches` arguments in `regex.matches`
  - the replacements are `numCaptures` and `maxMatches`
- makes sure that `maxMatches` actually works and is tested.

Test:

- [x] standard