### PR TITLE
Update PALS launcher to work with or without `cray` wrapper.

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -223,18 +223,19 @@ OPT_CFLAGS += -fno-ipa-cp-clone
 endif
 
 #
-# Avoid false positives for allocation size, memcpy, and string truncation.
+# Avoid false positives for allocation size, memcpy, and string and
+# unchecked bounded formatted conversion (snprintf()) truncation.
 # Note that we use -Walloc-size-larger-than=SIZE_MAX instead of
 # `-Wno-alloc-size-larger-than` since that did not exist in gcc 8.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 7; echo "$$?"),0)
 WARN_CXXFLAGS += -Walloc-size-larger-than=18446744073709551615
-WARN_CXXFLAGS += -Wno-stringop-truncation
+WARN_CXXFLAGS += -Wno-stringop-truncation -Wno-format-truncation
 endif
 
 ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -gt 7; echo "$$?"),0)
 WARN_CFLAGS += -Walloc-size-larger-than=18446744073709551615
-WARN_CFLAGS += -Wno-stringop-truncation
+WARN_CFLAGS += -Wno-stringop-truncation -Wno-format-truncation
 SQUASH_WARN_GEN_CFLAGS += -Walloc-size-larger-than=18446744073709551615 -Wno-restrict
 endif
 

--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -35,6 +35,7 @@ void chpl_append_to_largv(int* largc, const char*** largv, int* largv_len,
 int chpl_run_utility1K(const char *command, char *const argv[],
                        char *outbuf, int outbuflen);
 int chpl_run_cmdstr(const char *commandStr, char *outbuf, int outbuflen);
+char *chpl_find_executable(const char *prog_name);
 void chpl_launcher_record_env_var(const char*, const char *);
 char **chpl_bundle_exec_args(int argc, char *const argv[],
                              int largc, char *const largv[]);

--- a/runtime/src/launch/pals/launch-pals.c
+++ b/runtime/src/launch/pals/launch-pals.c
@@ -33,10 +33,8 @@ static const char *ccArg = NULL;
 
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  return chpl_launch_using_exec("cray",
-                                chpl_create_pals_cmd(argc, argv, numLocales,
-                                                     ccArg),
-                                argv[0]);
+  char **launchCmd = chpl_create_pals_cmd(argc, argv, numLocales, ccArg);
+  return chpl_launch_using_exec(launchCmd[0], launchCmd, argv[0]);
 }
 
 

--- a/runtime/src/launch/pals/pals-utils.c
+++ b/runtime/src/launch/pals/pals-utils.c
@@ -83,7 +83,14 @@ char** chpl_create_pals_cmd(int argc, char* argv[], int32_t numLocales,
   int largv_len = 0;
 #define APPEND_LARGV(arg) chpl_append_to_largv(&largc, &largv, &largv_len, arg)
 
-  APPEND_LARGV("cray");
+  //
+  // Some systems using the PALS launcher have it behind a `cray`
+  // utility wrapper, and some do not.  Adapt to circumstances.
+  //
+  if (chpl_find_executable("cray") != NULL) {
+    APPEND_LARGV("cray");
+  }
+
   APPEND_LARGV("mpiexec");
 
   if (verbosity < 2) {

--- a/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
+++ b/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
@@ -71,9 +71,6 @@ typedef enum {
 static qsubVersion determineQsubVersion(void) {
   const int buflen = 256;
   char version[buflen];
-  char whichMoab[buflen];
-  FILE *whichOutput;
-  int fileError = 1;
   char *argv[3];
   argv[0] = (char *) "qsub";
   argv[1] = (char *) "--version";
@@ -88,19 +85,10 @@ static qsubVersion determineQsubVersion(void) {
     return nccs;
   } else if (strstr(version, "pbs_version") || strstr(version, "PBSPro")) {
     return pbspro;
-  } else {
-    memset(whichMoab, 0, buflen);
-    whichOutput = popen("which moab 2>&1 >/dev/null", "r");
-    if (whichOutput != NULL ) {
-      fgets(whichMoab, buflen, whichOutput);
-      fileError = ferror(whichOutput);
-      pclose(whichOutput);
-      if (strlen(whichMoab) == 0 && !fileError) {
-        return moab;
-      }
-    }
-    return unknown;
+  } else if (chpl_find_executable("moab") != NULL) {
+    return moab;
   }
+  return unknown;
 }
 
 //


### PR DESCRIPTION
HPE Cray EX system configurations have evolved such that the PALS
launcher used with the PBS workload manager may either be exposed
directly to the user or hidden behind a `cray` wrapper.  Here, make
the Chapel PALS launcher work in either case.

This resolves https://github.com/Cray/chapel-private/issues/2801.