### PR TITLE
Report a clear error when using min/max(type t)

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -722,6 +722,11 @@ proc min(type t) where isComplexType(t) {
   return (min(real(floatwidth)), min(real(floatwidth))): t;
 }
 
+pragma "last resort" pragma "no doc"
+proc min(type t) {
+  compilerError("'min(type t)' is not defined for t=", t:string);
+}
+
 // joint documentation, for user convenience
 /*
 Returns the maximum value the type `t` can store.
@@ -758,6 +763,11 @@ pragma "no doc"
 proc max(type t) where isComplexType(t) {
   param floatwidth = numBits(t) / 2;
   return (max(real(floatwidth)), max(real(floatwidth))): t;
+}
+
+pragma "last resort" pragma "no doc"
+proc max(type t) {
+  compilerError("'max(type t)' is not defined for t=", t:string);
 }
 
 pragma "no doc"

--- a/test/expressions/vass/undefined-max-error.chpl
+++ b/test/expressions/vass/undefined-max-error.chpl
@@ -1,0 +1,5 @@
+// checks compile-time error when max(t) is not defined
+
+class C { }
+
+writeln(max(C));

--- a/test/expressions/vass/undefined-max-error.good
+++ b/test/expressions/vass/undefined-max-error.good
@@ -1,0 +1,1 @@
+undefined-max-error.chpl:5: error: 'max(type t)' is not defined for t=C

--- a/test/expressions/vass/undefined-min-error.chpl
+++ b/test/expressions/vass/undefined-min-error.chpl
@@ -1,0 +1,5 @@
+// checks compile-time error when min(t) is not defined
+
+record R { }
+
+writeln(min(R));

--- a/test/expressions/vass/undefined-min-error.good
+++ b/test/expressions/vass/undefined-min-error.good
@@ -1,0 +1,1 @@
+undefined-min-error.chpl:5: error: 'min(type t)' is not defined for t=R

--- a/test/studies/adventOfCode/2021/bradc/futures/day14-maxlocstringinds.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day14-maxlocstringinds.bad
@@ -1,7 +1,1 @@
-day14-maxlocstringinds.chpl:6: error: unresolved call 'max(type string)'
-$CHPL_HOME/modules/internal/ChapelTuple.chpl:393: note: this candidate did not match: max(type t)
-$CHPL_HOME/modules/internal/ChapelTuple.chpl:393: note: because where clause evaluated to false
-day14-maxlocstringinds.chpl:6: note: other candidates are:
-$CHPL_HOME/modules/standard/Types.chpl:734: note:   max(type t)
-$CHPL_HOME/modules/standard/Types.chpl:737: note:   max(type t)
-note: and 22 other candidates, use --print-all-candidates to see them
+day14-maxlocstringinds.chpl:6: error: 'max(type t)' is not defined for t=string


### PR DESCRIPTION
When invoking `min` or `max` on a type that does not define it,
report an error stating so instead of a generic "unresolved call" error.
This is reasonable given that these are predefined operations in Chapel.

The error overloads added here are marked with the "last resort" pragma,
so users are free to add their own overloads that will take priority.

Resolves #6312

Testing: standard paratest; multilocale tests under gasnet