### PR TITLE
Fix savec test for ChplConfig module/warning added in #19162

### DIFF
--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -1,3 +1,5 @@
+use ChplConfig;
+
 const outdir = "savec_output";
 const filename = "savec.chpl";
 


### PR DESCRIPTION
I didn't catch this failure in my testing because the test is skipped
with the LLVM back-end.  This should resolve the failures in asan,
linux32, c-backend, and quickstart testing.
