### PR TITLE
Squash compiler-generated hash functions for records with ==/!=; add operatorExists() utility

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1623,8 +1623,9 @@ static void checkNotPod(AggregateType* at) {
 
 static void buildRecordHashFunction(AggregateType *ct) {
   if (functionExists("hash", dtMethodToken, ct) ||
-      operatorExists("==", ct, ct) ||
-      operatorExists("!=", ct, ct))
+      (!ct->symbol->hasFlag(FLAG_TUPLE) &&  // tuples already always have ==/!=
+       (operatorExists("==", ct, ct) ||
+        operatorExists("!=", ct, ct))))
     return;
 
   FnSymbol *fn = new FnSymbol("hash");

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -339,11 +339,12 @@ static FnSymbol* operatorExists(const char* name,
                                 Type* formalType1,
                                 Type* formalType2,
                                 functionExistsKind kind=FIND_EITHER) {
-  // check for standalone operator
-  FnSymbol* retval = functionExists(name, formalType1, formalType2);
+  FnSymbol* retval = NULL;
+  // check for operator method
+  retval = functionExists(name, dtMethodToken, dtAny, formalType1, formalType2);
   if (retval == NULL) {
-    // check for operator method
-    retval = functionExists(name, dtMethodToken, dtAny, formalType1, formalType2);
+    // check for standalone operator
+    retval = functionExists(name, formalType1, formalType2);
   }
   return retval;
 }

--- a/test/exercises/duplicates/forStudents/FileHashing.chpl
+++ b/test/exercises/duplicates/forStudents/FileHashing.chpl
@@ -30,6 +30,11 @@ module FileHashing {
     proc init(hashVal: 8*uint(32)) {
       this.hashVal = hashVal;
     }
+
+    /* How to compute a hash a SHA256Hash */
+    proc hash() {
+      return hashVal.hash();
+    }
   }
 
   /* Called when assigning between SHA256Hash values */

--- a/test/types/chplhashtable/GenericAggregateHash.chpl
+++ b/test/types/chplhashtable/GenericAggregateHash.chpl
@@ -29,8 +29,16 @@ operator r1.==(lhs: r1, rhs: r1) {
   return lhs.x == rhs.x;
 }
 
+proc r1.hash() {
+  return x.hash();
+}
+
 operator r2.==(lhs: r2, rhs: r2) {
   return && reduce (lhs.a == rhs.a);
+}
+
+proc r2.hash() {
+  return a.hash();
 }
 
 class C { var x = 0; }

--- a/test/types/chplhashtable/Issue11613.chpl
+++ b/test/types/chplhashtable/Issue11613.chpl
@@ -11,6 +11,10 @@ operator R.!=(a: R, b: R) {
   return || reduce (a.a != b.a);
 }
 
+proc R.hash() {
+  return a.hash();
+}
+
 var d : domain(R(int));
 d += new R(int);
 

--- a/test/types/chplhashtable/nonPodRecord.chpl
+++ b/test/types/chplhashtable/nonPodRecord.chpl
@@ -1,0 +1,32 @@
+use Set;
+
+class C { var x: int; }
+
+var myC = new C?(45);
+var myC2 = new C?(33);
+
+var A: [1..10] owned C?;
+
+A[3] = myC;
+A[5] = myC;
+A[7] = myC2;
+
+record R {
+  var idx: int;
+}
+
+operator ==(lhs: R, rhs: R) {
+  return A[lhs.idx] == A[rhs.idx];
+}
+
+var s: set(R);
+
+var myR = new R(3);
+var myR2 = new R(5);
+var myR3 = new R(7);
+
+s.add(myR);
+s.add(myR2);
+s.add(myR3);
+
+writeln(s);

--- a/test/types/chplhashtable/nonPodRecord.good
+++ b/test/types/chplhashtable/nonPodRecord.good
@@ -6,6 +6,6 @@ $CHPL_HOME/modules/internal/ChapelHashing.chpl:61: note: is passed to formal 'th
 $CHPL_HOME/modules/standard/Set.chpl:290: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelHashing.chpl:68: note:   int.hash()
 $CHPL_HOME/modules/internal/ChapelHashing.chpl:72: note:   uint.hash()
-note: and 49 other candidates, use --print-all-candidates to see them
+note: and 50 other candidates, use --print-all-candidates to see them
   $CHPL_HOME/modules/standard/Set.chpl:335: called as (set(R,false))._addElem(elem: R) from method 'add'
   nonPodRecord.chpl:28: called as (set(R,false)).add(element: R)

--- a/test/types/chplhashtable/nonPodRecord.good
+++ b/test/types/chplhashtable/nonPodRecord.good
@@ -1,0 +1,11 @@
+$CHPL_HOME/modules/standard/Set.chpl:277: In method '_addElem':
+$CHPL_HOME/modules/standard/Set.chpl:290: error: unresolved call 'R.hash()'
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:61: note: this candidate did not match: bool.hash()
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:366: note: because method call receiver with type 'R'
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:61: note: is passed to formal 'this: bool'
+$CHPL_HOME/modules/standard/Set.chpl:290: note: other candidates are:
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:68: note:   int.hash()
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:72: note:   uint.hash()
+note: and 49 other candidates, use --print-all-candidates to see them
+  $CHPL_HOME/modules/standard/Set.chpl:335: called as (set(R,false))._addElem(elem: R) from method 'add'
+  nonPodRecord.chpl:28: called as (set(R,false)).add(element: R)

--- a/test/types/chplhashtable/nonPodRecord2.chpl
+++ b/test/types/chplhashtable/nonPodRecord2.chpl
@@ -1,0 +1,33 @@
+use Set;
+
+class C { var x: int; }
+
+var myC = new C?(45);
+var myC2 = new C?(33);
+
+var A: [1..10] owned C?;
+
+A[3] = myC;
+A[5] = myC;
+A[7] = myC2;
+
+record R {
+  var idx: int;
+
+  operator ==(lhs: R, rhs: R) {
+    return A[lhs.idx] == A[rhs.idx];
+  }
+}
+
+
+var s: set(R);
+
+var myR = new R(3);
+var myR2 = new R(5);
+var myR3 = new R(7);
+
+s.add(myR);
+s.add(myR2);
+s.add(myR3);
+
+writeln(s);

--- a/test/types/chplhashtable/nonPodRecord2.good
+++ b/test/types/chplhashtable/nonPodRecord2.good
@@ -1,0 +1,11 @@
+$CHPL_HOME/modules/standard/Set.chpl:277: In method '_addElem':
+$CHPL_HOME/modules/standard/Set.chpl:290: error: unresolved call 'R.hash()'
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:61: note: this candidate did not match: bool.hash()
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:366: note: because method call receiver with type 'R'
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:61: note: is passed to formal 'this: bool'
+$CHPL_HOME/modules/standard/Set.chpl:290: note: other candidates are:
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:68: note:   int.hash()
+$CHPL_HOME/modules/internal/ChapelHashing.chpl:72: note:   uint.hash()
+note: and 49 other candidates, use --print-all-candidates to see them
+  $CHPL_HOME/modules/standard/Set.chpl:335: called as (set(R,false))._addElem(elem: R) from method 'add'
+  nonPodRecord2.chpl:29: called as (set(R,false)).add(element: R)

--- a/test/types/chplhashtable/nonPodRecord2.good
+++ b/test/types/chplhashtable/nonPodRecord2.good
@@ -6,6 +6,6 @@ $CHPL_HOME/modules/internal/ChapelHashing.chpl:61: note: is passed to formal 'th
 $CHPL_HOME/modules/standard/Set.chpl:290: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelHashing.chpl:68: note:   int.hash()
 $CHPL_HOME/modules/internal/ChapelHashing.chpl:72: note:   uint.hash()
-note: and 49 other candidates, use --print-all-candidates to see them
+note: and 50 other candidates, use --print-all-candidates to see them
   $CHPL_HOME/modules/standard/Set.chpl:335: called as (set(R,false))._addElem(elem: R) from method 'add'
   nonPodRecord2.chpl:29: called as (set(R,false)).add(element: R)


### PR DESCRIPTION
This PR is primarily focused on having the compiler not be so aggressive
in generating hash functions for records that are insufficiently simple, as
we've been exploring in #18577.  Specifically, it says that if a record has
an `==` or `!=` operator defined on it, we will conservatively assume that
it is not so simple that our compiler-generated hash function makes
sense for it because two record values aren't equivalent simply because
their fields are the same.

A reasonably compelling example of this is added in this PR in which a
record contains a single `int` field that serves as an index into an array
of classes and the records are logically `==` if their table entries point
to the same class.  SInce one would want a hash function to similarly
hash such records with the same logical value to the same hash, it
doesn't make sense to simply hash the table index because it treats two
logically equivalent records as different.  Another motivating example is
the `bigint` type, which happens to be implemented a a record, but whose
logical value relates to what's implemented in the limbs of its mpz_t type.

While working on this, I had a buggy version of the code in which I hadn't
done the method operator form lookup of `==`/`!=` correctly (due to a
simple typo/misunderstanding), so to help others not step into this same
trap, I created a variant of `functionExists()` in buildDefaultFunctions.cpp
called `operatorExists()` that will look for both the standalone and method
versions of the operator to answer the question, simplifying callsites that
were manually calling both `functionExists()` signatures previously.

TODO: finish this
