### PR TITLE
Make some minor adjustments to the Reflection and ChplConfig documentation

### DIFF
--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -18,12 +18,8 @@
  * limitations under the License.
  */
 
-//
-// ChapelEnv.chpl
-//
-
 /*
-Access to Configuration information for the ``chpl`` compiler
+Access to configuration information for the ``chpl`` compiler
 
 This module's contents provide access to compile-time aspects of
 Chapel's configuration, such as those specified by ``CHPL_*``

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -20,15 +20,21 @@
 
 /*
 
-   Functions for finding out about fields, functions, and methods.
+   Functions for reflecting about language elements, such as fields,
+   functions, and methods.
 
    .. note ::
 
-     There are several ways in which this module could be improved upon:
+     There are several ways in which this module could be improved:
 
        * the methods here might be better as type methods,
          so you could use `R.numFields()` instead of `numFields(R)`.
        * :proc:`getField` does not yet return a mutable value.
+
+   .. note ::
+
+     For reflecting about aspects of the compilation process, see
+     :mod:`ChplConfig`.
 */
 module Reflection {
 


### PR DESCRIPTION
Minor doc updates, motivated by a user discussion:

* made Reflection cross-reference ChplConfig (since it seemed
  plausible that someone might view questions that ChplConfig
  answers as being a style of reflection) and tried to clarify
  its role in its one-liner description slightly

* removed a trailing preposition

* de-capitalized a stray capitalized word in ChplConfig's
  one-liner

* remove a comment mis-labeling ChplConfig as ChapelEnv (which
  was serving no purpose anyway)
