### PR TITLE
Rename regexMatch fields

### DIFF
--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -241,7 +241,7 @@ class RecordReader {
     // This will only loop through  at most one time before returning
     // FEATURE REQUEST: Make this so we don't need a for loop here
     for m in myReader.matches(matchRegex, num_fields, 1) {
-      if (((m(0).offset) >= offst+len) && len != -1) { // rec.start >= start + len
+      if (((m(0).byteOffset) >= offst+len) && len != -1) { // rec.start >= start + len
         // Then break and dont return any record
         return (rec, false);
       }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7572,7 +7572,7 @@ iter channel.matches(re:regex(?), param captures=0, maxmatches:int = max(int))
           error = qio_channel_mark(false, _channel_internal);
           if !error {
             var cur = qio_channel_offset_unlocked(_channel_internal);
-            var target = m.offset:int;
+            var target = m.byteOffset:int;
             error = qio_channel_advance(false, _channel_internal, target - cur);
           }
         } else {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7159,7 +7159,7 @@ pragma "no doc"
 proc channel._extractMatch(m:regexMatch, ref arg:bytes, ref error:syserr) {
   var cur:int(64);
   var target = m.offset:int;
-  var len = m.size;
+  var len = m.numBytes;
 
   // If there was no match, return the default value of the type
   if !m.matched {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7158,7 +7158,7 @@ proc channel._extractMatch(m:regexMatch, ref arg:regexMatch, ref error:syserr) {
 pragma "no doc"
 proc channel._extractMatch(m:regexMatch, ref arg:bytes, ref error:syserr) {
   var cur:int(64);
-  var target = m.offset:int;
+  var target = m.byteOffset:int;
   var len = m.numBytes;
 
   // If there was no match, return the default value of the type

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -529,7 +529,7 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
       if !m then do_something_if_not_matched();
 
     .. warning::
-      offset field is deprecated, use byte offset instead
+      offset field is deprecated, use byteOffset instead
     .. warning::
       size field is deprecated, use numBytes instead
  */
@@ -540,19 +540,6 @@ record regexMatch {
   var byteOffset:byteIndex;
   /* the length of the match. 0 if matched==false */
   var numBytes:int;
-
-  //TODO: remove when removing offset and size
-  pragma "no doc"
-  proc init(){
-
-  }
-
-  pragma "no doc"
-  proc init(matched: bool, byteOffset: byteIndex, numBytes: int){
-    this.matched = matched;
-    this.byteOffset = byteOffset;
-    this.numBytes = numBytes;
-  }
 
   pragma "no doc"
   deprecated "field offset is deprecated, use byteOffset instead"

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -533,7 +533,7 @@ record regexMatch {
   /* true if the regular expression search matched successfully */
   var matched:bool;
   /* 0-based offset into the string or channel that matched; -1 if matched=false */
-  var offset:byteIndex; // 0-based, -1 if matched==false
+  var byteOffset:byteIndex; // 0-based, -1 if matched==false
   /* the length of the match. 0 if matched==false */
   var numBytes:int; // 0 if matched==false
 }
@@ -569,7 +569,7 @@ inline proc regexMatch.chpl_cond_test_method() return this.matched;
     :returns: the portion of ``this`` referred to by the match
  */
 proc string.this(m:regexMatch) {
-  if m.matched then return this[m.offset..#m.numBytes];
+  if m.matched then return this[m.byteOffset..#m.numBytes];
   else return "";
 }
 
@@ -582,7 +582,7 @@ proc string.this(m:regexMatch) {
     :returns: the portion of ``this`` referred to by the match
  */
 proc bytes.this(m:regexMatch) {
-  if m.matched then return this[m.offset:int..#m.numBytes];
+  if m.matched then return this[m.byteOffset:int..#m.numBytes];
   else return b"";
 }
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -535,7 +535,7 @@ record regexMatch {
   /* 0-based offset into the string or channel that matched; -1 if matched=false */
   var offset:byteIndex; // 0-based, -1 if matched==false
   /* the length of the match. 0 if matched==false */
-  var size:int; // 0 if matched==false
+  var numBytes:int; // 0 if matched==false
 }
 
 pragma "no doc"
@@ -569,7 +569,7 @@ inline proc regexMatch.chpl_cond_test_method() return this.matched;
     :returns: the portion of ``this`` referred to by the match
  */
 proc string.this(m:regexMatch) {
-  if m.matched then return this[m.offset..#m.size];
+  if m.matched then return this[m.offset..#m.numBytes];
   else return "";
 }
 
@@ -582,7 +582,7 @@ proc string.this(m:regexMatch) {
     :returns: the portion of ``this`` referred to by the match
  */
 proc bytes.this(m:regexMatch) {
-  if m.matched then return this[m.offset:int..#m.size];
+  if m.matched then return this[m.offset:int..#m.numBytes];
   else return b"";
 }
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -529,6 +529,8 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
       if !m then do_something_if_not_matched();
 
  */
+
+/*
 record regexMatch {
   /* true if the regular expression search matched successfully */
   var matched:bool;
@@ -547,6 +549,39 @@ record regexMatch {
     this.matched = matched;
     this.byteOffset = byteOffset;
     this.numBytes = numBytes;
+  }
+}
+*/
+
+record regexMatch {
+  /* true if the regular expression search matched successfully */
+  var matched:bool;
+  /* 0-based offset into the string or channel that matched; -1 if matched=false */
+  var byteOffset:byteIndex;
+  /* the length of the match. 0 if matched==false */
+  var numBytes:int;
+  //TODO: remove when removing offset and size
+  proc init(){
+
+  }
+
+  pragma "no doc"
+  proc init(matched: bool, byteOffset: byteIndex, numBytes: int){
+    this.matched = matched;
+    this.byteOffset = byteOffset;
+    this.numBytes = numBytes;
+  }
+
+  pragma "no doc"
+  deprecated "field offset is deprecated, use byteOffset instead" 
+  proc offset:byteIndex {
+    return this.byteOffset;
+  }
+
+  pragma "no doc"
+  deprecated "field size is deprecated, use numBytes instead"
+  proc size:int {
+    return this.numBytes;
   }
 }
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -532,12 +532,11 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
       offset field is deprecated, use byte offset instead
     .. warning::
       size field is deprecated, use numBytes instead
- 
  */
 record regexMatch {
   /* true if the regular expression search matched successfully */
   var matched:bool;
-  /* 0-based offset into the string or channel that matched; -1 if matched=false */ 
+  /* 0-based offset into the string or channel that matched; -1 if matched=false */
   var byteOffset:byteIndex;
   /* the length of the match. 0 if matched==false */
   var numBytes:int;
@@ -556,7 +555,7 @@ record regexMatch {
   }
 
   pragma "no doc"
-  deprecated "field offset is deprecated, use byteOffset instead" 
+  deprecated "field offset is deprecated, use byteOffset instead"
   proc offset:byteIndex {
     return this.byteOffset;
   }

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -533,10 +533,34 @@ record regexMatch {
   /* true if the regular expression search matched successfully */
   var matched:bool;
   /* 0-based offset into the string or channel that matched; -1 if matched=false */
+  var byteOffset:byteIndex;
+  deprecated "field offset is deprecated, use byteOffset instead" var offset:byteIndex = byteOffset;
+  /* the length of the match. 0 if matched==false */
+  var numBytes:int; 
+  deprecated "field size is deprecated, use numBytes instead" var size:int = numBytes;
+  //TODO: remove when removing offset and size
+  proc init(){
+    
+  }
+
+  proc init(matched: bool, byteOffset: byteIndex, numBytes: int){
+    this.matched = matched;
+    this.byteOffset = byteOffset;
+    this.numBytes = numBytes;
+  }
+}
+
+
+/*
+record regexMatch {
+  /* true if the regular expression search matched successfully */
+  var matched:bool;
+  /* 0-based offset into the string or channel that matched; -1 if matched=false */
   var byteOffset:byteIndex; // 0-based, -1 if matched==false
   /* the length of the match. 0 if matched==false */
   var numBytes:int; // 0 if matched==false
 }
+*/
 
 pragma "no doc"
 proc reMatch type

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -528,39 +528,22 @@ proc compile(pattern: ?t, posix=false, literal=false, noCapture=false,
       if m then do_something_if_matched();
       if !m then do_something_if_not_matched();
 
+    .. warning::
+      offset field is deprecated, use byte offset instead
+    .. warning::
+      size field is deprecated, use numBytes instead
+ 
  */
-
-/*
 record regexMatch {
   /* true if the regular expression search matched successfully */
   var matched:bool;
-  /* 0-based offset into the string or channel that matched; -1 if matched=false */
-  var byteOffset:byteIndex;
-  deprecated "field offset is deprecated, use byteOffset instead" var offset:byteIndex = byteOffset;
-  /* the length of the match. 0 if matched==false */
-  var numBytes:int; 
-  deprecated "field size is deprecated, use numBytes instead" var size:int = numBytes;
-  //TODO: remove when removing offset and size
-  proc init(){
-    
-  }
-
-  proc init(matched: bool, byteOffset: byteIndex, numBytes: int){
-    this.matched = matched;
-    this.byteOffset = byteOffset;
-    this.numBytes = numBytes;
-  }
-}
-*/
-
-record regexMatch {
-  /* true if the regular expression search matched successfully */
-  var matched:bool;
-  /* 0-based offset into the string or channel that matched; -1 if matched=false */
+  /* 0-based offset into the string or channel that matched; -1 if matched=false */ 
   var byteOffset:byteIndex;
   /* the length of the match. 0 if matched==false */
   var numBytes:int;
+
   //TODO: remove when removing offset and size
+  pragma "no doc"
   proc init(){
 
   }
@@ -584,18 +567,6 @@ record regexMatch {
     return this.numBytes;
   }
 }
-
-
-/*
-record regexMatch {
-  /* true if the regular expression search matched successfully */
-  var matched:bool;
-  /* 0-based offset into the string or channel that matched; -1 if matched=false */
-  var byteOffset:byteIndex; // 0-based, -1 if matched==false
-  /* the length of the match. 0 if matched==false */
-  var numBytes:int; // 0 if matched==false
-}
-*/
 
 pragma "no doc"
 proc reMatch type

--- a/test/deprecated/regexMatchFields.chpl
+++ b/test/deprecated/regexMatchFields.chpl
@@ -1,0 +1,17 @@
+use Regex;
+
+config type t = string;
+
+writeln("Search 1");
+{
+  var r = compile("[a-z]+":t);
+
+  var str = " test ":t;
+  {
+    var match = r.search(str);
+
+    writeln(match.size);
+    writeln(match.offset);
+  }
+}
+

--- a/test/deprecated/regexMatchFields.good
+++ b/test/deprecated/regexMatchFields.good
@@ -1,0 +1,5 @@
+regexMatchFields.chpl:13: warning: field size is deprecated, use numBytes instead
+regexMatchFields.chpl:14: warning: field offset is deprecated, use byteOffset instead
+Search 1
+4
+1

--- a/test/deprecated/regexMatchesArgs.good
+++ b/test/deprecated/regexMatchesArgs.good
@@ -1,2 +1,2 @@
 regexMatchesArgs.chpl:7: warning: regex.matches arguments 'captures' and 'maxmatches' are deprecated. Use 'numCaptures' and/or 'maxMatches instead.
-((matched = true, offset = 4, size = 3))
+((matched = true, byteOffset = 4, numBytes = 3))

--- a/test/deprecated/regexpSearch.good
+++ b/test/deprecated/regexpSearch.good
@@ -1,10 +1,10 @@
 regexpSearch.chpl:11: warning: the 'needle' argument is deprecated, use 'pattern' instead
 regexpSearch.chpl:27: warning: the 'needle' argument is deprecated, use 'pattern' instead
 search string
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 1)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 1)
 test
 search bytes
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 1)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 1)
 test

--- a/test/regex/bytes/cast.good
+++ b/test/regex/bytes/cast.good
@@ -1,4 +1,4 @@
-(matched = true, offset = 0, numBytes = 8)
-(matched = true, offset = 0, numBytes = 8)
-(matched = false, offset = -1, numBytes = 0)
-(matched = false, offset = -1, numBytes = 0)
+(matched = true, byteOffset = 0, numBytes = 8)
+(matched = true, byteOffset = 0, numBytes = 8)
+(matched = false, byteOffset = -1, numBytes = 0)
+(matched = false, byteOffset = -1, numBytes = 0)

--- a/test/regex/bytes/cast.good
+++ b/test/regex/bytes/cast.good
@@ -1,4 +1,4 @@
-(matched = true, offset = 0, size = 8)
-(matched = true, offset = 0, size = 8)
-(matched = false, offset = -1, size = 0)
-(matched = false, offset = -1, size = 0)
+(matched = true, offset = 0, numBytes = 8)
+(matched = true, offset = 0, numBytes = 8)
+(matched = false, offset = -1, numBytes = 0)
+(matched = false, offset = -1, numBytes = 0)

--- a/test/regex/emptyregex.chpl
+++ b/test/regex/emptyregex.chpl
@@ -10,8 +10,8 @@ var matches = r.matches(s);
 assert(matches.size == (s.size + 1));
 writeln(matches.size);
 for (i, (match,)) in zip(matches.domain, matches) {
-  writeln("offset=", match.offset);
-  assert(i == match.offset);
+  writeln("offset=", match.byteOffset);
+  assert(i == match.byteOffset);
 }
 
 writeln();

--- a/test/regex/ferguson/regex-no-leak.good
+++ b/test/regex/ferguson/regex-no-leak.good
@@ -1,54 +1,54 @@
 Compile/Delete
 Search 1
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
 Search 2
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 t
 test
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 t
 test
 Search 3
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 1)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 1)
 test
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 1)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 1)
 test
 Search 4
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
 Search 5
-(matched = true, offset = 1, size = 2)
+(matched = true, offset = 1, numBytes = 2)
 57
 57
-(matched = true, offset = 1, size = 2)
+(matched = true, offset = 1, numBytes = 2)
 57
 57
 Match 1
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 test
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 test
 Match 2
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 t
 test
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 t
 test
 Match 3
-(matched = false, offset = -1, size = 0)
+(matched = false, offset = -1, numBytes = 0)
 
 
-(matched = false, offset = -1, size = 0)
+(matched = false, offset = -1, numBytes = 0)
 
 
 Split 1

--- a/test/regex/ferguson/regex-no-leak.good
+++ b/test/regex/ferguson/regex-no-leak.good
@@ -1,54 +1,54 @@
 Compile/Delete
 Search 1
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
 Search 2
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 t
 test
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 t
 test
 Search 3
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 1)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 1)
 test
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 1)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 1)
 test
 Search 4
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
 Search 5
-(matched = true, offset = 1, numBytes = 2)
+(matched = true, byteOffset = 1, numBytes = 2)
 57
 57
-(matched = true, offset = 1, numBytes = 2)
+(matched = true, byteOffset = 1, numBytes = 2)
 57
 57
 Match 1
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 test
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 test
 Match 2
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 t
 test
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 t
 test
 Match 3
-(matched = false, offset = -1, numBytes = 0)
+(matched = false, byteOffset = -1, numBytes = 0)
 
 
-(matched = false, offset = -1, numBytes = 0)
+(matched = false, byteOffset = -1, numBytes = 0)
 
 
 Split 1

--- a/test/regex/ferguson/regexp.good
+++ b/test/regex/ferguson/regexp.good
@@ -1,54 +1,54 @@
 Compile/Delete
 Search 1
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
 Search 2
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 t
 test
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
 t
 test
 Search 3
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 1)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 1)
 test
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 1)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 1)
 test
 Search 4
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, size = 4)
-(matched = true, offset = 1, size = 4)
+(matched = true, offset = 1, numBytes = 4)
+(matched = true, offset = 1, numBytes = 4)
 test
 Search 5
-(matched = true, offset = 1, size = 2)
+(matched = true, offset = 1, numBytes = 2)
 57
 57
-(matched = true, offset = 1, size = 2)
+(matched = true, offset = 1, numBytes = 2)
 57
 57
 Match 1
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 test
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 test
 Match 2
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 t
 test
-(matched = true, offset = 0, size = 4)
+(matched = true, offset = 0, numBytes = 4)
 t
 test
 Match 3
-(matched = false, offset = -1, size = 0)
+(matched = false, offset = -1, numBytes = 0)
 
 
-(matched = false, offset = -1, size = 0)
+(matched = false, offset = -1, numBytes = 0)
 
 
 Split 1

--- a/test/regex/ferguson/regexp.good
+++ b/test/regex/ferguson/regexp.good
@@ -1,54 +1,54 @@
 Compile/Delete
 Search 1
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
 Search 2
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 t
 test
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 t
 test
 Search 3
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 1)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 1)
 test
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 1)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 1)
 test
 Search 4
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
-(matched = true, offset = 1, numBytes = 4)
-(matched = true, offset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
+(matched = true, byteOffset = 1, numBytes = 4)
 test
 Search 5
-(matched = true, offset = 1, numBytes = 2)
+(matched = true, byteOffset = 1, numBytes = 2)
 57
 57
-(matched = true, offset = 1, numBytes = 2)
+(matched = true, byteOffset = 1, numBytes = 2)
 57
 57
 Match 1
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 test
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 test
 Match 2
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 t
 test
-(matched = true, offset = 0, numBytes = 4)
+(matched = true, byteOffset = 0, numBytes = 4)
 t
 test
 Match 3
-(matched = false, offset = -1, numBytes = 0)
+(matched = false, byteOffset = -1, numBytes = 0)
 
 
-(matched = false, offset = -1, numBytes = 0)
+(matched = false, byteOffset = -1, numBytes = 0)
 
 
 Split 1

--- a/test/regex/localFastPath.good
+++ b/test/regex/localFastPath.good
@@ -1,15 +1,15 @@
 searchL
-(matched = true, offset = 0, size = 5)
+(matched = true, offset = 0, numBytes = 5)
 aaa
 bb
 
 searchR(rvf=true)
-(matched = true, offset = 0, size = 5)
+(matched = true, offset = 0, numBytes = 5)
 aaa
 bb
 
 searchR(rvf=false)
-(matched = true, offset = 0, size = 5)
+(matched = true, offset = 0, numBytes = 5)
 aaa
 bb
 
@@ -41,19 +41,19 @@ aaa
 b
 
 matchesL
-((matched = true, offset = 0, size = 2), (matched = true, offset = 0, size = 1), (matched = true, offset = 1, size = 1))
-((matched = true, offset = 2, size = 3), (matched = true, offset = 2, size = 2), (matched = true, offset = 4, size = 1))
-((matched = true, offset = 5, size = 4), (matched = true, offset = 5, size = 3), (matched = true, offset = 8, size = 1))
+((matched = true, offset = 0, numBytes = 2), (matched = true, offset = 0, numBytes = 1), (matched = true, offset = 1, numBytes = 1))
+((matched = true, offset = 2, numBytes = 3), (matched = true, offset = 2, numBytes = 2), (matched = true, offset = 4, numBytes = 1))
+((matched = true, offset = 5, numBytes = 4), (matched = true, offset = 5, numBytes = 3), (matched = true, offset = 8, numBytes = 1))
 
 matchesR(rvf=true)
-((matched = true, offset = 0, size = 2), (matched = true, offset = 0, size = 1), (matched = true, offset = 1, size = 1))
-((matched = true, offset = 2, size = 3), (matched = true, offset = 2, size = 2), (matched = true, offset = 4, size = 1))
-((matched = true, offset = 5, size = 4), (matched = true, offset = 5, size = 3), (matched = true, offset = 8, size = 1))
+((matched = true, offset = 0, numBytes = 2), (matched = true, offset = 0, numBytes = 1), (matched = true, offset = 1, numBytes = 1))
+((matched = true, offset = 2, numBytes = 3), (matched = true, offset = 2, numBytes = 2), (matched = true, offset = 4, numBytes = 1))
+((matched = true, offset = 5, numBytes = 4), (matched = true, offset = 5, numBytes = 3), (matched = true, offset = 8, numBytes = 1))
 
 matchesR(rvf=false)
-((matched = true, offset = 0, size = 2), (matched = true, offset = 0, size = 1), (matched = true, offset = 1, size = 1))
-((matched = true, offset = 2, size = 3), (matched = true, offset = 2, size = 2), (matched = true, offset = 4, size = 1))
-((matched = true, offset = 5, size = 4), (matched = true, offset = 5, size = 3), (matched = true, offset = 8, size = 1))
+((matched = true, offset = 0, numBytes = 2), (matched = true, offset = 0, numBytes = 1), (matched = true, offset = 1, numBytes = 1))
+((matched = true, offset = 2, numBytes = 3), (matched = true, offset = 2, numBytes = 2), (matched = true, offset = 4, numBytes = 1))
+((matched = true, offset = 5, numBytes = 4), (matched = true, offset = 5, numBytes = 3), (matched = true, offset = 8, numBytes = 1))
 
 subL
 AbAbAb

--- a/test/regex/localFastPath.good
+++ b/test/regex/localFastPath.good
@@ -1,15 +1,15 @@
 searchL
-(matched = true, offset = 0, numBytes = 5)
+(matched = true, byteOffset = 0, numBytes = 5)
 aaa
 bb
 
 searchR(rvf=true)
-(matched = true, offset = 0, numBytes = 5)
+(matched = true, byteOffset = 0, numBytes = 5)
 aaa
 bb
 
 searchR(rvf=false)
-(matched = true, offset = 0, numBytes = 5)
+(matched = true, byteOffset = 0, numBytes = 5)
 aaa
 bb
 
@@ -41,19 +41,19 @@ aaa
 b
 
 matchesL
-((matched = true, offset = 0, numBytes = 2), (matched = true, offset = 0, numBytes = 1), (matched = true, offset = 1, numBytes = 1))
-((matched = true, offset = 2, numBytes = 3), (matched = true, offset = 2, numBytes = 2), (matched = true, offset = 4, numBytes = 1))
-((matched = true, offset = 5, numBytes = 4), (matched = true, offset = 5, numBytes = 3), (matched = true, offset = 8, numBytes = 1))
+((matched = true, byteOffset = 0, numBytes = 2), (matched = true, byteOffset = 0, numBytes = 1), (matched = true, byteOffset = 1, numBytes = 1))
+((matched = true, byteOffset = 2, numBytes = 3), (matched = true, byteOffset = 2, numBytes = 2), (matched = true, byteOffset = 4, numBytes = 1))
+((matched = true, byteOffset = 5, numBytes = 4), (matched = true, byteOffset = 5, numBytes = 3), (matched = true, byteOffset = 8, numBytes = 1))
 
 matchesR(rvf=true)
-((matched = true, offset = 0, numBytes = 2), (matched = true, offset = 0, numBytes = 1), (matched = true, offset = 1, numBytes = 1))
-((matched = true, offset = 2, numBytes = 3), (matched = true, offset = 2, numBytes = 2), (matched = true, offset = 4, numBytes = 1))
-((matched = true, offset = 5, numBytes = 4), (matched = true, offset = 5, numBytes = 3), (matched = true, offset = 8, numBytes = 1))
+((matched = true, byteOffset = 0, numBytes = 2), (matched = true, byteOffset = 0, numBytes = 1), (matched = true, byteOffset = 1, numBytes = 1))
+((matched = true, byteOffset = 2, numBytes = 3), (matched = true, byteOffset = 2, numBytes = 2), (matched = true, byteOffset = 4, numBytes = 1))
+((matched = true, byteOffset = 5, numBytes = 4), (matched = true, byteOffset = 5, numBytes = 3), (matched = true, byteOffset = 8, numBytes = 1))
 
 matchesR(rvf=false)
-((matched = true, offset = 0, numBytes = 2), (matched = true, offset = 0, numBytes = 1), (matched = true, offset = 1, numBytes = 1))
-((matched = true, offset = 2, numBytes = 3), (matched = true, offset = 2, numBytes = 2), (matched = true, offset = 4, numBytes = 1))
-((matched = true, offset = 5, numBytes = 4), (matched = true, offset = 5, numBytes = 3), (matched = true, offset = 8, numBytes = 1))
+((matched = true, byteOffset = 0, numBytes = 2), (matched = true, byteOffset = 0, numBytes = 1), (matched = true, byteOffset = 1, numBytes = 1))
+((matched = true, byteOffset = 2, numBytes = 3), (matched = true, byteOffset = 2, numBytes = 2), (matched = true, byteOffset = 4, numBytes = 1))
+((matched = true, byteOffset = 5, numBytes = 4), (matched = true, byteOffset = 5, numBytes = 3), (matched = true, byteOffset = 8, numBytes = 1))
 
 subL
 AbAbAb

--- a/test/regex/maxMatches.good
+++ b/test/regex/maxMatches.good
@@ -1,1 +1,1 @@
-((matched = true, offset = 4, size = 3))
+((matched = true, offset = 4, numBytes = 3))

--- a/test/regex/maxMatches.good
+++ b/test/regex/maxMatches.good
@@ -1,1 +1,1 @@
-((matched = true, offset = 4, numBytes = 3))
+((matched = true, byteOffset = 4, numBytes = 3))


### PR DESCRIPTION
This PR changes the regexMatch fields `offset` and `size` to `byteOffset` and `numBytes` following the discussion in #19076. The old fields (`offset` and `size`) are now paren-less procs so that a deprecation warning can be added and the number of fields in the regexMatch record remains the same.

This PR also:
- modifies the IO module and record parser package to use the renamed fields
- modifies regex tests to use the renamed fields
- adds a new deprecation test

Passed paratests with `CHPL_RE2=bundled`