### PR TITLE
Include device in verbose OFI output

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1912,8 +1912,9 @@ void init_ofiFabricDomain(void) {
       size_t size;
       chpl_comm_regMemHeapInfo(&start, &size);
       char buf[10];
-      printf("COMM=ofi: %s MCM mode, \"%s\" provider, %s fixed heap\n",
+      printf("COMM=ofi: %s MCM mode, \"%s\" provider, \"%s\" device, %s fixed heap\n",
              mcmModeNames[mcmMode], ofi_info->fabric_attr->prov_name,
+             ofi_info->domain_attr->name,
              ((size == 0)
               ? "no"
               : chpl_snprintf_KMG_z(buf, sizeof(buf), size)));


### PR DESCRIPTION
Include the device in the verbose OFI output in addition to the MCM mode, provider, and heap size. This will facilitate debugging on nodes with multiple devices.

Resolves cray/chapel-private#3134.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>