### PR TITLE
compiler/next: parse modules on use/import

### DIFF
--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -104,8 +104,19 @@ using ModuleVec = std::vector<const uast::Module*>;
 const ModuleVec& parse(Context* context, UniqueString path);
 
 /**
+  Return the current module search path.
+ */
+const std::vector<UniqueString>& moduleSearchPath(Context* context);
+
+/**
+  Sets the current module search path.
+ */
+void setModuleSearchPath(Context* context,
+                         std::vector<UniqueString> searchPath);
+
+/**
  This query parses a toplevel module by name. Returns nullptr
- if no such toplevel module can be found.
+ if no such toplevel module can be found in the module search path.
  */
 const uast::Module* getToplevelModule(Context* context, UniqueString name);
 

--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -106,13 +106,13 @@ const ModuleVec& parse(Context* context, UniqueString path);
 /**
   Return the current module search path.
  */
-const std::vector<UniqueString>& moduleSearchPath(Context* context);
+const std::vector<std::string>& moduleSearchPath(Context* context);
 
 /**
   Sets the current module search path.
  */
 void setModuleSearchPath(Context* context,
-                         std::vector<UniqueString> searchPath);
+                         std::vector<std::string> searchPath);
 
 /**
  This query parses a toplevel module by name. Returns nullptr

--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -41,18 +41,37 @@ namespace parsing {
  In case there is an error reading the file, the error is stored in the error
  field of the FileContents.
  */
+const FileContents& fileText(Context* context, std::string path);
+
+/**
+ Convenience function to call fileText given a UniqueString.
+ */
 const FileContents& fileText(Context* context, UniqueString path);
 
 /**
  This function sets the FileContents that will be returned by the fileText
  query above.
  */
-void setFileText(Context* context, UniqueString path, FileContents result);
+void setFileText(Context* context, std::string path, FileContents result);
+
+/**
+ This function sets the string that will be returned by the fileText
+ query above. The FileContents stored will have an empty ErrorMessage field.
+ */
+void setFileText(Context* context, std::string path, std::string text);
+
 /**
  This function sets the string that will be returned by the fileText
  query above. The FileContents stored will have an empty ErrorMessage field.
  */
 void setFileText(Context* context, UniqueString path, std::string text);
+
+
+/**
+ This function returns `true` if the current revision already has contents
+ stored in the fileText query for the given path.
+ */
+bool hasFileText(Context* context, const std::string& path);
 
 /**
   This query reads a file (with the fileText query) and then parses it.

--- a/compiler/next/include/chpl/parsing/parsing-queries.h
+++ b/compiler/next/include/chpl/parsing/parsing-queries.h
@@ -55,7 +55,9 @@ void setFileText(Context* context, UniqueString path, FileContents result);
 void setFileText(Context* context, UniqueString path, std::string text);
 
 /**
- This query reads a file (with the fileText query) and then parses it.
+  This query reads a file (with the fileText query) and then parses it.
+
+  Any errors encountered will be reported to the Context.
  */
 const uast::BuilderResult& parseFile(Context* context, UniqueString path);
 

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -365,6 +365,22 @@ class Context {
   bool hasFilePathForId(ID id);
 
   /**
+    Sets the file path for the given module ID. This
+    is suitable to call from a parse query.
+   */
+  void setFilePathForModuleID(ID moduleID, UniqueString path);
+
+  /**
+    Return the current module search path.
+   */
+  const std::vector<UniqueString>& moduleSearchPath();
+
+  /**
+    Sets the current module search path.
+   */
+  void setModuleSearchPath(std::vector<UniqueString> searchPath);
+
+  /**
     This function increments the current revision number stored
     in the context. After it is called, the setters below can
     be used to provide the input at that revision.
@@ -390,14 +406,6 @@ class Context {
     is running.
    */
   void collectGarbage();
-
-  // setters for named queries.
-
-  /**
-    Sets the file path for the given module ID. This
-    is suitable to call from a parse query.
-   */
-  void setFilePathForModuleID(ID moduleID, UniqueString path);
 
   /**
     Note an error for the currently running query and report it

--- a/compiler/next/include/chpl/queries/Context.h
+++ b/compiler/next/include/chpl/queries/Context.h
@@ -373,16 +373,6 @@ class Context {
   void setFilePathForModuleID(ID moduleID, UniqueString path);
 
   /**
-    Return the current module search path.
-   */
-  const std::vector<UniqueString>& moduleSearchPath();
-
-  /**
-    Sets the current module search path.
-   */
-  void setModuleSearchPath(std::vector<UniqueString> searchPath);
-
-  /**
     This function increments the current revision number stored
     in the context. After it is called, the setters below can
     be used to provide the input at that revision.

--- a/compiler/next/include/chpl/queries/query-impl.h
+++ b/compiler/next/include/chpl/queries/query-impl.h
@@ -487,10 +487,9 @@ Context::updateResultForQuery(
 template<typename ResultType,
          typename... ArgTs>
 bool
-Context::hasResultForQuery(
+Context::hasCurrentResultForQuery(
      const ResultType& (*queryFunction)(Context* context, ArgTs...),
-     const std::tuple<ArgTs...>& tupleOfArgs,
-     const char* traceQueryName) {
+     const std::tuple<ArgTs...>& tupleOfArgs) {
 
   // Look up the map entry for this query name
   const void* queryFuncV = (const void*) queryFunction;
@@ -509,7 +508,7 @@ Context::hasResultForQuery(
     return false;
   }
 
-  return true;
+  return queryCanUseSavedResult(queryFuncV, &(*search2));
 }
 
 template<typename ResultType,

--- a/compiler/next/include/chpl/util/filesystem.h
+++ b/compiler/next/include/chpl/util/filesystem.h
@@ -33,6 +33,10 @@ namespace chpl {
  */
 bool readfile(const char* path, std::string& strOut, ErrorMessage& errorOut);
 
+/**
+  Checks to see if a file exists at path. Returns 'true' if it does.
+ */
+bool fileExists(const char* path);
 
 } // end namespace chpl
 

--- a/compiler/next/lib/parsing/parsing-queries.cpp
+++ b/compiler/next/lib/parsing/parsing-queries.cpp
@@ -149,6 +149,26 @@ const ModuleVec& parse(Context* context, UniqueString path) {
   return QUERY_END(result);
 }
 
+static const std::vector<UniqueString>&
+moduleSearchPathQuery(Context* context) {
+  QUERY_BEGIN_INPUT(moduleSearchPathQuery, context);
+
+  // return the empty path if it wasn't already set in
+  // setModuleSearchPath
+  std::vector<UniqueString> result;
+
+  return QUERY_END(result);
+}
+
+const std::vector<UniqueString>& moduleSearchPath(Context* context) {
+  return moduleSearchPathQuery(context);
+}
+
+void setModuleSearchPath(Context* context,
+                         std::vector<UniqueString> searchPath) {
+  QUERY_STORE_INPUT_RESULT(moduleSearchPathQuery, context, searchPath);
+}
+
 static const Module* const& getToplevelModuleQuery(Context* context,
                                                    UniqueString name) {
   QUERY_BEGIN(getToplevelModuleQuery, context, name);
@@ -175,7 +195,7 @@ static const Module* const& getToplevelModuleQuery(Context* context,
     // Check the module search path for the module.
     std::string check;
 
-    for (auto path : context->moduleSearchPath()) {
+    for (auto path : moduleSearchPath(context)) {
       check.clear();
       check += path.c_str();
       // Remove any '/' characters before adding one so we don't double.

--- a/compiler/next/lib/parsing/parsing-queries.cpp
+++ b/compiler/next/lib/parsing/parsing-queries.cpp
@@ -149,23 +149,23 @@ const ModuleVec& parse(Context* context, UniqueString path) {
   return QUERY_END(result);
 }
 
-static const std::vector<UniqueString>&
+static const std::vector<std::string>&
 moduleSearchPathQuery(Context* context) {
   QUERY_BEGIN_INPUT(moduleSearchPathQuery, context);
 
   // return the empty path if it wasn't already set in
   // setModuleSearchPath
-  std::vector<UniqueString> result;
+  std::vector<std::string> result;
 
   return QUERY_END(result);
 }
 
-const std::vector<UniqueString>& moduleSearchPath(Context* context) {
+const std::vector<std::string>& moduleSearchPath(Context* context) {
   return moduleSearchPathQuery(context);
 }
 
 void setModuleSearchPath(Context* context,
-                         std::vector<UniqueString> searchPath) {
+                         std::vector<std::string> searchPath) {
   QUERY_STORE_INPUT_RESULT(moduleSearchPathQuery, context, searchPath);
 }
 
@@ -197,7 +197,7 @@ static const Module* const& getToplevelModuleQuery(Context* context,
 
     for (auto path : moduleSearchPath(context)) {
       check.clear();
-      check += path.c_str();
+      check += path;
       // Remove any '/' characters before adding one so we don't double.
       while (!check.empty() && check.back() == '/') {
         check.pop_back();

--- a/compiler/next/lib/parsing/parsing-queries.cpp
+++ b/compiler/next/lib/parsing/parsing-queries.cpp
@@ -84,7 +84,7 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path) {
   QUERY_BEGIN(parseFile, context, path);
 
   // Run the fileText query to get the file contents
-  const FileContents& contents = fileText(context, path.str());
+  const FileContents& contents = fileText(context, path);
   const std::string& text = contents.text();
   const ErrorMessage& error = contents.error();
   uast::BuilderResult result(path);

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -476,38 +476,6 @@ void Context::setFilePathForModuleID(ID moduleID, UniqueString path) {
   assert(hasFilePathForId(moduleID));
 }
 
-static const std::vector<UniqueString>&
-moduleSearchPathQuery(Context* context) {
-  QUERY_BEGIN(moduleSearchPathQuery, context);
-
-  // return the empty path if it wasn't already set in
-  // setModuleSearchPath
-  std::vector<UniqueString> result;
-
-  return QUERY_END(result);
-}
-
-const std::vector<UniqueString>& Context::moduleSearchPath() {
-  return moduleSearchPathQuery(this);
-}
-
-void Context::setModuleSearchPath(std::vector<UniqueString> searchPath) {
-  auto tupleOfArgs = std::make_tuple();
-
-  updateResultForQuery(moduleSearchPathQuery,
-                       tupleOfArgs, searchPath,
-                       "moduleSearchPathQuery",
-                       /* isInputQuery */ false,
-                       /* forSetter */ true);
-
-  if (enableDebugTrace) {
-    printf("SETTING MODULE SEARCH PATH to:\n");
-    for (auto elt : searchPath) {
-      printf("  %s\n", elt.c_str());
-    }
-  }
-}
-
 void Context::advanceToNextRevision(bool prepareToGC) {
   this->currentRevisionNumber++;
   this->numQueriesRunThisRevision_ = 0;

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -423,9 +423,8 @@ UniqueString Context::filePathForId(ID id) {
   while (!symbolPath.isEmpty()) {
     auto tupleOfArgs = std::make_tuple(symbolPath);
 
-    bool got = hasResultForQuery(filePathForModuleIdSymbolPathQuery,
-                                 tupleOfArgs,
-                                 "filePathForModuleIdSymbolPathQuery");
+    bool got = hasCurrentResultForQuery(filePathForModuleIdSymbolPathQuery,
+                                        tupleOfArgs);
 
     if (got) {
       const UniqueString& p =
@@ -446,9 +445,8 @@ bool Context::hasFilePathForId(ID id) {
   while (!symbolPath.isEmpty()) {
     auto tupleOfArgs = std::make_tuple(symbolPath);
 
-    bool got = hasResultForQuery(filePathForModuleIdSymbolPathQuery,
-                                 tupleOfArgs,
-                                 "filePathForModuleIdSymbolPathQuery");
+    bool got = hasCurrentResultForQuery(filePathForModuleIdSymbolPathQuery,
+                                        tupleOfArgs);
 
     if (got) {
       return true;
@@ -728,7 +726,7 @@ void Context::updateForReuse(const QueryMapResultBase* resultEntry) {
   }
 }
 
-bool Context::queryCanUseSavedResultAndPushIfNot(
+bool Context::queryCanUseSavedResult(
                    const void* queryFunction,
                    const QueryMapResultBase* resultEntry) {
 
@@ -759,6 +757,15 @@ bool Context::queryCanUseSavedResultAndPushIfNot(
       updateForReuse(resultEntry);
     }
   }
+
+  return useSaved;
+}
+
+bool Context::queryCanUseSavedResultAndPushIfNot(
+                   const void* queryFunction,
+                   const QueryMapResultBase* resultEntry) {
+
+  bool useSaved = queryCanUseSavedResult(queryFunction, resultEntry);
 
   if (useSaved == false) {
     // Since the result cannot be reused, the query will be evaluated.

--- a/compiler/next/lib/queries/Context.cpp
+++ b/compiler/next/lib/queries/Context.cpp
@@ -461,6 +461,55 @@ bool Context::hasFilePathForId(ID id) {
   return false;
 }
 
+void Context::setFilePathForModuleID(ID moduleID, UniqueString path) {
+  UniqueString moduleIdSymbolPath = moduleID.symbolPath();
+  auto tupleOfArgs = std::make_tuple(moduleIdSymbolPath);
+
+  updateResultForQuery(filePathForModuleIdSymbolPathQuery,
+                       tupleOfArgs, path,
+                       "filePathForModuleIdSymbolPathQuery",
+                       /* isInputQuery */ false,
+                       /* forSetter */ true);
+
+  if (enableDebugTrace) {
+    printf("SETTING FILE PATH FOR MODULE %s -> %s\n",
+           moduleIdSymbolPath.c_str(), path.c_str());
+  }
+  assert(hasFilePathForId(moduleID));
+}
+
+static const std::vector<UniqueString>&
+moduleSearchPathQuery(Context* context) {
+  QUERY_BEGIN(moduleSearchPathQuery, context);
+
+  // return the empty path if it wasn't already set in
+  // setModuleSearchPath
+  std::vector<UniqueString> result;
+
+  return QUERY_END(result);
+}
+
+const std::vector<UniqueString>& Context::moduleSearchPath() {
+  return moduleSearchPathQuery(this);
+}
+
+void Context::setModuleSearchPath(std::vector<UniqueString> searchPath) {
+  auto tupleOfArgs = std::make_tuple();
+
+  updateResultForQuery(moduleSearchPathQuery,
+                       tupleOfArgs, searchPath,
+                       "moduleSearchPathQuery",
+                       /* isInputQuery */ false,
+                       /* forSetter */ true);
+
+  if (enableDebugTrace) {
+    printf("SETTING MODULE SEARCH PATH to:\n");
+    for (auto elt : searchPath) {
+      printf("  %s\n", elt.c_str());
+    }
+  }
+}
+
 void Context::advanceToNextRevision(bool prepareToGC) {
   this->currentRevisionNumber++;
   this->numQueriesRunThisRevision_ = 0;
@@ -543,23 +592,6 @@ void Context::collectGarbage() {
              (int)(nUniqueStringsBefore-nUniqueStringsAfter));
     }
   }
-}
-
-void Context::setFilePathForModuleID(ID moduleID, UniqueString path) {
-  UniqueString moduleIdSymbolPath = moduleID.symbolPath();
-  auto tupleOfArgs = std::make_tuple(moduleIdSymbolPath);
-
-  updateResultForQuery(filePathForModuleIdSymbolPathQuery,
-                       tupleOfArgs, path,
-                       "filePathForModuleIdSymbolPathQuery",
-                       /* isInputQuery */ false,
-                       /* forSetter */ true);
-
-  if (enableDebugTrace) {
-    printf("SETTING FILE PATH FOR MODULE %s -> %s\n",
-           moduleIdSymbolPath.c_str(), path.c_str());
-  }
-  assert(hasFilePathForId(moduleID));
 }
 
 void Context::error(ErrorMessage error) {

--- a/compiler/next/lib/util/filesystem.cpp
+++ b/compiler/next/lib/util/filesystem.cpp
@@ -26,7 +26,12 @@
 
 #include <cerrno>
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 namespace chpl {
+
 
 static std::string my_strerror(int errno_) {
   char errbuf[256];
@@ -100,5 +105,12 @@ bool readfile(const char* path,
 
   return true;
 }
+
+bool fileExists(const char* path) {
+  struct stat s;
+  int err = stat(path, &s);
+  return err == 0;
+}
+
 
 }

--- a/compiler/next/test/parsing/testParsingQueries.cpp
+++ b/compiler/next/test/parsing/testParsingQueries.cpp
@@ -618,6 +618,29 @@ static void test8() {
   assert(o == v[2]);
 }
 
+static void test9() {
+  Context ctx;
+  Context* context = &ctx;
+
+  std::vector<std::string> searchPath;
+  searchPath.push_back("/test/path/library");
+  searchPath.push_back("/test/path/program/");
+
+  setModuleSearchPath(context, searchPath);
+
+  setFileText(context, "/test/path/program/Program.chpl",
+                       "module Program { use Library; var x = libY; }");
+  setFileText(context, "/test/path/library/Library.chpl",
+                       "module Library { var libY = 3; }");
+
+  auto Program = UniqueString::get(context, "Program");
+  auto Library = UniqueString::get(context, "Library");
+  auto pMod = getToplevelModule(context, Program);
+  auto lMod = getToplevelModule(context, Library);
+
+  assert(pMod != nullptr);
+  assert(lMod != nullptr);
+}
 
 int main() {
   test0();
@@ -629,6 +652,7 @@ int main() {
   test6();
   test7();
   test8();
+  test9();
 
   return 0;
 }

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -215,7 +215,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  ctx->setModuleSearchPath(searchPath);
+  setModuleSearchPath(ctx, searchPath);
 
   if (firstfile == argc) {
     usage(argc, argv);

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -188,23 +188,46 @@ computeAndPrintStuff(Context* context,
   }*/
 }
 
-int main(int argc, char** argv) {
+static void usage(int argc, char** argv) {
+  printf("Usage: %s [--search path --search otherPath ...] "
+         "file.chpl otherFile.chpl ...\n", argv[0]);
+}
 
-  if (argc == 1) {
-    printf("Usage: %s file.chpl otherFile.chpl ...\n", argv[0]);
-    return 0; // need this to return 0 for testing to be happy
-  }
+int main(int argc, char** argv) {
 
   bool gc = false;
   Context context;
   Context* ctx = &context;
+
+  std::vector<UniqueString> searchPath;
+  int firstfile = 1;
+  for (int i = 1; i < argc; i++) {
+    if (0 == strcmp(argv[i], "--search")) {
+      if (i+1 == argc || firstfile != 1) {
+        usage(argc, argv);
+        return 1;
+      }
+      searchPath.push_back(UniqueString::get(ctx, argv[i+1]));
+      i++;
+    } else {
+      firstfile = i;
+      break;
+    }
+  }
+
+  ctx->setModuleSearchPath(searchPath);
+
+  if (firstfile == argc) {
+    usage(argc, argv);
+    return 0; // need this to return 0 for testing to be happy
+  }
 
   while (true) {
     ctx->advanceToNextRevision(gc);
 
     std::set<const ResolvedFunction*> calledFns;
 
-    for (int i = 1; i < argc; i++) {
+    for (int i = firstfile; i < argc; i++) {
       auto filepath = UniqueString::get(ctx, argv[i]);
 
       const ModuleVec& mods = parse(ctx, filepath);

--- a/compiler/next/test/resolution/testInteractive.cpp
+++ b/compiler/next/test/resolution/testInteractive.cpp
@@ -199,7 +199,7 @@ int main(int argc, char** argv) {
   Context context;
   Context* ctx = &context;
 
-  std::vector<UniqueString> searchPath;
+  std::vector<std::string> searchPath;
   int firstfile = 1;
   for (int i = 1; i < argc; i++) {
     if (0 == strcmp(argv[i], "--search")) {
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
         usage(argc, argv);
         return 1;
       }
-      searchPath.push_back(UniqueString::get(ctx, argv[i+1]));
+      searchPath.push_back(argv[i+1]);
       i++;
     } else {
       firstfile = i;


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/2637

This PR adjusts the compiler/next code to handle parsing a module on a use/import.
 * adds a settable module search path (`moduleSearchPath` / `setModuleSearchPath`) to parsing-queries.h
 * to avoid polluting the unique strings map with pathname components, adjusted `fileText`, `setFileText` to accept the path as a `std::string`
 * added `hasFileText` for use when testing to see if a file at a particular path is already known to the compiler from `setFileText`
 * `getToplevelModule` can now find modules using the module search path. When it does so, it checks if `setFileText` has already indicated the file at a particular path (by calling `hasFileText`); if not it uses a new file system call to check if the file exists at the various module path locations. The `hasFileText` enables C++ tests of the use/import parsing to work without storing anything in the filesystem.
 * Moved the implementation of `Context::setFilePathForModuleID` closer to the related functions and added `Context::hasCurrentResultForQuery` for use in `hasFileText` and similar.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing