### PR TITLE
Add future to track #19304 (duplicate deprecation warnings for caught errors)

### DIFF
--- a/test/deprecated-keyword/catchDeprecatedError.bad
+++ b/test/deprecated-keyword/catchDeprecatedError.bad
@@ -1,0 +1,6 @@
+catchDeprecatedError.chpl:5: In function 'throwsDepErr':
+catchDeprecatedError.chpl:6: warning: MyDepErr is deprecated
+catchDeprecatedError.chpl:9: In function 'main':
+catchDeprecatedError.chpl:12: warning: MyDepErr is deprecated
+catchDeprecatedError.chpl:12: warning: MyDepErr is deprecated
+owned MyDepErr

--- a/test/deprecated-keyword/catchDeprecatedError.chpl
+++ b/test/deprecated-keyword/catchDeprecatedError.chpl
@@ -1,0 +1,17 @@
+deprecated
+class MyDepErr : Error {
+}
+
+proc throwsDepErr() throws {
+  throw new MyDepErr();
+}
+
+proc main() {
+  try {
+    throwsDepErr();
+  } catch (e: MyDepErr) {
+    writeln(e.type: string);
+  } catch {
+    writeln("whatever");
+  }
+}

--- a/test/deprecated-keyword/catchDeprecatedError.future
+++ b/test/deprecated-keyword/catchDeprecatedError.future
@@ -1,0 +1,2 @@
+error: multiple deprecation warnings for same reference to deprecated symbol
+#19304

--- a/test/deprecated-keyword/catchDeprecatedError.good
+++ b/test/deprecated-keyword/catchDeprecatedError.good
@@ -1,0 +1,5 @@
+catchDeprecatedError.chpl:5: In function 'throwsDepErr':
+catchDeprecatedError.chpl:6: warning: MyDepErr is deprecated
+catchDeprecatedError.chpl:9: In function 'main':
+catchDeprecatedError.chpl:12: warning: MyDepErr is deprecated
+owned MyDepErr


### PR DESCRIPTION
I discovered a bug where using a deprecated symbol in a catch clause would
result in more than one deprecation warning being generated for a single
reference.  This is not ideal - deprecation warnings should be 1:1 for
references to deprecated symbols.

Passed a fresh checkout of the test