### PR TITLE
Update user-defined hash documentation

### DIFF
--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -643,30 +643,46 @@ order they are declared in the record definition.
 Hashing a Record
 ~~~~~~~~~~~~~~~~
 
-When a record is the key for a hashtable, including when using it as the index
-type for an associative domain, the compiler will generate a default hash
-function to use. This behavior can be overridden if more control of the
-hashing used is desired. This can be done by defining a ``hash`` method on
-a record.
+For any record that does not have a user-defined ``==`` or ``!=``
+operator, the compiler will automatically define a default hash method
+for it.  This allows values of that record type to be used as the
+indices of an associative domain, the elements of a set, or the keys
+of a map.  The user can override this default hash method (or provide
+one in cases that the compiler does not) by defining their own method
+named ``hash`` on the record which takes no arguments and returns a
+``uint`` or ``int``.
 
-.. code-block:: chapel
+   *Example (userhash.chpl)*.
 
-   use Map;
-   var m = new map(R, int);
-   proc R.hash() {
-     writeln("In custom hash function");
-     return i;
-   }
-   var myR = new R();
-   // Indexing the map using an instance of R using the R.hash() method
-   m[myR] = 5;
+   .. code-block:: chapel
 
-   var myD = domain(R);
-   myD += myR;
 
-Note that the compiler generated ``hash`` can only be overriden on records
-that have been defined in user code, and will not override the compiler hash
-for ``int.hash``, for example.
+      record R {
+        var i: uint;
+
+        proc hash() {
+          writeln("In custom hash function");
+          return i;
+        }
+      }
+
+      // Creating an associative domain with an 'idxType' of 'R'
+      // invokes R.hash() as part of its implementation
+
+      var D: domain(R);
+      var r = new R(42);
+      D += r;
+      writeln(D);
+
+   .. BLOCK-test-chapeloutput
+
+      In custom hash function
+      {(i = 42)}
+
+Note that the compiler-generated ``hash`` can only be overridden for
+records that have been defined in user code, and cannot be used to
+override the default hash for built-in types like ``int``, for
+example.
 
 
 

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -660,7 +660,7 @@ named ``hash`` on the record which takes no arguments and returns a
       record R {
         var i: uint;
 
-        proc hash() {
+        proc hash(): uint {
           writeln("In custom hash function");
           return i;
         }
@@ -680,9 +680,9 @@ named ``hash`` on the record which takes no arguments and returns a
       {(i = 42)}
 
 Note that the compiler-generated ``hash`` can only be overridden for
-records that have been defined in user code, and cannot be used to
-override the default hash for built-in types like ``int``, for
-example.
+records that have been defined in user code.  As an result, this
+feature cannot be used to override the default hash for built-in types
+like ``int``.
 
 
 

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -114,6 +114,13 @@ writeln(r.vals);
   --------------
 */
 
+// By default, the compiler will define a hash method for any record
+// that does not define its own ``==`` or ``!=`` overloads.  This
+// permits such records to be used as the indices of associative
+// domains, the values in a :mod:`Set`, or the keys in a :mod:`Map`.
+// Users can override this default by supplying their own hash method
+// that returns a ``uint`` or ``int`` value.  For example:
+
 use Map;
 
 proc R.hash() {
@@ -121,10 +128,10 @@ proc R.hash() {
   return vals[0];
 }
 
-// Now that the record R has a ``hash`` method defined, Chapel's map
-// and associative domain will call this custom ``hash`` instead of
-// the compiler generated method for ``hash``. Note that this only works
-// for records and will not apply to defining a ``int.hash`` for example.
+// Now that the record R has a ``hash`` method defined, Chapel's,
+// ``set``, ``map``, and associative domain types will call this
+// custom ``hash`` instead of the compiler-generated method.
+
 var myMap = new map(R, int);
 var myD: domain(R);
 var myR = new R();

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -123,7 +123,7 @@ writeln(r.vals);
 
 use Map;
 
-proc R.hash() {
+proc R.hash(): int {
   writeln("In custom hash function");
   return vals[0];
 }


### PR DESCRIPTION
This is a follow-on to #19243 to document when the compiler
will or will not provide a hash function for a user record.  While
here, I also attempted to improve the existing documentation by:
* making the spec example for a user-defined hash testable and
  complete, fixing some typos
* providing a bit more context in the primer and removing the note
  about built-in types (since the primer is about special methods
  on classes and records and doesn't need to be as complete as
  the spec)
* word-smithing
* adding return types to the documentation examples of hash()

While here, I found myself questioning whether "returning `int`
or `uint`" was what we wanted to commit to, combined with
slight discomfort with the fact that the high bit is ignored in our
implementation without us saying so, so filed
https://github.com/chapel-lang/chapel/issues/19285 to capture
this concern.