### PR TITLE
Update sort docs to use `operator` for defining `<`

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -91,7 +91,7 @@ themselves like so:
 
 .. code-block:: chapel
 
-  proc op<(a: returnType, b: returnType): bool {
+  operator <(a: returnType, b: returnType): bool {
     ...
   }
 


### PR DESCRIPTION
Update some stale docs for defining a `proc <` to `operator <`
