### PR TITLE
dyno: add `stringify` tests

### DIFF
--- a/compiler/next/test/uast/CMakeLists.txt
+++ b/compiler/next/test/uast/CMakeLists.txt
@@ -18,3 +18,4 @@
 comp_unit_test(testBuildIDs)
 comp_unit_test(testConsistentEnums)
 comp_unit_test(testVisit)
+comp_unit_test(testStringify)

--- a/compiler/next/test/uast/testStringify.cpp
+++ b/compiler/next/test/uast/testStringify.cpp
@@ -36,7 +36,7 @@ static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl", "");
   auto mod = parseResult.singleModule();
   std::ostringstream ss;
-  mod->stringify(ss, DEBUG_DETAIL);
+  mod->stringify(ss, CHPL_SYNTAX);
   assert(ss.str() == "test0Module test0 \n");
 }
 
@@ -46,7 +46,7 @@ static void test1(Parser* parser) {
   auto mod = parseResult.singleModule();
   auto identifier = mod->stmt(0)->toIdentifier();
   std::ostringstream ss;
-  identifier->stringify(ss, DEBUG_DETAIL);
+  identifier->stringify(ss, CHPL_SYNTAX);
   assert(ss.str() == "test1@0Identifier x \n");
 }
 
@@ -57,7 +57,7 @@ static void test2(Parser* parser) {
   const AggregateDecl* agg = mod->stmt(0)->toAggregateDecl();
   auto cls = agg->toClass();
   std::ostringstream ss;
-  cls->stringify(ss, DEBUG_DETAIL);
+  cls->stringify(ss, CHPL_SYNTAX);
   assert(ss.str() == "test2.CClass C \n");
 }
 
@@ -69,7 +69,7 @@ static void test3(Parser* parser) {
   const AggregateDecl* agg = mod->stmt(0)->toAggregateDecl();
   auto rec = agg->toRecord();
   std::ostringstream ss;
-  rec->stringify(ss, DEBUG_DETAIL);
+  rec->stringify(ss, CHPL_SYNTAX);
   assert(ss.str() == "         test3.RRecord R \n"
                      "       test3.R@0  Variable x \n"
                      "  test3.R.method  Function method \n"

--- a/compiler/next/test/uast/testStringify.cpp
+++ b/compiler/next/test/uast/testStringify.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/queries/Context.h"
+#include "chpl/queries/UniqueString.h"
+#include "chpl/uast/all-uast.h"
+#include "chpl/parsing/Parser.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+using namespace chpl;
+using namespace uast;
+using namespace parsing;
+
+static void test0(Parser* parser) {
+  // test Module stringify
+  auto parseResult = parser->parseString("test0.chpl", "");
+  auto mod = parseResult.singleModule();
+  std::ostringstream ss;
+  mod->stringify(ss, DEBUG_DETAIL);
+  assert(ss.str() == "test0Module test0 \n");
+}
+
+static void test1(Parser* parser) {
+  // test Identifier stringify
+  auto parseResult = parser->parseString("test1.chpl", "x;");
+  auto mod = parseResult.singleModule();
+  auto identifier = mod->stmt(0)->toIdentifier();
+  std::ostringstream ss;
+  identifier->stringify(ss, DEBUG_DETAIL);
+  assert(ss.str() == "test1@0Identifier x \n");
+}
+
+static void test2(Parser* parser) {
+  // test Class stringify
+  auto parseResult = parser->parseString("test2.chpl", "class C { }");
+  auto mod = parseResult.singleModule();
+  const AggregateDecl* agg = mod->stmt(0)->toAggregateDecl();
+  auto cls = agg->toClass();
+  std::ostringstream ss;
+  cls->stringify(ss, DEBUG_DETAIL);
+  assert(ss.str() == "test2.CClass C \n");
+}
+
+static void test3(Parser* parser) {
+  // test record stringify
+  auto parseResult = parser->parseString("test3.chpl",
+                                         "record R { var x; proc method() { } }");
+  auto mod = parseResult.singleModule();
+  const AggregateDecl* agg = mod->stmt(0)->toAggregateDecl();
+  auto rec = agg->toRecord();
+  std::ostringstream ss;
+  rec->stringify(ss, DEBUG_DETAIL);
+  assert(ss.str() == "         test3.RRecord R \n"
+                     "       test3.R@0  Variable x \n"
+                     "  test3.R.method  Function method \n"
+                     "test3.R.method@1    Formal this \n"
+                     "test3.R.method@0      Identifier R \n"
+                     "test3.R.method@2    Block \n");
+}
+
+
+int main(int argc, char** argv) {
+  Context context;
+  Context* ctx = &context;
+
+  auto parser = Parser::build(ctx);
+  Parser* p = parser.get();
+  test0(p);
+  test1(p);
+  test2(p);
+  test3(p);
+
+  return 0;
+}

--- a/compiler/next/test/uast/testStringify.cpp
+++ b/compiler/next/test/uast/testStringify.cpp
@@ -59,6 +59,15 @@ static void stringifyNode(const ASTNode* node, chpl::StringifyKind kind) {
     assert(!ss.str().empty());
 }
 
+static void test0(Parser* parser) {
+  // stringify an empty Module
+  auto parseResult = parser->parseString("test0.chpl", "");
+  auto mod = parseResult.singleModule();
+  std::ostringstream ss;
+  mod->stringify(ss, CHPL_SYNTAX);
+  assert(!ss.str().empty());
+}
+
 static void test1(Parser* parser) {
   // the one test to rule them all
   std::string testCode;
@@ -235,6 +244,7 @@ int main(int argc, char** argv) {
 
   auto parser = Parser::build(ctx);
   Parser* p = parser.get();
+  test0(p);
   test1(p);
   test2(p);
 


### PR DESCRIPTION
This PR adds tests for `stringify` methods and templates.

Each of the template specializations are instantiated and
tested to make sure they produce some output, although the
contents of the output are not checked at this time. Future
work will adjust the output of uAST nodes and after that 
is done we can do more concrete comparisons of expected
outputs.

New `stringify` template added for `std::map`, small corrections
to output and calls within 

TESTING:

- [x] paratest
- [x] dyno tests pass in Linux (GCC, LLVM), builds on Mac (clang)

Reviewed by @dlongnecke-cray - Thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>