### PR TITLE
Remove script to set COMPILER_PATH for our LLVM system install

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -28,8 +28,5 @@ else
   [ "$1" == y ] && log_info "Expected Cray CS, but does not seem to be one."
 fi
 
-# Point clang to standard libraries
-source $CWD/common-llvm-comp-path.bash
-
 # https://github.com/Cray/chapel-private/issues/1601
 export SLURM_CPU_FREQ_REQ=high

--- a/util/cron/common-llvm-comp-path.bash
+++ b/util/cron/common-llvm-comp-path.bash
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Set COMPILER_PATH to point to a gnu compiler/library install. This is
-# needed when using the clang in our "system" LLVM installs on systems that
-# have a different organization for libraries than where LLVM/clang were built.
-
-export COMPILER_PATH="$(dirname $(dirname $(g++ --print-file-name=libstdc++.so)))"

--- a/util/cron/common-slurm-gasnet-cray-cs.bash
+++ b/util/cron/common-slurm-gasnet-cray-cs.bash
@@ -11,8 +11,6 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 source $CWD/common-cray-cs.bash y
 
-source $CWD/common-llvm-comp-path.bash
-
 export CHPL_COMM=gasnet
 
 unset CHPL_START_TEST_ARGS

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -20,7 +20,6 @@ module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp
-source $CWD/common-llvm-comp-path.bash
 
 module list
 

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -20,7 +20,6 @@ module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp
-source $CWD/common-llvm-comp-path.bash
 
 module list
 


### PR DESCRIPTION
#18551 made it so this setting should no longer be required. Stop using it.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>