### PR TITLE
Add comments for why we disable merging/splitting under ugni

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -418,6 +418,8 @@ void chpl_mem_layerInit(void) {
   //   memory allocation routines, the allocator initializes its internals"
   if (heap_base != NULL) {
     heap.type = FIXED;
+    // With a fixed heap all memory should be registered together so
+    // merging/splitting is allowed
     merge_split_chunks = chpl_env_rt_get_bool("MERGE_SPLIT_CHUNKS", true);
     heap.base = heap_base;
     heap.size = heap_size;
@@ -428,6 +430,9 @@ void chpl_mem_layerInit(void) {
     initializeSharedHeap();
   } else if (chpl_comm_regMemAllocThreshold() < SIZE_MAX) {
     heap.type = DYNAMIC;
+    // With a dynamic heap, extensions can be split, but merging may not work
+    // since we'd have a single blob of memory covered by multiple registration
+    // regions, which our comm layers may not support.
     merge_split_chunks = chpl_env_rt_get_bool("MERGE_SPLIT_CHUNKS", false);
     initializeSharedHeap();
   } else {


### PR DESCRIPTION
In #18738 we disabled merge/split hooks under ugni as a workaround to a
bug we didn't fully understand. We have since figured out that the
problem was that we had a single blob of memory spanning multiple memory
registration regions created by merging chunks, and this isn't something
ugni supports. #19127 added checks for this condition and this just
adds comments to indicate why we disable merge/split for ugni.