### PR TITLE
Add `c_` prefix to Chapel's `size_t` and `ssize_t` types

### DIFF
--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -167,8 +167,8 @@ static WellKnownType sWellKnownTypes[] = {
   { "c_intptr",              &dt_c_intptr    },
   { "c_uintptr",             &dt_c_uintptr   },
   { "c_ptrdiff",             &dt_c_ptrdiff   },
-  { "ssize_t",               &dt_ssize_t     },
-  { "size_t",                &dt_size_t      },
+  { "c_ssize_t",             &dt_ssize_t     },
+  { "c_size_t",              &dt_size_t      },
 };
 
 static void removeIfUndefinedGlobalType(AggregateType*& t) {

--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -55,7 +55,7 @@ module ByteBufferHelpers {
 
   inline proc chpl_string_comm_get(dest: bufferType, src_loc_id: int(64),
                                    src_addr: bufferType, len: integral) {
-    __primitive("chpl_comm_get", dest, src_loc_id, src_addr, len.safeCast(size_t));
+    __primitive("chpl_comm_get", dest, src_loc_id, src_addr, len.safeCast(c_size_t));
   }
 
   private inline proc getGoodAllocSize(requestedSize: int): int {

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -61,7 +61,7 @@ module BytesCasts {
     extern proc integral_to_c_string(x:int(64), size:uint(32), isSigned: bool,
                                      ref err: bool) : c_string;
     pragma "fn synchronization free"
-    extern proc strlen(const str: c_string) : size_t;
+    extern proc strlen(const str: c_string) : c_size_t;
 
     var isErr: bool;
     var csc = integral_to_c_string(x:int(64), numBytes(x.type),
@@ -160,7 +160,7 @@ module BytesCasts {
     pragma "fn synchronization free"
     extern proc real_to_c_string(x:real(64), isImag: bool) : c_string;
     pragma "fn synchronization free"
-    extern proc strlen(const str: c_string) : size_t;
+    extern proc strlen(const str: c_string) : c_size_t;
 
     var csc = real_to_c_string(x:real(64), isImag);
 

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -235,19 +235,19 @@ module BytesStringCommon {
     extern proc qio_decode_char_buf(ref chr:int(32),
                                     ref nBytes:c_int,
                                     buf:c_string,
-                                    buflen:ssize_t): syserr;
+                                    buflen:c_ssize_t): syserr;
     pragma "fn synchronization free"
     extern proc qio_decode_char_buf_esc(ref chr:int(32),
                                         ref nBytes:c_int,
                                         buf:c_string,
-                                        buffLen:ssize_t): syserr;
+                                        buffLen:c_ssize_t): syserr;
     // esc chooses between qio_decode_char_buf_esc and
     // qio_decode_char_buf as a single wrapper function
     var chr: int(32);
     var nBytes: c_int;
     var start = offset:c_int;
     var multibytes = (buff + start): c_string;
-    var maxbytes = (buffLen - start): ssize_t;
+    var maxbytes = (buffLen - start): c_ssize_t;
     var decodeRet: syserr;
     if(allowEsc) then
       decodeRet = qio_decode_char_buf_esc(chr, nBytes,

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3300,7 +3300,7 @@ module ChapelArray {
     var r = if shapeful then ir._shape_ else 1..0;
 
     var i  = 0;
-    var size = r.sizeAs(size_t);
+    var size = r.sizeAs(c_size_t);
     type elemType = iteratorToArrayElementType(ir.type);
     var data:_ddata(elemType) = nil;
 

--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -403,7 +403,7 @@ module ChapelAutoAggregation {
           assert(lArr.domain.low == 0);
           assert(lArr.locale.id == here.id);
         }
-        const byte_size = size:size_t * c_sizeof(elemType);
+        const byte_size = size:c_size_t * c_sizeof(elemType);
         AggregationPrimitives.PUT(c_ptrTo(lArr[0]), loc, data, byte_size);
       }
 
@@ -411,7 +411,7 @@ module ChapelAutoAggregation {
         if boundsChecking {
           assert(size <= this.size);
         }
-        const byte_size = size:size_t * c_sizeof(elemType);
+        const byte_size = size:c_size_t * c_sizeof(elemType);
         AggregationPrimitives.PUT(lArr, loc, data, byte_size);
       }
 
@@ -422,7 +422,7 @@ module ChapelAutoAggregation {
           assert(lArr.domain.low == 0);
           assert(lArr.locale.id == here.id);
         }
-        const byte_size = size:size_t * c_sizeof(elemType);
+        const byte_size = size:c_size_t * c_sizeof(elemType);
         AggregationPrimitives.GET(c_ptrTo(lArr[0]), loc, data, byte_size);
       }
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -948,11 +948,11 @@ module ChapelBase {
     return ret;
   }
 
-  inline proc _ddata_sizeof_element(type t: _ddata): size_t {
-    return __primitive("sizeof_ddata_element", t):size_t;
+  inline proc _ddata_sizeof_element(type t: _ddata): c_size_t {
+    return __primitive("sizeof_ddata_element", t):c_size_t;
   }
 
-  inline proc _ddata_sizeof_element(x: _ddata): size_t {
+  inline proc _ddata_sizeof_element(x: _ddata): c_size_t {
     return _ddata_sizeof_element(x.type);
   }
 
@@ -979,11 +979,11 @@ module ChapelBase {
                                      subloc = c_sublocid_none) {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_array_alloc(nmemb: size_t, eltSize: size_t,
+    extern proc chpl_mem_array_alloc(nmemb: c_size_t, eltSize: c_size_t,
                                      subloc: chpl_sublocID_t,
                                      ref callPostAlloc: bool): c_void_ptr;
     var ret: _ddata(eltType);
-    ret = chpl_mem_array_alloc(size:size_t, _ddata_sizeof_element(ret),
+    ret = chpl_mem_array_alloc(size:c_size_t, _ddata_sizeof_element(ret),
                                subloc, callPostAlloc):ret.type;
     return ret;
   }
@@ -991,9 +991,9 @@ module ChapelBase {
   inline proc _ddata_allocate_postalloc(data:_ddata, size: integral) {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_array_postAlloc(data: c_void_ptr, nmemb: size_t,
-                                         eltSize: size_t);
-    chpl_mem_array_postAlloc(data:c_void_ptr, size:size_t,
+    extern proc chpl_mem_array_postAlloc(data: c_void_ptr, nmemb: c_size_t,
+                                         eltSize: c_size_t);
+    chpl_mem_array_postAlloc(data:c_void_ptr, size:c_size_t,
                              _ddata_sizeof_element(data));
   }
 
@@ -1020,11 +1020,11 @@ module ChapelBase {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_array_supports_realloc(ptr: c_void_ptr,
-                                                oldNmemb: size_t, newNmemb:
-                                                size_t, eltSize: size_t): bool;
+                                                oldNmemb: c_size_t, newNmemb:
+                                                c_size_t, eltSize: c_size_t): bool;
       return chpl_mem_array_supports_realloc(oldDdata: c_void_ptr,
-                                             oldSize.safeCast(size_t),
-                                             newSize.safeCast(size_t),
+                                             oldSize.safeCast(c_size_t),
+                                             newSize.safeCast(c_size_t),
                                              _ddata_sizeof_element(oldDdata));
   }
 
@@ -1056,8 +1056,8 @@ module ChapelBase {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_array_realloc(ptr: c_void_ptr,
-                                       oldNmemb: size_t, newNmemb: size_t,
-                                       eltSize: size_t,
+                                       oldNmemb: c_size_t, newNmemb: c_size_t,
+                                       eltSize: c_size_t,
                                        subloc: chpl_sublocID_t,
                                        ref callPostAlloc: bool): c_void_ptr;
     var callPostAlloc: bool;
@@ -1076,8 +1076,8 @@ module ChapelBase {
     }
 
     var newDdata = chpl_mem_array_realloc(oldDdata: c_void_ptr,
-                                          oldSize.safeCast(size_t),
-                                          newSize.safeCast(size_t),
+                                          oldSize.safeCast(c_size_t),
+                                          newSize.safeCast(c_size_t),
                                           _ddata_sizeof_element(oldDdata),
                                           subloc,
                                           callPostAlloc): oldDdata.type;
@@ -1101,12 +1101,12 @@ module ChapelBase {
       pragma "fn synchronization free"
       pragma "insert line file info"
       extern proc chpl_mem_array_postRealloc(oldData: c_void_ptr,
-                                             oldNmemb: size_t,
+                                             oldNmemb: c_size_t,
                                              newData: c_void_ptr,
-                                             newNmemb: size_t,
-                                             eltSize: size_t);
-      chpl_mem_array_postRealloc(oldDdata:c_void_ptr, oldSize.safeCast(size_t),
-                                 newDdata:c_void_ptr, newSize.safeCast(size_t),
+                                             newNmemb: c_size_t,
+                                             eltSize: c_size_t);
+      chpl_mem_array_postRealloc(oldDdata:c_void_ptr, oldSize.safeCast(c_size_t),
+                                 newDdata:c_void_ptr, newSize.safeCast(c_size_t),
                                  _ddata_sizeof_element(oldDdata));
     }
     return newDdata;
@@ -1119,9 +1119,9 @@ module ChapelBase {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_array_free(data: c_void_ptr,
-                                    nmemb: size_t, eltSize: size_t,
+                                    nmemb: c_size_t, eltSize: c_size_t,
                                     subloc: chpl_sublocID_t);
-    chpl_mem_array_free(data:c_void_ptr, size:size_t,
+    chpl_mem_array_free(data:c_void_ptr, size:c_size_t,
                         _ddata_sizeof_element(data),
                         subloc);
   }

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -337,7 +337,7 @@ module ChapelLocale {
 
     var maxTaskPar: int;
 
-    var callStackSize: size_t;
+    var callStackSize: c_size_t;
 
     proc id : int return chpl_nodeFromLocaleID(__primitive("_wide_get_locale", this));
 
@@ -706,7 +706,7 @@ module ChapelLocale {
                   __primitive("array_get", newRL, 0),
                   0 /* locale 0 */,
                   __primitive("array_get", origRL, 0),
-                  numLocales:size_t);
+                  numLocales:c_size_t);
       // Set the rootLocale to the local copy
       rootLocale._instance = newRootLocale;
     }

--- a/modules/internal/ChapelTaskData.chpl
+++ b/modules/internal/ChapelTaskData.chpl
@@ -28,7 +28,7 @@ module ChapelTaskData {
   // up to 16 bytes of wide pointer for _remoteEndCountType
   // 1 byte for serial_state
   // 1 byte for nextCoStmtSerial
-  private const chpl_offset_endCount = 0:size_t;
+  private const chpl_offset_endCount = 0:c_size_t;
   private const chpl_offset_serial = sizeof_endcount_ptr();
   private const chpl_offset_nextCoStmtSerial = chpl_offset_serial+1;
   private const chpl_offset_end = chpl_offset_nextCoStmtSerial+1;
@@ -43,7 +43,7 @@ module ChapelTaskData {
   // task local storage starting from a pointer to the tls region.
   proc chpl_task_data_setDynamicEndCount(tls:c_ptr(chpl_task_infoChapel_t), end: _remoteEndCountType) {
     var prv = tls:c_ptr(c_uchar);
-    var i:size_t;
+    var i:c_size_t;
 
     // Get the wide pointer components
     var loc = __primitive("_wide_get_locale", end);
@@ -60,7 +60,7 @@ module ChapelTaskData {
 
   proc chpl_task_data_getDynamicEndCount(tls:c_ptr(chpl_task_infoChapel_t)) {
     var prv = tls:c_ptr(c_uchar);
-    var i:size_t;
+    var i:c_size_t;
 
     var loc:chpl_localeID_t;
     var adr:c_void_ptr;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1877,14 +1877,14 @@ module DefaultRectangular {
       const elemSize = c_sizeof(arr.eltType);
       if boundsChecking {
         var rw = if f.writing then "write" else "read";
-        assert((dom.dsiNumIndices:uint*elemSize:uint) <= max(ssize_t):uint,
-               "length of array to ", rw, " is greater than ssize_t can hold");
+        assert((dom.dsiNumIndices:uint*elemSize:uint) <= max(c_ssize_t):uint,
+               "length of array to ", rw, " is greater than c_ssize_t can hold");
       }
 
       const len = dom.dsiNumIndices;
       const src = arr.theData;
       const idx = arr.getDataIndex(dom.dsiLow);
-      const size = len:ssize_t*elemSize:ssize_t;
+      const size = len:c_ssize_t*elemSize:c_ssize_t;
       try {
         if f.writing {
           f.writeBytes(_ddata_shift(arr.eltType, src, idx), size);
@@ -1985,7 +1985,7 @@ module DefaultRectangular {
     for param i in 0..rank-1 do
       Blo(i) = Bdims(i).first;
 
-    const len = aView.sizeAs(aView.intIdxType).safeCast(size_t);
+    const len = aView.sizeAs(aView.intIdxType).safeCast(c_size_t);
 
     if len == 0 then return;
 
@@ -2165,7 +2165,7 @@ module DefaultRectangular {
     // each level. It will ultimately be an array of size `stridelevels+1`.
     //
     var countDom = {1..inferredRank+1};
-    var count : [countDom] size_t;
+    var count : [countDom] c_size_t;
     for c in count do c = 1; // serial to avoid task creation overhead
 
     //
@@ -2174,7 +2174,7 @@ module DefaultRectangular {
     // it can be aggregated. Will ultimately be of size `stridelevels`.
     //
     var strideDom = {1..inferredRank};
-    var dstStride, srcStride : [strideDom] size_t;
+    var dstStride, srcStride : [strideDom] c_size_t;
 
     //
     // If the last dimension is strided then we can only copy one element at a
@@ -2188,8 +2188,8 @@ module DefaultRectangular {
     if LBlk(inferredRank-1) > 1 || RBlk(inferredRank-1) > 1 {
       stridelevels           += 1;
       count[stridelevels]     = 1;
-      dstStride[stridelevels] = LBlk(inferredRank-1).safeCast(size_t);
-      srcStride[stridelevels] = RBlk(inferredRank-1).safeCast(size_t);
+      dstStride[stridelevels] = LBlk(inferredRank-1).safeCast(c_size_t);
+      srcStride[stridelevels] = RBlk(inferredRank-1).safeCast(c_size_t);
     }
 
     //
@@ -2201,21 +2201,21 @@ module DefaultRectangular {
     for i in 2..inferredRank by -1 {
       // Each corresponding dimension in A and B should have the same length,
       // so it doesn't matter which we use here.
-      count[stridelevels+1] *= DimSizes(i).safeCast(size_t);
+      count[stridelevels+1] *= DimSizes(i).safeCast(c_size_t);
 
       const bothReuse = canReuseStride(LBlk, i, stridelevels, count, dstStride) &&
                         canReuseStride(RBlk, i, stridelevels, count, srcStride);
 
       if !bothReuse {
         stridelevels += 1;
-        dstStride[stridelevels] = LBlk(i-2).safeCast(size_t);
-        srcStride[stridelevels] = RBlk(i-2).safeCast(size_t);
+        dstStride[stridelevels] = LBlk(i-2).safeCast(c_size_t);
+        srcStride[stridelevels] = RBlk(i-2).safeCast(c_size_t);
       }
     }
-    count[stridelevels+1] *= DimSizes(1).safeCast(size_t);
+    count[stridelevels+1] *= DimSizes(1).safeCast(c_size_t);
 
     assert(stridelevels <= inferredRank, "BulkTransferStride: stride levels greater than rank.");
-    if stridelevels == 0 then assert(count[1] == LViewDom.sizeAs(size_t), "BulkTransferStride: bulk-count incorrect for stride level of 0: ", count[1], " != ", LViewDom.sizeAs(size_t));
+    if stridelevels == 0 then assert(count[1] == LViewDom.sizeAs(c_size_t), "BulkTransferStride: bulk-count incorrect for stride level of 0: ", count[1], " != ", LViewDom.sizeAs(c_size_t));
 
     countDom  = {1..stridelevels+1};
     strideDom = {1..stridelevels};

--- a/modules/internal/ISO_Fortran_binding.chpl
+++ b/modules/internal/ISO_Fortran_binding.chpl
@@ -93,12 +93,12 @@ module ISO_Fortran_binding {
   pragma "no doc"
   extern proc for_CFI_address(ref dv : CFI_cdesc_t, subscripts : c_ptr(CFI_index_t)) : c_void_ptr;
 
-  inline proc CFI_allocate(ref dv: CFI_cdesc_t, lower_bounds: c_ptr(CFI_index_t), upper_bounds: c_ptr(CFI_index_t), elem_len: size_t): c_int {
+  inline proc CFI_allocate(ref dv: CFI_cdesc_t, lower_bounds: c_ptr(CFI_index_t), upper_bounds: c_ptr(CFI_index_t), elem_len: c_size_t): c_int {
     return for_CFI_allocate(dv, lower_bounds, upper_bounds, elem_len);
   }
 
   pragma "no doc"
-  extern proc for_CFI_allocate(ref dv : CFI_cdesc_t, lower_bounds : c_ptr(CFI_index_t), upper_bounds : c_ptr(CFI_index_t), elem_len : size_t) : c_int;
+  extern proc for_CFI_allocate(ref dv : CFI_cdesc_t, lower_bounds : c_ptr(CFI_index_t), upper_bounds : c_ptr(CFI_index_t), elem_len : c_size_t) : c_int;
 
   inline proc CFI_deallocate(ref dv: CFI_cdesc_t): c_int {
     return for_CFI_deallocate(dv);
@@ -107,12 +107,12 @@ module ISO_Fortran_binding {
   pragma "no doc"
   extern proc for_CFI_deallocate(ref dv : CFI_cdesc_t) : c_int;
 
-  inline proc CFI_establish(ref dv: CFI_cdesc_t, base_addr: c_void_ptr, attribute: CFI_attribute_t, type_arg: CFI_type_t, elem_len: size_t, rank: CFI_rank_t, extents: c_ptr(CFI_index_t)): c_int {
+  inline proc CFI_establish(ref dv: CFI_cdesc_t, base_addr: c_void_ptr, attribute: CFI_attribute_t, type_arg: CFI_type_t, elem_len: c_size_t, rank: CFI_rank_t, extents: c_ptr(CFI_index_t)): c_int {
     return for_CFI_establish(dv, base_addr, attribute, type_arg, elem_len, rank, extents, CFI_VERSION);
   }
 
   pragma "no doc"
-  extern proc for_CFI_establish(ref dv : CFI_cdesc_t, base_addr : c_void_ptr, attribute : CFI_attribute_t, type_arg : CFI_type_t, elem_len : size_t, rank : CFI_rank_t, extents : c_ptr(CFI_index_t), version : c_int) : c_int;
+  extern proc for_CFI_establish(ref dv : CFI_cdesc_t, base_addr : c_void_ptr, attribute : CFI_attribute_t, type_arg : CFI_type_t, elem_len : c_size_t, rank : CFI_rank_t, extents : c_ptr(CFI_index_t), version : c_int) : c_int;
 
   inline proc CFI_is_contiguous(ref dv: CFI_cdesc_t): c_int {
     return for_CFI_is_contiguous(dv);
@@ -128,12 +128,12 @@ module ISO_Fortran_binding {
   pragma "no doc"
   extern proc for_CFI_section(ref result : CFI_cdesc_t, ref source : CFI_cdesc_t, lower_bounds : c_ptr(CFI_index_t), upper_bounds : c_ptr(CFI_index_t), strides : c_ptr(CFI_index_t)) : c_int;
 
-  inline proc CFI_select_part(ref result: CFI_cdesc_t, ref source: CFI_cdesc_t, displacement: size_t, elem_len: size_t): c_int {
+  inline proc CFI_select_part(ref result: CFI_cdesc_t, ref source: CFI_cdesc_t, displacement: c_size_t, elem_len: c_size_t): c_int {
     return for_CFI_select_part(result, source, displacement, elem_len);
   }
 
   pragma "no doc"
-  extern proc for_CFI_select_part(ref result : CFI_cdesc_t, ref source : CFI_cdesc_t, displacement : size_t, elem_len : size_t) : c_int;
+  extern proc for_CFI_select_part(ref result : CFI_cdesc_t, ref source : CFI_cdesc_t, displacement : c_size_t, elem_len : c_size_t) : c_int;
 
   inline proc CFI_setpointer(ref result: CFI_cdesc_t, ref source: CFI_cdesc_t, lower_bounds: c_ptr(CFI_index_t)): c_int {
     return for_CFI_setpointer(result, source, lower_bounds);
@@ -148,7 +148,7 @@ module ISO_Fortran_binding {
 
   extern record CFI_cdesc_t {
     var base_addr: c_void_ptr;
-    var elem_len: size_t;
+    var elem_len: c_size_t;
     var version: c_int;
     var attribute: CFI_attribute_t;
     var rank: CFI_rank_t;
@@ -159,7 +159,7 @@ module ISO_Fortran_binding {
   extern record CFI_CDESC_T {
     param r: int;
     var base_addr: c_void_ptr;
-    var elem_len: size_t;
+    var elem_len: c_size_t;
     var version: c_int;
     var attribute: CFI_attribute_t;
     var rank: CFI_rank_t;

--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -86,7 +86,7 @@ module LocaleModelHelpAPU {
   proc chpl_executeOn(loc: chpl_localeID_t, // target locale
                       fn: int,              // on-body function idx
                       args: chpl_comm_on_bundle_p,     // function args
-                      args_size: size_t     // args size
+                      args_size: c_size_t     // args size
                      ) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -127,7 +127,7 @@ module LocaleModelHelpAPU {
   proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
                           fn: int,              // on-body function idx
                           args: chpl_comm_on_bundle_p,     // function args
-                          args_size: size_t     // args size
+                          args_size: c_size_t     // args size
                          ) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -156,7 +156,7 @@ module LocaleModelHelpAPU {
   proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
                         fn: int,              // on-body function idx
                         args: chpl_comm_on_bundle_p,     // function args
-                        args_size: size_t     // args size
+                        args_size: c_size_t     // args size
                        ) {
     //
     // If we're in serial mode, we should use blocking rather than

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -58,7 +58,7 @@ module LocaleModelHelpFlat {
   proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
                       fn: int,              // on-body function idx
                       args: chpl_comm_on_bundle_p,     // function args
-                      args_size: size_t     // args size
+                      args_size: c_size_t     // args size
                      ) {
     const node = chpl_nodeFromLocaleID(loc);
     if (node == chpl_nodeID) {
@@ -84,7 +84,7 @@ module LocaleModelHelpFlat {
   proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
                           fn: int,              // on-body function idx
                           args: chpl_comm_on_bundle_p,     // function args
-                          args_size: size_t     // args size
+                          args_size: c_size_t     // args size
                          ) {
     const node = chpl_nodeFromLocaleID(loc);
     if (node == chpl_nodeID) {
@@ -106,7 +106,7 @@ module LocaleModelHelpFlat {
   proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
                         fn: int,              // on-body function idx
                         args: chpl_comm_on_bundle_p,     // function args
-                        args_size: size_t     // args size
+                        args_size: c_size_t     // args size
                        ) {
     //
     // If we're in serial mode, we should use blocking rather than

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -85,7 +85,7 @@ module LocaleModelHelpGPU {
   proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
                       fn: int,              // on-body function idx
                       args: chpl_comm_on_bundle_p,     // function args
-                      args_size: size_t     // args size
+                      args_size: c_size_t     // args size
                      ) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -126,7 +126,7 @@ module LocaleModelHelpGPU {
   proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
                           fn: int,              // on-body function idx
                           args: chpl_comm_on_bundle_p,     // function args
-                          args_size: size_t     // args size
+                          args_size: c_size_t     // args size
                          ) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -155,7 +155,7 @@ module LocaleModelHelpGPU {
   proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
                         fn: int,              // on-body function idx
                         args: chpl_comm_on_bundle_p,     // function args
-                        args_size: size_t     // args size
+                        args_size: c_size_t     // args size
                        ) {
     //
     // If we're in serial mode, we should use blocking rather than

--- a/modules/internal/LocaleModelHelpMem.chpl
+++ b/modules/internal/LocaleModelHelpMem.chpl
@@ -53,8 +53,8 @@ module LocaleModelHelpMem {
   proc chpl_here_alloc(size:int(64), md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+      extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_alloc(size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
@@ -63,8 +63,8 @@ module LocaleModelHelpMem {
   proc chpl_here_alloc(size:integral, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+      extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_alloc(size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
@@ -74,9 +74,9 @@ module LocaleModelHelpMem {
                                md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_memalign(alignment:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_memalign(alignment.safeCast(size_t),
-                             size.safeCast(size_t),
+    extern proc chpl_mem_memalign(alignment:c_size_t, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_memalign(alignment.safeCast(c_size_t),
+                             size.safeCast(c_size_t),
                              md + chpl_memhook_md_num());
   }
 
@@ -86,8 +86,8 @@ module LocaleModelHelpMem {
   proc chpl_here_calloc(size:integral, number:integral, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
+      extern proc chpl_mem_calloc(number:c_size_t, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_calloc(number.safeCast(c_size_t), size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
@@ -95,8 +95,8 @@ module LocaleModelHelpMem {
   proc chpl_here_realloc(ptr:c_void_ptr, size:integral, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
-    return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
+      extern proc chpl_mem_realloc(ptr:c_void_ptr, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    return chpl_mem_realloc(ptr, size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "fn synchronization free"
@@ -104,8 +104,8 @@ module LocaleModelHelpMem {
   proc chpl_here_good_alloc_size(min_size:integral): min_size.type {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
-    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(min_size.type);
+      extern proc chpl_mem_good_alloc_size(min_size:c_size_t) : c_size_t;
+    return chpl_mem_good_alloc_size(min_size.safeCast(c_size_t)).safeCast(min_size.type);
   }
 
   pragma "locale model free"

--- a/modules/internal/LocaleModelHelpNUMA.chpl
+++ b/modules/internal/LocaleModelHelpNUMA.chpl
@@ -86,7 +86,7 @@ module LocaleModelHelpNUMA {
   proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
                       fn: int,              // on-body function idx
                       args: chpl_comm_on_bundle_p,     // function args
-                      args_size: size_t     // args size
+                      args_size: c_size_t     // args size
                      ) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -119,7 +119,7 @@ module LocaleModelHelpNUMA {
   proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
                           fn: int,              // on-body function idx
                           args: chpl_comm_on_bundle_p,     // function args
-                          args_size: size_t     // args size
+                          args_size: c_size_t     // args size
                          ) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -150,7 +150,7 @@ module LocaleModelHelpNUMA {
   proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
                         fn: int,              // on-body function idx
                         args: chpl_comm_on_bundle_p,     // function args
-                        args_size: size_t     // args size
+                        args_size: c_size_t     // args size
                        ) {
     //
     // If we're in serial mode, we should use blocking rather than

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -96,16 +96,16 @@ module LocaleModelHelpRuntime {
   //
   pragma "insert line file info"
   extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
-                                   args: chpl_comm_on_bundle_p, arg_size: size_t);
+                                   args: chpl_comm_on_bundle_p, arg_size: c_size_t);
   pragma "insert line file info"
   extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
-                                        args: chpl_comm_on_bundle_p, args_size: size_t);
+                                        args: chpl_comm_on_bundle_p, args_size: c_size_t);
   pragma "insert line file info"
   extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
-                                      args: chpl_comm_on_bundle_p, args_size: size_t);
+                                      args: chpl_comm_on_bundle_p, args_size: c_size_t);
   pragma "insert line file info"
     extern proc chpl_comm_taskCallFTable(fn: int,
-                                         args: chpl_comm_on_bundle_p, args_size: size_t,
+                                         args: chpl_comm_on_bundle_p, args_size: c_size_t,
                                          subloc_id: int): void;
   extern proc chpl_ftable_call(fn: int, args: chpl_comm_on_bundle_p): void;
   extern proc chpl_ftable_call(fn: int, args: chpl_task_bundle_p): void;
@@ -120,7 +120,7 @@ module LocaleModelHelpRuntime {
   //
   pragma "insert line file info"
   extern proc chpl_task_addTask(fn: int,
-                                args: chpl_task_bundle_p, args_size: size_t,
+                                args: chpl_task_bundle_p, args_size: c_size_t,
                                 subloc_id: int);
   extern proc chpl_task_yield();
 
@@ -132,7 +132,7 @@ module LocaleModelHelpRuntime {
   proc chpl_taskAddBegin(subloc_id: int,            // target sublocale
                          fn: int,                   // task body function idx
                          args: chpl_task_bundle_p,  // function args
-                         args_size: size_t          // args size
+                         args_size: c_size_t          // args size
                         ) {
     var tls = chpl_task_getInfoChapel();
     var isSerial = chpl_task_data_getSerial(tls);
@@ -152,7 +152,7 @@ module LocaleModelHelpRuntime {
   proc chpl_taskAddCoStmt(subloc_id: int,            // target sublocale
                           fn: int,                   // task body function idx
                           args: chpl_task_bundle_p,  // function args
-                          args_size: size_t          // args size
+                          args_size: c_size_t          // args size
                          ) {
     var tls = chpl_task_getInfoChapel();
     var isSerial = chpl_task_data_getSerial(tls);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -158,7 +158,7 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleFlat(dst:borrowed LocaleModel, out local_name:string) {
     local_name = getNodeName();
 
-    extern proc chpl_task_getCallStackSize(): size_t;
+    extern proc chpl_task_getCallStackSize(): c_size_t;
     dst.callStackSize = chpl_task_getCallStackSize();
 
     extern proc chpl_topo_getNumCPUsPhysical(accessible_only: bool): c_int;

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -54,9 +54,9 @@ module MemTracking
   config const
     memLeaksByDesc: string;
 
-  // Safely cast to size_t instances of memMax and memThreshold.
-  const cMemMax = memMax.safeCast(size_t),
-    cMemThreshold = memThreshold.safeCast(size_t);
+  // Safely cast to c_size_t instances of memMax and memThreshold.
+  const cMemMax = memMax.safeCast(c_size_t),
+    cMemThreshold = memThreshold.safeCast(c_size_t);
 
   //
   // This communicates the settings of the various memory tracking
@@ -76,8 +76,8 @@ module MemTracking
                                          ref ret_memLeaksByType: bool,
                                          ref ret_memLeaksByDesc: c_string,
                                          ref ret_memLeaks: bool,
-                                         ref ret_memMax: size_t,
-                                         ref ret_memThreshold: size_t,
+                                         ref ret_memMax: c_size_t,
+                                         ref ret_memThreshold: c_size_t,
                                          ref ret_memLog: c_string,
                                          ref ret_memLeaksLog: c_string) {
     ret_memTrack = memTrack;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -220,12 +220,12 @@ module String {
   private extern proc qio_decode_char_buf(ref chr:int(32),
                                           ref nbytes:c_int,
                                           buf:c_string,
-                                          buflen:ssize_t): syserr;
+                                          buflen:c_ssize_t): syserr;
   pragma "fn synchronization free"
   private extern proc qio_decode_char_buf_esc(ref chr:int(32),
                                               ref nbytes:c_int,
                                               buf:c_string,
-                                              buflen:ssize_t): syserr;
+                                              buflen:c_ssize_t): syserr;
   pragma "fn synchronization free"
   private extern proc qio_encode_char_buf(dst:c_void_ptr, chr:int(32)):syserr;
   pragma "fn synchronization free"
@@ -1515,7 +1515,7 @@ module String {
       return chpl_createStringWithOwnedBufferNV(newBuff, 1, allocSize, 1);
     }
     else {
-      var maxbytes = (this.buffLen - idx): ssize_t;
+      var maxbytes = (this.buffLen - idx): c_ssize_t;
       if maxbytes < 0 || maxbytes > 4 then
         maxbytes = 4;
       var (newBuff, allocSize) = bufferCopy(buf=this.buff, off=idx,

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -64,7 +64,7 @@ module StringCasts {
     pragma "fn synchronization free"
     extern proc integral_to_c_string(x:int(64), size:uint(32), isSigned: bool, ref err: bool) : c_string;
     pragma "fn synchronization free"
-    extern proc strlen(const str: c_string) : size_t;
+    extern proc strlen(const str: c_string) : c_size_t;
 
     var isErr: bool;
     var csc = integral_to_c_string(x:int(64), numBytes(x.type), isIntType(x.type), isErr);
@@ -155,7 +155,7 @@ module StringCasts {
     pragma "fn synchronization free"
     extern proc real_to_c_string(x:real(64), isImag: bool) : c_string;
     pragma "fn synchronization free"
-    extern proc strlen(const str: c_string) : size_t;
+    extern proc strlen(const str: c_string) : c_size_t;
 
     var csc = real_to_c_string(x:real(64), isImag);
 

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -67,17 +67,17 @@ module LocaleModel {
   proc chpl_here_alloc(size:int(64), md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_gpu_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_gpu_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
 
     if runningOnGPUSublocale() then
-      return chpl_gpu_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_gpu_mem_alloc(size.safeCast(c_size_t), md + chpl_memhook_md_num());
     else
-      return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_mem_alloc(size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
@@ -86,17 +86,17 @@ module LocaleModel {
   proc chpl_here_alloc(size:integral, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_gpu_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_gpu_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
 
     if runningOnGPUSublocale() then
-      return chpl_gpu_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_gpu_mem_alloc(size.safeCast(c_size_t), md + chpl_memhook_md_num());
     else
-      return chpl_mem_alloc(size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_mem_alloc(size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
@@ -106,19 +106,19 @@ module LocaleModel {
                                md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_memalign(alignment:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_memalign(alignment:c_size_t, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_gpu_mem_memalign(alignment:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_gpu_mem_memalign(alignment:c_size_t, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     if runningOnGPUSublocale() then
-      return chpl_gpu_mem_memalign(alignment.safeCast(size_t),
-                                   size.safeCast(size_t),
+      return chpl_gpu_mem_memalign(alignment.safeCast(c_size_t),
+                                   size.safeCast(c_size_t),
                                    md + chpl_memhook_md_num());
     else
-      return chpl_mem_memalign(alignment.safeCast(size_t),
-                               size.safeCast(size_t),
+      return chpl_mem_memalign(alignment.safeCast(c_size_t),
+                               size.safeCast(c_size_t),
                                md + chpl_memhook_md_num());
   }
 
@@ -128,16 +128,16 @@ module LocaleModel {
   proc chpl_here_calloc(size:integral, number:integral, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_calloc(number:c_size_t, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_gpu_mem_calloc(number:size_t, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_gpu_mem_calloc(number:c_size_t, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     if runningOnGPUSublocale() then
-      return chpl_gpu_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_gpu_mem_calloc(number.safeCast(c_size_t), size.safeCast(c_size_t), md + chpl_memhook_md_num());
     else
-      return chpl_mem_calloc(number.safeCast(size_t), size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_mem_calloc(number.safeCast(c_size_t), size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "allocator"
@@ -145,20 +145,20 @@ module LocaleModel {
   proc chpl_here_realloc(ptr:c_void_ptr, size:integral, md:chpl_mem_descInt_t): c_void_ptr {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_realloc(ptr:c_void_ptr, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_gpu_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_gpu_mem_realloc(ptr:c_void_ptr, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
 
     if addrIsInGPU(ptr) {
       if !runningOnGPUSublocale() {
         halt("Trying to realloc a GPU pointer outside a GPU sublocale");
       }
-      return chpl_gpu_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_gpu_mem_realloc(ptr, size.safeCast(c_size_t), md + chpl_memhook_md_num());
     }
     else {
-      return chpl_mem_realloc(ptr, size.safeCast(size_t), md + chpl_memhook_md_num());
+      return chpl_mem_realloc(ptr, size.safeCast(c_size_t), md + chpl_memhook_md_num());
     }
   }
 
@@ -167,12 +167,12 @@ module LocaleModel {
   proc chpl_here_good_alloc_size(min_size:integral): min_size.type {
     pragma "fn synchronization free"
     pragma "insert line file info"
-    extern proc chpl_mem_good_alloc_size(min_size:size_t) : size_t;
+    extern proc chpl_mem_good_alloc_size(min_size:c_size_t) : c_size_t;
 
     // This is currently here only for completeness: I am not sure if need
     // something like this for the GPU, and it doesn't call anything specific
     // for it.
-    return chpl_mem_good_alloc_size(min_size.safeCast(size_t)).safeCast(min_size.type);
+    return chpl_mem_good_alloc_size(min_size.safeCast(c_size_t)).safeCast(min_size.type);
   }
 
   pragma "locale model free"

--- a/modules/minimal/internal/MemTracking.chpl
+++ b/modules/minimal/internal/MemTracking.chpl
@@ -38,11 +38,11 @@ module MemTracking
                                          ref ret_memLog: c_string,
                                          ref ret_memLeaksLog: c_string) {
 
-    // ** In minimal-modules mode, I've hard-coded these size_t
-    // arguments to uint(64) rather than using the size_t aliases
+    // ** In minimal-modules mode, I've hard-coded these c_size_t
+    // arguments to uint(64) rather than using the c_size_t aliases
     // in CTypes.chpl because doing that requires dragging in a
     // bunch of other ChapelBase code.  My assumption here is that
-    // size_t will either be, or be compatible with, uint(64) for
+    // c_size_t will either be, or be compatible with, uint(64) for
     // most developers.  If that turns out not to be the case, we
     // can reconsider this choice.
   }

--- a/modules/packages/Buffers.chpl
+++ b/modules/packages/Buffers.chpl
@@ -695,7 +695,7 @@ module Buffers {
       if !err {
         this.advance(start, numBytes(int));
         this.advance(end, len);
-        var buf = c_calloc(uint(8), (len+1):size_t);
+        var buf = c_calloc(uint(8), (len+1):c_size_t);
         err = qbuffer_copyout(this._buf_internal,
                               start._bufit_internal, end._bufit_internal,
                               buf, len);

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -379,7 +379,7 @@ module Crypto {
     md = EVP_get_digestbyname(digestName.c_str());
 
     EVP_DigestInit_ex(CHPL_EVP_MD_CTX_ptr(ctx), md, c_nil: ENGINE_PTR);
-    EVP_DigestUpdate(CHPL_EVP_MD_CTX_ptr(ctx), c_ptrTo(inputBuffer.buff): c_void_ptr, inputBuffer._len: size_t);
+    EVP_DigestUpdate(CHPL_EVP_MD_CTX_ptr(ctx), c_ptrTo(inputBuffer.buff): c_void_ptr, inputBuffer._len: c_size_t);
     EVP_DigestFinal_ex(CHPL_EVP_MD_CTX_ptr(ctx), c_ptrTo(hash): c_ptr(c_uchar), retHashLen);
 
     CHPL_EVP_MD_CTX_free(ctx);
@@ -1252,7 +1252,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     extern proc CHPL_EVP_MD_CTX_free(ref c: CHPL_EVP_MD_CTX);
     extern proc CHPL_EVP_MD_CTX_ptr(ref c: CHPL_EVP_MD_CTX):EVP_MD_CTX_PTR;
     extern proc EVP_DigestInit_ex(ctx: EVP_MD_CTX_PTR, types: CONST_EVP_MD_PTR, impl: ENGINE_PTR): c_int;
-    extern proc EVP_DigestUpdate(ctx: EVP_MD_CTX_PTR, const d: c_void_ptr, cnt: size_t): c_int;
+    extern proc EVP_DigestUpdate(ctx: EVP_MD_CTX_PTR, const d: c_void_ptr, cnt: c_size_t): c_int;
     extern proc EVP_DigestFinal_ex(ctx: EVP_MD_CTX_PTR, md: c_ptr(c_uchar), ref s: c_uint): c_int;
 
     extern proc RAND_bytes(buf: c_ptr(c_uchar), num: c_int) : c_int;

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -127,7 +127,7 @@ issue a POST request:
 
     // Called with the contents of the server's response; does nothing with it.
     // Else libcurl writes it to stdout.
-    proc null_write_callback(ptr: c_ptr(c_char), size: size_t, nmemb: size_t, userdata: c_void_ptr) {
+    proc null_write_callback(ptr: c_ptr(c_char), size: c_size_t, nmemb: c_size_t, userdata: c_void_ptr) {
       return size * nmemb;
     }
 
@@ -348,9 +348,9 @@ module Curl {
   private extern proc qio_mkerror_errno():syserr;
   private extern proc qio_int_to_err(a:int(32)):syserr;
   private extern proc qio_channel_nbytes_available_unlocked(ch:qio_channel_ptr_t):int(64);
-  private extern proc qio_channel_copy_to_available_unlocked(ch:qio_channel_ptr_t, ptr:c_void_ptr, len:ssize_t):syserr;
+  private extern proc qio_channel_copy_to_available_unlocked(ch:qio_channel_ptr_t, ptr:c_void_ptr, len:c_ssize_t):syserr;
   private extern proc qio_channel_nbytes_write_behind_unlocked(ch:qio_channel_ptr_t):int(64);
-  private extern proc qio_channel_copy_from_buffered_unlocked(ch:qio_channel_ptr_t, ptr:c_void_ptr, len:ssize_t, ref n_written_out:ssize_t):syserr;
+  private extern proc qio_channel_copy_from_buffered_unlocked(ch:qio_channel_ptr_t, ptr:c_void_ptr, len:c_ssize_t, ref n_written_out:c_ssize_t):syserr;
   private extern proc qio_channel_end_offset_unlocked(ch:qio_channel_ptr_t):int(64);
   private extern proc qio_channel_offset_unlocked(ch:qio_channel_ptr_t):int(64);
   private extern proc qio_channel_writable(ch:qio_channel_ptr_t):bool;
@@ -381,9 +381,9 @@ module Curl {
   // Other Curl constants
   private extern const CURLINFO_CONTENT_LENGTH_DOWNLOAD: c_int;
 
-  private extern const CURL_READFUNC_PAUSE:size_t;
-  private extern const CURL_READFUNC_ABORT:size_t;
-  private extern const CURL_WRITEFUNC_PAUSE:size_t;
+  private extern const CURL_READFUNC_PAUSE:c_size_t;
+  private extern const CURL_READFUNC_ABORT:c_size_t;
+  private extern const CURL_WRITEFUNC_PAUSE:c_size_t;
   private extern const CURLPAUSE_ALL: c_int;
   private extern const CURLPAUSE_CONT: c_int;
 
@@ -509,7 +509,7 @@ module Curl {
     class CurlFile : QioPluginFile {
 
       var url_c: c_string;     // Path/URL
-      var length: ssize_t;    // length of what we are reading, -1 if we can't get
+      var length: c_ssize_t;    // length of what we are reading, -1 if we can't get
 
       var seekable: bool;
 
@@ -590,10 +590,10 @@ module Curl {
     record curl_iovec_t {
       var vec:c_ptr(qiovec_t); // iovec to read into --
                                // (the iovec passed in curl_readv/curl_preadv)
-      var total_read:size_t;   // total amount read
-      var amt_read:size_t;     // amount read into the current iovec buffer
+      var total_read:c_size_t;   // total amount read
+      var amt_read:c_size_t;     // amount read into the current iovec buffer
       var count:c_int;         // number of buffers in the iovec
-      var offset:size_t;       // offset that we want to skip to
+      var offset:c_size_t;       // offset that we want to skip to
                                // (in the case where we cannot request byteranges)
       var curr:c_int;          // the index of the current buffer
     };
@@ -603,23 +603,23 @@ module Curl {
     // call CURLOPT_WRITEDATA in curl_preadv and curl_readv.
     // FUTURE: If we have filled the iovec, but have not finished reading from the curl
     // handle, pause it (i.e., return CURL_WRITE_PAUSE).
-    private proc pause_writer(ptr:c_void_ptr, size:size_t, nmemb:size_t, userdata:c_void_ptr):size_t
+    private proc pause_writer(ptr:c_void_ptr, size:c_size_t, nmemb:c_size_t, userdata:c_void_ptr):c_size_t
     {
       //writeln("in pause_writer");
       return CURL_WRITEFUNC_PAUSE;
     }
-    private proc pause_reader(ptr:c_void_ptr, size:size_t, nmemb:size_t, userdata:c_void_ptr):size_t
+    private proc pause_reader(ptr:c_void_ptr, size:c_size_t, nmemb:c_size_t, userdata:c_void_ptr):c_size_t
     {
       //writeln("in pause_reader");
       return CURL_READFUNC_PAUSE;
     }
 
 
-    private proc buf_writer(ptr:c_void_ptr, size:size_t, nmemb:size_t, userdata:c_void_ptr):size_t
+    private proc buf_writer(ptr:c_void_ptr, size:c_size_t, nmemb:c_size_t, userdata:c_void_ptr):c_size_t
     {
       var ptr_data = ptr:c_ptr(uint(8));
-      var realsize:size_t = size*nmemb;
-      var real_realsize:size_t = realsize;
+      var realsize:c_size_t = size*nmemb;
+      var real_realsize:c_size_t = realsize;
       var retptr = userdata:c_ptr(curl_iovec_t);
       ref ret = retptr.deref();
 
@@ -689,19 +689,19 @@ module Curl {
 
     record curl_str_buf {
       var mem:c_ptr(uint(8));
-      var len: size_t;
-      var alloced: size_t;
+      var len: c_size_t;
+      var alloced: c_size_t;
     }
 
 
     private proc startsWith(haystack:c_string, needle:c_string) {
-      extern proc strncmp(s1:c_string, s2:c_string, n:size_t):c_int;
+      extern proc strncmp(s1:c_string, s2:c_string, n:c_size_t):c_int;
 
-      return strncmp(haystack, needle, needle.size:size_t) == 0;
+      return strncmp(haystack, needle, needle.size:c_size_t) == 0;
     }
 
-    private proc curl_write_string(contents: c_void_ptr, size:size_t, nmemb:size_t, userp: c_void_ptr) {
-      var realsize:size_t = size * nmemb;
+    private proc curl_write_string(contents: c_void_ptr, size:c_size_t, nmemb:c_size_t, userp: c_void_ptr) {
+      var realsize:c_size_t = size * nmemb;
       var bufptr = userp:c_ptr(curl_str_buf);
       ref buf = bufptr.deref();
 
@@ -846,15 +846,15 @@ module Curl {
       return ENOERR;
     }
 
-    private proc curl_write_received(contents: c_void_ptr, size:size_t, nmemb:size_t, userp: c_void_ptr):size_t {
-      var realsize:size_t = size * nmemb;
+    private proc curl_write_received(contents: c_void_ptr, size:c_size_t, nmemb:c_size_t, userp: c_void_ptr):c_size_t {
+      var realsize:c_size_t = size * nmemb;
       var cc = userp:unmanaged CurlChannel?;
       var err:syserr = ENOERR;
 
       // lock the channel if it's not already locked
       assert(cc!.have_channel_lock);
 
-      var amt = realsize.safeCast(ssize_t);
+      var amt = realsize.safeCast(c_ssize_t);
 
       //writeln("curl_write_received offset=", qio_channel_offset_unlocked(cc!.qio_ch), " len=", amt);
 
@@ -978,20 +978,20 @@ module Curl {
     // Send some data somewhere with curl
     // Returning 0 will signal end-of-file to the curl library
     // and cause it to stop the transfer.
-    private proc curl_read_buffered(contents: c_void_ptr, size:size_t, nmemb:size_t, userp: c_void_ptr):size_t {
-      var realsize:size_t = size * nmemb;
+    private proc curl_read_buffered(contents: c_void_ptr, size:c_size_t, nmemb:c_size_t, userp: c_void_ptr):c_size_t {
+      var realsize:c_size_t = size * nmemb;
       var cc = userp:unmanaged CurlChannel?;
       var err:syserr = ENOERR;
 
       // lock the channel if it's not already locked
       assert(cc!.have_channel_lock);
 
-      var amt = realsize.safeCast(ssize_t);
+      var amt = realsize.safeCast(c_ssize_t);
 
       // Write from the buffer's start position up until the start
       // of the user-visible data.
 
-      var gotamt: ssize_t = 0;
+      var gotamt: c_ssize_t = 0;
       // copy the data from the channel's buffer
       err = qio_channel_copy_from_buffered_unlocked(cc!.qio_ch, contents, amt, gotamt);
 
@@ -1009,7 +1009,7 @@ module Curl {
         return CURL_READFUNC_PAUSE;
       }
 
-      return gotamt:size_t;
+      return gotamt:c_size_t;
     }
 
     private proc write_amount(cc:CurlChannel, requestedAmount:int(64)):syserr {
@@ -1149,7 +1149,7 @@ module Curl {
         fl.seekable = false;
       } else {
         fl.seekable = seekable(fl, filelength);
-        fl.length = filelength:ssize_t;
+        fl.length = filelength:c_ssize_t;
       }
 
       var err: CURLcode = 0;

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -1176,7 +1176,7 @@ module DistributedBag {
                                   break;
                                 }
 
-                                extern proc sizeof(type x): size_t;
+                                extern proc sizeof(type x): c_size_t;
                                 // We steal at most 1MB worth of data. If the user has less than that, we steal a %, at least 1.
                                 const mb = distributedBagWorkStealingMemCap * 1024 * 1024;
                                 var toSteal = max(distributedBagWorkStealingMinElems, min(mb / sizeof(eltType), targetSegment.nElems.read() * distributedBagWorkStealingRatio)) : int;

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -820,11 +820,11 @@ module FFTW {
 
     extern proc fftw_sprint_plan(p : fftw_plan) : c_string;
 
-    extern proc fftw_malloc(n : size_t) : c_void_ptr;
+    extern proc fftw_malloc(n : c_size_t) : c_void_ptr;
 
-    extern proc fftw_alloc_real(n : size_t) : c_ptr(c_double);
+    extern proc fftw_alloc_real(n : c_size_t) : c_ptr(c_double);
 
-    extern proc fftw_alloc_complex(n : size_t) : c_ptr(fftw_complex);
+    extern proc fftw_alloc_complex(n : c_size_t) : c_ptr(fftw_complex);
 
     extern proc fftw_free(p : c_void_ptr) : void;
 

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -101,9 +101,9 @@ module HDF5 {
 
     extern proc H5free_memory(mem : c_void_ptr) : herr_t;
 
-    extern proc H5allocate_memory(size : size_t, clear : hbool_t) : c_void_ptr;
+    extern proc H5allocate_memory(size : c_size_t, clear : hbool_t) : c_void_ptr;
 
-    extern proc H5resize_memory(mem : c_void_ptr, size : size_t) : c_void_ptr;
+    extern proc H5resize_memory(mem : c_void_ptr, size : c_size_t) : c_void_ptr;
 
     extern proc H5Iregister(type_arg : H5I_type_t, object : c_void_ptr) : hid_t;
 
@@ -115,7 +115,7 @@ module HDF5 {
 
     extern proc H5Iget_file_id(id : hid_t) : hid_t;
 
-    extern proc H5Iget_name(id : hid_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Iget_name(id : hid_t, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Iinc_ref(id : hid_t) : c_int;
 
@@ -123,7 +123,7 @@ module HDF5 {
 
     extern proc H5Iget_ref(id : hid_t) : c_int;
 
-    extern proc H5Iregister_type(hash_size : size_t, reserved : c_uint, free_func : H5I_free_t) : H5I_type_t;
+    extern proc H5Iregister_type(hash_size : c_size_t, reserved : c_uint, free_func : H5I_free_t) : H5I_type_t;
 
     extern proc H5Iclear_type(type_arg : H5I_type_t, force : hbool_t) : herr_t;
 
@@ -313,7 +313,7 @@ module HDF5 {
 
     extern var H5T_NATIVE_UINT_FAST64_g : hid_t;
 
-    extern proc H5Tcreate(type_arg : H5T_class_t, size : size_t) : hid_t;
+    extern proc H5Tcreate(type_arg : H5T_class_t, size : c_size_t) : hid_t;
 
     extern proc H5Tcopy(type_id : hid_t) : hid_t;
 
@@ -333,7 +333,7 @@ module HDF5 {
 
     extern proc H5Tcommitted(type_id : hid_t) : htri_t;
 
-    extern proc H5Tencode(obj_id : hid_t, buf : c_void_ptr, ref nalloc : size_t) : herr_t;
+    extern proc H5Tencode(obj_id : hid_t, buf : c_void_ptr, ref nalloc : c_size_t) : herr_t;
 
     extern proc H5Tdecode(buf : c_void_ptr) : hid_t;
 
@@ -341,7 +341,7 @@ module HDF5 {
 
     extern proc H5Trefresh(type_id : hid_t) : herr_t;
 
-    extern proc H5Tinsert(parent_id : hid_t, name : c_string, offset : size_t, member_id : hid_t) : herr_t;
+    extern proc H5Tinsert(parent_id : hid_t, name : c_string, offset : c_size_t, member_id : hid_t) : herr_t;
 
     extern proc H5Tpack(type_id : hid_t) : herr_t;
 
@@ -349,7 +349,7 @@ module HDF5 {
 
     extern proc H5Tenum_insert(type_arg : hid_t, name : c_string, value : c_void_ptr) : herr_t;
 
-    extern proc H5Tenum_nameof(type_arg : hid_t, value : c_void_ptr, name : c_string, size : size_t) : herr_t;
+    extern proc H5Tenum_nameof(type_arg : hid_t, value : c_void_ptr, name : c_string, size : c_size_t) : herr_t;
 
     extern proc H5Tenum_valueof(type_arg : hid_t, name : c_string, value : c_void_ptr) : herr_t;
 
@@ -371,11 +371,11 @@ module HDF5 {
 
     extern proc H5Tdetect_class(type_id : hid_t, cls : H5T_class_t) : htri_t;
 
-    extern proc H5Tget_size(type_id : hid_t) : size_t;
+    extern proc H5Tget_size(type_id : hid_t) : c_size_t;
 
     extern proc H5Tget_order(type_id : hid_t) : H5T_order_t;
 
-    extern proc H5Tget_precision(type_id : hid_t) : size_t;
+    extern proc H5Tget_precision(type_id : hid_t) : c_size_t;
 
     extern proc H5Tget_offset(type_id : hid_t) : c_int;
 
@@ -383,9 +383,9 @@ module HDF5 {
 
     extern proc H5Tget_sign(type_id : hid_t) : H5T_sign_t;
 
-    extern proc H5Tget_fields(type_id : hid_t, ref spos : size_t, ref epos : size_t, ref esize : size_t, ref mpos : size_t, ref msize : size_t) : herr_t;
+    extern proc H5Tget_fields(type_id : hid_t, ref spos : c_size_t, ref epos : c_size_t, ref esize : c_size_t, ref mpos : c_size_t, ref msize : c_size_t) : herr_t;
 
-    extern proc H5Tget_ebias(type_id : hid_t) : size_t;
+    extern proc H5Tget_ebias(type_id : hid_t) : c_size_t;
 
     extern proc H5Tget_norm(type_id : hid_t) : H5T_norm_t;
 
@@ -399,7 +399,7 @@ module HDF5 {
 
     extern proc H5Tget_member_index(type_id : hid_t, name : c_string) : c_int;
 
-    extern proc H5Tget_member_offset(type_id : hid_t, membno : c_uint) : size_t;
+    extern proc H5Tget_member_offset(type_id : hid_t, membno : c_uint) : c_size_t;
 
     extern proc H5Tget_member_class(type_id : hid_t, membno : c_uint) : H5T_class_t;
 
@@ -413,21 +413,21 @@ module HDF5 {
 
     extern proc H5Tget_native_type(type_id : hid_t, direction : H5T_direction_t) : hid_t;
 
-    extern proc H5Tset_size(type_id : hid_t, size : size_t) : herr_t;
+    extern proc H5Tset_size(type_id : hid_t, size : c_size_t) : herr_t;
 
     extern proc H5Tset_order(type_id : hid_t, order : H5T_order_t) : herr_t;
 
-    extern proc H5Tset_precision(type_id : hid_t, prec : size_t) : herr_t;
+    extern proc H5Tset_precision(type_id : hid_t, prec : c_size_t) : herr_t;
 
-    extern proc H5Tset_offset(type_id : hid_t, offset : size_t) : herr_t;
+    extern proc H5Tset_offset(type_id : hid_t, offset : c_size_t) : herr_t;
 
     extern proc H5Tset_pad(type_id : hid_t, lsb : H5T_pad_t, msb : H5T_pad_t) : herr_t;
 
     extern proc H5Tset_sign(type_id : hid_t, sign : H5T_sign_t) : herr_t;
 
-    extern proc H5Tset_fields(type_id : hid_t, spos : size_t, epos : size_t, esize : size_t, mpos : size_t, msize : size_t) : herr_t;
+    extern proc H5Tset_fields(type_id : hid_t, spos : c_size_t, epos : c_size_t, esize : c_size_t, mpos : c_size_t, msize : c_size_t) : herr_t;
 
-    extern proc H5Tset_ebias(type_id : hid_t, ebias : size_t) : herr_t;
+    extern proc H5Tset_ebias(type_id : hid_t, ebias : c_size_t) : herr_t;
 
     extern proc H5Tset_norm(type_id : hid_t, norm : H5T_norm_t) : herr_t;
 
@@ -445,7 +445,7 @@ module HDF5 {
 
     extern proc H5Tcompiler_conv(src_id : hid_t, dst_id : hid_t) : htri_t;
 
-    extern proc H5Tconvert(src_id : hid_t, dst_id : hid_t, nelmts : size_t, buf : c_void_ptr, background : c_void_ptr, plist_id : hid_t) : herr_t;
+    extern proc H5Tconvert(src_id : hid_t, dst_id : hid_t, nelmts : c_size_t, buf : c_void_ptr, background : c_void_ptr, plist_id : hid_t) : herr_t;
 
     extern proc H5Tcommit1(loc_id : hid_t, name : c_string, type_id : hid_t) : herr_t;
 
@@ -467,9 +467,9 @@ module HDF5 {
 
     extern proc H5Ldelete_by_idx(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, lapl_id : hid_t) : herr_t;
 
-    extern proc H5Lget_val(loc_id : hid_t, name : c_string, buf : c_void_ptr, size : size_t, lapl_id : hid_t) : herr_t;
+    extern proc H5Lget_val(loc_id : hid_t, name : c_string, buf : c_void_ptr, size : c_size_t, lapl_id : hid_t) : herr_t;
 
-    extern proc H5Lget_val_by_idx(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, buf : c_void_ptr, size : size_t, lapl_id : hid_t) : herr_t;
+    extern proc H5Lget_val_by_idx(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, buf : c_void_ptr, size : c_size_t, lapl_id : hid_t) : herr_t;
 
     extern proc H5Lexists(loc_id : hid_t, name : c_string, lapl_id : hid_t) : htri_t;
 
@@ -477,7 +477,7 @@ module HDF5 {
 
     extern proc H5Lget_info_by_idx(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, ref linfo : H5L_info_t, lapl_id : hid_t) : herr_t;
 
-    extern proc H5Lget_name_by_idx(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, name : c_string, size : size_t, lapl_id : hid_t) : ssize_t;
+    extern proc H5Lget_name_by_idx(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, name : c_string, size : c_size_t, lapl_id : hid_t) : c_ssize_t;
 
     extern proc H5Literate(grp_id : hid_t, idx_type : H5_index_t, order : H5_iter_order_t, ref idx : hsize_t, op : H5L_iterate_t, op_data : c_void_ptr) : herr_t;
 
@@ -487,7 +487,7 @@ module HDF5 {
 
     extern proc H5Lvisit_by_name(loc_id : hid_t, group_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, op : H5L_iterate_t, op_data : c_void_ptr, lapl_id : hid_t) : herr_t;
 
-    extern proc H5Lcreate_ud(link_loc_id : hid_t, link_name : c_string, link_type : H5L_type_t, udata : c_void_ptr, udata_size : size_t, lcpl_id : hid_t, lapl_id : hid_t) : herr_t;
+    extern proc H5Lcreate_ud(link_loc_id : hid_t, link_name : c_string, link_type : H5L_type_t, udata : c_void_ptr, udata_size : c_size_t, lcpl_id : hid_t, lapl_id : hid_t) : herr_t;
 
     extern proc H5Lregister(ref cls : H5L_class_t) : herr_t;
 
@@ -495,7 +495,7 @@ module HDF5 {
 
     extern proc H5Lis_registered(id : H5L_type_t) : htri_t;
 
-    extern proc H5Lunpack_elink_val(ext_linkval : c_void_ptr, link_size : size_t, ref flags : c_uint, ref filename : c_string, ref obj_path : c_string) : herr_t;
+    extern proc H5Lunpack_elink_val(ext_linkval : c_void_ptr, link_size : c_size_t, ref flags : c_uint, ref filename : c_string, ref obj_path : c_string) : herr_t;
 
     extern proc H5Lcreate_external(file_name : c_string, obj_name : c_string, link_loc_id : hid_t, link_name : c_string, lcpl_id : hid_t, lapl_id : hid_t) : herr_t;
 
@@ -525,9 +525,9 @@ module HDF5 {
 
     extern proc H5Oset_comment_by_name(loc_id : hid_t, name : c_string, comment : c_string, lapl_id : hid_t) : herr_t;
 
-    extern proc H5Oget_comment(obj_id : hid_t, comment : c_string, bufsize : size_t) : ssize_t;
+    extern proc H5Oget_comment(obj_id : hid_t, comment : c_string, bufsize : c_size_t) : c_ssize_t;
 
-    extern proc H5Oget_comment_by_name(loc_id : hid_t, name : c_string, comment : c_string, bufsize : size_t, lapl_id : hid_t) : ssize_t;
+    extern proc H5Oget_comment_by_name(loc_id : hid_t, name : c_string, comment : c_string, bufsize : c_size_t, lapl_id : hid_t) : c_ssize_t;
 
     extern proc H5Ovisit(obj_id : hid_t, idx_type : H5_index_t, order : H5_iter_order_t, op : H5O_iterate_t, op_data : c_void_ptr) : herr_t;
 
@@ -567,9 +567,9 @@ module HDF5 {
 
     extern proc H5Aget_create_plist(attr_id : hid_t) : hid_t;
 
-    extern proc H5Aget_name(attr_id : hid_t, buf_size : size_t, buf : c_string) : ssize_t;
+    extern proc H5Aget_name(attr_id : hid_t, buf_size : c_size_t, buf : c_string) : c_ssize_t;
 
-    extern proc H5Aget_name_by_idx(loc_id : hid_t, obj_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, name : c_string, size : size_t, lapl_id : hid_t) : ssize_t;
+    extern proc H5Aget_name_by_idx(loc_id : hid_t, obj_name : c_string, idx_type : H5_index_t, order : H5_iter_order_t, n : hsize_t, name : c_string, size : c_size_t, lapl_id : hid_t) : c_ssize_t;
 
     extern proc H5Aget_storage_size(attr_id : hid_t) : hsize_t;
 
@@ -670,7 +670,7 @@ module HDF5 {
 
     extern proc H5Dscatter(op : H5D_scatter_func_t, op_data : c_void_ptr, type_id : hid_t, dst_space_id : hid_t, dst_buf : c_void_ptr) : herr_t;
 
-    extern proc H5Dgather(src_space_id : hid_t, src_buf : c_void_ptr, type_id : hid_t, dst_buf_size : size_t, dst_buf : c_void_ptr, op : H5D_gather_func_t, op_data : c_void_ptr) : herr_t;
+    extern proc H5Dgather(src_space_id : hid_t, src_buf : c_void_ptr, type_id : hid_t, dst_buf_size : c_size_t, dst_buf : c_void_ptr, op : H5D_gather_func_t, op_data : c_void_ptr) : herr_t;
 
     extern proc H5Ddebug(dset_id : hid_t) : herr_t;
 
@@ -1026,7 +1026,7 @@ module HDF5 {
 
     extern proc H5Eclose_stack(stack_id : hid_t) : herr_t;
 
-    extern proc H5Eget_class_name(class_id : hid_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Eget_class_name(class_id : hid_t, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Eset_current_stack(err_stack_id : hid_t) : herr_t;
 
@@ -1035,7 +1035,7 @@ module HDF5 {
     // Overload for empty varargs
     extern proc H5Epush2(err_stack : hid_t,file : c_string,func : c_string,line : c_uint,cls_id : hid_t,maj_id : hid_t,min_id : hid_t,msg : c_string) : herr_t;
 
-    extern proc H5Epop(err_stack : hid_t, count : size_t) : herr_t;
+    extern proc H5Epop(err_stack : hid_t, count : c_size_t) : herr_t;
 
     extern proc H5Eprint2(err_stack : hid_t, ref stream : _file) : herr_t;
 
@@ -1049,9 +1049,9 @@ module HDF5 {
 
     extern proc H5Eauto_is_v2(err_stack : hid_t, ref is_stack : c_uint) : herr_t;
 
-    extern proc H5Eget_msg(msg_id : hid_t, ref type_arg : H5E_type_t, msg : c_string, size : size_t) : ssize_t;
+    extern proc H5Eget_msg(msg_id : hid_t, ref type_arg : H5E_type_t, msg : c_string, size : c_size_t) : c_ssize_t;
 
-    extern proc H5Eget_num(error_stack_id : hid_t) : ssize_t;
+    extern proc H5Eget_num(error_stack_id : hid_t) : c_ssize_t;
 
     extern proc H5Eclear1() : herr_t;
 
@@ -1087,9 +1087,9 @@ module HDF5 {
 
     extern proc H5Fget_intent(file_id : hid_t, ref intent : c_uint) : herr_t;
 
-    extern proc H5Fget_obj_count(file_id : hid_t, types : c_uint) : ssize_t;
+    extern proc H5Fget_obj_count(file_id : hid_t, types : c_uint) : c_ssize_t;
 
-    extern proc H5Fget_obj_ids(file_id : hid_t, types : c_uint, max_objs : size_t, ref obj_id_list : hid_t) : ssize_t;
+    extern proc H5Fget_obj_ids(file_id : hid_t, types : c_uint, max_objs : c_size_t, ref obj_id_list : hid_t) : c_ssize_t;
 
     extern proc H5Fget_vfd_handle(file_id : hid_t, fapl : hid_t, ref file_handle : c_void_ptr) : herr_t;
 
@@ -1101,7 +1101,7 @@ module HDF5 {
 
     extern proc H5Fget_filesize(file_id : hid_t, ref size : hsize_t) : herr_t;
 
-    extern proc H5Fget_file_image(file_id : hid_t, buf_ptr : c_void_ptr, buf_len : size_t) : ssize_t;
+    extern proc H5Fget_file_image(file_id : hid_t, buf_ptr : c_void_ptr, buf_len : c_size_t) : c_ssize_t;
 
     extern proc H5Fget_mdc_config(file_id : hid_t, ref config_ptr : H5AC_cache_config_t) : herr_t;
 
@@ -1109,11 +1109,11 @@ module HDF5 {
 
     extern proc H5Fget_mdc_hit_rate(file_id : hid_t, ref hit_rate_ptr : c_double) : herr_t;
 
-    extern proc H5Fget_mdc_size(file_id : hid_t, ref max_size_ptr : size_t, ref min_clean_size_ptr : size_t, ref cur_size_ptr : size_t, ref cur_num_entries_ptr : c_int) : herr_t;
+    extern proc H5Fget_mdc_size(file_id : hid_t, ref max_size_ptr : c_size_t, ref min_clean_size_ptr : c_size_t, ref cur_size_ptr : c_size_t, ref cur_num_entries_ptr : c_int) : herr_t;
 
     extern proc H5Freset_mdc_hit_rate_stats(file_id : hid_t) : herr_t;
 
-    extern proc H5Fget_name(obj_id : hid_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Fget_name(obj_id : hid_t, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Fget_info2(obj_id : hid_t, ref finfo : H5F_info2_t) : herr_t;
 
@@ -1121,7 +1121,7 @@ module HDF5 {
 
     extern proc H5Fstart_swmr_write(file_id : hid_t) : herr_t;
 
-    extern proc H5Fget_free_sections(file_id : hid_t, type_arg : H5F_mem_t, nsects : size_t, ref sect_info : H5F_sect_info_t) : ssize_t;
+    extern proc H5Fget_free_sections(file_id : hid_t, type_arg : H5F_mem_t, nsects : c_size_t, ref sect_info : H5F_sect_info_t) : c_ssize_t;
 
     extern proc H5Fclear_elink_file_cache(file_id : hid_t) : herr_t;
 
@@ -1180,9 +1180,9 @@ module HDF5 {
 
     extern proc H5FDget_vfd_handle(ref file : H5FD_t, fapl : hid_t, ref file_handle : c_void_ptr) : herr_t;
 
-    extern proc H5FDread(ref file : H5FD_t, type_arg : H5FD_mem_t, dxpl_id : hid_t, addr : haddr_t, size : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5FDread(ref file : H5FD_t, type_arg : H5FD_mem_t, dxpl_id : hid_t, addr : haddr_t, size : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5FDwrite(ref file : H5FD_t, type_arg : H5FD_mem_t, dxpl_id : hid_t, addr : haddr_t, size : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5FDwrite(ref file : H5FD_t, type_arg : H5FD_mem_t, dxpl_id : hid_t, addr : haddr_t, size : c_size_t, buf : c_void_ptr) : herr_t;
 
     extern proc H5FDflush(ref file : H5FD_t, dxpl_id : hid_t, closing : hbool_t) : herr_t;
 
@@ -1212,7 +1212,7 @@ module HDF5 {
 
     extern proc H5Grefresh(group_id : hid_t) : herr_t;
 
-    extern proc H5Gcreate1(loc_id : hid_t, name : c_string, size_hint : size_t) : hid_t;
+    extern proc H5Gcreate1(loc_id : hid_t, name : c_string, size_hint : c_size_t) : hid_t;
 
     extern proc H5Gopen1(loc_id : hid_t, name : c_string) : hid_t;
 
@@ -1226,11 +1226,11 @@ module HDF5 {
 
     extern proc H5Gunlink(loc_id : hid_t, name : c_string) : herr_t;
 
-    extern proc H5Gget_linkval(loc_id : hid_t, name : c_string, size : size_t, buf : c_string) : herr_t;
+    extern proc H5Gget_linkval(loc_id : hid_t, name : c_string, size : c_size_t, buf : c_string) : herr_t;
 
     extern proc H5Gset_comment(loc_id : hid_t, name : c_string, comment : c_string) : herr_t;
 
-    extern proc H5Gget_comment(loc_id : hid_t, name : c_string, bufsize : size_t, buf : c_string) : c_int;
+    extern proc H5Gget_comment(loc_id : hid_t, name : c_string, bufsize : c_size_t, buf : c_string) : c_int;
 
     extern proc H5Giterate(loc_id : hid_t, name : c_string, ref idx : c_int, op : H5G_iterate_t, op_data : c_void_ptr) : herr_t;
 
@@ -1238,7 +1238,7 @@ module HDF5 {
 
     extern proc H5Gget_objinfo(loc_id : hid_t, name : c_string, follow_link : hbool_t, ref statbuf : H5G_stat_t) : herr_t;
 
-    extern proc H5Gget_objname_by_idx(loc_id : hid_t, idx : hsize_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Gget_objname_by_idx(loc_id : hid_t, idx : hsize_t, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Gget_objtype_by_idx(loc_id : hid_t, idx : hsize_t) : H5G_obj_t;
 
@@ -1322,21 +1322,21 @@ module HDF5 {
 
     extern proc H5Pcreate(cls_id : hid_t) : hid_t;
 
-    extern proc H5Pregister2(cls_id : hid_t, name : c_string, size : size_t, def_value : c_void_ptr, prp_create : H5P_prp_create_func_t, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_del : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_cmp : H5P_prp_compare_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
+    extern proc H5Pregister2(cls_id : hid_t, name : c_string, size : c_size_t, def_value : c_void_ptr, prp_create : H5P_prp_create_func_t, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_del : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_cmp : H5P_prp_compare_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
 
-    extern proc H5Pinsert2(plist_id : hid_t, name : c_string, size : size_t, value : c_void_ptr, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_delete : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_cmp : H5P_prp_compare_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
+    extern proc H5Pinsert2(plist_id : hid_t, name : c_string, size : c_size_t, value : c_void_ptr, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_delete : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_cmp : H5P_prp_compare_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
 
     extern proc H5Pset(plist_id : hid_t, name : c_string, value : c_void_ptr) : herr_t;
 
     extern proc H5Pexist(plist_id : hid_t, name : c_string) : htri_t;
 
-    extern proc H5Pencode(plist_id : hid_t, buf : c_void_ptr, ref nalloc : size_t) : herr_t;
+    extern proc H5Pencode(plist_id : hid_t, buf : c_void_ptr, ref nalloc : c_size_t) : herr_t;
 
     extern proc H5Pdecode(buf : c_void_ptr) : hid_t;
 
-    extern proc H5Pget_size(id : hid_t, name : c_string, ref size : size_t) : herr_t;
+    extern proc H5Pget_size(id : hid_t, name : c_string, ref size : c_size_t) : herr_t;
 
-    extern proc H5Pget_nprops(id : hid_t, ref nprops : size_t) : herr_t;
+    extern proc H5Pget_nprops(id : hid_t, ref nprops : c_size_t) : herr_t;
 
     extern proc H5Pget_class(plist_id : hid_t) : hid_t;
 
@@ -1374,15 +1374,15 @@ module HDF5 {
 
     extern proc H5Pget_obj_track_times(plist_id : hid_t, ref track_times : hbool_t) : herr_t;
 
-    extern proc H5Pmodify_filter(plist_id : hid_t, filter : H5Z_filter_t, flags : c_uint, cd_nelmts : size_t, cd_values : c_ptr(c_uint)) : herr_t;
+    extern proc H5Pmodify_filter(plist_id : hid_t, filter : H5Z_filter_t, flags : c_uint, cd_nelmts : c_size_t, cd_values : c_ptr(c_uint)) : herr_t;
 
-    extern proc H5Pset_filter(plist_id : hid_t, filter : H5Z_filter_t, flags : c_uint, cd_nelmts : size_t, c_values : c_ptr(c_uint)) : herr_t;
+    extern proc H5Pset_filter(plist_id : hid_t, filter : H5Z_filter_t, flags : c_uint, cd_nelmts : c_size_t, c_values : c_ptr(c_uint)) : herr_t;
 
     extern proc H5Pget_nfilters(plist_id : hid_t) : c_int;
 
-    extern proc H5Pget_filter2(plist_id : hid_t, filter : c_uint, ref flags : c_uint, ref cd_nelmts : size_t, cd_values : c_ptr(c_uint), namelen : size_t, name : c_ptr(c_char), ref filter_config : c_uint) : H5Z_filter_t;
+    extern proc H5Pget_filter2(plist_id : hid_t, filter : c_uint, ref flags : c_uint, ref cd_nelmts : c_size_t, cd_values : c_ptr(c_uint), namelen : c_size_t, name : c_ptr(c_char), ref filter_config : c_uint) : H5Z_filter_t;
 
-    extern proc H5Pget_filter_by_id2(plist_id : hid_t, id : H5Z_filter_t, ref flags : c_uint, ref cd_nelmts : size_t, cd_values : c_ptr(c_uint), namelen : size_t, name : c_ptr(c_char), ref filter_config : c_uint) : herr_t;
+    extern proc H5Pget_filter_by_id2(plist_id : hid_t, id : H5Z_filter_t, ref flags : c_uint, ref cd_nelmts : c_size_t, cd_values : c_ptr(c_uint), namelen : c_size_t, name : c_ptr(c_char), ref filter_config : c_uint) : herr_t;
 
     extern proc H5Pall_filters_avail(plist_id : hid_t) : htri_t;
 
@@ -1396,9 +1396,9 @@ module HDF5 {
 
     extern proc H5Pget_userblock(plist_id : hid_t, ref size : hsize_t) : herr_t;
 
-    extern proc H5Pset_sizes(plist_id : hid_t, sizeof_addr : size_t, sizeof_size : size_t) : herr_t;
+    extern proc H5Pset_sizes(plist_id : hid_t, sizeof_addr : c_size_t, sizeof_size : c_size_t) : herr_t;
 
-    extern proc H5Pget_sizes(plist_id : hid_t, ref sizeof_addr : size_t, ref sizeof_size : size_t) : herr_t;
+    extern proc H5Pget_sizes(plist_id : hid_t, ref sizeof_addr : c_size_t, ref sizeof_size : c_size_t) : herr_t;
 
     extern proc H5Pset_sym_k(plist_id : hid_t, ik : c_uint, lk : c_uint) : herr_t;
 
@@ -1446,9 +1446,9 @@ module HDF5 {
 
     extern proc H5Pget_multi_type(fapl_id : hid_t, ref type_arg : H5FD_mem_t) : herr_t;
 
-    extern proc H5Pset_cache(plist_id : hid_t, mdc_nelmts : c_int, rdcc_nslots : size_t, rdcc_nbytes : size_t, rdcc_w0 : c_double) : herr_t;
+    extern proc H5Pset_cache(plist_id : hid_t, mdc_nelmts : c_int, rdcc_nslots : c_size_t, rdcc_nbytes : c_size_t, rdcc_w0 : c_double) : herr_t;
 
-    extern proc H5Pget_cache(plist_id : hid_t, ref mdc_nelmts : c_int, ref rdcc_nslots : size_t, ref rdcc_nbytes : size_t, ref rdcc_w0 : c_double) : herr_t;
+    extern proc H5Pget_cache(plist_id : hid_t, ref mdc_nelmts : c_int, ref rdcc_nslots : c_size_t, ref rdcc_nbytes : c_size_t, ref rdcc_w0 : c_double) : herr_t;
 
     extern proc H5Pset_mdc_config(plist_id : hid_t, ref config_ptr : H5AC_cache_config_t) : herr_t;
 
@@ -1466,9 +1466,9 @@ module HDF5 {
 
     extern proc H5Pget_meta_block_size(fapl_id : hid_t, ref size : hsize_t) : herr_t;
 
-    extern proc H5Pset_sieve_buf_size(fapl_id : hid_t, size : size_t) : herr_t;
+    extern proc H5Pset_sieve_buf_size(fapl_id : hid_t, size : c_size_t) : herr_t;
 
-    extern proc H5Pget_sieve_buf_size(fapl_id : hid_t, ref size : size_t) : herr_t;
+    extern proc H5Pget_sieve_buf_size(fapl_id : hid_t, ref size : c_size_t) : herr_t;
 
     extern proc H5Pset_small_data_block_size(fapl_id : hid_t, size : hsize_t) : herr_t;
 
@@ -1482,17 +1482,17 @@ module HDF5 {
 
     extern proc H5Pget_elink_file_cache_size(plist_id : hid_t, ref efc_size : c_uint) : herr_t;
 
-    extern proc H5Pset_file_image(fapl_id : hid_t, buf_ptr : c_void_ptr, buf_len : size_t) : herr_t;
+    extern proc H5Pset_file_image(fapl_id : hid_t, buf_ptr : c_void_ptr, buf_len : c_size_t) : herr_t;
 
-    extern proc H5Pget_file_image(fapl_id : hid_t, ref buf_ptr_ptr : c_void_ptr, ref buf_len_ptr : size_t) : herr_t;
+    extern proc H5Pget_file_image(fapl_id : hid_t, ref buf_ptr_ptr : c_void_ptr, ref buf_len_ptr : c_size_t) : herr_t;
 
     extern proc H5Pset_file_image_callbacks(fapl_id : hid_t, ref callbacks_ptr : H5FD_file_image_callbacks_t) : herr_t;
 
     extern proc H5Pget_file_image_callbacks(fapl_id : hid_t, ref callbacks_ptr : H5FD_file_image_callbacks_t) : herr_t;
 
-    extern proc H5Pset_core_write_tracking(fapl_id : hid_t, is_enabled : hbool_t, page_size : size_t) : herr_t;
+    extern proc H5Pset_core_write_tracking(fapl_id : hid_t, is_enabled : hbool_t, page_size : c_size_t) : herr_t;
 
-    extern proc H5Pget_core_write_tracking(fapl_id : hid_t, ref is_enabled : hbool_t, ref page_size : size_t) : herr_t;
+    extern proc H5Pget_core_write_tracking(fapl_id : hid_t, ref is_enabled : hbool_t, ref page_size : c_size_t) : herr_t;
 
     extern proc H5Pset_metadata_read_attempts(plist_id : hid_t, attempts : c_uint) : herr_t;
 
@@ -1504,7 +1504,7 @@ module HDF5 {
 
     extern proc H5Pset_mdc_log_options(plist_id : hid_t, is_enabled : hbool_t, location : c_string, start_on_access : hbool_t) : herr_t;
 
-    extern proc H5Pget_mdc_log_options(plist_id : hid_t, ref is_enabled : hbool_t, location : c_string, ref location_size : size_t, ref start_on_access : hbool_t) : herr_t;
+    extern proc H5Pget_mdc_log_options(plist_id : hid_t, ref is_enabled : hbool_t, location : c_string, ref location_size : c_size_t, ref start_on_access : hbool_t) : herr_t;
 
     extern proc H5Pset_evict_on_close(fapl_id : hid_t, evict_on_close : hbool_t) : herr_t;
 
@@ -1514,9 +1514,9 @@ module HDF5 {
 
     extern proc H5Pget_mdc_image_config(plist_id : hid_t, ref config_ptr : H5AC_cache_image_config_t) : herr_t;
 
-    extern proc H5Pset_page_buffer_size(plist_id : hid_t, buf_size : size_t, min_meta_per : c_uint, min_raw_per : c_uint) : herr_t;
+    extern proc H5Pset_page_buffer_size(plist_id : hid_t, buf_size : c_size_t, min_meta_per : c_uint, min_raw_per : c_uint) : herr_t;
 
-    extern proc H5Pget_page_buffer_size(plist_id : hid_t, ref buf_size : size_t, ref min_meta_per : c_uint, ref min_raw_per : c_uint) : herr_t;
+    extern proc H5Pget_page_buffer_size(plist_id : hid_t, ref buf_size : c_size_t, ref min_meta_per : c_uint, ref min_raw_per : c_uint) : herr_t;
 
     extern proc H5Pset_layout(plist_id : hid_t, layout : H5D_layout_t) : herr_t;
 
@@ -1528,15 +1528,15 @@ module HDF5 {
 
     extern proc H5Pset_virtual(dcpl_id : hid_t, vspace_id : hid_t, src_file_name : c_string, src_dset_name : c_string, src_space_id : hid_t) : herr_t;
 
-    extern proc H5Pget_virtual_count(dcpl_id : hid_t, ref count : size_t) : herr_t;
+    extern proc H5Pget_virtual_count(dcpl_id : hid_t, ref count : c_size_t) : herr_t;
 
-    extern proc H5Pget_virtual_vspace(dcpl_id : hid_t, index_arg : size_t) : hid_t;
+    extern proc H5Pget_virtual_vspace(dcpl_id : hid_t, index_arg : c_size_t) : hid_t;
 
-    extern proc H5Pget_virtual_srcspace(dcpl_id : hid_t, index_arg : size_t) : hid_t;
+    extern proc H5Pget_virtual_srcspace(dcpl_id : hid_t, index_arg : c_size_t) : hid_t;
 
-    extern proc H5Pget_virtual_filename(dcpl_id : hid_t, index_arg : size_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Pget_virtual_filename(dcpl_id : hid_t, index_arg : c_size_t, name : c_string, size : c_size_t) : c_ssize_t;
 
-    extern proc H5Pget_virtual_dsetname(dcpl_id : hid_t, index_arg : size_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Pget_virtual_dsetname(dcpl_id : hid_t, index_arg : c_size_t, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Pset_external(plist_id : hid_t, name : c_string, offset : off_t, size : hsize_t) : herr_t;
 
@@ -1546,7 +1546,7 @@ module HDF5 {
 
     extern proc H5Pget_external_count(plist_id : hid_t) : c_int;
 
-    extern proc H5Pget_external(plist_id : hid_t, idx : c_uint, name_size : size_t, name : c_string, ref offset : off_t, ref size : hsize_t) : herr_t;
+    extern proc H5Pget_external(plist_id : hid_t, idx : c_uint, name_size : c_size_t, name : c_string, ref offset : off_t, ref size : hsize_t) : herr_t;
 
     extern proc H5Pset_szip(plist_id : hid_t, options_mask : c_uint, pixels_per_block : c_uint) : herr_t;
 
@@ -1570,9 +1570,9 @@ module HDF5 {
 
     extern proc H5Pget_fill_time(plist_id : hid_t, ref fill_time : H5D_fill_time_t) : herr_t;
 
-    extern proc H5Pset_chunk_cache(dapl_id : hid_t, rdcc_nslots : size_t, rdcc_nbytes : size_t, rdcc_w0 : c_double) : herr_t;
+    extern proc H5Pset_chunk_cache(dapl_id : hid_t, rdcc_nslots : c_size_t, rdcc_nbytes : c_size_t, rdcc_w0 : c_double) : herr_t;
 
-    extern proc H5Pget_chunk_cache(dapl_id : hid_t, ref rdcc_nslots : size_t, ref rdcc_nbytes : size_t, ref rdcc_w0 : c_double) : herr_t;
+    extern proc H5Pget_chunk_cache(dapl_id : hid_t, ref rdcc_nslots : c_size_t, ref rdcc_nbytes : c_size_t, ref rdcc_w0 : c_double) : herr_t;
 
     extern proc H5Pset_virtual_view(plist_id : hid_t, view : H5D_vds_view_t) : herr_t;
 
@@ -1588,15 +1588,15 @@ module HDF5 {
 
     extern proc H5Pset_efile_prefix(dapl_id : hid_t, prefix : c_string) : herr_t;
 
-    extern proc H5Pget_efile_prefix(dapl_id : hid_t, prefix : c_string, size : size_t) : ssize_t;
+    extern proc H5Pget_efile_prefix(dapl_id : hid_t, prefix : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Pset_data_transform(plist_id : hid_t, expression : c_string) : herr_t;
 
-    extern proc H5Pget_data_transform(plist_id : hid_t, expression : c_string, size : size_t) : ssize_t;
+    extern proc H5Pget_data_transform(plist_id : hid_t, expression : c_string, size : c_size_t) : c_ssize_t;
 
-    extern proc H5Pset_buffer(plist_id : hid_t, size : size_t, tconv : c_void_ptr, bkg : c_void_ptr) : herr_t;
+    extern proc H5Pset_buffer(plist_id : hid_t, size : c_size_t, tconv : c_void_ptr, bkg : c_void_ptr) : herr_t;
 
-    extern proc H5Pget_buffer(plist_id : hid_t, ref tconv : c_void_ptr, ref bkg : c_void_ptr) : size_t;
+    extern proc H5Pget_buffer(plist_id : hid_t, ref tconv : c_void_ptr, ref bkg : c_void_ptr) : c_size_t;
 
     extern proc H5Pset_preserve(plist_id : hid_t, status : hbool_t) : herr_t;
 
@@ -1616,9 +1616,9 @@ module HDF5 {
 
     extern proc H5Pget_vlen_mem_manager(plist_id : hid_t, ref alloc_func : H5MM_allocate_t, ref alloc_info : c_void_ptr, ref free_func : H5MM_free_t, ref free_info : c_void_ptr) : herr_t;
 
-    extern proc H5Pset_hyper_vector_size(fapl_id : hid_t, size : size_t) : herr_t;
+    extern proc H5Pset_hyper_vector_size(fapl_id : hid_t, size : c_size_t) : herr_t;
 
-    extern proc H5Pget_hyper_vector_size(fapl_id : hid_t, ref size : size_t) : herr_t;
+    extern proc H5Pget_hyper_vector_size(fapl_id : hid_t, ref size : c_size_t) : herr_t;
 
     extern proc H5Pset_type_conv_cb(dxpl_id : hid_t, op : H5T_conv_except_func_t, operate_data : c_void_ptr) : herr_t;
 
@@ -1628,9 +1628,9 @@ module HDF5 {
 
     extern proc H5Pget_create_intermediate_group(plist_id : hid_t, ref crt_intmd : c_uint) : herr_t;
 
-    extern proc H5Pset_local_heap_size_hint(plist_id : hid_t, size_hint : size_t) : herr_t;
+    extern proc H5Pset_local_heap_size_hint(plist_id : hid_t, size_hint : c_size_t) : herr_t;
 
-    extern proc H5Pget_local_heap_size_hint(plist_id : hid_t, ref size_hint : size_t) : herr_t;
+    extern proc H5Pget_local_heap_size_hint(plist_id : hid_t, ref size_hint : c_size_t) : herr_t;
 
     extern proc H5Pset_link_phase_change(plist_id : hid_t, max_compact : c_uint, min_dense : c_uint) : herr_t;
 
@@ -1648,13 +1648,13 @@ module HDF5 {
 
     extern proc H5Pget_char_encoding(plist_id : hid_t, ref encoding : H5T_cset_t) : herr_t;
 
-    extern proc H5Pset_nlinks(plist_id : hid_t, nlinks : size_t) : herr_t;
+    extern proc H5Pset_nlinks(plist_id : hid_t, nlinks : c_size_t) : herr_t;
 
-    extern proc H5Pget_nlinks(plist_id : hid_t, ref nlinks : size_t) : herr_t;
+    extern proc H5Pget_nlinks(plist_id : hid_t, ref nlinks : c_size_t) : herr_t;
 
     extern proc H5Pset_elink_prefix(plist_id : hid_t, prefix : c_string) : herr_t;
 
-    extern proc H5Pget_elink_prefix(plist_id : hid_t, prefix : c_string, size : size_t) : ssize_t;
+    extern proc H5Pget_elink_prefix(plist_id : hid_t, prefix : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Pget_elink_fapl(lapl_id : hid_t) : hid_t;
 
@@ -1680,13 +1680,13 @@ module HDF5 {
 
     extern proc H5Pget_mcdt_search_cb(plist_id : hid_t, ref func : H5O_mcdt_search_cb_t, ref op_data : c_void_ptr) : herr_t;
 
-    extern proc H5Pregister1(cls_id : hid_t, name : c_string, size : size_t, def_value : c_void_ptr, prp_create : H5P_prp_create_func_t, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_del : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
+    extern proc H5Pregister1(cls_id : hid_t, name : c_string, size : c_size_t, def_value : c_void_ptr, prp_create : H5P_prp_create_func_t, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_del : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
 
-    extern proc H5Pinsert1(plist_id : hid_t, name : c_string, size : size_t, value : c_void_ptr, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_delete : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
+    extern proc H5Pinsert1(plist_id : hid_t, name : c_string, size : c_size_t, value : c_void_ptr, prp_set : H5P_prp_set_func_t, prp_get : H5P_prp_get_func_t, prp_delete : H5P_prp_delete_func_t, prp_copy : H5P_prp_copy_func_t, prp_close : H5P_prp_close_func_t) : herr_t;
 
-    extern proc H5Pget_filter1(plist_id : hid_t, filter : c_uint, ref flags : c_uint, ref cd_nelmts : size_t, cd_values : c_ptr(c_uint), namelen : size_t, name : c_ptr(c_char)) : H5Z_filter_t;
+    extern proc H5Pget_filter1(plist_id : hid_t, filter : c_uint, ref flags : c_uint, ref cd_nelmts : c_size_t, cd_values : c_ptr(c_uint), namelen : c_size_t, name : c_ptr(c_char)) : H5Z_filter_t;
 
-    extern proc H5Pget_filter_by_id1(plist_id : hid_t, id : H5Z_filter_t, ref flags : c_uint, ref cd_nelmts : size_t, cd_values : c_ptr(c_uint), namelen : size_t, name : c_ptr(c_char)) : herr_t;
+    extern proc H5Pget_filter_by_id1(plist_id : hid_t, id : H5Z_filter_t, ref flags : c_uint, ref cd_nelmts : c_size_t, cd_values : c_ptr(c_uint), namelen : c_size_t, name : c_ptr(c_char)) : herr_t;
 
     extern proc H5Pget_version(plist_id : hid_t, ref boot : c_uint, ref freelist : c_uint, ref stab : c_uint, ref shhdr : c_uint) : herr_t;
 
@@ -1708,7 +1708,7 @@ module HDF5 {
 
     extern proc H5PLremove(index_arg : c_uint) : herr_t;
 
-    extern proc H5PLget(index_arg : c_uint, pathname : c_string, size : size_t) : ssize_t;
+    extern proc H5PLget(index_arg : c_uint, pathname : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5PLsize(ref listsize : c_uint) : herr_t;
 
@@ -1720,7 +1720,7 @@ module HDF5 {
 
     extern proc H5Rget_obj_type2(id : hid_t, ref_type : H5R_type_t, _ref : c_void_ptr, ref obj_type : H5O_type_t) : herr_t;
 
-    extern proc H5Rget_name(loc_id : hid_t, ref_type : H5R_type_t, ref_arg : c_void_ptr, name : c_string, size : size_t) : ssize_t;
+    extern proc H5Rget_name(loc_id : hid_t, ref_type : H5R_type_t, ref_arg : c_void_ptr, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5Rget_obj_type1(id : hid_t, ref_type : H5R_type_t, _ref : c_void_ptr) : H5G_obj_t;
 
@@ -1736,7 +1736,7 @@ module HDF5 {
 
     extern proc H5Sclose(space_id : hid_t) : herr_t;
 
-    extern proc H5Sencode(obj_id : hid_t, buf : c_void_ptr, ref nalloc : size_t) : herr_t;
+    extern proc H5Sencode(obj_id : hid_t, buf : c_void_ptr, ref nalloc : c_size_t) : herr_t;
 
     extern proc H5Sdecode(buf : c_void_ptr) : hid_t;
 
@@ -1752,7 +1752,7 @@ module HDF5 {
 
     extern proc H5Sselect_hyperslab(space_id : hid_t, op : H5S_seloper_t, start : c_ptr(hsize_t), _stride : c_ptr(hsize_t), count : c_ptr(hsize_t), _block : c_ptr(hsize_t)) : herr_t;
 
-    extern proc H5Sselect_elements(space_id : hid_t, op : H5S_seloper_t, num_elem : size_t, ref coord : hsize_t) : herr_t;
+    extern proc H5Sselect_elements(space_id : hid_t, op : H5S_seloper_t, num_elem : c_size_t, ref coord : hsize_t) : herr_t;
 
     extern proc H5Sget_simple_extent_type(space_id : hid_t) : H5S_class_t;
 
@@ -1788,9 +1788,9 @@ module HDF5 {
 
     extern proc H5FD_core_init() : hid_t;
 
-    extern proc H5Pset_fapl_core(fapl_id : hid_t, increment : size_t, backing_store : hbool_t) : herr_t;
+    extern proc H5Pset_fapl_core(fapl_id : hid_t, increment : c_size_t, backing_store : hbool_t) : herr_t;
 
-    extern proc H5Pget_fapl_core(fapl_id : hid_t, ref increment : size_t, ref backing_store : hbool_t) : herr_t;
+    extern proc H5Pget_fapl_core(fapl_id : hid_t, ref increment : c_size_t, ref backing_store : hbool_t) : herr_t;
 
     extern proc H5FD_family_init() : hid_t;
 
@@ -1800,7 +1800,7 @@ module HDF5 {
 
     extern proc H5FD_log_init() : hid_t;
 
-    extern proc H5Pset_fapl_log(fapl_id : hid_t, logfile : c_string, flags : c_ulonglong, buf_size : size_t) : herr_t;
+    extern proc H5Pset_fapl_log(fapl_id : hid_t, logfile : c_string, flags : c_ulonglong, buf_size : c_size_t) : herr_t;
 
     extern proc H5FD_multi_init() : hid_t;
 
@@ -1818,9 +1818,9 @@ module HDF5 {
 
     extern proc H5Pset_fapl_stdio(fapl_id : hid_t) : herr_t;
 
-    extern proc H5DOwrite_chunk(dset_id : hid_t, dxpl_id : hid_t, filters : uint(32), ref offset : hsize_t, data_size : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5DOwrite_chunk(dset_id : hid_t, dxpl_id : hid_t, filters : uint(32), ref offset : hsize_t, data_size : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5DOappend(dset_id : hid_t, dxpl_id : hid_t, axis : c_uint, extension : size_t, memtype : hid_t, buf : c_void_ptr) : herr_t;
+    extern proc H5DOappend(dset_id : hid_t, dxpl_id : hid_t, axis : c_uint, extension : c_size_t, memtype : hid_t, buf : c_void_ptr) : herr_t;
 
     extern proc H5DSattach_scale(did : hid_t, dsid : hid_t, idx : c_uint) : herr_t;
 
@@ -1832,9 +1832,9 @@ module HDF5 {
 
     extern proc H5DSset_label(did : hid_t, idx : c_uint, label_arg : c_string) : herr_t;
 
-    extern proc H5DSget_label(did : hid_t, idx : c_uint, label_arg : c_string, size : size_t) : ssize_t;
+    extern proc H5DSget_label(did : hid_t, idx : c_uint, label_arg : c_string, size : c_size_t) : c_ssize_t;
 
-    extern proc H5DSget_scale_name(did : hid_t, name : c_string, size : size_t) : ssize_t;
+    extern proc H5DSget_scale_name(did : hid_t, name : c_string, size : c_size_t) : c_ssize_t;
 
     extern proc H5DSis_scale(did : hid_t) : htri_t;
 
@@ -1876,34 +1876,34 @@ module HDF5 {
 
     extern proc H5LTget_dataset_ndims(loc_id : hid_t, dset_name : c_string, ref rank : c_int) : herr_t;
 
-    extern proc H5LTget_dataset_info(loc_id : hid_t, dset_name : c_string, ref dims : hsize_t, ref type_class : H5T_class_t, ref type_size : size_t) : herr_t;
-    extern proc H5LTget_dataset_info(loc_id : hid_t, dset_name : c_string, ref dims : hsize_t, type_class : c_ptr(H5T_class_t), type_size : c_ptr(size_t)) : herr_t;
+    extern proc H5LTget_dataset_info(loc_id : hid_t, dset_name : c_string, ref dims : hsize_t, ref type_class : H5T_class_t, ref type_size : c_size_t) : herr_t;
+    extern proc H5LTget_dataset_info(loc_id : hid_t, dset_name : c_string, ref dims : hsize_t, type_class : c_ptr(H5T_class_t), type_size : c_ptr(c_size_t)) : herr_t;
 
     extern proc H5LTfind_dataset(loc_id : hid_t, name : c_string) : herr_t;
 
     extern proc H5LTset_attribute_string(loc_id : hid_t, obj_name : c_string, attr_name : c_string, attr_data : c_string) : herr_t;
 
-    extern proc H5LTset_attribute_char(loc_id : hid_t, obj_name : c_string, attr_name : c_string, buffer : c_string, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_char(loc_id : hid_t, obj_name : c_string, attr_name : c_string, buffer : c_string, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_uchar(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_uchar, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_uchar(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_uchar, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_short(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_short, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_short(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_short, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_ushort(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_ushort, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_ushort(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_ushort, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_int(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_int, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_int(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_int, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_uint(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_uint, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_uint(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_uint, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_long(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_long, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_long(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_long, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_long_long(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_longlong, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_long_long(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_longlong, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_ulong(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_ulong, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_ulong(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_ulong, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_float(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_float, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_float(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_float, size : c_size_t) : herr_t;
 
-    extern proc H5LTset_attribute_double(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_double, size : size_t) : herr_t;
+    extern proc H5LTset_attribute_double(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref buffer : c_double, size : c_size_t) : herr_t;
 
     extern proc H5LTget_attribute(loc_id : hid_t, obj_name : c_string, attr_name : c_string, mem_type_id : hid_t, data : c_void_ptr) : herr_t;
 
@@ -1933,17 +1933,17 @@ module HDF5 {
 
     extern proc H5LTget_attribute_ndims(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref rank : c_int) : herr_t;
 
-    extern proc H5LTget_attribute_info(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref dims : hsize_t, ref type_class : H5T_class_t, ref type_size : size_t) : herr_t;
+    extern proc H5LTget_attribute_info(loc_id : hid_t, obj_name : c_string, attr_name : c_string, ref dims : hsize_t, ref type_class : H5T_class_t, ref type_size : c_size_t) : herr_t;
 
     extern proc H5LTtext_to_dtype(text : c_string, lang_type : H5LT_lang_t) : hid_t;
 
-    extern proc H5LTdtype_to_text(dtype : hid_t, str : c_string, lang_type : H5LT_lang_t, ref len : size_t) : herr_t;
+    extern proc H5LTdtype_to_text(dtype : hid_t, str : c_string, lang_type : H5LT_lang_t, ref len : c_size_t) : herr_t;
 
     extern proc H5LTfind_attribute(loc_id : hid_t, name : c_string) : herr_t;
 
     extern proc H5LTpath_valid(loc_id : hid_t, path : c_string, check_object_valid : hbool_t) : htri_t;
 
-    extern proc H5LTopen_file_image(buf_ptr : c_void_ptr, buf_size : size_t, flags : c_uint) : hid_t;
+    extern proc H5LTopen_file_image(buf_ptr : c_void_ptr, buf_size : c_size_t, flags : c_uint) : hid_t;
 
     extern proc H5IMmake_image_8bit(loc_id : hid_t, dset_name : c_string, width : hsize_t, height : hsize_t, ref buffer : c_uchar) : herr_t;
 
@@ -1969,31 +1969,31 @@ module HDF5 {
 
     extern proc H5IMis_palette(loc_id : hid_t, dset_name : c_string) : herr_t;
 
-    extern proc H5TBmake_table(table_title : c_string, loc_id : hid_t, dset_name : c_string, nfields : hsize_t, nrecords : hsize_t, type_size : size_t, field_names : c_ptr(c_string), ref field_offset : size_t, ref field_types : hid_t, chunk_size : hsize_t, fill_data : c_void_ptr, compress : c_int, buf : c_void_ptr) : herr_t;
+    extern proc H5TBmake_table(table_title : c_string, loc_id : hid_t, dset_name : c_string, nfields : hsize_t, nrecords : hsize_t, type_size : c_size_t, field_names : c_ptr(c_string), ref field_offset : c_size_t, ref field_types : hid_t, chunk_size : hsize_t, fill_data : c_void_ptr, compress : c_int, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBappend_records(loc_id : hid_t, dset_name : c_string, nrecords : hsize_t, type_size : size_t, ref field_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBappend_records(loc_id : hid_t, dset_name : c_string, nrecords : hsize_t, type_size : c_size_t, ref field_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBwrite_records(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t, type_size : size_t, ref field_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBwrite_records(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t, type_size : c_size_t, ref field_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBwrite_fields_name(loc_id : hid_t, dset_name : c_string, field_names : c_string, start : hsize_t, nrecords : hsize_t, type_size : size_t, ref field_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBwrite_fields_name(loc_id : hid_t, dset_name : c_string, field_names : c_string, start : hsize_t, nrecords : hsize_t, type_size : c_size_t, ref field_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBwrite_fields_index(loc_id : hid_t, dset_name : c_string, nfields : hsize_t, ref field_index : c_int, start : hsize_t, nrecords : hsize_t, type_size : size_t, ref field_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBwrite_fields_index(loc_id : hid_t, dset_name : c_string, nfields : hsize_t, ref field_index : c_int, start : hsize_t, nrecords : hsize_t, type_size : c_size_t, ref field_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBread_table(loc_id : hid_t, dset_name : c_string, dst_size : size_t, ref dst_offset : size_t, ref dst_sizes : size_t, dst_buf : c_void_ptr) : herr_t;
+    extern proc H5TBread_table(loc_id : hid_t, dset_name : c_string, dst_size : c_size_t, ref dst_offset : c_size_t, ref dst_sizes : c_size_t, dst_buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBread_fields_name(loc_id : hid_t, dset_name : c_string, field_names : c_string, start : hsize_t, nrecords : hsize_t, type_size : size_t, ref field_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBread_fields_name(loc_id : hid_t, dset_name : c_string, field_names : c_string, start : hsize_t, nrecords : hsize_t, type_size : c_size_t, ref field_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBread_fields_index(loc_id : hid_t, dset_name : c_string, nfields : hsize_t, ref field_index : c_int, start : hsize_t, nrecords : hsize_t, type_size : size_t, ref field_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBread_fields_index(loc_id : hid_t, dset_name : c_string, nfields : hsize_t, ref field_index : c_int, start : hsize_t, nrecords : hsize_t, type_size : c_size_t, ref field_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
-    extern proc H5TBread_records(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t, type_size : size_t, ref dst_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBread_records(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t, type_size : c_size_t, ref dst_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
     extern proc H5TBget_table_info(loc_id : hid_t, dset_name : c_string, ref nfields : hsize_t, ref nrecords : hsize_t) : herr_t;
 
-    extern proc H5TBget_field_info(loc_id : hid_t, dset_name : c_string, field_names : c_ptr(c_string), ref field_sizes : size_t, ref field_offsets : size_t, ref type_size : size_t) : herr_t;
+    extern proc H5TBget_field_info(loc_id : hid_t, dset_name : c_string, field_names : c_ptr(c_string), ref field_sizes : c_size_t, ref field_offsets : c_size_t, ref type_size : c_size_t) : herr_t;
 
     extern proc H5TBdelete_record(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t) : herr_t;
 
-    extern proc H5TBinsert_record(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t, dst_size : size_t, ref dst_offset : size_t, ref dst_sizes : size_t, buf : c_void_ptr) : herr_t;
+    extern proc H5TBinsert_record(loc_id : hid_t, dset_name : c_string, start : hsize_t, nrecords : hsize_t, dst_size : c_size_t, ref dst_offset : c_size_t, ref dst_sizes : c_size_t, buf : c_void_ptr) : herr_t;
 
     extern proc H5TBadd_records_from(loc_id : hid_t, dset_name1 : c_string, start1 : hsize_t, nrecords : hsize_t, dset_name2 : c_string, start2 : hsize_t) : herr_t;
 
@@ -2015,11 +2015,11 @@ module HDF5 {
 
     extern proc H5PTcreate_fl(loc_id : hid_t, dset_name : c_string, dtype_id : hid_t, chunk_size : hsize_t, compression : c_int) : hid_t;
 
-    extern proc H5PTappend(table_id : hid_t, nrecords : size_t, data : c_void_ptr) : herr_t;
+    extern proc H5PTappend(table_id : hid_t, nrecords : c_size_t, data : c_void_ptr) : herr_t;
 
-    extern proc H5PTget_next(table_id : hid_t, nrecords : size_t, data : c_void_ptr) : herr_t;
+    extern proc H5PTget_next(table_id : hid_t, nrecords : c_size_t, data : c_void_ptr) : herr_t;
 
-    extern proc H5PTread_packets(table_id : hid_t, start : hsize_t, nrecords : size_t, data : c_void_ptr) : herr_t;
+    extern proc H5PTread_packets(table_id : hid_t, start : hsize_t, nrecords : c_size_t, data : c_void_ptr) : herr_t;
 
     extern proc H5PTget_num_packets(table_id : hid_t, ref nrecords : hsize_t) : herr_t;
 
@@ -2037,11 +2037,11 @@ module HDF5 {
 
     extern proc H5PTget_index(table_id : hid_t, ref pt_index : hsize_t) : herr_t;
 
-    extern proc H5PTfree_vlen_buff(table_id : hid_t, bufflen : size_t, buff : c_void_ptr) : herr_t;
+    extern proc H5PTfree_vlen_buff(table_id : hid_t, bufflen : c_size_t, buff : c_void_ptr) : herr_t;
 
     extern proc H5LDget_dset_dims(did : hid_t, ref cur_dims : hsize_t) : herr_t;
 
-    extern proc H5LDget_dset_type_size(did : hid_t, fields : c_string) : size_t;
+    extern proc H5LDget_dset_type_size(did : hid_t, fields : c_string) : c_size_t;
 
     extern proc H5LDget_dset_elmts(did : hid_t, ref prev_dims : hsize_t, ref cur_dims : hsize_t, fields : c_string, buf : c_void_ptr) : herr_t;
 
@@ -2055,16 +2055,16 @@ module HDF5 {
       var trace_file_name : c_ptr(c_char);
       var evictions_enabled : hbool_t;
       var set_initial_size : hbool_t;
-      var initial_size : size_t;
+      var initial_size : c_size_t;
       var min_clean_fraction : c_double;
-      var max_size : size_t;
-      var min_size : size_t;
+      var max_size : c_size_t;
+      var min_size : c_size_t;
       var epoch_length : c_long;
       var incr_mode : H5C_cache_incr_mode;
       var lower_hr_threshold : c_double;
       var increment : c_double;
       var apply_max_increment : hbool_t;
-      var max_increment : size_t;
+      var max_increment : c_size_t;
       var flash_incr_mode : H5C_cache_flash_incr_mode;
       var flash_multiple : c_double;
       var flash_threshold : c_double;
@@ -2072,11 +2072,11 @@ module HDF5 {
       var upper_hr_threshold : c_double;
       var decrement : c_double;
       var apply_max_decrement : hbool_t;
-      var max_decrement : size_t;
+      var max_decrement : c_size_t;
       var epochs_before_eviction : c_int;
       var apply_empty_reserve : hbool_t;
       var empty_reserve : c_double;
-      var dirty_bytes_threshold : size_t;
+      var dirty_bytes_threshold : c_size_t;
       var metadata_write_strategy : c_int;
     }
 
@@ -2248,11 +2248,11 @@ module HDF5 {
       var sb_size : c_fn_ptr;
       var sb_encode : c_fn_ptr;
       var sb_decode : c_fn_ptr;
-      var fapl_size : size_t;
+      var fapl_size : c_size_t;
       var fapl_get : c_fn_ptr;
       var fapl_copy : c_fn_ptr;
       var fapl_free : c_fn_ptr;
-      var dxpl_size : size_t;
+      var dxpl_size : c_size_t;
       var dxpl_copy : c_fn_ptr;
       var dxpl_free : c_fn_ptr;
       var open : c_fn_ptr;
@@ -2911,7 +2911,7 @@ module HDF5 {
     extern type htri_t = c_int;
 
     extern record hvl_t {
-      var len : size_t;
+      var len : c_size_t;
       var p : c_void_ptr;
     }
 
@@ -3452,7 +3452,7 @@ module HDF5 {
       return H5T_C_S1_g;
     }
     proc H5T_VARIABLE {
-      return (-1):size_t;
+      return (-1):c_size_t;
     }
 
     /* Types particular to Fortran.  */
@@ -3474,7 +3474,7 @@ module HDF5 {
                                            dset_name: c_string,
                                            dims: c_void_ptr,
                                            type_class: c_ptr(H5T_class_t),
-                                           type_size: c_ptr(size_t)): herr_t;
+                                           type_size: c_ptr(c_size_t)): herr_t;
 
       extern proc H5LTmake_dataset_WAR(loc_id: hid_t,
                                        dset_name: c_string,

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -170,10 +170,10 @@ module HDFS {
   // QIO extern stuff
   private extern proc qio_strdup(s: c_string): c_string;
   private extern proc qio_mkerror_errno():syserr;
-  private extern proc qio_channel_get_allocated_ptr_unlocked(ch:qio_channel_ptr_t, amt_requested:int(64), ref ptr_out:c_void_ptr, ref len_out:ssize_t, ref offset_out:int(64)):syserr;
-  private extern proc qio_channel_advance_available_end_unlocked(ch:qio_channel_ptr_t, len:ssize_t);
-  private extern proc qio_channel_get_write_behind_ptr_unlocked(ch:qio_channel_ptr_t, ref ptr_out:c_void_ptr, ref len_out:ssize_t, ref offset_out:int(64)):syserr;
-  private extern proc qio_channel_advance_write_behind_unlocked(ch:qio_channel_ptr_t, len:ssize_t);
+  private extern proc qio_channel_get_allocated_ptr_unlocked(ch:qio_channel_ptr_t, amt_requested:int(64), ref ptr_out:c_void_ptr, ref len_out:c_ssize_t, ref offset_out:int(64)):syserr;
+  private extern proc qio_channel_advance_available_end_unlocked(ch:qio_channel_ptr_t, len:c_ssize_t);
+  private extern proc qio_channel_get_write_behind_ptr_unlocked(ch:qio_channel_ptr_t, ref ptr_out:c_void_ptr, ref len_out:c_ssize_t, ref offset_out:int(64)):syserr;
+  private extern proc qio_channel_advance_write_behind_unlocked(ch:qio_channel_ptr_t, len:c_ssize_t);
 
   private param verbose = false;
 
@@ -477,7 +477,7 @@ module HDFS {
       var remaining = amt;
       while remaining > 0 {
         var ptr:c_void_ptr = c_nil;
-        var len = 0:ssize_t;
+        var len = 0:c_ssize_t;
         var offset = 0;
         err = qio_channel_get_allocated_ptr_unlocked(qio_ch, amt, ptr, len, offset);
         if err then
@@ -516,7 +516,7 @@ module HDFS {
       var remaining = amt;
       while remaining > 0 {
         var ptr:c_void_ptr = c_nil;
-        var len = 0:ssize_t;
+        var len = 0:c_ssize_t;
         var offset = 0;
         err = qio_channel_get_write_behind_ptr_unlocked(qio_ch, ptr, len, offset);
         if err then
@@ -524,7 +524,7 @@ module HDFS {
         if ptr == nil || len == 0 then
           return EINVAL;
 
-        len = min(len, amt.safeCast(ssize_t));
+        len = min(len, amt.safeCast(c_ssize_t));
         if len >= max(int(32)) then
           len = max(int(32));
 

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -440,7 +440,7 @@ module MPI {
 
   {
     pragma "no doc"
-    extern proc sizeof(type t): size_t;
+    extern proc sizeof(type t): csize_t;
     assert(sizeof(MPI_Aint) == sizeof(c_ptrdiff));
   }
 

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -440,7 +440,7 @@ module MPI {
 
   {
     pragma "no doc"
-    extern proc sizeof(type t): csize_t;
+    extern proc sizeof(type t): c_size_t;
     assert(sizeof(MPI_Aint) == sizeof(c_ptrdiff));
   }
 

--- a/modules/packages/NetCDF.chpl
+++ b/modules/packages/NetCDF.chpl
@@ -148,7 +148,7 @@ module NetCDF {
     extern const NC_FORMAT_DAP4 : c_int;
     extern const NC_FORMAT_UNDEFINED : c_int;
     extern const NC_SIZEHINT_DEFAULT : c_int;
-    extern const NC_ALIGN_CHUNK : size_t;
+    extern const NC_ALIGN_CHUNK : c_size_t;
     extern const NC_UNLIMITED : c_int;
     extern const NC_GLOBAL : c_int;
     extern const NC_MAX_DIMS : c_int;
@@ -285,15 +285,15 @@ module NetCDF {
 
     extern proc nc_strerror(ncerr : c_int) : c_string;
 
-    extern proc nc__create(path : c_string, cmode : c_int, initialsz : size_t, ref chunksizehintp : size_t, ref ncidp : c_int) : c_int;
+    extern proc nc__create(path : c_string, cmode : c_int, initialsz : c_size_t, ref chunksizehintp : c_size_t, ref ncidp : c_int) : c_int;
 
     extern proc nc_create(path : c_string, cmode : c_int, ref ncidp : c_int) : c_int;
 
-    extern proc nc__open(path : c_string, mode : c_int, ref chunksizehintp : size_t, ref ncidp : c_int) : c_int;
+    extern proc nc__open(path : c_string, mode : c_int, ref chunksizehintp : c_size_t, ref ncidp : c_int) : c_int;
 
     extern proc nc_open(path : c_string, mode : c_int, ref ncidp : c_int) : c_int;
 
-    extern proc nc_inq_path(ncid : c_int, ref pathlen : size_t, path : c_string) : c_int;
+    extern proc nc_inq_path(ncid : c_int, ref pathlen : c_size_t, path : c_string) : c_int;
 
     extern proc nc_inq_ncid(ncid : c_int, name : c_string, ref grp_ncid : c_int) : c_int;
 
@@ -301,9 +301,9 @@ module NetCDF {
 
     extern proc nc_inq_grpname(ncid : c_int, name : c_string) : c_int;
 
-    extern proc nc_inq_grpname_full(ncid : c_int, ref lenp : size_t, full_name : c_string) : c_int;
+    extern proc nc_inq_grpname_full(ncid : c_int, ref lenp : c_size_t, full_name : c_string) : c_int;
 
-    extern proc nc_inq_grpname_len(ncid : c_int, ref lenp : size_t) : c_int;
+    extern proc nc_inq_grpname_len(ncid : c_int, ref lenp : c_size_t) : c_int;
 
     extern proc nc_inq_grp_parent(ncid : c_int, ref parent_ncid : c_int) : c_int;
 
@@ -323,31 +323,31 @@ module NetCDF {
 
     extern proc nc_rename_grp(grpid : c_int, name : c_string) : c_int;
 
-    extern proc nc_def_compound(ncid : c_int, size : size_t, name : c_string, ref typeidp : nc_type) : c_int;
+    extern proc nc_def_compound(ncid : c_int, size : c_size_t, name : c_string, ref typeidp : nc_type) : c_int;
 
-    extern proc nc_insert_compound(ncid : c_int, xtype : nc_type, name : c_string, offset : size_t, field_typeid : nc_type) : c_int;
+    extern proc nc_insert_compound(ncid : c_int, xtype : nc_type, name : c_string, offset : c_size_t, field_typeid : nc_type) : c_int;
 
-    extern proc nc_insert_array_compound(ncid : c_int, xtype : nc_type, name : c_string, offset : size_t, field_typeid : nc_type, ndims : c_int, ref dim_sizes : c_int) : c_int;
+    extern proc nc_insert_array_compound(ncid : c_int, xtype : nc_type, name : c_string, offset : c_size_t, field_typeid : nc_type, ndims : c_int, ref dim_sizes : c_int) : c_int;
 
-    extern proc nc_inq_type(ncid : c_int, xtype : nc_type, name : c_string, ref size : size_t) : c_int;
+    extern proc nc_inq_type(ncid : c_int, xtype : nc_type, name : c_string, ref size : c_size_t) : c_int;
 
     extern proc nc_inq_typeid(ncid : c_int, name : c_string, ref typeidp : nc_type) : c_int;
 
-    extern proc nc_inq_compound(ncid : c_int, xtype : nc_type, name : c_string, ref sizep : size_t, ref nfieldsp : size_t) : c_int;
+    extern proc nc_inq_compound(ncid : c_int, xtype : nc_type, name : c_string, ref sizep : c_size_t, ref nfieldsp : c_size_t) : c_int;
 
     extern proc nc_inq_compound_name(ncid : c_int, xtype : nc_type, name : c_string) : c_int;
 
-    extern proc nc_inq_compound_size(ncid : c_int, xtype : nc_type, ref sizep : size_t) : c_int;
+    extern proc nc_inq_compound_size(ncid : c_int, xtype : nc_type, ref sizep : c_size_t) : c_int;
 
-    extern proc nc_inq_compound_nfields(ncid : c_int, xtype : nc_type, ref nfieldsp : size_t) : c_int;
+    extern proc nc_inq_compound_nfields(ncid : c_int, xtype : nc_type, ref nfieldsp : c_size_t) : c_int;
 
-    extern proc nc_inq_compound_field(ncid : c_int, xtype : nc_type, fieldid : c_int, name : c_string, ref offsetp : size_t, ref field_typeidp : nc_type, ref ndimsp : c_int, ref dim_sizesp : c_int) : c_int;
+    extern proc nc_inq_compound_field(ncid : c_int, xtype : nc_type, fieldid : c_int, name : c_string, ref offsetp : c_size_t, ref field_typeidp : nc_type, ref ndimsp : c_int, ref dim_sizesp : c_int) : c_int;
 
     extern proc nc_inq_compound_fieldname(ncid : c_int, xtype : nc_type, fieldid : c_int, name : c_string) : c_int;
 
     extern proc nc_inq_compound_fieldindex(ncid : c_int, xtype : nc_type, name : c_string, ref fieldidp : c_int) : c_int;
 
-    extern proc nc_inq_compound_fieldoffset(ncid : c_int, xtype : nc_type, fieldid : c_int, ref offsetp : size_t) : c_int;
+    extern proc nc_inq_compound_fieldoffset(ncid : c_int, xtype : nc_type, fieldid : c_int, ref offsetp : c_size_t) : c_int;
 
     extern proc nc_inq_compound_fieldtype(ncid : c_int, xtype : nc_type, fieldid : c_int, ref field_typeidp : nc_type) : c_int;
 
@@ -357,21 +357,21 @@ module NetCDF {
 
     extern proc nc_def_vlen(ncid : c_int, name : c_string, base_typeid : nc_type, ref xtypep : nc_type) : c_int;
 
-    extern proc nc_inq_vlen(ncid : c_int, xtype : nc_type, name : c_string, ref datum_sizep : size_t, ref base_nc_typep : nc_type) : c_int;
+    extern proc nc_inq_vlen(ncid : c_int, xtype : nc_type, name : c_string, ref datum_sizep : c_size_t, ref base_nc_typep : nc_type) : c_int;
 
     extern proc nc_free_vlen(ref vl : nc_vlen_t) : c_int;
 
-    extern proc nc_free_vlens(len : size_t, vlens : c_ptr(nc_vlen_t)) : c_int;
+    extern proc nc_free_vlens(len : c_size_t, vlens : c_ptr(nc_vlen_t)) : c_int;
 
-    extern proc nc_put_vlen_element(ncid : c_int, typeid1 : c_int, vlen_element : c_void_ptr, len : size_t, data : c_void_ptr) : c_int;
+    extern proc nc_put_vlen_element(ncid : c_int, typeid1 : c_int, vlen_element : c_void_ptr, len : c_size_t, data : c_void_ptr) : c_int;
 
-    extern proc nc_get_vlen_element(ncid : c_int, typeid1 : c_int, vlen_element : c_void_ptr, ref len : size_t, data : c_void_ptr) : c_int;
+    extern proc nc_get_vlen_element(ncid : c_int, typeid1 : c_int, vlen_element : c_void_ptr, ref len : c_size_t, data : c_void_ptr) : c_int;
 
-    extern proc nc_free_string(len : size_t, ref data : c_string) : c_int;
+    extern proc nc_free_string(len : c_size_t, ref data : c_string) : c_int;
 
-    extern proc nc_inq_user_type(ncid : c_int, xtype : nc_type, name : c_string, ref size : size_t, ref base_nc_typep : nc_type, ref nfieldsp : size_t, ref classp : c_int) : c_int;
+    extern proc nc_inq_user_type(ncid : c_int, xtype : nc_type, name : c_string, ref size : c_size_t, ref base_nc_typep : nc_type, ref nfieldsp : c_size_t, ref classp : c_int) : c_int;
 
-    extern proc nc_put_att(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, op : c_void_ptr) : c_int;
+    extern proc nc_put_att(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, op : c_void_ptr) : c_int;
 
     extern proc nc_get_att(ncid : c_int, varid : c_int, name : c_string, ip : c_void_ptr) : c_int;
 
@@ -379,35 +379,35 @@ module NetCDF {
 
     extern proc nc_insert_enum(ncid : c_int, xtype : nc_type, name : c_string, value : c_void_ptr) : c_int;
 
-    extern proc nc_inq_enum(ncid : c_int, xtype : nc_type, name : c_string, ref base_nc_typep : nc_type, ref base_sizep : size_t, ref num_membersp : size_t) : c_int;
+    extern proc nc_inq_enum(ncid : c_int, xtype : nc_type, name : c_string, ref base_nc_typep : nc_type, ref base_sizep : c_size_t, ref num_membersp : c_size_t) : c_int;
 
     extern proc nc_inq_enum_member(ncid : c_int, xtype : nc_type, idx : c_int, name : c_string, value : c_void_ptr) : c_int;
 
     extern proc nc_inq_enum_ident(ncid : c_int, xtype : nc_type, value : c_longlong, identifier : c_string) : c_int;
 
-    extern proc nc_def_opaque(ncid : c_int, size : size_t, name : c_string, ref xtypep : nc_type) : c_int;
+    extern proc nc_def_opaque(ncid : c_int, size : c_size_t, name : c_string, ref xtypep : nc_type) : c_int;
 
-    extern proc nc_inq_opaque(ncid : c_int, xtype : nc_type, name : c_string, ref sizep : size_t) : c_int;
+    extern proc nc_inq_opaque(ncid : c_int, xtype : nc_type, name : c_string, ref sizep : c_size_t) : c_int;
 
     extern proc nc_put_var(ncid : c_int, varid : c_int, op : c_void_ptr) : c_int;
 
     extern proc nc_get_var(ncid : c_int, varid : c_int, ip : c_void_ptr) : c_int;
 
-    extern proc nc_put_var1(ncid : c_int, varid : c_int, ref indexp : size_t, op : c_void_ptr) : c_int;
+    extern proc nc_put_var1(ncid : c_int, varid : c_int, ref indexp : c_size_t, op : c_void_ptr) : c_int;
 
-    extern proc nc_get_var1(ncid : c_int, varid : c_int, ref indexp : size_t, ip : c_void_ptr) : c_int;
+    extern proc nc_get_var1(ncid : c_int, varid : c_int, ref indexp : c_size_t, ip : c_void_ptr) : c_int;
 
-    extern proc nc_put_vara(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, op : c_void_ptr) : c_int;
+    extern proc nc_put_vara(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, op : c_void_ptr) : c_int;
 
-    extern proc nc_get_vara(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ip : c_void_ptr) : c_int;
+    extern proc nc_get_vara(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ip : c_void_ptr) : c_int;
 
-    extern proc nc_put_vars(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, op : c_void_ptr) : c_int;
+    extern proc nc_put_vars(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, op : c_void_ptr) : c_int;
 
-    extern proc nc_get_vars(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ip : c_void_ptr) : c_int;
+    extern proc nc_get_vars(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ip : c_void_ptr) : c_int;
 
-    extern proc nc_put_varm(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, op : c_void_ptr) : c_int;
+    extern proc nc_put_varm(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, op : c_void_ptr) : c_int;
 
-    extern proc nc_get_varm(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ip : c_void_ptr) : c_int;
+    extern proc nc_get_varm(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ip : c_void_ptr) : c_int;
 
     extern proc nc_def_var_deflate(ncid : c_int, varid : c_int, shuffle : c_int, deflate : c_int, deflate_level : c_int) : c_int;
 
@@ -419,9 +419,9 @@ module NetCDF {
 
     extern proc nc_inq_var_fletcher32(ncid : c_int, varid : c_int, ref fletcher32p : c_int) : c_int;
 
-    extern proc nc_def_var_chunking(ncid : c_int, varid : c_int, storage : c_int, ref chunksizesp : size_t) : c_int;
+    extern proc nc_def_var_chunking(ncid : c_int, varid : c_int, storage : c_int, ref chunksizesp : c_size_t) : c_int;
 
-    extern proc nc_inq_var_chunking(ncid : c_int, varid : c_int, ref storagep : c_int, ref chunksizesp : size_t) : c_int;
+    extern proc nc_inq_var_chunking(ncid : c_int, varid : c_int, ref storagep : c_int, ref chunksizesp : c_size_t) : c_int;
 
     extern proc nc_def_var_fill(ncid : c_int, varid : c_int, no_fill : c_int, fill_value : c_void_ptr) : c_int;
 
@@ -431,25 +431,25 @@ module NetCDF {
 
     extern proc nc_inq_var_endian(ncid : c_int, varid : c_int, ref endianp : c_int) : c_int;
 
-    extern proc nc_def_var_filter(ncid : c_int, varid : c_int, id : c_uint, nparams : size_t, ref parms : c_uint) : c_int;
+    extern proc nc_def_var_filter(ncid : c_int, varid : c_int, id : c_uint, nparams : c_size_t, ref parms : c_uint) : c_int;
 
-    extern proc nc_inq_var_filter(ncid : c_int, varid : c_int, ref idp : c_uint, ref nparams : size_t, ref params : c_uint) : c_int;
+    extern proc nc_inq_var_filter(ncid : c_int, varid : c_int, ref idp : c_uint, ref nparams : c_size_t, ref params : c_uint) : c_int;
 
     extern proc nc_set_fill(ncid : c_int, fillmode : c_int, ref old_modep : c_int) : c_int;
 
     extern proc nc_set_default_format(format : c_int, ref old_formatp : c_int) : c_int;
 
-    extern proc nc_set_chunk_cache(size : size_t, nelems : size_t, preemption : c_float) : c_int;
+    extern proc nc_set_chunk_cache(size : c_size_t, nelems : c_size_t, preemption : c_float) : c_int;
 
-    extern proc nc_get_chunk_cache(ref sizep : size_t, ref nelemsp : size_t, ref preemptionp : c_float) : c_int;
+    extern proc nc_get_chunk_cache(ref sizep : c_size_t, ref nelemsp : c_size_t, ref preemptionp : c_float) : c_int;
 
-    extern proc nc_set_var_chunk_cache(ncid : c_int, varid : c_int, size : size_t, nelems : size_t, preemption : c_float) : c_int;
+    extern proc nc_set_var_chunk_cache(ncid : c_int, varid : c_int, size : c_size_t, nelems : c_size_t, preemption : c_float) : c_int;
 
-    extern proc nc_get_var_chunk_cache(ncid : c_int, varid : c_int, ref sizep : size_t, ref nelemsp : size_t, ref preemptionp : c_float) : c_int;
+    extern proc nc_get_var_chunk_cache(ncid : c_int, varid : c_int, ref sizep : c_size_t, ref nelemsp : c_size_t, ref preemptionp : c_float) : c_int;
 
     extern proc nc_redef(ncid : c_int) : c_int;
 
-    extern proc nc__enddef(ncid : c_int, h_minfree : size_t, v_align : size_t, v_minfree : size_t, r_align : size_t) : c_int;
+    extern proc nc__enddef(ncid : c_int, h_minfree : c_size_t, v_align : c_size_t, v_minfree : c_size_t, r_align : c_size_t) : c_int;
 
     extern proc nc_enddef(ncid : c_int) : c_int;
 
@@ -475,25 +475,25 @@ module NetCDF {
 
     extern proc nc_inq_format_extended(ncid : c_int, ref formatp : c_int, ref modep : c_int) : c_int;
 
-    extern proc nc_def_dim(ncid : c_int, name : c_string, len : size_t, ref idp : c_int) : c_int;
+    extern proc nc_def_dim(ncid : c_int, name : c_string, len : c_size_t, ref idp : c_int) : c_int;
 
     extern proc nc_inq_dimid(ncid : c_int, name : c_string, ref idp : c_int) : c_int;
 
-    extern proc nc_inq_dim(ncid : c_int, dimid : c_int, name : c_string, ref lenp : size_t) : c_int;
+    extern proc nc_inq_dim(ncid : c_int, dimid : c_int, name : c_string, ref lenp : c_size_t) : c_int;
 
     extern proc nc_inq_dimname(ncid : c_int, dimid : c_int, name : c_string) : c_int;
 
-    extern proc nc_inq_dimlen(ncid : c_int, dimid : c_int, ref lenp : size_t) : c_int;
+    extern proc nc_inq_dimlen(ncid : c_int, dimid : c_int, ref lenp : c_size_t) : c_int;
 
     extern proc nc_rename_dim(ncid : c_int, dimid : c_int, name : c_string) : c_int;
 
-    extern proc nc_inq_att(ncid : c_int, varid : c_int, name : c_string, ref xtypep : nc_type, ref lenp : size_t) : c_int;
+    extern proc nc_inq_att(ncid : c_int, varid : c_int, name : c_string, ref xtypep : nc_type, ref lenp : c_size_t) : c_int;
 
     extern proc nc_inq_attid(ncid : c_int, varid : c_int, name : c_string, ref idp : c_int) : c_int;
 
     extern proc nc_inq_atttype(ncid : c_int, varid : c_int, name : c_string, ref xtypep : nc_type) : c_int;
 
-    extern proc nc_inq_attlen(ncid : c_int, varid : c_int, name : c_string, ref lenp : size_t) : c_int;
+    extern proc nc_inq_attlen(ncid : c_int, varid : c_int, name : c_string, ref lenp : c_size_t) : c_int;
 
     extern proc nc_inq_attname(ncid : c_int, varid : c_int, attnum : c_int, name : c_string) : c_int;
 
@@ -503,55 +503,55 @@ module NetCDF {
 
     extern proc nc_del_att(ncid : c_int, varid : c_int, name : c_string) : c_int;
 
-    extern proc nc_put_att_text(ncid : c_int, varid : c_int, name : c_string, len : size_t, op : c_string) : c_int;
+    extern proc nc_put_att_text(ncid : c_int, varid : c_int, name : c_string, len : c_size_t, op : c_string) : c_int;
 
     extern proc nc_get_att_text(ncid : c_int, varid : c_int, name : c_string, ip : c_string) : c_int;
 
-    extern proc nc_put_att_string(ncid : c_int, varid : c_int, name : c_string, len : size_t, ref op : c_string) : c_int;
+    extern proc nc_put_att_string(ncid : c_int, varid : c_int, name : c_string, len : c_size_t, ref op : c_string) : c_int;
 
     extern proc nc_get_att_string(ncid : c_int, varid : c_int, name : c_string, ref ip : c_string) : c_int;
 
-    extern proc nc_put_att_uchar(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_uchar) : c_int;
+    extern proc nc_put_att_uchar(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_uchar) : c_int;
 
     extern proc nc_get_att_uchar(ncid : c_int, varid : c_int, name : c_string, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_att_schar(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_schar) : c_int;
+    extern proc nc_put_att_schar(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_schar) : c_int;
 
     extern proc nc_get_att_schar(ncid : c_int, varid : c_int, name : c_string, ref ip : c_schar) : c_int;
 
-    extern proc nc_put_att_short(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_short) : c_int;
+    extern proc nc_put_att_short(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_short) : c_int;
 
     extern proc nc_get_att_short(ncid : c_int, varid : c_int, name : c_string, ref ip : c_short) : c_int;
 
-    extern proc nc_put_att_int(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_int) : c_int;
+    extern proc nc_put_att_int(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_int) : c_int;
 
     extern proc nc_get_att_int(ncid : c_int, varid : c_int, name : c_string, ref ip : c_int) : c_int;
 
-    extern proc nc_put_att_long(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_long) : c_int;
+    extern proc nc_put_att_long(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_long) : c_int;
 
     extern proc nc_get_att_long(ncid : c_int, varid : c_int, name : c_string, ref ip : c_long) : c_int;
 
-    extern proc nc_put_att_float(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_float) : c_int;
+    extern proc nc_put_att_float(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_float) : c_int;
 
     extern proc nc_get_att_float(ncid : c_int, varid : c_int, name : c_string, ref ip : c_float) : c_int;
 
-    extern proc nc_put_att_double(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_double) : c_int;
+    extern proc nc_put_att_double(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_double) : c_int;
 
     extern proc nc_get_att_double(ncid : c_int, varid : c_int, name : c_string, ref ip : c_double) : c_int;
 
-    extern proc nc_put_att_ushort(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_ushort) : c_int;
+    extern proc nc_put_att_ushort(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_ushort) : c_int;
 
     extern proc nc_get_att_ushort(ncid : c_int, varid : c_int, name : c_string, ref ip : c_ushort) : c_int;
 
-    extern proc nc_put_att_uint(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_uint) : c_int;
+    extern proc nc_put_att_uint(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_uint) : c_int;
 
     extern proc nc_get_att_uint(ncid : c_int, varid : c_int, name : c_string, ref ip : c_uint) : c_int;
 
-    extern proc nc_put_att_longlong(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_longlong) : c_int;
+    extern proc nc_put_att_longlong(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_longlong) : c_int;
 
     extern proc nc_get_att_longlong(ncid : c_int, varid : c_int, name : c_string, ref ip : c_longlong) : c_int;
 
-    extern proc nc_put_att_ulonglong(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_ulonglong) : c_int;
+    extern proc nc_put_att_ulonglong(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_ulonglong) : c_int;
 
     extern proc nc_get_att_ulonglong(ncid : c_int, varid : c_int, name : c_string, ref ip : c_ulonglong) : c_int;
 
@@ -575,213 +575,213 @@ module NetCDF {
 
     extern proc nc_copy_var(ncid_in : c_int, varid : c_int, ncid_out : c_int) : c_int;
 
-    extern proc nc_put_var1_text(ncid : c_int, varid : c_int, ref indexp : size_t, op : c_string) : c_int;
+    extern proc nc_put_var1_text(ncid : c_int, varid : c_int, ref indexp : c_size_t, op : c_string) : c_int;
 
-    extern proc nc_get_var1_text(ncid : c_int, varid : c_int, ref indexp : size_t, ip : c_string) : c_int;
+    extern proc nc_get_var1_text(ncid : c_int, varid : c_int, ref indexp : c_size_t, ip : c_string) : c_int;
 
-    extern proc nc_put_var1_uchar(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_uchar) : c_int;
+    extern proc nc_put_var1_uchar(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_var1_uchar(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_uchar) : c_int;
+    extern proc nc_get_var1_uchar(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_var1_schar(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_schar) : c_int;
+    extern proc nc_put_var1_schar(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_schar) : c_int;
 
-    extern proc nc_get_var1_schar(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_schar) : c_int;
+    extern proc nc_get_var1_schar(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_schar) : c_int;
 
-    extern proc nc_put_var1_short(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_short) : c_int;
+    extern proc nc_put_var1_short(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_short) : c_int;
 
-    extern proc nc_get_var1_short(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_short) : c_int;
+    extern proc nc_get_var1_short(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_short) : c_int;
 
-    extern proc nc_put_var1_int(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_int) : c_int;
+    extern proc nc_put_var1_int(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_int) : c_int;
 
-    extern proc nc_get_var1_int(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_int) : c_int;
+    extern proc nc_get_var1_int(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_int) : c_int;
 
-    extern proc nc_put_var1_long(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_long) : c_int;
+    extern proc nc_put_var1_long(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_long) : c_int;
 
-    extern proc nc_get_var1_long(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_long) : c_int;
+    extern proc nc_get_var1_long(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_long) : c_int;
 
-    extern proc nc_put_var1_float(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_float) : c_int;
+    extern proc nc_put_var1_float(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_float) : c_int;
 
-    extern proc nc_get_var1_float(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_float) : c_int;
+    extern proc nc_get_var1_float(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_float) : c_int;
 
-    extern proc nc_put_var1_double(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_double) : c_int;
+    extern proc nc_put_var1_double(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_double) : c_int;
 
-    extern proc nc_get_var1_double(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_double) : c_int;
+    extern proc nc_get_var1_double(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_double) : c_int;
 
-    extern proc nc_put_var1_ushort(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_ushort) : c_int;
+    extern proc nc_put_var1_ushort(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_ushort) : c_int;
 
-    extern proc nc_get_var1_ushort(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_ushort) : c_int;
+    extern proc nc_get_var1_ushort(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_ushort) : c_int;
 
-    extern proc nc_put_var1_uint(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_uint) : c_int;
+    extern proc nc_put_var1_uint(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_uint) : c_int;
 
-    extern proc nc_get_var1_uint(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_uint) : c_int;
+    extern proc nc_get_var1_uint(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_uint) : c_int;
 
-    extern proc nc_put_var1_longlong(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_longlong) : c_int;
+    extern proc nc_put_var1_longlong(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_longlong) : c_int;
 
-    extern proc nc_get_var1_longlong(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_longlong) : c_int;
+    extern proc nc_get_var1_longlong(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_longlong) : c_int;
 
-    extern proc nc_put_var1_ulonglong(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_ulonglong) : c_int;
+    extern proc nc_put_var1_ulonglong(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_ulonglong) : c_int;
 
-    extern proc nc_get_var1_ulonglong(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_ulonglong) : c_int;
+    extern proc nc_get_var1_ulonglong(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_ulonglong) : c_int;
 
-    extern proc nc_put_var1_string(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_string) : c_int;
+    extern proc nc_put_var1_string(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_string) : c_int;
 
-    extern proc nc_get_var1_string(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_string) : c_int;
+    extern proc nc_get_var1_string(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_string) : c_int;
 
-    extern proc nc_put_vara_text(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, op : c_string) : c_int;
+    extern proc nc_put_vara_text(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, op : c_string) : c_int;
 
-    extern proc nc_get_vara_text(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ip : c_string) : c_int;
+    extern proc nc_get_vara_text(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ip : c_string) : c_int;
 
-    extern proc nc_put_vara_uchar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_uchar) : c_int;
+    extern proc nc_put_vara_uchar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_vara_uchar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_uchar) : c_int;
+    extern proc nc_get_vara_uchar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_vara_schar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_schar) : c_int;
+    extern proc nc_put_vara_schar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_schar) : c_int;
 
-    extern proc nc_get_vara_schar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_schar) : c_int;
+    extern proc nc_get_vara_schar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_schar) : c_int;
 
-    extern proc nc_put_vara_short(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_short) : c_int;
+    extern proc nc_put_vara_short(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_short) : c_int;
 
-    extern proc nc_get_vara_short(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_short) : c_int;
+    extern proc nc_get_vara_short(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_short) : c_int;
 
-    extern proc nc_put_vara_int(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_int) : c_int;
+    extern proc nc_put_vara_int(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_int) : c_int;
 
-    extern proc nc_get_vara_int(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_int) : c_int;
+    extern proc nc_get_vara_int(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_int) : c_int;
 
-    extern proc nc_put_vara_long(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_long) : c_int;
+    extern proc nc_put_vara_long(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_long) : c_int;
 
-    extern proc nc_get_vara_long(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_long) : c_int;
+    extern proc nc_get_vara_long(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_long) : c_int;
 
-    extern proc nc_put_vara_float(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_float) : c_int;
+    extern proc nc_put_vara_float(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_float) : c_int;
 
-    extern proc nc_get_vara_float(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_float) : c_int;
+    extern proc nc_get_vara_float(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_float) : c_int;
 
-    extern proc nc_put_vara_double(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_double) : c_int;
+    extern proc nc_put_vara_double(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_double) : c_int;
 
-    extern proc nc_get_vara_double(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_double) : c_int;
+    extern proc nc_get_vara_double(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_double) : c_int;
 
-    extern proc nc_put_vara_ushort(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_ushort) : c_int;
+    extern proc nc_put_vara_ushort(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_ushort) : c_int;
 
-    extern proc nc_get_vara_ushort(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_ushort) : c_int;
+    extern proc nc_get_vara_ushort(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_ushort) : c_int;
 
-    extern proc nc_put_vara_uint(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_uint) : c_int;
+    extern proc nc_put_vara_uint(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_uint) : c_int;
 
-    extern proc nc_get_vara_uint(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_uint) : c_int;
+    extern proc nc_get_vara_uint(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_uint) : c_int;
 
-    extern proc nc_put_vara_longlong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_longlong) : c_int;
+    extern proc nc_put_vara_longlong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_longlong) : c_int;
 
-    extern proc nc_get_vara_longlong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_longlong) : c_int;
+    extern proc nc_get_vara_longlong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_longlong) : c_int;
 
-    extern proc nc_put_vara_ulonglong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_ulonglong) : c_int;
+    extern proc nc_put_vara_ulonglong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_ulonglong) : c_int;
 
-    extern proc nc_get_vara_ulonglong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_ulonglong) : c_int;
+    extern proc nc_get_vara_ulonglong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_ulonglong) : c_int;
 
-    extern proc nc_put_vara_string(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_string) : c_int;
+    extern proc nc_put_vara_string(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_string) : c_int;
 
-    extern proc nc_get_vara_string(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_string) : c_int;
+    extern proc nc_get_vara_string(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_string) : c_int;
 
-    extern proc nc_put_vars_text(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, op : c_string) : c_int;
+    extern proc nc_put_vars_text(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, op : c_string) : c_int;
 
-    extern proc nc_get_vars_text(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ip : c_string) : c_int;
+    extern proc nc_get_vars_text(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ip : c_string) : c_int;
 
-    extern proc nc_put_vars_uchar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_uchar) : c_int;
+    extern proc nc_put_vars_uchar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_vars_uchar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_uchar) : c_int;
+    extern proc nc_get_vars_uchar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_vars_schar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_schar) : c_int;
+    extern proc nc_put_vars_schar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_schar) : c_int;
 
-    extern proc nc_get_vars_schar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_schar) : c_int;
+    extern proc nc_get_vars_schar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_schar) : c_int;
 
-    extern proc nc_put_vars_short(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_short) : c_int;
+    extern proc nc_put_vars_short(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_short) : c_int;
 
-    extern proc nc_get_vars_short(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_short) : c_int;
+    extern proc nc_get_vars_short(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_short) : c_int;
 
-    extern proc nc_put_vars_int(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_int) : c_int;
+    extern proc nc_put_vars_int(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_int) : c_int;
 
-    extern proc nc_get_vars_int(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_int) : c_int;
+    extern proc nc_get_vars_int(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_int) : c_int;
 
-    extern proc nc_put_vars_long(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_long) : c_int;
+    extern proc nc_put_vars_long(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_long) : c_int;
 
-    extern proc nc_get_vars_long(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_long) : c_int;
+    extern proc nc_get_vars_long(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_long) : c_int;
 
-    extern proc nc_put_vars_float(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_float) : c_int;
+    extern proc nc_put_vars_float(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_float) : c_int;
 
-    extern proc nc_get_vars_float(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_float) : c_int;
+    extern proc nc_get_vars_float(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_float) : c_int;
 
-    extern proc nc_put_vars_double(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_double) : c_int;
+    extern proc nc_put_vars_double(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_double) : c_int;
 
-    extern proc nc_get_vars_double(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_double) : c_int;
+    extern proc nc_get_vars_double(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_double) : c_int;
 
-    extern proc nc_put_vars_ushort(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_ushort) : c_int;
+    extern proc nc_put_vars_ushort(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_ushort) : c_int;
 
-    extern proc nc_get_vars_ushort(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_ushort) : c_int;
+    extern proc nc_get_vars_ushort(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_ushort) : c_int;
 
-    extern proc nc_put_vars_uint(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_uint) : c_int;
+    extern proc nc_put_vars_uint(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_uint) : c_int;
 
-    extern proc nc_get_vars_uint(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_uint) : c_int;
+    extern proc nc_get_vars_uint(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_uint) : c_int;
 
-    extern proc nc_put_vars_longlong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_longlong) : c_int;
+    extern proc nc_put_vars_longlong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_longlong) : c_int;
 
-    extern proc nc_get_vars_longlong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_longlong) : c_int;
+    extern proc nc_get_vars_longlong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_longlong) : c_int;
 
-    extern proc nc_put_vars_ulonglong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_ulonglong) : c_int;
+    extern proc nc_put_vars_ulonglong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_ulonglong) : c_int;
 
-    extern proc nc_get_vars_ulonglong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_ulonglong) : c_int;
+    extern proc nc_get_vars_ulonglong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_ulonglong) : c_int;
 
-    extern proc nc_put_vars_string(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_string) : c_int;
+    extern proc nc_put_vars_string(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_string) : c_int;
 
-    extern proc nc_get_vars_string(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_string) : c_int;
+    extern proc nc_get_vars_string(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_string) : c_int;
 
-    extern proc nc_put_varm_text(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, op : c_string) : c_int;
+    extern proc nc_put_varm_text(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, op : c_string) : c_int;
 
-    extern proc nc_get_varm_text(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ip : c_string) : c_int;
+    extern proc nc_get_varm_text(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ip : c_string) : c_int;
 
-    extern proc nc_put_varm_uchar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_uchar) : c_int;
+    extern proc nc_put_varm_uchar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_varm_uchar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_uchar) : c_int;
+    extern proc nc_get_varm_uchar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_varm_schar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_schar) : c_int;
+    extern proc nc_put_varm_schar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_schar) : c_int;
 
-    extern proc nc_get_varm_schar(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_schar) : c_int;
+    extern proc nc_get_varm_schar(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_schar) : c_int;
 
-    extern proc nc_put_varm_short(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_short) : c_int;
+    extern proc nc_put_varm_short(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_short) : c_int;
 
-    extern proc nc_get_varm_short(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_short) : c_int;
+    extern proc nc_get_varm_short(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_short) : c_int;
 
-    extern proc nc_put_varm_int(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_int) : c_int;
+    extern proc nc_put_varm_int(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_int) : c_int;
 
-    extern proc nc_get_varm_int(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_int) : c_int;
+    extern proc nc_get_varm_int(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_int) : c_int;
 
-    extern proc nc_put_varm_long(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_long) : c_int;
+    extern proc nc_put_varm_long(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_long) : c_int;
 
-    extern proc nc_get_varm_long(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_long) : c_int;
+    extern proc nc_get_varm_long(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_long) : c_int;
 
-    extern proc nc_put_varm_float(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_float) : c_int;
+    extern proc nc_put_varm_float(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_float) : c_int;
 
-    extern proc nc_get_varm_float(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_float) : c_int;
+    extern proc nc_get_varm_float(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_float) : c_int;
 
-    extern proc nc_put_varm_double(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_double) : c_int;
+    extern proc nc_put_varm_double(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_double) : c_int;
 
-    extern proc nc_get_varm_double(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_double) : c_int;
+    extern proc nc_get_varm_double(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_double) : c_int;
 
-    extern proc nc_put_varm_ushort(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_ushort) : c_int;
+    extern proc nc_put_varm_ushort(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_ushort) : c_int;
 
-    extern proc nc_get_varm_ushort(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_ushort) : c_int;
+    extern proc nc_get_varm_ushort(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_ushort) : c_int;
 
-    extern proc nc_put_varm_uint(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_uint) : c_int;
+    extern proc nc_put_varm_uint(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_uint) : c_int;
 
-    extern proc nc_get_varm_uint(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_uint) : c_int;
+    extern proc nc_get_varm_uint(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_uint) : c_int;
 
-    extern proc nc_put_varm_longlong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_longlong) : c_int;
+    extern proc nc_put_varm_longlong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_longlong) : c_int;
 
-    extern proc nc_get_varm_longlong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_longlong) : c_int;
+    extern proc nc_get_varm_longlong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_longlong) : c_int;
 
-    extern proc nc_put_varm_ulonglong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_ulonglong) : c_int;
+    extern proc nc_put_varm_ulonglong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_ulonglong) : c_int;
 
-    extern proc nc_get_varm_ulonglong(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_ulonglong) : c_int;
+    extern proc nc_get_varm_ulonglong(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_ulonglong) : c_int;
 
-    extern proc nc_put_varm_string(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_string) : c_int;
+    extern proc nc_put_varm_string(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_string) : c_int;
 
-    extern proc nc_get_varm_string(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_string) : c_int;
+    extern proc nc_get_varm_string(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_string) : c_int;
 
     extern proc nc_put_var_text(ncid : c_int, varid : c_int, op : c_string) : c_int;
 
@@ -835,25 +835,25 @@ module NetCDF {
 
     extern proc nc_get_var_string(ncid : c_int, varid : c_int, ref ip : c_string) : c_int;
 
-    extern proc nc_put_att_ubyte(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : size_t, ref op : c_uchar) : c_int;
+    extern proc nc_put_att_ubyte(ncid : c_int, varid : c_int, name : c_string, xtype : nc_type, len : c_size_t, ref op : c_uchar) : c_int;
 
     extern proc nc_get_att_ubyte(ncid : c_int, varid : c_int, name : c_string, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_var1_ubyte(ncid : c_int, varid : c_int, ref indexp : size_t, ref op : c_uchar) : c_int;
+    extern proc nc_put_var1_ubyte(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_var1_ubyte(ncid : c_int, varid : c_int, ref indexp : size_t, ref ip : c_uchar) : c_int;
+    extern proc nc_get_var1_ubyte(ncid : c_int, varid : c_int, ref indexp : c_size_t, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_vara_ubyte(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref op : c_uchar) : c_int;
+    extern proc nc_put_vara_ubyte(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_vara_ubyte(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref ip : c_uchar) : c_int;
+    extern proc nc_get_vara_ubyte(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_vars_ubyte(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref op : c_uchar) : c_int;
+    extern proc nc_put_vars_ubyte(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_vars_ubyte(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref ip : c_uchar) : c_int;
+    extern proc nc_get_vars_ubyte(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref ip : c_uchar) : c_int;
 
-    extern proc nc_put_varm_ubyte(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_uchar) : c_int;
+    extern proc nc_put_varm_ubyte(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref op : c_uchar) : c_int;
 
-    extern proc nc_get_varm_ubyte(ncid : c_int, varid : c_int, ref startp : size_t, ref countp : size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_uchar) : c_int;
+    extern proc nc_get_varm_ubyte(ncid : c_int, varid : c_int, ref startp : c_size_t, ref countp : c_size_t, ref stridep : c_ptrdiff, ref imapp : c_ptrdiff, ref ip : c_uchar) : c_int;
 
     extern proc nc_put_var_ubyte(ncid : c_int, varid : c_int, ref op : c_uchar) : c_int;
 
@@ -861,9 +861,9 @@ module NetCDF {
 
     extern proc nc_show_metadata(ncid : c_int) : c_int;
 
-    extern proc nc__create_mp(path : c_string, cmode : c_int, initialsz : size_t, basepe : c_int, ref chunksizehintp : size_t, ref ncidp : c_int) : c_int;
+    extern proc nc__create_mp(path : c_string, cmode : c_int, initialsz : c_size_t, basepe : c_int, ref chunksizehintp : c_size_t, ref ncidp : c_int) : c_int;
 
-    extern proc nc__open_mp(path : c_string, mode : c_int, basepe : c_int, ref chunksizehintp : size_t, ref ncidp : c_int) : c_int;
+    extern proc nc__open_mp(path : c_string, mode : c_int, basepe : c_int, ref chunksizehintp : c_size_t, ref ncidp : c_int) : c_int;
 
     extern proc nc_delete(path : c_string) : c_int;
 
@@ -961,7 +961,7 @@ module NetCDF {
     extern type nc_type = c_int;
 
     extern record nc_vlen_t {
-      var len : size_t;
+      var len : c_size_t;
       var p : c_void_ptr;
     }
 

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -324,7 +324,7 @@ proc tcpConn.writeThis(f) throws {
 }
 
 pragma "no doc"
-private extern proc sizeof(e): size_t;
+private extern proc sizeof(e): c_size_t;
 
 pragma "no doc"
 extern "struct event_base" record event_base {};
@@ -775,7 +775,7 @@ proc udpSocket.close throws {
 }
 
 pragma "no doc"
-private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:size_t, flags:c_int, ref src_addr_out:sys_sockaddr_t, ref num_recvd_out:ssize_t):err_t;
+private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:c_size_t, flags:c_int, ref src_addr_out:sys_sockaddr_t, ref num_recvd_out:c_ssize_t):err_t;
 
 /*
   Reads upto `bufferLen` bytes from the socket, and
@@ -801,9 +801,9 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
                         flags:c_int = 0):(bytes, ipAddr) throws {
   var err_out:err_t = 0;
   var buffer = c_calloc(c_uchar, bufferLen);
-  var length:ssize_t;
+  var length:c_ssize_t;
   var addressStorage = new sys_sockaddr_t();
-  err_out = sys_recvfrom(this.socketFd, buffer, bufferLen:size_t, 0, addressStorage, length);
+  err_out = sys_recvfrom(this.socketFd, buffer, bufferLen:c_size_t, 0, addressStorage, length);
   if err_out == 0 {
     return (createBytesWithOwnedBuffer(buffer, length, bufferLen), new ipAddr(addressStorage));
   }
@@ -832,7 +832,7 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
       throw SystemError.fromSyserr(ETIMEDOUT, "recv timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
-    err_out = sys_recvfrom(this.socketFd, buffer, bufferLen:size_t, 0, addressStorage, length);
+    err_out = sys_recvfrom(this.socketFd, buffer, bufferLen:c_size_t, 0, addressStorage, length);
     if err_out != 0 {
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
         c_free(buffer);
@@ -888,7 +888,7 @@ proc udpSocket.recv(bufferLen: int, timeout: real) throws {
 }
 
 pragma "no doc"
-private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c_int, const ref address:sys_sockaddr_t,  ref num_sent_out:ssize_t):err_t;
+private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c_int, const ref address:sys_sockaddr_t,  ref num_sent_out:c_ssize_t):err_t;
 
 /*
   Send `data` over socket to the provided address and
@@ -907,14 +907,14 @@ private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c
   :arg timeout: time to wait for data to arrive.
   :type timeval: :type:`~Sys.timeval`
   :return: sentBytes
-  :rtype: `ssize_t`
+  :rtype: `c_ssize_t`
   :throws SystemError: Upon failure to send any data
                         within given `timeout`.
 */
 proc udpSocket.send(data: bytes, in address: ipAddr,
-                    in timeout = new timeval(-1,0)):ssize_t throws {
+                    in timeout = new timeval(-1,0)):c_ssize_t throws {
   var err_out:err_t = 0;
-  var length:ssize_t;
+  var length:c_ssize_t;
   err_out = sys_sendto(this.socketFd, data.c_str():c_void_ptr, data.size:c_long, 0, address._addressStorage, length);
   if err_out == 0 {
     return length;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1920,7 +1920,7 @@ module ShallowCopy {
 
     if A._instance.isDefaultRectangular() {
       type st = __primitive("static field type", A._value, "eltType");
-      var size = (nElts:size_t)*c_sizeof(st);
+      var size = (nElts:c_size_t)*c_sizeof(st);
       c_memcpy(ptrTo(A[dst]), ptrTo(A[src]), size);
     } else {
       var ok = chpl__bulkTransferArray(/*dst*/ A, {dst..#nElts},
@@ -1947,7 +1947,7 @@ module ShallowCopy {
     if DstA._instance.isDefaultRectangular() &&
        SrcA._instance.isDefaultRectangular() {
       type st = __primitive("static field type", DstA._value, "eltType");
-      var size = (nElts:size_t)*c_sizeof(st);
+      var size = (nElts:c_size_t)*c_sizeof(st);
       c_memcpy(ptrTo(DstA[dst]), ptrTo(SrcA[src]), size);
     } else {
       var ok = chpl__bulkTransferArray(/*dst*/ DstA, {dst..#nElts},
@@ -1960,7 +1960,7 @@ module ShallowCopy {
       }
     }
   }
-  proc shallowCopyPutGetRefs(ref dst, const ref src, numBytes: size_t) {
+  proc shallowCopyPutGetRefs(ref dst, const ref src, numBytes: c_size_t) {
     if dst.locale.id == here.id {
       __primitive("chpl_comm_get", dst, src.locale.id, src, numBytes);
     } else if src.locale.id == here.id {
@@ -1973,7 +1973,7 @@ module ShallowCopy {
   // For the case in which we know that the source and dest regions
   // are contiguous within a locale
   proc shallowCopyPutGet(ref DstA, dst, const ref SrcA, src, nElts) {
-    var size = (nElts:size_t)*c_sizeof(DstA.eltType);
+    var size = (nElts:c_size_t)*c_sizeof(DstA.eltType);
     shallowCopyPutGetRefs(DstA[dst], SrcA[src], size);
   }
 }

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -263,26 +263,26 @@ module ZMQ {
   private extern proc zmq_errno(): c_int;
   private extern proc zmq_msg_init(ref msg: zmq_msg_t): c_int;
   private extern proc zmq_msg_init_size(ref msg: zmq_msg_t,
-                                        size: size_t): c_int;
+                                        size: c_size_t): c_int;
   private extern proc zmq_msg_init_data(ref msg: zmq_msg_t,
                                         data: c_void_ptr,
-                                        size: size_t,
+                                        size: c_size_t,
                                         ffn: c_fn_ptr,
                                         hint: c_void_ptr): c_int;
   private extern proc zmq_msg_data(ref msg: zmq_msg_t): c_void_ptr;
-  private extern proc zmq_msg_size(ref msg: zmq_msg_t): size_t;
+  private extern proc zmq_msg_size(ref msg: zmq_msg_t): c_size_t;
   private extern proc zmq_msg_send(ref msg: zmq_msg_t, sock: c_void_ptr,
                                    flags: c_int): c_int;
   private extern proc zmq_msg_recv(ref msg: zmq_msg_t, sock: c_void_ptr,
                                    flags: c_int): c_int;
   private extern proc zmq_msg_close(ref msg: zmq_msg_t): c_int;
   private extern proc zmq_recv(sock: c_void_ptr, buf: c_void_ptr,
-                               len: size_t, flags: c_int): c_int;
+                               len: c_size_t, flags: c_int): c_int;
   private extern proc zmq_send(sock: c_void_ptr, buf: c_void_ptr,
-                               len: size_t, flags: c_int): c_int;
+                               len: c_size_t, flags: c_int): c_int;
   private extern proc zmq_setsockopt (sock: c_void_ptr, option_name: int,
                                       const option_value: c_void_ptr,
-                                      option_len: size_t): c_int;
+                                      option_len: c_size_t): c_int;
   private extern proc zmq_socket(ctx: c_void_ptr, socktype: c_int): c_void_ptr;
   private extern proc zmq_strerror(errnum: c_int): c_string;
   private extern proc zmq_version(major: c_ptr(c_int),
@@ -801,7 +801,7 @@ module ZMQ {
       on classRef.home {
         var ret = zmq_setsockopt(classRef.socket, ZMQ_SUBSCRIBE,
                                  value.c_str(): c_void_ptr,
-                                 value.numBytes:size_t): int;
+                                 value.numBytes:c_size_t): int;
         if ret == -1 {
           var errmsg = zmq_strerror(errno):string;
           // It would be good to use a factory method for a ZMQError subclass,
@@ -841,7 +841,7 @@ module ZMQ {
       on classRef.home {
         var ret = zmq_setsockopt(classRef.socket, ZMQ_UNSUBSCRIBE,
                                  value.c_str(): c_void_ptr,
-                                 value.numBytes:size_t): int;
+                                 value.numBytes:c_size_t): int;
         if ret == -1 {
           var errmsg = zmq_strerror(errno):string;
           // It would be good to use a factory method for a ZMQError subclass,
@@ -897,7 +897,7 @@ module ZMQ {
         // Create the ZeroMQ message from the data buffer
         var msg: zmq_msg_t;
         if (0 != zmq_msg_init_data(msg, copy.c_str():c_void_ptr,
-                                   copy.numBytes:size_t, c_ptrTo(free_helper),
+                                   copy.numBytes:c_size_t, c_ptrTo(free_helper),
                                    c_nil)) {
           try throw_socket_error(errno, "send");
         }
@@ -920,7 +920,7 @@ module ZMQ {
       on classRef.home {
         var copy = data;
         while (-1 == zmq_send(classRef.socket, c_ptrTo(copy):c_void_ptr,
-                              numBytes(T):size_t,
+                              numBytes(T):c_size_t,
                               (ZMQ_DONTWAIT | flags):c_int)) {
           if errno == EAGAIN then
             chpl_task_yield();
@@ -1020,7 +1020,7 @@ module ZMQ {
       on classRef.home {
         var data: T;
         while (-1 == zmq_recv(classRef.socket, c_ptrTo(data):c_void_ptr,
-                              numBytes(T):size_t,
+                              numBytes(T):c_size_t,
                               (ZMQ_DONTWAIT | flags):c_int)) {
           if errno == EAGAIN then
             chpl_task_yield();

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -303,8 +303,8 @@ module BigInteger {
          bigint.size() is deprecated
     */
     deprecated "bigint.size() is deprecated"
-    proc size() : size_t {
-      var ret: size_t;
+    proc size() : c_size_t {
+      var ret: c_size_t;
 
       if _local {
         ret = mpz_size(this.mpz);
@@ -350,7 +350,7 @@ module BigInteger {
      */
     proc sizeInBase(base: int) : int {
       const base_ = base.safeCast(c_int);
-      var   ret: size_t;
+      var   ret: c_size_t;
 
       if _local {
         ret = mpz_sizeinbase(this.mpz, base_);

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -50,10 +50,10 @@ module CTypes {
                     "'use'/'import' statements accordingly.", errorDepth=2);
   }
 
-  /* The type corresponding to a C float */
+  /* The Chapel type corresponding to the C 'float' type */
   extern type c_float = real(32);
 
-  /* The type corresponding to a C double */
+  /* The Chapel type corresponding to the C 'double' type */
   extern type c_double = real(64);
 
   // Former CPtr contents start here
@@ -536,9 +536,9 @@ module CTypes {
          * Behavior of ``c_sizeof`` with Chapel types may change
          * Behavior given a Chapel class type is not well-defined
    */
-  inline proc c_sizeof(type x): size_t {
+  inline proc c_sizeof(type x): c_size_t {
     pragma "fn synchronization free"
-    extern proc sizeof(type x): size_t;
+    extern proc sizeof(type x): c_size_t;
     return sizeof(x);
   }
 
@@ -555,13 +555,13 @@ module CTypes {
       * Behavior of ``c_offsetof`` may change
       * Behavior given a Chapel class type field is not well-defined
    */
-  proc c_offsetof(type t, param fieldname : string): size_t where isRecordType(t) {
+  proc c_offsetof(type t, param fieldname : string): c_size_t where isRecordType(t) {
     use Reflection;
     pragma "no auto destroy"
     pragma "no init"
     var x: t;
 
-    return c_ptrTo(getFieldRef(x, fieldname)):size_t - c_ptrTo(x):size_t;
+    return c_ptrTo(getFieldRef(x, fieldname)):c_size_t - c_ptrTo(x):c_size_t;
   }
 
   pragma "no doc"
@@ -580,7 +580,7 @@ module CTypes {
     :returns: a c_ptr(eltType) to allocated memory
     */
   inline proc c_calloc(type eltType, size: integral) : c_ptr(eltType) {
-    const alloc_size = size.safeCast(size_t) * c_sizeof(eltType);
+    const alloc_size = size.safeCast(c_size_t) * c_sizeof(eltType);
     return chpl_here_calloc(alloc_size, 1, offset_ARRAY_ELEMENTS):c_ptr(eltType);
   }
 
@@ -593,7 +593,7 @@ module CTypes {
     :returns: a c_ptr(eltType) to allocated memory
     */
   inline proc c_malloc(type eltType, size: integral) : c_ptr(eltType) {
-    const alloc_size = size.safeCast(size_t) * c_sizeof(eltType);
+    const alloc_size = size.safeCast(c_size_t) * c_sizeof(eltType);
     return chpl_here_alloc(alloc_size, offset_ARRAY_ELEMENTS):c_ptr(eltType);
   }
 
@@ -616,9 +616,9 @@ module CTypes {
                               size: integral) : c_ptr(eltType) {
     // check alignment, size restriction
     if boundsChecking {
-      var one:size_t = 1;
+      var one:c_size_t = 1;
       // Round the alignment up to the nearest power of 2
-      var aln = alignment.safeCast(size_t);
+      var aln = alignment.safeCast(c_size_t);
       if aln == 0 then
         halt("c_aligned_alloc called with alignment of 0");
       var p = log2(aln); // power of 2 rounded down
@@ -632,8 +632,8 @@ module CTypes {
         halt("c_aligned_alloc called with alignment smaller than pointer size");
     }
 
-    const alloc_size = size.safeCast(size_t) * c_sizeof(eltType);
-    return chpl_here_aligned_alloc(alignment.safeCast(size_t),
+    const alloc_size = size.safeCast(c_size_t) * c_sizeof(eltType);
+    return chpl_here_aligned_alloc(alignment.safeCast(c_size_t),
                                    alloc_size,
                                    offset_ARRAY_ELEMENTS):c_ptr(eltType);
   }
@@ -668,8 +668,8 @@ module CTypes {
   pragma "fn synchronization free"
   inline proc c_memmove(dest:c_void_ptr, const src:c_void_ptr, n: integral) {
     pragma "fn synchronization free"
-    extern proc memmove(dest: c_void_ptr, const src: c_void_ptr, n: size_t);
-    memmove(dest, src, n.safeCast(size_t));
+    extern proc memmove(dest: c_void_ptr, const src: c_void_ptr, n: c_size_t);
+    memmove(dest, src, n.safeCast(c_size_t));
   }
 
   /*
@@ -685,8 +685,8 @@ module CTypes {
   pragma "fn synchronization free"
   inline proc c_memcpy(dest:c_void_ptr, const src:c_void_ptr, n: integral) {
     pragma "fn synchronization free"
-    extern proc memcpy (dest: c_void_ptr, const src: c_void_ptr, n: size_t);
-    memcpy(dest, src, n.safeCast(size_t));
+    extern proc memcpy (dest: c_void_ptr, const src: c_void_ptr, n: c_size_t);
+    memcpy(dest, src, n.safeCast(c_size_t));
   }
 
   /*
@@ -701,8 +701,8 @@ module CTypes {
   pragma "fn synchronization free"
   inline proc c_memcmp(const s1:c_void_ptr, const s2:c_void_ptr, n: integral) {
     pragma "fn synchronization free"
-    extern proc memcmp(const s1: c_void_ptr, const s2: c_void_ptr, n: size_t) : c_int;
-    return memcmp(s1, s2, n.safeCast(size_t)).safeCast(int);
+    extern proc memcmp(const s1: c_void_ptr, const s2: c_void_ptr, n: c_size_t) : c_int;
+    return memcmp(s1, s2, n.safeCast(c_size_t)).safeCast(int);
   }
 
   /*
@@ -719,8 +719,8 @@ module CTypes {
   pragma "fn synchronization free"
   inline proc c_memset(s:c_void_ptr, c:integral, n: integral) {
     pragma "fn synchronization free"
-    extern proc memset(s: c_void_ptr, c: c_int, n: size_t) : c_void_ptr;
-    memset(s, c.safeCast(c_int), n.safeCast(size_t));
+    extern proc memset(s: c_void_ptr, c: c_int, n: c_size_t) : c_void_ptr;
+    memset(s, c.safeCast(c_int), n.safeCast(c_size_t));
     return s;
   }
 }

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -417,8 +417,8 @@ module DateTime {
 
   /* Return a formatted `string` matching the `format` argument and the date */
   proc date.strftime(fmt: string) {
-    extern proc strftime(s: c_void_ptr, size: size_t, format: c_string, ref timeStruct: tm);
-    const bufLen: size_t = 100;
+    extern proc strftime(s: c_void_ptr, size: c_size_t, format: c_string, ref timeStruct: tm);
+    const bufLen: c_size_t = 100;
     var buf: [1..bufLen] c_char;
     var timeStruct: tm;
 
@@ -660,8 +660,8 @@ module DateTime {
 
   /* Return a `string` matching the `format` argument for this `time` */
   proc time.strftime(fmt: string) {
-    extern proc strftime(s: c_void_ptr, size: size_t, format: c_string, ref timeStruct: tm);
-    const bufLen: size_t = 100;
+    extern proc strftime(s: c_void_ptr, size: c_size_t, format: c_string, ref timeStruct: tm);
+    const bufLen: c_size_t = 100;
     var buf: [1..bufLen] c_char;
     var timeStruct: tm;
 
@@ -1182,8 +1182,8 @@ module DateTime {
 
   /* Create a `string` from a `datetime` matching the `format` string */
   proc datetime.strftime(fmt: string) {
-    extern proc strftime(s: c_void_ptr, size: size_t, format: c_string, ref timeStruct: tm);
-    const bufLen: size_t = 100;
+    extern proc strftime(s: c_void_ptr, size: c_size_t, format: c_string, ref timeStruct: tm);
+    const bufLen: c_size_t = 100;
     var buf: [1..bufLen] c_char;
     var timeStruct: tm;
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -896,16 +896,16 @@ private module GlobWrappers {
 
   // glob_num wrapper that takes care of casting
   inline proc glob_num_w(glb: glob_t): int {
-    extern proc chpl_glob_num(glb: glob_t): size_t;
+    extern proc chpl_glob_num(glb: glob_t): c_size_t;
     return chpl_glob_num(glb).safeCast(int);
   }
 
   // glob_index wrapper that takes care of casting
   inline proc glob_index_w(glb: glob_t, idx: int): string {
-    extern proc chpl_glob_index(glb: glob_t, idx: size_t): c_string;
+    extern proc chpl_glob_index(glb: glob_t, idx: c_size_t): c_string;
     try! {
       return createStringWithNewBuffer(chpl_glob_index(glb,
-                                                       idx.safeCast(size_t)),
+                                                       idx.safeCast(c_size_t)),
                                        policy=decodePolicy.escape);
     }
   }

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -113,22 +113,22 @@ module GMP {
 
   require "GMPHelper/chplgmp.h";
 
-  proc chpl_gmp_alloc(size:size_t) : c_void_ptr {
+  proc chpl_gmp_alloc(size:c_size_t) : c_void_ptr {
     pragma "insert line file info"
-    extern proc chpl_mem_alloc(size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     extern const CHPL_RT_MD_GMP:chpl_mem_descInt_t;
     return chpl_mem_alloc(size, CHPL_RT_MD_GMP);
   }
 
   proc chpl_gmp_realloc(ptr:c_void_ptr,
-                               old_size:size_t, new_size:size_t) : c_void_ptr {
+                               old_size:c_size_t, new_size:c_size_t) : c_void_ptr {
     pragma "insert line file info"
-    extern proc chpl_mem_realloc(ptr:c_void_ptr, size:size_t, md:chpl_mem_descInt_t) : c_void_ptr;
+    extern proc chpl_mem_realloc(ptr:c_void_ptr, size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
     extern const CHPL_RT_MD_GMP:chpl_mem_descInt_t;
     return chpl_mem_realloc(ptr, new_size, CHPL_RT_MD_GMP);
   }
 
-  proc chpl_gmp_free(ptr:c_void_ptr, old_size:size_t) {
+  proc chpl_gmp_free(ptr:c_void_ptr, old_size:c_size_t) {
     pragma "insert line file info"
       extern proc chpl_mem_free(ptr:c_void_ptr) : void;
     chpl_mem_free(ptr);
@@ -802,7 +802,7 @@ module GMP {
          proc mpz_even_p(const ref op: mpz_t) : c_int;
 
   extern proc mpz_sizeinbase(const ref op: mpz_t,
-                             base: c_int) : size_t;
+                             base: c_int) : c_size_t;
 
 
   //
@@ -815,7 +815,7 @@ module GMP {
   private extern proc mpz_getlimbn(const ref op: mpz_t,
                                    n: mp_size_t) : mp_limb_t;
 
-  extern proc mpz_size(const ref x: mpz_t): size_t;
+  extern proc mpz_size(const ref x: mpz_t): c_size_t;
 
   extern proc mpz_limbs_write(ref x: mpz_t, n: mp_size_t): c_ptr(mp_limb_t);
   extern proc mpz_limbs_finish(ref x: mpz_t, s: mp_size_t);
@@ -1014,7 +1014,7 @@ module GMP {
 
   extern proc mpf_out_str(stream: _file,
                           base: c_int,
-                          n_digits: size_t,
+                          n_digits: c_size_t,
                           const ref op: mpf_t);
 
   extern proc mpf_inp_str(ref rop: mpf_t,
@@ -1146,7 +1146,7 @@ module GMP {
 
     __primitive("chpl_comm_get", dst_limbs_ptr[0],
                                  src_locale, src_limbs_ptr[0],
-                                 (new_size:size_t)*c_sizeof(mp_limb_t));
+                                 (new_size:c_size_t)*c_sizeof(mp_limb_t));
 
     // Update the sign and size of the number
     chpl_gmp_mpz_set_sign_size(ret, src_sign_size);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -792,7 +792,7 @@ private extern const QIO_FILE_PTR_NULL:qio_file_ptr_t;
 pragma "no doc"
 extern record qiovec_t {
   var iov_base: c_void_ptr;
-  var iov_len: size_t;
+  var iov_len: c_size_t;
 }
 
 pragma "no doc"
@@ -1140,20 +1140,20 @@ private extern proc qio_channel_close(threadsafe:c_int, ch:qio_channel_ptr_t):sy
 pragma "no doc"
 extern proc qio_channel_isclosed(threadsafe:c_int, ch:qio_channel_ptr_t):bool;
 
-private extern proc qio_channel_read(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:ssize_t, ref amt_read:ssize_t):syserr;
-private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:ssize_t):syserr;
+private extern proc qio_channel_read(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:c_ssize_t, ref amt_read:c_ssize_t):syserr;
+private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:c_ssize_t):syserr;
 pragma "no doc"
 // A specialization is needed for _ddata as the value is the pointer its memory
-private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ptr:_ddata, len:ssize_t):syserr;
+private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ptr:_ddata, len:c_ssize_t):syserr;
 // and for c_ptr
-private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ptr:c_ptr, len:ssize_t):syserr;
+private extern proc qio_channel_read_amt(threadsafe:c_int, ch:qio_channel_ptr_t, ptr:c_ptr, len:c_ssize_t):syserr;
 private extern proc qio_channel_read_byte(threadsafe:c_int, ch:qio_channel_ptr_t):int(32);
 
-private extern proc qio_channel_write(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:ssize_t, ref amt_written:ssize_t):syserr;
-private extern proc qio_channel_write_amt(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:ssize_t):syserr;
+private extern proc qio_channel_write(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:c_ssize_t, ref amt_written:c_ssize_t):syserr;
+private extern proc qio_channel_write_amt(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:c_ssize_t):syserr;
 pragma "no doc"
 // A specialization is needed for _ddata as the value is the pointer its memory
-private extern proc qio_channel_write_amt(threadsafe:c_int, ch:qio_channel_ptr_t, const ptr:_ddata, len:ssize_t):syserr;
+private extern proc qio_channel_write_amt(threadsafe:c_int, ch:qio_channel_ptr_t, const ptr:_ddata, len:c_ssize_t):syserr;
 private extern proc qio_channel_write_byte(threadsafe:c_int, ch:qio_channel_ptr_t, byte:uint(8)):syserr;
 
 private extern proc qio_channel_offset_unlocked(ch:qio_channel_ptr_t):int(64);
@@ -1223,43 +1223,43 @@ private extern proc qio_channel_write_float64(threadsafe:c_int, byteorder:c_int,
 private extern proc qio_channel_read_float64(threadsafe:c_int, byteorder:c_int, ch:qio_channel_ptr_t, ref ptr:imag(64)):syserr;
 private extern proc qio_channel_write_float64(threadsafe:c_int, byteorder:c_int, ch:qio_channel_ptr_t, x:imag(64)):syserr;
 
-private extern proc qio_channel_read_string(threadsafe:c_int, byteorder:c_int, str_style:int(64), ch:qio_channel_ptr_t, ref s:c_string, ref len:int(64), maxlen:ssize_t):syserr;
-private extern proc qio_channel_write_string(threadsafe:c_int, byteorder:c_int, str_style:int(64), ch:qio_channel_ptr_t, const s:c_string, len:ssize_t):syserr;
+private extern proc qio_channel_read_string(threadsafe:c_int, byteorder:c_int, str_style:int(64), ch:qio_channel_ptr_t, ref s:c_string, ref len:int(64), maxlen:c_ssize_t):syserr;
+private extern proc qio_channel_write_string(threadsafe:c_int, byteorder:c_int, str_style:int(64), ch:qio_channel_ptr_t, const s:c_string, len:c_ssize_t):syserr;
 
-private extern proc qio_channel_scan_int(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:size_t, issigned:c_int):syserr;
-private extern proc qio_channel_print_int(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:size_t, issigned:c_int):syserr;
+private extern proc qio_channel_scan_int(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:c_size_t, issigned:c_int):syserr;
+private extern proc qio_channel_print_int(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:c_size_t, issigned:c_int):syserr;
 
-private extern proc qio_channel_scan_float(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:size_t):syserr;
-private extern proc qio_channel_print_float(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:size_t):syserr;
+private extern proc qio_channel_scan_float(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:c_size_t):syserr;
+private extern proc qio_channel_print_float(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:c_size_t):syserr;
 
 // These are the same as scan/print float but they assume an 'i' afterwards.
-private extern proc qio_channel_scan_imag(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:size_t):syserr;
-private extern proc qio_channel_print_imag(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:size_t):syserr;
+private extern proc qio_channel_scan_imag(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:c_size_t):syserr;
+private extern proc qio_channel_print_imag(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:c_size_t):syserr;
 
 
-private extern proc qio_channel_scan_complex(threadsafe:c_int, ch:qio_channel_ptr_t, ref re_ptr, ref im_ptr, len:size_t):syserr;
-private extern proc qio_channel_print_complex(threadsafe:c_int, ch:qio_channel_ptr_t, const ref re_ptr, const ref im_ptr, len:size_t):syserr;
+private extern proc qio_channel_scan_complex(threadsafe:c_int, ch:qio_channel_ptr_t, ref re_ptr, ref im_ptr, len:c_size_t):syserr;
+private extern proc qio_channel_print_complex(threadsafe:c_int, ch:qio_channel_ptr_t, const ref re_ptr, const ref im_ptr, len:c_size_t):syserr;
 
 
 private extern proc qio_channel_read_char(threadsafe:c_int, ch:qio_channel_ptr_t, ref char:int(32)):syserr;
 
 private extern proc qio_nbytes_char(chr:int(32)):c_int;
 private extern proc qio_encode_to_string(chr:int(32)):c_string;
-private extern proc qio_decode_char_buf(ref chr:int(32), ref nbytes:c_int, buf:c_string, buflen:ssize_t):syserr;
+private extern proc qio_decode_char_buf(ref chr:int(32), ref nbytes:c_int, buf:c_string, buflen:c_ssize_t):syserr;
 
 private extern proc qio_channel_write_char(threadsafe:c_int, ch:qio_channel_ptr_t, char:int(32)):syserr;
 private extern proc qio_channel_skip_past_newline(threadsafe:c_int, ch:qio_channel_ptr_t, skipOnlyWs:c_int):syserr;
 private extern proc qio_channel_write_newline(threadsafe:c_int, ch:qio_channel_ptr_t):syserr;
 
-private extern proc qio_channel_scan_string(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr:c_string, ref len:int(64), maxlen:ssize_t):syserr;
-private extern proc qio_channel_scan_bytes(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr:c_string, ref len:int(64), maxlen:ssize_t):syserr;
-private extern proc qio_channel_print_bytes(threadsafe:c_int, ch:qio_channel_ptr_t, const ptr:c_string, len:ssize_t):syserr;
-private extern proc qio_channel_print_string(threadsafe:c_int, ch:qio_channel_ptr_t, const ptr:c_string, len:ssize_t):syserr;
+private extern proc qio_channel_scan_string(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr:c_string, ref len:int(64), maxlen:c_ssize_t):syserr;
+private extern proc qio_channel_scan_bytes(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr:c_string, ref len:int(64), maxlen:c_ssize_t):syserr;
+private extern proc qio_channel_print_bytes(threadsafe:c_int, ch:qio_channel_ptr_t, const ptr:c_string, len:c_ssize_t):syserr;
+private extern proc qio_channel_print_string(threadsafe:c_int, ch:qio_channel_ptr_t, const ptr:c_string, len:c_ssize_t):syserr;
 
-private extern proc qio_channel_scan_literal(threadsafe:c_int, ch:qio_channel_ptr_t, const match:c_string, len:ssize_t, skipwsbefore:c_int):syserr;
-private extern proc qio_channel_scan_literal_2(threadsafe:c_int, ch:qio_channel_ptr_t, match:c_void_ptr, len:ssize_t, skipwsbefore:c_int):syserr;
-private extern proc qio_channel_print_literal(threadsafe:c_int, ch:qio_channel_ptr_t, const match:c_string, len:ssize_t):syserr;
-private extern proc qio_channel_print_literal_2(threadsafe:c_int, ch:qio_channel_ptr_t, match:c_void_ptr, len:ssize_t):syserr;
+private extern proc qio_channel_scan_literal(threadsafe:c_int, ch:qio_channel_ptr_t, const match:c_string, len:c_ssize_t, skipwsbefore:c_int):syserr;
+private extern proc qio_channel_scan_literal_2(threadsafe:c_int, ch:qio_channel_ptr_t, match:c_void_ptr, len:c_ssize_t, skipwsbefore:c_int):syserr;
+private extern proc qio_channel_print_literal(threadsafe:c_int, ch:qio_channel_ptr_t, const match:c_string, len:c_ssize_t):syserr;
+private extern proc qio_channel_print_literal_2(threadsafe:c_int, ch:qio_channel_ptr_t, match:c_void_ptr, len:c_ssize_t):syserr;
 
 private extern proc qio_channel_skip_json_field(threadsafe:c_int, ch:qio_channel_ptr_t):syserr;
 
@@ -1314,7 +1314,7 @@ private extern const QIO_CONV_SET_CAPTURE:c_int;
 private extern const QIO_CONV_SET_DONE:c_int;
 
 pragma "insert line file info"
-private extern proc qio_conv_parse(const fmt:c_string, start:size_t, ref end:uint(64), scanning:c_int, ref spec:qio_conv_t, ref style:iostyleInternal):syserr;
+private extern proc qio_conv_parse(const fmt:c_string, start:c_size_t, ref end:uint(64), scanning:c_int, ref spec:qio_conv_t, ref style:iostyleInternal):syserr;
 
 private extern proc qio_format_error_too_many_args():syserr;
 private extern proc qio_format_error_too_few_args():syserr;
@@ -2974,12 +2974,12 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
     var err:syserr = ENOERR;
     var got:bool = false;
 
-    err = qio_channel_scan_literal(false, _channel_internal, c"true", "true".numBytes:ssize_t, 1);
+    err = qio_channel_scan_literal(false, _channel_internal, c"true", "true".numBytes:c_ssize_t, 1);
     if !err {
       got = true;
     } else if err == EFORMAT {
       // try reading false instead.
-      err = qio_channel_scan_literal(false, _channel_internal, c"false", "false".numBytes:ssize_t, 1);
+      err = qio_channel_scan_literal(false, _channel_internal, c"false", "false".numBytes:c_ssize_t, 1);
       // got is already false, so we don't need to set it.
     }
     if !err then x = got;
@@ -3021,7 +3021,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
       { // try to read e.g. red for colorenum.red
         var str = i:string;
         if st == QIO_AGGREGATE_FORMAT_JSON then str = '"'+str+'"';
-        var slen:ssize_t = str.numBytes.safeCast(ssize_t);
+        var slen:c_ssize_t = str.numBytes.safeCast(c_ssize_t);
         err = qio_channel_scan_literal(false, _channel_internal, str.c_str(), slen, 1);
         if !err {
           x = i;
@@ -3032,7 +3032,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
       { // try to read e.g. colorenum.red for colorenum.red
         var str = t:string + "." + i:string;
         if st == QIO_AGGREGATE_FORMAT_JSON then str = '"'+str+'"';
-        var slen:ssize_t = str.numBytes.safeCast(ssize_t);
+        var slen:c_ssize_t = str.numBytes.safeCast(c_ssize_t);
         err = qio_channel_scan_literal(false, _channel_internal, str.c_str(), slen, 1);
         if !err {
           x = i;
@@ -3050,9 +3050,9 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
 private proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):syserr where _isIoPrimitiveType(t) {
   if isBoolType(t) {
     if x {
-      return qio_channel_print_literal(false, _channel_internal, c"true", "true".numBytes:ssize_t);
+      return qio_channel_print_literal(false, _channel_internal, c"true", "true".numBytes:c_ssize_t);
     } else {
-      return qio_channel_print_literal(false, _channel_internal, c"false", "false".numBytes:ssize_t);
+      return qio_channel_print_literal(false, _channel_internal, c"false", "false".numBytes:c_ssize_t);
     }
   } else if isIntegralType(t) {
     // handles int types
@@ -3075,16 +3075,16 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):sys
     if local_x.hasEscapes {
       return EILSEQ;
     }
-    return qio_channel_print_string(false, _channel_internal, local_x.c_str(), local_x.numBytes:ssize_t);
+    return qio_channel_print_string(false, _channel_internal, local_x.c_str(), local_x.numBytes:c_ssize_t);
   } else if t == bytes {
     // handle bytes
     const local_x = x.localize();
-    return qio_channel_print_bytes(false, _channel_internal, local_x.c_str(), local_x.numBytes:ssize_t);
+    return qio_channel_print_bytes(false, _channel_internal, local_x.c_str(), local_x.numBytes:c_ssize_t);
   } else if isEnumType(t) {
     var st = qio_channel_style_element(_channel_internal, QIO_STYLE_ELEMENT_AGGREGATE);
     var s = x:string;
     if st == QIO_AGGREGATE_FORMAT_JSON then s = '"'+s+'"';
-    return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.numBytes:ssize_t);
+    return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.numBytes:c_ssize_t);
   } else {
     compilerError("Unknown primitive type in _write_text_internal ", t:string);
   }
@@ -3254,10 +3254,10 @@ private proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, param b
     if local_x.hasEscapes {
       return EILSEQ;
     }
-    return qio_channel_write_string(false, byteorder:c_int, qio_channel_str_style(_channel_internal), _channel_internal, local_x.c_str(), local_x.numBytes: ssize_t);
+    return qio_channel_write_string(false, byteorder:c_int, qio_channel_str_style(_channel_internal), _channel_internal, local_x.c_str(), local_x.numBytes: c_ssize_t);
   } else if t == bytes {
     var local_x = x.localize();
-    return qio_channel_write_string(false, byteorder:c_int, qio_channel_str_style(_channel_internal), _channel_internal, local_x.c_str(), local_x.numBytes: ssize_t);
+    return qio_channel_write_string(false, byteorder:c_int, qio_channel_str_style(_channel_internal), _channel_internal, local_x.c_str(), local_x.numBytes: c_ssize_t);
   } else if isEnumType(t) {
     var i = chpl__enumToOrder(x):chpl_enum_mintype(t);
     // call the integer version
@@ -3328,7 +3328,7 @@ private proc _read_io_type_internal(_channel_internal:qio_channel_ptr_t,
   } else if t == ioLiteral {
     return qio_channel_scan_literal(false, _channel_internal,
                                     x.val.localize().c_str(),
-                                    x.val.numBytes: ssize_t, x.ignoreWhiteSpace);
+                                    x.val.numBytes: c_ssize_t, x.ignoreWhiteSpace);
   } else if t == ioBits {
     return qio_channel_read_bits(false, _channel_internal, x.v, x.nbits);
   } else if kind == iokind.dynamic {
@@ -3380,7 +3380,7 @@ private proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
   } else if t == ioChar {
     return qio_channel_write_char(false, _channel_internal, x.ch);
   } else if t == ioLiteral {
-    return qio_channel_print_literal(false, _channel_internal, x.val.localize().c_str(), x.val.numBytes:ssize_t);
+    return qio_channel_print_literal(false, _channel_internal, x.val.localize().c_str(), x.val.numBytes:c_ssize_t);
   } else if t == ioBits {
     return qio_channel_write_bits(false, _channel_internal, x.v, x.nbits);
   } else if kind == iokind.dynamic {
@@ -3645,7 +3645,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
 
      :throws SystemError: Thrown if the byte sequence could not be written.
    */
-  proc channel.writeBytes(x, len:ssize_t):bool throws {
+  proc channel.writeBytes(x, len:c_ssize_t):bool throws {
     var err:syserr = ENOERR;
     on this.home {
       try this.lock(); defer { this.unlock(); }
@@ -3726,7 +3726,7 @@ proc stringify(const args ...?k):string {
       var r = f.reader(locking=false);
       defer try! r.close();
 
-      r.readBytes(buf, offset:ssize_t);
+      r.readBytes(buf, offset:c_ssize_t);
       // Add the terminating NULL byte to make C string conversion easy.
       buf[offset] = 0;
 
@@ -3956,12 +3956,12 @@ private proc readBytesOrString(ch: channel, ref out_var: ?t,  len: int(64))
     var tx:c_string;
     var lentmp:int(64);
     var actlen:int(64);
-    var uselen:ssize_t;
+    var uselen:c_ssize_t;
 
-    if len == -1 then uselen = max(ssize_t);
+    if len == -1 then uselen = max(c_ssize_t);
     else {
-      uselen = len:ssize_t;
-      if ssize_t != int(64) then assert( len == uselen );
+      uselen = len:c_ssize_t;
+      if c_ssize_t != int(64) then assert( len == uselen );
     }
 
     try ch.lock(); defer { ch.unlock(); }
@@ -4467,7 +4467,7 @@ proc channel.isclosed() {
 // in the type of the argument will only be caught by a type mismatch
 // in the call to qio_channel_read_amt.
 pragma "no doc"
-proc channel.readBytes(x, len:ssize_t) throws {
+proc channel.readBytes(x, len:c_ssize_t) throws {
   if here != this.home then
     throw new owned IllegalArgumentError("bad remote channel.readBytes");
   var err = qio_channel_read_amt(false, _channel_internal, x, len);
@@ -5772,7 +5772,7 @@ proc _toChar(x:?t) where t == string
   var chr:int(32);
   var nbytes:c_int;
   var local_x = x.localize();
-  qio_decode_char_buf(chr, nbytes, local_x.c_str(), local_x.numBytes:ssize_t);
+  qio_decode_char_buf(chr, nbytes, local_x.c_str(), local_x.numBytes:c_ssize_t);
   return (chr, true);
 }
 private inline
@@ -5903,7 +5903,7 @@ class _channel_regex_info {
 }
 
 pragma "no doc"
-proc channel._match_regex_if_needed(cur:size_t, len:size_t, ref error:syserr,
+proc channel._match_regex_if_needed(cur:c_size_t, len:c_size_t, ref error:syserr,
     ref style:iostyleInternal, r:unmanaged _channel_regex_info)
 {
   if qio_regex_ok(r.theRegex) {
@@ -5968,7 +5968,7 @@ proc channel._match_regex_if_needed(cur:size_t, len:size_t, ref error:syserr,
 //  in readf. (used in the regex handling here).
 pragma "no doc"
 proc channel._format_reader(
-    fmtStr:?fmtType, ref cur:size_t, len:size_t, ref error:syserr,
+    fmtStr:?fmtType, ref cur:c_size_t, len:c_size_t, ref error:syserr,
     ref conv:qio_conv_t, ref gotConv:bool, ref style:iostyleInternal,
     ref r:unmanaged _channel_regex_info?,
     isReadf:bool)
@@ -5983,7 +5983,7 @@ proc channel._format_reader(
       error = qio_conv_parse(fmt, cur, end, isReadf, conv, style);
       if error {
       }
-      cur = end:size_t;
+      cur = end:c_size_t;
       if error then break;
       if conv.argType == QIO_CONV_ARG_TYPE_NONE_LITERAL {
         // Print whitespace or I/O literal.
@@ -6011,11 +6011,11 @@ proc channel._format_reader(
               error = EFORMAT;
             }
           } else {
-            error = qio_channel_scan_literal_2(false, _channel_internal, conv.literal, conv.literal_length:ssize_t, 0);
+            error = qio_channel_scan_literal_2(false, _channel_internal, conv.literal, conv.literal_length:c_ssize_t, 0);
           }
         } else {
           // when printing we don't care if it's just whitespace.
-          error = qio_channel_print_literal_2(false, _channel_internal, conv.literal, conv.literal_length:ssize_t);
+          error = qio_channel_print_literal_2(false, _channel_internal, conv.literal, conv.literal_length:c_ssize_t);
         }
       } else if conv.argType == QIO_CONV_ARG_TYPE_NONE_REGEX_LITERAL {
         if ! isReadf {
@@ -6409,12 +6409,12 @@ proc channel._read_complex(width:uint(32), out t:complex, i:int)
 // for which we have already created and instantiation of this.
 pragma "no doc"
 proc channel._writefOne(fmtStr, ref arg, i: int,
-                        ref cur: size_t, ref j: int,
+                        ref cur: c_size_t, ref j: int,
                         ref r: unmanaged _channel_regex_info?,
                         argType: c_ptr(c_int), argTypeLen: int,
                         ref conv: qio_conv_t, ref gotConv: bool,
                         ref style: iostyleInternal, ref err: syserr,
-                        origLocale: locale, len: size_t) throws {
+                        origLocale: locale, len: c_size_t) throws {
   if boundsChecking {
     if i >= argTypeLen {
       halt("Index ", i, " is accessed on argType of length ", argTypeLen);
@@ -6545,8 +6545,8 @@ proc channel.writef(fmtStr: ?t, const args ...?k): bool throws
     defer {
       this._set_styleInternal(save_style);
     }
-    var cur:size_t = 0;
-    var len:size_t = fmtStr.size:size_t;
+    var cur:c_size_t = 0;
+    var len:c_size_t = fmtStr.size:c_size_t;
     var conv:qio_conv_t;
     var gotConv:bool;
     var style:iostyleInternal;
@@ -6603,12 +6603,12 @@ proc channel.writef(fmtStr:?t): bool throws
     defer {
       this._set_styleInternal(save_style);
     }
-    var cur:size_t = 0;
-    var len:size_t = fmtStr.size:size_t;
+    var cur:c_size_t = 0;
+    var len:c_size_t = fmtStr.size:c_size_t;
     var conv:qio_conv_t;
     var gotConv:bool;
     var style:iostyleInternal;
-    var end:size_t;
+    var end:c_size_t;
     var dummy:c_int;
 
     var r:unmanaged _channel_regex_info?;
@@ -6673,12 +6673,12 @@ proc channel.readf(fmtStr:?t, ref args ...?k): bool throws
     defer {
       this._set_styleInternal(save_style);
     }
-    var cur:size_t = 0;
-    var len:size_t = fmtStr.size:size_t;
+    var cur:c_size_t = 0;
+    var len:c_size_t = fmtStr.size:c_size_t;
     var conv:qio_conv_t;
     var gotConv:bool;
     var style:iostyleInternal;
-    var end:size_t;
+    var end:c_size_t;
 
     param argTypeLen = k+5;
     // we don't use a tuple here for being able to use conv_helper. This will be
@@ -6951,12 +6951,12 @@ proc channel.readf(fmtStr:?t) throws
     defer {
       this._set_styleInternal(save_style);
     }
-    var cur:size_t = 0;
-    var len:size_t = fmtStr.size:size_t;
+    var cur:c_size_t = 0;
+    var len:c_size_t = fmtStr.size:c_size_t;
     var conv:qio_conv_t;
     var gotConv:bool;
     var style:iostyleInternal;
-    var end:size_t;
+    var end:c_size_t;
     var dummy:c_int;
 
     var r:unmanaged _channel_regex_info?;
@@ -7121,7 +7121,7 @@ private proc chpl_do_format(fmt:?t, args ...?k): t throws
     } catch { /* ignore deferred close error */ }
   }
 
-  try r.readBytes(buf, offset:ssize_t);
+  try r.readBytes(buf, offset:c_ssize_t);
 
   // close errors are thrown instead of ignored
   try r.close();
@@ -7185,7 +7185,7 @@ proc channel._extractMatch(m:regexMatch, ref arg:bytes, ref error:syserr) {
     var ts: c_string;
     error =
         qio_channel_read_string(false, iokind.native:c_int, len: int(64),
-                                _channel_internal, ts, gotlen, len: ssize_t);
+                                _channel_internal, ts, gotlen, len: c_ssize_t);
     s = createBytesWithOwnedBuffer(ts, length=gotlen);
   }
 

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -156,7 +156,7 @@ module Subprocess {
   // the C allocator instead of the Chapel one.
 
   private extern proc qio_spawn_strdup(str: c_string): c_string;
-  private extern proc qio_spawn_allocate_ptrvec(count: size_t): c_ptr(c_string);
+  private extern proc qio_spawn_allocate_ptrvec(count: c_size_t): c_ptr(c_string);
   private extern proc qio_spawn_free_ptrvec(args: c_ptr(c_string));
   private extern proc qio_spawn_free_str(str: c_string);
 
@@ -490,14 +490,14 @@ module Subprocess {
     // that are NULL terminated and consist of C strings.
 
     var nargs = args.size + 1;
-    var use_args = qio_spawn_allocate_ptrvec( nargs.safeCast(size_t) );
+    var use_args = qio_spawn_allocate_ptrvec( nargs.safeCast(c_size_t) );
     for (a,i) in zip(args, 0..) {
       use_args[i] = qio_spawn_strdup(a.c_str());
     }
     var use_env:c_ptr(c_string) = nil;
     if env.size != 0 {
       var nenv = env.size + 1;
-      use_env = qio_spawn_allocate_ptrvec( nenv.safeCast(size_t) );
+      use_env = qio_spawn_allocate_ptrvec( nenv.safeCast(c_size_t) );
       for (a,i) in zip(env, 0..) {
         use_env[i] = qio_spawn_strdup(a.c_str());
       }

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -429,8 +429,8 @@ module Sys {
   /* The type corresponding to C's off_t */
   extern type off_t = int(64);
 
-  extern proc sys_mmap(addr:c_void_ptr, length:size_t, prot:c_int, flags:c_int, fd:fd_t, offset:off_t, ref ret_out:c_void_ptr):err_t;
-  extern proc sys_munmap(addr:c_void_ptr, length:size_t):err_t;
+  extern proc sys_mmap(addr:c_void_ptr, length:c_size_t, prot:c_int, flags:c_int, fd:fd_t, offset:off_t, ref ret_out:c_void_ptr):err_t;
+  extern proc sys_munmap(addr:c_void_ptr, length:c_size_t):err_t;
 
   // readv, writev, preadv, pwritev -- can't (yet) pass array.
 

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -373,10 +373,10 @@ private extern proc sys_strerror_syserr_str(error:syserr, out err_in_strerror:er
 /* This function takes in a string and returns it in double-quotes,
    with internal double-quotes escaped with backslash.
    */
-private proc quote_string(s:string, len:ssize_t) {
+private proc quote_string(s:string, len:c_ssize_t) {
   extern const QIO_STRING_FORMAT_CHPL: uint(8);
   extern proc qio_quote_string(s:uint(8), e:uint(8), f:uint(8),
-                               ptr: c_string, len:ssize_t,
+                               ptr: c_string, len:c_ssize_t,
                                ref ret:c_string, ti: c_void_ptr): syserr;
   extern proc qio_strdup(s: c_string): c_string;
 
@@ -412,7 +412,7 @@ pragma "always propagate line file info"
 proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
 {
   if error {
-    const quotedpath = quote_string(path, path.numBytes:ssize_t);
+    const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     var   details    = msg + " with path " + quotedpath +
                        " offset " + offset:string;
     throw SystemError.fromSyserr(error, details);
@@ -425,7 +425,7 @@ pragma "always propagate line file info"
 proc ioerror(error:syserr, msg:string, path:string) throws
 {
   if error {
-    const quotedpath = quote_string(path, path.numBytes:ssize_t);
+    const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     var   details    = msg + " with path " + quotedpath;
     throw SystemError.fromSyserr(error, details);
   }
@@ -453,7 +453,7 @@ pragma "insert line file info"
 pragma "always propagate line file info"
 proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
 {
-  const quotedpath = quote_string(path, path.numBytes:ssize_t);
+  const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
   const details    = errstr + " " + msg + " with path " + quotedpath +
                      " offset " + offset:string;
   throw SystemError.fromSyserr(EIO:syserr, details);

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -64,6 +64,8 @@ typedef void* c_fn_ptr;  // a white lie
 typedef uintptr_t c_uintptr;
 typedef intptr_t c_intptr;
 typedef ptrdiff_t c_ptrdiff;
+typedef size_t c_size_t;
+typedef ssize_t c_ssize_t;
 
 // C++ does not support c99 bools
 #ifndef __cplusplus

--- a/test/deprecated/depSsize_t.chpl
+++ b/test/deprecated/depSsize_t.chpl
@@ -1,0 +1,6 @@
+use SysCTypes;
+
+var x: size_t;
+var y: ssize_t;
+
+writeln((x,y));

--- a/test/deprecated/depSsize_t.good
+++ b/test/deprecated/depSsize_t.good
@@ -1,0 +1,4 @@
+depSsize_t.chpl:1: warning: 'SysCTypes' is deprecated; please use the 'CTypes' module instead
+depSsize_t.chpl:3: warning: 'size_t' has been deprecated in favor of 'c_size_t'
+depSsize_t.chpl:4: warning: 'ssize_t' has been deprecated in favor of 'c_ssize_t'
+(0, 0)

--- a/test/deprecated/depSsize_t2.chpl
+++ b/test/deprecated/depSsize_t2.chpl
@@ -1,0 +1,6 @@
+use CTypes;
+
+var x: size_t;
+var y: ssize_t;
+
+writeln((x,y));

--- a/test/deprecated/depSsize_t2.good
+++ b/test/deprecated/depSsize_t2.good
@@ -1,0 +1,3 @@
+depSsize_t2.chpl:3: warning: 'size_t' has been deprecated in favor of 'c_size_t'
+depSsize_t2.chpl:4: warning: 'ssize_t' has been deprecated in favor of 'c_ssize_t'
+(0, 0)

--- a/test/extern/ferguson/ctypes.chpl
+++ b/test/extern/ferguson/ctypes.chpl
@@ -14,8 +14,8 @@ var v_c_ushort: c_ushort = 0;
 var v_c_intptr: c_intptr = 0;
 var v_c_uintptr: c_uintptr = 0;
 var v_c_ptrdiff: c_ptrdiff = 0;
-var v_c_ssize_t: ssize_t = 0;
-var v_c_size_t: size_t = 0;
+var v_c_ssize_t: c_ssize_t = 0;
+var v_c_size_t: c_size_t = 0;
 
 writeln(v_c_int);
 writeln(v_c_uint);

--- a/test/extern/ferguson/extern-inline.chpl
+++ b/test/extern/ferguson/extern-inline.chpl
@@ -2,8 +2,8 @@
 
 use CTypes;
 
-extern "strlen"        proc f1(c_string): size_t;
-extern "strlen" inline proc f2(c_string): size_t;
+extern "strlen"        proc f1(c_string): c_size_t;
+extern "strlen" inline proc f2(c_string): c_size_t;
 
 writeln(f1("what's the length of this?"));
 writeln(f2("and of this?"));

--- a/test/extern/ferguson/externblock/extern_block_primer.chpl
+++ b/test/extern/ferguson/externblock/extern_block_primer.chpl
@@ -69,7 +69,7 @@ var result:c_int;
 
 hostname_ptr = c_calloc(c_char, hostname_len);
 
-result = gethostname(hostname_ptr:c_ptr(c_char), hostname_len:size_t);
+result = gethostname(hostname_ptr:c_ptr(c_char), hostname_len:c_size_t);
 if !quiet {
   if result == 0 {
     writeln("gethostname returned:");

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.chpl
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.chpl
@@ -1,7 +1,7 @@
 proc doit() {
   use CTypes;
 
-  extern proc sizeof(type t): size_t;
+  extern proc sizeof(type t): c_size_t;
 
   // We just want to check that this gets code
   // generated as sizeof(c_int) vs e.g. sizeof(int32_t);

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.chpl
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.chpl
@@ -1,7 +1,7 @@
 {
   use CTypes;
 
-  extern proc sizeof(type t): size_t;
+  extern proc sizeof(type t): c_size_t;
 
   // We just want to check that this gets code
   // generated as sizeof(c_int) vs e.g. sizeof(int32_t);

--- a/test/extern/nil/passNilToExtern.chpl
+++ b/test/extern/nil/passNilToExtern.chpl
@@ -2,6 +2,6 @@ use CTypes;
 
 require "passNilToExtern.h";
 
-extern proc foo(ptr: c_ptr(size_t));
+extern proc foo(ptr: c_ptr(c_size_t));
 
 foo(nil);

--- a/test/gpu/interop/cuBLAS/cuBLAS.chpl
+++ b/test/gpu/interop/cuBLAS/cuBLAS.chpl
@@ -17,21 +17,21 @@ module cuBLAS {
     cublas_destroy(handle);
   }
 
-  proc cu_array(size: size_t){
+  proc cu_array(size: c_size_t){
      require "c_cublas.h", "c_cublas.o";
      var x;
      x = cublas_array(size);
      return x;
   }
 
-  proc cpu_to_gpu(src_ptr: c_ptr(?t), size: size_t){
+  proc cpu_to_gpu(src_ptr: c_ptr(?t), size: c_size_t){
     require "c_cublas.h", "c_cublas.o";
     var gpu_ptr: DevicePtr(t);
     gpu_ptr.val = to_gpu(src_ptr, size): c_ptr(t);
     return gpu_ptr;
   }
 
-  proc gpu_to_cpu(dst_ptr: c_void_ptr, src_ptr: DevicePtr, size: size_t){
+  proc gpu_to_cpu(dst_ptr: c_void_ptr, src_ptr: DevicePtr, size: c_size_t){
     require "c_cublas.h", "c_cublas.o";
     to_cpu(dst_ptr, src_ptr.val, size);
   }
@@ -391,9 +391,9 @@ module cuBLAS {
 
     extern proc cublas_create(): c_void_ptr;
     extern proc cublas_destroy(handle: c_void_ptr);
-    extern proc cublas_array(size: size_t): c_ptr(c_float);
-    extern proc to_gpu(src_ptr: c_void_ptr, size: size_t): c_ptr(c_float);
-    extern proc to_cpu(dst_ptr: c_void_ptr, src_ptr: c_void_ptr, size: size_t): c_void_ptr;
+    extern proc cublas_array(size: c_size_t): c_ptr(c_float);
+    extern proc to_gpu(src_ptr: c_void_ptr, size: c_size_t): c_ptr(c_float);
+    extern proc to_cpu(dst_ptr: c_void_ptr, src_ptr: c_void_ptr, size: c_size_t): c_void_ptr;
  
     extern proc cublas_saxpy(handle: c_void_ptr, n: c_int, alpha: c_float, x: c_ptr(c_float), incX: c_int, y: c_ptr(c_float), incY: c_int);
     extern proc cublas_daxpy(handle: c_void_ptr, n: c_int, alpha: c_double, x: c_ptr(c_double), incX: c_int, y: c_ptr(c_double), incY: c_int);

--- a/test/gpu/interop/cuBLAS/level1/test_cublas1.chpl
+++ b/test/gpu/interop/cuBLAS/level1/test_cublas1.chpl
@@ -169,7 +169,7 @@ proc test_cuamax_helper(type t) {
     var r: int(32);
 
     //Get pointer to X allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -192,7 +192,7 @@ proc test_cuamax_helper(type t) {
     var r: int(32);
 
     //Get pointer to X allocated in GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -223,7 +223,7 @@ proc test_cuamin_helper(type t) {
     var r: int(32);
 
     //Get pointer to X allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -247,7 +247,7 @@ proc test_cuamin_helper(type t) {
     var r: int(32);
 
     //Get pointer to X allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -290,7 +290,7 @@ proc test_cuasum_helper(type t) {
     }
 
     //Get pointer to X allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -324,8 +324,8 @@ proc test_cucopy_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -335,7 +335,7 @@ proc test_cucopy_helper(type t) {
       cu_copy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
     }
 
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in D {
       var err = abs(Y[i] - X[i]);
@@ -362,8 +362,8 @@ proc test_cuaxpy_helper(type t) {
     const Yin = Y;
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -373,7 +373,7 @@ proc test_cuaxpy_helper(type t) {
       cu_axpy(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, a);
     }
 
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in D {
       var err = abs(a*X[i] + Yin[i] - Y[i]);
@@ -398,8 +398,8 @@ proc test_cudot_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     var prod = X*Y;
     var red = + reduce prod;
@@ -433,8 +433,8 @@ proc test_cudotu_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     var prod = X*Y;
     var red = + reduce prod;
@@ -468,8 +468,8 @@ proc test_cudotc_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     var prod = conjg(X)*Y;
     var red = + reduce prod;
@@ -506,7 +506,7 @@ proc test_cunrm2_helper(type t) {
     const norm = sqrt(+ reduce (abs(X)*abs(X)));
 
     //Get pointer to X allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -547,8 +547,8 @@ proc test_curot_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -557,8 +557,8 @@ proc test_curot_helper(type t) {
       cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in X.domain {
       err = abs(Xin[i] * c + Yin[i] * s - X[i]);
@@ -595,8 +595,8 @@ proc test_cucrot_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -605,8 +605,8 @@ proc test_cucrot_helper(type t) {
       cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in X.domain {
       err = abs(Xin[i] * c + Yin[i] * s - X[i]);
@@ -643,8 +643,8 @@ proc test_cuzrot_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -653,8 +653,8 @@ proc test_cuzrot_helper(type t) {
       cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in X.domain {
       err = abs(Xin[i] * c + Yin[i] * s - X[i]);
@@ -691,8 +691,8 @@ proc test_cucsrot_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -701,8 +701,8 @@ proc test_cucsrot_helper(type t) {
       cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in X.domain {
 
@@ -740,8 +740,8 @@ proc test_cuzdrot_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -750,8 +750,8 @@ proc test_cuzdrot_helper(type t) {
       cu_rot(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, c, s);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in X.domain {
 
@@ -970,8 +970,8 @@ proc test_curotm_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y and P allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -980,8 +980,8 @@ proc test_curotm_helper(type t) {
       cu_rotm(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y, P);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     var flag = P[0],
         h11 = P[1],
@@ -1100,7 +1100,7 @@ proc test_cuscal_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y and P allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -1110,7 +1110,7 @@ proc test_cuscal_helper(type t) {
       cu_scal(cublas_handle, N, a, gpu_ptr_X);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
 
     for i in D {
       var err = abs(a * Xin[i] - X[i]);
@@ -1137,7 +1137,7 @@ proc test_cucsscal_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y and P allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -1146,7 +1146,7 @@ proc test_cucsscal_helper(type t) {
       cu_scal(cublas_handle, N, a, gpu_ptr_X);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
 
     for i in D {
       var err = abs(a * Xin[i] - X[i]);
@@ -1173,7 +1173,7 @@ proc test_cuzdscal_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y and P allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -1182,7 +1182,7 @@ proc test_cuzdscal_helper(type t) {
       cu_scal(cublas_handle, N, a, gpu_ptr_X);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
 
     for i in D {
       var err = abs(a * Xin[i] - X[i]);
@@ -1211,8 +1211,8 @@ proc test_cuswap_helper(type t) {
     var N = X.size:int(32);
 
     //Get pointer to X and Y and P allocated on GPU
-    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:size_t);
-    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:size_t);
+    var gpu_ptr_X = cpu_to_gpu(c_ptrTo(X), c_sizeof(t)*N:c_size_t);
+    var gpu_ptr_Y = cpu_to_gpu(c_ptrTo(Y), c_sizeof(t)*N:c_size_t);
 
     //Create cublas handle
     var cublas_handle = cublas_create_handle();
@@ -1222,8 +1222,8 @@ proc test_cuswap_helper(type t) {
       cu_swap(cublas_handle, N, gpu_ptr_X, gpu_ptr_Y);
     }
 
-    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:size_t);
-    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:size_t);
+    gpu_to_cpu(c_ptrTo(X), gpu_ptr_X, c_sizeof(t)*N:c_size_t);
+    gpu_to_cpu(c_ptrTo(Y), gpu_ptr_Y, c_sizeof(t)*N:c_size_t);
 
     for i in D {
       var err = abs(Xin[i] - Y[i]);

--- a/test/gpu/native/memory/basic.chpl
+++ b/test/gpu/native/memory/basic.chpl
@@ -1,7 +1,7 @@
 use CTypes;
 
 
-extern proc chpl_gpu_get_alloc_size(arg): size_t;
+extern proc chpl_gpu_get_alloc_size(arg): c_size_t;
 extern proc chpl_gpu_copy_device_to_host(dst: c_void_ptr, src: c_void_ptr, n): void;
 extern proc chpl_gpu_copy_host_to_device(dst: c_void_ptr, src: c_void_ptr, n): void;
 extern proc chpl_gpu_is_device_ptr(ptr): bool;

--- a/test/io/ferguson/seeking.chpl
+++ b/test/io/ferguson/seeking.chpl
@@ -6,10 +6,10 @@ config const maxint = 32*1024;
 config const seed = SeedGenerator.oddCurrentTime;
 
 config const bufsz = 0;
-extern var qbytes_iobuf_size:size_t;
+extern var qbytes_iobuf_size:c_size_t;
 
 if bufsz > 0 {
-  qbytes_iobuf_size = bufsz:size_t;
+  qbytes_iobuf_size = bufsz:c_size_t;
 }
 
 proc test1() {

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -96,8 +96,8 @@ module CheckHttpSetOpt {
   }
 
   // Test a string-type option, CURLOPT_URL, via the libcurl-based API
-  proc write_callback(ptr: c_ptr(c_char), size: size_t,
-		      nmemb: size_t, userdata: c_void_ptr) {
+  proc write_callback(ptr: c_ptr(c_char), size: c_size_t,
+		      nmemb: c_size_t, userdata: c_void_ptr) {
     writeln("callback called");
     var str = try! createStringWithBorrowedBuffer(ptr:c_string,
                                                   (size * nmemb):int);

--- a/test/library/packages/Curl/check-http.chpl
+++ b/test/library/packages/Curl/check-http.chpl
@@ -8,10 +8,10 @@ module CheckHttp {
   config const verbose = false;
   config const bufsz = 0;
 
-  extern var qbytes_iobuf_size:size_t;
+  extern var qbytes_iobuf_size:c_size_t;
 
   if bufsz > 0 {
-    qbytes_iobuf_size = bufsz:size_t;
+    qbytes_iobuf_size = bufsz:c_size_t;
   }
 
   proc runtest() throws {

--- a/test/library/packages/HDF5/ex_lite2.chpl
+++ b/test/library/packages/HDF5/ex_lite2.chpl
@@ -8,7 +8,7 @@ proc main {
   var file_id: hid_t,
       data: [0..#6] c_int,
       dims: [0..#2] hsize_t,
-      i, j, nrow, n_values: size_t;
+      i, j, nrow, n_values: c_size_t;
 
   const filename = "ex_lite2_input.h5";
   var pathPrefix = readPrefixEnv();
@@ -28,8 +28,8 @@ proc main {
   H5LTget_dataset_info_WAR(file_id, c"/dset", c_ptrTo(dims), nil, nil);
 
   /* print it by rows */
-  n_values = (dims[0]*dims[1]): size_t;
-  nrow = dims[1]: size_t;
+  n_values = (dims[0]*dims[1]): c_size_t;
+  nrow = dims[1]: c_size_t;
   for i in 0..#n_values/nrow {
     for j in 0..#nrow {
       write("  ", data[i*nrow:int + j]);

--- a/test/library/packages/HDF5/htable/HTable.chpl
+++ b/test/library/packages/HDF5/htable/HTable.chpl
@@ -102,7 +102,7 @@ module HTable {
     extern proc H5TBappend_records(loc_id : hid_t, dset_name: c_string,
                                    numRecords : hsize_t, type_size : hsize_t,
                                    field_offset : c_array(hsize_t),
-                                   field_sizes : c_array(size_t),
+                                   field_sizes : c_array(c_size_t),
                                    data : c_void_ptr);
     var meta = new H5MetaTable(R);
     var cname = name.c_str();
@@ -134,9 +134,9 @@ module HTable {
   {
     extern proc H5TBread_fields_name(loc_id : hid_t, dset_name : c_string,
                                      field_names : c_string, start : hsize_t,
-                                     nrecords : hsize_t, type_size : size_t,
+                                     nrecords : hsize_t, type_size : c_size_t,
                                      field_offset : c_array(hsize_t),
-                                     field_sizes : c_array(size_t),
+                                     field_sizes : c_array(c_size_t),
                                      data : c_void_ptr);
     extern proc H5TBget_table_info(loc_id : hid_t, table_name : c_string,
                                    nfields : c_ptr(hsize_t), nrecords : c_ptr(hsize_t));
@@ -176,7 +176,7 @@ module HTable {
     param nFields : int;
 
     /* The size of `R` as reported by C `sizeof` */
-    const Rsize : size_t;
+    const Rsize : c_size_t;
 
     /* A c_array of names of fields */
     var names : c_array(c_string, nFields);
@@ -185,7 +185,7 @@ module HTable {
     /* HDF5 types of fields */
     var types : c_array(hid_t, nFields);
     /* Sizes of fields */
-    var sizes : c_array(size_t, nFields);
+    var sizes : c_array(c_size_t, nFields);
 
     /* Are the types created by this routine (currently,
      `c_array` types fall into this class). If so, this
@@ -223,12 +223,12 @@ module HTable {
           var dim : hsize_t = ifield.size : hsize_t; 
           types[ii] = H5Tarray_create2(getHDF5Type(ifield.eltType), 1, c_ptrTo(dim));
           ownedtypes[ii] = true;
-          sizes[ii] = (c_sizeof(ifield.eltType)*dim):size_t;
+          sizes[ii] = (c_sizeof(ifield.eltType)*dim):c_size_t;
           continue;
         }
         // All other cases
         types[ii] = getHDF5Type(fieldtype);
-        sizes[ii] = c_sizeof(fieldtype) : size_t;
+        sizes[ii] = c_sizeof(fieldtype) : c_size_t;
         ownedtypes[ii] = false;
       }
 

--- a/test/library/packages/HDFS/hdfsNumbers.chpl
+++ b/test/library/packages/HDFS/hdfsNumbers.chpl
@@ -12,12 +12,12 @@ config const path = "/tmp/lots-of-numbers.txt";
 config const n = 10000;
 config const bufsz = 0;
 
-extern var qbytes_iobuf_size:size_t;
+extern var qbytes_iobuf_size:c_size_t;
 
 proc main() {
 
   if bufsz > 0 {
-    qbytes_iobuf_size = bufsz:size_t;
+    qbytes_iobuf_size = bufsz:c_size_t;
   }
 
   var fs = HDFS.connect();

--- a/test/library/packages/NetCDF/pres_temp_4D_rd.chpl
+++ b/test/library/packages/NetCDF/pres_temp_4D_rd.chpl
@@ -39,7 +39,7 @@ proc main {
 
   /* The start and count arrays will tell the netCDF library where to
      read our data. */
-  var start, count: [0..#ndims] size_t;
+  var start, count: [0..#ndims] c_size_t;
 
   /* Program variables to hold the data we will read. We will only
      need enough space to hold one timestep of data; one record. */
@@ -94,8 +94,8 @@ proc main {
 
   /* Read and check one record at a time. */
   for rec in 0..#nrec {
-    start[0] = rec: size_t;
-    extern proc nc_get_vara_float_WAR(ncid: c_int, pres_varid: c_int, ref start: size_t, ref count: size_t, ref pres_out: real(32)): c_int;
+    start[0] = rec: c_size_t;
+    extern proc nc_get_vara_float_WAR(ncid: c_int, pres_varid: c_int, ref start: c_size_t, ref count: c_size_t, ref pres_out: real(32)): c_int;
     cdfError(nc_get_vara_float_WAR(ncid, pres_varid, start[0],
                                    count[0], pres_in[0, 0, 0]));
     cdfError(nc_get_vara_float_WAR(ncid, temp_varid, start[0],

--- a/test/library/packages/NetCDF/pres_temp_4D_wr.chpl
+++ b/test/library/packages/NetCDF/pres_temp_4D_wr.chpl
@@ -50,7 +50,7 @@ proc main {
 
   /* The start and count arrays will tell the netCDF library where to
      write our data. */
-  var start, count: [0..#ndims] size_t;
+  var start, count: [0..#ndims] c_size_t;
 
   /* Program variables to hold the data we will write out. We will only
      need enough space to hold one timestep of data; one record. */
@@ -92,7 +92,7 @@ proc main {
   cdfError(nc_def_dim(ncid, lvlName, nlvl, lvl_dimid));
   cdfError(nc_def_dim(ncid, latName, nlat, lat_dimid));
   cdfError(nc_def_dim(ncid, lonName, nlon, lon_dimid));
-  cdfError(nc_def_dim(ncid, recName, NC_UNLIMITED: size_t, rec_dimid));
+  cdfError(nc_def_dim(ncid, recName, NC_UNLIMITED: c_size_t, rec_dimid));
 
   /* Define the coordinate variables. We will only define coordinate
      variables for lat and lon.  Ordinarily we would need to provide
@@ -156,9 +156,9 @@ proc main {
      surface temperature data. The arrays only hold one timestep worth
      of data. We will just rewrite the same data for each timestep. In
      a real application, the data would change between timesteps. */
-  extern proc nc_put_vara_float_WAR(ncid: c_int, pres_varid: c_int, ref start: size_t, ref count: size_t, ref pres_out: real(32)): c_int;
+  extern proc nc_put_vara_float_WAR(ncid: c_int, pres_varid: c_int, ref start: c_size_t, ref count: c_size_t, ref pres_out: real(32)): c_int;
   for rec in 0..#nrec {
-    start[0] = rec: size_t;
+    start[0] = rec: c_size_t;
     cdfError(nc_put_vara_float_WAR(ncid, pres_varid, start[0], count[0],
                                    pres_out[0, 0, 0]));
     cdfError(nc_put_vara_float_WAR(ncid, temp_varid, start[0], count[0],

--- a/test/library/packages/NetCDF/sfc_pres_temp_wr.chpl
+++ b/test/library/packages/NetCDF/sfc_pres_temp_wr.chpl
@@ -94,9 +94,9 @@ proc main {
 
   /* Define units attributes for vars. */
   cdfError(nc_put_att_text(ncid, presVarId, units.c_str(),
-                           presUnits.numBytes:size_t, presUnits.c_str()));
+                           presUnits.numBytes:c_size_t, presUnits.c_str()));
   cdfError(nc_put_att_text(ncid, tempVarId, units.c_str(),
-                           tempUnits.numBytes:size_t, tempUnits.c_str()));
+                           tempUnits.numBytes:c_size_t, tempUnits.c_str()));
 
   /* End define mode. */
   cdfError(nc_enddef(ncid));

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -275,11 +275,11 @@ proc shallowCopy(ref A, dst, src, nElts) {
   // Ideally this would just be
   //A[dst..#nElts] = A[src..#nElts];
 
-    var size = (nElts:size_t)*c_sizeof(A.eltType);
+    var size = (nElts:c_size_t)*c_sizeof(A.eltType);
     c_memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size);
     /*
   if A._instance.isDefaultRectangular() {
-    var size = (nElts:size_t)*c_sizeof(A.eltType);
+    var size = (nElts:c_size_t)*c_sizeof(A.eltType);
     c_memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size);
   } else {
     var ok = chpl__bulkTransferArray(/*dst*/ A._instance, {dst..#nElts},
@@ -294,11 +294,11 @@ proc shallowCopy(ref DstA, dst, ref SrcA, src, nElts) {
   // Ideally this would just be
   //DstA[dst..#nElts] = SrcA[src..#nElts];
 
-    var size = (nElts:size_t)*c_sizeof(DstA.eltType);
+    var size = (nElts:c_size_t)*c_sizeof(DstA.eltType);
     c_memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size);
     /*
   if DstA._instance.isDefaultRectangular() && SrcA._instance.isDefaultRectangular() {
-    var size = (nElts:size_t)*c_sizeof(DstA.eltType);
+    var size = (nElts:c_size_t)*c_sizeof(DstA.eltType);
     c_memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size);
   } else {
     var ok = chpl__bulkTransferArray(/*dst*/ DstA._instance, {dst..#nElts},

--- a/test/library/packages/TensorFlow/TensorFlow.chpl
+++ b/test/library/packages/TensorFlow/TensorFlow.chpl
@@ -6,7 +6,7 @@ module TensorFlow {
 
     extern proc TF_Version() : c_string;
 
-    extern proc TF_DataTypeSize(dt : TF_DataType) : size_t;
+    extern proc TF_DataTypeSize(dt : TF_DataType) : c_size_t;
 
     extern proc TF_NewStatus() : c_ptr(TF_Status);
 
@@ -26,7 +26,7 @@ module TensorFlow {
 
     extern proc TF_Message(s : c_ptr(TF_Status)) : c_string;
 
-    extern proc TF_NewBufferFromString(proto : c_void_ptr, proto_len : size_t) : c_ptr(TF_Buffer);
+    extern proc TF_NewBufferFromString(proto : c_void_ptr, proto_len : c_size_t) : c_ptr(TF_Buffer);
 
     extern proc TF_NewBuffer() : c_ptr(TF_Buffer);
 
@@ -38,13 +38,13 @@ module TensorFlow {
 
     extern proc TF_GetBuffer(buffer : c_ptr(TF_Buffer)) : TF_Buffer;
 
-    extern proc TF_NewTensor(arg0 : TF_DataType, ref dims : int(64), num_dims : c_int, data : c_void_ptr, len : size_t, ref deallocator : c_fn_ptr, deallocator_arg : c_void_ptr) : c_ptr(TF_Tensor);
+    extern proc TF_NewTensor(arg0 : TF_DataType, ref dims : int(64), num_dims : c_int, data : c_void_ptr, len : c_size_t, ref deallocator : c_fn_ptr, deallocator_arg : c_void_ptr) : c_ptr(TF_Tensor);
 
-    extern proc TF_NewTensor(arg0 : TF_DataType, dims : c_ptr(int(64)), num_dims : c_int, data : c_void_ptr, len : size_t, deallocator : c_fn_ptr, deallocator_arg : c_void_ptr) : c_ptr(TF_Tensor);
+    extern proc TF_NewTensor(arg0 : TF_DataType, dims : c_ptr(int(64)), num_dims : c_int, data : c_void_ptr, len : c_size_t, deallocator : c_fn_ptr, deallocator_arg : c_void_ptr) : c_ptr(TF_Tensor);
 
-    extern proc TF_AllocateTensor(arg0 : TF_DataType, ref dims : int(64), num_dims : c_int, len : size_t) : c_ptr(TF_Tensor);
+    extern proc TF_AllocateTensor(arg0 : TF_DataType, ref dims : int(64), num_dims : c_int, len : c_size_t) : c_ptr(TF_Tensor);
 
-    extern proc TF_AllocateTensor(arg0 : TF_DataType, dims : c_ptr(int(64)), num_dims : c_int, len : size_t) : c_ptr(TF_Tensor);
+    extern proc TF_AllocateTensor(arg0 : TF_DataType, dims : c_ptr(int(64)), num_dims : c_int, len : c_size_t) : c_ptr(TF_Tensor);
 
     extern proc TF_TensorMaybeMove(ref tensor : TF_Tensor) : c_ptr(TF_Tensor);
 
@@ -66,23 +66,23 @@ module TensorFlow {
 
     extern proc TF_Dim(tensor : c_ptr(TF_Tensor), dim_index : c_int) : int(64);
 
-    extern proc TF_TensorByteSize(ref arg0 : TF_Tensor) : size_t;
+    extern proc TF_TensorByteSize(ref arg0 : TF_Tensor) : c_size_t;
 
-    extern proc TF_TensorByteSize(arg0 : c_ptr(TF_Tensor)) : size_t;
+    extern proc TF_TensorByteSize(arg0 : c_ptr(TF_Tensor)) : c_size_t;
 
     extern proc TF_TensorData(ref arg0 : TF_Tensor) : c_void_ptr;
 
     extern proc TF_TensorData(arg0 : c_ptr(TF_Tensor)) : c_void_ptr;
 
-    extern proc TF_StringEncode(src : c_string, src_len : size_t, dst : c_string, dst_len : size_t, ref status : TF_Status) : size_t;
+    extern proc TF_StringEncode(src : c_string, src_len : c_size_t, dst : c_string, dst_len : c_size_t, ref status : TF_Status) : c_size_t;
 
-    extern proc TF_StringEncode(src : c_string, src_len : size_t, dst : c_string, dst_len : size_t, status : c_ptr(TF_Status)) : size_t;
+    extern proc TF_StringEncode(src : c_string, src_len : c_size_t, dst : c_string, dst_len : c_size_t, status : c_ptr(TF_Status)) : c_size_t;
 
-    extern proc TF_StringDecode(src : c_string, src_len : size_t, ref dst : c_string, ref dst_len : size_t, ref status : TF_Status) : size_t;
+    extern proc TF_StringDecode(src : c_string, src_len : c_size_t, ref dst : c_string, ref dst_len : c_size_t, ref status : TF_Status) : c_size_t;
 
-    extern proc TF_StringDecode(src : c_string, src_len : size_t, dst : c_ptr(c_string), dst_len : c_ptr(size_t), status : c_ptr(TF_Status)) : size_t;
+    extern proc TF_StringDecode(src : c_string, src_len : c_size_t, dst : c_ptr(c_string), dst_len : c_ptr(c_size_t), status : c_ptr(TF_Status)) : c_size_t;
 
-    extern proc TF_StringEncodedSize(len : size_t) : size_t;
+    extern proc TF_StringEncodedSize(len : c_size_t) : c_size_t;
 
     extern proc TF_NewSessionOptions() : c_ptr(TF_SessionOptions);
 
@@ -90,9 +90,9 @@ module TensorFlow {
 
     extern proc TF_SetTarget(options : c_ptr(TF_SessionOptions), target : c_string) : void;
 
-    extern proc TF_SetConfig(ref options : TF_SessionOptions, proto : c_void_ptr, proto_len : size_t, ref status : TF_Status) : void;
+    extern proc TF_SetConfig(ref options : TF_SessionOptions, proto : c_void_ptr, proto_len : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_SetConfig(options : c_ptr(TF_SessionOptions), proto : c_void_ptr, proto_len : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_SetConfig(options : c_ptr(TF_SessionOptions), proto : c_void_ptr, proto_len : c_size_t, status : c_ptr(TF_Status)) : void;
 
     extern proc TF_DeleteSessionOptions(ref arg0 : TF_SessionOptions) : void;
 
@@ -140,13 +140,13 @@ module TensorFlow {
 
     extern proc TF_ColocateWith(desc : c_ptr(TF_OperationDescription), op : c_ptr(TF_Operation)) : void;
 
-    extern proc TF_SetAttrString(ref desc : TF_OperationDescription, attr_name : c_string, value : c_void_ptr, length : size_t) : void;
+    extern proc TF_SetAttrString(ref desc : TF_OperationDescription, attr_name : c_string, value : c_void_ptr, length : c_size_t) : void;
 
-    extern proc TF_SetAttrString(desc : c_ptr(TF_OperationDescription), attr_name : c_string, value : c_void_ptr, length : size_t) : void;
+    extern proc TF_SetAttrString(desc : c_ptr(TF_OperationDescription), attr_name : c_string, value : c_void_ptr, length : c_size_t) : void;
 
-    extern proc TF_SetAttrStringList(ref desc : TF_OperationDescription, attr_name : c_string, ref values : c_void_ptr, ref lengths : size_t, num_values : c_int) : void;
+    extern proc TF_SetAttrStringList(ref desc : TF_OperationDescription, attr_name : c_string, ref values : c_void_ptr, ref lengths : c_size_t, num_values : c_int) : void;
 
-    extern proc TF_SetAttrStringList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, values : c_ptr(c_void_ptr), lengths : c_ptr(size_t), num_values : c_int) : void;
+    extern proc TF_SetAttrStringList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, values : c_ptr(c_void_ptr), lengths : c_ptr(c_size_t), num_values : c_int) : void;
 
     extern proc TF_SetAttrInt(ref desc : TF_OperationDescription, attr_name : c_string, value : int(64)) : void;
 
@@ -180,9 +180,9 @@ module TensorFlow {
 
     extern proc TF_SetAttrTypeList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, values : c_ptr(TF_DataType), num_values : c_int) : void;
 
-    extern proc TF_SetAttrFuncName(ref desc : TF_OperationDescription, attr_name : c_string, value : c_string, length : size_t) : void;
+    extern proc TF_SetAttrFuncName(ref desc : TF_OperationDescription, attr_name : c_string, value : c_string, length : c_size_t) : void;
 
-    extern proc TF_SetAttrFuncName(desc : c_ptr(TF_OperationDescription), attr_name : c_string, value : c_string, length : size_t) : void;
+    extern proc TF_SetAttrFuncName(desc : c_ptr(TF_OperationDescription), attr_name : c_string, value : c_string, length : c_size_t) : void;
 
     extern proc TF_SetAttrShape(ref desc : TF_OperationDescription, attr_name : c_string, ref dims : int(64), num_dims : c_int) : void;
 
@@ -192,13 +192,13 @@ module TensorFlow {
 
     extern proc TF_SetAttrShapeList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, dims : c_ptr(c_ptr(int(64))), num_dims : c_ptr(c_int), num_shapes : c_int) : void;
 
-    extern proc TF_SetAttrTensorShapeProto(ref desc : TF_OperationDescription, attr_name : c_string, proto : c_void_ptr, proto_len : size_t, ref status : TF_Status) : void;
+    extern proc TF_SetAttrTensorShapeProto(ref desc : TF_OperationDescription, attr_name : c_string, proto : c_void_ptr, proto_len : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_SetAttrTensorShapeProto(desc : c_ptr(TF_OperationDescription), attr_name : c_string, proto : c_void_ptr, proto_len : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_SetAttrTensorShapeProto(desc : c_ptr(TF_OperationDescription), attr_name : c_string, proto : c_void_ptr, proto_len : c_size_t, status : c_ptr(TF_Status)) : void;
 
-    extern proc TF_SetAttrTensorShapeProtoList(ref desc : TF_OperationDescription, attr_name : c_string, ref protos : c_void_ptr, ref proto_lens : size_t, num_shapes : c_int, ref status : TF_Status) : void;
+    extern proc TF_SetAttrTensorShapeProtoList(ref desc : TF_OperationDescription, attr_name : c_string, ref protos : c_void_ptr, ref proto_lens : c_size_t, num_shapes : c_int, ref status : TF_Status) : void;
 
-    extern proc TF_SetAttrTensorShapeProtoList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, protos : c_ptr(c_void_ptr), proto_lens : c_ptr(size_t), num_shapes : c_int, status : c_ptr(TF_Status)) : void;
+    extern proc TF_SetAttrTensorShapeProtoList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, protos : c_ptr(c_void_ptr), proto_lens : c_ptr(c_size_t), num_shapes : c_int, status : c_ptr(TF_Status)) : void;
 
     extern proc TF_SetAttrTensor(ref desc : TF_OperationDescription, attr_name : c_string, ref value : TF_Tensor, ref status : TF_Status) : void;
 
@@ -208,9 +208,9 @@ module TensorFlow {
 
     extern proc TF_SetAttrTensorList(desc : c_ptr(TF_OperationDescription), attr_name : c_string, values : c_ptr(c_ptr(TF_Tensor)), num_values : c_int, status : c_ptr(TF_Status)) : void;
 
-    extern proc TF_SetAttrValueProto(ref desc : TF_OperationDescription, attr_name : c_string, proto : c_void_ptr, proto_len : size_t, ref status : TF_Status) : void;
+    extern proc TF_SetAttrValueProto(ref desc : TF_OperationDescription, attr_name : c_string, proto : c_void_ptr, proto_len : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_SetAttrValueProto(desc : c_ptr(TF_OperationDescription), attr_name : c_string, proto : c_void_ptr, proto_len : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_SetAttrValueProto(desc : c_ptr(TF_OperationDescription), attr_name : c_string, proto : c_void_ptr, proto_len : c_size_t, status : c_ptr(TF_Status)) : void;
 
     extern proc TF_FinishOperation(ref desc : TF_OperationDescription, ref status : TF_Status) : c_ptr(TF_Operation);
 
@@ -276,13 +276,13 @@ module TensorFlow {
 
     extern proc TF_OperationGetAttrMetadata(oper : c_ptr(TF_Operation), attr_name : c_string, status : c_ptr(TF_Status)) : TF_AttrMetadata;
 
-    extern proc TF_OperationGetAttrString(ref oper : TF_Operation, attr_name : c_string, value : c_void_ptr, max_length : size_t, ref status : TF_Status) : void;
+    extern proc TF_OperationGetAttrString(ref oper : TF_Operation, attr_name : c_string, value : c_void_ptr, max_length : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_OperationGetAttrString(oper : c_ptr(TF_Operation), attr_name : c_string, value : c_void_ptr, max_length : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_OperationGetAttrString(oper : c_ptr(TF_Operation), attr_name : c_string, value : c_void_ptr, max_length : c_size_t, status : c_ptr(TF_Status)) : void;
 
-    extern proc TF_OperationGetAttrStringList(ref oper : TF_Operation, attr_name : c_string, ref values : c_void_ptr, ref lengths : size_t, max_values : c_int, storage : c_void_ptr, storage_size : size_t, ref status : TF_Status) : void;
+    extern proc TF_OperationGetAttrStringList(ref oper : TF_Operation, attr_name : c_string, ref values : c_void_ptr, ref lengths : c_size_t, max_values : c_int, storage : c_void_ptr, storage_size : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_OperationGetAttrStringList(oper : c_ptr(TF_Operation), attr_name : c_string, values : c_ptr(c_void_ptr), lengths : c_ptr(size_t), max_values : c_int, storage : c_void_ptr, storage_size : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_OperationGetAttrStringList(oper : c_ptr(TF_Operation), attr_name : c_string, values : c_ptr(c_void_ptr), lengths : c_ptr(c_size_t), max_values : c_int, storage : c_void_ptr, storage_size : c_size_t, status : c_ptr(TF_Status)) : void;
 
     extern proc TF_OperationGetAttrInt(ref oper : TF_Operation, attr_name : c_string, ref value : int(64), ref status : TF_Status) : void;
 
@@ -348,9 +348,9 @@ module TensorFlow {
 
     extern proc TF_GraphOperationByName(graph : c_ptr(TF_Graph), oper_name : c_string) : c_ptr(TF_Operation);
 
-    extern proc TF_GraphNextOperation(ref graph : TF_Graph, ref pos : size_t) : c_ptr(TF_Operation);
+    extern proc TF_GraphNextOperation(ref graph : TF_Graph, ref pos : c_size_t) : c_ptr(TF_Operation);
 
-    extern proc TF_GraphNextOperation(graph : c_ptr(TF_Graph), pos : c_ptr(size_t)) : c_ptr(TF_Operation);
+    extern proc TF_GraphNextOperation(graph : c_ptr(TF_Graph), pos : c_ptr(c_size_t)) : c_ptr(TF_Operation);
 
     extern proc TF_GraphToGraphDef(ref graph : TF_Graph, ref output_graph_def : TF_Buffer, ref status : TF_Status) : void;
 
@@ -486,13 +486,13 @@ module TensorFlow {
 
     extern proc TF_FunctionToFunctionDef(func : c_ptr(TF_Function), output_func_def : c_ptr(TF_Buffer), status : c_ptr(TF_Status)) : void;
 
-    extern proc TF_FunctionImportFunctionDef(proto : c_void_ptr, proto_len : size_t, ref status : TF_Status) : c_ptr(TF_Function);
+    extern proc TF_FunctionImportFunctionDef(proto : c_void_ptr, proto_len : c_size_t, ref status : TF_Status) : c_ptr(TF_Function);
 
-    extern proc TF_FunctionImportFunctionDef(proto : c_void_ptr, proto_len : size_t, status : c_ptr(TF_Status)) : c_ptr(TF_Function);
+    extern proc TF_FunctionImportFunctionDef(proto : c_void_ptr, proto_len : c_size_t, status : c_ptr(TF_Status)) : c_ptr(TF_Function);
 
-    extern proc TF_FunctionSetAttrValueProto(ref func : TF_Function, attr_name : c_string, proto : c_void_ptr, proto_len : size_t, ref status : TF_Status) : void;
+    extern proc TF_FunctionSetAttrValueProto(ref func : TF_Function, attr_name : c_string, proto : c_void_ptr, proto_len : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_FunctionSetAttrValueProto(func : c_ptr(TF_Function), attr_name : c_string, proto : c_void_ptr, proto_len : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_FunctionSetAttrValueProto(func : c_ptr(TF_Function), attr_name : c_string, proto : c_void_ptr, proto_len : c_size_t, status : c_ptr(TF_Status)) : void;
 
     extern proc TF_FunctionGetAttrValueProto(ref func : TF_Function, attr_name : c_string, ref output_attr_value : TF_Buffer, ref status : TF_Status) : void;
 
@@ -552,9 +552,9 @@ module TensorFlow {
 
     extern proc TF_Reset(opt : c_ptr(TF_SessionOptions), containers : c_ptr(c_string), ncontainers : c_int, status : c_ptr(TF_Status)) : void;
 
-    extern proc TF_ExtendGraph(ref arg0 : TF_DeprecatedSession, proto : c_void_ptr, proto_len : size_t, ref arg3 : TF_Status) : void;
+    extern proc TF_ExtendGraph(ref arg0 : TF_DeprecatedSession, proto : c_void_ptr, proto_len : c_size_t, ref arg3 : TF_Status) : void;
 
-    extern proc TF_ExtendGraph(arg0 : c_ptr(TF_DeprecatedSession), proto : c_void_ptr, proto_len : size_t, arg3 : c_ptr(TF_Status)) : void;
+    extern proc TF_ExtendGraph(arg0 : c_ptr(TF_DeprecatedSession), proto : c_void_ptr, proto_len : c_size_t, arg3 : c_ptr(TF_Status)) : void;
 
     extern proc TF_Run(ref arg0 : TF_DeprecatedSession, ref run_options : TF_Buffer, ref input_names : c_string, ref inputs : c_ptr(TF_Tensor), ninputs : c_int, ref output_names : c_string, ref outputs : c_ptr(TF_Tensor), noutputs : c_int, ref target_oper_names : c_string, ntargets : c_int, ref run_metadata : TF_Buffer, ref arg11 : TF_Status) : void;
 
@@ -622,13 +622,13 @@ module TensorFlow {
 
     extern proc TF_DeleteApiDefMap(apimap : c_ptr(TF_ApiDefMap)) : void;
 
-    extern proc TF_ApiDefMapPut(ref api_def_map : TF_ApiDefMap, text : c_string, text_len : size_t, ref status : TF_Status) : void;
+    extern proc TF_ApiDefMapPut(ref api_def_map : TF_ApiDefMap, text : c_string, text_len : c_size_t, ref status : TF_Status) : void;
 
-    extern proc TF_ApiDefMapPut(api_def_map : c_ptr(TF_ApiDefMap), text : c_string, text_len : size_t, status : c_ptr(TF_Status)) : void;
+    extern proc TF_ApiDefMapPut(api_def_map : c_ptr(TF_ApiDefMap), text : c_string, text_len : c_size_t, status : c_ptr(TF_Status)) : void;
 
-    extern proc TF_ApiDefMapGet(ref api_def_map : TF_ApiDefMap, name : c_string, name_len : size_t, ref status : TF_Status) : c_ptr(TF_Buffer);
+    extern proc TF_ApiDefMapGet(ref api_def_map : TF_ApiDefMap, name : c_string, name_len : c_size_t, ref status : TF_Status) : c_ptr(TF_Buffer);
 
-    extern proc TF_ApiDefMapGet(api_def_map : c_ptr(TF_ApiDefMap), name : c_string, name_len : size_t, status : c_ptr(TF_Status)) : c_ptr(TF_Buffer);
+    extern proc TF_ApiDefMapGet(api_def_map : c_ptr(TF_ApiDefMap), name : c_string, name_len : c_size_t, status : c_ptr(TF_Status)) : c_ptr(TF_Buffer);
 
     extern proc TF_GetAllRegisteredKernels(ref status : TF_Status) : c_ptr(TF_Buffer);
 
@@ -661,7 +661,7 @@ module TensorFlow {
 
     extern record TF_Buffer {
       var data : c_void_ptr;
-      var length : size_t;
+      var length : c_size_t;
       var data_deallocator : c_fn_ptr;
     }
 

--- a/test/library/packages/TensorFlow/load_graph.chpl
+++ b/test/library/packages/TensorFlow/load_graph.chpl
@@ -7,7 +7,7 @@ use TensorFlow.C_TensorFlow;
 
 config const filename = "graph.pb";
 
-proc deallocateBuffer(buf: c_void_ptr, size: size_t) {
+proc deallocateBuffer(buf: c_void_ptr, size: c_size_t) {
   extern "free" proc c_free(ptr: c_void_ptr);
   c_free(buf);
 }
@@ -17,20 +17,20 @@ proc readBufferFromFile(filename: string) {
   extern type FILE;
   extern "fopen"  proc c_fopen(filename: c_string, mode: c_string): c_ptr(FILE);
   extern "fclose" proc c_fclose(fp: c_ptr(FILE)): c_int;
-  extern "fread"  proc c_fread(ptr: c_void_ptr, size: size_t, nitems: size_t, fp: c_ptr(FILE)): size_t;
-  extern "malloc" proc c_malloc(length: size_t): c_void_ptr;
+  extern "fread"  proc c_fread(ptr: c_void_ptr, size: c_size_t, nitems: c_size_t, fp: c_ptr(FILE)): c_size_t;
+  extern "malloc" proc c_malloc(length: c_size_t): c_void_ptr;
 
   const length = getFileSize(filename);
-  var data = c_malloc(length: size_t);
+  var data = c_malloc(length: c_size_t);
 
   var infile = c_fopen(filename.c_str(), c"r");
-  const readLen = c_fread(data, length:size_t, 1, infile);
+  const readLen = c_fread(data, length:c_size_t, 1, infile);
   assert(readLen == 1);
   c_fclose(infile);
 
   var buf: c_ptr(TF_Buffer) = TF_NewBuffer();
   buf.deref().data = data;
-  buf.deref().size = length:size_t;
+  buf.deref().size = length:c_size_t;
   buf.deref().data_deallocator = c_ptrTo(deallocateBuffer);
 
   return buf;

--- a/test/library/standard/GMP/studies/gmp-chudnovsky.chpl
+++ b/test/library/standard/GMP/studies/gmp-chudnovsky.chpl
@@ -252,7 +252,7 @@ proc main() {
   /* output Pi and timing statistics */
   if (_out&1)  {
     writeln("pi(0,", terms, ")=");
-    mpf_out_str(chpl_cstdout(), 10:c_int, (d+2):size_t, qi);
+    mpf_out_str(chpl_cstdout(), 10:c_int, (d+2):c_size_t, qi);
     writeln();
   }
 

--- a/test/library/standard/Spawn/cat-test.chpl
+++ b/test/library/standard/Spawn/cat-test.chpl
@@ -4,10 +4,10 @@ config const n = 4;
 config const verbose = false;
 
 config const bufsz = 0;
-extern var qbytes_iobuf_size:size_t;
+extern var qbytes_iobuf_size:c_size_t;
 
 if bufsz > 0 {
-  qbytes_iobuf_size = bufsz:size_t;
+  qbytes_iobuf_size = bufsz:c_size_t;
 }
 
 

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -354,9 +354,9 @@ prototype module DistributedFFT {
   */
   proc copy(ref dst, const ref src, numBytes: int) {
     if dst.locale.id == here.id {
-      __primitive("chpl_comm_get", dst, src.locale.id, src, numBytes.safeCast(size_t));
+      __primitive("chpl_comm_get", dst, src.locale.id, src, numBytes.safeCast(c_size_t));
     } else if src.locale.id == here.id {
-      __primitive("chpl_comm_put", src, dst.locale.id, dst, numBytes.safeCast(size_t));
+      __primitive("chpl_comm_put", src, dst.locale.id, dst, numBytes.safeCast(c_size_t));
     } else {
       halt("Remote src and remote dst not yet supported");
     }

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
@@ -15,9 +15,9 @@ proc BlockArr.copyBtoC(B)
   coforall loc in Locales do on loc
   {
     param stridelevels=1;
-    var dststrides:[1..#stridelevels] size_t;
-    var srcstrides: [1..#stridelevels] size_t;
-    var count: [1..#(stridelevels+1)] size_t;
+    var dststrides:[1..#stridelevels] c_size_t;
+    var srcstrides: [1..#stridelevels] c_size_t;
+    var count: [1..#(stridelevels+1)] c_size_t;
     var lid=loc.id;
 
     var numLocales: int(32)=dom.dist.targetLocDom.dim(0).size:int(32);
@@ -25,7 +25,7 @@ proc BlockArr.copyBtoC(B)
     var src = locArr[lid].myElems._value.theData;
 
     dststrides[1]=1;
-    srcstrides[1]=numLocales.safeCast(size_t);
+    srcstrides[1]=numLocales.safeCast(c_size_t);
 
     var dststr=dststrides._value.theData;
     var srcstr=srcstrides._value.theData;
@@ -62,7 +62,7 @@ proc BlockArr.copyBtoC(B)
       //var destr = privB.locArr[dst].myElems._value.theData;
       var destr = B._value.locArr[dst].myElems._value.theData;
       count[1]=1;
-      count[2]=chunksize.safeCast(size_t);
+      count[2]=chunksize.safeCast(c_size_t);
 
       __primitive("chpl_comm_put_strd",
 		  __primitive("array_get",destr,
@@ -85,9 +85,9 @@ proc  BlockArr.copyCtoB(B)
   coforall loc in Locales do on loc
   {
     param stridelevels=1;
-    var dststrides:[1..#stridelevels] size_t;
-    var srcstrides: [1..#stridelevels] size_t;
-    var count: [1..#(stridelevels+1)] size_t;
+    var dststrides:[1..#stridelevels] c_size_t;
+    var srcstrides: [1..#stridelevels] c_size_t;
+    var count: [1..#(stridelevels+1)] c_size_t;
     var lid=loc.id;
     var numLocales: int=dom.dist.targetLocDom.dim(0).size;
     var n:int(32)=dom.dist.boundingBox.dim(0).size:int(32);
@@ -120,10 +120,10 @@ proc  BlockArr.copyCtoB(B)
       else chunksize=num/numLocales+1;
 
       var destr = B._value.locArr[dst].myElems._value.theData;
-      dststrides[1]=numLocales:size_t;
+      dststrides[1]=numLocales:c_size_t;
       srcstrides[1]=1;
       count[1]=1;
-      count[2]=chunksize:size_t;
+      count[2]=chunksize:c_size_t;
 
       __primitive("chpl_comm_get_strd",
 		  __primitive("array_get",src,

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/PARACR-BC-bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/PARACR-BC-bulk.chpl
@@ -15,9 +15,9 @@ proc BlockArr.copyBtoC(B)
   coforall loc in Locales do on loc
   {
     param stridelevels=1;
-    var dststrides:[1..#stridelevels] size_t;
-    var srcstrides: [1..#stridelevels] size_t;
-    var count: [1..#(stridelevels+1)] size_t;
+    var dststrides:[1..#stridelevels] c_size_t;
+    var srcstrides: [1..#stridelevels] c_size_t;
+    var count: [1..#(stridelevels+1)] c_size_t;
     var lid=loc.id; 
 
     var numLocales: int(32)=dom.dist.targetLocDom.dim(0).size:int(32);
@@ -25,7 +25,7 @@ proc BlockArr.copyBtoC(B)
     var src = locArr[lid].myElems._value.theData;
 
     dststrides[1]=1;
-    srcstrides[1]=numLocales.safeCast(size_t);
+    srcstrides[1]=numLocales.safeCast(c_size_t);
 
     var dststr=dststrides._value.theData;
     var srcstr=srcstrides._value.theData;
@@ -62,7 +62,7 @@ proc BlockArr.copyBtoC(B)
       //var destr = privB.locArr[dst].myElems._value.theData;
       var destr = B._value.locArr[dst].myElems._value.theData;
       count[1]=1;
-      count[2]=chunksize.safeCast(size_t);
+      count[2]=chunksize.safeCast(c_size_t);
 
       __primitive("chpl_comm_put_strd",
 		  __primitive("array_get",destr,
@@ -85,9 +85,9 @@ proc  BlockArr.copyCtoB(B)
   coforall loc in Locales do on loc
   {
     param stridelevels=1;
-    var dststrides:[1..#stridelevels] size_t;
-    var srcstrides: [1..#stridelevels] size_t;
-    var count: [1..#(stridelevels+1)] size_t;
+    var dststrides:[1..#stridelevels] c_size_t;
+    var srcstrides: [1..#stridelevels] c_size_t;
+    var count: [1..#(stridelevels+1)] c_size_t;
     var lid=loc.id;
     var numLocales: int=dom.dist.targetLocDom.dim(0).size;
     var n:int(32)=dom.dist.boundingBox.dim(0).size:int(32);
@@ -120,10 +120,10 @@ proc  BlockArr.copyCtoB(B)
       else chunksize=num/numLocales+1;
 
       var destr = B._value.locArr[dst].myElems._value.theData;
-      dststrides[1]=numLocales:size_t;
+      dststrides[1]=numLocales:c_size_t;
       srcstrides[1]=1;
       count[1]=1;
-      count[2]=chunksize:size_t;
+      count[2]=chunksize:c_size_t;
 
       __primitive("chpl_comm_get_strd",
 		  __primitive("array_get",src,

--- a/test/optimizations/bulkcomm/asenjo/testGasnet/puts-gets-commNone.chpl
+++ b/test/optimizations/bulkcomm/asenjo/testGasnet/puts-gets-commNone.chpl
@@ -14,9 +14,9 @@ proc BlockArr.TestGetsPuts(B)
 
   param stridelevels=1;
   //Errors below if stridelevels=0 !!
-  var dststrides:[1..#stridelevels] size_t;
-  var srcstrides: [1..#stridelevels] size_t;
-  var count: [1..#(stridelevels+1)] size_t;
+  var dststrides:[1..#stridelevels] c_size_t;
+  var srcstrides: [1..#stridelevels] c_size_t;
+  var count: [1..#(stridelevels+1)] c_size_t;
   var lid=0; //local locale id
 
   on Locales[0] {

--- a/test/optimizations/bulkcomm/asenjo/testGasnet/puts-gets-strdlvl0.chpl
+++ b/test/optimizations/bulkcomm/asenjo/testGasnet/puts-gets-strdlvl0.chpl
@@ -14,12 +14,12 @@ proc TestGetsPuts(A:[], B:[])
 proc BlockArr.TestGetsPuts(B)
 {
   param stridelevels=0;
-  //  var dststrides:[1..#stridelevels] size_t;
-  var dststrides:[1..1] size_t;
-  //  var srcstrides: [1..#stridelevels] size_t;
-  var srcstrides: [1..1] size_t;
-  //  var count: [1..#(stridelevels+1)] size_t;
-  var count: [1..2] size_t;
+  //  var dststrides:[1..#stridelevels] c_size_t;
+  var dststrides:[1..1] c_size_t;
+  //  var srcstrides: [1..#stridelevels] c_size_t;
+  var srcstrides: [1..1] c_size_t;
+  //  var count: [1..#(stridelevels+1)] c_size_t;
+  var count: [1..2] c_size_t;
   var rid=1; //remote locale id
   var lid=0; //local locale id
 

--- a/test/optimizations/bulkcomm/asenjo/testGasnet/puts-gets.chpl
+++ b/test/optimizations/bulkcomm/asenjo/testGasnet/puts-gets.chpl
@@ -15,9 +15,9 @@ proc BlockArr.TestGetsPuts(B)
 {
   param stridelevels=1;
   //Errors below if stridelevels=0 !!
-  var dststrides:[1..#stridelevels] size_t;
-  var srcstrides: [1..#stridelevels] size_t;
-  var count: [1..#(stridelevels+1)] size_t;
+  var dststrides:[1..#stridelevels] c_size_t;
+  var srcstrides: [1..#stridelevels] c_size_t;
+  var count: [1..#(stridelevels+1)] c_size_t;
   var rid=1; //remote locale id
   var lid=0; //local locale id
 

--- a/test/optimizations/cache-remote/ferguson/comm_counting/test-invalidate.chpl
+++ b/test/optimizations/cache-remote/ferguson/comm_counting/test-invalidate.chpl
@@ -5,7 +5,7 @@ use Random;
 
 pragma "insert line file info"
 extern proc chpl_cache_invalidate(node:c_int, raddr:c_void_ptr,
-                                  size: size_t);
+                                  size: c_size_t);
 
 config const verbose = false;
 param testSize = 4096;
@@ -80,7 +80,7 @@ proc test_invalidate_mode(const start:int, const size:int, const mode:int,
     assert(warmCounts.cache_get_misses == 0);
 
     // Now do the invalidate call
-    chpl_cache_invalidate(0:c_int, eltPtr, size:size_t);
+    chpl_cache_invalidate(0:c_int, eltPtr, size:c_size_t);
 
     // Read up until 'start'
     if mode == 0 {

--- a/test/performance/comm/low-level/arrayTransfer.chpl
+++ b/test/performance/comm/low-level/arrayTransfer.chpl
@@ -30,7 +30,7 @@ if xferMem > maxMem {
 }
 
 // apply limiting due to addressability
-const maxAlloc = (if numBits(size_t) == 64 then 2**48 else 2**30);
+const maxAlloc = (if numBits(c_size_t) == 64 then 2**48 else 2**30);
 if xferMem > maxAlloc {
   xferMem = maxAlloc;
   if verboseLimiting then

--- a/test/portability/boolLiteralSizes.chpl
+++ b/test/portability/boolLiteralSizes.chpl
@@ -1,6 +1,6 @@
 use CTypes;
 
-extern proc sizeof(e): size_t;
+extern proc sizeof(e): c_size_t;
 
 writeln("sizes of bool literals");
 writeln(sizeof(true:bool(8)));

--- a/test/portability/floatLiteralSizes.chpl
+++ b/test/portability/floatLiteralSizes.chpl
@@ -1,6 +1,6 @@
 use CTypes;
 
-extern proc sizeof(e): size_t;
+extern proc sizeof(e): c_size_t;
 
 writeln("sizes of real literals");
 writeln(sizeof(1.0:real(32)));

--- a/test/portability/intLiteralSizes.chpl
+++ b/test/portability/intLiteralSizes.chpl
@@ -1,6 +1,6 @@
 use CTypes;
 
-extern proc sizeof(e): size_t;
+extern proc sizeof(e): c_size_t;
 
 writeln("sizes of signed integer literals");
 writeln(sizeof(1:int(8)));

--- a/test/runtime/configMatters/comm/bigTransfer.chpl
+++ b/test/runtime/configMatters/comm/bigTransfer.chpl
@@ -20,7 +20,7 @@ if xferMem > maxMem {
 }
 
 // apply limiting due to addressability
-const maxAlloc = (if numBits(size_t) == 64 then 2**48 else 2**30);
+const maxAlloc = (if numBits(c_size_t) == 64 then 2**48 else 2**30);
 if xferMem > maxAlloc {
   xferMem = maxAlloc;
   if verboseLimiting then

--- a/test/runtime/configMatters/comm/maxHeapSizeAsPct.chpl
+++ b/test/runtime/configMatters/comm/maxHeapSizeAsPct.chpl
@@ -3,7 +3,7 @@ use CTypes;
 extern proc chpl_sys_physicalMemoryBytes(): uint(64);
 const physMemSize_1pct: real = chpl_sys_physicalMemoryBytes():real * 0.01;
 
-extern proc chpl_comm_getenvMaxHeapSize(): ssize_t;
+extern proc chpl_comm_getenvMaxHeapSize(): c_ssize_t;
 const maxHeapSize: real = chpl_comm_getenvMaxHeapSize():real;
 
 writeln(if abs(maxHeapSize - physMemSize_1pct) / physMemSize_1pct < 0.001

--- a/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
+++ b/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
@@ -5,15 +5,15 @@ const desiredTasks = oversubscription * here.maxTaskPar;
 
 // At most use 1/memFraction of available/addressable memory
 var memAvail = here.physicalMemory(unit=MemUnits.Bytes);
-if numBits(size_t) < 64 then
+if numBits(c_size_t) < 64 then
   memAvail = min(memAvail, 2**30);
 
 config const memFraction = 10;
 config var maxMem = memAvail / memFraction;
 const arrSize = maxMem / desiredTasks;
 
-extern proc chpl_comm_regMemAllocThreshold(): size_t;
-extern var SIZE_MAX: size_t;
+extern proc chpl_comm_regMemAllocThreshold(): c_size_t;
+extern var SIZE_MAX: c_size_t;
 if chpl_comm_regMemAllocThreshold() != SIZE_MAX then
   if chpl_comm_regMemAllocThreshold():int > arrSize then
     writeln("Warning: Array size is too small to test registered allocation");

--- a/test/runtime/configMatters/mem/arrayRealloc.chpl
+++ b/test/runtime/configMatters/mem/arrayRealloc.chpl
@@ -50,8 +50,8 @@ config type arrayType = int;
 // just use 64MB.
 proc arraySize() {
   use CTypes;
-  extern proc chpl_comm_regMemAllocThreshold(): size_t;
-  extern var SIZE_MAX: size_t;
+  extern proc chpl_comm_regMemAllocThreshold(): c_size_t;
+  extern var SIZE_MAX: c_size_t;
   if chpl_comm_regMemAllocThreshold() != SIZE_MAX then
     return chpl_comm_regMemAllocThreshold():int * 4 / numBytes(arrayType);
   else

--- a/test/runtime/configMatters/mem/fragmentation/MemUtil.chpl
+++ b/test/runtime/configMatters/mem/fragmentation/MemUtil.chpl
@@ -4,9 +4,9 @@ use Memory.Diagnostics;
 // chpl_comm_regMemHeapInfo if using a fixed heap, otherwise physical memory
 proc availMem() {
   use CTypes;
-  extern proc chpl_comm_regMemHeapInfo(ref start: c_void_ptr, ref size: size_t): void;
+  extern proc chpl_comm_regMemHeapInfo(ref start: c_void_ptr, ref size: c_size_t): void;
   var unused: c_void_ptr;
-  var heap_size: size_t;
+  var heap_size: c_size_t;
   chpl_comm_regMemHeapInfo(unused, heap_size);
   if heap_size != 0 then
     return heap_size.safeCast(int);

--- a/test/runtime/ferguson/cache-remote-mock-tests/mock-double-ra.chpl
+++ b/test/runtime/ferguson/cache-remote-mock-tests/mock-double-ra.chpl
@@ -13,7 +13,7 @@ use Time;
 use Random;
 
 extern proc chpl_cache_print_stats();
-extern proc chpl_cache_mock_get(node:c_int, raddr:uint(64), size:size_t):c_int;
+extern proc chpl_cache_mock_get(node:c_int, raddr:uint(64), size:c_size_t):c_int;
 extern proc printf(fmt:c_string, arg:c_int);
 
 config const seed = 97;

--- a/test/runtime/ferguson/cache-remote-mock-tests/mock-ra-perf.chpl
+++ b/test/runtime/ferguson/cache-remote-mock-tests/mock-ra-perf.chpl
@@ -6,7 +6,7 @@ use Time;
 use Random;
 
 extern proc chpl_cache_print_stats();
-extern proc chpl_cache_mock_get(node:c_int, raddr:uint(64), size:size_t):c_int;
+extern proc chpl_cache_mock_get(node:c_int, raddr:uint(64), size:c_size_t):c_int;
 
 config const printStats = true;
 config const seed = 101;

--- a/test/runtime/ferguson/cache-remote-mock-tests/mock-ra.chpl
+++ b/test/runtime/ferguson/cache-remote-mock-tests/mock-ra.chpl
@@ -6,7 +6,7 @@ use Time;
 use Random;
 
 extern proc chpl_cache_print_stats();
-extern proc chpl_cache_mock_get(node:c_int, raddr:uint(64), size:size_t):c_int;
+extern proc chpl_cache_mock_get(node:c_int, raddr:uint(64), size:c_size_t):c_int;
 
 config const seed = 97;
 config const nLocales:uint = 512;

--- a/test/runtime/gbt/tasks/idToString.chpl
+++ b/test/runtime/gbt/tasks/idToString.chpl
@@ -4,7 +4,7 @@ use CTypes;
 type buf_t = c_char;
 
 extern proc chpl_task_idToString(buf: c_void_ptr,
-                                 size: size_t,
+                                 size: c_size_t,
                                  id: chpl_taskID_t): c_string;
 extern proc chpl_task_getId(): chpl_taskID_t;
 
@@ -14,7 +14,7 @@ proc main() {
   proc showMe(what) {
     var id = chpl_task_getId();
     var buf: [1..bufLen] buf_t;
-    var idStr = chpl_task_idToString(c_ptrTo(buf), buf.size:size_t, id);
+    var idStr = chpl_task_idToString(c_ptrTo(buf), buf.size:c_size_t, id);
     writeln('task ID of ', what, ' is: ',
             if idStr==c_nil:c_string then '<OVF>'
                                      else createStringWithNewBuffer(idStr));

--- a/test/runtime/gbt/topo/array-loc.chpl
+++ b/test/runtime/gbt/topo/array-loc.chpl
@@ -17,9 +17,9 @@ proc localityStr(loc: localityCheck_t): string {
 //
 // Supporting stuff elsewhere, e.g. the runtime.
 //
-extern proc sizeof(type x): size_t;
+extern proc sizeof(type x): c_size_t;
 
-extern proc chpl_getHeapPageSize(): size_t;
+extern proc chpl_getHeapPageSize(): c_size_t;
 const pgSize = chpl_getHeapPageSize();
 const pgMask = pgSize - 1;
 
@@ -41,12 +41,12 @@ extern proc chpl_topo_getMemLocality(p: c_ptr): chpl_sublocID_t;
 //
 proc checkMemLocalityParts(p: c_ptr, size, type eltType) {
   var myP = __primitive("cast", c_ptr(int(8)), p);
-  var sizeBytes = size:size_t * sizeof(eltType);
+  var sizeBytes = size:c_size_t * sizeof(eltType);
 
   //
   // We ignore any leading partial edge page.
   //
-  const offInPage = __primitive("cast", size_t, myP) & pgMask;
+  const offInPage = __primitive("cast", c_size_t, myP) & pgMask;
   if offInPage != 0 {
     const offToPage = pgSize - offInPage;
     if sizeBytes <= offToPage then
@@ -87,12 +87,12 @@ proc checkMemLocalityWhole(p: c_ptr, size, type eltType,
   extern proc chpl_topo_getMemLocality(p: c_ptr): chpl_sublocID_t;
 
   var myP = __primitive("cast", c_ptr(int(8)), p);
-  var sizeBytes = size:size_t * sizeof(eltType);
+  var sizeBytes = size:c_size_t * sizeof(eltType);
 
   //
   // We ignore any leading partial edge page.
   //
-  const offInPage = __primitive("cast", size_t, myP) & pgMask;
+  const offInPage = __primitive("cast", c_size_t, myP) & pgMask;
   if offInPage != 0 {
     const offToPage = pgSize - offInPage;
     if sizeBytes <= offToPage then

--- a/test/studies/compOcean/compOcean.chpl
+++ b/test/studies/compOcean/compOcean.chpl
@@ -32,7 +32,7 @@ proc readData(param dims: int, dataname: string) {
   assert(ndims == dims);
 
   var dimids: [0..#ndims] c_int;
-  var dimlens: [0..#ndims] size_t;
+  var dimlens: [0..#ndims] c_size_t;
 
   cdfError(nc_inq_vardimid(ncid, varid, dimids[0]));
   extern proc nc_inq_dimlen_WAR(ncid:c_int, dimid: c_int, ref dimlens): c_int;

--- a/test/studies/dedup/dedup-extern.chpl
+++ b/test/studies/dedup/dedup-extern.chpl
@@ -15,7 +15,7 @@ require "openssl/sha.h", "-lcrypto", "-lssl";
 // This 'extern proc' declaration tells the Chapel compiler that a C
 // function SHA1 is available and describes the arguments in the
 // Chapel type system.
-extern proc SHA1(d:c_ptr(uint(8)), n:size_t, md:c_ptr(uint(8)));
+extern proc SHA1(d:c_ptr(uint(8)), n:c_size_t, md:c_ptr(uint(8)));
 
 proc main(args:[] string)
 {

--- a/test/studies/glob/Glob.chpl
+++ b/test/studies/glob/Glob.chpl
@@ -7,11 +7,11 @@ extern type wordexp_t;
 extern proc chpl_study_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
 extern proc chpl_wordexp(pattern:c_string, flags:c_int, ref ret_glob:wordexp_t):c_int;
 
-extern proc glob_num(x:glob_t): size_t;
-extern proc glob_index(x:glob_t, idx:size_t): c_string;
+extern proc glob_num(x:glob_t): c_size_t;
+extern proc glob_index(x:glob_t, idx:c_size_t): c_string;
 
-extern proc wordexp_num(x:wordexp_t): size_t;
-extern proc wordexp_index(x:wordexp_t, idx:size_t): c_string;
+extern proc wordexp_num(x:wordexp_t): c_size_t;
+extern proc wordexp_index(x:wordexp_t, idx:c_size_t): c_string;
 
 extern proc chpl_isdir(path:c_string):c_int;
 extern proc globfree(ref glb:glob_t);

--- a/test/studies/glob/globerator.chpl
+++ b/test/studies/glob/globerator.chpl
@@ -4,10 +4,10 @@ extern type wordexp_t;
 extern proc chpl_study_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
 extern proc chpl_wordexp(pattern:c_string, flags:c_int, ref ret_glob:wordexp_t):c_int;
 extern proc chpl_isdir(path:c_string):c_int;
-extern proc glob_num(x:glob_t): size_t;
-extern proc glob_index(x:glob_t, idx:size_t): c_string;
-extern proc wordexp_num(x:wordexp_t): size_t;
-extern proc wordexp_index(x:wordexp_t, idx:size_t): c_string;
+extern proc glob_num(x:glob_t): c_size_t;
+extern proc glob_index(x:glob_t, idx:c_size_t): c_string;
+extern proc wordexp_num(x:wordexp_t): c_size_t;
+extern proc wordexp_index(x:wordexp_t, idx:c_size_t): c_string;
 
 iter glob(pattern:string, flags:int, expand:bool = false, recursive:bool = false, extension:string = ""):string {
     var err: c_int;

--- a/test/studies/glob/recursive-par-glob.chpl
+++ b/test/studies/glob/recursive-par-glob.chpl
@@ -4,10 +4,10 @@ extern type wordexp_t;
 extern proc chpl_study_glob(pattern:c_string, flags:c_int, ref ret_glob:glob_t):c_int;
 extern proc chpl_wordexp(pattern:c_string, flags:c_int, ref ret_glob:wordexp_t):c_int;
 extern proc chpl_isdir(path:c_string):c_int;
-extern proc glob_num(x:glob_t): size_t;
-extern proc glob_index(x:glob_t, idx:size_t): c_string;
-extern proc wordexp_num(x:wordexp_t): size_t;
-extern proc wordexp_index(x:wordexp_t, idx:size_t): c_string;
+extern proc glob_num(x:glob_t): c_size_t;
+extern proc glob_index(x:glob_t, idx:c_size_t): c_string;
+extern proc wordexp_num(x:wordexp_t): c_size_t;
+extern proc wordexp_index(x:wordexp_t, idx:c_size_t): c_string;
 
 iter glob(pattern:string, flags:int, expand:bool = false, recursive:bool = false, extension:string = ""):string {
     var err: c_int;

--- a/test/studies/parboil/BFS/Deque.chpl
+++ b/test/studies/parboil/BFS/Deque.chpl
@@ -4,19 +4,19 @@ module Deque {
   extern type deque_t;
   extern type deque_iterator_t;
 
-  extern proc deque_init(eltSize: ssize_t, ref deque: deque_t, initSize: ssize_t);
-  extern proc deque_push_front(eltSize: ssize_t, ref deque: deque_t, ref val);
-  extern proc deque_push_back(eltSize: ssize_t, ref deque: deque_t, ref val);
-  extern proc deque_pop_front(eltSize: ssize_t, ref deque: deque_t);
-  extern proc deque_pop_back(eltSize: ssize_t, ref deque: deque_t);
+  extern proc deque_init(eltSize: c_ssize_t, ref deque: deque_t, initSize: c_ssize_t);
+  extern proc deque_push_front(eltSize: c_ssize_t, ref deque: deque_t, ref val);
+  extern proc deque_push_back(eltSize: c_ssize_t, ref deque: deque_t, ref val);
+  extern proc deque_pop_front(eltSize: c_ssize_t, ref deque: deque_t);
+  extern proc deque_pop_back(eltSize: c_ssize_t, ref deque: deque_t);
   extern proc deque_destroy(ref deque: deque_t);
 
-  extern proc deque_last(eltSize: ssize_t, ref deque: deque_t): deque_iterator_t;
+  extern proc deque_last(eltSize: c_ssize_t, ref deque: deque_t): deque_iterator_t;
   extern proc deque_begin(ref deque: deque_t): deque_iterator_t;
-  extern proc deque_it_get_cur(eltSize: ssize_t, it: deque_iterator_t, ref output);
-  extern proc deque_size(eltSize: ssize_t, ref deque: deque_t): ssize_t;
+  extern proc deque_it_get_cur(eltSize: c_ssize_t, it: deque_iterator_t, ref output);
+  extern proc deque_size(eltSize: c_ssize_t, ref deque: deque_t): c_ssize_t;
 
-  extern proc sizeof(type t): ssize_t;
+  extern proc sizeof(type t): c_ssize_t;
 
   record deque {
     type eltType;

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
@@ -43,7 +43,7 @@ record buf {
     if cur >= cap {
       if numLeft > 0 {
         cap = min(bufSize, numLeft);
-        chan.readBytes(c_ptrTo(buf), cap:ssize_t);
+        chan.readBytes(c_ptrTo(buf), cap:c_ssize_t);
         numLeft -= cap;
 
         // ensure we return an empty slice if we run out of bytes
@@ -62,9 +62,9 @@ record buf {
   }
 
   proc _memchr(c : uint(8), arr : []) {
-    extern proc memchr(s:c_void_ptr, c : c_int, n : size_t) : c_void_ptr;
+    extern proc memchr(s:c_void_ptr, c : c_int, n : c_size_t) : c_void_ptr;
     const ptr = c_ptrTo(arr);
-    const ret = memchr(ptr, c:c_int, arr.size:size_t);
+    const ret = memchr(ptr, c:c_int, arr.size:c_size_t);
     if ret != c_nil {
       const idx = arr.domain.first + ret:c_intptr - ptr:c_intptr;
       return idx;

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
@@ -42,7 +42,7 @@ record buf {
     if cur >= cap {
       if numLeft > 0 {
         cap = min(bufSize, numLeft);
-        chan.readBytes(c_ptrTo(buf), cap:ssize_t);
+        chan.readBytes(c_ptrTo(buf), cap:c_ssize_t);
         numLeft -= cap;
 
         // ensure we return an empty slice if we run out of bytes
@@ -61,9 +61,9 @@ record buf {
   }
 
   proc _memchr(c : uint(8), arr : []) {
-    extern proc memchr(s:c_void_ptr, c : c_int, n : size_t) : c_void_ptr;
+    extern proc memchr(s:c_void_ptr, c : c_int, n : c_size_t) : c_void_ptr;
     const ptr = c_ptrTo(arr);
-    const ret = memchr(ptr, c:c_int, arr.size:size_t);
+    const ret = memchr(ptr, c:c_int, arr.size:c_size_t);
     if ret != c_nil {
       const idx = arr.domain.first + ret:c_intptr - ptr:c_intptr;
       return idx;

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -46,7 +46,7 @@ proc main(args: [] string) {
 
       // Read until nextDescOffset into the data array.
       input.readBytes(c_ptrTo(data[descOffset]),
-          (nextDescOffset-descOffset):ssize_t);
+          (nextDescOffset-descOffset):c_ssize_t);
       
 
       if !eof {

--- a/test/types/bool/kushal/reportLiteralSize.chpl
+++ b/test/types/bool/kushal/reportLiteralSize.chpl
@@ -1,6 +1,6 @@
 use CTypes;
 
-extern proc sizeof(e): size_t;
+extern proc sizeof(e): c_size_t;
 
 /* Testing that the size reported is correct */
 writeln(sizeof(true:bool(8)));

--- a/test/types/imag/imagSizeof.chpl
+++ b/test/types/imag/imagSizeof.chpl
@@ -1,6 +1,6 @@
 use CTypes;
 
-extern proc sizeof(e): ssize_t;
+extern proc sizeof(e): c_ssize_t;
 
 writeln(sizeof(1.0i));
 writeln(sizeof(1.2i));

--- a/test/types/string/nspark/cast-cstring-to-cvoidptr.chpl
+++ b/test/types/string/nspark/cast-cstring-to-cvoidptr.chpl
@@ -2,8 +2,8 @@ require 'cast-cstring-to-cvoidptr.h', 'cast-cstring-to-cvoidptr.c';
 
 use CTypes;
 
-extern proc strlen(const s: c_string): size_t;
-extern proc strlen_voidptr(const s: c_void_ptr): size_t;
+extern proc strlen(const s: c_string): c_size_t;
+extern proc strlen_voidptr(const s: c_void_ptr): c_size_t;
 
 config const buf = "Hello, World";
 assert(strlen(buf.c_str()) == strlen_voidptr(buf.c_str():c_void_ptr));

--- a/test/users/aroonsharma/CyclicZipOpt.chpl
+++ b/test/users/aroonsharma/CyclicZipOpt.chpl
@@ -826,8 +826,8 @@ proc CyclicZipOptArr.dsiDynamicFastFollowCheck(lead: domain)
   return lead._value == this.dom;
 
 iter CyclicZipOptArr.these(param tag: iterKind, followThis, param fast: bool = false) var where tag == iterKind.follower {
-  extern proc sizeof(type t): size_t;
-  extern proc memcmp(ref a, ref b, n:size_t):c_int;
+  extern proc sizeof(type t): c_size_t;
+  extern proc memcmp(ref a, ref b, n:c_size_t):c_int;
   if testFastFollowerOptimization then
     writeln((if fast then "fast" else "regular") + " follower invoked for Cyclic array");
 


### PR DESCRIPTION
This adds the `c_` prefix to the `size_t` and `ssize_t` types in Chapel
for uniformity with the other type definitions in `Ctypes` as generally
discussed and agreed upon in https://github.com/chapel-lang/chapel/issues/18012

Updated the script that generates ChapelSysCTypes to generate these
aliases as well as the old ones with deprecation warnings.  Also touched
up the chpldocumentation for these entries while here and made the
sizeof() assertions use the new type names:
* util/config/make_sys_basic_types.py

Updated the compiler to reflect the new names as being well-known:
* compiler/AST/wellknown.cpp

Threaded new types through the runtime:
* runtime/include/chpltypes.h

Added deprecation tests:
* test/deprecated/depSsize_t*.*

Unified chpldocumentation of float/double with other types:
* modules/standard/CTypes.chpl

Updated modules and tests to reflect new names:
* all other modules and tests as well as CTypes itself.