### PR TITLE
Use fi_cntr_wait when waiting on a completion counter

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2326,7 +2326,7 @@ void init_ofiEp(void) {
     txCQLen = cqAttr.size;
     cntrAttr = (struct fi_cntr_attr)
                { .events = FI_CNTR_EVENTS_COMP,
-                 .wait_obj = FI_WAIT_NONE, };
+                 .wait_obj = FI_WAIT_UNSPEC, };
     DBG_PRINTF(DBG_TCIPS, "creating tx endpoints/contexts");
     for (int i = 0; i < numWorkerTxCtxs; i++) {
       init_ofiEpTxCtx(i, false /*isAMHandler*/, &avAttr, &cqAttr,
@@ -2350,7 +2350,7 @@ void init_ofiEp(void) {
              .wait_set = ofi_amhWaitSet, };
   cntrAttr = (struct fi_cntr_attr)
              { .events = FI_CNTR_EVENTS_COMP,
-               .wait_obj = waitObj,
+               .wait_obj = FI_WAIT_UNSPEC,
                .wait_set = ofi_amhWaitSet, };
   DBG_PRINTF(DBG_TCIPS, "creating AM handler tx endpoints/contexts");
   for (int i = numWorkerTxCtxs; i < tciTabLen; i++) {
@@ -2372,7 +2372,7 @@ void init_ofiEp(void) {
              .wait_set = ofi_amhWaitSet, };
   cntrAttr = (struct fi_cntr_attr)
              { .events = FI_CNTR_EVENTS_COMP,
-               .wait_obj = waitObj,
+               .wait_obj = FI_WAIT_UNSPEC,
                .wait_set = ofi_amhWaitSet, };
 
   OFI_CHK(fi_endpoint(ofi_domain, ofi_info, &ofi_rxEp, NULL));
@@ -6872,23 +6872,24 @@ void checkTxCmplsCQ(struct perTxCtxInfo_t* tcip) {
 
 static
 void checkTxCmplsCntr(struct perTxCtxInfo_t* tcip) {
-  if (envProgressCntr) {
-    // Manually progress the counter
-    int rc = fi_cq_read(tcip->txCQ, NULL, 0);
-    if ((rc < 0) && (rc != -FI_EAGAIN)) {
-      INTERNAL_ERROR_V("fi_cq_read failed: %s", fi_strerror(rc));
-    }
-  }
-  uint64_t count = fi_cntr_read(tcip->txCntr);
-  if (count > tcip->numTxnsSent) {
-    INTERNAL_ERROR_V("fi_cntr_read() %" PRIu64 ", but numTxnsSent %" PRIu64,
-                     count, tcip->numTxnsSent);
-  }
-  tcip->numTxnsOut = tcip->numTxnsSent - count;
   if (tcip->numTxnsOut > 0) {
-    count = fi_cntr_readerr(tcip->txCntr);
-    if (count > 0) {
-      INTERNAL_ERROR_V("error count %" PRIu64, count);
+    if (envProgressCntr) {
+      // Manually progress the counter
+      int rc;
+      OFI_CHK_2(fi_cq_read(tcip->txCQ, NULL, 0), rc, -FI_EAGAIN);
+    }
+    OFI_CHK(fi_cntr_wait(tcip->txCntr, tcip->numTxnsSent, -1));
+    uint64_t count = fi_cntr_read(tcip->txCntr);
+    if (count > tcip->numTxnsSent) {
+      INTERNAL_ERROR_V("fi_cntr_read() %" PRIu64 ", but numTxnsSent %" PRIu64,
+                       count, tcip->numTxnsSent);
+    }
+    tcip->numTxnsOut = tcip->numTxnsSent - count;
+    if (tcip->numTxnsOut > 0) {
+      count = fi_cntr_readerr(tcip->txCntr);
+      if (count > 0) {
+        INTERNAL_ERROR_V("error count %" PRIu64, count);
+      }
     }
   }
 }


### PR DESCRIPTION
`Libfabric` providers may implement completion counters that simply count completion events. This is a lightweight way to wait for events to complete as opposed to using completion queues. However, spinning on a counter via `fi_cntr_read` has its own overheads. Calling `fi_cntr_wait` causes the calling thread to wait for the counter to reach a specified value, avoiding the spin. Specifying `FI_WAIT_UNSPEC` allows the `libfabric` library to implement the wait using "the most appropriate or highest performing wait object available, including custom wait mechanisms". Using a completion counter means it's not possible to wait for a specific transaction to complete; instead, we must wait until all outstanding transactions to complete.

This resolves cray/chapel-private#2751.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>