### PR TITLE
Quiet some multi-locale test failures on crays

### DIFF
--- a/test/distributions/privatization/stress-privatization.execenv
+++ b/test/distributions/privatization/stress-privatization.execenv
@@ -1,0 +1,2 @@
+# This test creates a large number of tasks repeatedly
+CHPL_RT_CALL_STACK_SIZE=256K

--- a/test/multilocale/engin/verboseComm.cache.block.good
+++ b/test/multilocale/engin/verboseComm.cache.block.good
@@ -1,0 +1,4 @@
+0: verboseComm.chpl:5: remote executeOn, node 1
+1
+1: :-1: remote put, node 0, 8 bytes, commid #
+1: verboseComm.chpl:6: remote cache-put, node 0, 8 bytes, commid #

--- a/test/multilocale/engin/verboseComm.compopts
+++ b/test/multilocale/engin/verboseComm.compopts
@@ -3,7 +3,12 @@
 import os
 
 do_cache = os.getenv('CHPL_SANITIZE_EXE', '') == 'none'
+comm = os.getenv('CHPL_COMM')
 
 print(  '--no-cache-remote # verboseComm.no-cache.good')
 if do_cache:
-  print('--cache-remote    # verboseComm.cache.good')
+    # ofi and ugni support the cache, but don't implement non-blocking ops
+    if comm in ('ugni', 'ofi'):
+        print('--cache-remote    # verboseComm.cache.block.good')
+    else:
+        print('--cache-remote    # verboseComm.cache.good')

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
@@ -3,5 +3,5 @@ echo "EVARS=vals" \
      "srun --job-name=CHPL-testVFlag --quiet" \
      "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
      "--exclusive --mem=0" \
-     "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P} " \
+     "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P}${CHPL_LAUNCHER_EXCLUDE:+ --exclude=E} " \
      "./testVFlag_real -v -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -70,6 +70,7 @@ case $launcher in
          mv $2.tmp $2;;
   slurm-srun) sed -e "s/ \(--cpus-per-task\)=[1-9][0-9]* / \1=N /" \
                   -e "s/ \(--partition\)=[^ ]* / \1=P /" \
+                  -e "s/ \(--exclude\)=[^ ]* / \1=E /" \
                   -e "s/ --time=[^ ]*//" \
                   -e 's/ *$//' \
                   $2 > $2.tmp &&

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
@@ -3,5 +3,5 @@ echo "EVARS=vals" \
      "srun --job-name=CHPL-testVerbos --quiet" \
      "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
      "--exclusive --mem=0" \
-     "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P} " \
+     "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P}${CHPL_LAUNCHER_EXCLUDE:+ --exclude=E} " \
      "./testVerboseFlag_real --verbose -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -70,6 +70,7 @@ case $launcher in
          mv $2.tmp $2;;
   slurm-srun) sed -e "s/ \(--cpus-per-task\)=[1-9][0-9]* / \1=N /" \
                   -e "s/ \(--partition\)=[^ ]* / \1=P /" \
+                  -e "s/ \(--exclude\)=[^ ]* / \1=E /" \
                   -e "s/ --time=[^ ]*//" \
                   -e 's/ *$//' \
                   $2 > $2.tmp &&

--- a/test/optimizations/sungeun/optimized-on/extern_proc.good
+++ b/test/optimizations/sungeun/optimized-on/extern_proc.good
@@ -1,3 +1,3 @@
-in foo(): x=3
-in foo(): x=2
 in foo(): x=1
+in foo(): x=2
+in foo(): x=3

--- a/test/optimizations/sungeun/optimized-on/extern_proc.prediff
+++ b/test/optimizations/sungeun/optimized-on/extern_proc.prediff
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This test does printf's in order, but the order output shows up can depend on
+# the launcher
+sort $2 > $2.prediff.tmp
+mv $2.prediff.tmp $2


### PR DESCRIPTION
`-multilocale-only` testing exposed test issues that are fixed here:
- Sort the output for `optimizations/sungeun/optimized-on/extern_proc`.
  The test makes extern'd `printf` calls serially, but the order they
  actually show up in can depend on how a launcher propagates stdout
  back so we can't rely on the order. Sort the output to avoid this.
- Lower stack for `distributions/privatization/stress-privatization`
  This test creates a lot of tasks, which causes high memory usage,
  especially on high core count systems. On 128-core nodes I was seeing
  ~17GB total usage on locale 0. Lower the stack size to 256K to bring
  that down to ~1/2 GB.
- Fix `multilocale/engin/verboseComm` for ofi/ugni. Our ugni and ofi
  comm layers don't currently support non-blocking puts so update the
  verbose comm output for this test to reflect that.
- Add support for handling srun exclude to our verbose output tests. We
  need to exclude some nodes on systems we've been doing testing on
  recently and this was causing failures for some of the verbose output
  tests. Update them to handle slurm exclude lists like we did before
  for slurm partitions.

Part of https://github.com/Cray/chapel-private/issues/3147