### PR TITLE
A spectral norm variant that avoids a reciprocal and unrolls by two

### DIFF
--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -1,9 +1,9 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
-   contributed by Brad Chamberlain
-   a serial version derived from the Chapel version by Lydia Duncan,
-   Albert Sidelnik, and Brad Chamberlain
+   contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
+   derived from the GNU C version by Sebastien Loisel and the C# version
+   by Isaac Gouy
 */
 
 config const n = 500;           // the size of A (n x n), u and v (n-vectors)
@@ -33,29 +33,21 @@ proc multiplyAtAv(v, tmp, AtAv) {
 // Compute A * v ('Av').
 //
 proc multiplyAv(v: [?Dv], Av: [?DAv]) {
-  for i in DAv {
-    var av = 0.0;
-    for j in Dv do
-      av += A[i,j] * v[j];
-    Av[i] = av;
-  }
+  forall i in DAv do
+    Av[i] = + reduce (for j in Dv by 2 do (v[j] / A[i,j] + v[j+1] / A[i,j+1]));
 }
 
 //
 // Compute A-tranpose * v ('Atv').
 //
 proc multiplyAtv(v: [?Dv], Atv: [?DAtv]) {
-  for i in DAtv {
-    var atv = 0.0;
-    for j in Dv do
-      atv += A[j,i] * v[j];
-    Atv[i] = atv;
-  }
+  forall i in DAtv do
+    Atv[i] = + reduce (for j in Dv by 2 do (v[j] / A[j,i] + v[j+1] / A[j+1,i]));
 }
 
 //
 // Compute element i,j of the conceptually infinite matrix A.
 //
-inline proc A(i, j) {
-  return 1.0 / ((((i+j) * (i+j+1)) / 2) + i + 1);
+inline proc A(i:real, j:real) {
+  return ((((i+j) * (i+j+1)) / 2) + i + 1);
 }


### PR DESCRIPTION
This seemed to give a nice speedup on my Mac.  Let's see what it does in
nightly testing.
