### PR TITLE
Add perf annotations for 2022-02-10

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -539,12 +539,6 @@ AllCompTime: &timecomp-base
     - Stop converting PRIM_ZIP to tuples for forall statements (#17212)
   05/14/21:
     - Resolve some issues with finding primary and secondary operator methods (#17684)
-  02/13/22:
-    - Simplify locale setup barrier (#18868)
-  02/19/22:
-    - Move some method definitions into headers (#18961)
-  02/25/22:
-    - Move SSCA out of release/examples (#19054)
 
 allocate:
   06/11/20:
@@ -2134,6 +2128,12 @@ compilerAndTestingStats: &compiler-perf-base
     - Heap allocate string literals (#18307)
   11/03/21:
     - buildDefaultFunctions perf improvement (#18624)
+  01/13/22:
+    - Simplify locale setup barrier (#18868)
+  01/19/22:
+    - Move some method definitions into headers (#18961)
+  01/25/22:
+    - Move SSCA out of release/examples (#19054)
 
 allTotalTime:
   <<: *compiler-perf-base
@@ -2241,7 +2241,10 @@ arkouda: &arkouda-base
     - Optimize small and medium int in1d operations (mhmerrill/arkouda#1044)
   02/02/22:
     - Fix sum precision for real this time (mhmerrill/arkouda#1055)
-    - Issue 1049 Adds capability to print server commands from the client. (mhmerrill/arkouda#1049)
+  02/05/22:
+    - Optimize sorting calls when both keys and ranks are needed (mhmerrill/arkouda#1063)
+  02/10/22:
+    - String ops follow byte locality (mhmerrill/arkouda#1060)
 
 
 arkouda-string:
@@ -2265,3 +2268,9 @@ arkouda-comp:
     - Fix some issues with constant domain optimization (#16397)
   02/25/21:
     - Stop converting PRIM_ZIP to tuples for forall statements (#17212)
+  02/02/22:
+    - Issue 1049 Adds capability to print server commands from the client. (mhmerrill/arkouda#1049)
+  02/07/22:
+    - Add support for arrays of unsigned integers (mhmerrill/arkouda#1070)
+  02/10/22:
+    - Add in1d and setops support for uint pdarrays (mhmerrill/arkouda#1085)


### PR DESCRIPTION
Add annotations for:
 - Arkouda in1d optimizations
 - Arkouda compile time regressions from new uint code
 - Arkouda string regressions from different hash strategy

And fix annotation for some compiler speed changes from last time (wrong
month and applied to wrong compiler speed graphs)