### PR TITLE
Update GPU tests PREDIFF filter

### DIFF
--- a/test/gpu/native/PREDIFF
+++ b/test/gpu/native/PREDIFF
@@ -5,3 +5,6 @@ mv $2.no_version_warn $2
 
 awk '!/ptxas warning : Unresolved extern variable/ {print};' $2 > $2.no_extern_warn
 mv $2.no_extern_warn $2
+
+awk '!/warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors/ {print};' $2 > $2.no_numa_thread_mismatch_warn
+mv $2.no_numa_thread_mismatch_warn $2


### PR DESCRIPTION
After submitting PR #19265 (Bandaid fix to avoid race condition in gpu testing) we're now getting a warning:

"warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors"

I don't think this is relevant for these tests so I'm going to filter it out while the "bandaid fix" of setting number of threads to 1 is in effect. The hope is this cuts down on triage noise while I investigate the real source of the failure and undo this short "fix". I have a Github issue to do the investigation here: https://github.com/Cray/chapel-private/issues/3100