### PR TITLE
Don't warn when `CHPL_TARGET_CPU` is set to the inferred value on Crays

### DIFF
--- a/test/compflags/link/sungeun/static_dynamic.prediff
+++ b/test/compflags/link/sungeun/static_dynamic.prediff
@@ -7,9 +7,8 @@ import subprocess
 from pkg_resources import parse_version
 
 def testFailed(f, output):
-    logfile = file(f, 'a')
-    logfile.write('%s' % (output))
-    logfile.close()
+    with open(f, 'w') as logfile:
+        logfile.write('%s' % (output))
 
 
 execname = sys.argv[1]

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -99,8 +99,7 @@ def adjust_cpu_for_compiler(cpu, flag, get_lcd):
         else:
             # for C compilation, CPU needs to be set by cray-prgenv-*
             # and not by e.g. CHPL_TARGET_CPU.
-            cpu = cray_cpu
-            if has_cpu:
+            if has_cpu and cpu != cray_cpu:
                 warning("Setting the processor type through environment "
                         "variables is not supported for cray-prgenv-*. "
                         "Please use the appropriate craype-* module for your "
@@ -109,6 +108,7 @@ def adjust_cpu_for_compiler(cpu, flag, get_lcd):
                 warning("No craype-* processor type module was detected, "
                         "please load the appropriate one if you want any "
                         "specialization to occur.")
+            cpu = cray_cpu
 
         if get_lcd:
             cpu = get_module_lcd_cpu(platform_val, cpu)


### PR DESCRIPTION
On Cray XC/EX `CHPL_TARGET_CPU` is based on the loaded `craype-` cpu
targeting module and we don't want users to set it explicitly so we warn
if they do. However, there's no reason to warn if the user set the value
to the inferred one so stop doing that here. This was causing test
failures for a prediff because we inject the chplenv into the prediff
env, which resulted in `CHPL_TARGET_CPU` being set explicitly, which
caused the printchplenv called from the prediff to warn. While here fix
a python2/3 incompatibly in the prediff.

Part of Cray/chapel-private#3147