### PR TITLE
Adjustments to the visibility of bigint's implementation details

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -203,7 +203,8 @@ module BigInteger {
 
   pragma "ignore noinit"
   record bigint {
-    /* The underlying GMP C structure */
+    // The underlying GMP C structure
+    pragma "no doc"
     var mpz      : mpz_t;              // A dynamic-vector of C integers
 
     pragma "no doc"
@@ -368,12 +369,12 @@ module BigInteger {
       return ret.safeCast(int);
     }
 
-    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_nlimbs` on the :var:`mpz` field instead"
+    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_nlimbs` on the result of :proc:`getImpl` instead"
     proc numLimbs : uint {
       return chpl_gmp_mpz_nlimbs(this.mpz);
     }
 
-    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_getlimbn` on the :var:`mpz` field instead"
+    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_getlimbn` on the result of :proc:`getImpl` instead"
     proc get_limbn(n: integral) : uint {
       var   ret: uint;
 
@@ -394,7 +395,18 @@ module BigInteger {
       return ret;
     }
 
+    deprecated "This method is deprecated, please use :proc:`getImpl` instead"
     proc mpzStruct() : __mpz_struct {
+      return getImpl();
+    }
+
+    /* Return the underlying implementation of :record:`bigint`.  Currently,
+       that type is ``__mpz_struct``.
+
+       This method is provided as a convenience but its result may change in the
+       future.
+    */
+    proc getImpl(): __mpz_struct {
       var ret: __mpz_struct;
 
       if _local {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -222,7 +222,7 @@ module BigInteger {
       if _local || num.localeId == chpl_nodeID {
         mpz_init_set(this.mpz, num.mpz);
       } else {
-        var mpz_struct = num.mpzStruct();
+        var mpz_struct = num.getImpl();
 
         mpz_init(this.mpz);
 
@@ -5298,7 +5298,7 @@ module BigInteger {
       const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
       on __primitive("chpl_on_locale_num", thisLoc) {
-        const mpz_struct = a.mpzStruct();
+        const mpz_struct = a.getImpl();
 
         chpl_gmp_get_mpz(this.mpz, a.localeId, mpz_struct);
       }

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -369,12 +369,12 @@ module BigInteger {
       return ret.safeCast(int);
     }
 
-    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_nlimbs` on the result of :proc:`getImpl` instead"
+    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_nlimbs` on the mpz field instead"
     proc numLimbs : uint {
       return chpl_gmp_mpz_nlimbs(this.mpz);
     }
 
-    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_getlimbn` on the result of :proc:`getImpl` instead"
+    deprecated "This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_getlimbn` on the mpz field instead"
     proc get_limbn(n: integral) : uint {
       var   ret: uint;
 
@@ -395,13 +395,13 @@ module BigInteger {
       return ret;
     }
 
-    deprecated "This method is deprecated, please use :proc:`getImpl` instead"
+    deprecated "mpzStruct is deprecated, please use :proc:`getImpl` instead"
     proc mpzStruct() : __mpz_struct {
       return getImpl();
     }
 
     /* Return the underlying implementation of :record:`bigint`.  Currently,
-       that type is ``__mpz_struct``.
+       the type returned is ``__mpz_struct``.
 
        This method is provided as a convenience but its result may change in the
        future.

--- a/test/deprecated/BigInteger/deprecateMpzStruct.chpl
+++ b/test/deprecated/BigInteger/deprecateMpzStruct.chpl
@@ -1,0 +1,9 @@
+use BigInteger;
+use GMP;
+
+config const debug = false;
+
+var a: bigint = 14;
+var impl = a.mpzStruct();
+var ret = chpl_gmp_mpz_nlimbs((impl,));
+if debug then writeln(ret);

--- a/test/deprecated/BigInteger/deprecateMpzStruct.good
+++ b/test/deprecated/BigInteger/deprecateMpzStruct.good
@@ -1,0 +1,1 @@
+deprecateMpzStruct.chpl:7: warning: mpzStruct is deprecated, please use getImpl instead


### PR DESCRIPTION
Stops documenting the `mpz` field for the `bigint` type in the BigInteger
module, and deprecates the `mpzStruct` method in favor of a new method
called `getImpl`, which is documented as an implementation detail that may
change in the future.

Resolves #17694

Updates some uses of the now deprecated method to use the new method
instead.  Updates some documentation links to the `mpz` field to not be
links any more - the field still exists, so it's okay for users to refer to it though
it may become private later when private fields are implemented.

Adds a new test locking in the deprecation message for `mpzStruct`.

Passed a full paratest with futures