### PR TITLE
Properly wire llvm and c configs for CHAMPS nightly testing

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -71,12 +71,12 @@ function test_compile() {
   fi
   test_end
 
-  $CHPL_HOME/util/test/computePerfStats comp-time-$kind $CHPL_TEST_PERF_DIR $CHAMPS_GRAPH_PATH/comp-time.perfkeys $kind.comp.out.tmp
+  $CHPL_HOME/util/test/computePerfStats comp-time-$kind $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION $CHAMPS_GRAPH_PATH/comp-time.perfkeys $kind.comp.out.tmp
   if [[ $? -ne 0 ]] ; then
     log_fatal_error "computing compile time stats for ${kind}"
   fi
 
-  $CHPL_HOME/util/test/computePerfStats emitted-code-size-$kind $CHPL_TEST_PERF_DIR $CHAMPS_GRAPH_PATH/emitted-code-size.perfkeys $kind.comp.out.tmp
+  $CHPL_HOME/util/test/computePerfStats emitted-code-size-$kind $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION $CHAMPS_GRAPH_PATH/emitted-code-size.perfkeys $kind.comp.out.tmp
   if [[ $? -ne 0 ]] ; then
     log_fatal_error "computing emitted code size stats for ${kind}"
   fi
@@ -104,7 +104,7 @@ function test_run() {
     $CHAMPS_GRAPH_PATH/$kind.prediff dummy $kind.exec.out.tmp
   fi
 
-  $CHPL_HOME/util/test/computePerfStats exec-time-$kind $CHPL_TEST_PERF_DIR $CHAMPS_GRAPH_PATH/$kind.perfkeys $kind.exec.out.tmp
+  $CHPL_HOME/util/test/computePerfStats exec-time-$kind $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION $CHAMPS_GRAPH_PATH/$kind.perfkeys $kind.exec.out.tmp
   if [[ $? -ne 0 ]] ; then
     log_fatal_error "computing performance stats for ${kind}"
   fi

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -57,6 +57,6 @@ test_compile icing
 cp $CHAMPS_DATA_PATH/CRMHL_coarse_768B.cgns $CHAMPS_HOME/
 test_run flow 16
 
-$CHPL_HOME/util/test/genGraphs --perfdir $CHPL_TEST_PERF_DIR --outdir $CHPL_TEST_PERF_DIR/html --graphlist $CHAMPS_GRAPH_PATH/GRAPHLIST --testdir $CHAMPS_GRAPH_PATH --alttitle "CHAMPS Performance Graphs"
+$CHPL_HOME/util/test/genGraphs --configs $CHPL_TEST_PERF_CONFIGS --annotate $CHPL_HOME/test/ANNOTATIONS.yaml --name $CHPL_TEST_PERF_CONFIG_NAME --perfdir $CHPL_TEST_PERF_DIR --outdir $CHPL_TEST_PERF_DIR/html --graphlist $CHAMPS_GRAPH_PATH/GRAPHLIST --testdir $CHAMPS_GRAPH_PATH --alttitle "CHAMPS Performance Graphs"
 
 subtest_end


### PR DESCRIPTION
This PR adjusts CHAMPS testing to be able to plot both llvm and c-backend configs.