### PR TITLE
dyno: rename flags and internal vars with dyno prefix

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -272,7 +272,7 @@ extern bool fPrintAdditionalErrors;
 extern bool fDynoCompilerLibrary;
 extern bool fDynoDebugTrace;
 
-extern size_t fDynoBreakOnQueryHash;
+extern size_t fDynoBreakOnHash;
 
 namespace chpl {
   class Context;

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -269,10 +269,10 @@ extern std::string llvmFlags;
 
 extern bool fPrintAdditionalErrors;
 
-extern bool fCompilerLibraryParser;
-extern bool fDebugTrace;
+extern bool fDynoCompilerLibrary;
+extern bool fDynoDebugTrace;
 
-extern size_t fBreakOnQueryHash;
+extern size_t fDynoBreakOnQueryHash;
 
 namespace chpl {
   class Context;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -301,7 +301,7 @@ bool fPrintChplSettings = false;
 
 bool fDynoCompilerLibrary = false;
 bool fDynoDebugTrace = false;
-size_t fDynoBreakOnQueryHash = 0;
+size_t fDynoBreakOnHash = 0;
 
 int fGPUBlockSize = 0;
 char fCUDAArch[16] = "sm_60";
@@ -1202,7 +1202,7 @@ static ArgumentDescription arg_desc[] = {
 
  {"dyno", ' ', NULL, "Enable [disable] using dyno compiler library", "N", &fDynoCompilerLibrary, "CHPL_DYNO_COMPILER_LIBRARY", NULL},
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
- {"dyno-break-on-query-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "U", &fDynoBreakOnQueryHash, "CHPL_DYNO_BREAK_ON_QUERY_HASH", NULL},
+ {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "U", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
 
 
  DRIVER_ARG_PRINT_CHPL_HOME,
@@ -1797,8 +1797,8 @@ int main(int argc, char* argv[]) {
 
     if (gContext != nullptr) {
       gContext->setDebugTraceFlag(fDynoDebugTrace);
-      if (fDynoBreakOnQueryHash != 0)
-        gContext->setBreakOnHash(fDynoBreakOnQueryHash);
+      if (fDynoBreakOnHash != 0)
+        gContext->setBreakOnHash(fDynoBreakOnHash);
     }
 
     initCompilerGlobals(); // must follow argument parsing

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -299,9 +299,9 @@ bool fPrintAdditionalErrors;
 static
 bool fPrintChplSettings = false;
 
-bool fCompilerLibraryParser = false;
-bool fDebugTrace = false;
-size_t fBreakOnQueryHash = 0;
+bool fDynoCompilerLibrary = false;
+bool fDynoDebugTrace = false;
+size_t fDynoBreakOnQueryHash = 0;
 
 int fGPUBlockSize = 0;
 char fCUDAArch[16] = "sm_60";
@@ -1200,9 +1200,9 @@ static ArgumentDescription arg_desc[] = {
  {"warn-tuple-iteration", ' ', NULL, "Enable [disable] warnings for tuple iteration", "n", &fNoWarnTupleIteration, "CHPL_WARN_TUPLE_ITERATION", setWarnTupleIteration},
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},
 
- {"compiler-library-parser", ' ', NULL, "Enable [disable] using compiler library parser", "N", &fCompilerLibraryParser, "CHPL_COMPILER_LIBRARY_PARSER", NULL},
- {"debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using compiler library parser", "N", &fDebugTrace, "CHPL_DEBUG_TRACE", NULL},
- {"break-on-query-hash", ' ' , NULL, "Break when query with given hash value is executed when using compiler library parser", "U", &fBreakOnQueryHash, "CHPL_BREAK_ON_QUERY_HASH", NULL},
+ {"dyno", ' ', NULL, "Enable [disable] using dyno compiler library", "N", &fDynoCompilerLibrary, "CHPL_DYNO_COMPILER_LIBRARY", NULL},
+ {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
+ {"dyno-break-on-query-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "U", &fDynoBreakOnQueryHash, "CHPL_DYNO_BREAK_ON_QUERY_HASH", NULL},
 
 
  DRIVER_ARG_PRINT_CHPL_HOME,
@@ -1796,9 +1796,9 @@ int main(int argc, char* argv[]) {
     postprocess_args();
 
     if (gContext != nullptr) {
-      gContext->setDebugTraceFlag(fDebugTrace);
-      if (fBreakOnQueryHash != 0)
-        gContext->setBreakOnHash(fBreakOnQueryHash);
+      gContext->setDebugTraceFlag(fDynoDebugTrace);
+      if (fDynoBreakOnQueryHash != 0)
+        gContext->setBreakOnHash(fDynoBreakOnQueryHash);
     }
 
     initCompilerGlobals(); // must follow argument parsing

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -38,7 +38,7 @@
 
 #include "chpl/parsing/parsing-queries.h"
 
-// Turn this on to dump AST/uAST when using --compiler-library-parser.
+// Turn this on to dump AST/uAST when using --dyno.
 #define DUMP_WHEN_CONVERTING_UAST_TO_AST 0
 
 // Turn this on to report which modules are parsed as uAST.
@@ -375,7 +375,7 @@ static void parseChplSourceFile(const char* inputFileName) {
     USR_FATAL(errorMessage, baseName, maxFileName);
   }
 
-  if (fCompilerLibraryParser == false) {
+  if (fDynoCompilerLibrary == false) {
     parseFile(inputFileName, MOD_USER, true, false);
   } else {
     uASTParseFile(inputFileName, MOD_USER, true, false);
@@ -595,7 +595,7 @@ static bool uASTAttemptToParseMod(const char* modName,
                                   const char* path,
                                   ModTag modTag,
                                   ModuleSymbol*& outModSym) {
-  if (!fCompilerLibraryParser) return false;
+  if (!fDynoCompilerLibrary) return false;
 
   if (UAST_CONVERT_USER_MODULE_ONLY && modTag != MOD_USER) return false;
   const bool namedOnCommandLine = false;
@@ -1167,7 +1167,7 @@ ModuleSymbol* parseIncludedSubmodule(const char* name, const char* path) {
   const bool namedOnCommandLine = false;
   const bool include = true;
 
-  if (fCompilerLibraryParser) {
+  if (fDynoCompilerLibrary) {
     ret = uASTParseFile(astr(includeFile), currentModuleType,
                         namedOnCommandLine,
                         include);

--- a/test/dyno/primers/COMPOPTS
+++ b/test/dyno/primers/COMPOPTS
@@ -1,1 +1,1 @@
---compiler-library-parser
+--dyno

--- a/test/dyno/primers/cClient/cClient.precomp
+++ b/test/dyno/primers/cClient/cClient.precomp
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo Compiling interopWithC.chpl
-$3 --compiler-library-parser --library --static interopWithC.chpl cHelper.h cHelper.c --savec ccode
+$3 --dyno --library --static interopWithC.chpl cHelper.h cHelper.c --savec ccode

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -58,7 +58,7 @@ _chpl ()
 --dynamic \
 --dynamic-auto-local-access \
 --dyno \
---dyno-break-on-query-hash \
+--dyno-break-on-hash \
 --dyno-debug-trace \
 --early-deinit \
 --explain-call \

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -44,7 +44,6 @@ _chpl ()
 --comm \
 --comm-substrate \
 --compile-time-nil-checking \
---compiler-library-parser \
 --copy-elision \
 --copy-propagation \
 --copyright \
@@ -60,6 +59,7 @@ _chpl ()
 --div-by-zero-checks \
 --dynamic \
 --dynamic-auto-local-access \
+--dyno \
 --early-deinit \
 --explain-call \
 --explain-call-id \
@@ -157,7 +157,6 @@ _chpl ()
 --no-checks \
 --no-codegen \
 --no-compile-time-nil-checking \
---no-compiler-library-parser \
 --no-copy-elision \
 --no-copy-propagation \
 --no-count-tokens \
@@ -170,6 +169,7 @@ _chpl ()
 --no-devel \
 --no-div-by-zero-checks \
 --no-dynamic-auto-local-access \
+--no-dyno \
 --no-early-deinit \
 --no-explain-verbose \
 --no-fast-followers \

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -32,7 +32,6 @@ _chpl ()
 --break-on-codegen \
 --break-on-codegen-id \
 --break-on-id \
---break-on-query-hash \
 --break-on-remove-id \
 --break-on-resolve-id \
 --cache-remote \
@@ -52,7 +51,6 @@ _chpl ()
 --dead-code-elimination \
 --debug \
 --debug-short-loc \
---debug-trace \
 --default-dist \
 --denormalize \
 --devel \
@@ -60,6 +58,8 @@ _chpl ()
 --dynamic \
 --dynamic-auto-local-access \
 --dyno \
+--dyno-break-on-query-hash \
+--dyno-debug-trace \
 --early-deinit \
 --explain-call \
 --explain-call-id \
@@ -164,12 +164,12 @@ _chpl ()
 --no-dead-code-elimination \
 --no-debug \
 --no-debug-short-loc \
---no-debug-trace \
 --no-denormalize \
 --no-devel \
 --no-div-by-zero-checks \
 --no-dynamic-auto-local-access \
 --no-dyno \
+--no-dyno-debug-trace \
 --no-early-deinit \
 --no-explain-verbose \
 --no-fast-followers \


### PR DESCRIPTION
This PR adds the `dyno` prefix to some compiler flags and replaces
the `compiler-library-parser` flag with the `dyno` flag to indicate
that the compiler should use the `dyno` project code when compiling.

Flags changed:

- `--compiler-library-parser` -> `--dyno`
- `--debug-trace` -> `--dyno-debug-trace`
- `--break-on-query-hash` -> `--dyno-break-on-hash`


TESTING:

- [x] paratest


Reviewed by @mppf - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>