### PR TITLE
very minor format changes to Version

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -115,19 +115,23 @@ module Version {
     compared to one whose ``update`` is non-empty, the latter is
     considered to be earlier than (less than) the former, due to the
     interpretation that it represents a pre-release of the official
-    release.  */
+    release.
+  */
 
-    record sourceVersion {
-    /* The major version number.  For version ``2.0.1``, this would be
-       ``2``. */
+  record sourceVersion {
+    /*
+      The major version number. For version ``2.0.1``, this would be ``2``.
+    */
     param major: int;
 
-    /* The minor version number.  For version ``2.0.1``, this would be
-       ``0``. */
+    /*
+      The minor version number. For version ``2.0.1``, this would be ``0``.
+    */
     param minor: int;
 
-    /* The update version number.  For version ``2.0.1``, this would
-       be ``1``. */
+    /*
+      The update version number. For version ``2.0.1``, this would be ``1``.
+    */
     param update: int;
 
     /* The commit ID of the version (e.g., a Git SHA) */


### PR DESCRIPTION
This PR makes some minor formatting adjustments to the `Version` module.
Specifically, the indentation of the `sourceVersion` record, was adjusted
and some comments that were multi-line were made into single lines for
readability.

TESTING:

- Manually reviewed the generated documentation for the `Version` module
- No other tests

Reviewed by @bradcray

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>