### PR TITLE
Fix couple of missed operator declarations

### DIFF
--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -159,7 +159,7 @@ record ipAddr {
     return try! _addressStorage.port();
   }
 
-  proc =(in other: ipAddr) {
+  operator =(in other: ipAddr) {
     this._addressStorage = new sys_sockaddr_t(other._addressStorage);
   }
 }
@@ -241,7 +241,7 @@ proc ipAddr.writeThis(f) throws {
 }
 
 pragma "no doc"
-proc timeval.=(other: real) {
+operator timeval.=(other: real) {
   this.tv_sec = other:c_long;
   this.tv_usec = (other - this.tv_sec) * 1000000;
 }

--- a/test/types/tuple/ferguson/const-ref-tuple-decl.chpl
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.chpl
@@ -22,7 +22,7 @@ record R {
     if print then writeln("deinit ", x);
   }
 }
-proc =(ref lhs:R, rhs:R) {
+operator =(ref lhs:R, rhs:R) {
   if print then writeln("= ", lhs.x, " ", rhs.x);
   lhs.x = rhs.x;
 }


### PR DESCRIPTION
One was in the Socket library, which had apparently been
broken for a little while and we hadn't noticed.  The other was
in a future that didn't have a .bad file, so it had just changed
behavior unnecessarily (but we happened to notice it did so)

Passed a full paratest with futures