### PR TITLE
Adjust _ddata_allocate call in interface test

### DIFF
--- a/test/constrained-generics/basic/set3/hashtable-table.chpl
+++ b/test/constrained-generics/basic/set3/hashtable-table.chpl
@@ -4,7 +4,7 @@
 //   test/constrained-generics/hashtable/test-chpl-hashtable.chpl
 
 record my__hashtable {
-  var table: _ddata(int) = _ddata_allocate(int, 2, initElts=true);
+  var table: _ddata(int) = _ddata_allocate(int, 2);
 }
 
 interface chpl_Hashtable(HT) {


### PR DESCRIPTION
Adjust _ddata_allocate call in interface test (#19247)

In #18928 I adjusted `_ddata_allocate` to no longer take a
`param initElts: bool` argument. While I adjusted the (few) callsites
for the function in module code, I missed this test that only
runs under `--no-local`.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>