### PR TITLE
When looking for supported LLVM versions stop after one is found

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -146,6 +146,9 @@ def find_system_llvm_config():
             if entry[1] == vers:
                 found = entry
                 break
+        # Found the most preferred supported version available. Look no further.
+        if found[0] != '':
+            break
 
     # command set, version > 0, no error
     command = found[0]


### PR DESCRIPTION
The LLVM versions are listed in chpl_llvm.py/llvm_versions() in preferred
order. Stop searching for other versions after the first is found so we get
the most preferred version instead of the least.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>