### PR TITLE
handle converting tuple of tuples

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1656,11 +1656,10 @@ struct Converter {
       } else if (auto var = decl->toVariable()) {
         const bool useLinkageName = false;
         conv = convertVariable(var, useLinkageName);
-
       // It must be a tuple.
       } else {
         assert(decl->isTupleDecl());
-        conv = convertAST(decl);
+        conv = convertTupleDeclComponents(decl->toTupleDecl());
       }
 
       INT_ASSERT(conv);


### PR DESCRIPTION
This PR fixes an issue when converting from uAST to AST
when tuples are nested (tuple of tuples).

Previously, we used the `visit` method to convert nested
tuples, which assumes the end of a tuple is a statement and
breaks if the tuple being converted is a nested tuple.


TESTING:

- [x] paratest 13595 pass, 0 fail
- [x] paratest with `--dyno` 12873 pass, 706 fails (down from ~730)
 
Reviewed by @dlongnecke-cray 

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>