### PR TITLE
Replace segfault due to applying 'override' to a non-method with an error

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -380,6 +380,10 @@ checkFunction(FnSymbol* fn) {
     }
   }
 
+  if (fn->hasFlag(FLAG_OVERRIDE) && fn->_this == NULL) {
+    USR_FATAL("'override' cannot be applied to non-method '%s'", fn->name);
+  }
+
   if (fn->retTag == RET_TYPE || fn->retTag == RET_PARAM) {
     for_formals(formal, fn) {
       if (formal->intent == INTENT_OUT ||

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -1093,6 +1093,11 @@ static void checkMethodsOverride() {
     // output error for overriding for non-class methods
     if (aFn->hasFlag(FLAG_OVERRIDE)) {
 
+      if (aFn->_this == NULL) {
+        USR_FATAL("'override' cannot be applied to non-method '%s'",
+                  aFn->name);
+      }
+
       //
       // Type methods may have managed receiver types, which would normally
       // not be recognized as a class.

--- a/test/classes/override/override-nonmethod.chpl
+++ b/test/classes/override/override-nonmethod.chpl
@@ -1,0 +1,13 @@
+module M {
+  class X {    
+    proc Y() {
+      if (true) {
+        if (true) {
+        } else {}
+      }
+
+      // Must be `override`!
+      override proc Z() {}
+    }
+  }
+}

--- a/test/classes/override/override-nonmethod.good
+++ b/test/classes/override/override-nonmethod.good
@@ -1,0 +1,1 @@
+error: 'override' cannot be applied to non-method 'Z'


### PR DESCRIPTION
As things stood, the compiler assumed that `override` would only
be applied to methods, which led to a segfault when it was not.
This replaces that segfault with a user-facing error message.

Resolves #19249