### PR TITLE
Fix some .good mismatches

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -602,7 +602,7 @@ module Bytes {
   }
 
   pragma "last resort"
-  deprecated "find with needle and region arguments is deprecated, use pattern and indices instead"
+  deprecated "the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead"
   inline proc bytes.find(needle: bytes,
                          region: range(?) = this.indices) : idxType {
     return this.find(needle, region);
@@ -627,7 +627,7 @@ module Bytes {
   }
 
   pragma "last resort"
-  deprecated "rfind with needle and region arguments is deprecated, use pattern and indices instead"
+  deprecated "the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead"
   inline proc bytes.rfind(needle: bytes,
                           region: range(?) = this.indices) : idxType {
     return this.rfind(needle, region);
@@ -653,7 +653,7 @@ module Bytes {
   }
 
   pragma "last resort"
-  deprecated "count with needles and regions arguments is deprecated, use pattern and indices instead"
+  deprecated "the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead"
   inline proc bytes.count(needle: bytes,
                           region: range(?) = this.indices) : int {
     return this.count(needle, region);
@@ -676,7 +676,7 @@ module Bytes {
   }
 
   pragma "last resort"
-  deprecated "replace with needle argument is deprecated, use pattern instead"
+  deprecated "the 'needle' argument is deprecated, use 'pattern' instead"
   inline proc bytes.replace(needle: bytes,
                             replacement: bytes,
                             count: int = -1) : bytes {

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1636,7 +1636,7 @@ module String {
   }
 
   pragma "last resort"
-  deprecated "find with needle and region arguments is deprecated, use pattern and indices instead"
+  deprecated "the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead"
   inline proc string.find(needle: string,
                           region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
     return this.find(needle, region);
@@ -1661,7 +1661,7 @@ module String {
   }
 
   pragma "last resort"
-  deprecated "rfind with needle and region arguments is deprecated, use pattern and indices instead"
+  deprecated "the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead"
   inline proc string.rfind(needle: string,
                            region: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
     return this.rfind(needle, region);
@@ -1687,7 +1687,7 @@ module String {
   }
 
   pragma "last resort"
-  deprecated "count with needle and region arguments is deprecated, use pattern and indices instead"
+  deprecated "the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead"
   inline proc string.count(needle: string,
                            region: range(?) = this.indices) : int {
     return this.count(needle, region);
@@ -1710,7 +1710,7 @@ module String {
   }
 
   pragma "last resort"
-  deprecated "replace with needle argument is deprecated, use pattern instead"
+  deprecated "the 'needle' argument is deprecated, use 'pattern' instead"
   inline proc string.replace(needle: string, replacement: string,
                              count: int = -1) : string {
     return this.replace(needle, replacement, count);

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1189,7 +1189,7 @@ proc bytes.search(pattern: regex(bytes)):regexMatch
 
 
 pragma "last resort"
-deprecated "search with needle argument is deprecated, use pattern instead"
+deprecated "the 'needle' argument is deprecated, use 'pattern' instead"
 proc string.search(needle: regex(string), ref captures ...?k):regexMatch
 {
   return needle.search(this, (...captures));
@@ -1210,7 +1210,7 @@ proc string.search(pattern: regex(string), ref captures ...?k):regexMatch
 }
 
 pragma "last resort"
-deprecated "search with needle argument is deprecated, use pattern instead"
+deprecated "the 'needle' argument is deprecated, use 'pattern' instead"
 proc bytes.search(needle: regex(bytes), ref captures ...?k):regexMatch
 {
   return needle.search(this, (...captures));

--- a/test/deprecated/argsNeedleRegion.good
+++ b/test/deprecated/argsNeedleRegion.good
@@ -1,23 +1,23 @@
-argsNeedleRegion.chpl:3: warning: find with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:4: warning: find with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:5: warning: find with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:7: warning: rfind with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:8: warning: rfind with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:9: warning: rfind with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:11: warning: count with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:12: warning: count with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:13: warning: count with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:15: warning: replace with needle argument is deprecated, use pattern instead
-argsNeedleRegion.chpl:19: warning: find with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:20: warning: find with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:21: warning: find with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:23: warning: rfind with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:24: warning: rfind with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:25: warning: rfind with needle and region argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:27: warning: count with needles and regions argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:28: warning: count with needles and regions argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:29: warning: count with needles and regions argument is deprecated, use pattern and indices instead
-argsNeedleRegion.chpl:31: warning: replace with needle argument is deprecated, use pattern instead
+argsNeedleRegion.chpl:3: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:4: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:5: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:7: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:8: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:9: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:11: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:12: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:13: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:15: warning: the 'needle' argument is deprecated, use 'pattern' instead
+argsNeedleRegion.chpl:19: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:20: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:21: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:23: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:24: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:25: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:27: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:28: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:29: warning: the 'needle' and 'region' arguments are deprecated, use 'pattern' and 'indices' instead
+argsNeedleRegion.chpl:31: warning: the 'needle' argument is deprecated, use 'pattern' instead
 find: 7
 find: 14
 find: 14

--- a/test/deprecated/regexpSearch.good
+++ b/test/deprecated/regexpSearch.good
@@ -1,5 +1,5 @@
-regexpSearch.chpl:11: warning: search with needle argument is deprecated, use pattern instead
-regexpSearch.chpl:27: warning: search with needle argument is deprecated, use pattern instead
+regexpSearch.chpl:11: warning: the 'needle' argument is deprecated, use 'pattern' instead
+regexpSearch.chpl:27: warning: the 'needle' argument is deprecated, use 'pattern' instead
 search string
 (matched = true, offset = 1, size = 4)
 (matched = true, offset = 1, size = 1)

--- a/test/types/chplhashtable/recordOfNonHashRecord.good
+++ b/test/types/chplhashtable/recordOfNonHashRecord.good
@@ -4,8 +4,8 @@ recordOfNonHashRecord.chpl:22: note: this candidate did not match: WrapR.hash()
 recordOfNonHashRecord.chpl:22: note: because method call receiver with type 'R'
 recordOfNonHashRecord.chpl:22: note: is passed to formal 'this: WrapR'
 $CHPL_HOME/modules/standard/Set.chpl:290: note: other candidates are:
-$CHPL_HOME/modules/internal/Bytes.chpl:1251: note:   bytes.hash()
-$CHPL_HOME/modules/internal/String.chpl:2521: note:   string.hash()
+$CHPL_HOME/modules/internal/Bytes.chpl:1281: note:   bytes.hash()
+$CHPL_HOME/modules/internal/String.chpl:2548: note:   string.hash()
 note: and 38 other candidates, use --print-all-candidates to see them
   $CHPL_HOME/modules/standard/Set.chpl:335: called as (set(WrapR,false))._addElem(elem: WrapR) from method 'add'
   recordOfNonHashRecord.chpl:32: called as (set(WrapR,false)).add(element: WrapR)


### PR DESCRIPTION
Fix some .good mismatches due to the deprecated warnings in #19222.
While there, tweak the phrasing of the warnings for clarity.

Testing: affected tests
