### PR TITLE
Only do ofi liveness checks when using the rxm utility provider

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2940,9 +2940,13 @@ void chpl_comm_rollcall(void) {
 
   //
   // Only node 0 in multi-node programs does liveness checks, and only
-  // after we're sure all the other nodes' AM handlers are running.
+  // after we're sure all the other nodes' AM handlers are running. By default
+  // we only do liveness checks with the rxm utility provider to turn hangs
+  // into hard failures.
   //
-  if (chpl_numNodes > 1 && chpl_nodeID == 0) {
+  bool envLivenessChecks = chpl_env_rt_get_bool("COMM_OFI_LIVENESS_CHECKS",
+                                                providerInUse(provType_rxm));
+  if (envLivenessChecks && chpl_numNodes > 1 && chpl_nodeID == 0) {
     amDoLivenessChecks = true;
   }
 }


### PR DESCRIPTION
#15751 added liveness checks to the ofi comm layer to turn hangs with the
rxm utility provider into hard failures to aid debugging. These liveness
checks should be cheap since we limit how often we do them, but there's
no need to do them on providers like cxi or efa so don't waste the time.

The liveness checks were leading to extra error messages for tests that
halt since node 0 could do a liveness check to node 1 while node 1 is
halting. This motivated disabling liveness checks now, but we had been
thinking about disabling them anyways as they're not needed for cxi.

Resolves Cray/chapel-private#2870
Part of Cray/chapel-private#3147