### PR TITLE
Use PassManager in addInitGuards, localizeGlobals, bulkCopyRecords, and removeUnnecessaryAutoCopyCalls

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -21,6 +21,7 @@
 #ifndef _PASSES_H_
 #define _PASSES_H_
 
+#include "FnSymbol.h"
 #include "symbol.h"
 #include "PassManager.h"
 
@@ -179,6 +180,28 @@ class ComputeCallSitesPass : public PassT<FnSymbol*> {
 
 class FlattenClasses : public PassT<TypeSymbol*> {
   void process(TypeSymbol* ts) override;
+};
+
+// addInitGuards.cpp
+class AddInitGuards : public PassT<ModuleSymbol*> {
+ public:
+  AddInitGuards();
+  bool shouldProcess(ModuleSymbol* mod) override;
+  void process(ModuleSymbol* mod) override;
+
+  static FnSymbol* getOrCreatePreInitFn();
+  static void addInitGuard(FnSymbol* fn, FnSymbol* preInitfn);
+  static void addPrintModInitOrder(FnSymbol* fn);
+
+ private:
+  // This is the global preInitFn
+  FnSymbol* preInitFn;
+};
+
+class AddModuleInitBlocks : public PassT<ModuleSymbol*> {
+ public:
+  bool shouldProcess(ModuleSymbol* mod) override;
+  void process(ModuleSymbol* mod) override;
 };
 
 #endif

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -213,4 +213,23 @@ class LocalizeGlobals : public PassT<FnSymbol*> {
   std::vector<SymExpr*> symExprs;
 };
 
+class BulkCopyRecords : public PassT<FnSymbol*> {
+ public:
+  bool shouldProcess(FnSymbol* fn) override;
+  void process(FnSymbol* fn) override;
+
+  // TODO: this is a "pure" function on types, but uses
+  // a map for caching. Could break out
+  bool typeContainsRef(Type* t, bool isRoot = true);
+
+  bool isTrivialAssignment(FnSymbol* fn);
+
+  static void replaceSimpleAssignment(FnSymbol* fn);
+
+  static bool isAssignment(FnSymbol* fn);
+
+ private:
+  std::map<Type*, bool> containsRef;
+};
+
 #endif

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -204,4 +204,13 @@ class AddModuleInitBlocks : public PassT<ModuleSymbol*> {
   void process(ModuleSymbol* mod) override;
 };
 
+class LocalizeGlobals : public PassT<FnSymbol*> {
+ public:
+  void process(FnSymbol* fn) override;
+
+ private:
+  Map<Symbol*, VarSymbol*> globals;
+  std::vector<SymExpr*> symExprs;
+};
+
 #endif

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -232,4 +232,13 @@ class BulkCopyRecords : public PassT<FnSymbol*> {
   std::map<Type*, bool> containsRef;
 };
 
+class RemoveUnnecessaryAutoCopyCalls : public PassT<FnSymbol*> {
+ public:
+  bool shouldProcess(FnSymbol* fn) override;
+  void process(FnSymbol* fn) override;
+
+ private:
+  std::vector<CallExpr*> calls;
+};
+
 #endif

--- a/compiler/optimizations/bulkCopyRecords.cpp
+++ b/compiler/optimizations/bulkCopyRecords.cpp
@@ -23,6 +23,9 @@
 // Look for record assignment functions that can be replaced by an assign
 // primitive.
 //
+#include "FnSymbol.h"
+#include "PassManager.h"
+#include "baseAST.h"
 #include "passes.h" // For global declaration of the main routine.
 
 #include "stmt.h"
@@ -30,12 +33,7 @@
 #include "stlUtil.h"
 #include "resolution.h" // isPOD
 
-#include "global-ast-vecs.h"
-
-static bool isAssignment(FnSymbol* fn);
-static bool isTrivialAssignment(FnSymbol* fn);
-
-static bool isAssignment(FnSymbol* fn)
+bool BulkCopyRecords::isAssignment(FnSymbol* fn)
 {
   if (! fn->hasFlag(FLAG_ASSIGNOP))
     return false;
@@ -45,9 +43,7 @@ static bool isAssignment(FnSymbol* fn)
   return true;
 }
 
-static std::map<Type*, bool> containsRef;
-
-static bool typeContainsRef(Type* t, bool isRoot = true)
+bool BulkCopyRecords::typeContainsRef(Type* t, bool isRoot)
 {
   if (containsRef.count(t))
     return containsRef[t];
@@ -78,7 +74,7 @@ static bool typeContainsRef(Type* t, bool isRoot = true)
     - the lhs and rhs arguments are POD types
     - the lhs and rhs arguments do not contain references
  */
-static bool isTrivialAssignment(FnSymbol* fn)
+bool BulkCopyRecords::isTrivialAssignment(FnSymbol* fn)
 {
   if (! isAssignment(fn))
     return false;
@@ -114,7 +110,7 @@ static bool isTrivialAssignment(FnSymbol* fn)
 // (PRIM_ASSIGN) operation.  In the generated code, PRIM_ASSIGN on a type that
 // is represented by a C struct will be rendered as a struct assignment, which
 // the C compiler can implement as a memcpy.
-static void replaceSimpleAssignment(FnSymbol* fn)
+void BulkCopyRecords::replaceSimpleAssignment(FnSymbol* fn)
 {
   SET_LINENO(fn);
   SymExpr* lhs = new SymExpr(fn->getFormal(1));
@@ -125,19 +121,27 @@ static void replaceSimpleAssignment(FnSymbol* fn)
   fn->body->replace(block);
 }
 
+bool BulkCopyRecords::shouldProcess(FnSymbol* fn) {
+  // We do not convert wrapper functions (only the functions that do the
+  // actual assignment).
+  if (fn->hasFlag(FLAG_WRAPPER))
+    return false;
 
-void bulkCopyRecords()
-{
-  forv_Vec(FnSymbol, fn, gFnSymbols)
-  {
-    // We do not convert wrapper functions (only the functions that do the
-    // actual assignment).
-    if (fn->hasFlag(FLAG_WRAPPER))
-      continue;
+  return isTrivialAssignment(fn);
+}
 
-    if (isTrivialAssignment(fn))
-      replaceSimpleAssignment(fn);
-  }
+void BulkCopyRecords::process(FnSymbol* fn) {
+  replaceSimpleAssignment(fn);
+  // TODO PAssManager I think here would be a great place
+  // for a stats gather method so we can easiliy count how
+  // many things actually got replaced
+  // passes do this on their own today in various forms
+  // And this could also extend to a verify
+}
 
-  containsRef.clear();
+#include "global-ast-vecs.h"
+
+void bulkCopyRecords() {
+  PassManager pm;
+  pm.runPass<FnSymbol*>(BulkCopyRecords(), gFnSymbols);
 }

--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#include "FnSymbol.h"
+#include "PassManager.h"
+#include "baseAST.h"
 #include "passes.h"
 
 #include "astutil.h"
@@ -27,10 +30,10 @@
 #include "stmt.h"
 #include "stringutil.h"
 
-#include "global-ast-vecs.h"
 
 #include <cstdio>
 
+// ---------- LocalizeGlobals ----------
 // This pass pulls out any global constants to the top of the given
 // function (with the motivation to avoid loads during loops).
 
@@ -39,56 +42,65 @@
 // would set a local copy of a given value, and other functions wouldn't
 // see the intended value.
 
-void localizeGlobals() {
-  if (fNoGlobalConstOpt) return;
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    Map<Symbol*,VarSymbol*> globals;
-    std::vector<BaseAST*> asts;
-    collect_asts(fn->body, asts);
-    for_vector(BaseAST, ast, asts) {
-      if (SymExpr* se = toSymExpr(ast)) {
-        Symbol* var = se->symbol();
-        ModuleSymbol* parentmod = toModuleSymbol(var->defPoint->parentSymbol);
-        CallExpr* parentExpr = toCallExpr(se->parentExpr);
-        bool inAddrOf = parentExpr && (parentExpr->isPrimitive(PRIM_ADDR_OF) || parentExpr->isPrimitive(PRIM_SET_REFERENCE));
-        bool lhsOfMove = parentExpr && isMoveOrAssign(parentExpr) && (parentExpr->get(1) == se);
+void LocalizeGlobals::process(FnSymbol* fn) {
+  // REFACTOR Q -- keeping these around is nice for re-use, but maybe we should
+  // have a standard method like ::cleanup/teardown
+  symExprs.clear();
+  globals.clear();
 
-        // Is var a global constant?
-        // Don't replace the var name in its init function since that's
-        //      where we're setting the value. Similarly, dont replace them
-        //      inside initStringLiterals
-        // If the parentSymbol is the rootModule, the var is 'void,'
-        //      'false,' '0,' ...
-        // Also don't replace it when it's in an addr of primitive.
-        if (parentmod &&
-            fn != parentmod->initFn &&
-            fn != initStringLiterals &&
-            !inAddrOf &&
-            !lhsOfMove &&
-            var->hasFlag(FLAG_CONST) &&
-            !var->hasFlag(FLAG_EXTERN) &&
-            var->defPoint->parentSymbol != rootModule) {
-          VarSymbol* local_global = globals.get(var);
-          SET_LINENO(se); // Set the se line number for output
-          if (!local_global) {
-            const char * newname = astr("local_", var->cname);
-            local_global = newTemp(newname, var->qualType());
-            fn->insertAtHead(new CallExpr(PRIM_MOVE, local_global, var));
-            fn->insertAtHead(new DefExpr(local_global));
+  // TODO TRAVERSE
+  collectSymExprs(fn->body, symExprs);
+  for (SymExpr* se : symExprs) {
+    Symbol* var = se->symbol();
+    ModuleSymbol* parentmod = toModuleSymbol(var->defPoint->parentSymbol);
+    CallExpr* parentExpr = toCallExpr(se->parentExpr);
+    bool inAddrOf = parentExpr && (parentExpr->isPrimitive(PRIM_ADDR_OF) ||
+                                   parentExpr->isPrimitive(PRIM_SET_REFERENCE));
+    bool lhsOfMove =
+        parentExpr && isMoveOrAssign(parentExpr) && (parentExpr->get(1) == se);
 
-            // Copy string immediates to localized strings so that
-            // we can show the string value in comments next to uses.
-            if (!fLlvmCodegen)
-              if (VarSymbol* localVarSym = toVarSymbol(var))
-                if (Immediate* immediate = localVarSym->immediate)
-                  if (immediate->const_kind == CONST_KIND_STRING)
-                    local_global->immediate = new Immediate(immediate);
+    // Is var a global constant?
+    // Don't replace the var name in its init function since that's
+    //      where we're setting the value. Similarly, dont replace them
+    //      inside initStringLiterals
+    // If the parentSymbol is the rootModule, the var is 'void,'
+    //      'false,' '0,' ...
+    // Also don't replace it when it's in an addr of primitive.
+    if (parentmod &&
+        fn != parentmod->initFn &&
+        fn != initStringLiterals &&
+        !inAddrOf &&
+        !lhsOfMove &&
+        var->hasFlag(FLAG_CONST) &&
+        !var->hasFlag(FLAG_EXTERN) &&
+        var->defPoint->parentSymbol != rootModule) {
+      VarSymbol* local_global = globals.get(var);
+      SET_LINENO(se); // Set the se line number for output
+      if (!local_global) {
+        const char* newname = astr("local_", var->cname);
+        local_global = newTemp(newname, var->qualType());
+        fn->insertAtHead(new CallExpr(PRIM_MOVE, local_global, var));
+        fn->insertAtHead(new DefExpr(local_global));
 
-            globals.put(var, local_global);
-          }
-          se->replace(new SymExpr(toSymbol(local_global)));
-        }
+        // Copy string immediates to localized strings so that
+        // we can show the string value in comments next to uses.
+        if (!fLlvmCodegen)
+          if (VarSymbol* localVarSym = toVarSymbol(var))
+            if (Immediate* immediate = localVarSym->immediate)
+              if (immediate->const_kind == CONST_KIND_STRING)
+                local_global->immediate = new Immediate(immediate);
+
+        globals.put(var, local_global);
       }
+      se->replace(new SymExpr(toSymbol(local_global)));
     }
   }
+}
+
+#include "global-ast-vecs.h"
+
+void localizeGlobals() {
+  PassManager pm;
+  if (fNoGlobalConstOpt) return;
+  pm.runPass<FnSymbol*>(LocalizeGlobals(), gFnSymbols);
 }

--- a/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
+++ b/compiler/optimizations/removeUnnecessaryAutoCopyCalls.cpp
@@ -27,83 +27,84 @@
 #include "stlUtil.h"
 #include "stmt.h"
 
-#include "global-ast-vecs.h"
-
 // We can remove the calls to chpl__initCopy (should actually be chpl__autoCopy)
 // and corresponding calls to chpl__autoDestroy for Plain-Old-Data (POD) types.
 // See isPOD() and propagateNotPOD().
-static void removePODinitDestroy()
+
+//
+// remove pointless initCopy calls, e.g., initCopy calls on records of
+// primitive types
+//
+
+bool RemoveUnnecessaryAutoCopyCalls::shouldProcess(FnSymbol* fn) {
+  if (fn->hasEitherFlag(FLAG_INIT_COPY_FN, FLAG_AUTO_COPY_FN)) {
+    if (fn->retType == dtNothing)
+      // initCopy(none) and autoCopy(none) will have had their nothing
+      // argument removed
+      return false;
+
+    // We expect both initCopy and autoCopy functions to have two arguments
+    // second argument: whose type is the same as the return type
+    // definedConst: whether the LHS was defined const
+    INT_ASSERT(fn->numFormals() >= 2);
+
+    if (fn->getFormal(1)->type != fn->retType)
+      // In some cases, the autoCopy function has a different return type than
+      // its argument type.
+      // In that case, the replace() below won't work because it will cause a
+      // type mismatch at the call sites, so we just punt.
+      return false;
+
+    return isPOD(fn->retType);
+  }
+
+  return false;
+}
+
+// TODO this uses removeInitOrAutoCopyPostResolution
+void RemoveUnnecessaryAutoCopyCalls::process(FnSymbol* fn)
 {
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->hasFlag(FLAG_INIT_COPY_FN) || fn->hasFlag(FLAG_AUTO_COPY_FN))
-    {
-      if (fn->retType == dtNothing)
-        // initCopy(none) and autoCopy(none) will have had their nothing
-        // argument removed
-        continue;
+  calls.clear();
+  assert(isPOD(fn->retType)); // precondition from shouldProcess
 
-      // We expect both initCopy and autoCopy functions to have two arguments
-      // second argument: whose type is the same as the return type
-      // definedConst: whether the LHS was defined const
-      INT_ASSERT(fn->numFormals() >= 2);
+  // Gather calls of this function
+  for_SymbolSymExprs(se, fn) { calls.push_back(toCallExpr(se->parentExpr)); }
 
-      if (fn->getFormal(1)->type != fn->retType)
-        // In some cases, the autoCopy function has a different return type than
-        // its argument type.
-        // In that case, the replace() below won't work because it will cause a
-        // type mismatch at the call sites, so we just punt.
-        continue;
+  // Remove those calls we gathered
+  for (CallExpr* call : calls) {
+    Expr* actual = call->get(1);
+    ArgSymbol* arg = actual_to_formal(actual);
+    if (arg) {
+      arg->removeFlag(FLAG_INSERT_AUTO_DESTROY);
+      arg->removeFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW);
+    } else
+      INT_FATAL(arg, "Expected autoCopy argument to be a SymExpr.");
 
-      if (isPOD(fn->retType)) {
-        std::vector<CallExpr*> calls;
+    // Bridge out the autoCopy call.
 
-        // Gather calls of this function
-        for_SymbolSymExprs(se, fn) {
-          calls.push_back(toCallExpr(se->parentExpr));
-        }
+    Type* lhsType = NULL;
+    Type* rhsType = actual->typeInfo();
 
-        // Remove those calls we gathered
-        for_vector(CallExpr, call, calls) {
-          Expr* actual = call->get(1);
-          ArgSymbol* arg = actual_to_formal(actual);
-          if (arg)
-          {
-            arg->removeFlag(FLAG_INSERT_AUTO_DESTROY);
-            arg->removeFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW);
-          }
-          else
-            INT_FATAL(arg, "Expected autoCopy argument to be a SymExpr.");
+    CallExpr* move = toCallExpr(call->parentExpr);
+    INT_ASSERT(isMoveOrAssign(move));
+    lhsType = move->get(1)->typeInfo();
 
-          // Bridge out the autoCopy call.
+    SET_LINENO(call);
 
-          Type* lhsType = NULL;
-          Type* rhsType = actual->typeInfo();
-
-          CallExpr* move = toCallExpr(call->parentExpr);
-          INT_ASSERT(isMoveOrAssign(move));
-          lhsType = move->get(1)->typeInfo();
-
-          SET_LINENO(call);
-
-          if (lhsType->getValType() != rhsType->getValType()) {
-            INT_FATAL(actual, "Type mismatch in updateAutoCopy");
-          } else {
-            removeInitOrAutoCopyPostResolution(call);
-          }
-        }
-      }
+    if (lhsType->getValType() != rhsType->getValType()) {
+      INT_FATAL(actual, "Type mismatch in updateAutoCopy");
+    } else {
+      removeInitOrAutoCopyPostResolution(call);
     }
   }
 }
 
+#include "global-ast-vecs.h"
 
 void removeUnnecessaryAutoCopyCalls() {
   if (fNoRemoveCopyCalls)
     return;
 
-  //
-  // remove pointless initCopy calls, e.g., initCopy calls on records of
-  // primitive types
-  //
-  removePODinitDestroy();
+  PassManager pm;
+  pm.runPass<FnSymbol*>(RemoveUnnecessaryAutoCopyCalls(), gFnSymbols);
 }

--- a/compiler/passes/addInitGuards.cpp
+++ b/compiler/passes/addInitGuards.cpp
@@ -31,6 +31,9 @@
 // This pass must be run after parallel().
 //
 
+#include "ModuleSymbol.h"
+#include "baseAST.h"
+#include "misc.h"
 #include "passes.h"
 
 #include "astutil.h"
@@ -39,64 +42,10 @@
 #include "stringutil.h"
 #include "wellknown.h"
 
-#include "global-ast-vecs.h"
+#include "PassManager.h"
 
-static void addModuleInitBlocks();
-static void addInitGuards();
-static void addInitGuard(FnSymbol* fn, FnSymbol* preInitFn);
-static void addPrintModInitOrder(FnSymbol* fn);
-
-void addInitCalls()
-{
-  addModuleInitBlocks();
-  addInitGuards();
-}
-
-
-void addModuleInitBlocks() {
-  forv_Vec(ModuleSymbol, mod, gModuleSymbols) {
-    // Not for the root module
-    if (mod == rootModule) continue;
-
-    FnSymbol* fn = toFnSymbol(mod->initFn);
-    if (!fn) {
-      INT_ASSERT(!mod->deinitFn); // otherwise need to reinstate initFn
-      // Sometimes a module parsed on the command line
-      // is not actually used, so its initializer is pruned during resolution.
-      continue;
-    }
-
-    SET_LINENO(mod);
-    if (mod->deinitFn)
-      // This needs to go after initBlock: we want addModule(mod)
-      // to be called *after* addModule on modules used by mod.
-      fn->insertAtHead(new CallExpr(gAddModuleFn,
-                                    buildCStringLiteral(mod->name),
-                                    mod->deinitFn));
-
-    BlockStmt* initBlock = new BlockStmt();
-
-    // If I have a parent, I need it initialized first,
-    // since all of its symbols are visible to me.
-    if (ModuleSymbol* parent = mod->defPoint->getModule())
-      // The initializer for theProgram is called specially in main.c,
-      // so we don't have to call it here.
-      if (parent != theProgram && parent != rootModule)
-        initBlock->insertAtTail(new CallExpr(parent->initFn));
-
-    // Call the initializer for each module I use.
-    for_vector(ModuleSymbol, usedMod, mod->modUseList) {
-      if (usedMod != standardModule) {
-        initBlock->insertAtTail(new CallExpr(usedMod->initFn));
-      }
-    }
-
-    if (initBlock->body.length > 0) fn->insertAtHead(initBlock);
-  }
-}
-
-
-// This function makes the initialization functions idempotent --
+// ---------- AddInitGuards ----------
+// This pass makes the initialization functions idempotent --
 // meaning that they can be executed any number of times, but the net
 // effect is as if they were only called once.  That is done using the
 // idiom:
@@ -109,6 +58,7 @@ void addModuleInitBlocks() {
 // The guard code is added only if the initialization function has a
 // nontrivial body.
 //
+//
 // This pass also creates the function "chpl__init_preInit()", which
 // initializes all of the initialization flags to false.
 //
@@ -116,8 +66,12 @@ void addModuleInitBlocks() {
 // being initialized if the config const --printModuleInitOrder is set
 // at run time.
 //
-static void addInitGuards(void) {
-  // We need a function to drop the initializers into.
+
+
+// TODO GLOBALS theProgram and baseModule
+// TODO IDEMPOTENT
+// We need a function to drop the initializers into.
+FnSymbol* AddInitGuards::getOrCreatePreInitFn() {
   SET_LINENO(baseModule);
   FnSymbol* preInitFn = new FnSymbol(astr("chpl__init_preInit"));
   preInitFn->retType = dtVoid;
@@ -127,29 +81,37 @@ static void addInitGuards(void) {
   theProgram->block->insertAtTail(new DefExpr(preInitFn));
   normalize(preInitFn);
 
-  // Iterate all modules and select their module initialization functions.
-  forv_Vec(ModuleSymbol, mod, gModuleSymbols) {
-    if (mod == rootModule)
-      continue;
-
-    FnSymbol* fn = toFnSymbol(mod->initFn);
-    if (!fn)
-      // Sometimes a module parsed on the command line
-      // is not actually used, so its initializer is pruned.
-      continue;
-
-    // Test if this fn has a nontrivial body.
-    BlockStmt* body = fn->body;
-    if (body->length() < 1)
-      continue;
-
-    // Alright then, add the guard.
-    addInitGuard(fn, preInitFn);
-  }
+  return preInitFn;
+}
+AddInitGuards::AddInitGuards() {
+  preInitFn = getOrCreatePreInitFn();
 }
 
-static void addInitGuard(FnSymbol* fn, FnSymbol* preInitFn)
-{
+bool AddInitGuards::shouldProcess(ModuleSymbol* mod) {
+  if (mod == rootModule)
+    return false;
+
+  FnSymbol* fn = toFnSymbol(mod->initFn);
+  if (!fn)
+    // Sometimes a module parsed on the command line
+    // is not actually used, so its initializer is pruned.
+    return false;
+
+  // Test if this fn has a nontrivial body.
+  BlockStmt* body = fn->body;
+  if (body->length() < 1)
+    return false;
+
+  return true;
+}
+
+void AddInitGuards::process(ModuleSymbol* mod) {
+  FnSymbol* init = toFnSymbol(mod->initFn);
+  assert(init); // precondition from shouldProcess
+  addInitGuard(init, preInitFn);
+}
+
+void AddInitGuards::addInitGuard(FnSymbol* fn, FnSymbol* preInitFn) {
     SET_LINENO(fn);
     // The declaration:
     //      var <init_fn_name>_p : bool;
@@ -187,6 +149,7 @@ static void addInitGuard(FnSymbol* fn, FnSymbol* preInitFn)
     fn->insertAtHead(ifStmt);
 }
 
+// TODO GLOBALS gPrintmoduleinitfn, gModuleInitindentlevel
 //
 // Insert code that prints out the name of the module as it is
 // initialized.  We do this by inserting a call to printModInitOrder()
@@ -194,8 +157,7 @@ static void addInitGuard(FnSymbol* fn, FnSymbol* preInitFn)
 // (but after the guard) and then decrementing the indent level at the
 // end of the function.
 //
-static void addPrintModInitOrder(FnSymbol* fn)
-{
+void AddInitGuards::addPrintModInitOrder(FnSymbol* fn) {
   //
   // Only do this if gPrintModuleInitFn exists.  It won't exist when
   // compiling --minimal-modules
@@ -248,4 +210,67 @@ static void addPrintModInitOrder(FnSymbol* fn)
   fn->insertAtHead(new DefExpr(s2tmp));
   fn->insertAtHead(new DefExpr(s1tmp));
   fn->insertBeforeEpilogue(decIndentLevel);
+}
+
+
+// ---------- AddModuleInitBlocks ----------
+
+bool AddModuleInitBlocks::shouldProcess(ModuleSymbol* mod) {
+  if (mod == rootModule)
+    return false;
+
+  FnSymbol* fn = toFnSymbol(mod->initFn);
+  if (!fn) {
+    INT_ASSERT(!mod->deinitFn); // otherwise need to reinstate initFn
+    // Sometimes a module parsed on the command line
+    // is not actually used, so its initializer is pruned during resolution.
+    return false;
+  }
+  return true;
+}
+
+// TODO GLOBALS standardModule gAddModuleFn
+void AddModuleInitBlocks::process(ModuleSymbol* mod) {
+  FnSymbol* fn = toFnSymbol(mod->initFn);
+  INT_ASSERT(fn); // precondition from shouldProcess
+
+  SET_LINENO(mod);
+  if (mod->deinitFn)
+    // This needs to go after initBlock: we want addModule(mod)
+    // to be called *after* addModule on modules used by mod.
+    fn->insertAtHead(new CallExpr(gAddModuleFn, buildCStringLiteral(mod->name),
+                                  mod->deinitFn));
+
+  BlockStmt* initBlock = new BlockStmt();
+
+  // If I have a parent, I need it initialized first,
+  // since all of its symbols are visible to me.
+  if (ModuleSymbol* parent = mod->defPoint->getModule())
+    // The initializer for theProgram is called specially in main.c,
+    // so we don't have to call it here.
+    if (parent != theProgram && parent != rootModule)
+      initBlock->insertAtTail(new CallExpr(parent->initFn));
+
+  // Call the initializer for each module I use.
+  for (ModuleSymbol* usedMod : mod->modUseList) {
+    if (usedMod != standardModule) {
+      initBlock->insertAtTail(new CallExpr(usedMod->initFn));
+    }
+  }
+
+  // TODO REFACTOR Q can't we check this before and only create all the above if its true?
+  if (initBlock->body.length > 0)
+    fn->insertAtHead(initBlock);
+}
+
+#include "global-ast-vecs.h"
+
+void addInitCalls() {
+  PassManager pm;
+
+  PassTList<ModuleSymbol*> passes;
+  passes.push_back(std::make_unique<AddModuleInitBlocks>());
+  passes.push_back(std::make_unique<AddInitGuards>());
+  // TODO these are good candidates for runPassChained
+  pm.runPass(std::move(passes), gModuleSymbols);
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4586,9 +4586,16 @@ static void find_printModuleInit_stuff() {
 
     // TODO -- move this logic to wellknown.cpp
     if (symbol->hasFlag(FLAG_PRINT_MODULE_INIT_INDENT_LEVEL)) {
+      // assert that we haven't set this already this loop, b/c duplicates
+      // would be an error
+      INT_ASSERT(!gModuleInitIndentLevel);
       gModuleInitIndentLevel = toVarSymbol(symbol);
-      INT_ASSERT(gModuleInitIndentLevel);
-      // Q why  doesn't this break out of the loop
+
+      // NOTE: we do not `break` here b/c we'd like to verify there is only
+      // one such var with that pragma. This is only walking over PrintModuleInitOrder.chpl
+      // so the number of symbols is small
     }
   }
+  // assert that we actually found such a symbol
+  INT_ASSERT(gModuleInitIndentLevel);
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4588,6 +4588,7 @@ static void find_printModuleInit_stuff() {
     if (symbol->hasFlag(FLAG_PRINT_MODULE_INIT_INDENT_LEVEL)) {
       gModuleInitIndentLevel = toVarSymbol(symbol);
       INT_ASSERT(gModuleInitIndentLevel);
+      // Q why  doesn't this break out of the loop
     }
   }
 }


### PR DESCRIPTION
Continues #19164

This begins a refactor on passes in addInitGuards, localizeGlobals, bulkCopyRecords, and removeUnnecessaryAutoCopyCalls. See commits for more commentary on a per-pass basis, but generally my approach was:

1) isolate the use of the global ast vecs
2) convert file statics into class statics
3) convert forv_* as appropriate (see #19240 for why this is complicated)
4) leave comments about other global state that could be an issue

As ever, this is an active WIP so I feel okay leaving so many comments because I anticipate answering a lot of the questions as the PassManager effort progresses.

Testing
* [x] paratest
* [x] paratest with --fast
* [x] paratest with comm