### PR TITLE
Wait for catfiles to exist in sub_test

### DIFF
--- a/test/exercises/Mandelbrot/solutions/CATFILES
+++ b/test/exercises/Mandelbrot/solutions/CATFILES
@@ -1,0 +1,1 @@
+mandelbrot.ppm

--- a/test/exercises/Mandelbrot/solutions/PREDIFF
+++ b/test/exercises/Mandelbrot/solutions/PREDIFF
@@ -1,2 +1,0 @@
-#!/bin/sh
-cat mandelbrot.ppm >> $1.exec.out.tmp

--- a/test/studies/ssca2/test-rmatalt/reproduc.prediff
+++ b/test/studies/ssca2/test-rmatalt/reproduc.prediff
@@ -4,6 +4,11 @@ output=${2:-}
 execopts=${5:-}
 
 function doit {
+  # Wait 10 seconds if the file doesn't exist. Useful on systems where file
+  # IO may only complete after the launcher returns
+  if ! [ -f rmatalt.weights ]; then
+    sleep 10
+  fi
   sort rmatalt.weights | { diff rmatalt.weights.good - && echo weights match; }
   sort rmatalt.neis    | { diff rmatalt.neis.good - && echo neis match; }
 }

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -276,6 +276,15 @@ def expandvars_chpl(path):
     expand_env.update(get_chplenv())
     return string.Template(path).safe_substitute(expand_env)
 
+# Wait up to timeout seconds for files to exist. Useful on systems where file
+# IO may only complete after the launcher returns
+def WaitForFiles(files, timeout=10):
+    waited = 0
+    for f in files:
+        while not os.path.exists(f) and waited < timeout:
+            time.sleep(1)
+            waited += 1
+
 # Read a file or if the file is executable read its output. If the file is
 # executable, the current chplenv is copied into the env before executing.
 # Expands shell and chplenv variables and strip out comments/whitespace.
@@ -1722,6 +1731,7 @@ for testname in testsrc:
                 sys.stdout.write('[Concatenating extra files: %s]\n'%
                                  (test_filename+'.catfiles'))
                 sys.stdout.flush()
+                WaitForFiles(catfiles.split())
                 p = py3_compat.Popen(['cat']+catfiles.split(),
                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 catoutput = p.communicate()[0]
@@ -2240,6 +2250,7 @@ for testname in testsrc:
                     sys.stdout.write('[Concatenating extra files: %s]\n'%
                                     (test_filename+'.catfiles'))
                     sys.stdout.flush()
+                    WaitForFiles(catfiles.split())
                     p = py3_compat.Popen(['cat']+catfiles.split(),
                                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     cat_output = p.communicate()[0]


### PR DESCRIPTION
Wait up to 10 seconds for catfiles to exist. Catfiles are used to add
files generated by tests to execution output in order to diff them
against .good files. On systems with a network mounted filesystem and a
launcher we have seen cases where the launcher returns before the file
is visible on disk. This adds up to a 10 second delay waiting for
catfiles to exist. In practice it's fractions of a second delay that we
see for our tests, but this seemed a little more robust.

This is motivated by testing failures we've seen on some Cray systems
when launching with `srun`. Note that this also changes a manual cat in
a prediff to use a catfile and adds a sleep to a test prediff that does
something like catfiles but more involved with sorting and diffing.

Part of Cray/chapel-private#3147