### PR TITLE
Update the Intel compiler version in cray-module testing

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -311,7 +311,7 @@ else
     fi
 
     gen_version_gcc=8.1.0
-    gen_version_intel=16.0.3.210
+    gen_version_intel=19.1.2.254
     gen_version_cce=10.0.3
 
     target_cpu_module=craype-sandybridge


### PR DESCRIPTION
The version we had been using went away. Update it to the closest available
version.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>