### PR TITLE
Remove colon that was causing issues for annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2241,7 +2241,7 @@ arkouda: &arkouda-base
     - Optimize small and medium int in1d operations (mhmerrill/arkouda#1044)
   02/02/22:
     - Fix sum precision for real this time (mhmerrill/arkouda#1055)
-    - Issue 1049: Adds capability to print server commands from the client. (mhmerrill/arkouda#1049)
+    - Issue 1049 Adds capability to print server commands from the client. (mhmerrill/arkouda#1049)
 
 
 arkouda-string:


### PR DESCRIPTION
In PR 19174, which added an Arkouda perf annotation,
I merged before letting the CI tests finish, and it
turns out there was an error in my code since I had
a colon in the annotation, which causes issues for
our annotations.