### PR TITLE
Add an extern declaration for chpl_nodeID for GPU

### DIFF
--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -26,6 +26,7 @@
 #include "chpltypes.h"
 #include "chpl-comm.h"
 
+extern __constant__ int32_t chpl_nodeID;
 
 // TODO
 __device__ static inline c_sublocid_t chpl_task_getRequestedSubloc(void)


### PR DESCRIPTION
This adds an `extern __constant__` for `chpl_nodeID` in the GPU part of the
runtime.

In summary, we need the GPU "version" of that constant so that the device
functions have a symbol to access to. Before switching to LLVM 12, we weren't
bumping into this issue because we were adding an extern definition in the
generated code. But with LLVM 12, we somehow stopped doing that.

This is definitely not the solution we need for this in the long term, and the
issue has already been captured in
https://github.com/Cray/chapel-private/issues/2758


