### PR TITLE
Fix test-dyno failure and adjust CI to avoid it in the future

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,9 +56,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: install deps
       run: sudo apt-get install $CHPL_APT_DEPS
-    - name: make test-dyno
+    - name: make test-dyno-with-asserts
       run: |
-        make test-dyno -j`util/buildRelease/chpl-make-cpu_count`
+        make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
+    - name: make test-dyno-no-asserts
+      run: |
+        make DYNO_ENABLE_ASSERTIONS=0 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD make run-dyno-linters

--- a/compiler/dyno/CMakeLists.txt
+++ b/compiler/dyno/CMakeLists.txt
@@ -42,6 +42,43 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 # tools like the fieldsUsed linter require this
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# add an option to enable/disable assertions
+# this is based upon LLVM cmake files
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+  option(DYNO_ENABLE_ASSERTIONS "Enable assertions" OFF)
+else()
+  option(DYNO_ENABLE_ASSERTIONS "Enable assertions" ON)
+endif()
+
+# adjust C/C++ flags to remove -DNDEBUG if assertions is enabled
+# this is based upon LLVM cmake files
+if( DYNO_ENABLE_ASSERTIONS )
+  # MSVC doesn't like _DEBUG on release builds. See PR 4379.
+  if( NOT MSVC )
+    add_definitions( -D_DEBUG )
+  endif()
+  # On non-Debug builds cmake automatically defines NDEBUG, so we
+  # explicitly undefine it:
+  if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    # NOTE: use `add_compile_options` rather than `add_definitions` since
+    # `add_definitions` does not support generator expressions.
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+
+    # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+    foreach (flags_var_to_scrub
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS_MINSIZEREL
+        CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_C_FLAGS_MINSIZEREL)
+      string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+        "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+    endforeach()
+  endif()
+endif()
+
 # set include directories for -I
 #include_directories(include)
 

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -86,7 +86,7 @@ clean-dyno-docs: FORCE
 clobber-dyno: clean-dyno-docs FORCE
 	rm -rf $(LIBCOMPILER_BUILD_DIR)
 
-test-dyno-assuming-asserts: $(LIBCOMPILER_BUILD_DIR) FORCE
+test-dyno: $(LIBCOMPILER_BUILD_DIR) FORCE
 	@echo "Making and running the tests..."
 	@if [ -f $(LIBCOMPILER_BUILD_DIR)/Makefile ]; then \
 	  JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n 's/.*\(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j\2/p'` ; \
@@ -94,9 +94,6 @@ test-dyno-assuming-asserts: $(LIBCOMPILER_BUILD_DIR) FORCE
 	else \
 	  cd $(LIBCOMPILER_BUILD_DIR) && $(CMAKE) --build .  --target tests && ctest . ; \
 	fi
-
-test-dyno: FORCE
-	$(MAKE) -f Makefile.help DYNO_ENABLE_ASSERTIONS=1 test-dyno-assuming-asserts
 
 FORCE:
 

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -86,7 +86,7 @@ clean-dyno-docs: FORCE
 clobber-dyno: clean-dyno-docs FORCE
 	rm -rf $(LIBCOMPILER_BUILD_DIR)
 
-test-dyno: $(LIBCOMPILER_BUILD_DIR) FORCE
+test-dyno-assuming-asserts: $(LIBCOMPILER_BUILD_DIR) FORCE
 	@echo "Making and running the tests..."
 	@if [ -f $(LIBCOMPILER_BUILD_DIR)/Makefile ]; then \
 	  JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n 's/.*\(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j\2/p'` ; \
@@ -94,6 +94,9 @@ test-dyno: $(LIBCOMPILER_BUILD_DIR) FORCE
 	else \
 	  cd $(LIBCOMPILER_BUILD_DIR) && $(CMAKE) --build .  --target tests && ctest . ; \
 	fi
+
+test-dyno: FORCE
+	$(MAKE) -f Makefile.help DYNO_ENABLE_ASSERTIONS=1 test-dyno-assuming-asserts
 
 FORCE:
 

--- a/compiler/dyno/Makefile.include
+++ b/compiler/dyno/Makefile.include
@@ -16,9 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LIB_CMAKE_ARG := -DCMAKE_BUILD_TYPE=Release
-LIBCOMPILER_BUILD_DIR := $(COMPILER_BUILD)/dyno/Release
-ifdef CHPL_DEVELOPER
+# Set CHPL_DEVELOPER to 0 if it is not set yet
+CHPL_DEVELOPER ?= 0
+# set DYNO_ENABLE_ASSERTIONS to 0 if it is not set yet
+DYNO_ENABLE_ASSERTIONS ?= 0
+
+ifeq ($(CHPL_DEVELOPER), 0)
+  ifeq ($(DYNO_ENABLE_ASSERTIONS), 0)
+    LIB_CMAKE_ARG := -DCMAKE_BUILD_TYPE=Release
+    LIBCOMPILER_BUILD_DIR := $(COMPILER_BUILD)/dyno/Release
+  else
+    LIB_CMAKE_ARG := -DCMAKE_BUILD_TYPE=Release -DDYNO_ENABLE_ASSERTIONS=ON
+    LIBCOMPILER_BUILD_DIR := $(COMPILER_BUILD)/dyno/ReleaseWithAsserts
+  endif
+else
   LIB_CMAKE_ARG := -DCMAKE_BUILD_TYPE=Debug
   LIBCOMPILER_BUILD_DIR := $(COMPILER_BUILD)/dyno/Debug
 endif

--- a/compiler/dyno/include/chpl/queries/query-impl.h
+++ b/compiler/dyno/include/chpl/queries/query-impl.h
@@ -530,8 +530,7 @@ Context::querySetterUpdateResult(
   auto* BEGIN_QUERY_FUNCTION = func; \
   Context* BEGIN_QUERY_CONTEXT = context; \
   const char* BEGIN_QUERY_FUNC_NAME = #func; \
-  const char* BEGIN_QUERY_IN_FUNC_NAME = __func__; \
-  assert(0 == strcmp(BEGIN_QUERY_FUNC_NAME, BEGIN_QUERY_IN_FUNC_NAME)); \
+  assert(0 == strcmp(BEGIN_QUERY_FUNC_NAME, __func__)); \
   auto BEGIN_QUERY_ARGS = std::make_tuple(__VA_ARGS__); \
   context->queryBeginTrace(BEGIN_QUERY_FUNC_NAME, BEGIN_QUERY_ARGS); \
   auto BEGIN_QUERY_MAP = context->queryBeginGetMap(BEGIN_QUERY_FUNCTION, \

--- a/compiler/dyno/include/chpl/uast/As.h
+++ b/compiler/dyno/include/chpl/uast/As.h
@@ -44,8 +44,7 @@ class As final : public Expression {
  private:
   As(ASTList children)
     : Expression(asttags::As, std::move(children)) {
-    auto rename = this->rename();
-    assert(rename->isIdentifier() || rename->isVariable());
+    assert(rename()->isIdentifier() || rename()->isVariable());
   }
 
   // No need to match 'symbolChildNum_' or 'renameChildNum_', they are const.

--- a/compiler/dyno/include/chpl/uast/Enum.h
+++ b/compiler/dyno/include/chpl/uast/Enum.h
@@ -52,13 +52,15 @@ class Enum final : public TypeDecl {
                /*linkageNameChildNum*/ -1,
                name) {
 
-    for (auto ast : declOrComments()) {
-      assert(ast->isEnumElement() || ast->isComment());
-    }
+    #ifndef NDEBUG
+      for (auto ast : declOrComments()) {
+        assert(ast->isEnumElement() || ast->isComment());
+      }
 
-    if (attributes()) {
-      assert(declOrCommentChildNum() > 0);
-    }
+      if (attributes()) {
+        assert(declOrCommentChildNum() > 0);
+      }
+    #endif
   }
 
   int declOrCommentChildNum() const {

--- a/compiler/dyno/include/chpl/uast/Function.h
+++ b/compiler/dyno/include/chpl/uast/Function.h
@@ -155,11 +155,13 @@ class Function final : public NamedDecl {
     }
     assert(isExpressionASTList(children_));
 
-    for (auto decl : formals()) {
-      bool isAcceptableDecl = decl->isFormal() || decl->isVarArgFormal() ||
-                              decl->isTupleDecl();
-      assert(isAcceptableDecl);
-    }
+    #ifndef NDEBUG
+      for (auto decl : formals()) {
+        bool isAcceptableDecl = decl->isFormal() || decl->isVarArgFormal() ||
+                                decl->isTupleDecl();
+        assert(isAcceptableDecl);
+      }
+    #endif
   }
 
   bool contentsMatchInner(const ASTNode* other) const override {

--- a/compiler/dyno/include/chpl/uast/Import.h
+++ b/compiler/dyno/include/chpl/uast/Import.h
@@ -50,11 +50,13 @@ class Import final : public Expression {
       visibility_(visibility) {
     assert(numChildren() >= 1);
 
-    for (auto vc : visibilityClauses()) {
-      bool acceptable = vc->limitationKind() == VisibilityClause::NONE ||
-                        vc->limitationKind() == VisibilityClause::BRACES;
-      assert(acceptable);
-    }
+    #ifndef NDEBUG
+      for (auto vc : visibilityClauses()) {
+        bool acceptable = vc->limitationKind() == VisibilityClause::NONE ||
+                          vc->limitationKind() == VisibilityClause::BRACES;
+        assert(acceptable);
+      }
+    #endif
   }
 
   bool contentsMatchInner(const ASTNode* other) const override {

--- a/compiler/dyno/include/chpl/uast/Manage.h
+++ b/compiler/dyno/include/chpl/uast/Manage.h
@@ -61,9 +61,11 @@ class Manage final : public SimpleBlockLike {
     assert(0 <= managerExprChildNum_);
     assert(managerExprChildNum_ < numChildren());
 
-    for (auto mgr : managers()) {
-      if (auto as = mgr->toAs()) assert(as->rename()->isVariable());
-    }
+    #ifndef NDEBUG
+      for (auto mgr : managers()) {
+        if (auto as = mgr->toAs()) assert(as->rename()->isVariable());
+      }
+    #endif
   }
 
   bool contentsMatchInner(const ASTNode* other) const override {

--- a/compiler/dyno/include/chpl/uast/Use.h
+++ b/compiler/dyno/include/chpl/uast/Use.h
@@ -50,17 +50,19 @@ class Use final : public Expression {
       visibility_(visibility) {
     assert(numChildren() >= 1);
 
-    if (numVisibilityClauses() == 1) {
-      auto vc = visibilityClause(0);
-      bool acceptable = vc->limitationKind() == VisibilityClause::NONE ||
-                        vc->limitationKind() == VisibilityClause::EXCEPT ||
-                        vc->limitationKind() == VisibilityClause::ONLY;
-      assert(acceptable);
-    } else {
-      for (auto vc : visibilityClauses()) {
-        assert(vc->limitationKind() == VisibilityClause::NONE);
+    #ifndef NDEBUG
+      if (numVisibilityClauses() == 1) {
+        auto vc = visibilityClause(0);
+        bool acceptable = vc->limitationKind() == VisibilityClause::NONE ||
+                          vc->limitationKind() == VisibilityClause::EXCEPT ||
+                          vc->limitationKind() == VisibilityClause::ONLY;
+        assert(acceptable);
+      } else {
+        for (auto vc : visibilityClauses()) {
+          assert(vc->limitationKind() == VisibilityClause::NONE);
+        }
       }
-    }
+    #endif
   }
 
   bool contentsMatchInner(const ASTNode* other) const override {

--- a/compiler/dyno/lib/parsing/ParserContextImpl.h
+++ b/compiler/dyno/lib/parsing/ParserContextImpl.h
@@ -1015,7 +1015,10 @@ FnCall* ParserContext::wrapCalledExpressionInNew(YYLTYPE location,
                                                  New::Management management,
                                                  FnCall* fnCall) {
   assert(fnCall->calledExpression());
-  bool wrappedBaseExpression = false;
+
+  #ifndef NDEBUG
+    bool wrappedBaseExpression = false;
+  #endif
 
   // Find the child slot containing the called expression. Then remove it,
   // wrap it in a new expression, and swap in the new expression.
@@ -1027,7 +1030,9 @@ FnCall* ParserContext::wrapCalledExpressionInNew(YYLTYPE location,
                                 toOwned(calledExpr),
                                 management);
       child = std::move(newExpr);
-      wrappedBaseExpression = true;
+      #ifndef NDEBUG
+        wrappedBaseExpression = true;
+      #endif
       break;
     }
   }

--- a/compiler/dyno/lib/uast/Attributes.cpp
+++ b/compiler/dyno/lib/uast/Attributes.cpp
@@ -29,9 +29,11 @@ owned<Attributes> Attributes::build(Builder* builder, Location loc,
                                     std::set<PragmaTag> pragmas,
                                     bool isDeprecated,
                                     UniqueString deprecationMessage) {
-  for (auto tag : pragmas) {
-    assert(tag >= 0 && tag < NUM_KNOWN_PRAGMAS);
-  }
+  #ifndef NDEBUG
+    for (auto tag : pragmas) {
+      assert(tag >= 0 && tag < NUM_KNOWN_PRAGMAS);
+    }
+  #endif
 
   Attributes* ret = new Attributes(std::move(pragmas), isDeprecated,
                                    deprecationMessage);

--- a/compiler/dyno/lib/uast/BuilderResult.cpp
+++ b/compiler/dyno/lib/uast/BuilderResult.cpp
@@ -117,7 +117,7 @@ void BuilderResult::mark(Context* context) const {
   markASTList(context, topLevelExpressions_);
 
   // NOTE: pair.first.mark(context) is redundant in each of these b/c any
-  // ID (pair.first) will be marked by markASTList below
+  // ID (pair.first) will be marked by markASTList above
 
   // mark UniqueStrings in the Locations
   for (const auto& pair : idToLocation_) {

--- a/compiler/dyno/lib/uast/BuilderResult.cpp
+++ b/compiler/dyno/lib/uast/BuilderResult.cpp
@@ -113,12 +113,15 @@ void BuilderResult::mark(Context* context) const {
   // mark the UniqueString file path
   filePath_.mark(context);
 
+  // mark UniqueStrings in the ASTs
+  markASTList(context, topLevelExpressions_);
+
   // NOTE: pair.first.mark(context) is redundant in each of these b/c any
   // ID (pair.first) will be marked by markASTList below
 
   // mark UniqueStrings in the Locations
   for (const auto& pair : idToLocation_) {
-    // pair.first.mark(context); // redundant
+    //pair.first.mark(context); // redundant
     pair.second.mark(context);
   }
 
@@ -139,9 +142,6 @@ void BuilderResult::mark(Context* context) const {
   for (const auto& em : errors_) {
     em.mark(context);
   }
-
-  // mark UniqueStrings in the ASTs
-  markASTList(context, topLevelExpressions_);
 
   // update the filePathForModuleName query
   BuilderResult::updateFilePaths(context, *this);

--- a/compiler/dyno/test/util/testQueryTimingAndTrace.cpp
+++ b/compiler/dyno/test/util/testQueryTimingAndTrace.cpp
@@ -68,7 +68,10 @@ int main(int argc, char** argv) {
   command += " --collapse-regex 'get.*Type'";
 
   printf("Running %s\n", command.c_str());
-  system(command.c_str());
+  int rc = system(command.c_str());
+  if (rc != 0) {
+    printf("Non-zero exit code from running %s\n", command.c_str());
+  }
 
   return 0;
 }


### PR DESCRIPTION
Starting with PR #19232 developers were seeing `make test-dyno` have failures. But, we didn't see the failure in CI testing (even though we expected to).

The reason we did not see the failure in CI testing is that in that configuration we were building everything with `-DNDEBUG` (i.e. without assertions).

The error causing the assertion failures itself was actually just from `BuilderResult::mark` calling markPointer on the uAST nodes before calling markASTList.

This PR makes these changes:
 * adjusts the build files to support `DYNO_ENABLE_ASSERTIONS` to choose whether assertions should be enabled or not during the build.
 * fixes `BuilderResult::mark` by moving markASTList earlier in the function.
 * fixes a bunch of code that leads to unused-variable warnings if built without assertions enabled
 * adjusts the github CI to `make test-dyno` with `DYNO_ENABLE_ASSERTIONS=1` and `DYNO_ENABLE_ASSERTIONS=0`.

Future Work:
 * reduce the check_compiler_dyno_tests CI time by
   * avoiding download of package with clang static libraries (the install deps phase sometimes takes 5+ minutes to download and the clang static libraries are the largest volume downloaded).
   * run only one of `DYNO_ENABLE_ASSERTIONS=1` or `DYNO_ENABLE_ASSERTIONS=0` and rely on another test configuration to detect problems compiling with assertions off. We could do this by throwing `-DNDEBUG` for production `chpl` builds but I did not want to do that in this PR.

Reviewed by @aconsroe-hpe - thanks!