### PR TITLE
Deprecate+better errors for | & ^ op= on rectangular domains

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1931,12 +1931,6 @@ module ChapelBase {
     lhs = lhs << rhs;
   }
 
-  /* domain += and -= add and remove indices */
-  inline operator +=(ref D: domain, idx) { D.add(idx); }
-  inline operator -=(ref D: domain, idx) { D.remove(idx); }
-  inline operator +=(ref D: domain, param idx) { D.add(idx); }
-  inline operator -=(ref D: domain, param idx) { D.remove(idx); }
-
   /* swap operator */
   pragma "ignore transfer errors"
   inline operator <=>(ref lhs, ref rhs) {

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -366,6 +366,9 @@ module ChapelDomain {
       compilerError("Cannot add indices to this domain type");
   }
 
+  inline operator +=(ref D: domain, idx) { D.add(idx); }
+  inline operator +=(ref D: domain, param idx) { D.add(idx); }
+
   operator -(d: domain, i: index(d)) {
     if d.isRectangular() then
       compilerError("Cannot remove indices from a rectangular domain");
@@ -392,6 +395,9 @@ module ChapelDomain {
     else
       compilerError("Cannot remove indices from this domain type");
   }
+
+  inline operator -=(ref D: domain, idx) { D.remove(idx); }
+  inline operator -=(ref D: domain, param idx) { D.remove(idx); }
 
   inline operator ==(d1: domain, d2: domain) where d1.isRectangular() &&
                                                    d2.isRectangular() {
@@ -488,10 +494,18 @@ module ChapelDomain {
     return a + b;
   }
 
+  deprecated "'|' on rectangular domains is deprecated"
+  operator |(a :domain, b: domain) where a.isRectangular() && b.isRectangular()
+    return forall (aa, bb) in zip(a, b) do aa|bb;
+
   operator |=(ref a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     for e in b do
       a.add(e);
+  }
+
+  operator |=(a :domain, b: domain) where a.isRectangular() {
+    compilerError("cannot invoke '|=' on a rectangular domain");
   }
 
   operator +=(ref a :domain, b: domain) where (a.type == b.type) &&
@@ -514,6 +528,10 @@ module ChapelDomain {
     return newDom;
   }
 
+  deprecated "'&' on rectangular domains is deprecated"
+  operator &(a :domain, b: domain) where a.isRectangular() && b.isRectangular()
+    return forall (aa, bb) in zip(a, b) do aa&bb;
+
   operator &=(ref a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     var removeSet: domain(a.idxType);
@@ -522,6 +540,10 @@ module ChapelDomain {
         removeSet += e;
     for e in removeSet do
       a.remove(e);
+  }
+
+  operator &=(a :domain, b: domain) where a.isRectangular() {
+    compilerError("cannot invoke '&=' on a rectangular domain");
   }
 
   operator ^(a :domain, b: domain) where (a.type == b.type) &&
@@ -538,6 +560,10 @@ module ChapelDomain {
     return newDom;
   }
 
+  deprecated "'^' on rectangular domains is deprecated"
+  operator ^(a :domain, b: domain) where a.isRectangular() && b.isRectangular()
+    return forall (aa, bb) in zip(a, b) do aa^bb;
+
   /*
      We remove elements in the RHS domain from those in the LHS domain only if
      they exist. If an element in the RHS is not present in the LHS, it is
@@ -550,6 +576,10 @@ module ChapelDomain {
         a.remove(e);
       else
         a.add(e);
+  }
+
+  operator ^=(a :domain, b: domain) where a.isRectangular() {
+    compilerError("cannot invoke '^=' on a rectangular domain");
   }
 
   //

--- a/test/deprecated/domain-or-and-xor.chpl
+++ b/test/deprecated/domain-or-and-xor.chpl
@@ -1,0 +1,7 @@
+
+var D1 = {1..3};
+var D2 = {9..25 by 8};
+
+writeln(D1 | D2);
+writeln(D1 & D2);
+writeln(D1 ^ D2);

--- a/test/deprecated/domain-or-and-xor.good
+++ b/test/deprecated/domain-or-and-xor.good
@@ -1,0 +1,6 @@
+domain-or-and-xor.chpl:5: warning: '|' on rectangular domains is deprecated
+domain-or-and-xor.chpl:6: warning: '&' on rectangular domains is deprecated
+domain-or-and-xor.chpl:7: warning: '^' on rectangular domains is deprecated
+9 19 27
+1 0 1
+8 19 26

--- a/test/domains/compilerErrors/rect-and-eq.chpl
+++ b/test/domains/compilerErrors/rect-and-eq.chpl
@@ -1,0 +1,6 @@
+
+var D1 = {1..3};
+var D2 = {9..25 by 8};
+
+D1 &= D2;   // error: not allowed
+writeln(D1);

--- a/test/domains/compilerErrors/rect-and-eq.good
+++ b/test/domains/compilerErrors/rect-and-eq.good
@@ -1,0 +1,1 @@
+rect-and-eq.chpl:5: error: cannot invoke '&=' on a rectangular domain

--- a/test/domains/compilerErrors/rect-or-eq.chpl
+++ b/test/domains/compilerErrors/rect-or-eq.chpl
@@ -1,0 +1,6 @@
+
+var D1 = {1..3};
+var D2 = {9..25 by 8};
+
+D1 |= D2;   // error: not allowed
+writeln(D1);

--- a/test/domains/compilerErrors/rect-or-eq.good
+++ b/test/domains/compilerErrors/rect-or-eq.good
@@ -1,0 +1,1 @@
+rect-or-eq.chpl:5: error: cannot invoke '|=' on a rectangular domain

--- a/test/domains/compilerErrors/rect-xor-eq.chpl
+++ b/test/domains/compilerErrors/rect-xor-eq.chpl
@@ -1,0 +1,6 @@
+
+var D1 = {1..3};
+var D2 = {9..25 by 8};
+
+D1 ^= D2;   // error: not allowed
+writeln(D1);

--- a/test/domains/compilerErrors/rect-xor-eq.good
+++ b/test/domains/compilerErrors/rect-xor-eq.good
@@ -1,0 +1,1 @@
+rect-xor-eq.chpl:5: error: cannot invoke '^=' on a rectangular domain

--- a/test/expressions/if-expr/if-loop-const.bad
+++ b/test/expressions/if-expr/if-loop-const.bad
@@ -1,4 +1,4 @@
 if-loop-const.chpl:4: In function 'main':
 if-loop-const.chpl:8: error: Unable to resolve type of if-expression
-note: 'then' branch returns type "_ir_chpl__loopexpr_iter11"
-note: 'else' branch returns type "_ir_chpl__loopexpr_iter12"
+note: 'then' branch returns type "_ir_chpl__loopexpr_iter14"
+note: 'else' branch returns type "_ir_chpl__loopexpr_iter15"

--- a/test/visibility/except/operatorsExceptions/exceptAnd.good
+++ b/test/visibility/except/operatorsExceptions/exceptAnd.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptAnd.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   &(a: int(8), b: int(8))
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   &(a: int(16), b: int(16))
-note: and 36 other candidates, use --print-all-candidates to see them
+note: and 37 other candidates, use --print-all-candidates to see them

--- a/test/visibility/except/operatorsExceptions/exceptOr.good
+++ b/test/visibility/except/operatorsExceptions/exceptOr.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptOr.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   |(a: int(8), b: int(8))
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   |(a: int(16), b: int(16))
-note: and 36 other candidates, use --print-all-candidates to see them
+note: and 37 other candidates, use --print-all-candidates to see them

--- a/test/visibility/except/operatorsExceptions/exceptXor.good
+++ b/test/visibility/except/operatorsExceptions/exceptXor.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 exceptXor.chpl:8: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   ^(a: int(8), b: int(8))
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   ^(a: int(16), b: int(16))
-note: and 36 other candidates, use --print-all-candidates to see them
+note: and 37 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
This PR implements an action item from the domain module review,
where we decided to disallow `|` `&` `^` on rectangular domains.
For this release these are deprecated. We will convert them
to compilation errors in a future release, unless we receive
opposing requests from users.
Given that `|=` `&=` `^=` on rectangular domains already generate
compile-time errors, this PR makes these error messages clear.

It adds tests of the deprecated warnings and the improved error messages.
A couple of .good/.bad files are adjusted also to account for a change
in program AST and the number of available candidates.

While there: move += and -= on (domain,idx) from ChapelBase into ChapelDomain
as that is where they belong.
Archaeology: they were added initially in cd9b794b5f
and had been in ChapelBase since then.

Testing: standard paratest; multilocale tests under gasnet.