### PR TITLE
Add supported LLVM versions to error message about unset/un-inferred LLVM

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -45,6 +45,8 @@ endif
 
 CMAKE ?= cmake
 
+CHPL_LLVM_SUPPORTED_VERSIONS := $(shell python -c 'import sys; sys.path.insert(0, "${CHPL_MAKE_HOME}"+"/util/chplenv"); import chpl_llvm; print chpl_llvm.llvm_versions_string()')
+
 default: $(CHPL_MAKE_LLVM)
 
 all: $(CHPL_MAKE_LLVM)
@@ -153,6 +155,7 @@ unset:
 	@echo "  1) 'none' to build without LLVM support"
 	@echo "  2) 'bundled' to build with the LLVM packaged in the third-party directory"
 	@echo "  3) 'system' to use a pre-installed system-wide LLVM"
+	@echo "     Currently supported LLVM versions are: $(CHPL_LLVM_SUPPORTED_VERSIONS)"
 	@echo "See: https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-llvm"
 	@exit 1
 

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -45,7 +45,7 @@ endif
 
 CMAKE ?= cmake
 
-CHPL_LLVM_SUPPORTED_VERSIONS := $(shell python -c 'import sys; sys.path.insert(0, "${CHPL_MAKE_HOME}"+"/util/chplenv"); import chpl_llvm; print(chpl_llvm.llvm_versions_string())')
+CHPL_LLVM_SUPPORTED_VERSIONS := $(shell ${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py --supported-versions)
 
 default: $(CHPL_MAKE_LLVM)
 

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -45,7 +45,7 @@ endif
 
 CMAKE ?= cmake
 
-CHPL_LLVM_SUPPORTED_VERSIONS := $(shell ${CHPL_MAKE_HOME}/util/chplenv/chpl_llvm.py --supported-versions)
+CHPL_LLVM_SUPPORTED_VERSIONS := $(shell ${CHPL_MAKE_HOME}/util/config/llvmVersions)
 
 default: $(CHPL_MAKE_LLVM)
 

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -45,7 +45,7 @@ endif
 
 CMAKE ?= cmake
 
-CHPL_LLVM_SUPPORTED_VERSIONS := $(shell python -c 'import sys; sys.path.insert(0, "${CHPL_MAKE_HOME}"+"/util/chplenv"); import chpl_llvm; print chpl_llvm.llvm_versions_string()')
+CHPL_LLVM_SUPPORTED_VERSIONS := $(shell python -c 'import sys; sys.path.insert(0, "${CHPL_MAKE_HOME}"+"/util/chplenv"); import chpl_llvm; print(chpl_llvm.llvm_versions_string())')
 
 default: $(CHPL_MAKE_LLVM)
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -689,6 +689,7 @@ def get_host_link_args():
 def _main():
     llvm_val = get()
     llvm_config = get_llvm_config()
+    llvm_versions = llvm_versions_string()
 
     parser = optparse.OptionParser(usage='usage: %prog [--needs-llvm-runtime]')
     parser.add_option('--needs-llvm-runtime', dest='action',
@@ -697,6 +698,9 @@ def _main():
     parser.add_option('--llvm-config', dest='action',
                       action='store_const',
                       const='llvmconfig', default='')
+    parser.add_option('--supported-versions', dest='action',
+                      action='store_const',
+                      const='llvmversions', default='')
 
     (options, args) = parser.parse_args()
 
@@ -708,6 +712,8 @@ def _main():
     elif options.action == 'llvmconfig':
         sys.stdout.write("{0}\n".format(llvm_config))
         validate_llvm_config()
+    elif options.action == 'llvmversions':
+        sys.stdout.write("{0}\n".format(llvm_versions))
     else:
         sys.stdout.write("{0}\n".format(llvm_val))
 

--- a/util/config/llvmVersions
+++ b/util/config/llvmVersions
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# get the chpl home directory
+CWD=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
+
+PY=`"$CWD/util/config/find-python.sh"`
+$PY "$CWD/util/chplenv/chpl_llvm.py" --supported-versions


### PR DESCRIPTION
In the error message asking to set CHPL_LLVM, add a list of supported LLVM
versions to the part talking about CHPL_LLVM=system.

Closes https://github.com/chapel-lang/chapel/issues/19182, https://github.com/cray/chapel-private/issues/3089

Signed-off-by: David Iten <daviditen@users.noreply.github.com>