### PR TITLE
Revert part of #19321

### DIFF
--- a/test/deprecated/RegexpModule.skipif
+++ b/test/deprecated/RegexpModule.skipif
@@ -1,1 +1,1 @@
-CHPL_RE2==none
+CHPL_REGEXP != re2


### PR DESCRIPTION
#19321 introduced a merge conflict for a change
to deprecated/RegexpModule.skipif in #19308.

Since the change to RegexpModule.skipif in #19321
is not necessary, reverting it here.

Tested: RegexpModule.chpl in the default and quickstart
configurations. (Skipped in both cases.)