### PR TITLE
Allow catfiles timeout to be set with an env var

### DIFF
--- a/test/studies/ssca2/test-rmatalt/reproduc.prediff
+++ b/test/studies/ssca2/test-rmatalt/reproduc.prediff
@@ -4,11 +4,15 @@ output=${2:-}
 execopts=${5:-}
 
 function doit {
-  # Wait 10 seconds if the file doesn't exist. Useful on systems where file
+  # Wait up to timeout seconds for files to exist. Useful on systems where file
   # IO may only complete after the launcher returns
-  if ! [ -f rmatalt.weights ]; then
-    sleep 10
-  fi
+  timeout=${CHPL_TEST_WAIT_FOR_FILES_TIMEOUT:-10}
+  waited=0
+  while [ ! -f rmatalt.weights ] && [ "$waited" -lt "$timeout" ] ; do
+    sleep 1
+    waited=$((waited+1))
+  done
+
   sort rmatalt.weights | { diff rmatalt.weights.good - && echo weights match; }
   sort rmatalt.neis    | { diff rmatalt.neis.good - && echo neis match; }
 }

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -278,7 +278,7 @@ def expandvars_chpl(path):
 
 # Wait up to timeout seconds for files to exist. Useful on systems where file
 # IO may only complete after the launcher returns
-def WaitForFiles(files, timeout=10):
+def WaitForFiles(files, timeout=int(os.getenv('CHPL_TEST_WAIT_FOR_FILES_TIMEOUT', '10'))):
     waited = 0
     for f in files:
         while not os.path.exists(f) and waited < timeout:


### PR DESCRIPTION
In #19342 a fixed 10 second timeout was used to wait for catfiles to
exist, but that turned out to not be enough occasionally. Allow the
timeout to be set by an env var to increase it on systems where more
time may be needed.

Part of https://github.com/Cray/chapel-private/issues/3147