### PR TITLE
Include internal modules in --print-callstack-on-error output

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9228,9 +9228,9 @@ static void resolveExprMaybeIssueError(CallExpr* call) {
         break;
 
       if (i <= head &&
-          frame->linenum()                     >  0             &&
+          frame->linenum() > 0                                  &&
           fn->hasFlag(FLAG_COMPILER_GENERATED) == false         &&
-          module->modTag                       != MOD_INTERNAL) {
+          (developer || module->modTag != MOD_INTERNAL)         ) {
         break;
       }
     }

--- a/test/compflags/vass/callstack-internal-modules.chpl
+++ b/test/compflags/vass/callstack-internal-modules.chpl
@@ -1,0 +1,21 @@
+// https://github.com/chapel-lang/chapel/issues/17406
+
+// The goal of this code is to trigger a compilation error
+// in an internal module. Currently it uses + on (int,uint)
+// and relies on operator + to invoke _throwOpError() in this case.
+// If the implementation changes, another way to get a compilation error
+// in an internal module may be needed.
+
+var x: int, y: uint;
+
+proc main() {
+  bar();
+}
+
+proc bar() {
+  foo();
+}
+
+proc foo() {
+  writeln(x+y);
+}

--- a/test/compflags/vass/callstack-internal-modules.chpl
+++ b/test/compflags/vass/callstack-internal-modules.chpl
@@ -3,8 +3,14 @@
 // The goal of this code is to trigger a compilation error
 // in an internal module. Currently it uses + on (int,uint)
 // and relies on operator + to invoke _throwOpError() in this case.
-// If the implementation changes, another way to get a compilation error
-// in an internal module may be needed.
+//
+// If this trick stops working, we could do something else, ex.
+// use the --prepend-internal-module-dir compiler flag to either:
+//  - replace an already-used module with a dummy module that will trigger
+//    this error, or
+//  - add a new dummy module with a function that will trigger
+//    a compilation error and adjust ChapelStandard to also publicly use
+//    that dummy module.
 
 var x: int, y: uint;
 

--- a/test/compflags/vass/callstack-internal-modules.compopts
+++ b/test/compflags/vass/callstack-internal-modules.compopts
@@ -1,0 +1,4 @@
+   --devel    --print-callstack-on-error # callstack-internal-modules.d+s+.good
+--no-devel    --print-callstack-on-error # callstack-internal-modules.d-s+.good
+   --devel --no-print-callstack-on-error # callstack-internal-modules.d+s-.good
+--no-devel --no-print-callstack-on-error # callstack-internal-modules.d-s-.good

--- a/test/compflags/vass/callstack-internal-modules.d+s+.good
+++ b/test/compflags/vass/callstack-internal-modules.d+s+.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: In function '+':
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: error: illegal use of '+' on operands of type uint(64) and signed integer
-  callstack-internal-modules.chpl:20: called as +(a: int(64), b: uint(64)) from function 'foo'
-  callstack-internal-modules.chpl:16: called as foo() from function 'bar'
-  callstack-internal-modules.chpl:12: called as bar() from function 'main'
+  callstack-internal-modules.chpl:26: called as +(a: int(64), b: uint(64)) from function 'foo'
+  callstack-internal-modules.chpl:22: called as foo() from function 'bar'
+  callstack-internal-modules.chpl:18: called as bar() from function 'main'

--- a/test/compflags/vass/callstack-internal-modules.d+s+.good
+++ b/test/compflags/vass/callstack-internal-modules.d+s+.good
@@ -1,0 +1,5 @@
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: In function '+':
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: error: illegal use of '+' on operands of type uint(64) and signed integer
+  callstack-internal-modules.chpl:20: called as +(a: int(64), b: uint(64)) from function 'foo'
+  callstack-internal-modules.chpl:16: called as foo() from function 'bar'
+  callstack-internal-modules.chpl:12: called as bar() from function 'main'

--- a/test/compflags/vass/callstack-internal-modules.d+s-.good
+++ b/test/compflags/vass/callstack-internal-modules.d+s-.good
@@ -1,0 +1,2 @@
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: In function '+':
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: error: illegal use of '+' on operands of type uint(64) and signed integer

--- a/test/compflags/vass/callstack-internal-modules.d-s+.good
+++ b/test/compflags/vass/callstack-internal-modules.d-s+.good
@@ -1,4 +1,4 @@
-callstack-internal-modules.chpl:19: In function 'foo':
-callstack-internal-modules.chpl:20: error: illegal use of '+' on operands of type uint(64) and signed integer
-  callstack-internal-modules.chpl:16: called as foo() from function 'bar'
-  callstack-internal-modules.chpl:12: called as bar() from function 'main'
+callstack-internal-modules.chpl:25: In function 'foo':
+callstack-internal-modules.chpl:26: error: illegal use of '+' on operands of type uint(64) and signed integer
+  callstack-internal-modules.chpl:22: called as foo() from function 'bar'
+  callstack-internal-modules.chpl:18: called as bar() from function 'main'

--- a/test/compflags/vass/callstack-internal-modules.d-s+.good
+++ b/test/compflags/vass/callstack-internal-modules.d-s+.good
@@ -1,0 +1,4 @@
+callstack-internal-modules.chpl:19: In function 'foo':
+callstack-internal-modules.chpl:20: error: illegal use of '+' on operands of type uint(64) and signed integer
+  callstack-internal-modules.chpl:16: called as foo() from function 'bar'
+  callstack-internal-modules.chpl:12: called as bar() from function 'main'

--- a/test/compflags/vass/callstack-internal-modules.d-s-.good
+++ b/test/compflags/vass/callstack-internal-modules.d-s-.good
@@ -1,2 +1,2 @@
-callstack-internal-modules.chpl:19: In function 'foo':
-callstack-internal-modules.chpl:20: error: illegal use of '+' on operands of type uint(64) and signed integer
+callstack-internal-modules.chpl:25: In function 'foo':
+callstack-internal-modules.chpl:26: error: illegal use of '+' on operands of type uint(64) and signed integer

--- a/test/compflags/vass/callstack-internal-modules.d-s-.good
+++ b/test/compflags/vass/callstack-internal-modules.d-s-.good
@@ -1,0 +1,2 @@
+callstack-internal-modules.chpl:19: In function 'foo':
+callstack-internal-modules.chpl:20: error: illegal use of '+' on operands of type uint(64) and signed integer

--- a/test/compflags/vass/callstack-internal-modules.prediff
+++ b/test/compflags/vass/callstack-internal-modules.prediff
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+# This is derived from test/library/packages/Sort/errors/PREDIFF
+# There and in many other prediffs, the match pattern is /:[0-9:]*:/
+# Here we drop : inside [] because it is not needed.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Resolves #17406

The compiler no longer suppresses stack frames in internal modules
when reporting errors in the `--devel` `--print-callstack-on-error` mode.

Testing: standard paratest with futures.