### PR TITLE
Use value-initialization to avoid clang warning

### DIFF
--- a/compiler/dyno/include/chpl/uast/ASTNode.h
+++ b/compiler/dyno/include/chpl/uast/ASTNode.h
@@ -239,9 +239,8 @@ class ASTNode {
         #undef IGNORE
       }
 
-      ReturnType dummy;
       assert(false && "this code should never be run");
-      return dummy;
+      return ReturnType();
     }
   };
   template <typename Visitor>


### PR DESCRIPTION
Follow-up to #19299.

This PR addresses a warning from clang when building `chpl` without `CHPL_DEVELOPER` and with `make WARNINGS=1`.

We had this in the ASTNode visitor template (where `ReturnType` is a template parameter):

    ReturnType dummy;
    assert(false && "this code should never be run");
    return dummy;

Change it to this instead to avoid a warning from clang that `dummy` is uninitialized (when ReturnType is int/bool/etc).

    assert(false && "this code should never be run");
    return ReturnType();

This is a value initialization in C++ and if `ReturnType` is `int` it will produce `0`.

Reviewed by @ronawho - thanks!