### PR TITLE
Document the ability to access FCF names

### DIFF
--- a/doc/rst/technotes/firstClassFns.rst
+++ b/doc/rst/technotes/firstClassFns.rst
@@ -134,7 +134,6 @@ For example:
 
   writeln("retType  = ", F.retType  : string);
   writeln("argTypes = ", F.argTypes : string);
-  writeln();
 
 generates the output::
 
@@ -143,6 +142,23 @@ generates the output::
   retType  = int(64)
   argTypes = 1*int(64)
 
+Additionally, first-class functions can be cast to a string to get the
+function name or printed to output the function name. For example:
+
+.. code-block:: chapel
+
+  proc myFunc(x:int) { return x + 1; }
+
+  var F = myFunc;
+  var Fname = F:string;
+
+  writeln(Fname);
+  writeln(F);
+
+generates the output::
+
+    myFunc()
+    myFunc()
 
 
 Future Directions


### PR DESCRIPTION
Document the ability to access first class function names in user code which was added https://github.com/chapel-lang/chapel/pull/13232.

Also remove an erroneous `writeln()` from the previous example.

Testing

- [x] confirmed the rendered docs look good
- [x] confirmed the code example works as expected