### PR TITLE
test: change decl from `ref` to `var` and add future for `ref` version

### DIFF
--- a/test/functions/varargs/stringVarargLeak.chpl
+++ b/test/functions/varargs/stringVarargLeak.chpl
@@ -11,7 +11,7 @@ record myRec {
 }
 
 proc bar(paths: myRec ...?n) {
-  ref refToArg = paths;
+  var refToArg = paths;
 
   for p in refToArg do writeln(p);
 

--- a/test/functions/varargs/stringVarargLeakByRef.chpl
+++ b/test/functions/varargs/stringVarargLeakByRef.chpl
@@ -1,0 +1,45 @@
+proc foo(paths: string ...?n) : string {
+  var ret : string;
+
+  for p in paths do writeln(p);
+
+  return ret;
+}
+
+record myRec {
+  var x: int;
+}
+
+proc bar(paths: myRec ...?n) {
+  ref refToArg = paths;
+
+  for p in refToArg do writeln(p);
+
+  return refToArg;
+}
+
+proc main() {
+  // some dummy strings built up to emphasize this isn't an issue with string
+  // literals
+  var x, y : string;
+  for i in 0..9 do x += i:string;
+  for i in 0..9 by -1 do y += i:string;
+
+  foo(x, y);
+
+  var r1, r2: myRec;
+  r1 = new myRec(x=10);
+  r2 = new myRec(x=20);
+
+  var (ret1, ret2) = bar(r1, r2);
+
+  writeln("After return");
+  writeln(ret1, " ", ret2);
+  writeln(r1, " ", r2);
+
+  r1.x *= -1;
+
+  writeln("After multiply");
+  writeln(ret1, " ", ret2);
+  writeln(r1, " ", r2);
+}

--- a/test/functions/varargs/stringVarargLeakByRef.future
+++ b/test/functions/varargs/stringVarargLeakByRef.future
@@ -1,3 +1,4 @@
-The function `bar` should probably generate an error message because it returns
-a ref to the local variable which goes out of scope. See
-https://github.com/chapel-lang/chapel/pull/19357#issuecomment-1062868709
+bug: capturing a const reference to a non-const ref should be an error
+#19614
+The function `bar` should probably generate an error message because it captures
+a non-const ref to a const-ref.

--- a/test/functions/varargs/stringVarargLeakByRef.future
+++ b/test/functions/varargs/stringVarargLeakByRef.future
@@ -1,0 +1,3 @@
+The function `bar` should probably generate an error message because it returns
+a ref to the local variable which goes out of scope. See
+https://github.com/chapel-lang/chapel/pull/19357#issuecomment-1062868709

--- a/test/functions/varargs/stringVarargLeakByRef.good
+++ b/test/functions/varargs/stringVarargLeakByRef.good
@@ -1,0 +1,1 @@
+stringVarargLeak.good

--- a/test/functions/varargs/stringVarargLeakByRef.good
+++ b/test/functions/varargs/stringVarargLeakByRef.good
@@ -1,1 +1,1 @@
-stringVarargLeak.good
+stringVarargLeakByRef.chpl:14: error: Cannot set a const reference to a non-const reference.


### PR DESCRIPTION
test: change decl from `ref` to `var` and add future for `ref` version

This PR updates the declaration of a variable in a test from `ref` to `var`.

When troubleshooting failing tests with the dyno parser, we discovered 
that this test declared a `ref` to the `vararg` formal, which is itself 
returned as a `ref`, so this should have produced a type or lifetime error
in the current compiler. However, it was compiling and running because
internally it was converting the `ref` to a `const val`. Redeclaring the 
variable as a `var` keeps tests passing. 

Captured the existing test as a future referring to issue 
https://github.com/chapel-lang/chapel/issues/19614.


TESTING:

- [x] paratest
- [x] paratest with `--dyno` (602 failures)

reviewed by @mppf - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>