### PR TITLE
dyno: Remove meaningless const qualifier for enum return type

### DIFF
--- a/compiler/dyno/include/chpl/queries/ErrorMessage.h
+++ b/compiler/dyno/include/chpl/queries/ErrorMessage.h
@@ -90,7 +90,7 @@ class ErrorMessage final {
 
   const std::vector<ErrorMessage>& details() const { return details_; }
 
-  const Kind kind() const { return kind_; }
+  Kind kind() const { return kind_; }
 
   inline bool operator==(const ErrorMessage& other) const {
     return kind_ == other.kind_ &&


### PR DESCRIPTION
dyno: Remove meaningless const qualifier for enum return type

In my recent work on the `ErrorMessage` class I mindlessly specified
`const Kind`, where `Kind` is an enum type (and thus the `const`
qualifier is meaningless). Some compiler configurations treat this
warning as an error, so remove the `const`.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>