### PR TITLE
Allow building GPU support with target compilers other than clang

### DIFF
--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -198,12 +198,6 @@ def get(flag='host'):
                 compiler_val = 'clang'
             else:
                 compiler_val = 'gnu'
-        elif locale_model_val == 'gpu':
-            if find_executable('clang'):
-                compiler_val = 'clang'
-            else:
-                error("clang not found. The 'gpu' locale model is supported "
-                      "with clang only.")
         else:
             compiler_val = 'gnu'
 


### PR DESCRIPTION
We need clang/llvm as the target compiler for GPU support, but
not as the host compiler. Don't force clang for host or issue an
error if it isn't available.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>