### PR TITLE
Remove manual reciprocal from my spectral norm version

### DIFF
--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -2,8 +2,8 @@
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
-   derived from the GNU C version by Sebastien Loisel and the C# version
-   by Isaac Gouy
+   derived from the Chapel version by Lydia Duncan et al. and the
+   Julia version by TODO
 */
 
 config const n = 500;           // the size of A (n x n), u and v (n-vectors)
@@ -22,7 +22,7 @@ proc main() {
 }
 
 //
-// Compute A-transpose * A * v ('AtAv').
+// Compute A-transpose * A * v ('AtAv')
 //
 proc multiplyAtAv(v, tmp, AtAv) {
   multiplyAv(v, tmp);
@@ -30,24 +30,24 @@ proc multiplyAtAv(v, tmp, AtAv) {
 }
 
 //
-// Compute A * v ('Av').
+// Compute A * v ('Av')
 //
 proc multiplyAv(v: [?Dv], Av: [?DAv]) {
   forall i in DAv do
-    Av[i] = + reduce (for j in Dv by 2 do (v[j] / A[i,j] + v[j+1] / A[i,j+1]));
+    Av[i] = + reduce (for j in Dv by 2 do (A[i,j]*v[j] + A[i,j+1]*v[j+1]));
 }
 
 //
-// Compute A-tranpose * v ('Atv').
+// Compute A-tranpose * v ('Atv')
 //
 proc multiplyAtv(v: [?Dv], Atv: [?DAtv]) {
   forall i in DAtv do
-    Atv[i] = + reduce (for j in Dv by 2 do (v[j] / A[j,i] + v[j+1] / A[j+1,i]));
+    Atv[i] = + reduce (for j in Dv by 2 do (A[j,i]*v[j] + A[j+1,i]*v[j+1]));
 }
 
 //
-// Compute element i,j of the conceptually infinite matrix A.
+// Compute element i,j of the conceptually infinite matrix A
 //
-inline proc A(i:real, j:real) {
-  return ((((i+j) * (i+j+1)) / 2) + i + 1);
+inline proc A(i: real, j: real) {
+  return 1.0 / ((((i+j) * (i+j+1)) / 2) + i + 1);
 }


### PR DESCRIPTION
This removes the manual reciprocal that I'd been using to see how
the performance compares in the nightly runs and because it seems
more "intuitive" to what the computation is requesting.