### PR TITLE
Restore intended PTRANS.valgrind behavior

### DIFF
--- a/test/studies/hpcc/PTRANS/PTRANS.valgrind.chpl
+++ b/test/studies/hpcc/PTRANS/PTRANS.valgrind.chpl
@@ -1,2 +1,1 @@
 use HPCC_PTRANS;
-HPCC_PTRANS.main();


### PR DESCRIPTION
This test's behavior started changing when we started running
initialization for all modules named on the command-line in #18724.
This is because we were calling main once for the `--main-module`
of PTRANS and once for the explicit call to main() in the PTRANS.valgrind
module.  When writing this, the author (could've been me) presumably
imagined that their explicit call to main() was happening and necessary
when in fact neither was true.  Since we permit users to call main(), the
test started working differently / as now intended when #18724 was
merged, but not how we expected.  Here, I'm removing the explicit
call to main() to restore the expected behavior.

Thanks to @aconsroe-hpe for helping to diagnose this.