### PR TITLE
Add test ensuring Sockets package compiles

### DIFF
--- a/test/library/packages/canCompileNoLink/testSockets.bad
+++ b/test/library/packages/canCompileNoLink/testSockets.bad
@@ -1,0 +1,12 @@
+$CHPL_HOME/modules/standard/Sys.chpl:258: error: symbol socklen_t is multiply defined
+$CHPL_HOME/modules/standard/SysBasic.chpl:78: note: also defined as a function here (and possibly elsewhere)
+$CHPL_HOME/modules/standard/Sys.chpl:258: error: symbol socklen_t is multiply defined
+$CHPL_HOME/modules/standard/SysBasic.chpl:78: note: also defined as a function here (and possibly elsewhere)
+$CHPL_HOME/modules/standard/Sys.chpl:258: error: symbol socklen_t is multiply defined
+$CHPL_HOME/modules/standard/SysBasic.chpl:78: note: also defined as a function here (and possibly elsewhere)
+$CHPL_HOME/modules/standard/Sys.chpl:258: error: symbol socklen_t is multiply defined
+$CHPL_HOME/modules/standard/SysBasic.chpl:78: note: also defined as a function here (and possibly elsewhere)
+$CHPL_HOME/modules/standard/Sys.chpl:258: error: symbol socklen_t is multiply defined
+$CHPL_HOME/modules/standard/SysBasic.chpl:78: note: also defined as a function here (and possibly elsewhere)
+$CHPL_HOME/modules/standard/Sys.chpl:258: error: symbol socklen_t is multiply defined
+$CHPL_HOME/modules/standard/SysBasic.chpl:78: note: also defined as a function here (and possibly elsewhere)

--- a/test/library/packages/canCompileNoLink/testSockets.chpl
+++ b/test/library/packages/canCompileNoLink/testSockets.chpl
@@ -1,0 +1,1 @@
+../Socket/tcpio.chpl

--- a/test/library/packages/canCompileNoLink/testSockets.future
+++ b/test/library/packages/canCompileNoLink/testSockets.future
@@ -1,0 +1,3 @@
+error: duplicate symbols when both Sys and SysBasic are used
+
+#19279


### PR DESCRIPTION
This adds a test to the "can compile no link" suite of tests for package
modules that strives to make sure that packages that we don't test
everywhere at least compile without errors.

Unfortunately, this test currently is a future because of #19279.
Had the test existed prior to #19262 being merged, we would've
caught the error more proactively.