### PR TITLE
Update references to SSCA2 in the GRAPHFILES

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -1,7 +1,4 @@
 # suite: Release examples
-release/examples/benchmarks/ssca2/SSCA2_main.graph
-release/examples/benchmarks/ssca2/edge_generation.graph
-release/examples/benchmarks/ssca2/total_time.graph
 release/examples/benchmarks/lcals/LCALS-raw-short.graph
 release/examples/benchmarks/lcals/LCALS-raw-medium.graph
 release/examples/benchmarks/lcals/LCALS-raw-long.graph
@@ -30,7 +27,6 @@ studies/shootout/reverse-complement/revcomp.graph
 studies/shootout/spectral-norm/spectralnorm.graph
 studies/shootout/thread-ring/thread-ring.graph
 # suite: Performance tracking
-release/examples/benchmarks/ssca2/total_time.graph
 release/examples/benchmarks/lulesh/lulesh.graph
 release/examples/benchmarks/miniMD/miniMD.graph
 studies/comd/llnl/CoMD.graph
@@ -110,8 +106,11 @@ release/examples/benchmarks/hpcc/ptrans_performance.graph
 release/examples/benchmarks/hpcc/fft_performance.graph
 release/examples/benchmarks/hpcc/hpl_performance.graph
 studies/hpcc/STREAM_study_performance.graph
-release/examples/benchmarks/ssca2/performance.graph
-# suite: DOE proxy apps
+studies/ssca2/main/performance.graph
+# suite: Proxy apps
+studies/ssca2/main/SSCA2_main.graph
+studies/ssca2/main/edge_generation.graph
+studies/ssca2/main/total_time.graph
 studies/lulesh/bradc/lulesh-dense.graph
 release/examples/benchmarks/miniMD/miniMD.graph
 studies/comd/llnl/CoMD.graph

--- a/test/ML-GRAPHFILES
+++ b/test/ML-GRAPHFILES
@@ -12,7 +12,7 @@ release/examples/benchmarks/hpcc/stream-ep.ml-perf.graph
 release/examples/benchmarks/hpcc/stream.ml-perf.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-perf.graph
 studies/prk/Stencil/prk-stencil.ml-perf.graph
-release/examples/benchmarks/ssca2/SSCA2_main.ml-time.graph
+studies/ssca2/main/SSCA2_main.ml-time.graph
 studies/lulesh/bradc/lulesh-dense.ml-time.graph
 release/examples/benchmarks/miniMD/miniMD.ml-time.graph
 studies/isx/isx.ml-time.graph
@@ -30,7 +30,7 @@ release/examples/benchmarks/hpcc/ra.ml-perf.graph
 release/examples/benchmarks/hpcc/stream-ep.ml-perf.graph
 release/examples/benchmarks/hpcc/stream.ml-perf.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-perf.graph
-release/examples/benchmarks/ssca2/SSCA2_main.ml-perf.graph
+studies/ssca2/main/SSCA2_main.ml-perf.graph
 studies/prk/Stencil/prk-stencil.ml-perf.graph
 studies/bale/histogram/histo-atomics.ml-perf.graph
 studies/bale/histogram/histo-atomics-agg.ml-perf.graph
@@ -52,7 +52,7 @@ release/examples/benchmarks/hpcc/stream-ep.ml-perf.graph
 release/examples/benchmarks/hpcc/stream.ml-perf.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-perf.graph
 # suite: - SSCA (perf)
-release/examples/benchmarks/ssca2/SSCA2_main.ml-perf.graph
+studies/ssca2/main/SSCA2_main.ml-perf.graph
 # suite: - PRK (perf)
 studies/prk/Stencil/prk-stencil.ml-perf.graph
 # suite: - Bale (perf)
@@ -74,7 +74,7 @@ release/examples/benchmarks/hpcc/ra.ml-time.graph
 release/examples/benchmarks/hpcc/stream-ep.ml-time.graph
 release/examples/benchmarks/hpcc/stream.ml-time.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-time.graph
-release/examples/benchmarks/ssca2/SSCA2_main.ml-time.graph
+studies/ssca2/main/SSCA2_main.ml-time.graph
 studies/lulesh/bradc/lulesh-dense.ml-time.graph
 release/examples/benchmarks/miniMD/miniMD.ml-time.graph
 scan/scanPerf.ml-time.graph
@@ -102,7 +102,7 @@ release/examples/benchmarks/hpcc/stream-ep.ml-time.graph
 release/examples/benchmarks/hpcc/stream.ml-time.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-time.graph
 # suite: - SSCA (time)
-release/examples/benchmarks/ssca2/SSCA2_main.ml-time.graph
+studies/ssca2/main/SSCA2_main.ml-time.graph
 # suite: - DOE (time)
 studies/lulesh/bradc/lulesh-dense.ml-time.graph
 release/examples/benchmarks/miniMD/miniMD.ml-time.graph


### PR DESCRIPTION
Uses new location, and performs some re-sorting - now that the test no longer
lives in release/examples, it shouldn't be part of the `Release examples` suite.
We also don't want it to be part of the `Performance tracking` suite since we
don't feel as confident in it.  Elliot suggested moving it to the `Proxy apps`
suite (and renaming the suite so it is no longer DOE specific).

Double checked `--gen-graphs` on a fresh checkout