### PR TITLE
Filter out `-g` from gathered args from gasnet

### DIFF
--- a/util/chplenv/chpl_gasnet.py
+++ b/util/chplenv/chpl_gasnet.py
@@ -54,7 +54,7 @@ def filter_compile_args(args):
     # certain flags from the gasnet .pc file
     more_filtered = [ ]
     for arg in ret:
-        if arg.startswith('-O') or arg == '-Winline':
+        if arg.startswith('-O') or arg == '-Winline' or arg == '-g':
             pass # leave out this flag
         else:
             more_filtered.append(arg)
@@ -74,7 +74,7 @@ def get_compile_args():
 def filter_link_args(args):
     ret = [ ]
     for arg in args:
-        if arg.startswith('-O') or arg.startswith('-W'):
+        if arg.startswith('-O') or arg.startswith('-W') or arg == '-g':
             pass # leave out this flag
         else:
             ret.append(arg)


### PR DESCRIPTION
Resolves #19185

The gasnet .pc file we parse includes `-g` if `CHPL_COMM_DEBUG` is set, but that causes LLVM verification failures. Filter out that argument.

- [x] full gasnet testing