### PR TITLE
gModuleInitIndentLevel only needs to exist for non minimal-modules

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4596,6 +4596,8 @@ static void find_printModuleInit_stuff() {
       // so the number of symbols is small
     }
   }
-  // assert that we actually found such a symbol
-  INT_ASSERT(gModuleInitIndentLevel);
+  // assert that we actually found such a symbol unless in minimal modules mode
+  if (!fMinimalModules) {
+    INT_ASSERT(gModuleInitIndentLevel);
+  }
 }


### PR DESCRIPTION
In #19273 I tacked on an additional commit that strengthened an
assert, but this did not apply for minimal modules. Because this was
an tack-on commit and I was in a rush, something in my testing run did
not work properly.

The proper behavior is that we only expect the
PrintModuleInitOrder module to exist if not in minimal modules mode

Paratest definitely passes this time