### PR TITLE
Add skipif for a regex deprecation test

### DIFF
--- a/test/deprecated/regexMatchesArgs.skipif
+++ b/test/deprecated/regexMatchesArgs.skipif
@@ -1,0 +1,1 @@
+CHPL_RE2==none


### PR DESCRIPTION
This adds a typical skipif for a regex deprecation test I recently added.

`start_test --respect-skipifs` skips the test in quickstart setting.