### PR TITLE
Add a prediff to fix .good mismatch

### DIFF
--- a/test/deprecated/regexp-rechan.good
+++ b/test/deprecated/regexp-rechan.good
@@ -1,17 +1,17 @@
 regexp-rechan.chpl:16: warning: `channel.match(re:regex(?))` is deprecated
-$CHPL_HOME/modules/standard/IO.chpl:7130: In method 'match':
-$CHPL_HOME/modules/standard/IO.chpl:7134: warning: `channel.match(re:regex(?), ref error:syserr)` is deprecated
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'match':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: `channel.match(re:regex(?), ref error:syserr)` is deprecated
   regexp-rechan.chpl:16: called as (channel(false,dynamic,true)).match(re: regex(string))
 regexp-rechan.chpl:27: warning: `channel.match(re:regex(?))` is deprecated
 regexp-rechan.chpl:39: warning: `channel.match(re:regex(?), ref captures ...?k)` is deprecated
-$CHPL_HOME/modules/standard/IO.chpl:7196: In method 'match':
-$CHPL_HOME/modules/standard/IO.chpl:7200: warning: `channel.match(re:regex(?), ref captures ...?k, ref error:syserr)` is deprecated
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'match':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: `channel.match(re:regex(?), ref captures ...?k, ref error:syserr)` is deprecated
   regexp-rechan.chpl:39: called as (channel(false,dynamic,true)).match(re: regex(string), captures(0): string)
 regexp-rechan.chpl:52: warning: `channel.match(re:regex(?), ref captures ...?k)` is deprecated
 regexp-rechan.chpl:65: warning: `channel.match(re:regex(?), ref captures ...?k)` is deprecated
 regexp-rechan.chpl:78: warning: `channel.match(re:regex(?), ref captures ...?k)` is deprecated
-$CHPL_HOME/modules/standard/IO.chpl:7023: In method 'search':
-$CHPL_HOME/modules/standard/IO.chpl:7026: warning: `channel.search(re:regex(?), ref error:syserr)` is deprecated
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'search':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: `channel.search(re:regex(?), ref error:syserr)` is deprecated
   regexp-rechan.chpl:93: called as (channel(false,dynamic,true)).search(re: regex(string))
 Words words words
 +match: One word no captures

--- a/test/deprecated/regexp-rechan.prediff
+++ b/test/deprecated/regexp-rechan.prediff
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+# This is derived from test/library/packages/Sort/errors/PREDIFF
+# There and in many other prediffs, the match pattern is /:[0-9:]*:/
+# Here we drop : inside [] because it is not needed.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
#19321 inadvertently enabled the testing of:

    test/deprecated/RegexpModule.chpl
    test/deprecated/regexp-rechan.chpl
    test/deprecated/regexp_error.chpl

in the default configuration (and many others).

While they were not being tested, however, a difference in line numbers
in modules/standard/IO.chpl has crept in for `regexp-rechan.chpl`
so it started to fail.

This PR adds a .prediff to eliminate sensitivity of this test
to such line numbers so now it passes.
