### PR TITLE
Refactor insertLineNumbers to use the PassManager

### DIFF
--- a/compiler/include/PassManager.h
+++ b/compiler/include/PassManager.h
@@ -225,7 +225,17 @@ class PassManager {
   void runPassChained(PassTList<T>&& passes, Container& xs) {
     for (auto& x : xs) {
       for (auto& p : passes) {
-        // NOTE: these passes can't currently have leftovers
+        // NOTE: these passes can't currently have leftovers:
+        // In other words, it's not as easy to run multiple PassTU chained
+        // together because we don't know for sure that at its legal to do
+        //   p1.run(x); p2.run(x);
+        // without
+        //   p1.run(x); while (p1.hasNext()); p1.processNext(); p2.run(x)
+        // and in the latter case, you're not guaranteed that another
+        // call to
+        //   p1.run(y)
+        // for some y would have enqueued more work for x that should
+        // be processed before p2.run(x).
         p.run(x);
       }
     }

--- a/compiler/include/PassManager.h
+++ b/compiler/include/PassManager.h
@@ -107,7 +107,7 @@ template <typename T, typename ResultType = void> class PassT {
 //   1) enqueue(T x)        | enqueue(FnSymbol* fn)
 //   2) enqueue(T x, U, y)  | enqueue(FnSymbol* fn, CallExpr* call)
 //
-// Each `enqueue` overload corresponds to a `process` overload and is in-effect
+// Each `enqueue` overload corresponds to a `process` overload and is in effect
 // a delayed function call.
 //
 // The second overload is called to process a `call` in its enclosing `fn`

--- a/compiler/include/PassManager.h
+++ b/compiler/include/PassManager.h
@@ -22,6 +22,7 @@
 #define _PASS_MANAGER_H_
 
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 //
@@ -68,6 +69,93 @@ template <typename T, typename ResultType = void> class PassT {
   virtual ResultType getResult() {
     // return nothing
   }
+
+  virtual bool hasNext() {
+    return false;
+  }
+
+  virtual void processNext() {
+    // do nothing
+  }
+
+  virtual bool alreadyProcessed(T x) {
+    auto it = processed_.find(x);
+    bool ret = it != processed_.end();
+    processed_.emplace_hint(it, x);
+    return ret;
+  }
+
+ private:
+  std::unordered_set<T> processed_;
+};
+
+//
+// A PassTU is a PassT that is concerned with processing things of type T and U
+//
+// A common example of this two type pass is FnSymbol and CallExpr and the
+// following documentation uses it as a running example.
+//
+// There are two overloads of the `process` method that should be overridden:
+//      general             | example
+//   1) process(T x)        | process(FnSymbol* fn)
+//   2) process(T x, U, y)  | process(FnSymbol* fn, CallExpr* call)
+//
+// The first overload serves to process the "primary" unit of work and can
+// modify itself, but if/when it discovers more work to be done, it should use
+// the appropriate overload of `enqueue`:
+//      general             | example
+//   1) enqueue(T x)        | enqueue(FnSymbol* fn)
+//   2) enqueue(T x, U, y)  | enqueue(FnSymbol* fn, CallExpr* call)
+//
+// Each `enqueue` overload corresponds to a `process` overload and is in-effect
+// a delayed function call.
+//
+// The second overload is called to process a `call` in its enclosing `fn`
+//
+template <typename T, typename U, typename ResultType = void>
+class PassTU : public PassT<T, ResultType> {
+ public:
+
+  // We need this to get an overload of an inherited method
+  using PassT<T, ResultType>::process;
+
+  virtual void process(T x, U y) {
+    // do nothing
+  }
+
+  void enqueue(T x) { TQueue_.push_back(x); }
+
+  void enqueue(T x, U y) { TUQueue_.push_back({x, y}); }
+
+  bool hasNext() override {
+    return !TQueue_.empty() || !TUQueue_.empty();
+  }
+
+  void processNext() override {
+    if (!TQueue_.empty()) {
+      auto x = TQueue_.back();
+      TQueue_.pop_back();
+      process(x);
+
+    } else if (!TUQueue_.empty()) {
+      auto pair = TUQueue_.back();
+      TUQueue_.pop_back();
+      process(pair.first, pair.second);
+    }
+  }
+
+ private:
+  // This might be different for different ordering guarantees
+  template<typename QT>
+  using Queue = std::vector<QT>;
+
+  Queue<T> TQueue_;
+  Queue<std::pair<T, U>> TUQueue_;
+
+  // another queueing method is something like
+  // std::unordered_map<T, std::vector<U>>
+  // which might give you better locality and/or visibility
+  // into whether there are remaining tasks for a specific T
 };
 
 template <typename T> using PassTList = std::vector<std::unique_ptr<PassT<T>>>;
@@ -94,34 +182,39 @@ class PassManager {
  private:
   // Run pass over many and return it's results (if any)
   template <typename T, typename R, typename Container>
-  R runPass(PassT<T, R>& pass, const Container& xs) {
+  R runPassImpl(PassT<T, R>& pass, const Container& xs) {
     for (auto& x : xs) {
       pass.run(x);
     }
+
+    while (pass.hasNext()) {
+      pass.processNext();
+    }
+
     return pass.getResult();
   }
 
  public:
   // We take pass by && in these for the common case where the caller
-  // sinks their argument; like runPass(myPassName(), ...);
+  // sinks their argument; like runPass(myPassName(), ...); Also
+  // because a pass list should get moved in so we can own it
 
-  // Run pass on a single item and return it's results (if any)
-  template <typename T, typename R>
-  R runPass(PassT<T, R>&& pass, T x) {
-    return runPass(pass, {x});
+  template <typename T, typename R, typename Container>
+  R runPass(PassT<T, R>& pass, const Container& xs) {
+    return runPassImpl(pass, xs);
   }
 
   // Run pass on many items and return it's results (if any)
   template <typename T, typename R, typename Container>
   R runPass(PassT<T, R>&& pass, const Container& xs) {
-    return runPass(pass, xs);
+    return runPassImpl(pass, xs);
   }
 
   // Run multiple passes on many items, pass at a time. Does not return results
   template <typename T, typename Container>
   void runPass(PassTList<T>&& passes, const Container& xs) {
     for (auto& p : passes) {
-      runPass(*p, xs);
+      runPassImpl(*p, xs);
     }
   }
 
@@ -132,6 +225,7 @@ class PassManager {
   void runPassChained(PassTList<T>&& passes, Container& xs) {
     for (auto& x : xs) {
       for (auto& p : passes) {
+        // NOTE: these passes can't currently have leftovers
         p.run(x);
       }
     }

--- a/compiler/include/insertLineNumbers.h
+++ b/compiler/include/insertLineNumbers.h
@@ -31,6 +31,6 @@ extern std::vector<std::string> gFilenameLookup;
 // Caches the location of filenames in gFilenameLookup
 extern std::map<std::string, int> gFilenameLookupCache;
 
-int getFilenameLookupPosition(std::string name);
+int getFilenameLookupPosition(const std::string& name);
 
 #endif //_INSERT_LINE_NUMBERS_H

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -24,6 +24,7 @@
 #include "FnSymbol.h"
 #include "symbol.h"
 #include "PassManager.h"
+#include <unordered_set>
 
 extern bool parsed;
 extern bool normalized;
@@ -163,6 +164,9 @@ CallExpr* findDownEndCount(FnSymbol* fn);
 Expr*     resolveExpr(Expr* expr);
 void      resolveBlockStmt(BlockStmt* blockStmt);
 
+// --- Pass Manager passes ---
+
+// returnStarTuplesByRefArgs
 class returnStarTuplesByRefArgsPass1 : public PassT<FnSymbol*> {
   bool shouldProcess(FnSymbol* fn) override;
   void process(FnSymbol* fn) override;
@@ -173,11 +177,13 @@ class returnStarTuplesByRefArgsPass2 : public PassT<CallExpr*> {
   void process(CallExpr* fn) override;
 };
 
+// general
 class ComputeCallSitesPass : public PassT<FnSymbol*> {
   bool shouldProcess(FnSymbol* fn) override;
   void process(FnSymbol* fn) override;
 };
 
+// flattenClasses.cpp
 class FlattenClasses : public PassT<TypeSymbol*> {
   void process(TypeSymbol* ts) override;
 };
@@ -239,6 +245,35 @@ class RemoveUnnecessaryAutoCopyCalls : public PassT<FnSymbol*> {
 
  private:
   std::vector<CallExpr*> calls;
+};
+
+// insertLineNumbers.cpp
+class InsertNilChecksPass : public PassT<CallExpr*> {
+  bool shouldProcess(CallExpr* call) override;
+  void process(CallExpr* call) override;
+};
+
+struct LineAndFile {
+  Symbol* line;
+  Symbol* file;
+};
+
+class InsertLineNumbers : public PassTU<FnSymbol*, CallExpr*> {
+ public:
+  void process(FnSymbol* fn) override;
+  void process(FnSymbol* fn, CallExpr* call) override;
+
+  static bool shouldPreferASTLine(/*const*/ FnSymbol* fn, ModuleSymbol* mod = nullptr);
+  static LineAndFile makeASTLine(CallExpr* call);
+  static void insertLineNumber(CallExpr* call, LineAndFile lineAndFile);
+
+ private:
+
+  static void precondition(FnSymbol *fn);
+
+  LineAndFile getLineAndFileForFn(FnSymbol *fn);
+
+  std::unordered_map<FnSymbol*, LineAndFile> lineAndFilenameMap;
 };
 
 #endif

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -20,7 +20,10 @@
 
 #include "insertLineNumbers.h"
 
+#include "CallExpr.h"
+#include "FnSymbol.h"
 #include "astutil.h"
+#include "baseAST.h"
 #include "driver.h"
 #include "expr.h"
 #include "passes.h"
@@ -30,10 +33,9 @@
 #include "symbol.h"
 #include "virtualDispatch.h"
 
-#include "global-ast-vecs.h"
-
 #include <algorithm>
 #include <queue>
+#include <unordered_set>
 
 //
 // insertLineNumbers() inserts line numbers and filenames into
@@ -45,13 +47,12 @@
 // number and a filename.
 //
 
-
 std::vector<std::string>   gFilenameLookup;
 
 // Caches lookups into our filename vector
 std::map<std::string, int> gFilenameLookupCache;
 
-int getFilenameLookupPosition(std::string name) {
+int getFilenameLookupPosition(const std::string& name) {
   std::map<std::string, int>::iterator it = gFilenameLookupCache.find(name);
   int idx;
   if (it != gFilenameLookupCache.end()) {
@@ -77,166 +78,7 @@ int getFilenameLookupPosition(std::string name) {
   return idx;
 }
 
-static void moveLinenoInsideArgBundle();
-
-//
-// The queue keeps track of the functions to which line number and
-// filename arguments have been added so that calls to these functions
-// can be updated with new actual arguments.
-//
-static std::queue<FnSymbol*> queue;
-
-static Map<FnSymbol*,ArgSymbol*> linenoMap; // fn to line number argument
-static Map<FnSymbol*,ArgSymbol*> filenameMap; // fn to filename argument
-
-static ArgSymbol* newLine(FnSymbol* fn) {
-  ArgSymbol* line = new ArgSymbol(INTENT_CONST_IN, "_ln", dtInt[INT_SIZE_DEFAULT]);
-  fn->insertFormalAtTail(line);
-  linenoMap.put(fn, line);
-  if (Vec<FnSymbol*>* rootFns = virtualRootsMap.get(fn)) {
-    forv_Vec(FnSymbol, rootFn, *rootFns)
-      if (!linenoMap.get(rootFn))
-        newLine(rootFn);
-  } else if (Vec<FnSymbol*>* childrenFns = virtualChildrenMap.get(fn)) {
-    forv_Vec(FnSymbol, childrenFn, *childrenFns)
-      if (!linenoMap.get(childrenFn))
-        newLine(childrenFn);
-  }
-  return line;
-}
-
-static ArgSymbol* newFile(FnSymbol* fn) {
-  ArgSymbol* file = new ArgSymbol(INTENT_IN, "_fn", dtInt[INT_SIZE_32]);
-  fn->insertFormalAtTail(file);
-  filenameMap.put(fn, file);
-  queue.push(fn);
-  if (Vec<FnSymbol*>* rootFns = virtualRootsMap.get(fn)) {
-    forv_Vec(FnSymbol, rootFn, *rootFns)
-      if (!filenameMap.get(rootFn))
-        newFile(rootFn);
-  } else if (Vec<FnSymbol*>* childrenFns = virtualChildrenMap.get(fn)) {
-    forv_Vec(FnSymbol, childrenFn, *childrenFns)
-      if (!filenameMap.get(childrenFn))
-        newFile(childrenFn);
-  }
-  return file;
-}
-
-//
-// insert a line number and filename actual into a call; add line
-// number and filename formal arguments to the function in which this
-// call lives if necessary, and add it to the queue.
-//
-static void
-insertLineNumber(CallExpr* call) {
-  SET_LINENO(call);
-
-  FnSymbol*     fn   = call->getFunction();
-  ModuleSymbol* mod  = fn->getModule();
-  ArgSymbol*    fileArg = filenameMap.get(fn);
-  ArgSymbol*    lineArg = linenoMap.get(fn);
-  Symbol*       file    = NULL;
-  Symbol*       line    = NULL;
-
-  if (strcmp(fn->name, "chpl__heapAllocateGlobals") == 0 ||
-      strcmp(fn->name, "chpl__initStringLiterals")  == 0 ||
-      strcmp(fn->name, "chpl__initModuleGuards")    == 0 ||
-      strcmp(fn->name, "chpl_gen_main") == 0) {
-    assert( fn->hasFlag(FLAG_EXPORT) &&
-           !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO));
-  }
-
-  bool preferASTLine = false;
-
-  // Should we prefer to use the AST's line and file info
-  // rather than adding an argument and propagating it at runtime?
-  if ((fn->hasFlag(FLAG_EXTERN) || fn->hasFlag(FLAG_EXPORT)) &&
-      !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO))
-    preferASTLine = true; // don't add arguments to extern/export fns
-                          // but do use arguments already added if the fn
-                          // is marked with FLAG_INSERT_LINE_FILE_INFO
-  else if (ftableMap.count(fn))
-    preferASTLine = true; // don't add arguments to ftable calls
-  else if ((mod->modTag == MOD_USER || fn->hasFlag(FLAG_LINE_NUMBER_OK)) &&
-           !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
-           !fn->hasFlag(FLAG_INLINE))
-    preferASTLine = true; // in user's code, it's better to use AST line number
-                          // as long as it's not compiler generated/inline
-  else if (developer && !fn->hasFlag(FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO))
-    preferASTLine = true; // developer mode generally uses AST line numbers
-                          // FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO overrides
-
-  if (preferASTLine) {
-    // This branch handles the case in which line number
-    // should just be whatever is in the AST node
-    // Sets file and line based on call's AST node
-
-    if (call->isResolved() &&
-        call->resolvedFunction()->hasFlag(FLAG_COMMAND_LINE_SETTING)) {
-      // Make up pretend line numbers for errors with command line
-      // configuration variables.
-      line = new_IntSymbol(0);
-
-      FnSymbol* fn = call->resolvedFunction();
-
-      INT_ASSERT(fn);
-      INT_ASSERT(fn->substitutionsPostResolve.size() > 0);
-
-      VarSymbol* var = toVarSymbol(fn->substitutionsPostResolve[0].value);
-
-      INT_ASSERT(var);
-      INT_ASSERT(var->immediate);
-      INT_ASSERT(var->immediate->const_kind == CONST_KIND_STRING);
-
-      const char* cmdLineSetting = astr("<command line setting of '",
-                                        var->immediate->v_string.c_str(),
-                                        "'>");
-
-      int         filenameIdx    = getFilenameLookupPosition(cmdLineSetting);
-
-      file = new_IntSymbol(filenameIdx, INT_SIZE_32);
-
-    } else {
-      // Apply the line number from the call AST node
-      line = new_IntSymbol(call->linenum());
-
-      int filenameIdx = getFilenameLookupPosition(call->fname());
-
-      file = new_IntSymbol(filenameIdx, INT_SIZE_32);
-    }
-  } else {
-    // This branch handles the case in which we should be using
-    // file/line arguments in the enclosing function.
-
-    // Create them if they don't exist yet.
-    if (lineArg == NULL)
-      lineArg = newLine(fn);
-    if (fileArg == NULL)
-      fileArg = newFile(fn);
-
-    line = lineArg;
-    file = fileArg;
-  }
-
-  if (call->isPrimitive(PRIM_GET_USER_FILE) ||
-      call->isPrimitive(PRIM_GET_USER_LINE)) {
-
-    // Replace these primitives with whatever line/file we chose
-    // (probably an argument)
-    if (call->isPrimitive(PRIM_GET_USER_FILE)) {
-      call->replace(new SymExpr(file));
-    } else if (call->isPrimitive(PRIM_GET_USER_LINE)) {
-      call->replace(new SymExpr(line));
-    }
-
-  } else {
-    // add line/file as arguments to the call
-    call->insertAtTail(line);
-    call->insertAtTail(file);
-  }
-}
-
-
+// TODO refactor into a nicer home
 static bool isClassMethodCall(CallExpr* call) {
   FnSymbol* fn     = call->resolvedFunction();
   bool      retval = false;
@@ -251,11 +93,300 @@ static bool isClassMethodCall(CallExpr* call) {
       }
     }
   }
-
   return retval;
 }
 
+static bool isWrapper(FnSymbol* fn) {
+  return (fn->hasFlag(FLAG_ON_BLOCK) ||
+          fn->hasFlag(FLAG_BEGIN_BLOCK) ||
+          fn->hasFlag(FLAG_COBEGIN_OR_COFORALL_BLOCK));
+}
 
+// TODO GLOBALS the use of virtualRootsMap and virtualChildrenMap
+static Vec<FnSymbol*>* rootsOrChildren(FnSymbol* fn) {
+  // TODO refactor question: why are these branches exclusive
+  if (Vec<FnSymbol*>* rootFns = virtualRootsMap.get(fn)) {
+    return rootFns;
+  } else if (Vec<FnSymbol*>* childrenFns = virtualChildrenMap.get(fn)) {
+    return childrenFns;
+  }
+  return nullptr;
+}
+
+// ---------- InsertLineNumbers ----------
+
+// NOTE, shouldPreferASTLine, makeASTLine, and insertLineNumber are static
+// functions so that we might unit test or otherwise execercise them on their
+// own them one day in the future
+
+// Should we prefer to use the AST's line and file info
+// rather than adding an argument and propagating it at runtime?
+// `fn` is const in this function but ftableMap stores by non-const
+// `mod` can be passed in if its already been looked up
+// TODO GLOBALS use of developer and ftableMap
+bool InsertLineNumbers::shouldPreferASTLine(/*const*/ FnSymbol* fn,
+                                            ModuleSymbol* mod) {
+  if (!mod) {
+    mod = fn->getModule();
+  }
+  // don't add arguments to extern/export fns
+  // but do use arguments already added if the fn
+  // is marked with FLAG_INSERT_LINE_FILE_INFO
+  if ((fn->hasFlag(FLAG_EXTERN) || fn->hasFlag(FLAG_EXPORT)) &&
+      !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO))
+    return true;
+
+  // TODO can we mark the FnSymbol directly instead of checking this global map
+  // don't add arguments to ftable calls
+  if (ftableMap.count(fn))
+    return true;
+
+  // in user's code, it's better to use AST line number
+  // as long as it's not compiler generated/inline
+  if ((mod->modTag == MOD_USER || fn->hasFlag(FLAG_LINE_NUMBER_OK)) &&
+      !fn->hasFlag(FLAG_COMPILER_GENERATED) && !fn->hasFlag(FLAG_INLINE))
+    return true;
+
+  // developer mode generally uses AST line numbers
+  // FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO overrides
+  else if (developer && !fn->hasFlag(FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO))
+    return true;
+
+  return false;
+}
+
+// This creates the line and file symbols for a call when we want it to come
+// from the AST itself
+// TODO GLOBALS getFilenamelookupposition
+LineAndFile InsertLineNumbers::makeASTLine(CallExpr* call) {
+  SET_LINENO(call);
+
+  if (call->isResolved() &&
+      call->resolvedFunction()->hasFlag(FLAG_COMMAND_LINE_SETTING)) {
+    // Make up pretend line numbers for errors with command line
+    // configuration variables.
+    Symbol* line = new_IntSymbol(0);
+
+    FnSymbol* fn = call->resolvedFunction();
+
+    INT_ASSERT(fn);
+    INT_ASSERT(fn->substitutionsPostResolve.size() > 0);
+
+    VarSymbol* var = toVarSymbol(fn->substitutionsPostResolve[0].value);
+
+    INT_ASSERT(var);
+    INT_ASSERT(var->immediate);
+    INT_ASSERT(var->immediate->const_kind == CONST_KIND_STRING);
+
+    const char* cmdLineSetting = astr("<command line setting of '",
+                                      var->immediate->v_string.c_str(), "'>");
+
+    int filenameIdx = getFilenameLookupPosition(cmdLineSetting);
+
+    Symbol* file = new_IntSymbol(filenameIdx, INT_SIZE_32);
+
+    return {line, file};
+
+  } else {
+    // Apply the line number from the call AST node
+    Symbol* line = new_IntSymbol(call->linenum());
+
+    int filenameIdx = getFilenameLookupPosition(call->fname());
+
+    Symbol* file = new_IntSymbol(filenameIdx, INT_SIZE_32);
+    return {line, file};
+  }
+}
+
+//
+// insert a line number and filename actual into a call
+// This can either be:
+//   * PRIM_GET_USER_FILE     -> replace
+//   * PRIM_GET_USER_LINE     -> replace
+//   * a call to a wrapper fn -> assign to arg bundle
+//   * a regular call         -> append to call args
+//
+void InsertLineNumbers::insertLineNumber(CallExpr* call, LineAndFile lineAndFile) {
+  SET_LINENO(call);
+  // Replace these primitives with whatever line/file we chose
+  // (probably an argument)
+  if (call->isPrimitive(PRIM_GET_USER_FILE)) {
+    call->replace(new SymExpr(lineAndFile.file));
+  } else if (call->isPrimitive(PRIM_GET_USER_LINE)) {
+    call->replace(new SymExpr(lineAndFile.line));
+  } else {
+    FnSymbol* fn = call->resolvedFunction();
+    if (fn && isWrapper(fn)) {
+      SET_LINENO(call);
+      // Refactor note: I pulled this case out of the moveLinenoInsideArgBundle
+      // pass b/c it seems better to handle in one go instead of fixing things
+      // up later. But, we do pull out the lineField and fileField each time
+      // here, which is an implicit coupling with the field names (and also a
+      // string lookup). Perhaps these should go in a map
+      //
+      // add line/file as assignments into the arg bundle
+      DefExpr* bundleArg = toDefExpr(fn->formals.tail);
+      Expr* bundleActual = call->argList.tail;
+      AggregateType* bundleType = toAggregateType(bundleArg->sym->typeInfo());
+      Symbol* lineField = bundleType->getField("_ln");
+      Symbol* fileField = bundleType->getField("_fn");
+      call->insertBefore(new CallExpr(PRIM_SET_MEMBER, bundleActual->copy(),
+                                      lineField, lineAndFile.line));
+      call->insertBefore(new CallExpr(PRIM_SET_MEMBER, bundleActual->copy(),
+                                      fileField, lineAndFile.file));
+
+    } else {
+      // add line/file as arguments to the call
+      call->insertAtTail(lineAndFile.line);
+      call->insertAtTail(lineAndFile.file);
+    }
+  }
+}
+
+// TODO refactor -- pulled this out as it can be checked per fn instead of per call
+void InsertLineNumbers::precondition(FnSymbol* fn) {
+  if (strcmp(fn->name, "chpl__heapAllocateGlobals") == 0 ||
+      strcmp(fn->name, "chpl__initStringLiterals") == 0 ||
+      strcmp(fn->name, "chpl__initModuleGuards") == 0 ||
+      strcmp(fn->name, "chpl_gen_main") == 0) {
+    assert(fn->hasFlag(FLAG_EXPORT) &&
+           !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO));
+  }
+}
+
+//
+// Get the line/file symbols for a function, creating them if necessary
+// The fn is either
+//   * a wrapper    -> add fields to arg bundle
+//   * a regular fn -> add formals to fn
+//
+// Since adding additional args (in any form) imposes work on all of fn's
+// callers, we enqueue each callsite to get procesed later. We don't fix them
+// immediately so that we aren't modifying someone else's FnSymbol
+//
+// If we have virtual roots or children, we also need them to to take line/file
+// args (if they aren't already). Here we do mark them with
+// FLAG_INSERT_LINE_FILE_INFO so that later processing can treat them
+// appropriately
+//
+LineAndFile InsertLineNumbers::getLineAndFileForFn(FnSymbol *fn) {
+  auto it = lineAndFilenameMap.find(fn);
+  if (it != lineAndFilenameMap.end()) {
+    return it->second;
+  }
+
+  SET_LINENO(fn);
+
+  LineAndFile result;
+
+  if (isWrapper(fn)) {
+    // In the body of the wrapper, create a local lineno variable initialized
+    // from the new corresponding field in the argument bundle.
+    DefExpr* bundleArg = toDefExpr(fn->formals.tail);
+    AggregateType* bundleType = toAggregateType(bundleArg->sym->typeInfo());
+
+    VarSymbol* lineField = newTemp("_ln", dtInt[INT_SIZE_DEFAULT]);
+    bundleType->fields.insertAtTail(new DefExpr(lineField));
+
+    VarSymbol* lineLocal = newTemp("_ln", dtInt[INT_SIZE_DEFAULT]);
+
+    fn->insertAtHead("'move'(%S, '.v'(%S, %S))", lineLocal, bundleArg->sym,
+                     lineField);
+    fn->insertAtHead(new DefExpr(lineLocal));
+
+    // Same thing, just for the filename index now.
+
+    VarSymbol* fileField = newTemp("_fn", dtInt[INT_SIZE_32]);
+    bundleType->fields.insertAtTail(new DefExpr(fileField));
+
+    VarSymbol* fileLocal = newTemp("_fn", dtInt[INT_SIZE_32]);
+
+    fn->insertAtHead("'move'(%S, '.v'(%S, %S))", fileLocal, bundleArg->sym,
+                     fileField);
+    fn->insertAtHead(new DefExpr(fileLocal));
+
+    result = {lineLocal, fileLocal};
+
+  } else {
+    ArgSymbol* line =
+        new ArgSymbol(INTENT_CONST_IN, "_ln", dtInt[INT_SIZE_DEFAULT]);
+    fn->insertFormalAtTail(line);
+
+    ArgSymbol* file = new ArgSymbol(INTENT_IN, "_fn", dtInt[INT_SIZE_32]);
+    fn->insertFormalAtTail(file);
+
+    result = {line, file};
+  }
+
+  lineAndFilenameMap.emplace_hint(it, fn, result);
+
+  for (CallExpr* call : *fn->calledBy) {
+    enqueue(call->getFunction(), call);
+  }
+
+  if (auto* others = rootsOrChildren(fn)) {
+    for (FnSymbol* fn : *others) {
+      fn->addFlag(FLAG_INSERT_LINE_FILE_INFO);
+      enqueue(fn);
+    }
+  }
+
+  return result;
+}
+
+//
+// InsertLineNumbers works on a function and has to take care of
+//   * modifying our own function (if necessary) to take line/file formals
+//   * modifying calls in our body that need line/file actuals
+//
+void InsertLineNumbers::process(FnSymbol *fn) {
+  // Refactor note: this precondition is a general check that could be hoisted
+  precondition(fn);
+
+  // if we must have line/file info formals
+  if (fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO) &&
+      !fn->hasFlag(FLAG_LINE_NUMBER_OK)) {
+    // Explicitly ignore the return result since we don't need it right now. Our
+    // call sites will be enqueued
+    std::ignore = getLineAndFileForFn(fn);
+  }
+
+  // We only need to process each call in our body once; calls which may later
+  // require line numbers will be enqueued by their function.
+  // We may need to process the fn itself more than once, so that if we discover
+  // a function needs a line/file formal after processing the first time, we can
+  // do so
+  if (alreadyProcessed(fn))
+    return;
+
+  // TODO iterator (or reuse calls)
+  std::vector<CallExpr*> calls;
+  collectCallExprs(fn, calls);
+
+  for (CallExpr* call : calls) {
+    if (call->primitive && call->primitive->passLineno) {
+      process(fn, call);
+    }
+  }
+}
+
+//
+// inserts the line number for `call` which is in the body `fn`
+// The line/file either come from the AST itself, or from the fn formals (or arg
+// pack), which is determined by `shouldPreferASTLine`
+//
+void InsertLineNumbers::process(FnSymbol *fn, CallExpr* call) {
+  if (shouldPreferASTLine(fn)) {
+    insertLineNumber(call, makeASTLine(call));
+
+  } else {
+    insertLineNumber(call, getLineAndFileForFn(fn));
+  }
+}
+
+// TODO move this into a more sensible home
+// ---------- InsertNilChecksPass ----------
+//
 // insert nil checks primitives in front of most member accesses
 //
 // Exceptions:
@@ -263,170 +394,77 @@ static bool isClassMethodCall(CallExpr* call) {
 //      invoke the destructor on NIL, so we avoid doing so when
 //      handling a call to a destructor.
 //
-static void insertNilChecks() {
-  forv_expanding_Vec(CallExpr, call, gCallExprs) {
-    // A member access is one of these primitives or a method call.
-    // A method call is expected to access its "this" argument.
-    if (call->isPrimitive(PRIM_GET_MEMBER)       ||
+bool InsertNilChecksPass::shouldProcess(CallExpr *call) {
+  if (!(call->isPrimitive(PRIM_GET_MEMBER) ||
         call->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
-        call->isPrimitive(PRIM_SET_MEMBER)       ||
-        call->isPrimitive(PRIM_GETCID)           ||
-        call->isPrimitive(PRIM_TESTCID)          ||
-        isClassMethodCall(call)) {
-      Expr*          arg0 = call->get(1);
-      AggregateType* ct   = toAggregateType(arg0->typeInfo());
-
-      if (ct && (isClass(ct) || ct->symbol->hasFlag(FLAG_WIDE_CLASS))) {
-        FnSymbol* fn = call->resolvedFunction();
-
-        // Avoid inserting a nil-check if this is a call to a destructor
-        if (fn == NULL || fn->hasFlag(FLAG_DESTRUCTOR) == false) {
-          Expr* stmt = call->getStmtExpr();
-
-          SET_LINENO(stmt);
-
-          stmt->insertBefore(new CallExpr(PRIM_CHECK_NIL, arg0->copy()));
-        }
-      }
-    }
+        call->isPrimitive(PRIM_SET_MEMBER) ||
+        call->isPrimitive(PRIM_GETCID) ||
+        call->isPrimitive(PRIM_TESTCID) ||
+        isClassMethodCall(call))) {
+    return false;
   }
+
+  Expr* arg0 = call->get(1);
+  AggregateType* ct = toAggregateType(arg0->typeInfo());
+
+  if (ct && (isClass(ct) || ct->symbol->hasFlag(FLAG_WIDE_CLASS))) {
+    // Avoid inserting a nil-check if this is a call to a destructor
+    if (FnSymbol* fn = call->resolvedFunction()) {
+      return !fn->hasFlag(FLAG_DESTRUCTOR);
+    }
+
+    return true;
+  }
+
+  return false;
 }
+
+void InsertNilChecksPass::process(CallExpr* call) {
+  Expr* arg0 = call->get(1);
+  Expr* stmt = call->getStmtExpr();
+
+  SET_LINENO(stmt);
+
+  stmt->insertBefore(new CallExpr(PRIM_CHECK_NIL, arg0->copy()));
+}
+
+// --------------------
+
+#include "global-ast-vecs.h"
 
 void insertLineNumbers() {
-  compute_call_sites();
+  PassManager pm;
 
-  // Temporary vector that stores some constant filenames that are used
-  // directly by the runtime. The index for these matter, and are provided to
-  // the runtime as defines in chpl-linefile-support.h
-  std::vector<std::string> constantFilenames;
+  // It's pretty apparent in this refactoring that we don't actually need to
+  // recompute all call sites, but only the subset we'll be working on, which
+  // is probably better done on demand
+  pm.runPass<FnSymbol*>(ComputeCallSitesPass(), gFnSymbols);
 
-  // Put a null string into the iterator at the first position, some runtime
-  // calls will pass in NULL for their filename, we can then use this null
-  // string to deal with that case.
-  constantFilenames.push_back("");
+  {
+    std::vector<std::string> constantFilenames;
 
-  // Add "<internal>" to the filename table if it didn't make it in there, some
-  // runtime functions use this name directly, and it doesn't always end up in
-  // the table otherwise
-  constantFilenames.push_back("<internal>");
+    // Put a null string into the iterator at the first position, some runtime
+    // calls will pass in NULL for their filename, we can then use this null
+    // string to deal with that case.
+    constantFilenames.push_back("");
 
-  gFilenameLookup.insert(gFilenameLookup.begin(),
-                         constantFilenames.begin(),
-                         constantFilenames.end());
+    // Add "<internal>" to the filename table if it didn't make it in there,
+    // some runtime functions use this name directly, and it doesn't always end
+    // up in the table otherwise
+    constantFilenames.push_back("<internal>");
 
+    gFilenameLookup.insert(gFilenameLookup.begin(), constantFilenames.begin(),
+                           constantFilenames.end());
+  }
+
+  // refactoring  TODO: why is InsertNilChecks in this pass?
   if (!fNoNilChecks) {
-    insertNilChecks();
+    pm.runPass<CallExpr*>(InsertNilChecksPass(), gCallExprs);
   }
 
-  // loop over all primitives that require a line number and filename
-  // and pass them an actual line number and filename
-  forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->primitive && call->primitive->passLineno) {
-      insertLineNumber(call);
-    }
-  }
-
-  // loop over all marked functions ("insert line file info"), add
-  // line number and filename arguments to these functions, and add
-  // them to the queue
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO) &&
-        !fn->hasFlag(FLAG_LINE_NUMBER_OK)) {
-      if (!filenameMap.get(fn)) {  // avoid duplicates
-        SET_LINENO(fn);
-        newLine(fn);
-        newFile(fn);
-      }
-    }
-  }
-
-  // loop over all functions in the queue and all calls to these
-  // functions, and pass the calls an actual line number and filename
-  // Note: 'queue' may be appended to during this loop
-  while (queue.empty() == false) {
-    FnSymbol* fn = queue.front();
-    queue.pop();
-
-    forv_Vec(CallExpr, call, *fn->calledBy) {
-      insertLineNumber(call);
-    }
-  }
-
-  moveLinenoInsideArgBundle();
-}
-
-static void moveLinenoInsideArgBundle()
-{
-  // pass line number and filename arguments to functions that are
-  // forked via the argument class
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    ArgSymbol* lineArgSym;
-    ArgSymbol* filenameArgSym;
-
-    if (fn->hasFlag(FLAG_ON_BLOCK) ||
-        fn->hasFlag(FLAG_BEGIN_BLOCK) ||
-        fn->hasFlag(FLAG_COBEGIN_OR_COFORALL_BLOCK)) {
-
-      lineArgSym = linenoMap.get(fn);
-      filenameArgSym = filenameMap.get(fn);
-
-      // Either both should be set, or neither.
-      INT_ASSERT( (lineArgSym == NULL && filenameArgSym == NULL) ||
-                  (lineArgSym != NULL && filenameArgSym != NULL) );
-
-      if (lineArgSym != NULL && filenameArgSym != NULL) {
-        // This task (wrapper) function is not actually called with lineno, fname
-        // arguments, so remove them.
-        SET_LINENO(fn);
-        DefExpr* fileArg = filenameArgSym->defPoint;
-        fileArg->remove();
-        DefExpr* lineArg = lineArgSym->defPoint;
-        lineArg->remove();
-
-        // In the body of the wrapper, create a local lineno variable initialized
-        // from the new corresponding field in the argument bundle.
-        DefExpr* bundleArg = toDefExpr(fn->formals.tail);
-        AggregateType* bundleType = toAggregateType(bundleArg->sym->typeInfo());
-
-        VarSymbol* lineField = newTemp("_ln", lineArg->sym->typeInfo());
-        bundleType->fields.insertAtTail(new DefExpr(lineField));
-
-        VarSymbol* lineLocal = newTemp("_ln", lineArg->sym->typeInfo());
-
-        fn->insertAtHead("'move'(%S, '.v'(%S, %S))", lineLocal, bundleArg->sym, lineField);
-        fn->insertAtHead(new DefExpr(lineLocal));
-
-        // Same thing, just for the filename index now.
-
-        VarSymbol* fileField = newTemp("_fn", fileArg->sym->typeInfo());
-        bundleType->fields.insertAtTail(new DefExpr(fileField));
-
-        VarSymbol* fileLocal = newTemp("_fn", fileArg->sym->typeInfo());
-
-        fn->insertAtHead("'move'(%S, '.v'(%S, %S))", fileLocal, bundleArg->sym, fileField);
-        fn->insertAtHead(new DefExpr(fileLocal));
-
-        // Replace references to the (removed) arguments with
-        // references to these local variables.
-        SymbolMap update;
-        update.put(fileArg->sym, fileLocal);
-        update.put(lineArg->sym, lineLocal);
-        update_symbols(fn->body, &update);
-
-        // In each direct caller of this wrapper function (are there any?),
-        // Remove actual arguments containing the lineno and filename.
-        // Put these in the argument bundle instead.
-        forv_Vec(CallExpr, call, *fn->calledBy) {
-          SET_LINENO(call);
-          Expr* fileActual = call->argList.tail->remove();
-          Expr* lineActual = call->argList.tail->remove();
-          Expr* bundleActual = call->argList.tail;
-          call->insertBefore(new CallExpr(PRIM_SET_MEMBER, bundleActual->copy(),
-                                          lineField, lineActual));
-          call->insertBefore(new CallExpr(PRIM_SET_MEMBER, bundleActual->copy(),
-                                          fileField, fileActual));
-        }
-      }
-    }
-  }
+  // TODO: this is a WIP state on integrating with the PassManager
+  // right now, we pass the same instance of InsertLineNumbers so it can
+  // maintain state and it handles the queuing
+  //
+  pm.runPass<FnSymbol*>(InsertLineNumbers(), gFnSymbols);
 }

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -321,6 +321,7 @@ LineAndFile InsertLineNumbers::getLineAndFileForFn(FnSymbol *fn) {
 
   lineAndFilenameMap.emplace_hint(it, fn, result);
 
+  // NOTE: this requires that we have run ComputeCallSitesPass
   for (CallExpr* call : *fn->calledBy) {
     enqueue(call->getFunction(), call);
   }
@@ -437,9 +438,11 @@ void InsertNilChecksPass::process(CallExpr* call) {
 void insertLineNumbers() {
   PassManager pm;
 
-  // TODO It's pretty apparent in this refactoring that we don't actually need to
-  // recompute all call sites, but only the subset we'll be working on, which
+  // TODO It's pretty apparent in this refactoring that we don't actually need
+  // to recompute all call sites, but only the subset we'll be working on, which
   // is probably better done on demand
+  // NOTE this is required for looking up fn->calledBy in
+  // InsertLineNumbers::getLineAndFileForFn
   pm.runPass<FnSymbol*>(ComputeCallSitesPass(), gFnSymbols);
 
   {

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -136,7 +136,8 @@ bool InsertLineNumbers::shouldPreferASTLine(/*const*/ FnSymbol* fn,
       !fn->hasFlag(FLAG_INSERT_LINE_FILE_INFO))
     return true;
 
-  // TODO can we mark the FnSymbol directly instead of checking this global map
+  // TODO can we mark the FnSymbol directly instead of checking this global map?
+  //      Or maybe you could know it is an ftable call based on how it is called
   // don't add arguments to ftable calls
   if (ftableMap.count(fn))
     return true;
@@ -351,11 +352,12 @@ void InsertLineNumbers::process(FnSymbol *fn) {
     std::ignore = getLineAndFileForFn(fn);
   }
 
-  // We only need to process each call in our body once; calls which may later
-  // require line numbers will be enqueued by their function.
-  // We may need to process the fn itself more than once, so that if we discover
-  // a function needs a line/file formal after processing the first time, we can
-  // do so
+  // This check is after the above getLineAndFileForFn because we only
+  // need to process each call in our body once; calls which may later
+  // require line numbers will be enqueued by their function.  We may
+  // need to process the fn itself more than once, so that if we
+  // discover a function needs a line/file formal after processing the
+  // first time, we can do so
   if (alreadyProcessed(fn))
     return;
 
@@ -435,7 +437,7 @@ void InsertNilChecksPass::process(CallExpr* call) {
 void insertLineNumbers() {
   PassManager pm;
 
-  // It's pretty apparent in this refactoring that we don't actually need to
+  // TODO It's pretty apparent in this refactoring that we don't actually need to
   // recompute all call sites, but only the subset we'll be working on, which
   // is probably better done on demand
   pm.runPass<FnSymbol*>(ComputeCallSitesPass(), gFnSymbols);


### PR DESCRIPTION
Refactor insertLineNumbers to use the PassManager.

This is a refactor of the insertLineNumbers (and insertNilChecks
pass(es) to use the PassManager.

insertNilChecks is straightforward and all good -- though perhaps out
of place for this pass.

The real crux in insertLineNumbers is that it quickly pops out of
isolation. With the PassManager, we'd like to move towards a world
where a pass operates on a Function (for instance) and only modify
things it contains. In this case, we run into a scenario where we need
to modify ourselves (the Function we're working on) AND all of its
call sites. This is a common pattern in whole program compilers.

To do that, the InsertLineNumbers has a (unordered) queue of Functions
that need to be processed. When processing our own function, if we
need to modify someone else, we instead enqueue the work and trust
that the PassManager will drain the queue. Similarly, when we need to
process a Call that does not live in the currently processed Function,
we instead enqueue it because processing it may modify its enclosing
Function.

By queueing work later and waiting for the PassManager to drive it,
we're giving the PassManager a place to -- in the future -- mediate
these modifications so they may take place on different parts of the
AST in different parts of the compilation pipeline.

In this refactor, I've also removed the need for "move line inside
args bundle" because I'm handling them in the general case instead of
fixing them up afterwards.

* [x] paratest
* [x] paratest --fast
* [x] paratest w/ comm