### PR TITLE
Rename Subprocess.send_signal() to Subprocess.sendPosixSignal()

### DIFF
--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -997,6 +997,10 @@ module Subprocess {
 
   private extern proc qio_send_signal(pid: int(64), sig: c_int): syserr;
 
+  deprecated "'send_signal' is deprecated, please use 'sendPosixSignal' instead"
+  proc subprocess.send_signal(signal:int) throws {
+    sendPosixSignal(signal);
+  }
   /*
     Send a signal to a child process.
 
@@ -1022,33 +1026,33 @@ module Subprocess {
 
     :arg signal: the signal to send
    */
-  proc subprocess.send_signal(signal:int) throws {
+  proc subprocess.sendPosixSignal(signal:int) throws {
     try _throw_on_launch_error();
 
     var err: syserr = ENOERR;
     on home {
       err = qio_send_signal(pid, signal:c_int);
     }
-    if err then try ioerror(err, "in subprocess.send_signal, with signal " + signal:string);
+    if err then try ioerror(err, "in subprocess.sendPosixSignal, with signal " + signal:string);
   }
 
   /*
     Unconditionally kill the child process.  The associated signal,
     `SIGKILL`, cannot be caught by the child process. See
-    :proc:`subprocess.send_signal`.
+    :proc:`subprocess.sendPosixSignal`.
    */
   proc subprocess.kill() throws {
     try _throw_on_launch_error();
-    try this.send_signal(SIGKILL);
+    try this.sendPosixSignal(SIGKILL);
   }
 
   /*
     Request termination of the child process.  The associated signal,
     `SIGTERM`, may be caught and handled by the child process. See
-    :proc:`subprocess.send_signal`.
+    :proc:`subprocess.sendPosixSignal`.
    */
   proc subprocess.terminate() throws {
     try _throw_on_launch_error();
-    try this.send_signal(SIGTERM);
+    try this.sendPosixSignal(SIGTERM);
   }
 }

--- a/test/deprecated/subprocess-send_signal.chpl
+++ b/test/deprecated/subprocess-send_signal.chpl
@@ -1,0 +1,9 @@
+use Subprocess;
+use Time;
+
+var sub = spawn(["sleep", "60"]);
+sleep(1);
+sub.send_signal(SIGKILL);
+while sub.running do
+  sub.poll();
+assert(sub.exitCode == -SIGKILL);

--- a/test/deprecated/subprocess-send_signal.good
+++ b/test/deprecated/subprocess-send_signal.good
@@ -1,0 +1,1 @@
+subprocess-send_signal.chpl:6: warning: 'send_signal' is deprecated, please use 'sendPosixSignal' instead

--- a/test/library/packages/Curl/RunServer.chpl
+++ b/test/library/packages/Curl/RunServer.chpl
@@ -55,7 +55,7 @@ proc stopServer() {
   if server.running {
     // Kill the little HTTP server
     try! {
-      server.send_signal(SIGINT);
+      server.sendPosixSignal(SIGINT);
     } catch e:ProcessLookupError {
       // Ignore it already being dead
     }


### PR DESCRIPTION
Deprecate the name Subprocess.send_signal() and add a deprecation test for it.

Update a test to use the new name.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>