### PR TITLE
Don't inject a message that is too large

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -5847,6 +5847,10 @@ ssize_t wrap_fi_writemsg(const void* addr, void* mrDesc,
                             .rma_iov = &rma_iov,
                             .rma_iov_count = 1,
                             .context = ctx };
+
+  if ((flags & FI_INJECT) && (size > ofi_info->tx_attr->inject_size)) {
+    flags &= ~FI_INJECT;
+  }
   DBG_PRINTF(DBG_RMA | DBG_RMA_WRITE,
              "tx write msg: %d:%#" PRIx64 " <= %p, size %zd, ctx %p, "
              "flags %#" PRIx64,


### PR DESCRIPTION
The function `wrap_fi_writemsg` now clears the `FI_INJECT` flag before calling `fi_writemsg` if the message is too large to inject. The function `ofi_put_lowLevel` will call `wrap_fi_writemsg` with `FI_INJECT` set even if the message is too large to inject, so catch and fix the problem in `wrap_fi_writemsg`.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>