### PR TITLE
Create standalone versions of the readline() routines

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3863,7 +3863,7 @@ proc channel.readline(ref arg: ?t): bool throws where t==string || t==bytes {
 
   return true;
 }
-  
+
 /* read a given number of bytes from a channel
 
    :arg str_out: The string to be read into

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3863,7 +3863,7 @@ proc channel.readline(ref arg: ?t): bool throws where t==string || t==bytes {
 
   return true;
 }
-
+  
 /* read a given number of bytes from a channel
 
    :arg str_out: The string to be read into
@@ -4401,10 +4401,24 @@ stdout = try! openfp(chpl_cstdout()).writer();
 /* standard error, otherwise known as file descriptor 2 */
 const stderr:channel(true, iokind.dynamic, true);
 stderr = try! openfp(chpl_cstderr()).writer();
-
 /* Equivalent to ``stdin.read``. See :proc:`channel.read` */
 proc read(ref args ...?n):bool throws {
   return stdin.read((...args));
+}
+/* Equivalent to ``stdin.read``. See :proc:`channel.read` for types */
+proc read(type t ...?numTypes) throws {
+  return stdin.read((...t));
+}
+/* Equivalent to ``stdin.readline``.  See :proc:`channel.readline` */
+proc readline(arg: [] uint(8), out numRead : int, start = arg.domain.low,
+              amount = arg.domain.high - start + 1) : bool throws
+                where arg.rank == 1 && arg.isRectangular() {
+  return stdin.readline(arg, numRead, start, amount);
+}
+
+/* Equivalent to ``stdin.readline``.  See :proc:`channel.readline` */
+proc readline(ref arg: ?t): bool throws where t==string || t==bytes {
+  return stdin.readline(arg);
 }
 /* Equivalent to ``stdin.readln``. See :proc:`channel.readln` */
 proc readln(ref args ...?n):bool throws {
@@ -4419,10 +4433,6 @@ proc readln():bool throws {
 /* Equivalent to ``stdin.readln``. See :proc:`channel.readln` for types */
 proc readln(type t ...?numTypes) throws {
   return stdin.readln((...t));
-}
-/* Equivalent to ``stdin.read``. See :proc:`channel.read` for types */
-proc read(type t ...?numTypes) throws {
-  return stdin.read((...t));
 }
 
 

--- a/test/studies/adventOfCode/2021/bradc/day10.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day10.chpl
@@ -7,7 +7,7 @@ const Scores = [')'=>3,   ']'=>57,  '}'=>1197, '>'=>25137];
 
 iter readlines() {
   var line: string;
-  while (stdin.readline(line)) {
+  while readline(line) {
     yield line.strip();
   }
 }

--- a/test/studies/adventOfCode/2021/bradc/day10a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day10a.chpl
@@ -7,7 +7,7 @@ const Scores = [')'=>1,   ']'=>2,  '}'=>3, '>'=>4];
 
 iter readlines() {
   var line: string;
-  while (stdin.readline(line)) {
+  while readline(line) {
     yield line.strip();
   }
 }

--- a/test/studies/adventOfCode/2021/bradc/day11.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day11.chpl
@@ -38,7 +38,7 @@ writeln("total flashes: ", flashes.read());
 proc readEnergies() {
   var line: string;
   var row = 0;
-  while (stdin.readline(line)) {
+  while readline(line) {
     line = line.strip();
     row += 1;
     stringToRow(line, row);

--- a/test/studies/adventOfCode/2021/bradc/day11a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day11a.chpl
@@ -42,7 +42,7 @@ writeln("total flashes: ", flashes.read());
 proc readEnergies() {
   var line: string;
   var row = 0;
-  while (stdin.readline(line)) {
+  while readline(line) {
     line = line.strip();
     row += 1;
     stringToRow(line, row);

--- a/test/studies/adventOfCode/2021/bradc/day12.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day12.chpl
@@ -6,7 +6,7 @@ var Caves: domain(string);
 var Corridors: [Caves] list(string);
 
 var line: string;
-while stdin.readline(line) {
+while readline(line) {
   var pair = line.strip().split("-");
   Caves += pair[0];
   Caves += pair[1];

--- a/test/studies/adventOfCode/2021/bradc/day12a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day12a.chpl
@@ -6,7 +6,7 @@ var Caves: domain(string);
 var Corridors: [Caves] list(string);
 
 var line: string;
-while stdin.readline(line) {
+while readline(line) {
   var pair = line.strip().split("-");
   Caves += pair[0];
   Caves += pair[1];

--- a/test/studies/adventOfCode/2021/bradc/day13.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day13.chpl
@@ -44,7 +44,7 @@ foldSheet(Sheet);
 iter readDots() {
   var line: string;
   do {
-    stdin.readline(line);
+    readline(line);
     var A = line.strip().split(",");
     if (A.size == 2) then
       yield (A[0]:int, A[1]:int);
@@ -55,7 +55,7 @@ iter readFolds() {
   var line: string;
   try {
     var fold: string;
-    while stdin.readf("fold along %s\n", fold) {
+    while readf("fold along %s\n", fold) {
       yield fold;
     }
   } catch { }

--- a/test/studies/adventOfCode/2021/bradc/day14.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day14.chpl
@@ -6,7 +6,7 @@ config const steps = 10,
 // TODO: bytes + array of uint(8) would be more appropriate, storage-wise
 
 var polyTemplStr: string;
-stdin.readline(polyTemplStr);  
+readline(polyTemplStr);  
 polyTemplStr = polyTemplStr.strip();
 
 var polyTempl = [ch in polyTemplStr] ch;
@@ -18,7 +18,7 @@ var prodMap: map(string, string);
 try {
   var line: string;
   readln();
-  while (stdin.readline(line)) {
+  while readline(line) {
     prodMap.add(line[0..1], line[6]);
     // TODO: This has got to be too conservative:
     allChars.add[line[0]];

--- a/test/studies/adventOfCode/2021/bradc/day14a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day14a.chpl
@@ -6,7 +6,7 @@ config const steps = 10,
 // TODO: bytes + array of uint(8) would be more appropriate, storage-wise
 
 var polyTemplStr: string;
-stdin.readline(polyTemplStr);  
+readline(polyTemplStr);  
 polyTemplStr = polyTemplStr.strip();
 
 var allChars: domain(string);
@@ -15,7 +15,7 @@ var prodMap: map(string, string);
 try {
   var line: string;
   readln();
-  while (stdin.readline(line)) {
+  while readline(line) {
     prodMap.add(line[0..1], line[6]);
     // TODO: This has got to be too conservative:
     allChars.add[line[0]];

--- a/test/studies/adventOfCode/2021/bradc/day15.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day15.chpl
@@ -47,7 +47,7 @@ while !Q.isEmpty() {
 
 proc readRisk() {
   var line: string;
-  while (stdin.readline(line)) {
+  while readline(line) {
     line = line.strip();
     rows += 1;
     if cols == 0 then cols = line.size;

--- a/test/studies/adventOfCode/2021/bradc/day15a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day15a.chpl
@@ -68,7 +68,7 @@ while !Q.isEmpty() {
 
 proc readRisk() {
   var line: string;
-  while (stdin.readline(line)) {
+  while readline(line) {
     line = line.strip();
     rows += 1;
     if cols == 0 then cols = line.size;

--- a/test/studies/adventOfCode/2021/bradc/day16.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day16.chpl
@@ -3,7 +3,7 @@ use IO;
 param bitsPerHex = 4;
 
 var line: bytes;
-stdin.readline(line);
+readline(line);
 line = line.strip();
 writeln(line);
 

--- a/test/studies/adventOfCode/2021/bradc/day16a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day16a.chpl
@@ -3,7 +3,7 @@ use IO, List;
 param bitsPerHex = 4;
 
 var line: bytes;
-stdin.readline(line);
+readline(line);
 line = line.strip();
 writeln(line);
 

--- a/test/studies/adventOfCode/2021/bradc/day18.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day18.chpl
@@ -135,7 +135,7 @@ operator +(ref lhs: owned Node?, ref rhs: owned Node?) {
 
 proc readNormalizedSnailfish(): Node? throws {
   var line: string;
-  if (stdin.readline(line)) {
+  if readline(line) {
     var pos = 0;
     var tree = lineToTree(line, pos); // TODO: See following TODO
     tree!.process();

--- a/test/studies/adventOfCode/2021/bradc/day18a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day18a.chpl
@@ -141,7 +141,7 @@ operator +(ref lhs: owned Node?, ref rhs: owned Node?) {
 
 proc readNormalizedSnailfish(): Node? throws {
   var line: string;
-  if (stdin.readline(line)) {
+  if readline(line) {
     var pos = 0;
     var tree = lineToTree(line, pos); // TODO: See following TODO
     tree!.process();

--- a/test/studies/adventOfCode/2021/bradc/day19.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day19.chpl
@@ -11,7 +11,7 @@ var Landscape: map(3*int, item);
 
 iter readScanner() {
   var header: string;
-  stdin.readline(header);
+  readline(header);
 //  writeln(header);
   var x, y, z: int;
   try {  // TODO: 'try' seems like it shouldn't be necessary here for scanner 0, yet it is due to the commas... is that as intended?  (vs. returning false?)
@@ -21,7 +21,7 @@ iter readScanner() {
   } catch {
   }
   readln();
-//  stdin.readline(header);
+//  readline(header);
 //  writeln("tail:", header);
 }
 

--- a/test/studies/adventOfCode/2021/bradc/day19a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day19a.chpl
@@ -11,7 +11,7 @@ var Landscape: map(3*int, item);
 
 iter readScanner() {
   var header: string;
-  stdin.readline(header);
+  readline(header);
 //  writeln(header);
   var x, y, z: int;
   try {  // TODO: 'try' seems like it shouldn't be necessary here for scanner 0, yet it is due to the commas... is that as intended?  (vs. returning false?)
@@ -21,7 +21,7 @@ iter readScanner() {
   } catch {
   }
   readln();
-//  stdin.readline(header);
+//  readline(header);
 //  writeln("tail:", header);
 }
 

--- a/test/studies/adventOfCode/2021/bradc/day20.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day20.chpl
@@ -3,17 +3,17 @@ use IO;
 config const numSteps = 2, debug = false;
 
 var decoder: string;
-stdin.readline(decoder);
+readline(decoder);
 
 var blank: string;
-stdin.readline(blank);
+readline(blank);
 
 var D: domain(2) = {-(2*numSteps+1)..2*numSteps+1, 1..0};
 var A, B: [D] bool;
 
 var line: string;
 var numLines = 0;
-while stdin.readline(line) {
+while readline(line) {
   numLines += 1;
   D = {-(2*numSteps+1)..numLines+2*numSteps+1, -(2*numSteps+1)..line.size+2*numSteps+1};
   for (ch,col) in zip(line, 0..) do

--- a/test/studies/adventOfCode/2021/bradc/day22.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day22.chpl
@@ -5,7 +5,7 @@ var A: [D] bool;
 
 var val: string;
 var xlo, xhi, ylo, yhi, zlo, zhi: int;
-while stdin.readf("%s x=%i..%i,y=%i..%i,z=%i..%i", val, xlo, xhi, ylo, yhi, zlo, zhi) {
+while readf("%s x=%i..%i,y=%i..%i,z=%i..%i", val, xlo, xhi, ylo, yhi, zlo, zhi) {
   writeln("Got: ", (val, xlo, xhi, ylo, yhi, zlo, zhi));
   const setting = val == "on";
   const SubD = D[xlo..xhi, ylo..yhi, zlo..zhi];

--- a/test/studies/adventOfCode/2021/bradc/day22a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day22a.chpl
@@ -29,7 +29,7 @@ proc addCube(newCube) {
 var allRegions = readLines();
 
 iter readLines() {
-  while stdin.readf("%s x=%i..%i,y=%i..%i,z=%i..%i", val, xlo, xhi, ylo, yhi, zlo, zhi) {
+  while readf("%s x=%i..%i,y=%i..%i,z=%i..%i", val, xlo, xhi, ylo, yhi, zlo, zhi) {
 //    writeln("Got: ", (val, xlo, xhi, ylo, yhi, zlo, zhi));
     yield new Region(val == "off", {xlo..xhi, ylo..yhi, zlo..zhi});
     xmin = min(xlo, xmin);

--- a/test/studies/adventOfCode/2021/bradc/day25.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day25.chpl
@@ -8,7 +8,7 @@ var A: [D] cuc;
 var numrows, numcols = 0;
 
 var line: string;
-while stdin.readline(line) {
+while readline(line) {
   line = line.strip();
   numcols = line.size;
   D = {0..numrows, 0..<numcols};

--- a/test/studies/adventOfCode/2021/bradc/day8.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day8.chpl
@@ -3,7 +3,7 @@ use IO;
 var line: string;
 
 iter getOutputs() {
-  while (stdin.readline(line)) {
+  while readline(line) {
     //  writeln("Got: ", line);
     var parts: [1..2] string = line.split(" | ");
     //  writeln("Got: ", (parts[1], parts[2]));

--- a/test/studies/adventOfCode/2021/bradc/day8a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day8a.chpl
@@ -32,7 +32,7 @@ proc contains(teststring, seekstring) {
 }
 
 iter getDigitsOutputs() {
-  while (stdin.readline(line)) {
+  while readline(line) {
     //  writeln("Got: ", line);
     var parts: [1..2] string = line.split(" | ");
     //  writeln("Got: ", (parts[1], parts[2]));

--- a/test/studies/adventOfCode/2021/bradc/day9.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day9.chpl
@@ -23,7 +23,7 @@ proc stringToRow(str: string, row) {
 /*
 proc readFirstLine() {
   var line: string;
-  stdin.readline(line);
+  readline(line);
   line = line.strip();
   rows = 1;
   cols = line.size;
@@ -34,7 +34,7 @@ proc readFirstLine() {
 
 proc readHeights() {
   var line: string;
-  while (stdin.readline(line)) {
+  while readline(line) {
     line = line.strip();
     rows += 1;
     if cols == 0 then cols = line.size;

--- a/test/studies/adventOfCode/2021/bradc/day9a.chpl
+++ b/test/studies/adventOfCode/2021/bradc/day9a.chpl
@@ -22,7 +22,7 @@ proc stringToRow(str: string, row) {
 
 proc readHeights() {
   var line: string;
-  while (stdin.readline(line)) {
+  while readline(line) {
     line = line.strip();
     rows += 1;
     if cols == 0 then cols = line.size;


### PR DESCRIPTION
This adds support for a standalone `readline()` routine that acts the
same as `stdin.readline()`, to make it as easy to use with `stdin` as
`read()`, `readf()`, and `readln()` are (not to mention `write()` and
`writeln()`).

Resolves #19229.