### PR TITLE
Fix EOF handling for ASCII files

### DIFF
--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -4372,7 +4372,7 @@ qioerr _qio_channel_read_char_slow_unlocked(qio_channel_t* restrict ch, int32_t*
         // We always read 1 character at least.
         gotch = qio_channel_read_byte(false, ch);
         if( gotch < 0 ) {
-          err = qio_int_to_err(-got);
+          err = qio_int_to_err(-gotch);
           *chr = -1;
           break;
         }


### PR DESCRIPTION
Chapel documents a requirement that UTF-8 should be set in LANG,
but if it is not set, there is a separate code path that handles
text files as ASCII and this mishandled EOF. This was expressed
by procs such as channel.readf/readln segfaulting or hanging.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>