### PR TITLE
Fix sporadic gpu issue (race condition between memory allocation and CUDA context initialization)

### DIFF
--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -42,7 +42,7 @@ module LocaleModel {
   private inline
   proc runningOnGPUSublocale(): bool {
     extern proc chpl_gpu_has_context(): bool;
-    return chpl_gpu_has_context() && chpl_task_getRequestedSubloc()>0;
+    return chpl_task_getRequestedSubloc()>0;
   }
 
   private inline

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -145,7 +145,7 @@ size_t chpl_gpu_get_alloc_size(void* ptr) {
 }
 
 bool chpl_gpu_running_on_gpu_locale() {
-  return chpl_gpu_has_context() && chpl_task_getRequestedSubloc()>0;
+  return chpl_task_getRequestedSubloc()>0;
 }
 
 static void chpl_gpu_launch_kernel_help(const char* fatbinData,

--- a/test/gpu/native/PREDIFF
+++ b/test/gpu/native/PREDIFF
@@ -5,6 +5,3 @@ mv $2.no_version_warn $2
 
 awk '!/ptxas warning : Unresolved extern variable/ {print};' $2 > $2.no_extern_warn
 mv $2.no_extern_warn $2
-
-awk '!/warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors/ {print};' $2 > $2.no_numa_thread_mismatch_warn
-mv $2.no_numa_thread_mismatch_warn $2

--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -16,9 +16,4 @@ export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=stormP100
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
 
-# Setting this export is a temporary solution in the hopes that it will prevent
-# a race condition that is causing sporadic test failures in Jenkins (see
-# Github issue #3073 for more information).
-export CHPL_RT_NUM_THREADS_PER_LOCALE=1
-
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Do not require CUDA context to be initialized prior to calling functions that call out to `chpl_gpu_mem_alloc`. `chpl_gpu_mem_alloc()` already checks to see if the context has been initialized and will initialize it if needed.

This caused a sporadic issue (race condition) where sometimes the memory allocation function would be called before something else caused the context to be initialized. In such cases, the memory allocation would be done on the CPU (and we'd segfault after a GPU kernel tries to access that memory)

I go into more detail about this in the comment here: https://github.com/Cray/chapel-private/issues/3100#issuecomment-1051417481