### PR TITLE
Update the xc-x86_64 build_config to use gcc/8.1.0 instead of gcc/8.3.0

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -310,7 +310,7 @@ else
         list_loaded_modules
     fi
 
-    gen_version_gcc=8.3.0
+    gen_version_gcc=8.1.0
     gen_version_intel=16.0.3.210
     gen_version_cce=10.0.3
 


### PR DESCRIPTION
Our build machine for this configuration no longer has gcc/8.3.0 available,
so switch to 8.1.0 to get past the problem loading gcc.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>