### PR TITLE
Switch test to use the TARGET_CC clang vs. any clang in PATH

### DIFF
--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.precomp
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.precomp
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-clang -S -emit-llvm llvmIntrinsicAttributes.cu --cuda-gpu-arch=sm_60 -L/global/opt/nvidia/cuda-11.0/lib64/ -lcudart_static -pthread
+TARGET_CC=`$CHPL_HOME/util/printchplenv --all | sed -ne 's/ *CHPL_TARGET_CC: //p' | sed -e 's/ *[*+]*$//'`
+
+$TARGET_CC -S -emit-llvm llvmIntrinsicAttributes.cu --cuda-gpu-arch=sm_60 -L/global/opt/nvidia/cuda-11.0/lib64/ -lcudart_static -pthread
 
 # We're expecting to see the following declaration for the intrinsic to get 
 # a thread ID from the CUDA kernel.  I'm locking down that this intrinsic has


### PR DESCRIPTION
Switch this gpu intrinsics test to use the clang from CHPL_TARGET_CC instead
of using whichever clang happens to be first in PATH.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>