### PR TITLE
In comm=ugni, sanity-check transfer extents against their apparent MRs.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2761,10 +2761,13 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
                    : (mr - &mem_regions->mregs[0] + 1)));
   }
   PERFSTATS_ADD(local_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if (mr != NULL
-      && ((uint64_t) addr + size
-          > mr->addr + ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE))) {
-    CHPL_INTERNAL_ERROR("local xfer size extends beyond MR!");
+  if (mr != NULL) {
+    size_t mrLen = chpl_cache_enabled()
+                   ? ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE)
+                   : mrtl_len(mr->len);
+    if ((uint64_t) addr + size > mr->addr + mrLen) {
+      CHPL_INTERNAL_ERROR("local xfer size extends beyond MR!");
+    }
   }
   return mr;
 }
@@ -2795,10 +2798,13 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
                    : (mr - &mem_regions_all_entries[locale]->mregs[0] + 1)));
   }
   PERFSTATS_ADD(remote_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if (mr != NULL
-      && ((uint64_t) addr + size
-          > mr->addr + ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE))) {
-    CHPL_INTERNAL_ERROR("remote xfer size extends beyond MR!");
+  if (mr != NULL) {
+    size_t mrLen = chpl_cache_enabled()
+                   ? ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE)
+                   : mrtl_len(mr->len);
+    if ((uint64_t) addr + size > mr->addr + mrLen) {
+      CHPL_INTERNAL_ERROR("remote xfer size extends beyond MR!");
+    }
   }
   return mr;
 }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2759,7 +2759,7 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
                    : (mr - &mem_regions->mregs[0] + 1)));
   }
   PERFSTATS_ADD(local_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if ((uint64_t) addr + size > mr->addr + mrtl_len(mr->len)) {
+  if (mr != NULL && (uint64_t) addr + size > mr->addr + mrtl_len(mr->len)) {
     CHPL_INTERNAL_ERROR("local xfer size extends beyond MR!");
   }
   return mr;
@@ -2791,7 +2791,7 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
                    : (mr - &mem_regions_all_entries[locale]->mregs[0] + 1)));
   }
   PERFSTATS_ADD(remote_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if ((uint64_t) addr + size > mr->addr + mrtl_len(mr->len)) {
+  if (mr != NULL && (uint64_t) addr + size > mr->addr + mrtl_len(mr->len)) {
     CHPL_INTERNAL_ERROR("remote xfer size extends beyond MR!");
   }
   return mr;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2765,7 +2765,6 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
                    ? mem_regions->mreg_cnt
                    : (mr - &mem_regions->mregs[0] + 1)));
   }
-  PERFSTATS_ADD(local_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
   if (do_mr_extent_checks && mr != NULL) {
     size_t mrLen = chpl_cache_enabled()
                    ? ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE)
@@ -2774,6 +2773,7 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
       CHPL_INTERNAL_ERROR("local xfer size extends beyond MR!");
     }
   }
+  PERFSTATS_ADD(local_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
   return mr;
 }
 
@@ -2802,7 +2802,6 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
                    ? mem_regions_all_entries[locale]->mreg_cnt
                    : (mr - &mem_regions_all_entries[locale]->mregs[0] + 1)));
   }
-  PERFSTATS_ADD(remote_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
   if (do_mr_extent_checks && mr != NULL) {
     size_t mrLen = chpl_cache_enabled()
                    ? ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE)
@@ -2811,6 +2810,7 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
       CHPL_INTERNAL_ERROR("remote xfer size extends beyond MR!");
     }
   }
+  PERFSTATS_ADD(remote_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
   return mr;
 }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5890,7 +5890,7 @@ void do_remote_get(void* tgt_addr, c_nodeid_t locale, void* src_addr,
   src_addr_xmit_off = VP_TO_UI64(src_addr) - VP_TO_UI64(src_addr_xmit);
   xmit_size         = ALIGN_32_UP(size + src_addr_xmit_off);
 
-  local_mr = mreg_for_local_addr(tgt_addr_xmit, xmit_size);
+  local_mr = mreg_for_local_addr(tgt_addr, size);
   if (local_mr != NULL
       && src_addr_xmit == src_addr
       && xmit_size == size) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2759,7 +2759,9 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
                    : (mr - &mem_regions->mregs[0] + 1)));
   }
   PERFSTATS_ADD(local_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if (mr != NULL && (uint64_t) addr + size > mr->addr + mrtl_len(mr->len)) {
+  if (mr != NULL
+      && ((uint64_t) addr + size
+          > mr->addr + ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE))) {
     CHPL_INTERNAL_ERROR("local xfer size extends beyond MR!");
   }
   return mr;
@@ -2791,7 +2793,9 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
                    : (mr - &mem_regions_all_entries[locale]->mregs[0] + 1)));
   }
   PERFSTATS_ADD(remote_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if (mr != NULL && (uint64_t) addr + size > mr->addr + mrtl_len(mr->len)) {
+  if (mr != NULL
+      && ((uint64_t) addr + size
+          > mr->addr + ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE))) {
     CHPL_INTERNAL_ERROR("remote xfer size extends beyond MR!");
   }
   return mr;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -574,6 +574,8 @@ static mem_region_table_t** mem_regions_all_my_entry_map;
 
 static chpl_bool can_register_memory = false;
 
+static chpl_bool do_mr_extent_checks;
+
 //
 // The high bit of the 'len' member of a mem_region_t in the table
 // indicates whether the region is registered.  mrtl_encode() and
@@ -1896,6 +1898,9 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
   // We can reach 16k memory regions on Aries.
   max_mem_regions = chpl_env_rt_get_int("COMM_UGNI_MAX_MEM_REGIONS", 16384);
 
+  do_mr_extent_checks = chpl_env_rt_get_bool("COMM_UGNI_DO_MR_EXTENT_CHECKS",
+                                             true);
+
   //
   // We have to create the local memory region table before the first
   // call to regMemAlloc() is made.  But that could come from the memory
@@ -2761,7 +2766,7 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
                    : (mr - &mem_regions->mregs[0] + 1)));
   }
   PERFSTATS_ADD(local_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if (mr != NULL) {
+  if (do_mr_extent_checks && mr != NULL) {
     size_t mrLen = chpl_cache_enabled()
                    ? ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE)
                    : mrtl_len(mr->len);
@@ -2798,7 +2803,7 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
                    : (mr - &mem_regions_all_entries[locale]->mregs[0] + 1)));
   }
   PERFSTATS_ADD(remote_mreg_nsecs, PERFSTATS_TELAPSED(pstStart));
-  if (mr != NULL) {
+  if (do_mr_extent_checks && mr != NULL) {
     size_t mrLen = chpl_cache_enabled()
                    ? ALIGN_UP(mrtl_len(mr->len), CACHE_LINE_SIZE)
                    : mrtl_len(mr->len);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -159,8 +159,8 @@ static atomic_uint_least32_t next_thread_idx;
 
 #define CHPL_INTERNAL_ERROR(msg)                                        \
         do {                                                            \
-          DBG_P_LP(~0U, "%s:%d: internal error: %s",                    \
-                   __FILE__, (int) __LINE__, msg);                      \
+          fprintf(stderr, "%d:%s:%d: internal error: %s\n",             \
+                  (int) chpl_nodeID, __FILE__, (int) __LINE__, msg);    \
           fflush(NULL);                                                 \
           abort();                                                      \
         } while (0)


### PR DESCRIPTION
We've been assuming in comm=ugni that if the starting address of a
transfer was found to be within some memory registration, there were
sufficient constraints elsewhere in the Chapel software stack to
guarantee the whole extent of the transfer would lie within that MR.  We
still believe that should be true for Chapel itself, but we've recently
encountered a situation in which not-strictly-Chapel code made it false.
Specifically, turning on chunk merging and splitting in the jemalloc
memory allocation package caused us to end up with arrays that spanned
uGNI memory registration boundaries, leading to error returns from uGNI
that are hard to diagnose because the specific error code we get back
isn't pretty nonspecific.  We've fixed that problem, but in addition to
that, here adjust the comm layer to sanity-check the whole extent of
each transfer against the MR containing its starting address.  This will
give us a specific error for this problem if something else causes it in
the future.

This resolves https://github.com/Cray/chapel-private/issues/2994