### PR TITLE
add DUMP macro to uAST classes

### DIFF
--- a/compiler/next/include/chpl/queries/ID.h
+++ b/compiler/next/include/chpl/queries/ID.h
@@ -176,7 +176,9 @@ class ID final {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 // docs are turned off for this as a workaround for breathe errors

--- a/compiler/next/include/chpl/queries/ID.h
+++ b/compiler/next/include/chpl/queries/ID.h
@@ -175,6 +175,8 @@ class ID final {
   static bool update(chpl::ID& keep, chpl::ID& addin);
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  DECLARE_DUMP;
 };
 
 // docs are turned off for this as a workaround for breathe errors

--- a/compiler/next/include/chpl/queries/UniqueString.h
+++ b/compiler/next/include/chpl/queries/UniqueString.h
@@ -147,6 +147,8 @@ class UniqueString final {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  DECLARE_DUMP;
+
   bool isEmpty() const {
     return s.i.c_str()[0] == '\0';
   }

--- a/compiler/next/include/chpl/queries/UniqueString.h
+++ b/compiler/next/include/chpl/queries/UniqueString.h
@@ -147,8 +147,6 @@ class UniqueString final {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  DECLARE_DUMP;
-
   bool isEmpty() const {
     return s.i.c_str()[0] == '\0';
   }
@@ -245,11 +243,12 @@ class UniqueString final {
   void mark(Context* context) const {
     s.i.mark(context);
   }
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
+
 };
-
-/// \cond DO_NOT_DOCUMENT
-
-/// \endcond
 
 
 } // end namespace chpl

--- a/compiler/next/include/chpl/queries/stringify-functions.h
+++ b/compiler/next/include/chpl/queries/stringify-functions.h
@@ -360,14 +360,19 @@ template<typename... ArgTs> struct stringify<std::tuple<ArgTs...>> {
 };
 
 
-// TODO: Check if we can use this to ensure debug always builds,
-// so it can be avalialbe during debugging.
-  template<typename T>
-  void debugPrint(const T &arg) {
-    stringify<T> stringTemplate;
-    stringTemplate(std::cout, chpl::StringifyKind::DEBUG_DETAIL, arg);
-  }
 /// \endcond
+
+#define DECLARE_DUMP \
+  void dump() const; \
+  void dump(chpl::StringifyKind debug_level) const
+
+#define IMPLEMENT_DUMP(T) \
+  void T::dump() const { \
+    stringify(std::cerr, DEBUG_DETAIL); \
+  } \
+  void T::dump(chpl::StringifyKind debug_level) const { \
+    stringify(std::cerr, debug_level); \
+  }
 
 } // end namespace chpl
 

--- a/compiler/next/include/chpl/queries/stringify-functions.h
+++ b/compiler/next/include/chpl/queries/stringify-functions.h
@@ -359,20 +359,24 @@ template<typename... ArgTs> struct stringify<std::tuple<ArgTs...>> {
   }
 };
 
-
-/// \endcond
-
+/**
+ macros that define methods to write the object to std::cout
+ */
 #define DECLARE_DUMP \
   void dump() const; \
   void dump(chpl::StringifyKind debug_level) const
 
 #define IMPLEMENT_DUMP(T) \
   void T::dump() const { \
-    stringify(std::cerr, DEBUG_DETAIL); \
+    dump(DEBUG_DETAIL); \
   } \
   void T::dump(chpl::StringifyKind debug_level) const { \
     stringify(std::cerr, debug_level); \
   }
+
+
+/// \endcond
+
 
 } // end namespace chpl
 

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -70,8 +70,9 @@ class UntypedFnSignature {
         ss << " ";
       }
     }
-
+    /// \cond DO_NOT_DOCUMENT
     DECLARE_DUMP;
+    /// \endcond DO_NOT_DOCUMENT
   };
 
  private:
@@ -215,7 +216,9 @@ class UntypedFnSignature {
     ss << " ";
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 using SubstitutionsMap = std::unordered_map<const uast::Decl*, types::QualifiedType>;
@@ -255,7 +258,9 @@ class CallInfoActual {
     ss << " ";
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /** CallInfo */
@@ -316,7 +321,9 @@ class CallInfo {
       ss << " ";
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 
@@ -436,7 +443,9 @@ class PoiInfo {
     poiScope()->stringify(ss, stringKind);
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 // TODO: should this actually be types::FunctionType?
@@ -514,8 +523,6 @@ class TypedFnSignature {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  DECLARE_DUMP;
-
   /** Returns the id of the relevant uast node (usually a Function
       but it can be a Record or Class for compiler-generated functions) */
   const ID& id() const {
@@ -574,6 +581,10 @@ class TypedFnSignature {
     assert(0 <= i && (size_t) i < formalTypes_.size());
     return formalTypes_[i];
   }
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /**
@@ -797,7 +808,9 @@ class ResolvedExpression {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /**

--- a/compiler/next/include/chpl/resolution/resolution-types.h
+++ b/compiler/next/include/chpl/resolution/resolution-types.h
@@ -70,6 +70,8 @@ class UntypedFnSignature {
         ss << " ";
       }
     }
+
+    DECLARE_DUMP;
   };
 
  private:
@@ -212,6 +214,8 @@ class UntypedFnSignature {
     ss << std::to_string(numFormals());
     ss << " ";
   }
+
+  DECLARE_DUMP;
 };
 
 using SubstitutionsMap = std::unordered_map<const uast::Decl*, types::QualifiedType>;
@@ -244,12 +248,14 @@ class CallInfoActual {
     return chpl::hash(type_, byName_);
   }
 
-  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) {
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
     byName().stringify(ss, stringKind);
     ss << " ";
     type().stringify(ss, stringKind);
     ss << " ";
   }
+
+  DECLARE_DUMP;
 };
 
 /** CallInfo */
@@ -309,6 +315,8 @@ class CallInfo {
       name().stringify(ss, stringKind);
       ss << " ";
   }
+
+  DECLARE_DUMP;
 };
 
 
@@ -427,6 +435,8 @@ class PoiInfo {
     ss << "PoiInfo: ";
     poiScope()->stringify(ss, stringKind);
   }
+
+  DECLARE_DUMP;
 };
 
 // TODO: should this actually be types::FunctionType?
@@ -503,6 +513,8 @@ class TypedFnSignature {
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  DECLARE_DUMP;
 
   /** Returns the id of the relevant uast node (usually a Function
       but it can be a Record or Class for compiler-generated functions) */
@@ -784,6 +796,8 @@ class ResolvedExpression {
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  DECLARE_DUMP;
 };
 
 /**

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -174,6 +174,8 @@ class BorrowedIdsWithName {
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
     ID().stringify(ss, stringKind);
   }
+
+  DECLARE_DUMP;
 };
 
 // DeclMap: key - string name,  value - vector of ID of a NamedDecl
@@ -281,6 +283,8 @@ class Scope {
     ss << " ";
     ss << std::to_string(numDeclared());
   }
+
+  DECLARE_DUMP;
 };
 
 /**
@@ -488,6 +492,8 @@ class PoiScope {
       inFnPoi()->stringify(ss, stringKind);
     }
   }
+
+  DECLARE_DUMP;
 };
 
 /**
@@ -535,8 +541,11 @@ class InnermostMatch {
     id_.mark(context);
   }
 
-  void stringify(std::ostream &ss, chpl::StringifyKind stringKind) const;
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
+    ss << "InnermostMatch not yet strigified";
+  }
 
+  DECLARE_DUMP;
 };
 
 

--- a/compiler/next/include/chpl/resolution/scope-types.h
+++ b/compiler/next/include/chpl/resolution/scope-types.h
@@ -175,7 +175,9 @@ class BorrowedIdsWithName {
     ID().stringify(ss, stringKind);
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 // DeclMap: key - string name,  value - vector of ID of a NamedDecl
@@ -284,7 +286,9 @@ class Scope {
     ss << std::to_string(numDeclared());
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /**
@@ -493,7 +497,9 @@ class PoiScope {
     }
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /**
@@ -545,7 +551,9 @@ class InnermostMatch {
     ss << "InnermostMatch not yet strigified";
   }
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 

--- a/compiler/next/include/chpl/types/CompositeType.h
+++ b/compiler/next/include/chpl/types/CompositeType.h
@@ -71,7 +71,9 @@ class CompositeType : public Type {
       type.stringify(ss, stringKind);
     }
 
+    /// \cond DO_NOT_DOCUMENT
     DECLARE_DUMP;
+    /// \endcond DO_NOT_DOCUMENT
   };
  protected:
   // TODO: add fields and accessors for a QualifiedType per field

--- a/compiler/next/include/chpl/types/CompositeType.h
+++ b/compiler/next/include/chpl/types/CompositeType.h
@@ -70,6 +70,8 @@ class CompositeType : public Type {
       //decl.stringify(ss, stringKind);
       type.stringify(ss, stringKind);
     }
+
+    DECLARE_DUMP;
   };
  protected:
   // TODO: add fields and accessors for a QualifiedType per field

--- a/compiler/next/include/chpl/types/Param.h
+++ b/compiler/next/include/chpl/types/Param.h
@@ -149,6 +149,8 @@ class Param {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  DECLARE_DUMP;
+
   static uint64_t binStr2uint64(const char* str, size_t len, std::string& err);
   static uint64_t octStr2uint64(const char* str, size_t len, std::string& err);
   static uint64_t decStr2uint64(const char* str, size_t len, std::string& err);

--- a/compiler/next/include/chpl/types/Param.h
+++ b/compiler/next/include/chpl/types/Param.h
@@ -149,8 +149,6 @@ class Param {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  DECLARE_DUMP;
-
   static uint64_t binStr2uint64(const char* str, size_t len, std::string& err);
   static uint64_t octStr2uint64(const char* str, size_t len, std::string& err);
   static uint64_t decStr2uint64(const char* str, size_t len, std::string& err);
@@ -191,6 +189,10 @@ class Param {
   // clear the macros
   #undef PARAM_NODE
   #undef PARAM_TO
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 // define the subclasses using macros and ParamClassesList.h

--- a/compiler/next/include/chpl/types/QualifiedType.h
+++ b/compiler/next/include/chpl/types/QualifiedType.h
@@ -178,6 +178,8 @@ class QualifiedType final {
   void mark(Context* context) const;
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  DECLARE_DUMP;
 };
 
 

--- a/compiler/next/include/chpl/types/QualifiedType.h
+++ b/compiler/next/include/chpl/types/QualifiedType.h
@@ -179,7 +179,9 @@ class QualifiedType final {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -103,6 +103,8 @@ class Type {
 
   virtual void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  DECLARE_DUMP;
+
   // define is__ methods for the various Type subclasses
   // using macros and TypeClassesList.h
   /// \cond DO_NOT_DOCUMENT

--- a/compiler/next/include/chpl/types/Type.h
+++ b/compiler/next/include/chpl/types/Type.h
@@ -103,7 +103,6 @@ class Type {
 
   virtual void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  DECLARE_DUMP;
 
   // define is__ methods for the various Type subclasses
   // using macros and TypeClassesList.h
@@ -200,6 +199,10 @@ class Type {
   #undef TYPE_BEGIN_SUBCLASSES
   #undef TYPE_END_SUBCLASSES
   #undef TYPE_TO
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 

--- a/compiler/next/include/chpl/uast/ASTNode.h
+++ b/compiler/next/include/chpl/uast/ASTNode.h
@@ -153,6 +153,8 @@ class ASTNode {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  DECLARE_DUMP;
+
   // define is__ methods for the various AST types
   // using macros and ASTClassesList.h
   /// \cond DO_NOT_DOCUMENT

--- a/compiler/next/include/chpl/uast/ASTNode.h
+++ b/compiler/next/include/chpl/uast/ASTNode.h
@@ -153,7 +153,9 @@ class ASTNode {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 
   // define is__ methods for the various AST types
   // using macros and ASTClassesList.h

--- a/compiler/next/lib/queries/ID.cpp
+++ b/compiler/next/lib/queries/ID.cpp
@@ -95,4 +95,6 @@ void ID::stringify(std::ostream& ss,
   }
 }
 
+IMPLEMENT_DUMP(ID);
+
 } // end namespace chpl

--- a/compiler/next/lib/queries/UniqueString.cpp
+++ b/compiler/next/lib/queries/UniqueString.cpp
@@ -190,5 +190,6 @@ void UniqueString::stringify(std::ostream& ss,
                              chpl::StringifyKind stringKind) const {
   ss.write(c_str(),length());
 }
+IMPLEMENT_DUMP(UniqueString);
 
 } // end namespace chpl

--- a/compiler/next/lib/resolution/resolution-types.cpp
+++ b/compiler/next/lib/resolution/resolution-types.cpp
@@ -302,6 +302,13 @@ void ResolvedExpression::stringify(std::ostream& ss,
   }
 }
 
+IMPLEMENT_DUMP(PoiInfo);
+IMPLEMENT_DUMP(UntypedFnSignature);
+IMPLEMENT_DUMP(UntypedFnSignature::FormalDetail);
+IMPLEMENT_DUMP(TypedFnSignature);
+IMPLEMENT_DUMP(ResolvedExpression);
+IMPLEMENT_DUMP(CallInfoActual);
+IMPLEMENT_DUMP(CallInfo);
 
 } // end namespace resolution
 } // end namespace chpl

--- a/compiler/next/lib/resolution/scope-types.cpp
+++ b/compiler/next/lib/resolution/scope-types.cpp
@@ -44,6 +44,10 @@ void Scope::addBuiltin(UniqueString name) {
   declared_.emplace(name, ID());
 }
 
+IMPLEMENT_DUMP(BorrowedIdsWithName);
+IMPLEMENT_DUMP(Scope);
+IMPLEMENT_DUMP(PoiScope);
+IMPLEMENT_DUMP(InnermostMatch);
 
 } // end namespace resolution
 } // end namespace chpl

--- a/compiler/next/lib/types/CompositeType.cpp
+++ b/compiler/next/lib/types/CompositeType.cpp
@@ -87,6 +87,7 @@ void CompositeType::stringify(std::ostream& ss,
   }
 }
 
+IMPLEMENT_DUMP(CompositeType::FieldDetail);
 
 
 } // end namespace types

--- a/compiler/next/lib/types/Param.cpp
+++ b/compiler/next/lib/types/Param.cpp
@@ -631,6 +631,8 @@ double Param::str2double(const char* str, size_t len, std::string& err) {
   return num;
 }
 
+IMPLEMENT_DUMP(Param);
+
 // implement the subclasses using macros and ParamClassesList.h
 #define PARAM_NODE(NAME, VALTYPE) \
   const owned<NAME>& NAME::get##NAME(Context* context, VALTYPE value) { \

--- a/compiler/next/lib/types/QualifiedType.cpp
+++ b/compiler/next/lib/types/QualifiedType.cpp
@@ -85,6 +85,7 @@ void QualifiedType::stringify(std::ostream& ss,
   }
 }
 
+IMPLEMENT_DUMP(QualifiedType);
 
 } // end namespace types
 } // end namespace chpl

--- a/compiler/next/lib/types/Type.cpp
+++ b/compiler/next/lib/types/Type.cpp
@@ -132,6 +132,8 @@ void Type::stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
   ss << " \n";
 }
 
+IMPLEMENT_DUMP(Type);
+
 bool Type::isNilablePtrType() const {
   if (isPtrType()) {
 

--- a/compiler/next/lib/uast/ASTNode.cpp
+++ b/compiler/next/lib/uast/ASTNode.cpp
@@ -190,6 +190,7 @@ void ASTNode::stringify(std::ostream& ss,
   dumpHelper(ss, this, maxIdLen, leadingSpaces);
 }
 
+IMPLEMENT_DUMP(ASTNode);
 
 } // end namespace uast
 } // end namespace chpl


### PR DESCRIPTION
This PR demonstrates an implementation of a macro to build `dump()` methods 
that are callable from the debugger. 


TESTING:

- [x] can call `dump()` on objects during `gdb` session

Future work: 

- [ ] cray/chapel-private/issues/2963

Reviewed by @mppf, thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>