### PR TITLE
Work around a PMI bug on HPE Cray EX systems.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 
 #include "chplrt.h"
+#include "chplcgfns.h"
 #include "chpl-comm-launch.h"
 #include "chpl-env.h"
 
@@ -67,5 +68,20 @@ void chpl_comm_preLaunch(int32_t numLocales) {
     // won't hurt anything.
     //
     chpl_env_set("FI_SOCKETS_PE_WAITTIME", "0", 0);
+  }
+
+  if (strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex") == 0) {
+    //
+    // On HPE Cray EX systems, temporarily work around a PMI bug by
+    // setting PMI_NO_PREINITIALIZE=y which prevents PMI initializing
+    // itself more than once and thus getting into the bug situation.
+    //
+    // The fix for the bug is in the PMI module version that follows
+    // 6.1.0, so this workaround can be removed as soon as no system
+    // has that or earlier.  (PMI_NO_PREINITIALIZE actually defaults
+    // to "y" in PMI 6.0.17 and later, but even with that we have to
+    // override the user if they set it otherwise.)
+    //
+    chpl_env_set("PMI_NO_PREINITIALIZE", "y", 1);
   }
 }


### PR DESCRIPTION
On HPE Cray EX systems, temporarily work around a PMI bug by setting
`PMI_NO_PREINITIALIZE=y` which prevents PMI initializing itself more than
once and thus getting into the bug situation.  PMI's fix for this bug
will appear in the PMI module version that follows 6.1.0.

This resolves https://github.com/Cray/chapel-private/issues/3129.