### PR TITLE
Improve oversubscribedArrayAlloc test for configs using a fixed heap

### DIFF
--- a/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
+++ b/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
@@ -4,7 +4,7 @@ config const oversubscription = 4;
 const desiredTasks = oversubscription * here.maxTaskPar;
 
 // At most use 1/memFraction of available/addressable memory
-var memAvail = here.physicalMemory(unit=MemUnits.Bytes);
+var memAvail = availMem();
 if numBits(c_size_t) < 64 then
   memAvail = min(memAvail, 2**30);
 
@@ -36,4 +36,17 @@ timer.stop();
 if showPerf {
   writeln("Array size in bytes: ", arrSize);
   writeln("Time: ", timer.elapsed());
+}
+
+// Estimate for how much memory we can allocate. Based on
+// chpl_comm_regMemHeapInfo if using a fixed heap, otherwise physical memory
+proc availMem() {
+  use CTypes;
+  extern proc chpl_comm_regMemHeapInfo(ref start: c_void_ptr, ref size: c_size_t): void;
+  var unused: c_void_ptr;
+  var heap_size: c_size_t;
+  chpl_comm_regMemHeapInfo(unused, heap_size);
+  if heap_size != 0 then
+    return heap_size.safeCast(int);
+  return here.physicalMemory(unit = MemUnits.Bytes);
 }


### PR DESCRIPTION
This test attempts to use a large fraction of memory to stress test
array allocations. However, it was trying to use a fraction of physical
memory, which can be much larger than what we can actually allocate when
using a fixed heap with `CHPL_RT_MAX_HEAP_SIZE` set lower, which we do
sometimes to speed up testing.

Base the amount of memory used on the heap size if one is used to avoid
this issue.

Part of https://github.com/Cray/chapel-private/issues/3147