### PR TITLE
Reduce amount of testing of day21a AOC codes

### DIFF
--- a/test/studies/adventOfCode/2021/bradc/day21a.execopts
+++ b/test/studies/adventOfCode/2021/bradc/day21a.execopts
@@ -1,2 +1,2 @@
---practice=true   # day21a-test.good
+# Takes awhile, and the next line should cover it: --practice=true   # day21a-test.good
 --practice=false  # day21a.good

--- a/test/studies/adventOfCode/2021/bradc/day21a.skipif
+++ b/test/studies/adventOfCode/2021/bradc/day21a.skipif
@@ -1,2 +1,3 @@
-# valgrind takes too long for these tests, so skip them
+# valgrind and memleaks take too long for these tests, so skip them
 CHPL_TEST_VGRND_EXE == on
+EXECOPTS <= memLeaks


### PR DESCRIPTION
This test is highly recursive and copies tiny arrays on each function
call, so is pretty brutal with memtracking on.  Skip the test when
that's the case as a result.  In addition, the two configurations are
testing virtually the same thing and take ~15-20 seconds on a Mac or
linux64, so let's just run one of them (where the "non-practice" run
tends to be faster in my experience).
