### PR TITLE
Bandaid fix to avoid race condition in gpu testing

### DIFF
--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -16,4 +16,9 @@ export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=stormP100
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
 
+# Setting this export is a temporary solution in the hopes that it will prevent
+# a race condition that is causing sporadic test failures in Jenkins (see
+# Github issue #3073 for more information).
+export CHPL_RT_NUM_THREADS_PER_LOCALE=1
+
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
We're seeing this sporadic failure (https://github.com/Cray/chapel-private/issues/2606) almost every night in our Jenkins job.

I'm thinking there's a race condition that exists between memory being allocated and launching a kernel (see https://github.com/Cray/chapel-private/issues/3073#issuecomment-1039680523 for more details). So I'm hoping if I set `CHPL_RT_NUM_THREADS_PER_LOCALE=1` the race condition will go away.

Obviously this isn't ideal (we want users to be able to run GPU code and have more than one task per locale). But in the interest of making our Jenkins job less noisy until we find a better solution I'd like to submit this "bandaid fix".