### PR TITLE
Fix paratest.chapcs detection for draining nodes

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -70,7 +70,7 @@ def get_exclusive_nodes():
                  '--partition=chapel',
                  '--noheader',
                  '--responding',
-                 '--format="NO;%D;%N;%N"',
+                 '--format="NO;%D;%N;%N;None"',
                  '--states=DRAINING']
     sinfo_out = run_command_wrapper(sinfo_cmd)
 


### PR DESCRIPTION
#8020 added support for avoiding nodes that were draining, but this
support was broken in #12654, which added another field to parse. We
didn't notice until now because we haven't had any nodes go into a
draining state, but fix it now that we have.