### PR TITLE
Non-debug builds of chpl use -DNDEBUG

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,9 +59,6 @@ jobs:
     - name: make test-dyno-with-asserts
       run: |
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
-    - name: make test-dyno-no-asserts
-      run: |
-        make DYNO_ENABLE_ASSERTIONS=0 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD make run-dyno-linters

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -2077,7 +2077,7 @@ returnTypeForTypeCtorQuery(Context* context,
 
   const UntypedFnSignature* untyped = sig->untyped();
 
-  const Type* result;
+  const Type* result = nullptr;
 
   // handle type construction
   const AggregateDecl* ad = nullptr;

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -293,17 +293,19 @@ namespace {
 
   void checkFunctionExistAndHasArgs(Value* f, Type* t, unsigned nArgs)
   {
-    assert(f);
-    if( Function* ff = dyn_cast<Function>(f) ) {
-      assert(ff->getParent());
-    }
-    FunctionType* ft = NULL;
-    if( PointerType* pt = dyn_cast<PointerType>(t) ) {
-      t = pt->getElementType();
-    }
-    ft = cast<FunctionType>(t);
-    assert(ft);
-    assert(ft->getNumParams() == nArgs);
+    #ifndef NDEBUG
+      assert(f);
+      if( Function* ff = dyn_cast<Function>(f) ) {
+        assert(ff->getParent());
+      }
+      FunctionType* ft = NULL;
+      if( PointerType* pt = dyn_cast<PointerType>(t) ) {
+        t = pt->getElementType();
+      }
+      ft = cast<FunctionType>(t);
+      assert(ft);
+      assert(ft->getNumParams() == nArgs);
+    #endif
   }
 
 
@@ -664,7 +666,7 @@ namespace {
 #else
             Value* call = CallInst::Create(getFn, args, "", oldLoad);
 #endif
-            assert(call);
+            if (call == nullptr) assert(false && "failure creating call");
 
             // Now load from the alloc'd area.
             Instruction* loadedWide = new LoadInst(wLoadedTy, alloc, "",
@@ -717,7 +719,7 @@ namespace {
                                             oldStore->getOrdering(),
                                             oldStore->getSyncScopeID(),
                                             oldStore);
-            assert(st);
+            if (st == nullptr) assert(false && "failure creating store");
 
             Value* node = createRnode(info, wAddr, oldStore);
             Value* raddr = createRaddr(info, wAddr, oldStore);
@@ -751,10 +753,9 @@ namespace {
           PtrToIntInst *ptrToInt = cast<PtrToIntInst>(insn);
           if( ptrToInt->getPointerAddressSpace() == info->globalSpace ) {
             Value* ptr = ptrToInt->getPointerOperand();
-            const DataLayout& DL = M.getDataLayout();
 
-            assert(DL.getTypeSizeInBits(ptrToInt->getType()) ==
-                   DL.getTypeSizeInBits(ptr->getType()));
+            assert(M.getDataLayout().getTypeSizeInBits(ptrToInt->getType()) ==
+                   M.getDataLayout().getTypeSizeInBits(ptr->getType()));
 
             Instruction* conv = createStoreLoadCast(ptr,
                                                     ptrToInt->getType(),
@@ -766,10 +767,9 @@ namespace {
           IntToPtrInst *intToPtr = cast<IntToPtrInst>(insn);
           if( intToPtr->getAddressSpace() == info->globalSpace ) {
             Value* i = intToPtr->getOperand(0);
-            const DataLayout& DL = M.getDataLayout();
 
-            assert(DL.getTypeSizeInBits(intToPtr->getType()) ==
-                   DL.getTypeSizeInBits(i->getType()));
+            assert(M.getDataLayout().getTypeSizeInBits(intToPtr->getType()) ==
+                   M.getDataLayout().getTypeSizeInBits(i->getType()));
 
             Instruction* conv = createStoreLoadCast(i,
                                                     intToPtr->getType(),
@@ -1122,7 +1122,8 @@ namespace {
           // We don't do this for instructions since in
           // general we might not have remapped them yet.
           assert(newV != NULL);
-          assert( newV->getType() == new_type );
+          if (newV->getType() != new_type)
+            assert(false && "new argument is not mapped type");
         }
       }
 
@@ -1133,7 +1134,6 @@ namespace {
 
 
     Type *old_type = I->getType();
-    Type *new_type = NULL;
     if( old_type ) TypeMapper->remapType(old_type);
 
     // Now, remap operands that we know about needing remap
@@ -1144,15 +1144,6 @@ namespace {
     // been remapped.
     //
     RemapInstruction(I, VM, RF_IgnoreMissingLocals, TypeMapper);
-
-    if( extraChecks ) {
-      if( VM.count(I) ) {
-        Value* V = VM[I];
-        if( new_type ) assert(V->getType() == new_type);
-      } else {
-        if( new_type ) assert(I->getType() == new_type);
-      }
-    }
   }
 
 
@@ -2319,7 +2310,8 @@ Type* convertTypeGlobalToWide(Module* module, GlobalToWideInfo* info, Type* t)
 #endif
   }
 
-  assert(0);
+  assert(false && "should not be reached");
+  return nullptr;
 }
 
 

--- a/compiler/make/Makefile.compiler.head
+++ b/compiler/make/Makefile.compiler.head
@@ -20,19 +20,33 @@
 # settings for the build
 #
 
+# Set CHPL_DEVELOPER to 0 if it is not set yet
+CHPL_DEVELOPER ?= 0
+# set DYNO_ENABLE_ASSERTIONS to 0 if it is not set yet
+DYNO_ENABLE_ASSERTIONS ?= 0
+
 ifneq ($(NO_DEPEND), 1)
 DEPEND=1
 endif
 
-ifdef CHPL_DEVELOPER
+ifeq ($(CHPL_DEVELOPER), 0)
+OPTIMIZE=1
+else
 DEBUG=1
 WARNINGS=1
 TAGS=1
-else
-OPTIMIZE=1
+# always enable assertions in CHPL_DEVELOPER/debug mode
+DYNO_ENABLE_ASSERTIONS=1
 endif
 #PROFILE=1
 
+ifeq ($(DYNO_ENABLE_ASSERTIONS), 0)
+  # disable assertions
+  ASSERTIONS_FLAG:=-DNDEBUG
+else
+  # leave assertions enabled
+  ASSERTIONS_FLAG:=
+endif
 
 #
 # include the standard Chapel Makefile.base
@@ -79,6 +93,7 @@ COMP_CXXFLAGS := $(COMP_CXXFLAGS) \
                  $(CHPL_MAKE_HOST_BUNDLED_COMPILE_ARGS) \
                  $(LLVM_EXTRA_CFLAGS) \
                  $(CHPL_MAKE_HOST_SYSTEM_COMPILE_ARGS) \
+                 $(ASSERTIONS_FLAG)
 
 
 #

--- a/compiler/optimizations/replaceArrayAccessesWithRefTemps.cpp
+++ b/compiler/optimizations/replaceArrayAccessesWithRefTemps.cpp
@@ -141,7 +141,7 @@ void replaceArrayAccessesWithRefTemps() {
                 if (toSymExpr(call->get(1))->symbol()->hasFlag(FLAG_TEMP)) {
                   loopIdx = toSymExpr(call->get(1));
                 } else {
-                  assert(indexMove == NULL && indexVar == NULL);
+                  INT_ASSERT(indexMove == NULL && indexVar == NULL);
                   indexMove = call;
                   indexVar = toSymExpr(call->get(1))->symbol();
                 }
@@ -177,7 +177,7 @@ void replaceArrayAccessesWithRefTemps() {
 
           if (FnSymbol* fn = call->resolvedFunction()) {
             if (fn->hasFlag(FLAG_REMOVABLE_ARRAY_ACCESS)) {
-              assert(isSymExpr(call->get(1)));
+              INT_ASSERT(isSymExpr(call->get(1)));
 
               Symbol* arraySym = toSymExpr(call->get(1))->symbol();
 

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -35,11 +35,8 @@ TARGETS = $(PARSER_OBJS)
 
 include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
 
-ifdef CHPL_DEVELOPER
 CLEAN_TARGS += \
                bison-chapel.output
-
-endif
 
 # Don't create rules for bison-chapel.cpp or flex-chapel.cpp since we don't
 # want them to be rebuilt automatically. (This is because of the bison version

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -117,11 +117,11 @@ struct Converter {
     if (!attr) return;
 
     if (!attr->isDeprecated()) {
-      assert(attr->deprecationMessage().isEmpty());
+      INT_ASSERT(attr->deprecationMessage().isEmpty());
     }
 
     if (attr->isDeprecated()) {
-      assert(!sym->hasFlag(FLAG_DEPRECATED));
+      INT_ASSERT(!sym->hasFlag(FLAG_DEPRECATED));
       sym->addFlag(FLAG_DEPRECATED);
 
       auto msg = attr->deprecationMessage();
@@ -225,7 +225,7 @@ struct Converter {
       ret = convertAST(stmt);
     }
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     return ret;
   }
@@ -233,7 +233,7 @@ struct Converter {
   Expr* visit(const uast::Begin* node) {
     CallExpr* byrefVars = convertWithClause(node->withClause(), node);
     Expr* stmt = createBlockWithStmts(node->stmts());
-    assert(stmt);
+    INT_ASSERT(stmt);
     return buildBeginStmt(byrefVars, stmt);
   }
 
@@ -270,8 +270,8 @@ struct Converter {
         managerExpr = convertAST(as->symbol());
 
         auto var = as->rename()->toVariable();
-        assert(var);
-        assert(!var->initExpression() && !var->typeExpression());
+        INT_ASSERT(var);
+        INT_ASSERT(!var->initExpression() && !var->typeExpression());
 
         resourceName = astr(var->name().c_str());
 
@@ -390,7 +390,7 @@ struct Converter {
     CallExpr* actuals = new CallExpr(PRIM_ACTUALS_LIST);
     for (auto expr : node->exprs()) {
       Expr* conv = convertAST(expr);
-      assert(conv);
+      INT_ASSERT(conv);
       actuals->insertAtTail(conv);
     }
 
@@ -405,7 +405,7 @@ struct Converter {
     bool isPrototype = node->isPrototype();
 
     auto& loc = chpl::parsing::locateAst(gContext, node);
-    assert(!loc.isEmpty());
+    INT_ASSERT(!loc.isEmpty());
     auto path = astr(loc.path().c_str());
 
     ModuleSymbol* mod = parseIncludedSubmodule(name, path);
@@ -445,13 +445,13 @@ struct Converter {
 
       switch (vc->limitationKind()) {
         case uast::VisibilityClause::NONE: {
-          assert(vc->numLimitations() == 0);
+          INT_ASSERT(vc->numLimitations() == 0);
 
           // Handles case: 'import foo as bar'
           if (auto as = vc->symbol()->toAs()) {
             Expr* mod = convertAST(as->symbol());
             auto ident = as->rename()->toIdentifier();
-            assert(ident);
+            INT_ASSERT(ident);
             const char* rename = astr(ident->name().c_str());
             conv = buildImportStmt(mod, rename);
 
@@ -475,11 +475,11 @@ struct Converter {
           conv = buildImportStmt(mod, names);
         } break;
         default:
-          assert(0 == "Not possible!");
+          INT_FATAL("Not possible!");
           break;
       }
 
-      assert(conv != nullptr);
+      INT_ASSERT(conv != nullptr);
 
       ret->insertAtTail(conv);
     }
@@ -509,10 +509,10 @@ struct Converter {
       case uast::New::SHARED: symManager = dtShared->symbol; break;
       case uast::New::UNMANAGED: symManager = dtUnmanaged->symbol; break;
       case uast::New::BORROWED: symManager = dtBorrowed->symbol; break;
-      default: assert(0 == "Not handled!"); break;
+      default: INT_FATAL("Not handled!"); break;
     }
 
-    assert(symManager);
+    INT_ASSERT(symManager);
 
     /*
     2238 | TNEW TUNMANAGED
@@ -717,7 +717,7 @@ struct Converter {
       ret = CatchStmt::build(body);
     }
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     return ret;
   }
@@ -753,22 +753,22 @@ struct Converter {
   }
 
   Expr* visit(const uast::Conditional* node) {
-    assert(node->condition());
+    INT_ASSERT(node->condition());
 
     Expr* ret = nullptr;
 
     if (node->isExpressionLevel()) {
       auto cond = toExpr(convertAST(node->condition()));
-      assert(cond);
+      INT_ASSERT(cond);
       auto thenExpr = singleExprFromStmts(node->thenStmts());
-      assert(thenExpr);
+      INT_ASSERT(thenExpr);
       auto elseExpr = singleExprFromStmts(node->elseStmts());
-      assert(elseExpr);
+      INT_ASSERT(elseExpr);
       ret = new IfExpr(cond, thenExpr, elseExpr);
 
     } else {
       auto thenBlock = createBlockWithStmts(node->thenStmts());
-      assert(thenBlock);
+      INT_ASSERT(thenBlock);
       auto elseBlock = node->hasElseBlock()
             ? createBlockWithStmts(node->elseStmts())
             : nullptr;
@@ -777,9 +777,9 @@ struct Converter {
 
       // TODO: Can 'ifVars' happen in expression-level conditionals?
       if (auto ifVar = node->condition()->toVariable()) {
-        assert(ifVar->kind() == uast::Variable::CONST ||
-               ifVar->kind() == uast::Variable::VAR);
-        assert(ifVar->initExpression());
+        INT_ASSERT(ifVar->kind() == uast::Variable::CONST ||
+                   ifVar->kind() == uast::Variable::VAR);
+        INT_ASSERT(ifVar->initExpression());
         // astr() varNameStr so it doesn't go out of scope when passed to
         // buildIfVar
         auto varNameStr = astr(ifVar->name().c_str());
@@ -790,12 +790,12 @@ struct Converter {
         cond = toExpr(convertAST(node->condition()));
       }
 
-      assert(cond);
+      INT_ASSERT(cond);
 
       ret = buildIfStmt(cond, thenBlock, elseBlock);
     }
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     return ret;
   }
@@ -809,7 +809,7 @@ struct Converter {
   Expr* visit(const uast::Label* node) {
     const char* name = astr(node->name().c_str());
     Expr* stmt = toExpr(convertAST(node->loop()));
-    assert(stmt);
+    INT_ASSERT(stmt);
     return buildLabelStmt(name, stmt);
   }
 
@@ -848,13 +848,13 @@ struct Converter {
   Expr* visit(const uast::Try* node) {
     if (node->isExpressionLevel()) {
 
-      assert(node->numStmts() == 1);
-      assert(node->stmt(0)->isExpression() && !node->stmt(0)->isBlock());
+      INT_ASSERT(node->numStmts() == 1);
+      INT_ASSERT(node->stmt(0)->isExpression() && !node->stmt(0)->isBlock());
       Expr* expr = convertAST(node->stmt(0));
 
       // Use this instead of 'TryStmt::build'.
       auto ret = node->isTryBang() ? tryBangExpr(expr) : tryExpr(expr);
-      assert(ret);
+      INT_ASSERT(ret);
 
       return ret;
 
@@ -865,7 +865,7 @@ struct Converter {
       bool isSyncTry = false; // TODO: When can this be true?
 
       for (auto handler : node->handlers()) {
-        assert(handler->isCatch());
+        INT_ASSERT(handler->isCatch());
         auto conv = toExpr(convertAST(handler));
         catches->insertAtTail(conv);
       }
@@ -938,8 +938,8 @@ struct Converter {
   Expr* convertBracketLoopExpr(const uast::BracketLoop* node) {
     astlocMarker markAstLoc(node->id());
 
-    assert(node->isExpressionLevel());
-    assert(node->numStmts() == 1);
+    INT_ASSERT(node->isExpressionLevel());
+    INT_ASSERT(node->numStmts() == 1);
 
     // The pieces that we need for 'buildForallLoopExpr'.
     Expr* indices = convertLoopIndexDecl(node->index());
@@ -951,16 +951,16 @@ struct Converter {
 
       // Unpack things differently if body is a conditional.
       if (auto origCond = node->stmt(0)->toConditional()) {
-        assert(origCond->numThenStmts() == 1);
-        assert(!origCond->hasElseBlock());
+        INT_ASSERT(origCond->numThenStmts() == 1);
+        INT_ASSERT(!origCond->hasElseBlock());
         expr = singleExprFromStmts(origCond->thenStmts());
         cond = convertAST(origCond->condition());
-        assert(cond);
+        INT_ASSERT(cond);
       } else {
         expr = singleExprFromStmts(node->stmts());
       }
 
-    assert(expr != nullptr);
+    INT_ASSERT(expr != nullptr);
 
     return buildForallLoopExpr(indices, iteratorExpr, expr, cond,
                                maybeArrayType,
@@ -1020,19 +1020,19 @@ struct Converter {
     bool isForExpr = node->isExpressionLevel();
 
     if (node->isExpressionLevel()) {
-      assert(node->numStmts() == 1);
+      INT_ASSERT(node->numStmts() == 1);
 
       // Unpack things differently if body is a conditional.
       if (auto origCond = node->stmt(0)->toConditional()) {
-        assert(origCond->numThenStmts() == 1);
-        assert(!origCond->hasElseBlock());
+        INT_ASSERT(origCond->numThenStmts() == 1);
+        INT_ASSERT(!origCond->hasElseBlock());
         body = singleExprFromStmts(origCond->thenStmts());
         cond = toExpr(convertAST(origCond->condition()));
       } else {
         body = singleExprFromStmts(node->stmts());
       }
 
-      assert(body);
+      INT_ASSERT(body);
 
       ret = buildForLoopExpr(index, iteratorExpr, body, cond,
                              maybeArrayType,
@@ -1040,25 +1040,25 @@ struct Converter {
 
     // Param loops use the index variable name as 'const char*'.
     } else if (node->isParam()) {
-      assert(node->index() && node->index()->isVariable());
+      INT_ASSERT(node->index() && node->index()->isVariable());
 
       const char* indexStr = astr(node->index()->toVariable()->name().c_str());
       body = createBlockWithStmts(node->stmts());
       BlockStmt* block = toBlockStmt(body);
-      assert(block);
+      INT_ASSERT(block);
 
       ret = buildParamForLoopStmt(indexStr, iteratorExpr, block);
 
     } else {
       body = createBlockWithStmts(node->stmts());
       BlockStmt* block = toBlockStmt(body);
-      assert(block);
+      INT_ASSERT(block);
 
       ret = ForLoop::buildForLoop(index, iteratorExpr, block, zippered,
                                   isForExpr);
     }
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     return ret;
   }
@@ -1067,8 +1067,8 @@ struct Converter {
   Expr* convertForallLoopExpr(const uast::Forall* node) {
     astlocMarker markAstLoc(node->id());
 
-    assert(node->isExpressionLevel());
-    assert(node->numStmts() == 1);
+    INT_ASSERT(node->isExpressionLevel());
+    INT_ASSERT(node->numStmts() == 1);
 
     // The pieces that we need for 'buildForallLoopExpr'.
     Expr* indices = convertLoopIndexDecl(node->index());
@@ -1080,16 +1080,16 @@ struct Converter {
 
       // Unpack things differently if body is a conditional.
       if (auto origCond = node->stmt(0)->toConditional()) {
-        assert(origCond->numThenStmts() == 1);
-        assert(!origCond->hasElseBlock());
+        INT_ASSERT(origCond->numThenStmts() == 1);
+        INT_ASSERT(!origCond->hasElseBlock());
         expr = singleExprFromStmts(origCond->thenStmts());
         cond = toExpr(convertAST(origCond->condition()));
-        assert(cond);
+        INT_ASSERT(cond);
       } else {
         expr = singleExprFromStmts(node->stmts());
       }
 
-    assert(expr != nullptr);
+    INT_ASSERT(expr != nullptr);
 
     return buildForallLoopExpr(indices, iteratorExpr, expr, cond,
                                maybeArrayType,
@@ -1118,7 +1118,7 @@ struct Converter {
   BlockStmt* visit(const uast::Foreach* node) {
 
     // Does not appear possible right now, from reading the grammar.
-    assert(!node->isExpressionLevel());
+    INT_ASSERT(!node->isExpressionLevel());
 
     // The pieces that we need for 'buildForallLoopExpr'.
     Expr* indices = convertLoopIndexDecl(node->index());
@@ -1156,14 +1156,14 @@ struct Converter {
       if (auto opCall = expr->toOpCall()) {
         if (opCall->op() == USTR("=>")) {
           isAssociativeList = true;
-          assert(opCall->numActuals() == 2);
+          INT_ASSERT(opCall->numActuals() == 2);
           Expr* lhs = convertAST(opCall->actual(0));
           Expr* rhs = convertAST(opCall->actual(1));
           actualList->insertAtTail(lhs);
           actualList->insertAtTail(rhs);
           hasConvertedThisIter = true;
         } else {
-          if (isAssociativeList) assert(0 == "Not possible!");
+          if (isAssociativeList) INT_FATAL("Not possible!");
         }
       }
 
@@ -1181,7 +1181,7 @@ struct Converter {
                          new SymExpr(gTrue));
     }
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     return ret;
   }
@@ -1347,20 +1347,20 @@ struct Converter {
     astlocMarker markAstLoc(node->id());
 
     auto calledExpression = node->calledExpression();
-    assert(calledExpression);
+    INT_ASSERT(calledExpression);
     CallExpr* ret = nullptr;
 
     if (auto kwSparse = calledExpression->toIdentifier()) {
       if (kwSparse->name() == USTR("sparse")) {
-        assert(node->numActuals() == 1);
+        INT_ASSERT(node->numActuals() == 1);
 
         if (auto innerCall = node->actual(0)->toFnCall()) {
           auto innerCalledExpression = innerCall->calledExpression();
-          assert(innerCalledExpression);
+          INT_ASSERT(innerCalledExpression);
 
           if (auto kwSubdomain = innerCalledExpression->toIdentifier()) {
             if (kwSubdomain->name() == USTR("subdomain")) {
-              assert(innerCall->numActuals() == 1);
+              INT_ASSERT(innerCall->numActuals() == 1);
 
               ret = new CallExpr
                       ("chpl__buildSparseDomainRuntimeTypeForParentDomain");
@@ -1384,7 +1384,7 @@ struct Converter {
 
     if (auto newExpression = calledExpression->toNew()) {
       CallExpr* newExprStart = convertNewManagement(newExpression);
-      assert(newExprStart);
+      INT_ASSERT(newExprStart);
 
       // TODO: Need to check for special identifiers?
       Expr* typeExpr = convertAST(newExpression->typeExpression());
@@ -1472,10 +1472,10 @@ struct Converter {
     Expr* expr = convertAST(node->actual(0));
     if (auto call = toCallExpr(expr)) {
       if (call->isPrimitive(PRIM_NEW)) {
-        assert(call->numActuals() <= 2);
+        INT_ASSERT(call->numActuals() <= 2);
         Expr* child = nullptr;
         if (call->numActuals() == 2) {
-          assert(isNamedExpr(call->get(1)));
+          INT_ASSERT(isNamedExpr(call->get(1)));
           child = call->get(2);
         } else if (call->numActuals() == 1) {
           child = call->get(1);
@@ -1553,7 +1553,7 @@ struct Converter {
       ret = convertRegularBinaryOrUnaryOp(node);
     }
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     return ret;
   }
@@ -1571,7 +1571,7 @@ struct Converter {
   // Note that this conversion is for the reduce expression, and not for
   // the reduce intent (see conversion for 'WithClause').
   Expr* visit(const uast::Reduce* node) {
-    assert(node->numActuals() == 1);
+    INT_ASSERT(node->numActuals() == 1);
     Expr* opExpr = convertScanReduceOp(node->op());
     Expr* dataExpr = convertAST(node->actual(0));
     bool zippered = node->actual(0)->isZip();;
@@ -1579,7 +1579,7 @@ struct Converter {
   }
 
   Expr* visit(const uast::Scan* node) {
-    assert(node->numActuals() == 1);
+    INT_ASSERT(node->numActuals() == 1);
     Expr* opExpr = convertScanReduceOp(node->op());
     Expr* dataExpr = convertAST(node->actual(0));
     bool zippered = node->actual(0)->isZip();;
@@ -1606,7 +1606,7 @@ struct Converter {
     (void) node->linkageName();
 
     for (auto decl : node->decls()) {
-      assert(decl->linkage() == node->linkage());
+      INT_ASSERT(decl->linkage() == node->linkage());
 
       Expr* conv = nullptr;
       if (auto var = decl->toVariable()) {
@@ -1620,12 +1620,12 @@ struct Converter {
         conv = convertAST(decl);
       }
 
-      assert(conv);
+      INT_ASSERT(conv);
       ret->insertAtTail(conv);
     }
 
     if (!fDocs) {
-      assert(!inTupleDecl);
+      INT_ASSERT(!inTupleDecl);
       CallExpr* end = new CallExpr(PRIM_END_OF_STATEMENT);
       ret->insertAtTail(end);
     }
@@ -1647,9 +1647,9 @@ struct Converter {
 
       // Formals are converted into variables.
       if (auto formal = decl->toFormal()) {
-        assert(formal->intent() == uast::Formal::DEFAULT_INTENT);
-        assert(!formal->initExpression());
-        assert(!formal->typeExpression());
+        INT_ASSERT(formal->intent() == uast::Formal::DEFAULT_INTENT);
+        INT_ASSERT(!formal->initExpression());
+        INT_ASSERT(!formal->typeExpression());
         conv = new DefExpr(new VarSymbol(formal->name().c_str()));
 
       // Do not use the visitor because it produces a block statement.
@@ -1658,7 +1658,7 @@ struct Converter {
         conv = convertVariable(var, useLinkageName);
       // It must be a tuple.
       } else {
-        assert(decl->isTupleDecl());
+        INT_ASSERT(decl->isTupleDecl());
         conv = convertTupleDeclComponents(decl->toTupleDecl());
       }
 
@@ -1702,7 +1702,7 @@ struct Converter {
 
     // Add a PRIM_END_OF_STATEMENT.
     if (!fDocs) {
-      assert(!inTupleDecl);
+      INT_ASSERT(!inTupleDecl);
       CallExpr* end = new CallExpr(PRIM_END_OF_STATEMENT);
       ret->insertAtTail(end);
     }
@@ -1794,7 +1794,7 @@ struct Converter {
       ret = name.c_str();
     }
 
-    assert(ret);
+    INT_ASSERT(ret);
 
     // We have to uniquify the name now because it may be inlined (and thus
     // stack allocated).
@@ -1806,39 +1806,40 @@ struct Converter {
   Expr* convertLifetimeClause(const uast::Expression* node) {
     astlocMarker markAstLoc(node->id());
 
-    assert(node->isOpCall() || node->isReturn());
+    INT_ASSERT(node->isOpCall() || node->isReturn());
     if (auto opCall = node->toOpCall()) {
-      assert(opCall->numActuals()==2);
+      INT_ASSERT(opCall->numActuals()==2);
       auto lhsIdent = opCall->actual(0)->toIdentifier();
       auto rhsIdent = opCall->actual(1)->toIdentifier();
-      assert(lhsIdent && rhsIdent);
-      assert(opCall->op() == USTR("=") ||
-             opCall->op() == USTR("<") ||
-             opCall->op() == USTR(">") ||
-             opCall->op() == USTR("==")||
-             opCall->op() == USTR("<=")||
-             opCall->op() == USTR(">="));
+      INT_ASSERT(lhsIdent && rhsIdent);
+      INT_ASSERT(opCall->op() == USTR("=") ||
+                 opCall->op() == USTR("<") ||
+                 opCall->op() == USTR(">") ||
+                 opCall->op() == USTR("==")||
+                 opCall->op() == USTR("<=")||
+                 opCall->op() == USTR(">="));
       Expr* lhs = convertLifetimeIdent(lhsIdent);
       Expr* rhs = convertLifetimeIdent(rhsIdent);
       return new CallExpr(opCall->op().c_str(), lhs, rhs);
     } else if (auto ret = node->toReturn()) {
-      assert(ret->value() && ret->value()->isIdentifier());
+      INT_ASSERT(ret->value() && ret->value()->isIdentifier());
       auto ident = ret->value()->toIdentifier();
 
       Expr* val = convertLifetimeIdent(ident);
       return new CallExpr(PRIM_RETURN, val);
 
     } else {
-      assert(false); // should not arrive here, or else we missed something
+      // should not arrive here, or else we missed something
+      INT_FATAL("should not be reached");
+      return nullptr;
     }
-
   }
 
   CallExpr* convertLifetimeIdent(const uast::Identifier* node) {
     astlocMarker markAstLoc(node->id());
 
     auto ident = node->toIdentifier();
-    assert(ident);
+    INT_ASSERT(ident);
     CallExpr* callExpr = new CallExpr(PRIM_LIFETIME_OF,
                                       convertExprOrNull(node));
     return callExpr;
@@ -1883,7 +1884,7 @@ struct Converter {
 
           // Special handling for implicit receiver formal.
           if (formal->name() == USTR("this")) {
-            assert(!hasConvertedReceiver);
+            INT_ASSERT(!hasConvertedReceiver);
             hasConvertedReceiver = true;
 
             thisTag = convertFormalIntent(formal->intent());
@@ -1899,21 +1900,21 @@ struct Converter {
           // Else convert it like normal.
           } else {
             conv = toDefExpr(convertAST(formal));
-            assert(conv);
+            INT_ASSERT(conv);
           }
 
         // A varargs formal.
         } else if (auto formal = decl->toVarArgFormal()) {
-          assert(formal->name() != USTR("this"));
+          INT_ASSERT(formal->name() != USTR("this"));
           conv = toDefExpr(convertAST(formal));
-          assert(conv);
+          INT_ASSERT(conv);
 
         // A tuple decl, where components are formals or tuple decls.
         } else if (auto formal = decl->toTupleDecl()) {
           auto castIntent = (uast::Formal::Intent)formal->intentOrKind();
           IntentTag tag = convertFormalIntent(castIntent);
           BlockStmt* tuple = convertTupleDeclComponents(formal);
-          assert(tuple);
+          INT_ASSERT(tuple);
 
           Expr* type = convertExprOrNull(formal->typeExpression());
           Expr* init = convertExprOrNull(formal->initExpression());
@@ -1921,9 +1922,9 @@ struct Converter {
           // TODO: Move this specialization into visitor? We can just
           // detect if components are formals.
           conv = buildTupleArgDefExpr(tag, tuple, type, init);
-          assert(conv);
+          INT_ASSERT(conv);
         } else {
-          assert(0 == "Not handled yet!");
+          INT_FATAL("Not handled yet!");
         }
 
         // Attaches def to function's formal list.
@@ -2091,7 +2092,7 @@ struct Converter {
                                 typeExpr,
                                 initExpr,
                                 /*varargsVariable*/ nullptr);
-    assert(ret->sym);
+    INT_ASSERT(ret->sym);
 
     attachSymbolAttributes(node, ret->sym);
 
@@ -2148,7 +2149,7 @@ struct Converter {
                                typeExpr,
                                initExpr,
                                varargsVariable);
-    assert(ret->sym);
+    INT_ASSERT(ret->sym);
 
     attachSymbolAttributes(node, ret->sym);
 
@@ -2165,7 +2166,7 @@ struct Converter {
 
     auto ret = ShadowVarSymbol::buildForPrefix(prefix, nameExp, type, init);
 
-    assert(ret != nullptr);
+    INT_ASSERT(ret != nullptr);
 
     attachSymbolAttributes(node, ret);
 
@@ -2205,7 +2206,7 @@ struct Converter {
         vs->addFlag(FLAG_TYPE_VARIABLE);
         break;
       case uast::Variable::INDEX:
-        assert(false && "Index variables should be handled elsewhere");
+        INT_FATAL("Index variables should be handled elsewhere");
         break;
     }
   }
@@ -2293,9 +2294,9 @@ struct Converter {
     // TODO (dlongnecke): Should be sanitized by the new parser.
     if (useLinkageName) {
       if (auto linkageName = node->linkageName()) {
-        assert(linkageFlag != FLAG_UNKNOWN);
+        INT_ASSERT(linkageFlag != FLAG_UNKNOWN);
         auto strLit = linkageName->toStringLiteral();
-        assert(strLit);
+        INT_ASSERT(strLit);
         varSym->cname = astr(strLit->str().c_str());
       }
     }
@@ -2339,14 +2340,14 @@ struct Converter {
     auto stmts = new BlockStmt(BLOCK_SCOPELESS);
 
     auto defExpr = convertVariable(node, true);
-    assert(defExpr);
+    INT_ASSERT(defExpr);
 
     stmts->insertAtTail(defExpr);
 
     // Special handling for extern type variables.
     if (node->kind() == uast::Variable::TYPE) {
       if (node->linkage() == uast::Decl::EXTERN) {
-        assert(!node->isConfig());
+        INT_ASSERT(!node->isConfig());
         stmts = convertTypesToExtern(stmts);
       }
     }
@@ -2410,7 +2411,7 @@ struct Converter {
                                  decls,
                                  externFlag,
                                  /*docs*/ nullptr);
-    assert(ret->sym);
+    INT_ASSERT(ret->sym);
 
     attachSymbolAttributes(node, ret->sym);
 
@@ -2427,14 +2428,14 @@ struct Converter {
     // TODO (dlongnecke): This should be sanitized by the new parser.
     if (node->linkageName()) {
       cname = astrFromStringLiteral(node->linkageName());
-      assert(cname);
+      INT_ASSERT(cname);
     }
 
     auto ret = buildClassDefExpr(name, cname, AGGREGATE_RECORD, inherit,
                                  decls,
                                  linkageFlag,
                                  /*docs*/ nullptr);
-    assert(ret->sym);
+    INT_ASSERT(ret->sym);
 
     attachSymbolAttributes(node, ret->sym);
 
@@ -2451,14 +2452,14 @@ struct Converter {
     // TODO (dlongnecke): This should be sanitized by the new parser.
     if (node->linkageName()) {
       cname = astrFromStringLiteral(node->linkageName());
-      assert(cname);
+      INT_ASSERT(cname);
     }
 
     auto ret = buildClassDefExpr(name, cname, AGGREGATE_UNION, inherit,
                                  decls,
                                  linkageFlag,
                                  /*docs*/ nullptr);
-    assert(ret->sym);
+    INT_ASSERT(ret->sym);
 
     attachSymbolAttributes(node, ret->sym);
 


### PR DESCRIPTION
Follow-up to PR #19294

Generally, the production compiler doesn't use `assert`, although it does appear a bit in some custom LLVM passes and in code from LLVM headers. At the same time, it is used more heavily in the dyno effort.

This PR changes the non-debug builds of `chpl` to add `-DNDEBUG` to disable assertions. This makes it more consistent with what we do for runtime builds. Errors that can be user facing should use `INT_FATAL` in the production compiler or `context->error` in dyno.

In slightly more detail, this PR:
 * updates the CI to only do `test-dyno` for `DYNO_ENABLE_ASSERTIONS=1` since other configurations will check that we can build with assertions disabled
 * fixes a variety of "unused variable" and "variable may be used before it is set" errors with `-DNDEBUG`
   * the `extraChecks` block in llvmGlobalToWide.cpp that I removed is just dead code because in that block `new_type` is never set to anything other than `NULL`
 * adjusted compiler/make/Makefile.compiler.head to include the logic to include `-DNDEBUG` (or not)
 * migrated `assert` to `INT_ASSERT` in other places in the production compiler - especially convert-uast.cpp
 * adjusted compiler/parser/Makefile to clean bison-chapel.output regardless of CHPL_DEVELOPER setting.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing
- [x] full gasnet testing