### PR TITLE
Fixes to error handling with iterators

### DIFF
--- a/compiler/dyno/include/chpl/uast/PragmaList.h
+++ b/compiler/dyno/include/chpl/uast/PragmaList.h
@@ -235,6 +235,9 @@ PRAGMA(FN_RETARG, npr, "fn returns via _retArg", ncm)
 PRAGMA(FOLLOWER_INDEX, npr,
        "follower index",
        "a variable representing a follower loop index")
+PRAGMA(FORALL_BREAK_LABEL, npr,
+       "forall break label",
+       "target of error handling in the forall")
 PRAGMA(FORMAL_TEMP, npr,
        "formal temp",
        "a formal temp requiring write-back for an out or inout argument")
@@ -434,6 +437,9 @@ PRAGMA(OVERRIDE, npr, "method overrides", ncm)
 
 // variables added by flatten functions
 PRAGMA(OUTER_VARIABLE, npr, "outer variable", ncm)
+
+// this (task) function is not within a try or try! or a 'throws' function
+PRAGMA(OUTSIDE_TRY, npr, "outside try", ncm)
 
 // This means that the yielding loops themselves within an iterator
 // are order independent. It does not mean that all uses of the iterator

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -143,7 +143,7 @@ bool isOuterVarLoop(Symbol* sym, Expr* enclosingExpr);
 
 // lowerIterators.cpp, lowerForalls.cpp
 void lowerForallStmtsInline();
-void handleChplPropagateErrorCall(CallExpr* call);
+void handleChplPropagateErrorCall(CallExpr* call, bool allowForall = false);
 void fixupErrorHandlingExits(BlockStmt* body, bool& adjustCaller);
 void addDummyErrorArgumentToCall(CallExpr* call);
 bool isVirtualIterator(FnSymbol* iterFn);

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -355,6 +355,7 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
         TryInfo info = tryStack.top();
         errorVar = info.errorVar;
 
+        // (a) an enclosing try/try!
         errorPolicy->insertAtTail(gotoHandler());
       } else {
         // without try, need an error variable
@@ -363,10 +364,31 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
         insert->insertBefore(new DefExpr(errorVar));
         insert->insertBefore(new CallExpr(PRIM_MOVE, errorVar, gNil));
 
-        if (outError != NULL && node->tryTag != TRY_TAG_IN_TRYBANG && deferDepth == 0)
+        // TODO: if deferDepth > 0, either implement error handling
+        // or make the program halt regardless of insideTry or outError.
+        if (outError != NULL && node->tryTag != TRY_TAG_IN_TRYBANG &&
+            deferDepth == 0 && !node->parentSymbol->hasFlag(FLAG_OUTSIDE_TRY)) {
+          // (b) throw from the enclosing function
           errorPolicy->insertAtTail(setOutGotoEpilogue(errorVar));
-        else
-          errorPolicy->insertAtTail(haltExpr(errorVar, false));
+        }
+        else if (calledFn->hasFlag(FLAG_TASK_JOIN_IMPL_FN)) {
+          if (node->parentSymbol->hasFlag(FLAG_ITERATOR_FN))
+            // (c) coforall or similar in a non-throwing iterator
+            // ==> we will propagate the error when the iterator is inlined
+            errorPolicy->insertAtTail(haltExpr(errorVar, false));
+          else if (node->parentSymbol->hasFlag(FLAG_TASK_FN_FROM_ITERATOR_FN))
+            // (d) coforall/... in a task function in a non-throwing iterator
+            // ==> propagate the error through the task function
+            errorPolicy->insertAtTail(setOutGotoEpilogue(errorVar));
+          else
+            // (e) coforall or similar in a non-throwing procedure
+            // ==> halt right away
+            errorPolicy->insertAtTail(haltExpr(errorVar, true));
+        }
+        else {
+          // (f) a throwing call in a non-throwing function ==> halt right away
+          errorPolicy->insertAtTail(haltExpr(errorVar, true));
+        }
       }
 
       node->insertAtTail(errorVar); // adding error argument to call
@@ -450,6 +472,7 @@ bool ErrorHandlingVisitor::enterForLoop(ForLoop* node) {
     LabelSymbol* b = new LabelSymbol("forall_break_label");
     // intentionally *not* marked with FLAG_ERROR_LABEL so that
     // we don't auto-destroy everything just before it.
+    b->addFlag(FLAG_FORALL_BREAK_LABEL);
     node->breakLabelSet(b);
     node->insertAfter(new DefExpr(b));
   }
@@ -460,7 +483,7 @@ bool ErrorHandlingVisitor::enterForLoop(ForLoop* node) {
 }
 
 
-static bool canForallStmtThrow(ForallStmt* fs) {
+static void checkTPVs(ForallStmt* fs) {
   // Do this first to check for throwing non-POD initializer exprs.
   for_shadow_vars(svar, temp, fs) {
     if (BlockStmt* IB = svar->initBlock()) {
@@ -472,7 +495,6 @@ static bool canForallStmtThrow(ForallStmt* fs) {
           USR_FATAL_CONT(IB, "the initialization expression of the task-private"
             " variable '%s' throws - this is currently not supported"
             " for variables of non-POD types", svar->name);
-        return true;
       }
     }
     if (BlockStmt* DB = svar->deinitBlock()) {
@@ -482,19 +504,19 @@ static bool canForallStmtThrow(ForallStmt* fs) {
                        " throws - this is currently not supported", svar->name);
     }
   }
-
-  // Now check the loop body.
-  if (canBlockStmtThrow(fs->loopBody()))
-    return true;
-
-  // Did not find anything that throws.
-  return false;
 }
 
 bool ErrorHandlingVisitor::enterForallStmt(ForallStmt* node) {
-  // We assume that fRecIterGetIterator/fRecIterFreeIterator do not throw.
+  checkTPVs(node);
 
-  if (!canForallStmtThrow(node))
+  // If 'node' is outside an error handling context:, the body will need to
+  // halt on an error, so treat this as non-throwing.
+  if (tryStack.empty() &&
+      (outError == NULL || node->parentSymbol->hasFlag(FLAG_OUTSIDE_TRY)))
+    return true;
+
+  // We assume that fRecIterGetIterator/fRecIterFreeIterator do not throw.
+  if (!canBlockStmtThrow(node->loopBody()))
     return true;
 
   SET_LINENO(node);
@@ -504,6 +526,7 @@ bool ErrorHandlingVisitor::enterForallStmt(ForallStmt* node) {
     LabelSymbol* b = new LabelSymbol("forall_break_label");
     // intentionally *not* marked with FLAG_ERROR_LABEL so that
     // we don't auto-destroy everything just before it.
+    b->addFlag(FLAG_FORALL_BREAK_LABEL);
     node->fErrorHandlerLabel = b;
     node->insertAfter(new DefExpr(b));
   }
@@ -933,7 +956,32 @@ static void issueThrowingFnError(FnSymbol* calledFn,
   printReason(node, reasons);
 }
 
-
+/*
+If this is a call to a task function TF:
+* The call itself is (correctly) not checked for errors.
+* If TF is not implicitly-throwing
+  (which happens when all errors inside it, if any, are handled):
+  - no error checking inside TF is performed here;
+  - error checking inside TF is done by checkErrorHandling(TF),
+    at which point TF is treated as a non-throwing function;
+    however the only errors it can generate are an improper catchall
+    or "throwing call without try or try! (strict mode)",
+    if there were any other offenders, it would have been marked
+    implicitly-throwing.
+* If TF is implicitly-throwing:
+  - TF is checked recursively here if its enclosing non-task function
+    is non-throwing, including the case where taskFunctionDepth > 0,
+    which can occur only under this same condition;
+    TODO: simplify this check to 'if (!fnCanThrow)'
+  - TF is checked again by checkErrorHandling(TF),
+    at which point TF is treated as a throwing function; for this reason
+    the only errors it can generate are again an improper catchall
+    or "throwing call without try or try! (strict mode)", all other
+    conditions are acceptable within a throwing function.
+TODO: simplify this logic and do not descend into TF here.
+Instead check inside a TF only in checkErrorHandling(). Use FLAG_OUTSIDE_TRY
+to determine whether the enclosing function is non-throwing.
+*/
 bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
   bool insideTry = (tryDepth > 0);
 
@@ -958,10 +1006,21 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
             taskFunctionDepth--;
             return true;
           } else {
+            // The above logic never descends into a task function - therefore
+            // never gets to this point - unless the top-most non-task parentFn
+            // is non-throwing. Cf. at this point we are in a throwing task fn.
+            // So, adjust 'inThrowingFunction' to correspond to the top-most
+            // non-task parentFn. This will make it equivalent to 'fnCanThrow'.
             inThrowingFunction = false;
           }
+        } else if (isTaskFun(calledFn)) {
+          // One way or another, we should not be going further
+          // if it is a task function.
+          return true;
+        } else {
         }
       }
+      INT_ASSERT(inThrowingFunction == fnCanThrow);
 
       if (insideTry || node->tryTag == TRY_TAG_IN_TRYBANG) {
 

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -348,7 +348,7 @@ public:
       if (isTaskFun(calledFn)) {
         expandTaskFn(this, node, calledFn);
       } else if (calledFn == gChplPropagateError) {
-        handleChplPropagateErrorCall(node);
+        handleChplPropagateErrorCall(node, true);
       }
     }
     // There shouldn't be anything interesting inside the call.
@@ -844,7 +844,7 @@ static void expandTaskFn(ExpandVisitor* EV, CallExpr* callToTFn, FnSymbol* taskF
   // No need for taskFnCopies.
 
   // This holds because we flatten everything right away.
-  // We need it so that we can place the def of 'fcopy' anywhere
+  // We need it so that we can place the def of 'cloneTaskFn' anywhere
   // while preserving correct scoping of its SymExprs.
   INT_ASSERT(isGlobal(taskFn));
 

--- a/test/errhandling/parallel/forall-in-function-throws.bad
+++ b/test/errhandling/parallel/forall-in-function-throws.bad
@@ -1,3 +1,0 @@
-uncaught TaskErrors: 1 errors: Error: 
-  forall-in-function-throws.chpl:8: thrown here
-  forall-in-function-throws.chpl:8: uncaught here

--- a/test/errhandling/parallel/forall-in-function-throws.future
+++ b/test/errhandling/parallel/forall-in-function-throws.future
@@ -1,7 +1,0 @@
-bug: throwing within a forall in a function not caught in try/catch
-
-This test exhibits a behavior in which throwing within a forall in
-a function will not be caught, even if the function call is wrapped
-in a try/catch.
-
-#19378

--- a/test/errhandling/parallel/forall-iterator-catches-1.bad
+++ b/test/errhandling/parallel/forall-iterator-catches-1.bad
@@ -1,0 +1,3 @@
+before forall block
+myiter caught TaskErrors: 2 errors: Error:  ... Error: 
+after forall block

--- a/test/errhandling/parallel/forall-iterator-catches-1.chpl
+++ b/test/errhandling/parallel/forall-iterator-catches-1.chpl
@@ -1,0 +1,34 @@
+// The parallel iterator has an error handler around its body.
+// It should catch errors thrown by the iterator, not by the loop body.
+
+iter myiter() {
+  yield 5;
+}
+
+iter myiter(param tag) where tag == iterKind.standalone {
+  try {
+    coforall idx in 1..2 {
+      yield idx;
+      if idx == 1 then
+        throw new Error();
+    }
+  }
+  catch err {
+    writeln("myiter caught ", err);
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter() {
+      if i == 2 then
+        throw new Error();
+    }
+    writeln("after forall block");
+  } catch e {
+    writeln("test caught ", e);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-catches-1.future
+++ b/test/errhandling/parallel/forall-iterator-catches-1.future
@@ -1,0 +1,9 @@
+bug: iterator handler catches errors in loop body
+
+Currently a try block within a parallel iterator handles both the exceptions
+thrown within the iterator and those thrown in the loop body of the forall.
+It should handle only the exceptions thrown within its lexical scope.
+
+This happens when the try block surrounds a task construct.
+Cf. when the try block surrounds a yield without a task construct in between,
+the behavior is correct, see forall-iterator-catches-2.chpl

--- a/test/errhandling/parallel/forall-iterator-catches-1.good
+++ b/test/errhandling/parallel/forall-iterator-catches-1.good
@@ -1,0 +1,4 @@
+before forall block
+myiter caught TaskErrors: 1 errors: Error: 
+test caught TaskErrors: 1 errors: Error: 
+after forall block

--- a/test/errhandling/parallel/forall-iterator-catches-2.chpl
+++ b/test/errhandling/parallel/forall-iterator-catches-2.chpl
@@ -1,0 +1,34 @@
+// The parallel iterator has an error handler around its yields
+// It should catch errors thrown by the iterator, not by the loop body.
+
+iter myiter() {
+  yield 5;
+}
+
+iter myiter(param tag) where tag == iterKind.standalone {
+  coforall idx in 1..2 {
+    try {
+      yield idx;
+      if idx == 1 then
+        throw new Error("from iterator");
+    }
+    catch err {
+      writeln("myiter caught ", err);
+    }
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter() {
+      if i == 2 then
+        throw new Error("from loop body");
+    }
+    writeln("after forall block");
+  } catch e {
+    writeln("test caught ", e);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-catches-2.good
+++ b/test/errhandling/parallel/forall-iterator-catches-2.good
@@ -1,0 +1,3 @@
+before forall block
+myiter caught Error: from iterator
+test caught TaskErrors: 1 errors: Error: from loop body

--- a/test/errhandling/parallel/forall-iterator-throws-prototype.chpl
+++ b/test/errhandling/parallel/forall-iterator-throws-prototype.chpl
@@ -1,0 +1,30 @@
+
+proc throwError(i) throws {
+  if i == 1 then
+    throw new Error("abc");
+}
+
+iter myiter() {
+  yield 5;
+}
+
+iter myiter(param tag) where tag == iterKind.standalone {
+  coforall idx in 1..2 {
+    yield idx;
+    throwError(idx);
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter() {
+      // this may execute once or twice
+    }
+    writeln("after forall block");
+  } catch e {
+    writeln("test caught ", e);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-throws-prototype.good
+++ b/test/errhandling/parallel/forall-iterator-throws-prototype.good
@@ -1,0 +1,4 @@
+before forall block
+uncaught Error: abc
+  forall-iterator-throws-prototype.chpl:4: thrown here
+  forall-iterator-throws-prototype.chpl:21: uncaught here

--- a/test/errhandling/parallel/forall-throws-prototype.chpl
+++ b/test/errhandling/parallel/forall-throws-prototype.chpl
@@ -1,0 +1,15 @@
+
+proc throwError(i) throws {
+  if i == 1 then
+    throw new Error("abc");
+}
+
+proc test() {
+    writeln("before forall block");
+    forall idx in 1..2 {
+      throwError(idx);
+    }
+    writeln("after forall block");
+}
+
+test();

--- a/test/errhandling/parallel/forall-throws-prototype.good
+++ b/test/errhandling/parallel/forall-throws-prototype.good
@@ -1,0 +1,4 @@
+before forall block
+uncaught Error: abc
+  forall-throws-prototype.chpl:4: thrown here
+  forall-throws-prototype.chpl:10: uncaught here

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.chpl
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.chpl
@@ -41,12 +41,12 @@ proc asdf(adx: int) throws {
 }
 
 proc main {
-  forall idx in RR()
+  try! { forall idx in RR()
     with (
       var tp1 = asdf(cnt.fetchAdd(1)),
       var tp2 = asdf(tp1 * 10)
           )
   {
     writeln(tp1, tp2, asdf(tp2*100));
-  }
+  } }
 }

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.chpl
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.chpl
@@ -41,12 +41,12 @@ proc asdf(adx: int) throws {
 }
 
 proc main {
-  forall idx in RR()
+  try! { forall idx in RR()
     with (
       var tp1 = asdf(cnt.fetchAdd(1)),
       var tp2 = asdf(tp1 * 10)
           )
   {
     writeln(tp1, tp2, asdf(tp2*100));
-  }
+  } }
 }

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/nonpod-tpvs.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/nonpod-tpvs.good
@@ -1,2 +1,4 @@
 nonpod-tpvs.chpl:58: In function 'main':
 nonpod-tpvs.chpl:61: error: the initialization expression of the task-private variable 'tp1' throws - this is currently not supported for variables of non-POD types
+nonpod-tpvs.chpl:62: error: the initialization expression of the task-private variable 'tp2' throws - this is currently not supported for variables of non-POD types
+nonpod-tpvs.chpl:63: error: the initialization expression of the task-private variable 'tp3' throws - this is currently not supported for variables of non-POD types

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.chpl
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.chpl
@@ -45,12 +45,12 @@ proc asdf(adx: int) throws {
 }
 
 proc main {
-  forall idx in RR()
+  try! { forall idx in RR()
     with (
       var tp1 = asdf(cnt.fetchAdd(1)),
       var tp2 = asdf(tp1.jj * 10)
           )
   {
     writeln(tp1.jj, tp2.jj, asdf(tp2.jj*100).jj);
-  }
+  } }
 }

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.chpl
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.chpl
@@ -45,12 +45,12 @@ proc asdf(adx: int) throws {
 }
 
 proc main {
-  forall idx in RR()
+  try! { forall idx in RR()
     with (
       var tp1 = asdf(cnt.fetchAdd(1)),
       var tp2 = asdf(tp1.jj * 10)
           )
   {
     writeln(tp1.jj, tp2.jj, asdf(tp2.jj*100).jj);
-  }
+  } }
 }


### PR DESCRIPTION
This PR improves the handling of errors within a "halting" context, i.e., when the throwing expression - either a `throw` statement or a call of a throwing function - occurs outside of a "try" context, i.e., a `try` or `try!` block or else in a function that `throws`. It makes the behavior more consistent with the "immediate" option in #19388. For example, an error thrown in a "halting" context in an iterator is now reported as "uncaught" in the iterator, not in the loop over the iterator. An error thrown in a "halting" context in a forall statement is reported as "uncaught" where it is thrown, not at the forall statement. The PR fixes some bugs and resolves #19378.

### Implementation Details

A key change is to tune up decision making in ErrorHandlingVisitor::enterCallExpr() where it chooses between propagating the thrown error to the function's error_out, to an enclosing try block, or halding immediately.

* Calls to throwing functions in a halting context are lowered during the `lowerErrorHandling` pass by adding calls to `chpl_uncaught_error`, not `chpl_propagate_error`, as it used to be.

* Calls to `_waitEndCount()` are a special case, as this function propagates errors from the associated task functions. They used to be lowered in a halting context always by adding calls `chpl_propagate_error`, like all other throwing functions. This PR changes that to call:
  - `chpl_uncaught_error` when the corresponding source code appears lexically within a procedure,
  - `chpl_propagate_error` when it is within an iterator.

  Background: `chpl_uncaught_error` always causes the program to halt. `chpl_propagate_error` also always causes the program to halt, however it may be replaced during lowerIterators / iterator inlining to propagating the exception to a now-enclosing try block or throwing function.

* Task functions that correspond to task constructs that, in the source code, occur in a halting context, are marked with `FLAG_OUTSIDE_TRY`. This is easiest to do before the task constructs get converted to task functions, so I put it in createTaskFunctions.

* The new `FLAG_FORALL_BREAK_LABEL` helps find the forall statement's error handler just like FLAG_ERROR_LABEL helps find other handlers in handleChplPropagateErrorCall(), i.e., when lowering calls to chpl_propagate_error / gChplPropagateError. These are inserted in lowerErrorHandling() to pass error handling information to lowerIterators(), where they are lowered away. The behavior of handleChplPropagateErrorCall() remains unchanged unless we are lowering a forall statement. This reduces the chance of introducing unwanted behavior.

* The changes to the tests in `parallel/forall/task-private-vars/throwing-init-exprs/` are aimed to preserve the previously-observed behavior so that their (numerous) .good files do not need to change.

* I added comments based on what I learned.

### Future work

(f1) Clarify the [error handling section of the language spec](https://chapel-lang.org/docs/master/language/spec/error-handling.html#handling-errors) that the relationship between a thrown error and its try/try! block is lexical, not dynamic. "Lexical" is mentioned in one case and omitted in another case. This PR and this writeup assume this is the desired semantics.

(f2) Have a `try` block within a parallel iterator handle only the exceptions thrown within its lexical scope, not those thrown in the loop body. For example:
```chpl
proc myIter(param tag) where tag == iterKind.standalone {
  try {
    coforall ... {
      functionThatThrows();
      yield ...;
    }
  }
}
```

When this iterator is invoked in a forall statement under the current implementation, the above try-block will handle both the exceptions thrown by functionThatThrows() and those thrown in the loop body of the forall.

(f3) Report correct line numbers when an error is handled or not handled in an iterator that is inlined. For example:
```chpl
proc myIter(param tag) where tag == iterKind.standalone {
  ...
  functionThatThrows(); // assume no surrounding 'try'
  ...
}
```

When this iterator is invoked in a forall statement and the program reports during execution that an exception is thrown at line NNN and uncaught at line MMM, the line MMM points into the forall statement, whereas it should point into `myIter()`.

This problem is due to the inlining-based implementation of loops, whereby the line numbers associated with the iterator code are replaced with the loop's line number upon inlining the iterator into the loop. For the same reason if we were stepping through the iterator code in the debugger, it would be pointing at the loop line number, not the iterator line numbers. Iterator line numbers can be observed in both of these scenarios if compiling with `--preserve-inlined-line-numbers`.

(f4) Make it a compile-time error to have something thrown in a `defer` statement -- until such time that we figure out how to make the program behavior reasonable (and implement it). Currently it may be a runtime error or might even propagate the error upstream.

Testing: standard paratest; multilocale tests under gasnet
