### PR TITLE
Update start_test to squash thread limit warnings when doing valgrind testing

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -839,6 +839,7 @@ def set_up_general():
         if args.valgrind_exe:
             logger.write("[valgrind: EXE only]")
             os.environ["CHPL_TEST_VGRND_EXE"] = "on"
+            os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET"] = "yes"
         else:
             logger.write("[valgrind: OFF]")
             os.environ["CHPL_TEST_VGRND_EXE"] = "off"

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -839,7 +839,6 @@ def set_up_general():
         if args.valgrind_exe:
             logger.write("[valgrind: EXE only]")
             os.environ["CHPL_TEST_VGRND_EXE"] = "on"
-            os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET"] = "yes"
         else:
             logger.write("[valgrind: OFF]")
             os.environ["CHPL_TEST_VGRND_EXE"] = "off"
@@ -848,6 +847,10 @@ def set_up_general():
         # Stay below valgrind's --max-threads option, which defaults to 500
         if not "CHPL_RT_NUM_THREADS_PER_LOCALE" in os.environ:
             os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE"] = "450";
+
+        # Squash the warning about the potential for deadlock when setting
+        # the number of threads, or all tests will fail with that warning
+        os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET"] = "yes"
 
         # Additionally, fail with an error if valgrind testing is running without
         # tasks=fifo, mem=cstdlib, or with re2 built w/o valgrind support

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -847,6 +847,8 @@ def set_up_general():
         # Stay below valgrind's --max-threads option, which defaults to 500
         if not "CHPL_RT_NUM_THREADS_PER_LOCALE" in os.environ:
             os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE"] = "450";
+        else:
+            logger.write("[Warning: Deadlock is possible since you set CHPL_RT_NUM_THREADS_PER_LOCALE]")
 
         # Squash the warning about the potential for deadlock when setting
         # the number of threads, or all tests will fail with that warning


### PR DESCRIPTION
PR #18871 introduced a warning if a thread limit is given for `CHPL_TASKS=fifo`,
but our testing scripts do exactly this for `-valgrindexe` testing, which only works
for `CHPL_TASKS=fifo`.  Here, I used the accompanying environment variable to
squash these warnings in the testing scripts when doing `-valgrindexe` or `-valgrind`
testing to stop this.

At @aconsroe-hpe's request, I also put in a warning if the developer has set
CHPL_RT_NUM_THREADS_PER_LOCALE explicitly and is doing valgrind testing
to alert them to that possibility.  We also talked about printing this out only in
the event that a test has an execution timeout so that (a) the warning wouldn't
show up in the log of every such run and (b) would be attached to the place where
the timeout (possible deadlock) occurred, but that was more than I wanted to
take on here, and it feels like we're increasingly in a corner of the development
space that nobody spends much time in.  That could be a future improvement,
however, if someone found the current behavior too confusing (in the event of
hitting deadlocks) or noisy (when no deadlocks occur).