### PR TITLE
Adjust spec wording for main module details

### DIFF
--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -1207,9 +1207,12 @@ multiple modules.
 
    *Implementation Notes*.
 
-   In the current Chapel compiler implementation, the *– –main-module* flag
-   can be used to specify the module from which the main function
-   definition will be used.
+   A ``main`` function will only be considered to identify the main
+   module if it appears within a file named on the command line.
+
+   The *––main-module* flag can be used to specify the module from which
+   the main function definition will be used.
+
 
 ..
 
@@ -1281,7 +1284,17 @@ main function is equivalent to
 
 .. code-block:: chapel
 
-   proc main() {}
+     proc main() {}
+
+
+..
+
+  *Implementation Notes*.
+
+  The default ``main`` will be created only for a single module in a file
+  named on the command line or for whatever module is indicated by the
+  *--main-module* flag.
+
 
 ..
 


### PR DESCRIPTION
Resolves #19258.

To clarify the docs for issue #19258.

 * Describes identifying the "main module" in a new section
 * use "procedure" instead of "function" when referring to a `proc` (including for `main`) in the Modules chapter
 * improved the module initialization section to talk about what happens when a particular module is initialized instead of generally describing all module initialization at once
 * improved the module initialization to indicate top-level modules in files mentioned on the command line are initialized (from PR #18724)

Reviewed by @bradcray - thanks!