### PR TITLE
Don't run n=10000 problem size of pidigits5 in valgrind

### DIFF
--- a/test/studies/shootout/pidigits/bradc/pidigits-blc.execopts
+++ b/test/studies/shootout/pidigits/bradc/pidigits-blc.execopts
@@ -1,10 +1,3 @@
-#!/usr/bin/env python3
-import os
-
-# This configuration is particularly long-running under valgrind, so
-# let's skip it valgrindexe testing.
-if os.getenv('CHPL_TEST_VGRND_EXE') != 'on':
-   print('--n=10000')
-
-print('--n=27     # pidigits-27.good')
-print('--n=57     # pidigits-57.good')
+--n=10000
+--n=27     # pidigits-27.good
+--n=57     # pidigits-57.good

--- a/test/studies/shootout/submitted/pidigits5.execopts
+++ b/test/studies/shootout/submitted/pidigits5.execopts
@@ -1,2 +1,9 @@
---n=10000 # pidigits.good
---n=27    # pidigits-27-nospace.good
+#!/usr/bin/env python3
+import os
+
+# This configuration is particularly long-running under valgrind, so
+# let's skip it valgrindexe testing.
+if os.getenv('CHPL_TEST_VGRND_EXE') != 'on':
+   print('--n=10000 # pidigits.good')
+
+print('--n=27     # pidigits-27-nospace.good')


### PR DESCRIPTION
In the "Brad can be a slow learner" category, this moves the .execopts
that I applied to my study version of pidigits (in #19189 to avoid a
valgrind timeout) over to the snapshot of the submitted version.
Since my version is now simple / serial, I also restored the
traditional .execopts for my study version.
