### PR TITLE
Spectral-norm: Change / 2 into * 0.5 to see the impact on nightly testing

### DIFF
--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-blc.chpl
@@ -1,15 +1,15 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
-   contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
-   derived from the Chapel version by Lydia Duncan et al. and the
-   Julia version by TODO
+   contributed by Brad Chamberlain
+   derived from the Chapel version by Lydia Duncan et al.
+   and the Julia version by Adam Beckmeyer and Vincent Yu
 */
 
 config const n = 500;           // the size of A (n x n), u and v (n-vectors)
 
 proc main() {
-  var tmp, u, v: [0..#n] real;
+  var tmp, u, v: [0..<n] real;
 
   u = 1.0;
 
@@ -49,5 +49,5 @@ proc multiplyAtv(v: [?Dv], Atv: [?DAtv]) {
 // Compute element i,j of the conceptually infinite matrix A
 //
 inline proc A(i: real, j: real) {
-  return 1.0 / ((((i+j) * (i+j+1)) / 2) + i + 1);
+  return 1.0 / ((((i+j) * (i+j+1)) * 0.5) + i + 1);
 }


### PR DESCRIPTION
Elliot was curious what would happen if we changed `/ 2[.0]` into `* 0.5`
in spectral-norm.  On my Mac, it _looked_ like a wash, but did turn in the
best time I've seen so far (but Macs are noisy), so checking this in to see
what happens in the nightlies.

While here, I got the comment correct and changed a `0..#n` into `0..<n`
which is my current preferred form.
