### PR TITLE
Fix simple problem with cproj() pointed out by Damian

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -459,11 +459,11 @@ module Math {
   }
 
   /* Returns the projection of `z` on a Riemann sphere. */
-  inline proc cproj(z: complex(?w)): real(w/2) {
+  inline proc cproj(z: complex(?w)): complex(w) {
     pragma "fn synchronization free"
-    extern proc cprojf(z: complex(64)): real(32);
+    extern proc cprojf(z: complex(64)): complex(64);
     pragma "fn synchronization free"
-    extern proc cproj(z: complex(128)): real(64);
+    extern proc cproj(z: complex(128)): complex(128);
     if w == 64 then
       return cprojf(z);
     else

--- a/test/types/complex/diten/cplxMathFnTypes.chpl
+++ b/test/types/complex/diten/cplxMathFnTypes.chpl
@@ -9,7 +9,7 @@ proc testTypes(x: complex(?w)) {
   assert(res3.type == complex(w));
 
   const res4 = cproj(x);
-  assert(res4.type == real(w/2));
+  assert(res4.type == complex(w));
 
   const res5 = exp(x);
   assert(res5.type == complex(w));


### PR DESCRIPTION
In discussing math stuff recently, @damianmoz pointed out that Chapel's
cproj() function returned (and assumed C was returning) reals/floats
rather than complexes.  This makes the simple update to address that.
Though the imaginary part is always 0.0, Damian points out that it can
matter since it should retain the sign of the original value (+0.0 or -0.0).
And also that users expect these routines to be closed on the input type.

Damian also suggested that cproj() is so simple that we ought to
implement it in Chapel (from a simplicity / optimizability of code
perspective), but I did not feel I had the time or energy to take that up late
on a Friday.  Someone should open an issue about this or take it on
themselves if they feel strongly about it.