### PR TITLE
Update new signaling functions to use sendPosixSignal instead of send_signal

### DIFF
--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -1043,7 +1043,7 @@ module Subprocess {
    */
   proc subprocess.abort() throws {
     try _throw_on_launch_error();
-    try this.send_signal(SIGABRT);
+    try this.sendPosixSignal(SIGABRT);
   }
 
   /* Send the child processan alarm signal. The associated signal,
@@ -1052,7 +1052,7 @@ module Subprocess {
    */
   proc subprocess.alarm() throws {
     try _throw_on_launch_error();
-    try this.send_signal(SIGALRM);
+    try this.sendPosixSignal(SIGALRM);
   }
 
   /*


### PR DESCRIPTION
This avoids deprecation messages from send_signal when using these functions.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>