### PR TITLE
Update test to use operator keyword

### DIFF
--- a/test/studies/madness/aniruddha/madchap/mytests/par-reconstruct/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-reconstruct/MRA.chpl
@@ -618,14 +618,17 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
+operator Function.+(F: unmanaged Function,
+                    G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
+operator Function.-(F: unmanaged Function,
+                    G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
+operator Function.*(F: unmanaged Function,
+                    G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }


### PR DESCRIPTION
This test got missed in the initial deprecation due to suppressing warnings at
compilation.  Now that it results in a compilation failure, we were able to
detect it.

Ran a fresh copy of test/studies/madness