### PR TITLE
Remove the occurrence of module `distutils` for Python 3.10

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -685,8 +685,8 @@ static void makePYFile() {
     }
 
     // Imports
-    fprintf(py.fptr, "from distutils.core import setup\n");
-    fprintf(py.fptr, "from distutils.core import Extension\n");
+    fprintf(py.fptr, "from setuptools import setup\n");
+    fprintf(py.fptr, "from setuptools import Extension\n");
     fprintf(py.fptr, "from Cython.Build import cythonize\n");
     fprintf(py.fptr, "import numpy\n\n");
 
@@ -759,7 +759,7 @@ static void makePYInitFile() {
              "existing file", libDir);
     return;
   }
- 
+
   openLibraryHelperFile(&py, "__init__", "py");
 
   if (py.fptr != NULL) {

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -57,13 +57,13 @@ parser: FORCE flex_version_check
 
 # Require that the flex version is at least 2.6.0
 flex_version_check:
-	@if $(CHPL_MAKE_PYTHON) -c "import sys;                           \
-	               from distutils.version import LooseVersion as LV;  \
-	               sys.exit(LV(sys.argv[1]) >= LV(sys.argv[2]))"      \
-	           `flex --version | sed -e 's/flex //' -e 's/ .*//'`     \
-	           "2.6.0";                                               \
-	then echo "PROBLEM: flex version must be at least 2.6.0";         \
-	  exit 1;                                                         \
+	@if $(CHPL_MAKE_PYTHON) -c "import sys;                        \
+	               from pkg_resources import parse_version as PV;  \
+	               sys.exit(PV(sys.argv[1]) >= PV(sys.argv[2]))"   \
+	           `flex --version | sed -e 's/flex //' -e 's/ .*//'`  \
+	           "2.6.0";                                            \
+	then echo "PROBLEM: flex version must be at least 2.6.0";      \
+	  exit 1;                                                      \
 	fi
 
 #

--- a/test/compflags/link/sungeun/static_dynamic.prediff
+++ b/test/compflags/link/sungeun/static_dynamic.prediff
@@ -1,25 +1,28 @@
 #!/usr/bin/env python3
 
-import sys, os, subprocess, string
+import sys
+import os
+import subprocess
 
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 def testFailed(f, output):
     logfile = file(f, 'a')
-    logfile.write('%s'%(output))
+    logfile.write('%s' % (output))
     logfile.close()
 
-execname=sys.argv[1]
-logfilename=sys.argv[2]
-compopts=sys.argv[4].split()
 
-chpl_home=os.getenv('CHPL_HOME', '.');
-printchplenv = chpl_home+'/util/printchplenv'
+execname = sys.argv[1]
+logfilename = sys.argv[2]
+compopts = sys.argv[4].split()
+
+chpl_home = os.getenv('CHPL_HOME', '.')
+printchplenv = chpl_home + '/util/printchplenv'
 try:
-    p = subprocess.Popen([printchplenv,'--simple', '--all', '--no-tidy', '--anonymize'],
-                         stdout=subprocess.PIPE);
+    p = subprocess.Popen([printchplenv, '--simple', '--all', '--no-tidy', '--anonymize'],
+                         stdout=subprocess.PIPE)
 except:
-    testFailed(logfilename, 'Prediff script: Error executing '+printchplenv);
+    testFailed(logfilename, 'Prediff script: Error executing ' + printchplenv)
     raise
 chpl_env = p.communicate()[0].decode()
 
@@ -32,38 +35,37 @@ for l in chpl_env.split('\n'):
     if var == 'CHPL_TARGET_PLATFORM':
         if val.find('cray-x') == 0:
             pe_ver = os.getenv('CRAYPE_VERSION', '0.0.0.0')
-            if LooseVersion(pe_ver) < LooseVersion('2.6.0.1'):
-              defaultLinkStyle = 'statically'
+            if parse_version(pe_ver) < parse_version('2.6.0.1'):
+                defaultLinkStyle = 'statically'
 
     if var == 'CHPL_COMM':
-        chpl_comm=val
+        chpl_comm = val
 
 if chpl_comm != 'none':
     execname += '_real'
 
 
-linkStyle=defaultLinkStyle # the default
+linkStyle = defaultLinkStyle  # the default
 for opt in compopts:
-    if opt=='--static':
-        linkStyle='statically'
-    elif opt=='--dynamic':
-        linkStyle='dynamically'
+    if opt == '--static':
+        linkStyle = 'statically'
+    elif opt == '--dynamic':
+        linkStyle = 'dynamically'
 
 try:
     p = subprocess.Popen(['file', execname],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 except:
-    testFailed(logfilename, 'Prediff script: Error executing file command');
+    testFailed(logfilename, 'Prediff script: Error executing file command')
     raise
 
 myoutput = p.communicate()[0].decode()
 
 if p.returncode == 0:
-    if myoutput.find(linkStyle+' linked')==-1:
+    if myoutput.find(linkStyle + ' linked') == -1:
         testFailed(logfilename, myoutput)
     else:
         with open(logfilename, 'w') as logfile:
             logfile.write('SUCCESS\n')
 else:
     testFailed(logfilename, myoutput)
-

--- a/test/gpu/interop/cuBLAS.skipif
+++ b/test/gpu/interop/cuBLAS.skipif
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-from distutils.spawn import find_executable
 import os
+import shutil
 
-missing_nvcc = find_executable("nvcc") is None
+
+missing_nvcc = shutil.which("nvcc") is None
 
 # We don't have a great way to autodetect if we're going to launch onto a
 # compute node with GPUs, so we currently use `CHPL_TEST_GPU` as a proxy

--- a/test/gpu/interop/stream.skipif
+++ b/test/gpu/interop/stream.skipif
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-from distutils.spawn import find_executable
 import os
+import shutil
 
-missing_nvcc = find_executable("nvcc") is None
+
+missing_nvcc = shutil.which("nvcc") is None
 
 # We don't have a great way to autodetect if we're going to launch onto a
 # compute node with GPUs, so we currently use `CHPL_TEST_GPU` as a proxy

--- a/test/gpu/native.skipif
+++ b/test/gpu/native.skipif
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-from distutils.spawn import find_executable
 import os
+import shutil
+
 
 # Native GPU tests require nvcc, llvm, and the gpu locale model
-missing_nvcc = find_executable("nvcc") is None
+missing_nvcc = shutil.which("nvcc") is None
 no_llvm = os.getenv('CHPL_TARGET_COMPILER') != 'llvm'
 gpu_loc = os.getenv('CHPL_LOCALE_MODEL') == 'gpu'
 

--- a/test/interop/python/arrayAndExternArrayType.good
+++ b/test/interop/python/arrayAndExternArrayType.good
@@ -43,8 +43,8 @@ def returnsExternArray():
 	ret = ExternalArray()
 	ret._extern_arr = ret_arr
 	return ret
-from distutils.core import setup
-from distutils.core import Extension
+from setuptools import setup
+from setuptools import Extension
 from Cython.Build import cythonize
 import numpy
 

--- a/test/library/packages/Crypto.skipif
+++ b/test/library/packages/Crypto.skipif
@@ -2,22 +2,22 @@
 
 import os
 import subprocess
-import sys
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
-platform=os.getenv('CHPL_TARGET_PLATFORM')
 
-Ok=False
+platform = os.getenv('CHPL_TARGET_PLATFORM')
 
-if platform!='linux64':
-    Ok=False # not linux
+Ok = False
+
+if platform != 'linux64':
+    Ok = False  # not linux
 else:
 
     v = subprocess.check_output(['pkg-config', '--modversion', 'libcrypto'])
     v = v.rstrip()
     v = str(v, encoding='utf-8', errors='surrogateescape')
 
-    if LooseVersion(v) >= LooseVersion('1.1'):
+    if parse_version(v) >= parse_version('1.1'):
         # OK, version is compatible.
         Ok = True
 

--- a/test/library/packages/Socket.skipif
+++ b/test/library/packages/Socket.skipif
@@ -2,25 +2,25 @@
 
 import os
 import subprocess
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 platform = os.getenv('CHPL_TARGET_PLATFORM')
 
 skip = False
 
 if platform != 'linux64':
-  skip = True
+    skip = True
 else:
-  v = subprocess.check_output(['pkg-config', '--modversion', 'libevent'])
-  v = v.rstrip()
-  v = str(v, encoding='utf-8', errors='surrogateescape')
+    v = subprocess.check_output(['pkg-config', '--modversion', 'libevent'])
+    v = v.rstrip()
+    v = str(v, encoding='utf-8', errors='surrogateescape')
 
-  if LooseVersion(v) < LooseVersion('2.1'):
-    # skip, version not is compatible.
-    skip = True
+    if parse_version(v) < parse_version('2.1'):
+        # skip, version not is compatible.
+        skip = True
 
-  if os.getenv('CHPL_TASKS') == 'fifo' or os.getenv('CHPL_TARGET_COMPILER') == 'llvm':
-    skip = True
+    if os.getenv('CHPL_TASKS') == 'fifo' or os.getenv('CHPL_TARGET_COMPILER') == 'llvm':
+        skip = True
 
 
 print(skip)

--- a/test/setchplenv/verify_setchplenv_scripts.py
+++ b/test/setchplenv/verify_setchplenv_scripts.py
@@ -7,13 +7,10 @@ Also verify there are the correct setchplenv.* scripts and error if new ones
 show up without updating this test.
 """
 
-from __future__ import print_function
-
-import distutils.spawn
 import glob
 import os
 import os.path
-import shlex
+import shutil
 import subprocess
 import sys
 import unittest
@@ -177,7 +174,7 @@ class SetChplEnvTests(unittest.TestCase):
         """Verify csh versions of setchplenv.* work as expected."""
         self.check_scripts('csh', 'source', ':', post_source_cmd='rehash', shell_cmd='tcsh')
 
-    @_skip_if(distutils.spawn.find_executable('fish') is None,
+    @_skip_if(shutil.which('fish') is None,
               'fish is not installed on system.')
     def test_setchplenv__fish(self):
         """Verify fish versions of setchplenv.* work as expected."""
@@ -187,7 +184,7 @@ class SetChplEnvTests(unittest.TestCase):
         """Verify sh versions of setchplenv.* work as expected."""
         self.check_scripts('sh', '.', ':')
 
-    @_skip_if(distutils.spawn.find_executable('zsh') is None,
+    @_skip_if(shutil.which('zsh') is None,
               'zsh is not installed on system.')
     def test_setchplenv__zsh(self):
         """Verify bash versions of setchplenv.* work as expected with zsh."""

--- a/test/studies/dedup/dedup-externblock.skipif
+++ b/test/studies/dedup/dedup-externblock.skipif
@@ -2,22 +2,22 @@
 
 import os
 import subprocess
-import sys
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
-llvm=os.getenv('CHPL_LLVM')
-platform=os.getenv('CHPL_TARGET_PLATFORM')
 
-Ok=False
+llvm = os.getenv('CHPL_LLVM')
+platform = os.getenv('CHPL_TARGET_PLATFORM')
 
-if llvm=='none' or platform!='linux64':
-    Ok=False # not linux / no llvm
+Ok = False
+
+if llvm == 'none' or platform != 'linux64':
+    Ok = False  # not linux / no llvm
 else:
     output = subprocess.check_output(['openssl', 'version']).rstrip()
     output = str(output, encoding='utf-8', errors='surrogateescape')
     output = output.replace("OpenSSL", "")
     output = output.strip()
-    if LooseVersion(output) >= LooseVersion('1.1'):
-        Ok=True
+    if parse_version(output) >= parse_version('1.1'):
+        Ok = True
 
 print(not Ok)

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -4,16 +4,8 @@ import optparse
 import os
 import sys
 
-try:
-    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
-    # Prefer `shutil.which` in Python 3.2+
-    from shutil import which
-except ImportError:
-    # Backport for pre Python 3.2
-    from distutils.spawn import find_executable as which
-
 import chpl_platform, chpl_locale_model, overrides
-from utils import error, memoize, warning
+from utils import which, error, memoize, warning
 
 
 #

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
-from distutils.spawn import find_executable
+
 import sys
+
+try:
+    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
+    # Prefer `shutil.which` in Python 3.2+
+    from shutil import which
+except ImportError:
+    # Backport for pre Python 3.2
+    from distutils.spawn import find_executable as which
 
 import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
 from utils import error, memoize, warning
 
+
 def slurm_prefix(base_launcher, platform_val):
     """ If salloc is available and we're on a cray-cs/hpe-apollo, prefix with slurm-"""
-    if platform_val in ('cray-cs', 'hpe-apollo') and find_executable('salloc'):
+    if platform_val in ('cray-cs', 'hpe-apollo') and which('salloc'):
         return 'slurm-{}'.format(base_launcher)
     return base_launcher
 
@@ -22,15 +31,15 @@ def get():
             launcher_val = 'amudprun'
         elif launcher_val not in ('none', 'amudprun'):
             error('CHPL_LAUNCHER={} is not supported for CHPL_COMM=gasnet '
-		  'CHPL_COMM_SUBSTRATE=udp, CHPL_LAUNCHER=amudprun is '
+                  'CHPL_COMM_SUBSTRATE=udp, CHPL_LAUNCHER=amudprun is '
                   'required'.format(launcher_val))
 
     if not launcher_val:
         platform_val = chpl_platform.get('target')
 
         if platform_val.startswith('cray-x') or platform_val.startswith('hpe-cray-'):
-            has_aprun = find_executable('aprun')
-            has_slurm = find_executable('srun')
+            has_aprun = which('aprun')
+            has_slurm = which('srun')
             if has_aprun and has_slurm:
                 launcher_val = 'none'
             elif has_aprun:
@@ -60,7 +69,7 @@ def get():
             elif substrate_val == 'ofi':
                 launcher_val = slurm_prefix('gasnetrun_ofi', platform_val)
         else:
-            if platform_val in ('cray-cs', 'hpe-apollo') and find_executable('srun'):
+            if platform_val in ('cray-cs', 'hpe-apollo') and which('srun'):
                 launcher_val = 'slurm-srun'
             else:
                 launcher_val = 'none'

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -2,16 +2,8 @@
 
 import sys
 
-try:
-    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
-    # Prefer `shutil.which` in Python 3.2+
-    from shutil import which
-except ImportError:
-    # Backport for pre Python 3.2
-    from distutils.spawn import find_executable as which
-
 import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
-from utils import error, memoize, warning
+from utils import which, error, memoize, warning
 
 
 def slurm_prefix(base_launcher, platform_val):

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -5,17 +5,9 @@ import os
 import sys
 import re
 
-try:
-    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
-    # Prefer `shutil.which` in Python 3.2+
-    from shutil import which
-except ImportError:
-    # Backport for pre Python 3.2
-    from distutils.spawn import find_executable as which
-
 import chpl_bin_subdir, chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import get_chpl_third_party, get_chpl_home
-from utils import memoize, error, run_command, try_run_command, warning
+from utils import which, memoize, error, run_command, try_run_command, warning
 
 # returns a tuple of supported major LLVM versions as strings
 def llvm_versions():

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
+
 import optparse
 import os
 import sys
-from distutils.spawn import find_executable
 import re
+
+try:
+    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
+    # Prefer `shutil.which` in Python 3.2+
+    from shutil import which
+except ImportError:
+    # Backport for pre Python 3.2
+    from distutils.spawn import find_executable as which
 
 import chpl_bin_subdir, chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import get_chpl_third_party, get_chpl_home
@@ -14,18 +22,18 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
-    return ('12','11',)
+    return ('12', '11',)
 
 @memoize
 def get_uniq_cfg_path_for(llvm_val):
     if llvm_val == "bundled":
-      # put platform-arch-compiler for included llvm
-      host_bin_subdir = chpl_bin_subdir.get('host')
-      host_compiler = chpl_compiler.get('host')
-      llvm_target_dir = '{0}-{1}'.format(host_bin_subdir, host_compiler)
+        # put platform-arch-compiler for included llvm
+        host_bin_subdir = chpl_bin_subdir.get('host')
+        host_compiler = chpl_compiler.get('host')
+        llvm_target_dir = '{0}-{1}'.format(host_bin_subdir, host_compiler)
     else:
-      # just put 'system' for system llvm
-      llvm_target_dir = llvm_val
+        # just put 'system' for system llvm
+        llvm_target_dir = llvm_val
 
     return llvm_target_dir
 
@@ -51,9 +59,9 @@ def is_included_llvm_built():
         return False
 
 def compatible_platform_for_llvm():
-  target_arch = chpl_arch.get('target')
-  target_platform = chpl_platform.get('target')
-  return (target_arch != "i368" and target_platform != "linux32")
+    target_arch = chpl_arch.get('target')
+    target_platform = chpl_platform.get('target')
+    return (target_arch != "i368" and target_platform != "linux32")
 
 # returns a string of the supported llvm versions suitable for error msgs
 def llvm_versions_string():
@@ -97,13 +105,13 @@ def check_llvm_config(llvm_config):
         return (got_version, s)
 
     if not llvm_include_ok:
-       s = "Could not find the LLVM header {0}".format(llvm_header)
-       s += "\nPerhaps you need to install clang and llvm dev packages"
-       return (got_version, s)
+        s = "Could not find the LLVM header {0}".format(llvm_header)
+        s += "\nPerhaps you need to install clang and llvm dev packages"
+        return (got_version, s)
     elif not clang_include_ok:
-       s = "Could not find the clang header {0}".format(clang_header)
-       s += "\nPerhaps you need to install clang and llvm dev packages"
-       return (got_version, s)
+        s = "Could not find the clang header {0}".format(clang_header)
+        s += "\nPerhaps you need to install clang and llvm dev packages"
+        return (got_version, s)
 
     return (got_version, '')
 
@@ -138,7 +146,7 @@ def find_system_llvm_config():
 
     for command in paths:
         found_version, found_config_err = check_llvm_config(command)
-        all_found.append( (command, found_version, found_config_err) )
+        all_found.append((command, found_version, found_config_err))
 
     found = ('', '', '')
     for vers in llvm_versions():
@@ -167,7 +175,7 @@ def get_llvm_config():
         llvm_subdir = get_bundled_llvm_dir()
         bundled_config = os.path.join(llvm_subdir, 'bin', 'llvm-config')
         if llvm_config != 'none' and llvm_config != bundled_config:
-            warning("CHPL_LLVM_CONFIG is ignored for CHPL_LLVM=bundled");
+            warning("CHPL_LLVM_CONFIG is ignored for CHPL_LLVM=bundled")
         llvm_config = bundled_config
 
     elif llvm_config == 'none' and llvm_val == 'system':
@@ -319,12 +327,12 @@ def get_gcc_prefix():
 
         # When 'gcc' is a command other than '/usr/bin/gcc',
         # compute the 'gcc' prefix that LLVM should use.
-        gcc_path = find_executable('gcc')
-        if gcc_path == '/usr/bin/gcc' :
+        gcc_path = which('gcc')
+        if gcc_path == '/usr/bin/gcc':
             # In this common case, nothing else needs to be done,
             # because we can assume that clang can find this gcc.
             pass
-        elif gcc_path == None:
+        elif gcc_path is None:
             # Nothing else we can do here
             pass
         else:
@@ -388,8 +396,8 @@ def get_sysroot_resource_dir_args():
         if not os.path.isfile(cfile):
             error("error computing isysroot -- sys_basic.h is missing")
 
-        (out,err) = run_command(['clang', '-###', cfile],
-                                stdout=True, stderr=True)
+        (out, err) = run_command(['clang', '-###', cfile],
+                                 stdout=True, stderr=True)
         out += err
 
         found = re.search('"-isysroot" "([^"]+)"', out)
@@ -443,6 +451,7 @@ def gather_pe_chpl_pkgconfig_libs():
         return ""
 
     import chpl_comm, chpl_comm_substrate, chpl_aux_filesys, chpl_libfabric
+
     platform = chpl_platform.get('target')
     comm = chpl_comm.get()
     substrate = chpl_comm_substrate.get()
@@ -470,10 +479,10 @@ def gather_pe_chpl_pkgconfig_libs():
         # on login/compute nodes, lustre requires the devel api to make
         # lustre/lustreapi.h available (it's implicitly available on esl nodes)
         if 'lustre' in auxfs:
-          exists, returncode, out, err = try_run_command(
-              ['pkg-config', '--exists', 'cray-lustre-api-devel'])
-          if exists and returncode == 0:
-            ret = 'cray-lustre-api-devel:' + ret
+            exists, returncode, out, err = try_run_command(
+                ['pkg-config', '--exists', 'cray-lustre-api-devel'])
+            if exists and returncode == 0:
+                ret = 'cray-lustre-api-devel:' + ret
 
     return ret
 
@@ -493,7 +502,7 @@ def get_clang_prgenv_args():
         # Set up the environment to make the proper libraries and include
         # files available.
         os.environ['PE_PKGCONFIG_PRODUCTS'] = (
-            'PE_CHAPEL:' + os.environ.get('PE_PKGCONFIG_PRODUCTS',''));
+            'PE_CHAPEL:' + os.environ.get('PE_PKGCONFIG_PRODUCTS', ''))
 
         os.environ['PE_CHAPEL_MODULE_NAME'] = 'chapel'
         os.environ['PE_CHAPEL_PKGCONFIG_LIBS'] = gather_pe_chpl_pkgconfig_libs()
@@ -637,7 +646,7 @@ def get_host_link_args():
 
         ldflags = run_command([llvm_config,
                                '--ldflags', '--system-libs', '--libs'] +
-                               llvm_components)
+                              llvm_components)
         if ldflags:
             system.extend(filter_llvm_link_flags(ldflags.split()))
 
@@ -670,7 +679,7 @@ def get_host_link_args():
 
             ldflags = run_command([llvm_config,
                                    '--ldflags', '--libs'] +
-                                   llvm_components)
+                                  llvm_components)
 
             bundled.extend(ldflags.split())
 
@@ -679,7 +688,6 @@ def get_host_link_args():
                                       llvm_components)
 
             system.extend(system_libs.split())
-
 
         else:
             warning("included llvm not built yet")
@@ -700,16 +708,16 @@ def _main():
 
     (options, args) = parser.parse_args()
 
-    #if --needs-llvm-runtime is set, print out llvm if runtime is needed,
+    # if --needs-llvm-runtime is set, print out llvm if runtime is needed,
     # and print out nothing if it is not.
     if options.action == 'needsllvm':
         if llvm_val == 'system' or llvm_val == 'bundled':
-            sys.stdout.write("llvm\n");
+            sys.stdout.write("llvm\n")
     elif options.action == 'llvmconfig':
         sys.stdout.write("{0}\n".format(llvm_config))
         validate_llvm_config()
     else:
-      sys.stdout.write("{0}\n".format(llvm_val))
+        sys.stdout.write("{0}\n".format(llvm_val))
 
 
 if __name__ == '__main__':

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
-from distutils.spawn import find_executable
+
 import sys
+
+try:
+    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
+    # Prefer `shutil.which` in Python 3.2+
+    from shutil import which
+except ImportError:
+    # Backport for pre Python 3.2
+    from distutils.spawn import find_executable as which
 
 import chpl_platform, overrides
 from utils import memoize
@@ -14,7 +22,7 @@ def get():
         if platform_val.startswith('cygwin') or platform_val == 'darwin':
             make_val = 'make'
         elif platform_val.startswith('linux'):
-            if find_executable('gmake'):
+            if which('gmake'):
                 make_val = 'gmake'
             else:
                 make_val = 'make'

--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -2,16 +2,8 @@
 
 import sys
 
-try:
-    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
-    # Prefer `shutil.which` in Python 3.2+
-    from shutil import which
-except ImportError:
-    # Backport for pre Python 3.2
-    from distutils.spawn import find_executable as which
-
 import chpl_platform, overrides
-from utils import memoize
+from utils import which, memoize
 
 
 @memoize

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -1,7 +1,17 @@
 """Utility functions for chplenv modules"""
+
 import os
 import subprocess
 import sys
+
+try:
+    # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
+    # Prefer `shutil.which` in Python 3.2+
+    from shutil import which
+except ImportError:
+    # Backport for pre Python 3.2
+    from distutils.spawn import find_executable as which
+
 
 def warning(msg):
     if not os.environ.get('CHPLENV_SUPPRESS_WARNINGS'):

--- a/util/chpltags
+++ b/util/chpltags
@@ -4,8 +4,7 @@ import optparse
 import os
 import subprocess
 import sys
-
-from utils import which
+from shutil import which
 
 
 # ctags regexes

--- a/util/chpltags
+++ b/util/chpltags
@@ -2,9 +2,10 @@
 
 import optparse
 import os
-import shutil
 import subprocess
 import sys
+
+from utils import which
 
 
 # ctags regexes
@@ -44,7 +45,7 @@ etags_opts = [
 
 
 def check_ex_ctags():
-    if not shutil.which('ctags'):
+    if not which('ctags'):
         return False
 
     process = subprocess.Popen(['ctags', '--version'],
@@ -119,7 +120,7 @@ def _main():
         process.communicate()
         sys.exit(process.returncode)
     elif options.emacs:
-        if not shutil.which('etags'):
+        if not which('etags'):
             sys.stderr.write("chpltags: Must have either Exuberant Ctags "
                              "with +regex or etags installed to create "
                              "Chapel tags.\n")

--- a/util/chpltags
+++ b/util/chpltags
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
-import os, sys, re, subprocess, optparse
-from distutils.spawn import find_executable
+
+import optparse
+import os
+import shutil
+import subprocess
+import sys
+
 
 # ctags regexes
 c_module = r'/^[ \t]*module[ \t]+([_a-zA-Z0-9$]+)/\1/'
@@ -39,7 +44,7 @@ etags_opts = [
 
 
 def check_ex_ctags():
-    if not find_executable('ctags'):
+    if not shutil.which('ctags'):
         return False
 
     process = subprocess.Popen(['ctags', '--version'],
@@ -114,7 +119,7 @@ def _main():
         process.communicate()
         sys.exit(process.returncode)
     elif options.emacs:
-        if not find_executable('etags'):
+        if not shutil.which('etags'):
             sys.stderr.write("chpltags: Must have either Exuberant Ctags "
                              "with +regex or etags installed to create "
                              "Chapel tags.\n")


### PR DESCRIPTION
Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12. `distutils` will no longer be a Python built-in module (standard library) and have been migrated to `setuptools`.

See [PEP 632 -- Deprecate `distutils` module](https://www.python.org/dev/peps/pep-0632/).

In this PR:

1. `distutils.spawn.find_executable` → `shutil.which` (python >= 3.2)
2. `distutils.version.LooseVersion` → `pkg_resources.parse_version` (NOTE: `pkg_resources` is part of `setuptools`)
3. `distutils.core` → `setuptools`