### PR TITLE
When cloning CHAMPS, make sure to get tags

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -23,7 +23,7 @@ export CHAMPS_HOME=$CWD/champs
 rm -rf ${CHAMPS_HOME}
 
 # Clone CHAMPS 
-if ! git clone --depth=1 ${CHAMPS_URL} --branch=${CHAMPS_BRANCH} ; then
+if ! git clone ${CHAMPS_URL} --branch=${CHAMPS_BRANCH} ; then
   log_fatal_error "cloning CHAMPS"
 else
   echo "Cloned CHAMPS successfully"


### PR DESCRIPTION
I used the `--depth` argument as we do for Arkouda in hopes to keep the clone
small. However, that also led to a position where if the HEAD we are cloning
doesn't have a tag, we don't have any tag at all. CHAMPS uses tags to name their
executables. So, it is important that our clone has tags.
