### PR TITLE
Replace the starting_bit argument name from bigint.scan0 and bigint.scan1

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3694,8 +3694,14 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
+  pragma "last resort"
+  deprecated "The 'starting_bit' argument is deprecated, please use 'startBitIdx' instead"
   proc bigint.scan0(starting_bit: integral) : uint {
-    const sb_ = starting_bit.safeCast(c_ulong);
+    return this.scan0(startBitIdx = starting_bit);
+  }
+
+  proc bigint.scan0(startBitIdx: integral): uint {
+    const sb_ = startBitIdx.safeCast(c_ulong);
     var   ret: c_ulong;
 
     if _local {
@@ -3713,8 +3719,14 @@ module BigInteger {
     return ret.safeCast(uint);
   }
 
+  pragma "last resort"
+  deprecated "The 'starting_bit' argument is deprecated, please use 'startBitIdx' instead"
   proc bigint.scan1(starting_bit: integral) : uint {
-    const sb_ = starting_bit.safeCast(c_ulong);
+    return this.scan1(startBitIdx = starting_bit);
+  }
+
+  proc bigint.scan1(startBitIdx: integral): uint {
+    const sb_ = startBitIdx.safeCast(c_ulong);
     var   ret: c_ulong;
 
     if _local {

--- a/test/deprecated/BigInteger/deprecateScanArg.chpl
+++ b/test/deprecated/BigInteger/deprecateScanArg.chpl
@@ -1,0 +1,8 @@
+use BigInteger;
+
+var a: bigint;
+a.set(79);
+writeln(a, "'s first 0 bit is in position ", a.scan0(starting_bit=0));
+
+a.set(96);
+writeln(a, "'s first 1 bit is in position ", a.scan1(starting_bit=0));

--- a/test/deprecated/BigInteger/deprecateScanArg.good
+++ b/test/deprecated/BigInteger/deprecateScanArg.good
@@ -1,0 +1,4 @@
+deprecateScanArg.chpl:5: warning: The 'starting_bit' argument is deprecated, please use 'startBitIdx' instead
+deprecateScanArg.chpl:8: warning: The 'starting_bit' argument is deprecated, please use 'startBitIdx' instead
+79's first 0 bit is in position 4
+96's first 1 bit is in position 5


### PR DESCRIPTION
The new name, startBitIdx, conforms more to our intended style for argument
names.

Resolves #17734

Added a test to lock in the deprecation message when using the old argument
name.

Passed a full paratest with futures