### PR TITLE
Add knucleotide4 to submitted graphs

### DIFF
--- a/test/studies/shootout/submitted/knucleotide-submitted.graph
+++ b/test/studies/shootout/submitted/knucleotide-submitted.graph
@@ -1,5 +1,5 @@
-perfkeys: real, real
-graphkeys: release, submitted
-files: knucleotide.dat, knucleotide-submitted.dat
+perfkeys: real, real, real
+graphkeys: release, submitted, knucleotide-hash
+files: knucleotide.dat, knucleotide-submitted.dat, knucleotide-hash.dat
 graphtitle: Submitted K-nucleotide Shootout Benchmark
 ylabel: Time (seconds)

--- a/test/studies/shootout/submitted/knucleotide4.perfexecopts
+++ b/test/studies/shootout/submitted/knucleotide4.perfexecopts
@@ -1,1 +1,1 @@
---n=0 < $CHPL_TEST_TMP_DIR/fasta.knucl # knucleotide-submitted
+--n=0 < $CHPL_TEST_TMP_DIR/fasta.knucl # knucleotide-hash


### PR DESCRIPTION
I had not added knucleotide4 to the graphs after adding my knucleotide4 submission to the submitted directory, this PR adds that to the graphs.