### PR TITLE
Fix bug in _ddata helper function added for `unsafeAssign()`

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1034,7 +1034,7 @@ module ChapelBase {
                           hi: integral,
                           fill: int(8)=0) {
     if hi > lo {
-      const elemWidthInBytes = _ddata_sizeof_element(ddata);
+      const elemWidthInBytes: uint  = _ddata_sizeof_element(ddata);
       const numElems = (hi - lo).safeCast(uint);
       if safeMul(numElems, elemWidthInBytes) {
         const numBytes = numElems * elemWidthInBytes;


### PR DESCRIPTION
Fix bug in _ddata helper function added for `unsafeAssign()`

In #18928 I added a helper function for `_ddata` which takes a
`_ddata` buffer and memsets it with a fill value. I did not realize
that the result of `_ddata_sizeof_element()` is a signed integer.
This caused test failures on `linux32` boxes.

Convert buffer size to `uint` before using.

TESTING

- [x] `make && make check` on `linux64`, `linux32`, `darwin`
- [x] `arrays, domains` on `linux64` with `COMM=none`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>