### PR TITLE
Add a warning to the I/O style section of the IO docs and remove a note

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -125,6 +125,10 @@ to perform I/O will need to know how to open files as well as create channels.
 I/O Styles
 ----------
 
+.. warning::
+
+   :record:`iostyle` is now deprecated.  It will be replaced by a new solution.
+
 Reading and writing of Chapel's basic types is regulated by an applicable
 :record:`iostyle`.  In particular, the I/O style controls whether binary or
 text I/O should be performed. For binary I/O it specifies, for example, byte
@@ -159,12 +163,6 @@ A channel's I/O style may be retrieved using :proc:`channel._style` and set
 using :proc:`channel._set_style`. These functions should only be called while
 the channel lock is held, however. See :ref:`about-io-channel-synchronization`
 for more information on channel locks.
-
-.. note::
-
-  :record:`iostyle` is work in progress: the fields and/or their types may
-  change. Among other changes, we expect to be replacing the types of some
-  multiple-choice fields from integral to enums.
 
 As an example for specifying an I/O style, the code below specifies the minimum width for writing numbers so array elements are aligned in the output:
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -127,7 +127,10 @@ I/O Styles
 
 .. warning::
 
-   :record:`iostyle` is now deprecated.  It will be replaced by a new solution.
+   :record:`iostyle` is now deprecated.
+   We are working on creating a full-featured replacement for it
+   but in the meantime the :ref:`about-io-formatted-io` facilities are still
+   available to control formatting.
 
 Reading and writing of Chapel's basic types is regulated by an applicable
 :record:`iostyle`.  In particular, the I/O style controls whether binary or


### PR DESCRIPTION
The `iostyle` record is now deprecated, so the documentation about using it
needed to reflect that.  There was a note in that section about it being a work
in progress - remove that note, since we don't intend to improve `iostyle`
itself any more.

Double-checked the built docs look good with this change

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>